### PR TITLE
fix(telegram): gracefully handle deleted reply targets

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 
 try:
     from telegram import Update, Bot, Message
+    from telegram.error import BadRequest as TelegramBadRequest
     from telegram.ext import (
         Application,
         CommandHandler,
@@ -28,6 +29,7 @@ try:
     TELEGRAM_AVAILABLE = True
 except ImportError:
     TELEGRAM_AVAILABLE = False
+    TelegramBadRequest = Exception  # type: ignore[assignment,misc]
     Update = Any
     Bot = Any
     Message = Any
@@ -526,6 +528,17 @@ class TelegramAdapter(BasePlatformAdapter):
                             else:
                                 raise
                         break  # success
+                    except TelegramBadRequest as bad_req:
+                        if "message to be replied not found" in str(bad_req).lower():
+                            # Original message was deleted before we could reply to it.
+                            # Clear the reply target and retry so the message is still delivered.
+                            logger.warning(
+                                "[%s] Reply target deleted, retrying without thread: %s",
+                                self.name, bad_req,
+                            )
+                            reply_to_id = None
+                        else:
+                            raise
                     except _NetErr as send_err:
                         if _send_attempt < 2:
                             wait = 2 ** _send_attempt


### PR DESCRIPTION
Fixes #3229

 Race condition: user deletes their message while Hermes processes → Telegram returns BadRequest: Message to be replied not found → previously uncaught, delivery silently failed.

Fix: catch TelegramBadRequest with that specific message in the send() retry loop, clear reply_to_id, retry without threading. Message is always delivered.


