### PR TITLE
fix(security): prevent zip-slip path traversal in self-update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2383,6 +2383,12 @@ def _update_via_zip(args):
         
         print("→ Extracting...")
         with zipfile.ZipFile(zip_path, 'r') as zf:
+            # Validate paths to prevent zip-slip (path traversal)
+            tmp_dir_real = os.path.realpath(tmp_dir)
+            for member in zf.infolist():
+                member_path = os.path.realpath(os.path.join(tmp_dir, member.filename))
+                if not member_path.startswith(tmp_dir_real + os.sep) and member_path != tmp_dir_real:
+                    raise ValueError(f"Zip-slip detected: {member.filename} escapes extraction directory")
             zf.extractall(tmp_dir)
         
         # GitHub ZIPs extract to hermes-agent-<branch>/


### PR DESCRIPTION
## Summary
Salvaged from PR #3088 by @thakoreh — cherry-picked onto current main with original authorship preserved.

## Root cause
`_update_via_zip()` calls `zf.extractall(tmp_dir)` with no explicit path validation. While Python 3.11's `_extract_member()` does strip `..` components and leading slashes internally, the Python maintainers consider this an "attempt" rather than a guarantee (bugs.python.org/issue40763). A crafted ZIP with traversal entries could potentially escape the temp directory.

## Fix
Adds OWASP-recommended `os.path.realpath()` validation before extraction — resolves each member's target path and rejects any that escape the extraction directory. This is defense-in-depth on top of Python's built-in sanitization.

Verified that the PATH_MAX `realpath()` bypass (CVE-2025-4138/4517) does NOT apply here — that attack requires symlink creation during extraction, which Python's zipfile module does not do.

## Validation
- Full suite: 6204 passed, 1 pre-existing failure (unrelated `test_429_exhausts_all_retries`)

Closes #3088
Fixes #3075

Co-authored-by: Hiren <hiren.thakore58@gmail.com>