### PR TITLE
fix: update api_key in _try_activate_fallback for subagent auth

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3987,6 +3987,7 @@ class AIAgent:
                 # Build native Anthropic client instead of using OpenAI client
                 from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token, _is_oauth_token
                 effective_key = (fb_client.api_key or resolve_anthropic_token() or "") if fb_provider == "anthropic" else (fb_client.api_key or "")
+                self.api_key = effective_key
                 self._anthropic_api_key = effective_key
                 self._anthropic_base_url = getattr(fb_client, "base_url", None)
                 self._anthropic_client = build_anthropic_client(effective_key, self._anthropic_base_url)
@@ -3995,6 +3996,7 @@ class AIAgent:
                 self._client_kwargs = {}
             else:
                 # Swap OpenAI client and config in-place
+                self.api_key = fb_client.api_key
                 self.client = fb_client
                 self._client_kwargs = {
                     "api_key": fb_client.api_key,


### PR DESCRIPTION
## Summary

When provider fallback activates (e.g. minimax → OpenRouter), `_try_activate_fallback()` updated `self.provider`, `self.base_url`, `self.api_mode`, and `self._client_kwargs` — but never `self.api_key`.

`delegate_tool.py:186` reads `parent_agent.api_key` to pass credentials to child agents. After fallback, this returned the stale pre-fallback key (e.g. a minimax API key being sent to OpenRouter), causing `401 Missing Authentication header` errors on all subagents.

## Fix

Add `self.api_key = ...` in both branches of `_try_activate_fallback()`:
- **anthropic_messages path**: `self.api_key = effective_key`
- **chat_completions path**: `self.api_key = fb_client.api_key`

## Test plan

- `test_run_agent.py`: 199 passed
- `test_fallback_model.py`: 27 passed