### PR TITLE
fix: YAML boolean handling for tool_progress config

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1035,7 +1035,9 @@ class HermesCLI:
         self.config = CLI_CONFIG
         self.compact = compact if compact is not None else CLI_CONFIG["display"].get("compact", False)
         # tool_progress: "off", "new", "all", "verbose" (from config.yaml display section)
-        self.tool_progress_mode = CLI_CONFIG["display"].get("tool_progress", "all")
+        # YAML 1.1 parses bare `off` as boolean False — normalise to string.
+        _raw_tp = CLI_CONFIG["display"].get("tool_progress", "all")
+        self.tool_progress_mode = "off" if _raw_tp is False else str(_raw_tp)
         # resume_display: "full" (show history) | "minimal" (one-liner only)
         self.resume_display = CLI_CONFIG["display"].get("resume_display", "full")
         # bell_on_complete: play terminal bell (\a) when agent finishes a response

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4805,9 +4805,14 @@ class GatewayRunner:
         enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
 
         # Tool progress mode from config.yaml: "all", "new", "verbose", "off"
-        # Falls back to env vars for backward compatibility
+        # Falls back to env vars for backward compatibility.
+        # YAML 1.1 parses bare `off` as boolean False — normalise before
+        # the `or` chain so it doesn't silently fall through to "all".
+        _raw_tp = user_config.get("display", {}).get("tool_progress")
+        if _raw_tp is False:
+            _raw_tp = "off"
         progress_mode = (
-            user_config.get("display", {}).get("tool_progress")
+            _raw_tp
             or os.getenv("HERMES_TOOL_PROGRESS_MODE")
             or "all"
         )


### PR DESCRIPTION
## Summary

Fixes #2859 (reported by @gibbsoft).

`display.tool_progress: off` in config.yaml was silently ignored — YAML 1.1 parses bare `off` as boolean `False`, which is falsy in Python's `or` chain and falls through to the `"all"` default. Users thought they'd turned off tool progress but it stayed on.

### The fix

Normalise `False` → `"off"` before the `or` chain at both read sites:

**gateway/run.py** (`_run_agent` tool progress reader):
```python
_raw_tp = user_config.get("display", {}).get("tool_progress")
if _raw_tp is False:
    _raw_tp = "off"
progress_mode = _raw_tp or os.getenv(...) or "all"
```

**cli.py** (`HermesCLI.__init__`):
```python
_raw_tp = CLI_CONFIG["display"].get("tool_progress", "all")
self.tool_progress_mode = "off" if _raw_tp is False else str(_raw_tp)
```

Note: the `/verbose` gateway handler (merged in #3262) already handles this correctly — these are the two remaining read sites.

### Why not cherry-pick #2859

The original PR is 99 commits stale and bundles an unrelated toolset map refactor that no longer applies (code was restructured). The actual fix is two one-liners.