### PR TITLE
fix(telegram): complete 3-layer defense against invalid thread_id in non-forum DMs

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -667,6 +667,8 @@ class TelegramAdapter(BasePlatformAdapter):
             except ImportError:
                 _NetErr = OSError  # type: ignore[misc,assignment]
 
+            effective_thread_id = int(thread_id) if thread_id else None
+
             for i, chunk in enumerate(chunks):
                 should_thread = self._should_thread_reply(reply_to, i)
                 reply_to_id = int(reply_to) if should_thread else None
@@ -681,9 +683,16 @@ class TelegramAdapter(BasePlatformAdapter):
                                 text=chunk,
                                 parse_mode=ParseMode.MARKDOWN_V2,
                                 reply_to_message_id=reply_to_id,
-                                message_thread_id=int(thread_id) if thread_id else None,
+                                message_thread_id=effective_thread_id,
                             )
                         except Exception as md_error:
+                            # Thread not found — drop thread_id and retry immediately
+                            if "thread not found" in str(md_error).lower():
+                                if effective_thread_id is not None:
+                                    logger.warning("[%s] Thread %s not found, retrying without thread_id", self.name, effective_thread_id)
+                                    effective_thread_id = None
+                                    continue
+                                raise
                             # Markdown parsing failed, try plain text
                             if "parse" in str(md_error).lower() or "markdown" in str(md_error).lower():
                                 logger.warning("[%s] MarkdownV2 parse failed, falling back to plain text: %s", self.name, md_error)
@@ -693,12 +702,18 @@ class TelegramAdapter(BasePlatformAdapter):
                                     text=plain_chunk,
                                     parse_mode=None,
                                     reply_to_message_id=reply_to_id,
-                                    message_thread_id=int(thread_id) if thread_id else None,
+                                    message_thread_id=effective_thread_id,
                                 )
                             else:
                                 raise
                         break  # success
                     except _NetErr as send_err:
+                        # Thread not found may also surface as a network-layer error
+                        if "thread not found" in str(send_err).lower():
+                            if effective_thread_id is not None:
+                                logger.warning("[%s] Thread %s not found (network layer), retrying without thread_id", self.name, effective_thread_id)
+                                effective_thread_id = None
+                                continue
                         if _send_attempt < 2:
                             wait = 2 ** _send_attempt
                             logger.warning("[%s] Network error on send (attempt %d/3), retrying in %ds: %s",
@@ -1810,6 +1825,12 @@ class TelegramAdapter(BasePlatformAdapter):
                     self._cache_dm_topic_from_message(str(chat.id), thread_id_str, created_name)
                     if not chat_topic:
                         chat_topic = created_name
+
+            # If no DM topic was resolved, Telegram may have set message_thread_id
+            # to indicate a reply chain (not a real forum topic).  Drop it so
+            # downstream send calls don't fail with "Message thread not found".
+            if not chat_topic:
+                thread_id_str = None
 
         # Build source
         source = self.build_source(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4865,7 +4865,14 @@ class GatewayRunner:
         # final reply will be threaded under the original message via reply_to.
         # Use event_message_id as fallback so progress messages land in the
         # same thread as the final response instead of going to the DM root.
-        _progress_thread_id = source.thread_id or event_message_id
+        # NOTE: Only use event_message_id fallback for platforms that support
+        # threading by message ID (Slack, Discord).  Telegram uses dedicated
+        # forum topic IDs for message_thread_id — passing a regular message ID
+        # causes "Message thread not found" errors.
+        if source.platform in ("slack", "discord"):
+            _progress_thread_id = source.thread_id or event_message_id
+        else:
+            _progress_thread_id = source.thread_id
         _progress_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else None
 
         async def send_progress_messages():


### PR DESCRIPTION
## What does this PR do?

Comprehensive fix for Telegram DM sends failing with `Message thread not found` when replying to messages in non-forum chats. Addresses the root cause at three layers for defense-in-depth.

## Related Issue

Fixes #3206

## Type of Change
🐛 Bug fix (non-breaking change that fixes an issue)

## Root Cause

Telegram sets `message_thread_id` on incoming reply-chain messages in non-forum DMs. This value is **not valid** for outgoing `send_message()` calls — Telegram rejects it with `BadRequest: Message thread not found`. The error cascades through streaming, progress messages, and all send types, causing 1000+ errors per session.

## Changes Made — 3 Layers

### Layer 1 — Source (`telegram.py: _build_message_event`)
Drop spurious `message_thread_id` when no forum topic was resolved. Prevents invalid thread IDs from entering the system.

### Layer 2 — Send fallback (`telegram.py: send`)
When `send_message()` gets "Message thread not found", clear `effective_thread_id` and retry immediately — instead of retrying 3x with the same broken value. Catches both `Exception` and `NetworkError` paths.

### Layer 3 — Progress messages (`run.py: _progress_thread_id`)
The `event_message_id` fallback in `_progress_thread_id` was designed for **Slack** (where message IDs are valid thread identifiers). On Telegram, this re-introduces invalid thread IDs even when Layers 1-2 correctly handle the send path. Now platform-aware:
- **Slack/Discord:** `source.thread_id or event_message_id` (correct for their threading model)
- **Telegram & others:** `source.thread_id` only (no message ID fallback)

**Without Layer 3, the bug persists** — progress/status messages bypass the telegram.py fixes entirely via `run.py`.

## Why this supersedes #3207 and #3218

- **#3207** implements Layer 1 only (source-level drop)
- **#3218** implements Layer 2 only (send-level fallback)
- **Neither addresses Layer 3** — the `run.py` progress message path that re-introduces invalid thread IDs from a Slack-specific fallback

This PR combines all three layers into a single coherent fix.

## How to Test

1. Open a Telegram DM (non-forum chat) with the bot
2. Reply to an existing message (creates a reply chain with `message_thread_id`)
3. Trigger the bot to respond (streaming or normal)
4. Verify: no "Message thread not found" errors in logs, messages send successfully

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs before opening this one
- [x] Only 2 files changed, minimal diff, no unrelated changes