### PR TITLE
fix(telegram): ignore invalid message_thread_id in non-forum DMs

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1811,6 +1811,12 @@ class TelegramAdapter(BasePlatformAdapter):
                     if not chat_topic:
                         chat_topic = created_name
 
+            # If no DM topic was resolved, Telegram may have set message_thread_id
+            # to indicate a reply chain (not a real forum topic). Drop it so downstream
+            # send calls don't fail with "Message thread not found".
+            if not chat_topic:
+                thread_id_str = None
+
         # Build source
         source = self.build_source(
             chat_id=str(chat.id),


### PR DESCRIPTION
## What does this PR do?

Fixes a Telegram DM bug where message_thread_id is incorrectly propagated from reply chains and used in send_message() calls.

In non-forum (non-topic) Telegram DMs, the API may include a message_thread_id on incoming messages to represent reply chains. However, this value is not valid for outgoing messages. Passing it causes Telegram to return:

BadRequest: Message thread not found

This PR prevents those invalid thread IDs from being used by clearing them when no real chat_topic is resolved.

## Related Issue

Fixes #3206 

## Type of Change
 🐛 Bug fix (non-breaking change that fixes an issue)
 

## Changes Made

1. gateway/platforms/telegram.py
- Drop thread_id when no chat_topic is resolved
- Prevents invalid message_thread_id from being passed downstream
2. Added safeguard comment explaining Telegram’s reply-chain behavior in DMs

## How to Test

1. Open a Telegram DM (non-forum chat)
2. Reply to an existing message (this creates a reply chain)
3. Trigger Hermes to send a response (streaming or normal)
4. Verify:
-Before fix: Message thread not found errors + retries
-After fix: messages send successfully without retries or errors

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run pytest tests/ -q and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)

## Documentation & Housekeeping
- I've updated relevant documentation — N/A
- I've updated cli-config.yaml.example — N/A
- I've updated CONTRIBUTING.md or AGENTS.md — N/A
- I've considered cross-platform impact — N/A
- I've updated tool descriptions/schemas — N/A
