### PR TITLE
fix: add collision protection for plugin commands and plugin names

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -10,6 +10,7 @@ To add an alias: set ``aliases=("short",)`` on the existing ``CommandDef``.
 
 from __future__ import annotations
 
+import logging
 import os
 import re
 from collections.abc import Callable, Mapping
@@ -18,6 +19,8 @@ from typing import Any
 
 from prompt_toolkit.auto_suggest import AutoSuggest, Suggestion
 from prompt_toolkit.completion import Completer, Completion
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -161,7 +164,22 @@ def resolve_command(name: str) -> CommandDef | None:
 
 
 def register_plugin_command(cmd: CommandDef) -> None:
-    """Append a plugin-defined command to the registry and refresh lookups."""
+    """Append a plugin-defined command to the registry and refresh lookups.
+
+    Logs a warning (and skips registration) if the command name or any of
+    its aliases collide with an existing built-in command — prevents plugins
+    from silently overwriting core functionality like /help or /update.
+    """
+    all_names = [cmd.name, *cmd.aliases]
+    for name in all_names:
+        existing = _COMMAND_LOOKUP.get(name)
+        if existing is not None:
+            logger.warning(
+                "Plugin command '/%s' collides with existing command '/%s' "
+                "— skipping plugin command to preserve built-in",
+                cmd.name, existing.name,
+            )
+            return
     COMMAND_REGISTRY.append(cmd)
     rebuild_lookups()
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -331,6 +331,13 @@ class PluginManager:
             loaded.error = str(exc)
             logger.warning("Failed to load plugin '%s': %s", manifest.name, exc)
 
+        existing = self._plugins.get(manifest.name)
+        if existing is not None and existing.manifest.source != manifest.source:
+            logger.warning(
+                "Plugin name collision: '%s' (source '%s') is being "
+                "overwritten by source '%s'",
+                manifest.name, existing.manifest.source, manifest.source,
+            )
         self._plugins[manifest.name] = loaded
 
     def _load_directory_module(self, manifest: PluginManifest) -> types.ModuleType:

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -504,3 +504,60 @@ class TestGhostText:
         s = _suggestion("/model anthropic:cl", completer=completer)
         assert s is not None
         assert s.startswith("aude-")
+
+
+# ---------------------------------------------------------------------------
+# Plugin command collision protection
+# ---------------------------------------------------------------------------
+
+class TestPluginCommandCollision:
+    """register_plugin_command() must not silently overwrite built-in commands."""
+
+    def test_plugin_command_skipped_when_name_collides_with_builtin(self, caplog):
+        """A plugin trying to register /help should be skipped with a warning."""
+        import logging
+        from hermes_cli.commands import register_plugin_command, rebuild_lookups
+
+        original_count = len(COMMAND_REGISTRY)
+        plugin_cmd = CommandDef("help", "Fake help from plugin", "Info")
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.commands"):
+            register_plugin_command(plugin_cmd)
+
+        assert any("collides" in r.message.lower() for r in caplog.records)
+        # Registry should NOT have grown — the plugin command was rejected
+        assert len(COMMAND_REGISTRY) == original_count
+
+    def test_plugin_command_skipped_when_alias_collides_with_builtin(self, caplog):
+        """A plugin whose alias clashes with an existing command name is skipped."""
+        import logging
+        from hermes_cli.commands import register_plugin_command
+
+        original_count = len(COMMAND_REGISTRY)
+        # "bg" is an alias for the built-in /background command
+        plugin_cmd = CommandDef("myplugin", "Some plugin", "Info", aliases=("bg",))
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.commands"):
+            register_plugin_command(plugin_cmd)
+
+        assert any("collides" in r.message.lower() for r in caplog.records)
+        assert len(COMMAND_REGISTRY) == original_count
+
+    def test_plugin_command_registered_when_no_collision(self):
+        """A plugin with a unique name registers successfully."""
+        from hermes_cli.commands import register_plugin_command
+
+        original_count = len(COMMAND_REGISTRY)
+        plugin_cmd = CommandDef(
+            "my_unique_test_plugin_cmd", "Test plugin", "Tools & Skills",
+        )
+
+        register_plugin_command(plugin_cmd)
+
+        assert len(COMMAND_REGISTRY) == original_count + 1
+        assert resolve_command("my_unique_test_plugin_cmd") is not None
+
+        # Cleanup: remove the test command
+        COMMAND_REGISTRY.pop()
+        from hermes_cli.commands import rebuild_lookups
+        rebuild_lookups()

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -371,3 +371,41 @@ class TestPluginManagerList:
 # in PluginContext (hermes_cli/plugins.py).  The tests referenced _plugin_commands,
 # commands_registered, get_plugin_command_handler, and GATEWAY_KNOWN_COMMANDS
 # integration — all of which are unimplemented features.
+
+
+class TestPluginNameCollision:
+    """PluginManager warns when two plugins with the same name come from different sources."""
+
+    def test_same_name_different_source_logs_warning(self, caplog):
+        """Loading a plugin that collides with one from a different source emits a warning."""
+        mgr = PluginManager()
+
+        # Simulate first plugin loaded from "user" source
+        manifest_a = PluginManifest(name="my-plugin", source="user")
+        loaded_a = LoadedPlugin(manifest=manifest_a, enabled=True)
+        mgr._plugins["my-plugin"] = loaded_a
+
+        # Now load a second plugin with the same name from "entrypoint"
+        manifest_b = PluginManifest(name="my-plugin", source="entrypoint")
+        loaded_b = LoadedPlugin(manifest=manifest_b, enabled=True)
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            mgr._load_plugin(manifest_b)
+
+        assert any("collision" in r.message.lower() for r in caplog.records)
+
+    def test_same_name_same_source_no_warning(self, caplog):
+        """Re-loading a plugin from the same source is silent."""
+        mgr = PluginManager()
+
+        manifest_a = PluginManifest(name="my-plugin", source="user")
+        loaded_a = LoadedPlugin(manifest=manifest_a, enabled=True)
+        mgr._plugins["my-plugin"] = loaded_a
+
+        # Reload from the same source
+        manifest_b = PluginManifest(name="my-plugin", source="user")
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            mgr._load_plugin(manifest_b)
+
+        assert not any("collision" in r.message.lower() for r in caplog.records)


### PR DESCRIPTION
## Description

Follow-up to #3077 which added collision protection for MCP tools in the tool registry. The same silent-overwrite issue exists in two other registries:

1. **Slash commands** — `register_plugin_command()` in `hermes_cli/commands.py` blindly appends to `COMMAND_REGISTRY` and rebuilds lookups. A plugin registering a command named `help` or using the alias `bg` silently overwrites the built-in `/help` or `/background` command with no warning.

2. **Plugin names** — `PluginManager._load_plugin()` in `hermes_cli/plugins.py` does `self._plugins[manifest.name] = loaded` without checking if a plugin with that name already exists from a different source (user dir vs pip entrypoint).

## Type of Change

- [x] Bug fix (defense in depth)

## Changes Made

- `hermes_cli/commands.py`: `register_plugin_command()` now checks `_COMMAND_LOOKUP` for name/alias collisions before registration. If a collision is found, the plugin command is skipped and a warning is logged.
- `hermes_cli/plugins.py`: `_load_plugin()` now warns when a plugin name from a different source is about to overwrite an existing one.
- 5 new tests covering both registries (collision detected, collision from alias, clean registration, cross-source warning, same-source silent).

## Testing

- All 87 tests pass across both test files
- Zero regressions in existing tests

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the code
- [x] Added tests that prove the fix is effective
- [x] All tests pass locally
- [x] No breaking changes introduced