### PR TITLE
fix(session-search): MiniMax OpenAI endpoint + FTS fallback

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -56,7 +56,7 @@ logger = logging.getLogger(__name__)
 _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "zai": "glm-4.5-flash",
     "kimi-coding": "kimi-k2-turbo-preview",
-    "minimax": "MiniMax-M2.7-highspeed",
+    "minimax": "MiniMax-M2.7",
     "minimax-cn": "MiniMax-M2.7-highspeed",
     "anthropic": "claude-haiku-4-5-20251001",
     "ai-gateway": "google/gemini-3-flash",

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -377,23 +377,32 @@ def session_search(
             }, ensure_ascii=False)
 
         summaries = []
-        for (session_id, match_info, _, _), result in zip(tasks, results):
-            if isinstance(result, Exception):
-                logging.warning(
-                    "Failed to summarize session %s: %s",
-                    session_id,
-                    result,
-                    exc_info=True,
-                )
-                continue
-            if result:
+        for (session_id, match_info, conversation_text, session_meta), result in zip(tasks, results):
+            # Fallback: if summarization failed, use the raw FTS snippet + truncated conversation
+            if result is None or isinstance(result, Exception):
+                fallback = match_info.get("snippet", conversation_text[:500])
+                summary = fallback
+                if isinstance(result, Exception):
+                    logging.warning(
+                        "Session %s summarization failed, using FTS snippet: %s",
+                        session_id,
+                        result,
+                    )
                 summaries.append({
                     "session_id": session_id,
                     "when": _format_timestamp(match_info.get("session_started")),
                     "source": match_info.get("source", "unknown"),
                     "model": match_info.get("model"),
-                    "summary": result,
+                    "summary": f"[Summary unavailable — raw FTS match]\n{summary}",
                 })
+                continue
+            summaries.append({
+                "session_id": session_id,
+                "when": _format_timestamp(match_info.get("session_started")),
+                "source": match_info.get("source", "unknown"),
+                "model": match_info.get("model"),
+                "summary": result,
+            })
 
         return json.dumps({
             "success": True,


### PR DESCRIPTION
## Problem

1. **MiniMax global default model mismatch**: agent/auxiliary_client.py defaulted minimax aux model to MiniMax-M2.7-highspeed, but standard plans only have MiniMax-M2.7. This caused 500 errors on every aux call.

2. **Silent empty results on summarization failure**: tools/session_search_tool.py dropped search results entirely when LLM summarization failed (no API key, credits, network error), returning empty results instead of a useful fallback.

## Fix

| File | Change |
|------|--------|
| agent/auxiliary_client.py | minimax default aux model: MiniMax-M2.7-highspeed → MiniMax-M2.7 |
| tools/session_search_tool.py | On summarization failure → return raw FTS snippets instead of dropping results |

## Verification

Tested with session_search(query=hermes update stash) — MiniMax-M2.7 successfully summarizes matching sessions. Fallback FTS path confirmed working when summarization is unavailable.

## Not in latest release

Confirmed: v2026.3.23 (latest tag) still has both issues.
- Default aux model still MiniMax-M2.7-highspeed (confirmed)
- session_search_tool.py still drops results on exception (confirmed)

---

*Note: This PR was drafted by a Hermes agent running on MiniMax-M2.7.*