### PR TITLE
fix: use sys.executable for pip in update commands to fix PEP 668

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2439,8 +2439,9 @@ def _update_via_zip(args):
                 cwd=PROJECT_ROOT, check=True, env=uv_env,
             )
     else:
-        venv_pip = PROJECT_ROOT / "venv" / ("Scripts" if sys.platform == "win32" else "bin") / "pip"
-        pip_cmd = [str(venv_pip)] if venv_pip.exists() else ["pip"]
+        # Use sys.executable to explicitly call the venv's pip module,
+        # avoiding PEP 668 'externally-managed-environment' errors on Debian/Ubuntu
+        pip_cmd = [sys.executable, "-m", "pip"]
         try:
             subprocess.run(pip_cmd + ["install", "-e", ".[all]", "--quiet"], cwd=PROJECT_ROOT, check=True)
         except subprocess.CalledProcessError:
@@ -2752,8 +2753,9 @@ def cmd_update(args):
                     cwd=PROJECT_ROOT, check=True, env=uv_env,
                 )
         else:
-            venv_pip = PROJECT_ROOT / "venv" / ("Scripts" if sys.platform == "win32" else "bin") / "pip"
-            pip_cmd = [str(venv_pip)] if venv_pip.exists() else ["pip"]
+            # Use sys.executable to explicitly call the venv's pip module,
+            # avoiding PEP 668 'externally-managed-environment' errors on Debian/Ubuntu
+            pip_cmd = [sys.executable, "-m", "pip"]
             try:
                 subprocess.run(pip_cmd + ["install", "-e", ".[all]", "--quiet"], cwd=PROJECT_ROOT, check=True)
             except subprocess.CalledProcessError:


### PR DESCRIPTION
The update commands called bare `pip` as fallback when uv wasn't found. On modern Debian/Ubuntu enforcing PEP 668, this resolves to system pip which refuses to install in an externally-managed environment.

Use `sys.executable -m pip` to ensure the venv's pip is used. Fixed in both `cmd_update` and `_update_via_zip` (the original PR only caught one instance).

Salvaged from PR #2655 by @devorun. Fixes #2648.