### PR TITLE
fix(terminal): preserve partial output when command times out

### DIFF
--- a/tests/tools/test_terminal_timeout_output.py
+++ b/tests/tools/test_terminal_timeout_output.py
@@ -1,0 +1,27 @@
+"""Verify that terminal command timeouts preserve partial output."""
+from tools.environments.local import LocalEnvironment
+
+
+class TestTimeoutPreservesPartialOutput:
+    """When a command times out, any output captured before the deadline
+    should be included in the result — not discarded."""
+
+    def test_timeout_includes_partial_output(self):
+        """A command that prints then sleeps past the deadline should
+        return both the printed text and the timeout notice."""
+        env = LocalEnvironment()
+        result = env.execute("echo 'hello from test' && sleep 30", timeout=2)
+
+        assert result["returncode"] == 124
+        assert "hello from test" in result["output"]
+        assert "timed out" in result["output"].lower()
+
+    def test_timeout_with_no_output(self):
+        """A command that produces nothing before timeout should still
+        return a clean timeout message."""
+        env = LocalEnvironment()
+        result = env.execute("sleep 30", timeout=1)
+
+        assert result["returncode"] == 124
+        assert "timed out" in result["output"].lower()
+        assert not result["output"].startswith("\n")

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -468,7 +468,12 @@ class LocalEnvironment(PersistentShellMixin, BaseEnvironment):
                 except (ProcessLookupError, PermissionError):
                     proc.kill()
                 reader.join(timeout=2)
-                return self._timeout_result(effective_timeout)
+                partial = "".join(_output_chunks)
+                timeout_msg = f"\n[Command timed out after {effective_timeout}s]"
+                return {
+                    "output": partial + timeout_msg if partial else timeout_msg.lstrip(),
+                    "returncode": 124,
+                }
             time.sleep(0.2)
 
         reader.join(timeout=5)


### PR DESCRIPTION
When a command times out in `_execute_oneshot`, all the output captured before the deadline gets thrown away — the agent only sees "Command timed out after Xs" with zero context about what actually happened. For long builds or test runs, that means no way to tell which tests passed, where the build failed, etc.

The interrupt path (user sends a new message) already does this correctly — it returns the buffered output plus an `[interrupted]` notice. The timeout path just wasn't doing the same thing.

Now timeout returns the partial output followed by `[Command timed out after Xs]`, matching the interrupt behavior.

## Changes Made

- `tools/environments/local.py`: return buffered `_output_chunks` + timeout notice instead of calling `_timeout_result()` which discards everything
- `tests/tools/test_terminal_timeout_output.py`: 2 tests — partial output preserved on timeout, and no-output timeouts produce a clean message

## How to Test

1. `pytest tests/tools/test_terminal_timeout_output.py -v` — 2 tests pass

Verified manually with real commands:

- `echo line1 && echo line2 && sleep 30` (timeout=2) → all lines captured + timeout notice
- `sleep 30` (timeout=1) → clean timeout message, no leading newline
- 500-line output + sleep → all 500 lines (11k chars) preserved + timeout notice
- stderr + stdout mixed → stdout captured + timeout notice
- `python3 -u -c "print(...); time.sleep(30)"` → both print lines captured + timeout notice

## Checklist

- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 22.04