### PR TITLE
feat(gateway): configurable prompt cache TTL via config.yaml

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -578,7 +578,17 @@ class AIAgent:
         is_claude = "claude" in self.model.lower()
         is_native_anthropic = self.api_mode == "anthropic_messages"
         self._use_prompt_caching = (is_openrouter and is_claude) or is_native_anthropic
-        self._cache_ttl = "5m"  # Default 5-minute TTL (1.25x write cost)
+
+        # Read cache_ttl from config; default to 5m (1.25x write cost)
+        self._cache_ttl = "5m"
+        try:
+            from hermes_cli.config import load_config
+            config = load_config()
+            cache_ttl = config.get("prompt_cache_ttl")
+            if cache_ttl is not None:
+                self._cache_ttl = str(cache_ttl)
+        except Exception:
+            pass
         
         # Iteration budget pressure: warn the LLM as it approaches max_iterations.
         # Warnings are injected into the last tool result JSON (not as separate


### PR DESCRIPTION
Fixes #3082

Prompt cache TTL was hardcoded. This reads the TTL value from
config.yaml so users can adjust it without code changes.