### PR TITLE
feat: add Google Gemini support to provider registry and models

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -63,6 +63,7 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "opencode-zen": "gemini-3-flash",
     "opencode-go": "glm-5",
     "kilocode": "google/gemini-3-flash-preview",
+    "google": "gemini-3-flash",
 }
 
 # OpenRouter app attribution headers

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -212,6 +212,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("KILOCODE_API_KEY",),
         base_url_env_var="KILOCODE_BASE_URL",
     ),
+    "google": ProviderConfig(
+        id="google",
+        name="Google Gemini",
+        auth_type="api_key",
+        inference_base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+        api_key_env_vars=("GOOGLE_API_KEY", "GEMINI_API_KEY"),
+        base_url_env_var="GOOGLE_BASE_URL",
+    ),
 }
 
 
@@ -687,6 +695,7 @@ def resolve_provider(
         "opencode": "opencode-zen", "zen": "opencode-zen",
         "go": "opencode-go", "opencode-go-sub": "opencode-go",
         "kilo": "kilocode", "kilo-code": "kilocode", "kilo-gateway": "kilocode",
+        "gemini": "google", "google-gemini": "google",
     }
     normalized = _PROVIDER_ALIASES.get(normalized, normalized)
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -200,6 +200,16 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "qwen3.5-flash",
         "qwen-vl-max",
     ],
+    "google": [
+        "gemini-3-flash",
+        "gemini-3-flash-preview",
+        "gemini-3-pro",
+        "gemini-3-pro-preview",
+        "gemini-2.5-pro",
+        "gemini-2.5-flash",
+        "gemini-2.0-flash",
+        "gemini-2.0-pro",
+    ],
 }
 
 _PROVIDER_LABELS = {
@@ -219,6 +229,7 @@ _PROVIDER_LABELS = {
     "ai-gateway": "AI Gateway",
     "kilocode": "Kilo Code",
     "alibaba": "Alibaba Cloud (DashScope)",
+    "google": "Google Gemini",
     "custom": "Custom endpoint",
 }
 
@@ -254,6 +265,8 @@ _PROVIDER_ALIASES = {
     "aliyun": "alibaba",
     "qwen": "alibaba",
     "alibaba-cloud": "alibaba",
+    "gemini": "google",
+    "google-gemini": "google",
 }
 
 
@@ -289,7 +302,7 @@ def list_available_providers() -> list[dict[str, str]]:
         "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
         "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "anthropic", "alibaba",
         "opencode-zen", "opencode-go",
-        "ai-gateway", "deepseek", "custom",
+        "ai-gateway", "deepseek", "google", "custom",
     ]
     # Build reverse alias map
     aliases_for: dict[str, list[str]] = {}

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -389,7 +389,7 @@ def resolve_runtime_provider(
             "requested_provider": requested_provider,
         }
 
-    # API-key providers (z.ai/GLM, Kimi, MiniMax, MiniMax-CN)
+    # API-key providers (z.ai/GLM, Kimi, MiniMax, MiniMax-CN, Google, etc)
     pconfig = PROVIDER_REGISTRY.get(provider)
     if pconfig and pconfig.auth_type == "api_key":
         creds = resolve_api_key_provider_credentials(provider)

--- a/tests/test_api_key_providers.py
+++ b/tests/test_api_key_providers.py
@@ -1,4 +1,4 @@
-"""Tests for API-key provider support (z.ai/GLM, Kimi, MiniMax, AI Gateway)."""
+"""Tests for API-key provider support (z.ai/GLM, Kimi, MiniMax, AI Gateway, Google, etc)."""
 
 import os
 import sys
@@ -44,6 +44,7 @@ class TestProviderRegistry:
         ("minimax-cn", "MiniMax (China)", "api_key"),
         ("ai-gateway", "AI Gateway", "api_key"),
         ("kilocode", "Kilo Code", "api_key"),
+        ("google", "Google Gemini", "api_key"),
     ])
     def test_provider_registered(self, provider_id, name, auth_type):
         assert provider_id in PROVIDER_REGISTRY
@@ -184,6 +185,15 @@ class TestResolveProvider:
     def test_alias_kilo_gateway(self):
         assert resolve_provider("kilo-gateway") == "kilocode"
 
+    def test_explicit_google(self):
+        assert resolve_provider("google") == "google"
+
+    def test_alias_gemini(self):
+        assert resolve_provider("gemini") == "google"
+
+    def test_alias_google_gemini(self):
+        assert resolve_provider("google-gemini") == "google"
+
     def test_alias_case_insensitive(self):
         assert resolve_provider("GLM") == "zai"
         assert resolve_provider("Z-AI") == "zai"
@@ -234,7 +244,13 @@ class TestResolveProvider:
     def test_auto_detects_kilocode_key(self, monkeypatch):
         monkeypatch.setenv("KILOCODE_API_KEY", "test-kilo-key")
         assert resolve_provider("auto") == "kilocode"
+    def test_auto_detects_google_api_key(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-google-api-key")
+        assert resolve_provider("auto") == "google"
 
+    def test_auto_detects_gemini_api_key(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "test-gemini-api-key")
+        assert resolve_provider("auto") == "google"
     def test_openrouter_takes_priority_over_glm(self, monkeypatch):
         """OpenRouter API key should win over GLM in auto-detection."""
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
@@ -427,6 +443,27 @@ class TestResolveApiKeyProviderCredentials:
         monkeypatch.setenv("KILOCODE_BASE_URL", "https://custom.kilo.example/v1")
         creds = resolve_api_key_provider_credentials("kilocode")
         assert creds["base_url"] == "https://custom.kilo.example/v1"
+
+    def test_resolve_google_with_api_key(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "google-secret-key")
+        creds = resolve_api_key_provider_credentials("google")
+        assert creds["provider"] == "google"
+        assert creds["api_key"] == "google-secret-key"
+        assert creds["base_url"] == "https://generativelanguage.googleapis.com/v1beta/openai"
+        assert creds["source"] == "GOOGLE_API_KEY"
+
+    def test_resolve_google_with_gemini_api_key(self, monkeypatch):
+        """GEMINI_API_KEY should work as fallback when GOOGLE_API_KEY not set."""
+        monkeypatch.setenv("GEMINI_API_KEY", "gemini-secret-key")
+        creds = resolve_api_key_provider_credentials("google")
+        assert creds["api_key"] == "gemini-secret-key"
+        assert creds["source"] == "GEMINI_API_KEY"
+
+    def test_resolve_google_custom_base_url(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_API_KEY", "google-key")
+        monkeypatch.setenv("GOOGLE_BASE_URL", "https://custom.google.example/v1")
+        creds = resolve_api_key_provider_credentials("google")
+        assert creds["base_url"] == "https://custom.google.example/v1"
 
     def test_resolve_with_custom_base_url(self, monkeypatch):
         monkeypatch.setenv("GLM_API_KEY", "glm-key")

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -630,7 +630,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             f"Cannot resolve delegation provider '{configured_provider}': {exc}. "
             f"Check that the provider is configured (API key set, valid provider name), "
             f"or set delegation.base_url/delegation.api_key for a direct endpoint. "
-            f"Available providers: openrouter, nous, zai, kimi-coding, minimax."
+            f"Available providers: openrouter, nous, anthropic, zai, kimi-coding, minimax, minimax-cn, deepseek, google, and others."
         ) from exc
 
     api_key = runtime.get("api_key", "")


### PR DESCRIPTION
## What does this PR do?

Adds native support for Google Gemini API as a new provider in Hermes Agent. Users can now use Gemini models (Flash, Pro series) through the standard Hermes CLI interface with API key authentication.

The implementation follows the existing API-key provider pattern (similar to z.ai, Kimi, MiniMax) for consistency.

## Related Issue

<!-- No specific issue - this is a new feature addition -->

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- `hermes_cli/auth.py`: Added "google" provider configuration to PROVIDER_REGISTRY with API-key auth type
- `hermes_cli/models.py`: Added Gemini model list (gemini-3-flash, gemini-3-pro, gemini-2.5/2.0 series) and provider aliases
- `agent/auxiliary_client.py`: Added model mapping for "google" provider
- `hermes_cli/runtime_provider.py`: Updated comment to include Google in API-key providers list
- `tools/delegate_tool.py`: Updated error message to include Google in available providers
- `tests/test_api_key_providers.py`: Added comprehensive tests for Google provider resolution, aliases, and credential handling

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Set `GOOGLE_API_KEY` or `GEMINI_API_KEY` environment variable
2. Run `hermes --provider google --model gemini-3-flash "Hello"`
3. Verify provider auto-detection: `hermes --provider auto` (with Google API key set)
4. Run tests: `pytest tests/test_api_key_providers.py -v -k google`

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 --> macOS 15

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (provider follows existing patterns)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill out if you're adding a skill. Delete this section otherwise. -->

N/A - This is a provider addition, not a skill.

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

Example usage:
```bash
$ export GOOGLE_API_KEY="your-api-key"
$ hermes --provider google --model gemini-3-flash "Explain quantum computing"
```
