### PR TITLE
fix: store asyncio task references in SmsAdapter and WebhookAdapter

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -363,7 +363,10 @@ class WebhookAdapter(BasePlatformAdapter):
         )
 
         # Non-blocking — return 202 Accepted immediately
-        asyncio.create_task(self.handle_message(event))
+        task = asyncio.create_task(self.handle_message(event))
+        if hasattr(self, "_background_tasks"):
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
 
         return web.json_response(
             {


### PR DESCRIPTION
SmsAdapter and WebhookAdapter both call asyncio.create_task() without
storing the returned task reference. This is a known Python bug — tasks
not referenced elsewhere can be garbage collected mid-execution, silently
dropping messages.

BasePlatformAdapter already provides _background_tasks (a set) and the
correct add_done_callback pattern for task lifecycle management. This fix
applies the same pattern to both adapters.

- gateway/platforms/sms.py: store handle_message task in _background_tasks
- gateway/platforms/webhook.py: store handle_message task in _background_tasks