### PR TITLE
fix(gateway): coerce YAML boolean to string for streaming.transport and reply_to_mode

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -172,7 +172,9 @@ class PlatformConfig:
             token=data.get("token"),
             api_key=data.get("api_key"),
             home_channel=home_channel,
-            reply_to_mode=data.get("reply_to_mode", "first"),
+            # YAML parses bare `off` as boolean False — coerce to string
+            reply_to_mode=("off" if data.get("reply_to_mode") is False
+                           else data.get("reply_to_mode", "first")),
             extra=data.get("extra", {}),
         )
 
@@ -199,9 +201,13 @@ class StreamingConfig:
     def from_dict(cls, data: Dict[str, Any]) -> "StreamingConfig":
         if not data:
             return cls()
+        # YAML parses bare `off` as boolean False — coerce to string
+        raw_transport = data.get("transport", "edit")
+        if isinstance(raw_transport, bool):
+            raw_transport = "off" if not raw_transport else "edit"
         return cls(
             enabled=data.get("enabled", False),
-            transport=data.get("transport", "edit"),
+            transport=raw_transport,
             edit_interval=float(data.get("edit_interval", 0.3)),
             buffer_threshold=int(data.get("buffer_threshold", 40)),
             cursor=data.get("cursor", " ▉"),

--- a/tests/gateway/test_yaml_boolean_config.py
+++ b/tests/gateway/test_yaml_boolean_config.py
@@ -1,0 +1,60 @@
+"""Tests for YAML boolean coercion in gateway config fields.
+
+YAML parses bare ``off`` as boolean ``False``, not the string ``"off"``.
+Config fields that expect string values like ``"off"`` must coerce
+booleans to avoid silent misinterpretation.
+"""
+
+from gateway.config import StreamingConfig, PlatformConfig
+
+
+class TestStreamingTransportBoolean:
+    """StreamingConfig.from_dict must coerce boolean transport values."""
+
+    def test_bare_off_parsed_as_false_becomes_off_string(self):
+        """YAML ``transport: off`` → Python ``False`` → should be ``"off"``."""
+        config = StreamingConfig.from_dict({"enabled": True, "transport": False})
+        assert config.transport == "off"
+
+    def test_bare_on_parsed_as_true_becomes_edit(self):
+        """YAML ``transport: on`` → Python ``True`` → should default to ``"edit"``."""
+        config = StreamingConfig.from_dict({"enabled": True, "transport": True})
+        assert config.transport == "edit"
+
+    def test_string_off_preserved(self):
+        """Quoted ``transport: "off"`` stays as ``"off"``."""
+        config = StreamingConfig.from_dict({"enabled": True, "transport": "off"})
+        assert config.transport == "off"
+
+    def test_string_edit_preserved(self):
+        config = StreamingConfig.from_dict({"enabled": True, "transport": "edit"})
+        assert config.transport == "edit"
+
+    def test_missing_transport_defaults_to_edit(self):
+        config = StreamingConfig.from_dict({"enabled": True})
+        assert config.transport == "edit"
+
+
+class TestReplyToModeBoolean:
+    """PlatformConfig.from_dict must coerce boolean reply_to_mode values."""
+
+    def test_bare_off_parsed_as_false_becomes_off_string(self):
+        """YAML ``reply_to_mode: off`` → Python ``False`` → should be ``"off"``."""
+        config = PlatformConfig.from_dict({"reply_to_mode": False})
+        assert config.reply_to_mode == "off"
+
+    def test_string_off_preserved(self):
+        config = PlatformConfig.from_dict({"reply_to_mode": "off"})
+        assert config.reply_to_mode == "off"
+
+    def test_string_first_preserved(self):
+        config = PlatformConfig.from_dict({"reply_to_mode": "first"})
+        assert config.reply_to_mode == "first"
+
+    def test_string_all_preserved(self):
+        config = PlatformConfig.from_dict({"reply_to_mode": "all"})
+        assert config.reply_to_mode == "all"
+
+    def test_missing_defaults_to_first(self):
+        config = PlatformConfig.from_dict({})
+        assert config.reply_to_mode == "first"


### PR DESCRIPTION
## Summary

Fixes `streaming.transport: off` and `reply_to_mode: off` being silently ignored when written without quotes in config.yaml.

## Problem

YAML parses bare `off` as boolean `False`, not the string `"off"`. Two gateway config fields compare against the string `"off"` but receive `False` (bool):

1. **`streaming.transport: off`** — `False != "off"` is `True`, so streaming proceeds despite the user's intent to disable it.
2. **`reply_to_mode: off`** — `False or 'first'` evaluates to `'first'`, silently resetting to the default threading mode.

The same class of issue was previously fixed for `approvals.mode` in PR #2620. These two fields were missed.

## Fixes

**1. `StreamingConfig.from_dict`** (`gateway/config.py`)

Check if `transport` is a bool; coerce `False` → `"off"`, `True` → `"edit"`.

**2. `PlatformConfig.from_dict`** (`gateway/config.py`)

Check if `reply_to_mode` is `False`; coerce to `"off"`.

## Changes

| File | Change |
|---|---|
| `gateway/config.py` | Boolean coercion in `StreamingConfig.from_dict` and `PlatformConfig.from_dict` |
| `tests/gateway/test_yaml_boolean_config.py` | 10 new tests: boolean/string inputs for both fields + default checks |

## Tests

```
10 passed
```