### PR TITLE
fix(gateway): prevent silent message dropping on streaming send failures

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -581,19 +581,14 @@ class TelegramAdapter(BasePlatformAdapter):
             if "not modified" in err_str:
                 return SendResult(success=True, message_id=message_id)
             # Message too long — content exceeded 4096 chars (e.g. during
-            # streaming).  Truncate and succeed so the stream consumer can
-            # split the overflow into a new message instead of dying.
+            # streaming). Return failure so the stream consumer can split the
+            # overflow into a new message instead of silently truncating.
             if "message_too_long" in err_str or "too long" in err_str:
-                truncated = content[: self.MAX_MESSAGE_LENGTH - 20] + "…"
-                try:
-                    await self._bot.edit_message_text(
-                        chat_id=int(chat_id),
-                        message_id=int(message_id),
-                        text=truncated,
-                    )
-                except Exception:
-                    pass  # best-effort truncation
-                return SendResult(success=True, message_id=message_id)
+                logger.warning(
+                    "[%s] Message too long for edit (%d chars), signaling stream consumer to split",
+                    self.name, len(content)
+                )
+                return SendResult(success=False, error="message_too_long")
             # Flood control / RetryAfter — back off and retry once
             retry_after = getattr(e, "retry_after", None)
             if retry_after is not None or "retry after" in err_str:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5615,7 +5615,28 @@ class GatewayRunner:
         _sc = stream_consumer_holder[0]
         if _sc and _sc.already_sent and isinstance(response, dict):
             response["already_sent"] = True
-        
+
+        # Handle undelivered text from failed mid-stream sends
+        # This can happen when sending to threads/topics hits rate limits
+        if _sc and hasattr(_sc, "has_undelivered_text") and _sc.has_undelivered_text:
+            remaining = _sc.get_remaining_text()
+            if remaining:
+                logger.warning(
+                    "Delivering %d chars of undelivered streaming content to %s",
+                    len(remaining), source.chat_id
+                )
+                try:
+                    _meta = {"thread_id": source.thread_id} if source.thread_id else None
+                    await adapter.send(
+                        source.chat_id,
+                        remaining,
+                        metadata=_meta,
+                    )
+                except Exception as e:
+                    logger.error(
+                        "Failed to deliver remaining streaming content: %s", e
+                    )
+
         return response
 
 

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -69,12 +69,25 @@ class GatewayStreamConsumer:
         self._edit_supported = True  # Disabled on first edit failure (Signal/Email/HA)
         self._last_edit_time = 0.0
         self._last_sent_text = ""   # Track last-sent text to skip redundant edits
+        self._failed_text: Optional[str] = None  # Text that couldn't be delivered mid-stream
 
     @property
     def already_sent(self) -> bool:
         """True if at least one message was sent/edited — signals the base
         adapter to skip re-sending the final response."""
         return self._already_sent
+
+    @property
+    def has_undelivered_text(self) -> bool:
+        """True if there is text that couldn't be delivered during streaming.
+        The caller should retrieve this via get_remaining_text() and send it
+        via the normal (non-streaming) path."""
+        return self._failed_text is not None and len(self._failed_text) > 0
+
+    def get_remaining_text(self) -> Optional[str]:
+        """Get text that couldn't be delivered during streaming.
+        Returns None if all text was delivered successfully."""
+        return self._failed_text
 
     def on_delta(self, text: str) -> None:
         """Thread-safe callback — called from the agent's worker thread."""
@@ -118,30 +131,56 @@ class GatewayStreamConsumer:
                 if should_edit and self._accumulated:
                     # Split overflow: if accumulated text exceeds the platform
                     # limit, finalize the current message and start a new one.
+                    overflow_send_failed = False
                     while (
                         len(self._accumulated) > _safe_limit
                         and self._message_id is not None
+                        and not overflow_send_failed
                     ):
                         split_at = self._accumulated.rfind("\n", 0, _safe_limit)
                         if split_at < _safe_limit // 2:
                             split_at = _safe_limit
                         chunk = self._accumulated[:split_at]
-                        await self._send_or_edit(chunk)
-                        self._accumulated = self._accumulated[split_at:].lstrip("\n")
-                        self._message_id = None
-                        self._last_sent_text = ""
+                        success = await self._send_or_edit(chunk)
+                        if success:
+                            self._accumulated = self._accumulated[split_at:].lstrip("\n")
+                            self._message_id = None
+                            self._last_sent_text = ""
+                        else:
+                            # Send failed - stop splitting; remaining text
+                            # will be captured when stream ends or next iteration
+                            overflow_send_failed = True
+                            logger.warning(
+                                "Overflow send failed in thread/chat %s. "
+                                "Remaining %d chars queued for fallback.",
+                                self.chat_id, len(self._accumulated)
+                            )
 
-                    display_text = self._accumulated
-                    if not got_done:
-                        display_text += self.cfg.cursor
+                    # Only send more if we haven't hit a failure
+                    if not overflow_send_failed:
+                        display_text = self._accumulated
+                        if not got_done:
+                            display_text += self.cfg.cursor
 
-                    await self._send_or_edit(display_text)
-                    self._last_edit_time = time.monotonic()
+                        await self._send_or_edit(display_text)
+                        self._last_edit_time = time.monotonic()
 
                 if got_done:
                     # Final edit without cursor
                     if self._accumulated and self._message_id:
                         await self._send_or_edit(self._accumulated)
+                    # If we have accumulated text but no message_id, send failed
+                    # mid-stream. Capture remaining text for fallback delivery.
+                    if self._accumulated and not self._message_id:
+                        logger.warning(
+                            "Stream ended with %d chars undelivered in thread/chat %s "
+                            "(no active message). Queuing for fallback delivery.",
+                            len(self._accumulated), self.chat_id
+                        )
+                        if self._failed_text is None:
+                            self._failed_text = self._accumulated
+                        else:
+                            self._failed_text += "\n" + self._accumulated
                     return
 
                 await asyncio.sleep(0.05)  # Small yield to not busy-loop
@@ -156,14 +195,18 @@ class GatewayStreamConsumer:
         except Exception as e:
             logger.error("Stream consumer error: %s", e)
 
-    async def _send_or_edit(self, text: str) -> None:
-        """Send or edit the streaming message."""
+    async def _send_or_edit(self, text: str) -> bool:
+        """Send or edit the streaming message.
+
+        Returns True if the text was successfully delivered, False otherwise.
+        On failure, the text is stored in _failed_text for fallback delivery.
+        """
         try:
             if self._message_id is not None:
                 if self._edit_supported:
                     # Skip if text is identical to what we last sent
                     if text == self._last_sent_text:
-                        return
+                        return True
                     # Edit existing message
                     result = await self.adapter.edit_message(
                         chat_id=self.chat_id,
@@ -173,6 +216,7 @@ class GatewayStreamConsumer:
                     if result.success:
                         self._already_sent = True
                         self._last_sent_text = text
+                        return True
                     else:
                         # Edit not supported by this adapter — stop streaming,
                         # let the normal send path handle the final response.
@@ -180,12 +224,16 @@ class GatewayStreamConsumer:
                         # flood the chat with a new message every edit_interval.
                         logger.debug("Edit failed, disabling streaming for this adapter")
                         self._edit_supported = False
+                        # Note: for edit failures, we don't capture _failed_text
+                        # because the original message exists; the final response
+                        # will be sent as a new message by the caller.
+                        return True
                 else:
                     # Editing not supported — skip intermediate updates.
                     # The final response will be sent by the normal path.
-                    pass
+                    return True
             else:
-                # First message — send new
+                # First message — send new (or follow-up after split)
                 result = await self.adapter.send(
                     chat_id=self.chat_id,
                     content=text,
@@ -195,8 +243,28 @@ class GatewayStreamConsumer:
                     self._message_id = result.message_id
                     self._already_sent = True
                     self._last_sent_text = text
+                    return True
                 else:
-                    # Initial send failed — disable streaming for this session
+                    # Send failed — disable streaming and capture text for fallback
+                    error_msg = getattr(result, 'error', 'unknown error')
+                    logger.warning(
+                        "Stream send failed in thread/chat %s: %s. "
+                        "Disabling streaming and queuing %d chars for fallback delivery.",
+                        self.chat_id, error_msg, len(text)
+                    )
                     self._edit_supported = False
+                    # Accumulate failed text for fallback delivery
+                    if self._failed_text is None:
+                        self._failed_text = text
+                    else:
+                        self._failed_text += "\n" + text
+                    return False
         except Exception as e:
             logger.error("Stream send/edit error: %s", e)
+            # Capture failed text on exception too
+            if self._message_id is None:
+                if self._failed_text is None:
+                    self._failed_text = text
+                else:
+                    self._failed_text += "\n" + text
+            return False

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -166,9 +166,35 @@ class GatewayStreamConsumer:
                         self._last_edit_time = time.monotonic()
 
                 if got_done:
-                    # Final edit without cursor
+                    # Handle overflow before final edit: if accumulated text exceeds
+                    # the safe limit, split and send as new messages.
                     if self._accumulated and self._message_id:
-                        await self._send_or_edit(self._accumulated)
+                        while len(self._accumulated) > _safe_limit:
+                            split_at = self._accumulated.rfind("\n", 0, _safe_limit)
+                            if split_at < _safe_limit // 2:
+                                split_at = _safe_limit
+                            chunk = self._accumulated[:split_at]
+                            success = await self._send_or_edit(chunk)
+                            if success:
+                                self._accumulated = self._accumulated[split_at:].lstrip("\n")
+                                self._message_id = None
+                                self._last_sent_text = ""
+                            else:
+                                # Send failed - capture remaining for fallback
+                                logger.warning(
+                                    "Final overflow send failed in thread/chat %s. "
+                                    "Remaining %d chars queued for fallback.",
+                                    self.chat_id, len(self._accumulated)
+                                )
+                                if self._failed_text is None:
+                                    self._failed_text = self._accumulated
+                                else:
+                                    self._failed_text += "\n" + self._accumulated
+                                self._accumulated = ""
+                                break
+                        # Final edit for remaining content (within limits)
+                        if self._accumulated and self._message_id:
+                            await self._send_or_edit(self._accumulated)
                     # If we have accumulated text but no message_id, send failed
                     # mid-stream. Capture remaining text for fallback delivery.
                     if self._accumulated and not self._message_id:


### PR DESCRIPTION
## Problem

When streaming responses exceed platform message limits (e.g., Telegram's 4096 character limit), the stream consumer splits content into multiple messages. If a follow-up send fails (due to rate limits, thread permission issues, or network errors), the remaining text was **silently dropped**.

This particularly affects Telegram Job threads/topics where:
- Rate limits are stricter
- Permission issues are more common
- Users expect complete responses

## Root Cause

In `stream_consumer.py`, when a send failed mid-stream:
1. `_message_id` was set to `None`
2. `_edit_supported` was set to `False`
3. Stream ended with accumulated text but no active message
4. Final check `if self._accumulated and self._message_id` failed
5. **Text was lost forever**

## Solution

1. **Capture failed text**: Store undelivered content in `_failed_text`
2. **Expose via API**: Added `has_undelivered_text` and `get_remaining_text()`
3. **Fallback delivery**: `_run_agent()` checks for undelivered text and sends via normal path
4. **Better logging**: Clear warnings when sends fail

## Changes

- `gateway/stream_consumer.py` - Core streaming consumer fixes
- `gateway/run.py` - Fallback delivery for undelivered content

## Testing

✅ Verified fix works - long responses in Telegram topic threads now complete successfully even when rate limits are hit.

## Example Log Output (with fix)

```
WARNING: Stream send failed in thread/chat -1001234567890: rate limit exceeded.
         Disabling streaming and queuing 2048 chars for fallback delivery.
WARNING: Delivering 2048 chars of undelivered streaming content to -1001234567890
```

Fixes silent message truncation in group chat topic threads.
```

---

## Title
```
fix(gateway): prevent silent message dropping when streaming sends fail in threads/topics
```