### PR TITLE
fix(gateway): include ~/.local/bin in systemd unit PATH

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -434,13 +434,20 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
         resolved_node_dir = str(Path(resolved_node).resolve().parent)
         if resolved_node_dir not in path_entries:
             path_entries.append(resolved_node_dir)
-    path_entries.extend(["/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin", "/sbin", "/bin"])
-    sane_path = ":".join(path_entries)
 
     hermes_home = str(get_hermes_home().resolve())
 
     if system:
         username, group_name, home_dir = _system_service_identity(run_as_user)
+        user_local_bin = str(Path(home_dir) / ".local" / "bin")
+        path_entries.append(user_local_bin)
+    else:
+        path_entries.append(str(Path.home() / ".local" / "bin"))
+
+    path_entries.extend(["/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin", "/sbin", "/bin"])
+    sane_path = ":".join(path_entries)
+
+    if system:
         return f"""[Unit]
 Description={SERVICE_DESCRIPTION}
 After=network-online.target


### PR DESCRIPTION
## Summary

Closes #3327

When Hermes is installed via the official install script, `uv`/`uvx` land in `~/.local/bin`. `hermes chat` works because that directory is in the user's shell PATH, but the systemd service unit constructed by `hermes gateway install` did not include it, causing all MCP servers that depend on `uvx` to fail with `missing executable 'uvx'`.

## Fix

In `generate_systemd_unit()`, append `~/.local/bin` to `path_entries` before building `PATH`:

- **User units** (`system=False`): uses `Path.home() / '.local/bin'`
- **System units** (`system=True`): resolves the home directory via `_system_service_identity()` (already called to get `username`/`group_name`/`home_dir`) and appends `{home_dir}/.local/bin`