### PR TITLE
fix(security): prevent zip-slip path traversal in self-update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2383,6 +2383,12 @@ def _update_via_zip(args):
         
         print("→ Extracting...")
         with zipfile.ZipFile(zip_path, 'r') as zf:
+            # Validate paths to prevent zip-slip (path traversal)
+            tmp_dir_real = os.path.realpath(tmp_dir)
+            for member in zf.infolist():
+                member_path = os.path.realpath(os.path.join(tmp_dir, member.filename))
+                if not member_path.startswith(tmp_dir_real + os.sep) and member_path != tmp_dir_real:
+                    raise ValueError(f"Zip-slip detected: {member.filename} escapes extraction directory")
             zf.extractall(tmp_dir)
         
         # GitHub ZIPs extract to hermes-agent-<branch>/


### PR DESCRIPTION
Fixes #3075

cmd_update_zip used zipfile.extractall() without validating member
paths. A crafted ZIP could contain entries like ../../../etc/cron.d/evil
that escape the temp directory.

This validates each member's resolved path using os.path.realpath()
and rejects entries that fall outside the extraction directory.