### PR TITLE
fix(cli): prevent update crash in non-TTY environments

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2812,7 +2812,10 @@ def cmd_update(args):
                 print(f"  ℹ️  {len(missing_config)} new config option(s) available")
             
             print()
-            response = input("Would you like to configure them now? [Y/n]: ").strip().lower()
+            if sys.stdin.isatty():
+                response = input("Would you like to configure them now? [Y/n]: ").strip().lower()
+            else:
+                response = "n"
             
             if response in ('', 'y', 'yes'):
                 print()


### PR DESCRIPTION
`cmd_update` calls `input()` unconditionally during config migration. In headless environments (Telegram gateway, systemd), there's no TTY — `input()` throws `EOFError` and the update crashes, preventing the gateway from restarting.

Guard with `sys.stdin.isatty()`, default to skipping the migration prompt when non-interactive.

Salvaged from PR #2850 by @devorun. Closes #2848.