### PR TITLE
fix(gateway): honor config provider precedence

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -241,9 +241,11 @@ def _resolve_runtime_agent_kwargs() -> dict:
     )
 
     try:
-        runtime = resolve_runtime_provider(
-            requested=os.getenv("HERMES_INFERENCE_PROVIDER"),
-        )
+        # Keep gateway provider resolution aligned with the normal CLI path:
+        # explicit call-site overrides win, then config.yaml, then env vars.
+        # Passing HERMES_INFERENCE_PROVIDER here incorrectly let stale .env
+        # values override the saved config only in gateway sessions.
+        runtime = resolve_runtime_provider()
     except Exception as exc:
         raise RuntimeError(format_runtime_provider_error(exc)) from exc
 

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -1,6 +1,7 @@
 import os
 
 from gateway.config import Platform
+import gateway.run as gateway_run
 from gateway.run import GatewayRunner
 from gateway.session import SessionContext, SessionSource
 
@@ -43,3 +44,30 @@ def test_clear_session_env_removes_thread_id(monkeypatch):
     assert os.getenv("HERMES_SESSION_CHAT_ID") is None
     assert os.getenv("HERMES_SESSION_CHAT_NAME") is None
     assert os.getenv("HERMES_SESSION_THREAD_ID") is None
+
+
+def test_resolve_runtime_agent_kwargs_does_not_force_env_provider(monkeypatch):
+    captured = {}
+
+    def fake_resolve_runtime_provider(*, requested=None, **_kwargs):
+        captured["requested"] = requested
+        return {
+            "api_key": "test-key",
+            "base_url": "https://opencode.ai/zen/go/v1",
+            "provider": "opencode-go",
+            "api_mode": "chat_completions",
+            "command": None,
+            "args": [],
+        }
+
+    monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "openai-codex")
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        fake_resolve_runtime_provider,
+    )
+
+    resolved = gateway_run._resolve_runtime_agent_kwargs()
+
+    assert captured["requested"] is None
+    assert resolved["provider"] == "opencode-go"
+    assert resolved["api_key"] == "test-key"


### PR DESCRIPTION
## Summary
- stop forcing `HERMES_INFERENCE_PROVIDER` into gateway runtime resolution
- keep gateway-created agents aligned with the shared config-first provider resolver used by normal CLI chat
- add a regression test covering stale env provider overrides in gateway sessions

## Why
A stale `.env` value like `HERMES_INFERENCE_PROVIDER=openai-codex` could override `config.yaml` only in gateway sessions. That made Telegram/Discord/etc. use a different provider/model pairing than normal terminal chat.

## Testing
- `/home/juan/.hermes/hermes-agent/venv/bin/pytest -q tests/gateway/test_session_env.py`