### PR TITLE
feat(nix): add suffix PATHs during nix build for more agent-friendliness

### DIFF
--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -121,6 +121,21 @@
         chmod 0440 /etc/sudoers.d/hermes
       fi
 
+      # ── Provision mutable agent tools (first boot only, cached in writable layer) ──
+      # Agents need extensible tools (nodejs/npm for npm i -g, uv for Python).
+      # These live in /usr/bin and ~/.local/bin so they're writable, unlike nix store.
+      # The hermes wrapper uses --suffix PATH so these take priority over nix fallbacks.
+      if [ ! -f /var/lib/hermes-tools-provisioned ] && command -v apt-get >/dev/null 2>&1; then
+        echo "First boot: provisioning agent tools..."
+        apt-get update -qq
+        apt-get install -y -qq nodejs npm curl
+        # uv (Python manager) — not in Ubuntu repos, installed as target user
+        if ! command -v uv >/dev/null 2>&1; then
+          su -s /bin/sh "$TARGET_USER" -c 'curl -LsSf https://astral.sh/uv/install.sh | sh' || true
+        fi
+        touch /var/lib/hermes-tools-provisioned
+      fi
+
       if command -v setpriv >/dev/null 2>&1; then
         exec setpriv --reuid="$HERMES_UID" --regid="$HERMES_GID" --init-groups "$@"
       elif command -v su >/dev/null 2>&1; then

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -10,6 +10,11 @@
 # container recreation. Environment variables are written to $HERMES_HOME/.env
 # and read by hermes at startup — no container recreation needed for env changes.
 #
+# Tool resolution: the hermes wrapper uses --suffix PATH for nix store tools,
+# so apt-installed versions in /usr/bin take priority. The container entrypoint
+# apt-installs extensible tools (nodejs, npm, uv) on first boot, giving agents
+# writable tool prefixes for npm i -g, uv tool install, etc.
+#
 # Usage:
 #   services.hermes-agent = {
 #     enable = true;

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -11,9 +11,10 @@
 # and read by hermes at startup — no container recreation needed for env changes.
 #
 # Tool resolution: the hermes wrapper uses --suffix PATH for nix store tools,
-# so apt-installed versions in /usr/bin take priority. The container entrypoint
-# apt-installs extensible tools (nodejs, npm, uv) on first boot, giving agents
-# writable tool prefixes for npm i -g, uv tool install, etc.
+# so apt/uv-installed versions take priority. The container entrypoint provisions
+# extensible tools on first boot: nodejs/npm via apt, uv via curl, and a Python
+# 3.11 venv (bootstrapped entirely by uv) at ~/.venv with pip seeded. Agents get
+# writable tool prefixes for npm i -g, pip install, uv tool install, etc.
 #
 # Usage:
 #   services.hermes-agent = {
@@ -116,29 +117,43 @@
         chown -R "$HERMES_UID:$HERMES_GID" "$HERMES_HOME"
       fi
 
-      # Install sudo on Debian/Ubuntu if missing (first boot only, cached in writable layer)
-      if command -v apt-get >/dev/null 2>&1 && ! command -v sudo >/dev/null 2>&1; then
-        apt-get update -qq >/dev/null 2>&1 && apt-get install -y -qq sudo >/dev/null 2>&1 || true
+      # ── Provision apt packages (first boot only, cached in writable layer) ──
+      # sudo: agent self-modification
+      # nodejs/npm: writable node so npm i -g works (nix store copies are read-only)
+      # curl: needed for uv installer
+      if [ ! -f /var/lib/hermes-tools-provisioned ] && command -v apt-get >/dev/null 2>&1; then
+        echo "First boot: provisioning agent tools..."
+        apt-get update -qq
+        apt-get install -y -qq sudo nodejs npm curl
+        touch /var/lib/hermes-tools-provisioned
       fi
+
       if command -v sudo >/dev/null 2>&1 && [ ! -f /etc/sudoers.d/hermes ]; then
         mkdir -p /etc/sudoers.d
         echo "$TARGET_USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/hermes
         chmod 0440 /etc/sudoers.d/hermes
       fi
 
-      # ── Provision mutable agent tools (first boot only, cached in writable layer) ──
-      # Agents need extensible tools (nodejs/npm for npm i -g, uv for Python).
-      # These live in /usr/bin and ~/.local/bin so they're writable, unlike nix store.
-      # The hermes wrapper uses --suffix PATH so these take priority over nix fallbacks.
-      if [ ! -f /var/lib/hermes-tools-provisioned ] && command -v apt-get >/dev/null 2>&1; then
-        echo "First boot: provisioning agent tools..."
-        apt-get update -qq
-        apt-get install -y -qq nodejs npm curl
-        # uv (Python manager) — not in Ubuntu repos, installed as target user
-        if ! command -v uv >/dev/null 2>&1; then
-          su -s /bin/sh "$TARGET_USER" -c 'curl -LsSf https://astral.sh/uv/install.sh | sh' || true
-        fi
-        touch /var/lib/hermes-tools-provisioned
+      # uv (Python manager) — not in Ubuntu repos, retry-safe outside the sentinel
+      if ! command -v uv >/dev/null 2>&1 && [ ! -x "$TARGET_HOME/.local/bin/uv" ] && command -v curl >/dev/null 2>&1; then
+        su -s /bin/sh "$TARGET_USER" -c 'curl -LsSf https://astral.sh/uv/install.sh | sh' || true
+      fi
+
+      # Python 3.11 venv — gives the agent a writable Python with pip.
+      # Uses uv to install Python 3.11 (Ubuntu 24.04 ships 3.12).
+      # --seed includes pip/setuptools so bare `pip install` works.
+      _UV_BIN="$TARGET_HOME/.local/bin/uv"
+      if [ ! -d "$TARGET_HOME/.venv" ] && [ -x "$_UV_BIN" ]; then
+        su -s /bin/sh "$TARGET_USER" -c "
+          export PATH=\"\$HOME/.local/bin:\$PATH\"
+          uv python install 3.11
+          uv venv --python 3.11 --seed \"\$HOME/.venv\"
+        " || true
+      fi
+
+      # Put the agent venv first on PATH so python/pip resolve to writable copies
+      if [ -d "$TARGET_HOME/.venv/bin" ]; then
+        export PATH="$TARGET_HOME/.venv/bin:$PATH"
       fi
 
       if command -v setpriv >/dev/null 2>&1; then

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -35,7 +35,7 @@
 
           ${pkgs.lib.concatMapStringsSep "\n" (name: ''
             makeWrapper ${hermesVenv}/bin/${name} $out/bin/${name} \
-              --prefix PATH : "${runtimePath}" \
+              --suffix PATH : "${runtimePath}" \
               --set HERMES_BUNDLED_SKILLS $out/share/hermes-agent/skills
           '') [ "hermes" "hermes-agent" "hermes-acp" ]}
 


### PR DESCRIPTION
## What does this PR do?

This PR makes the NixOS container mode agent-friendly by ensuring tools with writable global state (node/npm, Python/pip, uv) resolve to mutable copies instead of read-only nix store binaries. It also bootstraps a Python 3.11 venv via uv so agents get a working `pip install` out of the box.

The core problem: when hermes runs in container mode, `/nix/store` is bind-mounted read-only. Tools like `npm i -g` and `pip install` fail because the nix-store node/python have their prefixes baked to read-only paths. Agents hit confusing "read-only file system" errors on routine package management operations.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Changed `makeWrapper` from `--prefix PATH` to `--suffix PATH` in `nix/packages.nix` so nix store tools become fallbacks instead of taking priority. Apt-installed tools in `/usr/bin` now win in container mode; native NixOS mode is unaffected since `/run/current-system/sw/bin` already precedes suffix paths.
- Consolidated the container entrypoint's sudo and tool provisioning into a single `apt-get update` + `apt-get install` call (sudo, nodejs, npm, curl), guarded by a sentinel file at `/var/lib/hermes-tools-provisioned`.
- Moved uv installation (curl-pipe-sh) outside the sentinel guard so transient network failures retry on next boot instead of being permanently skipped.
- Added Python 3.11 venv bootstrapping via `uv python install 3.11` + `uv venv --python 3.11 --seed`, creating `~/.venv` with pip seeded. No apt Python packages needed — uv handles the entire Python toolchain.
- Prepended `~/.venv/bin` to PATH in the entrypoint before exec'ing hermes, so `python`, `pip`, and `node` all resolve to writable copies.
- Updated the nixosModules header documentation to describe the tool resolution and provisioning strategy.

## How to Test

1. Build: `nix build .#default`
2. Verify wrapper uses suffix: `cat result/bin/hermes` — nix store paths should be appended to `$PATH`, not prepended
3. Deploy container mode (`container.enable = true`), restart service
4. Verify first boot provisions tools:
   - `which node` → `/usr/bin/node` (not `/nix/store/...`)
   - `which python` → `~/.venv/bin/python`
   - `python --version` → `Python 3.11.x`
   - `npm i -g cowsay` → succeeds (writes to `/usr/local/lib/node_modules/`)
   - `pip install requests` → succeeds (writes to `~/.venv/`)
   - `which uv` → `~/.local/bin/uv`
5. Restart container → no reinstall (sentinel present, venv exists)
6. Native NixOS mode: verify tools still available via suffix fallback

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've tested on my platform: NixOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A