### PR TITLE
fix(matrix): add missing matrix entry in PLATFORMS dict

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -133,6 +133,7 @@ PLATFORMS = {
     "signal":   {"label": "📡 Signal",     "default_toolset": "hermes-signal"},
     "homeassistant": {"label": "🏠 Home Assistant", "default_toolset": "hermes-homeassistant"},
     "email":    {"label": "📧 Email",      "default_toolset": "hermes-email"},
+    "matrix":   {"label": "💬 Matrix",     "default_toolset": "hermes-matrix"},
     "dingtalk": {"label": "💬 DingTalk",   "default_toolset": "hermes-dingtalk"},
     "api_server": {"label": "🌐 API Server", "default_toolset": "hermes-api-server"},
 }


### PR DESCRIPTION
Matrix platform was missing from the PLATFORMS config, causing a KeyError in _get_platform_tools() when handling Matrix messages. Every other platform (telegram, discord, slack, etc.) was present but matrix was overlooked.

## What does this PR do?

Fixes Matrix messaging


Fixes #

## Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

Add Matrix to PLATFORMS config

## How to Test

1. Install hermes-agent and use matrix for messaging
2. Send a message, logs/errors.log will show a keyerror re: Matrix missing

## Screenshots / Logs

```
Traceback (most recent call last):
  File "/home/ai/.hermes/hermes-agent/gateway/run.py", line 2467, in _handle_message_with_agent
    agent_result = await self._run_agent(
                   ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ai/.hermes/hermes-agent/gateway/run.py", line 4805, in _run_agent
    enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ai/.hermes/hermes-agent/hermes_cli/tools_config.py", line 413, in _get_platform_tools
    default_ts = PLATFORMS[platform]["default_toolset"]
                 ~~~~~~~~~^^^^^^^^^^
KeyError: 'matrix'
```
