### PR TITLE
fix(whatsapp): add **kwargs to media sending to prevent metadata error

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -525,6 +525,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
         image_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        **kwargs
     ) -> SendResult:
         """Send a local image file natively via bridge."""
         return await self._send_media_to_bridge(chat_id, image_path, "image", caption)


### PR DESCRIPTION
## What does this PR do?

This PR fixes a `TypeError` in the WhatsApp platform gateway. When using tools that generate media (such as `matplotlib` for charts or image generation tools) which pass additional `metadata` to the media sending function, the `WhatsAppAdapter.send_image_file` method crashes because it doesn't accept extra keyword arguments. 

By adding `**kwargs` to the method signature, we ensure the adapter safely handles (and ignores) any supplementary metadata or future parameters passed by the orchestrator, making the WhatsApp integration more robust and consistent with other platforms like Telegram.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **File:** `gateway/platforms/whatsapp.py`
- **Change:** Added `**kwargs` to the `send_image_file` method signature to handle unexpected keyword arguments (specifically `metadata`) passed during tool execution.

## How to Test

1. Use a tool that generates an image (e.g., asking the agent to "create a price trend chart using matplotlib").
2. Attempt to send the resulting image via the WhatsApp adapter.
3. **Observation (Before Fix):** The logs show `[Whatsapp] Error sending media: WhatsAppAdapter.send_image_file() got an unexpected keyword argument 'metadata'`.
4. **Observation (After Fix):** The image is sent successfully to the WhatsApp chat without any errors in the PM2 logs.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(whatsapp): allow extra keyword arguments in media sending`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [x] I've tested on my platform: macOS 15.x (Apple Silicon / Mac Mini)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — or N/A
- [x] I've considered cross-platform impact — or N/A
- [x] I've updated tool descriptions/schemas — or N/A

## Screenshots / Logs

```text
18|bot-kel | [Whatsapp] Error sending media: WhatsAppAdapter.send_image_file() got an unexpected keyword argument 'metadata'
18|bot-kel |   [tool] (¬‿¬) brainstorming...
```
(The fix allows the adapter to swallow the `metadata` argument, resolving the crash.)