### PR TITLE
fix: handle addition-only hunks in V4A patch parser

### DIFF
--- a/tests/tools/test_patch_parser.py
+++ b/tests/tools/test_patch_parser.py
@@ -185,3 +185,71 @@ class TestApplyUpdate:
             '    result = 1\n'
             '    return result + 1'
         )
+
+
+class TestAdditionOnlyHunks:
+    """Regression tests for #3081 — addition-only hunks were silently dropped."""
+
+    def test_addition_only_hunk_with_context_hint(self):
+        """A hunk with only + lines should insert at the context hint location."""
+        patch = """\
+*** Begin Patch
+*** Update File: src/app.py
+@@ def main @@
++def helper():
++    return 42
+*** End Patch"""
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+        assert len(ops) == 1
+        assert len(ops[0].hunks) == 1
+
+        hunk = ops[0].hunks[0]
+        # All lines should be additions
+        assert all(l.prefix == '+' for l in hunk.lines)
+
+        # Apply to a file that contains the context hint
+        class FakeFileOps:
+            written = None
+            def read_file(self, path, **kw):
+                return SimpleNamespace(
+                    content="def main():\n    pass\n",
+                    error=None,
+                )
+            def write_file(self, path, content):
+                self.written = content
+                return SimpleNamespace(error=None)
+
+        file_ops = FakeFileOps()
+        result = apply_v4a_operations(ops, file_ops)
+        assert result.success is True
+        assert "def helper():" in file_ops.written
+        assert "return 42" in file_ops.written
+
+    def test_addition_only_hunk_without_context_hint(self):
+        """A hunk with only + lines and no context hint appends at end of file."""
+        patch = """\
+*** Begin Patch
+*** Update File: src/app.py
++def new_func():
++    return True
+*** End Patch"""
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+
+        class FakeFileOps:
+            written = None
+            def read_file(self, path, **kw):
+                return SimpleNamespace(
+                    content="existing = True\n",
+                    error=None,
+                )
+            def write_file(self, path, content):
+                self.written = content
+                return SimpleNamespace(error=None)
+
+        file_ops = FakeFileOps()
+        result = apply_v4a_operations(ops, file_ops)
+        assert result.success is True
+        assert file_ops.written.endswith("def new_func():\n    return True\n")
+        assert "existing = True" in file_ops.written

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -419,6 +419,23 @@ def _apply_update(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
                 
                 if error:
                     return False, f"Could not apply hunk: {error}"
+        else:
+            # Addition-only hunk (no context or removed lines).
+            # Insert at the location indicated by the context hint, or at end of file.
+            insert_text = '\n'.join(replace_lines)
+            if hunk.context_hint:
+                hint_pos = new_content.find(hunk.context_hint)
+                if hint_pos != -1:
+                    # Insert after the line containing the context hint
+                    eol = new_content.find('\n', hint_pos)
+                    if eol != -1:
+                        new_content = new_content[:eol + 1] + insert_text + '\n' + new_content[eol + 1:]
+                    else:
+                        new_content = new_content + '\n' + insert_text
+                else:
+                    new_content = new_content.rstrip('\n') + '\n' + insert_text + '\n'
+            else:
+                new_content = new_content.rstrip('\n') + '\n' + insert_text + '\n'
     
     # Write new content
     write_result = file_ops.write_file(op.file_path, new_content)


### PR DESCRIPTION
## Summary
Salvaged from PR #3092 by @thakoreh — cherry-picked onto current main with original authorship preserved, plus 2 regression tests.

## Root cause
V4A patches with only `+` lines (no context or `-` lines) were silently dropped. The parser builds `search_lines` from context/removed lines and `replace_lines` from context/added lines. When a hunk is pure additions, `search_lines` is empty, the `if search_lines:` block is skipped, and there's no `else` — the additions vanish.

This is common when the model generates patches for new functions, new blocks, or appending to files.

## Fix
Adds an `else` branch that:
1. If `context_hint` exists and is found in the file → insert after that line
2. If hint not found or absent → append at end of file

Consistent with the existing hint-based fallback in the `if search_lines:` path.

## Validation
- `python -m pytest tests/tools/test_patch_parser.py -n0 -q` → 11 passed (9 existing + 2 new)
- New tests: addition-only hunk with context hint, addition-only hunk without context hint

Closes #3092
Fixes #3081

Co-authored-by: Hiren <hiren.thakore58@gmail.com>