### PR TITLE
fix(acp): handle AuthMethod removal in agent-client-protocol 0.9.0

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -12,7 +12,6 @@ import acp
 from acp.schema import (
     AgentCapabilities,
     AuthenticateResponse,
-    AuthMethod,
     ClientCapabilities,
     EmbeddedResourceContentBlock,
     ForkSessionResponse,
@@ -33,6 +32,15 @@ from acp.schema import (
     TextContentBlock,
     Usage,
 )
+
+# AuthMethod was removed in agent-client-protocol 0.9.0 — use AuthMethodAgent instead
+try:
+    from acp.schema import AuthMethod
+except ImportError:
+    try:
+        from acp.schema import AuthMethodAgent as AuthMethod
+    except ImportError:
+        AuthMethod = None  # type: ignore
 
 from acp_adapter.auth import detect_provider, has_provider
 from acp_adapter.events import (
@@ -101,7 +109,7 @@ class HermesACPAgent(acp.Agent):
     ) -> InitializeResponse:
         provider = detect_provider()
         auth_methods = None
-        if provider:
+        if provider and AuthMethod is not None:
             auth_methods = [
                 AuthMethod(
                     id=provider,


### PR DESCRIPTION
Fixes #3150

## Problem
agent-client-protocol 0.9.0 removed AuthMethod from acp.schema. The newer API uses AuthMethodAgent, AuthMethodEnvVar, AuthMethodTerminal instead. Hermes pinned >=0.8.1,<1.0 in pyproject.toml, so 0.9.0 could be installed, causing ImportError on startup.

## Fix
Added compat import:
1. Try importing AuthMethod (works with 0.8.x)
2. Fall back to AuthMethodAgent as AuthMethod (works with 0.9.x)
3. If neither exists, set to None and guard the usage site

Also added `if provider and AuthMethod is not None` guard to prevent crash when neither import works.
