### PR TITLE
fix(acp): rename AuthMethod to AuthMethodAgent for agent-client-protocol 0.9.0

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -12,7 +12,7 @@ import acp
 from acp.schema import (
     AgentCapabilities,
     AuthenticateResponse,
-    AuthMethod,
+    AuthMethodAgent,
     ClientCapabilities,
     EmbeddedResourceContentBlock,
     ForkSessionResponse,
@@ -103,7 +103,7 @@ class HermesACPAgent(acp.Agent):
         auth_methods = None
         if provider:
             auth_methods = [
-                AuthMethod(
+                AuthMethodAgent(
                     id=provider,
                     name=f"{provider} runtime credentials",
                     description=f"Authenticate Hermes using the currently configured {provider} runtime credentials.",


### PR DESCRIPTION
Fixes the CI import error that's been breaking the test suite on main since `agent-client-protocol` 0.9.0 landed.

## Root cause

`0.9.0` split `AuthMethod` into three specific classes:
- `AuthMethodAgent` — agent-managed auth (our case)
- `AuthMethodEnvVar` — env var injection
- `AuthMethodTerminal` — terminal prompt

`AuthMethod` no longer exists, causing:
```
ImportError: cannot import name 'AuthMethod' from 'acp.schema'
```

## Fix

Two-character rename: `AuthMethod` → `AuthMethodAgent` in the import and the one call site. Signature is identical — same `id`, `name`, `description` fields.

## Verified

`tests/acp/test_server.py`: 31/31 pass.