### PR TITLE
feat(ollama): pass think=false to custom providers when reasoning_effort is none

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4446,6 +4446,18 @@ class AIAgent:
         if _is_nous:
             extra_body["tags"] = ["product=hermes-agent"]
 
+        # Ollama / custom provider: pass think=false when reasoning is disabled.
+        # Ollama does not recognise the OpenRouter-style `reasoning` extra_body
+        # field, so we use its native `think` parameter instead.
+        # This prevents thinking-capable models (Qwen3, etc.) from generating
+        # <think> blocks and producing empty-response errors when the user has
+        # set reasoning_effort: none.
+        if self.provider == "custom" and self.reasoning_config and isinstance(self.reasoning_config, dict):
+            _effort = (self.reasoning_config.get("effort") or "").strip().lower()
+            _enabled = self.reasoning_config.get("enabled", True)
+            if _effort == "none" or _enabled is False:
+                extra_body["think"] = False
+
         if extra_body:
             api_kwargs["extra_body"] = extra_body
 

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -674,6 +674,45 @@ class TestBuildApiKwargs:
         kwargs = agent._build_api_kwargs(messages)
         assert kwargs["max_tokens"] == 4096
 
+    def test_ollama_think_false_on_effort_none(self, agent):
+        """Custom (Ollama) provider with effort=none should inject think=false."""
+        agent.provider = "custom"
+        agent.base_url = "http://localhost:11434/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.reasoning_config = {"effort": "none"}
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs.get("extra_body", {}).get("think") is False
+
+    def test_ollama_think_false_on_enabled_false(self, agent):
+        """Custom (Ollama) provider with enabled=false should inject think=false."""
+        agent.provider = "custom"
+        agent.base_url = "http://localhost:11434/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.reasoning_config = {"enabled": False}
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs.get("extra_body", {}).get("think") is False
+
+    def test_ollama_no_think_param_when_reasoning_enabled(self, agent):
+        """Custom provider with reasoning enabled should NOT inject think=false."""
+        agent.provider = "custom"
+        agent.base_url = "http://localhost:11434/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.reasoning_config = {"enabled": True, "effort": "medium"}
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs.get("extra_body", {}).get("think") is None
+
+    def test_non_custom_provider_unaffected(self, agent):
+        """OpenRouter provider with effort=none should NOT inject think=false."""
+        agent.provider = "openrouter"
+        agent.model = "qwen/qwen3.5-plus-02-15"
+        agent.reasoning_config = {"effort": "none"}
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs.get("extra_body", {}).get("think") is None
+
 
 class TestBuildAssistantMessage:
     def test_basic_message(self, agent):


### PR DESCRIPTION
## Summary

Closes #3191

When a custom/Ollama provider is used with `reasoning_effort: none` (or `enabled: false`), inject `"think": false` into the request `extra_body`.

## Root Cause

Ollama does not recognise the OpenRouter-style `reasoning` extra_body field. Thinking-capable models (Qwen3, etc.) therefore generate `<think>` blocks regardless of the `reasoning_effort` setting. This produces empty-response errors that corrupt session state.

The existing `_supports_reasoning_extra_body()` guard correctly blocks the `reasoning` field from being sent to custom endpoints — but there was no mechanism to affirmatively disable thinking on Ollama's side.

## Fix

One block added in `_build_api_kwargs()`, after the `extra_body` assembly:

```python
if self.provider == "custom" and self.reasoning_config and isinstance(self.reasoning_config, dict):
    _effort = (self.reasoning_config.get("effort") or "").strip().lower()
    _enabled = self.reasoning_config.get("enabled", True)
    if _effort == "none" or _enabled is False:
        extra_body["think"] = False
```

This covers both config shapes users might use:
- `reasoning_effort: none` → `{"effort": "none"}`
- `reasoning: {enabled: false}` → `{"enabled": false}`

Non-custom providers and Ollama with reasoning enabled are unaffected.

## Tests

4 new tests in `TestBuildApiKwargs`:
- `test_ollama_think_false_on_effort_none` — effort=none triggers think=false
- `test_ollama_think_false_on_enabled_false` — enabled=false triggers think=false
- `test_ollama_no_think_param_when_reasoning_enabled` — enabled provider → no think param
- `test_non_custom_provider_unaffected` — OpenRouter with effort=none is not affected

## Scope

Single file change (`run_agent.py`), 12 lines added.