### PR TITLE
fix(honcho): enforce contextTokens budget on prefetched Honcho context

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2325,6 +2325,40 @@ class AIAgent:
         except Exception as exc:
             logger.debug("Honcho background prefetch failed (non-fatal): %s", exc)
 
+    def _honcho_context_token_budget(self) -> int | None:
+        """Return the configured Honcho context budget, if any."""
+        config_budget = getattr(self._honcho_config, "context_tokens", None)
+        if isinstance(config_budget, int) and config_budget > 0:
+            return config_budget
+
+        manager_budget = getattr(self._honcho, "_context_tokens", None)
+        if isinstance(manager_budget, int) and manager_budget > 0:
+            return manager_budget
+        return None
+
+    def _truncate_honcho_context(self, text: str) -> str:
+        """Fit assembled Honcho context to the configured budget."""
+        token_budget = self._honcho_context_token_budget()
+        if not token_budget or token_budget <= 0:
+            return text
+
+        char_budget = token_budget * 4
+        if len(text) <= char_budget:
+            return text
+
+        suffix = "\n\n[… truncated to fit token budget]"
+        head_budget = max(char_budget - len(suffix), 0)
+        truncated = text[:head_budget].rstrip()
+        logger.debug(
+            "Honcho context exceeds budget (%d chars > %d char limit from %d tokens), truncating",
+            len(text),
+            char_budget,
+            token_budget,
+        )
+        if not truncated:
+            return suffix.lstrip()
+        return truncated + suffix
+
     def _honcho_prefetch(self, user_message: str) -> str:
         """Assemble the first-turn Honcho context from the pre-warmed cache."""
         if not self._honcho or not self._honcho_session_key:
@@ -2359,7 +2393,8 @@ class AIAgent:
                 "and what you were working on together. Do not call tools to "
                 "look up information that is already present here.\n"
             )
-            return header + "\n\n".join(parts)
+            assembled = header + "\n\n".join(parts)
+            return self._truncate_honcho_context(assembled)
         except Exception as e:
             logger.debug("Honcho prefetch failed (non-fatal): %s", e)
             return ""

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1996,6 +1996,58 @@ class TestHonchoPrefetchScheduling:
         assert "Continuity synthesis" in context
         assert "migration checklist" in context
 
+    def test_honcho_prefetch_truncates_to_token_budget(self, agent):
+        """context_tokens budget should truncate the assembled Honcho block."""
+        agent._honcho = MagicMock()
+        agent._honcho_session_key = "session-key"
+        agent._honcho._context_tokens = 50  # 50 tokens ≈ 200 chars
+        # Return a large representation that exceeds the budget
+        large_rep = "x" * 5000
+        agent._honcho.pop_context_result.return_value = {
+            "representation": large_rep,
+            "card": "",
+        }
+        agent._honcho.pop_dialectic_result.return_value = ""
+
+        context = agent._honcho_prefetch("hello")
+
+        # Should be truncated: 50 tokens * 4 chars = 200 chars
+        assert len(context) < 300  # 200 chars + truncation marker
+        assert "truncated to fit token budget" in context
+
+    def test_honcho_prefetch_no_truncation_within_budget(self, agent):
+        """Honcho block within token budget should not be truncated."""
+        agent._honcho = MagicMock()
+        agent._honcho_session_key = "session-key"
+        agent._honcho._context_tokens = 5000  # generous budget
+        agent._honcho.pop_context_result.return_value = {
+            "representation": "User likes Python.",
+            "card": "",
+        }
+        agent._honcho.pop_dialectic_result.return_value = ""
+
+        context = agent._honcho_prefetch("hello")
+
+        assert "truncated" not in context
+        assert "User likes Python" in context
+
+    def test_honcho_prefetch_no_truncation_when_no_budget(self, agent):
+        """No context_tokens set means no truncation."""
+        agent._honcho = MagicMock()
+        agent._honcho_session_key = "session-key"
+        agent._honcho._context_tokens = None  # no budget
+        large_rep = "x" * 5000
+        agent._honcho.pop_context_result.return_value = {
+            "representation": large_rep,
+            "card": "",
+        }
+        agent._honcho.pop_dialectic_result.return_value = ""
+
+        context = agent._honcho_prefetch("hello")
+
+        assert "truncated" not in context
+        assert len(context) > 5000
+
     def test_queue_honcho_prefetch_skips_tools_mode(self, agent):
         agent._honcho = MagicMock()
         agent._honcho_session_key = "session-key"


### PR DESCRIPTION
Refreshes #1878 onto current `main`. Credit to @AzothZephyr for the original fix and for identifying the issue.

## Problem

Honcho's `context(tokens=...)` parameter only constrains message history retrieval -- the `peer_representation` and `peer_card` fields grow unbounded. Setting `contextTokens` in config had no effect on those blocks, which regularly hit 4000-5000+ tokens.

## Fix

Client-side truncation in `_honcho_prefetch()`: assemble the full Honcho context block, then trim to the configured `context_tokens` budget with a truncation marker when needed. Factored into small helpers instead of inline logic.

## Test plan

- 3 passed: truncation-focused tests
- 17 passed: broader Honcho/run_agent coverage