### PR TITLE
fix(session): preserve reasoning fields in rewrite_transcript

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -955,13 +955,17 @@ class SessionStore:
             try:
                 self._db.clear_messages(session_id)
                 for msg in messages:
+                    role = msg.get("role", "unknown")
                     self._db.append_message(
                         session_id=session_id,
-                        role=msg.get("role", "unknown"),
+                        role=role,
                         content=msg.get("content"),
                         tool_name=msg.get("tool_name"),
                         tool_calls=msg.get("tool_calls"),
                         tool_call_id=msg.get("tool_call_id"),
+                        reasoning=msg.get("reasoning") if role == "assistant" else None,
+                        reasoning_details=msg.get("reasoning_details") if role == "assistant" else None,
+                        codex_reasoning_items=msg.get("codex_reasoning_items") if role == "assistant" else None,
                     )
             except Exception as e:
                 logger.debug("Failed to rewrite transcript in DB: %s", e)

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -859,3 +859,46 @@ class TestLastPromptTokens:
             billing_base_url=None,
             model="openai/gpt-5.4",
         )
+
+
+class TestRewriteTranscriptPreservesReasoning:
+    """rewrite_transcript must not drop reasoning fields from SQLite."""
+
+    def test_reasoning_survives_rewrite(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "test.db")
+        session_id = "reasoning-test"
+        db.create_session(session_id=session_id, source="cli")
+
+        # Insert a message WITH all three reasoning fields
+        db.append_message(
+            session_id=session_id,
+            role="assistant",
+            content="The answer is 42.",
+            reasoning="I need to think step by step.",
+            reasoning_details=[{"type": "summary", "text": "step by step"}],
+            codex_reasoning_items=[{"id": "r1", "type": "reasoning"}],
+        )
+
+        # Verify all three were stored
+        before = db.get_messages_as_conversation(session_id)
+        assert before[0].get("reasoning") == "I need to think step by step."
+        assert before[0].get("reasoning_details") == [{"type": "summary", "text": "step by step"}]
+        assert before[0].get("codex_reasoning_items") == [{"id": "r1", "type": "reasoning"}]
+
+        # Now simulate /retry: build the SessionStore and call rewrite_transcript
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._db = db
+        store._loaded = True
+
+        # rewrite_transcript receives the messages that load_transcript returned
+        store.rewrite_transcript(session_id, before)
+
+        # Load again — all three reasoning fields must survive
+        after = db.get_messages_as_conversation(session_id)
+        assert after[0].get("reasoning") == "I need to think step by step."
+        assert after[0].get("reasoning_details") == [{"type": "summary", "text": "step by step"}]
+        assert after[0].get("codex_reasoning_items") == [{"id": "r1", "type": "reasoning"}]


### PR DESCRIPTION
## Summary
Salvaged from PR #3199 by @alireza78a — cherry-picked onto current main with original authorship preserved.

## Root cause
`rewrite_transcript()` (called by `/retry`, `/undo`, `/compress`) clears all session messages from SQLite and re-inserts them — but drops `reasoning`, `reasoning_details`, and `codex_reasoning_items`. Since `load_transcript` reads from SQLite first, the reasoning data is permanently lost for all future loads.

## Fix
Pass all three reasoning fields through to `append_message()` in `rewrite_transcript`, gated on `role == "assistant"` (only assistant messages carry reasoning).

## Validation
- `python -m pytest tests/gateway/test_session.py -n0 -q` → 54 passed
- Includes regression test: inserts message with all 3 reasoning fields, calls rewrite, verifies all survive.

Closes #3199

Co-authored-by: alireza78a <alireza78.crypto@gmail.com>