### PR TITLE
fix(model-switcher): custom endpoint persistence, pre-fill, and silent validation failures

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1116,24 +1116,53 @@ def _model_flow_custom(config):
     from hermes_cli.auth import _save_model_choice, deactivate_provider
     from hermes_cli.config import get_env_value, save_env_value, load_config, save_config
 
-    current_url = get_env_value("OPENAI_BASE_URL") or ""
+    # Read saved values from config.yaml first, then fall back to env vars.
+    # This ensures a previously configured custom endpoint is offered as the
+    # default rather than requiring the user to re-type it every time.
+    _cfg = load_config()
+    _model_cfg = _cfg.get("model") or {}
+    current_url = (
+        _model_cfg.get("base_url", "").strip()
+        or get_env_value("OPENAI_BASE_URL")
+        or ""
+    )
     current_key = get_env_value("OPENAI_API_KEY") or ""
+    current_model = (
+        _model_cfg.get("default", "").strip()
+        or get_env_value("HERMES_MODEL")
+        or ""
+    )
 
     print("Custom OpenAI-compatible endpoint configuration:")
     if current_url:
         print(f"  Current URL: {current_url}")
     if current_key:
         print(f"  Current key: {current_key[:8]}...")
+    if current_model:
+        print(f"  Current model: {current_model}")
+    print()
+    print("  Press Enter to keep the current value shown in [brackets].")
     print()
 
     try:
-        base_url = input(f"API base URL [{current_url or 'e.g. https://api.example.com/v1'}]: ").strip()
-        api_key = input(f"API key [{current_key[:8] + '...' if current_key else 'optional'}]: ").strip()
-        model_name = input("Model name (e.g. gpt-4, llama-3-70b): ").strip()
+        _url_hint = current_url or "e.g. https://api.example.com/v1"
+        base_url = input(f"API base URL [{_url_hint}]: ").strip()
+        _key_hint = (current_key[:8] + "...") if current_key else "optional, press Enter to skip"
+        api_key = input(f"API key [{_key_hint}]: ").strip()
+        _model_hint = current_model or "e.g. gpt-4, llama-3-70b"
+        model_name = input(f"Model name [{_model_hint}]: ").strip()
         context_length_str = input("Context length in tokens [leave blank for auto-detect]: ").strip()
     except (KeyboardInterrupt, EOFError):
         print("\nCancelled.")
         return
+
+    # Apply defaults: empty input → keep current value
+    if not base_url and current_url:
+        base_url = current_url
+    if not api_key and current_key:
+        api_key = current_key
+    if not model_name and current_model:
+        model_name = current_model
 
     context_length = None
     if context_length_str:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -141,7 +141,33 @@ def switch_model(
             api_key=api_key,
             base_url=base_url,
         )
-    except Exception:
+    except Exception as _val_exc:
+        _exc_str = str(_val_exc)
+        # For custom/local endpoints, surface connection errors explicitly so
+        # the user knows their endpoint is unreachable (fixes silent failures
+        # where "Connection refused" was swallowed and reported as success).
+        _is_custom_endpoint = target_provider == "custom" or (
+            base_url
+            and "openrouter.ai" not in base_url
+            and ("localhost" in base_url or "127.0.0.1" in base_url or "0.0.0.0" in base_url)
+        )
+        _is_connection_error = any(
+            kw in _exc_str.lower()
+            for kw in ("connection refused", "connectionrefused", "connect error",
+                       "connecterror", "connection error", "econnrefused",
+                       "timed out", "timeout", "name or service not known",
+                       "no route to host", "network is unreachable", "401", "403", "404")
+        )
+        if _is_custom_endpoint and _is_connection_error:
+            return ModelSwitchResult(
+                success=False,
+                new_model=new_model,
+                target_provider=target_provider,
+                base_url=base_url,
+                error_message=f"Could not reach custom endpoint: {_exc_str}",
+            )
+        # For cloud providers or unrecognised errors, fall back to accepting
+        # the model so a temporary API outage doesn't block the switch.
         validation = {
             "accepted": True,
             "persist": True,

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -234,6 +234,12 @@ def _resolve_openrouter_runtime(
         if requested_norm == "auto":
             if (not cfg_provider or cfg_provider == "auto") and not env_openai_base_url:
                 use_config_base_url = True
+            elif cfg_provider == "custom":
+                # Config has provider:custom with a base_url — honour it even
+                # when requested_norm is "auto" so that OPENROUTER_API_KEY in
+                # .env doesn't silently override an explicitly saved custom
+                # endpoint on CLI restart (fixes #3263 config persistence loss).
+                use_config_base_url = True
         elif requested_norm == "custom" and cfg_provider == "custom":
             # provider: custom — use base_url from config (Fixes #1760).
             use_config_base_url = True

--- a/tests/test_model_switcher_custom_3263.py
+++ b/tests/test_model_switcher_custom_3263.py
@@ -1,0 +1,200 @@
+"""Tests for model switcher custom endpoint fixes (#3263).
+
+Covers:
+1. Silent validation failure surfaces connection errors for custom endpoints
+2. _model_flow_custom pre-fills base_url / model from config.yaml
+3. runtime_provider honours config.yaml custom endpoint over OPENROUTER_API_KEY
+"""
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# 1. Silent validation failure — model_switch.py
+# ---------------------------------------------------------------------------
+
+def _make_switch_result(raw_input, base_url, exc):
+    """Run switch_model with a validate_requested_model that raises exc."""
+    from hermes_cli.model_switch import switch_model
+
+    def _fake_resolve(requested=None, **kw):
+        return {"provider": "custom", "api_key": "fake", "base_url": base_url,
+                "api_mode": "chat_completions", "source": "config"}
+
+    with patch("hermes_cli.runtime_provider.resolve_runtime_provider", side_effect=_fake_resolve), \
+         patch("hermes_cli.models.validate_requested_model", side_effect=exc), \
+         patch("hermes_cli.models.detect_provider_for_model", return_value=None), \
+         patch("hermes_cli.models.parse_model_input", return_value=("custom", "llama3")):
+        return switch_model(raw_input, current_provider="custom", current_base_url=base_url)
+
+
+def test_connection_refused_surfaced_for_localhost():
+    result = _make_switch_result(
+        "llama3",
+        "http://localhost:11434/v1",
+        ConnectionError("Connection refused"),
+    )
+    assert result.success is False
+    assert "connection" in result.error_message.lower() or "refused" in result.error_message.lower()
+
+
+def test_timeout_surfaced_for_custom_endpoint():
+    result = _make_switch_result(
+        "llama3",
+        "http://127.0.0.1:8080/v1",
+        TimeoutError("timed out"),
+    )
+    assert result.success is False
+    assert result.error_message != ""
+
+
+def test_404_surfaced_for_custom_endpoint():
+    result = _make_switch_result(
+        "llama3",
+        "http://localhost:11434/v1",
+        Exception("404 Not Found"),
+    )
+    assert result.success is False
+
+
+def test_cloud_provider_validation_error_still_accepts():
+    """Cloud provider validation errors should NOT block the switch (temporary outages)."""
+    from hermes_cli.model_switch import switch_model
+
+    def _fake_resolve(requested=None, **kw):
+        return {"provider": "openrouter", "api_key": "sk-test", "base_url": "https://openrouter.ai/api/v1",
+                "api_mode": "chat_completions", "source": "env"}
+
+    with patch("hermes_cli.runtime_provider.resolve_runtime_provider", side_effect=_fake_resolve), \
+         patch("hermes_cli.models.validate_requested_model", side_effect=Exception("temporary error")), \
+         patch("hermes_cli.models.detect_provider_for_model", return_value=None), \
+         patch("hermes_cli.models.parse_model_input", return_value=("openrouter", "gpt-4o")):
+        result = switch_model("gpt-4o", current_provider="openrouter",
+                              current_base_url="https://openrouter.ai/api/v1")
+
+    # Cloud provider: accept despite error (temporary outage tolerance)
+    assert result.success is True
+
+
+# ---------------------------------------------------------------------------
+# 2. Pre-fill from config.yaml — _model_flow_custom
+# ---------------------------------------------------------------------------
+
+def test_model_flow_custom_prefills_from_config(monkeypatch):
+    """When config.yaml has base_url and model.default, they appear as defaults."""
+    import hermes_cli.main as _main
+
+    saved_inputs = []
+
+    def _fake_input(prompt=""):
+        saved_inputs.append(prompt)
+        return ""  # empty — should fall back to config default
+
+    fake_cfg = {
+        "model": {
+            "base_url": "http://localhost:11434/v1",
+            "default": "llama3",
+            "provider": "custom",
+        }
+    }
+    applied = {}
+
+    monkeypatch.setattr("builtins.input", _fake_input)
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: fake_cfg)
+    monkeypatch.setattr("hermes_cli.config.get_env_value", lambda key: "")
+
+    with patch("hermes_cli.models.probe_api_models",
+               return_value={"models": ["llama3"], "probed_url": "http://localhost:11434/v1/models"}), \
+         patch("hermes_cli.auth._save_model_choice", side_effect=lambda n: applied.update(model=n)), \
+         patch("hermes_cli.config.save_env_value"), \
+         patch("hermes_cli.config.save_config"), \
+         patch("hermes_cli.auth.deactivate_provider"), \
+         patch("hermes_cli.main._save_custom_provider"):
+        _main._model_flow_custom(fake_cfg)
+
+    url_prompt = next((p for p in saved_inputs if "base URL" in p), "")
+    assert "localhost:11434" in url_prompt, f"URL not pre-filled in prompt: {url_prompt!r}"
+
+    model_prompt = next((p for p in saved_inputs if "Model name" in p), "")
+    assert "llama3" in model_prompt, f"Model not pre-filled in prompt: {model_prompt!r}"
+
+    assert applied.get("model") == "llama3", "Empty input should default to config model"
+
+
+def test_model_flow_custom_uses_config_base_url_when_empty_input(monkeypatch):
+    """Empty URL input with existing config should keep the existing URL for probing."""
+    import hermes_cli.main as _main
+
+    fake_cfg = {
+        "model": {
+            "base_url": "http://localhost:11434/v1",
+            "default": "llama3",
+            "provider": "custom",
+        }
+    }
+    probed = {}
+
+    monkeypatch.setattr("builtins.input", lambda p="": "")
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: fake_cfg)
+    monkeypatch.setattr("hermes_cli.config.get_env_value", lambda key: "")
+
+    def _capture_probe(key, url):
+        probed["url"] = url
+        return {"models": ["llama3"], "probed_url": url}
+
+    with patch("hermes_cli.models.probe_api_models", side_effect=_capture_probe), \
+         patch("hermes_cli.auth._save_model_choice"), \
+         patch("hermes_cli.config.save_env_value"), \
+         patch("hermes_cli.config.save_config"), \
+         patch("hermes_cli.auth.deactivate_provider"), \
+         patch("hermes_cli.main._save_custom_provider"):
+        _main._model_flow_custom(fake_cfg)
+
+    assert probed.get("url") == "http://localhost:11434/v1", (
+        f"Expected config URL to be used for probing, got: {probed.get('url')!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. runtime_provider — config.yaml custom takes precedence over OPENROUTER_API_KEY
+# ---------------------------------------------------------------------------
+
+def test_custom_config_wins_over_openrouter_key(monkeypatch):
+    """When config has provider:custom + base_url, OPENROUTER_API_KEY must not flip base_url."""
+    import os
+    import hermes_cli.runtime_provider as rp
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-openrouter-test")
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    cfg = {
+        "model": {
+            "provider": "custom",
+            "base_url": "http://localhost:11434/v1",
+            "default": "llama3",
+        }
+    }
+
+    with patch("hermes_cli.runtime_provider.load_config", return_value=cfg):
+        result = rp.resolve_runtime_provider(requested="auto")
+
+    assert "openrouter.ai" not in result["base_url"], (
+        f"Expected custom base_url to win, got: {result['base_url']!r}"
+    )
+    assert "localhost" in result["base_url"]
+
+
+def test_openrouter_key_still_works_without_custom_config(monkeypatch):
+    """Without a custom config, OPENROUTER_API_KEY should still route to OpenRouter."""
+    import hermes_cli.runtime_provider as rp
+
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-openrouter-test")
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    cfg = {"model": {"provider": "openrouter", "default": "gpt-4o"}}
+
+    with patch("hermes_cli.runtime_provider.load_config", return_value=cfg):
+        result = rp.resolve_runtime_provider(requested="auto")
+
+    assert "openrouter.ai" in result["base_url"]


### PR DESCRIPTION
Closes #3263

Three independent fixes for the custom endpoint experience with Ollama, LM Studio, and other local/custom OpenAI-compatible servers.

---

## Fix 1 — Surface connection errors (silent validation failure)

**File:** `hermes_cli/model_switch.py`

The `except Exception` block in Step 5 was swallowing all validation errors and returning `accepted: True`, so switching to an unreachable `http://localhost:11434/v1` would report "Switched successfully" even when Ollama wasn't running.

**Before:**
```
> /model llama3
Switched to llama3 (custom)
[chat proceeds to fail silently]
```

**After:**
```
> /model llama3
Error: Could not reach custom endpoint: Connection refused
```

The fix detects connection-class errors (refused, timeout, 401, 403, 404) specifically on custom/localhost targets. Cloud providers keep the previous lenient behaviour — a temporary OpenRouter outage should not block switching to a model that's likely fine.

---

## Fix 2 — Pre-fill base_url and model from config.yaml

**File:** `hermes_cli/main.py` → `_model_flow_custom()`

The interactive setup flow read `OPENAI_BASE_URL` from env but ignored `model.base_url` and `model.default` in `config.yaml`, presenting blank prompts every time even after a successful previous setup.

**Before:**
```
Custom OpenAI-compatible endpoint configuration:

API base URL [e.g. https://api.example.com/v1]: _
API key [optional]: _
Model name (e.g. gpt-4, llama-3-70b): _
```

**After:**
```
Custom OpenAI-compatible endpoint configuration:
  Current URL: http://localhost:11434/v1
  Current model: llama3

  Press Enter to keep the current value shown in [brackets].

API base URL [http://localhost:11434/v1]: _
API key [optional, press Enter to skip]: _
Model name [llama3]: _
```

Empty input → keeps the current value. The config is read from `config.yaml` first, with env vars as fallback.

---

## Fix 3 — config.yaml custom endpoint survives `OPENROUTER_API_KEY` in `.env`

**File:** `hermes_cli/runtime_provider.py`

When `requested_norm` was `"auto"` (normal CLI startup) and `cfg_provider` was `"custom"`, `use_config_base_url` was not set. The `base_url` resolution chain then fell through to `OPENROUTER_BASE_URL`, flipping the active provider back to OpenRouter on every restart.

The existing `#1760` fix only handled `requested_norm == "custom"` explicitly, missing the `"auto"` path used at startup.

**Fix:** added `elif cfg_provider == "custom"` inside the `"auto"` block so that an explicitly saved custom endpoint always wins, regardless of what env vars are present.

---

## Tests

8 new tests in `tests/test_model_switcher_custom_3263.py`:

| Test | Covers |
|---|---|
| `test_connection_refused_surfaced_for_localhost` | Fix 1 — refused → failure |
| `test_timeout_surfaced_for_custom_endpoint` | Fix 1 — timeout → failure |
| `test_404_surfaced_for_custom_endpoint` | Fix 1 — 404 → failure |
| `test_cloud_provider_validation_error_still_accepts` | Fix 1 — cloud keeps lenient path |
| `test_model_flow_custom_prefills_from_config` | Fix 2 — hints and empty-input defaults |
| `test_model_flow_custom_uses_config_base_url_when_empty_input` | Fix 2 — config URL used for probing |
| `test_custom_config_wins_over_openrouter_key` | Fix 3 — OPENROUTER_API_KEY doesn't flip provider |
| `test_openrouter_key_still_works_without_custom_config` | Fix 3 — OpenRouter path unaffected |

44 total pass (36 existing + 8 new).
