### PR TITLE
fix: gateway token double-counting — use absolute set instead of increment

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -762,14 +762,14 @@ class SessionStore:
             if session_key in self._entries:
                 entry = self._entries[session_key]
                 entry.updated_at = _now()
-                entry.input_tokens += input_tokens
-                entry.output_tokens += output_tokens
-                entry.cache_read_tokens += cache_read_tokens
-                entry.cache_write_tokens += cache_write_tokens
+                entry.input_tokens = input_tokens
+                entry.output_tokens = output_tokens
+                entry.cache_read_tokens = cache_read_tokens
+                entry.cache_write_tokens = cache_write_tokens
                 if last_prompt_tokens is not None:
                     entry.last_prompt_tokens = last_prompt_tokens
                 if estimated_cost_usd is not None:
-                    entry.estimated_cost_usd += estimated_cost_usd
+                    entry.estimated_cost_usd = estimated_cost_usd
                 if cost_status:
                     entry.cost_status = cost_status
                 entry.total_tokens = (
@@ -783,7 +783,7 @@ class SessionStore:
 
         if self._db and db_session_id:
             try:
-                self._db.update_token_counts(
+                self._db.set_token_counts(
                     db_session_id,
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -375,6 +375,72 @@ class SessionDB:
             )
             self._conn.commit()
 
+    def set_token_counts(
+        self,
+        session_id: str,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+        model: str = None,
+        cache_read_tokens: int = 0,
+        cache_write_tokens: int = 0,
+        reasoning_tokens: int = 0,
+        estimated_cost_usd: Optional[float] = None,
+        actual_cost_usd: Optional[float] = None,
+        cost_status: Optional[str] = None,
+        cost_source: Optional[str] = None,
+        pricing_version: Optional[str] = None,
+        billing_provider: Optional[str] = None,
+        billing_base_url: Optional[str] = None,
+        billing_mode: Optional[str] = None,
+    ) -> None:
+        """Set token counters to absolute values (not increment).
+
+        Use this when the caller provides cumulative totals from a completed
+        conversation run (e.g. the gateway, where the cached agent's
+        session_prompt_tokens already reflects the running total).
+        """
+        with self._lock:
+            self._conn.execute(
+                """UPDATE sessions SET
+                   input_tokens = ?,
+                   output_tokens = ?,
+                   cache_read_tokens = ?,
+                   cache_write_tokens = ?,
+                   reasoning_tokens = ?,
+                   estimated_cost_usd = ?,
+                   actual_cost_usd = CASE
+                       WHEN ? IS NULL THEN actual_cost_usd
+                       ELSE ?
+                   END,
+                   cost_status = COALESCE(?, cost_status),
+                   cost_source = COALESCE(?, cost_source),
+                   pricing_version = COALESCE(?, pricing_version),
+                   billing_provider = COALESCE(billing_provider, ?),
+                   billing_base_url = COALESCE(billing_base_url, ?),
+                   billing_mode = COALESCE(billing_mode, ?),
+                   model = COALESCE(model, ?)
+                   WHERE id = ?""",
+                (
+                    input_tokens,
+                    output_tokens,
+                    cache_read_tokens,
+                    cache_write_tokens,
+                    reasoning_tokens,
+                    estimated_cost_usd,
+                    actual_cost_usd,
+                    actual_cost_usd,
+                    cost_status,
+                    cost_source,
+                    pricing_version,
+                    billing_provider,
+                    billing_base_url,
+                    billing_mode,
+                    model,
+                    session_id,
+                ),
+            )
+            self._conn.commit()
+
     def get_session(self, session_id: str) -> Optional[Dict[str, Any]]:
         """Get a session by ID."""
         with self._lock:

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -846,7 +846,7 @@ class TestLastPromptTokens:
 
         store.update_session("k1", model="openai/gpt-5.4")
 
-        store._db.update_token_counts.assert_called_once_with(
+        store._db.set_token_counts.assert_called_once_with(
             "s1",
             input_tokens=0,
             output_tokens=0,


### PR DESCRIPTION
## Summary
The gateway's token usage stats inflate with every message because `update_session()` uses `+=` for cumulative values the agent already tracks.

## Root cause
The cached agent's `session_prompt_tokens` / `session_completion_tokens` are running totals that accumulate across `run_conversation()` calls. The gateway reads these cumulative values and passes them to `update_session()`, which does `entry.input_tokens += cumulative`. Each message re-adds the full running total.

**Live test result (before fix):**
```
After msg 1: input=1000 → stored 1000 ✓
After msg 2: input=2500 → stored 3500 (should be 2500) ✗
After msg 3: input=5000 → stored 8500 (should be 5000) ✗
Token inflation: 1.7x after 3 messages
```

## Fix
- **gateway/session.py**: Change `+=` to `=` for input_tokens, output_tokens, cache_read/write_tokens, estimated_cost_usd
- **hermes_state.py**: Add `set_token_counts()` — uses SQL direct assignment (`input_tokens = ?`) instead of increment (`input_tokens = input_tokens + ?`)
- **gateway/session.py**: Switch DB call from `update_token_counts` to `set_token_counts`

CLI mode continues using `update_token_counts()` (increment) since it tracks per-API-call deltas.

**Live test result (after fix):**
```
After msg 1: input=1000 → stored 1000 ✓
After msg 2: input=2500 → stored 2500 ✓
After msg 3: input=5000 → stored 5000 ✓
Token inflation: 1.0x
```

## Validation
- `python -m pytest tests/test_hermes_state.py tests/gateway/test_session.py -n0 -q` → 186 passed

Based on analysis from PR #3222 by @zaycruz.
Co-authored-by: zaycruz <zay@users.noreply.github.com>