### PR TITLE
feat: DISCORD_IGNORE_NO_MENTION — skip messages that @mention others but not the bot

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -550,6 +550,20 @@ class DiscordAdapter(BasePlatformAdapter):
                             return
                     # "all" falls through to handle_message
                 
+                # If the message @mentions other users but NOT the bot, the
+                # sender is talking to someone else — stay silent.
+                # Controlled by DISCORD_IGNORE_NO_MENTION (default: true).
+                _ignore_no_mention = os.getenv(
+                    "DISCORD_IGNORE_NO_MENTION", "true"
+                ).lower() in ("true", "1", "yes")
+                if _ignore_no_mention and message.mentions:
+                    _bot_mentioned = (
+                        self._client.user is not None
+                        and self._client.user in message.mentions
+                    )
+                    if not _bot_mentioned:
+                        return  # Talking to someone else, don't interrupt
+
                 await self._handle_message(message)
 
             @self._client.event


### PR DESCRIPTION
When `DISCORD_IGNORE_NO_MENTION=true` (default), if a message mentions other users but not the bot, the bot stays silent. This prevents the bot from interrupting conversations between users in shared channels.

Configurable via environment variable. Set to `false` to disable.