### PR TITLE
fix(gateway): fingerprint full auth token in agent cache signature

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4684,10 +4684,18 @@ class GatewayRunner:
         prompt cache hits.
         """
         import hashlib, json as _j
+
+        # Fingerprint the FULL credential string instead of using a short
+        # prefix. OAuth/JWT-style tokens frequently share a common prefix
+        # (e.g. "eyJhbGci"), which can cause false cache hits across auth
+        # switches if only the first few characters are considered.
+        _api_key = str(runtime.get("api_key", "") or "")
+        _api_key_fingerprint = hashlib.sha256(_api_key.encode()).hexdigest() if _api_key else ""
+
         blob = _j.dumps(
             [
                 model,
-                runtime.get("api_key", "")[:8],  # first 8 chars only
+                _api_key_fingerprint,
                 runtime.get("base_url", ""),
                 runtime.get("provider", ""),
                 runtime.get("api_mode", ""),

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -48,6 +48,28 @@ class TestAgentConfigSignature:
         sig2 = GatewayRunner._agent_config_signature("claude-opus-4.6", runtime, ["hermes-telegram"], "")
         assert sig1 != sig2
 
+    def test_same_token_prefix_different_full_token_changes_signature(self):
+        """Tokens sharing a JWT-style prefix must not collide."""
+        from gateway.run import GatewayRunner
+
+        rt1 = {
+            "api_key": "eyJhbGci.token-for-account-a",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "provider": "openai-codex",
+            "api_mode": "codex_responses",
+        }
+        rt2 = {
+            "api_key": "eyJhbGci.token-for-account-b",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "provider": "openai-codex",
+            "api_mode": "codex_responses",
+        }
+
+        assert rt1["api_key"][:8] == rt2["api_key"][:8]
+        sig1 = GatewayRunner._agent_config_signature("gpt-5.3-codex", rt1, ["hermes-telegram"], "")
+        sig2 = GatewayRunner._agent_config_signature("gpt-5.3-codex", rt2, ["hermes-telegram"], "")
+        assert sig1 != sig2
+
     def test_provider_change_different_signature(self):
         from gateway.run import GatewayRunner
 


### PR DESCRIPTION
## Summary
Salvaged from PR #3117 by @EmpireOperating — cherry-picked onto current main with authorship preserved, plus a test fix (reverted accidental redaction of a mock API key in an existing test).

## Root cause
`_agent_config_signature()` used `api_key[:8]` to fingerprint credentials for cache deduplication. JWT/OAuth tokens commonly share prefixes like `eyJhbGci`, so different accounts produced identical cache signatures. This caused cross-account cache collisions — one user's cached agent would serve another user's requests.

## Changes
- **gateway/run.py**: SHA-256 hash the full API key instead of truncating to 8 chars
- **tests/gateway/test_agent_cache.py**: Add regression test proving same-prefix, different-token credentials produce different signatures

## Validation
- `python -m pytest tests/gateway/test_agent_cache.py -n0 -q` → 13 passed
- Full suite: 6204 passed, 1 pre-existing failure (unrelated `test_429_exhausts_all_retries`)

Closes #3117