### PR TITLE
fix(session): prefer longer source in load_transcript to prevent legacy truncation

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -974,35 +974,51 @@ class SessionStore:
 
     def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
         """Load all messages from a session's transcript."""
+        db_messages = []
         # Try SQLite first
         if self._db:
             try:
-                messages = self._db.get_messages_as_conversation(session_id)
-                if messages:
-                    return messages
+                db_messages = self._db.get_messages_as_conversation(session_id)
             except Exception as e:
                 logger.debug("Could not load messages from DB: %s", e)
-        
-        # Fall back to legacy JSONL
+
+        # Load legacy JSONL transcript (may contain more history than SQLite
+        # for sessions created before the DB layer was introduced).
         transcript_path = self.get_transcript_path(session_id)
-        
-        if not transcript_path.exists():
-            return []
-        
-        messages = []
-        with open(transcript_path, "r", encoding="utf-8") as f:
-            for line in f:
-                line = line.strip()
-                if line:
-                    try:
-                        messages.append(json.loads(line))
-                    except json.JSONDecodeError:
-                        logger.warning(
-                            "Skipping corrupt line in transcript %s: %s",
-                            session_id, line[:120],
-                        )
-        
-        return messages
+        jsonl_messages = []
+        if transcript_path.exists():
+            with open(transcript_path, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if line:
+                        try:
+                            jsonl_messages.append(json.loads(line))
+                        except json.JSONDecodeError:
+                            logger.warning(
+                                "Skipping corrupt line in transcript %s: %s",
+                                session_id, line[:120],
+                            )
+
+        # Prefer whichever source has more messages.
+        #
+        # Background: when a session pre-dates SQLite storage (or when the DB
+        # layer was added while a long-lived session was already active), the
+        # first post-migration turn writes only the *new* messages to SQLite
+        # (because _flush_messages_to_session_db skips messages already in
+        # conversation_history, assuming they're persisted).  On the *next*
+        # turn load_transcript returns those few SQLite rows and ignores the
+        # full JSONL history — the model sees a context of 1-4 messages instead
+        # of hundreds.  Using the longer source prevents this silent truncation.
+        if len(jsonl_messages) > len(db_messages):
+            if db_messages:
+                logger.debug(
+                    "Session %s: JSONL has %d messages vs SQLite %d — "
+                    "using JSONL (legacy session not yet fully migrated)",
+                    session_id, len(jsonl_messages), len(db_messages),
+                )
+            return jsonl_messages
+
+        return db_messages
 
 
 def build_session_context(


### PR DESCRIPTION
## Summary

Closes #3212

Fixes conversation context silently truncating to 4 messages after a gateway restart for sessions with long JSONL history.

## Root Cause

`_flush_messages_to_session_db` deliberately skips messages already in `conversation_history` to avoid duplicate writes (the #860 fix). The assumption is that those messages are already persisted in SQLite. That assumption is false for:

- Sessions created before the SQLite layer was introduced
- Sessions after a deployment that reset or replaced the DB
- Any session where the DB was unavailable during earlier turns

**Exact failure trace for the reporter's session (994 JSONL messages):**

```
Turn N  (first after restart):
  load_transcript(id)          → SQLite: 0 rows → falls back to JSONL: 994 ✓
  _flush_messages_to_session_db:
    start_idx = len(conversation_history) = 994
    flush_from = max(994, 0) = 994
    writes messages[994:] = [user_msg, assistant_msg]  → SQLite now has 2 rows

Turn N+1:
  load_transcript(id)          → SQLite: 2 rows → returns immediately ✗
  agent sees 2 messages of history
  _save_session_log writes messages=[2 history + 2 new] = 4 to session JSON
```

This matches the reporter's exact evidence: JSONL 994 ✅, session JSON 4 ❌.

## Fix

`load_transcript` now loads **both** SQLite and JSONL, then returns whichever has more messages.

```python
if len(jsonl_messages) > len(db_messages):
    # Legacy session not yet fully migrated — use JSONL
    return jsonl_messages
return db_messages
```

For a fully-migrated session, SQLite will always be ≥ JSONL (JSONL is append-only and stops being written once SQLite takes over). There is no regression for normal sessions.

The JSONL read is a sequential scan; for very large transcripts it adds a small I/O cost, but `load_transcript` is called once per gateway turn and the file is already in the OS page cache for active sessions. The trade-off is acceptable.

## Note on a related bug

This is a separate fix from #3210 / PR #3220 (cached agent `session_id` mismatch after session reset). That PR covers the case where a session *reset* causes the agent to write to the wrong session. This PR covers the case where a *legacy JSONL session* is never bootstrapped into SQLite, causing subsequent turns to see only the most recent 2 messages.

## Tests

1453 gateway tests + 456 session tests pass. No regressions.