### PR TITLE
fix(tts): check Homebrew paths when resolving ffmpeg binary

### DIFF
--- a/tests/tools/test_tts_ffmpeg_path.py
+++ b/tests/tools/test_tts_ffmpeg_path.py
@@ -1,0 +1,50 @@
+"""Tests for ffmpeg binary resolution in tts_tool.
+
+Verifies that _find_ffmpeg() checks Homebrew paths (/opt/homebrew/bin,
+/usr/local/bin) when ffmpeg is not on the standard PATH — matching the
+pattern from transcription_tools._find_binary().
+"""
+
+import os
+from unittest.mock import patch
+from tools.tts_tool import _find_ffmpeg, _has_ffmpeg
+
+
+class TestFindFfmpeg:
+
+    @patch("shutil.which", return_value="/usr/bin/ffmpeg")
+    def test_finds_ffmpeg_on_path(self, _which):
+        assert _find_ffmpeg() == "/usr/bin/ffmpeg"
+
+    @patch("shutil.which", return_value=None)
+    @patch("os.path.isfile", return_value=True)
+    @patch("os.access", return_value=True)
+    def test_finds_ffmpeg_in_homebrew(self, _access, _isfile, _which):
+        result = _find_ffmpeg()
+        assert result == "/opt/homebrew/bin/ffmpeg"
+
+    @patch("shutil.which", return_value=None)
+    @patch("os.path.isfile", return_value=False)
+    def test_returns_none_when_not_found(self, _isfile, _which):
+        assert _find_ffmpeg() is None
+
+    @patch("shutil.which", return_value=None)
+    def test_checks_usr_local_bin(self, _which):
+        """Falls through to /usr/local/bin if /opt/homebrew/bin fails."""
+        def fake_isfile(p):
+            return p == "/usr/local/bin/ffmpeg"
+
+        with patch("os.path.isfile", side_effect=fake_isfile), \
+             patch("os.access", return_value=True):
+            assert _find_ffmpeg() == "/usr/local/bin/ffmpeg"
+
+
+class TestHasFfmpeg:
+
+    @patch("tools.tts_tool._find_ffmpeg", return_value="/usr/bin/ffmpeg")
+    def test_true_when_found(self, _find):
+        assert _has_ffmpeg() is True
+
+    @patch("tools.tts_tool._find_ffmpeg", return_value=None)
+    def test_false_when_not_found(self, _find):
+        assert _has_ffmpeg() is False

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -108,9 +108,24 @@ def _get_provider(tts_config: Dict[str, Any]) -> str:
 # ===========================================================================
 # ffmpeg Opus conversion (Edge TTS MP3 -> OGG Opus for Telegram)
 # ===========================================================================
+_COMMON_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
+
+
+def _find_ffmpeg() -> Optional[str]:
+    """Locate the ffmpeg binary, checking Homebrew paths on macOS."""
+    path = shutil.which("ffmpeg")
+    if path:
+        return path
+    for d in _COMMON_BIN_DIRS:
+        candidate = os.path.join(d, "ffmpeg")
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
 def _has_ffmpeg() -> bool:
     """Check if ffmpeg is available on the system."""
-    return shutil.which("ffmpeg") is not None
+    return _find_ffmpeg() is not None
 
 
 def _convert_to_opus(mp3_path: str) -> Optional[str]:
@@ -129,7 +144,7 @@ def _convert_to_opus(mp3_path: str) -> Optional[str]:
     ogg_path = mp3_path.rsplit(".", 1)[0] + ".ogg"
     try:
         result = subprocess.run(
-            ["ffmpeg", "-i", mp3_path, "-acodec", "libopus",
+            [_find_ffmpeg(), "-i", mp3_path, "-acodec", "libopus",
              "-ac", "1", "-b:a", "64k", "-vbr", "off", ogg_path, "-y"],
             capture_output=True, timeout=30,
         )
@@ -325,7 +340,7 @@ def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) ->
 
     # If the caller wanted .mp3 or .ogg, convert from WAV
     if wav_path != output_path:
-        ffmpeg = shutil.which("ffmpeg")
+        ffmpeg = _find_ffmpeg()
         if ffmpeg:
             conv_cmd = [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path]
             subprocess.run(conv_cmd, check=True, timeout=30)


### PR DESCRIPTION
## Summary

On macOS with Homebrew-installed ffmpeg but a minimal PATH (launchd gateway, systemd service), `ffmpeg` isn't found. Edge TTS voice bubbles silently fall back to MP3 (Telegram renders these as file attachments instead of inline voice), and NeuTTS silently renames WAV instead of converting.

## Root Cause

`_has_ffmpeg()` and the NeuTTS converter both use bare `shutil.which("ffmpeg")`, which only checks the process PATH. `/opt/homebrew/bin` isn't in PATH for services launched by launchd or systemd.

`transcription_tools.py` already handles this with `COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")` and a `_find_binary()` helper. `browser_tool.py` has `_SANE_PATH` for the same reason. `tts_tool.py` was missed.

## Fix

**Add `_find_ffmpeg()` helper** (`tools/tts_tool.py`)

Checks `shutil.which("ffmpeg")` first, then falls back to `/opt/homebrew/bin/ffmpeg` and `/usr/local/bin/ffmpeg`. All three call sites (`_has_ffmpeg`, `_convert_to_opus`, `_generate_neutts`) now use it.

## Tests

6 new tests: PATH resolution, Homebrew fallback, /usr/local/bin fallback, not-found, and `_has_ffmpeg` wrapper.

```
6 passed
```