### PR TITLE
fix(gateway): persist flushed-session set to DB to prevent double flush on restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -570,8 +570,10 @@ class GatewayRunner:
             # Read live memory state from disk so the flush agent can see
             # what's already saved and avoid overwriting newer entries.
             _current_memory = ""
+            _memory_near_full = False
             try:
                 from tools.memory_tool import MEMORY_DIR
+                MEMORY_LIMITS = {"MEMORY.md": 2200, "USER.md": 1375}
                 for fname, label in [
                     ("MEMORY.md", "MEMORY (your personal notes)"),
                     ("USER.md", "USER PROFILE (who the user is)"),
@@ -581,6 +583,9 @@ class GatewayRunner:
                         content = fpath.read_text(encoding="utf-8").strip()
                         if content:
                             _current_memory += f"\n\n## Current {label}:\n{content}"
+                            limit = MEMORY_LIMITS.get(fname, 2200)
+                            if len(content) >= limit * 0.9:
+                                _memory_near_full = True
             except Exception:
                 pass  # Non-fatal — flush still works, just without the guard
 
@@ -596,6 +601,16 @@ class GatewayRunner:
                 "problem, consider saving it as a skill.\n"
                 "3. If nothing is worth saving, that's fine — just skip.\n\n"
             )
+
+            if _memory_near_full:
+                flush_prompt += (
+                    "WARNING — memory is at or near capacity (>=90% full). "
+                    "Do NOT attempt to add new entries without first removing or "
+                    "consolidating existing ones. Use action='replace' to update "
+                    "stale entries in-place, or action='remove' to delete entries "
+                    "that are now obsolete, before adding anything new. "
+                    "Adding entries when memory is full will fail.\n\n"
+                )
 
             if _current_memory:
                 flush_prompt += (
@@ -1151,6 +1166,12 @@ class GatewayRunner:
                         await self._async_flush_memories(entry.session_id, key)
                         self._shutdown_gateway_honcho(key)
                         self.session_store._pre_flushed_sessions.add(entry.session_id)
+                        # Persist to DB so the marker survives gateway restarts
+                        if self.session_store._db:
+                            try:
+                                self.session_store._db.add_flushed_session(entry.session_id)
+                            except Exception as db_err:
+                                logger.debug("Failed to persist flushed session %s: %s", entry.session_id, db_err)
                     except Exception as e:
                         logger.debug("Proactive memory flush failed for %s: %s", entry.session_id, e)
             except Exception as e:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -482,12 +482,15 @@ class SessionStore:
         # on_auto_reset is deprecated — memory flush now runs proactively
         # via the background session expiry watcher in GatewayRunner.
         self._pre_flushed_sessions: set = set()  # session_ids already flushed by watcher
-        
+
         # Initialize SQLite session database
         self._db = None
         try:
             from hermes_state import SessionDB
             self._db = SessionDB()
+            # Restore flushed-session set from DB so gateway restarts don't
+            # trigger duplicate memory flushes for already-flushed sessions.
+            self._pre_flushed_sessions = self._db.load_flushed_sessions()
         except Exception as e:
             print(f"[gateway] Warning: SQLite session store unavailable, falling back to JSONL: {e}")
     
@@ -692,7 +695,8 @@ class SessionStore:
                     # Track whether the expired session had any real conversation
                     reset_had_activity = entry.total_tokens > 0
                     db_end_session_id = entry.session_id
-                    self._pre_flushed_sessions.discard(entry.session_id)
+                    flushed_session_id = entry.session_id
+                    self._pre_flushed_sessions.discard(flushed_session_id)
             else:
                 was_auto_reset = False
                 auto_reset_reason = None
@@ -729,6 +733,12 @@ class SessionStore:
                 self._db.end_session(db_end_session_id, "session_reset")
             except Exception as e:
                 logger.debug("Session DB operation failed: %s", e)
+            try:
+                # Clean up the flushed-session record so it doesn't accumulate
+                # in the DB indefinitely after the session has been reset.
+                self._db.remove_flushed_session(db_end_session_id)
+            except Exception as e:
+                logger.debug("Failed to remove flushed session record %s: %s", db_end_session_id, e)
 
         if self._db and db_create_kwargs:
             try:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -27,7 +27,7 @@ from typing import Dict, Any, List, Optional
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -78,6 +78,11 @@ CREATE TABLE IF NOT EXISTS messages (
     reasoning TEXT,
     reasoning_details TEXT,
     codex_reasoning_items TEXT
+);
+
+CREATE TABLE IF NOT EXISTS flushed_sessions (
+    session_id TEXT PRIMARY KEY,
+    flushed_at REAL NOT NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
@@ -212,8 +217,18 @@ class SessionDB:
                     except sqlite3.OperationalError:
                         pass  # Column already exists
                 cursor.execute("UPDATE schema_version SET version = 6")
+            if current_version < 7:
+                # v7: persist proactively-flushed sessions so they survive gateway restarts
+                try:
+                    cursor.execute(
+                        "CREATE TABLE IF NOT EXISTS flushed_sessions ("
+                        "session_id TEXT PRIMARY KEY, flushed_at REAL NOT NULL)"
+                    )
+                except sqlite3.OperationalError:
+                    pass  # Table already exists
+                cursor.execute("UPDATE schema_version SET version = 7")
 
-        # Unique title index — always ensure it exists (safe to run after migrations
+        # Unique title index — always ensure it exists
         # since the title column is guaranteed to exist at this point)
         try:
             cursor.execute(
@@ -1008,3 +1023,30 @@ class SessionDB:
 
             self._conn.commit()
         return len(session_ids)
+
+    # ------------------------------------------------------------------
+    # Flushed-session persistence (prevents double flush after restart)
+    # ------------------------------------------------------------------
+
+    def add_flushed_session(self, session_id: str) -> None:
+        """Record that a session's memories have been proactively flushed."""
+        import time
+        with self._lock:
+            self._conn.execute(
+                "INSERT OR REPLACE INTO flushed_sessions (session_id, flushed_at) VALUES (?, ?)",
+                (session_id, time.time()),
+            )
+            self._conn.commit()
+
+    def load_flushed_sessions(self) -> set:
+        """Return the set of session_ids that have already been flushed."""
+        cursor = self._conn.execute("SELECT session_id FROM flushed_sessions")
+        return {row[0] for row in cursor.fetchall()}
+
+    def remove_flushed_session(self, session_id: str) -> None:
+        """Remove a session from the flushed set (e.g. after it is fully reset)."""
+        with self._lock:
+            self._conn.execute(
+                "DELETE FROM flushed_sessions WHERE session_id = ?", (session_id,)
+            )
+            self._conn.commit()


### PR DESCRIPTION
## Problem

Fixes #3059.

When the gateway restarted, `_pre_flushed_sessions` (an in-memory `set`) was reset to empty. The background expiry watcher would then see the same expired session and flush it again, causing:

- Duplicate LLM API calls
- Memory tool errors when trying to save already-saved entries
- Wasted tokens and potential memory corruption

## Root cause

```python
self._pre_flushed_sessions: set = set()  # resets on every restart
```

## Fix

**`hermes_state.py`** — Schema v7 migration adds a `flushed_sessions` table:
- `add_flushed_session(session_id)` — called after each successful proactive flush
- `load_flushed_sessions()` — returns the set of already-flushed session IDs
- `remove_flushed_session(session_id)` — called when a session is fully reset

Also fixes an existing bug in the v6 migration block that incorrectly bumped `schema_version` to 5 instead of 6.

**`gateway/session.py`** — On `SessionStore` init, load the persisted flushed-session set from DB so markers survive restarts. On session reset, call `remove_flushed_session` to clean up the DB record.

**`gateway/run.py`** — After a successful proactive flush, persist the marker to DB. Also adds memory-near-full detection to the flush prompt: when memory is >=90% full, the agent is warned to consolidate or remove stale entries before adding new ones, preventing invalid tool calls at capacity (the second issue noted in #3059).