### PR TITLE
fix: Anthropic OAuth token refresh URL migration + WSL credential path detection

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -144,6 +144,67 @@ def build_anthropic_client(api_key: str, base_url: str = None):
     return _anthropic_sdk.Anthropic(**kwargs)
 
 
+def _is_wsl() -> bool:
+    """Detect if running inside Windows Subsystem for Linux."""
+    try:
+        return "microsoft" in Path("/proc/version").read_text().lower()
+    except (OSError, IOError):
+        return False
+
+
+def _wsl_windows_credential_path() -> Optional[Path]:
+    """Resolve the Windows-side Claude credentials path from WSL.
+
+    Claude Code on Windows writes credentials to %USERPROFILE%\\.claude\\.credentials.json.
+    From WSL, this is accessible via /mnt/c/Users/<username>/.claude/.credentials.json.
+    """
+    import subprocess as _sp
+
+    try:
+        result = _sp.run(
+            ["cmd.exe", "/C", "echo", "%USERPROFILE%"],
+            capture_output=True, timeout=5,
+        )
+        result = _sp.CompletedProcess(
+            result.args, result.returncode,
+            result.stdout.decode("utf-8", errors="replace"),
+            result.stderr.decode("utf-8", errors="replace"),
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            win_profile = result.stdout.strip().replace("\\", "/")
+            # Convert C:/Users/name to /mnt/c/Users/name
+            if len(win_profile) >= 2 and win_profile[1] == ":":
+                drive = win_profile[0].lower()
+                rest = win_profile[2:]
+                wsl_path = Path(f"/mnt/{drive}{rest}") / ".claude" / ".credentials.json"
+                if wsl_path.exists():
+                    return wsl_path
+    except (OSError, FileNotFoundError, _sp.TimeoutExpired):
+        pass
+
+    # Fallback: enumerate /mnt/c/Users/ directly
+    mnt_users = Path("/mnt/c/Users")
+    if mnt_users.is_dir():
+        for user_dir in mnt_users.iterdir():
+            if user_dir.name in ("Public", "Default", "Default User", "All Users"):
+                continue
+            cred = user_dir / ".claude" / ".credentials.json"
+            if cred.exists():
+                return cred
+
+    return None
+
+
+def _get_credential_paths() -> list:
+    """Return candidate paths for .credentials.json, including WSL cross-filesystem."""
+    paths = [Path.home() / ".claude" / ".credentials.json"]
+    if _is_wsl():
+        wsl_path = _wsl_windows_credential_path()
+        if wsl_path:
+            paths.append(wsl_path)
+    return paths
+
+
 def read_claude_code_credentials() -> Optional[Dict[str, Any]]:
     """Read refreshable Claude Code OAuth credentials from ~/.claude/.credentials.json.
 
@@ -152,24 +213,28 @@ def read_claude_code_credentials() -> Optional[Dict[str, Any]]:
     and native direct Anthropic provider usage should follow that path rather
     than auto-detecting Claude's first-party managed key.
 
+    On WSL, also checks the Windows-side credential file if the native Linux
+    path doesn't exist, since Claude Code on Windows writes credentials to
+    the Windows user profile.
+
     Returns dict with {accessToken, refreshToken?, expiresAt?} or None.
     """
-    cred_path = Path.home() / ".claude" / ".credentials.json"
-    if cred_path.exists():
-        try:
-            data = json.loads(cred_path.read_text(encoding="utf-8"))
-            oauth_data = data.get("claudeAiOauth")
-            if oauth_data and isinstance(oauth_data, dict):
-                access_token = oauth_data.get("accessToken", "")
-                if access_token:
-                    return {
-                        "accessToken": access_token,
-                        "refreshToken": oauth_data.get("refreshToken", ""),
-                        "expiresAt": oauth_data.get("expiresAt", 0),
-                        "source": "claude_code_credentials_file",
-                    }
-        except (json.JSONDecodeError, OSError, IOError) as e:
-            logger.debug("Failed to read ~/.claude/.credentials.json: %s", e)
+    for cred_path in _get_credential_paths():
+        if cred_path.exists():
+            try:
+                data = json.loads(cred_path.read_text(encoding="utf-8"))
+                oauth_data = data.get("claudeAiOauth")
+                if oauth_data and isinstance(oauth_data, dict):
+                    access_token = oauth_data.get("accessToken", "")
+                    if access_token:
+                        return {
+                            "accessToken": access_token,
+                            "refreshToken": oauth_data.get("refreshToken", ""),
+                            "expiresAt": oauth_data.get("expiresAt", 0),
+                            "source": "claude_code_credentials_file",
+                        }
+            except (json.JSONDecodeError, OSError, IOError) as e:
+                logger.debug("Failed to read %s: %s", cred_path, e)
 
     return None
 
@@ -230,7 +295,7 @@ def _refresh_oauth_token(creds: Dict[str, Any]) -> Optional[str]:
     }).encode()
 
     req = urllib.request.Request(
-        "https://console.anthropic.com/v1/oauth/token",
+        "https://platform.claude.com/v1/oauth/token",
         data=data,
         headers={
             "Content-Type": "application/x-www-form-urlencoded",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2236,7 +2236,7 @@ def _model_flow_anthropic(config, current_model=""):
 
         elif choice == "2":
             print()
-            print("  Get an API key at: https://console.anthropic.com/settings/keys")
+            print("  Get an API key at: https://platform.claude.com/settings/keys")
             print()
             try:
                 api_key = input("  API key (sk-ant-...): ").strip()

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1331,7 +1331,7 @@ def setup_model_provider(config: dict):
                         print_warning("Skipped — install Claude Code and re-run setup")
             else:
                 print()
-                print_info("Get an API key at: https://console.anthropic.com/settings/keys")
+                print_info("Get an API key at: https://platform.claude.com/settings/keys")
                 print()
                 api_key = prompt("API key (sk-ant-...)", password=True)
                 if api_key:

--- a/run_agent.py
+++ b/run_agent.py
@@ -6463,7 +6463,7 @@ class AIAgent:
                         print(f"{self.log_prefix}   Troubleshooting:")
                         print(f"{self.log_prefix}     • Check ANTHROPIC_TOKEN in ~/.hermes/.env for Hermes-managed OAuth/setup tokens")
                         print(f"{self.log_prefix}     • Check ANTHROPIC_API_KEY in ~/.hermes/.env for API keys or legacy token values")
-                        print(f"{self.log_prefix}     • For API keys: verify at https://console.anthropic.com/settings/keys")
+                        print(f"{self.log_prefix}     • For API keys: verify at https://platform.claude.com/settings/keys")
                         print(f"{self.log_prefix}     • For Claude Code: run 'claude /login' to refresh, then retry")
                         print(f"{self.log_prefix}     • Clear stale keys: hermes config set ANTHROPIC_TOKEN \"\"")
                         print(f"{self.log_prefix}     • Legacy cleanup: hermes config set ANTHROPIC_API_KEY \"\"")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,13 @@ def _isolate_hermes_home(tmp_path, monkeypatch):
     monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
     monkeypatch.delenv("HERMES_SESSION_CHAT_NAME", raising=False)
     monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    # Disable WSL detection in tests — prevents cmd.exe calls and
+    # cross-filesystem credential lookups during unit tests.
+    try:
+        import agent.anthropic_adapter as _aa
+        monkeypatch.setattr(_aa, "_is_wsl", lambda: False)
+    except Exception:
+        pass
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary

Anthropic migrated their developer console from `console.anthropic.com` to `platform.claude.com`. The old domain now 302-redirects. This breaks OAuth token refresh and leaves display URLs stale. Additionally, on WSL, `read_claude_code_credentials()` can never find credentials because Claude Code on Windows writes to a different filesystem than WSL's `Path.home()`.

## Bug 1: Stale OAuth Token Refresh URL

`_refresh_oauth_token()` POSTs to `https://console.anthropic.com/v1/oauth/token` (line 233). Anthropic's token endpoint now lives at `https://platform.claude.com/v1/oauth/token`. The 302 redirect breaks the token exchange because the refresh request fails when followed through a redirect.

**Impact:** Every user's OAuth token refresh silently fails once their initial token expires. This is a ticking time bomb — works until the first expiry, then auth is dead until the user manually re-authenticates.

**Fix:** Update the URL to `platform.claude.com`.

**Evidence:** Claude Code v2.1.84's own source (`cli.js`) uses `platform.claude.com` for all OAuth endpoints. Manual token exchange against the old endpoint returns `invalid_grant`.

## Bug 2: WSL Cannot Find Claude Code Credentials

`read_claude_code_credentials()` reads from `Path.home() / ".claude" / ".credentials.json"`. On WSL:

- WSL home: `/home/<user>/` (Linux filesystem)
- Windows home: `/mnt/c/Users/<user>/` (mounted Windows filesystem)

Claude Code (running on Windows) writes credentials to `C:\Users\<user>\.claude\.credentials.json`. WSL's `Path.home()` resolves to `/home/<user>/` where no `.credentials.json` exists. Result: `read_claude_code_credentials()` always returns `None` on WSL.

**Impact:** All WSL users who run Claude Code on Windows cannot use the native Anthropic provider — credentials are never found.

**Fix:** Add WSL detection via `/proc/version` and resolve the Windows-side credential path via `cmd.exe %USERPROFILE%` with a `/mnt/c/Users/` enumeration fallback. `read_claude_code_credentials()` now checks both native Linux and WSL-mounted Windows paths.

## Additional: Display URL Updates

Three user-facing messages in `setup.py`, `main.py`, and `run_agent.py` point users to `console.anthropic.com/settings/keys` — updated to `platform.claude.com/settings/keys`.

## Changes

| File | Change |
|---|---|
| `agent/anthropic_adapter.py` | Token refresh URL: `console.anthropic.com` → `platform.claude.com` |
| `agent/anthropic_adapter.py` | Add `_is_wsl()`, `_wsl_windows_credential_path()`, `_get_credential_paths()` |
| `agent/anthropic_adapter.py` | `read_claude_code_credentials()` iterates candidate paths |
| `hermes_cli/setup.py` | Display URL update |
| `hermes_cli/main.py` | Display URL update |
| `run_agent.py` | Display URL update |
| `tests/conftest.py` | Disable WSL detection in test suite (autouse fixture) |

## Testing

- 77/77 tests pass in `test_anthropic_adapter.py`
- WSL credential resolution verified manually on WSL2 + Windows 11
- Non-UTF-8 `cmd.exe` output (German locale) handled gracefully with `errors='replace'`

## Context: Claude 4 Models + OAuth

During debugging, we also discovered that Claude 4+ models (Sonnet 4, Opus 4, Opus 4.6) require the Claude Code system prompt prefix (`"You are Claude Code, Anthropic's official CLI for Claude."`) when authenticating via OAuth tokens. Without it, the API returns a bare `400 {"error": {"message": "Error"}}` with no details. This is already handled correctly by `build_anthropic_kwargs()` when `is_oauth=True` — but the OAuth path was never reached because of Bugs 1 and 2, making it appear broken.

Claude 3 models (Haiku 3, Haiku 4.5) work without the prefix. This is an Anthropic-side behavior that ideally should return a descriptive error.