### PR TITLE
fix(agent): salvage reasoning content when model produces only think blocks

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6017,7 +6017,22 @@ class AIAgent:
                                 self._response_was_previewed = True
                                 break
                             
-                            # No fallback -- append the empty message as-is
+                            # Reasoning-only salvage: some models (e.g. GLM-5-Turbo
+                            # via OpenRouter) consistently produce reasoning/think
+                            # content without visible text.  Use the reasoning as
+                            # the final response rather than returning an error.
+                            salvage = reasoning_text
+                            if not salvage:
+                                # Also check inline <think> blocks in content
+                                think_blocks = re.findall(r'<think>(.*?)</think>', final_response, flags=re.DOTALL)
+                                if think_blocks:
+                                    salvage = "\n\n".join(b.strip() for b in think_blocks if b.strip())
+                            if salvage:
+                                self._vprint(f"{self.log_prefix}💡 Using reasoning content as final response ({len(salvage)} chars)")
+                                final_response = salvage
+                                break
+
+                            # No fallback and no reasoning -- append the empty message as-is
                             empty_msg = {
                                 "role": "assistant",
                                 "content": final_response,
@@ -6025,10 +6040,10 @@ class AIAgent:
                                 "finish_reason": finish_reason,
                             }
                             messages.append(empty_msg)
-                            
+
                             self._cleanup_task_resources(effective_task_id)
                             self._persist_session(messages, conversation_history)
-                            
+
                             return {
                                 "final_response": final_response or None,
                                 "messages": messages,

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1059,14 +1059,13 @@ class TestRunConversation:
         assert result["completed"] is True
         assert result["api_calls"] == 2
 
-    def test_empty_content_retry_and_fallback(self, agent):
-        """Empty content (only think block) retries, then falls back to partial."""
+    def test_empty_content_retry_salvages_inline_think_blocks(self, agent):
+        """Inline <think> blocks are used as final response after retries exhaust."""
         self._setup_agent(agent)
         empty_resp = _mock_response(
             content="<think>internal reasoning</think>",
             finish_reason="stop",
         )
-        # Return empty 3 times to exhaust retries
         agent.client.chat.completions.create.side_effect = [
             empty_resp,
             empty_resp,
@@ -1078,7 +1077,46 @@ class TestRunConversation:
             patch.object(agent, "_cleanup_task_resources"),
         ):
             result = agent.run_conversation("answer me")
-        # After 3 retries with no real content, should return partial
+        # Reasoning content should be salvaged as the final response
+        assert result["completed"] is True
+        assert result["final_response"] == "internal reasoning"
+
+    def test_empty_content_retry_salvages_structured_reasoning(self, agent):
+        """Structured reasoning fields are used as final response after retries exhaust."""
+        self._setup_agent(agent)
+        empty_resp = _mock_response(
+            content="", finish_reason="stop",
+            reasoning="GLM-5-Turbo detailed analysis here",
+        )
+        agent.client.chat.completions.create.side_effect = [
+            empty_resp,
+            empty_resp,
+            empty_resp,
+        ]
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("answer me")
+        assert result["completed"] is True
+        assert result["final_response"] == "GLM-5-Turbo detailed analysis here"
+
+    def test_truly_empty_content_returns_partial(self, agent):
+        """No content and no reasoning returns partial error after retries exhaust."""
+        self._setup_agent(agent)
+        empty_resp = _mock_response(content="", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [
+            empty_resp,
+            empty_resp,
+            empty_resp,
+        ]
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("answer me")
         assert result["completed"] is False
         assert result.get("partial") is True
 


### PR DESCRIPTION
## Summary

- Models like GLM-5-Turbo via OpenRouter consistently return reasoning/think content without visible text, causing "Max retries (3) for empty content exceeded" errors
- After exhausting empty-content retries and the `_last_content_with_tools` fallback, the agent now uses reasoning content (structured API fields or inline `<think>` blocks) as the final response instead of returning an error
- Truly empty responses (no content AND no reasoning) still return the existing partial error

## Context

Reproduced with GLM-5-Turbo over OpenRouter — the model responds successfully on the first turn, then on follow-up turns produces only reasoning/think blocks with no visible content. The existing retry logic retries 3 times but the model keeps doing the same thing, resulting in an error even though useful content was generated.

Related: #3010 (added inline reasoning extraction), #2559 (Codex think-only fix, different code path), #2128 (empty assistant message leak, different root cause).

## Test plan

- [x] `test_empty_content_retry_salvages_inline_think_blocks` — inline `<think>` blocks used as response after retries
- [x] `test_empty_content_retry_salvages_structured_reasoning` — structured reasoning fields used as response after retries
- [x] `test_truly_empty_content_returns_partial` — no content + no reasoning still returns partial error (regression guard)
- [x] Full `tests/test_run_agent.py` suite passes (172 tests)

## Platforms tested

- Linux