### PR TITLE
feat(slack): add SLACK_ALLOW_BOTS env var for bot-to-bot communication

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -71,6 +71,7 @@ class SlackAdapter(BasePlatformAdapter):
         self._app: Optional[AsyncApp] = None
         self._handler: Optional[AsyncSocketModeHandler] = None
         self._bot_user_id: Optional[str] = None
+        self._bot_id: Optional[str] = None  # bot_id from auth.test, used for self-message detection
         self._user_name_cache: Dict[str, str] = {}  # user_id → display name
 
     async def connect(self) -> bool:
@@ -97,6 +98,7 @@ class SlackAdapter(BasePlatformAdapter):
             # Get our own bot user ID for mention detection
             auth_response = await self._app.client.auth_test()
             self._bot_user_id = auth_response.get("user_id")
+            self._bot_id = auth_response.get("bot_id")
             bot_name = auth_response.get("user", "unknown")
 
             # Register message event handler
@@ -625,9 +627,22 @@ class SlackAdapter(BasePlatformAdapter):
 
     async def _handle_slack_message(self, event: dict) -> None:
         """Handle an incoming Slack message event."""
-        # Ignore bot messages (including our own)
+        # Bot message filtering (SLACK_ALLOW_BOTS):
+        #   "none"     — ignore all bot messages (default, backward-compatible)
+        #   "mentions" — accept bot messages only when they @mention us
+        #   "all"      — accept all bot messages (except our own)
         if event.get("bot_id") or event.get("subtype") == "bot_message":
-            return
+            allow_bots = os.getenv("SLACK_ALLOW_BOTS", "none").lower().strip()
+            if allow_bots == "none":
+                return
+            elif allow_bots == "mentions":
+                text_check = event.get("text", "")
+                if self._bot_user_id and f"<@{self._bot_user_id}>" not in text_check:
+                    return
+            # "all" falls through to handle_message
+            # Always ignore our own messages to prevent echo loops
+            if self._bot_id and event.get("bot_id") == self._bot_id:
+                return
 
         # Ignore message edits and deletions
         subtype = event.get("subtype")

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -506,7 +506,7 @@ class TestMessageRouting:
 
     @pytest.mark.asyncio
     async def test_bot_messages_ignored(self, adapter):
-        """Messages from bots should be ignored."""
+        """Messages from bots should be ignored by default (SLACK_ALLOW_BOTS=none)."""
         event = {
             "text": "bot response",
             "bot_id": "B_OTHER",
@@ -516,6 +516,91 @@ class TestMessageRouting:
         }
         await adapter._handle_slack_message(event)
         adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_allow_bots_all_accepts_other_bot(self, adapter, monkeypatch):
+        """SLACK_ALLOW_BOTS=all should let other bots' messages through."""
+        monkeypatch.setenv("SLACK_ALLOW_BOTS", "all")
+        event = {
+            "text": "hello from bot",
+            "bot_id": "B_OTHER",
+            "channel": "C123",
+            "channel_type": "im",
+            "ts": "1234567890.000001",
+        }
+        await adapter._handle_slack_message(event)
+        adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_allow_bots_all_still_ignores_own_messages(self, adapter, monkeypatch):
+        """SLACK_ALLOW_BOTS=all should drop our own bot's messages to prevent echo loops."""
+        monkeypatch.setenv("SLACK_ALLOW_BOTS", "all")
+        adapter._bot_id = "B_SELF"
+        event = {
+            "text": "our own message",
+            "bot_id": "B_SELF",
+            "channel": "C123",
+            "channel_type": "im",
+            "ts": "1234567890.000001",
+        }
+        await adapter._handle_slack_message(event)
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_allow_bots_mentions_accepts_when_mentioned(self, adapter, monkeypatch):
+        """SLACK_ALLOW_BOTS=mentions should accept bot messages that @mention us."""
+        monkeypatch.setenv("SLACK_ALLOW_BOTS", "mentions")
+        event = {
+            "text": "<@U_BOT> please summarise this",
+            "bot_id": "B_OTHER",
+            "channel": "C123",
+            "channel_type": "channel",
+            "ts": "1234567890.000001",
+        }
+        await adapter._handle_slack_message(event)
+        adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_allow_bots_mentions_ignores_without_mention(self, adapter, monkeypatch):
+        """SLACK_ALLOW_BOTS=mentions should drop bot messages that don't @mention us."""
+        monkeypatch.setenv("SLACK_ALLOW_BOTS", "mentions")
+        event = {
+            "text": "just a bot talking to itself",
+            "bot_id": "B_OTHER",
+            "channel": "C123",
+            "channel_type": "im",
+            "ts": "1234567890.000001",
+        }
+        await adapter._handle_slack_message(event)
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_allow_bots_none_explicit_still_ignores(self, adapter, monkeypatch):
+        """Explicit SLACK_ALLOW_BOTS=none behaves like the default."""
+        monkeypatch.setenv("SLACK_ALLOW_BOTS", "none")
+        event = {
+            "text": "bot chatter",
+            "bot_id": "B_OTHER",
+            "channel": "C123",
+            "channel_type": "im",
+            "ts": "1234567890.000001",
+        }
+        await adapter._handle_slack_message(event)
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_allow_bots_subtype_bot_message(self, adapter, monkeypatch):
+        """SLACK_ALLOW_BOTS=all should also accept bot_message subtype events."""
+        monkeypatch.setenv("SLACK_ALLOW_BOTS", "all")
+        event = {
+            "text": "posted by webhook",
+            "subtype": "bot_message",
+            "channel": "C123",
+            "channel_type": "im",
+            "ts": "1234567890.000001",
+        }
+        await adapter._handle_slack_message(event)
+        adapter.handle_message.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_message_edits_ignored(self, adapter):


### PR DESCRIPTION
## Summary

Closes #3198

Adds `SLACK_ALLOW_BOTS` env var to the Slack adapter, bringing it to parity with `DISCORD_ALLOW_BOTS`.

## Modes

| Value | Behavior |
|-------|----------|
| `none` (default) | Ignore all bot messages — backward-compatible |
| `mentions` | Accept bot messages only when they @mention the Hermes bot |
| `all` | Accept all bot messages from other bots |

The self-message guard is always active regardless of mode — the bot never processes its own messages (prevents echo loops).

## Implementation

Two changes in `gateway/platforms/slack.py`:

**1. Store `bot_id` from `auth.test`** — used to identify our own messages:
```python
self._bot_id = auth_response.get("bot_id")
```

**2. Replace the hard filter with the three-mode check:**
```python
if event.get("bot_id") or event.get("subtype") == "bot_message":
    allow_bots = os.getenv("SLACK_ALLOW_BOTS", "none").lower().strip()
    if allow_bots == "none":
        return
    elif allow_bots == "mentions":
        if self._bot_user_id and f"<@{self._bot_user_id}>" not in text_check:
            return
    # "all" falls through
    if self._bot_id and event.get("bot_id") == self._bot_id:
        return  # always drop our own messages
```

Note on `SLACK_ALLOWED_USERS`: bot user IDs are not subject to the allowlist check (the allowlist is applied later in `handle_message` via the base class, keyed on the `user` field which bots don't populate). No change needed there.

## Tests

6 new tests in `TestMessageRouting`:
- `test_allow_bots_all_accepts_other_bot`
- `test_allow_bots_all_still_ignores_own_messages`
- `test_allow_bots_mentions_accepts_when_mentioned`
- `test_allow_bots_mentions_ignores_without_mention`
- `test_allow_bots_none_explicit_still_ignores`
- `test_allow_bots_subtype_bot_message`

All 70 tests pass.