### PR TITLE
fix(doctor): catch OpenRouter 402/429 + validate model/provider config

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -239,6 +239,80 @@ def run_doctor(args):
     config_path = HERMES_HOME / 'config.yaml'
     if config_path.exists():
         check_ok("~/.hermes/config.yaml exists")
+
+        # Validate model.provider and model.default values
+        try:
+            import yaml as _yaml
+            cfg_text = config_path.read_text(encoding="utf-8")
+            cfg = _yaml.safe_load(cfg_text) or {}
+
+            model_section = cfg.get("model", {}) or {}
+            provider = (model_section.get("provider") or "").strip().lower()
+            default_model = (model_section.get("default") or "").strip()
+
+            # Build the known-provider list from auth.py PROVIDER_REGISTRY
+            try:
+                import sys as _sys
+                _sys.path.insert(0, str(PROJECT_ROOT))
+                from hermes_cli.auth import PROVIDER_REGISTRY
+                known_providers = list(PROVIDER_REGISTRY.keys())
+                # Also accept these well-known aliases
+                known_providers += ["auto", "openrouter", "custom"]
+            except Exception:
+                known_providers = [
+                    "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
+                    "zai", "kimi-coding", "minimax", "minimax-cn", "anthropic",
+                    "alibaba", "openai", "custom", "auto",
+                ]
+
+            if provider and provider not in known_providers:
+                check_fail(
+                    f"model.provider '{provider}' is not a recognised provider",
+                    f"(known: {', '.join(sorted(set(known_providers)))})",
+                )
+                issues.append(
+                    f"model.provider '{provider}' is unknown. "
+                    f"Valid providers: {', '.join(sorted(set(known_providers)))}. "
+                    f"Fix: run 'hermes config set model.provider <valid_provider>'"
+                )
+
+            # Warn if model is set to a provider-specific model without that provider
+            if default_model and "/" in default_model and provider not in ("openrouter", "custom", "auto"):
+                # Provider-specific model notation like "anthropic/claude-opus-4" — valid only for openrouter/custom
+                check_warn(
+                    f"model.default '{default_model}' uses a provider-prefixed model name "
+                    f"but provider is set to '{provider}'",
+                    "(provider-prefixed models only work with openrouter or custom providers)",
+                )
+                issues.append(
+                    f"model.default '{default_model}' is a provider-prefixed model "
+                    f"but model.provider is '{provider}'. "
+                    f"Either set model.provider to 'openrouter', or remove the prefix from model.default "
+                    f"(e.g. use 'claude-opus-4' instead of 'anthropic/claude-opus-4')"
+                )
+
+            # Warn if model is set but provider credentials are not configured
+            if default_model and provider:
+                try:
+                    from hermes_cli.auth import get_provider_credentials
+                    creds = get_provider_credentials(provider)
+                    has_key = creds and creds.get("api_key")
+                    has_url = creds and creds.get("base_url")
+                    if not has_key and not has_url:
+                        check_fail(
+                            f"model.provider '{provider}' is set but no API key or base_url is configured",
+                            "(check ~/.hermes/.env or your provider dashboard)",
+                        )
+                        issues.append(
+                            f"No credentials found for provider '{provider}'. "
+                            f"Set {provider.upper()}_API_KEY in ~/.hermes/.env, "
+                            f"or switch to a configured provider with 'hermes config set model.provider <name>'"
+                        )
+                except Exception:
+                    pass
+
+        except Exception as e:
+            check_warn("Could not validate model/provider config", f"({e})")
     else:
         fallback_config = PROJECT_ROOT / 'cli-config.yaml'
         if fallback_config.exists():
@@ -521,6 +595,16 @@ def run_doctor(args):
             elif response.status_code == 401:
                 print(f"\r  {color('✗', Colors.RED)} OpenRouter API {color('(invalid API key)', Colors.DIM)}                ")
                 issues.append("Check OPENROUTER_API_KEY in .env")
+            elif response.status_code == 402:
+                print(f"\r  {color('✗', Colors.RED)} OpenRouter API {color('(out of credits — payment required)', Colors.DIM)}")
+                issues.append(
+                    "OpenRouter account has insufficient credits. "
+                    "Fix: run 'hermes config set model.provider <provider>' to switch providers, "
+                    "or fund your OpenRouter account at https://openrouter.ai/settings/credits"
+                )
+            elif response.status_code == 429:
+                print(f"\r  {color('✗', Colors.RED)} OpenRouter API {color('(rate limited)', Colors.DIM)}                ")
+                issues.append("OpenRouter rate limit hit — consider switching to a different provider or waiting")
             else:
                 print(f"\r  {color('✗', Colors.RED)} OpenRouter API {color(f'(HTTP {response.status_code})', Colors.DIM)}                ")
         except Exception as e:
@@ -705,7 +789,7 @@ def run_doctor(args):
         _honcho_cfg_path = resolve_config_path()
 
         if not _honcho_cfg_path.exists():
-            check_warn("Honcho config not found", "run: hermes honcho setup")
+            check_warn("Honcho config not found", f"run: hermes honcho setup")
         elif not hcfg.enabled:
             check_info(f"Honcho disabled (set enabled: true in {_honcho_cfg_path} to activate)")
         elif not hcfg.api_key:


### PR DESCRIPTION
## Problem

Running `hermes doctor` failed to surface two real failures that caused Hermes to be unusable:

### Bug 1 — OpenRouter HTTP 402 (credits exhausted) silently ignored

When OpenRouter returns HTTP 402 (Payment Required), the health-check code fell into the generic `else` branch:

```python
if response.status_code == 200:
    print(f"\r  ✓ OpenRouter API")
elif response.status_code == 401:
    print(...)  # fails red, added to issues
else:
    print(f"\r  ✗ OpenRouter API (HTTP {response.status_code})")
    # 402 fell here — not added to issues, not fixable via --fix
```

`hermes doctor --fix` never showed the 402 problem because it was never added to the `issues` list. A user with an empty OpenRouter account would see a yellow warning but no actionable fix.

**Real outcome:** User had to manually run `hermes config set model.provider minimax` to recover.

### Bug 2 — Unknown provider not detected at check time

When `model.provider` in `config.yaml` contains an invalid provider name, `hermes doctor` only checked that `config.yaml` *exists* — it never validated `model.provider` or `model.default`.

A stale gateway state or config corruption could write an invalid provider string (e.g. `'main'`), causing `Unknown provider 'main'` at runtime. `hermes doctor` reported all checks passed right before the same error crashed the TUI.

---

## Fix

### Change 1 — OpenRouter 402/429 now caught and added to issues

```python
elif response.status_code == 402:
    print(f"\r  ✗ OpenRouter API (out of credits — payment required)")
    issues.append(
        "OpenRouter account has insufficient credits. "
        "Fix: run 'hermes config set model.provider <provider>' to switch providers, "
        "or fund your OpenRouter account at https://openrouter.ai/settings/credits"
    )
elif response.status_code == 429:
    print(f"\r  ✗ OpenRouter API (rate limited)")
    issues.append("OpenRouter rate limit hit — consider switching to a different provider or waiting")
```

Both 402 and 429 now print red ✗, add a fixable issue to the list, and are surfaced by `hermes doctor --fix`.

### Change 2 — Config model/provider validation (new section)

After confirming `config.yaml` exists, `doctor` now validates:

1. **`model.provider`** — checks against `PROVIDER_REGISTRY` from `auth.py` (with fallback list). Unknown provider → fails red with the full valid list and a fix command.

2. **`model.default` with `/` prefix** — warns if e.g. `anthropic/claude-opus-4` is set but `model.provider` is `minimax`. Provider-prefixed models only work with `openrouter` or `custom`.

3. **Provider credentials** — if `model.provider` is set but the corresponding API key env var is missing, fails red with the exact env var name.

---

## Discovery method

Both bugs were found during a real user session on Windows WSL where Hermes failed to start. The user fixed them manually via trial and error. Root-cause analysis of the `hermes doctor` source code revealed the structural gaps — and the fixes are general, not hardcoded to one setup.

---

## Testing

- [x] `hermes doctor` runs cleanly with no errors on a healthy config
- [x] New 402 branch reachable by mocking `httpx.get` to return 402
- [x] New config validation reachable by passing invalid `model.provider` values