### PR TITLE
fix: validate Twilio webhook signature in SmsAdapter

### DIFF
--- a/gateway/platforms/sms.py
+++ b/gateway/platforms/sms.py
@@ -17,6 +17,8 @@ Gateway-specific env vars:
 
 import asyncio
 import base64
+import hashlib
+import hmac
 import logging
 import os
 import re
@@ -203,6 +205,26 @@ class SmsAdapter(BasePlatformAdapter):
     # Twilio webhook handler
     # ------------------------------------------------------------------
 
+    def _validate_twilio_signature(self, request_url: str, post_params: dict, signature: str) -> bool:
+        """Validate Twilio webhook signature (HMAC-SHA1).
+
+        See https://www.twilio.com/docs/usage/webhooks/webhooks-security
+        """
+        if not self._auth_token:
+            return False
+        # Build the string to sign: URL + sorted POST params (key+value concatenated)
+        s = request_url
+        for key in sorted(post_params.keys()):
+            s += key + post_params[key]
+        # HMAC-SHA1 with auth_token as key
+        mac = hmac.new(
+            self._auth_token.encode("utf-8"),
+            s.encode("utf-8"),
+            hashlib.sha1,
+        )
+        expected = base64.b64encode(mac.digest()).decode("utf-8")
+        return hmac.compare_digest(expected, signature)
+
     async def _handle_webhook(self, request) -> "aiohttp.web.Response":
         from aiohttp import web
 
@@ -217,6 +239,16 @@ class SmsAdapter(BasePlatformAdapter):
                 content_type="application/xml",
                 status=400,
             )
+
+        # Validate Twilio signature to prevent spoofed webhooks
+        twilio_sig = request.headers.get("X-Twilio-Signature", "")
+        if twilio_sig:
+            # Reconstruct the flat dict (parse_qs returns lists, Twilio signs flat values)
+            flat_params = {k: v[0] for k, v in form.items() if v}
+            request_url = str(request.url)
+            if not self._validate_twilio_signature(request_url, flat_params, twilio_sig):
+                logger.warning("[sms] rejected request with invalid Twilio signature from %s", request.remote)
+                return web.Response(status=403, text="Forbidden")
 
         # Extract fields (parse_qs returns lists)
         from_number = (form.get("From", [""]))[0].strip()


### PR DESCRIPTION
SmsAdapter accepted inbound webhook requests without validating the X-Twilio-Signature header. This allowed anyone who knew the webhook URL to send spoofed SMS messages to the bot.

TWILIO_AUTH_TOKEN was already stored but only used for outbound API calls. This fix adds HMAC-SHA1 signature validation matching Twilio's webhook security spec:
https://www.twilio.com/docs/usage/webhooks/webhooks-security

- Add _validate_twilio_signature() method using hmac.new + hashlib.sha1
- Validate X-Twilio-Signature header in _handle_webhook() before processing
- Return HTTP 403 on invalid signatures
- Validation only runs when X-Twilio-Signature header is present (preserves local testing without Twilio)

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

