### PR TITLE
fix(session): add /resume CLI handler, session log truncation guard, reopen_session API

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2949,6 +2949,82 @@ class HermesCLI:
         if not silent:
             print("(^_^)v New session started!")
 
+    def _handle_resume_command(self, cmd_original: str) -> None:
+        """Handle /resume <session_id_or_title> — switch to a previous session mid-conversation."""
+        parts = cmd_original.split(None, 1)
+        target = parts[1].strip() if len(parts) > 1 else ""
+
+        if not target:
+            _cprint("  Usage: /resume <session_id_or_title>")
+            _cprint("  Tip:   Use /history or `hermes sessions list` to find sessions.")
+            return
+
+        if not self._session_db:
+            _cprint("  Session database not available.")
+            return
+
+        # Resolve title or ID
+        from hermes_cli.main import _resolve_session_by_name_or_id
+        resolved = _resolve_session_by_name_or_id(target)
+        target_id = resolved or target
+
+        session_meta = self._session_db.get_session(target_id)
+        if not session_meta:
+            _cprint(f"  Session not found: {target}")
+            _cprint("  Use /history or `hermes sessions list` to see available sessions.")
+            return
+
+        if target_id == self.session_id:
+            _cprint("  Already on that session.")
+            return
+
+        # End current session
+        try:
+            self._session_db.end_session(self.session_id, "resumed_other")
+        except Exception:
+            pass
+
+        # Switch to the target session
+        self.session_id = target_id
+        self._resumed = True
+        self._pending_title = None
+
+        # Load conversation history
+        restored = self._session_db.get_messages_as_conversation(target_id)
+        self.conversation_history = restored or []
+
+        # Re-open the target session so it's not marked as ended
+        try:
+            self._session_db.reopen_session(target_id)
+        except Exception:
+            pass
+
+        # Sync the agent if already initialised
+        if self.agent:
+            self.agent.session_id = target_id
+            self.agent.reset_session_state()
+            if hasattr(self.agent, "_last_flushed_db_idx"):
+                self.agent._last_flushed_db_idx = len(self.conversation_history)
+            if hasattr(self.agent, "_todo_store"):
+                try:
+                    from tools.todo_tool import TodoStore
+                    self.agent._todo_store = TodoStore()
+                except Exception:
+                    pass
+            if hasattr(self.agent, "_invalidate_system_prompt"):
+                self.agent._invalidate_system_prompt()
+
+        title_part = f" \"{session_meta['title']}\"" if session_meta.get("title") else ""
+        msg_count = len([m for m in self.conversation_history if m.get("role") == "user"])
+        if self.conversation_history:
+            _cprint(
+                f"  ↻ Resumed session {target_id}{title_part}"
+                f" ({msg_count} user message{'s' if msg_count != 1 else ''},"
+                f" {len(self.conversation_history)} total)"
+            )
+        else:
+            _cprint(f"  ↻ Resumed session {target_id}{title_part} — no messages, starting fresh.")
+
     def reset_conversation(self):
         """Reset the conversation by starting a new session."""
         self.new_session()
@@ -3667,6 +3743,8 @@ class HermesCLI:
                     _cprint("  Session database not available.")
         elif canonical == "new":
             self.new_session()
+        elif canonical == "resume":
+            self._handle_resume_command(cmd_original)
         elif canonical == "provider":
             self._show_model_and_providers()
         elif canonical == "prompt":

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -284,6 +284,15 @@ class SessionDB:
             )
             self._conn.commit()
 
+    def reopen_session(self, session_id: str) -> None:
+        """Clear ended_at/end_reason so a session can be resumed."""
+        with self._lock:
+            self._conn.execute(
+                "UPDATE sessions SET ended_at = NULL, end_reason = NULL WHERE id = ?",
+                (session_id,),
+            )
+            self._conn.commit()
+
     def update_system_prompt(self, session_id: str, system_prompt: str) -> None:
         """Store the full assembled system prompt snapshot."""
         with self._lock:

--- a/run_agent.py
+++ b/run_agent.py
@@ -2055,6 +2055,23 @@ class AIAgent:
                     msg["content"] = self._clean_session_content(msg["content"])
                 cleaned.append(msg)
 
+            # Guard: never overwrite a larger session log with fewer messages.
+            # This protects against data loss when --resume loads a session whose
+            # messages weren't fully written to SQLite — the resumed agent starts
+            # with partial history and would otherwise clobber the full JSON log.
+            if self.session_log_file.exists():
+                try:
+                    existing = json.loads(self.session_log_file.read_text(encoding="utf-8"))
+                    existing_count = existing.get("message_count", len(existing.get("messages", [])))
+                    if existing_count > len(cleaned):
+                        logging.debug(
+                            "Skipping session log overwrite: existing has %d messages, current has %d",
+                            existing_count, len(cleaned),
+                        )
+                        return
+                except Exception:
+                    pass  # corrupted existing file — allow the overwrite
+
             entry = {
                 "session_id": self.session_id,
                 "model": self.model,


### PR DESCRIPTION
## Summary

Closes #3123. Salvaged from #3225 by @Mibayy.

### 1. `/resume` CLI handler

The command was registered in `commands.py` but had no handler in `process_command()` — typing `/resume <id>` hit the catch-all. Now handles:
- Resolves target by title or session ID (reuses `_resolve_session_by_name_or_id`)
- Ends current session cleanly in the DB
- Loads conversation history from SQLite
- Re-opens target session via new `reopen_session()` API
- Syncs the `AIAgent` instance (session_id, flush index, todo store, system prompt)
- Follows the same pattern as `new_session()`

### 2. Session log truncation guard

`_save_session_log` now reads the existing JSON file before writing. If the file already has more messages than the current batch, the write is skipped. Prevents data loss when `--resume` loads a session with incomplete SQLite history — the first save would have overwritten the full JSON log with just the current turn.

### 3. `reopen_session()` API

New method on `SessionDB` that clears `ended_at`/`end_reason` so a resumed session isn't stuck as ended. Proper API instead of reaching into `_conn` directly.

### Skipped from original PR

Bug 1 (INSERT OR IGNORE + `_session_db = None`) is already fixed on main — `create_session()` already uses `INSERT OR IGNORE` and the `_session_db = None` line was previously removed.

## Test plan

- [x] `test_cli_init.py` + `test_hermes_state.py`: 152 passed
- [x] `test_run_agent.py` + `test_hermes_state.py`: 331 passed