### PR TITLE
fix(matrix): add backoff for SyncError in sync loop

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -551,9 +551,20 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def _sync_loop(self) -> None:
         """Continuously sync with the homeserver."""
+        import nio
+
         while not self._closing:
             try:
-                await self._client.sync(timeout=30000)
+                resp = await self._client.sync(timeout=30000)
+                if isinstance(resp, nio.SyncError):
+                    if self._closing:
+                        return
+                    logger.warning(
+                        "Matrix: sync returned %s: %s — retrying in 5s",
+                        type(resp).__name__,
+                        getattr(resp, "message", resp),
+                    )
+                    await asyncio.sleep(5)
             except asyncio.CancelledError:
                 return
             except Exception as exc:


### PR DESCRIPTION
## Summary

Salvage of PR #2937 by @ticketclosed-wontfix, cherry-picked onto current main.

### The bug

When the Matrix homeserver returns an error response, matrix-nio parses it as a `SyncError` return value rather than raising an exception. The sync loop only had backoff logic in the `except` handler, so `SyncError` responses caused an immediate tight retry loop (~489 req/s) flooding logs and hammering the homeserver.

### The fix

Check the `sync()` return value for `nio.SyncError` and sleep 5s before retrying, matching the existing exception-handling backoff. The `self._closing` guard prevents delay during shutdown.

### Tests

Matrix adapter tests: 40 passed.

Closes #2937