### PR TITLE
fix(ci): pin acp <0.9 and update retry-exhaust test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ honcho = ["honcho-ai>=2.0.1,<3"]
 mcp = ["mcp>=1.2.0,<2"]
 homeassistant = ["aiohttp>=3.9.0,<4"]
 sms = ["aiohttp>=3.9.0,<4"]
-acp = ["agent-client-protocol>=0.8.1,<1.0"]
+acp = ["agent-client-protocol>=0.8.1,<0.9"]
 dingtalk = ["dingtalk-stream>=0.1.0,<1"]
 rl = [
   "atroposlib @ git+https://github.com/NousResearch/atropos.git",

--- a/tests/test_anthropic_error_handling.py
+++ b/tests/test_anthropic_error_handling.py
@@ -217,10 +217,17 @@ def test_529_overloaded_is_retried_and_recovers(monkeypatch):
 
 
 def test_429_exhausts_all_retries_before_raising(monkeypatch):
-    """429 must retry max_retries times, not abort on first attempt."""
+    """429 must retry max_retries times, then return a failed result.
+
+    The agent no longer re-raises after exhausting retries — it returns a
+    result dict with the error in final_response.  This changed when the
+    fallback-provider feature was added (the agent tries a fallback before
+    giving up, and returns a result dict either way).
+    """
     agent_cls = _make_agent_cls(_RateLimitError)  # always fails
-    with pytest.raises(_RateLimitError):
-        _run_with_agent(monkeypatch, agent_cls)
+    result = _run_with_agent(monkeypatch, agent_cls)
+    resp = str(result.get("final_response", ""))
+    assert "429" in resp or "retries" in resp.lower()
 
 
 def test_400_bad_request_is_non_retryable(monkeypatch):


### PR DESCRIPTION
## Summary

Two remaining CI failures after #3312.

### 1. Pin agent-client-protocol <0.9 (pyproject.toml)

`acp` 0.9.0 removed `AuthMethod` (replaced with `AuthMethodAgent`/`AuthMethodEnvVar`/`AuthMethodTerminal`). Our code uses `AuthMethod(id=..., name=..., description=...)` which doesn't map 1:1 to the new types. Pin to `<0.9` until evaluated.

### 2. Update retry-exhaust test (test_anthropic_error_handling.py)

`test_429_exhausts_all_retries_before_raising` expected `pytest.raises(_RateLimitError)` but the agent no longer re-raises after exhausting retries — the fallback-provider feature changed behavior to return a result dict with error in `final_response`. Updated test to match.