### PR TITLE
fix(ci): catch anthropic ImportError, pin acp <0.9, fix retry test

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -693,7 +693,13 @@ def _try_anthropic() -> Tuple[Optional[Any], Optional[str]]:
     is_oauth = _is_oauth_token(token)
     model = _API_KEY_PROVIDER_AUX_MODELS.get("anthropic", "claude-haiku-4-5-20251001")
     logger.debug("Auxiliary client: Anthropic native (%s) at %s (oauth=%s)", model, base_url, is_oauth)
-    real_client = build_anthropic_client(token, base_url)
+    try:
+        real_client = build_anthropic_client(token, base_url)
+    except ImportError:
+        # The anthropic_adapter module imports fine but the SDK itself is
+        # missing — build_anthropic_client raises ImportError at call time
+        # when _anthropic_sdk is None.  Treat as unavailable.
+        return None, None
     return AnthropicAuxiliaryClient(real_client, model, token, base_url, is_oauth=is_oauth), model
 
 


### PR DESCRIPTION
## Summary

Three fixes to make CI green.

### Fix 1: Catch ImportError from build_anthropic_client (auxiliary_client.py)

`_try_anthropic()` caught ImportError on the module import but not on the `build_anthropic_client()` call. When the SDK isn't installed, `build_anthropic_client()` raises ImportError at call time, killing the entire vision auto-detection chain and causing 7 test failures locally.

### Fix 2: Pin agent-client-protocol <0.9 (pyproject.toml)

`acp` 0.9.0 removed `AuthMethod` (replaced with `AuthMethodAgent`/`AuthMethodEnvVar`/`AuthMethodTerminal`). Our code uses `AuthMethod(id=..., name=..., description=...)` which doesn't map 1:1 to the new types. Pin to `<0.9` until the new API is properly evaluated.

### Fix 3: Update retry-exhaust test (test_anthropic_error_handling.py)

`test_429_exhausts_all_retries_before_raising` expected `pytest.raises(_RateLimitError)` but the agent no longer re-raises after exhausting retries. The fallback-provider feature changed the behavior: try fallback → return result dict with error in `final_response`. Updated test to check `final_response` contains `429`.

### CI impact
- Fix 1: resolves 7 local test failures (vision/codex auth chain)
- Fix 2: resolves `tests/acp/test_server.py` import error in CI
- Fix 3: resolves `test_429_exhausts_all_retries_before_raising` in CI