### PR TITLE
fix(telegram): self-reschedule reconnect when start_polling fails after network error

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -219,7 +219,12 @@ class TelegramAdapter(BasePlatformAdapter):
             self._polling_network_error_count = 0
         except Exception as retry_err:
             logger.warning("[%s] Telegram polling reconnect failed: %s", self.name, retry_err)
-            # The next network error will trigger another attempt.
+            # start_polling failed — polling is now dead and no further error
+            # callbacks will fire, so we must schedule the next attempt ourselves
+            # rather than waiting for a callback that will never come.
+            loop = asyncio.get_event_loop()
+            if loop.is_running() and not self.has_fatal_error:
+                loop.create_task(self._handle_polling_network_error(retry_err))
 
     async def _handle_polling_conflict(self, error: Exception) -> None:
         if self.has_fatal_error and self.fatal_error_code == "telegram_polling_conflict":

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -1,0 +1,172 @@
+"""
+Tests for Telegram polling network error recovery.
+
+Specifically tests the fix for #3173 — when start_polling() fails after a
+network error, the adapter must self-reschedule the next reconnect attempt
+rather than silently leaving polling dead.
+"""
+
+import asyncio
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    telegram_mod = MagicMock()
+    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    telegram_mod.constants.ChatType.GROUP = "group"
+    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
+    telegram_mod.constants.ChatType.CHANNEL = "channel"
+    telegram_mod.constants.ChatType.PRIVATE = "private"
+
+    for name in ("telegram", "telegram.ext", "telegram.constants"):
+        sys.modules.setdefault(name, telegram_mod)
+
+
+_ensure_telegram_mock()
+
+from gateway.platforms.telegram import TelegramAdapter  # noqa: E402
+
+
+def _make_adapter() -> TelegramAdapter:
+    return TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+
+
+@pytest.mark.asyncio
+async def test_reconnect_self_schedules_on_start_polling_failure():
+    """
+    When start_polling() raises during a network error retry, the adapter must
+    create a new task to retry again — otherwise polling stays dead with no
+    further error callbacks to trigger recovery.
+
+    Regression test for #3173: gateway becomes unresponsive after Telegram 502.
+    """
+    adapter = _make_adapter()
+
+    # Simulate: we've already had 1 network error attempt
+    adapter._polling_network_error_count = 1
+
+    # Mock app/updater: stop succeeds, start_polling fails
+    mock_updater = MagicMock()
+    mock_updater.running = True
+    mock_updater.stop = AsyncMock()
+    mock_updater.start_polling = AsyncMock(side_effect=Exception("Timed out"))
+
+    mock_app = MagicMock()
+    mock_app.updater = mock_updater
+    adapter._app = mock_app
+
+    tasks_created = []
+
+    original_create_task = asyncio.get_event_loop().create_task
+
+    with patch("asyncio.sleep", new_callable=AsyncMock), \
+         patch("asyncio.get_event_loop") as mock_get_loop:
+        mock_loop = MagicMock()
+        mock_loop.is_running.return_value = True
+
+        def _capture_task(coro):
+            tasks_created.append(coro)
+            # Don't actually run it — just capture it
+            coro.close()
+
+        mock_loop.create_task = _capture_task
+        mock_get_loop.return_value = mock_loop
+
+        error = Exception("Bad Gateway")
+        await adapter._handle_polling_network_error(error)
+
+    # A new task must have been scheduled to continue retrying
+    assert len(tasks_created) == 1, (
+        "Expected exactly one self-rescheduled retry task after start_polling failure, "
+        f"got {len(tasks_created)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reconnect_does_not_self_schedule_when_fatal_error_set():
+    """
+    When a fatal error is already set, the failed reconnect should NOT create
+    another retry task — the gateway is already shutting down this adapter.
+    """
+    adapter = _make_adapter()
+    adapter._polling_network_error_count = 1
+    adapter._set_fatal_error("telegram_network_error", "already fatal", retryable=True)
+
+    mock_updater = MagicMock()
+    mock_updater.running = True
+    mock_updater.stop = AsyncMock()
+    mock_updater.start_polling = AsyncMock(side_effect=Exception("Timed out"))
+
+    mock_app = MagicMock()
+    mock_app.updater = mock_updater
+    adapter._app = mock_app
+
+    tasks_created = []
+
+    with patch("asyncio.sleep", new_callable=AsyncMock), \
+         patch("asyncio.get_event_loop") as mock_get_loop:
+        mock_loop = MagicMock()
+        mock_loop.is_running.return_value = True
+        mock_loop.create_task = lambda coro: tasks_created.append(coro) or coro.close()
+        mock_get_loop.return_value = mock_loop
+
+        await adapter._handle_polling_network_error(Exception("Timed out"))
+
+    assert len(tasks_created) == 0, (
+        "Should not schedule a retry when a fatal error is already set"
+    )
+
+
+@pytest.mark.asyncio
+async def test_reconnect_success_resets_error_count():
+    """
+    When start_polling() succeeds, _polling_network_error_count should reset to 0.
+    """
+    adapter = _make_adapter()
+    adapter._polling_network_error_count = 3
+
+    mock_updater = MagicMock()
+    mock_updater.running = True
+    mock_updater.stop = AsyncMock()
+    mock_updater.start_polling = AsyncMock()  # succeeds
+
+    mock_app = MagicMock()
+    mock_app.updater = mock_updater
+    adapter._app = mock_app
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await adapter._handle_polling_network_error(Exception("Bad Gateway"))
+
+    assert adapter._polling_network_error_count == 0
+
+
+@pytest.mark.asyncio
+async def test_reconnect_triggers_fatal_after_max_retries():
+    """
+    After MAX_NETWORK_RETRIES attempts, the adapter should set a fatal error
+    rather than retrying forever.
+    """
+    adapter = _make_adapter()
+    adapter._polling_network_error_count = 10  # MAX_NETWORK_RETRIES
+
+    fatal_handler = AsyncMock()
+    adapter.set_fatal_error_handler(fatal_handler)
+
+    mock_app = MagicMock()
+    adapter._app = mock_app
+
+    await adapter._handle_polling_network_error(Exception("still failing"))
+
+    assert adapter.has_fatal_error
+    assert adapter.fatal_error_code == "telegram_network_error"
+    fatal_handler.assert_called_once()


### PR DESCRIPTION
## Summary

Closes #3173

Fixes the gateway becoming completely unresponsive after Telegram returns HTTP 502 (Bad Gateway) and the reconnect attempt also fails.

## Root cause

When Telegram returns a 502, `_handle_polling_network_error` does:
1. `await updater.stop()` — kills the internal updater loop
2. `await updater.start_polling(...)` — tries to reconnect

If step 2 raises (e.g. "Timed out"), the old code logged a warning and returned, with this comment:

```python
# The next network error will trigger another attempt.
```

That comment was wrong. The polling error callback is only fired by the updater's internal loop. Once `stop()` has been called, that loop is dead. No further error callbacks ever fire, so the retry chain silently terminates — leaving the gateway alive but completely deaf to messages and unable to run cron jobs.

## Fix

When `start_polling()` raises in the `except` branch, explicitly schedule a new `_handle_polling_network_error` task on the running event loop so the exponential-backoff retry chain continues without needing the updater loop to be alive.

```python
except Exception as retry_err:
    logger.warning("[%s] Telegram polling reconnect failed: %s", self.name, retry_err)
    # start_polling failed — polling is now dead and no further error
    # callbacks will fire, so we must schedule the next attempt ourselves.
    loop = asyncio.get_event_loop()
    if loop.is_running() and not self.has_fatal_error:
        loop.create_task(self._handle_polling_network_error(retry_err))
```

Guards: only schedules when the loop is running and no fatal error is already set (avoids creating tasks during shutdown).

## What this changes

- After a failed reconnect, the retry chain continues using the existing exponential backoff (5s → 10s → 20s → 40s → 60s cap, up to 10 attempts)
- After 10 failed attempts, `_set_fatal_error` is called as before → `_handle_adapter_fatal_error` queues the platform for background reconnection via `_platform_reconnect_watcher`
- No change to behavior when reconnect succeeds or when a fatal error is already set

## Tests

4 new tests in `tests/gateway/test_telegram_network_reconnect.py`:
- `test_reconnect_self_schedules_on_start_polling_failure` — regression test for the exact bug
- `test_reconnect_does_not_self_schedule_when_fatal_error_set` — no spurious tasks during shutdown
- `test_reconnect_success_resets_error_count` — happy path unchanged
- `test_reconnect_triggers_fatal_after_max_retries` — escalation path unchanged

```
152 passed  (148 pre-existing + 4 new)
```