### PR TITLE
fix(gateway): prevent auth-switch cache collisions for OAuth tokens

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4652,10 +4652,18 @@ class GatewayRunner:
         prompt cache hits.
         """
         import hashlib, json as _j
+
+        # Fingerprint the FULL credential string instead of using a short
+        # prefix. OAuth/JWT-style tokens frequently share a common prefix
+        # (e.g. "eyJhbGci"), which can cause false cache hits across auth
+        # switches if only the first few characters are considered.
+        _api_key = str(runtime.get("api_key", "") or "")
+        _api_key_fingerprint = hashlib.sha256(_api_key.encode()).hexdigest() if _api_key else ""
+
         blob = _j.dumps(
             [
                 model,
-                runtime.get("api_key", "")[:8],  # first 8 chars only
+                _api_key_fingerprint,
                 runtime.get("base_url", ""),
                 runtime.get("provider", ""),
                 runtime.get("api_mode", ""),

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -42,10 +42,32 @@ class TestAgentConfigSignature:
     def test_model_change_different_signature(self):
         from gateway.run import GatewayRunner
 
-        runtime = {"api_key": "sk-test12345678", "base_url": "https://openrouter.ai/api/v1",
+        runtime = {"api_key": "***", "base_url": "https://openrouter.ai/api/v1",
                     "provider": "openrouter"}
         sig1 = GatewayRunner._agent_config_signature("claude-sonnet-4", runtime, ["hermes-telegram"], "")
         sig2 = GatewayRunner._agent_config_signature("claude-opus-4.6", runtime, ["hermes-telegram"], "")
+        assert sig1 != sig2
+
+    def test_same_token_prefix_different_full_token_changes_signature(self):
+        """Tokens sharing a JWT-style prefix must not collide."""
+        from gateway.run import GatewayRunner
+
+        rt1 = {
+            "api_key": "eyJhbGci.token-for-account-a",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "provider": "openai-codex",
+            "api_mode": "codex_responses",
+        }
+        rt2 = {
+            "api_key": "eyJhbGci.token-for-account-b",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "provider": "openai-codex",
+            "api_mode": "codex_responses",
+        }
+
+        assert rt1["api_key"][:8] == rt2["api_key"][:8]
+        sig1 = GatewayRunner._agent_config_signature("gpt-5.3-codex", rt1, ["hermes-telegram"], "")
+        sig2 = GatewayRunner._agent_config_signature("gpt-5.3-codex", rt2, ["hermes-telegram"], "")
         assert sig1 != sig2
 
     def test_provider_change_different_signature(self):


### PR DESCRIPTION
## Summary
- Fixes gateway agent cache-key generation to fingerprint the full runtime auth token instead of using the first 8 characters
- Prevents false cache hits when switching OAuth accounts/tokens that share a common JWT-style prefix (for example eyJhbGci...)
- Adds a regression test proving same-prefix, different-token credentials produce different cache signatures

## Root cause
GatewayRunner._agent_config_signature previously used only the first 8 characters of runtime["api_key"].
For JWT-like bearer tokens, those prefixes are often identical across different accounts/sessions, so cache signatures could collide and incorrectly reuse a stale AIAgent after auth switch.

## Changes
- gateway/run.py
  - Compute sha256(full_api_key) and include that fingerprint in the signature payload
  - Keep full secrets out of the cache key while eliminating prefix collisions
- tests/gateway/test_agent_cache.py
  - Add test_same_token_prefix_different_full_token_changes_signature

## Validation
- python -m pytest tests/gateway/test_agent_cache.py -q
- Result: 13 passed

## Notes
This fix applies to OAuth-backed bearer tokens as well as API-key style auth, because both flow through runtime["api_key"] for request execution.
