### PR TITLE
feat(models): add glm-5-turbo to zai provider model list

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -87,6 +87,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     ],
     "zai": [
         "glm-5",
+        "glm-5-turbo",
         "glm-4.7",
         "glm-4.5",
         "glm-4.5-flash",


### PR DESCRIPTION
Cherry-picked from PR #2542 by @ReqX.

Adds `glm-5-turbo` to `_PROVIDER_MODELS["zai"]` so `/model zai:glm-5-turbo` validates correctly. The model was already in `_OPENROUTER_UPSTREAM_MODELS` but missing from the direct provider list.

Context length is already covered by the fuzzy `"glm": 202752` entry in `DEFAULT_CONTEXT_LENGTHS`.