### PR TITLE
feat(gateway): deliver background review notifications to user chat

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5128,7 +5128,25 @@ class GatewayRunner:
             agent.stream_delta_callback = _stream_delta_cb
             agent.status_callback = _status_callback_sync
             agent.reasoning_config = reasoning_config
-            
+
+            # Background review delivery — send "💾 Memory updated" etc. to user
+            def _bg_review_send(message: str) -> None:
+                if not _status_adapter:
+                    return
+                try:
+                    asyncio.run_coroutine_threadsafe(
+                        _status_adapter.send(
+                            _status_chat_id,
+                            message,
+                            metadata=_status_thread_metadata,
+                        ),
+                        _loop_for_step,
+                    )
+                except Exception as _e:
+                    logger.debug("background_review_callback error: %s", _e)
+
+            agent.background_review_callback = _bg_review_send
+
             # Store agent reference for interrupt support
             agent_holder[0] = agent
             # Capture the full tool definitions for transcript logging

--- a/run_agent.py
+++ b/run_agent.py
@@ -486,6 +486,7 @@ class AIAgent:
         # instead of going directly to stdout where patch_stdout's StdoutProxy
         # would mangle the escape sequences.  None = use builtins.print.
         self._print_fn = None
+        self.background_review_callback = None  # Optional sync callback for gateway delivery
         self.skip_context_files = skip_context_files
         self.pass_session_id = pass_session_id
         self.log_prefix_chars = log_prefix_chars
@@ -1525,6 +1526,12 @@ class AIAgent:
                 if actions:
                     summary = " · ".join(dict.fromkeys(actions))
                     self._safe_print(f"  💾 {summary}")
+                    _bg_cb = self.background_review_callback
+                    if _bg_cb:
+                        try:
+                            _bg_cb(f"💾 {summary}")
+                        except Exception:
+                            pass
 
             except Exception as e:
                 logger.debug("Background memory/skill review failed: %s", e)


### PR DESCRIPTION
## Summary

The background memory/skill review (`_spawn_background_review`) fires after the agent response when turn/iteration counters exceed their thresholds (default: every 10 turns for memory, every 10 tool iterations for skills). It spawns a review agent that saves memories and skills, then prints a summary like `💾 Memory updated · User profile updated`.

**The problem:** In CLI mode, the summary goes to the terminal via `_safe_print()`. In gateway mode, `_safe_print` routes to `print()` which goes to the gateway process's stdout — completely invisible to the Telegram/Discord/etc. user. The saves still happen, but silently.

### Changes

**`run_agent.py`:**
- Add `background_review_callback` attribute (default `None`)
- After the review completes and builds a summary, call the callback if set

**`gateway/run.py`:**
- Create a `_bg_review_send` closure that bridges sync→async via `run_coroutine_threadsafe` (same pattern as `_status_callback_sync`)
- Set it on the agent as `background_review_callback` alongside the other per-message callbacks

### Tests

Gateway + agent tests: 1670 passed, 21 skipped.