### PR TITLE
fix(doctor): distinguish available-but-disabled toolsets from enabled ones

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -638,14 +638,21 @@ def run_doctor(args):
         # Add project root to path for imports
         sys.path.insert(0, str(PROJECT_ROOT))
         from model_tools import check_tool_availability, TOOLSET_REQUIREMENTS
-        
+        from hermes_cli.tools_config import load_config, _get_platform_tools
+
         available, unavailable = check_tool_availability()
         available, unavailable = _apply_doctor_tool_availability_overrides(available, unavailable)
-        
+
+        _cli_enabled = _get_platform_tools(load_config(), "cli")
+
         for tid in available:
             info = TOOLSET_REQUIREMENTS.get(tid, {})
-            check_ok(info.get("name", tid))
-        
+            label = info.get("name", tid)
+            if tid in _cli_enabled:
+                check_ok(label)
+            else:
+                check_warn(label, "(requirements met, but disabled — enable with: hermes tools enable " + tid + ")")
+
         for item in unavailable:
             env_vars = item.get("missing_vars") or item.get("env_vars") or []
             if env_vars:


### PR DESCRIPTION
## Summary

Closes #3145

`hermes doctor` reported mixture-of-agents (and any toolset in `_DEFAULT_OFF_TOOLSETS`) as a green ✓ when `OPENROUTER_API_KEY` was set, even though the toolset was disabled in the CLI config. `hermes tools list` correctly showed it as disabled, creating a confusing inconsistency.

## Root cause

`check_tool_availability()` only tests whether API-key requirements are met — it has no knowledge of the enabled/disabled state stored in the platform config. The doctor displayed every toolset that passed the requirements check as ✓, regardless of whether it was actually switched on.

## Fix

The doctor now also reads the CLI platform config via `_get_platform_tools(load_config(), "cli")` and, for each toolset whose requirements are met, shows:

- ✓ **check_ok** — requirements met **and** the toolset is enabled in the CLI config  
- ⚠ **check_warn** — requirements met but the toolset is **disabled** (`"requirements met, but disabled — enable with: hermes tools enable <id>"`)

This makes `hermes doctor` consistent with `hermes tools list` while still surfacing the useful signal that the API key is present and the toolset can be turned on immediately.

## Affected file

- `hermes_cli/doctor.py` — Tool Availability section (+11 / -4 lines)