### PR TITLE
fix: /usage shows pricing unknown for default Anthropic model aliases

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -330,8 +330,36 @@ def resolve_billing_route(
     return BillingRoute(provider=provider_name or "unknown", model=model.split("/")[-1] if model else "", base_url=base_url or "", billing_mode="unknown")
 
 
+# Undated alias → dated name used in the pricing table.
+# The model catalog lists aliases like claude-opus-4-6 as the default,
+# but pricing is keyed by the dated version.
+_MODEL_ALIASES: Dict[str, str] = {
+    # Dot-versioned aliases (what hermes_cli/models.py lists as default)
+    "claude-opus-4.6": "claude-opus-4-20250514",
+    "claude-sonnet-4.6": "claude-sonnet-4-20250514",
+    "claude-opus-4.5": "claude-opus-4-20250514",
+    "claude-sonnet-4.5": "claude-sonnet-4-20250514",
+    "claude-haiku-4.5": "claude-3-5-haiku-20241022",
+    # Hyphen-versioned aliases (alternate format)
+    "claude-opus-4-6": "claude-opus-4-20250514",
+    "claude-sonnet-4-6": "claude-sonnet-4-20250514",
+    "claude-opus-4-5": "claude-opus-4-20250514",
+    "claude-sonnet-4-5": "claude-sonnet-4-20250514",
+    "claude-haiku-4-5": "claude-3-5-haiku-20241022",
+    # Dated non-matching variants
+    "claude-opus-4-5-20251101": "claude-opus-4-20250514",
+    "claude-sonnet-4-5-20250929": "claude-sonnet-4-20250514",
+    "claude-haiku-4-5-20251001": "claude-3-5-haiku-20241022",
+    # Short aliases
+    "claude-3-5-sonnet": "claude-3-5-sonnet-20241022",
+    "claude-3-5-haiku": "claude-3-5-haiku-20241022",
+}
+
+
 def _lookup_official_docs_pricing(route: BillingRoute) -> Optional[PricingEntry]:
-    return _OFFICIAL_DOCS_PRICING.get((route.provider, route.model.lower()))
+    model = route.model.lower()
+    model = _MODEL_ALIASES.get(model, model)
+    return _OFFICIAL_DOCS_PRICING.get((route.provider, model))
 
 
 def _openrouter_pricing_entry(route: BillingRoute) -> Optional[PricingEntry]:

--- a/tests/test_pricing_model_aliases.py
+++ b/tests/test_pricing_model_aliases.py
@@ -1,0 +1,66 @@
+"""Tests for model alias resolution in usage pricing.
+
+The pricing table uses dated model names (claude-opus-4-20250514) but the
+model catalog lists undated aliases (claude-opus-4-6) as the default.
+Without alias resolution, /usage shows "Pricing unknown" for most
+Anthropic direct-provider users.
+"""
+
+from agent.usage_pricing import (
+    _lookup_official_docs_pricing,
+    resolve_billing_route,
+    get_pricing_entry,
+    BillingRoute,
+)
+
+
+class TestModelAliasResolution:
+
+    def test_dated_model_has_pricing(self):
+        """The dated name should always work."""
+        route = BillingRoute(provider="anthropic", model="claude-opus-4-20250514", base_url="", billing_mode="official_docs_snapshot")
+        entry = _lookup_official_docs_pricing(route)
+        assert entry is not None
+
+    def test_dot_versioned_opus_alias_resolves(self):
+        """claude-opus-4.6 (actual default model name) should resolve."""
+        route = BillingRoute(provider="anthropic", model="claude-opus-4.6", base_url="", billing_mode="official_docs_snapshot")
+        entry = _lookup_official_docs_pricing(route)
+        assert entry is not None
+        assert entry.input_cost_per_million > 0
+
+    def test_dot_versioned_sonnet_alias_resolves(self):
+        """claude-sonnet-4.6 should resolve."""
+        route = BillingRoute(provider="anthropic", model="claude-sonnet-4.6", base_url="", billing_mode="official_docs_snapshot")
+        entry = _lookup_official_docs_pricing(route)
+        assert entry is not None
+
+    def test_hyphen_versioned_opus_alias_resolves(self):
+        """claude-opus-4-6 (alternate format) should also resolve."""
+        route = BillingRoute(provider="anthropic", model="claude-opus-4-6", base_url="", billing_mode="official_docs_snapshot")
+        entry = _lookup_official_docs_pricing(route)
+        assert entry is not None
+
+    def test_older_dated_alias_resolves(self):
+        """claude-opus-4-5-20251101 should resolve."""
+        route = BillingRoute(provider="anthropic", model="claude-opus-4-5-20251101", base_url="", billing_mode="official_docs_snapshot")
+        entry = _lookup_official_docs_pricing(route)
+        assert entry is not None
+
+    def test_haiku_alias_resolves(self):
+        """claude-haiku-4-5 should resolve to 3-5-haiku pricing."""
+        route = BillingRoute(provider="anthropic", model="claude-haiku-4-5", base_url="", billing_mode="official_docs_snapshot")
+        entry = _lookup_official_docs_pricing(route)
+        assert entry is not None
+
+    def test_unknown_model_returns_none(self):
+        """A model not in the table or aliases returns None."""
+        route = BillingRoute(provider="anthropic", model="claude-unknown-99", base_url="", billing_mode="official_docs_snapshot")
+        entry = _lookup_official_docs_pricing(route)
+        assert entry is None
+
+    def test_full_pipeline_opus_46_dot(self):
+        """End-to-end: get_pricing_entry for anthropic/claude-opus-4.6 (real model string)."""
+        entry = get_pricing_entry("anthropic/claude-opus-4.6", provider="anthropic")
+        assert entry is not None
+        assert entry.source == "official_docs_snapshot"


### PR DESCRIPTION
## Summary

`/usage` shows "Pricing unknown" for `claude-opus-4.6` and `claude-sonnet-4.6` — the default models listed at the top of the Anthropic provider catalog. Cost tracking is broken for most Anthropic direct-provider users.

**Before (hermes v0.4.0, Claude Opus 4.6):**

![before fix — pricing unknown](https://i.imgur.com/3jowyhq.png)

**After fix:**

![after fix — cost estimated](https://i.imgur.com/E6BK0uy.png)

## Root Cause

The pricing table in `agent/usage_pricing.py` uses dated model names as keys (`claude-opus-4-20250514`), but the model catalog in `hermes_cli/models.py` lists dot-versioned aliases (`claude-opus-4.6`) as the primary models. `_lookup_official_docs_pricing` does an exact dictionary lookup with no alias resolution — so these commonly-used model names return `None` and cost tracking falls back to "unknown".

Affected models: `claude-opus-4.6`, `claude-sonnet-4.6`, `claude-opus-4.5`, `claude-sonnet-4.5`, `claude-haiku-4.5` — basically every non-dated model entry.

## Fix

Added `_MODEL_ALIASES` dict mapping dot-versioned and undated names to their dated equivalents. `_lookup_official_docs_pricing` resolves aliases before the dictionary lookup.

## Tests

8 new tests: dot-versioned aliases, hyphen-versioned aliases, dated name, older dated variants, haiku, unknown model, and full end-to-end pipeline with `anthropic/claude-opus-4.6`.

```
8 passed
```