### PR TITLE
fix(security): normalize input before dangerous command detection

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -13,6 +13,7 @@ import os
 import re
 import sys
 import threading
+import unicodedata
 from typing import Optional
 
 logger = logging.getLogger(__name__)
@@ -82,13 +83,31 @@ def _approval_key_aliases(pattern_key: str) -> set[str]:
 # Detection
 # =========================================================================
 
+def _normalize_command_for_detection(command: str) -> str:
+    """Normalize a command string before dangerous-pattern matching.
+
+    Strips ANSI escape sequences, null bytes, and normalizes Unicode
+    fullwidth characters so that obfuscation techniques cannot bypass
+    the pattern-based detection.
+    """
+    # Strip ANSI escape sequences (CSI and OSC variants)
+    command = re.sub(r'\x1b\[[0-9;]*[a-zA-Z]', '', command)
+    command = re.sub(r'\x1b\].*?\x07', '', command)
+    command = re.sub(r'\x1b\\', '', command)
+    # Strip null bytes
+    command = command.replace('\x00', '')
+    # Normalize Unicode (fullwidth Latin, halfwidth Katakana, etc.)
+    command = unicodedata.normalize('NFKC', command)
+    return command
+
+
 def detect_dangerous_command(command: str) -> tuple:
     """Check if a command matches any dangerous patterns.
 
     Returns:
         (is_dangerous, pattern_key, description) or (False, None, None)
     """
-    command_lower = command.lower()
+    command_lower = _normalize_command_for_detection(command).lower()
     for pattern, description in DANGEROUS_PATTERNS:
         if re.search(pattern, command_lower, re.IGNORECASE | re.DOTALL):
             pattern_key = description


### PR DESCRIPTION
Fixes #3076

detect_dangerous_command ran regex patterns against raw command strings
without normalization, allowing bypass via Unicode fullwidth chars,
ANSI escape codes, null bytes, and bash ANSI-C quoting.

This adds input normalization (NFKC unicode, strip ANSI escapes and
null bytes) before running the detection patterns.