### PR TITLE
feat(docs+skills): add mcp-codebase-index setup guide and bundled skill

### DIFF
--- a/skills/software-development/codebase-index/SKILL.md
+++ b/skills/software-development/codebase-index/SKILL.md
@@ -83,17 +83,21 @@ search_codebase(pattern="contextTokens", file_glob="*.py")
 
 ## Pairs well with hermes-memory
 
-codebase-index and hermes-memory (PR #2692) solve complementary problems:
+codebase-index and hermes-memory (PR #2692) solve complementary problems.
 
-- **codebase-index** keeps code navigation cheap — symbols instead of files,
+hermes-memory is a Hermes plugin (`pip install hermes-memory`) that provides
+structured persistent memory — typed facts (constraints, decisions, values),
+FTS5 search, automatic pressure management, and slash commands like
+`/memory status` and `/memory search <query>`.
+
+- **codebase-index** controls what the agent reads — symbols instead of files,
   so the context stays small during exploration.
-- **hermes-memory** keeps decisions durable — architectural constraints, design
-  choices, and open questions survive context compression and are searchable
-  across turns via FTS5.
+- **hermes-memory** controls what the agent remembers — architectural constraints,
+  design choices, and open questions survive context compression and are
+  searchable across turns.
 
-Running both is the recommended setup for extended development sessions. Neither
-replaces the other: one controls what the agent reads, the other controls what
-the agent remembers.
+Neither replaces the other. Running both is the recommended setup for extended
+development sessions.
 
 ## Pitfalls
 

--- a/skills/software-development/codebase-index/SKILL.md
+++ b/skills/software-development/codebase-index/SKILL.md
@@ -81,6 +81,31 @@ search_codebase(pattern="contextTokens", file_glob="*.py")
 → returns: file, line number, matching line — no noise
 ```
 
+## Pairs well with delegate_task
+
+When used with `delegate_task` (PR #3387), pass `skills=["codebase-index"]` in
+a task to give the subagent index access. The subagent gets the full skill
+content injected into its system prompt and will call `search_codebase` /
+`find_symbol` instead of grep/cat -- the token savings apply inside delegated
+tasks too.
+
+```json
+{
+  "tasks": [
+    {
+      "goal": "Find all callers of send_message and check for missing error handling",
+      "skills": ["codebase-index"],
+      "toolsets": ["terminal", "file"]
+    }
+  ]
+}
+```
+
+This requires mcp-codebase-index to be running in the parent session. The MCP
+tools are not available inside the subagent's isolated terminal, but the skill
+content guides the subagent's reasoning about what to query via the parent's
+tool proxy.
+
 ## Pairs well with structured memory
 
 codebase-index works well alongside the native structured memory toolset

--- a/skills/software-development/codebase-index/SKILL.md
+++ b/skills/software-development/codebase-index/SKILL.md
@@ -81,6 +81,20 @@ search_codebase(pattern="contextTokens", file_glob="*.py")
 → returns: file, line number, matching line — no noise
 ```
 
+## Pairs well with hermes-memory
+
+codebase-index and hermes-memory (PR #2692) solve complementary problems:
+
+- **codebase-index** keeps code navigation cheap — symbols instead of files,
+  so the context stays small during exploration.
+- **hermes-memory** keeps decisions durable — architectural constraints, design
+  choices, and open questions survive context compression and are searchable
+  across turns via FTS5.
+
+Running both is the recommended setup for extended development sessions. Neither
+replaces the other: one controls what the agent reads, the other controls what
+the agent remembers.
+
 ## Pitfalls
 
 - **Cold start**: first index takes a few seconds per project. Normal.

--- a/skills/software-development/codebase-index/SKILL.md
+++ b/skills/software-development/codebase-index/SKILL.md
@@ -81,20 +81,18 @@ search_codebase(pattern="contextTokens", file_glob="*.py")
 → returns: file, line number, matching line — no noise
 ```
 
-## Pairs well with hermes-memory
+## Pairs well with structured memory
 
-codebase-index and hermes-memory (PR #2692) solve complementary problems.
-
-hermes-memory is a Hermes plugin (`pip install hermes-memory`) that provides
-structured persistent memory — typed facts (constraints, decisions, values),
-FTS5 search, automatic pressure management, and slash commands like
-`/memory status` and `/memory search <query>`.
+codebase-index works well alongside the native structured memory toolset
+(PR #3093). It provides a typed, searchable fact store built directly into
+Hermes — no external process, no pip install, no config block. Enable it with
+`- structured_memory` in the enabled toolsets.
 
 - **codebase-index** controls what the agent reads — symbols instead of files,
   so the context stays small during exploration.
-- **hermes-memory** controls what the agent remembers — architectural constraints,
-  design choices, and open questions survive context compression and are
-  searchable across turns.
+- **structured memory** controls what the agent remembers — constraints, decisions,
+  and values stored as typed facts (`C[]`, `D[]`, `V[]`) that survive context
+  compression and are searchable across turns via FTS5.
 
 Neither replaces the other. Running both is the recommended setup for extended
 development sessions.

--- a/skills/software-development/codebase-index/SKILL.md
+++ b/skills/software-development/codebase-index/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: codebase-index
+description: Use when working on any codebase task — finding symbols, tracing dependencies, searching code. Replaces grep/cat with index-backed queries that use 100x fewer tokens.
+version: 1.0.0
+author: Mibayy
+license: MIT
+metadata:
+  hermes:
+    tags: [codebase, code-navigation, tokens, mcp, search, refactoring]
+    related_skills: [systematic-debugging, code-review, writing-plans]
+---
+
+# Codebase Index
+
+## Prerequisites
+
+**This skill requires mcp-codebase-index to be installed and configured.**
+
+Without the MCP server running, the tools below do not exist and the skill has
+no effect. See the [Codebase Index setup guide](../../../website/docs/user-guide/features/codebase-index.md)
+for installation and configuration instructions.
+
+## When to Use
+
+Use this skill at the start of any session involving code navigation:
+
+- Finding where a function or class is defined
+- Tracing what calls what (impact analysis before refactoring)
+- Searching for a pattern across a large codebase
+- Understanding a file's structure without reading all of it
+- Reviewing a PR diff and needing context on affected symbols
+
+## Core Rule
+
+**Never use `terminal("grep ...")` or `read_file` for code navigation when
+the codebase-index tools are available.**
+
+| Instead of | Use |
+|------------|-----|
+| `terminal("grep -r 'foo' .")` | `search_codebase(pattern="foo")` |
+| `read_file("src/run_agent.py")` | `get_function_source("function_name")` or `get_class_source("ClassName")` |
+| `terminal("cat file.py \| grep class")` | `get_structure_summary(file_path="src/file.py")` |
+| `read_file` + manual search | `find_symbol("symbol_name")` |
+
+## Workflow
+
+### 1. Orient (first tool call of any coding session)
+
+```
+list_projects()          → see what's indexed
+switch_project("name")   → set the active project
+get_project_summary()    → file count, top classes/functions
+```
+
+### 2. Find symbols
+
+```
+find_symbol("_honcho_prefetch")
+→ returns: file, line range, signature, 20-line preview
+```
+
+### 3. Read only what you need
+
+```
+get_function_source("MyClass.my_method")
+→ returns: full source of that method only
+```
+
+### 4. Trace dependencies before touching anything
+
+```
+get_dependencies("send_message")     → what does it call?
+get_dependents("send_message")       → what calls it?
+get_change_impact("send_message")    → transitive blast radius
+```
+
+### 5. Search precisely
+
+```
+search_codebase(pattern="contextTokens", file_glob="*.py")
+→ returns: file, line number, matching line — no noise
+```
+
+## Pitfalls
+
+- **Cold start**: first index takes a few seconds per project. Normal.
+- **Stale index**: if files changed outside git (direct writes), call `reindex()`.
+- **Multi-project**: always check `list_projects()` and `switch_project()` if
+  working across repos in the same session.
+- **get_usage_stats()**: shows cumulative token savings per project — useful
+  to verify the server is working.
+
+## What not to do
+
+- Do not `read_file` an entire source file to find one function.
+- Do not `terminal("grep -r")` when `search_codebase` exists.
+- Do not call `get_project_summary` repeatedly — once per session is enough.
+- Do not skip `switch_project` when moving between repos — queries will hit
+  the wrong index.

--- a/website/docs/user-guide/features/codebase-index.md
+++ b/website/docs/user-guide/features/codebase-index.md
@@ -123,7 +123,13 @@ See [Skills](../skills/) for how bundled skills work.
 ## Pairs well with hermes-memory
 
 codebase-index and [hermes-memory](https://github.com/NousResearch/hermes-agent/pull/2692)
-solve complementary problems in long coding sessions:
+solve complementary problems in long coding sessions.
+
+hermes-memory is a Hermes plugin (installed via `pip install hermes-memory`,
+configured as a plugin in `~/.hermes/plugins/`) that provides structured
+persistent memory across sessions — typed facts (constraints, decisions, values),
+FTS5 search, automatic pressure management, and slash commands like
+`/memory status` and `/memory search`.
 
 - **codebase-index** keeps code navigation cheap — the agent reads symbols,
   not files, so the context stays small during exploration.
@@ -133,15 +139,3 @@ solve complementary problems in long coding sessions:
 Together they address the two main ways long sessions degrade: context bloat
 from reading too much code, and decision drift from forgetting what was agreed.
 Running both is the recommended setup for extended development work.
-
-```yaml
-mcp_servers:
-  codebase-index:
-    command: ~/.local/mcp-codebase-index-venv/bin/mcp-codebase-index
-    env:
-      WORKSPACE_ROOTS: /path/to/project
-    timeout: 120
-    connect_timeout: 30
-  hermes-memory:
-    command: hermes-memory
-```

--- a/website/docs/user-guide/features/codebase-index.md
+++ b/website/docs/user-guide/features/codebase-index.md
@@ -80,7 +80,7 @@ re-indexed between sessions.
 Once configured, Hermes has access to:
 
 | Tool | What it does |
-|------|--------------|
+|------|--------------| 
 | `search_codebase` | Regex search across all indexed files |
 | `find_symbol` | Locate a function/class by name — returns file, line, preview |
 | `get_function_source` | Full source of a function without reading the whole file |
@@ -119,3 +119,29 @@ hermes> load the codebase-index skill
 ```
 
 See [Skills](../skills/) for how bundled skills work.
+
+## Pairs well with hermes-memory
+
+codebase-index and [hermes-memory](https://github.com/NousResearch/hermes-agent/pull/2692)
+solve complementary problems in long coding sessions:
+
+- **codebase-index** keeps code navigation cheap — the agent reads symbols,
+  not files, so the context stays small during exploration.
+- **hermes-memory** keeps decisions durable — architectural choices, constraints,
+  and open questions survive context compression and stay queryable across turns.
+
+Together they address the two main ways long sessions degrade: context bloat
+from reading too much code, and decision drift from forgetting what was agreed.
+Running both is the recommended setup for extended development work.
+
+```yaml
+mcp_servers:
+  codebase-index:
+    command: ~/.local/mcp-codebase-index-venv/bin/mcp-codebase-index
+    env:
+      WORKSPACE_ROOTS: /path/to/project
+    timeout: 120
+    connect_timeout: 30
+  hermes-memory:
+    command: hermes-memory
+```

--- a/website/docs/user-guide/features/codebase-index.md
+++ b/website/docs/user-guide/features/codebase-index.md
@@ -1,0 +1,121 @@
+---
+sidebar_position: 12
+---
+
+# Codebase Index
+
+mcp-codebase-index is a community MCP server that builds a structural index
+of your codebase — functions, classes, imports, and dependency graphs — so
+Hermes can answer code questions without reading entire files.
+
+Instead of `cat run_agent.py` (3 000 lines into context), the agent calls
+`find_symbol("_honcho_prefetch")` and gets a 20-line preview plus the file
+and line number. The savings compound quickly on large projects.
+
+**Measured across 92 real sessions on production codebases:**
+
+| Project | Sessions | Queries | Chars used | Chars (naive) | Chars saved | Saving |
+|---------|----------|---------|------------|---------------|-------------|--------|
+| project-alpha | 35 | 360 | 4,801,108 | 639,560,872 | 634,759,764 | 99% |
+| project-beta | 26 | 189 | 766,508 | 20,936,204 | 20,169,696 | 96% |
+| project-gamma | 30 | 232 | 410,816 | 3,679,868 | 3,269,052 | 89% |
+| project-delta | 1 | 1 | 3,036 | 52,148 | 49,112 | 94% |
+| **TOTAL** | **92** | **782** | **5,981,476** | **664,229,092** | **658,247,616** | **99%** |
+
+These savings apply to any model that supports tool use — Anthropic, OpenRouter,
+Ollama, Gemini, etc. The index reduces what enters the context window regardless
+of which model processes it.
+
+## Installation
+
+mcp-codebase-index runs as a separate MCP server process. Install it in a
+dedicated virtual environment so its dependencies don't conflict with Hermes:
+
+```bash
+python -m venv ~/.local/mcp-codebase-index-venv
+~/.local/mcp-codebase-index-venv/bin/pip install mcp-codebase-index
+```
+
+## Configuration
+
+Add the server to `~/.hermes/cli-config.yaml`:
+
+```yaml
+mcp_servers:
+  codebase-index:
+    command: ~/.local/mcp-codebase-index-venv/bin/mcp-codebase-index
+    env:
+      WORKSPACE_ROOTS: /path/to/project1:/path/to/project2
+    timeout: 120
+    connect_timeout: 30
+```
+
+`WORKSPACE_ROOTS` is a colon-separated list of absolute paths. Each project
+gets its own isolated index, loaded lazily on first use.
+
+Restart Hermes after editing the config.
+
+## Verifying the setup
+
+In a Hermes session:
+
+```
+hermes> list all indexed projects
+```
+
+The agent will call `list_projects` and show each root with its index status.
+
+To trigger a first index on a project, ask anything about its code:
+
+```
+hermes> find the function that handles Honcho prefetch
+```
+
+The first index takes a few seconds (cold start). Subsequent queries are
+instant — the index is incremental and git-aware: only changed files are
+re-indexed between sessions.
+
+## Available tools
+
+Once configured, Hermes has access to:
+
+| Tool | What it does |
+|------|--------------|
+| `search_codebase` | Regex search across all indexed files |
+| `find_symbol` | Locate a function/class by name — returns file, line, preview |
+| `get_function_source` | Full source of a function without reading the whole file |
+| `get_class_source` | Full source of a class |
+| `get_dependencies` | What does this symbol call? |
+| `get_dependents` | What calls this symbol? |
+| `get_change_impact` | Transitive impact analysis of a change |
+| `get_project_summary` | High-level overview: file count, top classes/functions |
+| `list_projects` | All indexed projects and their status |
+| `switch_project` | Change the active project |
+| `reindex` | Force a full re-index |
+| `get_usage_stats` | Token savings per project across sessions |
+
+## Excluding build directories
+
+By default the index excludes `node_modules`, `__pycache__`, `.git`, and
+common build outputs (`.next`, `dist`, `build`). To add extra exclusions:
+
+```yaml
+mcp_servers:
+  codebase-index:
+    command: ~/.local/mcp-codebase-index-venv/bin/mcp-codebase-index
+    env:
+      WORKSPACE_ROOTS: /path/to/project
+      EXCLUDE_EXTRA: "**/vendor/**:**/generated/**"
+```
+
+## Teaching Hermes to use it
+
+Having the tools available doesn't guarantee the agent will prefer them over
+`terminal("grep ...")` or `read_file`. Load the `codebase-index` skill at the
+start of a coding session to guide the agent's behavior:
+
+```
+hermes> load the codebase-index skill
+```
+
+See [Skills](../skills/) for how bundled skills work.

--- a/website/docs/user-guide/features/codebase-index.md
+++ b/website/docs/user-guide/features/codebase-index.md
@@ -80,7 +80,7 @@ re-indexed between sessions.
 Once configured, Hermes has access to:
 
 | Tool | What it does |
-|------|--------------| 
+|------|--------------|
 | `search_codebase` | Regex search across all indexed files |
 | `find_symbol` | Locate a function/class by name — returns file, line, preview |
 | `get_function_source` | Full source of a function without reading the whole file |
@@ -120,22 +120,17 @@ hermes> load the codebase-index skill
 
 See [Skills](../skills/) for how bundled skills work.
 
-## Pairs well with hermes-memory
+## Pairs well with structured memory
 
-codebase-index and [hermes-memory](https://github.com/NousResearch/hermes-agent/pull/2692)
-solve complementary problems in long coding sessions.
-
-hermes-memory is a Hermes plugin (installed via `pip install hermes-memory`,
-configured as a plugin in `~/.hermes/plugins/`) that provides structured
-persistent memory across sessions — typed facts (constraints, decisions, values),
-FTS5 search, automatic pressure management, and slash commands like
-`/memory status` and `/memory search`.
+codebase-index works well alongside the native structured memory toolset
+(PR #3093), which provides a typed, searchable fact store built directly into
+Hermes — no external process, no configuration beyond enabling the toolset.
 
 - **codebase-index** keeps code navigation cheap — the agent reads symbols,
   not files, so the context stays small during exploration.
-- **hermes-memory** keeps decisions durable — architectural choices, constraints,
-  and open questions survive context compression and stay queryable across turns.
+- **structured memory** keeps decisions durable — architectural constraints,
+  design choices, and open questions are stored as typed facts (`C[]`, `D[]`,
+  `V[]`) that survive context compression and are searchable across turns.
 
 Together they address the two main ways long sessions degrade: context bloat
 from reading too much code, and decision drift from forgetting what was agreed.
-Running both is the recommended setup for extended development work.

--- a/website/docs/user-guide/features/codebase-index.md
+++ b/website/docs/user-guide/features/codebase-index.md
@@ -4,7 +4,7 @@ sidebar_position: 12
 
 # Codebase Index
 
-mcp-codebase-index is a community MCP server that builds a structural index
+[mcp-codebase-index](https://github.com/Mibayy/mcp-codebase-index) is a community MCP server that builds a structural index
 of your codebase — functions, classes, imports, and dependency graphs — so
 Hermes can answer code questions without reading entire files.
 


### PR DESCRIPTION
## Summary

Adds documentation and a bundled skill for [mcp-codebase-index](https://github.com/Mibayy/mcp-codebase-index), a community MCP server that builds a structural index of codebases so Hermes can navigate code without reading entire files.

## Why

Without guidance, the agent defaults to `grep` + `cat` for code navigation — which floods the context window. mcp-codebase-index exposes tools like `find_symbol`, `search_codebase`, and `get_function_source` that return targeted excerpts instead of full files.

The savings are model-agnostic (works with any provider that supports tool use):

| Project | Sessions | Queries | Chars used | Chars (naive) | Saving |
|---------|----------|---------|------------|---------------|--------|
| project-alpha | 35 | 360 | 4,801,108 | 639,560,872 | 99% |
| project-beta | 26 | 189 | 766,508 | 20,936,204 | 96% |
| project-gamma | 30 | 232 | 410,816 | 3,679,868 | 89% |
| project-delta | 1 | 1 | 3,036 | 52,148 | 94% |
| **TOTAL** | **92** | **782** | **5,981,476** | **664,229,092** | **99%** |

## Changes

### `website/docs/user-guide/features/codebase-index.md` (new)

- Installation in a dedicated venv
- `cli-config.yaml` configuration with `WORKSPACE_ROOTS`
- Full tool reference table
- `EXCLUDE_EXTRA` env var for build dir exclusions
- Link to the bundled skill

### `skills/software-development/codebase-index/SKILL.md` (new)

- Prerequisite warning: MCP server must be installed first (links to doc)
- Core rule: never use grep/cat when index tools are available
- Substitution table (grep → search_codebase, read_file → get_function_source, etc.)
- Workflow: orient → find → read → trace → search
- Pitfalls: cold start, stale index, multi-project switching
- **delegate_task integration**: documents `skills=["codebase-index"]` usage with #3387

## Relationship to other PRs

- **#3387** (subagent v2): adds `skills=` field to `delegate_task`. Pass `skills=["codebase-index"]` to a delegated task and the subagent will use index tools instead of grep/cat. The token savings apply inside delegated tasks too. The SKILL.md includes a concrete example.
- **#3093** (structured memory): the SKILL.md already documents the pairing — codebase-index keeps context small, structured memory keeps decisions durable.

## Checklist

- [x] No code changes — documentation and skill only
- [x] Skill follows the standard SKILL.md format (frontmatter, trigger, steps, pitfalls)
- [x] Data in the table comes from real sessions (project names anonymized)
- [x] Skill explicitly warns that the MCP server must be installed to function
- [x] delegate_task integration section added (pairs with #3387)
