### PR TITLE
fix(whatsapp): resolve LID to phone number in gateway authorization

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1487,10 +1487,26 @@ class GatewayRunner:
         if global_allowlist:
             allowed_ids.update(uid.strip() for uid in global_allowlist.split(",") if uid.strip())
 
-        # WhatsApp JIDs have @s.whatsapp.net suffix — strip it for comparison
+        # WhatsApp JIDs have @s.whatsapp.net suffix — strip it for comparison.
+        # WhatsApp also uses LID (Linked Identity Device) format e.g. 123456789@lid.
+        # Resolve LID to phone number using session mapping files so that users
+        # only need to configure their phone number in WHATSAPP_ALLOWED_USERS.
         check_ids = {user_id}
         if "@" in user_id:
             check_ids.add(user_id.split("@")[0])
+
+        if source.platform == Platform.WHATSAPP and user_id.endswith("@lid"):
+            lid_number = user_id.split("@")[0]
+            session_dir = os.path.expanduser("~/.hermes/whatsapp/session")
+            reverse_map_path = os.path.join(session_dir, f"lid-mapping-{lid_number}_reverse.json")
+            try:
+                with open(reverse_map_path) as f:
+                    phone = json.load(f)
+                if isinstance(phone, str) and phone:
+                    check_ids.add(phone)
+            except (OSError, ValueError, json.JSONDecodeError):
+                pass
+
         return bool(check_ids & allowed_ids)
 
     def _get_unauthorized_dm_behavior(self, platform: Optional[Platform]) -> str:


### PR DESCRIPTION
## Problem

WhatsApp now uses LID (Linked Identity Device) format for user identification (e.g. `123456789012345@lid`). The gateway's `_is_user_authorized()` checks the raw LID against `WHATSAPP_ALLOWED_USERS`, which only contains phone numbers — so every LID-based user gets rejected even when their phone is correctly configured.

The WhatsApp bridge (`bridge.js`) already resolves LIDs correctly via `lid-mapping-*_reverse.json` files in the session directory. The gateway had no equivalent logic.

Closes #2991

## Fix

In `_is_user_authorized()`, when `user_id` ends with `@lid` and the platform is WhatsApp, load the reverse mapping file (`~/.hermes/whatsapp/session/lid-mapping-{lid}_reverse.json`) to resolve the LID to a phone number, then include both the LID and phone number in the set of IDs checked against the allowlist.

The mapping file contains a JSON string (e.g. `"628123456789"`), matching exactly what the bridge already uses.

```python
if source.platform == Platform.WHATSAPP and user_id.endswith("@lid"):
    lid_number = user_id.split("@")[0]
    session_dir = os.path.expanduser("~/.hermes/whatsapp/session")
    reverse_map_path = os.path.join(session_dir, f"lid-mapping-{lid_number}_reverse.json")
    try:
        with open(reverse_map_path) as f:
            phone = json.load(f)
        if isinstance(phone, str) and phone:
            check_ids.add(phone)
    except (OSError, ValueError, json.JSONDecodeError):
        pass
```

## Behavior

- If mapping file exists: resolves LID → phone, checks both against allowlist
- If mapping file missing or malformed: silently falls back to existing behavior (no regression)
- No changes to other platforms