### PR TITLE
fix(security): validate Twilio webhook signatures to prevent SMS spoofing

### DIFF
--- a/gateway/platforms/sms.py
+++ b/gateway/platforms/sms.py
@@ -17,6 +17,8 @@ Gateway-specific env vars:
 
 import asyncio
 import base64
+import hashlib
+import hmac
 import logging
 import os
 import re
@@ -203,6 +205,48 @@ class SmsAdapter(BasePlatformAdapter):
     # Twilio webhook handler
     # ------------------------------------------------------------------
 
+    def _validate_twilio_signature(self, request, raw_body: bytes) -> bool:
+        """Validate X-Twilio-Signature to prevent webhook spoofing.
+
+        Uses HMAC-SHA1 as specified by the Twilio security docs.
+        Returns True if validation passes or is disabled (no auth token).
+        """
+        auth_token = self._auth_token
+        if not auth_token:
+            return True  # no token configured — can't validate
+
+        signature = request.headers.get("X-Twilio-Signature", "")
+        if not signature:
+            logger.warning("[sms] missing X-Twilio-Signature header")
+            return False
+
+        # Build the validation URL from the request
+        public_url = os.getenv("SMS_WEBHOOK_PUBLIC_URL", "")
+        if public_url:
+            url = public_url.rstrip("/")
+        else:
+            scheme = request.headers.get("X-Forwarded-Proto", request.scheme)
+            host = request.headers.get("X-Forwarded-Host", request.host)
+            url = f"{scheme}://{host}{request.path}"
+
+        # Parse form params and sort them alphabetically
+        params = urllib.parse.parse_qs(raw_body.decode("utf-8"), keep_blank_values=True)
+        sorted_params = sorted(
+            ((k, v[0]) for k, v in params.items()),
+            key=lambda x: x[0],
+        )
+        data_string = url + "".join(k + v for k, v in sorted_params)
+
+        # Compute expected signature
+        expected = base64.b64encode(
+            hmac.new(auth_token.encode("utf-8"), data_string.encode("utf-8"), hashlib.sha1).digest()
+        ).decode("utf-8")
+
+        if not hmac.compare_digest(signature, expected):
+            logger.warning("[sms] invalid X-Twilio-Signature (webhook spoofing attempt?)")
+            return False
+        return True
+
     async def _handle_webhook(self, request) -> "aiohttp.web.Response":
         from aiohttp import web
 
@@ -216,6 +260,14 @@ class SmsAdapter(BasePlatformAdapter):
                 text='<?xml version="1.0" encoding="UTF-8"?><Response></Response>',
                 content_type="application/xml",
                 status=400,
+            )
+
+        # Validate Twilio webhook signature to prevent spoofing
+        if not self._validate_twilio_signature(request, raw):
+            return web.Response(
+                text='<?xml version="1.0" encoding="UTF-8"?><Response></Response>',
+                content_type="application/xml",
+                status=403,
             )
 
         # Extract fields (parse_qs returns lists)

--- a/tests/gateway/test_sms_signature.py
+++ b/tests/gateway/test_sms_signature.py
@@ -1,0 +1,95 @@
+"""Tests for Twilio webhook signature validation in the SMS adapter.
+
+Without signature validation, any attacker who discovers the webhook URL
+can forge inbound SMS messages from any phone number — a complete
+authentication bypass.
+"""
+
+import base64
+import hashlib
+import hmac
+import urllib.parse
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gateway.platforms.sms import SmsAdapter
+
+
+def _compute_twilio_signature(auth_token: str, url: str, params: dict) -> str:
+    """Compute a valid Twilio X-Twilio-Signature for testing."""
+    sorted_params = sorted(params.items())
+    data_string = url + "".join(k + v for k, v in sorted_params)
+    return base64.b64encode(
+        hmac.new(auth_token.encode(), data_string.encode(), hashlib.sha1).digest()
+    ).decode()
+
+
+def _make_adapter():
+    """Build a minimal SMS adapter with a known auth token."""
+    config = MagicMock()
+    config.enabled = True
+    config.api_key = "test_auth_token_abc123"
+    config.extra = {}
+    with patch.dict("os.environ", {
+        "TWILIO_ACCOUNT_SID": "AC_test",
+        "TWILIO_AUTH_TOKEN": "test_auth_token_abc123",
+        "TWILIO_PHONE_NUMBER": "+15550001234",
+    }):
+        adapter = SmsAdapter.__new__(SmsAdapter)
+        adapter._account_sid = "AC_test"
+        adapter._auth_token = "test_auth_token_abc123"
+        adapter._from_number = "+15550001234"
+    return adapter
+
+
+def _make_request(signature: str = "", body_params: dict = None, url: str = "https://example.com/webhooks/twilio"):
+    """Build a mock aiohttp request."""
+    params = body_params or {"From": "+15559998888", "Body": "hello", "To": "+15550001234", "MessageSid": "SM123"}
+    body = urllib.parse.urlencode(params).encode()
+    req = MagicMock()
+    req.headers = {"X-Twilio-Signature": signature} if signature else {}
+    req.scheme = "https"
+    req.host = "example.com"
+    req.path = "/webhooks/twilio"
+    return req, body
+
+
+class TestTwilioSignatureValidation:
+
+    def test_valid_signature_passes(self):
+        adapter = _make_adapter()
+        url = "https://example.com/webhooks/twilio"
+        params = {"From": "+15559998888", "Body": "hello", "To": "+15550001234", "MessageSid": "SM123"}
+        sig = _compute_twilio_signature("test_auth_token_abc123", url, params)
+        req, body = _make_request(signature=sig, body_params=params)
+        assert adapter._validate_twilio_signature(req, body) is True
+
+    def test_missing_signature_rejected(self):
+        adapter = _make_adapter()
+        req, body = _make_request(signature="")
+        req.headers = {}  # no X-Twilio-Signature header
+        assert adapter._validate_twilio_signature(req, body) is False
+
+    def test_invalid_signature_rejected(self):
+        adapter = _make_adapter()
+        req, body = _make_request(signature="dGhpcyBpcyBmYWtl")  # base64("this is fake")
+        assert adapter._validate_twilio_signature(req, body) is False
+
+    def test_no_auth_token_skips_validation(self):
+        adapter = _make_adapter()
+        adapter._auth_token = ""  # no token configured
+        req, body = _make_request(signature="")
+        req.headers = {}
+        assert adapter._validate_twilio_signature(req, body) is True
+
+    def test_public_url_override(self):
+        adapter = _make_adapter()
+        custom_url = "https://my-domain.com/sms/inbound"
+        params = {"From": "+15559998888", "Body": "test", "To": "+15550001234", "MessageSid": "SM456"}
+        sig = _compute_twilio_signature("test_auth_token_abc123", custom_url, params)
+        req, body = _make_request(signature=sig, body_params=params)
+
+        with patch.dict("os.environ", {"SMS_WEBHOOK_PUBLIC_URL": custom_url}):
+            assert adapter._validate_twilio_signature(req, body) is True


### PR DESCRIPTION
## Summary

The SMS adapter accepts any POST to `/webhooks/twilio` without verifying the `X-Twilio-Signature` header. An attacker who discovers the webhook URL can forge inbound SMS from any phone number — if that number is in `SMS_ALLOWED_USERS`, they get full agent access.

## Root Cause

Twilio signs every webhook request with HMAC-SHA1 using the account's auth token, but `_handle_webhook()` in `sms.py` never checks the signature. The form-encoded body is parsed and dispatched directly to the agent.

## Fix

**1. Add `_validate_twilio_signature()` method** (`gateway/platforms/sms.py`)

Implements the standard Twilio validation: constructs the URL from the request (with `X-Forwarded-Proto`/`X-Forwarded-Host` for proxies, or explicit `SMS_WEBHOOK_PUBLIC_URL` override), sorts POST params alphabetically, computes HMAC-SHA1, and compares with `hmac.compare_digest`.

**2. Gate the webhook handler** (`gateway/platforms/sms.py`)

Returns 403 on invalid/missing signatures before any message processing. Fails open only when no auth token is configured (can't validate without the secret).

No new dependencies — uses stdlib `hmac`, `hashlib`, `base64`.

## Tests

5 new tests: valid signature passes, missing signature rejected, invalid signature rejected, no-auth-token skips validation, public URL override works.

```
5 passed
```