### PR TITLE
feat(cli): fuzzy "did you mean?" suggestions for mistyped commands

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3918,8 +3918,16 @@ class HermesCLI:
                     _cprint(f"{_GOLD}Ambiguous command: {cmd_lower}{_RST}")
                     _cprint(f"{_DIM}Did you mean: {', '.join(sorted(matches))}?{_RST}")
                 else:
-                    _cprint(f"\033[1;31mUnknown command: {cmd_lower}{_RST}")
-                    _cprint(f"{_DIM}{_GOLD}Type /help for available commands{_RST}")
+                    # No prefix match — try fuzzy matching for typo correction
+                    from hermes_cli.commands import suggest_similar_commands
+                    close = suggest_similar_commands(typed_base, all_known)
+                    if close:
+                        suggestions = ", ".join(close)
+                        _cprint(f"\033[1;31mUnknown command: {cmd_lower}{_RST}")
+                        _cprint(f"{_DIM}{_GOLD}Did you mean: {suggestions}?{_RST}")
+                    else:
+                        _cprint(f"\033[1;31mUnknown command: {cmd_lower}{_RST}")
+                        _cprint(f"{_DIM}{_GOLD}Type /help for available commands{_RST}")
         
         return True
     

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -160,6 +160,37 @@ def resolve_command(name: str) -> CommandDef | None:
     return _COMMAND_LOOKUP.get(name.lower().lstrip("/"))
 
 
+def suggest_similar_commands(
+    typed: str,
+    known_commands: set[str] | None = None,
+    n: int = 3,
+    cutoff: float = 0.6,
+) -> list[str]:
+    """Return fuzzy matches for a mistyped slash command.
+
+    Uses SequenceMatcher (same algorithm as git's "did you mean?" suggestions)
+    to find the closest known commands when prefix matching fails.
+
+    Args:
+        typed: The command the user typed (with or without leading slash).
+        known_commands: Set of known command strings to match against.
+            Defaults to the built-in COMMANDS dict.
+        n: Maximum number of suggestions.
+        cutoff: Minimum similarity ratio (0.0–1.0).
+
+    Returns:
+        List of closest matching command strings, best match first.
+    """
+    import difflib
+
+    if known_commands is None:
+        known_commands = set(COMMANDS)
+    # Normalize: ensure typed has leading slash for comparison
+    if not typed.startswith("/"):
+        typed = f"/{typed}"
+    return difflib.get_close_matches(typed, sorted(known_commands), n=n, cutoff=cutoff)
+
+
 def register_plugin_command(cmd: CommandDef) -> None:
     """Append a plugin-defined command to the registry and refresh lookups."""
     COMMAND_REGISTRY.append(cmd)

--- a/tests/hermes_cli/test_fuzzy_command_suggestion.py
+++ b/tests/hermes_cli/test_fuzzy_command_suggestion.py
@@ -1,0 +1,66 @@
+"""Tests for fuzzy slash command suggestions (typo correction)."""
+
+from hermes_cli.commands import COMMANDS, suggest_similar_commands
+
+
+# Fixed set of known commands for deterministic tests
+KNOWN = {"/help", "/history", "/update", "/background", "/model", "/config",
+         "/quit", "/clear", "/new", "/tools", "/toolsets", "/skills",
+         "/prompt", "/voice", "/plan", "/reasoning", "/compact", "/skin"}
+
+
+class TestFuzzySuggestions:
+    """suggest_similar_commands() returns close matches for typos."""
+
+    def test_hlep_suggests_help(self):
+        result = suggest_similar_commands("/hlep", KNOWN)
+        assert "/help" in result
+
+    def test_udpate_suggests_update(self):
+        result = suggest_similar_commands("/udpate", KNOWN)
+        assert "/update" in result
+
+    def test_bakground_suggests_background(self):
+        result = suggest_similar_commands("/bakground", KNOWN)
+        assert "/background" in result
+
+    def test_modle_suggests_model(self):
+        result = suggest_similar_commands("/modle", KNOWN)
+        assert "/model" in result
+
+    def test_confg_suggests_config(self):
+        result = suggest_similar_commands("/confg", KNOWN)
+        assert "/config" in result
+
+    def test_tolos_suggests_tools(self):
+        result = suggest_similar_commands("/tolos", KNOWN)
+        assert "/tools" in result
+
+    def test_skils_suggests_skills(self):
+        result = suggest_similar_commands("/skils", KNOWN)
+        assert "/skills" in result
+
+    def test_completely_unrelated_returns_empty(self):
+        """A string with no similarity to any command yields no suggestions."""
+        result = suggest_similar_commands("/zzzzxxx", KNOWN)
+        assert result == []
+
+    def test_max_three_suggestions(self):
+        """At most 3 suggestions are returned by default."""
+        result = suggest_similar_commands("/co", KNOWN)
+        assert len(result) <= 3
+
+    def test_without_leading_slash(self):
+        """Works even when the typed input has no leading slash."""
+        result = suggest_similar_commands("hlep", KNOWN)
+        assert "/help" in result
+
+    def test_against_real_commands(self):
+        """Verify fuzzy matching works against the actual COMMANDS dict."""
+        result = suggest_similar_commands("/hlep")
+        assert "/help" in result
+
+    def test_exact_match_not_needed(self):
+        """An exact command doesn't go through fuzzy — but if it did, it'd match."""
+        result = suggest_similar_commands("/help", KNOWN)
+        assert "/help" in result


### PR DESCRIPTION
## Description

When you mistype a slash command and no prefix match exists, the CLI shows a dead-end error with no guidance:

```
Unknown command: /hlep
Type /help for available commands
```

This adds fuzzy matching so the CLI suggests what you probably meant — same pattern as git's "did you mean?" feature:

```
Unknown command: /hlep
Did you mean: /help?
```

### Before vs After (tested on Hermes v0.4.0)

The existing `process_command()` only does prefix matching (`/qui` → `/quit`) but has zero typo correction when prefix matching fails. Tested against all 43 registered slash commands:

| Mistyped | Current (v0.4.0) | With this PR |
|----------|-------------------|-------------|
| `/hlep` | Unknown command | Did you mean: `/help`? |
| `/bakground` | Unknown command | Did you mean: `/background`? |
| `/modle` | Unknown command | Did you mean: `/model`? |
| `/confg` | Unknown command | Did you mean: `/config`? |
| `/skilsl` | Unknown command | Did you mean: `/skills`, `/skin`? |
| `/tols` | Unknown command | Did you mean: `/tools`, `/toolsets`? |
| `/voce` | Unknown command | Did you mean: `/voice`? |
| `/reasing` | Unknown command | Did you mean: `/reasoning`? |
| `/histroy` | Unknown command | Did you mean: `/history`? |
| `/retyr` | Unknown command | Did you mean: `/retry`, `/reset`? |
| `/pormpt` | Unknown command | Did you mean: `/prompt`? |
| `/brower` | Unknown command | Did you mean: `/browser`? |
| `/insghts` | Unknown command | Did you mean: `/insights`? |
| `/toollsets` | Unknown command | Did you mean: `/toolsets`, `/tools`? |
| `/zzzzxxx` | Unknown command | Unknown command *(no close match — falls back to existing message)* |

### How it works

Added `suggest_similar_commands()` in `hermes_cli/commands.py` using Python's built-in `difflib.get_close_matches()` (SequenceMatcher with 0.6 similarity cutoff). Returns up to 3 ranked suggestions. Matches against both built-in and installed skill commands. No new dependencies.

The suggestion triggers only when prefix matching already fails — the existing prefix expansion (`/qui` → `/quit`) is untouched.

## Type of Change

- [x] New feature (non-breaking)

## Changes Made

- `hermes_cli/commands.py`: Added `suggest_similar_commands()` function
- `cli.py`: Updated the "zero prefix matches" fallback in `process_command()` to call `suggest_similar_commands()` before showing the generic error
- `tests/hermes_cli/test_fuzzy_command_suggestion.py`: 12 tests covering common typos, edge cases, and validation against the real COMMANDS dict

## Testing

- 12 new tests pass
- 65 existing command tests pass
- Zero new dependencies (stdlib `difflib`)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-reviewed the code
- [x] Added tests that prove the feature works
- [x] All tests pass locally
- [x] No breaking changes introduced