### PR TITLE
fix(security): redact credentials from gateway and cron delivery

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -534,6 +534,15 @@ def tick(verbose: bool = True) -> int:
                 # If the agent responded with [SILENT], skip delivery (but
                 # output is already saved above).  Failed jobs always deliver.
                 deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
+
+                # Redact credentials/secrets before delivering to external platforms
+                if deliver_content:
+                    try:
+                        from agent.redact import redact_sensitive_text
+                        deliver_content = redact_sensitive_text(deliver_content)
+                    except Exception:
+                        pass  # Don't block delivery on redaction failure
+
                 should_deliver = bool(deliver_content)
                 if should_deliver and success and deliver_content.strip().upper().startswith(SILENT_MARKER):
                     logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2405,6 +2405,19 @@ class GatewayRunner:
             response = agent_result.get("final_response") or ""
             agent_messages = agent_result.get("messages", [])
 
+            # ── Structural output redaction ──────────────────────────────
+            # Redact credentials/secrets from the response BEFORE platform
+            # delivery.  The LLM can compose a response that re-states
+            # secrets (e.g. summarising a .env file or terminal output).
+            # This is the last structural defence before text reaches
+            # Discord/Telegram/etc.
+            if response:
+                try:
+                    from agent.redact import redact_sensitive_text
+                    response = redact_sensitive_text(response)
+                except Exception:
+                    pass  # Don't block delivery on redaction failure
+
             # Surface error details when the agent failed silently (final_response=None)
             if not response and agent_result.get("failed"):
                 error_detail = agent_result.get("error", "unknown error")


### PR DESCRIPTION
Add structural output redaction as the last defence before text reaches Discord/Telegram/Slack/etc:

- **gateway/run.py**: redact agent response before platform delivery
- **cron/scheduler.py**: redact cron job output before delivery

Uses the existing `agent.redact.redact_sensitive_text()` which catches API keys, tokens, passwords, and other credential patterns.

Wrapped in try/except so redaction failures never block delivery. This complements the behavioral instruction (SOUL.md tells the agent not to include credentials) with a structural guarantee.

**Files changed:** `gateway/run.py`, `cron/scheduler.py` (+22 lines)