### PR TITLE
feat(prompt): extensible system prompt — rules, samples, working state

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -438,6 +438,71 @@ def _truncate_content(content: str, filename: str, max_chars: int = CONTEXT_FILE
     return head + marker + tail
 
 
+def load_working_state() -> Optional[str]:
+    """Load working state from HERMES_HOME/working_state.md.
+
+    Provides cross-session context: active tasks, recent decisions, blockers.
+    Returns None if file doesn't exist or is empty.
+    """
+    state_path = get_hermes_home() / "working_state.md"
+    if not state_path.exists():
+        return None
+    try:
+        content = state_path.read_text(encoding="utf-8").strip()
+        if not content:
+            return None
+        content = _truncate_content(content, "working_state.md")
+        return content
+    except Exception as e:
+        logger.debug("Could not read working_state.md: %s", e)
+        return None
+
+
+def load_rules() -> Optional[str]:
+    """Load governance rules from HERMES_HOME/rules/ directory.
+
+    Each .md file in the rules directory is loaded and concatenated.
+    Rules supplement SOUL.md with extended traps, quality gates, etc.
+    Returns None if no rules directory or no files found.
+    """
+    rules_dir = get_hermes_home() / "rules"
+    if not rules_dir.is_dir():
+        return None
+    parts = []
+    for md_file in sorted(rules_dir.glob("*.md")):
+        try:
+            content = md_file.read_text(encoding="utf-8").strip()
+            if content:
+                content = _truncate_content(content, md_file.name)
+                parts.append(content)
+        except Exception as e:
+            logger.debug("Could not read rule %s: %s", md_file, e)
+    return "\n\n".join(parts) if parts else None
+
+
+def load_samples() -> Optional[str]:
+    """Load teaching samples from HERMES_HOME/samples/ directory.
+
+    Each .md file demonstrates correct vs incorrect behavior for
+    common scenarios. Returns None if no samples dir or no files.
+    """
+    samples_dir = get_hermes_home() / "samples"
+    if not samples_dir.is_dir():
+        return None
+    parts = []
+    for md_file in sorted(samples_dir.glob("*.md")):
+        try:
+            content = md_file.read_text(encoding="utf-8").strip()
+            if content:
+                content = _truncate_content(content, md_file.name)
+                parts.append(content)
+        except Exception as e:
+            logger.debug("Could not read sample %s: %s", md_file, e)
+    if not parts:
+        return None
+    return "## Behavioral Samples (learn from these)\n\n" + "\n\n---\n\n".join(parts)
+
+
 def load_soul_md() -> Optional[str]:
     """Load SOUL.md from HERMES_HOME and return its content, or None.
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -83,7 +83,7 @@ from agent.model_metadata import (
 )
 from agent.context_compressor import ContextCompressor
 from agent.prompt_caching import apply_anthropic_cache_control
-from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, load_soul_md
+from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, load_soul_md, load_rules, load_samples, load_working_state
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from agent.display import (
     KawaiiSpinner, build_tool_preview as _build_tool_preview,
@@ -2143,6 +2143,29 @@ class AIAgent:
                 logger.debug("Honcho context prefetch failed (non-fatal): %s", exc)
 
         self._register_honcho_exit_hook()
+        self._register_working_state_snapshot()
+
+    @staticmethod
+    def _register_working_state_snapshot():
+        """Register atexit handler to snapshot working_state.md on process exit."""
+        def _snapshot_working_state():
+            try:
+                home = os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes"))
+                state = Path(home) / "working_state.md"
+                if not state.exists():
+                    return
+                snapdir = Path(home) / "checkpoints" / "working_state"
+                snapdir.mkdir(parents=True, exist_ok=True)
+                from datetime import datetime
+                ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+                import shutil
+                shutil.copy2(state, snapdir / f"working_state_{ts}_atexit.md")
+                # Prune to last 10
+                for old in sorted(snapdir.glob("working_state_*.md"))[:-10]:
+                    old.unlink()
+            except Exception:
+                pass  # Never block process exit
+        atexit.register(_snapshot_working_state)
 
     def _register_honcho_exit_hook(self) -> None:
         """Register a process-exit flush hook without clobbering signal handlers."""
@@ -2296,6 +2319,15 @@ class AIAgent:
                 _identity = DEFAULT_AGENT_IDENTITY
             prompt_parts = [_identity]
 
+        # Governance rules from ~/.hermes/rules/*.md (extended traps, quality gate)
+        if not self.skip_context_files:
+            _rules_content = load_rules()
+            if _rules_content:
+                prompt_parts.append(_rules_content)
+            _samples_content = load_samples()
+            if _samples_content:
+                prompt_parts.append(_samples_content)
+
         # Tool-aware behavioral guidance: only inject when the tools are loaded
         tool_guidance = []
         if "memory" in self.valid_tool_names:
@@ -2376,6 +2408,12 @@ class AIAgent:
                 user_block = self._memory_store.format_for_system_prompt("user")
                 if user_block:
                     prompt_parts.append(user_block)
+
+        # Working state: cross-session context (active tasks, decisions, blockers)
+        if not self.skip_context_files:
+            _ws_content = load_working_state()
+            if _ws_content:
+                prompt_parts.append(_ws_content)
 
         has_skills_tools = any(name in self.valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])
         if has_skills_tools:


### PR DESCRIPTION
Add three new content loaders to `prompt_builder.py`:

- **load_rules()**: reads `~/.hermes/rules/*.md` — governance rules that supplement SOUL.md (extended traps, quality gates, checklists)
- **load_samples()**: reads `~/.hermes/samples/*.md` — behavioral examples demonstrating correct vs incorrect agent behavior
- **load_working_state()**: reads `~/.hermes/working_state.md` — cross-session context with active tasks, recent decisions, and blockers

System prompt order:
```
SOUL.md → rules → samples → tool guidance → honcho → system msg →
memory → user profile → working state → skills → context files
```

Also adds an atexit handler that snapshots `working_state.md` to `checkpoints/` on process exit (prunes to last 10). Zero-cost safety net — no LLM calls, no tokens.

All loaders return None gracefully when their files/dirs don't exist, so this is fully backward-compatible.

**Files changed:** `agent/prompt_builder.py`, `run_agent.py` (+104 lines)
BODY; __hermes_rc=$?; printf '__HERMES_FENCE_a9f7b3__'; exit $__hermes_rc
