### PR TITLE
feat(sessions): add --source flag for third-party session isolation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2916,7 +2916,7 @@ class HermesCLI:
                 try:
                     self._session_db.create_session(
                         session_id=self.session_id,
-                        source="cli",
+                        source=os.environ.get("HERMES_SESSION_SOURCE", "cli"),
                         model=self.model,
                         model_config={
                             "max_iterations": self.max_turns,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -513,6 +513,10 @@ def cmd_chat(args):
     if getattr(args, "yolo", False):
         os.environ["HERMES_YOLO_MODE"] = "1"
 
+    # --source: tag session source for filtering (e.g. 'tool' for third-party integrations)
+    if getattr(args, "source", None):
+        os.environ["HERMES_SESSION_SOURCE"] = args.source
+
     # Import and run the CLI
     from cli import main as cli_main
     
@@ -3164,6 +3168,11 @@ For more help on a command:
         default=False,
         help="Include the session ID in the agent's system prompt"
     )
+    chat_parser.add_argument(
+        "--source",
+        default=None,
+        help="Session source tag for filtering (default: cli). Use 'tool' for third-party integrations that should not appear in user session lists."
+    )
     chat_parser.set_defaults(func=cmd_chat)
 
     # =========================================================================
@@ -3863,7 +3872,7 @@ For more help on a command:
         action = args.sessions_action
 
         if action == "list":
-            sessions = db.list_sessions_rich(source=args.source, limit=args.limit)
+            sessions = db.list_sessions_rich(source=args.source, exclude_sources=["tool"], limit=args.limit)
             if not sessions:
                 print("No sessions found.")
                 return
@@ -3946,7 +3955,7 @@ For more help on a command:
         elif action == "browse":
             limit = getattr(args, "limit", 50) or 50
             source = getattr(args, "source", None)
-            sessions = db.list_sessions_rich(source=source, limit=limit)
+            sessions = db.list_sessions_rich(source=source, exclude_sources=["tool"], limit=limit)
             db.close()
             if not sessions:
                 print("No sessions found.")

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -548,6 +548,7 @@ class SessionDB:
     def list_sessions_rich(
         self,
         source: str = None,
+        exclude_sources: List[str] = None,
         limit: int = 20,
         offset: int = 0,
     ) -> List[Dict[str, Any]]:
@@ -559,7 +560,18 @@ class SessionDB:
 
         Uses a single query with correlated subqueries instead of N+2 queries.
         """
-        source_clause = "WHERE s.source = ?" if source else ""
+        where_clauses = []
+        params = []
+
+        if source:
+            where_clauses.append("s.source = ?")
+            params.append(source)
+        if exclude_sources:
+            placeholders = ",".join("?" for _ in exclude_sources)
+            where_clauses.append(f"s.source NOT IN ({placeholders})")
+            params.extend(exclude_sources)
+
+        where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
         query = f"""
             SELECT s.*,
                 COALESCE(
@@ -574,11 +586,11 @@ class SessionDB:
                     s.started_at
                 ) AS last_active
             FROM sessions s
-            {source_clause}
+            {where_sql}
             ORDER BY s.started_at DESC
             LIMIT ? OFFSET ?
         """
-        params = (source, limit, offset) if source else (limit, offset)
+        params.extend([limit, offset])
         with self._lock:
             cursor = self._conn.execute(query, params)
             rows = cursor.fetchall()
@@ -794,6 +806,7 @@ class SessionDB:
         self,
         query: str,
         source_filter: List[str] = None,
+        exclude_sources: List[str] = None,
         role_filter: List[str] = None,
         limit: int = 20,
         offset: int = 0,
@@ -825,6 +838,11 @@ class SessionDB:
             source_placeholders = ",".join("?" for _ in source_filter)
             where_clauses.append(f"s.source IN ({source_placeholders})")
             params.extend(source_filter)
+
+        if exclude_sources is not None:
+            exclude_placeholders = ",".join("?" for _ in exclude_sources)
+            where_clauses.append(f"s.source NOT IN ({exclude_placeholders})")
+            params.extend(exclude_sources)
 
         if role_filter:
             role_placeholders = ",".join("?" for _ in role_filter)

--- a/run_agent.py
+++ b/run_agent.py
@@ -883,7 +883,7 @@ class AIAgent:
             try:
                 self._session_db.create_session(
                     session_id=self.session_id,
-                    source=self.platform or "cli",
+                    source=self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
                     model=self.model,
                     model_config={
                         "max_iterations": self.max_iterations,
@@ -4844,7 +4844,7 @@ class AIAgent:
                 self.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
                 self._session_db.create_session(
                     session_id=self.session_id,
-                    source=self.platform or "cli",
+                    source=self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
                     model=self.model,
                     parent_session_id=old_session_id,
                 )

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -178,10 +178,16 @@ async def _summarize_session(
                 return None
 
 
+# Sources that are excluded from session browsing/searching by default.
+# Third-party integrations (Paperclip agents, etc.) tag their sessions with
+# HERMES_SESSION_SOURCE=tool so they don't clutter the user's session history.
+_HIDDEN_SESSION_SOURCES = ("tool",)
+
+
 def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str:
     """Return metadata for the most recent sessions (no LLM calls)."""
     try:
-        sessions = db.list_sessions_rich(limit=limit + 5)  # fetch extra to skip current
+        sessions = db.list_sessions_rich(limit=limit + 5, exclude_sources=list(_HIDDEN_SESSION_SOURCES))  # fetch extra to skip current
 
         # Resolve current session lineage to exclude it
         current_root = None
@@ -265,6 +271,7 @@ def session_search(
         raw_results = db.search_messages(
             query=query,
             role_filter=role_list,
+            exclude_sources=list(_HIDDEN_SESSION_SOURCES),
             limit=50,  # Get more matches to find unique sessions
             offset=0,
         )


### PR DESCRIPTION
## Problem

When third-party tools (like Paperclip orchestrator) spawn `hermes chat` as a subprocess, their agent sessions pollute the user's CLI session history, `hermes sessions list`, `hermes sessions browse`, and `session_search` results.

## Solution

Add a `--source <tag>` flag to `hermes chat` that tags sessions with a custom source identifier. Sessions tagged with `source=tool` are filtered out from user-facing session lists and search by default.

### Changes

- **`hermes chat --source <tag>`**: New CLI flag (also settable via `HERMES_SESSION_SOURCE` env var, same pattern as `--yolo`)
- **`hermes_state.py`**: Added `exclude_sources` parameter to `list_sessions_rich()` and `search_messages()`
- **`session_search_tool.py`**: Added `_HIDDEN_SESSION_SOURCES` constant; recent sessions and FTS5 search exclude `source=tool` by default
- **`hermes_cli/main.py`**: `sessions list` and `sessions browse` exclude `tool` sessions by default
- **`cli.py` + `run_agent.py`**: Read `HERMES_SESSION_SOURCE` env var, falling back to `"cli"`

### Usage for third-party adapters

```bash
# Option 1: CLI flag
hermes chat -q "..." --source tool -Q

# Option 2: Environment variable
HERMES_SESSION_SOURCE=tool hermes chat -q "..."
```

### Backwards compatible

- Default behavior unchanged (source defaults to "cli")
- Filtering only hides `source=tool` sessions which don't exist yet
- Users can still see tool sessions with `hermes sessions list --source tool`

### Context

Companion PR: hermes-paperclip-adapter will pass `--source tool` when spawning Hermes.