### PR TITLE
fix(security): add SSRF protection to gateway media downloads

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -27,6 +27,11 @@ from gateway.config import Platform, PlatformConfig
 from gateway.session import SessionSource, build_session_key
 from hermes_cli.config import get_hermes_home
 
+try:
+    from tools.url_safety import is_safe_url as _is_safe_url
+except Exception:
+    _is_safe_url = lambda url: False  # noqa: E731 — fail-closed
+
 
 GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE = (
     "Secure secret entry is not supported over messaging. "
@@ -83,7 +88,13 @@ async def cache_image_from_url(url: str, ext: str = ".jpg") -> str:
 
     Returns:
         Absolute path to the cached image file as a string.
+
+    Raises:
+        ValueError: If the URL targets a private/internal address (SSRF).
     """
+    if not _is_safe_url(url):
+        raise ValueError(f"Blocked download from private/internal address: {url}")
+
     import httpx
 
     async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
@@ -163,7 +174,13 @@ async def cache_audio_from_url(url: str, ext: str = ".ogg") -> str:
 
     Returns:
         Absolute path to the cached audio file as a string.
+
+    Raises:
+        ValueError: If the URL targets a private/internal address (SSRF).
     """
+    if not _is_safe_url(url):
+        raise ValueError(f"Blocked download from private/internal address: {url}")
+
     import httpx
 
     async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:

--- a/tests/gateway/test_media_ssrf_guard.py
+++ b/tests/gateway/test_media_ssrf_guard.py
@@ -1,0 +1,81 @@
+"""Tests for SSRF protection in gateway media download functions.
+
+Verifies that cache_image_from_url and cache_audio_from_url block
+requests to private/internal addresses before making any HTTP call.
+"""
+
+import asyncio
+from unittest.mock import patch, AsyncMock
+import pytest
+
+from gateway.platforms.base import cache_image_from_url, cache_audio_from_url
+
+
+# ── Image download ────────────────────────────────────────────────────────
+
+def test_image_blocks_metadata_endpoint():
+    with pytest.raises(ValueError, match="private/internal"):
+        asyncio.run(cache_image_from_url("http://169.254.169.254/latest/meta-data/"))
+
+
+def test_image_blocks_localhost():
+    with pytest.raises(ValueError, match="private/internal"):
+        asyncio.run(cache_image_from_url("http://127.0.0.1:8080/secret.jpg"))
+
+
+def test_image_blocks_private_network():
+    with pytest.raises(ValueError, match="private/internal"):
+        asyncio.run(cache_image_from_url("http://192.168.1.1/admin/logo.png"))
+
+
+def test_image_blocks_link_local():
+    with pytest.raises(ValueError, match="private/internal"):
+        asyncio.run(cache_image_from_url("http://169.254.1.1/internal"))
+
+
+@patch("gateway.platforms.base._is_safe_url", return_value=True)
+def test_image_allows_public_url(_safe):
+    """Public URLs proceed to the HTTP call (mocked)."""
+    mock_response = AsyncMock()
+    mock_response.status_code = 200
+    mock_response.content = b"\x89PNG\r\n\x1a\n"
+    mock_response.raise_for_status = lambda: None
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = AsyncMock(return_value=mock_response)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = asyncio.run(cache_image_from_url("https://example.com/photo.jpg"))
+        assert result.endswith(".jpg")
+
+
+# ── Audio download ────────────────────────────────────────────────────────
+
+def test_audio_blocks_metadata_endpoint():
+    with pytest.raises(ValueError, match="private/internal"):
+        asyncio.run(cache_audio_from_url("http://169.254.169.254/latest/meta-data/"))
+
+
+def test_audio_blocks_localhost():
+    with pytest.raises(ValueError, match="private/internal"):
+        asyncio.run(cache_audio_from_url("http://127.0.0.1:9000/internal.ogg"))
+
+
+@patch("gateway.platforms.base._is_safe_url", return_value=True)
+def test_audio_allows_public_url(_safe):
+    """Public URLs proceed to the HTTP call (mocked)."""
+    mock_response = AsyncMock()
+    mock_response.status_code = 200
+    mock_response.content = b"OggS\x00\x02"
+    mock_response.raise_for_status = lambda: None
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = AsyncMock(return_value=mock_response)
+
+    with patch("httpx.AsyncClient", return_value=mock_client):
+        result = asyncio.run(cache_audio_from_url("https://example.com/voice.ogg"))
+        assert result.endswith(".ogg")


### PR DESCRIPTION
## Summary

`cache_image_from_url` and `cache_audio_from_url` in `gateway/platforms/base.py` have no SSRF protection. An attacker can send a message with an attachment URL pointing at `http://169.254.169.254/latest/meta-data/` and the gateway fetches it.

## Root Cause

Both functions use `httpx.AsyncClient(follow_redirects=True)` to fetch user-controlled URLs from platform attachments (Telegram photos, Discord attachments, Slack files, etc.) with no address validation. The `is_safe_url` check from `tools/url_safety` is already used in `browser_tool.py`, `web_tools.py`, and `vision_tools.py` — these two were missed.

## Fix

Added `is_safe_url` pre-flight check to both download functions with a fail-closed import guard (`lambda url: False` if the module is unavailable). Raises `ValueError` on private/internal addresses before any HTTP request.

## Tests

8 new tests: cloud metadata, localhost, private network, link-local (all blocked) + public URLs with mocked HTTP client (allowed).

```
8 passed
```