### PR TITLE
docs(delegate): clarify that toolsets controls network and shell access

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -732,7 +732,9 @@ DELEGATE_TASK_SCHEMA = {
                     "Default: inherits your enabled toolsets. "
                     "Common patterns: ['terminal', 'file'] for code work, "
                     "['web'] for research, ['terminal', 'file', 'web'] for "
-                    "full-stack tasks."
+                    "full-stack tasks. Use 'web' to grant network access "
+                    "(web_search, web_extract). Use 'terminal' for shell "
+                    "access (also has network via curl, requests, etc.)."
                 ),
             },
             "tasks": {
@@ -745,7 +747,7 @@ DELEGATE_TASK_SCHEMA = {
                         "toolsets": {
                             "type": "array",
                             "items": {"type": "string"},
-                            "description": "Toolsets for this specific task",
+                            "description": "Toolsets for this specific task. Use 'web' for network access, 'terminal' for shell.",
                         },
                     },
                     "required": ["goal"],


### PR DESCRIPTION
## Context

Issue #2986 requested configurable network access for subagents. Network access (and more generally, fine-grained toolset control) is already fully supported via the `toolsets` parameter — the gap was purely in documentation.

## Change

Improved the tool schema description for `toolsets` in `delegate_task` to make it explicit that:
- `'web'` grants network access (`web_search`, `web_extract`)
- `'terminal'` provides shell access (which also has network via curl, requests, etc.)
- Each task in batch mode can have its own toolsets

## Example (already works today, no code change needed)

```python
# Single task with network
delegate_task(
    goal="Fetch top HN stories and summarize",
    toolsets=["web"]
)

# Batch with per-task toolsets
delegate_task(tasks=[
    {"goal": "Fetch data from API",     "toolsets": ["web"]},
    {"goal": "Process local CSV files", "toolsets": ["terminal", "file"]},
])
```

Closes #2986