### PR TITLE
fix(gateway): include per-platform ALLOW_ALL and SIGNAL_GROUP in startup allowlist check

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -958,12 +958,20 @@ class GatewayRunner:
             os.getenv(v)
             for v in ("TELEGRAM_ALLOWED_USERS", "DISCORD_ALLOWED_USERS",
                        "WHATSAPP_ALLOWED_USERS", "SLACK_ALLOWED_USERS",
-                       "SIGNAL_ALLOWED_USERS", "EMAIL_ALLOWED_USERS",
+                       "SIGNAL_ALLOWED_USERS", "SIGNAL_GROUP_ALLOWED_USERS",
+                       "EMAIL_ALLOWED_USERS",
                        "SMS_ALLOWED_USERS", "MATTERMOST_ALLOWED_USERS",
                        "MATRIX_ALLOWED_USERS", "DINGTALK_ALLOWED_USERS",
                        "GATEWAY_ALLOWED_USERS")
         )
-        _allow_all = os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes")
+        _allow_all = os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes") or any(
+            os.getenv(v, "").lower() in ("true", "1", "yes")
+            for v in ("TELEGRAM_ALLOW_ALL_USERS", "DISCORD_ALLOW_ALL_USERS",
+                       "WHATSAPP_ALLOW_ALL_USERS", "SLACK_ALLOW_ALL_USERS",
+                       "SIGNAL_ALLOW_ALL_USERS", "EMAIL_ALLOW_ALL_USERS",
+                       "SMS_ALLOW_ALL_USERS", "MATTERMOST_ALLOW_ALL_USERS",
+                       "MATRIX_ALLOW_ALL_USERS", "DINGTALK_ALLOW_ALL_USERS")
+        )
         if not _any_allowlist and not _allow_all:
             logger.warning(
                 "No user allowlists configured. All unauthorized users will be denied. "

--- a/tests/gateway/test_allowlist_startup_check.py
+++ b/tests/gateway/test_allowlist_startup_check.py
@@ -1,0 +1,46 @@
+"""Tests for the startup allowlist warning check in gateway/run.py."""
+
+import os
+from unittest.mock import patch
+
+
+def _would_warn():
+    """Replicate the startup allowlist warning logic. Returns True if warning fires."""
+    _any_allowlist = any(
+        os.getenv(v)
+        for v in ("TELEGRAM_ALLOWED_USERS", "DISCORD_ALLOWED_USERS",
+                   "WHATSAPP_ALLOWED_USERS", "SLACK_ALLOWED_USERS",
+                   "SIGNAL_ALLOWED_USERS", "SIGNAL_GROUP_ALLOWED_USERS",
+                   "EMAIL_ALLOWED_USERS",
+                   "SMS_ALLOWED_USERS", "MATTERMOST_ALLOWED_USERS",
+                   "MATRIX_ALLOWED_USERS", "DINGTALK_ALLOWED_USERS",
+                   "GATEWAY_ALLOWED_USERS")
+    )
+    _allow_all = os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes") or any(
+        os.getenv(v, "").lower() in ("true", "1", "yes")
+        for v in ("TELEGRAM_ALLOW_ALL_USERS", "DISCORD_ALLOW_ALL_USERS",
+                   "WHATSAPP_ALLOW_ALL_USERS", "SLACK_ALLOW_ALL_USERS",
+                   "SIGNAL_ALLOW_ALL_USERS", "EMAIL_ALLOW_ALL_USERS",
+                   "SMS_ALLOW_ALL_USERS", "MATTERMOST_ALLOW_ALL_USERS",
+                   "MATRIX_ALLOW_ALL_USERS", "DINGTALK_ALLOW_ALL_USERS")
+    )
+    return not _any_allowlist and not _allow_all
+
+
+class TestAllowlistStartupCheck:
+
+    def test_no_config_emits_warning(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert _would_warn() is True
+
+    def test_signal_group_allowed_users_suppresses_warning(self):
+        with patch.dict(os.environ, {"SIGNAL_GROUP_ALLOWED_USERS": "user1"}, clear=True):
+            assert _would_warn() is False
+
+    def test_telegram_allow_all_users_suppresses_warning(self):
+        with patch.dict(os.environ, {"TELEGRAM_ALLOW_ALL_USERS": "true"}, clear=True):
+            assert _would_warn() is False
+
+    def test_gateway_allow_all_users_suppresses_warning(self):
+        with patch.dict(os.environ, {"GATEWAY_ALLOW_ALL_USERS": "yes"}, clear=True):
+            assert _would_warn() is False


### PR DESCRIPTION
## Summary

Second piece from PR #3202 by @binhnt92.

The startup warning `No user allowlists configured` missed `SIGNAL_GROUP_ALLOWED_USERS` and per-platform `*_ALLOW_ALL_USERS` vars. The actual auth check already recognized them, causing a false warning.

4 new tests.