### PR TITLE
fix(paths): respect HERMES_HOME for protected Hermes env path

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -32,6 +32,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any
 from pathlib import Path
+from hermes_constants import get_hermes_home
 
 
 # ---------------------------------------------------------------------------
@@ -46,7 +47,7 @@ WRITE_DENIED_PATHS = {
         os.path.join(_HOME, ".ssh", "id_rsa"),
         os.path.join(_HOME, ".ssh", "id_ed25519"),
         os.path.join(_HOME, ".ssh", "config"),
-        os.path.join(_HOME, ".hermes", ".env"),
+        str(get_hermes_home() / ".env"),
         os.path.join(_HOME, ".bashrc"),
         os.path.join(_HOME, ".zshrc"),
         os.path.join(_HOME, ".profile"),


### PR DESCRIPTION
## Summary

Updates the protected write deny list to respect `HERMES_HOME` instead of using a hardcoded `~/.hermes/.env` path.

## Why

The deny list should follow the active Hermes profile. Hardcoding `~/.hermes/.env` bypasses `HERMES_HOME` and can miss the actual protected env file in custom or multi-instance setups.

## Changes

- Replaced the hardcoded Hermes env path in `tools/file_operations.py`
- Uses `get_hermes_home()` for consistency with the rest of the codebase

## Scope

Minimal path-consistency fix with no behavior change beyond correctly respecting `HERMES_HOME`.