### PR TITLE
fix(gateway): self-heal missing launchd plist on start

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -863,12 +863,23 @@ def launchd_uninstall():
     print("✓ Service uninstalled")
 
 def launchd_start():
-    refresh_launchd_plist_if_needed()
     plist_path = get_launchd_plist_path()
+
+    # Self-heal if the plist is missing entirely (e.g., manual cleanup, failed upgrade)
+    if not plist_path.exists():
+        print("↻ launchd plist missing; regenerating service definition")
+        plist_path.parent.mkdir(parents=True, exist_ok=True)
+        plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
+        subprocess.run(["launchctl", "load", str(plist_path)], check=True)
+        subprocess.run(["launchctl", "start", "ai.hermes.gateway"], check=True)
+        print("✓ Service started")
+        return
+
+    refresh_launchd_plist_if_needed()
     try:
         subprocess.run(["launchctl", "start", "ai.hermes.gateway"], check=True)
     except subprocess.CalledProcessError as e:
-        if e.returncode != 3 or not plist_path.exists():
+        if e.returncode != 3:
             raise
         print("↻ launchd job was unloaded; reloading service definition")
         subprocess.run(["launchctl", "load", str(plist_path)], check=True)

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -177,6 +177,42 @@ class TestLaunchdPlistRefresh:
         assert any("unload" in s for s in cmd_strs)
         assert any("start" in s for s in cmd_strs)
 
+    def test_launchd_start_recreates_missing_plist_and_loads_service(self, tmp_path, monkeypatch):
+        """launchd_start self-heals when the plist file is missing entirely.
+
+        This covers the edge case where the plist has been removed (manual cleanup,
+        failed upgrade, launchd state drift) but the user expects `hermes gateway start`
+        to just work.
+
+        Regression test for #3318.
+        """
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        # Ensure plist does NOT exist
+        assert not plist_path.exists()
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        calls = []
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_start()
+
+        # Should have created the plist
+        assert plist_path.exists()
+        # Plist should contain the generated content
+        assert "--replace" in plist_path.read_text()
+
+        cmd_strs = [" ".join(c) for c in calls]
+        # Should load the new plist, then start
+        assert any("load" in s for s in cmd_strs)
+        assert any("start" in s for s in cmd_strs)
+        # Should NOT call unload (nothing to unload)
+        assert not any("unload" in s for s in cmd_strs)
+
 
 class TestCmdUpdateLaunchdRestart:
     """cmd_update correctly detects and handles launchd on macOS."""


### PR DESCRIPTION
## Summary

When the launchd plist file is missing (manual cleanup, failed upgrade, launchd state drift), `hermes gateway start` now regenerates the plist, loads it, and starts the service instead of crashing with exit status 3.

## Problem

Previously, `refresh_launchd_plist_if_needed()` returned early if the plist was missing:

```python
if not plist_path.exists() or launchd_plist_is_current():
    return False
```

And the recovery path in `launchd_start()` was skipped because it only triggered when the plist existed:

```python
if e.returncode != 3 or not plist_path.exists():
    raise
```

This meant users in the missing-plist state had to run `hermes gateway install` manually to recover.

## Solution

Check for missing plist at the start of `launchd_start()` and self-heal:
1. Regenerate the plist
2. Load it with `launchctl load`
3. Start the service

This makes `hermes gateway start` robust to missing plists, regardless of how the plist disappeared.

## Testing

Added regression test: `test_launchd_start_recreates_missing_plist_and_loads_service`

Fixes #3318