### PR TITLE
feat: add smart home tools (Tesla, Tapo, LG TV, Sonos, Rheem)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ mini-swe-agent/
 # Nix
 .direnv/
 result
+
+# Smart home config files (contain IPs, MACs, device-specific info)
+# These live in ~/.hermes/smart_home/*.yaml at runtime

--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,6 @@ apps/desktop/demo/
 # PR body is the archive. See the hermes-agent-dev skill's
 # pr-infographic-workflow reference (storage rule + lapse #8 / #COMMIT-1).
 infographic/
+
+# Smart home config files (contain IPs, MACs, device-specific info)
+# These live in ~/.hermes/smart_home/*.yaml at runtime

--- a/tests/tools/test_smart_home_tools.py
+++ b/tests/tools/test_smart_home_tools.py
@@ -1,0 +1,56 @@
+"""Tests for the smart-home tools feature branch.
+
+Verifies that the five smart-home tools (Tesla, Tapo, LG TV, Sonos, Rheem)
+self-register via the tools.registry auto-discovery mechanism and that their
+toolsets are wired into toolsets.py correctly.
+"""
+import pytest
+
+SMART_HOME_TOOLS = ["tesla", "tapo", "lgtv", "sonos", "rheem"]
+
+
+@pytest.fixture(scope="module")
+def loaded_registry():
+    from tools.registry import discover_builtin_tools, registry
+    discover_builtin_tools()
+    return registry
+
+
+@pytest.mark.parametrize("tool_name", SMART_HOME_TOOLS)
+def test_smart_home_tool_is_registered(loaded_registry, tool_name):
+    """Each smart-home tool self-registers and is discoverable by name."""
+    all_names = loaded_registry.get_all_tool_names()
+    assert tool_name in all_names, (
+        f"{tool_name} not found in registry after auto-discovery; "
+        f"tools/{tool_name}_tool.py should call registry.register()"
+    )
+
+
+@pytest.mark.parametrize("tool_name", SMART_HOME_TOOLS)
+def test_smart_home_tool_has_schema(loaded_registry, tool_name):
+    """Each smart-home tool exposes a usable schema with a name + description."""
+    schema = loaded_registry.get_schema(tool_name)
+    assert schema is not None, f"{tool_name} has no schema"
+    assert schema.get("name") == tool_name
+    assert schema.get("description"), f"{tool_name} schema missing description"
+
+
+@pytest.mark.parametrize("tool_name", SMART_HOME_TOOLS)
+def test_smart_home_toolset_registered(tool_name):
+    """Each smart-home toolset is declared in toolsets.py TOOLSETS."""
+    from toolsets import TOOLSETS
+    assert tool_name in TOOLSETS, f"{tool_name} toolset missing from TOOLSETS"
+    entry = TOOLSETS[tool_name]
+    assert tool_name in entry.get("tools", []), (
+        f"toolset '{tool_name}' should list tool '{tool_name}'"
+    )
+    assert entry.get("description"), f"toolset '{tool_name}' missing description"
+
+
+@pytest.mark.parametrize("tool_name", SMART_HOME_TOOLS)
+def test_smart_home_in_core_tools(tool_name):
+    """Each smart-home tool is included in the default core toolset."""
+    from toolsets import _HERMES_CORE_TOOLS
+    assert tool_name in _HERMES_CORE_TOOLS, (
+        f"{tool_name} missing from _HERMES_CORE_TOOLS"
+    )

--- a/tools/lgtv_tool.py
+++ b/tools/lgtv_tool.py
@@ -1,0 +1,314 @@
+"""
+LG webOS TV control tool for Hermes.
+
+Controls LG TVs on the local network via PyWebOSTV.
+TV names, IPs, and MAC addresses are loaded from config file.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+import yaml
+
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_DIR = Path.home() / ".hermes" / "smart_home"
+_CONFIG_FILE = _CONFIG_DIR / "lgtv.yaml"
+
+
+def _load_config() -> dict:
+    """Load tool config from YAML file."""
+    if not _CONFIG_FILE.exists():
+        logger.warning("LGTV config not found: %s", _CONFIG_FILE)
+        return {}
+    try:
+        with open(_CONFIG_FILE) as f:
+            return yaml.safe_load(f) or {}
+    except Exception:
+        return {}
+
+
+def _get_devices() -> dict:
+    """Build device dict from config."""
+    config = _load_config()
+    devices = {}
+    for tv in config.get("tvs", []):
+        devices[tv["name"]] = {"ip": tv["ip"], "mac": tv.get("mac", "")}
+    return devices
+
+
+def _get_keys_path() -> Path:
+    """Get the pairing keys file path from config."""
+    config = _load_config()
+    keys_file = config.get("keys_file", "~/.hermes/smart_home/lgtv_keys.json")
+    return Path(keys_file).expanduser()
+
+
+def _check_lgtv_reqs() -> bool:
+    try:
+        from pywebostv.connection import WebOSClient
+        config = _load_config()
+        if not config.get("tvs"):
+            return False
+        return True
+    except ImportError:
+        return False
+
+
+def _load_keys() -> dict:
+    key_path = _get_keys_path()
+    if key_path.exists():
+        try:
+            return json.loads(key_path.read_text())
+        except Exception:
+            pass
+    return {}
+
+
+def _save_keys(keys: dict):
+    key_path = _get_keys_path()
+    key_path.parent.mkdir(parents=True, exist_ok=True)
+    key_path.write_text(json.dumps(keys, indent=2))
+
+
+def _get_client(ip: str):
+    """Connect and register with the TV, using cached key if available."""
+    from pywebostv.connection import WebOSClient
+
+    keys = _load_keys()
+    store = {}
+    if ip in keys:
+        store = {"client_key": keys[ip]}
+
+    client = WebOSClient(ip, secure=True)
+    client.connect()
+    for status in client.register(store):
+        if status == WebOSClient.PROMPTED:
+            logger.info("Pairing prompt shown on TV at %s", ip)
+        elif status == WebOSClient.REGISTERED:
+            if "client_key" in store:
+                keys[ip] = store["client_key"]
+                _save_keys(keys)
+    return client
+
+
+def _find_tv(name: str = None) -> dict:
+    """Find TV by name (partial match). Checks global cache first, falls back to config."""
+    devices = _get_devices()
+    try:
+        from tools.device_scanner import load_cache
+        cache = load_cache()
+        lgtv_cache = cache.get("lgtv", {})
+        if lgtv_cache:
+            if not name:
+                ip = list(lgtv_cache.values())[0]
+                for alias, info in devices.items():
+                    if info["ip"] == ip:
+                        return info
+                return {"ip": ip, "mac": ""}
+            name_lower = name.lower().strip()
+            for alias, ip in lgtv_cache.items():
+                if name_lower in alias.lower():
+                    for ha, info in devices.items():
+                        if info["ip"] == ip:
+                            return info
+                    return {"ip": ip, "mac": ""}
+    except Exception:
+        pass
+    
+    if not name:
+        return list(devices.values())[0] if devices else {"ip": "", "mac": ""}
+    name_lower = name.lower().strip()
+    for alias, info in devices.items():
+        if name_lower in alias.lower():
+            return info
+    return list(devices.values())[0] if devices else {"ip": "", "mac": ""}
+
+
+def lgtv_control(action: str, tv_name: str = None, param: str = None) -> str:
+    try:
+        from pywebostv.controls import (
+            MediaControl, SystemControl, ApplicationControl,
+            SourceControl, InputControl,
+        )
+
+        devices = _get_devices()
+
+        if action == "list":
+            return json.dumps({"success": True, "tvs": [
+                {"name": name, **info} for name, info in devices.items()
+            ]})
+
+        tv = _find_tv(tv_name)
+        ip = tv["ip"]
+
+        if action == "wake":
+            from wakeonlan import send_magic_packet
+            mac = tv.get("mac", "")
+            if not mac:
+                return json.dumps({"error": "No MAC address configured for this TV"})
+            send_magic_packet(mac)
+            return json.dumps({"success": True, "message": f"Wake-on-LAN sent to {mac}"})
+
+        # All other actions need a WebSocket connection (TV must be on)
+        try:
+            client = _get_client(ip)
+        except Exception:
+            # IP may have changed, try rescan
+            try:
+                from tools.device_scanner import rescan
+                rescan(force=True)
+                tv = _find_tv(tv_name)
+                ip = tv["ip"]
+                client = _get_client(ip)
+            except Exception as e:
+                return json.dumps({"error": f"Cannot connect to TV: {e}"})
+        system = SystemControl(client)
+        media = MediaControl(client)
+
+        if action == "status":
+            vol = media.get_volume()
+            # Handle both flat and nested volumeStatus response formats
+            vs = vol.get("volumeStatus", vol)
+            return json.dumps({
+                "success": True,
+                "ip": ip,
+                "volume": vs.get("volume"),
+                "muted": vs.get("muteStatus", vs.get("muted")),
+            })
+
+        elif action == "power_off":
+            system.power_off()
+            return json.dumps({"success": True, "message": "TV powered off"})
+
+        elif action == "screen_off":
+            system.screen_off()
+            return json.dumps({"success": True, "message": "Screen turned off (audio continues)"})
+
+        elif action == "screen_on":
+            system.screen_on()
+            return json.dumps({"success": True, "message": "Screen turned on"})
+
+        elif action == "volume":
+            if not param:
+                vol = media.get_volume()
+                vs = vol.get("volumeStatus", vol)
+                return json.dumps({"success": True, "volume": vs.get("volume"), "muted": vs.get("muteStatus", vs.get("muted"))})
+            media.set_volume(int(param))
+            return json.dumps({"success": True, "message": f"Volume set to {param}"})
+
+        elif action == "volume_up":
+            media.volume_up()
+            return json.dumps({"success": True, "message": "Volume up"})
+
+        elif action == "volume_down":
+            media.volume_down()
+            return json.dumps({"success": True, "message": "Volume down"})
+
+        elif action == "mute":
+            media.mute(True)
+            return json.dumps({"success": True, "message": "Muted"})
+
+        elif action == "unmute":
+            media.mute(False)
+            return json.dumps({"success": True, "message": "Unmuted"})
+
+        elif action == "input":
+            if not param:
+                source = SourceControl(client)
+                sources = source.list_sources()
+                return json.dumps({"success": True, "sources": [str(s) for s in sources]})
+            source = SourceControl(client)
+            sources = source.list_sources()
+            for s in sources:
+                if param.lower() in str(s).lower():
+                    source.set_source(s)
+                    return json.dumps({"success": True, "message": f"Switched to {s}"})
+            return json.dumps({"error": f"Source '{param}' not found. Available: {[str(s) for s in sources]}"})
+
+        elif action == "app":
+            app_ctrl = ApplicationControl(client)
+            if not param:
+                apps = app_ctrl.list_apps()
+                app_names = [{"title": a["title"], "id": a["id"]} for a in apps]
+                return json.dumps({"success": True, "apps": app_names}, ensure_ascii=False)
+            apps = app_ctrl.list_apps()
+            for a in apps:
+                if param.lower() in a["title"].lower() or param.lower() == a["id"].lower():
+                    app_ctrl.launch(a)
+                    return json.dumps({"success": True, "message": f"Launched {a['title']}"})
+            return json.dumps({"error": f"App '{param}' not found"})
+
+        elif action == "play":
+            media.play()
+            return json.dumps({"success": True, "message": "Play"})
+
+        elif action == "pause":
+            media.pause()
+            return json.dumps({"success": True, "message": "Paused"})
+
+        elif action == "stop":
+            media.stop()
+            return json.dumps({"success": True, "message": "Stopped"})
+
+        else:
+            return json.dumps({"error": f"Unknown action: {action}"})
+
+    except Exception as e:
+        logger.error("LG TV tool error: %s", e, exc_info=True)
+        return json.dumps({"error": str(e)})
+
+
+LGTV_SCHEMA = {
+    "name": "lgtv",
+    "description": (
+        "Control LG webOS TVs on the local network. "
+        "Actions: list, status, wake (WOL power on), power_off, "
+        "screen_off, screen_on, "
+        "volume (param=0-100, omit to get current), volume_up, volume_down, "
+        "mute, unmute, "
+        "input (param=source name like 'HDMI 1', omit to list), "
+        "app (param=app name like 'YouTube'/'Netflix', omit to list), "
+        "play, pause, stop."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": [
+                    "list", "status", "wake", "power_off",
+                    "screen_off", "screen_on",
+                    "volume", "volume_up", "volume_down", "mute", "unmute",
+                    "input", "app", "play", "pause", "stop",
+                ],
+                "description": "Action to perform on the TV",
+            },
+            "tv_name": {
+                "type": "string",
+                "description": "TV name (partial match). Defaults to first configured TV.",
+            },
+            "param": {
+                "type": "string",
+                "description": "Extra parameter — volume level, input name, or app name",
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+registry.register(
+    name="lgtv",
+    toolset="lgtv",
+    schema=LGTV_SCHEMA,
+    handler=lambda args, **kw: lgtv_control(
+        action=args["action"],
+        tv_name=args.get("tv_name"),
+        param=args.get("param"),
+    ),
+    check_fn=_check_lgtv_reqs,
+    emoji="📺",
+)

--- a/tools/rheem_tool.py
+++ b/tools/rheem_tool.py
@@ -1,0 +1,183 @@
+"""
+Rheem EcoNet water heater control tool for Hermes.
+
+Controls Rheem heat pump water heater via the EcoNet cloud API (pyeconet).
+Requires RHEEM_EMAIL and RHEEM_PASSWORD.
+"""
+
+import asyncio
+import json
+import logging
+import os
+from pathlib import Path
+
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+
+def _check_rheem_reqs() -> bool:
+    email, password = _get_credentials()
+    return bool(email and password)
+
+
+def _get_credentials():
+    env_path = Path.home() / ".hermes/.env"
+    email = os.getenv("RHEEM_EMAIL", "")
+    password = os.getenv("RHEEM_PASSWORD", "")
+    if not email or not password:
+        try:
+            with open(env_path) as f:
+                for line in f:
+                    line = line.strip()
+                    if line.startswith("RHEEM_EMAIL="):
+                        email = line.split("=", 1)[1]
+                    elif line.startswith("RHEEM_PASSWORD="):
+                        password = line.split("=", 1)[1]
+        except FileNotFoundError:
+            pass
+    return email, password
+
+
+MODE_MAP = {
+    "off": 1,
+    "electric": 2,
+    "energy_saving": 3,
+    "heat_pump": 4,
+    "high_demand": 5,
+    "vacation": 9,
+}
+
+MODE_NAMES = {v: k for k, v in MODE_MAP.items()}
+
+
+async def _do_action(action: str, param: str = None):
+    from pyeconet import EcoNetApiInterface
+    from pyeconet.equipment import EquipmentType
+    from pyeconet.equipment.water_heater import WaterHeaterOperationMode
+
+    email, password = _get_credentials()
+    api = await EcoNetApiInterface.login(email=email, password=password)
+    result = await api.get_equipment_by_type([EquipmentType.WATER_HEATER])
+    heaters = result.get(EquipmentType.WATER_HEATER, [])
+
+    if not heaters:
+        return {"error": "No water heater found on EcoNet account"}
+
+    wh = heaters[0]
+
+    if action == "status":
+        return {
+            "success": True,
+            "name": wh.device_name,
+            "connected": wh.connected,
+            "running": wh.running,
+            "running_state": wh.running_state,
+            "set_point_f": wh.set_point,
+            "set_point_range_f": list(wh.set_point_limits),
+            "mode": MODE_NAMES.get(wh.mode, str(wh.mode)),
+            "available_modes": [MODE_NAMES.get(m.value, m.name) for m in wh.modes],
+            "hot_water_availability": f"{wh.tank_hot_water_availability}%",
+            "vacation": wh.vacation,
+            "compressor_health": f"{wh.compressor_health}%",
+            "tank_health": f"{wh.tank_health}%",
+            "leak_installed": wh.leak_installed,
+            "shutoff_valve_open": wh.shutoff_valve_open,
+            "alert_count": wh.alert_count,
+        }
+
+    elif action == "set_temp":
+        if not param:
+            return {"error": "param (temperature in °F) is required"}
+        temp = int(param)
+        low, high = wh.set_point_limits
+        if temp < low or temp > high:
+            return {"error": f"Temperature must be between {low}°F and {high}°F"}
+        wh.set_set_point(temp)
+        await api.publish(wh)
+        return {"success": True, "message": f"Temperature set to {temp}°F"}
+
+    elif action == "set_mode":
+        if not param:
+            return {
+                "error": "param required: off, electric, energy_saving, heat_pump, high_demand, vacation",
+                "available_modes": [MODE_NAMES.get(m.value, m.name) for m in wh.modes],
+            }
+        mode_val = MODE_MAP.get(param.lower().strip())
+        if mode_val is None:
+            return {"error": f"Unknown mode '{param}'. Use: off, electric, energy_saving, heat_pump, high_demand, vacation"}
+        # Find the matching WaterHeaterOperationMode enum
+        target_mode = None
+        for m in wh.modes:
+            if m.value == mode_val:
+                target_mode = m
+                break
+        if target_mode is None:
+            return {"error": f"Mode '{param}' not supported by this water heater"}
+        wh.set_mode(target_mode)
+        await api.publish(wh)
+        return {"success": True, "message": f"Mode set to {param}"}
+
+    elif action == "set_vacation":
+        if not param:
+            return {"error": "param required: on or off"}
+        on = param.lower().strip() in ("on", "true", "1", "yes")
+        if on:
+            wh.set_mode(WaterHeaterOperationMode.VACATION)
+        else:
+            # Return to energy saving mode when turning off vacation
+            wh.set_mode(WaterHeaterOperationMode.ENERGY_SAVING)
+        await api.publish(wh)
+        return {"success": True, "message": f"Vacation mode {'enabled' if on else 'disabled'}"}
+
+    else:
+        return {"error": f"Unknown action: {action}"}
+
+
+def rheem_control(action: str, param: str = None) -> str:
+    try:
+        result = asyncio.run(_do_action(action, param))
+        return json.dumps(result, ensure_ascii=False)
+    except Exception as e:
+        logger.error("Rheem tool error: %s", e, exc_info=True)
+        return json.dumps({"error": str(e)})
+
+
+RHEEM_SCHEMA = {
+    "name": "rheem",
+    "description": (
+        "Control a Rheem heat pump water heater via EcoNet cloud API. "
+        "Actions: status (temperature, mode, hot water availability, health), "
+        "set_temp (param=°F, range 110-140), "
+        "set_mode (param=off|electric|energy_saving|heat_pump|high_demand|vacation), "
+        "set_vacation (param=on|off)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["status", "set_temp", "set_mode", "set_vacation"],
+                "description": "Action to perform",
+            },
+            "param": {
+                "type": "string",
+                "description": "Temperature in °F, mode name, or on/off for vacation",
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+registry.register(
+    name="rheem",
+    toolset="rheem",
+    schema=RHEEM_SCHEMA,
+    handler=lambda args, **kw: rheem_control(
+        action=args["action"],
+        param=args.get("param"),
+    ),
+    check_fn=_check_rheem_reqs,
+    requires_env=["RHEEM_EMAIL", "RHEEM_PASSWORD"],
+    emoji="🔥",
+)

--- a/tools/sonos_tool.py
+++ b/tools/sonos_tool.py
@@ -1,0 +1,215 @@
+"""
+Sonos speaker control tool for Hermes.
+
+Controls Sonos speakers on the local network via SoCo library.
+Speaker IPs and coordinator are loaded from config file.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+import yaml
+
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_DIR = Path.home() / ".hermes" / "smart_home"
+_CONFIG_FILE = _CONFIG_DIR / "sonos.yaml"
+
+
+def _load_config() -> dict:
+    """Load tool config from YAML file."""
+    if not _CONFIG_FILE.exists():
+        logger.warning("Sonos config not found: %s", _CONFIG_FILE)
+        return {}
+    try:
+        with open(_CONFIG_FILE) as f:
+            return yaml.safe_load(f) or {}
+    except Exception:
+        return {}
+
+
+def _check_sonos_reqs() -> bool:
+    try:
+        import soco
+        config = _load_config()
+        if not config.get("coordinator_ip"):
+            return False
+        return True
+    except ImportError:
+        return False
+
+
+def _get_coordinator_ip() -> str:
+    """Get Sonos coordinator IP from global cache, fallback to config."""
+    config = _load_config()
+    default_ip = config.get("coordinator_ip", "")
+    try:
+        from tools.device_scanner import load_cache
+        cache = load_cache()
+        sonos = cache.get("sonos", {})
+        # Find the Playbar (coordinator)
+        for name, ip in sonos.items():
+            if "playbar" in name.lower() or "coordinator" in name.lower():
+                return ip
+        # Fallback to first non-sub device
+        for name, ip in sonos.items():
+            if "sub" not in name.lower():
+                return ip
+    except Exception:
+        pass
+    return default_ip
+
+
+def sonos_control(action: str, param: str = None) -> str:
+    try:
+        import soco
+
+        coordinator_ip = _get_coordinator_ip()
+        try:
+            speaker = soco.SoCo(coordinator_ip)
+            _ = speaker.player_name  # Test connection
+        except Exception:
+            # IP may have changed, try rescan
+            try:
+                from tools.device_scanner import rescan
+                rescan(force=True)
+                coordinator_ip = _get_coordinator_ip()
+            except Exception:
+                pass
+            speaker = soco.SoCo(coordinator_ip)
+
+        if action == "status":
+            info = speaker.get_speaker_info()
+            track = speaker.get_current_track_info()
+            transport = speaker.get_current_transport_info()
+            return json.dumps({
+                "success": True,
+                "name": speaker.player_name,
+                "model": info.get("model_name", ""),
+                "volume": speaker.volume,
+                "muted": speaker.mute,
+                "playback_state": transport.get("current_transport_state", ""),
+                "current_track": {
+                    "title": track.get("title", ""),
+                    "artist": track.get("artist", ""),
+                    "album": track.get("album", ""),
+                    "duration": track.get("duration", ""),
+                    "position": track.get("position", ""),
+                },
+                "group_members": [
+                    {"name": m.player_name, "ip": m.ip_address, "model": m.get_speaker_info().get("model_name", "")}
+                    for m in speaker.group.members
+                ] if speaker.group else [],
+            }, ensure_ascii=False)
+
+        elif action == "play":
+            if param:
+                # Play a URI or favorite
+                favs = speaker.music_library.get_sonos_favorites()
+                for fav in favs:
+                    if param.lower() in fav.title.lower():
+                        speaker.play_uri(fav.reference)
+                        return json.dumps({"success": True, "message": f"Playing favorite: {fav.title}"})
+                # Try as direct URI
+                speaker.play_uri(param)
+                return json.dumps({"success": True, "message": f"Playing: {param}"})
+            else:
+                speaker.play()
+                return json.dumps({"success": True, "message": "Playback resumed"})
+
+        elif action == "pause":
+            speaker.pause()
+            return json.dumps({"success": True, "message": "Paused"})
+
+        elif action == "stop":
+            speaker.stop()
+            return json.dumps({"success": True, "message": "Stopped"})
+
+        elif action == "next":
+            speaker.next()
+            return json.dumps({"success": True, "message": "Next track"})
+
+        elif action == "previous":
+            speaker.previous()
+            return json.dumps({"success": True, "message": "Previous track"})
+
+        elif action == "volume":
+            if not param:
+                return json.dumps({"success": True, "volume": speaker.volume})
+            vol = int(param)
+            speaker.volume = vol
+            return json.dumps({"success": True, "message": f"Volume set to {vol}"})
+
+        elif action == "volume_up":
+            amount = int(param) if param else 5
+            speaker.volume = min(100, speaker.volume + amount)
+            return json.dumps({"success": True, "message": f"Volume: {speaker.volume}"})
+
+        elif action == "volume_down":
+            amount = int(param) if param else 5
+            speaker.volume = max(0, speaker.volume - amount)
+            return json.dumps({"success": True, "message": f"Volume: {speaker.volume}"})
+
+        elif action == "mute":
+            speaker.mute = True
+            return json.dumps({"success": True, "message": "Muted"})
+
+        elif action == "unmute":
+            speaker.mute = False
+            return json.dumps({"success": True, "message": "Unmuted"})
+
+        elif action == "favorites":
+            favs = speaker.music_library.get_sonos_favorites()
+            fav_list = [{"title": f.title} for f in favs]
+            return json.dumps({"success": True, "favorites": fav_list}, ensure_ascii=False)
+
+        else:
+            return json.dumps({"error": f"Unknown action: {action}"})
+
+    except Exception as e:
+        logger.error("Sonos tool error: %s", e, exc_info=True)
+        return json.dumps({"error": str(e)})
+
+
+SONOS_SCHEMA = {
+    "name": "sonos",
+    "description": (
+        "Control Sonos speakers on the local network. "
+        "Actions: status, play (param=favorite name or URI, omit to resume), pause, stop, "
+        "next, previous, volume (param=0-100), volume_up (param=amount, default 5), "
+        "volume_down (param=amount, default 5), mute, unmute, favorites (list saved favorites)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": [
+                    "status", "play", "pause", "stop", "next", "previous",
+                    "volume", "volume_up", "volume_down", "mute", "unmute", "favorites",
+                ],
+                "description": "Action to perform",
+            },
+            "param": {
+                "type": "string",
+                "description": "Optional parameter — volume level (0-100), favorite name, or URI",
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+registry.register(
+    name="sonos",
+    toolset="sonos",
+    schema=SONOS_SCHEMA,
+    handler=lambda args, **kw: sonos_control(
+        action=args["action"],
+        param=args.get("param"),
+    ),
+    check_fn=_check_sonos_reqs,
+    emoji="🔊",
+)

--- a/tools/tapo_tool.py
+++ b/tools/tapo_tool.py
@@ -1,0 +1,289 @@
+"""
+TP-Link Tapo smart home device control tool for Hermes.
+
+Controls Tapo smart plugs/switches on the local network
+via python-kasa using KLAP protocol. Requires TAPO_EMAIL and TAPO_PASSWORD.
+Device IPs and config are loaded from config file.
+"""
+
+import asyncio
+import json
+import logging
+import os
+from pathlib import Path
+
+import yaml
+
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_DIR = Path.home() / ".hermes" / "smart_home"
+_CONFIG_FILE = _CONFIG_DIR / "tapo.yaml"
+
+
+def _load_config() -> dict:
+    """Load tool config from YAML file."""
+    if not _CONFIG_FILE.exists():
+        logger.warning("Tapo config not found: %s", _CONFIG_FILE)
+        return {}
+    try:
+        with open(_CONFIG_FILE) as f:
+            return yaml.safe_load(f) or {}
+    except Exception:
+        return {}
+
+
+def _get_known_ips() -> list:
+    """Get known device IPs from config."""
+    return _load_config().get("known_ips", [])
+
+
+def _get_device_cache_path() -> Path:
+    """Get device cache path from config."""
+    config = _load_config()
+    cache_path = config.get("device_cache", "~/.hermes/smart_home/tapo_devices.json")
+    return Path(cache_path).expanduser()
+
+
+def _check_tapo_reqs() -> bool:
+    """Check if Tapo credentials are available."""
+    email, password = _get_credentials()
+    return bool(email and password)
+
+
+def _get_credentials():
+    """Read Tapo credentials from .env file."""
+    env_path = Path.home() / ".hermes/.env"
+    email = os.getenv("TAPO_EMAIL", "")
+    password = os.getenv("TAPO_PASSWORD", "")
+    if not email or not password:
+        try:
+            with open(env_path) as f:
+                for line in f:
+                    line = line.strip()
+                    if line.startswith("TAPO_EMAIL="):
+                        email = line.split("=", 1)[1]
+                    elif line.startswith("TAPO_PASSWORD="):
+                        password = line.split("=", 1)[1]
+        except FileNotFoundError:
+            pass
+    return email, password
+
+
+def _load_device_cache():
+    """Load cached device name -> IP mapping from global cache."""
+    try:
+        from tools.device_scanner import load_cache
+        return load_cache().get("tapo", {})
+    except Exception:
+        cache_path = _get_device_cache_path()
+        if cache_path.exists():
+            try:
+                return json.loads(cache_path.read_text())
+            except Exception:
+                pass
+    return {}
+
+
+def _save_device_cache(cache):
+    """Save device name -> IP mapping to global cache."""
+    try:
+        from tools.device_scanner import load_cache, save_cache
+        global_cache = load_cache()
+        global_cache["tapo"] = cache
+        save_cache(global_cache)
+    except Exception:
+        cache_path = _get_device_cache_path()
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(json.dumps(cache, indent=2))
+
+
+def _find_device_ip(name: str, cache: dict) -> str | None:
+    """Find device IP by name (case-insensitive, partial match)."""
+    name_lower = name.lower().strip()
+    # Exact match first
+    for alias, ip in cache.items():
+        if alias.lower() == name_lower:
+            return ip
+    # Partial match
+    for alias, ip in cache.items():
+        if name_lower in alias.lower():
+            return ip
+    return None
+
+
+async def _connect_device(ip: str):
+    """Connect to a Tapo device by IP."""
+    from kasa import Discover, Credentials
+    email, password = _get_credentials()
+    dev = await Discover.discover_single(
+        ip,
+        credentials=Credentials(email, password),
+        timeout=10,
+    )
+    await dev.update()
+    return dev
+
+
+async def _scan_all_devices():
+    """Scan all known IPs and return device info + update cache."""
+    known_ips = _get_known_ips()
+    cache = {}
+    devices = []
+    for ip in known_ips:
+        try:
+            dev = await _connect_device(ip)
+            cache[dev.alias] = ip
+            info = {
+                "name": dev.alias,
+                "ip": ip,
+                "model": dev.model,
+                "is_on": dev.is_on,
+            }
+            if hasattr(dev, "children") and dev.children:
+                info["outlets"] = [
+                    {"name": c.alias, "is_on": c.is_on} for c in dev.children
+                ]
+            devices.append(info)
+        except Exception as e:
+            devices.append({"ip": ip, "error": str(e)})
+    _save_device_cache(cache)
+    return devices
+
+
+async def _do_action(action: str, device_name: str = None, param: str = None):
+    """Execute a Tapo device action."""
+
+    if action == "list":
+        devices = await _scan_all_devices()
+        return {"success": True, "devices": devices}
+
+    if action == "scan":
+        devices = await _scan_all_devices()
+        online = [d for d in devices if "error" not in d]
+        offline = [d for d in devices if "error" in d]
+        return {
+            "success": True,
+            "online": len(online),
+            "offline": len(offline),
+            "devices": devices,
+        }
+
+    # All other actions need a device name
+    if not device_name:
+        return {"error": "device_name is required for this action"}
+
+    cache = _load_device_cache()
+    ip = _find_device_ip(device_name, cache)
+
+    if not ip:
+        # Try global rescan to refresh cache
+        try:
+            from tools.device_scanner import rescan
+            rescan(force=True)
+            cache = _load_device_cache()
+            ip = _find_device_ip(device_name, cache)
+        except Exception:
+            await _scan_all_devices()
+            cache = _load_device_cache()
+            ip = _find_device_ip(device_name, cache)
+        if not ip:
+            return {"error": f"Device '{device_name}' not found. Use action=list to see all devices."}
+
+    try:
+        dev = await _connect_device(ip)
+    except Exception:
+        # IP might have changed, rescan and retry
+        try:
+            from tools.device_scanner import rescan
+            rescan(force=True)
+            cache = _load_device_cache()
+            ip = _find_device_ip(device_name, cache)
+            if not ip:
+                return {"error": f"Device '{device_name}' not reachable after rescan."}
+            dev = await _connect_device(ip)
+        except Exception as e:
+            return {"error": f"Cannot connect to '{device_name}': {e}"}
+
+    if action == "status":
+        info = {
+            "name": dev.alias,
+            "ip": ip,
+            "model": dev.model,
+            "is_on": dev.is_on,
+        }
+        if hasattr(dev, "children") and dev.children:
+            info["outlets"] = [
+                {"name": c.alias, "is_on": c.is_on} for c in dev.children
+            ]
+        return {"success": True, **info}
+
+    elif action == "on":
+        await dev.turn_on()
+        return {"success": True, "message": f"{dev.alias} turned ON"}
+
+    elif action == "off":
+        await dev.turn_off()
+        return {"success": True, "message": f"{dev.alias} turned OFF"}
+
+    elif action == "toggle":
+        if dev.is_on:
+            await dev.turn_off()
+            return {"success": True, "message": f"{dev.alias} toggled OFF"}
+        else:
+            await dev.turn_on()
+            return {"success": True, "message": f"{dev.alias} toggled ON"}
+
+    else:
+        return {"error": f"Unknown action: {action}"}
+
+
+def tapo_control(action: str, device_name: str = None, param: str = None) -> str:
+    """Sync wrapper for async Tapo control."""
+    try:
+        result = asyncio.run(_do_action(action, device_name, param))
+        return json.dumps(result, ensure_ascii=False)
+    except Exception as e:
+        logger.error("Tapo tool error: %s", e, exc_info=True)
+        return json.dumps({"error": str(e)})
+
+
+TAPO_SCHEMA = {
+    "name": "tapo",
+    "description": (
+        "Control TP-Link Tapo smart switches/plugs on the local network. "
+        "Actions: list (scan & show all devices), status (single device state), "
+        "on (turn on), off (turn off), toggle. "
+        "device_name: partial match OK. Use action=list to discover available devices."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["list", "status", "on", "off", "toggle"],
+                "description": "Action to perform",
+            },
+            "device_name": {
+                "type": "string",
+                "description": "Device name (partial match supported). Required for status/on/off/toggle.",
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+registry.register(
+    name="tapo",
+    toolset="tapo",
+    schema=TAPO_SCHEMA,
+    handler=lambda args, **kw: tapo_control(
+        action=args["action"],
+        device_name=args.get("device_name"),
+        param=args.get("param"),
+    ),
+    check_fn=_check_tapo_reqs,
+    requires_env=["TAPO_EMAIL", "TAPO_PASSWORD"],
+    emoji="💡",
+)

--- a/tools/tesla_tool.py
+++ b/tools/tesla_tool.py
@@ -1,0 +1,453 @@
+"""
+Tesla vehicle control tool for Hermes.
+
+Controls Tesla vehicles via the Fleet API.
+Supports: status, wake, lock, unlock, climate on/off, set temp, horn, flash lights, charge start/stop.
+API audience and token/key paths are loaded from config file.
+"""
+
+import json
+import logging
+import os
+import time
+from pathlib import Path
+
+import yaml
+
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_DIR = Path.home() / ".hermes" / "smart_home"
+_CONFIG_FILE = _CONFIG_DIR / "tesla.yaml"
+
+
+def _load_config() -> dict:
+    """Load tool config from YAML file."""
+    if not _CONFIG_FILE.exists():
+        logger.warning("Tesla config not found: %s", _CONFIG_FILE)
+        return {}
+    try:
+        with open(_CONFIG_FILE) as f:
+            return yaml.safe_load(f) or {}
+    except Exception:
+        return {}
+
+
+def _get_audience() -> str:
+    return _load_config().get("api_audience", "https://fleet-api.prd.na.vn.cloud.tesla.com")
+
+
+def _get_token_path() -> Path:
+    config = _load_config()
+    return Path(config.get("token_file", "~/.hermes/smart_home/tesla_token.json")).expanduser()
+
+
+def _check_tesla_reqs() -> bool:
+    return _get_token_path().exists()
+
+
+def _load_token() -> dict:
+    return json.loads(_get_token_path().read_text())
+
+
+def _get_headers() -> dict:
+    import requests
+    tokens = _load_token()
+    # Refresh if expiring within 60s
+    if tokens.get("expires_at", 0) < time.time() + 60:
+        client_id     = os.getenv("TESLA_CLIENT_ID", "")
+        client_secret = os.getenv("TESLA_CLIENT_SECRET", "")
+        resp = requests.post("https://auth.tesla.com/oauth2/v3/token", json={
+            "grant_type":    "refresh_token",
+            "client_id":     client_id,
+            "client_secret": client_secret,
+            "refresh_token": tokens["refresh_token"],
+        })
+        if resp.status_code == 200:
+            new = resp.json()
+            tokens.update({
+                "access_token": new["access_token"],
+                "expires_at":   time.time() + new.get("expires_in", 3600) - 60,
+            })
+            if "refresh_token" in new:
+                tokens["refresh_token"] = new["refresh_token"]
+            _get_token_path().write_text(json.dumps(tokens, indent=2))
+    return {
+        "Authorization": f"Bearer {tokens['access_token']}",
+        "Content-Type":  "application/json",
+    }
+
+
+def _get_vin(vin: str = None) -> str:
+    import requests
+    audience = _get_audience()
+    resp = requests.get(f"{audience}/api/1/vehicles", headers=_get_headers())
+    vehicles = resp.json().get("response", [])
+    if not vehicles:
+        raise RuntimeError("No Tesla vehicles found")
+    if vin:
+        for v in vehicles:
+            if v["vin"] == vin:
+                return vin
+        raise RuntimeError(f"VIN {vin} not found")
+    return vehicles[0]["vin"]
+
+
+def _wake(vin: str) -> bool:
+    import requests
+    audience = _get_audience()
+    requests.post(f"{audience}/api/1/vehicles/{vin}/wake_up", headers=_get_headers())
+    for _ in range(12):
+        time.sleep(5)
+        r = requests.get(f"{audience}/api/1/vehicles/{vin}", headers=_get_headers())
+        if r.json().get("response", {}).get("state") == "online":
+            return True
+    return False
+
+
+def tesla_control(action: str, vin: str = None, param: str = None) -> str:
+    import requests
+    # pylint: disable=possibly-used-before-assignment
+    AUDIENCE = _get_audience()
+
+    try:
+        v = _get_vin(vin)
+
+        if action == "status":
+            _wake(v)
+            r = requests.get(f"{AUDIENCE}/api/1/vehicles/{v}/vehicle_data", headers=_get_headers())
+            d = r.json().get("response", {})
+            charge  = d.get("charge_state", {})
+            climate = d.get("climate_state", {})
+            vehicle = d.get("vehicle_state", {})
+            drive   = d.get("drive_state", {})
+
+            battery_range_mi = charge.get("battery_range", 0)
+            locked = vehicle.get("locked", True)
+            result = {
+                "name":            d.get("display_name", "Tesla"),
+                "battery_level":   charge.get("battery_level"),
+                "range_miles":     round(battery_range_mi, 1),
+                "charging_state":  charge.get("charging_state"),
+                "charge_limit_pct": charge.get("charge_limit_soc"),
+                "charge_amps":     charge.get("charge_current_request"),
+                "locked":          locked,
+                "sentry_mode":     vehicle.get("sentry_mode"),
+                "inside_temp_c":   climate.get("inside_temp"),
+                "outside_temp_c":  climate.get("outside_temp"),
+                "climate_on":      climate.get("is_climate_on"),
+                "climate_keeper":  climate.get("climate_keeper_mode"),
+                "latitude":        drive.get("latitude"),
+                "longitude":       drive.get("longitude"),
+                "odometer_mi":     round(vehicle.get("odometer", 0), 1),
+                "sw_version":      vehicle.get("car_version", "").split(" ")[0],
+                "sw_update":       d.get("vehicle_state", {}).get("software_update", {}).get("status"),
+            }
+            return json.dumps(result)
+
+        elif action == "wake":
+            ok = _wake(v)
+            return json.dumps({"success": ok, "message": "Vehicle is online" if ok else "Wake timed out"})
+
+        elif action == "lock":
+            _wake(v)
+            requests.post(f"{AUDIENCE}/api/1/vehicles/{v}/command/door_lock", headers=_get_headers())
+            return json.dumps({"success": True, "message": "Car locked"})
+
+        elif action == "unlock":
+            _wake(v)
+            requests.post(f"{AUDIENCE}/api/1/vehicles/{v}/command/door_unlock", headers=_get_headers())
+            return json.dumps({"success": True, "message": "Car unlocked"})
+
+        elif action == "climate_on":
+            _wake(v)
+            requests.post(f"{AUDIENCE}/api/1/vehicles/{v}/command/auto_conditioning_start", headers=_get_headers())
+            return json.dumps({"success": True, "message": "Climate started"})
+
+        elif action == "climate_off":
+            _wake(v)
+            requests.post(f"{AUDIENCE}/api/1/vehicles/{v}/command/auto_conditioning_stop", headers=_get_headers())
+            return json.dumps({"success": True, "message": "Climate stopped"})
+
+        elif action == "set_temp":
+            if not param:
+                return json.dumps({"error": "param (temperature in °C) is required"})
+            _wake(v)
+            temp = float(param)
+            requests.post(f"{AUDIENCE}/api/1/vehicles/{v}/command/set_temps",
+                          headers=_get_headers(),
+                          json={"driver_temp": temp, "passenger_temp": temp})
+            return json.dumps({"success": True, "message": f"Temperature set to {temp}°C"})
+
+        elif action == "horn":
+            _wake(v)
+            requests.post(f"{AUDIENCE}/api/1/vehicles/{v}/command/honk_horn", headers=_get_headers())
+            return json.dumps({"success": True, "message": "Horn honked"})
+
+        elif action == "flash":
+            _wake(v)
+            requests.post(f"{AUDIENCE}/api/1/vehicles/{v}/command/flash_lights", headers=_get_headers())
+            return json.dumps({"success": True, "message": "Lights flashed"})
+
+        elif action == "set_charge_limit":
+            if not param:
+                return json.dumps({"error": "param (percent 50-100) is required"})
+            _wake(v)
+            pct = int(param)
+            r = requests.post(f"{AUDIENCE}/api/1/vehicles/{v}/command/set_charge_limit",
+                              headers=_get_headers(),
+                              json={"percent": pct})
+            resp_data = r.json()
+            ok = resp_data.get("response", {}).get("result", False)
+            return json.dumps({"success": ok, "message": f"Charge limit set to {pct}%"})
+
+        elif action == "charge_max_range":
+            _wake(v)
+            r = requests.post(f"{AUDIENCE}/api/1/vehicles/{v}/command/charge_max_range", headers=_get_headers())
+            resp_data = r.json()
+            ok = resp_data.get("response", {}).get("result", False)
+            return json.dumps({"success": ok, "message": "Charge limit set to max range (100%)"})
+
+        elif action == "set_charging_amps":
+            if not param:
+                return json.dumps({"error": "param (amps as integer) is required"})
+            _wake(v)
+            r = requests.post(f"{AUDIENCE}/api/1/vehicles/{v}/command/set_charging_amps",
+                              headers=_get_headers(),
+                              json={"charging_amps": int(param)})
+            resp_data = r.json()
+            ok = resp_data.get("response", {}).get("result", False)
+            return json.dumps({"success": ok, "message": f"Charging amps set to {param}A"})
+
+        elif action == "charge_port_open":
+            _wake(v)
+            r = requests.post(f"{AUDIENCE}/api/1/vehicles/{v}/command/charge_port_door_open", headers=_get_headers())
+            resp_data = r.json()
+            ok = resp_data.get("response", {}).get("result", False)
+            return json.dumps({"success": ok, "message": "Charge port opened"})
+
+        elif action == "charge_port_close":
+            _wake(v)
+            r = requests.post(f"{AUDIENCE}/api/1/vehicles/{v}/command/charge_port_door_close", headers=_get_headers())
+            resp_data = r.json()
+            ok = resp_data.get("response", {}).get("result", False)
+            return json.dumps({"success": ok, "message": "Charge port closed"})
+
+        elif action == "trunk_open":
+            _wake(v)
+            which = param if param in ("front", "rear") else "rear"
+            r = requests.post(f"{AUDIENCE}/api/1/vehicles/{v}/command/actuate_trunk",
+                              headers=_get_headers(),
+                              json={"which_trunk": which})
+            resp_data = r.json()
+            ok = resp_data.get("response", {}).get("result", False)
+            return json.dumps({"success": ok, "message": f"{which.title()} trunk actuated"})
+
+        elif action == "sentry_on":
+            _wake(v)
+            r = requests.post(f"{AUDIENCE}/api/1/vehicles/{v}/command/set_sentry_mode",
+                              headers=_get_headers(),
+                              json={"on": True})
+            resp_data = r.json()
+            ok = resp_data.get("response", {}).get("result", False)
+            return json.dumps({"success": ok, "message": "Sentry mode enabled"})
+
+        elif action == "sentry_off":
+            _wake(v)
+            r = requests.post(f"{AUDIENCE}/api/1/vehicles/{v}/command/set_sentry_mode",
+                              headers=_get_headers(),
+                              json={"on": False})
+            resp_data = r.json()
+            ok = resp_data.get("response", {}).get("result", False)
+            return json.dumps({"success": ok, "message": "Sentry mode disabled"})
+
+        elif action == "window_vent":
+            _wake(v)
+            r = requests.post(f"{AUDIENCE}/api/1/vehicles/{v}/command/window_control",
+                              headers=_get_headers(),
+                              json={"command": "vent", "lat": 0, "lon": 0})
+            resp_data = r.json()
+            ok = resp_data.get("response", {}).get("result", False)
+            return json.dumps({"success": ok, "message": "Windows vented"})
+
+        elif action == "window_close":
+            _wake(v)
+            r = requests.post(f"{AUDIENCE}/api/1/vehicles/{v}/command/window_control",
+                              headers=_get_headers(),
+                              json={"command": "close", "lat": 0, "lon": 0})
+            resp_data = r.json()
+            ok = resp_data.get("response", {}).get("result", False)
+            return json.dumps({"success": ok, "message": "Windows closed"})
+
+        elif action == "trigger_homelink":
+            _wake(v)
+            # Need current vehicle location for homelink
+            r = requests.get(f"{AUDIENCE}/api/1/vehicles/{v}/vehicle_data",
+                             headers=_get_headers(),
+                             params={"endpoints": "drive_state"})
+            d = r.json().get("response", {})
+            lat = d.get("drive_state", {}).get("latitude", 0)
+            lon = d.get("drive_state", {}).get("longitude", 0)
+            r = requests.post(f"{AUDIENCE}/api/1/vehicles/{v}/command/trigger_homelink",
+                              headers=_get_headers(),
+                              json={"lat": lat, "lon": lon})
+            resp_data = r.json()
+            ok = resp_data.get("response", {}).get("result", False)
+            return json.dumps({"success": ok, "message": "HomeLink triggered"})
+
+        elif action == "navigate":
+            if not param:
+                return json.dumps({"error": "param (address or 'lat,lon') is required"})
+            _wake(v)
+            # Check if param is lat,lon format
+            if "," in param and all(p.strip().replace("-", "").replace(".", "").isdigit() for p in param.split(",")):
+                lat, lon = [float(x.strip()) for x in param.split(",")]
+                r = requests.post(f"{AUDIENCE}/api/1/vehicles/{v}/command/navigation_gps_request",
+                                  headers=_get_headers(),
+                                  json={"lat": lat, "lon": lon, "order": 0})
+            else:
+                r = requests.post(f"{AUDIENCE}/api/1/vehicles/{v}/command/navigation_request",
+                                  headers=_get_headers(),
+                                  json={"type": "share_ext_content_raw",
+                                        "value": {"android.intent.extra.TEXT": param},
+                                        "locale": "en-US",
+                                        "timestamp_ms": str(int(time.time() * 1000))})
+            resp_data = r.json()
+            ok = resp_data.get("response", {}).get("result", False)
+            return json.dumps({"success": ok, "message": f"Navigation sent: {param}"})
+
+        elif action == "climate_keeper":
+            if not param:
+                return json.dumps({"error": "param required: off, keep, dog, camp"})
+            mode_map = {"off": 0, "keep": 1, "dog": 2, "camp": 3}
+            mode = mode_map.get(param.lower(), 0)
+            _wake(v)
+            r = requests.post(f"{AUDIENCE}/api/1/vehicles/{v}/command/set_climate_keeper_mode",
+                              headers=_get_headers(),
+                              json={"climate_keeper_mode": mode})
+            resp_data = r.json()
+            ok = resp_data.get("response", {}).get("result", False)
+            return json.dumps({"success": ok, "message": f"Climate keeper set to {param}"})
+
+        elif action == "remote_start":
+            _wake(v)
+            r = requests.post(f"{AUDIENCE}/api/1/vehicles/{v}/command/remote_start_drive",
+                              headers=_get_headers())
+            resp_data = r.json()
+            ok = resp_data.get("response", {}).get("result", False)
+            return json.dumps({"success": ok, "message": "Remote start activated (2 min to shift into gear)"})
+
+        elif action == "seat_heater":
+            if not param:
+                return json.dumps({"error": "param required: 'seat,level' e.g. '0,3' (seat 0=driver,1=passenger,2=rear-left,4=rear-center,5=rear-right; level 0=off,1=low,2=med,3=high)"})
+            parts = param.split(",")
+            seat = int(parts[0])
+            level = int(parts[1])
+            _wake(v)
+            r = requests.post(f"{AUDIENCE}/api/1/vehicles/{v}/command/remote_seat_heater_request",
+                              headers=_get_headers(),
+                              json={"heater": seat, "level": level})
+            resp_data = r.json()
+            ok = resp_data.get("response", {}).get("result", False)
+            seat_names = {0: "Driver", 1: "Passenger", 2: "Rear-left", 4: "Rear-center", 5: "Rear-right"}
+            level_names = {0: "Off", 1: "Low", 2: "Medium", 3: "High"}
+            return json.dumps({"success": ok, "message": f"{seat_names.get(seat, f'Seat {seat}')} heater set to {level_names.get(level, f'level {level}')}"})
+
+        elif action == "schedule_sw_update":
+            _wake(v)
+            offset = int(param) if param else 0  # seconds from now
+            r = requests.post(f"{AUDIENCE}/api/1/vehicles/{v}/command/schedule_software_update",
+                              headers=_get_headers(),
+                              json={"offset_sec": offset})
+            resp_data = r.json()
+            ok = resp_data.get("response", {}).get("result", False)
+            return json.dumps({"success": ok, "message": f"Software update scheduled in {offset}s"})
+
+        elif action == "cancel_sw_update":
+            _wake(v)
+            r = requests.post(f"{AUDIENCE}/api/1/vehicles/{v}/command/cancel_software_update", headers=_get_headers())
+            resp_data = r.json()
+            ok = resp_data.get("response", {}).get("result", False)
+            return json.dumps({"success": ok, "message": "Software update cancelled"})
+
+        elif action == "charge_start":
+            _wake(v)
+            requests.post(f"{AUDIENCE}/api/1/vehicles/{v}/command/charge_start", headers=_get_headers())
+            return json.dumps({"success": True, "message": "Charging started"})
+
+        elif action == "charge_stop":
+            _wake(v)
+            requests.post(f"{AUDIENCE}/api/1/vehicles/{v}/command/charge_stop", headers=_get_headers())
+            return json.dumps({"success": True, "message": "Charging stopped"})
+
+        else:
+            return json.dumps({"error": f"Unknown action: {action}"})
+
+    except Exception as e:
+        logger.error("Tesla tool error: %s", e, exc_info=True)
+        return json.dumps({"error": str(e)})
+
+
+TESLA_SCHEMA = {
+    "name": "tesla",
+    "description": (
+        "Control and query a Tesla vehicle via the Fleet API. "
+        "Actions: status, wake, lock, unlock, climate_on, climate_off, "
+        "set_temp (param=°C), horn, flash, "
+        "set_charge_limit (param=percent 50-100), charge_max_range, "
+        "set_charging_amps (param=amps), charge_start, charge_stop, "
+        "charge_port_open, charge_port_close, "
+        "trunk_open (param=front|rear, default rear), "
+        "sentry_on, sentry_off, "
+        "window_vent, window_close, "
+        "trigger_homelink (opens/closes garage door), "
+        "navigate (param=address or 'lat,lon'), "
+        "climate_keeper (param=off|keep|dog|camp), "
+        "remote_start (2 min to shift into gear), "
+        "seat_heater (param='seat,level' e.g. '0,3'), "
+        "schedule_sw_update (param=seconds delay), cancel_sw_update."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": [
+                    "status", "wake", "lock", "unlock",
+                    "climate_on", "climate_off", "set_temp",
+                    "horn", "flash",
+                    "set_charge_limit", "charge_max_range", "set_charging_amps",
+                    "charge_start", "charge_stop", "charge_port_open", "charge_port_close",
+                    "trunk_open", "sentry_on", "sentry_off",
+                    "window_vent", "window_close", "trigger_homelink",
+                    "navigate", "climate_keeper", "remote_start",
+                    "seat_heater", "schedule_sw_update", "cancel_sw_update"
+                ],
+                "description": "Action to perform on the vehicle",
+            },
+            "vin": {
+                "type": "string",
+                "description": "Vehicle VIN (optional, defaults to the only/first vehicle)",
+            },
+            "param": {
+                "type": "string",
+                "description": "Extra parameter — required for set_temp (temperature in °C as string)",
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+registry.register(
+    name="tesla",
+    toolset="tesla",
+    schema=TESLA_SCHEMA,
+    handler=lambda args, **kw: tesla_control(
+        action=args["action"],
+        vin=args.get("vin"),
+        param=args.get("param"),
+    ),
+    check_fn=_check_tesla_reqs,
+    emoji="🚗",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -65,6 +65,16 @@ _HERMES_CORE_TOOLS = [
     "execute_code", "delegate_task",
     # Cronjob management
     "cronjob",
+    # Tesla vehicle control
+    "tesla",
+    # Tapo smart home control
+    "tapo",
+    # LG TV control
+    "lgtv",
+    # Rheem water heater control
+    "rheem",
+    # Sonos speaker control
+    "sonos",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
     # Kanban multi-agent coordination — only in schema when the agent is
@@ -321,6 +331,37 @@ TOOLSETS = {
             "spotify_playback", "spotify_devices", "spotify_queue", "spotify_search",
             "spotify_playlists", "spotify_albums", "spotify_library",
         ],
+        "includes": []
+    },
+
+
+    "tesla": {
+        "description": "Tesla vehicle control — status, lock/unlock, climate, charging, horn, flash lights",
+        "tools": ["tesla"],
+        "includes": []
+    },
+
+    "tapo": {
+        "description": "TP-Link Tapo smart switch/plug control — on/off/toggle/status for home lights and devices",
+        "tools": ["tapo"],
+        "includes": []
+    },
+
+    "lgtv": {
+        "description": "LG webOS TV control — power, volume, input switching, app launching",
+        "tools": ["lgtv"],
+        "includes": []
+    },
+
+    "sonos": {
+        "description": "Sonos speaker control — playback, volume, favorites",
+        "tools": ["sonos"],
+        "includes": []
+    },
+
+    "rheem": {
+        "description": "Rheem water heater control — temperature, mode, vacation, status",
+        "tools": ["rheem"],
         "includes": []
     },
 


### PR DESCRIPTION
Adds 5 smart home device control tools:

- **Tesla** — Fleet API: status, lock/unlock, climate, charging, navigation, sentry mode, etc.
- **Tapo** — TP-Link smart switches/plugs via python-kasa (KLAP protocol): on/off/toggle/status/scan
- **LG TV** — webOS TVs via PyWebOSTV: power, volume, input switching, app launching, WOL wake
- **Sonos** — Speakers via SoCo: playback, volume, favorites
- **Rheem** — Water heater via EcoNet cloud API: temperature, mode, vacation

All user-specific configuration (IPs, MACs, device names) is loaded from YAML config files in `~/.hermes/smart_home/`. No hardcoded values in tool code. Config files are gitignored.

Each tool uses the standard `registry.register()` pattern with `check_fn` that verifies config/credentials exist before enabling.