### PR TITLE
fix(signal): track SSE keepalive comments as connection activity

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -279,6 +279,12 @@ class SignalAdapter(BasePlatformAdapter):
                             line = line.strip()
                             if not line:
                                 continue
+                            # SSE keepalive comments (":") prove the connection
+                            # is alive — update activity so the health monitor
+                            # doesn't report false idle warnings.
+                            if line.startswith(":"):
+                                self._last_sse_activity = time.time()
+                                continue
                             # Parse SSE data lines
                             if line.startswith("data:"):
                                 data_str = line[5:].strip()


### PR DESCRIPTION
signal-cli sends SSE comment lines (`:`) as keepalives every ~15s. The SSE listener only counted `data:` lines as activity, so the health monitor reported false `Signal: SSE idle for 120s` warnings every 2 minutes during quiet periods.

Recognize `:` lines as valid connection activity per the [SSE spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation), updating `_last_sse_activity` to suppress false idle warnings. Genuine connection drops are still detected (no keepalives = no activity updates).

Salvaged from #2938 by @ticketclosed-wontfix.

**Tests:** 33 Signal gateway tests passed.