### PR TITLE
fix(cli): handle update from non-main branches and ff-only failures

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2691,9 +2691,11 @@ def cmd_update(args):
             text=True,
             check=True
         )
-        branch = result.stdout.strip()
+        head_branch = result.stdout.strip()
 
-        # Fall back to main if the current branch doesn't exist on the remote
+        # The update target is always main (or the current branch if it tracks
+        # a remote).  Fall back to main when the current branch has no remote.
+        branch = head_branch
         verify = subprocess.run(
             git_cmd + ["rev-parse", "--verify", f"origin/{branch}"],
             cwd=PROJECT_ROOT, capture_output=True, text=True,
@@ -2723,7 +2725,26 @@ def cmd_update(args):
 
         print("→ Pulling updates...")
         try:
-            subprocess.run(git_cmd + ["pull", "--ff-only", "origin", branch], cwd=PROJECT_ROOT, check=True)
+            if head_branch == branch:
+                # On the target branch -- try fast-forward, fall back to rebase.
+                try:
+                    subprocess.run(git_cmd + ["pull", "--ff-only", "origin", branch], cwd=PROJECT_ROOT, check=True)
+                except subprocess.CalledProcessError:
+                    print("  Fast-forward not possible, rebasing...")
+                    subprocess.run(git_cmd + ["pull", "--rebase", "origin", branch], cwd=PROJECT_ROOT, check=True)
+            else:
+                # On a different branch -- update the target ref without switching.
+                fetch_result = subprocess.run(
+                    git_cmd + ["fetch", "origin", f"{branch}:{branch}"],
+                    cwd=PROJECT_ROOT, capture_output=True, text=True,
+                )
+                if fetch_result.returncode != 0:
+                    # Local ref diverged -- force-update since user isn't on it.
+                    subprocess.run(
+                        git_cmd + ["branch", "-f", branch, f"origin/{branch}"],
+                        cwd=PROJECT_ROOT, check=True,
+                    )
+                print(f"  Updated local {branch} (staying on {head_branch})")
         finally:
             if auto_stash_ref is not None:
                 _restore_stashed_changes(

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -61,10 +61,9 @@ class TestCmdUpdateBranchFallback:
         assert "origin/main" in rev_list_cmds[0]
         assert "origin/fix/stoicneko" not in rev_list_cmds[0]
 
-        # pull should use main, not fix/stoicneko
-        pull_cmds = [c for c in commands if "pull" in c]
-        assert len(pull_cmds) == 1
-        assert "main" in pull_cmds[0]
+        # Should update main ref without switching branches (fetch origin main:main)
+        fetch_ref_cmds = [c for c in commands if "fetch" in c and "main:main" in c]
+        assert len(fetch_ref_cmds) == 1
 
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")


### PR DESCRIPTION
## Summary
- Track `head_branch` separately from the update target `branch`
- When the user is on a different branch, update the local main ref via `git fetch origin main:main` rather than trying to merge into the current branch
- When on the target branch, fall back to `--rebase` if `--ff-only` fails

Closes #3213