### PR TITLE
feat(api-server): per-client model routing via model_routes config

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -377,6 +377,38 @@ session_reset:
 group_sessions_per_user: true
 
 # ─────────────────────────────────────────────────────────────────────────────
+# API Server — per-client model routing
+# ─────────────────────────────────────────────────────────────────────────────
+# Route different API clients to different models/providers on a single
+# Hermes deployment.  Clients choose a backend by sending a specific string
+# as the OpenAI ``model`` field.  Unmapped model values fall back to the
+# global model configured in the ``model:`` section above.
+#
+# Configure via the ``platforms.api_server.extra.model_routes`` gateway block
+# or by setting API_SERVER_* env vars and a gateway config file.  Example
+# gateway config section:
+#
+#   platforms:
+#     api_server:
+#       enabled: true
+#       extra:
+#         key: "your-api-server-secret"
+#         model_routes:
+#           # Xiaozhi clients send model="minimax-m2" → routed to MiniMax via OpenRouter
+#           minimax-m2:
+#             model: "minimax/minimax-m1"
+#             provider: "openrouter"          # optional — overrides global provider
+#             # api_key: "sk-..."             # optional — per-route key (uses global if omitted)
+#             # base_url: "https://..."       # optional — per-route base URL
+#           # GPT clients keep their own alias
+#           gpt-5:
+#             model: "openai/gpt-5"
+#             provider: "openrouter"
+#
+# Configured aliases are automatically listed by GET /v1/models so clients
+# can discover them without manual coordination.
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Gateway Streaming
 # ─────────────────────────────────────────────────────────────────────────────
 # Stream tokens to messaging platforms in real-time. The bot sends a message

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -279,6 +279,21 @@ class APIServerAdapter(BasePlatformAdapter):
         self._cors_origins: tuple[str, ...] = self._parse_cors_origins(
             extra.get("cors_origins", os.getenv("API_SERVER_CORS_ORIGINS", "")),
         )
+        # model_routes: maps incoming ``model`` field values to specific
+        # provider/model configs.  Allows one API server instance to serve
+        # multiple clients on different backends.
+        #
+        # Config format (cli-config.yaml or gateway config extra block):
+        #   model_routes:
+        #     minimax-m2:          # alias the client sends as the "model" field
+        #       model: "minimax/minimax-m1"
+        #       provider: "openrouter"   # optional — uses default provider if omitted
+        #       api_key: "sk-…"          # optional — per-route key override
+        #       base_url: "https://…"    # optional — per-route base URL override
+        raw_routes = extra.get("model_routes") or {}
+        self._model_routes: Dict[str, Dict[str, str]] = (
+            raw_routes if isinstance(raw_routes, dict) else {}
+        )
         self._app: Optional["web.Application"] = None
         self._runner: Optional["web.AppRunner"] = None
         self._site: Optional["web.TCPSite"] = None
@@ -356,23 +371,41 @@ class APIServerAdapter(BasePlatformAdapter):
     # Agent creation helper
     # ------------------------------------------------------------------
 
+    def _resolve_route(self, model_alias: str) -> Optional[Dict[str, str]]:
+        """Return the model_route config for *model_alias*, or None if not found."""
+        return self._model_routes.get(model_alias)
+
     def _create_agent(
         self,
         ephemeral_system_prompt: Optional[str] = None,
         session_id: Optional[str] = None,
         stream_delta_callback=None,
+        route: Optional[Dict[str, str]] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
 
         Uses _resolve_runtime_agent_kwargs() to pick up model, api_key,
         base_url, etc. from config.yaml / env vars.
+
+        If *route* is provided (a model_routes entry), its keys override the
+        global model/provider/api_key/base_url for this agent instance only.
         """
         from run_agent import AIAgent
         from gateway.run import _resolve_runtime_agent_kwargs, _resolve_gateway_model
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()
         model = _resolve_gateway_model()
+
+        if route:
+            if route.get("model"):
+                model = route["model"]
+            if route.get("provider"):
+                runtime_kwargs["provider"] = route["provider"]
+            if route.get("api_key"):
+                runtime_kwargs["api_key"] = route["api_key"]
+            if route.get("base_url"):
+                runtime_kwargs["base_url"] = route["base_url"]
 
         max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
 
@@ -398,25 +431,38 @@ class APIServerAdapter(BasePlatformAdapter):
         return web.json_response({"status": "ok", "platform": "hermes-agent"})
 
     async def _handle_models(self, request: "web.Request") -> "web.Response":
-        """GET /v1/models — return hermes-agent as an available model."""
+        """GET /v1/models — return hermes-agent and any configured model route aliases."""
         auth_err = self._check_auth(request)
         if auth_err:
             return auth_err
 
-        return web.json_response({
-            "object": "list",
-            "data": [
-                {
-                    "id": "hermes-agent",
-                    "object": "model",
-                    "created": int(time.time()),
-                    "owned_by": "hermes",
-                    "permission": [],
-                    "root": "hermes-agent",
-                    "parent": None,
-                }
-            ],
-        })
+        now = int(time.time())
+        models = [
+            {
+                "id": "hermes-agent",
+                "object": "model",
+                "created": now,
+                "owned_by": "hermes",
+                "permission": [],
+                "root": "hermes-agent",
+                "parent": None,
+            }
+        ]
+        # Expose configured model route aliases so clients can discover them.
+        for alias, route_cfg in self._model_routes.items():
+            if alias == "hermes-agent":
+                continue  # already listed above
+            models.append({
+                "id": alias,
+                "object": "model",
+                "created": now,
+                "owned_by": "hermes",
+                "permission": [],
+                "root": route_cfg.get("model", alias),
+                "parent": "hermes-agent",
+            })
+
+        return web.json_response({"object": "list", "data": models})
 
     async def _handle_chat_completions(self, request: "web.Request") -> "web.Response":
         """POST /v1/chat/completions — OpenAI Chat Completions format."""
@@ -473,6 +519,9 @@ class APIServerAdapter(BasePlatformAdapter):
         model_name = body.get("model", "hermes-agent")
         created = int(time.time())
 
+        # Resolve model route — allows per-client model/provider selection.
+        route = self._resolve_route(model_name)
+
         if stream:
             import queue as _q
             _stream_q: _q.Queue = _q.Queue()
@@ -495,6 +544,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 stream_delta_callback=_on_delta,
+                route=route,
             ))
 
             return await self._write_sse_chat_completion(
@@ -508,6 +558,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 conversation_history=history,
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
+                route=route,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -724,12 +775,16 @@ class APIServerAdapter(BasePlatformAdapter):
         # Run the agent (with Idempotency-Key support)
         session_id = str(uuid.uuid4())
 
+        # Resolve model route for per-client model/provider selection.
+        route = self._resolve_route(body.get("model", "hermes-agent"))
+
         async def _compute_response():
             return await self._run_agent(
                 user_message=user_message,
                 conversation_history=conversation_history,
                 ephemeral_system_prompt=instructions,
                 session_id=session_id,
+                route=route,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -1137,12 +1192,16 @@ class APIServerAdapter(BasePlatformAdapter):
         ephemeral_system_prompt: Optional[str] = None,
         session_id: Optional[str] = None,
         stream_delta_callback=None,
+        route: Optional[Dict[str, str]] = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
 
         Returns ``(result_dict, usage_dict)`` where *usage_dict* contains
         ``input_tokens``, ``output_tokens`` and ``total_tokens``.
+
+        *route* is an optional model_routes entry that overrides the global
+        model/provider for this specific request.
         """
         loop = asyncio.get_event_loop()
 
@@ -1151,6 +1210,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=ephemeral_system_prompt,
                 session_id=session_id,
                 stream_delta_callback=stream_delta_callback,
+                route=route,
             )
             result = agent.run_conversation(
                 user_message=user_message,

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1437,3 +1437,125 @@ class TestConversationParameter:
                 assert resp.status == 200
                 # Conversation mapping should NOT be set since store=false
                 assert adapter._response_store.get_conversation("ephemeral-chat") is None
+
+
+# ---------------------------------------------------------------------------
+# Model routing
+# ---------------------------------------------------------------------------
+
+
+def _make_routing_adapter(routes: dict) -> APIServerAdapter:
+    """Create an adapter with model_routes configured."""
+    config = PlatformConfig(enabled=True, extra={"model_routes": routes})
+    return APIServerAdapter(config)
+
+
+class TestModelRouting:
+    def test_resolve_route_returns_none_for_unknown_alias(self):
+        adapter = _make_routing_adapter({"minimax-m2": {"model": "minimax/minimax-m1"}})
+        assert adapter._resolve_route("unknown-model") is None
+
+    def test_resolve_route_returns_config_for_known_alias(self):
+        routes = {"minimax-m2": {"model": "minimax/minimax-m1", "provider": "openrouter"}}
+        adapter = _make_routing_adapter(routes)
+        route = adapter._resolve_route("minimax-m2")
+        assert route is not None
+        assert route["model"] == "minimax/minimax-m1"
+        assert route["provider"] == "openrouter"
+
+    def test_no_routes_configured(self):
+        adapter = _make_routing_adapter({})
+        assert adapter._resolve_route("hermes-agent") is None
+        assert adapter._resolve_route("any-model") is None
+
+    def test_invalid_routes_config_falls_back_to_empty(self):
+        """Non-dict model_routes should be silently ignored."""
+        config = PlatformConfig(enabled=True, extra={"model_routes": "not-a-dict"})
+        adapter = APIServerAdapter(config)
+        assert adapter._model_routes == {}
+
+    @pytest.mark.asyncio
+    async def test_models_endpoint_lists_route_aliases(self):
+        routes = {
+            "minimax-m2": {"model": "minimax/minimax-m1", "provider": "openrouter"},
+            "gpt-5": {"model": "openai/gpt-5"},
+        }
+        adapter = _make_routing_adapter(routes)
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/models")
+            assert resp.status == 200
+            data = await resp.json()
+            ids = {m["id"] for m in data["data"]}
+            assert "hermes-agent" in ids
+            assert "minimax-m2" in ids
+            assert "gpt-5" in ids
+
+    @pytest.mark.asyncio
+    async def test_models_endpoint_route_alias_root_field(self):
+        """Route alias entries should set ``root`` to the resolved model name."""
+        routes = {"my-alias": {"model": "openai/gpt-5"}}
+        adapter = _make_routing_adapter(routes)
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/models")
+            data = await resp.json()
+            alias_entry = next(m for m in data["data"] if m["id"] == "my-alias")
+            assert alias_entry["root"] == "openai/gpt-5"
+            assert alias_entry["parent"] == "hermes-agent"
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_passes_route_to_run_agent(self):
+        """When model matches a route, _run_agent should receive the route dict."""
+        routes = {"minimax-m2": {"model": "minimax/minimax-m1", "provider": "openrouter"}}
+        adapter = _make_routing_adapter(routes)
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "hi", "messages": [], "api_calls": 1},
+                    {"input_tokens": 5, "output_tokens": 5, "total_tokens": 10},
+                )
+                await cli.post("/v1/chat/completions", json={
+                    "model": "minimax-m2",
+                    "messages": [{"role": "user", "content": "hello"}],
+                })
+                _, kwargs = mock_run.call_args
+                assert kwargs.get("route") == {"model": "minimax/minimax-m1", "provider": "openrouter"}
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_no_route_for_unknown_model(self):
+        """Unknown model alias should pass route=None to _run_agent."""
+        adapter = _make_routing_adapter({"minimax-m2": {"model": "minimax/minimax-m1"}})
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "hi", "messages": [], "api_calls": 1},
+                    {"input_tokens": 5, "output_tokens": 5, "total_tokens": 10},
+                )
+                await cli.post("/v1/chat/completions", json={
+                    "model": "unknown-model",
+                    "messages": [{"role": "user", "content": "hello"}],
+                })
+                _, kwargs = mock_run.call_args
+                assert kwargs.get("route") is None
+
+    @pytest.mark.asyncio
+    async def test_responses_api_passes_route_to_run_agent(self):
+        """The /v1/responses endpoint should also honour model routing."""
+        routes = {"xiaozhi": {"model": "minimax/minimax-m1", "provider": "openrouter"}}
+        adapter = _make_routing_adapter(routes)
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "hi", "messages": [], "api_calls": 1},
+                    {"input_tokens": 5, "output_tokens": 5, "total_tokens": 10},
+                )
+                await cli.post("/v1/responses", json={
+                    "model": "xiaozhi",
+                    "input": "hello",
+                })
+                _, kwargs = mock_run.call_args
+                assert kwargs.get("route") == {"model": "minimax/minimax-m1", "provider": "openrouter"}


### PR DESCRIPTION
## Summary

Closes #3155

Adds a no-code routing layer to the OpenAI-compatible API server so one Hermes deployment can map different API clients to different model/provider backends — without running multiple instances.

## How it works

Clients choose a backend by sending a specific string as the OpenAI `model` field. If it matches a key in `model_routes`, the agent is created with that route's `model`/`provider`/`api_key`/`base_url` instead of the global defaults. Unmatched values fall back to the global model as before.

```yaml
# gateway config
platforms:
  api_server:
    enabled: true
    extra:
      key: "your-api-server-secret"
      model_routes:
        # Xiaozhi clients send model="minimax-m2" → routed to MiniMax via OpenRouter
        minimax-m2:
          model: "minimax/minimax-m1"
          provider: "openrouter"
          # api_key: "sk-..."      optional per-route key override
          # base_url: "https://..."  optional per-route base URL override
        # Keep a second alias for other clients
        gpt-5:
          model: "openai/gpt-5"
          provider: "openrouter"
```

## Changes

**`gateway/platforms/api_server.py`**
- `__init__`: reads `extra["model_routes"]` into `self._model_routes`
- `_resolve_route(alias)`: returns the route config for a model alias, or `None`
- `_create_agent`: accepts optional `route` param — applies model/provider/api_key/base_url overrides when set
- `_run_agent`: propagates `route` param to `_create_agent`
- `_handle_chat_completions`: resolves route from `body["model"]`, passes to `_run_agent`
- `_handle_responses`: same for `/v1/responses`
- `_handle_models`: `GET /v1/models` now lists all configured route aliases so clients can discover available backends — each alias shows `root` = the resolved model name and `parent` = `"hermes-agent"`

**`cli-config.yaml.example`**: documented the new `model_routes` config block with a working example

**`tests/gateway/test_api_server.py`**: 9 new tests in `TestModelRouting` covering unit and integration paths

## Test results

```
92 passed  (83 pre-existing + 9 new)
```