### PR TITLE
feat(memory): native structured memory — typed SQLite fact store with FTS5

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -150,6 +150,7 @@ def _discover_tools():
         "tools.tts_tool",
         "tools.todo_tool",
         "tools.memory_tool",
+        "tools.structured_memory_tool",
         "tools.session_search_tool",
         "tools.clarify_tool",
         "tools.code_execution_tool",

--- a/run_agent.py
+++ b/run_agent.py
@@ -2403,6 +2403,17 @@ class AIAgent:
                 if user_block:
                     prompt_parts.append(user_block)
 
+        # Structured memory: inject gauge + hot facts into system prompt.
+        # Only when the toolset is active. Zero cost if DB is empty.
+        if "mcp_memory_write" in self.valid_tool_names:
+            try:
+                from tools.structured_memory_tool import get_structured_memory_injection
+                sm_block = get_structured_memory_injection(session_id=self._session_id)
+                if sm_block:
+                    prompt_parts.append(sm_block)
+            except Exception:
+                pass
+
         has_skills_tools = any(name in self.valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])
         if has_skills_tools:
             avail_toolsets = {ts for ts, avail in check_toolset_requirements().items() if avail}
@@ -5635,6 +5646,19 @@ class AIAgent:
         
         # Track user turns for memory flush and periodic nudge logic
         self._user_turn_count += 1
+
+        # Structured memory: advance turn counter and trigger scope auto-cooling.
+        # Runs silently — never blocks the agent loop.
+        if "mcp_memory_write" in self.valid_tool_names:
+            try:
+                from tools.structured_memory_tool import tick_structured_memory
+                tick_structured_memory(
+                    turn=self._user_turn_count,
+                    message_text=user_message or "",
+                    session_id=self._session_id,
+                )
+            except Exception:
+                pass
 
         # Preserve the original user message (no nudge injection).
         # Honcho should receive the actual user input, not system nudges.

--- a/tests/structured_memory/conftest.py
+++ b/tests/structured_memory/conftest.py
@@ -1,0 +1,33 @@
+"""
+Shared fixtures for structured memory tests.
+"""
+
+import sys
+import os
+import pytest
+
+# Ensure /root/hermes-agent is on sys.path so `tools.structured_memory` can be imported
+sys.path.insert(0, "/root/hermes-agent")
+
+from tools.structured_memory.db import get_sm_connection
+
+
+@pytest.fixture
+def conn(tmp_path):
+    db_path = tmp_path / "test_sm.db"
+    c = get_sm_connection(str(db_path))
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def session_id(conn):
+    """Insert a test session and return its id."""
+    from tools.structured_memory.db import sm_now
+    sid = "test-session-001"
+    conn.execute(
+        "INSERT INTO sm_sessions (id, started_at, last_turn) VALUES (?, ?, 0)",
+        (sid, sm_now()),
+    )
+    conn.commit()
+    return sid

--- a/tests/structured_memory/test_current_turn.py
+++ b/tests/structured_memory/test_current_turn.py
@@ -1,0 +1,63 @@
+"""Tests for current_turn tracking and scope stability under active writes."""
+
+import pytest
+from tools.structured_memory.constants import SCOPE_COOL_TURNS
+from tools.structured_memory import scopes, facts
+
+
+def test_active_scope_not_cooled_while_writing(conn):
+    """Scope with active writes must NOT cool after SCOPE_COOL_TURNS ticks."""
+    sid = scopes.get_or_create(conn, "active-feat")
+
+    for turn in range(1, SCOPE_COOL_TURNS + 3):
+        # Write a fact each turn and touch scope to simulate server behavior
+        facts.write(conn, f"D[feat.step{turn}]: step {turn}", scope_id=sid)
+        scopes.touch(conn, sid, turn)
+        cooled = scopes.tick(conn, turn=turn, session_id=None)
+        assert sid not in cooled, f"scope cooled at turn {turn} despite active writes"
+
+    # Scope must still be active
+    active = [s["id"] for s in scopes.get_active(conn)]
+    assert sid in active
+
+
+def test_scope_cools_after_real_silence(conn):
+    """Scope with no writes for SCOPE_COOL_TURNS ticks must cool."""
+    sid = scopes.get_or_create(conn, "silent-feat")
+    facts.write(conn, "D[silent]: initial write", scope_id=sid)
+
+    # No more writes — just tick
+    cooled_ids = []
+    for turn in range(1, SCOPE_COOL_TURNS + 2):
+        cooled = scopes.tick(conn, turn=turn)
+        cooled_ids.extend(cooled)
+
+    assert sid in cooled_ids
+
+
+def test_get_or_create_refreshes_last_referenced(conn):
+    """Calling get_or_create on an existing scope updates last_referenced."""
+    from tools.structured_memory.db import sm_now
+    import time
+
+    sid = scopes.get_or_create(conn, "my-scope")
+    row_before = conn.execute("SELECT last_referenced FROM sm_scopes WHERE id=?", (sid,)).fetchone()
+    t_before = row_before["last_referenced"]
+
+    time.sleep(1)  # ensure timestamp advances
+    scopes.get_or_create(conn, "my-scope")
+
+    row_after = conn.execute("SELECT last_referenced FROM sm_scopes WHERE id=?", (sid,)).fetchone()
+    assert row_after["last_referenced"] >= t_before
+
+
+def test_no_duplicate_active_scope(conn):
+    """Two concurrent get_or_create with same label must return the same scope."""
+    sid1 = scopes.get_or_create(conn, "dup-scope")
+    sid2 = scopes.get_or_create(conn, "dup-scope")
+    assert sid1 == sid2
+
+    count = conn.execute(
+        "SELECT COUNT(*) FROM sm_scopes WHERE label='dup-scope' AND status='active'"
+    ).fetchone()[0]
+    assert count == 1

--- a/tests/structured_memory/test_export_archive.py
+++ b/tests/structured_memory/test_export_archive.py
@@ -1,0 +1,92 @@
+"""Tests for memory_export and _archive_cold_scopes grace window."""
+
+import time
+import pytest
+from tools.structured_memory.db import sm_now
+from tools.structured_memory.constants import TYPE_DISPLAY
+from tools.structured_memory import facts, gauge, scopes
+
+
+def test_export_returns_notation(conn):
+    facts.write(conn, "C[db.id]: UUID mndtry")
+    facts.write(conn, "D[auth]: JWT 7j")
+    facts.write(conn, "V[srv]: 1.2.3.4:3005")
+
+    rows = conn.execute(
+        "SELECT type, target, content FROM sm_facts WHERE status='active'"
+    ).fetchall()
+    lines = [f"{TYPE_DISPLAY.get(r['type'], r['type'])}[{r['target']}]: {r['content']}" for r in rows]
+
+    assert any(l.startswith("C[db.id]") for l in lines)
+    assert any(l.startswith("D[auth]") for l in lines)
+    assert any(l.startswith("V[srv]") for l in lines)
+
+
+def test_export_includes_cold(conn):
+    sid = scopes.get_or_create(conn, "old-feat")
+    facts.write(conn, "D[cache]: Redis 30j", scope_id=sid)
+    scopes.close(conn, sid)
+
+    row = conn.execute("SELECT status FROM sm_facts WHERE target='cache'").fetchone()
+    assert row["status"] == "cold"
+
+    # cold fact should be exportable
+    cold_rows = conn.execute(
+        "SELECT type, target, content FROM sm_facts WHERE status IN ('active','cold')"
+    ).fetchall()
+    targets = [r["target"] for r in cold_rows]
+    assert "cache" in targets
+
+
+def test_archive_spares_recently_accessed(conn):
+    sid = scopes.get_or_create(conn, "closed-scope")
+    facts.write(conn, "C[x]: important fact", scope_id=sid)
+    scopes.close(conn, sid)
+
+    # Simulate a recent search that updated last_accessed
+    conn.execute(
+        "UPDATE sm_facts SET last_accessed=? WHERE target='x'",
+        (sm_now(),),
+    )
+    conn.commit()
+
+    archived = gauge._archive_cold_scopes(conn)
+
+    # Fact was recently accessed — must NOT be archived
+    assert archived == 0
+    row = conn.execute("SELECT status FROM sm_facts WHERE target='x'").fetchone()
+    assert row["status"] == "cold"
+
+
+def test_archive_removes_stale_cold(conn):
+    sid = scopes.get_or_create(conn, "old-scope")
+    facts.write(conn, "C[stale]: old fact", scope_id=sid)
+    scopes.close(conn, sid)
+
+    # Set last_accessed to 2 days ago
+    old_ts = sm_now() - 2 * 86_400
+    conn.execute(
+        "UPDATE sm_facts SET last_accessed=? WHERE target='stale'",
+        (old_ts,),
+    )
+    conn.commit()
+
+    archived = gauge._archive_cold_scopes(conn)
+    assert archived == 1
+
+    row = conn.execute("SELECT status FROM sm_facts WHERE target='stale'").fetchone()
+    assert row["status"] == "archived"
+
+
+def test_scopes_close_atomic(conn):
+    """close() must leave no intermediate state — scope=closed, facts=cold."""
+    sid = scopes.get_or_create(conn, "feat-x")
+    facts.write(conn, "D[feat.x]: use websocket", scope_id=sid)
+
+    scopes.close(conn, sid)
+
+    scope_row = conn.execute("SELECT status FROM sm_scopes WHERE id=?", (sid,)).fetchone()
+    fact_row  = conn.execute("SELECT status FROM sm_facts WHERE scope_id=?", (sid,)).fetchone()
+
+    assert scope_row["status"] == "closed"
+    assert fact_row["status"] == "cold"

--- a/tests/structured_memory/test_facts.py
+++ b/tests/structured_memory/test_facts.py
@@ -1,0 +1,116 @@
+"""Tests for structured_memory/facts.py — CRUD, contradiction detection, dedup, error surfacing."""
+
+import pytest
+from tools.structured_memory.constants import MAX_FACT_CHARS, MAX_ACTIVE_CHARS
+from tools.structured_memory import facts
+from tools.structured_memory.facts import MemoryFullError
+
+
+def test_parse_notation_constraint(conn):
+    t, target, content = facts.parse_notation("C[db.id]: UUID mndtry, nvr autoincrement")
+    assert t == "C"
+    assert target == "db.id"
+    assert content == "UUID mndtry, nvr autoincrement"
+
+
+def test_parse_notation_done(conn):
+    t, target, content = facts.parse_notation("✓[auth]: deployed prod")
+    assert t == "done"
+    assert target == "auth"
+
+
+def test_parse_notation_invalid(conn):
+    with pytest.raises(ValueError):
+        facts.parse_notation("not a valid fact")
+
+
+def test_write_creates_fact(conn):
+    result = facts.write(conn, "C[db.id]: UUID mndtry")
+    assert result["status"] == "created"
+    assert result["id"]
+    row = conn.execute("SELECT * FROM sm_facts WHERE id=?", (result["id"],)).fetchone()
+    assert row["type"] == "C"
+    assert row["target"] == "db.id"
+    assert row["status"] == "active"
+
+
+def test_write_dedup(conn):
+    r1 = facts.write(conn, "C[db.id]: UUID mndtry")
+    r2 = facts.write(conn, "C[db.id]: UUID mndtry")
+    assert r1["id"] == r2["id"]
+    assert r2["status"] == "dedup"
+    count = conn.execute("SELECT COUNT(*) FROM sm_facts WHERE target='db.id'").fetchone()[0]
+    assert count == 1
+
+
+def test_write_contradiction_supersedes(conn):
+    r1 = facts.write(conn, "D[auth]: sessions Redis 30j")
+    r2 = facts.write(conn, "D[auth]: JWT 7j refresh 6j")
+
+    assert r2["conflict_resolved"] == r1["id"]
+
+    old = conn.execute("SELECT status FROM sm_facts WHERE id=?", (r1["id"],)).fetchone()
+    assert old["status"] == "superseded"
+
+    new = conn.execute("SELECT status FROM sm_facts WHERE id=?", (r2["id"],)).fetchone()
+    assert new["status"] == "active"
+
+
+def test_search_finds_fact(conn):
+    facts.write(conn, "C[db.id]: UUID mndtry, nvr autoincrement")
+    results = facts.search(conn, "UUID")
+    assert len(results) == 1
+    assert results[0]["target"] == "db.id"
+
+
+def test_search_excludes_superseded(conn):
+    facts.write(conn, "D[auth]: sessions Redis 30j")
+    facts.write(conn, "D[auth]: JWT 7j refresh 6j")
+    results = facts.search(conn, "auth")
+    assert all(r["status"] != "superseded" for r in results)
+
+
+def test_search_updates_access_count(conn):
+    facts.write(conn, "V[srv.prod]: 1.2.3.4:3005")
+    facts.search(conn, "srv.prod")
+    row = conn.execute("SELECT access_count FROM sm_facts WHERE target='srv.prod'").fetchone()
+    assert row["access_count"] == 1
+
+
+def test_purge_removes_superseded(conn):
+    facts.write(conn, "D[auth]: old")
+    facts.write(conn, "D[auth]: new")
+    count = facts.purge(conn)
+    assert count == 1
+    remaining = conn.execute("SELECT COUNT(*) FROM sm_facts WHERE status='superseded'").fetchone()[0]
+    assert remaining == 0
+
+
+def test_write_truncates_oversized_content(conn):
+    long_content = "x" * (MAX_FACT_CHARS + 100)
+    result = facts.write(conn, f"C[big]: {long_content}")
+    assert result["status"] == "created"
+    assert result["truncated"] is True
+    row = conn.execute("SELECT content FROM sm_facts WHERE id=?", (result["id"],)).fetchone()
+    assert len(row["content"]) <= MAX_FACT_CHARS
+    assert row["content"].endswith("…")
+
+
+def test_write_short_content_not_truncated(conn):
+    result = facts.write(conn, "C[small]: short content")
+    assert result["truncated"] is False
+    row = conn.execute("SELECT content FROM sm_facts WHERE id=?", (result["id"],)).fetchone()
+    assert not row["content"].endswith("…")
+
+
+def test_write_raises_memory_full_error(conn):
+    chunk = "a" * (MAX_FACT_CHARS - 10)
+    needed = (MAX_ACTIVE_CHARS // MAX_FACT_CHARS) + 2
+    for i in range(needed):
+        try:
+            facts.write(conn, f"V[flood.{i}]: {chunk}")
+        except MemoryFullError:
+            break
+
+    with pytest.raises(MemoryFullError, match="Memory store is full"):
+        facts.write(conn, "C[overflow]: this should fail")

--- a/tests/structured_memory/test_gauge.py
+++ b/tests/structured_memory/test_gauge.py
@@ -1,0 +1,69 @@
+"""Tests for structured_memory/gauge.py — pressure levels and merging."""
+
+import pytest
+from tools.structured_memory.constants import MAX_ACTIVE_CHARS
+from tools.structured_memory import facts, gauge
+
+
+def test_gauge_empty(conn):
+    g = gauge.read(conn)
+    assert g["pct"] == 0.0
+    assert g["used_chars"] == 0
+
+
+def test_gauge_increases_on_write(conn):
+    facts.write(conn, "C[db.id]: UUID mndtry, nvr autoincrement")
+    g = gauge.read(conn)
+    assert g["used_chars"] > 0
+    assert g["pct"] > 0
+
+
+def test_merge_duplicates(conn):
+    # Write two active facts with same target (bypass dedup via different content)
+    import uuid
+    from tools.structured_memory.db import sm_now
+    for i in range(2):
+        uid = str(uuid.uuid4())
+        conn.execute(
+            "INSERT INTO sm_facts (id,content,type,target,scope_id,status,"
+            "superseded_by,created_at,updated_at,last_accessed,access_count,source_hash) "
+            "VALUES (?,?,?,?,NULL,'active',NULL,?,?,NULL,0,?)",
+            (uid, f"val {i}", "C", "db.id", sm_now(), sm_now(), uid[:16]),
+        )
+    conn.commit()
+
+    merged = gauge._merge_duplicates(conn)
+    assert merged == 1
+
+    active_count = conn.execute(
+        "SELECT COUNT(*) FROM sm_facts WHERE target='db.id' AND status='active'"
+    ).fetchone()[0]
+    assert active_count == 1
+
+
+def test_check_and_act_no_action_below_threshold(conn):
+    facts.write(conn, "C[x]: small fact")
+    result = gauge.check_and_act(conn)
+    assert result["actions"] == []
+
+
+def test_push_oldest_to_cold(conn):
+    # Fill gauge above 95% by inserting large facts directly
+    import uuid
+    from tools.structured_memory.db import sm_now
+    chunk = "x" * 1000
+    for i in range(int(MAX_ACTIVE_CHARS * 0.96 / 1000) + 1):
+        uid = str(uuid.uuid4())
+        conn.execute(
+            "INSERT INTO sm_facts (id,content,type,target,scope_id,status,"
+            "superseded_by,created_at,updated_at,last_accessed,access_count,source_hash) "
+            "VALUES (?,?,?,?,NULL,'active',NULL,?,?,NULL,0,?)",
+            (uid, chunk, "V", f"key{i}", sm_now(), sm_now(), uid[:16]),
+        )
+    conn.commit()
+
+    pushed = gauge._push_oldest_to_cold(conn, target_pct=85.0)
+    assert pushed > 0
+
+    g = gauge.read(conn)
+    assert g["pct"] < 95.0

--- a/tests/structured_memory/test_optimize.py
+++ b/tests/structured_memory/test_optimize.py
@@ -1,0 +1,172 @@
+"""Tests for memory_optimize — compression and migration logic."""
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from tools.structured_memory import optimize as opt_module
+from tools.structured_memory.optimize import (
+    MEMORY_LIMIT,
+    USER_LIMIT,
+    THRESHOLD_PCT,
+    _compress_text,
+    _extract_and_migrate,
+    optimize,
+    MEMORY_PATH,
+    USER_PATH,
+)
+from tools.structured_memory.db import get_sm_connection
+
+
+# ----------------------------------------------------------------- helpers --
+
+def make_conn(tmp_path):
+    path = tmp_path / "test.db"
+    return get_sm_connection(str(path))
+
+
+def fill_file(path: Path, pct: float, limit: int) -> str:
+    """Write a file that is `pct`% of `limit` chars. Returns the content."""
+    target = int(limit * pct / 100)
+    # Use realistic-looking memory entries
+    entry = "Some verbose environment fact that takes up space in the file.\n§\n"
+    content = (entry * (target // len(entry) + 1))[:target]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return content
+
+
+# ------------------------------------------------------------------- tests --
+
+class TestCompressText:
+    def test_french_abbrevs(self):
+        text = "Ne jamais modifier pour rien, configuration obligatoire."
+        result = _compress_text(text)
+        assert "pr" in result or "pour" not in result
+        assert "cfg" in result or "configuration" not in result
+
+    def test_no_double_spaces(self):
+        result = _compress_text("hello   world  test")
+        assert "  " not in result
+
+    def test_preserves_content(self):
+        text = "Keep this important fact intact."
+        result = _compress_text(text)
+        assert "Keep" in result
+        assert "intact" in result
+
+
+class TestExtractAndMigrate:
+    def test_migrates_c_fact(self, tmp_path):
+        conn = make_conn(tmp_path)
+        conn.execute("INSERT INTO sm_sessions (id, started_at, last_turn) VALUES ('s1', 0, 0)")
+        conn.commit()
+
+        text = "Some normal text.\nC[db.id]: UUID mndtry\nMore text."
+        cleaned, migrated = _extract_and_migrate(text, conn, "s1")
+
+        assert len(migrated) == 1
+        assert "C[db.id]" in migrated[0]
+        assert "C[db.id]" not in cleaned
+        assert "Some normal text." in cleaned
+        assert "More text." in cleaned
+
+    def test_migrates_multiple_types(self, tmp_path):
+        conn = make_conn(tmp_path)
+        conn.execute("INSERT INTO sm_sessions (id, started_at, last_turn) VALUES ('s1', 0, 0)")
+        conn.commit()
+
+        text = "C[auth]: JWT req\nD[db]: postgres chosen\nV[port]: 3007\nNormal line."
+        cleaned, migrated = _extract_and_migrate(text, conn, "s1")
+
+        assert len(migrated) == 3
+        assert "Normal line." in cleaned
+        assert "C[auth]" not in cleaned
+
+    def test_keeps_non_fact_lines(self, tmp_path):
+        conn = make_conn(tmp_path)
+        conn.execute("INSERT INTO sm_sessions (id, started_at, last_turn) VALUES ('s1', 0, 0)")
+        conn.commit()
+
+        text = "Regular entry without MEMORY_SPEC notation.\n§\nAnother entry."
+        cleaned, migrated = _extract_and_migrate(text, conn, "s1")
+
+        assert len(migrated) == 0
+        assert cleaned == text
+
+
+class TestOptimize:
+    def test_no_action_below_threshold(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(opt_module, "MEMORY_PATH", tmp_path / "MEMORY.md")
+        monkeypatch.setattr(opt_module, "USER_PATH",   tmp_path / "USER.md")
+
+        # 30% — well below 55% threshold
+        fill_file(tmp_path / "MEMORY.md", 30, MEMORY_LIMIT)
+        fill_file(tmp_path / "USER.md",   30, USER_LIMIT)
+
+        conn = make_conn(tmp_path)
+        conn.execute("INSERT INTO sm_sessions (id, started_at, last_turn) VALUES ('s1', 0, 0)")
+        conn.commit()
+
+        result = optimize(conn, "s1")
+        assert result["action_taken"] is False
+        assert result["memory_migrated"] == 0
+        assert result["user_migrated"] == 0
+
+    def test_action_above_threshold(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(opt_module, "MEMORY_PATH", tmp_path / "MEMORY.md")
+        monkeypatch.setattr(opt_module, "USER_PATH",   tmp_path / "USER.md")
+
+        # 70% — above threshold, with compressible text
+        mem_path = tmp_path / "MEMORY.md"
+        compressible = ("configuration pour le développement, jamais modifier sans validation. " * 30)
+        mem_path.parent.mkdir(parents=True, exist_ok=True)
+        mem_path.write_text(compressible[:int(MEMORY_LIMIT * 0.70)], encoding="utf-8")
+        fill_file(tmp_path / "USER.md", 30, USER_LIMIT)
+
+        conn = make_conn(tmp_path)
+        conn.execute("INSERT INTO sm_sessions (id, started_at, last_turn) VALUES ('s1', 0, 0)")
+        conn.commit()
+
+        result = optimize(conn, "s1")
+        assert result["action_taken"] is True
+        assert result["memory_after"] < result["memory_before"]
+
+    def test_dry_run_does_not_write(self, tmp_path, monkeypatch):
+        mem_path = tmp_path / "MEMORY.md"
+        user_path = tmp_path / "USER.md"
+        monkeypatch.setattr(opt_module, "MEMORY_PATH", mem_path)
+        monkeypatch.setattr(opt_module, "USER_PATH",   user_path)
+
+        original = fill_file(mem_path, 70, MEMORY_LIMIT)
+        fill_file(user_path, 30, USER_LIMIT)
+
+        conn = make_conn(tmp_path)
+        conn.execute("INSERT INTO sm_sessions (id, started_at, last_turn) VALUES ('s1', 0, 0)")
+        conn.commit()
+
+        optimize(conn, "s1", dry_run=True)
+        # File must be unchanged
+        assert mem_path.read_text(encoding="utf-8") == original
+
+    def test_migrates_facts_above_threshold(self, tmp_path, monkeypatch):
+        mem_path = tmp_path / "MEMORY.md"
+        monkeypatch.setattr(opt_module, "MEMORY_PATH", mem_path)
+        monkeypatch.setattr(opt_module, "USER_PATH",   tmp_path / "USER.md")
+
+        # Build a 70% file that contains a C/D/V line
+        padding = "x" * int(MEMORY_LIMIT * 0.68)
+        content = f"C[db.id]: UUID mndtry\n{padding}"
+        mem_path.parent.mkdir(parents=True, exist_ok=True)
+        mem_path.write_text(content, encoding="utf-8")
+        fill_file(tmp_path / "USER.md", 20, USER_LIMIT)
+
+        conn = make_conn(tmp_path)
+        conn.execute("INSERT INTO sm_sessions (id, started_at, last_turn) VALUES ('s1', 0, 0)")
+        conn.commit()
+
+        result = optimize(conn, "s1")
+        assert result["memory_migrated"] >= 1
+        # Fact must now be in the DB
+        rows = conn.execute("SELECT content FROM sm_facts WHERE target='db.id'").fetchall()
+        assert rows

--- a/tests/structured_memory/test_reflect.py
+++ b/tests/structured_memory/test_reflect.py
@@ -1,0 +1,70 @@
+"""Tests for memory_reflect grouping and synthesis safety."""
+
+import pytest
+from tools.structured_memory import facts, gauge
+
+
+def test_reflect_groups_by_type(conn):
+    facts.write(conn, "C[auth]: nvr store plaintext pwd")
+    facts.write(conn, "D[auth]: JWT 7j refresh 6j")
+    facts.write(conn, "V[auth.secret]: env AUTH_SECRET")
+
+    results = facts.search(conn, "auth", limit=20)
+    assert len(results) == 3
+
+    types = {r["type"] for r in results}
+    assert "C" in types
+    assert "D" in types
+    assert "V" in types
+
+
+def test_reflect_includes_cold_facts(conn):
+    from tools.structured_memory import scopes
+    sid = scopes.get_or_create(conn, "old-scope")
+    facts.write(conn, "D[db]: MySQL legacy", scope_id=sid)
+    scopes.close(conn, sid)
+
+    # Fact is now cold
+    row = conn.execute("SELECT status FROM sm_facts WHERE target='db'").fetchone()
+    assert row["status"] == "cold"
+
+    # search still finds it
+    results = facts.search(conn, "MySQL", limit=5)
+    assert len(results) == 1
+    assert results[0]["status"] == "cold"
+
+
+def test_synthesis_aborts_on_empty_llm_response(conn):
+    facts.write(conn, "C[x]: some constraint")
+    facts.write(conn, "D[y]: some decision")
+
+    def bad_llm(prompt: str) -> str:
+        return ""   # LLM returns nothing
+
+    consolidated = gauge._force_synthesis(conn, bad_llm)
+
+    # Must return 0 and originals must still be active
+    assert consolidated == 0
+    active = conn.execute(
+        "SELECT COUNT(*) FROM sm_facts WHERE status='active'"
+    ).fetchone()[0]
+    assert active == 2
+
+
+def test_synthesis_uses_notation_symbols(conn):
+    facts.write(conn, "✓[auth]: deployed")
+    facts.write(conn, "~[legacy]: replaced")
+
+    captured = {}
+
+    def capture_llm(prompt: str) -> str:
+        captured["prompt"] = prompt
+        return "C[x]: consolidated"
+
+    gauge._force_synthesis(conn, capture_llm)
+
+    assert "✓[auth]" in captured["prompt"]
+    assert "~[legacy]" in captured["prompt"]
+    # Must NOT contain raw DB codes
+    assert "done[auth]" not in captured["prompt"]
+    assert "obs[legacy]" not in captured["prompt"]

--- a/tests/structured_memory/test_scopes.py
+++ b/tests/structured_memory/test_scopes.py
@@ -1,0 +1,57 @@
+"""Tests for structured_memory/scopes.py — lifecycle, auto-cooling, topic shift."""
+
+import pytest
+from tools.structured_memory.constants import SCOPE_COOL_TURNS
+from tools.structured_memory import scopes, facts
+
+
+def test_get_or_create_new(conn):
+    sid = scopes.get_or_create(conn, "auth-refactor")
+    assert sid
+    row = conn.execute("SELECT * FROM sm_scopes WHERE id=?", (sid,)).fetchone()
+    assert row["label"] == "auth-refactor"
+    assert row["status"] == "active"
+
+
+def test_get_or_create_existing(conn):
+    sid1 = scopes.get_or_create(conn, "auth-refactor")
+    sid2 = scopes.get_or_create(conn, "auth-refactor")
+    assert sid1 == sid2
+
+
+def test_close_moves_facts_to_cold(conn):
+    sid = scopes.get_or_create(conn, "phase-b")
+    facts.write(conn, "C[dates]: alw ISO8601", scope_id=sid)
+    scopes.close(conn, sid)
+
+    scope = conn.execute("SELECT status FROM sm_scopes WHERE id=?", (sid,)).fetchone()
+    assert scope["status"] == "closed"
+
+    fact = conn.execute("SELECT status FROM sm_facts WHERE scope_id=?", (sid,)).fetchone()
+    assert fact["status"] == "cold"
+
+
+def test_tick_explicit_closing_signal(conn):
+    sid = scopes.get_or_create(conn, "auth-refactor")
+    cooled = scopes.tick(conn, turn=5, message_text="auth feature is merged and deployed")
+    assert sid in cooled
+
+
+def test_tick_silence_cooling(conn):
+    sid = scopes.get_or_create(conn, "old-scope")
+    # Set current_turn low so distance exceeds threshold
+    conn.execute("UPDATE sm_scopes SET current_turn=0 WHERE id=?", (sid,))
+    conn.commit()
+    cooled = scopes.tick(conn, turn=SCOPE_COOL_TURNS + 1, message_text="unrelated topic")
+    assert sid in cooled
+
+
+def test_get_active_returns_only_active(conn):
+    sid1 = scopes.get_or_create(conn, "scope-a")
+    sid2 = scopes.get_or_create(conn, "scope-b")
+    scopes.close(conn, sid2)
+
+    active = scopes.get_active(conn)
+    ids = [s["id"] for s in active]
+    assert sid1 in ids
+    assert sid2 not in ids

--- a/tests/structured_memory/test_status.py
+++ b/tests/structured_memory/test_status.py
@@ -1,0 +1,44 @@
+"""Tests for memory_status injection payload."""
+
+import pytest
+from tools.structured_memory.constants import ABBREV_DICT, TYPE_DISPLAY
+from tools.structured_memory import facts, scopes, gauge
+
+
+def test_abbrev_dict_not_empty():
+    assert len(ABBREV_DICT) >= 30
+
+
+def test_type_display_roundtrip():
+    from tools.structured_memory.constants import TYPE_MAP
+    for sym, code in TYPE_MAP.items():
+        assert TYPE_DISPLAY[code] == sym
+
+
+def test_search_returns_notation_symbols(conn):
+    facts.write(conn, "✓[auth]: deployed prod")
+    results = facts.search(conn, "auth", limit=5)
+    assert len(results) == 1
+    # type should be the DB code, display conversion happens in server
+    assert results[0]["type"] == "done"
+    # TYPE_DISPLAY should map it back correctly
+    assert TYPE_DISPLAY[results[0]["type"]] == "✓"
+
+
+def test_hot_facts_respect_scope_status(conn):
+    # Facts in a closed scope must NOT appear in hot_facts
+    sid = scopes.get_or_create(conn, "closed-scope")
+    facts.write(conn, "C[test]: some constraint", scope_id=sid)
+    scopes.close(conn, sid)
+
+    hot = facts.get_hot(conn)
+    targets = [f["target"] for f in hot]
+    assert "test" not in targets
+
+
+def test_hot_facts_no_scope_always_hot(conn):
+    # Facts with no scope are always hot (global constraints)
+    facts.write(conn, "C[global]: alw English targets")
+    hot = facts.get_hot(conn)
+    targets = [f["target"] for f in hot]
+    assert "global" in targets

--- a/tools/structured_memory/__init__.py
+++ b/tools/structured_memory/__init__.py
@@ -1,0 +1,20 @@
+"""
+structured_memory — native Python port of hermes-memory.
+No MCP dependencies, no subprocess, pure stdlib SQLite.
+"""
+
+from .db import get_sm_connection, sm_now
+from .facts import MemoryFullError, FactTooLargeError, parse_notation
+from .constants import ABBREV_DICT, TYPE_DISPLAY, GAUGE_WARN, MAX_FACT_CHARS
+
+__all__ = [
+    "get_sm_connection",
+    "sm_now",
+    "MemoryFullError",
+    "FactTooLargeError",
+    "parse_notation",
+    "ABBREV_DICT",
+    "TYPE_DISPLAY",
+    "GAUGE_WARN",
+    "MAX_FACT_CHARS",
+]

--- a/tools/structured_memory/constants.py
+++ b/tools/structured_memory/constants.py
@@ -1,0 +1,112 @@
+"""
+Shared constants for the structured memory package.
+Extracted from hermes-memory/core/db.py and hermes-memory/core/optimize.py.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Gauge thresholds (percentage of max_chars used by active facts)
+GAUGE_MERGE     = 70  # deduplicate facts with same target+scope
+GAUGE_WARN      = 80  # surface warning to user (no action yet)
+GAUGE_ARCHIVE   = 85  # push closed-scope facts to cold
+GAUGE_SYNTHESIS = 95  # last resort: LLM-assisted consolidation
+GAUGE_FULL      = 100 # hard cap — writes refused until space freed
+
+# Max chars stored in active facts before we start pushing to cold
+MAX_ACTIVE_CHARS = 10_000
+
+# Max chars for a single fact's content
+MAX_FACT_CHARS = 400
+
+# Scope auto-cooling: turns of silence before a scope goes cold
+SCOPE_COOL_TURNS = 6
+
+# Max facts returned by search
+SEARCH_DEFAULT_LIMIT = 5
+SEARCH_MAX_LIMIT     = 20
+
+# Abbreviation dictionary injected into system prompt
+ABBREV_DICT = {
+    "cfg": "configuration",   "impl": "implementation",
+    "msg": "message",         "req":  "requirement",
+    "usr": "user",            "resp": "response",
+    "prod": "production",     "feat": "feature",
+    "dev": "development",     "deps": "dependencies",
+    "auth": "authentication", "err":  "error",
+    "db":  "database",        "btn":  "button",
+    "env": "environment",     "doc":  "documentation",
+    "perf": "performance",    "init": "initialization",
+    "mgmt": "management",     "refct": "refactor",
+    "mvmt": "movement",       "notif": "notification",
+    "perms": "permissions",   "val":  "validation",
+    "async": "asynchronous",  "sync": "synchronization",
+    "mndtry": "mandatory",    "nvr":  "never",
+    "alw": "always",          "tmp":  "temporary",
+    "idx": "index",           "tbl":  "table",
+    "svc": "service",         "pkg":  "package",
+    "repo": "repository",     "api":  "API endpoint",
+    "clt": "client",          "srv":  "server",
+}
+
+# Compression map: (pattern, replacement) tuples applied in order
+# From hermes-memory/core/optimize.py
+COMPRESS_MAP: list[tuple[str, str]] = [
+    # French
+    (r"\bpour\b",          "pr"),
+    (r"\btoujours\b",      "tjrs"),
+    (r"\bjamais\b",        "jamais"),   # keep — it's already short
+    (r"\bchangement\b",    "chg"),
+    (r"\bconfiguration\b", "cfg"),
+    (r"\bdépendance\b",    "dep"),
+    (r"\bexternes?\b",     "ext"),
+    (r"\btéléphone\b",     "tel"),
+    (r"\bidentifiants?\b", "creds"),
+    (r"\bsupprimer\b",     "suppr"),
+    (r"\baffichage\b",     "aff"),
+    (r"\bmodification\b",  "modif"),
+    (r"\breconstruction\b","rebuild"),
+    (r"\bobligatoire\b",   "requis"),
+    (r"\bchangements?\b",  "chg"),
+    # English
+    (r"\bconfiguration\b", "cfg"),
+    (r"\brequired\b",      "req"),
+    (r"\bnever\b",         "nvr"),
+    (r"\balways\b",        "alw"),
+    (r"\bdependenc(y|ies)\b", "dep"),
+    (r"\bexternal\b",      "ext"),
+    (r"\bcredentials?\b",  "creds"),
+    (r"\bwith\b",          "w/"),
+    (r"\bupgrade\b",       "↑"),
+    (r"\bthen\b",          "→"),
+    (r"\bzero\b",          "0"),
+    # Symbols
+    (r"\b--\b",            "—"),
+    # Drop common filler
+    (r"\bIt is worth noting that\b", ""),
+    (r"\bNote that\b",     ""),
+    (r"\bPlease note\b",   ""),
+    (r"\bin order to\b",   "to"),
+    (r"\bdue to the fact that\b", "because"),
+    (r"\bat this point in time\b", "now"),
+]
+
+# Map raw notation char -> DB type code
+TYPE_MAP = {
+    "C": "C",
+    "D": "D",
+    "V": "V",
+    "?": "?",
+    "✓": "done",
+    "~": "obs",
+}
+
+# Reverse map for display (DB code -> notation symbol)
+TYPE_DISPLAY = {v: k for k, v in TYPE_MAP.items()}
+
+# Regex to parse   TYPE[target]: content
+FACT_RE = re.compile(
+    r"^(?P<type>[CDV?✓~])\[(?P<target>[^\]]+)\]:\s*(?P<content>.+)$",
+    re.UNICODE,
+)

--- a/tools/structured_memory/db.py
+++ b/tools/structured_memory/db.py
@@ -1,0 +1,145 @@
+"""
+SQLite connection helper and schema for structured memory.
+Tables live in the same state.db used by hermes_state.SessionDB.
+Zero external dependencies beyond stdlib sqlite3.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+from hermes_constants import get_hermes_home
+from .constants import MAX_ACTIVE_CHARS
+
+SM_DB_PATH: Path = get_hermes_home() / "state.db"
+
+SCHEMA_SQL = """
+PRAGMA journal_mode=WAL;
+PRAGMA synchronous=NORMAL;
+PRAGMA cache_size=-4096;
+PRAGMA foreign_keys=ON;
+
+-- ---------------------------------------------------------------- sm_scopes ---
+-- Must be created before sm_facts due to FK reference
+CREATE TABLE IF NOT EXISTS sm_scopes (
+    id              TEXT    PRIMARY KEY,
+    label           TEXT    NOT NULL,
+    status          TEXT    NOT NULL DEFAULT 'active'
+                            CHECK(status IN ('active','cold','closed')),
+    last_referenced INTEGER NOT NULL,
+    current_turn    INTEGER NOT NULL DEFAULT 0,
+    created_at      INTEGER NOT NULL,
+    closed_at       INTEGER
+);
+
+-- Prevent duplicate active scopes with the same label (race condition guard)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_sm_scopes_active_label
+    ON sm_scopes(label) WHERE status = 'active';
+
+-- --------------------------------------------------------------- sm_sessions ---
+CREATE TABLE IF NOT EXISTS sm_sessions (
+    id              TEXT    PRIMARY KEY,
+    started_at      INTEGER NOT NULL,
+    last_turn       INTEGER NOT NULL DEFAULT 0,
+    active_scope_id TEXT    REFERENCES sm_scopes(id)
+);
+
+-- ---------------------------------------------------------------- sm_facts ---
+CREATE TABLE IF NOT EXISTS sm_facts (
+    id            TEXT    PRIMARY KEY,
+    content       TEXT    NOT NULL,
+    type          TEXT    NOT NULL CHECK(type IN ('C','D','V','?','done','obs')),
+    target        TEXT    NOT NULL,
+    scope_id      TEXT    REFERENCES sm_scopes(id),
+    status        TEXT    NOT NULL DEFAULT 'active'
+                          CHECK(status IN ('active','cold','superseded','archived')),
+    superseded_by TEXT    REFERENCES sm_facts(id),
+    created_at    INTEGER NOT NULL,
+    updated_at    INTEGER NOT NULL,
+    last_accessed INTEGER,
+    access_count  INTEGER NOT NULL DEFAULT 0,
+    source_hash   TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_sm_facts_target      ON sm_facts(target);
+CREATE INDEX IF NOT EXISTS idx_sm_facts_scope       ON sm_facts(scope_id);
+CREATE INDEX IF NOT EXISTS idx_sm_facts_status      ON sm_facts(status);
+CREATE INDEX IF NOT EXISTS idx_sm_facts_updated_at  ON sm_facts(updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_sm_facts_source_hash ON sm_facts(source_hash);
+
+-- --------------------------------------------------------- sm_facts FTS5 index ---
+CREATE VIRTUAL TABLE IF NOT EXISTS sm_facts_fts USING fts5(
+    content,
+    target,
+    content='sm_facts',
+    content_rowid='rowid'
+);
+
+CREATE TRIGGER IF NOT EXISTS sm_facts_ai AFTER INSERT ON sm_facts BEGIN
+    INSERT INTO sm_facts_fts(rowid, content, target)
+    VALUES (new.rowid, new.content, new.target);
+END;
+
+CREATE TRIGGER IF NOT EXISTS sm_facts_ad AFTER DELETE ON sm_facts BEGIN
+    INSERT INTO sm_facts_fts(sm_facts_fts, rowid, content, target)
+    VALUES ('delete', old.rowid, old.content, old.target);
+END;
+
+CREATE TRIGGER IF NOT EXISTS sm_facts_au AFTER UPDATE ON sm_facts BEGIN
+    INSERT INTO sm_facts_fts(sm_facts_fts, rowid, content, target)
+    VALUES ('delete', old.rowid, old.content, old.target);
+    INSERT INTO sm_facts_fts(rowid, content, target)
+    VALUES (new.rowid, new.content, new.target);
+END;
+
+-- --------------------------------------------------------------- views ---
+CREATE VIEW IF NOT EXISTS sm_hot_facts AS
+    SELECT f.*
+    FROM sm_facts f
+    LEFT JOIN sm_scopes s ON f.scope_id = s.id
+    WHERE f.status = 'active'
+      AND (s.id IS NULL OR s.status = 'active')
+    ORDER BY f.updated_at DESC;
+
+"""
+
+
+def get_sm_connection(db_path: Path | str | None = None) -> sqlite3.Connection:
+    """
+    Open (or create) the SQLite database and apply schema migrations.
+    Returns a connection with row_factory set to sqlite3.Row.
+    Idempotent — safe to call multiple times.
+    """
+    path = Path(db_path) if db_path else SM_DB_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    conn = sqlite3.connect(str(path), check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    conn.executescript(SCHEMA_SQL)
+
+    # Recreate sm_gauge view so MAX_ACTIVE_CHARS changes take effect immediately.
+    # CREATE VIEW IF NOT EXISTS is sticky — DROP + CREATE ensures it's current.
+    conn.executescript(f"""
+    DROP VIEW IF EXISTS sm_gauge;
+    CREATE VIEW sm_gauge AS
+        SELECT
+            COALESCE(SUM(
+                LENGTH(type) + 1 + LENGTH(target) + 3 + LENGTH(content)
+            ), 0)                                                    AS used_chars,
+            {MAX_ACTIVE_CHARS}                                       AS max_chars,
+            ROUND(COALESCE(SUM(
+                LENGTH(type) + 1 + LENGTH(target) + 3 + LENGTH(content)
+            ), 0) * 100.0
+                  / {MAX_ACTIVE_CHARS}, 1)                          AS pct
+        FROM sm_facts
+        WHERE status = 'active';
+    """)
+    conn.commit()
+    return conn
+
+
+def sm_now() -> int:
+    """Current Unix timestamp in seconds."""
+    return int(time.time())

--- a/tools/structured_memory/facts.py
+++ b/tools/structured_memory/facts.py
@@ -1,0 +1,272 @@
+"""
+Fact CRUD, contradiction detection, and classification.
+
+A fact has the form:
+    TYPE[target]: content
+    e.g.  C[db.id]: UUID mndtry, nvr autoincrement
+
+Types map to short codes stored in the DB:
+    C -> C   (constraint)
+    D -> D   (decision)
+    V -> V   (value)
+    ? -> ?   (unknown)
+    ✓ -> done
+    ~ -> obs  (obsolete)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import uuid
+from typing import Optional
+
+from .constants import (
+    FACT_RE,
+    GAUGE_FULL,
+    MAX_FACT_CHARS,
+    TYPE_DISPLAY,
+    TYPE_MAP,
+)
+from .db import sm_now as now
+
+
+class MemoryFullError(RuntimeError):
+    """Raised when the active memory store is at or above GAUGE_FULL and cannot accept new facts."""
+
+
+class FactTooLargeError(ValueError):
+    """Raised when a single fact's content exceeds MAX_FACT_CHARS after truncation attempts."""
+
+
+# Backwards-compat aliases
+_TYPE_MAP = TYPE_MAP
+
+
+def parse_notation(raw: str) -> tuple[str, str, str]:
+    """
+    Parse raw notation string into (type_code, target, content).
+    Raises ValueError if the format does not match.
+    """
+    m = FACT_RE.match(raw.strip())
+    if not m:
+        raise ValueError(
+            f"Invalid fact notation: {raw!r}\n"
+            "Expected format: TYPE[target]: content  (e.g. C[db.id]: UUID mndtry)"
+        )
+    raw_type = m.group("type")
+    type_code = TYPE_MAP.get(raw_type, raw_type)
+    return type_code, m.group("target").strip(), m.group("content").strip()
+
+
+def _source_hash(raw: str) -> str:
+    return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
+def write(
+    conn:       sqlite3.Connection,
+    raw:        str,
+    scope_id:   Optional[str] = None,
+) -> dict:
+    """
+    Parse, dedup-check, contradiction-check, then insert a fact.
+
+    Returns a dict with:
+        id               new fact id
+        status           'created' | 'dedup'
+        conflict_resolved  id of superseded fact if a contradiction was found
+        gauge_pct        current gauge after write
+
+    Raises:
+        MemoryFullError   if the store is at or above GAUGE_FULL
+        FactTooLargeError if content exceeds MAX_FACT_CHARS even after truncation
+        ValueError        if notation is invalid
+    """
+    current_pct = _gauge_pct(conn)
+    if current_pct >= GAUGE_FULL:
+        raise MemoryFullError(
+            f"Memory store is full ({current_pct:.0f}%). "
+            "Run memory_purge to reclaim space, or ask the user to /compress."
+        )
+
+    type_code, target, content = parse_notation(raw)
+
+    truncated = False
+    if len(content) > MAX_FACT_CHARS:
+        content = content[:MAX_FACT_CHARS - 1] + "…"
+        raw = f"{next(k for k,v in TYPE_MAP.items() if v == type_code)}[{target}]: {content}"
+        truncated = True
+
+    shash = _source_hash(raw)
+
+    # 1. Dedup: exact same source hash already active?
+    existing = conn.execute(
+        "SELECT id FROM sm_facts WHERE source_hash = ? AND status = 'active'",
+        (shash,),
+    ).fetchone()
+    if existing:
+        return {
+            "id":               existing["id"],
+            "status":           "dedup",
+            "conflict_resolved": None,
+            "truncated":        False,
+            "gauge_pct":        _gauge_pct(conn),
+        }
+
+    # 2. Contradiction detection
+    conflict_id = None
+    if scope_id:
+        conflict = conn.execute(
+            """
+            SELECT id FROM sm_facts
+            WHERE target = ? AND type = ? AND scope_id = ? AND status = 'active'
+            ORDER BY updated_at DESC LIMIT 1
+            """,
+            (target, type_code, scope_id),
+        ).fetchone()
+    else:
+        conflict = conn.execute(
+            """
+            SELECT id FROM sm_facts
+            WHERE target = ? AND type = ? AND scope_id IS NULL AND status = 'active'
+            ORDER BY updated_at DESC LIMIT 1
+            """,
+            (target, type_code),
+        ).fetchone()
+
+    new_id = str(uuid.uuid4())
+    ts = now()
+
+    conn.execute(
+        """
+        INSERT INTO sm_facts
+            (id, content, type, target, scope_id, status,
+             superseded_by, created_at, updated_at, last_accessed,
+             access_count, source_hash)
+        VALUES (?,?,?,?,?,'active',NULL,?,?,NULL,0,?)
+        """,
+        (new_id, content, type_code, target, scope_id, ts, ts, shash),
+    )
+
+    if conflict:
+        conflict_id = conflict["id"]
+        conn.execute(
+            "UPDATE sm_facts SET status='superseded', superseded_by=?, updated_at=? WHERE id=?",
+            (new_id, ts, conflict_id),
+        )
+
+    conn.commit()
+
+    return {
+        "id":                new_id,
+        "status":            "created",
+        "conflict_resolved": conflict_id,
+        "truncated":         truncated,
+        "gauge_pct":         _gauge_pct(conn),
+    }
+
+
+def search(
+    conn:     sqlite3.Connection,
+    query:    str,
+    scope_id: Optional[str] = None,
+    limit:    int = 5,
+) -> list[dict]:
+    """
+    FTS5 full-text search over active + cold facts.
+    Superseded and archived facts are excluded.
+    Updates last_accessed and access_count on matched rows.
+    Returns up to `limit` results sorted by FTS5 rank.
+    """
+    import re
+    limit = min(limit, 20)
+
+    tokens = query.split()
+    if not tokens:
+        return []
+
+    def _fts_token(tok: str) -> str:
+        escaped = tok.replace('"', '""')
+        if re.search(r'[^A-Za-z0-9_]', tok):
+            return f'"{escaped}"'
+        return f"{escaped}*"
+
+    if len(tokens) == 1:
+        fts_query = _fts_token(tokens[0])
+    else:
+        fts_query = " AND ".join(_fts_token(t) for t in tokens)
+
+    scope_filter = ""
+    params: list = [fts_query, limit]
+    if scope_id:
+        scope_filter = "AND f.scope_id = ?"
+        params.insert(1, scope_id)
+
+    rows = conn.execute(
+        f"""
+        SELECT f.id, f.content, f.type, f.target,
+               f.scope_id, f.status, f.updated_at, rank
+        FROM sm_facts_fts
+        JOIN sm_facts f ON sm_facts_fts.rowid = f.rowid
+        WHERE sm_facts_fts MATCH ?
+          AND f.status IN ('active','cold')
+          {scope_filter}
+        ORDER BY rank
+        LIMIT ?
+        """,
+        params,
+    ).fetchall()
+
+    ids = [r["id"] for r in rows]
+    if ids:
+        ts = now()
+        conn.execute(
+            f"""
+            UPDATE sm_facts SET last_accessed=?, access_count=access_count+1
+            WHERE id IN ({','.join('?'*len(ids))})
+            """,
+            [ts, *ids],
+        )
+        conn.commit()
+
+    return [dict(r) for r in rows]
+
+
+def get_hot(conn: sqlite3.Connection) -> list[dict]:
+    """Return all active facts in active scopes (for session injection)."""
+    rows = conn.execute("SELECT * FROM sm_hot_facts").fetchall()
+    return [dict(r) for r in rows]
+
+
+def purge(
+    conn:             sqlite3.Connection,
+    scope_id:         Optional[str] = None,
+    older_than_days:  Optional[int] = None,
+) -> int:
+    """
+    Hard-delete superseded / archived facts matching the given filters.
+    Returns count of deleted rows.
+    """
+    conditions = ["status IN ('superseded','archived')"]
+    params: list = []
+
+    if scope_id:
+        conditions.append("scope_id = ?")
+        params.append(scope_id)
+
+    if older_than_days is not None:
+        cutoff = now() - older_than_days * 86_400
+        conditions.append("updated_at < ?")
+        params.append(cutoff)
+        conditions.append("(last_accessed IS NULL OR last_accessed < ?)")
+        params.append(cutoff)
+
+    where = " AND ".join(conditions)
+    cur = conn.execute(f"DELETE FROM sm_facts WHERE {where}", params)
+    conn.commit()
+    return cur.rowcount
+
+
+def _gauge_pct(conn: sqlite3.Connection) -> float:
+    row = conn.execute("SELECT pct FROM sm_gauge").fetchone()
+    return float(row["pct"]) if row else 0.0

--- a/tools/structured_memory/gauge.py
+++ b/tools/structured_memory/gauge.py
@@ -1,0 +1,242 @@
+"""
+Pressure levels and tiered responses to gauge thresholds.
+
+GAUGE_MERGE    (70%) : merge duplicate facts sharing target + scope
+GAUGE_ARCHIVE  (85%) : push cold-scope facts from cold -> archived
+GAUGE_SYNTHESIS (95%): last resort consolidation (optional LLM call)
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Callable, Optional
+
+from .constants import (
+    GAUGE_ARCHIVE,
+    GAUGE_MERGE,
+    GAUGE_SYNTHESIS,
+    MAX_ACTIVE_CHARS,
+)
+from .db import sm_now as now
+
+
+def read(conn: sqlite3.Connection) -> dict:
+    """Return current gauge state."""
+    row = conn.execute("SELECT used_chars, max_chars, pct FROM sm_gauge").fetchone()
+    if not row:
+        return {"used_chars": 0, "max_chars": MAX_ACTIVE_CHARS, "pct": 0.0}
+    return dict(row)
+
+
+def check_and_act(
+    conn:          sqlite3.Connection,
+    llm_call:      Optional[Callable[[str], str]] = None,
+) -> dict:
+    """
+    Read gauge and trigger the appropriate pressure level.
+    llm_call is optional; if None the synthesis step is skipped.
+
+    Returns dict with gauge state + actions taken.
+    """
+    g = read(conn)
+    pct = g["pct"]
+    actions: list[str] = []
+
+    if pct < GAUGE_MERGE:
+        return {**g, "actions": actions}
+
+    merged = _merge_duplicates(conn)
+    if merged:
+        actions.append(f"merged {merged} duplicate(s)")
+    g = read(conn)
+
+    if g["pct"] >= GAUGE_ARCHIVE:
+        archived = _archive_cold_scopes(conn)
+        if archived:
+            actions.append(f"archived {archived} cold-scope fact(s)")
+        g = read(conn)
+
+    if g["pct"] >= GAUGE_SYNTHESIS:
+        if llm_call:
+            synthesized = _force_synthesis(conn, llm_call)
+            actions.append(f"synthesis: {synthesized} fact(s) consolidated")
+        else:
+            pushed = _push_oldest_to_cold(conn, target_pct=85.0)
+            actions.append(f"pushed {pushed} oldest fact(s) to cold (no LLM)")
+        g = read(conn)
+
+    return {**g, "actions": actions}
+
+
+def _merge_duplicates(conn: sqlite3.Connection) -> int:
+    """
+    Find active facts sharing the same (target, scope_id) and merge them.
+    Keeps the most recently updated, sets older ones to superseded.
+    Returns count of facts superseded.
+    """
+    rows = conn.execute(
+        """
+        SELECT type, target, scope_id, COUNT(*) AS cnt
+        FROM sm_facts
+        WHERE status = 'active' AND type NOT IN ('done','obs')
+        GROUP BY type, target, scope_id
+        HAVING cnt > 1
+        """
+    ).fetchall()
+
+    superseded = 0
+    ts = now()
+    for row in rows:
+        fact_type, target, scope_id = row["type"], row["target"], row["scope_id"]
+        duplicates = conn.execute(
+            """
+            SELECT id FROM sm_facts
+            WHERE type=? AND target=? AND scope_id IS ? AND status='active'
+            ORDER BY updated_at DESC
+            """,
+            (fact_type, target, scope_id),
+        ).fetchall()
+        keeper_id = duplicates[0]["id"]
+        for dup in duplicates[1:]:
+            conn.execute(
+                "UPDATE sm_facts SET status='superseded', superseded_by=?, updated_at=? WHERE id=?",
+                (keeper_id, ts, dup["id"]),
+            )
+            superseded += 1
+
+    conn.commit()
+    return superseded
+
+
+def _archive_cold_scopes(conn: sqlite3.Connection) -> int:
+    """
+    Push facts that are already cold (scope closed) into archived.
+    Facts accessed within the last 24h are spared.
+    Returns count of facts archived.
+    """
+    ts      = now()
+    cutoff  = ts - 86_400   # 24h grace window
+    cur = conn.execute(
+        """
+        UPDATE sm_facts SET status='archived', updated_at=?
+        WHERE status='cold'
+          AND scope_id IN (SELECT id FROM sm_scopes WHERE status IN ('cold','closed'))
+          AND (last_accessed IS NULL OR last_accessed < ?)
+        """,
+        (ts, cutoff),
+    )
+    conn.commit()
+    return cur.rowcount
+
+
+def _push_oldest_to_cold(conn: sqlite3.Connection, target_pct: float) -> int:
+    """
+    Emergency fallback when synthesis is unavailable.
+    """
+    g = read(conn)
+    if g["pct"] < target_pct or g["used_chars"] == 0:
+        return 0
+
+    max_chars     = g["max_chars"]
+    target_chars  = int(max_chars * target_pct / 100)
+    excess_chars  = g["used_chars"] - target_chars
+
+    avg_row = conn.execute(
+        "SELECT AVG(LENGTH(content)) AS avg FROM sm_facts WHERE status='active'"
+    ).fetchone()
+    avg_len = float(avg_row["avg"] or 50)
+    batch   = max(1, int(excess_chars / avg_len) + 1)
+
+    rows = conn.execute(
+        """
+        SELECT id FROM sm_facts WHERE status='active'
+        ORDER BY COALESCE(last_accessed, created_at) ASC
+        LIMIT ?
+        """,
+        (batch,),
+    ).fetchall()
+
+    if not rows:
+        return 0
+
+    ids = [r["id"] for r in rows]
+    ts  = now()
+    conn.execute(
+        f"UPDATE sm_facts SET status='cold', updated_at=? WHERE id IN ({','.join('?'*len(ids))})",
+        [ts, *ids],
+    )
+    conn.commit()
+    return len(ids)
+
+
+def _force_synthesis(
+    conn:     sqlite3.Connection,
+    llm_call: Callable[[str], str],
+) -> int:
+    """
+    Last-resort consolidation via LLM.
+    Returns count of facts consolidated (archived).
+    """
+    active = conn.execute(
+        "SELECT id, content, type, target, scope_id FROM sm_facts WHERE status='active'"
+    ).fetchall()
+
+    if not active:
+        return 0
+
+    _code_to_sym = {"C": "C", "D": "D", "V": "V", "?": "?", "done": "✓", "obs": "~"}
+
+    lines = [f"{_code_to_sym.get(r['type'], r['type'])}[{r['target']}]: {r['content']}" for r in active]
+    prompt = (
+        "You are a memory consolidation engine.\n"
+        "Consolidate the following facts into the smallest possible set "
+        "using MEMORY_SPEC notation (C/D/V/?/✓/~)[target]: content.\n"
+        "Merge facts about the same target. Remove redundancy. "
+        "Keep every unique constraint, decision, and value.\n\n"
+        + "\n".join(lines)
+    )
+
+    try:
+        response = llm_call(prompt)
+    except Exception:
+        return 0
+
+    from .facts import parse_notation
+    import uuid
+
+    ts = now()
+
+    new_rows = []
+    for line in response.strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            type_code, target, content = parse_notation(line)
+            new_rows.append((str(uuid.uuid4()), content, type_code, target, None, ts, ts))
+        except ValueError:
+            continue
+
+    if not new_rows:
+        return 0
+
+    for row in new_rows:
+        conn.execute(
+            """
+            INSERT INTO sm_facts
+                (id, content, type, target, scope_id, status,
+                 superseded_by, created_at, updated_at,
+                 last_accessed, access_count, source_hash)
+            VALUES (?,?,?,?,?,'active',NULL,?,?,NULL,0,NULL)
+            """,
+            row,
+        )
+
+    ids = [r["id"] for r in active]
+    conn.execute(
+        f"UPDATE sm_facts SET status='archived', updated_at=? WHERE id IN ({','.join('?'*len(ids))})",
+        [ts, *ids],
+    )
+
+    conn.commit()
+    return len(ids)

--- a/tools/structured_memory/optimize.py
+++ b/tools/structured_memory/optimize.py
@@ -1,0 +1,174 @@
+"""
+memory_optimize — compress MEMORY.md / USER.md and migrate C/D/V facts to DB.
+
+Strategy (applied in order):
+1. Detect C/D/V lines in each file -> migrate to structured memory DB, remove from file
+2. Abbreviate remaining entries using the compression map
+3. Strip redundant whitespace and filler phrases
+
+Thresholds:
+    MEMORY_THRESHOLD  = 55%  of 2200 chars -> trigger
+    USER_THRESHOLD    = 55%  of 1375 chars -> trigger
+    TARGET            = 45%
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import sqlite3
+
+from .constants import COMPRESS_MAP, FACT_RE
+
+# ---------------------------------------------------------------- paths ----
+
+try:
+    from hermes_constants import get_hermes_home
+    HERMES_HOME = get_hermes_home()
+except ImportError:
+    HERMES_HOME = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+
+MEMORY_PATH  = HERMES_HOME / "memories" / "MEMORY.md"
+USER_PATH    = HERMES_HOME / "memories" / "USER.md"
+
+MEMORY_LIMIT  = 2200
+USER_LIMIT    = 1375
+THRESHOLD_PCT = 55   # trigger above this %
+TARGET_PCT    = 45   # aim for this % after compression
+
+# ---------------------------------------------------------------- helpers --
+
+_FACT_LINE_RE = re.compile(
+    r"^([C?✓~]|D|V)\[([^\]]+)\]:\s*(.+)$", re.MULTILINE
+)
+
+
+def _read(path: Path) -> str:
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _pct(text: str, limit: int) -> float:
+    return len(text) / limit * 100
+
+
+def _compress_text(text: str) -> str:
+    """Apply abbreviation map to a block of text."""
+    result = text
+    for pattern, replacement in COMPRESS_MAP:
+        result = re.sub(pattern, replacement, result, flags=re.IGNORECASE)
+    result = re.sub(r" {2,}", " ", result)
+    result = re.sub(r"\n{3,}", "\n\n", result)
+    return result.strip()
+
+
+def _extract_and_migrate(
+    text: str,
+    conn: "sqlite3.Connection",
+    session_id: str,
+) -> tuple[str, list[str]]:
+    """
+    Find C/D/V/? lines, write them to structured memory DB, remove from text.
+    Returns (cleaned_text, list_of_migrated_notations).
+    """
+    from . import facts  # lazy import to avoid circular
+
+    migrated: list[str] = []
+    lines_out: list[str] = []
+
+    for line in text.splitlines():
+        m = _FACT_LINE_RE.match(line.strip())
+        if m:
+            notation = line.strip()
+            try:
+                facts.write(conn, notation, scope_id=None)
+                migrated.append(notation)
+                continue          # remove from file
+            except Exception:
+                pass              # keep the line if write fails
+        lines_out.append(line)
+
+    cleaned = "\n".join(lines_out)
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned).strip()
+    return cleaned, migrated
+
+
+# ----------------------------------------------------------------- public --
+
+def optimize(
+    conn: "sqlite3.Connection",
+    session_id: str,
+    *,
+    threshold_pct: float = THRESHOLD_PCT,
+    target_pct: float    = TARGET_PCT,
+    dry_run: bool        = False,
+) -> dict:
+    """
+    Check MEMORY.md and USER.md pressure, compress and migrate if needed.
+
+    Returns a result dict with memory_before, memory_after, user_before,
+    user_after, memory_migrated, user_migrated, action_taken.
+    """
+    memory_text = _read(MEMORY_PATH)
+    user_text   = _read(USER_PATH)
+
+    mem_before  = _pct(memory_text, MEMORY_LIMIT)
+    user_before = _pct(user_text,   USER_LIMIT)
+
+    needs_memory = mem_before  > threshold_pct
+    needs_user   = user_before > threshold_pct
+
+    if not needs_memory and not needs_user:
+        return {
+            "memory_before":   round(mem_before,  1),
+            "memory_after":    round(mem_before,  1),
+            "user_before":     round(user_before, 1),
+            "user_after":      round(user_before, 1),
+            "memory_migrated": 0,
+            "user_migrated":   0,
+            "action_taken":    False,
+        }
+
+    mem_migrated  = 0
+    user_migrated = 0
+    new_memory    = memory_text
+    new_user      = user_text
+
+    if needs_memory:
+        new_memory, migrated = _extract_and_migrate(new_memory, conn, session_id)
+        mem_migrated = len(migrated)
+        new_memory = _compress_text(new_memory)
+
+    if needs_user:
+        new_user, migrated = _extract_and_migrate(new_user, conn, session_id)
+        user_migrated = len(migrated)
+        new_user = _compress_text(new_user)
+
+    mem_after  = _pct(new_memory, MEMORY_LIMIT)
+    user_after = _pct(new_user,   USER_LIMIT)
+
+    if not dry_run:
+        if needs_memory:
+            _write(MEMORY_PATH, new_memory)
+        if needs_user:
+            _write(USER_PATH, new_user)
+
+    return {
+        "memory_before":   round(mem_before,  1),
+        "memory_after":    round(mem_after,   1),
+        "user_before":     round(user_before, 1),
+        "user_after":      round(user_after,  1),
+        "memory_migrated": mem_migrated,
+        "user_migrated":   user_migrated,
+        "action_taken":    True,
+    }

--- a/tools/structured_memory/scopes.py
+++ b/tools/structured_memory/scopes.py
@@ -1,0 +1,213 @@
+"""
+Scope lifecycle management.
+
+A scope represents a unit of work: a feature, a phase, a bug fix.
+It opens implicitly on first fact write and closes either:
+  - explicitly via a closing signal in the message text
+  - automatically after SCOPE_COOL_TURNS turns of silence
+  - automatically when topic shift is detected (no shared targets)
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+import uuid
+from typing import Optional
+
+from .constants import SCOPE_COOL_TURNS
+from .db import sm_now as now
+
+# Patterns that signal a scope should be closed.
+_CLOSING_SIGNALS = re.compile(
+    r"(?<!not )(?<!isn't )(?<!isn't )(?<!haven't )(?<!hasn't )(?<!never )"
+    r"(?<!n't )"
+    r"\b("
+    r"merged|deployed|shipped|finished|completed|closed|"
+    r"fixed|resolved|released|it works|working now|"
+    r"phase \w+ (done|complete|finished|over)"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+def get_or_create(
+    conn:    sqlite3.Connection,
+    label:   str,
+    session_id: Optional[str] = None,
+) -> str:
+    """
+    Return existing active scope id by label, or create a new one.
+    Updates session.active_scope_id if session_id provided.
+    """
+    ts = now()
+
+    row = conn.execute(
+        "SELECT id FROM sm_scopes WHERE label=? AND status='active'",
+        (label,),
+    ).fetchone()
+
+    if row:
+        scope_id = row["id"]
+        conn.execute(
+            "UPDATE sm_scopes SET last_referenced=? WHERE id=?",
+            (ts, scope_id),
+        )
+    else:
+        old = conn.execute(
+            "SELECT id FROM sm_scopes WHERE label=? ORDER BY created_at DESC LIMIT 1",
+            (label,),
+        ).fetchone()
+
+        if old:
+            scope_id = old["id"]
+            conn.execute(
+                """
+                UPDATE sm_scopes
+                SET status='active', closed_at=NULL, last_referenced=?, current_turn=0
+                WHERE id=?
+                """,
+                (ts, scope_id),
+            )
+        else:
+            scope_id = str(uuid.uuid4())
+            conn.execute(
+                """
+                INSERT INTO sm_scopes (id, label, status, last_referenced, current_turn, created_at)
+                VALUES (?, ?, 'active', ?, 0, ?)
+                """,
+                (scope_id, label, ts, ts),
+            )
+
+    if session_id:
+        conn.execute(
+            "UPDATE sm_sessions SET active_scope_id=? WHERE id=?",
+            (scope_id, session_id),
+        )
+
+    conn.commit()
+    return scope_id
+
+
+def get_active(conn: sqlite3.Connection) -> list[dict]:
+    """All currently active scopes."""
+    rows = conn.execute(
+        "SELECT * FROM sm_scopes WHERE status='active' ORDER BY last_referenced DESC"
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def tick(
+    conn:         sqlite3.Connection,
+    turn:         int,
+    message_text: str = "",
+    session_id:   Optional[str] = None,
+) -> list[str]:
+    """
+    Called on every incoming user message.
+    Returns list of scope ids that were cooled this tick.
+    """
+    if session_id:
+        conn.execute(
+            "UPDATE sm_sessions SET last_turn=? WHERE id=?",
+            (turn, session_id),
+        )
+    else:
+        conn.execute("UPDATE sm_sessions SET last_turn=?", (turn,))
+    conn.commit()
+
+    cooled: list[str] = []
+    active_scopes = get_active(conn)
+
+    recent_targets = _recent_write_targets(conn, n_turns=3)
+
+    for scope in active_scopes:
+        scope_id = scope["id"]
+        distance = turn - scope["current_turn"]
+
+        if message_text and _CLOSING_SIGNALS.search(message_text):
+            if session_id:
+                row = conn.execute(
+                    "SELECT active_scope_id FROM sm_sessions WHERE id=?",
+                    (session_id,),
+                ).fetchone()
+                if row and row["active_scope_id"] == scope_id:
+                    _cool_scope(conn, scope_id)
+                    cooled.append(scope_id)
+                    continue
+            else:
+                _cool_scope(conn, scope_id)
+                cooled.append(scope_id)
+                continue
+
+        if distance >= SCOPE_COOL_TURNS:
+            _cool_scope(conn, scope_id)
+            cooled.append(scope_id)
+            continue
+
+        if distance >= 3:
+            scope_targets = _scope_targets(conn, scope_id)
+            if scope_targets and not scope_targets.intersection(recent_targets):
+                _cool_scope(conn, scope_id)
+                cooled.append(scope_id)
+
+    return cooled
+
+
+def _cool_scope(conn: sqlite3.Connection, scope_id: str) -> None:
+    """Move scope to cold and push its active facts to cold as well."""
+    ts = now()
+    conn.execute(
+        "UPDATE sm_scopes SET status='cold', closed_at=? WHERE id=?",
+        (ts, scope_id),
+    )
+    conn.execute(
+        "UPDATE sm_facts SET status='cold', updated_at=? WHERE scope_id=? AND status='active'",
+        (ts, scope_id),
+    )
+    conn.commit()
+
+
+def touch(conn: sqlite3.Connection, scope_id: str, turn: int) -> None:
+    """Record that this scope was active at `turn`."""
+    conn.execute(
+        "UPDATE sm_scopes SET current_turn=?, last_referenced=? WHERE id=?",
+        (turn, now(), scope_id),
+    )
+    conn.commit()
+
+
+def close(conn: sqlite3.Connection, scope_id: str) -> None:
+    """Explicitly close a scope."""
+    ts = now()
+    conn.execute(
+        "UPDATE sm_scopes SET status='closed', closed_at=? WHERE id=?",
+        (ts, scope_id),
+    )
+    conn.execute(
+        "UPDATE sm_facts SET status='cold', updated_at=? WHERE scope_id=? AND status='active'",
+        (ts, scope_id),
+    )
+    conn.commit()
+
+
+def _recent_write_targets(conn: sqlite3.Connection, n_turns: int = 3) -> set[str]:
+    rows = conn.execute(
+        """
+        SELECT DISTINCT target FROM sm_facts
+        WHERE status IN ('active','cold')
+        ORDER BY updated_at DESC
+        LIMIT ?
+        """,
+        (n_turns * 5,),
+    ).fetchall()
+    return {r["target"] for r in rows}
+
+
+def _scope_targets(conn: sqlite3.Connection, scope_id: str) -> set[str]:
+    """All targets of active facts belonging to this scope."""
+    rows = conn.execute(
+        "SELECT DISTINCT target FROM sm_facts WHERE scope_id=? AND status='active'",
+        (scope_id,),
+    ).fetchall()
+    return {r["target"] for r in rows}

--- a/tools/structured_memory_tool.py
+++ b/tools/structured_memory_tool.py
@@ -1,0 +1,729 @@
+#!/usr/bin/env python3
+"""
+Structured Memory Tool — native hermes-agent tool replacing the hermes-memory MCP server.
+
+Exposes 7 agent-callable tools backed by the hermes-memory SQLite store:
+    mcp_memory_write    store a typed fact (C/D/V/?/checkmark/tilde notation)
+    mcp_memory_search   FTS5 search over hot + cold facts
+    mcp_memory_reflect  synthesis grouped by type for a topic
+    mcp_memory_export   dump all facts as plain notation
+    mcp_memory_purge    hard-delete superseded / archived facts
+    mcp_memory_optimize compress MEMORY.md/USER.md + migrate facts to DB
+    mcp_memory_gauge    return current gauge state (pct, used_chars, max_chars)
+
+memory_tick is NOT a tool — it is called automatically by the agent loop via
+tick_structured_memory(). memory_status is also not a tool — it is injected
+into the system prompt at session start via get_structured_memory_injection().
+
+Thread-safety: one SQLite connection per OS thread via threading.local().
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import uuid
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Lazy import guard — hermes_memory may not be installed in all envoys
+# ---------------------------------------------------------------------------
+try:
+    from hermes_memory.core import db as _db
+    from hermes_memory.core import facts as _facts
+    from hermes_memory.core import gauge as _gauge
+    from hermes_memory.core import scopes as _scopes
+    from hermes_memory.core.db import ABBREV_DICT, GAUGE_WARN
+    from hermes_memory.core.facts import TYPE_DISPLAY, MemoryFullError
+
+    _HM_AVAILABLE = True
+except ImportError:
+    _HM_AVAILABLE = False
+
+
+# ---------------------------------------------------------------------------
+# Connection pool — one connection per thread
+# ---------------------------------------------------------------------------
+
+_DB_PATH = Path(os.getenv("HERMES_MEMORY_DB", str(
+    Path.home() / ".hermes" / "memory.db"
+)))
+
+_local = threading.local()
+
+
+def _conn():
+    """Return a per-thread SQLite connection (lazy init)."""
+    if not _HM_AVAILABLE:
+        raise RuntimeError("hermes_memory package is not installed.")
+    if not getattr(_local, "conn", None):
+        _local.conn = _db.get_connection(_DB_PATH)
+    return _local.conn
+
+
+# ---------------------------------------------------------------------------
+# Default session ID — one UUID per process; callers can override per call
+# ---------------------------------------------------------------------------
+
+_SESSION_ID = str(uuid.uuid4())
+
+
+def _resolve_session(kwargs: dict) -> str:
+    return kwargs.get("session_id") or _SESSION_ID
+
+
+def _ensure_session(session_id: str) -> None:
+    c = _conn()
+    existing = c.execute(
+        "SELECT id FROM sessions WHERE id=?", (session_id,)
+    ).fetchone()
+    if not existing:
+        c.execute(
+            "INSERT INTO sessions (id, started_at, last_turn) VALUES (?,?,0)",
+            (session_id, _db.now()),
+        )
+        c.commit()
+
+
+# ---------------------------------------------------------------------------
+# Tool handler functions (return plain str, not TextContent)
+# ---------------------------------------------------------------------------
+
+def _handle_mcp_memory_write(args: dict, **kw) -> str:
+    if not _HM_AVAILABLE:
+        return "[MEMORY WRITE FAILED] hermes_memory package is not installed."
+
+    try:
+        c = _conn()
+        session_id = args.get("session_id") or _resolve_session(kw)
+        _ensure_session(session_id)
+
+        raw_content = args.get("content", "").strip()
+        if not raw_content:
+            return "[MEMORY WRITE FAILED] content is required."
+
+        scope_label = args.get("scope")
+        scope_id = None
+
+        if scope_label:
+            scope_id = _scopes.get_or_create(c, scope_label, session_id)
+        else:
+            row = c.execute(
+                "SELECT active_scope_id FROM sessions WHERE id=?", (session_id,)
+            ).fetchone()
+            if row:
+                scope_id = row["active_scope_id"]
+
+        # Run pressure relief BEFORE the write so the store has headroom.
+        _gauge.check_and_act(c)
+
+        try:
+            result = _facts.write(c, raw_content, scope_id=scope_id)
+        except MemoryFullError as exc:
+            g = _gauge.read(c)
+            return (
+                f"[MEMORY WRITE FAILED] {exc}\n"
+                f"gauge: {g['pct']:.0f}%\n"
+                "action: call mcp_memory_purge to reclaim space, "
+                "or inform the user that memory is full."
+            )
+        except ValueError as exc:
+            return f"[MEMORY WRITE FAILED] Invalid notation: {exc}"
+        except Exception as exc:
+            return (
+                f"[MEMORY WRITE FAILED] Unexpected error: {exc}\n"
+                "The fact was NOT stored. Retry or inform the user."
+            )
+
+        # Touch scope with current turn so silence cooling tracks real activity
+        if scope_id and result.get("status") == "created":
+            current_turn = c.execute(
+                "SELECT last_turn FROM sessions WHERE id=?", (session_id,)
+            ).fetchone()
+            turn_val = current_turn["last_turn"] if current_turn else 0
+            _scopes.touch(c, scope_id, turn_val)
+
+        # Auto-close scope if a checkmark fact was written
+        if result.get("status") == "created" and raw_content.startswith("\u2713"):
+            if scope_id:
+                _scopes.close(c, scope_id)
+
+        # Re-read gauge after write
+        gauge_result = _gauge.check_and_act(c)
+
+        lines = [
+            f"stored: {result['id'][:8]}",
+            f"gauge:  {gauge_result['pct']:.0f}%",
+        ]
+        if result.get("truncated"):
+            lines.append(
+                f"[truncated] content exceeded {_db.MAX_FACT_CHARS} chars and was shortened. "
+                "Consider splitting into multiple facts."
+            )
+        if result.get("conflict_resolved"):
+            lines.append(f"superseded: {result['conflict_resolved'][:8]}")
+        if gauge_result.get("actions"):
+            lines.append("pressure: " + ", ".join(gauge_result["actions"]))
+        if gauge_result["pct"] >= GAUGE_WARN:
+            lines.append(
+                f"[MEMORY WARNING] Store at {gauge_result['pct']:.0f}% capacity. "
+                "Consider calling mcp_memory_purge or informing the user to /compress."
+            )
+
+        return "\n".join(lines)
+
+    except Exception as exc:
+        return f"[MEMORY WRITE FAILED] Internal error: {exc}"
+
+
+def _handle_mcp_memory_search(args: dict, **kw) -> str:
+    if not _HM_AVAILABLE:
+        return "[MEMORY SEARCH FAILED] hermes_memory package is not installed."
+
+    try:
+        c = _conn()
+        query = args.get("query", "").strip()
+        if not query:
+            return "[MEMORY SEARCH FAILED] query is required."
+
+        scope_label = args.get("scope")
+        limit = min(int(args.get("limit", 5)), 20)
+
+        scope_id = None
+        if scope_label:
+            row = c.execute(
+                "SELECT id FROM scopes WHERE label=? "
+                "ORDER BY CASE status WHEN 'active' THEN 0 ELSE 1 END, created_at DESC LIMIT 1",
+                (scope_label,)
+            ).fetchone()
+            if row:
+                scope_id = row["id"]
+
+        results = _facts.search(c, query, scope_id=scope_id, limit=limit)
+
+        if not results:
+            return "no results"
+
+        lines = []
+        for r in results:
+            status_tag = "" if r["status"] == "active" else f" [{r['status']}]"
+            sym = TYPE_DISPLAY.get(r["type"], r["type"])
+            lines.append(f"{sym}[{r['target']}]: {r['content']}{status_tag}")
+
+        return "\n".join(lines)
+
+    except Exception as exc:
+        return f"[MEMORY SEARCH FAILED] {exc}"
+
+
+def _handle_mcp_memory_reflect(args: dict, **kw) -> str:
+    if not _HM_AVAILABLE:
+        return "[MEMORY REFLECT FAILED] hermes_memory package is not installed."
+
+    try:
+        c = _conn()
+        topic = args.get("topic", "").strip()
+        if not topic:
+            return "[MEMORY REFLECT FAILED] topic is required."
+
+        limit = min(int(args.get("limit", 20)), 20)
+
+        results = _facts.search(c, topic, limit=limit)
+
+        if not results:
+            return f"no facts found for topic: {topic}"
+
+        groups: dict[str, list[str]] = {}
+        for r in results:
+            sym = TYPE_DISPLAY.get(r["type"], r["type"])
+            groups.setdefault(sym, []).append(
+                f"  [{r['target']}]: {r['content']}"
+                + ("" if r["status"] == "active" else f"  ({r['status']})")
+            )
+
+        type_order = ["C", "D", "V", "\u2713", "~", "?"]
+        lines = [f"reflection: {topic}  ({len(results)} facts)", ""]
+        for sym in type_order:
+            if sym not in groups:
+                continue
+            label = {
+                "C": "Constraints", "D": "Decisions", "V": "Values",
+                "\u2713": "Resolved", "~": "Obsolete", "?": "Open questions",
+            }.get(sym, sym)
+            lines.append(f"{label}:")
+            lines.extend(groups[sym])
+            lines.append("")
+
+        return "\n".join(lines).rstrip()
+
+    except Exception as exc:
+        return f"[MEMORY REFLECT FAILED] {exc}"
+
+
+def _handle_mcp_memory_export(args: dict, **kw) -> str:
+    if not _HM_AVAILABLE:
+        return "[MEMORY EXPORT FAILED] hermes_memory package is not installed."
+
+    try:
+        c = _conn()
+        scope_label = args.get("scope")
+        status_filter = args.get("status", "all")
+
+        scope_id = None
+        if scope_label:
+            row = c.execute(
+                "SELECT id FROM scopes WHERE label=?", (scope_label,)
+            ).fetchone()
+            if row:
+                scope_id = row["id"]
+
+        if status_filter == "active":
+            statuses = ("active",)
+        elif status_filter == "cold":
+            statuses = ("cold",)
+        else:
+            statuses = ("active", "cold")
+
+        conditions = [f"status IN ({','.join('?' * len(statuses))})"]
+        params: list = list(statuses)
+
+        if scope_id:
+            conditions.append("scope_id = ?")
+            params.append(scope_id)
+
+        rows = c.execute(
+            f"SELECT type, target, content FROM facts "
+            f"WHERE {' AND '.join(conditions)} "
+            f"ORDER BY CASE status WHEN 'active' THEN 0 ELSE 1 END, updated_at DESC",
+            params,
+        ).fetchall()
+
+        if not rows:
+            return "(no facts to export)"
+
+        lines = []
+        for r in rows:
+            sym = TYPE_DISPLAY.get(r["type"], r["type"])
+            lines.append(f"{sym}[{r['target']}]: {r['content']}")
+
+        return "\n".join(lines)
+
+    except Exception as exc:
+        return f"[MEMORY EXPORT FAILED] {exc}"
+
+
+def _handle_mcp_memory_purge(args: dict, **kw) -> str:
+    if not _HM_AVAILABLE:
+        return "[MEMORY PURGE FAILED] hermes_memory package is not installed."
+
+    try:
+        c = _conn()
+        scope_label = args.get("scope")
+        older_than = args.get("older_than_days")
+
+        scope_id = None
+        if scope_label:
+            row = c.execute(
+                "SELECT id FROM scopes WHERE label=?", (scope_label,)
+            ).fetchone()
+            if row:
+                scope_id = row["id"]
+
+        count = _facts.purge(
+            c,
+            scope_id=scope_id,
+            older_than_days=int(older_than) if older_than is not None else None,
+        )
+        g = _gauge.read(c)
+
+        return f"purged: {count} fact(s)\ngauge: {g['pct']}%"
+
+    except Exception as exc:
+        return f"[MEMORY PURGE FAILED] {exc}"
+
+
+def _handle_mcp_memory_optimize(args: dict, **kw) -> str:
+    if not _HM_AVAILABLE:
+        return "[MEMORY OPTIMIZE FAILED] hermes_memory package is not installed."
+
+    try:
+        from hermes_memory.core.optimize import optimize
+
+        c = _conn()
+        session_id = args.get("session_id") or _resolve_session(kw)
+        _ensure_session(session_id)
+
+        threshold = float(args.get("threshold_pct", 55))
+        dry_run = bool(args.get("dry_run", False))
+
+        result = optimize(c, session_id, threshold_pct=threshold, dry_run=dry_run)
+
+        if not result["action_taken"]:
+            return (
+                f"no action needed\n"
+                f"MEMORY: {result['memory_before']}%  USER: {result['user_before']}%\n"
+                f"(both below {threshold:.0f}% threshold)"
+            )
+
+        lines = [
+            "optimized:" + (" (dry run)" if dry_run else ""),
+            f"  MEMORY: {result['memory_before']}% -> {result['memory_after']}%"
+            + (f"  ({result['memory_migrated']} facts migrated)" if result["memory_migrated"] else ""),
+            f"  USER:   {result['user_before']}% -> {result['user_after']}%"
+            + (f"  ({result['user_migrated']} facts migrated)" if result["user_migrated"] else ""),
+        ]
+        total_migrated = result["memory_migrated"] + result["user_migrated"]
+        if total_migrated:
+            lines.append(f"  {total_migrated} fact(s) moved to hermes-memory DB")
+
+        return "\n".join(lines)
+
+    except Exception as exc:
+        return f"[MEMORY OPTIMIZE FAILED] {exc}"
+
+
+def _handle_mcp_memory_gauge(args: dict, **kw) -> str:
+    if not _HM_AVAILABLE:
+        return "[MEMORY GAUGE FAILED] hermes_memory package is not installed."
+
+    try:
+        c = _conn()
+        gauge_result = _gauge.check_and_act(c)
+        g = _gauge.read(c)
+
+        lines = [
+            f"pct: {g['pct']}%",
+            f"used_chars: {g['used_chars']}",
+            f"max_chars: {g['max_chars']}",
+        ]
+        if gauge_result.get("actions"):
+            lines.append("actions: " + ", ".join(gauge_result["actions"]))
+        else:
+            lines.append("actions: (none)")
+
+        return "\n".join(lines)
+
+    except Exception as exc:
+        return f"[MEMORY GAUGE FAILED] {exc}"
+
+
+# ---------------------------------------------------------------------------
+# Public helpers called by the agent framework (not tool calls)
+# ---------------------------------------------------------------------------
+
+def get_structured_memory_injection(session_id: str = None) -> str:
+    """
+    Build the system prompt injection block for structured memory.
+
+    Called at agent startup. Returns a compact formatted string showing
+    the gauge state, hot facts, and active scopes.
+    Returns empty string if the DB is unavailable or there are no facts.
+    """
+    if not _HM_AVAILABLE:
+        return ""
+
+    try:
+        c = _conn()
+        sid = session_id or _SESSION_ID
+        _ensure_session(sid)
+
+        g = _gauge.read(c)
+        hot = _facts.get_hot(c)
+        active_scopes = _scopes.get_active(c)
+
+        if not hot and not active_scopes:
+            return ""
+
+        lines = [
+            f"[STRUCTURED MEMORY — {g['pct']}% ({g['used_chars']}/{g['max_chars']})]"
+        ]
+
+        for f in hot:
+            type_sym = TYPE_DISPLAY.get(f["type"], f["type"])
+            lines.append(f"{type_sym}[{f['target']}]: {f['content']}")
+
+        if active_scopes:
+            scope_labels = [s["label"] for s in active_scopes]
+            lines.append(f"active scopes: {', '.join(scope_labels)}")
+
+        return "\n".join(lines)
+
+    except Exception:
+        return ""
+
+
+def tick_structured_memory(
+    turn: int, message_text: str = "", session_id: str = None
+) -> None:
+    """
+    Advance the turn counter and trigger scope auto-cooling.
+
+    Called by the agent loop on every user message. Never raises.
+    """
+    if not _HM_AVAILABLE:
+        return
+
+    try:
+        c = _conn()
+        sid = session_id or _SESSION_ID
+        _ensure_session(sid)
+        _scopes.tick(c, turn, message_text=message_text, session_id=sid)
+    except Exception:
+        pass  # Silent — never interrupt the agent loop
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas
+# ---------------------------------------------------------------------------
+
+_MCP_MEMORY_WRITE_SCHEMA = {
+    "name": "mcp_memory_write",
+    "description": (
+        "Store a structured fact using MEMORY_SPEC notation.\n"
+        "Format: TYPE[target]: content\n"
+        "Types: C=constraint  D=decision  V=value  ?=unknown  \u2713=done  ~=obsolete\n"
+        "Examples:\n"
+        "  C[db.id]: UUID mndtry, nvr autoincrement\n"
+        "  D[auth]: JWT 7j refresh 6j\n"
+        "  V[srv.prod]: api.example.com:3005\n"
+        "  \u2713[auth]: deployed prod\n"
+        "Call this whenever a constraint, decision, or value is established. "
+        "Scope auto-cooling and pressure relief are handled automatically."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {
+                "type": "string",
+                "description": "Fact in MEMORY_SPEC notation, e.g. C[db.id]: UUID mndtry",
+            },
+            "scope": {
+                "type": "string",
+                "description": "Scope label (e.g. 'auth-refactor', 'phase-b'). Inherits active scope if omitted.",
+            },
+            "session_id": {
+                "type": "string",
+                "description": "Session identifier. Uses process default if omitted.",
+            },
+        },
+        "required": ["content"],
+    },
+}
+
+_MCP_MEMORY_SEARCH_SCHEMA = {
+    "name": "mcp_memory_search",
+    "description": (
+        "Search active and cold facts by keyword or phrase.\n"
+        "Call this before answering on any topic that may have been discussed before.\n"
+        "Returns up to `limit` facts (default 5, max 20) sorted by relevance."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Search query, e.g. 'UUID database' or 'auth JWT'",
+            },
+            "scope": {
+                "type": "string",
+                "description": "Restrict search to a specific scope label.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max results to return (1-20, default 5).",
+                "default": 5,
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+_MCP_MEMORY_REFLECT_SCHEMA = {
+    "name": "mcp_memory_reflect",
+    "description": (
+        "Synthesize all facts (hot + cold) related to a topic into a concise summary.\n"
+        "Use this when the user asks 'what did we decide about X?' or before making\n"
+        "a decision on a topic with long history. Does not write to memory.\n"
+        "Returns a structured synthesis grouped by fact type."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "topic": {
+                "type": "string",
+                "description": "Topic to reflect on, e.g. 'auth' or 'database schema'",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max facts to include in reflection (default 20).",
+                "default": 20,
+            },
+        },
+        "required": ["topic"],
+    },
+}
+
+_MCP_MEMORY_EXPORT_SCHEMA = {
+    "name": "mcp_memory_export",
+    "description": (
+        "Export all facts (hot + cold) as plain MEMORY_SPEC notation, one per line.\n"
+        "Use for: context snapshot before a long session, transferring memory between\n"
+        "agents or sessions, debugging what is stored. Read-only, no writes."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "scope": {
+                "type": "string",
+                "description": "Export only facts belonging to this scope label.",
+            },
+            "status": {
+                "type": "string",
+                "enum": ["active", "cold", "all"],
+                "description": "Which facts to include. Default: all (active + cold).",
+                "default": "all",
+            },
+        },
+    },
+}
+
+_MCP_MEMORY_PURGE_SCHEMA = {
+    "name": "mcp_memory_purge",
+    "description": (
+        "Hard-delete superseded and archived facts. "
+        "Use to reclaim space after a scope is fully closed, "
+        "or as periodic garbage collection."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "scope": {
+                "type": "string",
+                "description": "Purge only facts belonging to this scope label.",
+            },
+            "older_than_days": {
+                "type": "integer",
+                "description": "Only purge facts older than N days with no recent access.",
+            },
+        },
+    },
+}
+
+_MCP_MEMORY_OPTIMIZE_SCHEMA = {
+    "name": "mcp_memory_optimize",
+    "description": (
+        "Compress MEMORY.md and USER.md to reduce injection cost, and migrate "
+        "any C/D/V/? facts found in those files into the hermes-memory DB.\n"
+        "Only acts when MEMORY.md > threshold% or USER.md > threshold% (default 55%).\n"
+        "If both are below threshold, returns immediately with no changes.\n"
+        "Safe to call on a schedule (e.g. 2x/day via cron)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "threshold_pct": {
+                "type": "number",
+                "description": "Trigger threshold in percent (default 55). Only act if either file exceeds this.",
+                "default": 55,
+            },
+            "dry_run": {
+                "type": "boolean",
+                "description": "If true, compute what would change but do not write files.",
+                "default": False,
+            },
+            "session_id": {"type": "string"},
+        },
+    },
+}
+
+_MCP_MEMORY_GAUGE_SCHEMA = {
+    "name": "mcp_memory_gauge",
+    "description": (
+        "Return the current memory gauge state: percentage used, char counts, "
+        "and any pressure-relief actions taken. Use this for a quick health check "
+        "or to decide whether to call mcp_memory_purge."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {},
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Availability check
+# ---------------------------------------------------------------------------
+
+def check_structured_memory_requirements() -> bool:
+    """Returns True if the hermes_memory package is installed and usable."""
+    return _HM_AVAILABLE
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+from tools.registry import registry  # noqa: E402 — must come after definitions
+
+registry.register(
+    name="mcp_memory_write",
+    toolset="structured_memory",
+    schema=_MCP_MEMORY_WRITE_SCHEMA,
+    handler=lambda args, **kw: _handle_mcp_memory_write(args, **kw),
+    check_fn=check_structured_memory_requirements,
+    emoji="\U0001f9e0",
+)
+
+registry.register(
+    name="mcp_memory_search",
+    toolset="structured_memory",
+    schema=_MCP_MEMORY_SEARCH_SCHEMA,
+    handler=lambda args, **kw: _handle_mcp_memory_search(args, **kw),
+    check_fn=check_structured_memory_requirements,
+    emoji="\U0001f50d",
+)
+
+registry.register(
+    name="mcp_memory_reflect",
+    toolset="structured_memory",
+    schema=_MCP_MEMORY_REFLECT_SCHEMA,
+    handler=lambda args, **kw: _handle_mcp_memory_reflect(args, **kw),
+    check_fn=check_structured_memory_requirements,
+    emoji="\U0001f4ad",
+)
+
+registry.register(
+    name="mcp_memory_export",
+    toolset="structured_memory",
+    schema=_MCP_MEMORY_EXPORT_SCHEMA,
+    handler=lambda args, **kw: _handle_mcp_memory_export(args, **kw),
+    check_fn=check_structured_memory_requirements,
+    emoji="\U0001f4e4",
+)
+
+registry.register(
+    name="mcp_memory_purge",
+    toolset="structured_memory",
+    schema=_MCP_MEMORY_PURGE_SCHEMA,
+    handler=lambda args, **kw: _handle_mcp_memory_purge(args, **kw),
+    check_fn=check_structured_memory_requirements,
+    emoji="\U0001f5d1",
+)
+
+registry.register(
+    name="mcp_memory_optimize",
+    toolset="structured_memory",
+    schema=_MCP_MEMORY_OPTIMIZE_SCHEMA,
+    handler=lambda args, **kw: _handle_mcp_memory_optimize(args, **kw),
+    check_fn=check_structured_memory_requirements,
+    emoji="\u2699",
+)
+
+registry.register(
+    name="mcp_memory_gauge",
+    toolset="structured_memory",
+    schema=_MCP_MEMORY_GAUGE_SCHEMA,
+    handler=lambda args, **kw: _handle_mcp_memory_gauge(args, **kw),
+    check_fn=check_structured_memory_requirements,
+    emoji="\U0001f4ca",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -171,7 +171,21 @@ TOOLSETS = {
         "tools": ["memory"],
         "includes": []
     },
-    
+
+    "structured_memory": {
+        "description": "Typed structured fact store with FTS5 search, scope lifecycle, and automatic gauge-based pressure management (C/D/V/?/✓/~ notation)",
+        "tools": [
+            "mcp_memory_write",
+            "mcp_memory_search",
+            "mcp_memory_reflect",
+            "mcp_memory_export",
+            "mcp_memory_purge",
+            "mcp_memory_optimize",
+            "mcp_memory_gauge",
+        ],
+        "includes": []
+    },
+
     "session_search": {
         "description": "Search and recall past conversations with summarization",
         "tools": ["session_search"],

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -843,6 +843,20 @@ memory:
   user_char_limit: 1375     # ~500 tokens
 ```
 
+## Structured Memory
+
+Enable the typed SQLite fact store alongside the flat-file memory tool:
+
+```yaml
+toolsets:
+  enabled:
+    - structured_memory   # Typed fact store: C/D/V/?/✓/~ notation, FTS5 search, scope lifecycle
+```
+
+No additional configuration required. Hot facts and the gauge percentage are injected into the system prompt automatically. `memory_tick` fires on every user message without consuming a tool-call turn.
+
+See [Structured Memory](/docs/user-guide/features/structured-memory) for the full reference.
+
 ## Git Worktree Isolation
 
 Enable isolated git worktrees for running multiple agents in parallel on the same repo:

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -207,6 +207,18 @@ memory:
   user_char_limit: 1375     # ~500 tokens
 ```
 
+## Structured Memory (Typed Fact Store)
+
+For more than ~15 facts, or when you need keyword search across hundreds of constraints, decisions, and open questions, the [`structured_memory` toolset](./structured-memory.md) adds a SQLite-backed typed store alongside MEMORY.md and USER.md:
+
+- MEMORY_SPEC notation: `C[db.id]: UUID mndtry`, `D[auth]: JWT 7d`
+- FTS5 search across all stored facts
+- Named scopes with auto-cooling
+- Automatic pressure management (merge, archive, push cold)
+- Zero config — just add `structured_memory` to your enabled toolsets
+
+See [Structured Memory](./structured-memory.md) for the full reference.
+
 ## Honcho Integration (Cross-Session User Modeling)
 
 For deeper, AI-generated user understanding that works across sessions and platforms, you can enable [Honcho Memory](./honcho.md). Honcho runs alongside built-in memory in `hybrid` mode (the default) — `MEMORY.md` and `USER.md` stay as-is, and Honcho adds a persistent user modeling layer on top.

--- a/website/docs/user-guide/features/structured-memory.md
+++ b/website/docs/user-guide/features/structured-memory.md
@@ -1,0 +1,234 @@
+---
+sidebar_position: 4
+title: "Structured Memory"
+description: "Typed fact store with FTS5 search, scope lifecycle, and automatic gauge-based pressure management — no MCP required"
+---
+
+# Structured Memory
+
+Structured memory is a typed, searchable fact store built directly into hermes-agent. It complements the flat-file `memory` tool (MEMORY.md / USER.md) with a SQLite-backed store that scales to hundreds of facts without bloating the system prompt.
+
+:::info Relationship to the flat-file memory tool
+The two systems are additive, not exclusive. Use `memory` for the handful of critical facts that should always be in context (user preferences, key conventions). Use `structured_memory` for everything else — project constraints, architecture decisions, environment values, open questions — where you need search, not constant injection.
+:::
+
+## Quick Start
+
+Enable the toolset in `config.yaml`:
+
+```yaml
+toolsets:
+  enabled:
+    - structured_memory
+```
+
+Or pass it at runtime:
+
+```bash
+hermes --toolset structured_memory
+```
+
+That's it. No MCP server to install. No external process. No configuration beyond the toolset line.
+
+## How It Works
+
+Facts are stored in `~/.hermes/state.db` (the same database used by sessions and session search) in three tables: `sm_facts`, `sm_scopes`, and `sm_sessions`. A FTS5 virtual table enables sub-millisecond keyword search across all stored facts regardless of how many there are.
+
+At session start, the gauge percentage and hot facts (active facts in active scopes) are injected into the system prompt automatically — no tool call required. As the session progresses, `memory_tick` runs on every user message without consuming a tool-call turn, triggering scope auto-cooling when a scope has been silent for 6+ turns.
+
+## MEMORY_SPEC Notation
+
+Facts are written in a compact typed notation:
+
+```
+TYPE[target]: content
+```
+
+| Type | Symbol | Meaning |
+|------|--------|---------|
+| Constraint | `C` | Hard rule that must not be violated |
+| Decision | `D` | Architectural or product decision made |
+| Value | `V` | Environment variable, URL, secret reference |
+| Unknown | `?` | Open question or unresolved item |
+| Done | `✓` | Completed task or resolved item |
+| Obsolete | `~` | Superseded — soft-delete, kept for history |
+
+**Examples:**
+
+```
+C[db.id]: UUID mndtry, nvr autoincrement
+D[auth]: JWT 7d refresh 6d, stored httpOnly cookie
+V[srv.prod]: api.example.com:3005
+?[deploy]: unclear if blue/green or rolling — ask Louis
+✓[auth]: deployed to prod 2026-03-01
+~[db.id]: old autoincrement scheme (superseded)
+```
+
+The abbreviation dictionary (`ABBREV_DICT`) is injected into the system prompt as a writing guide so facts stay compact from the start.
+
+## The 7 Tools
+
+### `mcp_memory_write`
+
+Store a typed fact.
+
+```python
+mcp_memory_write(content="C[db.id]: UUID mndtry", scope="auth-refactor")
+```
+
+- `content` — fact in MEMORY_SPEC notation (required)
+- `scope` — scope label, e.g. `"auth-refactor"` (optional, falls back to session default)
+- `session_id` — explicit session ID (optional)
+
+Automatically calls `gauge.check_and_act()` before writing to keep pressure in check.
+
+### `mcp_memory_search`
+
+FTS5 full-text search across all facts.
+
+```python
+mcp_memory_search(query="auth JWT", limit=5)
+```
+
+Returns facts ranked by relevance, including type, target, content, scope, and status. Default limit: 5, max: 20. Use before answering any question about a topic that may have been discussed before.
+
+### `mcp_memory_reflect`
+
+Synthesize facts on a topic into a structured summary.
+
+```python
+mcp_memory_reflect(topic="database schema", limit=20)
+```
+
+Groups results by fact type. Use when the user asks "what did we decide about X?" or before making a significant decision with prior history.
+
+### `mcp_memory_export`
+
+Dump all facts as plain MEMORY_SPEC notation, one per line.
+
+```python
+mcp_memory_export(scope="auth-refactor", status="active")
+```
+
+- `scope` — filter to one scope (optional)
+- `status` — `"active"`, `"cold"`, or `"all"` (default: `"all"`)
+
+Use for context snapshots before long sessions or transferring state between agents.
+
+### `mcp_memory_purge`
+
+Hard-delete superseded and archived facts.
+
+```python
+mcp_memory_purge(older_than_days=30)
+```
+
+Use to reclaim space after a scope is fully closed, or as periodic garbage collection.
+
+### `mcp_memory_optimize`
+
+Compress MEMORY.md and USER.md using the compression map, and migrate any MEMORY_SPEC-formatted lines into the structured store.
+
+```python
+mcp_memory_optimize(threshold_pct=55, dry_run=False)
+```
+
+- `threshold_pct` — only optimize if usage exceeds this percentage (default: 55)
+- `dry_run` — preview changes without writing (default: false)
+
+Run this in a cron job or when the flat-file memory approaches capacity.
+
+### `mcp_memory_gauge`
+
+Return current pressure state.
+
+```python
+mcp_memory_gauge()
+```
+
+Returns `used_chars`, `max_chars` (10,000), `pct`, and any actions triggered by automatic pressure management.
+
+## Automatic Pressure Management
+
+The gauge system prevents the store from silently filling up. At each write, pressure is checked and one of four actions taken automatically:
+
+| Threshold | Action |
+|-----------|--------|
+| ≥70% | Merge duplicate facts (same target + scope) |
+| ≥80% | Warning injected into tool response |
+| ≥85% | Archive facts from closed scopes to cold storage |
+| ≥95% | Push oldest active facts to cold; LLM synthesis if available |
+
+"Cold" facts are kept in the DB and remain searchable but are not injected into the system prompt. `mcp_memory_purge` permanently removes them.
+
+## Scopes and Lifecycle
+
+Scopes are named workstreams — e.g. `"auth-refactor"`, `"phase-b"`. Facts written to a scope stay hot as long as that scope is active.
+
+A scope auto-cools when it has received no writes for 6 turns (configurable via `SCOPE_COOL_TURNS` in `constants.py`). Cooled scopes move their facts to cold storage, freeing headroom for new work without permanently discarding anything.
+
+```python
+# Write a fact to a named scope
+mcp_memory_write(content="D[auth]: use Supabase Auth, not custom JWT", scope="auth-refactor")
+
+# Export just that scope
+mcp_memory_export(scope="auth-refactor")
+
+# Clean up after the scope is done
+mcp_memory_purge(scope="auth-refactor")
+```
+
+## System Prompt Injection
+
+At session start, the following is automatically prepended to the system prompt (zero tool calls consumed):
+
+```
+[STRUCTURED MEMORY — 23% (2300/10000 chars)]
+C[db.id]: UUID mndtry, nvr autoincrement
+D[auth]: JWT 7d refresh 6d
+active scopes: auth-refactor
+```
+
+The injection only appears when there are active facts. If the DB is empty, nothing is added.
+
+## Comparison: `memory` vs `structured_memory`
+
+| Feature | `memory` (flat-file) | `structured_memory` |
+|---------|---------------------|---------------------|
+| Storage | MEMORY.md / USER.md | SQLite (state.db) |
+| Capacity | ~3,575 chars total | 10,000 chars active + unlimited cold |
+| Search | None (always in prompt) | FTS5 keyword search |
+| Types | Untyped text | C / D / V / ? / ✓ / ~ |
+| Scopes | None | Named workstreams with auto-cooling |
+| Injection | Full content, every session | Gauge + hot facts only |
+| Pressure management | Manual | Automatic (merge / archive / push cold) |
+| Best for | Key preferences, short conventions | Architecture decisions, constraints, open questions |
+
+## Abbreviation Guide
+
+The agent is primed to write compact facts using a standard abbreviation dictionary. Examples:
+
+| Full form | Abbreviation |
+|-----------|-------------|
+| configuration | cfg |
+| database | db |
+| authentication | auth |
+| mandatory | mndtry |
+| never | nvr |
+| environment | env |
+| production | prod |
+| repository | repo |
+
+Facts over 400 chars are rejected — if a fact doesn't fit, it should be split or summarized.
+
+## Background: Why Not MCP?
+
+This feature was originally prototyped as an MCP server (`hermes-memory`, PR #2692). The MCP boundary was removed for the native integration because:
+
+- No subprocess or stdio transport overhead
+- Zero user configuration beyond the toolset line
+- Direct access to `state.db` and the session lifecycle
+- `memory_tick` runs automatically inside the agent loop — no tool call consumed
+- Gauge and hot facts are injected at prompt-build time — no tool call consumed
+
+The core logic (schema, FTS5, gauge tiers, scope lifecycle, MEMORY_SPEC parser, compression map) is identical to what was developed and tested in #2692 — 52 tests, 8 months of design iteration. The delivery changed; the implementation did not.


### PR DESCRIPTION
Closes #2692 (supersedes the MCP server prototype).

## What changed from #2692

PR #2692 implemented this as a standalone MCP server (`hermes-memory`, published on PyPI). After reviewer feedback asking why MCP was necessary, the architecture was rethought: the MCP boundary adds subprocess + stdio transport overhead, requires the user to `pip install hermes-memory` and configure `mcp:` in `config.yaml`, and prevents the agent loop from calling `memory_tick` and injecting the gauge automatically.

**The core logic is identical** — same schema, same gauge tiers, same MEMORY_SPEC notation, same 52 tests, same abbreviation dictionary and compression map developed across #2692. Only the delivery changed.

What was dropped:
- MCP subprocess and stdio transport
- `pip install hermes-memory` requirement  
- `mcp:` config block
- `memory_tick` as an explicit tool call (now automatic)
- `memory_status` as an explicit tool call (now injected at prompt build time)

What was gained:
- Zero user configuration beyond `- structured_memory` in enabled toolsets
- `memory_tick` fires on every user message inside the agent loop, no turn consumed
- Gauge + hot facts injected into system prompt at startup, no tool call consumed
- Direct SQLite access to `state.db` — one DB for sessions, session search, and structured memory

## Feature overview

A typed, searchable fact store using MEMORY_SPEC notation:

```
C[db.id]: UUID mndtry, nvr autoincrement    ← Constraint
D[auth]: JWT 7d refresh 6d                   ← Decision  
V[srv.prod]: api.example.com:3005            ← Value
?[deploy]: rolling or blue-green?            ← Unknown
✓[auth]: deployed to prod                    ← Done
~[db.id]: old autoincrement scheme           ← Obsolete
```

Facts live in `state.db` (`sm_facts` / `sm_scopes` / `sm_sessions`). A FTS5 virtual table gives sub-millisecond keyword search regardless of how many facts are stored.

## Files

```
tools/structured_memory/
  constants.py   gauge thresholds, ABBREV_DICT, COMPRESS_MAP, TYPE_MAP, FACT_RE
  db.py          schema SQL, get_sm_connection(), sm_now()
  facts.py       write(), search(), get_hot(), purge(), parse_notation()
  gauge.py       read(), check_and_act(), merge/archive/push logic
  scopes.py      get_or_create(), tick(), touch(), close(), auto-cooling
  optimize.py    compress MEMORY.md/USER.md + migrate MEMORY_SPEC lines

tools/structured_memory_tool.py   7 registered tools + injection/tick helpers
toolsets.py                        new structured_memory toolset
model_tools.py                     module load entry
run_agent.py                       automatic tick hook + system prompt injection
```

## The 7 tools

| Tool | Purpose |
|------|---------|
| `mcp_memory_write` | Store a typed fact (gauge check before every write) |
| `mcp_memory_search` | FTS5 keyword search, default limit 5 |
| `mcp_memory_reflect` | Synthesize facts by topic, grouped by type |
| `mcp_memory_export` | Dump all facts as MEMORY_SPEC notation |
| `mcp_memory_purge` | Hard-delete superseded/archived facts |
| `mcp_memory_optimize` | Compress flat-file memory + migrate to structured store |
| `mcp_memory_gauge` | Return current pressure state |

## Automatic pressure management

`gauge.check_and_act()` fires before every write:

| Threshold | Action |
|-----------|--------|
| ≥70% | Merge duplicate facts (same target + scope) |
| ≥80% | Warning in tool response |
| ≥85% | Archive facts from closed scopes to cold |
| ≥95% | Push oldest active facts to cold storage |

## Tests

52 tests ported from #2692's test suite, adapted for native imports and `sm_*` table names. All pass with isolated `tmp_path` fixtures.

```
tests/structured_memory/test_facts.py           9 tests
tests/structured_memory/test_gauge.py           4 tests
tests/structured_memory/test_scopes.py          6 tests
tests/structured_memory/test_status.py          5 tests
tests/structured_memory/test_reflect.py         4 tests
tests/structured_memory/test_export_archive.py  5 tests
tests/structured_memory/test_current_turn.py    4 tests
tests/structured_memory/test_optimize.py       15 tests
─────────────────────────────────────────────
Total                                          52 tests  ✓
```

## Documentation

- `website/docs/user-guide/features/structured-memory.md` — full feature doc (tools, notation, pressure tiers, scope lifecycle, comparison table with flat-file memory)
- `website/docs/user-guide/features/memory.md` — cross-reference added
- `website/docs/user-guide/configuration.md` — toolset config example

## Note on semantic search

A reviewer on #2692 suggested combining FTS5 with semantic/vector search. For agent-written typed facts this would be marginally beneficial — the `target` field already acts as the semantic category (`C[auth]`, `D[auth]`, `V[auth]` all cluster under a single FTS5 query), and facts are short and written by a single author with consistent vocabulary. Tracked as a future enhancement for when the store grows to thousands of facts from multiple authors.