### PR TITLE
fix(fallback): forward base_url and api_key_env to resolve_provider_client

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4055,13 +4055,29 @@ class AIAgent:
         if not fb_provider or not fb_model:
             return False
 
+        # Resolve fallback-specific custom endpoint overrides.
+        # base_url and api_key_env are documented in the config reference and
+        # must be forwarded to resolve_provider_client so that a fallback to a
+        # *different* custom endpoint (e.g. a local LM Studio instance when the
+        # primary endpoint is a remote cloud) actually uses that endpoint rather
+        # than re-using the global OPENAI_BASE_URL / OPENAI_API_KEY values.
+        fb_base_url = (fb.get("base_url") or "").strip() or None
+        fb_api_key_env = (fb.get("api_key_env") or "").strip() or None
+        fb_explicit_key: Optional[str] = None
+        if fb_api_key_env:
+            import os as _os
+            fb_explicit_key = _os.getenv(fb_api_key_env, "").strip() or None
+
         # Use centralized router for client construction.
         # raw_codex=True because the main agent needs direct responses.stream()
         # access for Codex providers.
         try:
             from agent.auxiliary_client import resolve_provider_client
             fb_client, _ = resolve_provider_client(
-                fb_provider, model=fb_model, raw_codex=True)
+                fb_provider, model=fb_model, raw_codex=True,
+                explicit_base_url=fb_base_url,
+                explicit_api_key=fb_explicit_key,
+            )
             if fb_client is None:
                 logging.warning(
                     "Fallback to %s failed: provider not configured",

--- a/tests/test_fallback_model.py
+++ b/tests/test_fallback_model.py
@@ -375,3 +375,129 @@ class TestProviderCredentials:
             assert agent.client is mock_client
             assert agent.model == "test-model"
             assert agent.provider == provider
+
+
+# =============================================================================
+# Custom endpoint forwarding — regression tests for #3124
+# =============================================================================
+
+class TestCustomEndpointForwarding:
+    """Verify that fallback_model.base_url / api_key_env are forwarded to
+    resolve_provider_client() so a secondary custom endpoint is used instead
+    of the global OPENAI_BASE_URL value."""
+
+    def test_base_url_forwarded_to_resolve_provider_client(self):
+        """base_url in fallback config must be passed as explicit_base_url."""
+        agent = _make_agent(
+            fallback_model={
+                "provider": "custom",
+                "model": "local-llm",
+                "base_url": "http://localhost:1234/v1",
+            }
+        )
+        mock_client = _mock_resolve(base_url="http://localhost:1234/v1", api_key="lm-studio")
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, "local-llm"),
+        ) as mock_resolve:
+            result = agent._try_activate_fallback()
+
+        assert result is True
+        _, kwargs = mock_resolve.call_args
+        assert kwargs.get("explicit_base_url") == "http://localhost:1234/v1", (
+            "base_url from fallback config must be forwarded as explicit_base_url"
+        )
+
+    def test_api_key_env_resolved_and_forwarded(self):
+        """api_key_env in fallback config must be env-resolved and forwarded."""
+        agent = _make_agent(
+            fallback_model={
+                "provider": "custom",
+                "model": "local-llm",
+                "base_url": "http://localhost:1234/v1",
+                "api_key_env": "MY_LOCAL_KEY",
+            }
+        )
+        mock_client = _mock_resolve(base_url="http://localhost:1234/v1", api_key="sk-local")
+
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(mock_client, "local-llm"),
+            ) as mock_resolve,
+            patch.dict("os.environ", {"MY_LOCAL_KEY": "sk-local-123"}),
+        ):
+            result = agent._try_activate_fallback()
+
+        assert result is True
+        _, kwargs = mock_resolve.call_args
+        assert kwargs.get("explicit_api_key") == "sk-local-123", (
+            "api_key resolved from api_key_env must be forwarded as explicit_api_key"
+        )
+
+    def test_missing_api_key_env_forwards_none(self):
+        """When api_key_env is set but the env var is absent, explicit_api_key should be None."""
+        agent = _make_agent(
+            fallback_model={
+                "provider": "custom",
+                "model": "local-llm",
+                "base_url": "http://localhost:1234/v1",
+                "api_key_env": "NONEXISTENT_VAR_XYZ",
+            }
+        )
+        mock_client = _mock_resolve(base_url="http://localhost:1234/v1", api_key="")
+
+        with (
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(mock_client, "local-llm"),
+            ) as mock_resolve,
+            patch.dict("os.environ", {}, clear=False),
+        ):
+            # Remove the var if it exists
+            import os
+            os.environ.pop("NONEXISTENT_VAR_XYZ", None)
+            agent._try_activate_fallback()
+
+        _, kwargs = mock_resolve.call_args
+        assert kwargs.get("explicit_api_key") is None
+
+    def test_no_base_url_in_fallback_passes_none(self):
+        """When fallback config has no base_url, explicit_base_url must be None."""
+        agent = _make_agent(
+            fallback_model={"provider": "openrouter", "model": "google/gemini-3-flash"},
+        )
+        mock_client = _mock_resolve()
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, "google/gemini-3-flash"),
+        ) as mock_resolve:
+            agent._try_activate_fallback()
+
+        _, kwargs = mock_resolve.call_args
+        assert kwargs.get("explicit_base_url") is None
+        assert kwargs.get("explicit_api_key") is None
+
+    def test_base_url_actually_used_for_client_base_url(self):
+        """After activation, agent.base_url must reflect the fallback endpoint."""
+        agent = _make_agent(
+            fallback_model={
+                "provider": "custom",
+                "model": "gguf-model",
+                "base_url": "http://192.168.1.10:8080/v1",
+            }
+        )
+        mock_client = _mock_resolve(base_url="http://192.168.1.10:8080/v1", api_key="none")
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, "gguf-model"),
+        ):
+            result = agent._try_activate_fallback()
+
+        assert result is True
+        # str(client.base_url) appends a trailing slash — check with strip
+        assert agent.base_url.rstrip("/") == "http://192.168.1.10:8080/v1"
+        assert agent.model == "gguf-model"


### PR DESCRIPTION
## Summary

Closes #3124

`_activate_fallback_model()` called `resolve_provider_client(provider, model)` without forwarding the fallback-specific `base_url` / `api_key_env` from the config block. A fallback configured for a secondary custom endpoint would silently reuse the global `OPENAI_BASE_URL` / `OPENAI_API_KEY` — making the fallback no different from retrying the primary provider.

## Root Cause

```python
# run_agent.py:4064 — before this fix
fb_client, _ = resolve_provider_client(
    fb_provider, model=fb_model, raw_codex=True)
#              ↑ no explicit_base_url, no explicit_api_key
```

`resolve_provider_client()` already accepts `explicit_base_url` / `explicit_api_key` and uses them correctly in the `provider == "custom"` branch. `smart_model_routing.py` does this correctly. The fallback path was the odd one out.

The docs also already document `base_url` and `api_key_env` as supported fields for `fallback_model` — so this was purely a missing wire-up.

## Fix

```python
# run_agent.py — after this fix
fb_base_url = (fb.get("base_url") or "").strip() or None
fb_api_key_env = (fb.get("api_key_env") or "").strip() or None
fb_explicit_key = os.getenv(fb_api_key_env, "").strip() or None if fb_api_key_env else None

fb_client, _ = resolve_provider_client(
    fb_provider, model=fb_model, raw_codex=True,
    explicit_base_url=fb_base_url,
    explicit_api_key=fb_explicit_key,
)
```

This means the following config now works as documented:

```yaml
fallback_model:
  provider: custom
  model: my-local-llm
  base_url: http://localhost:1234/v1
  api_key_env: LM_STUDIO_KEY   # reads $LM_STUDIO_KEY at activation time
```

## What doesn't change

- Fallbacks without `base_url` / `api_key_env` pass `None` for both — identical behavior to before
- Named custom providers (`provider: custom:name`) are out of scope for this fix; that would require a config schema addition. The issue notes this as a separate improvement.

## Tests

5 new tests in `TestCustomEndpointForwarding` (regression test suite for #3124):

| Test | What it verifies |
|---|---|
| `test_base_url_forwarded_to_resolve_provider_client` | `explicit_base_url` is set to `fallback_model.base_url` |
| `test_api_key_env_resolved_and_forwarded` | env var is resolved and passed as `explicit_api_key` |
| `test_missing_api_key_env_forwards_none` | absent env var → `explicit_api_key=None` (no crash) |
| `test_no_base_url_in_fallback_passes_none` | config without `base_url` → `None` for both (unchanged behavior) |
| `test_base_url_actually_used_for_client_base_url` | `agent.base_url` reflects the fallback endpoint after activation |

```
32 passed  (27 pre-existing + 5 new)
```