### PR TITLE
fix: persist flushed-session set to disk

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1151,6 +1151,7 @@ class GatewayRunner:
                         await self._async_flush_memories(entry.session_id, key)
                         self._shutdown_gateway_honcho(key)
                         self.session_store._pre_flushed_sessions.add(entry.session_id)
+                        self.session_store._save_flushed_markers()
                     except Exception as e:
                         logger.debug("Proactive memory flush failed for %s: %s", entry.session_id, e)
             except Exception as e:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -483,7 +483,34 @@ class SessionStore:
         # via the background session expiry watcher in GatewayRunner.
         self._pre_flushed_sessions: set = set()  # session_ids already flushed by watcher
         
-        # Initialize SQLite session database
+        # Persist _pre_flushed_sessions to a small JSON sidecar so the set
+        # survives gateway restarts and prevents double-flushing.
+        self._flushed_marker_path = sessions_dir / ".flushed_sessions.json"
+        self._load_flushed_markers()
+        
+        def _load_flushed_markers(self) -> None:
+        """Load persisted flushed-session markers from disk."""
+        try:
+            if self._flushed_marker_path.exists():
+                import json
+                data = json.loads(self._flushed_marker_path.read_text())
+                if isinstance(data, list):
+                    self._pre_flushed_sessions.update(data)
+        except Exception:
+            pass  # non-critical; worst case is a redundant flush
+
+    def _save_flushed_markers(self) -> None:
+        """Persist flushed-session markers to disk."""
+        try:
+            import json
+            with self._lock:
+                self._flushed_marker_path.write_text(
+                    json.dumps(list(self._pre_flushed_sessions))
+                )
+        except Exception:
+            pass
+
+    # Initialize SQLite session database
         self._db = None
         try:
             from hermes_state import SessionDB
@@ -693,6 +720,7 @@ class SessionStore:
                     reset_had_activity = entry.total_tokens > 0
                     db_end_session_id = entry.session_id
                     self._pre_flushed_sessions.discard(entry.session_id)
+                    self._save_flushed_markers()
             else:
                 was_auto_reset = False
                 auto_reset_reason = None


### PR DESCRIPTION
Fixes #3078

The flushed-session set wasn't persisted to the database, so it
reset on gateway restart. This saves and restores the set from disk.