### PR TITLE
fix(display): show named custom_providers in /model CLI display

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3056,6 +3056,11 @@ class HermesCLI:
                     if is_active:
                         print(f"      model: {self.model} ← current")
                     print(f"      (use hermes model to change)")
+                elif p["id"].startswith("custom:"):
+                    # Named custom provider — label already contains endpoint + model hint
+                    if is_active:
+                        print(f"      model: {self.model} ← current")
+                    print(f"      (use /model {p['id']}:<model> to switch)")
                 else:
                     print(f"      (use hermes model to change)")
                 print()

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -320,6 +320,35 @@ def list_available_providers() -> list[dict[str, str]]:
             "aliases": alias_list,
             "authenticated": has_creds,
         })
+
+    # Append named custom providers from config.yaml custom_providers list.
+    # These are shown in the interactive `hermes model` menu (hermes_cli/main.py)
+    # but were missing from this function, causing /model to omit them.
+    try:
+        from hermes_cli.config import load_config as _load_cfg
+        _cfg = _load_cfg() or {}
+        _custom_providers_cfg = _cfg.get("custom_providers") or []
+        if isinstance(_custom_providers_cfg, list):
+            for _entry in _custom_providers_cfg:
+                if not isinstance(_entry, dict):
+                    continue
+                _name = _entry.get("name", "").strip()
+                _base_url = _entry.get("base_url", "").strip()
+                if not _name or not _base_url:
+                    continue
+                _pid = "custom:" + _name.lower().replace(" ", "-")
+                _short_url = _base_url.replace("https://", "").replace("http://", "").rstrip("/")
+                _saved_model = _entry.get("model", "")
+                _model_hint = f" — {_saved_model}" if _saved_model else ""
+                result.append({
+                    "id": _pid,
+                    "label": f"{_name} ({_short_url}){_model_hint}",
+                    "aliases": [],
+                    "authenticated": True,  # presence in config.yaml implies configured
+                })
+    except Exception:
+        pass
+
     return result
 
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -642,7 +642,8 @@ class TestVisionClientFallback:
     def test_vision_auto_includes_codex(self, codex_auth_dir):
         """Codex supports vision (gpt-5.3-codex), so auto mode should use it."""
         with patch("agent.auxiliary_client._read_nous_auth", return_value=None), \
-             patch("agent.auxiliary_client.OpenAI"):
+             patch("agent.auxiliary_client.OpenAI"), \
+             patch("agent.anthropic_adapter.build_anthropic_client", return_value=None):
             client, model = get_vision_auxiliary_client()
         from agent.auxiliary_client import CodexAuxiliaryClient
         assert isinstance(client, CodexAuxiliaryClient)
@@ -657,7 +658,8 @@ class TestVisionClientFallback:
         monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:1234/v1")
         monkeypatch.setenv("OPENAI_API_KEY", "local-key")
         with patch("agent.auxiliary_client._read_nous_auth", return_value=None), \
-             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+             patch("agent.auxiliary_client.OpenAI") as mock_openai, \
+             patch("agent.anthropic_adapter.build_anthropic_client", return_value=None):
             client, model = get_vision_auxiliary_client()
         assert client is not None  # Custom endpoint picked up as fallback
 
@@ -684,15 +686,17 @@ class TestVisionClientFallback:
 
     def test_vision_uses_openrouter_when_available(self, monkeypatch):
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
-        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai, \
+             patch("agent.anthropic_adapter.build_anthropic_client", return_value=None):
             client, model = get_vision_auxiliary_client()
         assert model == "google/gemini-3-flash-preview"
         assert client is not None
 
     def test_vision_uses_nous_when_available(self, monkeypatch):
         with patch("agent.auxiliary_client._read_nous_auth") as mock_nous, \
-             patch("agent.auxiliary_client.OpenAI"):
-            mock_nous.return_value = {"access_token": "nous-tok"}
+             patch("agent.auxiliary_client.OpenAI"), \
+             patch("agent.anthropic_adapter.build_anthropic_client", return_value=None):
+            mock_nous.return_value = {"access_token": "***"}
             client, model = get_vision_auxiliary_client()
         assert model == "gemini-3-flash"
         assert client is not None

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -92,7 +92,15 @@ class TestGeneratedSystemdUnits:
 
         assert "/home/test/.nvm/versions/node/v24.14.0/bin" in unit
 
-    def test_system_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout(self):
+    def test_system_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout(self, monkeypatch):
+        # generate_systemd_unit(system=True) calls _system_service_identity() which
+        # refuses to run as root (checks SUDO_USER/USER/LOGNAME/getpass.getuser).
+        # Mock all of these so the test passes in CI/root environments.
+        monkeypatch.setattr("os.getuid", lambda: 1000)
+        monkeypatch.setenv("SUDO_USER", "hermes")
+        monkeypatch.setenv("USER", "hermes")
+        monkeypatch.setenv("LOGNAME", "hermes")
+        monkeypatch.setattr("getpass.getuser", lambda: "hermes")
         unit = gateway_cli.generate_systemd_unit(system=True)
 
         assert "ExecStart=" in unit

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -90,6 +90,8 @@ def test_custom_setup_clears_active_oauth_provider(tmp_path, monkeypatch):
     def fake_prompt_choice(question, choices, default=0):
         if question == "Select your inference provider:":
             return 3
+        if question == "Configure vision:":
+            return len(choices) - 1  # skip vision
         tts_idx = _maybe_keep_current_tts(question, choices)
         if tts_idx is not None:
             return tts_idx
@@ -108,6 +110,7 @@ def test_custom_setup_clears_active_oauth_provider(tmp_path, monkeypatch):
     monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", lambda *args, **kwargs: False)
     monkeypatch.setattr("hermes_cli.auth.detect_external_credentials", lambda: [])
     monkeypatch.setattr("hermes_cli.main._save_custom_provider", lambda *args, **kwargs: None)
+    monkeypatch.setattr("agent.auxiliary_client.get_available_vision_backends", lambda: [])
     monkeypatch.setattr(
         "hermes_cli.models.probe_api_models",
         lambda api_key, base_url: {"models": ["m"], "probed_url": base_url + "/models"},
@@ -138,6 +141,8 @@ def test_codex_setup_uses_runtime_access_token_for_live_model_list(tmp_path, mon
             return 2  # OpenAI Codex
         if question == "Select default model:":
             return 0
+        if question == "Configure vision:":
+            return len(choices) - 1  # skip vision
         tts_idx = _maybe_keep_current_tts(question, choices)
         if tts_idx is not None:
             return tts_idx
@@ -147,6 +152,7 @@ def test_codex_setup_uses_runtime_access_token_for_live_model_list(tmp_path, mon
     monkeypatch.setattr("hermes_cli.setup.prompt", lambda *args, **kwargs: "")
     monkeypatch.setattr("hermes_cli.auth.detect_external_credentials", lambda: [])
     monkeypatch.setattr("hermes_cli.auth._login_openai_codex", lambda *args, **kwargs: None)
+    monkeypatch.setattr("agent.auxiliary_client.get_available_vision_backends", lambda: [])
     monkeypatch.setattr(
         "hermes_cli.auth.resolve_codex_runtime_credentials",
         lambda *args, **kwargs: {

--- a/tests/hermes_cli/test_setup_model_provider.py
+++ b/tests/hermes_cli/test_setup_model_provider.py
@@ -63,6 +63,8 @@ def test_setup_keep_current_custom_from_config_does_not_fall_through(tmp_path, m
         if question == "Select your inference provider:":
             assert choices[-1] == "Keep current (Custom: https://example.invalid/v1)"
             return len(choices) - 1
+        if question == "Configure vision:":
+            return len(choices) - 1  # skip vision
         tts_idx = _maybe_keep_current_tts(question, choices)
         if tts_idx is not None:
             return tts_idx
@@ -73,6 +75,7 @@ def test_setup_keep_current_custom_from_config_does_not_fall_through(tmp_path, m
     monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", lambda *args, **kwargs: False)
     monkeypatch.setattr("hermes_cli.auth.get_active_provider", lambda: None)
     monkeypatch.setattr("hermes_cli.auth.detect_external_credentials", lambda: [])
+    monkeypatch.setattr("agent.auxiliary_client.get_available_vision_backends", lambda: [])
 
     setup_model_provider(config)
     save_config(config)
@@ -404,6 +407,8 @@ def test_setup_switch_custom_to_codex_clears_custom_endpoint_and_updates_config(
             return 2  # OpenAI Codex
         if question == "Select default model:":
             return 0
+        if question == "Configure vision:":
+            return len(choices) - 1  # skip vision
         tts_idx = _maybe_keep_current_tts(question, choices)
         if tts_idx is not None:
             return tts_idx
@@ -415,11 +420,12 @@ def test_setup_switch_custom_to_codex_clears_custom_endpoint_and_updates_config(
     monkeypatch.setattr("hermes_cli.auth.get_active_provider", lambda: None)
     monkeypatch.setattr("hermes_cli.auth.detect_external_credentials", lambda: [])
     monkeypatch.setattr("hermes_cli.auth._login_openai_codex", lambda *args, **kwargs: None)
+    monkeypatch.setattr("agent.auxiliary_client.get_available_vision_backends", lambda: [])
     monkeypatch.setattr(
         "hermes_cli.auth.resolve_codex_runtime_credentials",
         lambda *args, **kwargs: {
             "base_url": "https://chatgpt.com/backend-api/codex",
-            "api_key": "codex-...oken",
+            "api_key": "***",
         },
     )
     monkeypatch.setattr(
@@ -449,6 +455,8 @@ def test_setup_summary_marks_codex_auth_as_vision_available(tmp_path, monkeypatc
     )
 
     monkeypatch.setattr("shutil.which", lambda _name: None)
+    # Codex supports vision — simulate the backend being available
+    monkeypatch.setattr("agent.auxiliary_client.get_available_vision_backends", lambda: ["openai-codex"])
 
     _print_setup_summary(load_config(), tmp_path)
     output = capsys.readouterr().out

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -45,6 +45,7 @@ def test_toolset_has_keys_for_vision_accepts_codex_auth(tmp_path, monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("AUXILIARY_VISION_PROVIDER", raising=False)
     monkeypatch.delenv("CONTEXT_VISION_PROVIDER", raising=False)
+    monkeypatch.setattr("agent.anthropic_adapter.build_anthropic_client", lambda *a, **kw: None)
 
     assert _toolset_has_keys("vision") is True
 

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -374,6 +374,7 @@ class TestVisionRequirements:
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         monkeypatch.delenv("AUXILIARY_VISION_PROVIDER", raising=False)
         monkeypatch.delenv("CONTEXT_VISION_PROVIDER", raising=False)
+        monkeypatch.setattr("agent.anthropic_adapter.build_anthropic_client", lambda *a, **kw: None)
 
         assert check_vision_requirements() is True
 


### PR DESCRIPTION
Closes #3114

## Root cause

`list_available_providers()` in `hermes_cli/models.py` iterated only over the hardcoded `_PROVIDER_ORDER` list (which contains only the bare `"custom"` entry). Named providers defined under `custom_providers` in `config.yaml` were therefore invisible to `/model` in the CLI session, even though they worked fine at runtime and appeared in the interactive `hermes model` TUI.

## Fix

After the `_PROVIDER_ORDER` loop, read `custom_providers` from the config and append each named entry as `custom:<name>` — the same key format used by `hermes_cli/main.py` and `parse_model_input()`.

Also adds a display branch in `_show_model_and_providers()` (cli.py) for `custom:*` providers that:
- marks the current model when active
- hints the correct `/model custom:<name>:<model>` syntax

## Before / after

**Before:** `/model` showed only built-in providers + bare `custom`.

**After:**
```
  Authenticated providers & models:
    [custom:my-llm-server]
      my-llm-server (api.example.com) — llama-3-70b
      (use /model custom:my-llm-server:<model> to switch)
```