### PR TITLE
fix: handle addition-only hunks in V4A patch parser

### DIFF
--- a/tests/tools/test_patch_parser.py
+++ b/tests/tools/test_patch_parser.py
@@ -185,3 +185,95 @@ class TestApplyUpdate:
             '    result = 1\n'
             '    return result + 1'
         )
+
+    def test_addition_only_hunk_must_not_silently_succeed(self):
+        """An update hunk with only '+' lines must not report success
+        while leaving the file unchanged."""
+        patch = """\
+*** Begin Patch
+*** Update File: app.py
+@@ def hello @@
++def goodbye():
++    pass
+*** End Patch"""
+        operations, err = parse_v4a_patch(patch)
+        assert err is None
+
+        original = "def hello():\n    return 1\n"
+
+        class FakeFileOps:
+            def __init__(self):
+                self.written = None
+
+            def read_file(self, path, offset=1, limit=500):
+                return SimpleNamespace(content=original, error=None)
+
+            def write_file(self, path, content):
+                self.written = content
+                return SimpleNamespace(error=None)
+
+        file_ops = FakeFileOps()
+        result = apply_v4a_operations(operations, file_ops)
+
+        assert result.success is True
+        assert result.error is None
+        assert file_ops.written != original
+        assert "def goodbye():" in file_ops.written
+        assert "    pass" in file_ops.written
+        # New lines must appear after the context hint anchor
+        assert file_ops.written == (
+            "def hello():\n"
+            "def goodbye():\n"
+            "    pass\n"
+            "    return 1\n"
+        )
+
+    def test_addition_only_hunk_errors_when_context_hint_not_found(self):
+        """Addition-only hunk must fail when context hint doesn't match."""
+        patch = """\
+*** Begin Patch
+*** Update File: app.py
+@@ no_such_function @@
++new_line = 1
+*** End Patch"""
+        operations, _ = parse_v4a_patch(patch)
+
+        class FakeFileOps:
+            def __init__(self):
+                self.written = None
+            def read_file(self, path, offset=1, limit=500):
+                return SimpleNamespace(content="x = 1\n", error=None)
+            def write_file(self, path, content):
+                self.written = content
+                return SimpleNamespace(error=None)
+
+        file_ops = FakeFileOps()
+        result = apply_v4a_operations(operations, file_ops)
+        assert result.success is False
+        assert "context hint" in result.error
+        assert "no_such_function" in result.error
+        assert file_ops.written is None
+
+    def test_addition_only_hunk_errors_when_no_context_hint(self):
+        """Addition-only hunk with no context hint at all must fail."""
+        patch = """\
+*** Begin Patch
+*** Update File: app.py
++orphan_line = 1
+*** End Patch"""
+        operations, _ = parse_v4a_patch(patch)
+
+        class FakeFileOps:
+            def __init__(self):
+                self.written = None
+            def read_file(self, path, offset=1, limit=500):
+                return SimpleNamespace(content="x = 1\n", error=None)
+            def write_file(self, path, content):
+                self.written = content
+                return SimpleNamespace(error=None)
+
+        file_ops = FakeFileOps()
+        result = apply_v4a_operations(operations, file_ops)
+        assert result.success is False
+        assert "no context" in result.error
+        assert file_ops.written is None

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -391,13 +391,13 @@ def _apply_update(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
         if search_lines:
             search_pattern = '\n'.join(search_lines)
             replacement = '\n'.join(replace_lines)
-            
+
             # Use fuzzy matching
             from tools.fuzzy_match import fuzzy_find_and_replace
             new_content, count, error = fuzzy_find_and_replace(
                 new_content, search_pattern, replacement, replace_all=False
             )
-            
+
             if error and count == 0:
                 # Try with context hint if available
                 if hunk.context_hint:
@@ -408,17 +408,32 @@ def _apply_update(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
                         window_start = max(0, hint_pos - 500)
                         window_end = min(len(new_content), hint_pos + 2000)
                         window = new_content[window_start:window_end]
-                        
+
                         window_new, count, error = fuzzy_find_and_replace(
                             window, search_pattern, replacement, replace_all=False
                         )
-                        
+
                         if count > 0:
                             new_content = new_content[:window_start] + window_new + new_content[window_end:]
                             error = None
-                
+
                 if error:
                     return False, f"Could not apply hunk: {error}"
+        elif replace_lines:
+            # No search lines — use context hint as insertion anchor
+            addition = '\n'.join(replace_lines)
+            if hunk.context_hint:
+                hint_pos = new_content.find(hunk.context_hint)
+                if hint_pos != -1:
+                    insert_pos = new_content.find('\n', hint_pos)
+                    if insert_pos != -1:
+                        new_content = new_content[:insert_pos] + '\n' + addition + new_content[insert_pos:]
+                    else:
+                        new_content = new_content + '\n' + addition
+                else:
+                    return False, f"Could not apply addition-only hunk: context hint '{hunk.context_hint}' not found"
+            else:
+                return False, "Could not apply addition-only hunk: no context lines and no context hint to determine insertion point"
     
     # Write new content
     write_result = file_ops.write_file(op.file_path, new_content)


### PR DESCRIPTION
## Problem

`_apply_update` silently drops addition-only hunks (hunks with only `+` lines, no context or `-` lines). The file is written back unchanged but the operation reports `success=True` and adds the file to `files_modified`.

## Root cause

`search_lines` is empty when a hunk has no context or removal lines, so the `if search_lines:` guard at line 391 skips the entire replacement block. No `else` branch existed, so the function fell through to write the original content back and return success.

## Fix

Added an `elif replace_lines:` branch that:
- Uses the `@@ context hint @@` to find the insertion point and inserts the new lines after it
- Returns a clear error if the context hint is not found in the file
- Returns a clear error if no context hint was provided at all

## Tests added

- `test_addition_only_hunk_must_not_silently_succeed` — valid hint, must actually modify the file
- `test_addition_only_hunk_errors_when_context_hint_not_found` — hint doesn't match, must fail
- `test_addition_only_hunk_errors_when_no_context_hint` — no hint at all, must fail
