### PR TITLE
fix(session): handle IntegrityError gracefully in create_session

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 import os
 import random
 import re
+import sqlite3
 import sys
 import tempfile
 import time
@@ -892,6 +893,9 @@ class AIAgent:
                     },
                     user_id=None,
                 )
+            except sqlite3.IntegrityError:
+                # Session already exists (e.g. gateway restart reusing session ID) — benign
+                logger.debug("Session %s already exists in DB — reusing", self.session_id)
             except Exception as e:
                 logger.warning("Session DB create_session failed — messages will NOT be indexed: %s", e)
                 self._session_db = None  # prevent silent data loss on every subsequent flush


### PR DESCRIPTION
## What changed and why

PR #2999 introduced `self._session_db = None` when `create_session()` fails, to prevent silent data loss. However, the catch-all `except Exception` handler treats **all** failures uniformly — including `sqlite3.IntegrityError` from duplicate session IDs, which is a benign condition.

This permanently disables `session_search` for the entire agent lifetime, returning `"Session database not available"` on every call.

`IntegrityError` (UNIQUE constraint on `sessions.id`) occurs when:
- The gateway restarts and reuses an existing session ID
- CLI resumes a session that already exists in the DB
- Concurrent CLI + gateway processes create sessions with the same ID

In all these cases the session already exists — the DB is healthy and `session_search` should continue working.

### Fix

Add a specific `except sqlite3.IntegrityError` handler **before** the generic `except Exception`, which logs at debug level and preserves `_session_db`. The existing nuclear option (`_session_db = None`) is preserved for genuinely broken DB scenarios.

## How to test

1. Start the gateway: `hermes gateway`
2. Send a message on any platform (Telegram, Signal, etc.) — note the session ID
3. Restart the gateway: `hermes gateway run --replace`
4. Send another message on the same platform (reuses the same session ID)
5. Ask the agent to use `session_search` (e.g. "what were we talking about?")
6. **Before fix:** returns `"Session database not available"`
7. **After fix:** returns search results normally

Alternatively, verify with existing tests:
```bash
pytest tests/test_hermes_state.py tests/tools/test_session_search.py -v
```

## Platform tested

Linux (Debian 13)

## Related issues

Closes #3139