### PR TITLE
fix(security): sanitize API server errors and use timing-safe auth

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -18,6 +18,7 @@ Requires:
 """
 
 import asyncio
+import hmac
 import json
 import logging
 import os
@@ -344,7 +345,7 @@ class APIServerAdapter(BasePlatformAdapter):
         auth_header = request.headers.get("Authorization", "")
         if auth_header.startswith("Bearer "):
             token = auth_header[7:].strip()
-            if token == self._api_key:
+            if hmac.compare_digest(token, self._api_key):
                 return None  # Auth OK
 
         return web.json_response(
@@ -518,7 +519,7 @@ class APIServerAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.error("Error running agent for chat completions: %s", e, exc_info=True)
                 return web.json_response(
-                    _openai_error(f"Internal server error: {e}", err_type="server_error"),
+                    _openai_error("Internal server error", err_type="server_error"),
                     status=500,
                 )
         else:
@@ -527,7 +528,7 @@ class APIServerAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.error("Error running agent for chat completions: %s", e, exc_info=True)
                 return web.json_response(
-                    _openai_error(f"Internal server error: {e}", err_type="server_error"),
+                    _openai_error("Internal server error", err_type="server_error"),
                     status=500,
                 )
 
@@ -743,7 +744,7 @@ class APIServerAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.error("Error running agent for responses: %s", e, exc_info=True)
                 return web.json_response(
-                    _openai_error(f"Internal server error: {e}", err_type="server_error"),
+                    _openai_error("Internal server error", err_type="server_error"),
                     status=500,
                 )
         else:
@@ -752,7 +753,7 @@ class APIServerAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.error("Error running agent for responses: %s", e, exc_info=True)
                 return web.json_response(
-                    _openai_error(f"Internal server error: {e}", err_type="server_error"),
+                    _openai_error("Internal server error", err_type="server_error"),
                     status=500,
                 )
 
@@ -896,7 +897,8 @@ class APIServerAdapter(BasePlatformAdapter):
             jobs = self._cron_list(include_disabled=include_disabled)
             return web.json_response({"jobs": jobs})
         except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
+            logger.exception("API server error: %s", e)
+            return web.json_response({"error": "Internal server error"}, status=500)
 
     async def _handle_create_job(self, request: "web.Request") -> "web.Response":
         """POST /api/jobs — create a new cron job."""
@@ -944,7 +946,8 @@ class APIServerAdapter(BasePlatformAdapter):
             job = self._cron_create(**kwargs)
             return web.json_response({"job": job})
         except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
+            logger.exception("API server error: %s", e)
+            return web.json_response({"error": "Internal server error"}, status=500)
 
     async def _handle_get_job(self, request: "web.Request") -> "web.Response":
         """GET /api/jobs/{job_id} — get a single cron job."""
@@ -963,7 +966,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})
         except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
+            logger.exception("API server error: %s", e)
+            return web.json_response({"error": "Internal server error"}, status=500)
 
     async def _handle_update_job(self, request: "web.Request") -> "web.Response":
         """PATCH /api/jobs/{job_id} — update a cron job."""
@@ -996,7 +1000,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})
         except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
+            logger.exception("API server error: %s", e)
+            return web.json_response({"error": "Internal server error"}, status=500)
 
     async def _handle_delete_job(self, request: "web.Request") -> "web.Response":
         """DELETE /api/jobs/{job_id} — delete a cron job."""
@@ -1015,7 +1020,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"ok": True})
         except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
+            logger.exception("API server error: %s", e)
+            return web.json_response({"error": "Internal server error"}, status=500)
 
     async def _handle_pause_job(self, request: "web.Request") -> "web.Response":
         """POST /api/jobs/{job_id}/pause — pause a cron job."""
@@ -1034,7 +1040,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})
         except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
+            logger.exception("API server error: %s", e)
+            return web.json_response({"error": "Internal server error"}, status=500)
 
     async def _handle_resume_job(self, request: "web.Request") -> "web.Response":
         """POST /api/jobs/{job_id}/resume — resume a paused cron job."""
@@ -1053,7 +1060,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})
         except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
+            logger.exception("API server error: %s", e)
+            return web.json_response({"error": "Internal server error"}, status=500)
 
     async def _handle_run_job(self, request: "web.Request") -> "web.Response":
         """POST /api/jobs/{job_id}/run — trigger immediate execution."""
@@ -1072,7 +1080,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})
         except Exception as e:
-            return web.json_response({"error": str(e)}, status=500)
+            logger.exception("API server error: %s", e)
+            return web.json_response({"error": "Internal server error"}, status=500)
 
     # ------------------------------------------------------------------
     # Output extraction helper

--- a/tests/gateway/test_api_server_security.py
+++ b/tests/gateway/test_api_server_security.py
@@ -1,0 +1,45 @@
+"""Tests for API server security hardening.
+
+1. Timing-safe API key comparison (hmac.compare_digest)
+2. Error responses do not leak exception details to callers
+"""
+
+import hmac
+from unittest.mock import MagicMock, patch
+import pytest
+
+
+class TestTimingSafeAuth:
+    """API key comparison must use hmac.compare_digest, not ==."""
+
+    def test_compare_digest_used_in_source(self):
+        """Verify the auth method uses hmac.compare_digest."""
+        import inspect
+        from gateway.platforms.api_server import APIServerAdapter
+
+        source = inspect.getsource(APIServerAdapter._check_auth)
+        assert "compare_digest" in source
+        assert "token ==" not in source
+
+
+class TestErrorSanitization:
+    """Error responses must not leak internal exception details."""
+
+    def test_openai_error_helper_no_exception_interpolation(self):
+        """_openai_error should not be called with f-string exception details."""
+        import inspect
+        from gateway.platforms import api_server
+
+        source = inspect.getsource(api_server)
+        # No f-string interpolation of exceptions in _openai_error calls
+        assert '_openai_error(f"Internal server error: {e}"' not in source
+        assert '_openai_error(f"Internal server error: {' not in source
+
+    def test_cron_endpoints_do_not_return_raw_exception(self):
+        """Cron error handlers must not return str(e) to callers."""
+        import inspect
+        from gateway.platforms import api_server
+
+        source = inspect.getsource(api_server)
+        # No raw str(e) in JSON responses
+        assert '{"error": str(e)}' not in source


### PR DESCRIPTION
## Summary

Prevents the OpenAI-compatible API server from leaking internal exception details to callers and hardens API key comparison against timing side-channel attacks.

## Problem

**Error leakage:** All 12 exception handlers in `api_server.py` return raw `str(e)` to API callers — either via `_openai_error(f"Internal server error: {e}")` (4 chat/responses endpoints) or `{"error": str(e)}` (8 cron endpoints). Python exception messages can contain internal file paths, database error details, library version info, and partial stack traces. Any OpenAI-compatible frontend (Open WebUI, LobeChat, etc.) receives these in the response body.

**Timing-unsafe auth:** API key comparison at line 347 uses `==` instead of `hmac.compare_digest()`, allowing timing side-channel brute-force.

## Fixes

**1. Error sanitization — 12 locations** (`gateway/platforms/api_server.py`)

- 4 chat/responses endpoints: stripped exception from `_openai_error()`, keeping generic message. `logger.error()` already exists above each handler for diagnostics.
- 8 cron endpoints: replaced `{"error": str(e)}` with generic message, added `logger.exception()` for server-side diagnostics.

**2. Timing-safe auth** (`gateway/platforms/api_server.py`)

Replaced `token == self._api_key` with `hmac.compare_digest(token, self._api_key)`.

## Changes

| File | Change |
|---|---|
| `gateway/platforms/api_server.py` | Add `import hmac`, use `compare_digest` for auth, strip `str(e)` from all 12 error responses, add `logger.exception` to cron handlers |
| `tests/gateway/test_api_server_security.py` | 3 new tests: verify `compare_digest` in source, no exception interpolation in `_openai_error`, no `str(e)` in cron responses |

## Tests

```
3 passed
```