### PR TITLE
feat(telegram): auto-discover fallback IPs via DoH when api.telegram.org is unreachable

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1035,7 +1035,9 @@ class HermesCLI:
         self.config = CLI_CONFIG
         self.compact = compact if compact is not None else CLI_CONFIG["display"].get("compact", False)
         # tool_progress: "off", "new", "all", "verbose" (from config.yaml display section)
-        self.tool_progress_mode = CLI_CONFIG["display"].get("tool_progress", "all")
+        # YAML 1.1 parses bare `off` as boolean False — normalise to string.
+        _raw_tp = CLI_CONFIG["display"].get("tool_progress", "all")
+        self.tool_progress_mode = "off" if _raw_tp is False else str(_raw_tp)
         # resume_display: "full" (show history) | "minimal" (one-liner only)
         self.resume_display = CLI_CONFIG["display"].get("resume_display", "full")
         # bell_on_complete: play terminal bell (\a) when agent finishes a response

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4805,9 +4805,14 @@ class GatewayRunner:
         enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
 
         # Tool progress mode from config.yaml: "all", "new", "verbose", "off"
-        # Falls back to env vars for backward compatibility
+        # Falls back to env vars for backward compatibility.
+        # YAML 1.1 parses bare `off` as boolean False — normalise before
+        # the `or` chain so it doesn't silently fall through to "all".
+        _raw_tp = user_config.get("display", {}).get("tool_progress")
+        if _raw_tp is False:
+            _raw_tp = "off"
         progress_mode = (
-            user_config.get("display", {}).get("tool_progress")
+            _raw_tp
             or os.getenv("HERMES_TOOL_PROGRESS_MODE")
             or "all"
         )


### PR DESCRIPTION
## Summary

Salvaged from PR #3129 by @Gavin-Qiao. Closes #3128.

On restricted networks (university, corporate), `api.telegram.org` may resolve to an IP that is unreachable due to routing or firewall rules. This PR adds automatic fallback IP discovery via DNS-over-HTTPS so the Telegram adapter can find and use an alternative endpoint.

### How it works

1. On gateway startup, the Telegram adapter queries Google DoH (`dns.google/resolve`) and Cloudflare DoH (`cloudflare-dns.com/dns-query`) in parallel for `api.telegram.org` A records
2. System-DNS-resolved IPs are excluded (they're presumably the unreachable ones)
3. Remaining IPs become fallback candidates
4. If DoH is also blocked, falls back to a seed IP (`149.154.167.220` — verified in Telegram's 149.154.160.0/20 range, AS62041)
5. A custom `TelegramFallbackTransport` (httpx async transport) tries the primary endpoint first, then sticks to the first working fallback IP

### Security audit

Verified safe:
- **TLS cert verification preserved**: `sni_hostname` extension controls both SNI and certificate hostname verification in httpx → httpcore → Python ssl. A malicious IP would fail the TLS handshake (no valid cert for `api.telegram.org`)
- **No `verify=False`** anywhere — default httpx TLS verification used
- **DoH endpoints verified**: `dns.google/resolve` and `cloudflare-dns.com/dns-query` confirmed via official Google/Cloudflare developer docs
- **Seed IP verified**: `149.154.167.220` is in Telegram's official CIDR range (`core.telegram.org/resources/cidr.txt`), announced by AS62041 with valid RPKI/ROA

On healthy networks, behavior is unchanged — the primary connection succeeds immediately.

### Files changed

| File | Change |
|------|--------|
| `gateway/platforms/telegram_network.py` | **New** — fallback transport, DoH discovery, IP validation (233 lines) |
| `gateway/platforms/telegram.py` | Wire fallback transport into Application builder |
| `gateway/config.py` | `TELEGRAM_FALLBACK_IPS` env var support |
| `tests/gateway/test_telegram_network.py` | **New** — 44 tests for transport + discovery |
| 5 existing test files | Add `telegram.request` mock + `_no_auto_discovery` fixture |

### Follow-up fixes (on top of cherry-pick)

- Added `telegram.request` mock to `test_dm_topics.py` and `test_telegram_network_reconnect.py` (missed by original PR)
- Added `_no_auto_discovery` fixture to reconnect test (reconnect handler calls `connect()` which now invokes `discover_fallback_ips()`)

### Test plan

- 4552 gateway/tools/agent/cron tests passed, 0 failures
- 200 telegram-specific tests passed
- Full suite has a pre-existing hang (also reproduces on main)