### PR TITLE
fix(logging): show HTTP status code and 400 body in API error output

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6371,11 +6371,17 @@ class AIAgent:
                     _provider = getattr(self, "provider", "unknown")
                     _base = getattr(self, "base_url", "unknown")
                     _model = getattr(self, "model", "unknown")
-                    self._vprint(f"{self.log_prefix}⚠️  API call failed (attempt {retry_count}/{max_retries}): {error_type}", force=True)
+                    _status_code_str = f" [HTTP {status_code}]" if status_code else ""
+                    self._vprint(f"{self.log_prefix}⚠️  API call failed (attempt {retry_count}/{max_retries}): {error_type}{_status_code_str}", force=True)
                     self._vprint(f"{self.log_prefix}   🔌 Provider: {_provider}  Model: {_model}", force=True)
                     self._vprint(f"{self.log_prefix}   🌐 Endpoint: {_base}", force=True)
                     cleaned_error = self._clean_error_message(str(api_error))
                     self._vprint(f"{self.log_prefix}   📝 Error: {cleaned_error}", force=True)
+                    if status_code == 400:
+                        _err_body = getattr(api_error, "body", None)
+                        _err_body_str = str(_err_body)[:300] if _err_body else None
+                        if _err_body_str:
+                            self._vprint(f"{self.log_prefix}   📋 Details: {_err_body_str}", force=True)
                     self._vprint(f"{self.log_prefix}   ⏱️  Elapsed: {elapsed_time:.2f}s  Context: {len(api_messages)} msgs, ~{approx_tokens:,} tokens")
                     
                     # Check for interrupt before deciding to retry


### PR DESCRIPTION
Appends `[HTTP 400]` etc. to the error header line and shows the provider's response body for 400 errors (truncated to 300 chars). Makes invalid model names, malformed requests, and provider-specific errors immediately visible instead of hidden behind generic messages.

Salvaged from PR #2646 by @Mibayy. Fixes #2644.