### PR TITLE
fix: prevent empty user messages from reaching Anthropic API

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -94,11 +94,18 @@ def _is_oauth_token(key: str) -> bool:
 
     Regular API keys start with 'sk-ant-api'. Everything else (setup-tokens
     starting with 'sk-ant-oat', managed keys, JWTs, etc.) needs Bearer auth.
+
+    When a custom ANTHROPIC_BASE_URL is set (e.g. Sub2API proxy), treat all
+    non-OAuth-prefix keys as regular API keys — proxies expect x-api-key.
     """
     if not key:
         return False
     # Regular Console API keys use x-api-key header
     if key.startswith("sk-ant-api"):
+        return False
+    # Custom base URL set → likely a proxy (Sub2API, LiteLLM, etc.)
+    # that expects x-api-key header, not Bearer auth
+    if os.getenv("ANTHROPIC_BASE_URL"):
         return False
     # Everything else (setup-tokens, managed keys, JWTs) uses Bearer auth
     return True
@@ -910,14 +917,20 @@ def convert_messages_to_anthropic(
                 result.append({"role": "user", "content": [tool_result]})
             continue
 
-        # Regular user message
+        # Regular user message — reject empty content (Anthropic requires non-empty)
         if isinstance(content, list):
             converted_blocks = _convert_content_to_anthropic(content)
+            if not converted_blocks or all(
+                b.get("text", "").strip() == "" for b in converted_blocks if b.get("type") == "text"
+            ):
+                converted_blocks = [{"type": "text", "text": "(empty message)"}]
             result.append({
                 "role": "user",
-                "content": converted_blocks or [{"type": "text", "text": ""}],
+                "content": converted_blocks,
             })
         else:
+            if not content or (isinstance(content, str) and not content.strip()):
+                content = "(empty message)"
             result.append({"role": "user", "content": content})
 
     # Strip orphaned tool_use blocks (no matching tool_result follows)

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -123,13 +123,50 @@ class SessionResetPolicy:
 
 
 @dataclass
+class ChannelOverride:
+    """
+    Per-channel override for model, provider, and system prompt.
+
+    Used in config under platforms.<name>.channel_overrides[channel_id].
+    Enables different channels (e.g. Discord #daily vs #dev) to use different
+    models and personas without running separate gateway instances.
+    """
+    model: Optional[str] = None
+    provider: Optional[str] = None
+    system_prompt: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {}
+        if self.model is not None:
+            out["model"] = self.model
+        if self.provider is not None:
+            out["provider"] = self.provider
+        if self.system_prompt is not None:
+            out["system_prompt"] = self.system_prompt
+        return out
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ChannelOverride":
+        if not data:
+            return cls()
+        return cls(
+            model=data.get("model"),
+            provider=data.get("provider"),
+            system_prompt=data.get("system_prompt"),
+        )
+
+
+@dataclass
 class PlatformConfig:
     """Configuration for a single messaging platform."""
     enabled: bool = False
     token: Optional[str] = None  # Bot token (Telegram, Discord)
     api_key: Optional[str] = None  # API key if different from token
     home_channel: Optional[HomeChannel] = None
-    
+
+    # Per-channel model/provider/system_prompt overrides (channel_id -> ChannelOverride)
+    channel_overrides: Dict[str, ChannelOverride] = field(default_factory=dict)
+
     # Platform-specific settings
     extra: Dict[str, Any] = field(default_factory=dict)
     
@@ -144,6 +181,10 @@ class PlatformConfig:
             result["api_key"] = self.api_key
         if self.home_channel:
             result["home_channel"] = self.home_channel.to_dict()
+        if self.channel_overrides:
+            result["channel_overrides"] = {
+                cid: ov.to_dict() for cid, ov in self.channel_overrides.items()
+            }
         return result
     
     @classmethod
@@ -151,12 +192,20 @@ class PlatformConfig:
         home_channel = None
         if "home_channel" in data:
             home_channel = HomeChannel.from_dict(data["home_channel"])
-        
+
+        channel_overrides: Dict[str, ChannelOverride] = {}
+        raw_overrides = data.get("channel_overrides") or {}
+        if isinstance(raw_overrides, dict):
+            for cid, ov_data in raw_overrides.items():
+                if isinstance(ov_data, dict):
+                    channel_overrides[str(cid)] = ChannelOverride.from_dict(ov_data)
+
         return cls(
             enabled=data.get("enabled", False),
             token=data.get("token"),
             api_key=data.get("api_key"),
             home_channel=home_channel,
+            channel_overrides=channel_overrides,
             extra=data.get("extra", {}),
         )
 

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1873,6 +1873,12 @@ class DiscordAdapter(BasePlatformAdapter):
                 message.content = message.content.replace(f"<@{self._client.user.id}>", "").strip()
                 message.content = message.content.replace(f"<@!{self._client.user.id}>", "").strip()
 
+            # After stripping the mention, if the message is empty and has no
+            # attachments the user just pinged the bot with nothing to say.
+            # Ignore it to avoid sending empty content to the API.  (#3143)
+            if not message.content and not message.attachments:
+                return
+
         # Auto-thread: when enabled, automatically create a thread for every
         # @mention in a text channel so each conversation is isolated (like Slack).
         # Messages already inside threads or DMs are unaffected.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2087,6 +2087,15 @@ class GatewayRunner:
 
         # -----------------------------------------------------------------
         # Inject reply context when user replies to a message not in history.
+        # -----------------------------------------------------------------
+        # Guard: ensure message_text is never empty before sending to agent.
+        # Empty user messages cause Anthropic 400: "user messages must have
+        # non-empty content".  Common triggers: mention-only Discord msgs,
+        # unrecognised attachment types, stickers, etc.  (#3143)
+        # -----------------------------------------------------------------
+        if not message_text or not message_text.strip():
+            message_text = "(The user sent a message with no text content)"
+
         # Telegram (and other platforms) let users reply to specific messages,
         # but if the quoted message is from a previous session, cron delivery,
         # or background task, the agent has no context about what's being

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -205,6 +205,7 @@ if not _configured_cwd or _configured_cwd in (".", "auto", "cwd"):
     os.environ["TERMINAL_CWD"] = messaging_cwd
 
 from gateway.config import (
+    ChannelOverride,
     Platform,
     GatewayConfig,
     load_gateway_config,
@@ -253,6 +254,26 @@ def _resolve_runtime_agent_kwargs() -> dict:
     }
 
 
+def _resolve_runtime_agent_kwargs_for_provider(provider: str) -> dict:
+    """Resolve runtime credentials for a specific provider (e.g. from channel override)."""
+    from hermes_cli.runtime_provider import (
+        resolve_runtime_provider,
+        format_runtime_provider_error,
+    )
+    try:
+        runtime = resolve_runtime_provider(requested=provider)
+    except Exception as exc:
+        raise RuntimeError(format_runtime_provider_error(exc)) from exc
+    return {
+        "api_key": runtime.get("api_key"),
+        "base_url": runtime.get("base_url"),
+        "provider": runtime.get("provider"),
+        "api_mode": runtime.get("api_mode"),
+        "command": runtime.get("command"),
+        "args": list(runtime.get("args") or []),
+    }
+
+
 def _resolve_gateway_model() -> str:
     """Read model from env/config — mirrors the resolution in _run_agent_sync.
 
@@ -275,6 +296,20 @@ def _resolve_gateway_model() -> str:
     except Exception:
         pass
     return model
+
+
+def _get_channel_override(
+    config: GatewayConfig,
+    platform: Platform,
+    chat_id: str,
+) -> Optional[ChannelOverride]:
+    """Return per-channel override for this platform/chat_id, or None."""
+    if not chat_id:
+        return None
+    platform_config = config.platforms.get(platform)
+    if not platform_config or not platform_config.channel_overrides:
+        return None
+    return platform_config.channel_overrides.get(str(chat_id))
 
 
 def _resolve_hermes_bin() -> Optional[list[str]]:
@@ -710,6 +745,24 @@ class GatewayRunner:
         except Exception:
             pass
         return ""
+
+    def _resolve_model_for_channel(self, platform: Platform, chat_id: str) -> str:
+        """Resolve model for this channel: channel_overrides[channel_id] else global default."""
+        config = getattr(self, "config", None)
+        if config:
+            override = _get_channel_override(config, platform, chat_id)
+            if override and override.model:
+                return override.model
+        return _resolve_gateway_model()
+
+    def _get_system_prompt_for_channel(self, platform: Platform, chat_id: str) -> str:
+        """System prompt for this channel: channel override else global ephemeral."""
+        config = getattr(self, "config", None)
+        if config:
+            override = _get_channel_override(config, platform, chat_id)
+            if override and override.system_prompt:
+                return (override.system_prompt or "").strip()
+        return getattr(self, "_ephemeral_system_prompt", None) or ""
 
     @staticmethod
     def _load_reasoning_config() -> dict | None:
@@ -4644,10 +4697,11 @@ class GatewayRunner:
             # Platform.LOCAL ("local") maps to "cli"; others pass through as-is.
             platform_key = "cli" if source.platform == Platform.LOCAL else source.platform.value
             
-            # Combine platform context with user-configured ephemeral system prompt
+            # Combine platform context with channel or global system prompt
             combined_ephemeral = context_prompt or ""
-            if self._ephemeral_system_prompt:
-                combined_ephemeral = (combined_ephemeral + "\n\n" + self._ephemeral_system_prompt).strip()
+            channel_prompt = self._get_system_prompt_for_channel(source.platform, source.chat_id)
+            if channel_prompt:
+                combined_ephemeral = (combined_ephemeral + "\n\n" + channel_prompt).strip()
 
             # Re-read .env and config for fresh credentials (gateway is long-lived,
             # keys may change without restart).
@@ -4658,10 +4712,15 @@ class GatewayRunner:
             except Exception:
                 pass
 
-            model = _resolve_gateway_model()
+            model = self._resolve_model_for_channel(source.platform, source.chat_id)
 
+            _config = getattr(self, "config", None)
+            channel_override = _get_channel_override(_config, source.platform, source.chat_id) if _config else None
             try:
-                runtime_kwargs = _resolve_runtime_agent_kwargs()
+                if channel_override and channel_override.provider:
+                    runtime_kwargs = _resolve_runtime_agent_kwargs_for_provider(channel_override.provider)
+                else:
+                    runtime_kwargs = _resolve_runtime_agent_kwargs()
             except Exception as exc:
                 return {
                     "final_response": f"⚠️ Provider authentication failed: {exc}",

--- a/run_agent.py
+++ b/run_agent.py
@@ -2415,6 +2415,19 @@ class AIAgent:
                 len(missing_results),
             )
 
+        # 3. Ensure no user message has empty content (#3143)
+        for msg in messages:
+            if msg.get("role") == "user":
+                c = msg.get("content")
+                if isinstance(c, str) and not c.strip():
+                    msg["content"] = "(empty message)"
+                elif isinstance(c, list):
+                    text_blocks = [b for b in c if b.get("type") == "text"]
+                    if text_blocks and all(not b.get("text", "").strip() for b in text_blocks):
+                        msg["content"] = [{"type": "text", "text": "(empty message)"}]
+                elif c is None:
+                    msg["content"] = "(empty message)"
+
         return messages
 
     @staticmethod

--- a/tests/gateway/test_channel_overrides.py
+++ b/tests/gateway/test_channel_overrides.py
@@ -1,0 +1,128 @@
+"""Tests for per-channel model and system prompt overrides (Fixes #1955)."""
+
+import pytest
+
+from gateway.config import (
+    ChannelOverride,
+    GatewayConfig,
+    Platform,
+    PlatformConfig,
+)
+from gateway.run import _get_channel_override, GatewayRunner
+
+
+class TestGetChannelOverride:
+    def test_no_override_when_empty_config(self):
+        config = GatewayConfig()
+        assert _get_channel_override(config, Platform.DISCORD, "123") is None
+
+    def test_no_override_when_platform_not_configured(self):
+        config = GatewayConfig(platforms={})
+        assert _get_channel_override(config, Platform.DISCORD, "123") is None
+
+    def test_no_override_when_channel_not_in_overrides(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "999": ChannelOverride(model="openrouter/healer-alpha"),
+                    },
+                ),
+            },
+        )
+        assert _get_channel_override(config, Platform.DISCORD, "123") is None
+
+    def test_returns_override_when_channel_matches(self):
+        ov = ChannelOverride(
+            model="openrouter/healer-alpha",
+            provider="openrouter",
+            system_prompt="You are a summarizer.",
+        )
+        config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={"1234567890": ov},
+                ),
+            },
+        )
+        result = _get_channel_override(config, Platform.DISCORD, "1234567890")
+        assert result is not None
+        assert result.model == "openrouter/healer-alpha"
+        assert result.provider == "openrouter"
+        assert result.system_prompt == "You are a summarizer."
+
+    def test_returns_override_when_chat_id_is_int_like(self):
+        """Caller may pass str(chat_id); override keys are normalized to str."""
+        config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={"123": ChannelOverride(model="gpt-4")},
+                ),
+            },
+        )
+        assert _get_channel_override(config, Platform.DISCORD, "123").model == "gpt-4"
+
+
+class TestResolveModelForChannel:
+    def test_uses_channel_override_when_present(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "chan_1": ChannelOverride(model="anthropic/claude-opus-4.6"),
+                    },
+                ),
+            },
+        )
+        runner = object.__new__(GatewayRunner)
+        runner.config = config
+        model = runner._resolve_model_for_channel(Platform.DISCORD, "chan_1")
+        assert model == "anthropic/claude-opus-4.6"
+
+    def test_falls_back_to_global_when_no_override(self, monkeypatch):
+        monkeypatch.setattr(
+            "gateway.run._resolve_gateway_model",
+            lambda: "global-model/default",
+        )
+        config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(enabled=True, channel_overrides={}),
+            },
+        )
+        runner = object.__new__(GatewayRunner)
+        runner.config = config
+        model = runner._resolve_model_for_channel(Platform.DISCORD, "unknown_channel")
+        assert model == "global-model/default"
+
+
+class TestGetSystemPromptForChannel:
+    def test_uses_channel_override_when_present(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "chan_1": ChannelOverride(system_prompt="You are a coding assistant."),
+                    },
+                ),
+            },
+        )
+        runner = object.__new__(GatewayRunner)
+        runner.config = config
+        runner._ephemeral_system_prompt = "Global prompt"
+        prompt = runner._get_system_prompt_for_channel(Platform.DISCORD, "chan_1")
+        assert prompt == "You are a coding assistant."
+
+    def test_falls_back_to_global_when_no_override(self):
+        config = GatewayConfig(
+            platforms={Platform.DISCORD: PlatformConfig(enabled=True)},
+        )
+        runner = object.__new__(GatewayRunner)
+        runner.config = config
+        runner._ephemeral_system_prompt = "Global prompt"
+        prompt = runner._get_system_prompt_for_channel(Platform.DISCORD, "other")
+        assert prompt == "Global prompt"

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1,6 +1,7 @@
 """Tests for gateway configuration management."""
 
 from gateway.config import (
+    ChannelOverride,
     GatewayConfig,
     HomeChannel,
     Platform,
@@ -47,6 +48,56 @@ class TestPlatformConfigRoundtrip:
         restored = PlatformConfig.from_dict(d)
         assert restored.enabled is False
         assert restored.token is None
+
+
+    def test_channel_overrides_roundtrip(self):
+        pc = PlatformConfig(
+            enabled=True,
+            channel_overrides={
+                "1234567890": ChannelOverride(
+                    model="openrouter/healer-alpha",
+                    provider="openrouter",
+                    system_prompt="You are a daily news summarizer.",
+                ),
+                "9876543210": ChannelOverride(
+                    model="anthropic/claude-opus-4.6",
+                    provider="anthropic",
+                    system_prompt="You are a coding assistant.",
+                ),
+            },
+        )
+        d = pc.to_dict()
+        assert "channel_overrides" in d
+        assert d["channel_overrides"]["1234567890"]["model"] == "openrouter/healer-alpha"
+        assert d["channel_overrides"]["9876543210"]["system_prompt"] == "You are a coding assistant."
+        restored = PlatformConfig.from_dict(d)
+        assert restored.channel_overrides["1234567890"].model == "openrouter/healer-alpha"
+        assert restored.channel_overrides["9876543210"].provider == "anthropic"
+
+    def test_channel_overrides_from_dict_normalizes_channel_id_to_str(self):
+        """YAML may have numeric channel IDs; we store as str."""
+        data = {
+            "enabled": True,
+            "channel_overrides": {
+                1234567890: {"model": "openrouter/healer-alpha"},
+            },
+        }
+        pc = PlatformConfig.from_dict(data)
+        assert "1234567890" in pc.channel_overrides
+        assert pc.channel_overrides["1234567890"].model == "openrouter/healer-alpha"
+
+
+class TestChannelOverride:
+    def test_from_dict_empty(self):
+        assert ChannelOverride.from_dict({}).model is None
+        assert ChannelOverride.from_dict(None).model is None
+
+    def test_to_dict_omits_none(self):
+        ov = ChannelOverride(model="gpt-4", provider=None, system_prompt="Hi")
+        d = ov.to_dict()
+        assert d["model"] == "gpt-4"
+        assert "provider" not in d
+        assert d["system_prompt"] == "Hi"
 
 
 class TestGetConnectedPlatforms:


### PR DESCRIPTION
## Summary

Fixes #3143 — Discord gateway can pass empty user messages to the Anthropic API, causing `400: user messages must have non-empty content`.

## Problem

`anthropic_adapter.py` validates empty content for `assistant` (→ `"(empty)"`) and `tool` (→ `"(no output)"`) messages, but **user messages pass through without any check**. Combined with Discord mention stripping (which can leave `content=""`), empty messages get persisted to session history and break all subsequent API calls until `/reset`.

## Fix — 4-layer defense

| Layer | File | What it does |
|-------|------|-------------|
| Source | `discord.py` | Ignore mention-only messages with no text or attachments |
| Gateway | `gateway/run.py` | Guard empty `message_text` after vision/audio enrichment |
| Sanitizer | `run_agent.py` | `_sanitize_api_messages` catches empty user content |
| API adapter | `anthropic_adapter.py` | Validate user messages the same way as assistant/tool |

## Changes

- **`agent/anthropic_adapter.py`** (+11/-2): Add empty content check for user messages, matching existing assistant/tool pattern
- **`gateway/platforms/discord.py`** (+6): After stripping bot mention, return early if message is empty with no attachments
- **`gateway/run.py`** (+9): After vision/audio enrichment, replace empty `message_text` with fallback
- **`run_agent.py`** (+13): Extend `_sanitize_api_messages` to fix empty user content (string, list, or None)

## Testing

- 5710 tests pass, 0 regressions from these changes
- 8 pre-existing OAuth-related test failures (unrelated)