### PR TITLE
fix: replace f-string formatting in logger calls

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -203,7 +203,7 @@ class GitHubAuth:
             if resp.status_code == 201:
                 return resp.json().get("token")
         except Exception as e:
-            logger.debug(f"GitHub App auth failed: {e}")
+            logger.debug("GitHub App auth failed: %s", e)
 
         return None
 
@@ -284,7 +284,7 @@ class GitHubSource(SkillSource):
                     if query_lower in searchable:
                         results.append(skill)
             except Exception as e:
-                logger.debug(f"Failed to search {tap['repo']}: {e}")
+                logger.debug("Failed to search %s: %s", tap['repo'], e)
                 continue
 
         # Deduplicate by name, preferring higher trust levels
@@ -2598,7 +2598,7 @@ def unified_search(query: str, sources: List[SkillSource],
             results = src.search(query, limit=limit)
             all_results.extend(results)
         except Exception as e:
-            logger.debug(f"Search failed for {src.source_id()}: {e}")
+            logger.debug("Search failed for %s: %s", src.source_id(), e)
 
     # Deduplicate by name, preferring higher trust levels
     _TRUST_RANK = {"builtin": 2, "trusted": 1, "community": 0}


### PR DESCRIPTION
Using f-strings in logger calls is a Python logging anti-pattern.
When the log level is disabled, f-strings are still evaluated eagerly,
wasting CPU. The correct pattern is to pass format args separately so
the logging framework skips formatting when the level is inactive.

Changed 19 occurrences across 4 files:
- environments/tool_call_parsers/deepseek_v3_parser.py (1)
- environments/web_research_env.py (5)
- tools/environments/docker.py (10)
- tools/skills_hub.py (3)