### PR TITLE
fix(session-search): correct MiniMax model + add FTS fallback

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -56,7 +56,7 @@ logger = logging.getLogger(__name__)
 _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "zai": "glm-4.5-flash",
     "kimi-coding": "kimi-k2-turbo-preview",
-    "minimax": "MiniMax-M2.7-highspeed",
+    "minimax": "MiniMax-M2.7",
     "minimax-cn": "MiniMax-M2.7-highspeed",
     "anthropic": "claude-haiku-4-5-20251001",
     "ai-gateway": "google/gemini-3-flash",

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -377,23 +377,32 @@ def session_search(
             }, ensure_ascii=False)
 
         summaries = []
-        for (session_id, match_info, _, _), result in zip(tasks, results):
-            if isinstance(result, Exception):
-                logging.warning(
-                    "Failed to summarize session %s: %s",
-                    session_id,
-                    result,
-                    exc_info=True,
-                )
-                continue
-            if result:
+        for (session_id, match_info, conversation_text, session_meta), result in zip(tasks, results):
+            # Fallback: if summarization failed, use the raw FTS snippet + truncated conversation
+            if result is None or isinstance(result, Exception):
+                fallback = match_info.get("snippet", conversation_text[:500])
+                summary = fallback
+                if isinstance(result, Exception):
+                    logging.warning(
+                        "Session %s summarization failed, using FTS snippet: %s",
+                        session_id,
+                        result,
+                    )
                 summaries.append({
                     "session_id": session_id,
                     "when": _format_timestamp(match_info.get("session_started")),
                     "source": match_info.get("source", "unknown"),
                     "model": match_info.get("model"),
-                    "summary": result,
+                    "summary": f"[Summary unavailable — raw FTS match]\n{summary}",
                 })
+                continue
+            summaries.append({
+                "session_id": session_id,
+                "when": _format_timestamp(match_info.get("session_started")),
+                "source": match_info.get("source", "unknown"),
+                "model": match_info.get("model"),
+                "summary": result,
+            })
 
         return json.dumps({
             "success": True,


### PR DESCRIPTION
## Summary

Two session_search fixes:

1. `MiniMax-M2.7` is the only MiniMax model on standard plans — aux calls were failing with 500 since the default was `M2.7-highspeed`
2. Search now returns FTS snippets when summarization is unavailable instead of empty results

## Changes

- `agent/auxiliary_client.py`: minimax aux default: `MiniMax-M2.7-highspeed` → `MiniMax-M2.7`
- `tools/session_search_tool.py`: fallback to raw FTS on summarization failure

Tested locally. Not present in `v2026.3.23`.

---

*Generated by Hermes (MiniMax-M2.7) — NOTE FROM MEATBAG: I'm really trying to be helpful, if this is slop I'm sorry. *
