### PR TITLE
Add whisper as local transcribe fallback for CUDA13 support

### DIFF
--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -29,12 +29,24 @@ import shlex
 import shutil
 import subprocess
 import tempfile
+import ctypes
+import ctypes.util
 from pathlib import Path
 from typing import Optional, Dict, Any
 
 from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Helper to check for CUDA
+# ---------------------------------------------------------------------------
+
+def _has_cuda_libraries() -> bool:
+    """Check if essential CUDA libraries are available."""
+    # Check for cublas and cudart
+    return (ctypes.util.find_library("cublas") is not None and 
+            ctypes.util.find_library("cudart") is not None)
 
 # ---------------------------------------------------------------------------
 # Optional imports — graceful degradation
@@ -267,83 +279,63 @@ def _validate_audio_file(file_path: str) -> Optional[Dict[str, Any]]:
 
 
 # ---------------------------------------------------------------------------
-# Provider: local (openai-whisper)
-# ---------------------------------------------------------------------------
-
-def _transcribe_local_fallback(file_path: str, model_name: str) -> Dict[str, Any]:
-    """Transcribe using vanilla openai-whisper (local, free)."""
-    global _local_model, _local_model_name
-
-    try:
-        import whisper
-        from typing import Dict, Any
-        from pathlib import Path
-        # Lazy-load the model
-        if _local_model is None or _local_model_name != model_name:
-            logger.info("Loading vanilla whisper model '%s'...", model_name)
-            # Vanilla whisper automatically detects CUDA; 
-            # use device="cpu" if you want to force CPU
-            _local_model = whisper.load_model(model_name)
-            _local_model_name = model_name
-
-        # Transcribe returns a dict containing 'text', 'segments', and 'language'
-        # fp16 parameter removed - not supported in newer faster-whisper versions
-        result = _local_model.transcribe(file_path, beam_size=5)
-
-        transcript = result["text"].strip()
-        language = result.get("language", "unknown")
-
-        logger.info(
-            "Transcribed %s via local vanilla whisper (%s, lang=%s)",
-            Path(file_path).name, model_name, language
-        )
-
-        return {
-            "success": True,
-            "transcript": transcript,
-            "provider": "local",
-            "language": language
-        }
-
-    except Exception as e:
-        logger.error("Local fallback transcription failed: %s", e, exc_info=True)
-        return {"success": False, "transcript": "", "error": f"Local transcription failed: {e}"}
-
-
-
-# ---------------------------------------------------------------------------
-# Provider: local (faster-whisper)
+# Provider: local (Unified: faster-whisper + vanilla openai-whisper)
 # ---------------------------------------------------------------------------
 
 
 def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
-    """Transcribe using faster-whisper (local, free)."""
+    """Transcribe using local models (faster-whisper preferred, fallback to openai-whisper)."""
     global _local_model, _local_model_name
 
-    if not _HAS_FASTER_WHISPER:
-        return {"success": False, "transcript": "", "error": "faster-whisper not installed"}
+    # Try faster-whisper first if installed
+    if _HAS_FASTER_WHISPER:
+        try:
+            from faster_whisper import WhisperModel
+            if _local_model_name != f"fw-{model_name}":
+                logger.info("Loading faster-whisper model '%s'...", model_name)
+                
+                device = "auto"
+                compute_type = "auto"
+                if not _has_cuda_libraries():
+                    logger.warning("CUDA libraries not found. Forcing CPU/int8 for faster-whisper.")
+                    device, compute_type = "cpu", "int8"
+                
+                _local_model = WhisperModel(model_name, device=device, compute_type=compute_type)
+                _local_model_name = f"fw-{model_name}"
 
+            segments, info = _local_model.transcribe(file_path, beam_size=5)
+            transcript = " ".join(segment.text.strip() for segment in segments)
+            
+            logger.info(
+                "Transcribed %s via faster-whisper (%s, lang=%s, %.1fs audio)",
+                Path(file_path).name, model_name, info.language, info.duration,
+            )
+            return {"success": True, "transcript": transcript, "provider": "local"}
+        except Exception as e:
+            logger.warning("faster-whisper failed: %s. Falling back to vanilla whisper.", e)
+            _local_model = None  # Reset singleton
+            _local_model_name = None
+
+    # Fallback to vanilla openai-whisper
     try:
-        from faster_whisper import WhisperModel
-        # Lazy-load the model (downloads on first use, ~150 MB for 'base')
-        if _local_model is None or _local_model_name != model_name:
-            logger.info("Loading faster-whisper model '%s' (first load downloads the model)...", model_name)
-            _local_model = WhisperModel(model_name, device="auto", compute_type="auto")
-            _local_model_name = model_name
+        import whisper
+        if _local_model_name != f"v-{model_name}":
+            logger.info("Loading vanilla whisper model '%s'...", model_name)
+            device = "cuda" if _has_cuda_libraries() else "cpu"
+            _local_model = whisper.load_model(model_name, device=device)
+            _local_model_name = f"v-{model_name}"
 
-        segments, info = _local_model.transcribe(file_path, beam_size=5)
-        transcript = " ".join(segment.text.strip() for segment in segments)
-
+        result = _local_model.transcribe(file_path, beam_size=5)
+        transcript = result["text"].strip()
+        
         logger.info(
-            "Transcribed %s via local whisper (%s, lang=%s, %.1fs audio)",
-            Path(file_path).name, model_name, info.language, info.duration,
+            "Transcribed %s via vanilla whisper (%s)",
+            Path(file_path).name, model_name
         )
-
         return {"success": True, "transcript": transcript, "provider": "local"}
-
     except Exception as e:
-        logger.warn("Local transcription failed: %s\nFalling back to openai-whisper", e)
-        return _transcribe_local_fallback(file_path, model_name)
+        logger.error("Local transcription (vanilla) failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"Local transcription failed: {e}"}
 
 
 def _prepare_local_audio(file_path: str, work_dir: str) -> tuple[Optional[str], Optional[str]]:

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -265,6 +265,52 @@ def _validate_audio_file(file_path: str) -> Optional[Dict[str, Any]]:
 
     return None
 
+
+# ---------------------------------------------------------------------------
+# Provider: local (openai-whisper)
+# ---------------------------------------------------------------------------
+
+def _transcribe_local_fallback(file_path: str, model_name: str) -> Dict[str, Any]:
+    """Transcribe using vanilla openai-whisper (local, free)."""
+    global _local_model, _local_model_name
+
+    try:
+        import whisper
+        from typing import Dict, Any
+        from pathlib import Path
+        # Lazy-load the model
+        if _local_model is None or _local_model_name != model_name:
+            logger.info("Loading vanilla whisper model '%s'...", model_name)
+            # Vanilla whisper automatically detects CUDA; 
+            # use device="cpu" if you want to force CPU
+            _local_model = whisper.load_model(model_name)
+            _local_model_name = model_name
+
+        # Transcribe returns a dict containing 'text', 'segments', and 'language'
+        # fp16 parameter removed - not supported in newer faster-whisper versions
+        result = _local_model.transcribe(file_path, beam_size=5)
+
+        transcript = result["text"].strip()
+        language = result.get("language", "unknown")
+
+        logger.info(
+            "Transcribed %s via local vanilla whisper (%s, lang=%s)",
+            Path(file_path).name, model_name, language
+        )
+
+        return {
+            "success": True,
+            "transcript": transcript,
+            "provider": "local",
+            "language": language
+        }
+
+    except Exception as e:
+        logger.error("Local fallback transcription failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"Local transcription failed: {e}"}
+
+
+
 # ---------------------------------------------------------------------------
 # Provider: local (faster-whisper)
 # ---------------------------------------------------------------------------
@@ -296,8 +342,8 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
         return {"success": True, "transcript": transcript, "provider": "local"}
 
     except Exception as e:
-        logger.error("Local transcription failed: %s", e, exc_info=True)
-        return {"success": False, "transcript": "", "error": f"Local transcription failed: {e}"}
+        logger.warn("Local transcription failed: %s\nFalling back to openai-whisper", e)
+        return _transcribe_local_fallback(file_path, model_name)
 
 
 def _prepare_local_audio(file_path: str, work_dir: str) -> tuple[Optional[str], Optional[str]]:


### PR DESCRIPTION
## What does this PR do?

Adds standard whisper as a fallback when faster-whisper fails.

A temporary work around while faster-whisper dependencies are updated to support cuda 13


## Related Issue

[#2885
](https://github.com/NousResearch/hermes-agent/issues/2885)

Implements [#2967](https://github.com/NousResearch/hermes-agent/pull/2967) retaining gpu whisper support

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- A fallback function which uses standard whisper passing through props from `_transcribe_local`

## How to Test

1. Install CUDA 13
2. Voice mode of any kind needing transcription
3. Get error about `libcublas.so.12`
4. Switch to branch AshMartian:fix/whisper-fallback
5. Voice mode of any kind
6. Whispers sweet somethings to your Ai

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

