### PR TITLE
fix: add logging and replace print() calls in gateway/hooks.py

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -23,10 +23,12 @@ import asyncio
 import importlib.util
 from typing import Any, Callable, Dict, List, Optional
 
+import logging
 import yaml
 
 from hermes_cli.config import get_hermes_home
 
+logger = logging.getLogger(__name__)
 
 HOOKS_DIR = get_hermes_home() / "hooks"
 
@@ -75,13 +77,13 @@ class HookRegistry:
             try:
                 manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
                 if not manifest or not isinstance(manifest, dict):
-                    print(f"[hooks] Skipping {hook_dir.name}: invalid HOOK.yaml", flush=True)
+                    logger.warning("[hooks] Skipping %s: invalid HOOK.yaml", hook_dir.name)
                     continue
 
                 hook_name = manifest.get("name", hook_dir.name)
                 events = manifest.get("events", [])
                 if not events:
-                    print(f"[hooks] Skipping {hook_name}: no events declared", flush=True)
+                    logger.warning("[hooks] Skipping %s: no events declared", hook_name)
                     continue
 
                 # Dynamically load the handler module
@@ -89,7 +91,7 @@ class HookRegistry:
                     f"hermes_hook_{hook_name}", handler_path
                 )
                 if spec is None or spec.loader is None:
-                    print(f"[hooks] Skipping {hook_name}: could not load handler.py", flush=True)
+                    logger.warning("[hooks] Skipping %s: could not load handler.py", hook_name)
                     continue
 
                 module = importlib.util.module_from_spec(spec)
@@ -97,7 +99,7 @@ class HookRegistry:
 
                 handle_fn = getattr(module, "handle", None)
                 if handle_fn is None:
-                    print(f"[hooks] Skipping {hook_name}: no 'handle' function found", flush=True)
+                    logger.warning("[hooks] Skipping %s: no 'handle' function found", hook_name)
                     continue
 
                 # Register the handler for each declared event
@@ -111,10 +113,10 @@ class HookRegistry:
                     "path": str(hook_dir),
                 })
 
-                print(f"[hooks] Loaded hook '{hook_name}' for events: {events}", flush=True)
+                logger.info("[hooks] Loaded hook '%s' for events: %s", hook_name, events)
 
             except Exception as e:
-                print(f"[hooks] Error loading hook {hook_dir.name}: {e}", flush=True)
+                logger.error("[hooks] Error loading hook %s: %s", hook_dir.name, e)
 
     async def emit(self, event_type: str, context: Optional[Dict[str, Any]] = None) -> None:
         """
@@ -148,4 +150,4 @@ class HookRegistry:
                 if asyncio.iscoroutine(result):
                     await result
             except Exception as e:
-                print(f"[hooks] Error in handler for '{event_type}': {e}", flush=True)
+                logger.error("[hooks] Error in handler for '%s': %s", event_type, e)


### PR DESCRIPTION
gateway/hooks.py had no logging setup and used bare print() calls throughout the hook loading and event dispatch code.

- Add `import logging` and module-level `logger = logging.getLogger(__name__)`
- Replace all 7 print() calls with appropriate logger.info(), logger.warning(), and logger.error() calls

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

