### PR TITLE
feat(skills): add browser-use/browser-use as trusted skill source

### DIFF
--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -36,7 +36,7 @@ from typing import List, Tuple
 # Hardcoded trust configuration
 # ---------------------------------------------------------------------------
 
-TRUSTED_REPOS = {"openai/skills", "anthropics/skills"}
+TRUSTED_REPOS = {"openai/skills", "anthropics/skills", "browser-use/browser-use"}
 
 INSTALL_POLICY = {
     #                  safe      caution    dangerous

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -251,6 +251,7 @@ class GitHubSource(SkillSource):
         {"repo": "openai/skills", "path": "skills/"},
         {"repo": "anthropics/skills", "path": "skills/"},
         {"repo": "VoltAgent/awesome-agent-skills", "path": "skills/"},
+        {"repo": "browser-use/browser-use", "path": "skills/"},
     ]
 
     def __init__(self, auth: GitHubAuth, extra_taps: Optional[List[Dict]] = None):


### PR DESCRIPTION
Add browser-use to DEFAULT_TAPS for discoverability via `hermes skills search` and to TRUSTED_REPOS so the allowed-tools frontmatter field does not block installation.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

The [browser-use CLI](https://github.com/browser-use/browser-use) provides fast, persistent browser automation from the terminal. It ships a [SKILL.md](https://github.com/browser-use/browser-use/blob/main/skills/browser-use/SKILL.md) in its repo that teaches Hermes how to use the CLI via the terminal tool.

This PR makes that skill discoverable and installable by:
1. Adding `browser-use/browser-use` to `DEFAULT_TAPS` — so `hermes skills search browser` finds it
2. Adding `browser-use/browser-use` to `TRUSTED_REPOS` — so the `allowed-tools: Bash(browser-use:*)` frontmatter field doesn't trigger a caution-level block during install

The SKILL.md lives in the browser-use repo and is fetched via the GitHub API at install time — no copy is maintained in this repo.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

N/A

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `tools/skills_guard.py` — Added `"browser-use/browser-use"` to `TRUSTED_REPOS`
- `tools/skills_hub.py` — Added `{"repo": "browser-use/browser-use", "path": "skills/"}` to `DEFAULT_TAPS`

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `python -m pytest tests/tools/test_skills_hub.py tests/tools/test_skills_guard.py -q` — all tests pass
2. `hermes skills search browser-use` — discovers the skill from the browser-use repo
3. `hermes skills install browser-use/browser-use/skills/browser-use` — installs without being blocked

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

N/A