### PR TITLE
fix(session): prevent resume data loss and add /resume slash command

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3647,6 +3647,73 @@ class HermesCLI:
                     _cprint("  Session database not available.")
         elif canonical == "new":
             self.new_session()
+        elif canonical == "resume":
+            parts = cmd_original.split(None, 1)
+            target_id = parts[1].strip() if len(parts) > 1 else ""
+            if not target_id:
+                _cprint("  Usage: /resume <session_id_or_title>")
+                _cprint("  Tip:   Use /history or `hermes sessions list` to find session IDs.")
+            elif not self._session_db:
+                _cprint("  Session database not available.")
+            else:
+                # Resolve title → session ID
+                from hermes_cli.main import _resolve_session_by_name_or_id
+                resolved = _resolve_session_by_name_or_id(target_id)
+                target_id = resolved or target_id
+
+                session_meta = self._session_db.get_session(target_id)
+                if not session_meta:
+                    _cprint(f"  Session not found: {target_id}")
+                    _cprint("  Use `hermes sessions list` to see available sessions.")
+                else:
+                    # End the current session cleanly
+                    if self._session_db and self.session_id:
+                        try:
+                            self._session_db.end_session(self.session_id, "resumed_other")
+                        except Exception:
+                            pass
+
+                    # Switch to the requested session
+                    old_id = self.session_id
+                    self.session_id = target_id
+                    self._resumed = True
+
+                    restored = self._session_db.get_messages_as_conversation(target_id)
+                    self.conversation_history = restored or []
+
+                    # Re-open the session (clear ended_at)
+                    try:
+                        self._session_db._conn.execute(
+                            "UPDATE sessions SET ended_at = NULL, end_reason = NULL WHERE id = ?",
+                            (target_id,),
+                        )
+                        self._session_db._conn.commit()
+                    except Exception:
+                        pass
+
+                    # Sync the agent if already initialised
+                    if self.agent:
+                        self.agent.session_id = target_id
+                        if hasattr(self.agent, "_last_flushed_db_idx"):
+                            self.agent._last_flushed_db_idx = len(self.conversation_history)
+                        if hasattr(self.agent, "_invalidate_system_prompt"):
+                            self.agent._invalidate_system_prompt()
+
+                    title_part = f" \"{session_meta['title']}\"" if session_meta.get("title") else ""
+                    msg_count = len([m for m in self.conversation_history if m.get("role") == "user"])
+                    if self.conversation_history:
+                        ChatConsole().print(
+                            f"[bold {_accent_hex()}]↻ Resumed session[/] "
+                            f"[bold]{_escape(target_id)}[/]"
+                            f"[bold {_accent_hex()}]{_escape(title_part)}[/] "
+                            f"({msg_count} user message{'s' if msg_count != 1 else ''}, "
+                            f"{len(self.conversation_history)} total messages)"
+                        )
+                    else:
+                        ChatConsole().print(
+                            f"[bold {_accent_hex()}]↻ Resumed session {_escape(target_id)}"
+                            f"{_escape(title_part)} — no messages found, starting fresh.[/]"
+                        )
         elif canonical == "provider":
             self._show_model_and_providers()
         elif canonical == "prompt":

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -252,11 +252,18 @@ class SessionDB:
         user_id: str = None,
         parent_session_id: str = None,
     ) -> str:
-        """Create a new session record. Returns the session_id."""
+        """Create a new session record. Returns the session_id.
+
+        Uses INSERT OR IGNORE so calling this for an already-existing session
+        (e.g. when AIAgent.__init__ and the CLI both register the same session_id)
+        is a safe no-op rather than raising a UNIQUE constraint error.  Without
+        this the exception handler in AIAgent sets self._session_db = None and
+        silently drops all subsequent append_message calls for the session.
+        """
         with self._lock:
             self._conn.execute(
-                """INSERT INTO sessions (id, source, user_id, model, model_config,
-                   system_prompt, parent_session_id, started_at)
+                """INSERT OR IGNORE INTO sessions (id, source, user_id, model,
+                   model_config, system_prompt, parent_session_id, started_at)
                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,

--- a/run_agent.py
+++ b/run_agent.py
@@ -893,8 +893,13 @@ class AIAgent:
                     user_id=None,
                 )
             except Exception as e:
-                logger.warning("Session DB create_session failed — messages will NOT be indexed: %s", e)
-                self._session_db = None  # prevent silent data loss on every subsequent flush
+                logger.warning("Session DB create_session failed — session may not be indexed: %s", e)
+                # Do NOT null out self._session_db here.  create_session now uses
+                # INSERT OR IGNORE so the only real failure cases are schema errors
+                # or I/O issues — in those cases append_message will also fail and
+                # log its own warning.  Nulling out _session_db caused all subsequent
+                # append_message calls to silently no-op, leaving the session row
+                # in the DB with zero messages (the --resume data-loss bug, #3123).
         
         # In-memory todo list for task planning (one per agent/session)
         from tools.todo_tool import TodoStore
@@ -2032,6 +2037,25 @@ class AIAgent:
                     msg = dict(msg)
                     msg["content"] = self._clean_session_content(msg["content"])
                 cleaned.append(msg)
+
+            # Safety guard: never overwrite a larger session log with a smaller one.
+            # This can happen when --resume is used on a session whose messages were
+            # never written to SQLite (bug #3123).  The resumed agent starts with an
+            # empty conversation_history, so the first _save_session_log call has only
+            # the current turn's messages — overwriting the full prior history on disk.
+            if self.session_log_file.exists():
+                try:
+                    import json as _json
+                    existing = _json.loads(self.session_log_file.read_text(encoding="utf-8"))
+                    existing_count = existing.get("message_count", len(existing.get("messages", [])))
+                    if existing_count > len(cleaned):
+                        logging.debug(
+                            "Skipping session log overwrite: existing has %d messages, current has %d",
+                            existing_count, len(cleaned),
+                        )
+                        return
+                except Exception:
+                    pass  # corrupted existing file — allow the overwrite
 
             entry = {
                 "session_id": self.session_id,


### PR DESCRIPTION
## Summary

Closes #3123

Three bugs in the session resume flow, all cascading from the same root cause.

---

## Bug 1 — Sessions recorded with zero messages (root cause)

`AIAgent.__init__` calls `create_session()` for the session ID. In the CLI flow, `__init__` already called `create_session()` earlier, so the INSERT hits a UNIQUE constraint. The exception handler did:

```python
self._session_db = None  # prevent silent data loss on every subsequent flush
```

This is self-defeating: it *caused* data loss by making every subsequent `append_message()` call silently no-op. The session row existed in the DB with zero messages. `--resume` found the row and printed `"has no messages. Starting fresh."`.

**Fix:** Change `INSERT` → `INSERT OR IGNORE` in `SessionDB.create_session()`. Re-registering an existing session is now a safe no-op. Also remove `self._session_db = None` — it made the situation worse, not better.

---

## Bug 2 — `--resume` overwrites session JSON with truncated history (data loss)

This is what the new comment reports. Sequence:

1. Session `X` has 200 messages in JSONL + `session_X.json`, but 0 in SQLite (due to bug 1)
2. User runs `hermes --resume X`
3. `_init_agent` loads 0 messages from SQLite, sets `conversation_history = []`
4. User sends a message → agent runs → `_save_session_log([user, assistant])` writes a **2-message** JSON file → **overwrites** the 200-message `session_X.json`
5. All history is gone

**Fix:** `_save_session_log` now reads the existing file before writing. If the file already has more messages than the current batch, the write is skipped. The full history is preserved until the in-memory `messages` list catches up through normal turns.

---

## Bug 3 — `/resume` is an unknown command

The commands registry (`hermes_cli/commands.py`) lists `resume` without `cli_only=True`, implying CLI availability — but `process_command()` had no handler for it. Typing `/resume <id>` produced `"Unknown command: /resume"`.

**Fix:** Add `elif canonical == "resume":` to `process_command()`. The handler:
- Resolves the target by title or session ID (reuses `_resolve_session_by_name_or_id`)
- Ends the current session cleanly in the DB
- Switches `self.session_id` and loads `conversation_history` from SQLite
- Re-opens the target session (clears `ended_at`)
- Syncs the cached `AIAgent` instance if one is already initialised (`session_id`, `_last_flushed_db_idx`, system prompt cache)

---

## Files changed

| File | Change |
|---|---|
| `hermes_state.py` | `INSERT OR IGNORE` in `create_session` |
| `run_agent.py` | Remove `self._session_db = None`; add truncation guard in `_save_session_log` |
| `cli.py` | Add `/resume` handler in `process_command` |

## Tests

1661 gateway + session + run_agent tests pass, 21 skipped, 0 failures.