### PR TITLE
fix(gateway): strip whitespace from platform token env vars

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -583,11 +583,16 @@ def load_gateway_config() -> GatewayConfig:
     return config
 
 
+def _strip_env(key: str) -> str:
+    """Read env var and strip whitespace; return empty string if unset or blank."""
+    return (os.getenv(key) or "").strip()
+
+
 def _apply_env_overrides(config: GatewayConfig) -> None:
     """Apply environment variable overrides to config."""
-    
+
     # Telegram
-    telegram_token = os.getenv("TELEGRAM_BOT_TOKEN")
+    telegram_token = _strip_env("TELEGRAM_BOT_TOKEN")
     if telegram_token:
         if Platform.TELEGRAM not in config.platforms:
             config.platforms[Platform.TELEGRAM] = PlatformConfig()
@@ -610,7 +615,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         )
     
     # Discord
-    discord_token = os.getenv("DISCORD_BOT_TOKEN")
+    discord_token = _strip_env("DISCORD_BOT_TOKEN")
     if discord_token:
         if Platform.DISCORD not in config.platforms:
             config.platforms[Platform.DISCORD] = PlatformConfig()
@@ -633,7 +638,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         config.platforms[Platform.WHATSAPP].enabled = True
     
     # Slack
-    slack_token = os.getenv("SLACK_BOT_TOKEN")
+    slack_token = _strip_env("SLACK_BOT_TOKEN")
     if slack_token:
         if Platform.SLACK not in config.platforms:
             config.platforms[Platform.SLACK] = PlatformConfig()
@@ -649,8 +654,8 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             )
     
     # Signal
-    signal_url = os.getenv("SIGNAL_HTTP_URL")
-    signal_account = os.getenv("SIGNAL_ACCOUNT")
+    signal_url = _strip_env("SIGNAL_HTTP_URL")
+    signal_account = _strip_env("SIGNAL_ACCOUNT")
     if signal_url and signal_account:
         if Platform.SIGNAL not in config.platforms:
             config.platforms[Platform.SIGNAL] = PlatformConfig()
@@ -669,7 +674,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             )
 
     # Mattermost
-    mattermost_token = os.getenv("MATTERMOST_TOKEN")
+    mattermost_token = _strip_env("MATTERMOST_TOKEN")
     if mattermost_token:
         mattermost_url = os.getenv("MATTERMOST_URL", "")
         if not mattermost_url:
@@ -688,7 +693,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             )
 
     # Matrix
-    matrix_token = os.getenv("MATRIX_ACCESS_TOKEN")
+    matrix_token = _strip_env("MATRIX_ACCESS_TOKEN")
     matrix_homeserver = os.getenv("MATRIX_HOMESERVER", "")
     if matrix_token or os.getenv("MATRIX_PASSWORD"):
         if not matrix_homeserver:
@@ -716,7 +721,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             )
 
     # Home Assistant
-    hass_token = os.getenv("HASS_TOKEN")
+    hass_token = _strip_env("HASS_TOKEN")
     if hass_token:
         if Platform.HOMEASSISTANT not in config.platforms:
             config.platforms[Platform.HOMEASSISTANT] = PlatformConfig()
@@ -727,10 +732,10 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             config.platforms[Platform.HOMEASSISTANT].extra["url"] = hass_url
 
     # Email
-    email_addr = os.getenv("EMAIL_ADDRESS")
-    email_pwd = os.getenv("EMAIL_PASSWORD")
-    email_imap = os.getenv("EMAIL_IMAP_HOST")
-    email_smtp = os.getenv("EMAIL_SMTP_HOST")
+    email_addr = _strip_env("EMAIL_ADDRESS")
+    email_pwd = _strip_env("EMAIL_PASSWORD")
+    email_imap = _strip_env("EMAIL_IMAP_HOST")
+    email_smtp = _strip_env("EMAIL_SMTP_HOST")
     if all([email_addr, email_pwd, email_imap, email_smtp]):
         if Platform.EMAIL not in config.platforms:
             config.platforms[Platform.EMAIL] = PlatformConfig()
@@ -749,7 +754,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             )
 
     # SMS (Twilio)
-    twilio_sid = os.getenv("TWILIO_ACCOUNT_SID")
+    twilio_sid = _strip_env("TWILIO_ACCOUNT_SID")
     if twilio_sid:
         if Platform.SMS not in config.platforms:
             config.platforms[Platform.SMS] = PlatformConfig()

--- a/tests/gateway/test_env_whitespace_strip.py
+++ b/tests/gateway/test_env_whitespace_strip.py
@@ -1,0 +1,67 @@
+"""Tests for whitespace-only env var stripping in gateway config.
+
+A .env entry like ``TELEGRAM_BOT_TOKEN=  `` (spaces only) should NOT
+enable the platform — it should be treated as empty/unset. Without
+stripping, the truthiness check passes and a whitespace token is stored,
+causing a cryptic auth error on connection instead of silently skipping
+the platform.
+"""
+
+import os
+from unittest.mock import patch
+
+from gateway.config import GatewayConfig, _apply_env_overrides, Platform
+
+
+def _make_config():
+    return GatewayConfig.from_dict({})
+
+
+class TestWhitespaceTokensIgnored:
+
+    @patch.dict(os.environ, {"TELEGRAM_BOT_TOKEN": "   "}, clear=False)
+    def test_whitespace_telegram_token_does_not_enable_platform(self):
+        config = _make_config()
+        _apply_env_overrides(config)
+        assert Platform.TELEGRAM not in config.platforms or not config.platforms[Platform.TELEGRAM].enabled
+
+    @patch.dict(os.environ, {"DISCORD_BOT_TOKEN": " \t "}, clear=False)
+    def test_whitespace_discord_token_does_not_enable_platform(self):
+        config = _make_config()
+        _apply_env_overrides(config)
+        assert Platform.DISCORD not in config.platforms or not config.platforms[Platform.DISCORD].enabled
+
+    @patch.dict(os.environ, {"SLACK_BOT_TOKEN": "  "}, clear=False)
+    def test_whitespace_slack_token_does_not_enable_platform(self):
+        config = _make_config()
+        _apply_env_overrides(config)
+        assert Platform.SLACK not in config.platforms or not config.platforms[Platform.SLACK].enabled
+
+    @patch.dict(os.environ, {"MATTERMOST_TOKEN": " ", "MATTERMOST_URL": "https://mm.example.com"}, clear=False)
+    def test_whitespace_mattermost_token_does_not_enable_platform(self):
+        config = _make_config()
+        _apply_env_overrides(config)
+        assert Platform.MATTERMOST not in config.platforms or not config.platforms[Platform.MATTERMOST].enabled
+
+    @patch.dict(os.environ, {"TWILIO_ACCOUNT_SID": "  "}, clear=False)
+    def test_whitespace_twilio_sid_does_not_enable_platform(self):
+        config = _make_config()
+        _apply_env_overrides(config)
+        assert Platform.SMS not in config.platforms or not config.platforms[Platform.SMS].enabled
+
+
+class TestValidTokensStillWork:
+
+    @patch.dict(os.environ, {"TELEGRAM_BOT_TOKEN": "123456:ABC-DEF"}, clear=False)
+    def test_real_telegram_token_enables_platform(self):
+        config = _make_config()
+        _apply_env_overrides(config)
+        assert config.platforms[Platform.TELEGRAM].enabled is True
+        assert config.platforms[Platform.TELEGRAM].token == "123456:ABC-DEF"
+
+    @patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "MTIz.abc.xyz"}, clear=False)
+    def test_real_discord_token_enables_platform(self):
+        config = _make_config()
+        _apply_env_overrides(config)
+        assert config.platforms[Platform.DISCORD].enabled is True
+        assert config.platforms[Platform.DISCORD].token == "MTIz.abc.xyz"


### PR DESCRIPTION
## Summary

Strips whitespace from all platform token/key environment variables in `_apply_env_overrides()`. Prevents whitespace-only `.env` entries from silently enabling platforms with invalid tokens.

## Problem

A `.env` entry like `TELEGRAM_BOT_TOKEN=   ` (trailing spaces from copy-paste or editor artifacts) passes the `if telegram_token:` truthiness check because a whitespace-only string is truthy in Python. The platform is enabled with the whitespace token, and the client fails on connection with a cryptic authentication error instead of silently skipping the unconfigured platform.

The same class of issue was fixed for `FIRECRAWL_API_KEY` in `web_tools._has_env()` (PR #2341). All 10 platform token reads in `_apply_env_overrides()` had the same vulnerability.

## Fixes

Added `_strip_env(key)` helper that returns `(os.getenv(key) or "").strip()` and applied it to all platform token/key reads: `TELEGRAM_BOT_TOKEN`, `DISCORD_BOT_TOKEN`, `SLACK_BOT_TOKEN`, `SIGNAL_HTTP_URL`, `SIGNAL_ACCOUNT`, `MATTERMOST_TOKEN`, `MATRIX_ACCESS_TOKEN`, `HASS_TOKEN`, `EMAIL_ADDRESS`/`PASSWORD`/`IMAP_HOST`/`SMTP_HOST`, `TWILIO_ACCOUNT_SID`.

## Changes

| File | Change |
|---|---|
| `gateway/config.py` | Add `_strip_env()` helper, apply to all 10 platform token reads |
| `tests/gateway/test_env_whitespace_strip.py` | 7 new tests: 5 whitespace-rejection + 2 valid-token-acceptance |

## Tests

```
7 passed
```