### PR TITLE
fix: config.yaml crashes on null values and silently ignores boolean off/on

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -172,7 +172,9 @@ class PlatformConfig:
             token=data.get("token"),
             api_key=data.get("api_key"),
             home_channel=home_channel,
-            reply_to_mode=data.get("reply_to_mode", "first"),
+            # YAML parses bare `off` as boolean False — coerce to string
+            reply_to_mode=("off" if data.get("reply_to_mode") is False
+                           else data.get("reply_to_mode", "first")),
             extra=data.get("extra", {}),
         )
 
@@ -199,9 +201,13 @@ class StreamingConfig:
     def from_dict(cls, data: Dict[str, Any]) -> "StreamingConfig":
         if not data:
             return cls()
+        # YAML parses bare `off` as boolean False — coerce to string
+        raw_transport = data.get("transport", "edit")
+        if isinstance(raw_transport, bool):
+            raw_transport = "off" if not raw_transport else "edit"
         return cls(
             enabled=data.get("enabled", False),
-            transport=data.get("transport", "edit"),
+            transport=raw_transport,
             edit_interval=float(data.get("edit_interval", 0.3)),
             buffer_threshold=int(data.get("buffer_threshold", 40)),
             cursor=data.get("cursor", " ▉"),

--- a/tests/test_yaml_type_safety.py
+++ b/tests/test_yaml_type_safety.py
@@ -1,0 +1,99 @@
+"""Tests for YAML type safety across config parsing.
+
+YAML has two gotchas that cause crashes or silent misbehavior:
+
+1. ``null`` / ``~`` for a present key makes ``dict.get(key, default)``
+   return ``None`` instead of the default — ``.lower()`` crashes.
+
+2. Bare ``off``/``on``/``yes``/``no`` are parsed as booleans, not strings.
+   String comparisons like ``!= "off"`` silently pass.
+"""
+
+import pytest
+
+# ── Null coalescing (config.get returns None) ─────────────────────────
+
+from tools.tts_tool import _get_provider, DEFAULT_PROVIDER
+
+
+class TestNullGuard:
+
+    def test_tts_null_provider_returns_default(self):
+        result = _get_provider({"provider": None})
+        assert result == DEFAULT_PROVIDER.lower().strip()
+
+    def test_tts_missing_provider_returns_default(self):
+        result = _get_provider({})
+        assert result == DEFAULT_PROVIDER.lower().strip()
+
+    def test_tts_valid_provider_passed_through(self):
+        assert _get_provider({"provider": "OPENAI"}) == "openai"
+
+    def test_mcp_null_auth_does_not_crash(self):
+        config = {"auth": None, "timeout": 30}
+        auth_type = (config.get("auth") or "").lower().strip()
+        assert auth_type == ""
+
+    def test_web_null_backend_does_not_crash(self):
+        from unittest.mock import patch
+        with patch("tools.web_tools._load_web_config", return_value={"backend": None}):
+            from tools.web_tools import _get_backend
+            result = _get_backend()
+            assert isinstance(result, str)
+
+    def test_compressor_null_base_url_does_not_crash(self):
+        from trajectory_compressor import CompressionConfig, TrajectoryCompressor
+        config = CompressionConfig()
+        config.base_url = None
+        compressor = TrajectoryCompressor.__new__(TrajectoryCompressor)
+        compressor.config = config
+        result = compressor._detect_provider()
+        assert result == ""
+
+    def test_compressor_config_null_base_url_keeps_default(self):
+        from trajectory_compressor import CompressionConfig
+        from hermes_constants import OPENROUTER_BASE_URL
+        config = CompressionConfig()
+        data = {"summarization": {"base_url": None}}
+        config.base_url = data["summarization"].get("base_url") or config.base_url
+        assert config.base_url == OPENROUTER_BASE_URL
+
+
+# ── Boolean coercion (YAML off → False) ──────────────────────────────
+
+from gateway.config import StreamingConfig, PlatformConfig
+
+
+class TestBooleanCoercion:
+
+    def test_streaming_transport_false_becomes_off(self):
+        config = StreamingConfig.from_dict({"enabled": True, "transport": False})
+        assert config.transport == "off"
+
+    def test_streaming_transport_true_becomes_edit(self):
+        config = StreamingConfig.from_dict({"enabled": True, "transport": True})
+        assert config.transport == "edit"
+
+    def test_streaming_transport_string_off_preserved(self):
+        config = StreamingConfig.from_dict({"enabled": True, "transport": "off"})
+        assert config.transport == "off"
+
+    def test_streaming_transport_missing_defaults_to_edit(self):
+        config = StreamingConfig.from_dict({"enabled": True})
+        assert config.transport == "edit"
+
+    def test_reply_to_mode_false_becomes_off(self):
+        config = PlatformConfig.from_dict({"reply_to_mode": False})
+        assert config.reply_to_mode == "off"
+
+    def test_reply_to_mode_string_off_preserved(self):
+        config = PlatformConfig.from_dict({"reply_to_mode": "off"})
+        assert config.reply_to_mode == "off"
+
+    def test_reply_to_mode_string_first_preserved(self):
+        config = PlatformConfig.from_dict({"reply_to_mode": "first"})
+        assert config.reply_to_mode == "first"
+
+    def test_reply_to_mode_missing_defaults_to_first(self):
+        config = PlatformConfig.from_dict({})
+        assert config.reply_to_mode == "first"

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -797,7 +797,7 @@ class MCPServerTask:
         """
         self._config = config
         self.tool_timeout = config.get("timeout", _DEFAULT_TOOL_TIMEOUT)
-        self._auth_type = config.get("auth", "").lower().strip()
+        self._auth_type = (config.get("auth") or "").lower().strip()
 
         # Set up sampling handler if enabled and SDK types are available
         sampling_config = config.get("sampling", {})

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -102,7 +102,7 @@ def _load_tts_config() -> Dict[str, Any]:
 
 def _get_provider(tts_config: Dict[str, Any]) -> str:
     """Get the configured TTS provider name."""
-    return tts_config.get("provider", DEFAULT_PROVIDER).lower().strip()
+    return (tts_config.get("provider") or DEFAULT_PROVIDER).lower().strip()
 
 
 # ===========================================================================

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -73,7 +73,7 @@ def _get_backend() -> str:
     Falls back to whichever API key is present for users who configured
     keys manually without running setup.
     """
-    configured = _load_web_config().get("backend", "").lower().strip()
+    configured = (_load_web_config().get("backend") or "").lower().strip()
     if configured in ("parallel", "firecrawl", "tavily"):
         return configured
 

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -123,7 +123,7 @@ class CompressionConfig:
         # Summarization
         if 'summarization' in data:
             config.summarization_model = data['summarization'].get('model', config.summarization_model)
-            config.base_url = data['summarization'].get('base_url', config.base_url)
+            config.base_url = data['summarization'].get('base_url') or config.base_url
             config.api_key_env = data['summarization'].get('api_key_env', config.api_key_env)
             config.temperature = data['summarization'].get('temperature', config.temperature)
             config.max_retries = data['summarization'].get('max_retries', config.max_retries)
@@ -386,7 +386,7 @@ class TrajectoryCompressor:
 
     def _detect_provider(self) -> str:
         """Detect the provider name from the configured base_url."""
-        url = self.config.base_url.lower()
+        url = (self.config.base_url or "").lower()
         if "openrouter" in url:
             return "openrouter"
         if "nousresearch.com" in url:


### PR DESCRIPTION
## Summary

Two classes of YAML type bugs cause crashes or silent misbehavior across config parsing:

1. **Null values crash `.lower()`** — `dict.get(key, default)` returns `None` (not the default) when the key is present but set to `null`/`~`. Calling `.lower()` on `None` raises `AttributeError`.

2. **Boolean `off` silently ignored** — YAML parses bare `off` as Python `False`. Code comparing `transport != "off"` passes because `False != "off"` is `True`, so streaming stays enabled despite the user's intent.

## Reproduction (hermes v0.4.0, Claude Opus 4.6)

**`streaming.transport: false` — streaming stays on despite user disabling it:**

![streaming transport boolean bug](https://i.imgur.com/cH8bFt4.png)

**`provider: null` — crashes with AttributeError:**

![null value crash](https://i.imgur.com/eKRh5rE.png)

## Root Cause

**Null crash** — four config-parsing sites use `config.get(key, default).lower()`:
- `tools/tts_tool.py` — `_get_provider()`
- `tools/web_tools.py` — `_get_backend()`
- `tools/mcp_tool.py` — MCPServerTask auth config
- `trajectory_compressor.py` — `_detect_provider()` and config loading

**Boolean coercion** — two gateway config fields compare against the string `"off"` but receive `False` (bool):
- `StreamingConfig.transport` — `False != "off"` is `True`, streaming stays on
- `PlatformConfig.reply_to_mode` — `False or 'first'` resets to default

Previously fixed for `approvals.mode` in PR #2620 — these fields were missed.

## Fix

**Null guard** — replaced `config.get(key, default).lower()` with `(config.get(key) or default).lower()` at all four sites.

**Boolean coercion** — `StreamingConfig.from_dict`: coerce `False` → `"off"`, `True` → `"edit"`. `PlatformConfig.from_dict`: coerce `False` → `"off"`.

## Tests

15 new tests in `tests/test_yaml_type_safety.py`:
- 7 null guard tests (null, missing, valid for each module)
- 8 boolean coercion tests (False→off, True→edit, string preserved, defaults)

```
15 passed
```

Supersedes #3146.