### PR TITLE
fix(cli): handle EOFError in update stash-restore prompts

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2539,7 +2539,10 @@ def _restore_stashed_changes(
         print("  Restoring them may reapply local customizations onto the updated codebase.")
         print("  Review the result afterward if Hermes behaves unexpectedly.")
         print("Restore local changes now? [Y/n]")
-        response = input().strip().lower()
+        try:
+            response = input().strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            response = "n"
         if response not in ("", "y", "yes"):
             print("Skipped restoring local changes.")
             print("Your changes are still preserved in git stash.")
@@ -2586,7 +2589,10 @@ def _restore_stashed_changes(
             print("\nReset working tree to clean state so Hermes can run?")
             print("  (You can re-apply your changes later with: git stash apply)")
             print("[Y/n] ", end="", flush=True)
-            response = input().strip().lower()
+            try:
+                response = input().strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                response = "n"
             if response not in ("", "y", "yes"):
                 do_reset = False
 

--- a/tests/hermes_cli/test_stash_restore_eof.py
+++ b/tests/hermes_cli/test_stash_restore_eof.py
@@ -1,0 +1,39 @@
+"""Tests for EOFError handling in _restore_stashed_changes prompts.
+
+When ``hermes update`` runs in a non-TTY environment (CI, systemd, piped
+stdin), ``input()`` raises ``EOFError``.  The prompts inside
+``_restore_stashed_changes`` must catch this and default to skipping the
+restore rather than crashing.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+import pytest
+
+from hermes_cli.main import _restore_stashed_changes
+
+
+class TestRestoreStashEOFError:
+    """hermes_cli/main.py — _restore_stashed_changes()"""
+
+    @patch("builtins.input", side_effect=EOFError)
+    def test_eof_on_restore_prompt_skips_restore(self, _input):
+        """EOFError on 'Restore local changes?' defaults to skip."""
+        result = _restore_stashed_changes(
+            git_cmd=["git"],
+            cwd=Path("/tmp"),
+            stash_ref="stash@{0}",
+            prompt_user=True,
+        )
+        assert result is False
+
+    @patch("builtins.input", side_effect=KeyboardInterrupt)
+    def test_keyboard_interrupt_on_restore_prompt_skips(self, _input):
+        """KeyboardInterrupt on 'Restore local changes?' defaults to skip."""
+        result = _restore_stashed_changes(
+            git_cmd=["git"],
+            cwd=Path("/tmp"),
+            stash_ref="stash@{0}",
+            prompt_user=True,
+        )
+        assert result is False


### PR DESCRIPTION
## Summary

`hermes update` crashes with `EOFError` when run in non-TTY environments (CI, systemd, piped stdin).

## Root Cause

`_restore_stashed_changes()` in `hermes_cli/main.py` has two bare `input()` calls (lines 2542 and 2589) that prompt for stash restore and working tree reset. Neither is wrapped in exception handlers. The post-update config migration prompt at line 2817 already has an `isatty()` guard — these two were missed.

## Fix

Wrapped both prompts in `try/except (EOFError, KeyboardInterrupt)` defaulting to skip. Stashed changes stay safe — user can restore manually with `git stash apply`.

## Tests

2 new tests: EOFError defaults to skip, KeyboardInterrupt defaults to skip.

```
2 passed
```