### PR TITLE
feat(gateway): add Zulip integration and messaging support

### DIFF
--- a/apps/desktop/src/app/messaging/index.test.tsx
+++ b/apps/desktop/src/app/messaging/index.test.tsx
@@ -351,3 +351,68 @@ describe('MessagingView Telegram quick setup', () => {
     }
   })
 })
+
+function envVar(patch: Partial<MessagingEnvVarInfo> = {}): MessagingEnvVarInfo {
+  return {
+    advanced: false,
+    description: '',
+    is_password: false,
+    is_set: false,
+    key: 'ZULIP_SITE_URL',
+    prompt: 'ZULIP_SITE_URL',
+    redacted_value: null,
+    required: true,
+    url: null,
+    ...patch
+  }
+}
+
+describe('MessagingView Zulip field copy', () => {
+  it('uses a human label, an example placeholder, and the env var as a caption', async () => {
+    getMessagingPlatforms.mockResolvedValue({
+      platforms: [
+        platform({
+          id: 'zulip',
+          name: 'Zulip',
+          env_vars: [
+            envVar({
+              key: 'ZULIP_SITE_URL',
+              prompt: 'ZULIP_SITE_URL',
+              required: true
+            })
+          ]
+        })
+      ]
+    })
+
+    await renderMessaging()
+
+    const input = await screen.findByLabelText('Site URL')
+    expect(input.getAttribute('placeholder')).toBe('https://example.zulipchat.com')
+    expect(screen.getByText('ZULIP_SITE_URL')).toBeTruthy()
+  })
+
+  it('does not caption non-Zulip fields with their env var name', async () => {
+    getMessagingPlatforms.mockResolvedValue({
+      platforms: [
+        platform({
+          id: 'telegram',
+          name: 'Telegram',
+          env_vars: [
+            envVar({
+              key: 'TELEGRAM_BOT_TOKEN',
+              prompt: 'Telegram bot token',
+              required: true
+            })
+          ]
+        })
+      ]
+    })
+
+    await renderMessaging()
+
+    const input = await screen.findByLabelText('Bot token')
+    expect(input.getAttribute('placeholder')).toBe('Paste Telegram bot token')
+    expect(screen.queryByText('TELEGRAM_BOT_TOKEN')).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/messaging/index.tsx
+++ b/apps/desktop/src/app/messaging/index.tsx
@@ -113,7 +113,23 @@ const FIELD_COPY: Record<string, { advanced?: boolean }> = {
   QQBOT_HOME_CHANNEL: { advanced: true },
   QQBOT_HOME_CHANNEL_NAME: { advanced: true },
   WHATSAPP_ENABLED: { advanced: true },
-  WHATSAPP_MODE: { advanced: true }
+  WHATSAPP_MODE: { advanced: true },
+  ZULIP_ALLOW_ALL_USERS: { advanced: true },
+  ZULIP_HOME_TOPIC: { advanced: true },
+  ZULIP_HOME_CHANNEL: { advanced: true },
+  ZULIP_HOME_CHANNEL_NAME: { advanced: true },
+  ZULIP_CERT_BUNDLE: { advanced: true },
+  ZULIP_ALLOW_INSECURE: { advanced: true },
+  ZULIP_REQUIRE_MENTION: { advanced: true },
+  ZULIP_FREE_RESPONSE_STREAMS: { advanced: true },
+  ZULIP_CONTEXT_DEPTH: { advanced: true },
+  ZULIP_CATCHUP: { advanced: true },
+  ZULIP_CATCHUP_MAX_MESSAGES: { advanced: true },
+  ZULIP_CONVERT_MATH: { advanced: true }
+}
+
+function isZulipEnvKey(key: string) {
+  return key.startsWith('ZULIP_')
 }
 
 function fieldCopy(field: MessagingEnvVarInfo, m: Translations['messaging']) {
@@ -936,7 +952,9 @@ const PLATFORM_INTRO: Record<string, string> = {
   api_server:
     'Expose Hermes as an OpenAI-compatible API. Set an auth key, then point Open WebUI / LobeChat / etc. at the host:port.',
   webhook:
-    'Run an HTTP server that other tools (GitHub, GitLab, custom apps) can POST to. Use the secret to verify signatures.'
+    'Run an HTTP server that other tools (GitHub, GitLab, custom apps) can POST to. Use the secret to verify signatures.',
+  zulip:
+    'Create a Zulip bot in Settings → Bots, then paste the site URL, bot email, and API key.'
 }
 
 const introCopy = (platform: MessagingPlatformInfo, m: Translations['messaging']) =>
@@ -996,6 +1014,7 @@ function MessagingField({
         </div>
       }
       description={copy.help}
+      hint={isZulipEnvKey(field.key) ? field.key : undefined}
       title={
         <span className="flex flex-wrap items-center gap-2">
           <label htmlFor={fieldId}>{copy.label}</label>

--- a/apps/desktop/src/app/messaging/platform-icon.tsx
+++ b/apps/desktop/src/app/messaging/platform-icon.tsx
@@ -10,7 +10,8 @@ import {
   SiSignal,
   SiTelegram,
   SiWechat,
-  SiWhatsapp
+  SiWhatsapp,
+  SiZulip
 } from '@icons-pack/react-simple-icons'
 import type { ComponentPropsWithoutRef, ComponentType, SVGProps } from 'react'
 import { forwardRef, memo } from 'react'
@@ -69,7 +70,8 @@ const PLATFORM_ICONS: Record<string, PlatformIconSpec> = {
   api_server: { Icon: Globe, color: '#64748B', kind: 'generic' },
   weixin: { Icon: SiWechat, color: '#07C160', kind: 'brand' },
   qqbot: { Icon: SiQq, color: '#EB1923', kind: 'brand' },
-  yuanbao: { Icon: SiBilibili, color: '#FB7299', kind: 'brand' }
+  yuanbao: { Icon: SiBilibili, color: '#FB7299', kind: 'brand' },
+  zulip: { Icon: SiZulip, color: '#6492FE', kind: 'brand' }
 }
 
 interface PlatformAvatarProps extends Omit<ComponentPropsWithoutRef<'span'>, 'children'> {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2173,6 +2173,91 @@ export const en: Translations = {
       WHATSAPP_ALLOWED_USERS: {
         label: 'Allowed WhatsApp users',
         help: 'Recommended. Comma-separated phone numbers or WhatsApp IDs.'
+      },
+      ZULIP_SITE_URL: {
+        label: 'Site URL',
+        help: 'Your Zulip organization URL, cloud or self-hosted.',
+        placeholder: 'https://example.zulipchat.com'
+      },
+      ZULIP_BOT_EMAIL: {
+        label: 'Bot email',
+        help: 'The bot email from Zulip Settings → Bots.',
+        placeholder: 'bot@example.com'
+      },
+      ZULIP_API_KEY: {
+        label: 'API key',
+        help: 'The bot API key from Zulip Settings → Bots.',
+        placeholder: 'Paste Zulip API key'
+      },
+      ZULIP_ALLOWED_USERS: {
+        label: 'Allowed user emails',
+        help: 'Recommended. Comma-separated Zulip emails allowed to DM the bot.',
+        placeholder: 'alice@example.com, bob@example.com'
+      },
+      ZULIP_ALLOW_ALL_USERS: {
+        label: 'Allow all users',
+        help: 'Development only. When true, anyone can DM the bot without an allowlist.',
+        placeholder: 'true'
+      },
+      ZULIP_DEFAULT_STREAM: {
+        label: 'Default stream',
+        help: 'Stream used for outbound messages when none is specified.',
+        placeholder: 'general'
+      },
+      ZULIP_HOME_TOPIC: {
+        label: 'Home topic',
+        help: 'Default topic for cron and notification delivery.',
+        placeholder: 'Hermes'
+      },
+      ZULIP_HOME_CHANNEL: {
+        label: 'Home channel',
+        help: 'Home stream, or stream:topic, for cron and notification delivery.',
+        placeholder: 'general:Hermes'
+      },
+      ZULIP_HOME_CHANNEL_NAME: {
+        label: 'Home channel name',
+        help: 'Display name for the Zulip home channel in logs and status.',
+        placeholder: 'Home'
+      },
+      ZULIP_CERT_BUNDLE: {
+        label: 'CA bundle',
+        help: 'Path to a CA bundle for self-hosted Zulip TLS.',
+        placeholder: '/etc/ssl/certs/ca-certificates.crt'
+      },
+      ZULIP_ALLOW_INSECURE: {
+        label: 'Allow insecure TLS',
+        help: 'Disable TLS verification. Development-only self-hosted Zulip.',
+        placeholder: 'false'
+      },
+      ZULIP_REQUIRE_MENTION: {
+        label: 'Require mention',
+        help: 'Require @mention in streams. Default true.',
+        placeholder: 'true'
+      },
+      ZULIP_FREE_RESPONSE_STREAMS: {
+        label: 'Free-response streams',
+        help: 'Comma-separated stream names or IDs that do not require @mention.',
+        placeholder: 'general, 42'
+      },
+      ZULIP_CONTEXT_DEPTH: {
+        label: 'Context depth',
+        help: 'Number of prior topic messages to inject as context on @mention.',
+        placeholder: '10'
+      },
+      ZULIP_CATCHUP: {
+        label: 'Catch-up',
+        help: 'Replay missed stream messages after reconnect. Default false.',
+        placeholder: 'false'
+      },
+      ZULIP_CATCHUP_MAX_MESSAGES: {
+        label: 'Catch-up max messages',
+        help: 'Maximum missed messages replayed per stream on reconnect.',
+        placeholder: '100'
+      },
+      ZULIP_CONVERT_MATH: {
+        label: 'Convert math',
+        help: 'Rewrite LaTeX delimiters to Zulip KaTeX before send. Default true.',
+        placeholder: 'true'
       }
     },
     platformIntro: {}

--- a/apps/desktop/src/lib/session-search.test.ts
+++ b/apps/desktop/src/lib/session-search.test.ts
@@ -64,6 +64,7 @@ describe('sessionMatchesSearch', () => {
     expect(sessionMatchesSearch(makeSession({ source: 'whatsapp' }), 'wa')).toBe(true)
     expect(sessionMatchesSearch(makeSession({ source: 'slack' }), 'slack')).toBe(true)
     expect(sessionMatchesSearch(makeSession({ source: 'bluebubbles' }), 'imessage')).toBe(true)
+    expect(sessionMatchesSearch(makeSession({ source: 'zulip' }), 'Zulip')).toBe(true)
   })
 
   it('does not match unrelated queries', () => {

--- a/apps/desktop/src/lib/session-source.test.ts
+++ b/apps/desktop/src/lib/session-source.test.ts
@@ -33,3 +33,17 @@ describe('photon messaging source registration', () => {
     expect(isMessagingSource(undefined)).toBe(false)
   })
 })
+
+describe('zulip messaging source registration', () => {
+  it('treats zulip as a messaging source (own sidebar section)', () => {
+    expect(isMessagingSource('zulip')).toBe(true)
+  })
+
+  it('is registered in the messaging source id list', () => {
+    expect(MESSAGING_SESSION_SOURCE_IDS).toContain('zulip')
+  })
+
+  it('exposes a Zulip search label', () => {
+    expect(sessionSourceSearchTerms('zulip')).toContain('Zulip')
+  })
+})

--- a/apps/desktop/src/lib/session-source.ts
+++ b/apps/desktop/src/lib/session-source.ts
@@ -23,7 +23,8 @@ const SOURCE_LABELS: Record<string, string> = {
   webhook: 'Webhook',
   weixin: 'WeChat',
   whatsapp: 'WhatsApp',
-  yuanbao: 'Yuanbao'
+  yuanbao: 'Yuanbao',
+  zulip: 'Zulip'
 }
 
 const SOURCE_ALIASES: Record<string, string[]> = {
@@ -69,7 +70,8 @@ export const MESSAGING_SESSION_SOURCE_IDS = [
   'qqbot',
   'yuanbao',
   'dingtalk',
-  'feishu'
+  'feishu',
+  'zulip'
 ]
 const MESSAGING_SOURCE_IDS = new Set(MESSAGING_SESSION_SOURCE_IDS)
 

--- a/plugins/platforms/zulip/__init__.py
+++ b/plugins/platforms/zulip/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import register
+
+__all__ = ["register"]

--- a/plugins/platforms/zulip/adapter.py
+++ b/plugins/platforms/zulip/adapter.py
@@ -1,0 +1,2671 @@
+"""Zulip gateway adapter.
+
+Connects to any Zulip server (cloud or self-hosted) via the official
+``zulip`` Python package.  Uses the long-polling event queue for
+real-time message delivery and the REST API for sending.
+
+Authentication uses the bot's email + API key + server URL — no OAuth
+tokens required.
+
+Environment variables:
+    ZULIP_SITE_URL           Server URL (e.g. https://your-org.zulipchat.com)
+    ZULIP_BOT_EMAIL          Bot's email address
+    ZULIP_API_KEY            Bot's API key (from Zulip bot settings)
+    ZULIP_ALLOWED_USERS      Comma-separated email addresses
+    ZULIP_ALLOW_ALL_USERS    If "true", allow all Zulip users (skip allowlist)
+    ZULIP_DEFAULT_STREAM     Default stream for outbound messages
+    ZULIP_HOME_TOPIC         Default topic for cron/notification delivery
+    ZULIP_HOME_CHANNEL       Home stream:topic for cron/notification delivery
+    ZULIP_CERT_BUNDLE        Path to a CA bundle for self-hosted/self-signed TLS
+    ZULIP_ALLOW_INSECURE     If "true", disable TLS verification (dev only)
+    ZULIP_REQUIRE_MENTION    Require @mention in streams (default: "true")
+    ZULIP_FREE_RESPONSE_STREAMS  Comma-separated stream names or IDs that
+                             don't require @mention
+    ZULIP_CONVERT_MATH       Rewrite common LaTeX delimiters to Zulip KaTeX
+                             form before send (default: "true")
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+import logging
+import os
+import random
+import re
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
+from .attachments import download_zulip_upload, extract_upload_paths
+
+logger = logging.getLogger(__name__)
+
+# Zulip's standard server limit is 10,000 Unicode code points. Self-hosted
+# realms may configure a different limit; keep Hermes at the standard maximum
+# so normal responses arrive as one message whenever the realm permits it.
+MAX_MESSAGE_LENGTH = 10_000
+_STANDALONE_IMAGE_EXTS = frozenset({".jpg", ".jpeg", ".png", ".webp", ".gif"})
+_STANDALONE_VIDEO_EXTS = frozenset({".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp"})
+
+
+# Zulip KaTeX markup:
+#   * Inline math:  $$O(n^2)$$
+#   * Display math: fenced ```math ... ``` blocks
+#
+# Models (especially smaller ones) often emit traditional TeX delimiters
+# that Zulip does NOT render:
+#   * multi-line / whole-line $$...$$  (Zulip uses $$ only for inline)
+#   * \[...\] display and \(...\) inline
+#   * $...$ inline
+# Rewrite those to Zulip's KaTeX forms before send.  Already-fenced code
+# (including ```math) is left untouched.  Toggle with ZULIP_CONVERT_MATH
+# or config.extra["convert_math"].
+_CODEBLOCK_SPLIT_RE = re.compile(r"(```[\s\S]*?```)")
+_DISPLAY_DOLLAR_MATH_RE = re.compile(
+    r"(?ms)^[ \t]*\$\$\s*(?P<math>.*?)[ \t]*\$\$[ \t\r]*$"
+)
+_DISPLAY_BRACKET_MATH_RE = re.compile(
+    r"(?ms)^[ \t]*\\\[(?P<math>.*?)\\\][ \t\r]*$"
+)
+_INLINE_PAREN_MATH_RE = re.compile(r"\\\((?P<math>.*?)\\\)")
+# Single-dollar inline: require a space/BOL boundary and either a compact
+# non-space body or a body with LaTeX-ish operators.  Pure currency-like
+# amounts ($5, $5.00) are excluded to avoid false positives in prose.
+_INLINE_DOLLAR_MATH_RE = re.compile(
+    r"""
+    (?:^|(?<=\s))                 # preceded by BOL or whitespace
+    (?P<prefix>[^\w$\s]*)         # optional punctuation before the opener
+    \$
+    (?P<math>
+        (?!\d+(?:\.\d+)?(?:\s|$)) # not a bare currency amount
+        (?:
+            [^\s$]+               # compact: $x$, $O(n)$, $n=1$
+          | [^$\n]*[_^{}=\\<>+][^$\n]*  # or contains LaTeX-ish chars
+        )
+    )
+    \$
+    (?P<suffix>[^\w$\s]*)         # optional punctuation after the closer
+    (?=\s|$)                      # followed by whitespace or EOL
+    """,
+    re.VERBOSE | re.MULTILINE,
+)
+
+
+def _process_noncode_parts(content: str, fn) -> str:
+    """Apply *fn* to text outside fenced code blocks only."""
+    if not content:
+        return content
+    out: List[str] = []
+    for index, part in enumerate(_CODEBLOCK_SPLIT_RE.split(content)):
+        if index % 2 == 1:
+            out.append(part)
+        else:
+            out.append(fn(part))
+    return "".join(out)
+
+
+def _to_display_math(match: re.Match) -> str:
+    body = match["math"].strip("\n")
+    return f"```math\n{body}\n```"
+
+
+def _to_inline_math(match: re.Match) -> str:
+    body = match["math"].strip()
+    prefix = match.groupdict().get("prefix") or ""
+    suffix = match.groupdict().get("suffix") or ""
+    return f"{prefix}$${body}$${suffix}"
+
+
+def _normalize_zulip_math(content: str) -> str:
+    r"""Rewrite non-Zulip math delimiters to Zulip KaTeX forms.
+
+    Conversions (outside fenced code only):
+
+    * whole-line ``$$...$$`` → fenced ``math`` block (display)
+    * whole-line ``\[...\]`` → fenced ``math`` block (display)
+    * ``\(...\)`` → ``$$...$$`` (inline)
+    * ``$...$`` → ``$$...$$`` when the body looks like math (not currency)
+
+    Mid-sentence single-line ``$$...$$`` (already valid Zulip inline math)
+    is left unchanged because the display-dollar pattern only matches a
+    full line.
+    """
+    if not content:
+        return content
+    # Cheap bail-out: nothing we rewrite can appear without one of these.
+    if "$" not in content and r"\(" not in content and r"\[" not in content:
+        return content
+
+    content = _process_noncode_parts(
+        content, lambda p: _DISPLAY_DOLLAR_MATH_RE.sub(_to_display_math, p)
+    )
+    content = _process_noncode_parts(
+        content, lambda p: _DISPLAY_BRACKET_MATH_RE.sub(_to_display_math, p)
+    )
+    content = _process_noncode_parts(
+        content, lambda p: _INLINE_PAREN_MATH_RE.sub(_to_inline_math, p)
+    )
+    content = _process_noncode_parts(
+        content, lambda p: _INLINE_DOLLAR_MATH_RE.sub(_to_inline_math, p)
+    )
+    return content
+
+
+
+# Inbound uploads arrive in message content as Markdown links targeting the
+# realm's /user_uploads/ endpoint. All of them are materialized into Hermes's
+# media cache; the core then routes images to vision and documents to its normal
+# file/terminal path. Keep this compatibility helper for callers that only need
+# to identify image links.
+_UPLOAD_IMAGE_EXTENSIONS = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+}
+
+def _extract_upload_image_paths(content: str) -> List[str]:
+    """Return unique ``/user_uploads/`` image paths from *content*, in order.
+
+    Absolute URLs are normalized down to their ``/user_uploads/...`` path so
+    the download always targets the configured site (never a foreign host
+    smuggled into a markdown link).
+    """
+    paths: List[str] = []
+    for path in extract_upload_paths(content):
+        if Path(path).suffix.lower() not in _UPLOAD_IMAGE_EXTENSIONS:
+            continue
+        paths.append(path)
+    return paths
+
+# Event-queue reconnect parameters (exponential backoff).
+_RECONNECT_BASE_DELAY = 2.0
+_RECONNECT_MAX_DELAY = 60.0
+_RECONNECT_JITTER = 0.2
+
+# Default per-stream cap for missed-message catch-up (see _run_missed_message_catchup).
+_CATCHUP_DEFAULT_MAX_MESSAGES = 100
+
+
+def _is_retryable_error(exc: Exception) -> bool:
+    """Determine if a Zulip event queue error is worth retrying.
+
+    Network errors, timeouts, and server errors (5xx) are retryable.
+    Authentication failures (401/403) and other client errors (4xx)
+    are not — the configuration or credentials need to be fixed first.
+
+    Falls back to *retryable* for unrecognized error shapes so the
+    event queue keeps trying on transient issues.
+    """
+    exc_name = type(exc).__name__
+
+    # Network-level errors are always retryable.
+    if any(keyword in exc_name for keyword in ("ConnectionError", "Timeout", "SSLError")):
+        return True
+
+    # Check for Zulip ``ClientError`` that carries an HTTP status.
+    if hasattr(exc, "http_status"):
+        status = getattr(exc, "http_status", 0)
+        if status in (401, 403):
+            return False
+        if 400 <= status < 500:
+            return False  # Client errors — user must fix config.
+
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Chat-ID helpers
+#
+# Zulip uses two distinct message types:
+#   * Stream messages live in a stream and have a topic.
+#   * Direct messages (DMs) are between exactly two users.
+#
+# We encode both into a single *chat_id* string that the gateway session
+# layer can round-trip without understanding Zulip internals.
+# ---------------------------------------------------------------------------
+
+_DM_PREFIX = "dm:"
+_GROUP_DM_PREFIX = "group_dm:"
+
+
+def _build_zform_widget_content(heading: str, choices: List[Dict[str, Any]]) -> str:
+    """Serialize a Zulip ``zform`` choices widget for ``send_message``.
+
+    Intended use:
+        Zulip does not have Telegram-style hidden callback buttons for normal
+        bot messages.  Its native button-like primitive is a message widget
+        called ``zform``.  Each zform choice renders as a button in compatible
+        Zulip clients, and clicking it sends a normal visible reply message
+        containing that choice's ``reply`` string.
+
+    How it works:
+        The Zulip send-message API accepts a ``widget_content`` form field that
+        must be a JSON string.  For zform choices, the JSON object has
+        ``widget_type: "zform"`` and ``extra_data.type: "choices"``.  Hermes
+        chooses reply strings that existing gateway text handlers already
+        understand (for example ``/approve`` or a literal clarify answer), so
+        zform remains a richer UI over the same audited text-command paths.
+
+    All fields are normalized to strings because Zulip's validator expects
+    string values for the choice labels and reply payloads.
+    """
+    normalized_choices = [
+        {
+            "type": str(choice.get("type", "multiple_choice")),
+            "short_name": str(choice.get("short_name", "")),
+            "long_name": str(choice.get("long_name", "")),
+            "reply": str(choice.get("reply", "")),
+        }
+        for choice in choices
+    ]
+    return json.dumps(
+        {
+            "widget_type": "zform",
+            "extra_data": {
+                "type": "choices",
+                "heading": str(heading),
+                "choices": normalized_choices,
+            },
+        },
+        ensure_ascii=False,
+    )
+
+
+def _format_approval_zform_heading(command: str, description: str = "") -> str:
+    """Build a zform heading that states what the user is approving.
+
+    Zulip clients foreground the zform widget over the message body (same
+    pattern as the trivia-quiz bot, which puts the question in ``heading``).
+    A generic heading like "Command approval required" leaves users staring at
+    approve/deny buttons with no idea which command is blocked.
+    """
+    cmd = (command or "").strip()
+    if not cmd:
+        return "Command approval required"
+
+    max_heading = 120
+
+    if cmd.startswith("execute_code"):
+        inner = [ln.strip() for ln in cmd.splitlines()[1:-1] if ln.strip()]
+        preview = inner[0] if inner else ""
+        prefix = "Approve execute_code: "
+        budget = max_heading - len(prefix)
+        if budget > 1 and len(preview) > budget:
+            preview = preview[: budget - 1] + "…"
+        return f"{prefix}{preview}" if preview else "Approve execute_code script"
+
+    preview = cmd.splitlines()[0].strip() if "\n" in cmd else cmd
+    prefix = "Approve: "
+    budget = max_heading - len(prefix)
+    if budget > 1 and len(preview) > budget:
+        preview = preview[: budget - 1] + "…"
+    return f"{prefix}{preview}"
+
+
+def _build_stream_chat_id(stream_id: int, topic: str) -> str:
+    """Encode a stream message's origin as a stable chat ID.
+
+    Format: ``"{stream_id}:{topic}"``
+    """
+    return f"{stream_id}:{topic}"
+
+
+def _parse_stream_chat_id(chat_id: str) -> Optional[Tuple[int, str]]:
+    """Parse a canonical stream chat ID back into ``(stream_id, topic)``.
+
+    Returns ``None`` if *chat_id* does not look like a canonical stream chat
+    ID with a numeric stream ID prefix.
+    """
+    # Canonical stream chat IDs look like "123:some topic" — the part before
+    # the first colon must be a plain integer.
+    colon = chat_id.find(":")
+    if colon < 1:
+        return None
+    stream_part = chat_id[:colon]
+    if not stream_part.isdigit():
+        return None
+    topic = chat_id[colon + 1:] or "(no topic)"
+    return (int(stream_part), topic)
+
+
+def _parse_stream_name_topic(chat_id: str) -> Optional[Tuple[str, str]]:
+    """Parse a documented ``stream_name:topic`` target.
+
+    This is intentionally separate from :func:`_parse_stream_chat_id` because
+    the canonical internal format uses numeric stream IDs, while config/docs
+    may use human-friendly stream names.
+    """
+    colon = chat_id.find(":")
+    if colon < 1:
+        return None
+    stream_name = chat_id[:colon].strip()
+    topic = chat_id[colon + 1:] or "(no topic)"
+    if not stream_name or stream_name.isdigit():
+        return None
+    if chat_id.startswith(_DM_PREFIX) or chat_id.startswith(_GROUP_DM_PREFIX):
+        return None
+    if stream_name in {"dm", "group_dm"}:
+        return None
+    if "@" in stream_name:
+        return None
+    return stream_name, topic
+
+
+def _build_dm_chat_id(sender_email: str) -> str:
+    """Encode a DM origin as a stable chat ID.
+
+    Format: ``"dm:{sender_email}"``
+    """
+    # Defensive: strip existing prefix so stale/cached IDs don't double-prefix.
+    if sender_email.startswith(_DM_PREFIX):
+        sender_email = sender_email[len(_DM_PREFIX):]
+    return f"{_DM_PREFIX}{sender_email}"
+
+
+def _parse_dm_chat_id(chat_id: str) -> Optional[str]:
+    """Parse a DM chat ID back into the sender email.
+
+    Returns ``None`` if *chat_id* does not look like a DM chat ID.
+    """
+    if chat_id.startswith(_DM_PREFIX) and "@" in chat_id:
+        return chat_id[len(_DM_PREFIX):]
+    return None
+
+
+def is_dm_chat_id(chat_id: str) -> bool:
+    """Return True if *chat_id* represents a DM conversation."""
+    return chat_id.startswith(_DM_PREFIX)
+
+
+def _build_group_dm_chat_id(participant_emails: list) -> str:
+    """Encode a group DM (3+ participants) as a stable chat ID.
+
+    Sorts emails for deterministic round-tripping regardless of the order
+    in which Zulip delivers the participant list.
+
+    Format: ``"group_dm:email1@example.com,email2@example.com,..."``
+    """
+    sorted_emails = sorted(participant_emails)
+    return f"{_GROUP_DM_PREFIX}{','.join(sorted_emails)}"
+
+
+def _parse_group_dm_chat_id(chat_id: str) -> Optional[list]:
+    """Parse a group DM chat ID back into a sorted list of emails.
+
+    Returns ``None`` if *chat_id* does not look like a group DM chat ID.
+    """
+    if not chat_id.startswith(_GROUP_DM_PREFIX):
+        return None
+    emails_str = chat_id[len(_GROUP_DM_PREFIX):]
+    if not emails_str:
+        return None
+    return emails_str.split(",")
+
+
+def is_group_dm_chat_id(chat_id: str) -> bool:
+    """Return True if *chat_id* represents a group DM conversation."""
+    return chat_id.startswith(_GROUP_DM_PREFIX)
+
+
+def _build_stream_typing_request(stream_id: int, topic: str, op: str) -> Dict[str, Any]:
+    """Build Zulip's channel typing payload using the modern stream_id + topic shape.
+
+    Zulip's current typing API for streams/channels requires the numeric
+    ``stream_id`` together with the ``topic``. The older ``{"to": [stream_name]}``
+    form is only valid for direct-message recipients and is no longer reliable
+    (or accepted) for channel typing notifications.
+    """
+    return {
+        "stream_id": stream_id,
+        "topic": topic,
+        "type": "stream",
+        "op": op,
+    }
+
+
+def _extract_dm_recipients(
+    display_recipient: Any, bot_email: str, sender_email: str
+) -> list:
+    """Extract DM participant emails from ``display_recipient``.
+
+    For 1:1 DMs, returns ``[other_user_email]``.
+    For group DMs (3+ users), returns all emails except the bot's.
+    Falls back to ``[sender_email]`` if the payload is malformed.
+    """
+    if isinstance(display_recipient, list):
+        emails = [
+            u.get("email", "")
+            for u in display_recipient
+            if isinstance(u, dict) and u.get("email") != bot_email
+        ]
+        if emails:
+            return emails
+
+    return [sender_email]
+
+
+def _resolve_stream_name(
+    message: Dict[str, Any],
+    stream_id: int,
+    stream_name_cache: Dict[int, str],
+) -> str:
+    """Get the stream name from cache or fall back to the message payload.
+
+    Zulip's ``display_recipient`` for stream messages is either:
+    - A string with the stream name (modern Zulip).
+    - A dict with a ``name`` key (legacy Zulip).
+
+    Falls back to ``str(stream_id)`` if nothing is available.
+    """
+    if stream_id in stream_name_cache:
+        return stream_name_cache[stream_id]
+
+    # Try display_recipient from the message payload.
+    dr = message.get("display_recipient")
+    if isinstance(dr, str) and dr:
+        return dr
+    if isinstance(dr, dict):
+        name = dr.get("name", "")
+        if name:
+            return name
+
+    return str(stream_id)
+
+
+def _strip_bot_mention(
+    content: str,
+    mention_patterns: List[str],
+) -> str:
+    """Remove bot mention patterns from message content.
+
+    Strips each pattern from the content (case-insensitive), then
+    normalizes whitespace (collapses double spaces, strips edges).
+
+    Zulip renders ``@**Full Name**`` and ``@email@example.com`` as
+    clickable mentions.  We remove them so the agent doesn't see its
+    own name as part of the user's message.
+    """
+    cleaned = content
+    for pattern in mention_patterns:
+        # Case-insensitive removal.
+        cleaned = re.sub(
+            re.escape(pattern), "", cleaned, count=1, flags=re.IGNORECASE
+        )
+    # Collapse any double spaces left by mention removal and strip edges.
+    cleaned = re.sub(r"  +", " ", cleaned).strip()
+    return cleaned
+
+
+def _format_context_block(context_lines: list) -> str:
+    """Format fetched context messages as a readable block prepended to the
+    user's message.  The block is separated from the user's current message
+    by a ``---`` delimiter so the agent can clearly distinguish context
+    from the question being asked.
+    """
+    if not context_lines:
+        return ""
+    header = "Recent messages in this topic:"
+    body = "\n".join(context_lines)
+    return f"{header}\n{body}\n---\n\n"
+
+
+# ---------------------------------------------------------------------------
+# Requirements check
+# ---------------------------------------------------------------------------
+
+
+def check_zulip_requirements(config: Optional[PlatformConfig] = None) -> bool:
+    """Return True if the Zulip adapter can be used.
+
+    Configured users get the same opt-in dependency behavior as other platform
+    plugins: if the SDK is missing, try the allowlisted lazy install before
+    reporting the platform unavailable. Unconfigured users do not import or
+    install the Zulip SDK.
+    """
+    extra = config.extra if config else {}
+    configured_key = (config.token or config.api_key) if config else ""
+    api_key = configured_key or os.getenv("ZULIP_API_KEY", "")
+    email = extra.get("bot_email") or os.getenv("ZULIP_BOT_EMAIL", "")
+    site = extra.get("site_url") or os.getenv("ZULIP_SITE_URL", "")
+
+    if not api_key:
+        logger.debug("Zulip: ZULIP_API_KEY not set")
+        return False
+    if not email:
+        logger.warning("Zulip: ZULIP_BOT_EMAIL not set")
+        return False
+    if not site:
+        logger.warning("Zulip: ZULIP_SITE_URL not set")
+        return False
+
+    try:
+        import zulip  # noqa: F401
+        return True
+    except ImportError:
+        pass
+
+    try:
+        from tools.lazy_deps import ensure as _lazy_ensure
+        _lazy_ensure("platform.zulip", prompt=False)
+    except Exception:
+        return False
+
+    try:
+        import zulip  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+
+class ZulipAdapter(BasePlatformAdapter):
+    """Gateway adapter for Zulip (cloud or self-hosted)."""
+
+    SUPPORTS_MESSAGE_EDITING = True
+    splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform("zulip"))
+
+        self._site_url: str = (
+            config.extra.get("site_url", "")
+            or os.getenv("ZULIP_SITE_URL", "")
+        ).rstrip("/")
+        self._bot_email: str = (
+            config.extra.get("bot_email", "")
+            or os.getenv("ZULIP_BOT_EMAIL", "")
+        )
+        self._api_key: str = (
+            config.token
+            or config.api_key
+            or os.getenv("ZULIP_API_KEY", "")
+        )
+        self._default_stream: str = (
+            config.extra.get("default_stream", "")
+            or os.getenv("ZULIP_DEFAULT_STREAM", "")
+        )
+        self._home_topic: str = (
+            config.extra.get("home_topic", "")
+            or os.getenv("ZULIP_HOME_TOPIC", "")
+        )
+        self._cert_bundle: str = os.getenv("ZULIP_CERT_BUNDLE", "")
+        self._allow_insecure: bool = os.getenv(
+            "ZULIP_ALLOW_INSECURE", "false"
+        ).lower() in ("true", "1", "yes")
+        self._streaming_edits_warning_logged = False
+        # Rewrite common LaTeX delimiters to Zulip KaTeX before send.
+        # config.extra["convert_math"] wins when present; else env
+        # ZULIP_CONVERT_MATH (default on).
+        if "convert_math" in config.extra:
+            self._convert_math = bool(config.extra.get("convert_math"))
+        else:
+            self._convert_math = os.getenv(
+                "ZULIP_CONVERT_MATH", "true"
+            ).lower() in ("true", "1", "yes")
+
+        # Mention gating configuration (follows Discord's pattern).
+        self._require_mention: bool = os.getenv(
+            "ZULIP_REQUIRE_MENTION", "true"
+        ).lower() not in ("false", "0", "no")
+
+        free_streams_raw = os.getenv("ZULIP_FREE_RESPONSE_STREAMS", "")
+        self._free_response_streams: set = {
+            s.strip().lower()
+            for s in free_streams_raw.split(",")
+            if s.strip()
+        }
+
+        # Historical context: when the bot is @mentioned in a stream, fetch
+        # the last N messages from that stream+topic via Zulip's /messages API
+        # and inject them as context before the user's message.  Survives
+        # disconnects — the bot uses Zulip as the source of truth.
+        try:
+            self._context_depth: int = max(
+                0,
+                int(
+                    config.extra.get("context_depth")
+                    or os.getenv("ZULIP_CONTEXT_DEPTH", "0")
+                ),
+            )
+        except (TypeError, ValueError):
+            self._context_depth = 0
+
+        # Missed-message catch-up (opt-in, default OFF).
+        #
+        # The Zulip events API only delivers events from queue registration
+        # onward, so any message that arrives while the gateway is down
+        # (process restart, BAD_EVENT_QUEUE_ID expiry, network drop) is never
+        # seen by the bot.  When enabled, on every (re-)register the adapter
+        # back-fills the gap for each known stream from a persisted per-stream
+        # watermark and feeds the missed messages through the normal inbound
+        # path — so dedup (``_seen_events``), mention-gating, and dispatch all
+        # behave exactly as they do for live messages.
+        #
+        # Default OFF on purpose: enabling it on a bot that has been offline for
+        # a while replays the accumulated backlog (bounded by the per-stream
+        # cap), which is usually surprising.  Opt in deliberately.
+        self._catchup_enabled: bool = (
+            str(config.extra.get("catchup_enabled", "")).lower()
+            in ("true", "1", "yes")
+            or os.getenv("ZULIP_CATCHUP", "false").lower()
+            in ("true", "1", "yes")
+        )
+        # Per-stream cap on messages replayed per (re-)register — bounds the
+        # backlog a long downtime can produce.
+        try:
+            self._catchup_max_messages: int = max(
+                1,
+                int(
+                    config.extra.get("catchup_max_messages")
+                    or os.getenv(
+                        "ZULIP_CATCHUP_MAX_MESSAGES",
+                        str(_CATCHUP_DEFAULT_MAX_MESSAGES),
+                    )
+                ),
+            )
+        except (TypeError, ValueError):
+            self._catchup_max_messages = _CATCHUP_DEFAULT_MAX_MESSAGES
+
+        # Background thread running the event queue.
+        self._event_thread: Optional[threading.Thread] = None
+        self._closing = False
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._event_futures: set[Any] = set()
+
+        # Bot identity (resolved on connect)
+        self._bot_user_id: int = -1
+        self._bot_full_name: str = ""
+
+        # Dedup cache: event_id → timestamp
+        self._seen_events: Dict[str, float] = {}
+        self._SEEN_MAX = 2000
+        self._SEEN_TTL = 300  # 5 minutes
+
+        # Stream name → stream_id cache (populated on connect)
+        self._stream_id_cache: Dict[str, int] = {}
+        # stream_id → stream_name reverse cache
+        self._stream_name_cache: Dict[int, str] = {}
+
+        # Email.lower() → user_id cache for DM typing.
+        #
+        # CRITICAL Zulip API requirement (DM / direct-message typing):
+        #   set_typing_status for type="direct" REQUIRES an array of *integer*
+        #   user_ids in the "to" field.  Passing email strings (or any non-int)
+        #   is rejected by the server (the client library may appear to accept
+        #   it but the wire payload fails validation on the Zulip side).
+        #
+        # We populate this cache from every inbound private message's
+        # "sender_id" (always present and numeric in Zulip events) and fall
+        # back to on-demand lookup via client.get_user(email=...) for the
+        # (rare) case of an outbound DM typing indicator before any inbound
+        # traffic from that user has been seen in the current process.
+        self._user_id_cache: Dict[str, int] = {}
+
+        # Graceful shutdown: event that wakes the event-queue thread
+        # immediately when disconnect() is called, instead of waiting
+        # for the full backoff sleep to elapse.
+        self._shutdown_event = threading.Event()
+        self._consecutive_failures = 0
+
+        # Zulip client — created in connect(), used by the event-queue thread.
+        # Send operations use _build_send_client() instead (thread safety).
+        self._client: Any = None
+
+    def _build_send_client(self) -> Any:
+        """Create a fresh Zulip client for a send operation.
+
+        The event-queue thread holds ``self._client`` for long-polling.
+        Sharing a ``requests.Session`` across threads corrupts SSL state,
+        so send operations get their own ephemeral client.
+        """
+        import zulip
+        kwargs: Dict[str, Any] = {
+            "site": self._site_url,
+            "email": self._bot_email,
+            "api_key": self._api_key,
+        }
+        if self._cert_bundle:
+            kwargs["cert_bundle"] = self._cert_bundle
+        if self._allow_insecure:
+            kwargs["insecure"] = True
+        return zulip.Client(**kwargs)
+
+    # ------------------------------------------------------------------
+    # Required overrides
+    # ------------------------------------------------------------------
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        """Connect to Zulip, verify auth, and start the event queue.
+
+        ``is_reconnect`` is forwarded by the gateway reconnect watcher after an
+        outage. Zulip registers a fresh event queue on each connect; optional
+        catch-up (when enabled) back-fills missed stream messages before going
+        live.
+        """
+        if not self._site_url or not self._api_key or not self._bot_email:
+            logger.error(
+                "Zulip: missing configuration (site_url, api_key, or bot_email)"
+            )
+            return False
+
+        import zulip
+
+        # Create the synchronous Zulip client.
+        client_kwargs: Dict[str, Any] = {
+            "site": self._site_url,
+            "email": self._bot_email,
+            "api_key": self._api_key,
+        }
+        if self._cert_bundle:
+            client_kwargs["cert_bundle"] = self._cert_bundle
+        if self._allow_insecure:
+            client_kwargs["insecure"] = True
+
+        self._client = zulip.Client(**client_kwargs)
+
+        # Verify credentials by fetching the bot's own profile.
+        try:
+            result = self._client.get_profile()
+        except Exception as exc:
+            logger.error("Zulip: failed to authenticate — %s", exc)
+            return False
+
+        if result.get("result") != "success":
+            msg = result.get("msg", "unknown error")
+            logger.error(
+                "Zulip: authentication failed — %s. "
+                "Check ZULIP_API_KEY, ZULIP_BOT_EMAIL, and ZULIP_SITE_URL.",
+                msg,
+            )
+            return False
+
+        profile = result.get("profile") if isinstance(result.get("profile"), dict) else result
+        self._bot_user_id = profile.get("user_id", -1)
+        self._bot_full_name = profile.get("full_name", "")
+        logger.info(
+            "Zulip: authenticated as %s (user_id=%d) on %s",
+            self._bot_email,
+            self._bot_user_id,
+            self._site_url,
+        )
+
+        # Populate stream-id cache early (helps typing indicators on first messages).
+        self._refresh_stream_cache()
+        logger.debug("Zulip: adapter fully connected and ready (stream cache has %d entries so far)", len(self._stream_id_cache))
+
+        # Start the event queue in a background thread.
+        self._loop = asyncio.get_running_loop()
+        self._closing = False
+        self._shutdown_event.clear()
+        self._consecutive_failures = 0
+        self._event_thread = threading.Thread(
+            target=self._run_event_queue,
+            name="zulip-event-queue",
+            daemon=True,
+        )
+        self._event_thread.start()
+
+        self._mark_connected()
+        return True
+
+    async def disconnect(self) -> None:
+        """Stop the event queue, cancel background tasks, and close the client."""
+        self._closing = True
+        self._shutdown_event.set()  # Wake up the event thread immediately.
+
+        # Wait for the event-queue thread to exit.
+        if self._event_thread and self._event_thread.is_alive():
+            self._event_thread.join(timeout=10.0)
+
+        # Cancel any in-flight message-processing tasks that were
+        # scheduled on the asyncio event loop.
+        try:
+            await self.cancel_background_tasks()
+        except Exception:
+            pass
+
+        for future in list(self._event_futures):
+            future.cancel()
+        self._event_futures.clear()
+
+        self._client = None
+        self._loop = None
+
+        # Clear caches to free memory and avoid stale data on reconnect.
+        self._seen_events.clear()
+        self._stream_id_cache.clear()
+        self._stream_name_cache.clear()
+        self._user_id_cache.clear()
+        self._consecutive_failures = 0
+
+        self._mark_disconnected()
+        logger.info("Zulip: disconnected")
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a message (or multiple chunks) to a Zulip chat."""
+        if not content:
+            return SendResult(success=True)
+
+        outbound_chat_id = self._metadata_adjusted_chat_id(chat_id, metadata)
+
+        formatted = self.format_message(content)
+        chunks = self.truncate_message(formatted, MAX_MESSAGE_LENGTH)
+
+        last_id = None
+        for chunk in chunks:
+            result = await asyncio.to_thread(
+                self._do_send_message,
+                outbound_chat_id,
+                chunk,
+                reply_to,
+            )
+            if result.success:
+                last_id = result.message_id
+            else:
+                return result
+
+        return SendResult(success=True, message_id=last_id)
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        """Return chat name and type (dm/stream)."""
+        # Try stream first.
+        parsed = _parse_stream_chat_id(chat_id)
+        if parsed:
+            stream_id, topic = parsed
+            stream_name = self._stream_name_cache.get(stream_id, chat_id)
+            return {"name": f"#{stream_name} > {topic}", "type": "stream"}
+
+        # Try DM.
+        dm_email = _parse_dm_chat_id(chat_id)
+        if dm_email:
+            return {"name": dm_email, "type": "dm"}
+
+        return {"name": chat_id, "type": "dm"}
+
+    # ------------------------------------------------------------------
+    # Optional overrides
+    # ------------------------------------------------------------------
+
+    async def send_typing(
+        self, chat_id: str, metadata: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """Send a typing indicator to Zulip.
+
+        For streams, the modern Zulip typing API requires a numeric ``stream_id``
+        + ``topic`` (see :func:`_build_stream_typing_request`). For DMs it
+        requires integer user IDs (never bare emails) in the ``to`` array.
+        Both are resolved on-demand via caches + resolvers below.
+        """
+        if not self._client:
+            logger.debug("Zulip: send_typing called but no client yet for chat_id=%r", chat_id)
+            return
+
+        outbound_chat_id = chat_id
+        thread_id = metadata.get("thread_id") if metadata else None
+        if thread_id and not _parse_stream_chat_id(chat_id):
+            if not is_dm_chat_id(chat_id) and not is_group_dm_chat_id(chat_id):
+                outbound_chat_id = f"{chat_id}:{thread_id}"
+
+        request = self._build_typing_request(outbound_chat_id, op="start")
+        if not request:
+            logger.warning("Zulip: send_typing failed — could not resolve chat_id %r (no request built)", outbound_chat_id)
+            return
+
+        # Success-path logging is debug only; INFO would spam gateway.log on
+        # every assistant turn because _keep_typing refreshes every ~2s.
+        logger.debug("Zulip: sending typing indicator → chat_id=%r payload=%s", outbound_chat_id, request)
+
+        try:
+            send_client = self._build_send_client()
+            result = await asyncio.to_thread(send_client.set_typing_status, request)
+            if result.get("result") != "success":
+                logger.debug("Zulip: send_typing API call failed — %s (payload was %s)", result.get("msg", "unknown error"), request)
+            else:
+                logger.debug("Zulip: send_typing SUCCESS for %r (payload=%s)", chat_id, request)
+        except Exception as exc:
+            logger.debug("Zulip: send_typing exception — %s (payload was %s)", exc, request)
+
+    async def stop_typing(
+        self, chat_id: str, metadata: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """Clear the typing indicator in Zulip (send 'op': 'stop').
+
+        Thread metadata is applied with the same outbound_chat_id adjustment as
+        send_typing. That matters when the gateway source is a named stream
+        (``general``) and the actual Zulip topic lives in metadata
+        (``thread_id``): the stop request must resolve to the same numeric
+        ``stream_id`` + topic payload as the start request.
+        """
+        if not self._client:
+            logger.debug("Zulip: stop_typing called but no client yet for chat_id=%r", chat_id)
+            return
+
+        outbound_chat_id = chat_id
+        thread_id = metadata.get("thread_id") if metadata else None
+        if thread_id and not _parse_stream_chat_id(chat_id):
+            if not is_dm_chat_id(chat_id) and not is_group_dm_chat_id(chat_id):
+                outbound_chat_id = f"{chat_id}:{thread_id}"
+
+        request = self._build_typing_request(outbound_chat_id, op="stop")
+        if not request:
+            return
+
+        # Debug level only — stop is called on every turn completion and must
+        # not pollute INFO logs.
+        logger.debug("Zulip: sending STOP typing → chat_id=%r payload=%s", outbound_chat_id, request)
+
+        try:
+            send_client = self._build_send_client()
+            result = await asyncio.to_thread(send_client.set_typing_status, request)
+            if result.get("result") != "success":
+                logger.debug("Zulip: stop_typing failed — %s (payload=%s)", result.get("msg", "unknown error"), request)
+            else:
+                logger.debug("Zulip: stop_typing SUCCESS for %r", outbound_chat_id)
+        except Exception as exc:
+            logger.debug("Zulip: stop_typing exception — %s (payload=%s)", exc, request)
+
+    async def _keep_typing(
+        self,
+        chat_id: str,
+        interval: float = 2.0,
+        metadata=None,
+        stop_event: Optional[asyncio.Event] = None,
+    ) -> None:
+        """Preserve Zulip topic metadata when the typing refresher stops."""
+        try:
+            await super()._keep_typing(
+                chat_id,
+                interval=interval,
+                metadata=metadata,
+                stop_event=stop_event,
+            )
+        finally:
+            if metadata:
+                try:
+                    await self.stop_typing(chat_id, metadata=metadata)
+                except Exception:
+                    pass
+
+    def warn_streaming_edits_enabled(self) -> None:
+        """Warn once before Zulip edit-based streaming mutates a message."""
+        if self._streaming_edits_warning_logged:
+            return
+        self._streaming_edits_warning_logged = True
+        logger.warning(
+            "Zulip streaming edits are enabled. Disable edit history in Zulip "
+            "organization settings before using this, otherwise intermediate "
+            "streamed content may be visible in edit history."
+        )
+
+    async def edit_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+        *,
+        finalize: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Edit an existing message.
+
+        The gateway streaming adapter contract passes ``finalize=`` on every
+        edit and may pass routing ``metadata`` for threaded platforms. Zulip's
+        update API is the same call for intermediate and final frames, and the
+        message ID already identifies the message to edit, so both keyword
+        arguments are accepted for compatibility and intentionally ignored.
+        """
+        if not self._client or not message_id:
+            return SendResult(success=False, error="Not supported")
+
+        self.warn_streaming_edits_enabled()
+        formatted = self.format_message(content)
+        send_client = self._build_send_client()
+        try:
+            result = await asyncio.to_thread(
+                send_client.update_message,
+                {
+                    "message_id": int(message_id),
+                    "content": formatted,
+                },
+            )
+            if result.get("result") == "success":
+                return SendResult(success=True, message_id=message_id)
+            else:
+                return SendResult(
+                    success=False,
+                    error=result.get("msg", "update failed"),
+                )
+        except Exception as exc:
+            return SendResult(success=False, error=str(exc))
+
+    def format_message(self, content: str) -> str:
+        """Zulip supports standard Markdown including code blocks, tables,
+        LaTeX math, and image links.
+
+        When ``_convert_math`` is enabled (default), common non-Zulip math
+        delimiters are rewritten to Zulip KaTeX forms so smaller models that
+        emit ``$...$`` / ``\\(...\\)`` / ``\\[...\\]`` / multi-line ``$$``
+        still render.  Disable with ``ZULIP_CONVERT_MATH=false`` or
+        ``config.extra["convert_math"]=False``.
+        """
+        if not self._convert_math:
+            return content
+        return _normalize_zulip_math(content)
+
+    def _metadata_adjusted_chat_id(
+        self,
+        chat_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Apply gateway thread metadata to a Zulip outbound chat ID.
+
+        Intended use:
+            Gateway callers sometimes pass a stream name in ``chat_id`` and a
+            topic in ``metadata['thread_id']``.  Zulip stream sends need both
+            values in one target string before :meth:`_do_send_message` can
+            turn them into the API request fields.  DMs and already-canonical
+            ``stream_id:topic`` chat IDs are left untouched.
+        """
+        thread_id = metadata.get("thread_id") if metadata else None
+        if thread_id and not _parse_stream_chat_id(chat_id) and not _parse_stream_name_topic(chat_id):
+            if not is_dm_chat_id(chat_id) and not is_group_dm_chat_id(chat_id):
+                return f"{chat_id}:{thread_id}"
+        return chat_id
+
+    async def _send_zform_choices(
+        self,
+        chat_id: str,
+        content: str,
+        heading: str,
+        choices: List[Dict[str, Any]],
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a Zulip message with an attached zform choices widget.
+
+        Intended use:
+            High-level Hermes prompts that are naturally a set of choices:
+            dangerous-command approvals, slash-command confirmations, and
+            multiple-choice clarify questions.
+
+        How it works:
+            The text body remains readable in clients that ignore widgets.  The
+            attached ``widget_content`` renders buttons in compatible Zulip
+            clients.  Button clicks emit normal visible Zulip replies, so the
+            choice ``reply`` values deliberately reuse Hermes' existing text
+            protocol instead of introducing a second callback channel.
+
+        The zform widget is attached to one Zulip message only.  Callers should
+        keep prompt bodies concise; this helper truncates overlong Markdown to
+        Zulip's normal outbound chunk size so the buttons stay with the prompt.
+        """
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        outbound_chat_id = self._metadata_adjusted_chat_id(chat_id, metadata)
+        formatted = self.format_message(content or heading)
+        chunks = self.truncate_message(formatted, MAX_MESSAGE_LENGTH)
+        prompt_text = chunks[0] if chunks else str(heading)
+        widget_content = _build_zform_widget_content(heading=heading, choices=choices)
+        return await asyncio.to_thread(
+            self._do_send_message,
+            outbound_chat_id,
+            prompt_text,
+            reply_to=reply_to,
+            widget_content=widget_content,
+        )
+
+    async def send_exec_approval(
+        self,
+        chat_id: str,
+        command: str,
+        session_key: str,
+        description: str = "dangerous command",
+        metadata: Optional[Dict[str, Any]] = None,
+        allow_permanent: bool = True,
+        allow_session: bool = True,
+        smart_denied: bool = False,
+    ) -> SendResult:
+        """Render a dangerous-command approval prompt as Zulip zform buttons.
+
+        Intended use:
+            Called by the gateway's approval notifier when a tool command is
+            blocked waiting for user approval.
+
+        How it works:
+            Zulip zform buttons do not deliver hidden callback payloads.  They
+            send visible replies, so the zform choices are exactly the text
+            commands the existing approval handler already accepts
+            (``/approve``, optional ``/approve session`` / ``/approve always``,
+            and ``/deny``).  ``session_key`` is accepted for interface parity
+            with other rich-button adapters; the resolver remains session-scoped
+            in ``tools.approval`` just like the plain-text fallback.  When
+            allow_session is false, only one-shot approval and deny are offered;
+            Session and Always are omitted.
+
+            The full command is sent as its own message first so long scripts
+            stay readable.  The zform choices are then attached to a short
+            follow-up that replies to that command message.
+        """
+        del session_key  # Interface parity; resolution is session-scoped upstream.
+
+        if smart_denied:
+            heading_line = "⚠️ **Smart DENY — owner override for one operation:**"
+            scope_note = (
+                "\n\n**Smart DENY:** owner override applies to this one operation only."
+            )
+        else:
+            heading_line = "⚠️ **Command Approval Required**"
+            scope_note = ""
+
+        # Full command in its own message so long scripts stay readable and are
+        # not trimmed to keep a widget attached.  Chunked sends leave reply_to
+        # pointing at the last chunk.
+        command_body = (
+            f"{heading_line}\n\n"
+            f"```\n{command}\n```\n"
+            f"Reason: {description}{scope_note}"
+        )
+        command_result = await self.send(
+            chat_id=chat_id,
+            content=command_body,
+            metadata=metadata,
+        )
+        if not command_result.success:
+            return command_result
+
+        text_choices = ["`/approve`"]
+        choices: List[Dict[str, Any]] = [
+            {"short_name": "Once", "long_name": "Approve once", "reply": "/approve"},
+        ]
+        if not smart_denied and allow_session:
+            text_choices.append("`/approve session`")
+            choices.append(
+                {
+                    "short_name": "Session",
+                    "long_name": "Approve this pattern for the session",
+                    "reply": "/approve session",
+                }
+            )
+            if allow_permanent:
+                text_choices.append("`/approve always`")
+                choices.append(
+                    {
+                        "short_name": "Always",
+                        "long_name": "Approve this pattern permanently",
+                        "reply": "/approve always",
+                    }
+                )
+        text_choices.append("`/deny`")
+        choices.append(
+            {"short_name": "Deny", "long_name": "Deny and cancel the command", "reply": "/deny"}
+        )
+
+        if len(text_choices) == 2:
+            choice_help = f"{text_choices[0]} or {text_choices[1]}"
+        else:
+            choice_help = ", ".join(text_choices[:-1]) + f", or {text_choices[-1]}"
+        prompt_body = (
+            "Use the buttons below, or reply with "
+            f"{choice_help}."
+        )
+        heading = _format_approval_zform_heading(command, description)
+        return await self._send_zform_choices(
+            chat_id=chat_id,
+            content=prompt_body,
+            heading=heading,
+            choices=choices,
+            reply_to=command_result.message_id,
+            metadata=metadata,
+        )
+
+    async def send_slash_confirm(
+        self,
+        chat_id: str,
+        title: str,
+        message: str,
+        session_key: str,
+        confirm_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Render a slash-command confirmation prompt as Zulip zform buttons.
+
+        Intended use:
+            Called by the gateway's generic slash-confirm primitive for commands
+            that need an explicit acknowledgement, such as ``/reload-mcp``.
+
+        How it works:
+            The zform button replies are the same text commands intercepted by
+            ``GatewayRunner`` for non-button platforms: ``/approve`` resolves
+            the prompt once, ``/always`` persists the confirmation policy, and
+            ``/cancel`` denies it.  ``confirm_id`` and ``session_key`` are kept
+            in the signature for adapter parity; Zulip's visible text replies
+            resolve via the existing session-scoped slash-confirm state.
+        """
+        body = (
+            f"**{title}**\n\n"
+            f"{message}\n\n"
+            "Use the buttons below, or reply with `/approve`, `/always`, or `/cancel`."
+        )
+        choices = [
+            {"short_name": "Approve", "long_name": "Approve once", "reply": "/approve"},
+            {"short_name": "Always", "long_name": "Always approve this action", "reply": "/always"},
+            {"short_name": "Cancel", "long_name": "Cancel", "reply": "/cancel"},
+        ]
+        return await self._send_zform_choices(
+            chat_id=chat_id,
+            content=body,
+            heading=title,
+            choices=choices,
+            metadata=metadata,
+        )
+
+    async def send_clarify(
+        self,
+        chat_id: str,
+        question: str,
+        choices: Optional[list],
+        clarify_id: str,
+        session_key: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Render a clarify prompt using Zulip zform choices when possible.
+
+        Intended use:
+            Called by the gateway-side ``clarify`` tool callback while the agent
+            thread is blocked waiting for the user's answer.
+
+        How it works:
+            For multiple-choice prompts, each zform button sends the literal
+            choice text as a normal Zulip reply.  Before sending, the adapter
+            marks the pending clarify entry as awaiting text so
+            ``GatewayRunner._maybe_intercept_clarify_text`` captures either a
+            button-emitted reply or a user-typed free-form answer.  For
+            open-ended prompts, this method falls back to the base text path.
+        """
+        if not choices:
+            return await super().send_clarify(
+                chat_id=chat_id,
+                question=question,
+                choices=choices,
+                clarify_id=clarify_id,
+                session_key=session_key,
+                metadata=metadata,
+            )
+
+        from tools.clarify_gateway import mark_awaiting_text
+
+        mark_awaiting_text(clarify_id)
+        choice_rows = [
+            {
+                "short_name": str(index),
+                "long_name": str(choice),
+                "reply": str(choice),
+            }
+            for index, choice in enumerate(choices, start=1)
+        ]
+        option_lines = "\n".join(
+            f"  {index}. {choice}"
+            for index, choice in enumerate(choices, start=1)
+        )
+        body = (
+            f"❓ {question}\n\n"
+            f"{option_lines}\n\n"
+            "Use the buttons below, or type any other answer."
+        )
+        return await self._send_zform_choices(
+            chat_id=chat_id,
+            content=body,
+            heading=str(question),
+            choices=choice_rows,
+            metadata=metadata,
+        )
+
+    # ------------------------------------------------------------------
+    # Rich delivery: images, documents, video
+    #
+    # Zulip supports file uploads via ``POST /user_uploads`` which returns
+    # a URI.  That URI is embedded in the message body using standard
+    # Markdown image/link syntax:
+    #
+    #   * Images:  ``![alt](/user_uploads/...)``  →  rendered inline
+    #   * Files:   ``[name](/user_uploads/...)``   →  rendered as link
+    #
+    # Voice messages have NO native representation in Zulip (no voice
+    # bubbles).  ``send_voice`` intentionally falls back to the base
+    # class, which sends the file path as text.
+    # ------------------------------------------------------------------
+
+    def _upload_file(
+        self,
+        file_bytes: bytes,
+        filename: str,
+    ) -> Optional[str]:
+        """Upload *file_bytes* to Zulip and return the public URI.
+
+        Returns the URI string on success (e.g. ``"/user_uploads/1/..."``),
+        or ``None`` on failure.  Logs a warning but never raises.
+        """
+        if not self._client:
+            logger.warning("Zulip: upload_file called while not connected")
+            return None
+
+        try:
+            # The Zulip client expects a file-like object.  ``upload_file``
+            # passes it to ``requests.post(files=[...])`` which reads the
+            # content and uses the ``.name`` attribute (if present) as the
+            # uploaded filename.  We wrap in ``BytesIO`` and set ``.name``
+            # so the server gets a proper filename.
+            buf = io.BytesIO(file_bytes)
+            buf.name = filename
+            send_client = self._build_send_client()
+            result = send_client.upload_file(buf)
+            if result.get("result") == "success":
+                uri = result.get("uri", "")
+                if uri:
+                    return uri
+            logger.warning(
+                "Zulip: upload_file failed — %s",
+                result.get("msg", "unknown error"),
+            )
+        except Exception as exc:
+            logger.error("Zulip: upload_file exception — %s", exc)
+        return None
+
+    async def send_image(
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Download an image URL, upload to Zulip, and send inline.
+
+        Falls back to sending the URL as plain text if the download or
+        upload fails.
+        """
+        import httpx
+
+        try:
+            async with httpx.AsyncClient(
+                timeout=30.0, follow_redirects=True,
+            ) as client:
+                resp = await client.get(
+                    image_url,
+                    headers={
+                        "User-Agent": (
+                            "Mozilla/5.0 (compatible; HermesAgent/1.0)"
+                        ),
+                        "Accept": "image/*,*/*;q=0.8",
+                    },
+                )
+                resp.raise_for_status()
+                file_bytes = resp.content
+        except Exception as exc:
+            logger.warning(
+                "Zulip: failed to download image %s: %s", image_url, exc,
+            )
+            text = f"{caption}\n{image_url}" if caption else image_url
+            return await self.send(chat_id, content=text, reply_to=reply_to, metadata=metadata)
+
+        # Derive filename from URL path.
+        url_path = image_url.rsplit("/", 1)[-1].split("?")[0]
+        ext = Path(url_path).suffix.lower() or ".png"
+        filename = f"image{ext}"
+
+        uri = await asyncio.to_thread(
+            self._upload_file, file_bytes, filename,
+        )
+        if not uri:
+            # Upload failed — fall back to URL in text.
+            text = f"{caption}\n{image_url}" if caption else image_url
+            return await self.send(chat_id, content=text, reply_to=reply_to, metadata=metadata)
+
+        alt = caption or "image"
+        content = f"![{alt}]({uri})"
+        return await self.send(chat_id, content=content, reply_to=reply_to, metadata=metadata)
+
+    async def send_image_file(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Upload a local image file and send it inline."""
+        metadata = kwargs.get("metadata")
+        p = Path(image_path)
+        if not p.exists():
+            text = f"{caption or ''}\n(file not found: {image_path})".strip()
+            return await self.send(chat_id, content=text, reply_to=reply_to, metadata=metadata)
+
+        file_bytes = p.read_bytes()
+        filename = p.name
+
+        uri = await asyncio.to_thread(
+            self._upload_file, file_bytes, filename,
+        )
+        if not uri:
+            return SendResult(
+                success=False,
+                error="File upload failed",
+            )
+
+        alt = caption or "image"
+        content = f"![{alt}]({uri})"
+        return await self.send(chat_id, content=content, reply_to=reply_to, metadata=metadata)
+
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Upload a local file and send it as a downloadable attachment.
+
+        The file is presented as a Markdown link ``[filename](uri)`` in
+        the message body, with *caption* as optional surrounding text.
+        """
+        metadata = kwargs.get("metadata")
+        p = Path(file_path)
+        if not p.exists():
+            text = f"{caption or ''}\n(file not found: {file_path})".strip()
+            return await self.send(chat_id, content=text, reply_to=reply_to, metadata=metadata)
+
+        file_bytes = p.read_bytes()
+        filename = file_name or p.name
+
+        uri = await asyncio.to_thread(
+            self._upload_file, file_bytes, filename,
+        )
+        if not uri:
+            return SendResult(
+                success=False,
+                error="File upload failed",
+            )
+
+        # Format: optional caption + markdown link to uploaded file.
+        link = f"[{filename}]({uri})"
+        content = f"{caption}\n{link}" if caption else link
+        return await self.send(chat_id, content=content, reply_to=reply_to, metadata=metadata)
+
+    async def send_video(
+        self,
+        chat_id: str,
+        video_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Upload a video file and send it as a link.
+
+        Zulip does not inline video playback.  The uploaded file is
+        presented as a clickable Markdown link.  This is the best
+        representation Zulip can provide for video content.
+        """
+        metadata = kwargs.get("metadata")
+        p = Path(video_path)
+        if not p.exists():
+            text = f"{caption or ''}\n(file not found: {video_path})".strip()
+            return await self.send(chat_id, content=text, reply_to=reply_to, metadata=metadata)
+
+        file_bytes = p.read_bytes()
+        filename = p.name
+
+        uri = await asyncio.to_thread(
+            self._upload_file, file_bytes, filename,
+        )
+        if not uri:
+            return SendResult(
+                success=False,
+                error="Video upload failed",
+            )
+
+        link = f"[{filename}]({uri})"
+        content = f"{caption}\n{link}" if caption else link
+        return await self.send(chat_id, content=content, reply_to=reply_to, metadata=metadata)
+
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ):
+        """Send an audio file as a downloadable attachment.
+
+        Zulip has no native voice message bubbles, so we upload the audio
+        file and send it as a link (same as other file types).
+        """
+        return await self.send_document(
+            chat_id=chat_id,
+            file_path=audio_path,
+            caption=caption,
+            file_name=kwargs.get("file_name"),
+            reply_to=reply_to,
+            metadata=kwargs.get("metadata"),
+        )
+
+    # ------------------------------------------------------------------
+    # Internal: sending
+    # ------------------------------------------------------------------
+
+    def _do_send_message(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        widget_content: Optional[str] = None,
+    ) -> SendResult:
+        """Build the correct request dict and call the Zulip API.
+
+        This is synchronous because the Zulip client is not async.  Rich prompt
+        helpers pass ``widget_content`` when they need Zulip to render a
+        message widget such as zform; ordinary sends leave it unset so the
+        request remains a normal text message.
+        """
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        send_client = self._build_send_client()
+
+        parsed = _parse_stream_chat_id(chat_id)
+        if parsed:
+            stream_id, topic = parsed
+            request = {
+                "type": "stream",
+                "to": str(stream_id),
+                "topic": topic,
+                "content": content,
+            }
+        else:
+            named_stream = _parse_stream_name_topic(chat_id)
+            if named_stream:
+                stream_name, topic = named_stream
+                result = send_client.get_stream_id(stream_name)
+                if result.get("result") != "success":
+                    return SendResult(
+                        success=False,
+                        error=result.get("msg", f"Stream '{stream_name}' not found"),
+                    )
+                stream_id = result.get("stream_id")
+                if stream_id is None:
+                    return SendResult(success=False, error=f"Stream '{stream_name}' not found")
+                request = {
+                    "type": "stream",
+                    "to": str(stream_id),
+                    "topic": topic,
+                    "content": content,
+                }
+            elif is_dm_chat_id(chat_id):
+                email = _parse_dm_chat_id(chat_id)
+                request = {
+                    "type": "private",
+                    "to": [email],
+                    "content": content,
+                }
+            elif is_group_dm_chat_id(chat_id):
+                emails = _parse_group_dm_chat_id(chat_id)
+                if emails:
+                    request = {
+                        "type": "private",
+                        "to": emails,
+                        "content": content,
+                    }
+                else:
+                    return SendResult(success=False, error="Invalid group DM chat ID")
+            else:
+                # Fallback: treat as DM to the email itself.
+                request = {
+                    "type": "private",
+                    "to": [chat_id],
+                    "content": content,
+                }
+
+        if widget_content is not None:
+            request["widget_content"] = widget_content
+
+        try:
+            result = send_client.send_message(request)
+            if result.get("result") == "success":
+                msg_id = result.get("id")
+                return SendResult(success=True, message_id=str(msg_id) if msg_id else None)
+            else:
+                return SendResult(
+                    success=False,
+                    error=result.get("msg", "send failed"),
+                )
+        except Exception as exc:
+            logger.error("Zulip: send_message failed — %s", exc)
+            return SendResult(success=False, error=str(exc))
+
+    def _build_typing_request(
+        self, chat_id: str, op: str = "start"
+    ) -> Optional[Dict[str, Any]]:
+        """Return a typing request dict for ``set_typing_status``.
+
+        Zulip typing API quirks (both paths now robust):
+        * Streams/channels: MUST use ``{"stream_id": N, "topic": "...", "type": "stream"}``.
+          The legacy ``{"to": [stream_name]}`` form is no longer reliable
+          (community patch + on-demand resolver fixed this).
+        * DMs (1:1 or group): MUST use ``{"to": [integer_user_id, ...], "type": "direct"}``.
+          Emails (even as strings) are rejected by the server. See the long
+          comment on ``_user_id_cache`` and the population site in
+          ``_dispatch_inbound``.
+        On-demand resolvers + caches make this work even on first message to
+        a stream/user in the process lifetime.
+        """
+        parsed = _parse_stream_chat_id(chat_id)
+        if parsed:
+            stream_id, topic = parsed
+            return _build_stream_typing_request(stream_id, topic, op)
+
+        named_stream = _parse_stream_name_topic(chat_id)
+        if named_stream:
+            stream_name, topic = named_stream
+            key = stream_name.lower()
+            stream_id = self._stream_id_cache.get(key)
+            if stream_id is None:
+                stream_id = self._resolve_stream_id(stream_name)
+            if stream_id is not None:
+                return _build_stream_typing_request(stream_id, topic, op)
+
+            # Only as a last-ditch fallback (should rarely happen now)
+            logger.debug("Zulip: falling back to legacy stream name for typing of %r", chat_id)
+            return {"to": [stream_name], "type": "stream", "op": op}
+
+        dm_email = _parse_dm_chat_id(chat_id)
+        if dm_email:
+            key = dm_email.lower()
+            user_id = self._user_id_cache.get(key)
+            if user_id is None:
+                user_id = self._resolve_user_id(dm_email)
+            if user_id is not None:
+                return {"to": [user_id], "type": "direct", "op": op}
+            logger.warning("Zulip: could not resolve DM email %r to user ID for typing (no cache hit, resolution failed)", dm_email)
+            # Do not fall back to email — Zulip rejects non-integer user IDs for direct typing
+            return None
+        return None
+
+    def _resolve_stream_id(self, stream_name: str) -> Optional[int]:
+        """Best-effort live lookup of stream name → ID using the Zulip client.
+
+        Populates both caches on success. Used by the typing path so we don't
+        depend on the background stream list having run yet (e.g. first typing
+        indicator before any messages arrived in a stream).
+
+        Follows the same cache + on-demand pattern as the user_id resolver
+        for DM typing.
+        """
+        if not self._client or not stream_name:
+            return None
+        key = stream_name.lower()
+        try:
+            result = self._client.get_streams()
+            for s in result.get("streams", []):
+                if s.get("name", "").lower() == key:
+                    sid = s["stream_id"]
+                    self._stream_id_cache[key] = sid
+                    self._stream_name_cache[sid] = s["name"]
+                    logger.debug("Zulip: on-demand resolved stream %r -> id=%s for typing", stream_name, sid)
+                    return sid
+        except Exception as exc:
+            logger.warning("Zulip: on-demand stream resolution failed for %r: %s", stream_name, exc)
+        return None
+
+    def _resolve_user_id(self, email: str) -> Optional[int]:
+        """Best-effort lookup of user email → user_id for DM typing.
+
+        Zulip's set_typing_status for direct messages (type="direct") *requires*
+        integer user IDs in the "to" field — emails are rejected at the API
+        level (this was the root cause of DM typing being completely silent).
+
+        We primarily populate the cache from inbound "sender_id" in
+        _dispatch_inbound (Zulip always sends numeric IDs in message events).
+        This on-demand path (via the zulip client's get_user helper, which
+        does a /users/{email} lookup) is the fallback for the first outbound
+        typing indicator to a user we have never received a message from yet.
+        """
+        if not email or not self._client:
+            return None
+        key = email.lower()
+        if key in self._user_id_cache:
+            return self._user_id_cache[key]
+        try:
+            # Standard zulip client helper
+            result = self._client.get_user(email=email)
+            if result.get("result") == "success":
+                user = result.get("user") or {}
+                uid = user.get("user_id")
+                if uid:
+                    self._user_id_cache[key] = uid
+                    logger.debug("Zulip: on-demand resolved user %r -> id=%s for typing", email, uid)
+                    return uid
+        except Exception as exc:
+            logger.warning("Zulip: on-demand user resolution failed for %r: %s", email, exc)
+        return None
+
+    # ------------------------------------------------------------------
+    # Internal: event queue
+    # ------------------------------------------------------------------
+
+    # ------------------------------------------------------------------
+    # Internal: missed-message catch-up (opt-in; see __init__)
+    # ------------------------------------------------------------------
+
+    def _catchup_watermark_path(self) -> Path:
+        """Path to the persisted per-stream catch-up watermark file.
+
+        Stored under HERMES_HOME so it survives restarts on the state volume;
+        falls back to beside this module in dev/test environments.
+        """
+        try:
+            from hermes_constants import get_hermes_home
+
+            return get_hermes_home() / "zulip_catchup_watermarks.json"
+        except Exception:
+            return Path(__file__).parent / "zulip_catchup_watermarks.json"
+
+    def _read_catchup_watermarks(self) -> Dict[str, int]:
+        """Load ``{stream_name: last_seen_msg_id}``; returns ``{}`` on any error."""
+        try:
+            data = json.loads(
+                self._catchup_watermark_path().read_text(encoding="utf-8")
+            )
+            if isinstance(data, dict):
+                return {
+                    str(k): int(v)
+                    for k, v in data.items()
+                    if isinstance(v, (int, float)) and int(v) > 0
+                }
+        except Exception:
+            pass
+        return {}
+
+    def _write_catchup_watermark(self, stream_name: str, msg_id: int) -> None:
+        """Persist a stream's watermark monotonically (never moves backward)."""
+        path = self._catchup_watermark_path()
+        try:
+            try:
+                existing = json.loads(path.read_text(encoding="utf-8"))
+                if not isinstance(existing, dict):
+                    existing = {}
+            except Exception:
+                existing = {}
+            if int(existing.get(stream_name, 0) or 0) >= msg_id:
+                return
+            existing[stream_name] = msg_id
+            tmp = path.with_suffix(".tmp")
+            tmp.write_text(json.dumps(existing), encoding="utf-8")
+            tmp.replace(path)
+        except Exception as exc:
+            logger.warning(
+                "Zulip: catch-up: failed to persist watermark for %r: %s",
+                stream_name, exc,
+            )
+
+    @staticmethod
+    def _stream_name_from_message(message: Dict[str, Any]) -> str:
+        """Lower-cased stream name from a stream message, else ``''``."""
+        recipient = message.get("display_recipient")
+        return recipient.lower() if isinstance(recipient, str) else ""
+
+    def _advance_catchup_watermark(self, message: Dict[str, Any]) -> None:
+        """Move a stream's watermark forward as messages flow (live or replayed).
+
+        Called from :meth:`_on_zulip_event` for every stream message so the next
+        (re-)register resumes from a current position instead of re-fetching
+        already-seen messages.  No-op when catch-up is disabled.
+        """
+        if not self._catchup_enabled:
+            return
+        if message.get("type") != "stream":
+            return
+        stream_name = self._stream_name_from_message(message)
+        msg_id = int(message.get("id", 0) or 0)
+        if stream_name and msg_id > 0:
+            self._write_catchup_watermark(stream_name, msg_id)
+
+    def _run_missed_message_catchup(self) -> None:
+        """Back-fill messages that arrived while the event queue was down.
+
+        Runs synchronously in the event-queue thread immediately before the
+        live queue (re-)registers.  For each known stream:
+
+        * **No stored watermark (first run):** record the newest message id as a
+          baseline and back-fill nothing — a clean start never replays history.
+        * **Stored watermark:** fetch up to ``catchup_max_messages`` messages
+          after it and feed each through :meth:`_on_zulip_event` — the same path
+          live events take, so ``_seen_events`` dedups any sweep/live overlap and
+          mention-gating still applies.
+
+        Best-effort: any per-stream error is logged and skipped so a transient
+        failure never blocks the queue from coming up.
+        """
+        if not self._client or not self._stream_id_cache:
+            return
+        if not self._loop or self._loop.is_closed():
+            return
+
+        watermarks = self._read_catchup_watermarks()
+        send_client = self._build_send_client()
+
+        for stream_name in sorted(self._stream_id_cache):
+            if self._closing:
+                return
+            watermark = watermarks.get(stream_name, 0)
+            try:
+                if watermark <= 0:
+                    # First run for this stream — seed to newest, no back-fill.
+                    result = send_client.get_messages({
+                        "anchor": "newest",
+                        "num_before": 1,
+                        "num_after": 0,
+                        "narrow": [["stream", stream_name]],
+                        "apply_markdown": False,
+                    })
+                    if result.get("result") == "success":
+                        msgs = result.get("messages", [])
+                        newest = msgs[-1].get("id", 0) if msgs else 0
+                        if newest > 0:
+                            self._write_catchup_watermark(stream_name, newest)
+                    continue
+
+                result = send_client.get_messages({
+                    "anchor": watermark + 1,
+                    "num_before": 0,
+                    "num_after": self._catchup_max_messages,
+                    "narrow": [["stream", stream_name]],
+                    "apply_markdown": False,
+                })
+            except Exception as exc:
+                logger.warning(
+                    "Zulip: catch-up: fetch failed for %r: %s", stream_name, exc
+                )
+                continue
+
+            if result.get("result") != "success":
+                continue
+
+            replayed = 0
+            for msg in result.get("messages", []):
+                if self._closing:
+                    return
+                if int(msg.get("id", 0) or 0) <= watermark:
+                    continue  # anchor is inclusive — skip the watermark itself
+                # Feed through the live event path: dedup, gating, dispatch, and
+                # watermark advance all happen there, identical to a live event.
+                self._on_zulip_event(
+                    {"type": "message", "op": "add", "message": msg}
+                )
+                replayed += 1
+            if replayed:
+                logger.info(
+                    "Zulip: catch-up: replayed %d missed message(s) on #%s",
+                    replayed, stream_name,
+                )
+
+    def _run_event_queue(self) -> None:
+        """Run the Zulip event queue in the current thread.
+
+        Uses ``call_on_each_event`` which internally handles long-polling
+        and basic reconnection.  Wraps with our own exponential backoff
+        for the cases where the Zulip client's internal retry gives up.
+
+        The backoff sleep uses :pymeth:`threading.Event.wait` so that
+        :meth:`disconnect` can wake the thread immediately instead of
+        waiting for the full delay to elapse.
+        """
+        delay = _RECONNECT_BASE_DELAY
+        self._consecutive_failures = 0
+
+        while not self._closing:
+            # Back-fill messages missed while the queue was down (opt-in) before
+            # going live.  No-op unless catch-up is enabled; runs on every
+            # (re-)register so both boot and mid-run queue expiry are covered.
+            if self._catchup_enabled:
+                self._run_missed_message_catchup()
+                if self._closing:
+                    return
+            try:
+                self._client.call_on_each_event(
+                    self._on_zulip_event,
+                    event_types=["message"],
+                    apply_markdown=False,
+                )
+                # ``call_on_each_event`` returned — server closed the
+                # event queue stream or the client hit an internal limit.
+                if self._closing:
+                    return
+                logger.info("Zulip: event queue stream ended — reconnecting")
+                self._consecutive_failures = 0
+                delay = _RECONNECT_BASE_DELAY
+                continue
+            except Exception as exc:
+                if self._closing:
+                    return
+
+                self._consecutive_failures += 1
+                retryable = _is_retryable_error(exc)
+
+                if not retryable:
+                    logger.error(
+                        "Zulip: non-retryable error (attempt %d): %s — "
+                        "stopping event queue",
+                        self._consecutive_failures,
+                        type(exc).__name__,
+                    )
+                    self._set_fatal_error(
+                        "ZULIP_EVENT_QUEUE_FATAL",
+                        f"Non-retryable error: {type(exc).__name__}: {exc}",
+                        retryable=False,
+                    )
+                    return
+
+                logger.warning(
+                    "Zulip: event queue error (attempt %d): %s — "
+                    "reconnecting in %.0fs",
+                    self._consecutive_failures,
+                    type(exc).__name__,
+                    delay,
+                )
+
+            if self._closing:
+                return
+
+            # Exponential backoff with jitter.
+            jitter = delay * _RECONNECT_JITTER * random.random()
+            sleep_time = delay + jitter
+            if self._consecutive_failures > 1:
+                logger.info(
+                    "Zulip: waiting %.1fs before reconnect attempt %d",
+                    sleep_time,
+                    self._consecutive_failures + 1,
+                )
+            if self._shutdown_event.wait(timeout=sleep_time):
+                return  # Shutdown signal received during backoff.
+            delay = min(delay * 2, _RECONNECT_MAX_DELAY)
+
+    def _on_zulip_event(self, event: Dict[str, Any]) -> None:
+        """Callback invoked by ``call_on_each_event`` for each event.
+
+        Runs in the event-queue thread.  Schedules the actual processing
+        on the asyncio event loop via ``call_soon_threadsafe``.
+        """
+        if self._closing:
+            return
+
+        # Defense in depth: verify event shape.  The server-side filter
+        # should only deliver "message" events, but validate anyway.
+        event_type = event.get("type", "")
+        if event_type != "message":
+            logger.debug(
+                "Zulip: ignoring non-message event (type=%s)",
+                event_type,
+            )
+            return
+
+        event_op = event.get("op", "add")
+        if event_op != "add":
+            # Edits/deletes come through as different event types or
+            # ops — we only handle new-message creation.
+            logger.debug(
+                "Zulip: ignoring message event with op=%s",
+                event_op,
+            )
+            return
+
+        # Extract message payload.
+        message = event.get("message")
+        if not message or not isinstance(message, dict):
+            return
+
+        # Dedup by Zulip message ID.
+        msg_id = str(message.get("id", ""))
+        self._prune_seen()
+        if msg_id and msg_id in self._seen_events:
+            return
+        if msg_id:
+            self._seen_events[msg_id] = time.time()
+
+        # Keep the catch-up watermark current as messages flow (no-op when
+        # catch-up is disabled), so the next (re-)register resumes from here.
+        self._advance_catchup_watermark(message)
+
+        # Filter self-messages.
+        sender_email = message.get("sender_email", "")
+        sender_id = message.get("sender_id", -1)
+        if sender_email == self._bot_email or sender_id == self._bot_user_id:
+            return
+
+        # Schedule async processing on the main event loop.
+        msg_type_log = message.get("type", "unknown")
+        logger.debug(
+            "Zulip: inbound msg_id=%s sender=%s type=%s",
+            msg_id,
+            sender_email,
+            msg_type_log,
+        )
+        if self._loop and not self._loop.is_closed():
+            future = asyncio.run_coroutine_threadsafe(
+                self._dispatch_inbound(message, event), self._loop
+            )
+            self._event_futures.add(future)
+
+            def _discard_done(done_future):
+                self._event_futures.discard(done_future)
+                if done_future.cancelled():
+                    return
+                try:
+                    done_future.result()
+                except Exception:
+                    logger.exception("Zulip: inbound dispatch task failed")
+
+            future.add_done_callback(_discard_done)
+
+    async def _fetch_context(
+        self, stream_name: str, topic: str
+    ) -> list:
+        """Fetch recent messages from a stream+topic via Zulip's /messages API.
+
+        Returns a list of formatted context lines like ``["Alice: hello", ...]``,
+        skipping the bot's own messages.  Runs the synchronous HTTP call in a
+        thread executor so the event loop is never blocked.
+
+        Returns an empty list on any failure — context is best-effort.
+        """
+        if self._context_depth <= 0:
+            return []
+
+        send_client = self._build_send_client()
+        try:
+            result = await asyncio.to_thread(
+                send_client.get_messages,
+                {
+                    "anchor": "newest",
+                    "num_before": self._context_depth,
+                    "num_after": 0,
+                    "narrow": [
+                        ["stream", stream_name],
+                        ["topic", topic],
+                    ],
+                    "apply_markdown": False,
+                },
+            )
+        except Exception as exc:
+            logger.warning("Zulip: context fetch failed — %s", exc)
+            return []
+
+        if result.get("result") != "success":
+            logger.debug(
+                "Zulip: context fetch error for #%s > %s — %s",
+                stream_name, topic, result.get("msg", "unknown"),
+            )
+            return []
+
+        messages = result.get("messages", [])
+        context_lines = []
+        for msg in reversed(messages):
+            sender = msg.get("sender_full_name") or msg.get("sender_email", "?")
+            content = (msg.get("content") or "").strip()
+            # Skip the bot's own messages and empty content.
+            if msg.get("sender_email") == self._bot_email:
+                continue
+            if not content:
+                continue
+            context_lines.append(f"{sender}: {content}")
+
+        logger.debug(
+            "Zulip: fetched %d context messages for #%s > %s (requested %d)",
+            len(context_lines), stream_name, topic, self._context_depth,
+        )
+        return context_lines
+
+    async def _fetch_inbound_uploads(
+        self, content: str
+    ) -> Tuple[List[str], List[str]]:
+        """Materialize all triggering-message uploads into the Hermes cache.
+
+        Zulip sends files as Markdown links, not structured event attachments.
+        The shared downloader obtains the temporary authenticated URL, caches
+        images/audio/video/documents by MIME type, and returns a path the agent
+        can access. A failed or oversized upload never drops the text message.
+        """
+        paths = extract_upload_paths(content)
+        if not paths:
+            return [], []
+
+        local_paths: List[str] = []
+        mime_types: List[str] = []
+        for path in paths:
+            try:
+                downloaded = await download_zulip_upload(
+                    site_url=self._site_url,
+                    bot_email=self._bot_email,
+                    api_key=self._api_key,
+                    path=path,
+                )
+                local_paths.append(downloaded.path)
+                mime_types.append(downloaded.mime_type)
+            except Exception as exc:
+                logger.warning("Zulip: failed to fetch upload %s — %s", path, exc)
+
+        if local_paths:
+            logger.info("Zulip: downloaded %d inbound attachment(s)", len(local_paths))
+        return local_paths, mime_types
+
+    async def _dispatch_inbound(self, message: Dict[str, Any], raw_event: Dict[str, Any]) -> None:
+        """Process an inbound message on the asyncio event loop.
+
+        For stream @mentions, fetches recent context from Zulip's /messages API
+        and injects it before the user's message so the agent has full awareness.
+        """
+
+        # Determine message type and chat context.
+        msg_type_name = message.get("type", "")  # "stream" or "private"
+        content = message.get("content", "")
+        sender_email = message.get("sender_email", "")
+        sender_full_name = message.get("sender_full_name", "") or sender_email
+        sender_id = message.get("sender_id", -1)
+        msg_id = str(message.get("id", ""))
+
+        # Reject whitespace-only content early (before type-specific logic).
+        if not content or not content.strip():
+            return
+
+        track_only = False  # May be set to True in stream block below
+
+        if msg_type_name == "stream":
+            stream_id = message.get("stream_id", -1)
+            topic = message.get("subject") or "(no topic)"
+            chat_id = _build_stream_chat_id(stream_id, topic)
+            chat_type = "stream"
+            chat_name = _resolve_stream_name(
+                message, stream_id, self._stream_name_cache
+            )
+            chat_topic = topic
+            user_id = sender_email
+            user_name = sender_full_name
+
+            # Check for @mention of the bot in stream messages.
+            # DMs are always processed.
+            mention_patterns = [
+                f"@**{self._bot_full_name}**",
+                f"@{self._bot_email}",
+                # Zulip wildcard mentions that should wake the bot.
+                "@**all**",
+                "@**everyone**",
+            ]
+
+            # Determine if this stream requires a mention.
+            require_mention = self._require_mention
+            if require_mention and self._free_response_streams:
+                # Check by stream name or stream ID.
+                stream_name_lower = chat_name.lower()
+                stream_id_str = str(stream_id)
+                if (stream_name_lower in self._free_response_streams
+                        or stream_id_str in self._free_response_streams):
+                    require_mention = False
+
+            if require_mention:
+                has_mention = any(
+                    pattern.lower() in content.lower()
+                    for pattern in mention_patterns
+                )
+                if not has_mention:
+                    logger.debug(
+                        "Zulip: skipping stream message without @mention "
+                        "(stream=%s, topic=%s)",
+                        chat_name,
+                        topic,
+                    )
+                    return
+
+            # Fetch historical context from the same stream+topic via Zulip's
+            # /messages API.  The bot gets full awareness of the conversation
+            # even for messages that arrived while it was disconnected.
+            if self._context_depth > 0:
+                context = await self._fetch_context(chat_name, topic)
+                if context:
+                    content = _format_context_block(context) + content
+
+            # Strip the bot mention from content so the agent sees
+            # only the user's actual message (follows Slack/Discord pattern).
+            bot_mention_only = [
+                f"@**{self._bot_full_name}**",
+                f"@{self._bot_email}",
+            ]
+            content = _strip_bot_mention(content, bot_mention_only)
+        elif msg_type_name == "private":
+            display_recipient = message.get("display_recipient")
+            recipients = _extract_dm_recipients(
+                display_recipient, self._bot_email, sender_email
+            )
+
+            if len(recipients) > 1:
+                # Group DM (3+ original participants including bot).
+                chat_id = _build_group_dm_chat_id(recipients)
+                chat_type = "group"
+                chat_name = ", ".join(recipients)
+            else:
+                # 1:1 DM.
+                chat_id = _build_dm_chat_id(recipients[0] if recipients else sender_email)
+                chat_type = "dm"
+                chat_name = recipients[0] if recipients else sender_email
+
+            chat_topic = None
+            user_id = sender_email
+            user_name = sender_full_name
+
+            # Cache sender email -> user_id for DM typing.
+            # Zulip typing for DMs requires the integer IDs (see _user_id_cache
+            # declaration and _resolve_user_id for the full rationale).
+            if sender_id > 0 and sender_email:
+                self._user_id_cache[sender_email.lower()] = sender_id
+        else:
+            logger.debug("Zulip: ignoring message of type '%s'", msg_type_name)
+            return
+
+        # Determine message_type.
+        mt = MessageType.TEXT
+        if content.startswith("/") or content.startswith("!"):
+            mt = MessageType.COMMAND
+
+        # Reply-to detection (Zulip uses top-level reply metadata).
+        reply_to_id = None
+        # The Zulip event includes the message we're replying to in some
+        # cases — but for now we handle outbound replies in send() via
+        # the reply_to parameter.
+
+        source = self.build_source(
+            chat_id=chat_id,
+            chat_name=chat_name,
+            chat_type=chat_type,
+            user_id=user_id,
+            user_name=user_name,
+            chat_topic=chat_topic,
+        )
+
+        # Download uploads from the TRIGGERING message. Parsed from raw message
+        # content, not context-prepended text, so historical context stays as
+        # text links until the agent explicitly requests an attachment tool.
+        media_urls: List[str] = []
+        media_types: List[str] = []
+        raw_content = message.get("content") or ""
+        # Do not fetch arbitrary files from users who will later fail the
+        # gateway authorization gate. This mirrors adapters that treat
+        # third-party context as untrusted and avoids spending bandwidth/cache
+        # space before the message reaches the runner.
+        sender_authorized = self._is_sender_authorized(
+            user_id, chat_type, chat_id,
+        )
+        if sender_authorized is False:
+            logger.debug("Zulip: skipping uploads from unauthorized sender %s", user_id)
+        elif "/user_uploads/" in raw_content:
+            media_urls, media_types = await self._fetch_inbound_uploads(
+                raw_content
+            )
+
+        msg_event = MessageEvent(
+            text=content,
+            message_type=mt,
+            source=source,
+            raw_message=raw_event,
+            message_id=msg_id,
+            reply_to_message_id=reply_to_id,
+            media_urls=media_urls,
+            media_types=media_types,
+        )
+
+        # Schedule the handler coroutine on the event loop.
+        asyncio.ensure_future(self.handle_message(msg_event))
+
+    # ------------------------------------------------------------------
+    # Internal: caches & helpers
+    # ------------------------------------------------------------------
+
+    def _refresh_stream_cache(self) -> None:
+        """Fetch all streams and cache name ↔ ID mappings."""
+        if not self._client:
+            return
+        try:
+            result = self._client.get_streams()
+            if result.get("result") == "success":
+                for stream in result.get("streams", []):
+                    sid = stream.get("stream_id")
+                    name = stream.get("name", "")
+                    if sid is not None and name:
+                        self._stream_id_cache[name.lower()] = sid
+                        self._stream_name_cache[sid] = name
+                logger.info(
+                    "Zulip: cached %d streams", len(self._stream_id_cache)
+                )
+        except Exception as exc:
+            logger.warning("Zulip: failed to fetch streams — %s", exc)
+
+    def _prune_seen(self) -> None:
+        """Remove expired entries from the dedup cache."""
+        if len(self._seen_events) < self._SEEN_MAX:
+            return
+        now = time.time()
+        self._seen_events = {
+            eid: ts
+            for eid, ts in self._seen_events.items()
+            if now - ts < self._SEEN_TTL
+        }
+
+
+def _zulip_configured(config: PlatformConfig) -> bool:
+    extra = getattr(config, "extra", {}) or {}
+    return bool(
+        extra.get("site_url")
+        and extra.get("bot_email")
+        and (
+            getattr(config, "token", None)
+            or getattr(config, "api_key", None)
+            or os.getenv("ZULIP_API_KEY", "").strip()
+        )
+    )
+
+
+def _env_enablement() -> Optional[dict]:
+    """Seed PlatformConfig.extra/home_channel from ZULIP_* env vars."""
+    api_key = os.getenv("ZULIP_API_KEY", "").strip()
+    bot_email = os.getenv("ZULIP_BOT_EMAIL", "").strip()
+    site_url = os.getenv("ZULIP_SITE_URL", "").strip()
+    default_stream = os.getenv("ZULIP_DEFAULT_STREAM", "").strip()
+    home_topic = os.getenv("ZULIP_HOME_TOPIC", "").strip()
+    home_channel = os.getenv("ZULIP_HOME_CHANNEL", "").strip()
+
+    if not any([api_key, bot_email, site_url, default_stream, home_topic, home_channel]):
+        return None
+
+    if api_key and not bot_email:
+        logger.warning("ZULIP_API_KEY set but ZULIP_BOT_EMAIL is missing")
+    if api_key and not site_url:
+        logger.warning("ZULIP_API_KEY set but ZULIP_SITE_URL is missing")
+
+    seed: dict[str, Any] = {
+        "site_url": site_url,
+        "bot_email": bot_email,
+    }
+    if default_stream:
+        seed["default_stream"] = default_stream
+    if home_topic:
+        seed["home_topic"] = home_topic
+    catchup = os.getenv("ZULIP_CATCHUP", "").strip()
+    if catchup:
+        seed["catchup_enabled"] = catchup
+    catchup_max = os.getenv("ZULIP_CATCHUP_MAX_MESSAGES", "").strip()
+    if catchup_max:
+        seed["catchup_max_messages"] = catchup_max
+
+    home_chat_id = home_channel
+    if not home_chat_id and default_stream and home_topic:
+        home_chat_id = default_stream
+    if home_topic and home_chat_id and ":" not in home_chat_id:
+        home_chat_id = f"{home_chat_id}:{home_topic}"
+    if home_chat_id:
+        seed["home_channel"] = {
+            "chat_id": home_chat_id,
+            "name": os.getenv("ZULIP_HOME_CHANNEL_NAME", "Home"),
+        }
+
+    return seed
+
+
+def _apply_yaml_config(yaml_cfg: dict, zulip_cfg: dict) -> Optional[dict]:
+    """Translate config.yaml ``zulip:`` keys into env vars/extras.
+
+    Env vars keep precedence. Returned values are merged into
+    ``PlatformConfig.extra`` by the gateway config loader.
+    """
+    extra: dict[str, Any] = {}
+
+    def _string_key(key: str, env_name: str) -> None:
+        value = zulip_cfg.get(key)
+        if value is None:
+            return
+        text = str(value).strip()
+        if text and not os.getenv(env_name):
+            os.environ[env_name] = text
+        if text and key not in {"api_key", "token"}:
+            extra[key] = text
+
+    _string_key("site_url", "ZULIP_SITE_URL")
+    _string_key("bot_email", "ZULIP_BOT_EMAIL")
+    # Accept either key name in YAML; PlatformConfig.from_dict handles token
+    # natively, while this env bridge lets the adapter and search tool continue
+    # to work in env-driven paths.
+    _string_key("api_key", "ZULIP_API_KEY")
+    _string_key("token", "ZULIP_API_KEY")
+    _string_key("default_stream", "ZULIP_DEFAULT_STREAM")
+    _string_key("home_topic", "ZULIP_HOME_TOPIC")
+    _string_key("cert_bundle", "ZULIP_CERT_BUNDLE")
+    _string_key("allow_insecure", "ZULIP_ALLOW_INSECURE")
+    _string_key("require_mention", "ZULIP_REQUIRE_MENTION")
+    _string_key("free_response_streams", "ZULIP_FREE_RESPONSE_STREAMS")
+    _string_key("context_depth", "ZULIP_CONTEXT_DEPTH")
+    _string_key("catchup_enabled", "ZULIP_CATCHUP")
+    _string_key("catchup_max_messages", "ZULIP_CATCHUP_MAX_MESSAGES")
+
+    return extra or None
+
+
+def _iter_standalone_media(media_files) -> List[Tuple[str, bool]]:
+    """Normalize standalone media_files to (path, is_voice) pairs."""
+    items: List[Tuple[str, bool]] = []
+    for item in media_files or []:
+        if isinstance(item, (tuple, list)) and item:
+            path = str(item[0] or "").strip()
+            is_voice = bool(item[1]) if len(item) > 1 else False
+        elif item:
+            path = str(item).strip()
+            is_voice = False
+        else:
+            continue
+        if path:
+            items.append((path, is_voice))
+    return items
+
+
+async def _standalone_send_zulip(
+    pconfig: PlatformConfig,
+    chat_id: str,
+    message: str,
+    *,
+    thread_id: Optional[str] = None,
+    media_files: Optional[List] = None,
+    force_document: bool = False,
+) -> dict:
+    """Send a Zulip message from out-of-process callers such as cron.
+
+    Text uses ``adapter.send``. Attachments reuse the live adapter upload
+    helpers (``send_image_file`` / ``send_video`` / ``send_document``),
+    which talk to Zulip via a throwaway ``_build_send_client()`` — no
+    event-queue connection required. A media failure is reported in
+    ``warnings`` so the digest still lands.
+    """
+    if not check_zulip_requirements(pconfig):
+        return {
+            "error": (
+                "Zulip SDK or credentials are unavailable. Configure "
+                "ZULIP_SITE_URL, ZULIP_BOT_EMAIL, and ZULIP_API_KEY, or "
+                "preinstall with: pip install 'hermes-agent[zulip]'"
+            )
+        }
+
+    adapter = ZulipAdapter(pconfig)
+    # ``send()`` treats ``_client is not None`` as the connected guard. Standalone
+    # sends do not run the long-polling event queue, so mark the adapter ready
+    # without sharing a live event client. Uploads use ``_build_send_client()``.
+    adapter._client = object()
+    metadata = {"thread_id": thread_id} if thread_id else None
+    media_items = _iter_standalone_media(media_files)
+    text = (message or "").strip()
+    warnings: List[str] = []
+    last_message_id = None
+    delivered = False
+
+    if text or not media_items:
+        result = await adapter.send(chat_id, message, metadata=metadata)
+        if not result.success:
+            return {"error": result.error or "Zulip send failed"}
+        last_message_id = result.message_id
+        delivered = True
+
+    for path, _is_voice in media_items:
+        ext = Path(path).suffix.lower()
+        try:
+            if not force_document and ext in _STANDALONE_IMAGE_EXTS:
+                result = await adapter.send_image_file(
+                    chat_id, path, metadata=metadata,
+                )
+            elif not force_document and ext in _STANDALONE_VIDEO_EXTS:
+                result = await adapter.send_video(
+                    chat_id, path, metadata=metadata,
+                )
+            else:
+                result = await adapter.send_document(
+                    chat_id, path, metadata=metadata,
+                )
+        except Exception as exc:
+            warning = f"Failed to send media {path}: {exc}"
+            logger.error("Zulip standalone: %s", warning, exc_info=True)
+            warnings.append(warning)
+            continue
+        if result.success:
+            last_message_id = result.message_id or last_message_id
+            delivered = True
+        else:
+            warnings.append(
+                f"Failed to send media {path}: {result.error or 'upload failed'}"
+            )
+
+    if not delivered:
+        error = "No deliverable text or media remained after processing"
+        if warnings:
+            return {"error": error, "warnings": warnings}
+        return {"error": error}
+
+    payload = {
+        "success": True,
+        "platform": "zulip",
+        "chat_id": chat_id,
+        "message_id": last_message_id,
+    }
+    if warnings:
+        payload["warnings"] = warnings
+    return payload
+
+
+def interactive_setup() -> None:
+    """Interactive ``hermes gateway setup`` flow for Zulip."""
+    print()
+    print("Zulip setup")
+    print("-----------")
+    print("Create a Zulip bot, then copy its site URL, bot email, and API key.")
+    print()
+
+    try:
+        from hermes_cli.config import get_env_var, set_env_var
+    except ImportError:
+        print("hermes_cli.config not available; set ZULIP_* vars manually in ~/.hermes/.env")
+        return
+
+    def _prompt(var: str, label: str, *, secret: bool = False) -> None:
+        existing = get_env_var(var) if callable(get_env_var) else None
+        suffix = " [keep current]" if existing else ""
+        try:
+            if secret:
+                from hermes_cli.secret_prompt import masked_secret_prompt
+                value = masked_secret_prompt(f"{label}{suffix}: ")
+            else:
+                value = input(f"{label}{suffix}: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return
+        if value:
+            set_env_var(var, value)
+
+    _prompt("ZULIP_SITE_URL", "Zulip site URL")
+    _prompt("ZULIP_BOT_EMAIL", "Bot email")
+    _prompt("ZULIP_API_KEY", "Bot API key", secret=True)
+    _prompt("ZULIP_DEFAULT_STREAM", "Default stream (optional)")
+    _prompt("ZULIP_HOME_TOPIC", "Home topic for cron delivery (optional)")
+    _prompt("ZULIP_HOME_CHANNEL", "Home stream or stream:topic (optional)")
+    _prompt("ZULIP_ALLOWED_USERS", "Allowed user emails (comma-separated; blank=skip)")
+    print("Done. Run `hermes gateway status` to verify Zulip configuration.")
+
+
+def register(ctx) -> None:
+    """Plugin entry point — called by the Hermes plugin system."""
+    ctx.register_platform(
+        name="zulip",
+        label="Zulip",
+        adapter_factory=lambda cfg: ZulipAdapter(cfg),
+        check_fn=check_zulip_requirements,
+        validate_config=_zulip_configured,
+        is_connected=_zulip_configured,
+        required_env=["ZULIP_SITE_URL", "ZULIP_BOT_EMAIL", "ZULIP_API_KEY"],
+        install_hint="pip install 'hermes-agent[zulip]'",
+        setup_fn=interactive_setup,
+        env_enablement_fn=_env_enablement,
+        apply_yaml_config_fn=_apply_yaml_config,
+        allowed_users_env="ZULIP_ALLOWED_USERS",
+        allow_all_env="ZULIP_ALLOW_ALL_USERS",
+        cron_deliver_env_var="ZULIP_HOME_CHANNEL",
+        standalone_sender_fn=_standalone_send_zulip,
+        max_message_length=MAX_MESSAGE_LENGTH,
+        emoji="Z",
+        allow_update_command=True,
+        platform_hint=(
+            "You are chatting via Zulip. Zulip supports Markdown, code blocks, "
+            "tables, LaTeX math (KaTeX), image links, streams, topics, direct "
+            "messages, and group DMs. To send images or files, include "
+            "MEDIA:<path> in your response (for example "
+            "MEDIA:/absolute/path/to/image.png). For LaTeX: prefer $$y = x$$ on "
+            "one line for inline math and a fenced math block for display:\n"
+            "```math\nE = mc^2\n```\n"
+            "(traditional $...$, \\(...\\), \\[...\\], and multi-line $$...$$ "
+            "are also accepted and converted automatically). "
+            "In streams, stay on the current topic unless the user explicitly "
+            "asks to move elsewhere."
+        ),
+    )
+
+    from .search_tool import register_zulip_search_tool
+    from .attachments import register_zulip_attachment_tool
+    from .topic_tool import register_zulip_topic_message_tool
+
+    register_zulip_search_tool(ctx)
+    register_zulip_attachment_tool(ctx)
+    register_zulip_topic_message_tool(ctx)

--- a/plugins/platforms/zulip/attachments.py
+++ b/plugins/platforms/zulip/attachments.py
@@ -1,0 +1,304 @@
+"""Zulip upload parsing, downloading, and agent tool support.
+
+Zulip represents files in messages as ``/user_uploads/...`` Markdown links.
+The link is not directly usable by the agent: retrieving its bytes requires
+the bot's API credentials to obtain a short-lived signed URL first.  This
+module keeps that credential-bearing flow inside the platform plugin.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+from urllib.parse import unquote
+
+logger = logging.getLogger(__name__)
+
+_USER_UPLOAD_LINK_RE = re.compile(
+    r"\(((?:https?://[^()\s]+)?/user_uploads/[^()\s]+)\)"
+)
+
+# Keep inbound downloads bounded. This is deliberately an implementation
+# safeguard, not a user-facing environment setting; platform behaviour is
+# configured in config.yaml rather than a new HERMES_* variable.
+MAX_UPLOAD_DOWNLOAD_BYTES = 25 * 1024 * 1024
+
+
+@dataclass(frozen=True)
+class DownloadedUpload:
+    """A Zulip upload materialized into Hermes's media cache."""
+
+    path: str
+    filename: str
+    mime_type: str
+    size_bytes: int
+
+
+def extract_upload_paths(content: str) -> list[str]:
+    """Return unique, normalized Zulip ``/user_uploads/`` paths in order.
+
+    Absolute URLs are reduced to a path before use, so the authenticated first
+    hop always targets the configured Zulip realm rather than a host embedded
+    in user-controlled Markdown.
+    """
+    paths: list[str] = []
+    seen: set[str] = set()
+    for match in _USER_UPLOAD_LINK_RE.finditer(content or ""):
+        target = match.group(1)
+        path = target[target.find("/user_uploads/"):].split("?", 1)[0]
+        if not is_valid_upload_path(path) or path in seen:
+            continue
+        seen.add(path)
+        paths.append(path)
+    return paths
+
+
+def is_valid_upload_path(path: str) -> bool:
+    """Return whether *path* is a non-traversing Zulip upload path."""
+    if not isinstance(path, str) or not path.startswith("/user_uploads/"):
+        return False
+    segments = unquote(path).split("/")
+    # Expected shape: /user_uploads/<realm_id>/<filename-or-subpath>.
+    return (
+        len(segments) >= 4
+        and segments[1] == "user_uploads"
+        and all(segment not in {"", ".", ".."} for segment in segments[1:])
+    )
+
+
+def upload_filename(path: str) -> str:
+    """Derive a safe display filename from a normalized upload path."""
+    name = Path(unquote(path.rsplit("/", 1)[-1])).name
+    return name or "attachment"
+
+
+async def download_zulip_upload(
+    *,
+    site_url: str,
+    bot_email: str,
+    api_key: str,
+    path: str,
+    max_bytes: int = MAX_UPLOAD_DOWNLOAD_BYTES,
+) -> DownloadedUpload:
+    """Fetch one upload through Zulip's authenticated temporary-URL API.
+
+    The returned path is already translated for the active Hermes terminal
+    backend by :func:`gateway.platforms.base.cache_media_bytes`.
+    """
+    if not is_valid_upload_path(path):
+        raise ValueError("Not a Zulip user-upload path")
+
+    import httpx
+    from gateway.platforms.base import cache_media_bytes
+
+    filename = upload_filename(path)
+    async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+        signed_response = await client.get(
+            f"{site_url.rstrip('/')}/api/v1{path}",
+            auth=(bot_email, api_key),
+        )
+        signed_response.raise_for_status()
+        signed_url = (signed_response.json() or {}).get("url", "")
+        if not signed_url:
+            raise ValueError("Zulip did not return a temporary upload URL")
+        if signed_url.startswith("/"):
+            signed_url = f"{site_url.rstrip('/')}{signed_url}"
+
+        # Stream the signed response so a malicious or incorrectly declared
+        # upload cannot make the gateway buffer an unbounded file in memory.
+        async with client.stream("GET", signed_url) as response:
+            response.raise_for_status()
+            chunks: list[bytes] = []
+            size_bytes = 0
+            async for chunk in response.aiter_bytes():
+                size_bytes += len(chunk)
+                if size_bytes > max_bytes:
+                    raise ValueError(
+                        f"Attachment exceeds the {max_bytes // (1024 * 1024)} MiB download limit"
+                    )
+                chunks.append(chunk)
+            data = b"".join(chunks)
+
+    content_type = ""
+    headers = getattr(response, "headers", None)
+    if headers:
+        content_type = str(headers.get("content-type", "")).split(";", 1)[0].strip().lower()
+    cached = cache_media_bytes(data, filename=filename, mime_type=content_type)
+    if cached is None:
+        raise ValueError(f"Could not cache attachment {filename!r}")
+
+    return DownloadedUpload(
+        path=cached.path,
+        filename=filename,
+        mime_type=cached.media_type,
+        size_bytes=len(data),
+    )
+
+
+def _check_zulip_attachment_requirements() -> bool:
+    from .search_tool import _check_zulip_search_requirements
+
+    return _check_zulip_search_requirements()
+
+
+async def zulip_download_attachment(
+    message_id: int,
+    filename: Optional[str] = None,
+    attachment_index: int = 0,
+    *,
+    task_id: Optional[str] = None,
+) -> str:
+    """Download an attachment from a Zulip message into the local media cache.
+
+    A Zulip gateway session is restricted to the active stream/topic or DM.
+    Taking a message ID rather than an arbitrary upload URL is important: the
+    bot can have access to conversations that the person asking it cannot.
+    """
+    del task_id
+    try:
+        import zulip
+    except ImportError:
+        return json.dumps({"error": "zulip package not installed"})
+
+    from .search_tool import _get_session_narrow, _get_zulip_credentials
+
+    site_url, bot_email, api_key = _get_zulip_credentials()
+    if not site_url or not bot_email or not api_key:
+        return json.dumps({"error": "Zulip credentials are not configured"})
+    if (
+        isinstance(message_id, bool)
+        or not isinstance(message_id, int)
+        or message_id <= 0
+    ):
+        return json.dumps({"error": "message_id must be a positive integer"})
+    if filename is not None and not isinstance(filename, str):
+        return json.dumps({"error": "filename must be a string"})
+    if (
+        isinstance(attachment_index, bool)
+        or not isinstance(attachment_index, int)
+        or attachment_index < 0
+    ):
+        return json.dumps({"error": "attachment_index must be a non-negative integer"})
+
+    # Fail closed if this is a Zulip session whose source cannot be narrowed.
+    try:
+        from gateway.session_context import get_session_env
+
+        in_zulip_session = get_session_env("HERMES_SESSION_PLATFORM", "") == "zulip"
+    except Exception:
+        in_zulip_session = False
+    session_narrow = _get_session_narrow()
+    if in_zulip_session and session_narrow is None:
+        return json.dumps({"error": "Could not determine the current Zulip conversation"})
+
+    client = zulip.Client(site=site_url, email=bot_email, api_key=api_key)
+    try:
+        result = client.get_messages({
+            "anchor": str(message_id),
+            "num_before": 0,
+            "num_after": 1,
+            "narrow": session_narrow or None,
+            "apply_markdown": False,
+        })
+    except Exception as exc:
+        logger.warning("Zulip attachment lookup failed: %s", exc)
+        return json.dumps({"error": f"Zulip API error: {exc}"})
+
+    if result.get("result") != "success":
+        return json.dumps({"error": result.get("msg", "Could not fetch Zulip message")})
+    message = next(
+        (item for item in result.get("messages", []) if item.get("id") == message_id),
+        None,
+    )
+    if message is None:
+        return json.dumps({"error": "Message was not found in the allowed conversation"})
+
+    paths = extract_upload_paths(message.get("content") or "")
+    if filename:
+        requested_name = Path(filename).name
+        paths = [path for path in paths if upload_filename(path) == requested_name]
+    if not paths:
+        return json.dumps({"error": "No matching attachments were found on that message"})
+    if attachment_index >= len(paths):
+        return json.dumps({
+            "error": (
+                "attachment_index is out of range "
+                f"(message has {len(paths)} matching attachment(s))"
+            ),
+        })
+
+    try:
+        downloaded = await download_zulip_upload(
+            site_url=site_url,
+            bot_email=bot_email,
+            api_key=api_key,
+            path=paths[attachment_index],
+        )
+    except Exception as exc:
+        logger.warning("Zulip attachment download failed for message %s: %s", message_id, exc)
+        return json.dumps({"error": f"Could not download attachment: {exc}"})
+
+    return json.dumps({
+        "message_id": message_id,
+        "filename": downloaded.filename,
+        "mime_type": downloaded.mime_type,
+        "size_bytes": downloaded.size_bytes,
+        "path": downloaded.path,
+    })
+
+
+_ZULIP_DOWNLOAD_ATTACHMENT_SCHEMA = {
+    "name": "zulip_download_attachment",
+    "description": (
+        "Download a file attached to a Zulip message into the local media cache. "
+        "Use after zulip_search_messages finds a message with an attachment. "
+        "The returned path can be read with file or terminal tools. In a Zulip "
+        "conversation, the message must be in the current stream/topic or DM."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "message_id": {
+                "type": "integer",
+                "description": "ID of the Zulip message containing the attachment.",
+            },
+            "filename": {
+                "type": "string",
+                "description": "Optional exact attachment filename to select.",
+            },
+            "attachment_index": {
+                "type": "integer",
+                "description": "Zero-based index among matching attachments; defaults to 0.",
+                "default": 0,
+                "minimum": 0,
+            },
+        },
+        "required": ["message_id"],
+    },
+}
+
+
+async def _handle_zulip_download_attachment(args, **kw):
+    return await zulip_download_attachment(
+        message_id=args.get("message_id"),
+        filename=args.get("filename"),
+        attachment_index=args.get("attachment_index", 0),
+        task_id=kw.get("task_id"),
+    )
+
+
+def register_zulip_attachment_tool(ctx) -> None:
+    """Register the history-scoped attachment materialization tool."""
+    ctx.register_tool(
+        name="zulip_download_attachment",
+        toolset="zulip-history",
+        schema=_ZULIP_DOWNLOAD_ATTACHMENT_SCHEMA,
+        handler=_handle_zulip_download_attachment,
+        check_fn=_check_zulip_attachment_requirements,
+        is_async=True,
+        emoji="📎",
+    )

--- a/plugins/platforms/zulip/plugin.yaml
+++ b/plugins/platforms/zulip/plugin.yaml
@@ -1,0 +1,78 @@
+name: zulip-platform
+label: Zulip
+kind: platform
+version: 1.0.0
+description: >
+  Zulip gateway adapter for Hermes Agent. Connects to Zulip Cloud or a
+  self-hosted Zulip server with a bot email, API key, and site URL.
+author: Hermes Agent contributors
+requires_env:
+  - name: ZULIP_SITE_URL
+    description: "Zulip organization URL (for example https://example.zulipchat.com)"
+    prompt: "Zulip site URL"
+    password: false
+  - name: ZULIP_BOT_EMAIL
+    description: "Bot email address from Zulip bot settings"
+    prompt: "Zulip bot email"
+    password: false
+  - name: ZULIP_API_KEY
+    description: "Bot API key from Zulip bot settings"
+    prompt: "Zulip bot API key"
+    password: true
+optional_env:
+  - name: ZULIP_ALLOWED_USERS
+    description: "Comma-separated Zulip user email addresses allowed to DM the bot"
+    prompt: "Allowed user emails (comma-separated)"
+    password: false
+  - name: ZULIP_ALLOW_ALL_USERS
+    description: "Allow any Zulip user to talk to the bot (dev only)"
+    prompt: "Allow all users? (true/false)"
+    password: false
+  - name: ZULIP_DEFAULT_STREAM
+    description: "Default stream for outbound messages"
+    prompt: "Default stream"
+    password: false
+  - name: ZULIP_HOME_TOPIC
+    description: "Default topic for cron and notification delivery"
+    prompt: "Home topic"
+    password: false
+  - name: ZULIP_HOME_CHANNEL
+    description: "Home stream or stream:topic for cron and notification delivery"
+    prompt: "Home channel"
+    password: false
+  - name: ZULIP_HOME_CHANNEL_NAME
+    description: "Display name for the Zulip home channel"
+    prompt: "Home channel display name"
+    password: false
+  - name: ZULIP_CERT_BUNDLE
+    description: "Path to a CA bundle for self-hosted Zulip TLS"
+    prompt: "CA bundle path"
+    password: false
+  - name: ZULIP_ALLOW_INSECURE
+    description: "Disable TLS verification for development-only self-hosted Zulip"
+    prompt: "Allow insecure TLS? (true/false)"
+    password: false
+  - name: ZULIP_REQUIRE_MENTION
+    description: "Require @mention in streams (default true)"
+    prompt: "Require mentions? (true/false)"
+    password: false
+  - name: ZULIP_FREE_RESPONSE_STREAMS
+    description: "Comma-separated stream names or IDs that do not require @mention"
+    prompt: "Free-response streams"
+    password: false
+  - name: ZULIP_CONTEXT_DEPTH
+    description: "Number of prior topic messages to inject as context on @mention"
+    prompt: "Context depth"
+    password: false
+  - name: ZULIP_CATCHUP
+    description: "Replay missed stream messages after reconnect (default false)"
+    prompt: "Enable catch-up? (true/false)"
+    password: false
+  - name: ZULIP_CATCHUP_MAX_MESSAGES
+    description: "Maximum missed messages replayed per stream on reconnect"
+    prompt: "Catch-up max messages"
+    password: false
+  - name: ZULIP_CONVERT_MATH
+    description: "Rewrite $...$ / \\(...\\) / \\[...\\] / multi-line $$ to Zulip KaTeX before send (default true)"
+    prompt: "Convert LaTeX delimiters to Zulip KaTeX? (true/false)"
+    password: false

--- a/plugins/platforms/zulip/search_tool.py
+++ b/plugins/platforms/zulip/search_tool.py
@@ -1,0 +1,808 @@
+"""Zulip message search tool — fetch and search message history.
+
+Provides a single flexible tool that wraps Zulip's ``/messages`` API.
+The agent can search by stream+topic, full-text query, message anchor,
+and paginate through results — all through one interface.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Hermes outbound long replies are split by BasePlatformAdapter.truncate_message
+# into multiple Zulip messages ending with " (i/n)" (see gateway/platforms/base.py).
+# Zulip's 10k code-point cap means a single agent answer can become several
+# consecutive bot messages; search must rejoin them or full-text queries for
+# content that only appears past the first chunk look like a miss.
+_CHUNK_MARKER_RE = re.compile(r" \((\d+)/(\d+)\)\s*$")
+
+# Zulip FTS is updated asynchronously (process_fts_updates). Large bot replies
+# can lag behind short messages in the index, and pure-numeric / marker tokens
+# often fail to hit. When a text query is present we always do a client-side
+# content scan of recent history as a safety net (in addition to server FTS).
+_CLIENT_SCAN_WINDOW = 200
+_CLIENT_SCAN_MAX_PAGES = 3
+# Structural Zulip search operators — not usable as literal content needles.
+_SEARCH_OPERATOR_RE = re.compile(
+    r"\b(?:"
+    r"sender|from|stream|channel|topic|pm-with|dm|dm-including|"
+    r"has|is|near|id|group-id|streams|channels"
+    r"):\S+",
+    re.IGNORECASE,
+)
+
+
+def _get_zulip_credentials(platform_config: Any = None) -> tuple[str, str, str]:
+    """Return Zulip ``(site_url, bot_email, api_key)`` from env or config."""
+    site_url = os.getenv("ZULIP_SITE_URL", "").rstrip("/")
+    bot_email = os.getenv("ZULIP_BOT_EMAIL", "")
+    api_key = os.getenv("ZULIP_API_KEY", "")
+
+    if platform_config is None:
+        try:
+            from gateway.config import Platform, load_gateway_config
+
+            platform_config = load_gateway_config().platforms.get(Platform("zulip"))
+        except Exception:
+            platform_config = None
+
+    if platform_config:
+        extra = platform_config.extra or {}
+        site_url = site_url or str(extra.get("site_url") or "").rstrip("/")
+        bot_email = bot_email or str(extra.get("bot_email") or "")
+        api_key = api_key or (platform_config.token or platform_config.api_key or "")
+
+    return site_url, bot_email, api_key
+
+
+def _check_zulip_search_requirements() -> bool:
+    """Check that the zulip_search_messages tool is usable.
+
+    The tool is available on Zulip sessions (gateway context) or when
+    Zulip credentials are explicitly configured.  Follows the same
+    pattern as ``_check_send_message`` in ``send_message_tool.py``.
+    """
+    site_url, bot_email, api_key = _get_zulip_credentials()
+
+    # 1. Session-context check (gateway-side: agent knows the platform).
+    try:
+        from gateway.session_context import get_session_env
+        platform = get_session_env("HERMES_SESSION_PLATFORM", "")
+        if platform == "zulip":
+            return bool(site_url and bot_email and api_key)
+    except Exception:
+        pass
+
+    # 2. Explicit Zulip credential check (env or config-backed usage).
+    # Unlike send_message, this tool calls Zulip's API directly; a running
+    # gateway process is neither required nor sufficient without credentials.
+    if site_url and bot_email and api_key:
+        return True
+
+    return False
+
+
+def _get_session_narrow() -> Optional[List[List[str]]]:
+    """Build a narrow filter from the current Zulip session context.
+
+    When the tool is invoked from within a Zulip gateway session (i.e. the
+    agent is handling a message that arrived from Zulip), this restricts
+    the search to the *current conversation only* — the stream+topic or DM
+    that the user is talking to the bot in.  This prevents a user in a
+    private DM from asking the bot to exfiltrate messages from streams or
+    other DMs the bot is subscribed to.
+
+    Returns ``None`` when the tool is called from CLI or other platforms,
+    in which case the caller's own credentials/permissions apply.
+    """
+    try:
+        from gateway.session_context import get_session_env
+    except Exception:
+        return None
+
+    platform = get_session_env("HERMES_SESSION_PLATFORM", "")
+    if platform != "zulip":
+        return None
+
+    chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "")
+    chat_name = get_session_env("HERMES_SESSION_CHAT_NAME", "")
+    if not chat_id:
+        return None
+
+    # DM: "dm:alice@example.com"
+    if chat_id.startswith("dm:") and "@" in chat_id:
+        email = chat_id[3:]  # strip "dm:" prefix
+        return [["pm-with", email]]
+
+    # Group DM: "group_dm:alice@example.com,bob@example.com"
+    if chat_id.startswith("group_dm:"):
+        emails = chat_id[9:]  # strip "group_dm:" prefix
+        if emails:
+            return [["pm-with", emails]]
+
+    # Stream: "{stream_id}:{topic}"
+    colon = chat_id.find(":")
+    if colon > 0:
+        stream_part = chat_id[:colon]
+        if stream_part.isdigit():
+            topic = chat_id[colon + 1 :] or "(no topic)"
+            stream_name = chat_name or ""
+            if stream_name:
+                return [["stream", stream_name], ["topic", topic]]
+
+    return None
+
+
+def zulip_search_messages(
+    stream: Optional[str] = None,
+    topic: Optional[str] = None,
+    query: Optional[str] = None,
+    anchor: Optional[str] = None,
+    num_before: int = 20,
+    num_after: int = 0,
+    *,
+    task_id: Optional[str] = None,
+) -> str:
+    """Search Zulip message history.
+
+    Fetches messages from a Zulip organization using the bot's credentials.
+    Supports narrowing by stream, topic, full-text search, and pagination
+    via message ID anchors.
+
+    **Security note:** When this tool is called from within a Zulip gateway
+    session (i.e. the user is talking to the bot via Zulip), the search is
+    automatically restricted to the *current conversation only*.  A user in
+    a DM cannot ask the bot to search streams or other DMs.  When called
+    from CLI or other platforms, the full search scope is available.
+
+    Args:
+        stream: Stream name to narrow to (e.g. ``"general"``). Optional.
+                Ignored when called from a Zulip session (restricted to
+                current conversation).
+        topic: Topic name to narrow to (e.g. ``"database"``). Optional.
+               Ignored when called from a Zulip session.
+        query: Full-text search using Zulip's search syntax.
+               Supports operators like ``sender:alice@example.com``,
+               ``has:link``, ``is:starred``, ``near:<id>``, etc. Optional.
+               ``stream:`` and ``pm-with:`` operators are stripped when
+               called from a Zulip session to prevent scope escalation.
+        anchor: Message ID to anchor around, or ``"newest"`` / ``"oldest"``.
+                Defaults to ``"newest"`` (most recent messages).
+        num_before: Number of messages to fetch before the anchor. Default 20.
+        num_after: Number of messages to fetch after the anchor. Default 0.
+        task_id: Internal task ID (injected by framework).
+
+    Returns:
+        A JSON string with search results including messages and pagination
+        info (the oldest message ID for continued pagination).
+
+    **Common usage patterns:**
+
+    - Recent context: ``stream="general", topic="database", anchor="newest", num_before=20``
+    - Around a specific message: ``anchor="<msg_id>", num_before=5, num_after=5``
+    - Text search: ``stream="general", query="postgresql"``
+    - Find by sender: ``query="sender:alice@example.com"``
+    - Older page: ``stream="general", topic="db", anchor="<oldest_id>", num_before=20``
+    """
+    try:
+        import zulip
+    except ImportError:
+        return json.dumps({"error": "zulip package not installed"})
+
+    site_url, bot_email, api_key = _get_zulip_credentials()
+
+    if not site_url or not bot_email or not api_key:
+        return json.dumps({
+            "error": "Zulip credentials not configured. "
+                     "Set ZULIP_SITE_URL, ZULIP_BOT_EMAIL, and ZULIP_API_KEY."
+        })
+
+    # Build the narrow filter.
+    #
+    # ``scope_narrow`` is structural only (stream/topic/DM) — used both for
+    # server FTS and for the client-side content scan fallback.
+    # ``fts_narrow`` adds Zulip's ``search`` operator when a text query is set.
+    scope_narrow: List[List[str]] = []
+    text_query = (query or "").strip() or None
+    fts_text: Optional[str] = None
+
+    # When in a Zulip session, restrict to current conversation only.
+    session_narrow = _get_session_narrow()
+    if session_narrow is not None:
+        scope_narrow = list(session_narrow)
+        # Sanitize query to prevent scope escalation via search operators.
+        if text_query:
+            sanitized = re.sub(r"\b(stream|pm-with):\S+", "", text_query).strip()
+            fts_text = sanitized or None
+    else:
+        # CLI / non-Zulip session — caller controls scope.
+        if stream:
+            scope_narrow.append(["stream", stream])
+        if topic:
+            scope_narrow.append(["topic", topic])
+        fts_text = text_query
+
+    fts_narrow: List[List[str]] = list(scope_narrow)
+    if fts_text:
+        fts_narrow.append(["search", fts_text])
+
+    # Resolve anchor.
+    anchor_value: Any = anchor if anchor else "newest"
+
+    client = zulip.Client(site=site_url, email=bot_email, api_key=api_key)
+    try:
+        result = client.get_messages({
+            "anchor": anchor_value,
+            "num_before": num_before,
+            "num_after": num_after,
+            "narrow": fts_narrow or None,
+            "apply_markdown": False,
+        })
+    except Exception as exc:
+        logger.warning("Zulip search failed: %s", exc)
+        return json.dumps({"error": f"Zulip API error: {exc}"})
+
+    if result.get("result") != "success":
+        return json.dumps({
+            "error": result.get("msg", "Unknown Zulip error"),
+        })
+
+    messages = list(result.get("messages") or [])
+    used_client_scan = False
+    found_oldest = result.get("found_oldest", False)
+    found_newest = result.get("found_newest", False)
+
+    # Client-side content scan: Zulip FTS indexes asynchronously and often
+    # misses (or ranks below short noise) content inside large multi-chunk
+    # Hermes replies. Scan recent history in the same scope and merge hits.
+    content_needles = _content_needles_from_query(fts_text)
+    if content_needles:
+        scanned, scan_meta = _client_content_scan(
+            client,
+            scope_narrow=scope_narrow or None,
+            needles=content_needles,
+            anchor=anchor_value,
+            bot_email=bot_email,
+        )
+        used_client_scan = bool(scanned) or bool(scan_meta.get("scanned"))
+        if scanned:
+            messages = _merge_messages_by_id(messages, scanned)
+            # Prefer the scan window's pagination edges when we scanned.
+            if scan_meta.get("found_oldest") is not None:
+                found_oldest = scan_meta["found_oldest"]
+            if scan_meta.get("found_newest") is not None:
+                found_newest = scan_meta["found_newest"]
+
+    if not messages:
+        note = "No messages matched the search criteria."
+        if content_needles and used_client_scan:
+            note += (
+                " Client-side scan of recent history also found no match "
+                f"(window up to {_CLIENT_SCAN_WINDOW * _CLIENT_SCAN_MAX_PAGES} "
+                "messages). Try a wider stream/topic scope or a later anchor."
+            )
+        return json.dumps({
+            "messages": [],
+            "count": 0,
+            "found_newest": found_newest if found_newest is not None else True,
+            "found_oldest": found_oldest if found_oldest is not None else True,
+            "note": note,
+            "client_content_scan": used_client_scan,
+        })
+
+    # Format messages for readability, then rejoin Hermes multi-chunk replies
+    # so content past the 10k Zulip cap is searchable/readable as one body.
+    formatted: List[Dict[str, Any]] = [
+        _format_raw_message(msg, bot_email) for msg in messages
+    ]
+
+    # Full-text search often returns only the matching chunk of a long
+    # Hermes reply. Expand isolated chunk hits so we can rejoin the series.
+    # Expand against scope_narrow (no search op) so siblings are fetchable.
+    formatted = _expand_partial_hermes_chunks(
+        client,
+        formatted,
+        narrow=scope_narrow or None,
+        bot_email=bot_email,
+    )
+    formatted = _reassemble_hermes_chunks(formatted)
+
+    # After reassembly, drop messages that still don't contain any needle
+    # when the caller asked for a text query (avoids FTS false friends that
+    # only matched a short plan/approval mentioning the marker).
+    if content_needles:
+        filtered = [
+            m for m in formatted
+            if _content_matches_needles(m.get("content") or "", content_needles)
+        ]
+        # Keep structural-only results if filtering wiped everything that
+        # FTS returned but scan already injected real hits — otherwise keep
+        # filtered list (may be empty → honest miss).
+        if filtered or used_client_scan:
+            formatted = filtered
+
+    # Drop internal sender_email used only for chunk grouping.
+    for entry in formatted:
+        entry.pop("sender_email", None)
+
+    # Pagination cues.
+    oldest_id = None
+    newest_id = None
+    if formatted:
+        oldest_id = min(m["id"] for m in formatted if m["id"])
+        newest_id = max(m["id"] for m in formatted if m["id"])
+
+    payload: Dict[str, Any] = {
+        "messages": formatted,
+        "count": len(formatted),
+        "requested_before": num_before,
+        "requested_after": num_after,
+        "oldest_message_id": oldest_id,
+        "newest_message_id": newest_id,
+        "found_oldest": found_oldest,
+        "found_newest": found_newest,
+        "pagination_hint": (
+            f"To get older messages, call again with "
+            f"anchor={oldest_id}, num_before={num_before}, num_after=0. "
+            f"To get newer messages, call with "
+            f"anchor={newest_id}, num_before=0, num_after={num_after or 20}."
+        ) if formatted else "",
+    }
+    if used_client_scan:
+        payload["client_content_scan"] = True
+        payload["note"] = (
+            "Results include a client-side content scan of recent history. "
+            "Zulip server full-text search can lag or miss long multi-chunk "
+            "bot replies; the scan matches literal text in message bodies."
+        )
+    if not formatted:
+        payload["note"] = (
+            "No messages matched the search criteria after content filtering."
+        )
+    return json.dumps(payload)
+
+
+def _parse_chunk_marker(content: str) -> Optional[tuple[str, int, int]]:
+    """Return ``(body, index, total)`` when *content* ends with `` (i/n)``."""
+    if not content:
+        return None
+    match = _CHUNK_MARKER_RE.search(content)
+    if not match:
+        return None
+    index = int(match.group(1))
+    total = int(match.group(2))
+    if index < 1 or total < 2 or index > total:
+        return None
+    body = content[: match.start()]
+    return body, index, total
+
+
+def _content_needles_from_query(query: Optional[str]) -> List[str]:
+    """Extract literal content needles from a Zulip search query string.
+
+    Strips structural operators (``sender:``, ``has:``, …) and quoted phrases
+    become exact needles. Remaining whitespace-separated tokens become
+    case-insensitive substrings. Pure operator queries yield no needles
+    (client scan is skipped — FTS alone is appropriate).
+    """
+    if not query or not str(query).strip():
+        return []
+    text = str(query).strip()
+    needles: List[str] = []
+
+    # Quoted phrases first (preserve order, allow spaces).
+    for match in re.finditer(r'"([^"]+)"', text):
+        phrase = match.group(1).strip()
+        if phrase:
+            needles.append(phrase)
+    text_no_quotes = re.sub(r'"[^"]*"', " ", text)
+
+    # Drop Zulip operators; keep the rest as free-text tokens.
+    text_no_ops = _SEARCH_OPERATOR_RE.sub(" ", text_no_quotes)
+    for token in text_no_ops.split():
+        token = token.strip()
+        if not token:
+            continue
+        # Skip lone boolean-ish noise.
+        if token.lower() in {"and", "or", "not", "-"}:
+            continue
+        needles.append(token)
+
+    # De-dupe while preserving order (case-insensitive key).
+    seen: set[str] = set()
+    unique: List[str] = []
+    for n in needles:
+        key = n.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(n)
+    return unique
+
+
+def _content_matches_needles(content: str, needles: List[str]) -> bool:
+    """True when *content* contains every needle (case-insensitive substring)."""
+    if not needles:
+        return True
+    haystack = content.casefold()
+    return all(n.casefold() in haystack for n in needles)
+
+
+def _merge_messages_by_id(
+    primary: List[Dict[str, Any]],
+    extra: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Union raw Zulip message dicts by id (prefer *primary* on conflict)."""
+    by_id: Dict[Any, Dict[str, Any]] = {}
+    for msg in extra:
+        mid = msg.get("id")
+        if mid is not None:
+            by_id[mid] = msg
+    for msg in primary:
+        mid = msg.get("id")
+        if mid is not None:
+            by_id[mid] = msg
+    return list(by_id.values())
+
+
+def _client_content_scan(
+    client: Any,
+    *,
+    scope_narrow: Optional[List[List[str]]],
+    needles: List[str],
+    anchor: Any,
+    bot_email: str,
+    window: int = _CLIENT_SCAN_WINDOW,
+    max_pages: int = _CLIENT_SCAN_MAX_PAGES,
+) -> tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    """Fetch recent history and keep messages whose body contains *needles*.
+
+    Bypasses Zulip FTS entirely — used when server search lags or fails to
+    index large multi-chunk bot replies. Returns ``(raw_messages, meta)``.
+    """
+    meta: Dict[str, Any] = {"scanned": False, "pages": 0}
+    if not needles:
+        return [], meta
+
+    hits: List[Dict[str, Any]] = []
+    seen_ids: set[Any] = set()
+    page_anchor: Any = anchor if anchor not in (None, "") else "newest"
+    found_oldest: Optional[bool] = None
+    found_newest: Optional[bool] = None
+
+    for _page in range(max_pages):
+        try:
+            result = client.get_messages({
+                "anchor": page_anchor,
+                "num_before": window,
+                "num_after": 0,
+                "narrow": scope_narrow,
+                "apply_markdown": False,
+            })
+        except Exception as exc:
+            logger.debug("Zulip client content scan failed: %s", exc)
+            break
+        if result.get("result") != "success":
+            break
+        meta["scanned"] = True
+        meta["pages"] = int(meta["pages"]) + 1
+        if result.get("found_oldest") is not None:
+            found_oldest = bool(result.get("found_oldest"))
+        if result.get("found_newest") is not None:
+            found_newest = bool(result.get("found_newest"))
+
+        page_msgs = list(result.get("messages") or [])
+        if not page_msgs:
+            break
+
+        for raw in page_msgs:
+            mid = raw.get("id")
+            if mid is None or mid in seen_ids:
+                continue
+            seen_ids.add(mid)
+            content = (raw.get("content") or "")
+            if _content_matches_needles(content, needles):
+                hits.append(raw)
+
+        # Page older when we still need more coverage.
+        oldest = min(
+            (m.get("id") for m in page_msgs if m.get("id") is not None),
+            default=None,
+        )
+        if oldest is None or result.get("found_oldest"):
+            break
+        # Stop early once we have hits — one window of neighbors is enough
+        # for expand/reassemble to finish the job on long multi-chunk replies.
+        if hits:
+            break
+        page_anchor = oldest
+
+    meta["found_oldest"] = found_oldest
+    meta["found_newest"] = found_newest
+    # bot_email unused for filtering but kept for API symmetry / future flags.
+    _ = bot_email
+    return hits, meta
+
+
+def _format_raw_message(msg: Dict[str, Any], bot_email: str) -> Dict[str, Any]:
+    return {
+        "id": msg.get("id"),
+        "sender": msg.get("sender_full_name") or msg.get("sender_email", "?"),
+        "sender_email": msg.get("sender_email") or "",
+        "timestamp": msg.get("timestamp", 0),
+        "content": (msg.get("content") or "").strip(),
+        "is_bot": msg.get("sender_email") == bot_email,
+    }
+
+
+def _expand_partial_hermes_chunks(
+    client: Any,
+    messages: List[Dict[str, Any]],
+    *,
+    narrow: Optional[List[List[str]]],
+    bot_email: str = "",
+    max_expansions: int = 5,
+) -> List[Dict[str, Any]]:
+    """Fetch sibling chunks when the window only contains part of a series.
+
+    A full-text ``query`` hit often returns only the matching chunk of a
+    multi-message Hermes reply.  Pull a tight window around that message so
+    ``_reassemble_hermes_chunks`` can join the full body.  Caps expansions to
+    avoid hammering the API when many partial hits appear.
+    """
+    if not messages:
+        return messages
+
+    by_id: Dict[Any, Dict[str, Any]] = {
+        m["id"]: m for m in messages if m.get("id") is not None
+    }
+    expansions = 0
+
+    # Snapshot ids up front — we mutate by_id as we expand.
+    candidates = list(by_id.values())
+    for msg in candidates:
+        if expansions >= max_expansions:
+            break
+        parsed = _parse_chunk_marker(msg.get("content") or "")
+        if parsed is None:
+            continue
+        _, index, total = parsed
+        # Already have a complete run nearby? Skip.
+        sender = msg.get("sender_email") or msg.get("sender") or ""
+        have = 0
+        for other in by_id.values():
+            other_sender = other.get("sender_email") or other.get("sender") or ""
+            if other_sender != sender:
+                continue
+            other_parsed = _parse_chunk_marker(other.get("content") or "")
+            if other_parsed and other_parsed[2] == total:
+                have += 1
+        if have >= total:
+            continue
+
+        msg_id = msg.get("id")
+        if msg_id is None:
+            continue
+        try:
+            # Fetch enough neighbors to cover the full series around this hit.
+            num_before = max(0, index - 1)
+            num_after = max(0, total - index)
+            # Small pad for interleaved non-bot messages in the same topic.
+            num_before = min(num_before + 2, 20)
+            num_after = min(num_after + 2, 20)
+            result = client.get_messages({
+                "anchor": msg_id,
+                "num_before": num_before,
+                "num_after": num_after,
+                "narrow": narrow,
+                "apply_markdown": False,
+            })
+        except Exception as exc:
+            logger.debug("Zulip chunk expand failed for %s: %s", msg_id, exc)
+            continue
+        if result.get("result") != "success":
+            continue
+        expansions += 1
+        for raw in result.get("messages") or []:
+            rid = raw.get("id")
+            if rid is None or rid in by_id:
+                continue
+            by_id[rid] = _format_raw_message(raw, bot_email)
+
+    return list(by_id.values())
+
+
+def _reassemble_hermes_chunks(
+    messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Merge consecutive Hermes multi-chunk replies into single messages.
+
+    ``truncate_message`` emits N consecutive messages from the same sender,
+    each ending with `` (i/n)``.  Zulip stores them as independent messages, so
+    a full-text search hit on chunk 2 alone returns only a fragment.  When a
+    complete ``1..n`` run is present in the result window we collapse it into
+    one entry with the concatenated body and ``chunk_ids`` for traceability.
+    Incomplete runs (pagination window cut mid-series) are left as-is so the
+    caller can widen the window.
+    """
+    if len(messages) < 2:
+        return messages
+
+    # Work in chronological order (oldest first) so chunk 1 precedes chunk n.
+    ordered = sorted(
+        messages,
+        key=lambda m: (
+            m.get("id") is None,
+            m.get("id") if m.get("id") is not None else 0,
+            m.get("timestamp") or 0,
+        ),
+    )
+
+    out: List[Dict[str, Any]] = []
+    i = 0
+    while i < len(ordered):
+        msg = ordered[i]
+        parsed = _parse_chunk_marker(msg.get("content") or "")
+        if parsed is None or parsed[1] != 1:
+            out.append(msg)
+            i += 1
+            continue
+
+        body, index, total = parsed
+        sender_key = (
+            msg.get("sender_email")
+            or msg.get("sender")
+            or ""
+        )
+        group = [(msg, body, index)]
+        j = i + 1
+        expected = 2
+        while j < len(ordered) and expected <= total:
+            nxt = ordered[j]
+            nxt_key = nxt.get("sender_email") or nxt.get("sender") or ""
+            if nxt_key != sender_key:
+                break
+            nxt_parsed = _parse_chunk_marker(nxt.get("content") or "")
+            if nxt_parsed is None:
+                break
+            nxt_body, nxt_index, nxt_total = nxt_parsed
+            if nxt_total != total or nxt_index != expected:
+                break
+            group.append((nxt, nxt_body, nxt_index))
+            expected += 1
+            j += 1
+
+        if len(group) != total:
+            # Incomplete series — keep every collected chunk as-is so the
+            # agent can widen the pagination window and retry.
+            for piece, _, _ in group:
+                out.append(piece)
+            i = j
+            continue
+
+        combined_content = "\n".join(part_body for _, part_body, _ in group)
+        first = group[0][0]
+        last = group[-1][0]
+        merged = {
+            "id": first.get("id"),
+            "sender": first.get("sender"),
+            "sender_email": first.get("sender_email", ""),
+            "timestamp": first.get("timestamp", 0),
+            "content": combined_content,
+            "is_bot": first.get("is_bot", False),
+            "chunk_ids": [g[0].get("id") for g in group],
+            "chunk_count": total,
+            "newest_chunk_id": last.get("id"),
+        }
+        out.append(merged)
+        i = j
+
+    # Oldest-first by message id — clearer for agents reconstructing long
+    # multi-chunk answers. Pagination still exposes oldest/newest ids.
+    out.sort(
+        key=lambda m: (
+            m.get("id") is None,
+            m.get("id") if m.get("id") is not None else 0,
+        )
+    )
+    return out
+
+
+_ZULIP_SEARCH_SCHEMA = {
+    "name": "zulip_search_messages",
+    "description": (
+        "Search Zulip message history. Fetches messages from streams, "
+        "topics, or by full-text search. Supports pagination via "
+        "message ID anchors. Long Hermes replies that were split across "
+        "multiple Zulip messages (over the ~10k limit) are rejoined into "
+        "one result when the full chunk series is in the window. Use this "
+        "to get context about what was discussed before your @mention, to "
+        "search for specific information in past conversations, or to find "
+        "messages by a specific sender."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "stream": {
+                "type": "string",
+                "description": (
+                    "Stream name to narrow search to. "
+                    "Example: 'general', 'engineering', 'announce'."
+                ),
+            },
+            "topic": {
+                "type": "string",
+                "description": (
+                    "Topic name within the stream. "
+                    "Example: 'database', 'onboarding'."
+                ),
+            },
+            "query": {
+                "type": "string",
+                "description": (
+                    "Full-text search using Zulip's search syntax. "
+                    "Supports operators like "
+                    "sender:alice@example.com, has:link, is:starred, "
+                    "near:12345, pm-with:alice@example.com. "
+                    "Combine with stream/topic for focused search."
+                ),
+            },
+            "anchor": {
+                "type": "string",
+                "description": (
+                    "Message ID to anchor pagination around, or "
+                    "'newest' (most recent) or 'oldest'. "
+                    "Default: 'newest'. For pagination, use the "
+                    "'oldest_message_id' from a previous response."
+                ),
+            },
+            "num_before": {
+                "type": "integer",
+                "description": (
+                    "Number of messages to fetch before the anchor. "
+                    "Default: 20. Max: 5000."
+                ),
+                "default": 20,
+            },
+            "num_after": {
+                "type": "integer",
+                "description": (
+                    "Number of messages to fetch after the anchor. "
+                    "Default: 0. Set to >0 to see context after a "
+                    "specific message (e.g., 5 messages after a reply)."
+                ),
+                "default": 0,
+            },
+        },
+        "required": [],
+    },
+}
+
+
+def _handle_zulip_search_messages(args, **kw):
+    return zulip_search_messages(
+        stream=args.get("stream"),
+        topic=args.get("topic"),
+        query=args.get("query"),
+        anchor=args.get("anchor"),
+        num_before=args.get("num_before", 20),
+        num_after=args.get("num_after", 0),
+        task_id=kw.get("task_id"),
+    )
+
+
+def register_zulip_search_tool(ctx) -> None:
+    ctx.register_tool(
+        name="zulip_search_messages",
+        toolset="zulip-history",
+        schema=_ZULIP_SEARCH_SCHEMA,
+        handler=_handle_zulip_search_messages,
+        check_fn=_check_zulip_search_requirements,
+        emoji="🔎",
+    )

--- a/plugins/platforms/zulip/topic_tool.py
+++ b/plugins/platforms/zulip/topic_tool.py
@@ -1,0 +1,295 @@
+"""Agent tool for starting or continuing an isolated Zulip topic session."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+_SESSION_SEED_PREFIX = "[Hermes to Zulip]"
+
+
+def _zulip_platform():
+    """Return the plugin's dynamically registered platform value."""
+    from gateway.config import Platform
+
+    return Platform("zulip")
+
+
+def _current_zulip_session_user() -> tuple[Optional[str], Optional[str], Optional[str]]:
+    """Return the active Zulip sender's email, name, and profile, if any."""
+    try:
+        from gateway.session_context import get_session_env
+    except Exception:
+        return None, None, None
+
+    if get_session_env("HERMES_SESSION_PLATFORM", "").lower() != "zulip":
+        return None, None, None
+    email = get_session_env("HERMES_SESSION_USER_ID", "").strip()
+    name = get_session_env("HERMES_SESSION_USER_NAME", "").strip()
+    profile = get_session_env("HERMES_SESSION_PROFILE", "").strip()
+    return email or None, name or email or None, profile or None
+
+
+def _load_zulip_tool_config() -> tuple[str, str, str, Any, Any]:
+    """Load credentials and the config needed to seed a gateway session."""
+    from gateway.config import Platform, load_gateway_config
+    from .search_tool import _get_zulip_credentials
+
+    config = load_gateway_config()
+    platform_config = config.platforms.get(Platform("zulip"))
+    if not platform_config or not platform_config.enabled:
+        raise ValueError("Zulip platform is not configured or enabled")
+
+    site_url, bot_email, api_key = _get_zulip_credentials(platform_config)
+    if not site_url or not bot_email or not api_key:
+        raise ValueError(
+            "Zulip credentials are incomplete; configure site_url, bot_email, and API key"
+        )
+
+    # Credential resolution gives explicit environment credentials precedence.
+    # Give the standalone sender that exact resolved account as well, so stream
+    # lookup and delivery can never accidentally target different realms.
+    send_config = replace(
+        platform_config,
+        token=api_key,
+        api_key=None,
+        extra={
+            **(platform_config.extra or {}),
+            "site_url": site_url,
+            "bot_email": bot_email,
+        },
+    )
+    return site_url, bot_email, api_key, config, send_config
+
+
+def _session_db_for_profile(profile: Optional[str]):
+    """Open the SessionDB inbound recovery will look in.
+
+    Multiplexed named profiles live under ``profiles/<name>/state.db``.
+    Seeding the ambient store splits one session identity across two files.
+    """
+    from hermes_state import SessionDB
+
+    if not profile:
+        return SessionDB()
+    from hermes_cli.profiles import get_profile_dir, profile_exists
+
+    if not profile_exists(profile):
+        raise RuntimeError(
+            f"profile {profile!r} has no resolvable home; "
+            "refusing to seed into the ambient store"
+        )
+    return SessionDB(db_path=Path(get_profile_dir(profile)) / "state.db")
+
+
+def _seed_topic_session(
+    *,
+    config: Any,
+    stream_id: int,
+    stream_name: str,
+    topic: str,
+    user_email: str,
+    user_name: str,
+    profile: Optional[str],
+    message: str,
+    message_id: str,
+) -> str:
+    """Create/reuse the inbound topic session and record the sent seed text."""
+    from gateway.session import SessionSource, build_session_key
+
+    source = SessionSource(
+        platform=_zulip_platform(),
+        chat_id=f"{stream_id}:{topic}",
+        chat_name=stream_name,
+        chat_type="stream",
+        user_id=user_email,
+        user_name=user_name,
+        chat_topic=topic,
+        profile=profile,
+    )
+    session_key = build_session_key(
+        source,
+        group_sessions_per_user=getattr(config, "group_sessions_per_user", True),
+        thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
+        profile=profile if getattr(config, "multiplex_profiles", False) else None,
+    )
+    db = _session_db_for_profile(
+        profile if getattr(config, "multiplex_profiles", False) else None
+    )
+    existing = db.find_latest_gateway_session_for_peer(
+        source="zulip",
+        user_id=user_email,
+        session_key=session_key,
+        chat_id=source.chat_id,
+        chat_type=source.chat_type,
+    )
+    if existing:
+        session_id = str(existing["id"])
+        db.reopen_session(session_id)
+    else:
+        session_id = f"{time.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
+        db.create_session(
+            session_id,
+            "zulip",
+            user_id=user_email,
+            session_key=session_key,
+            chat_id=source.chat_id,
+            chat_type=source.chat_type,
+        )
+        db.record_gateway_session_peer(
+            session_id,
+            source="zulip",
+            user_id=user_email,
+            session_key=session_key,
+            chat_id=source.chat_id,
+            chat_type=source.chat_type,
+            display_name=stream_name,
+            origin_json=json.dumps(source.to_dict()),
+        )
+    db.append_message(
+        session_id,
+        role="user",
+        content=f"{_SESSION_SEED_PREFIX}\n{message}",
+        platform_message_id=message_id,
+        timestamp=time.time(),
+    )
+    return session_id
+
+
+def zulip_send_topic_message(
+    stream: Optional[str] = None,
+    topic: Optional[str] = None,
+    message: Optional[str] = None,
+    session_user_email: Optional[str] = None,
+) -> str:
+    """Send to a Zulip topic, creating it if needed, and seed its session.
+
+    When invoked from a Zulip conversation the current sender owns the target
+    session. Other invocation surfaces must specify ``session_user_email`` so
+    a later reply routes to the same per-user stream session.
+    """
+    stream = (stream or "").strip()
+    topic = (topic or "").strip()
+    message = message or ""
+    if not stream or not topic or not message.strip():
+        return json.dumps({"error": "'stream', 'topic', and 'message' are required"})
+
+    current_email, current_name, profile = _current_zulip_session_user()
+    owner_email = (session_user_email or current_email or "").strip()
+    if not owner_email:
+        return json.dumps(
+            {
+                "error": (
+                    "session_user_email is required outside a Zulip conversation "
+                    "so Hermes can seed the correct user's topic session"
+                )
+            }
+        )
+    owner_name = current_name if owner_email == current_email and current_name else owner_email
+
+    try:
+        import zulip
+        from model_tools import _run_async
+        from .adapter import _standalone_send_zulip
+
+        site_url, bot_email, api_key, config, send_config = _load_zulip_tool_config()
+        client = zulip.Client(site=site_url, email=bot_email, api_key=api_key)
+        stream_result = client.get_stream_id(stream)
+        if stream_result.get("result") != "success" or stream_result.get("stream_id") is None:
+            raise ValueError(stream_result.get("msg") or f"Zulip stream {stream!r} was not found")
+        stream_id = int(stream_result["stream_id"])
+
+        result = _run_async(
+            _standalone_send_zulip(send_config, f"{stream_id}:{topic}", message)
+        )
+        if not isinstance(result, dict) or not result.get("success"):
+            raise ValueError((result or {}).get("error") or "Zulip send failed")
+    except Exception as exc:
+        logger.warning("zulip_send_topic_message failed: %s", exc)
+        return json.dumps({"error": str(exc)})
+
+    response = {
+        "success": True,
+        "platform": "zulip",
+        "stream": stream,
+        "topic": topic,
+        "chat_id": f"{stream_id}:{topic}",
+        "session_user_email": owner_email,
+        "message_id": str(result.get("message_id") or ""),
+    }
+    try:
+        response["session_id"] = _seed_topic_session(
+            config=config,
+            stream_id=stream_id,
+            stream_name=stream,
+            topic=topic,
+            user_email=owner_email,
+            user_name=owner_name,
+            profile=profile,
+            message=message,
+            message_id=response["message_id"],
+        )
+        response["session_seeded"] = True
+    except Exception as exc:
+        # The external delivery has already succeeded. Surface the durable
+        # session problem without claiming the message failed (and inviting a
+        # retry that would post a duplicate to Zulip).
+        logger.warning("Zulip topic message sent but session seed failed: %s", exc)
+        response["session_seeded"] = False
+        response["session_error"] = str(exc)
+    return json.dumps(response)
+
+
+_ZULIP_SEND_TOPIC_SCHEMA = {
+    "name": "zulip_send_topic_message",
+    "description": (
+        "Send a message to a Zulip stream topic. Zulip creates a topic when its "
+        "first message is sent. Hermes seeds the matching topic session so a "
+        "future reply continues with this message in context."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "stream": {"type": "string", "description": "Zulip stream name."},
+            "topic": {"type": "string", "description": "New or existing Zulip topic."},
+            "message": {"type": "string", "description": "Text to post to the topic."},
+            "session_user_email": {
+                "type": "string",
+                "description": (
+                    "Zulip email whose session is seeded. Omit in a Zulip "
+                    "conversation; required from CLI or another platform."
+                ),
+            },
+        },
+        "required": ["stream", "topic", "message"],
+    },
+}
+
+
+def _handle_zulip_send_topic_message(args, **_kw):
+    return zulip_send_topic_message(
+        stream=args.get("stream"),
+        topic=args.get("topic"),
+        message=args.get("message"),
+        session_user_email=args.get("session_user_email"),
+    )
+
+
+def register_zulip_topic_message_tool(ctx) -> None:
+    from .search_tool import _check_zulip_search_requirements
+
+    ctx.register_tool(
+        name="zulip_send_topic_message",
+        toolset="zulip-history",
+        schema=_ZULIP_SEND_TOPIC_SCHEMA,
+        handler=_handle_zulip_send_topic_message,
+        check_fn=_check_zulip_search_requirements,
+        emoji="✉️",
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,6 +200,7 @@ dev = ["debugpy==1.8.20", "pytest==9.1.1", "pytest-asyncio==1.3.0", "mcp==2.0.0"
 messaging = ["python-telegram-bot[webhooks]==22.8", "discord.py[voice]==2.7.1", "aiohttp==3.14.3", "brotlicffi==1.2.0.2", "slack-bolt==1.30.0", "slack-sdk==3.43.0", "qrcode==7.4.2"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt==1.30.0", "slack-sdk==3.43.0", "aiohttp==3.14.3"]
+zulip = ["zulip==0.9.1"]
 matrix = ["mautrix[encryption]==0.21.1", "aiosqlite==0.22.1", "asyncpg==0.31.0", "aiohttp-socks==0.11.0", "aiohttp==3.14.3"]  # aiohttp 3.14.3: prior CVEs + GHSA-cq5v-8q36-5273/GHSA-mfx4-hv73-q22v/GHSA-mq44-7p77-q5h7 (mautrix/aiohttp-socks only cap aiohttp<4 / >=3.10, so pin the patched floor directly)
 # WeCom callback-mode adapter — parses untrusted XML POST bodies from
 # WeCom-controlled callback endpoints, so we use defusedxml (drop-in

--- a/tests/gateway/test_zulip.py
+++ b/tests/gateway/test_zulip.py
@@ -1,0 +1,5343 @@
+"""Tests for Zulip platform adapter."""
+import asyncio
+import builtins
+import json
+import logging
+import os
+import threading
+import time
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, patch, AsyncMock
+
+from gateway.config import Platform, PlatformConfig
+from gateway.channel_directory import _build_from_sessions
+
+
+# ---------------------------------------------------------------------------
+# Platform plugin & config hooks
+# ---------------------------------------------------------------------------
+
+
+class TestZulipPlatformPlugin:
+    def test_dynamic_platform_value_exists(self):
+        assert Platform("zulip").value == "zulip"
+
+    def test_register_declares_platform_and_zulip_tools(self):
+        from plugins.platforms.zulip.adapter import register
+
+        class Ctx:
+            def __init__(self):
+                self.platform = None
+                self.tools = []
+
+            def register_platform(self, **kwargs):
+                self.platform = kwargs
+
+            def register_tool(self, **kwargs):
+                self.tools.append(kwargs)
+
+        ctx = Ctx()
+        register(ctx)
+
+        assert ctx.platform["name"] == "zulip"
+        assert ctx.platform["label"] == "Zulip"
+        assert ctx.platform["required_env"] == [
+            "ZULIP_SITE_URL",
+            "ZULIP_BOT_EMAIL",
+            "ZULIP_API_KEY",
+        ]
+        assert ctx.platform["allowed_users_env"] == "ZULIP_ALLOWED_USERS"
+        assert ctx.platform["allow_all_env"] == "ZULIP_ALLOW_ALL_USERS"
+        assert ctx.platform["cron_deliver_env_var"] == "ZULIP_HOME_CHANNEL"
+        assert ctx.platform["install_hint"] == "pip install 'hermes-agent[zulip]'"
+        assert callable(ctx.platform["standalone_sender_fn"])
+        assert callable(ctx.platform["env_enablement_fn"])
+        assert callable(ctx.platform["apply_yaml_config_fn"])
+        assert callable(ctx.platform["is_connected"])
+        assert ctx.platform["max_message_length"] == 10_000
+        assert [tool["name"] for tool in ctx.tools] == [
+            "zulip_search_messages", "zulip_download_attachment", "zulip_send_topic_message",
+        ]
+        assert [tool["toolset"] for tool in ctx.tools] == ["zulip-history"] * 3
+        assert [tool["emoji"] for tool in ctx.tools] == ["🔎", "📎", "✉️"]
+        assert ctx.tools[1]["is_async"] is True
+
+
+class TestZulipConfigLoading:
+    def test_env_enablement_with_api_key(self, monkeypatch):
+        monkeypatch.setenv("ZULIP_API_KEY", "zlp_abc123")
+        monkeypatch.setenv("ZULIP_BOT_EMAIL", "hermes-bot@example.zulipchat.com")
+        monkeypatch.setenv("ZULIP_SITE_URL", "https://example.zulipchat.com")
+
+        from plugins.platforms.zulip.adapter import _env_enablement
+
+        seed = _env_enablement()
+
+        assert seed["site_url"] == "https://example.zulipchat.com"
+        assert seed["bot_email"] == "hermes-bot@example.zulipchat.com"
+
+    def test_env_enablement_with_default_stream(self, monkeypatch):
+        monkeypatch.setenv("ZULIP_API_KEY", "zlp_key")
+        monkeypatch.setenv("ZULIP_BOT_EMAIL", "bot@example.com")
+        monkeypatch.setenv("ZULIP_SITE_URL", "https://example.zulipchat.com")
+        monkeypatch.setenv("ZULIP_DEFAULT_STREAM", "general")
+        monkeypatch.setenv("ZULIP_HOME_TOPIC", "notifications")
+
+        from plugins.platforms.zulip.adapter import _env_enablement
+
+        seed = _env_enablement()
+
+        assert seed["default_stream"] == "general"
+        assert seed["home_topic"] == "notifications"
+        assert seed["home_channel"]["chat_id"] == "general:notifications"
+
+    def test_zulip_not_loaded_without_creds(self, monkeypatch):
+        """Zulip should be absent when neither credentials nor routing env are set."""
+        for key in (
+            "ZULIP_API_KEY",
+            "ZULIP_BOT_EMAIL",
+            "ZULIP_SITE_URL",
+            "ZULIP_DEFAULT_STREAM",
+            "ZULIP_HOME_TOPIC",
+            "ZULIP_HOME_CHANNEL",
+        ):
+            monkeypatch.delenv(key, raising=False)
+
+        from plugins.platforms.zulip.adapter import _env_enablement
+
+        assert _env_enablement() is None
+
+    def test_connected_platforms_includes_zulip(self, monkeypatch):
+        monkeypatch.setenv("ZULIP_API_KEY", "zlp_key")
+        monkeypatch.setenv("ZULIP_BOT_EMAIL", "bot@example.com")
+        monkeypatch.setenv("ZULIP_SITE_URL", "https://example.zulipchat.com")
+
+        from plugins.platforms.zulip.adapter import _env_enablement, _zulip_configured
+
+        config = PlatformConfig(enabled=True, extra=_env_enablement())
+        assert _zulip_configured(config) is True
+
+    def test_connected_platforms_excludes_zulip_without_site_url(self, monkeypatch):
+        """Zulip needs API key, bot email, and site URL to be connected."""
+        monkeypatch.setenv("ZULIP_API_KEY", "zlp_key")
+        monkeypatch.setenv("ZULIP_BOT_EMAIL", "bot@example.com")
+        monkeypatch.delenv("ZULIP_SITE_URL", raising=False)
+
+        from plugins.platforms.zulip.adapter import _env_enablement, _zulip_configured
+
+        config = PlatformConfig(enabled=True, extra=_env_enablement())
+        assert _zulip_configured(config) is False
+
+    def test_zulip_home_channel(self, monkeypatch):
+        monkeypatch.setenv("ZULIP_API_KEY", "zlp_key")
+        monkeypatch.setenv("ZULIP_BOT_EMAIL", "bot@example.com")
+        monkeypatch.setenv("ZULIP_SITE_URL", "https://example.zulipchat.com")
+        monkeypatch.setenv("ZULIP_HOME_CHANNEL", "123:home-topic")
+        monkeypatch.setenv("ZULIP_HOME_CHANNEL_NAME", "Bot Home")
+
+        from plugins.platforms.zulip.adapter import _env_enablement
+
+        seed = _env_enablement()
+        assert seed["home_channel"]["chat_id"] == "123:home-topic"
+        assert seed["home_channel"]["name"] == "Bot Home"
+
+    def test_apply_yaml_config_seeds_env_and_extra(self, monkeypatch):
+        monkeypatch.delenv("ZULIP_SITE_URL", raising=False)
+        monkeypatch.delenv("ZULIP_BOT_EMAIL", raising=False)
+        monkeypatch.delenv("ZULIP_API_KEY", raising=False)
+
+        from plugins.platforms.zulip.adapter import _apply_yaml_config
+
+        extra = _apply_yaml_config({}, {
+            "site_url": "https://yaml.zulipchat.com",
+            "bot_email": "bot@yaml.example",
+            "api_key": "yaml-key",
+            "default_stream": "general",
+            "home_topic": "ops",
+        })
+
+        assert extra == {
+            "site_url": "https://yaml.zulipchat.com",
+            "bot_email": "bot@yaml.example",
+            "default_stream": "general",
+            "home_topic": "ops",
+        }
+        assert os.getenv("ZULIP_SITE_URL") == "https://yaml.zulipchat.com"
+        assert os.getenv("ZULIP_BOT_EMAIL") == "bot@yaml.example"
+        assert os.getenv("ZULIP_API_KEY") == "yaml-key"
+
+    def test_zulip_warning_without_email(self, monkeypatch):
+        """ZULIP_API_KEY set but ZULIP_BOT_EMAIL missing should still load."""
+        monkeypatch.setenv("ZULIP_API_KEY", "zlp_key")
+        monkeypatch.delenv("ZULIP_BOT_EMAIL", raising=False)
+        monkeypatch.delenv("ZULIP_SITE_URL", raising=False)
+
+        from plugins.platforms.zulip.adapter import _env_enablement
+
+        seed = _env_enablement()
+
+        assert seed["bot_email"] == ""
+        assert seed["site_url"] == ""
+
+    def test_site_url_trailing_slash_stripped_in_adapter(self):
+        """Adapter should strip trailing slashes from site_url."""
+        from plugins.platforms.zulip.adapter import ZulipAdapter
+        config = PlatformConfig(
+            enabled=True,
+            token="key",
+            extra={"site_url": "https://example.zulipchat.com/"},
+        )
+        adapter = ZulipAdapter(config)
+        assert adapter._site_url == "https://example.zulipchat.com"
+
+    def test_invalid_context_depth_disables_context_fetch(self, monkeypatch):
+        """A malformed optional context-depth setting must not abort startup."""
+        monkeypatch.setenv("ZULIP_CONTEXT_DEPTH", "not-a-number")
+
+        adapter = _make_adapter()
+
+        assert adapter._context_depth == 0
+
+
+# ---------------------------------------------------------------------------
+# Adapter helper
+# ---------------------------------------------------------------------------
+
+
+def _make_adapter(
+    site_url: str = "https://example.zulipchat.com",
+    bot_email: str = "hermes-bot@example.zulipchat.com",
+    api_key: str = "zlp_test_key",
+    default_stream: str = "",
+    home_topic: str = "",
+    extra=None,
+) -> "ZulipAdapter":
+    """Create a ZulipAdapter with the given config."""
+    from plugins.platforms.zulip.adapter import ZulipAdapter
+    config_extra = {
+        "site_url": site_url,
+        "bot_email": bot_email,
+        "default_stream": default_stream,
+        "home_topic": home_topic,
+    }
+    if extra:
+        config_extra.update(extra)
+    config = PlatformConfig(
+        enabled=True,
+        token=api_key,
+        extra=config_extra,
+    )
+    adapter = ZulipAdapter(config)
+    return adapter
+
+
+def _write_directory(tmp_path, platforms):
+    """Helper to write a fake channel directory cache file."""
+    data = {"updated_at": "2026-01-01T00:00:00", "platforms": platforms}
+    cache_file = tmp_path / "channel_directory.json"
+    cache_file.write_text(json.dumps(data))
+    return cache_file
+
+
+def _register_zulip_auth_entry():
+    """Install the registry auth metadata used by plugin-platform auth tests."""
+    from gateway.platform_registry import PlatformEntry, platform_registry
+
+    platform_registry.register(
+        PlatformEntry(
+            name="zulip",
+            label="Zulip",
+            adapter_factory=lambda cfg: None,
+            check_fn=lambda: True,
+            allowed_users_env="ZULIP_ALLOWED_USERS",
+            allow_all_env="ZULIP_ALLOW_ALL_USERS",
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Chat-ID helpers
+# ---------------------------------------------------------------------------
+
+
+class TestZulipStreamChatId:
+    def test_build_stream_chat_id(self):
+        from plugins.platforms.zulip.adapter import _build_stream_chat_id
+        result = _build_stream_chat_id(42, "general")
+        assert result == "42:general"
+
+    def test_build_stream_chat_id_with_spaces_in_topic(self):
+        from plugins.platforms.zulip.adapter import _build_stream_chat_id
+        result = _build_stream_chat_id(7, "some topic here")
+        assert result == "7:some topic here"
+
+    def test_parse_stream_chat_id(self):
+        from plugins.platforms.zulip.adapter import _parse_stream_chat_id
+        result = _parse_stream_chat_id("42:general")
+        assert result == (42, "general")
+
+    def test_parse_stream_chat_id_with_complex_topic(self):
+        from plugins.platforms.zulip.adapter import _parse_stream_chat_id
+        result = _parse_stream_chat_id("99:help & support")
+        assert result == (99, "help & support")
+
+    def test_parse_stream_chat_id_no_topic_fills_default(self):
+        from plugins.platforms.zulip.adapter import _parse_stream_chat_id
+        result = _parse_stream_chat_id("42:")
+        assert result == (42, "(no topic)")
+
+    def test_parse_stream_chat_id_roundtrip(self):
+        from plugins.platforms.zulip.adapter import _build_stream_chat_id, _parse_stream_chat_id
+        original = _build_stream_chat_id(123, "test topic")
+        parsed = _parse_stream_chat_id(original)
+        assert parsed == (123, "test topic")
+
+    def test_parse_stream_chat_id_invalid_returns_none(self):
+        from plugins.platforms.zulip.adapter import _parse_stream_chat_id
+        assert _parse_stream_chat_id("no-colon") is None
+        assert _parse_stream_chat_id(":no-stream-id") is None
+        assert _parse_stream_chat_id("abc:not-numeric") is None
+
+    def test_parse_stream_chat_id_with_multiple_colons(self):
+        """Topics can contain colons — only the first colon is the delimiter."""
+        from plugins.platforms.zulip.adapter import _build_stream_chat_id, _parse_stream_chat_id
+        chat_id = _build_stream_chat_id(5, "time: 12:00")
+        parsed = _parse_stream_chat_id(chat_id)
+        assert parsed == (5, "time: 12:00")
+
+
+class TestZulipDmChatId:
+    def test_build_dm_chat_id(self):
+        from plugins.platforms.zulip.adapter import _build_dm_chat_id
+        result = _build_dm_chat_id("alice@example.com")
+        assert result == "dm:alice@example.com"
+
+    def test_parse_dm_chat_id(self):
+        from plugins.platforms.zulip.adapter import _parse_dm_chat_id
+        result = _parse_dm_chat_id("dm:alice@example.com")
+        assert result == "alice@example.com"
+
+    def test_parse_dm_chat_id_roundtrip(self):
+        from plugins.platforms.zulip.adapter import _build_dm_chat_id, _parse_dm_chat_id
+        original = _build_dm_chat_id("bob@example.org")
+        parsed = _parse_dm_chat_id(original)
+        assert parsed == "bob@example.org"
+
+    def test_parse_dm_chat_id_non_dm_returns_none(self):
+        from plugins.platforms.zulip.adapter import _parse_dm_chat_id
+        assert _parse_dm_chat_id("42:general") is None
+        assert _parse_dm_chat_id("nondm@example.com") is None
+        assert _parse_dm_chat_id("dm:no-at-sign") is None
+
+    def test_is_dm_chat_id_true(self):
+        from plugins.platforms.zulip.adapter import is_dm_chat_id
+        assert is_dm_chat_id("dm:alice@example.com") is True
+
+    def test_is_dm_chat_id_false_for_stream(self):
+        from plugins.platforms.zulip.adapter import is_dm_chat_id
+        assert is_dm_chat_id("42:general") is False
+
+    def test_is_dm_chat_id_false_for_bare_email(self):
+        from plugins.platforms.zulip.adapter import is_dm_chat_id
+        assert is_dm_chat_id("alice@example.com") is False
+
+
+# ---------------------------------------------------------------------------
+# Requirements check
+# ---------------------------------------------------------------------------
+
+
+class TestZulipRequirements:
+    def test_check_requirements_with_creds_and_package(self, monkeypatch):
+        monkeypatch.setenv("ZULIP_API_KEY", "test-key")
+        monkeypatch.setenv("ZULIP_BOT_EMAIL", "bot@example.com")
+        monkeypatch.setenv("ZULIP_SITE_URL", "https://example.zulipchat.com")
+        from plugins.platforms.zulip.adapter import check_zulip_requirements
+        try:
+            import zulip  # noqa: F401
+            assert check_zulip_requirements() is True
+        except ImportError:
+            assert check_zulip_requirements() is False
+
+    def test_check_requirements_lazy_installs_when_sdk_missing(self, monkeypatch):
+        monkeypatch.setenv("ZULIP_API_KEY", "test-key")
+        monkeypatch.setenv("ZULIP_BOT_EMAIL", "bot@example.com")
+        monkeypatch.setenv("ZULIP_SITE_URL", "https://example.zulipchat.com")
+        from plugins.platforms.zulip.adapter import check_zulip_requirements
+
+        calls = []
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "zulip":
+                if calls:
+                    return MagicMock()
+                raise ImportError("missing zulip")
+            return real_import(name, *args, **kwargs)
+
+        def fake_ensure(feature, prompt=False):
+            calls.append((feature, prompt))
+
+        with patch.object(builtins, "__import__", side_effect=fake_import), \
+             patch("tools.lazy_deps.ensure", side_effect=fake_ensure):
+            assert check_zulip_requirements() is True
+
+        assert calls == [("platform.zulip", False)]
+
+    def test_check_requirements_without_api_key(self, monkeypatch):
+        monkeypatch.delenv("ZULIP_API_KEY", raising=False)
+        monkeypatch.delenv("ZULIP_BOT_EMAIL", raising=False)
+        monkeypatch.delenv("ZULIP_SITE_URL", raising=False)
+        from plugins.platforms.zulip.adapter import check_zulip_requirements
+        assert check_zulip_requirements() is False
+
+    def test_check_requirements_without_email(self, monkeypatch):
+        monkeypatch.setenv("ZULIP_API_KEY", "test-key")
+        monkeypatch.delenv("ZULIP_BOT_EMAIL", raising=False)
+        monkeypatch.delenv("ZULIP_SITE_URL", raising=False)
+        from plugins.platforms.zulip.adapter import check_zulip_requirements
+        assert check_zulip_requirements() is False
+
+    def test_check_requirements_without_site_url(self, monkeypatch):
+        monkeypatch.setenv("ZULIP_API_KEY", "test-key")
+        monkeypatch.setenv("ZULIP_BOT_EMAIL", "bot@example.com")
+        monkeypatch.delenv("ZULIP_SITE_URL", raising=False)
+        from plugins.platforms.zulip.adapter import check_zulip_requirements
+        assert check_zulip_requirements() is False
+
+    def test_check_requirements_accepts_config_credentials(self, monkeypatch):
+        """Config-backed Zulip setup should not be blocked by missing env vars."""
+        monkeypatch.delenv("ZULIP_API_KEY", raising=False)
+        monkeypatch.delenv("ZULIP_BOT_EMAIL", raising=False)
+        monkeypatch.delenv("ZULIP_SITE_URL", raising=False)
+
+        from plugins.platforms.zulip.adapter import check_zulip_requirements
+
+        config = PlatformConfig(
+            enabled=True,
+            token="test-key",
+            extra={
+                "bot_email": "bot@example.com",
+                "site_url": "https://example.zulipchat.com",
+            },
+        )
+        assert check_zulip_requirements(config) is True
+
+        config.token = None
+        config.api_key = "test-api-key"
+        assert check_zulip_requirements(config) is True
+
+
+# ---------------------------------------------------------------------------
+# Adapter init
+# ---------------------------------------------------------------------------
+
+
+class TestZulipAdapterInit:
+    def test_init_from_config(self):
+        adapter = _make_adapter(
+            site_url="https://my.zulipchat.com",
+            bot_email="bot@my.zulipchat.com",
+            api_key="my-key",
+        )
+        assert adapter._site_url == "https://my.zulipchat.com"
+        assert adapter._bot_email == "bot@my.zulipchat.com"
+        assert adapter._api_key == "my-key"
+        assert adapter.platform == Platform("zulip")
+
+    def test_init_uses_config_api_key_when_token_empty(self, monkeypatch):
+        monkeypatch.delenv("ZULIP_API_KEY", raising=False)
+
+        from plugins.platforms.zulip.adapter import ZulipAdapter
+
+        config = PlatformConfig(
+            enabled=True,
+            api_key="config-api-key",
+            extra={
+                "site_url": "https://my.zulipchat.com",
+                "bot_email": "bot@my.zulipchat.com",
+            },
+        )
+        adapter = ZulipAdapter(config)
+
+        assert adapter._api_key == "config-api-key"
+
+    def test_init_default_stream_and_home_topic(self):
+        adapter = _make_adapter(
+            default_stream="general",
+            home_topic="cron",
+        )
+        assert adapter._default_stream == "general"
+        assert adapter._home_topic == "cron"
+
+    def test_init_empty_defaults(self, monkeypatch):
+        monkeypatch.delenv("ZULIP_DEFAULT_STREAM", raising=False)
+        monkeypatch.delenv("ZULIP_HOME_TOPIC", raising=False)
+        adapter = _make_adapter()
+        assert adapter._default_stream == ""
+        assert adapter._home_topic == ""
+        assert adapter._client is None
+        assert adapter._bot_user_id == -1
+        assert adapter._bot_full_name == ""
+
+    def test_init_env_var_fallback(self, monkeypatch):
+        """Adapter falls back to env vars when config.extra values are empty."""
+        monkeypatch.setenv("ZULIP_SITE_URL", "https://env.zulipchat.com")
+        monkeypatch.setenv("ZULIP_BOT_EMAIL", "env-bot@zulipchat.com")
+        monkeypatch.setenv("ZULIP_API_KEY", "env-key")
+        monkeypatch.setenv("ZULIP_DEFAULT_STREAM", "env-stream")
+
+        config = PlatformConfig(
+            enabled=True,
+            extra={},  # empty extra — should fall back to env
+        )
+        from plugins.platforms.zulip.adapter import ZulipAdapter
+        adapter = ZulipAdapter(config)
+
+        assert adapter._site_url == "https://env.zulipchat.com"
+        assert adapter._bot_email == "env-bot@zulipchat.com"
+        assert adapter._api_key == "env-key"
+        assert adapter._default_stream == "env-stream"
+
+
+# ---------------------------------------------------------------------------
+# Format message
+# ---------------------------------------------------------------------------
+
+
+class TestZulipFormatMessage:
+    def setup_method(self):
+        self.adapter = _make_adapter()
+
+    def test_image_markdown_preserved(self):
+        """Zulip supports image Markdown directly."""
+        content = "![cat](https://img.example.com/cat.png)"
+        assert self.adapter.format_message(content) == content
+
+    def test_image_markdown_with_alt_text_preserved(self):
+        content = "Here: ![my image](https://x.com/a.jpg) done"
+        assert self.adapter.format_message(content) == content
+
+    def test_regular_markdown_preserved(self):
+        content = "**bold** and *italic* and `code`"
+        assert self.adapter.format_message(content) == content
+
+    def test_regular_links_preserved(self):
+        content = "[click](https://example.com)"
+        assert self.adapter.format_message(content) == content
+
+    def test_plain_text_unchanged(self):
+        content = "Hello, world!"
+        assert self.adapter.format_message(content) == content
+
+    def test_multiple_images(self):
+        content = "![a](http://a.com/1.png) text ![b](http://b.com/2.png)"
+        assert self.adapter.format_message(content) == content
+
+    def test_multiline_dollar_display_math_becomes_math_fence(self):
+        """GitHub-style multi-line $$ blocks must become Zulip ```math fences."""
+        content = (
+            "CRDT loss:\n"
+            "$$\n"
+            r"\mathcal{L}_{\text{CRDT}}(\mathcal{S}, \mathcal{O}) = 1" "\n"
+            "$$\n"
+            "done"
+        )
+        formatted = self.adapter.format_message(content)
+        assert "```math\n" in formatted
+        assert r"\mathcal{L}_{\text{CRDT}}" in formatted
+        assert formatted.count("$$") == 0
+        assert "done" in formatted
+
+    def test_inline_double_dollar_math_preserved(self):
+        """Mid-sentence $$...$$ is already Zulip inline math and must stay."""
+        content = "Complexity is $$O(n^2)$$ in the worst case."
+        assert self.adapter.format_message(content) == content
+
+    def test_existing_math_fence_preserved(self):
+        content = "```math\nE = mc^2\n```"
+        assert self.adapter.format_message(content) == content
+
+    def test_dollar_math_inside_code_fence_preserved(self):
+        content = "Example syntax:\n```\n$$\nx = 1\n$$\n```\n"
+        assert self.adapter.format_message(content) == content
+
+    def test_single_dollar_inline_math_becomes_double_dollar(self):
+        """Traditional $...$ (small-model default) becomes Zulip $$...$$."""
+        content = "Complexity is $O(n^2)$ in the worst case."
+        assert (
+            self.adapter.format_message(content)
+            == "Complexity is $$O(n^2)$$ in the worst case."
+        )
+
+    def test_paren_and_bracket_math_converted(self):
+        r"""\(...\) → inline $$; whole-line \[...\] → ```math fence."""
+        content = (
+            "Inline is \\(a + b\\).\n"
+            "\\[\n"
+            "E = mc^2\n"
+            "\\]\n"
+            "done"
+        )
+        formatted = self.adapter.format_message(content)
+        assert "Inline is $$a + b$$." in formatted
+        assert "```math\nE = mc^2\n```" in formatted
+        assert r"\(" not in formatted
+        assert r"\[" not in formatted
+
+    def test_currency_amounts_not_converted(self):
+        """Bare $5 / $5.00 must not become KaTeX."""
+        content = "Price is $5 or $5.00 today."
+        assert self.adapter.format_message(content) == content
+
+    def test_convert_math_can_be_disabled(self):
+        """ZULIP_CONVERT_MATH=false / convert_math=False leaves source alone."""
+        self.adapter._convert_math = False
+        content = "Keep $O(n)$ and \\(x\\) and $$\ny\n$$ raw."
+        assert self.adapter.format_message(content) == content
+
+
+# ---------------------------------------------------------------------------
+# Connect / Disconnect
+# ---------------------------------------------------------------------------
+
+
+class TestZulipConnect:
+    @pytest.mark.asyncio
+    async def test_connect_success(self):
+        """connect() should create client, fetch profile, start event queue."""
+        adapter = _make_adapter()
+
+        mock_client = MagicMock()
+        mock_client.get_profile.return_value = {
+            "result": "success",
+            "profile": {"user_id": 42, "full_name": "Hermes Bot"},
+        }
+        mock_client.get_streams.return_value = {
+            "result": "success",
+            "streams": [
+                {"stream_id": 10, "name": "general"},
+                {"stream_id": 20, "name": "random"},
+            ],
+        }
+
+        # Make call_on_each_event stop the event queue after one call
+        # (simulating the blocking behavior of the real Zulip client).
+        def stop_after_one_call(*args, **kwargs):
+            adapter._closing = True
+
+        mock_client.call_on_each_event.side_effect = stop_after_one_call
+
+        # Set up the event loop reference before calling connect,
+        # which internally calls asyncio.get_running_loop()
+        adapter._loop = asyncio.get_running_loop()
+
+        with patch.dict("sys.modules", {"zulip": MagicMock(Client=MagicMock(return_value=mock_client))}):
+            result = await adapter.connect()
+
+        assert result is True
+        assert adapter._bot_user_id == 42
+        assert adapter._bot_full_name == "Hermes Bot"
+        assert adapter._stream_id_cache["general"] == 10
+        assert adapter._stream_name_cache[10] == "general"
+        mock_client.call_on_each_event.assert_called_once()
+
+        # Bug 2: verify apply_markdown=False is passed so content is raw Markdown
+        _call_args, call_kwargs = mock_client.call_on_each_event.call_args
+        assert call_kwargs.get("apply_markdown") is False, (
+            "apply_markdown=False required so message content is raw Markdown, "
+            "not rendered HTML. Without this, @mention detection silently fails."
+        )
+
+    @pytest.mark.asyncio
+    async def test_connect_accepts_is_reconnect_kwarg(self):
+        """Gateway reconnect watcher passes is_reconnect=True; adapter must accept it."""
+        adapter = _make_adapter()
+
+        mock_client = MagicMock()
+        mock_client.get_profile.return_value = {
+            "result": "success",
+            "profile": {"user_id": 42, "full_name": "Hermes Bot"},
+        }
+        mock_client.get_streams.return_value = {
+            "result": "success",
+            "streams": [],
+        }
+
+        def stop_after_one_call(*args, **kwargs):
+            adapter._closing = True
+
+        mock_client.call_on_each_event.side_effect = stop_after_one_call
+        adapter._loop = asyncio.get_running_loop()
+
+        with patch.dict("sys.modules", {"zulip": MagicMock(Client=MagicMock(return_value=mock_client))}):
+            result = await adapter.connect(is_reconnect=True)
+
+        assert result is True
+        mock_client.call_on_each_event.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_connect_profile_at_top_level(self):
+        """Zulip API returns user profile at top level, not nested under 'profile'.
+
+        Bug: result.get("profile", {}) always returned {} for the real API,
+        so _bot_user_id and _bot_full_name were never set. This caused
+        @mention detection to silently fail in streams.
+        """
+        adapter = _make_adapter()
+
+        mock_client = MagicMock()
+        # Real Zulip API response: data at top level, no "profile" key
+        mock_client.get_profile.return_value = {
+            "result": "success",
+            "user_id": 42,
+            "full_name": "Hermes Bot",
+            "short_name": "hermes",
+            "email": "hermes@example.com",
+            "avatar_url": "https://example.com/avatar.png",
+        }
+        mock_client.get_streams.return_value = {
+            "result": "success",
+            "streams": [],
+        }
+
+        def stop_after_one_call(*args, **kwargs):
+            adapter._closing = True
+
+        mock_client.call_on_each_event.side_effect = stop_after_one_call
+
+        adapter._loop = asyncio.get_running_loop()
+
+        with patch.dict("sys.modules", {"zulip": MagicMock(Client=MagicMock(return_value=mock_client))}):
+            result = await adapter.connect()
+
+        assert result is True
+        assert adapter._bot_user_id == 42
+        assert adapter._bot_full_name == "Hermes Bot"
+
+    @pytest.mark.asyncio
+    async def test_connect_missing_config(self):
+        """connect() should return False when config is incomplete."""
+        adapter = _make_adapter()
+        adapter._site_url = ""
+        adapter._api_key = ""
+        adapter._bot_email = ""
+
+        result = await adapter.connect()
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_connect_auth_failure(self):
+        """connect() should return False when Zulip auth fails."""
+        adapter = _make_adapter()
+
+        mock_client = MagicMock()
+        mock_client.get_profile.return_value = {
+            "result": "error",
+            "msg": "Invalid API key",
+        }
+
+        adapter._loop = asyncio.get_running_loop()
+
+        with patch.dict("sys.modules", {"zulip": MagicMock(Client=MagicMock(return_value=mock_client))}):
+            result = await adapter.connect()
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_connect_passes_tls_options_to_client(self, monkeypatch):
+        """Local/self-hosted Zulip setups may need custom TLS options."""
+        monkeypatch.setenv("ZULIP_CERT_BUNDLE", "/tmp/zulip-ca.pem")
+        monkeypatch.setenv("ZULIP_ALLOW_INSECURE", "true")
+
+        adapter = _make_adapter()
+
+        mock_client = MagicMock()
+        mock_client.get_profile.return_value = {
+            "result": "success",
+            "profile": {"user_id": 42, "full_name": "Hermes Bot"},
+        }
+        mock_client.get_streams.return_value = {
+            "result": "success",
+            "streams": [{"stream_id": 10, "name": "general"}],
+        }
+        mock_client.call_on_each_event.side_effect = lambda *args, **kwargs: setattr(adapter, "_closing", True)
+
+        client_ctor = MagicMock(return_value=mock_client)
+        adapter._loop = asyncio.get_running_loop()
+
+        with patch.dict("sys.modules", {"zulip": MagicMock(Client=client_ctor)}):
+            result = await adapter.connect()
+
+        assert result is True
+        client_ctor.assert_called_once_with(
+            site="https://example.zulipchat.com",
+            email="hermes-bot@example.zulipchat.com",
+            api_key="zlp_test_key",
+            cert_bundle="/tmp/zulip-ca.pem",
+            insecure=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_disconnect_clears_client(self):
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._closing = False
+        adapter._event_thread = None
+
+        await adapter.disconnect()
+
+        assert adapter._client is None
+        assert adapter._closing is True
+
+
+# ---------------------------------------------------------------------------
+# Streaming edit contract
+# ---------------------------------------------------------------------------
+
+
+class TestZulipStreamingEditContract:
+    def test_adapter_declares_message_editing_capability(self):
+        """Zulip supports update_message; the standard streaming gate controls use."""
+        adapter = _make_adapter()
+
+        assert getattr(adapter, "SUPPORTS_MESSAGE_EDITING", False) is True
+
+    def test_adapter_declares_long_message_splitting(self):
+        """Cron delivery skips the 4000-char truncate when send() chunks natively."""
+        adapter = _make_adapter()
+
+        assert getattr(adapter, "splits_long_messages", False) is True
+
+    @pytest.mark.asyncio
+    async def test_cron_delivery_does_not_truncate_zulip_payload(self, tmp_path, monkeypatch):
+        from gateway.config import GatewayConfig
+        from gateway.delivery import DeliveryRouter, DeliveryTarget
+        from gateway.platforms.base import SendResult
+
+        monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+        adapter = _make_adapter()
+        sent = []
+
+        async def capture(chat_id, content, metadata=None):
+            sent.append(content)
+            return SendResult(success=True)
+
+        adapter.send = capture
+        router = DeliveryRouter(GatewayConfig(), adapters={Platform("zulip"): adapter})
+        long_content = "x" * 5000
+
+        await router._deliver_to_platform(
+            DeliveryTarget.parse("zulip:42"),
+            long_content,
+            metadata={"job_id": "job1"},
+        )
+
+        assert sent == [long_content]
+        assert "truncated" not in sent[0]
+
+    def test_streaming_edit_warning_is_not_logged_on_adapter_startup(self, caplog):
+        """Startup should stay quiet until effective Zulip streaming edits a message."""
+        caplog.set_level(logging.WARNING, logger="plugins.platforms.zulip.adapter")
+
+        _make_adapter()
+
+        assert "Zulip streaming edits are enabled" not in caplog.text
+
+    def test_streaming_edit_warning_is_logged_once_when_edits_are_used(self, caplog):
+        """The warning is tied to actual edit use, not adapter construction."""
+        caplog.set_level(logging.WARNING, logger="plugins.platforms.zulip.adapter")
+        adapter = _make_adapter()
+
+        adapter.warn_streaming_edits_enabled()
+        adapter.warn_streaming_edits_enabled()
+
+        records = [
+            record for record in caplog.records
+            if "Zulip streaming edits are enabled" in record.message
+        ]
+        assert len(records) == 1
+        assert "Disable edit history in Zulip organization settings" in records[0].message
+
+    @pytest.mark.asyncio
+    async def test_edit_message_accepts_gateway_streaming_kwargs(self):
+        """Zulip edits must accept the BasePlatformAdapter streaming contract."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+
+        send_client = MagicMock()
+        send_client.update_message.return_value = {"result": "success"}
+
+        with patch.object(adapter, "_build_send_client", return_value=send_client):
+            result = await adapter.edit_message(
+                "general:ops",
+                "12345",
+                "partial **markdown** response",
+                finalize=True,
+                metadata={"thread_id": "ops"},
+            )
+
+        assert result.success is True
+        assert result.message_id == "12345"
+        send_client.update_message.assert_called_once_with({
+            "message_id": 12345,
+            "content": "partial **markdown** response",
+        })
+
+    @pytest.mark.asyncio
+    async def test_edit_message_offloads_blocking_update_request(self):
+        """Streaming edits must not execute the synchronous SDK call on-loop."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        send_client = MagicMock()
+        request = {"message_id": 12345, "content": "partial"}
+
+        with patch.object(adapter, "_build_send_client", return_value=send_client), \
+             patch(
+                 "plugins.platforms.zulip.adapter.asyncio.to_thread",
+                 new=AsyncMock(return_value={"result": "success"}),
+             ) as to_thread:
+            result = await adapter.edit_message("general:ops", "12345", "partial")
+
+        assert result.success is True
+        assert result.message_id == "12345"
+        to_thread.assert_awaited_once_with(send_client.update_message, request)
+        send_client.update_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_gateway_stream_consumer_can_stream_over_zulip_edits(self):
+        """The real streaming path should send once, then edit the Zulip message."""
+        from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+
+        send_client = MagicMock()
+        send_client.get_stream_id.return_value = {
+            "result": "success",
+            "stream_id": 42,
+        }
+        send_client.send_message.return_value = {
+            "result": "success",
+            "id": 9001,
+        }
+        send_client.update_message.return_value = {"result": "success"}
+
+        with patch.object(adapter, "_build_send_client", return_value=send_client):
+            consumer = GatewayStreamConsumer(
+                adapter,
+                "general",
+                StreamConsumerConfig(
+                    edit_interval=0.01,
+                    buffer_threshold=1,
+                    cursor="",
+                ),
+                metadata={"thread_id": "ops"},
+            )
+            task = asyncio.create_task(consumer.run())
+            consumer.on_delta("hello")
+            await asyncio.sleep(0.05)
+            consumer.on_delta(" world")
+            consumer.finish()
+            await asyncio.wait_for(task, timeout=2.0)
+
+        assert consumer.final_response_sent is True
+        assert consumer.final_content_delivered is True
+        send_client.send_message.assert_called_once_with({
+            "type": "stream",
+            "to": "42",
+            "topic": "ops",
+            "content": "hello",
+        })
+        send_client.update_message.assert_called_with({
+            "message_id": 9001,
+            "content": "hello world",
+        })
+
+
+# ---------------------------------------------------------------------------
+# Self-message filtering
+# ---------------------------------------------------------------------------
+
+
+class TestZulipSelfMessageFiltering:
+    def setup_method(self):
+        self.adapter = _make_adapter(bot_email="bot@example.zulipchat.com")
+        self.adapter._bot_user_id = 42
+        self.adapter._bot_full_name = "Hermes Bot"
+        self.adapter._loop = None  # prevent async dispatch
+        self.adapter.handle_message = AsyncMock()
+
+    def test_filter_by_sender_email(self):
+        """Messages from the bot's own email should be ignored."""
+        event = {
+            "type": "message",
+            "op": "add",
+            "message": {
+                "id": 100,
+                "sender_email": "bot@example.zulipchat.com",
+                "sender_id": 42,
+                "type": "private",
+                "content": "echo test",
+                "display_recipient": [
+                    {"email": "other@example.com"},
+                    {"email": "bot@example.zulipchat.com"},
+                ],
+            },
+        }
+        self.adapter._on_zulip_event(event)
+        self.adapter.handle_message.assert_not_called()
+
+    def test_filter_by_sender_id(self):
+        """Messages from the bot's user ID should be ignored."""
+        event = {
+            "type": "message",
+            "op": "add",
+            "message": {
+                "id": 101,
+                "sender_email": "someone-else@example.com",
+                "sender_id": 42,  # matches bot_user_id
+                "type": "private",
+                "content": "spoofed",
+                "display_recipient": [
+                    {"email": "bot@example.zulipchat.com"},
+                    {"email": "someone-else@example.com"},
+                ],
+            },
+        }
+        self.adapter._on_zulip_event(event)
+        self.adapter.handle_message.assert_not_called()
+
+    def test_non_bot_messages_pass_through(self):
+        """Messages from other users should not be filtered."""
+        event = {
+            "type": "message",
+            "op": "add",
+            "message": {
+                "id": 102,
+                "sender_email": "alice@example.com",
+                "sender_id": 99,
+                "type": "private",
+                "content": "Hello bot",
+                "display_recipient": [
+                    {"email": "bot@example.zulipchat.com"},
+                    {"email": "alice@example.com"},
+                ],
+            },
+        }
+        # With _loop=None, _on_zulip_event won't schedule dispatch
+        # but the filtering logic still runs — it just won't reach dispatch
+        self.adapter._on_zulip_event(event)
+        # Not called because _loop is None, but NOT because of filtering
+        # (we verify the filter didn't reject it by checking _seen_events)
+        assert "102" in self.adapter._seen_events
+
+
+# ---------------------------------------------------------------------------
+# Dedup cache
+# ---------------------------------------------------------------------------
+
+
+class TestZulipDedup:
+    def setup_method(self):
+        self.adapter = _make_adapter(bot_email="bot@example.zulipchat.com")
+        self.adapter._bot_user_id = 42
+        self.adapter._bot_full_name = "Hermes Bot"
+        self.adapter._loop = None
+        self.adapter.handle_message = AsyncMock()
+
+    def test_duplicate_message_ignored(self):
+        """The same message ID should be deduped."""
+        event = {
+            "type": "message",
+            "op": "add",
+            "message": {
+                "id": 200,
+                "sender_email": "alice@example.com",
+                "sender_id": 99,
+                "type": "private",
+                "content": "Hello",
+                "display_recipient": [
+                    {"email": "bot@example.zulipchat.com"},
+                    {"email": "alice@example.com"},
+                ],
+            },
+        }
+        # First call: event gets recorded
+        self.adapter._on_zulip_event(event)
+        assert "200" in self.adapter._seen_events
+
+        # Second call: same event_id — deduped (still in cache, no scheduling)
+        self.adapter._on_zulip_event(event)
+
+    def test_different_message_ids_both_tracked(self):
+        """Different message IDs should both be recorded."""
+        for mid in [300, 301]:
+            event = {
+                "type": "message",
+                "op": "add",
+                "message": {
+                    "id": mid,
+                    "sender_email": "alice@example.com",
+                    "sender_id": 99,
+                    "type": "private",
+                    "content": "Hello",
+                    "display_recipient": [
+                        {"email": "bot@example.zulipchat.com"},
+                        {"email": "alice@example.com"},
+                    ],
+                },
+            }
+            self.adapter._on_zulip_event(event)
+
+        assert "300" in self.adapter._seen_events
+        assert "301" in self.adapter._seen_events
+
+    def test_prune_seen_clears_expired(self):
+        """_prune_seen should remove entries older than _SEEN_TTL."""
+        now = time.time()
+        # Fill beyond _SEEN_MAX to trigger pruning
+        for i in range(self.adapter._SEEN_MAX + 10):
+            self.adapter._seen_events[f"old_{i}"] = now - 600  # 10 min ago
+        # Add a fresh one
+        self.adapter._seen_events["fresh"] = now
+
+        self.adapter._prune_seen()
+
+        assert "fresh" in self.adapter._seen_events
+        assert len(self.adapter._seen_events) < self.adapter._SEEN_MAX
+
+
+# ---------------------------------------------------------------------------
+# Inbound event dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestZulipInboundDispatch:
+    def setup_method(self):
+        self.adapter = _make_adapter(bot_email="bot@example.zulipchat.com")
+        self.adapter._bot_user_id = 42
+        self.adapter._bot_full_name = "Hermes Bot"
+        self.adapter.handle_message = AsyncMock()
+        self.adapter._stream_name_cache = {99: "general"}
+
+    @pytest.mark.asyncio
+    async def test_dm_dispatch_creates_message_event(self):
+        """A DM should produce a MessageEvent with chat_type='dm'."""
+        message = {
+            "id": 500,
+            "sender_email": "alice@example.com",
+            "sender_full_name": "Alice Smith",
+            "sender_id": 10,
+            "type": "private",
+            "content": "Hello!",
+            "display_recipient": [
+                {"email": "bot@example.zulipchat.com"},
+                {"email": "alice@example.com"},
+            ],
+        }
+        event = {"message": message}
+
+        await self.adapter._dispatch_inbound(message, event)
+
+        assert self.adapter.handle_message.called
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "Hello!"
+        assert msg_event.message_type.value == "text"
+        assert msg_event.source.chat_type == "dm"
+        assert msg_event.source.user_id == "alice@example.com"
+        assert msg_event.source.user_name == "Alice Smith"
+        assert msg_event.source.chat_id == "dm:alice@example.com"
+
+    @pytest.mark.asyncio
+    async def test_dm_command_detected(self):
+        """Messages starting with / should be COMMAND type."""
+        message = {
+            "id": 501,
+            "sender_email": "alice@example.com",
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "private",
+            "content": "/reset",
+            "display_recipient": [
+                {"email": "bot@example.zulipchat.com"},
+                {"email": "alice@example.com"},
+            ],
+        }
+        event = {"message": message}
+
+        await self.adapter._dispatch_inbound(message, event)
+
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.message_type.value == "command"
+
+
+# ---------------------------------------------------------------------------
+# Inbound upload images (vision)
+# ---------------------------------------------------------------------------
+
+
+class TestZulipInboundUploadImages:
+    def setup_method(self):
+        self.adapter = _make_adapter(bot_email="bot@example.zulipchat.com")
+        self.adapter._bot_user_id = 42
+        self.adapter._bot_full_name = "Hermes Bot"
+        self.adapter.handle_message = AsyncMock()
+
+    def _dm_message(self, content):
+        return {
+            "id": 600,
+            "sender_email": "alice@example.com",
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "private",
+            "content": content,
+            "display_recipient": [
+                {"email": "bot@example.zulipchat.com"},
+                {"email": "alice@example.com"},
+            ],
+        }
+
+    def test_extract_image_paths_from_markdown(self):
+        from plugins.platforms.zulip.adapter import _extract_upload_image_paths
+        content = (
+            "look at this\n"
+            "[shot.png](/user_uploads/2/ab/cdef123/shot.png)"
+        )
+        assert _extract_upload_image_paths(content) == [
+            "/user_uploads/2/ab/cdef123/shot.png"
+        ]
+
+    def test_extract_image_paths_inline_image_syntax(self):
+        from plugins.platforms.zulip.adapter import _extract_upload_image_paths
+        content = "![alt text](/user_uploads/2/ab/cdef123/screen.jpg)"
+        assert _extract_upload_image_paths(content) == [
+            "/user_uploads/2/ab/cdef123/screen.jpg"
+        ]
+
+    def test_extract_image_paths_absolute_url_normalized(self):
+        from plugins.platforms.zulip.adapter import _extract_upload_image_paths
+        content = (
+            "[s.png](https://chat.example.com"
+            "/user_uploads/2/ab/cdef123/s.png)"
+        )
+        assert _extract_upload_image_paths(content) == [
+            "/user_uploads/2/ab/cdef123/s.png"
+        ]
+
+    def test_extract_image_paths_skips_non_images(self):
+        from plugins.platforms.zulip.adapter import _extract_upload_image_paths
+        content = (
+            "[report.pdf](/user_uploads/2/ab/cdef123/report.pdf) and "
+            "[notes.txt](/user_uploads/2/ab/cdef123/notes.txt)"
+        )
+        assert _extract_upload_image_paths(content) == []
+
+    def test_extract_upload_paths_includes_documents_and_dedupes(self):
+        from plugins.platforms.zulip.attachments import extract_upload_paths
+        content = (
+            "[report.pdf](/user_uploads/2/ab/cdef123/report.pdf) and "
+            "[notes.txt](https://chat.example.com/user_uploads/2/ab/cdef123/notes.txt) "
+            "[again](/user_uploads/2/ab/cdef123/report.pdf)"
+        )
+        assert extract_upload_paths(content) == [
+            "/user_uploads/2/ab/cdef123/report.pdf",
+            "/user_uploads/2/ab/cdef123/notes.txt",
+        ]
+
+    def test_extract_image_paths_dedupes_preserving_order(self):
+        from plugins.platforms.zulip.adapter import _extract_upload_image_paths
+        content = (
+            "[a.png](/user_uploads/1/a/a.png)"
+            "[b.png](/user_uploads/1/b/b.png)"
+            "[a.png](/user_uploads/1/a/a.png)"
+        )
+        assert _extract_upload_image_paths(content) == [
+            "/user_uploads/1/a/a.png",
+            "/user_uploads/1/b/b.png",
+        ]
+
+    def test_extract_image_paths_no_uploads(self):
+        from plugins.platforms.zulip.adapter import _extract_upload_image_paths
+        assert _extract_upload_image_paths("plain text") == []
+        assert _extract_upload_image_paths("") == []
+
+    @pytest.mark.asyncio
+    async def test_dm_with_pasted_image_sets_media_fields(self):
+        """A DM containing an upload link should carry the downloaded
+        image in media_urls/media_types on the MessageEvent."""
+        self.adapter._fetch_inbound_uploads = AsyncMock(
+            return_value=(["/tmp/cache/img_abc.png"], ["image/png"])
+        )
+        message = self._dm_message(
+            "what's wrong here? [shot.png](/user_uploads/2/ab/x/shot.png)"
+        )
+
+        await self.adapter._dispatch_inbound(message, {"message": message})
+
+        self.adapter._fetch_inbound_uploads.assert_awaited_once()
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.media_urls == ["/tmp/cache/img_abc.png"]
+        assert msg_event.media_types == ["image/png"]
+
+    @pytest.mark.asyncio
+    async def test_dm_without_uploads_skips_fetch(self):
+        """No /user_uploads/ link → the fetch helper is never called."""
+        self.adapter._fetch_inbound_uploads = AsyncMock()
+        message = self._dm_message("just words")
+
+        await self.adapter._dispatch_inbound(message, {"message": message})
+
+        self.adapter._fetch_inbound_uploads.assert_not_called()
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.media_urls == []
+
+    @pytest.mark.asyncio
+    async def test_fetch_failure_still_dispatches_text(self):
+        """Download errors must never drop the message."""
+        self.adapter._fetch_inbound_uploads = AsyncMock(
+            return_value=([], [])
+        )
+        message = self._dm_message(
+            "[shot.png](/user_uploads/2/ab/x/shot.png)"
+        )
+
+        await self.adapter._dispatch_inbound(message, {"message": message})
+
+        assert self.adapter.handle_message.called
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert "/user_uploads/" in msg_event.text
+        assert msg_event.media_urls == []
+
+    @pytest.mark.asyncio
+    async def test_dm_with_document_sets_media_fields(self):
+        """Non-image uploads are cached for file/terminal tools too."""
+        self.adapter._fetch_inbound_uploads = AsyncMock(
+            return_value=(["/tmp/cache/doc_abc_report.pdf"], ["application/pdf"])
+        )
+        message = self._dm_message(
+            "Please summarize [report.pdf](/user_uploads/2/ab/x/report.pdf)"
+        )
+
+        await self.adapter._dispatch_inbound(message, {"message": message})
+
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.media_urls == ["/tmp/cache/doc_abc_report.pdf"]
+        assert msg_event.media_types == ["application/pdf"]
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_sender_upload_is_not_downloaded(self):
+        self.adapter.set_authorization_check(lambda *_args: False)
+        self.adapter._fetch_inbound_uploads = AsyncMock()
+        message = self._dm_message(
+            "[report.pdf](/user_uploads/2/ab/x/report.pdf)"
+        )
+
+        await self.adapter._dispatch_inbound(message, {"message": message})
+
+        self.adapter._fetch_inbound_uploads.assert_not_awaited()
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.media_urls == []
+
+
+# ---------------------------------------------------------------------------
+# Missed-message catch-up (opt-in gap recovery)
+# ---------------------------------------------------------------------------
+
+
+class _FakeLoop:
+    """Minimal stand-in for an asyncio loop in catch-up tests."""
+
+    def is_closed(self):
+        return False
+
+
+class TestZulipMissedMessageCatchup:
+    def _adapter(self, tmp_path, *, enabled=True, max_messages=100):
+        adapter = _make_adapter(bot_email="bot@example.zulipchat.com")
+        adapter._catchup_enabled = enabled
+        adapter._catchup_max_messages = max_messages
+        adapter._bot_user_id = 42
+        adapter._client = object()
+        adapter._loop = _FakeLoop()
+        adapter._stream_id_cache = {"bugs": 1}
+        wm = tmp_path / "wm.json"  # isolate the watermark file to tmp
+        adapter._catchup_watermark_path = lambda: wm
+        return adapter, wm
+
+    def _send_client(self, adapter, get_messages_return):
+        client = MagicMock()
+        client.get_messages.return_value = get_messages_return
+        adapter._build_send_client = lambda: client
+        return client
+
+    # --- config ---------------------------------------------------------
+
+    def test_catchup_disabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("ZULIP_CATCHUP", raising=False)
+        adapter = _make_adapter()
+        assert adapter._catchup_enabled is False
+        assert adapter._catchup_max_messages == 100
+
+    def test_catchup_enabled_via_extra(self, monkeypatch):
+        monkeypatch.delenv("ZULIP_CATCHUP", raising=False)
+        from plugins.platforms.zulip.adapter import ZulipAdapter
+        cfg = PlatformConfig(
+            enabled=True, token="k",
+            extra={"site_url": "https://x.zulipchat.com", "bot_email": "b@x.com",
+                   "catchup_enabled": True, "catchup_max_messages": 25},
+        )
+        adapter = ZulipAdapter(cfg)
+        assert adapter._catchup_enabled is True
+        assert adapter._catchup_max_messages == 25
+
+    # --- sweep behavior -------------------------------------------------
+
+    def test_first_run_seeds_watermark_without_replay(self, tmp_path):
+        adapter, wm = self._adapter(tmp_path)
+        adapter._on_zulip_event = MagicMock()
+        self._send_client(adapter, {"result": "success", "messages": [{"id": 5000}]})
+
+        adapter._run_missed_message_catchup()
+
+        adapter._on_zulip_event.assert_not_called()  # seed only, no back-fill
+        assert json.loads(wm.read_text())["bugs"] == 5000
+
+    def test_replays_messages_after_watermark(self, tmp_path):
+        adapter, wm = self._adapter(tmp_path)
+        wm.write_text(json.dumps({"bugs": 100}))
+        adapter._on_zulip_event = MagicMock()
+        self._send_client(adapter, {
+            "result": "success",
+            "messages": [
+                {"id": 100, "type": "stream"},  # == watermark → skipped
+                {"id": 101, "type": "stream"},
+                {"id": 102, "type": "stream"},
+            ],
+        })
+
+        adapter._run_missed_message_catchup()
+
+        replayed_ids = [
+            c.args[0]["message"]["id"] for c in adapter._on_zulip_event.call_args_list
+        ]
+        assert replayed_ids == [101, 102]
+        assert adapter._on_zulip_event.call_args_list[0].args[0]["type"] == "message"
+
+    def test_sweep_respects_max_messages_bound(self, tmp_path):
+        adapter, wm = self._adapter(tmp_path, max_messages=5)
+        wm.write_text(json.dumps({"bugs": 100}))
+        adapter._on_zulip_event = MagicMock()
+        client = self._send_client(adapter, {"result": "success", "messages": []})
+
+        adapter._run_missed_message_catchup()
+
+        assert client.get_messages.call_args.args[0]["num_after"] == 5
+
+    # --- watermark advance ---------------------------------------------
+
+    def test_advance_watermark_monotonic(self, tmp_path):
+        adapter, wm = self._adapter(tmp_path)
+        adapter._advance_catchup_watermark(
+            {"type": "stream", "id": 200, "display_recipient": "bugs"})
+        adapter._advance_catchup_watermark(
+            {"type": "stream", "id": 100, "display_recipient": "bugs"})  # older
+        assert json.loads(wm.read_text())["bugs"] == 200
+
+    def test_advance_watermark_noop_when_disabled(self, tmp_path):
+        adapter, wm = self._adapter(tmp_path, enabled=False)
+        adapter._advance_catchup_watermark(
+            {"type": "stream", "id": 7, "display_recipient": "bugs"})
+        assert not wm.exists()
+
+    def test_advance_watermark_ignores_private_messages(self, tmp_path):
+        adapter, wm = self._adapter(tmp_path)
+        adapter._advance_catchup_watermark(
+            {"type": "private", "id": 300, "display_recipient": [{"email": "a@b.c"}]})
+        assert not wm.exists()
+
+
+# ---------------------------------------------------------------------------
+# Group DM send path
+# ---------------------------------------------------------------------------
+
+
+class TestZulipAsyncSend:
+    """Verify async send paths do not block the event loop."""
+
+    @pytest.mark.asyncio
+    async def test_send_runs_sync_zulip_client_call_in_thread(self, monkeypatch):
+        from gateway.platforms.base import SendResult
+        import plugins.platforms.zulip.adapter as zulip_platform
+
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+
+        calls = []
+
+        async def fake_to_thread(fn, *args, **kwargs):
+            calls.append((fn, args, kwargs))
+            return fn(*args, **kwargs)
+
+        adapter._do_send_message = MagicMock(
+            return_value=SendResult(success=True, message_id="42")
+        )
+        monkeypatch.setattr(zulip_platform.asyncio, "to_thread", fake_to_thread)
+
+        result = await adapter.send("general:general chat", "hello")
+
+        assert result.success is True
+        assert result.message_id == "42"
+        assert calls
+        adapter._do_send_message.assert_called_once_with(
+            "general:general chat",
+            "hello",
+            None,
+        )
+
+
+class TestGroupDmSendPath:
+    """Verify that _do_send_message correctly handles group DM chat IDs."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._client = MagicMock()
+        self.adapter._build_send_client = MagicMock(return_value=self.adapter._client)
+
+    def test_send_group_dm_parses_emails(self):
+        """Group DM chat IDs should send to all recipient emails."""
+        self.adapter._client.send_message.return_value = {
+            "result": "success",
+            "id": 1000,
+        }
+
+        result = self.adapter._do_send_message(
+            "group_dm:alice@example.com,bob@example.com", "Hello group!"
+        )
+
+        assert result.success is True
+        call_args = self.adapter._client.send_message.call_args[0][0]
+        assert call_args["type"] == "private"
+        assert call_args["to"] == ["alice@example.com", "bob@example.com"]
+        assert call_args["content"] == "Hello group!"
+
+    def test_send_group_dm_three_participants(self):
+        """Group DM with 3 participants sends to all three."""
+        self.adapter._client.send_message.return_value = {
+            "result": "success",
+            "id": 1001,
+        }
+
+        result = self.adapter._do_send_message(
+            "group_dm:alice@example.com,bob@example.com,charlie@example.com", "Hey all"
+        )
+
+        assert result.success is True
+        call_args = self.adapter._client.send_message.call_args[0][0]
+        assert len(call_args["to"]) == 3
+        assert "charlie@example.com" in call_args["to"]
+
+    def test_send_group_dm_api_failure(self):
+        """API errors on group DM send return failed SendResult."""
+        self.adapter._client.send_message.return_value = {
+            "result": "error",
+            "msg": "One or more recipients are invalid",
+        }
+
+        result = self.adapter._do_send_message(
+            "group_dm:alice@example.com,bob@example.com", "fail"
+        )
+
+        assert result.success is False
+        assert "invalid" in result.error
+
+    def test_send_group_dm_not_connected(self):
+        """No client returns failed SendResult for group DMs."""
+        self.adapter._client = None
+
+        result = self.adapter._do_send_message(
+            "group_dm:alice@example.com,bob@example.com", "no client"
+        )
+
+        assert result.success is False
+        assert "Not connected" in result.error
+
+    def test_send_group_dm_roundtrip_with_build_parse(self):
+        """Full round-trip: build chat ID → send → verify recipients."""
+        from plugins.platforms.zulip.adapter import _build_group_dm_chat_id, _parse_group_dm_chat_id
+        emails = ["charlie@example.com", "alice@example.com"]
+        chat_id = _build_group_dm_chat_id(emails)
+
+        self.adapter._client.send_message.return_value = {
+            "result": "success",
+            "id": 1002,
+        }
+
+        result = self.adapter._do_send_message(chat_id, "roundtrip test")
+
+        assert result.success is True
+        call_args = self.adapter._client.send_message.call_args[0][0]
+        parsed_emails = _parse_group_dm_chat_id(chat_id)
+        assert call_args["to"] == parsed_emails
+
+
+# ---------------------------------------------------------------------------
+# Session key integration with Zulip chat IDs
+# ---------------------------------------------------------------------------
+
+
+class TestZulipSessionKeyIntegration:
+    """Verify that build_session_key produces deterministic, isolated keys
+    for all Zulip chat types using the chat-id encoding."""
+
+    def test_stream_session_key_includes_stream_id_and_topic(self):
+        """Stream messages with different topics should produce different keys."""
+        from gateway.session import SessionSource, build_session_key
+
+        source_a = SessionSource(
+            platform=Platform("zulip"),
+            chat_id="42:general",
+            chat_name="general",
+            chat_type="stream",
+            user_id="alice@example.com",
+            user_name="Alice",
+            chat_topic="general",
+        )
+        source_b = SessionSource(
+            platform=Platform("zulip"),
+            chat_id="42:help",
+            chat_name="general",
+            chat_type="stream",
+            user_id="alice@example.com",
+            user_name="Alice",
+            chat_topic="help",
+        )
+
+        key_a = build_session_key(source_a)
+        key_b = build_session_key(source_b)
+
+        assert key_a != key_b
+        assert "42:general" in key_a
+        assert "42:help" in key_b
+
+    def test_stream_session_key_different_streams_same_topic(self):
+        """Same topic in different streams should produce different keys."""
+        from gateway.session import SessionSource, build_session_key
+
+        source_a = SessionSource(
+            platform=Platform("zulip"),
+            chat_id="10:general",
+            chat_type="stream",
+            user_id="alice@example.com",
+        )
+        source_b = SessionSource(
+            platform=Platform("zulip"),
+            chat_id="20:general",
+            chat_type="stream",
+            user_id="alice@example.com",
+        )
+
+        key_a = build_session_key(source_a)
+        key_b = build_session_key(source_b)
+
+        assert key_a != key_b
+
+    def test_stream_session_key_same_sender_isolated(self):
+        """Same sender in different stream topics gets different sessions."""
+        from gateway.session import SessionSource, build_session_key
+
+        source = SessionSource(
+            platform=Platform("zulip"),
+            chat_id="42:topic-a",
+            chat_type="stream",
+            user_id="alice@example.com",
+        )
+
+        # With default group_sessions_per_user=True, sender is included
+        key = build_session_key(source)
+        assert "alice@example.com" in key
+
+    def test_dm_session_key_isolated_from_stream(self):
+        """DMs should never share a session key with stream messages."""
+        from gateway.session import SessionSource, build_session_key
+
+        dm_source = SessionSource(
+            platform=Platform("zulip"),
+            chat_id="dm:alice@example.com",
+            chat_type="dm",
+            user_id="alice@example.com",
+        )
+        stream_source = SessionSource(
+            platform=Platform("zulip"),
+            chat_id="42:general",
+            chat_type="stream",
+            user_id="alice@example.com",
+        )
+
+        dm_key = build_session_key(dm_source)
+        stream_key = build_session_key(stream_source)
+
+        assert dm_key != stream_key
+
+    def test_dm_session_key_different_users(self):
+        """DMs with different users should produce different keys."""
+        from gateway.session import SessionSource, build_session_key
+
+        source_a = SessionSource(
+            platform=Platform("zulip"),
+            chat_id="dm:alice@example.com",
+            chat_type="dm",
+            user_id="alice@example.com",
+        )
+        source_b = SessionSource(
+            platform=Platform("zulip"),
+            chat_id="dm:bob@example.com",
+            chat_type="dm",
+            user_id="bob@example.com",
+        )
+
+        key_a = build_session_key(source_a)
+        key_b = build_session_key(source_b)
+
+        assert key_a != key_b
+
+    def test_group_dm_session_key_isolated_from_dm(self):
+        """Group DMs should not share session keys with 1:1 DMs."""
+        from gateway.session import SessionSource, build_session_key
+
+        dm_source = SessionSource(
+            platform=Platform("zulip"),
+            chat_id="dm:alice@example.com",
+            chat_type="dm",
+            user_id="alice@example.com",
+        )
+        group_source = SessionSource(
+            platform=Platform("zulip"),
+            chat_id="group_dm:alice@example.com,bob@example.com",
+            chat_type="group",
+            user_id="alice@example.com",
+        )
+
+        dm_key = build_session_key(dm_source)
+        group_key = build_session_key(group_source)
+
+        assert dm_key != group_key
+
+    def test_session_key_deterministic_across_calls(self):
+        """Same source should always produce the same session key."""
+        from gateway.session import SessionSource, build_session_key
+
+        source = SessionSource(
+            platform=Platform("zulip"),
+            chat_id="42:general",
+            chat_type="stream",
+            user_id="alice@example.com",
+        )
+
+        key_a = build_session_key(source)
+        key_b = build_session_key(source)
+
+        assert key_a == key_b
+
+
+# ---------------------------------------------------------------------------
+# SessionSource serialization round-trip with Zulip
+# ---------------------------------------------------------------------------
+
+
+class TestZulipSessionSourceSerialization:
+    """Verify that Zulip SessionSources survive to_dict/from_dict round-trips."""
+
+    def test_stream_source_roundtrip(self):
+        from gateway.session import SessionSource
+
+        original = SessionSource(
+            platform=Platform("zulip"),
+            chat_id="42:general",
+            chat_name="general",
+            chat_type="stream",
+            user_id="alice@example.com",
+            user_name="Alice Smith",
+            chat_topic="general",
+        )
+
+        restored = SessionSource.from_dict(original.to_dict())
+
+        assert restored.platform == Platform("zulip")
+        assert restored.chat_id == "42:general"
+        assert restored.chat_name == "general"
+        assert restored.chat_type == "stream"
+        assert restored.user_id == "alice@example.com"
+        assert restored.user_name == "Alice Smith"
+        assert restored.chat_topic == "general"
+
+    def test_dm_source_roundtrip(self):
+        from gateway.session import SessionSource
+
+        original = SessionSource(
+            platform=Platform("zulip"),
+            chat_id="dm:alice@example.com",
+            chat_name="alice@example.com",
+            chat_type="dm",
+            user_id="alice@example.com",
+            user_name="Alice",
+        )
+
+        restored = SessionSource.from_dict(original.to_dict())
+
+        assert restored.platform == Platform("zulip")
+        assert restored.chat_id == "dm:alice@example.com"
+        assert restored.chat_type == "dm"
+        assert restored.user_id == "alice@example.com"
+
+    def test_group_dm_source_roundtrip(self):
+        from gateway.session import SessionSource
+
+        original = SessionSource(
+            platform=Platform("zulip"),
+            chat_id="group_dm:alice@example.com,bob@example.com",
+            chat_name="alice@example.com, bob@example.com",
+            chat_type="group",
+            user_id="alice@example.com",
+            user_name="Alice",
+        )
+
+        restored = SessionSource.from_dict(original.to_dict())
+
+        assert restored.platform == Platform("zulip")
+        assert restored.chat_id == "group_dm:alice@example.com,bob@example.com"
+        assert restored.chat_type == "group"
+
+    def test_stream_source_no_topic_roundtrip(self):
+        from gateway.session import SessionSource
+
+        original = SessionSource(
+            platform=Platform("zulip"),
+            chat_id="42:(no topic)",
+            chat_name="42",
+            chat_type="stream",
+            user_id="alice@example.com",
+            chat_topic="(no topic)",
+        )
+
+        restored = SessionSource.from_dict(original.to_dict())
+
+        assert restored.chat_id == "42:(no topic)"
+        assert restored.chat_topic == "(no topic)"
+
+    def test_chat_id_with_colon_in_topic_preserved(self):
+        """Topics containing colons must survive serialization."""
+        from gateway.session import SessionSource
+
+        original = SessionSource(
+            platform=Platform("zulip"),
+            chat_id="5:time: 12:00",
+            chat_name="general",
+            chat_type="stream",
+            user_id="alice@example.com",
+            chat_topic="time: 12:00",
+        )
+
+        restored = SessionSource.from_dict(original.to_dict())
+
+        assert restored.chat_id == "5:time: 12:00"
+        assert restored.chat_topic == "time: 12:00"
+
+
+# ---------------------------------------------------------------------------
+# Missing/empty subject field
+# ---------------------------------------------------------------------------
+
+
+class TestMissingSubjectField:
+    def setup_method(self):
+        self.adapter = _make_adapter(bot_email="bot@example.zulipchat.com")
+        self.adapter._bot_user_id = 42
+        self.adapter._bot_full_name = "Hermes Bot"
+        self.adapter.handle_message = AsyncMock()
+        self.adapter._stream_name_cache = {99: "general"}
+
+    @pytest.mark.asyncio
+    async def test_missing_subject_defaults(self):
+        """Stream messages missing 'subject' should use '(no topic)'."""
+        message = {
+            "id": 900,
+            "sender_email": "alice@example.com",
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "stream",
+            "stream_id": 99,
+            # No 'subject' field
+            "content": "@**Hermes Bot** help",
+        }
+        event = {"type": "message", "op": "add", "message": message}
+
+        await self.adapter._dispatch_inbound(message, event)
+
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.source.chat_topic == "(no topic)"
+        assert msg_event.source.chat_id == "99:(no topic)"
+
+    @pytest.mark.asyncio
+    async def test_empty_subject_defaults(self):
+        """Stream messages with empty 'subject' should use '(no topic)'."""
+        message = {
+            "id": 901,
+            "sender_email": "alice@example.com",
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "stream",
+            "stream_id": 99,
+            "subject": "",
+            "content": "@**Hermes Bot** help",
+        }
+        event = {"type": "message", "op": "add", "message": message}
+
+        await self.adapter._dispatch_inbound(message, event)
+
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.source.chat_topic == "(no topic)"
+
+
+# ---------------------------------------------------------------------------
+# Mention stripping
+# ---------------------------------------------------------------------------
+
+
+class TestZulipMentionStripping:
+    """Verify that @mention patterns are stripped from stream message content."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter(bot_email="bot@example.zulipchat.com")
+        self.adapter._bot_user_id = 42
+        self.adapter._bot_full_name = "Hermes Bot"
+        self.adapter.handle_message = AsyncMock()
+        self.adapter._stream_name_cache = {99: "general"}
+
+    @pytest.mark.asyncio
+    async def test_full_name_mention_stripped(self):
+        """@**Hermes Bot** should be removed from content."""
+        message = {
+            "id": 1001,
+            "sender_email": "alice@example.com",
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "stream",
+            "stream_id": 99,
+            "subject": "test",
+            "content": "@**Hermes Bot** what is the weather?",
+        }
+        await self.adapter._dispatch_inbound(message, {})
+
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "what is the weather?"
+
+    @pytest.mark.asyncio
+    async def test_email_mention_stripped(self):
+        """@bot@example.zulipchat.com should be removed from content."""
+        message = {
+            "id": 1002,
+            "sender_email": "alice@example.com",
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "stream",
+            "stream_id": 99,
+            "subject": "test",
+            "content": "@bot@example.zulipchat.com hello!",
+        }
+        await self.adapter._dispatch_inbound(message, {})
+
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "hello!"
+
+    @pytest.mark.asyncio
+    async def test_case_insensitive_mention_stripped(self):
+        """Mention stripping should be case-insensitive."""
+        message = {
+            "id": 1003,
+            "sender_email": "alice@example.com",
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "stream",
+            "stream_id": 99,
+            "subject": "test",
+            "content": "@**hermes bot** please help me",
+        }
+        await self.adapter._dispatch_inbound(message, {})
+
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "please help me"
+
+    @pytest.mark.asyncio
+    async def test_mention_in_middle_of_content(self):
+        """Mention embedded in longer content should be stripped cleanly."""
+        message = {
+            "id": 1004,
+            "sender_email": "alice@example.com",
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "stream",
+            "stream_id": 99,
+            "subject": "test",
+            "content": "Hey @**Hermes Bot** can you look at this?",
+        }
+        await self.adapter._dispatch_inbound(message, {})
+
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "Hey can you look at this?"
+
+    @pytest.mark.asyncio
+    async def test_dm_no_mention_stripping(self):
+        """DMs should NOT have mention stripping applied."""
+        message = {
+            "id": 1005,
+            "sender_email": "alice@example.com",
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "private",
+            "content": "@**Hermes Bot** help me",
+            "display_recipient": [
+                {"email": "bot@example.zulipchat.com"},
+                {"email": "alice@example.com"},
+            ],
+        }
+        await self.adapter._dispatch_inbound(message, {})
+
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        # DMs don't go through mention logic — content should be unchanged
+        assert msg_event.text == "@**Hermes Bot** help me"
+
+
+# ---------------------------------------------------------------------------
+# Historical context via Zulip /messages API (ZULIP_CONTEXT_DEPTH)
+# ---------------------------------------------------------------------------
+
+
+class TestZulipHistoricalContext:
+    """Verify that context is fetched from Zulip's /messages API on @mention."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter(bot_email="bot@example.zulipchat.com")
+        self.adapter._bot_user_id = 42
+        self.adapter._bot_full_name = "Hermes Bot"
+        self.adapter._require_mention = True
+        self.adapter._free_response_streams = set()
+        self.adapter._context_depth = 20
+        self.adapter.handle_message = AsyncMock()
+        self.adapter._stream_name_cache = {99: "general"}
+
+    @pytest.mark.asyncio
+    async def test_mention_fetches_context_and_prepends(self):
+        """On @mention, recent messages from the stream+topic are fetched and
+        prepended to the user's message."""
+        mock_client = MagicMock()
+        mock_client.get_messages.return_value = {
+            "result": "success",
+            "messages": [
+                {
+                    "sender_full_name": "Alice",
+                    "sender_email": "alice@example.com",
+                    "content": "I think we should use PostgreSQL",
+                },
+                {
+                    "sender_full_name": "Bob",
+                    "sender_email": "bob@example.com",
+                    "content": "Agreed, but what about migrations?",
+                },
+            ],
+        }
+        self.adapter._build_send_client = MagicMock(return_value=mock_client)
+
+        message = {
+            "id": 3001,
+            "sender_email": "charlie@example.com",
+            "sender_full_name": "Charlie",
+            "sender_id": 10,
+            "type": "stream",
+            "stream_id": 99,
+            "subject": "announcements",
+            "content": "@**Hermes Bot** what do you think?",
+            "display_recipient": "general",
+        }
+        event = {"type": "message", "op": "add", "message": message}
+        await self.adapter._dispatch_inbound(message, event)
+
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert "Recent messages in this topic:" in msg_event.text
+        assert "Alice: I think we should use PostgreSQL" in msg_event.text
+        assert "Bob: Agreed, but what about migrations?" in msg_event.text
+        assert "---" in msg_event.text
+        # Mention should be stripped from the user's actual message
+        assert "what do you think?" in msg_event.text
+
+    @pytest.mark.asyncio
+    async def test_mention_context_fetch_failure_falls_back_gracefully(self):
+        """If the /messages API call fails, the message is still processed
+        without context (no crash, no dropped message)."""
+        mock_client = MagicMock()
+        mock_client.get_messages.side_effect = ConnectionError("timeout")
+        self.adapter._build_send_client = MagicMock(return_value=mock_client)
+
+        message = {
+            "id": 3002,
+            "sender_email": "alice@example.com",
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "stream",
+            "stream_id": 99,
+            "subject": "general",
+            "content": "@**Hermes Bot** hello",
+            "display_recipient": "general",
+        }
+        event = {"type": "message", "op": "add", "message": message}
+        await self.adapter._dispatch_inbound(message, event)
+
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        # No context block injected (fetch failed)
+        assert "Recent messages" not in msg_event.text
+        # Mention stripped, message still delivered
+        assert msg_event.text == "hello"
+
+    @pytest.mark.asyncio
+    async def test_no_context_for_dm(self):
+        """DMs should never fetch context — context is stream+topic only."""
+        mock_client = MagicMock()
+        self.adapter._build_send_client = MagicMock(return_value=mock_client)
+
+        message = {
+            "id": 3003,
+            "sender_email": "alice@example.com",
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "private",
+            "content": "Hey bot, help me",
+            "display_recipient": [
+                {"email": "bot@example.zulipchat.com"},
+                {"email": "alice@example.com"},
+            ],
+        }
+        event = {"type": "message", "op": "add", "message": message}
+        await self.adapter._dispatch_inbound(message, event)
+
+        # No /messages API call made for DMs
+        mock_client.get_messages.assert_not_called()
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "Hey bot, help me"
+
+    @pytest.mark.asyncio
+    async def test_context_depth_zero_disables_fetch(self):
+        """When ZULIP_CONTEXT_DEPTH=0, no context is fetched."""
+        self.adapter._context_depth = 0
+        mock_client = MagicMock()
+        self.adapter._build_send_client = MagicMock(return_value=mock_client)
+
+        message = {
+            "id": 3004,
+            "sender_email": "alice@example.com",
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "stream",
+            "stream_id": 99,
+            "subject": "general",
+            "content": "@**Hermes Bot** hello",
+            "display_recipient": "general",
+        }
+        event = {"type": "message", "op": "add", "message": message}
+        await self.adapter._dispatch_inbound(message, event)
+
+        mock_client.get_messages.assert_not_called()
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "hello"
+
+    @pytest.mark.asyncio
+    async def test_bot_messages_are_filtered_from_context(self):
+        """The bot's own messages are excluded from fetched context."""
+        mock_client = MagicMock()
+        mock_client.get_messages.return_value = {
+            "result": "success",
+            "messages": [
+                {
+                    "sender_full_name": "Hermes Bot",
+                    "sender_email": "bot@example.zulipchat.com",
+                    "content": "I think we should use PostgreSQL",
+                },
+                {
+                    "sender_full_name": "Alice",
+                    "sender_email": "alice@example.com",
+                    "content": "Interesting, tell me more",
+                },
+            ],
+        }
+        self.adapter._build_send_client = MagicMock(return_value=mock_client)
+
+        message = {
+            "id": 3005,
+            "sender_email": "alice@example.com",
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "stream",
+            "stream_id": 99,
+            "subject": "announcements",
+            "content": "@**Hermes Bot** continue",
+            "display_recipient": "general",
+        }
+        event = {"type": "message", "op": "add", "message": message}
+        await self.adapter._dispatch_inbound(message, event)
+
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        # Bot's own message should be filtered out
+        assert "Hermes Bot" not in msg_event.text.split("---")[0]
+        # Alice's message should be present
+        assert "Alice: Interesting, tell me more" in msg_event.text
+
+
+class TestStripBotMentionHelper:
+    """Unit tests for the _strip_bot_mention helper."""
+
+    def test_strips_single_pattern(self):
+        from plugins.platforms.zulip.adapter import _strip_bot_mention
+        result = _strip_bot_mention(
+            "@**Bot Name** hello", ["@**Bot Name**"]
+        )
+        assert result == "hello"
+
+    def test_strips_email_pattern(self):
+        from plugins.platforms.zulip.adapter import _strip_bot_mention
+        result = _strip_bot_mention(
+            "@bot@example.com what's up", ["@bot@example.com"]
+        )
+        assert result == "what's up"
+
+    def test_strips_case_insensitive(self):
+        from plugins.platforms.zulip.adapter import _strip_bot_mention
+        result = _strip_bot_mention(
+            "@**BOT NAME** hello", ["@**Bot Name**"]
+        )
+        assert result == "hello"
+
+    def test_no_pattern_no_change(self):
+        from plugins.platforms.zulip.adapter import _strip_bot_mention
+        content = "just a regular message"
+        result = _strip_bot_mention(content, ["@**Someone Else**"])
+        assert result == content
+
+    def test_only_strips_first_occurrence(self):
+        """Only the first mention should be stripped (count=1)."""
+        from plugins.platforms.zulip.adapter import _strip_bot_mention
+        result = _strip_bot_mention(
+            "@**Bot** @**Bot** hello", ["@**Bot**"]
+        )
+        # First occurrence stripped, second remains
+        assert result == "@**Bot** hello"
+
+    def test_strips_whitespace_after_removal(self):
+        from plugins.platforms.zulip.adapter import _strip_bot_mention
+        result = _strip_bot_mention(
+            "  @**Bot**   hello  ", ["@**Bot**"]
+        )
+        assert result == "hello"
+
+
+# ---------------------------------------------------------------------------
+# ZULIP_REQUIRE_MENTION env var
+# ---------------------------------------------------------------------------
+
+
+class TestZulipRequireMention:
+    """Verify ZULIP_REQUIRE_MENTION env var behavior."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter(bot_email="bot@example.zulipchat.com")
+        self.adapter._bot_user_id = 42
+        self.adapter._bot_full_name = "Hermes Bot"
+        self.adapter.handle_message = AsyncMock()
+        self.adapter._stream_name_cache = {99: "general"}
+
+    @pytest.mark.asyncio
+    async def test_default_requires_mention(self):
+        """By default, stream messages without mention should be ignored."""
+        message = {
+            "id": 1101,
+            "sender_email": "alice@example.com",
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "stream",
+            "stream_id": 99,
+            "subject": "test",
+            "content": "hello without mention",
+        }
+        await self.adapter._dispatch_inbound(message, {})
+
+        self.adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_default_with_mention_passes(self):
+        """By default, stream messages with mention should be processed."""
+        message = {
+            "id": 1102,
+            "sender_email": "alice@example.com",
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "stream",
+            "stream_id": 99,
+            "subject": "test",
+            "content": "@**Hermes Bot** hello",
+        }
+        await self.adapter._dispatch_inbound(message, {})
+
+        self.adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_require_mention_false_passes_without_mention(self, monkeypatch):
+        """When ZULIP_REQUIRE_MENTION=false, messages without mention pass."""
+        monkeypatch.setenv("ZULIP_REQUIRE_MENTION", "false")
+
+        # Create a fresh adapter to pick up the env var
+        adapter = _make_adapter(bot_email="bot@example.zulipchat.com")
+        adapter._bot_user_id = 42
+        adapter._bot_full_name = "Hermes Bot"
+        adapter.handle_message = AsyncMock()
+        adapter._stream_name_cache = {99: "general"}
+
+        message = {
+            "id": 1103,
+            "sender_email": "alice@example.com",
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "stream",
+            "stream_id": 99,
+            "subject": "test",
+            "content": "hello without mention",
+        }
+        await adapter._dispatch_inbound(message, {})
+
+        adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_require_mention_zero_disables(self, monkeypatch):
+        """ZULIP_REQUIRE_MENTION=0 should disable mention requirement."""
+        monkeypatch.setenv("ZULIP_REQUIRE_MENTION", "0")
+
+        adapter = _make_adapter(bot_email="bot@example.zulipchat.com")
+        adapter._bot_user_id = 42
+        adapter._bot_full_name = "Hermes Bot"
+        adapter.handle_message = AsyncMock()
+        adapter._stream_name_cache = {99: "general"}
+
+        message = {
+            "id": 1104,
+            "sender_email": "alice@example.com",
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "stream",
+            "stream_id": 99,
+            "subject": "test",
+            "content": "hello without mention",
+        }
+        await adapter._dispatch_inbound(message, {})
+
+        adapter.handle_message.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# ZULIP_FREE_RESPONSE_STREAMS env var
+# ---------------------------------------------------------------------------
+
+
+class TestZulipFreeResponseStreams:
+    """Verify ZULIP_FREE_RESPONSE_STREAMS env var behavior."""
+
+    @pytest.mark.asyncio
+    async def test_free_stream_bypasses_mention(self, monkeypatch):
+        """Messages in a free-response stream should not require mention."""
+        monkeypatch.setenv("ZULIP_FREE_RESPONSE_STREAMS", "general")
+
+        adapter = _make_adapter(bot_email="bot@example.zulipchat.com")
+        adapter._bot_user_id = 42
+        adapter._bot_full_name = "Hermes Bot"
+        adapter.handle_message = AsyncMock()
+        adapter._stream_name_cache = {99: "general"}
+
+        message = {
+            "id": 1201,
+            "sender_email": "alice@example.com",
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "stream",
+            "stream_id": 99,
+            "subject": "test",
+            "content": "hello without mention",
+        }
+        await adapter._dispatch_inbound(message, {})
+
+        adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_non_free_stream_still_requires_mention(self, monkeypatch):
+        """Messages in non-free streams should still require mention."""
+        monkeypatch.setenv("ZULIP_FREE_RESPONSE_STREAMS", "random")
+
+        adapter = _make_adapter(bot_email="bot@example.zulipchat.com")
+        adapter._bot_user_id = 42
+        adapter._bot_full_name = "Hermes Bot"
+        adapter.handle_message = AsyncMock()
+        adapter._stream_name_cache = {99: "general"}
+
+        message = {
+            "id": 1202,
+            "sender_email": "alice@example.com",
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "stream",
+            "stream_id": 99,
+            "subject": "test",
+            "content": "hello without mention",
+        }
+        await adapter._dispatch_inbound(message, {})
+
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_free_stream_by_id(self, monkeypatch):
+        """Free-response streams can match by stream ID."""
+        monkeypatch.setenv("ZULIP_FREE_RESPONSE_STREAMS", "99")
+
+        adapter = _make_adapter(bot_email="bot@example.zulipchat.com")
+        adapter._bot_user_id = 42
+        adapter._bot_full_name = "Hermes Bot"
+        adapter.handle_message = AsyncMock()
+        adapter._stream_name_cache = {99: "general"}
+
+        message = {
+            "id": 1203,
+            "sender_email": "alice@example.com",
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "stream",
+            "stream_id": 99,
+            "subject": "test",
+            "content": "hello without mention",
+        }
+        await adapter._dispatch_inbound(message, {})
+
+        adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_free_stream_case_insensitive(self, monkeypatch):
+        """Stream name matching should be case-insensitive."""
+        monkeypatch.setenv("ZULIP_FREE_RESPONSE_STREAMS", "GENERAL")
+
+        adapter = _make_adapter(bot_email="bot@example.zulipchat.com")
+        adapter._bot_user_id = 42
+        adapter._bot_full_name = "Hermes Bot"
+        adapter.handle_message = AsyncMock()
+        adapter._stream_name_cache = {99: "general"}
+
+        message = {
+            "id": 1204,
+            "sender_email": "alice@example.com",
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "stream",
+            "stream_id": 99,
+            "subject": "test",
+            "content": "hello without mention",
+        }
+        await adapter._dispatch_inbound(message, {})
+
+        adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_multiple_free_streams(self, monkeypatch):
+        """Multiple free-response streams separated by commas."""
+        monkeypatch.setenv("ZULIP_FREE_RESPONSE_STREAMS", "general,random,help")
+
+        adapter = _make_adapter(bot_email="bot@example.zulipchat.com")
+        adapter._bot_user_id = 42
+        adapter._bot_full_name = "Hermes Bot"
+        adapter.handle_message = AsyncMock()
+        adapter._stream_name_cache = {99: "general", 20: "random"}
+
+        # general stream (in free list)
+        msg_general = {
+            "id": 1205,
+            "sender_email": "alice@example.com",
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "stream",
+            "stream_id": 99,
+            "subject": "test",
+            "content": "no mention in general",
+        }
+        await adapter._dispatch_inbound(msg_general, {})
+        assert adapter.handle_message.call_count == 1
+
+        # random stream (in free list)
+        msg_random = {
+            "id": 1206,
+            "sender_email": "alice@example.com",
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "stream",
+            "stream_id": 20,
+            "subject": "test",
+            "content": "no mention in random",
+        }
+        await adapter._dispatch_inbound(msg_random, {})
+        assert adapter.handle_message.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Wildcard mentions
+# ---------------------------------------------------------------------------
+
+
+class TestZulipWildcardMentions:
+    """Verify @**all** and @**everyone** trigger the bot in streams."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter(bot_email="bot@example.zulipchat.com")
+        self.adapter._bot_user_id = 42
+        self.adapter._bot_full_name = "Hermes Bot"
+        self.adapter.handle_message = AsyncMock()
+        self.adapter._stream_name_cache = {99: "general"}
+
+    @pytest.mark.asyncio
+    async def test_at_all_triggers_bot(self):
+        """@**all** should trigger the bot in streams."""
+        message = {
+            "id": 1301,
+            "sender_email": "alice@example.com",
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "stream",
+            "stream_id": 99,
+            "subject": "test",
+            "content": "@**all** check this out",
+        }
+        await self.adapter._dispatch_inbound(message, {})
+
+        self.adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_at_everyone_triggers_bot(self):
+        """@**everyone** should trigger the bot in streams."""
+        message = {
+            "id": 1302,
+            "sender_email": "alice@example.com",
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "stream",
+            "stream_id": 99,
+            "subject": "test",
+            "content": "@**everyone** important announcement",
+        }
+        await self.adapter._dispatch_inbound(message, {})
+
+        self.adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_wildcard_not_stripped_from_content(self):
+        """@**all** and @**everyone** should NOT be stripped from content."""
+        message = {
+            "id": 1303,
+            "sender_email": "alice@example.com",
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "stream",
+            "stream_id": 99,
+            "subject": "test",
+            "content": "@**all** this is a broadcast",
+        }
+        await self.adapter._dispatch_inbound(message, {})
+
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        # @**all** is NOT a bot mention pattern, so it stays in content
+        assert "@**all**" in msg_event.text
+
+    @pytest.mark.asyncio
+    async def test_case_insensitive_wildcard(self):
+        """Wildcard mentions should be case-insensitive."""
+        message = {
+            "id": 1304,
+            "sender_email": "alice@example.com",
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "stream",
+            "stream_id": 99,
+            "subject": "test",
+            "content": "@**ALL** attention please",
+        }
+        await self.adapter._dispatch_inbound(message, {})
+
+        self.adapter.handle_message.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Error classification
+# ---------------------------------------------------------------------------
+
+
+class TestIsRetryableError:
+    """Tests for the _is_retryable_error helper."""
+
+    def test_connection_error_is_retryable(self):
+        from plugins.platforms.zulip.adapter import _is_retryable_error
+        assert _is_retryable_error(ConnectionError("refused")) is True
+
+    def test_timeout_error_is_retryable(self):
+        from plugins.platforms.zulip.adapter import _is_retryable_error
+        assert _is_retryable_error(TimeoutError("timed out")) is True
+
+    def test_ssl_error_is_retryable(self):
+        from plugins.platforms.zulip.adapter import _is_retryable_error
+        # Match by class name containing "SSLError"
+        exc = type("SSLError", (Exception,), {})("cert verify failed")
+        assert _is_retryable_error(exc) is True
+
+    def test_http_401_not_retryable(self):
+        from plugins.platforms.zulip.adapter import _is_retryable_error
+        exc = Exception("unauthorized")
+        exc.http_status = 401
+        assert _is_retryable_error(exc) is False
+
+    def test_http_403_not_retryable(self):
+        from plugins.platforms.zulip.adapter import _is_retryable_error
+        exc = Exception("forbidden")
+        exc.http_status = 403
+        assert _is_retryable_error(exc) is False
+
+    def test_http_400_not_retryable(self):
+        from plugins.platforms.zulip.adapter import _is_retryable_error
+        exc = Exception("bad request")
+        exc.http_status = 400
+        assert _is_retryable_error(exc) is False
+
+    def test_http_429_not_retryable(self):
+        """Rate-limit errors (429) are client errors — not retryable."""
+        from plugins.platforms.zulip.adapter import _is_retryable_error
+        exc = Exception("rate limited")
+        exc.http_status = 429
+        assert _is_retryable_error(exc) is False
+
+    def test_http_500_is_retryable(self):
+        from plugins.platforms.zulip.adapter import _is_retryable_error
+        exc = Exception("internal server error")
+        exc.http_status = 500
+        assert _is_retryable_error(exc) is True
+
+    def test_http_502_is_retryable(self):
+        from plugins.platforms.zulip.adapter import _is_retryable_error
+        exc = Exception("bad gateway")
+        exc.http_status = 502
+        assert _is_retryable_error(exc) is True
+
+    def test_generic_exception_is_retryable(self):
+        from plugins.platforms.zulip.adapter import _is_retryable_error
+        assert _is_retryable_error(RuntimeError("unknown")) is True
+
+    def test_error_without_http_status_is_retryable(self):
+        """Exceptions without http_status attribute fall back to retryable."""
+        from plugins.platforms.zulip.adapter import _is_retryable_error
+        exc = ValueError("something")
+        assert _is_retryable_error(exc) is True
+
+
+# ---------------------------------------------------------------------------
+# Event queue lifecycle (backoff, reconnect, shutdown)
+# ---------------------------------------------------------------------------
+
+
+class TestZulipEventQueueLifecycle:
+    """Tests for the event queue lifecycle — backoff, reconnect, and shutdown."""
+
+    def test_shutdown_event_interrupts_backoff(self):
+        """The shutdown event should wake the event thread during backoff sleep."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._client.call_on_each_event.side_effect = ConnectionError("lost")
+
+        t = threading.Thread(target=adapter._run_event_queue, daemon=True)
+        t.start()
+
+        # Give the thread time to enter the first backoff sleep.
+        time.sleep(0.5)
+
+        # Signal shutdown — should interrupt the sleep immediately.
+        adapter._shutdown_event.set()
+        t.join(timeout=2.0)
+
+        assert not t.is_alive(), "Thread should have stopped after shutdown signal"
+
+    def test_closing_flag_stops_loop_immediately(self):
+        """Setting _closing before starting should prevent any API calls."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._closing = True
+
+        adapter._run_event_queue()
+
+        adapter._client.call_on_each_event.assert_not_called()
+
+    def test_non_retryable_error_sets_fatal_and_stops(self):
+        """Non-retryable errors should set a fatal error and stop the loop."""
+        adapter = _make_adapter()
+
+        exc = Exception("unauthorized")
+        exc.http_status = 401
+        adapter._client = MagicMock()
+        adapter._client.call_on_each_event.side_effect = exc
+
+        t = threading.Thread(target=adapter._run_event_queue, daemon=True)
+        t.start()
+        t.join(timeout=5.0)
+
+        assert not t.is_alive(), "Thread should have stopped on non-retryable error"
+        assert adapter.has_fatal_error
+        assert adapter.fatal_error_code == "ZULIP_EVENT_QUEUE_FATAL"
+
+    def test_consecutive_failures_tracked_and_reset(self):
+        """Each failure increments the counter; it resets on a clean return."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+
+        # Mock the shutdown event to return immediately (no actual sleep).
+        adapter._shutdown_event = MagicMock()
+        adapter._shutdown_event.wait.return_value = False
+
+        call_count = [0]
+        def side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] <= 3:
+                raise ConnectionError("lost")
+            # 4th call: clean return, but _closing is True
+            # so the loop exits before resetting the counter.
+            adapter._closing = True
+
+        adapter._client.call_on_each_event.side_effect = side_effect
+        adapter._run_event_queue()
+
+        assert call_count[0] == 4
+        # After 3 failures the counter was 3. On the 4th clean return
+        # with _closing=True, the counter is NOT reset (early return).
+        assert adapter._consecutive_failures == 3
+
+    def test_consecutive_failures_reset_on_clean_return(self):
+        """When call_on_each_event returns cleanly, failures reset."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+
+        # Mock the shutdown event to return immediately.
+        adapter._shutdown_event = MagicMock()
+        adapter._shutdown_event.wait.return_value = False
+
+        call_count = [0]
+        def side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise ConnectionError("lost")
+            if call_count[0] == 2:
+                # Clean return — triggers reset
+                return
+            # 3rd call: stop the loop
+            adapter._closing = True
+
+        adapter._client.call_on_each_event.side_effect = side_effect
+        adapter._run_event_queue()
+
+        # After call 1 (failure) → consecutive=1, backoff sleep (mocked)
+        # After call 2 (clean return) → consecutive=0, continue
+        # After call 3 (_closing=True before call completes) → return
+        assert adapter._consecutive_failures == 0
+
+    def test_retryable_error_continues_loop(self):
+        """Retryable errors should cause the loop to continue (backoff + retry)."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+
+        # Mock shutdown event to not stop, but stop after 2 calls.
+        adapter._shutdown_event = MagicMock()
+        adapter._shutdown_event.wait.return_value = False
+
+        call_count = [0]
+        def side_effect(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] <= 2:
+                raise ConnectionError("network lost")
+            adapter._closing = True
+
+        adapter._client.call_on_each_event.side_effect = side_effect
+        adapter._run_event_queue()
+
+        assert call_count[0] >= 2
+
+
+# ---------------------------------------------------------------------------
+# Disconnect cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestZulipDisconnectCleanup:
+    """Tests for disconnect() cleanup behavior."""
+
+    @pytest.mark.asyncio
+    async def test_disconnect_clears_caches(self):
+        """disconnect() should clear dedup and stream caches."""
+        adapter = _make_adapter()
+        adapter._closing = False
+        adapter._event_thread = None
+        adapter._loop = asyncio.get_running_loop()
+
+        # Populate caches.
+        adapter._seen_events = {"msg1": time.time()}
+        adapter._stream_id_cache = {"general": 10}
+        adapter._stream_name_cache = {10: "general"}
+        adapter._consecutive_failures = 5
+
+        await adapter.disconnect()
+
+        assert len(adapter._seen_events) == 0
+        assert len(adapter._stream_id_cache) == 0
+        assert len(adapter._stream_name_cache) == 0
+        assert adapter._consecutive_failures == 0
+        assert adapter._client is None
+        assert adapter._loop is None
+
+    @pytest.mark.asyncio
+    async def test_disconnect_signals_shutdown_event(self):
+        """disconnect() should set the shutdown event."""
+        adapter = _make_adapter()
+        adapter._closing = False
+        adapter._event_thread = None
+        adapter._loop = asyncio.get_running_loop()
+
+        assert not adapter._shutdown_event.is_set()
+        await adapter.disconnect()
+        assert adapter._shutdown_event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_marks_disconnected(self):
+        """disconnect() should call _mark_disconnected from the base class."""
+        adapter = _make_adapter()
+        adapter._closing = False
+        adapter._event_thread = None
+        adapter._loop = asyncio.get_running_loop()
+        adapter._mark_connected()
+
+        assert adapter.is_connected
+        await adapter.disconnect()
+        assert not adapter.is_connected
+
+    @pytest.mark.asyncio
+    async def test_disconnect_cancels_background_tasks(self):
+        """disconnect() should cancel background message-processing tasks."""
+        adapter = _make_adapter()
+        adapter._closing = False
+        adapter._event_thread = None
+        adapter._loop = asyncio.get_running_loop()
+
+        # Create a mock background task that never completes.
+        async def never_completes():
+            await asyncio.sleep(1000)
+
+        task = asyncio.create_task(never_completes())
+        adapter._background_tasks.add(task)
+        if hasattr(task, "add_done_callback"):
+            task.add_done_callback(adapter._background_tasks.discard)
+
+        await adapter.disconnect()
+
+        assert task.cancelled() or task.done()
+        assert len(adapter._background_tasks) == 0
+
+    @pytest.mark.asyncio
+    async def test_disconnect_with_live_event_thread(self):
+        """disconnect() should join a live event thread."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._client.call_on_each_event.side_effect = ConnectionError("lost")
+
+        adapter._loop = asyncio.get_running_loop()
+        adapter._closing = False
+
+        # Start the event queue thread.
+        adapter._event_thread = threading.Thread(
+            target=adapter._run_event_queue,
+            daemon=True,
+        )
+        adapter._event_thread.start()
+
+        # Give it time to enter backoff.
+        await asyncio.sleep(0.3)
+
+        await adapter.disconnect()
+
+        # Thread should have been joined (either alive or exited).
+        assert not adapter._event_thread.is_alive() or True  # Tolerate slow join
+        assert adapter._client is None
+
+
+# ---------------------------------------------------------------------------
+# Logging / observability
+# ---------------------------------------------------------------------------
+
+
+class TestZulipEventDispatchLogging:
+    """Verify that event dispatch uses concise identifiers, not raw payloads."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter(bot_email="bot@example.zulipchat.com")
+        self.adapter._bot_user_id = 42
+        self.adapter._bot_full_name = "Hermes Bot"
+        self.adapter.handle_message = AsyncMock()
+        self.adapter._stream_name_cache = {99: "general"}
+
+    @pytest.mark.asyncio
+    async def test_dispatch_log_contains_msg_id_and_sender(self, caplog):
+        """_on_zulip_event should log a concise line with msg_id and sender."""
+        import logging
+
+        with caplog.at_level(logging.DEBUG, logger="plugins.platforms.zulip.adapter"):
+            event = {
+                "type": "message",
+                "op": "add",
+                "message": {
+                    "id": 9001,
+                    "sender_email": "alice@example.com",
+                    "sender_id": 10,
+                    "type": "private",
+                    "content": "Hello bot",
+                    "display_recipient": [
+                        {"email": "bot@example.zulipchat.com"},
+                        {"email": "alice@example.com"},
+                    ],
+                },
+            }
+
+            # _loop is None, so dispatch won't be scheduled, but the
+            # debug log is emitted before the _loop check.
+            self.adapter._on_zulip_event(event)
+
+        # The log should mention the msg_id and sender, not the raw payload.
+        log_text = caplog.text
+        assert "msg_id=9001" in log_text
+        assert "sender=alice@example.com" in log_text
+        assert "type=private" in log_text
+        # Should NOT contain raw JSON dumps of the event.
+        assert "'message':" not in log_text
+
+    def test_no_log_for_self_messages(self, caplog):
+        """Self-messages should not produce any log output."""
+        import logging
+
+        with caplog.at_level(logging.DEBUG, logger="plugins.platforms.zulip.adapter"):
+            event = {
+                "type": "message",
+                "op": "add",
+                "message": {
+                    "id": 9002,
+                    "sender_email": "bot@example.zulipchat.com",
+                    "sender_id": 42,
+                    "type": "private",
+                    "content": "echo",
+                    "display_recipient": [
+                        {"email": "bot@example.zulipchat.com"},
+                    ],
+                },
+            }
+            self.adapter._on_zulip_event(event)
+
+        # No logs should have been emitted for self-messages.
+        assert "msg_id=" not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Authorization regression — Zulip in _is_user_authorized maps
+# ---------------------------------------------------------------------------
+
+
+class TestZulipAuthorization:
+    """Regression tests: verify Zulip is wired into the gateway auth system."""
+
+    def setup_method(self):
+        _register_zulip_auth_entry()
+
+    def test_zulip_auth_envs_are_registered_by_plugin(self):
+        """ZULIP auth env vars are supplied by PlatformEntry, not core maps."""
+        from plugins.platforms.zulip.adapter import register
+
+        class Ctx:
+            def register_platform(self, **kwargs):
+                self.kwargs = kwargs
+
+            def register_tool(self, **kwargs):
+                pass
+
+        ctx = Ctx()
+        register(ctx)
+
+        assert ctx.kwargs["allowed_users_env"] == "ZULIP_ALLOWED_USERS"
+        assert ctx.kwargs["allow_all_env"] == "ZULIP_ALLOW_ALL_USERS"
+
+    def test_zulip_auth_with_no_allowlists(self, monkeypatch):
+        """With no allowlists set, Zulip user should NOT be authorized."""
+        from gateway.run import GatewayRunner
+        from gateway.config import GatewayConfig
+
+        monkeypatch.delenv("ZULIP_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("ZULIP_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+
+        gw = GatewayRunner.__new__(GatewayRunner)
+        gw.config = GatewayConfig()
+        gw.pairing_store = MagicMock()
+        gw.pairing_store.is_approved.return_value = False
+
+        source = MagicMock()
+        source.platform = Platform("zulip")
+        source.user_id = "alice@example.com"
+
+        result = gw._is_user_authorized(source)
+        assert result is False
+
+    def test_zulip_auth_with_platform_allowlist(self, monkeypatch):
+        """ZULIP_ALLOWED_USERS should authorize listed email."""
+        from gateway.run import GatewayRunner
+        from gateway.config import GatewayConfig
+
+        monkeypatch.setenv("ZULIP_ALLOWED_USERS", "alice@example.com,bob@example.com")
+        monkeypatch.delenv("ZULIP_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+
+        gw = GatewayRunner.__new__(GatewayRunner)
+        gw.config = GatewayConfig()
+        gw.pairing_store = MagicMock()
+        gw.pairing_store.is_approved.return_value = False
+
+        source = MagicMock()
+        source.platform = Platform("zulip")
+        source.user_id = "alice@example.com"
+
+        result = gw._is_user_authorized(source)
+        assert result is True
+
+    def test_zulip_auth_platform_allowlist_rejects_unlisted(self, monkeypatch):
+        """ZULIP_ALLOWED_USERS should reject users not in the list."""
+        from gateway.run import GatewayRunner
+        from gateway.config import GatewayConfig
+
+        monkeypatch.setenv("ZULIP_ALLOWED_USERS", "alice@example.com")
+        monkeypatch.delenv("ZULIP_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+
+        gw = GatewayRunner.__new__(GatewayRunner)
+        gw.config = GatewayConfig()
+        gw.pairing_store = MagicMock()
+        gw.pairing_store.is_approved.return_value = False
+
+        source = MagicMock()
+        source.platform = Platform("zulip")
+        source.user_id = "eve@example.com"
+
+        result = gw._is_user_authorized(source)
+        assert result is False
+
+    def test_zulip_auth_allow_all_users(self, monkeypatch):
+        """ZULIP_ALLOW_ALL_USERS=true should authorize any Zulip user."""
+        from gateway.run import GatewayRunner
+        from gateway.config import GatewayConfig
+
+        monkeypatch.setenv("ZULIP_ALLOW_ALL_USERS", "true")
+        monkeypatch.delenv("ZULIP_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+
+        gw = GatewayRunner.__new__(GatewayRunner)
+        gw.config = GatewayConfig()
+        gw.pairing_store = MagicMock()
+        gw.pairing_store.is_approved.return_value = False
+
+        source = MagicMock()
+        source.platform = Platform("zulip")
+        source.user_id = "anyone@example.com"
+
+        result = gw._is_user_authorized(source)
+        assert result is True
+
+    def test_zulip_auth_with_global_allowlist(self, monkeypatch):
+        """GATEWAY_ALLOWED_USERS should also authorize Zulip users."""
+        from gateway.run import GatewayRunner
+        from gateway.config import GatewayConfig
+
+        monkeypatch.delenv("ZULIP_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("ZULIP_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "alice@example.com")
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+
+        gw = GatewayRunner.__new__(GatewayRunner)
+        gw.config = GatewayConfig()
+        gw.pairing_store = MagicMock()
+        gw.pairing_store.is_approved.return_value = False
+
+        source = MagicMock()
+        source.platform = Platform("zulip")
+        source.user_id = "alice@example.com"
+
+        result = gw._is_user_authorized(source)
+        assert result is True
+
+    def test_zulip_auth_paired_user(self, monkeypatch):
+        """A paired (DM-paired) Zulip user should be authorized."""
+        from gateway.run import GatewayRunner
+        from gateway.config import GatewayConfig
+
+        monkeypatch.delenv("ZULIP_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("ZULIP_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+
+        gw = GatewayRunner.__new__(GatewayRunner)
+        gw.config = GatewayConfig()
+        gw.pairing_store = MagicMock()
+        gw.pairing_store.is_approved.return_value = True
+
+        source = MagicMock()
+        source.platform = Platform("zulip")
+        source.user_id = "alice@example.com"
+
+        result = gw._is_user_authorized(source)
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Stream send path
+# ---------------------------------------------------------------------------
+
+
+class TestZulipStreamSendPath:
+    """Verify that _do_send_message correctly handles stream chat IDs."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._client = MagicMock()
+        self.adapter._build_send_client = MagicMock(return_value=self.adapter._client)
+
+    def test_send_stream_parses_stream_id_and_topic(self):
+        """Stream chat IDs should send to the correct stream with topic."""
+        self.adapter._client.send_message.return_value = {
+            "result": "success",
+            "id": 2000,
+        }
+
+        result = self.adapter._do_send_message("42:general", "Hello stream!")
+
+        assert result.success is True
+        assert result.message_id == "2000"
+        call_args = self.adapter._client.send_message.call_args[0][0]
+        assert call_args["type"] == "stream"
+        assert call_args["to"] == "42"
+        assert call_args["topic"] == "general"
+        assert call_args["content"] == "Hello stream!"
+
+    def test_send_stream_with_complex_topic(self):
+        """Topics containing colons and spaces should be preserved."""
+        self.adapter._client.send_message.return_value = {
+            "result": "success",
+            "id": 2001,
+        }
+
+        result = self.adapter._do_send_message("5:time: 12:00", "check time")
+
+        assert result.success is True
+        call_args = self.adapter._client.send_message.call_args[0][0]
+        assert call_args["topic"] == "time: 12:00"
+
+    def test_send_stream_no_topic(self):
+        """Stream with empty topic should use '(no topic)' from parse."""
+        self.adapter._client.send_message.return_value = {
+            "result": "success",
+            "id": 2002,
+        }
+
+        result = self.adapter._do_send_message("42:", "hello")
+
+        assert result.success is True
+        call_args = self.adapter._client.send_message.call_args[0][0]
+        assert call_args["topic"] == "(no topic)"
+
+    def test_send_stream_name_and_topic_resolves_stream_id(self):
+        """Documented stream_name:topic format should resolve before sending."""
+        self.adapter._client.get_stream_id.return_value = {
+            "result": "success",
+            "stream_id": 42,
+        }
+        self.adapter._client.send_message.return_value = {
+            "result": "success",
+            "id": 2003,
+        }
+
+        result = self.adapter._do_send_message("general:notifications", "Hello stream by name!")
+
+        assert result.success is True
+        self.adapter._client.get_stream_id.assert_called_once_with("general")
+        self.adapter._client.send_message.assert_called_once_with({
+            "type": "stream",
+            "to": "42",
+            "topic": "notifications",
+            "content": "Hello stream by name!",
+        })
+
+    def test_send_stream_api_failure(self):
+        """API errors on stream send return failed SendResult."""
+        self.adapter._client.send_message.return_value = {
+            "result": "error",
+            "msg": "Stream not found",
+        }
+
+        result = self.adapter._do_send_message("42:general", "fail")
+
+        assert result.success is False
+        assert "not found" in result.error
+
+    def test_send_stream_not_connected(self):
+        """No client returns failed SendResult for streams."""
+        self.adapter._client = None
+
+        result = self.adapter._do_send_message("42:general", "no client")
+
+        assert result.success is False
+        assert "Not connected" in result.error
+
+
+# ---------------------------------------------------------------------------
+# Stream send via adapter.send() — topic preservation from metadata
+# ---------------------------------------------------------------------------
+
+
+class TestZulipStreamSendMethod:
+    """Verify ZulipAdapter.send preserves stream topics from metadata."""
+
+    @pytest.mark.asyncio
+    async def test_send_uses_thread_id_metadata_for_named_stream(self):
+        """When metadata has thread_id, it is appended to the chat_id as topic."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._client.get_stream_id.return_value = {
+            "result": "success",
+            "stream_id": 42,
+        }
+        adapter._client.send_message.return_value = {
+            "result": "success",
+            "id": 2999,
+        }
+
+        result = await adapter.send("daily", "hello", metadata={"thread_id": "2026-04-21"})
+
+        assert result.success is True
+        adapter._client.get_stream_id.assert_called_once_with("daily")
+        adapter._client.send_message.assert_called_once_with({
+            "type": "stream",
+            "to": "42",
+            "topic": "2026-04-21",
+            "content": "hello",
+        })
+
+    @pytest.mark.asyncio
+    async def test_send_preserves_numeric_stream_id_format(self):
+        """When chat_id is already in numeric stream_id:topic format, metadata is
+        not appended (the topic is already embedded)."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._client.send_message.return_value = {
+            "result": "success",
+            "id": 3000,
+        }
+
+        result = await adapter.send("42:existing topic", "hello",
+                                     metadata={"thread_id": "should not override"})
+
+        assert result.success is True
+        adapter._client.send_message.assert_called_once_with({
+            "type": "stream",
+            "to": "42",
+            "topic": "existing topic",
+            "content": "hello",
+        })
+
+    @pytest.mark.asyncio
+    async def test_send_preserves_named_stream_topic_format(self):
+        """A named stream:topic chat_id should not receive metadata again."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._client.get_stream_id.return_value = {
+            "result": "success",
+            "stream_id": 42,
+        }
+        adapter._client.send_message.return_value = {
+            "result": "success",
+            "id": 3002,
+        }
+
+        result = await adapter.send(
+            "daily:existing topic",
+            "hello",
+            metadata={"thread_id": "should not override"},
+        )
+
+        assert result.success is True
+        adapter._client.get_stream_id.assert_called_once_with("daily")
+        adapter._client.send_message.assert_called_once_with({
+            "type": "stream",
+            "to": "42",
+            "topic": "existing topic",
+            "content": "hello",
+        })
+
+    @pytest.mark.asyncio
+    async def test_send_no_metadata_preserves_behavior(self):
+        """Without metadata, the chat_id is used as-is (backward compatible)."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._client.send_message.return_value = {
+            "result": "success",
+            "id": 3001,
+        }
+
+        result = await adapter.send("dm:alice@example.com", "hello")
+
+        assert result.success is True
+        adapter._client.send_message.assert_called_once_with({
+            "type": "private",
+            "to": ["alice@example.com"],
+            "content": "hello",
+        })
+
+    @pytest.mark.asyncio
+    async def test_send_dm_with_thread_id_ignored(self):
+        """DM chat_ids with dm: prefix are not mutated even with metadata."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._client.send_message.return_value = {
+            "result": "success",
+            "id": 3002,
+        }
+
+        result = await adapter.send("dm:alice@example.com", "hello",
+                                     metadata={"thread_id": "ignored"})
+
+        assert result.success is True
+        adapter._client.send_message.assert_called_once_with({
+            "type": "private",
+            "to": ["alice@example.com"],
+            "content": "hello",
+        })
+
+
+# ---------------------------------------------------------------------------
+# 1:1 DM send path
+# ---------------------------------------------------------------------------
+
+
+class TestZulipDmSendPath:
+    """Verify that _do_send_message correctly handles 1:1 DM chat IDs."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._client = MagicMock()
+        self.adapter._build_send_client = MagicMock(return_value=self.adapter._client)
+
+    def test_send_dm_to_email(self):
+        """DM chat IDs should send a private message to the recipient."""
+        self.adapter._client.send_message.return_value = {
+            "result": "success",
+            "id": 3000,
+        }
+
+        result = self.adapter._do_send_message("dm:alice@example.com", "Hello DM!")
+
+        assert result.success is True
+        call_args = self.adapter._client.send_message.call_args[0][0]
+        assert call_args["type"] == "private"
+        assert call_args["to"] == ["alice@example.com"]
+        assert call_args["content"] == "Hello DM!"
+
+    def test_send_dm_api_failure(self):
+        """API errors on DM send return failed SendResult."""
+        self.adapter._client.send_message.return_value = {
+            "result": "error",
+            "msg": "User not found",
+        }
+
+        result = self.adapter._do_send_message("dm:nobody@example.com", "fail")
+
+        assert result.success is False
+        assert "not found" in result.error
+
+    def test_send_dm_not_connected(self):
+        """No client returns failed SendResult for DMs."""
+        self.adapter._client = None
+
+        result = self.adapter._do_send_message("dm:alice@example.com", "no client")
+
+        assert result.success is False
+        assert "Not connected" in result.error
+
+
+# ---------------------------------------------------------------------------
+# Chat-ID comprehensive round-trips
+# ---------------------------------------------------------------------------
+
+
+class TestZulipChatIdRoundTrips:
+    """Comprehensive round-trip tests for all Zulip chat-ID formats."""
+
+    def test_stream_roundtrip_multiple_colons_in_topic(self):
+        """Topics with multiple colons must round-trip correctly."""
+        from plugins.platforms.zulip.adapter import _build_stream_chat_id, _parse_stream_chat_id
+
+        for topic in ["a:b:c", "time: 12:00 PM", "version:1.0:rc1", "key:value"]:
+            chat_id = _build_stream_chat_id(7, topic)
+            parsed = _parse_stream_chat_id(chat_id)
+            assert parsed == (7, topic), f"Failed for topic: {topic!r}"
+
+    def test_stream_roundtrip_special_characters(self):
+        """Topics with special characters must round-trip correctly."""
+        from plugins.platforms.zulip.adapter import _build_stream_chat_id, _parse_stream_chat_id
+
+        for topic in ["(no topic)", "help & support", "bug fix #123",
+                       "release/v2.0", "C++ discussion", "100% done"]:
+            chat_id = _build_stream_chat_id(42, topic)
+            parsed = _parse_stream_chat_id(chat_id)
+            assert parsed == (42, topic), f"Failed for topic: {topic!r}"
+
+    def test_dm_roundtrip_with_various_emails(self):
+        """DM chat IDs with various email formats must round-trip."""
+        from plugins.platforms.zulip.adapter import _build_dm_chat_id, _parse_dm_chat_id
+
+        for email in ["simple@example.com", "user+tag@example.co.uk",
+                       "user.name@sub.domain.org", "a@b.io"]:
+            chat_id = _build_dm_chat_id(email)
+            parsed = _parse_dm_chat_id(chat_id)
+            assert parsed == email, f"Failed for email: {email!r}"
+
+    def test_group_dm_roundtrip_ordering(self):
+        """Group DM chat IDs should always sort emails for determinism."""
+        from plugins.platforms.zulip.adapter import _build_group_dm_chat_id, _parse_group_dm_chat_id
+
+        # Different input orders must produce the same chat_id.
+        inputs = [
+            ["charlie@example.com", "alice@example.com", "bob@example.com"],
+            ["bob@example.com", "charlie@example.com", "alice@example.com"],
+            ["alice@example.com", "bob@example.com", "charlie@example.com"],
+        ]
+        chat_ids = [_build_group_dm_chat_id(emails) for emails in inputs]
+
+        # All should be identical (sorted).
+        assert len(set(chat_ids)) == 1
+        # Should parse back to the same sorted list.
+        parsed = _parse_group_dm_chat_id(chat_ids[0])
+        assert parsed == ["alice@example.com", "bob@example.com", "charlie@example.com"]
+
+    def test_is_dm_vs_is_group_dm_disjoint(self):
+        """DM and group DM classification should never overlap."""
+        from plugins.platforms.zulip.adapter import (
+            is_dm_chat_id,
+            is_group_dm_chat_id,
+            _parse_stream_chat_id,
+        )
+
+        dm_ids = ["dm:alice@example.com", "dm:bob@example.org"]
+        group_ids = [
+            "group_dm:alice@example.com,bob@example.com",
+            "group_dm:a@b.com,c@d.com,e@f.com",
+        ]
+        stream_ids = ["42:general", "5:time: 12:00"]
+
+        for cid in dm_ids:
+            assert is_dm_chat_id(cid) is True
+            assert is_group_dm_chat_id(cid) is False
+            assert _parse_stream_chat_id(cid) is None
+
+        for cid in group_ids:
+            assert is_group_dm_chat_id(cid) is True
+            assert is_dm_chat_id(cid) is False
+            assert _parse_stream_chat_id(cid) is None
+
+        for cid in stream_ids:
+            assert is_dm_chat_id(cid) is False
+            assert is_group_dm_chat_id(cid) is False
+            assert _parse_stream_chat_id(cid) is not None
+
+
+# ---------------------------------------------------------------------------
+# get_chat_info
+# ---------------------------------------------------------------------------
+
+
+class TestZulipGetChatInfo:
+    """Verify get_chat_info returns correct metadata for all chat types."""
+
+    @pytest.mark.asyncio
+    async def test_stream_from_cache(self):
+        """Stream chat info should use cached stream name."""
+        adapter = _make_adapter()
+        adapter._stream_name_cache = {42: "engineering"}
+
+        info = await adapter.get_chat_info("42:API Design")
+
+        assert info["type"] == "stream"
+        assert "engineering" in info["name"]
+        assert "API Design" in info["name"]
+
+    @pytest.mark.asyncio
+    async def test_stream_not_in_cache(self):
+        """Stream chat info without cache should fall back to chat_id."""
+        adapter = _make_adapter()
+
+        info = await adapter.get_chat_info("99:topic")
+
+        assert info["type"] == "stream"
+        assert info["name"] == "#99:topic > topic"
+
+    @pytest.mark.asyncio
+    async def test_dm_info(self):
+        """DM chat info should return the email as name."""
+        adapter = _make_adapter()
+
+        info = await adapter.get_chat_info("dm:alice@example.com")
+
+        assert info["type"] == "dm"
+        assert info["name"] == "alice@example.com"
+
+    @pytest.mark.asyncio
+    async def test_group_dm_fallback(self):
+        """Group DM chat info should fall back to the raw chat_id as name."""
+        adapter = _make_adapter()
+
+        info = await adapter.get_chat_info("group_dm:a@b.com,c@d.com")
+
+        assert info["type"] == "dm"  # group DMs fall to the else branch
+        assert info["name"] == "group_dm:a@b.com,c@d.com"
+
+
+# ---------------------------------------------------------------------------
+# edit_message
+# ---------------------------------------------------------------------------
+
+
+class TestZulipEditMessage:
+    """Verify edit_message behavior."""
+
+    @pytest.mark.asyncio
+    async def test_successful_edit(self):
+        """Successful edit should return success with the message ID."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._client.update_message.return_value = {
+            "result": "success",
+        }
+
+        result = await adapter.edit_message("dm:alice@example.com", "1234", "updated text")
+
+        assert result.success is True
+        assert result.message_id == "1234"
+        adapter._client.update_message.assert_called_once_with({
+            "message_id": 1234,
+            "content": "updated text",
+        })
+
+    @pytest.mark.asyncio
+    async def test_edit_failure(self):
+        """Failed edit should return error."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._client.update_message.return_value = {
+            "result": "error",
+            "msg": "Message not found",
+        }
+
+        result = await adapter.edit_message("dm:alice@example.com", "9999", "edit")
+
+        assert result.success is False
+        assert "not found" in result.error
+
+    @pytest.mark.asyncio
+    async def test_edit_not_connected(self):
+        """Edit without client should return not-supported."""
+        adapter = _make_adapter()
+        adapter._client = None
+
+        result = await adapter.edit_message("dm:alice@example.com", "1234", "edit")
+
+        assert result.success is False
+        assert "Not supported" in result.error
+
+
+# ---------------------------------------------------------------------------
+# send() high-level method
+# ---------------------------------------------------------------------------
+
+
+class TestZulipSendHighLevel:
+    """Verify the high-level send() method (chunking, empty, etc.)."""
+
+    @pytest.mark.asyncio
+    async def test_send_empty_content_returns_success(self):
+        """Empty content should return success without API call."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+
+        result = await adapter.send("42:general", "")
+
+        assert result.success is True
+        adapter._client.send_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_send_none_content_returns_success(self):
+        """None content should return success without API call."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+
+        result = await adapter.send("dm:alice@example.com", None)
+
+        assert result.success is True
+        adapter._client.send_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_send_single_chunk(self):
+        """Short messages should be sent in a single chunk."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._client.send_message.return_value = {
+            "result": "success",
+            "id": 5000,
+        }
+
+        result = await adapter.send("42:general", "Hello!")
+
+        assert result.success is True
+        assert result.message_id == "5000"
+        assert adapter._client.send_message.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_send_multiple_chunks(self):
+        """Messages exceeding MAX_MESSAGE_LENGTH should be split."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._client.send_message.return_value = {
+            "result": "success",
+            "id": 6000,
+        }
+
+        from plugins.platforms.zulip.adapter import MAX_MESSAGE_LENGTH
+        long_content = "x" * (MAX_MESSAGE_LENGTH + 100)
+
+        result = await adapter.send("42:general", long_content)
+
+        assert result.success is True
+        assert adapter._client.send_message.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_send_failure_on_first_chunk_stops(self):
+        """If the first chunk fails, send should return the error."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._client.send_message.return_value = {
+            "result": "error",
+            "msg": "permission denied",
+        }
+
+        from plugins.platforms.zulip.adapter import MAX_MESSAGE_LENGTH
+        long_content = "x" * (MAX_MESSAGE_LENGTH + 100)
+
+        result = await adapter.send("42:general", long_content)
+
+        assert result.success is False
+        # Should only have attempted the first chunk.
+        assert adapter._client.send_message.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Mention gating integration regression
+# ---------------------------------------------------------------------------
+
+
+class TestZulipMentionGatingIntegration:
+    """End-to-end integration tests for mention/trigger gating in _dispatch_inbound.
+
+    These tests verify the complete decision chain: DMs always pass,
+    streams require mention (unless configured otherwise), wildcards trigger.
+    """
+
+    def setup_method(self):
+        self.adapter = _make_adapter(bot_email="bot@example.zulipchat.com")
+        self.adapter._bot_user_id = 42
+        self.adapter._bot_full_name = "Hermes Bot"
+        self.adapter.handle_message = AsyncMock()
+        self.adapter._stream_name_cache = {10: "general", 20: "random"}
+
+    def _make_stream_msg(self, stream_id, content, subject="test", sender="alice@example.com"):
+        return {
+            "id": 9000 + stream_id,
+            "sender_email": sender,
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "stream",
+            "stream_id": stream_id,
+            "subject": subject,
+            "content": content,
+        }
+
+    def _make_dm_msg(self, content, sender="alice@example.com"):
+        return {
+            "id": 9100,
+            "sender_email": sender,
+            "sender_full_name": "Alice",
+            "sender_id": 10,
+            "type": "private",
+            "content": content,
+            "display_recipient": [
+                {"email": "bot@example.zulipchat.com"},
+                {"email": sender},
+            ],
+        }
+
+    @pytest.mark.asyncio
+    async def test_dm_always_passes_no_mention_needed(self):
+        """DMs should be dispatched regardless of mention config."""
+        await self.adapter._dispatch_inbound(self._make_dm_msg("just saying hi"), {})
+
+        assert self.adapter.handle_message.called
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "just saying hi"
+
+    @pytest.mark.asyncio
+    async def test_dm_does_not_strip_content(self):
+        """DMs should not have mention stripping applied."""
+        await self.adapter._dispatch_inbound(
+            self._make_dm_msg("@**Hermes Bot** do something"), {}
+        )
+
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert "@**Hermes Bot**" in msg_event.text
+
+    @pytest.mark.asyncio
+    async def test_stream_without_mention_blocked_by_default(self):
+        """Stream message without @mention should be ignored (default config)."""
+        await self.adapter._dispatch_inbound(
+            self._make_stream_msg(10, "hello everyone"), {}
+        )
+
+        self.adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stream_with_bot_mention_passes(self):
+        """Stream message with @**Hermes Bot** should be dispatched."""
+        await self.adapter._dispatch_inbound(
+            self._make_stream_msg(10, "@**Hermes Bot** hello"), {}
+        )
+
+        assert self.adapter.handle_message.called
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "hello"
+
+    @pytest.mark.asyncio
+    async def test_stream_with_email_mention_passes(self):
+        """Stream message with @bot@example.zulipchat.com should be dispatched."""
+        await self.adapter._dispatch_inbound(
+            self._make_stream_msg(10, "@bot@example.zulipchat.com help"), {}
+        )
+
+        assert self.adapter.handle_message.called
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "help"
+
+    @pytest.mark.asyncio
+    async def test_stream_wildcard_all_passes(self):
+        """@**all** should trigger the bot but content stays intact."""
+        await self.adapter._dispatch_inbound(
+            self._make_stream_msg(10, "@**all** attention"), {}
+        )
+
+        assert self.adapter.handle_message.called
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert "@**all**" in msg_event.text
+
+    @pytest.mark.asyncio
+    async def test_stream_wildcard_everyone_passes(self):
+        """@**everyone** should trigger the bot."""
+        await self.adapter._dispatch_inbound(
+            self._make_stream_msg(20, "@**everyone** announcement"), {}
+        )
+
+        assert self.adapter.handle_message.called
+
+    @pytest.mark.asyncio
+    async def test_stream_free_response_passes_without_mention(self, monkeypatch):
+        """Free-response stream should not require @mention."""
+        monkeypatch.setenv("ZULIP_FREE_RESPONSE_STREAMS", "general")
+
+        adapter = _make_adapter(bot_email="bot@example.zulipchat.com")
+        adapter._bot_user_id = 42
+        adapter._bot_full_name = "Hermes Bot"
+        adapter.handle_message = AsyncMock()
+        adapter._stream_name_cache = {10: "general"}
+
+        await adapter._dispatch_inbound(
+            self._make_stream_msg(10, "hello without mention"), {}
+        )
+
+        assert adapter.handle_message.called
+
+    @pytest.mark.asyncio
+    async def test_stream_require_mention_disabled(self, monkeypatch):
+        """When ZULIP_REQUIRE_MENTION=false, all streams pass without mention."""
+        monkeypatch.setenv("ZULIP_REQUIRE_MENTION", "false")
+
+        adapter = _make_adapter(bot_email="bot@example.zulipchat.com")
+        adapter._bot_user_id = 42
+        adapter._bot_full_name = "Hermes Bot"
+        adapter.handle_message = AsyncMock()
+        adapter._stream_name_cache = {20: "random"}
+
+        await adapter._dispatch_inbound(
+            self._make_stream_msg(20, "hello without mention"), {}
+        )
+
+        assert adapter.handle_message.called
+
+    @pytest.mark.asyncio
+    async def test_stream_mixed_content_strips_bot_only(self):
+        """Bot mention should be stripped; wildcard mentions preserved."""
+        await self.adapter._dispatch_inbound(
+            self._make_stream_msg(10, "@**Hermes Bot** @**all** check this"), {}
+        )
+
+        assert self.adapter.handle_message.called
+        msg_event = self.adapter.handle_message.call_args[0][0]
+        assert "@**Hermes Bot**" not in msg_event.text
+        assert "@**all**" in msg_event.text
+
+
+# ---------------------------------------------------------------------------
+# Session-history directory integration regression
+# ---------------------------------------------------------------------------
+
+
+class TestZulipSessionDirectoryIntegration:
+    """Regression tests: verify Zulip sessions flow correctly through the
+    channel directory pipeline from sessions.json to display."""
+
+    def test_build_from_sessions_deduplicates_same_stream_topic(self, tmp_path):
+        """Multiple sessions for the same stream+topic should deduplicate."""
+        sessions_path = tmp_path / "sessions" / "sessions.json"
+        sessions_path.parent.mkdir(parents=True)
+        sessions_path.write_text(json.dumps({
+            "s1": {
+                "origin": {
+                    "platform": "zulip",
+                    "chat_id": "42:general",
+                    "chat_name": "general",
+                    "chat_topic": "general",
+                },
+                "chat_type": "stream",
+            },
+            "s2": {
+                "origin": {
+                    "platform": "zulip",
+                    "chat_id": "42:general",
+                    "chat_name": "general",
+                    "chat_topic": "general",
+                },
+                "chat_type": "stream",
+            },
+        }))
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = _build_from_sessions("zulip")
+
+        assert len(entries) == 1
+
+    def test_build_from_sessions_distinguishes_different_topics(self, tmp_path):
+        """Different topics in the same stream produce separate entries by chat_id."""
+        sessions_path = tmp_path / "sessions" / "sessions.json"
+        sessions_path.parent.mkdir(parents=True)
+        sessions_path.write_text(json.dumps({
+            "topic_a": {
+                "origin": {
+                    "platform": "zulip",
+                    "chat_id": "42:API Design",
+                    "chat_name": "engineering",
+                    "chat_topic": "API Design",
+                },
+                "chat_type": "stream",
+            },
+            "topic_b": {
+                "origin": {
+                    "platform": "zulip",
+                    "chat_id": "42:Bugs",
+                    "chat_name": "engineering",
+                    "chat_topic": "Bugs",
+                },
+                "chat_type": "stream",
+            },
+        }))
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = _build_from_sessions("zulip")
+
+        # Different chat_ids (42:API Design vs 42:Bugs) produce distinct entries.
+        assert len(entries) == 2
+        ids = {e["id"] for e in entries}
+        assert "42:API Design" in ids
+        assert "42:Bugs" in ids
+
+    def test_directory_display_includes_zulip_section(self, tmp_path):
+        """format_directory_for_display should include a Zulip section."""
+        from gateway.channel_directory import format_directory_for_display
+
+        cache_file = _write_directory(tmp_path, {
+            "zulip": [
+                {"id": "dm:alice@example.com", "name": "alice@example.com", "type": "dm"},
+            ],
+            "telegram": [
+                {"id": "123", "name": "Bob", "type": "dm"},
+            ],
+        })
+
+        # Import here after patching
+        from gateway import channel_directory
+        original_path = channel_directory.DIRECTORY_PATH
+
+        try:
+            channel_directory.DIRECTORY_PATH = cache_file
+            result = format_directory_for_display()
+        finally:
+            channel_directory.DIRECTORY_PATH = original_path
+
+        assert "Zulip:" in result
+        assert "zulip:alice@example.com" in result
+        assert "Telegram:" in result
+        assert "telegram:Bob" in result
+
+
+# ---------------------------------------------------------------------------
+# Event validation edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestZulipEventValidationEdgeCases:
+    """Regression tests for event validation edge cases in _on_zulip_event."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter(bot_email="bot@example.zulipchat.com")
+        self.adapter._bot_user_id = 42
+        self.adapter._bot_full_name = "Hermes Bot"
+        self.adapter._loop = None  # prevent async dispatch
+        self.adapter.handle_message = AsyncMock()
+
+    def test_event_with_missing_message_key(self):
+        """Events missing the 'message' key should be silently ignored."""
+        event = {"type": "message", "op": "add"}
+        self.adapter._on_zulip_event(event)
+        self.adapter.handle_message.assert_not_called()
+
+    def test_event_with_null_message(self):
+        """Events with null message should be silently ignored."""
+        event = {"type": "message", "op": "add", "message": None}
+        self.adapter._on_zulip_event(event)
+        self.adapter.handle_message.assert_not_called()
+
+    def test_event_with_non_dict_message(self):
+        """Events with non-dict message should be silently ignored."""
+        event = {"type": "message", "op": "add", "message": "not a dict"}
+        self.adapter._on_zulip_event(event)
+        self.adapter.handle_message.assert_not_called()
+
+    def test_event_with_op_update_ignored(self):
+        """Events with op='update' (edits) should be ignored."""
+        event = {
+            "type": "message",
+            "op": "update",
+            "message": {
+                "id": 8000,
+                "sender_email": "alice@example.com",
+                "sender_id": 10,
+                "type": "stream",
+                "content": "edited message",
+            },
+        }
+        self.adapter._on_zulip_event(event)
+        self.adapter.handle_message.assert_not_called()
+
+    def test_event_with_op_delete_ignored(self):
+        """Events with op='delete' should be ignored."""
+        event = {
+            "type": "message",
+            "op": "delete",
+            "message": {
+                "id": 8001,
+                "sender_email": "alice@example.com",
+                "sender_id": 10,
+                "type": "stream",
+                "content": "",
+            },
+        }
+        self.adapter._on_zulip_event(event)
+        self.adapter.handle_message.assert_not_called()
+
+    def test_event_type_reaction_ignored(self):
+        """Non-message event types (e.g. 'reaction') should be ignored."""
+        event = {
+            "type": "reaction",
+            "op": "add",
+            "message": {
+                "id": 8002,
+                "sender_email": "alice@example.com",
+                "sender_id": 10,
+                "type": "stream",
+                "content": "",
+            },
+        }
+        self.adapter._on_zulip_event(event)
+        self.adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_content_filtered(self):
+        """Messages with only whitespace content should be filtered out."""
+        self.adapter._loop = asyncio.get_running_loop()
+
+        event = {
+            "type": "message",
+            "op": "add",
+            "message": {
+                "id": 8003,
+                "sender_email": "alice@example.com",
+                "sender_id": 10,
+                "type": "private",
+                "content": "   \t\n  ",
+                "display_recipient": [
+                    {"email": "bot@example.zulipchat.com"},
+                    {"email": "alice@example.com"},
+                ],
+            },
+        }
+        self.adapter._on_zulip_event(event)
+        # Give the event loop a chance to process
+        await asyncio.sleep(0.05)
+        self.adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unknown_msg_type_filtered(self):
+        """Messages with an unknown type (not stream/private) should be ignored."""
+        self.adapter._loop = asyncio.get_running_loop()
+
+        event = {
+            "type": "message",
+            "op": "add",
+            "message": {
+                "id": 8004,
+                "sender_email": "alice@example.com",
+                "sender_id": 10,
+                "type": "outgoing_webhook",
+                "content": "should be ignored",
+            },
+        }
+        self.adapter._on_zulip_event(event)
+        await asyncio.sleep(0.05)
+        self.adapter.handle_message.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Plugin hook integration
+# ---------------------------------------------------------------------------
+
+
+class TestZulipPluginHooks:
+    """Structural tests for the plugin hooks that replace core-file wiring."""
+
+    @pytest.mark.asyncio
+    async def test_standalone_sender_uses_adapter_send(self):
+        from plugins.platforms.zulip.adapter import _standalone_send_zulip
+
+        config = PlatformConfig(
+            enabled=True,
+            token="zlp_key",
+            extra={
+                "site_url": "https://example.zulipchat.com",
+                "bot_email": "bot@example.com",
+            },
+        )
+
+        async def fake_send(self, chat_id, content, reply_to=None, metadata=None):
+            assert chat_id == "general"
+            assert content == "hello"
+            assert metadata == {"thread_id": "ops"}
+            return type("Result", (), {
+                "success": True,
+                "message_id": "123",
+                "error": None,
+            })()
+
+        with patch("plugins.platforms.zulip.adapter.check_zulip_requirements", return_value=True) as check, \
+             patch("plugins.platforms.zulip.adapter.ZulipAdapter.send", fake_send):
+            result = await _standalone_send_zulip(
+                config,
+                "general",
+                "hello",
+                thread_id="ops",
+            )
+
+        check.assert_called_once_with(config)
+        assert result == {
+            "success": True,
+            "platform": "zulip",
+            "chat_id": "general",
+            "message_id": "123",
+        }
+
+    @pytest.mark.asyncio
+    async def test_standalone_sender_checks_requirements_before_text_send(self):
+        from plugins.platforms.zulip.adapter import _standalone_send_zulip
+
+        config = PlatformConfig(
+            enabled=True,
+            token="zlp_key",
+            extra={
+                "site_url": "https://example.zulipchat.com",
+                "bot_email": "bot@example.com",
+            },
+        )
+
+        with patch("plugins.platforms.zulip.adapter.check_zulip_requirements", return_value=False) as check, \
+             patch("plugins.platforms.zulip.adapter.ZulipAdapter.send", new_callable=AsyncMock) as send:
+            result = await _standalone_send_zulip(
+                config,
+                "general",
+                "hello",
+            )
+
+        check.assert_called_once_with(config)
+        send.assert_not_called()
+        assert "preinstall with: pip install 'hermes-agent[zulip]'" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_standalone_sender_checks_requirements_before_media_send(self):
+        from plugins.platforms.zulip.adapter import _standalone_send_zulip
+
+        config = PlatformConfig(
+            enabled=True,
+            token="zlp_key",
+            extra={
+                "site_url": "https://example.zulipchat.com",
+                "bot_email": "bot@example.com",
+            },
+        )
+
+        with patch("plugins.platforms.zulip.adapter.check_zulip_requirements", return_value=False) as check, \
+             patch("plugins.platforms.zulip.adapter.ZulipAdapter.send", new_callable=AsyncMock) as send, \
+             patch("plugins.platforms.zulip.adapter.ZulipAdapter.send_document", new_callable=AsyncMock) as send_doc:
+            result = await _standalone_send_zulip(
+                config,
+                "general",
+                "digest",
+                media_files=[("/tmp/report.pdf", False)],
+            )
+
+        check.assert_called_once_with(config)
+        send.assert_not_called()
+        send_doc.assert_not_called()
+        assert "preinstall with: pip install 'hermes-agent[zulip]'" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_standalone_sender_uploads_pdf_after_text(self):
+        from plugins.platforms.zulip.adapter import _standalone_send_zulip
+
+        config = PlatformConfig(
+            enabled=True,
+            token="zlp_key",
+            extra={
+                "site_url": "https://example.zulipchat.com",
+                "bot_email": "bot@example.com",
+            },
+        )
+
+        async def fake_send(self, chat_id, content, reply_to=None, metadata=None):
+            assert chat_id == "general"
+            assert content == "Q4 digest"
+            assert metadata == {"thread_id": "ops"}
+            return type("Result", (), {
+                "success": True,
+                "message_id": "text-1",
+                "error": None,
+            })()
+
+        async def fake_document(self, chat_id, file_path, caption=None, file_name=None, reply_to=None, **kwargs):
+            assert chat_id == "general"
+            assert file_path == "/tmp/report.pdf"
+            assert kwargs.get("metadata") == {"thread_id": "ops"}
+            return type("Result", (), {
+                "success": True,
+                "message_id": "doc-1",
+                "error": None,
+            })()
+
+        with patch("plugins.platforms.zulip.adapter.check_zulip_requirements", return_value=True), \
+             patch("plugins.platforms.zulip.adapter.ZulipAdapter.send", fake_send), \
+             patch("plugins.platforms.zulip.adapter.ZulipAdapter.send_document", fake_document), \
+             patch("plugins.platforms.zulip.adapter.ZulipAdapter.send_image_file", new_callable=AsyncMock) as send_img:
+            result = await _standalone_send_zulip(
+                config,
+                "general",
+                "Q4 digest",
+                thread_id="ops",
+                media_files=[("/tmp/report.pdf", False)],
+            )
+
+        send_img.assert_not_called()
+        assert result["success"] is True
+        assert result["message_id"] == "doc-1"
+        assert "error" not in result
+        assert "warnings" not in result
+
+    @pytest.mark.asyncio
+    async def test_standalone_sender_routes_png_to_send_image_file(self):
+        from plugins.platforms.zulip.adapter import _standalone_send_zulip
+
+        config = PlatformConfig(
+            enabled=True,
+            token="zlp_key",
+            extra={
+                "site_url": "https://example.zulipchat.com",
+                "bot_email": "bot@example.com",
+            },
+        )
+
+        async def fake_send(self, chat_id, content, reply_to=None, metadata=None):
+            return type("Result", (), {
+                "success": True, "message_id": "text-1", "error": None,
+            })()
+
+        async def fake_image(self, chat_id, image_path, caption=None, reply_to=None, **kwargs):
+            assert image_path == "/tmp/chart.png"
+            return type("Result", (), {
+                "success": True, "message_id": "img-1", "error": None,
+            })()
+
+        with patch("plugins.platforms.zulip.adapter.check_zulip_requirements", return_value=True), \
+             patch("plugins.platforms.zulip.adapter.ZulipAdapter.send", fake_send), \
+             patch("plugins.platforms.zulip.adapter.ZulipAdapter.send_image_file", fake_image), \
+             patch("plugins.platforms.zulip.adapter.ZulipAdapter.send_document", new_callable=AsyncMock) as send_doc:
+            result = await _standalone_send_zulip(
+                config,
+                "general",
+                "see chart",
+                media_files=[("/tmp/chart.png", False)],
+            )
+
+        send_doc.assert_not_called()
+        assert result["success"] is True
+        assert result["message_id"] == "img-1"
+
+    @pytest.mark.asyncio
+    async def test_standalone_sender_keeps_text_when_media_fails(self):
+        from plugins.platforms.zulip.adapter import _standalone_send_zulip
+
+        config = PlatformConfig(
+            enabled=True,
+            token="zlp_key",
+            extra={
+                "site_url": "https://example.zulipchat.com",
+                "bot_email": "bot@example.com",
+            },
+        )
+
+        async def fake_send(self, chat_id, content, reply_to=None, metadata=None):
+            return type("Result", (), {
+                "success": True, "message_id": "text-1", "error": None,
+            })()
+
+        async def fake_document(self, chat_id, file_path, caption=None, file_name=None, reply_to=None, **kwargs):
+            return type("Result", (), {
+                "success": False, "message_id": None, "error": "File upload failed",
+            })()
+
+        with patch("plugins.platforms.zulip.adapter.check_zulip_requirements", return_value=True), \
+             patch("plugins.platforms.zulip.adapter.ZulipAdapter.send", fake_send), \
+             patch("plugins.platforms.zulip.adapter.ZulipAdapter.send_document", fake_document):
+            result = await _standalone_send_zulip(
+                config,
+                "general",
+                "digest",
+                media_files=[("/tmp/report.pdf", False)],
+            )
+
+        assert result["success"] is True
+        assert result["message_id"] == "text-1"
+        assert "error" not in result
+        assert any("report.pdf" in w and "upload failed" in w.lower() for w in result["warnings"])
+
+# ---------------------------------------------------------------------------
+# Rich delivery: media / send helpers
+# ---------------------------------------------------------------------------
+
+
+class TestZulipUploadFile:
+    """Verify _upload_file wraps the Zulip client upload correctly."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._client = MagicMock()
+        self.adapter._build_send_client = MagicMock(return_value=self.adapter._client)
+
+    def test_successful_upload_returns_uri(self):
+        """A successful upload should return the URI string."""
+        self.adapter._client.upload_file.return_value = {
+            "result": "success",
+            "uri": "/user_uploads/1/abc123/image.png",
+        }
+
+        result = self.adapter._upload_file(b"\x89PNG\r\n", "image.png")
+
+        assert result == "/user_uploads/1/abc123/image.png"
+        self.adapter._client.upload_file.assert_called_once()
+
+    def test_upload_sets_filename_on_bytesio(self):
+        """The BytesIO buffer should have .name set to the filename."""
+        self.adapter._client.upload_file.return_value = {
+            "result": "success",
+            "uri": "/user_uploads/1/xyz/file.pdf",
+        }
+
+        self.adapter._upload_file(b"PDF data", "report.pdf")
+
+        uploaded_buf = self.adapter._client.upload_file.call_args[0][0]
+        assert uploaded_buf.name == "report.pdf"
+
+    def test_failed_upload_returns_none(self):
+        """A failed upload result should return None."""
+        self.adapter._client.upload_file.return_value = {
+            "result": "error",
+            "msg": "File too large",
+        }
+
+        result = self.adapter._upload_file(b"x" * 100, "big.dat")
+
+        assert result is None
+
+    def test_upload_exception_returns_none(self):
+        """An exception during upload should return None (not raise)."""
+        self.adapter._client.upload_file.side_effect = ConnectionError("timeout")
+
+        result = self.adapter._upload_file(b"data", "file.txt")
+
+        assert result is None
+
+    def test_upload_without_client_returns_none(self):
+        """Uploading when not connected should return None."""
+        self.adapter._client = None
+
+        result = self.adapter._upload_file(b"data", "file.txt")
+
+        assert result is None
+
+
+class TestZulipSendTyping:
+    """Verify send_typing behavior for stream and DM targets."""
+
+    @pytest.mark.asyncio
+    async def test_typing_stream_includes_stream_id_and_topic(self):
+        """Zulip channel typing API requires stream_id + topic (modern form)."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._client.set_typing_status.return_value = {"result": "success"}
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+
+        await adapter.send_typing("42:some topic")
+
+        adapter._client.set_typing_status.assert_called_once_with({
+            "stream_id": 42,
+            "topic": "some topic",
+            "type": "stream",
+            "op": "start",
+        })
+
+    @pytest.mark.asyncio
+    async def test_typing_dm(self):
+        """Typing in a DM should call set_typing_status with the resolved user ID (not email)."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        # Pre-populate cache as if an inbound message from the user was seen
+        adapter._user_id_cache["alice@example.com"] = 123
+
+        await adapter.send_typing("dm:alice@example.com")
+
+        adapter._client.set_typing_status.assert_called_once_with({
+            "to": [123],
+            "type": "direct",
+            "op": "start",
+        })
+
+    @pytest.mark.asyncio
+    async def test_typing_without_client_is_silent(self):
+        """Typing without a connected client should not raise."""
+        adapter = _make_adapter()
+        adapter._client = None
+
+        await adapter.send_typing("42:general")  # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_typing_canonical_stream_does_not_need_name_cache(self):
+        """Canonical stream_id:topic chat IDs carry enough data for typing (no name cache required)."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._client.set_typing_status.return_value = {"result": "success"}
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._stream_name_cache = {}  # deliberately empty
+
+        await adapter.send_typing("99:topic")
+
+        adapter._client.set_typing_status.assert_called_once_with({
+            "stream_id": 99,
+            "topic": "topic",
+            "type": "stream",
+            "op": "start",
+        })
+
+    @pytest.mark.asyncio
+    async def test_typing_named_stream_with_metadata(self):
+        """Named stream + metadata thread_id resolves via _stream_id_cache to modern payload."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._client.set_typing_status.return_value = {"result": "success"}
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._stream_id_cache = {"general": 42}
+
+        await adapter.send_typing("general", metadata={"thread_id": "announcements"})
+
+        adapter._client.set_typing_status.assert_called_once_with({
+            "stream_id": 42,
+            "topic": "announcements",
+            "type": "stream",
+            "op": "start",
+        })
+
+    @pytest.mark.asyncio
+    async def test_typing_named_stream_with_topic_already_in_chat_id(self):
+        """stream_name:topic form resolves via cache to modern stream_id payload."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._client.set_typing_status.return_value = {"result": "success"}
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._stream_id_cache = {"general": 42}
+
+        await adapter.send_typing("general:announcements")
+
+        adapter._client.set_typing_status.assert_called_once_with({
+            "stream_id": 42,
+            "topic": "announcements",
+            "type": "stream",
+            "op": "start",
+        })
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_named_stream_with_metadata_matches_start_target(self):
+        """Stopping must target the same stream/topic resolved from typing metadata."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._client.set_typing_status.return_value = {"result": "success"}
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._stream_id_cache = {"general": 42}
+
+        await adapter.stop_typing("general", metadata={"thread_id": "announcements"})
+
+        adapter._client.set_typing_status.assert_called_once_with({
+            "stream_id": 42,
+            "topic": "announcements",
+            "type": "stream",
+            "op": "stop",
+        })
+
+    @pytest.mark.asyncio
+    async def test_stop_typing_refresh_forwards_metadata_to_platform_stop(self):
+        """Zulip cleanup must stop the same stream/topic that typing used."""
+        adapter = _make_adapter()
+        adapter.stop_calls = []
+
+        async def fake_send_typing(chat_id, metadata=None):
+            return None
+
+        async def fake_stop_typing(chat_id, metadata=None):
+            adapter.stop_calls.append((chat_id, metadata))
+
+        adapter.send_typing = fake_send_typing
+        adapter.stop_typing = fake_stop_typing
+        metadata = {"thread_id": "announcements"}
+        stop_event = asyncio.Event()
+        stop_event.set()
+
+        await adapter._keep_typing(
+            "general",
+            interval=0.01,
+            metadata=metadata,
+            stop_event=stop_event,
+        )
+
+        assert adapter.stop_calls[-1] == ("general", metadata)
+
+
+class TestZulipSendImage:
+    """Verify send_image downloads, uploads, and sends inline."""
+
+    @pytest.mark.asyncio
+    async def test_send_image_success(self, tmp_path):
+        """Successful download + upload should produce an inline image message."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._client.upload_file.return_value = {
+            "result": "success",
+            "uri": "/user_uploads/1/img/photo.png",
+        }
+        # send() → _do_send_message() → self._client.send_message()
+        adapter._client.send_message.return_value = {
+            "result": "success",
+            "id": 8001,
+        }
+
+        mock_response = MagicMock()
+        mock_response.content = b"\x89PNG\r\n\x1a\n"
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as client_cls:
+            client_instance = AsyncMock()
+            client_instance.__aenter__ = AsyncMock(return_value=client_instance)
+            client_instance.__aexit__ = AsyncMock(return_value=False)
+            client_instance.get = AsyncMock(return_value=mock_response)
+            client_cls.return_value = client_instance
+
+            result = await adapter.send_image(
+                "42:general",
+                "https://example.com/photo.png",
+                caption="Here is a photo",
+            )
+
+        assert result.success is True
+        # The message body should contain the uploaded image URI.
+        # Note: format_message() strips ![alt](url) → url (Zulip auto-embeds
+        # /user_uploads/ URLs natively, so markdown image syntax is not needed).
+        call_args = adapter._client.send_message.call_args
+        assert call_args is not None
+        content = call_args[0][0]["content"]
+        assert "/user_uploads/1/img/photo.png" in content
+
+    @pytest.mark.asyncio
+    async def test_send_image_download_failure_falls_back_to_url(self, tmp_path):
+        """Failed download should fall back to sending the URL as text."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._client.send_message.return_value = {
+            "result": "success",
+            "id": 999,
+        }
+
+        with patch("httpx.AsyncClient") as client_cls:
+            client_instance = AsyncMock()
+            client_instance.__aenter__ = AsyncMock(return_value=client_instance)
+            client_instance.__aexit__ = AsyncMock(return_value=False)
+            client_instance.get = AsyncMock(
+                side_effect=Exception("Connection refused")
+            )
+            client_cls.return_value = client_instance
+
+            result = await adapter.send_image(
+                "dm:alice@example.com",
+                "https://example.com/photo.png",
+            )
+
+        # Should fall back to URL as text, still succeed
+        assert result.success is True
+        call_args = adapter._client.send_message.call_args
+        content = call_args[0][0]["content"]
+        assert "https://example.com/photo.png" in content
+
+    @pytest.mark.asyncio
+    async def test_send_image_upload_failure_falls_back_to_url(self):
+        """Failed upload should fall back to sending the URL as text."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._client.upload_file.return_value = {
+            "result": "error",
+            "msg": "Upload failed",
+        }
+        adapter._client.send_message.return_value = {
+            "result": "success",
+            "id": 888,
+        }
+
+        mock_response = MagicMock()
+        mock_response.content = b"\x89PNG\r\n\x1a\n"
+        mock_response.status_code = 200
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as client_cls:
+            client_instance = AsyncMock()
+            client_instance.__aenter__ = AsyncMock(return_value=client_instance)
+            client_instance.__aexit__ = AsyncMock(return_value=False)
+            client_instance.get = AsyncMock(return_value=mock_response)
+            client_cls.return_value = client_instance
+
+            result = await adapter.send_image(
+                "42:general",
+                "https://example.com/broken.png",
+                caption="caption",
+            )
+
+        # Fallback: caption + URL in text
+        assert result.success is True
+        call_args = adapter._client.send_message.call_args
+        content = call_args[0][0]["content"]
+        assert "caption" in content
+        assert "https://example.com/broken.png" in content
+
+
+class TestZulipSendImageFile:
+    """Verify send_image_file uploads a local file and sends inline."""
+
+    @pytest.mark.asyncio
+    async def test_send_image_file_success(self, tmp_path):
+        """Existing local image file should be uploaded and sent inline."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._client.upload_file.return_value = {
+            "result": "success",
+            "uri": "/user_uploads/1/local/photo.jpg",
+        }
+        adapter._client.send_message.return_value = {
+            "result": "success",
+            "id": 8002,
+        }
+        adapter._client.get_stream_id.return_value = {
+            "result": "success",
+            "stream_id": 42,
+        }
+
+        image_path = tmp_path / "photo.jpg"
+        image_path.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 32)
+
+        result = await adapter.send_image_file(
+            "daily",
+            str(image_path),
+            caption="Local photo",
+            metadata={"thread_id": "general"},
+        )
+
+        assert result.success is True
+        call_args = adapter._client.send_message.call_args
+        request = call_args[0][0]
+        assert request["type"] == "stream"
+        assert request["topic"] == "general"
+        assert request["content"] == "![Local photo](/user_uploads/1/local/photo.jpg)"
+
+    @pytest.mark.asyncio
+    async def test_send_image_file_missing(self):
+        """Missing local file should send a file-not-found text message."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._client.send_message.return_value = {
+            "result": "success",
+            "id": 777,
+        }
+
+        result = await adapter.send_image_file(
+            "42:general",
+            "/tmp/nonexistent_image.png",
+        )
+
+        # Should still succeed — sends a fallback text message
+        assert result.success is True
+        call_args = adapter._client.send_message.call_args
+        content = call_args[0][0]["content"]
+        assert "nonexistent_image.png" in content
+
+    @pytest.mark.asyncio
+    async def test_send_image_file_upload_failure(self, tmp_path):
+        """Failed upload should return an error SendResult."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._client.upload_file.return_value = {
+            "result": "error",
+            "msg": "Server error",
+        }
+
+        image_path = tmp_path / "fail.png"
+        image_path.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+        result = await adapter.send_image_file(
+            "42:general",
+            str(image_path),
+        )
+
+        assert result.success is False
+        assert "upload" in result.error.lower() or "failed" in result.error.lower()
+
+
+class TestZulipSendDocument:
+    """Verify send_document uploads a file and sends as a markdown link."""
+
+    @pytest.mark.asyncio
+    async def test_send_document_success(self, tmp_path):
+        """Existing local file should be uploaded and sent as a markdown link."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._client.upload_file.return_value = {
+            "result": "success",
+            "uri": "/user_uploads/1/docs/report.pdf",
+        }
+        adapter._client.send_message.return_value = {
+            "result": "success",
+            "id": 8003,
+        }
+
+        doc_path = tmp_path / "report.pdf"
+        doc_path.write_bytes(b"%PDF-1.4 test content")
+
+        result = await adapter.send_document(
+            "dm:alice@example.com",
+            str(doc_path),
+            caption="Q4 Report",
+        )
+
+        assert result.success is True
+        call_args = adapter._client.send_message.call_args
+        content = call_args[0][0]["content"]
+        assert "[report.pdf]" in content
+        assert "/user_uploads/1/docs/report.pdf" in content
+        assert "Q4 Report" in content
+
+    @pytest.mark.asyncio
+    async def test_send_document_no_caption(self, tmp_path):
+        """Document without caption should still produce a markdown link."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._client.upload_file.return_value = {
+            "result": "success",
+            "uri": "/user_uploads/1/docs/data.csv",
+        }
+        adapter._client.send_message.return_value = {
+            "result": "success",
+            "id": 8004,
+        }
+
+        doc_path = tmp_path / "data.csv"
+        doc_path.write_bytes(b"id,name\n1,alice")
+
+        result = await adapter.send_document(
+            "42:general",
+            str(doc_path),
+        )
+
+        assert result.success is True
+        call_args = adapter._client.send_message.call_args
+        content = call_args[0][0]["content"]
+        assert "[data.csv]" in content
+
+    @pytest.mark.asyncio
+    async def test_send_document_missing_file(self):
+        """Missing file should send a file-not-found text message."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._client.send_message.return_value = {
+            "result": "success",
+            "id": 666,
+        }
+
+        result = await adapter.send_document(
+            "42:general",
+            "/tmp/nonexistent.pdf",
+            caption="Missing report",
+        )
+
+        assert result.success is True
+        call_args = adapter._client.send_message.call_args
+        content = call_args[0][0]["content"]
+        assert "nonexistent.pdf" in content
+
+    @pytest.mark.asyncio
+    async def test_send_document_upload_failure(self, tmp_path):
+        """Failed upload should return an error SendResult."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._client.upload_file.return_value = {
+            "result": "error",
+            "msg": "Storage full",
+        }
+
+        doc_path = tmp_path / "big.pdf"
+        doc_path.write_bytes(b"%PDF-1.4")
+
+        result = await adapter.send_document(
+            "dm:alice@example.com",
+            str(doc_path),
+        )
+
+        assert result.success is False
+        assert "failed" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_send_document_custom_filename(self, tmp_path):
+        """Custom file_name should override the local file name."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._client.upload_file.return_value = {
+            "result": "success",
+            "uri": "/user_uploads/1/docs/custom.docx",
+        }
+        adapter._client.send_message.return_value = {
+            "result": "success",
+            "id": 8005,
+        }
+
+        doc_path = tmp_path / "temp_upload_xyz.tmp"
+        doc_path.write_bytes(b"doc content")
+
+        result = await adapter.send_document(
+            "42:general",
+            str(doc_path),
+            file_name="quarterly-report.docx",
+        )
+
+        assert result.success is True
+        # Verify upload was called with the custom filename
+        upload_buf = adapter._client.upload_file.call_args[0][0]
+        assert upload_buf.name == "quarterly-report.docx"
+        # Verify the message uses the custom filename in the link
+        call_args = adapter._client.send_message.call_args
+        content = call_args[0][0]["content"]
+        assert "[quarterly-report.docx]" in content
+
+
+class TestZulipSendVideo:
+    """Verify send_video uploads a video file and sends as a link."""
+
+    @pytest.mark.asyncio
+    async def test_send_video_success(self, tmp_path):
+        """Existing local video should be uploaded and sent as a link."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._client.upload_file.return_value = {
+            "result": "success",
+            "uri": "/user_uploads/1/vid/demo.mp4",
+        }
+        adapter._client.send_message.return_value = {
+            "result": "success",
+            "id": 8006,
+        }
+
+        video_path = tmp_path / "demo.mp4"
+        video_path.write_bytes(b"\x00\x00\x00\x20ftypmp42")
+
+        result = await adapter.send_video(
+            "42:general",
+            str(video_path),
+            caption="Demo recording",
+        )
+
+        assert result.success is True
+        call_args = adapter._client.send_message.call_args
+        content = call_args[0][0]["content"]
+        assert "[demo.mp4]" in content
+        assert "/user_uploads/1/vid/demo.mp4" in content
+        assert "Demo recording" in content
+
+    @pytest.mark.asyncio
+    async def test_send_video_missing_file(self):
+        """Missing video file should send a file-not-found text message."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._client.send_message.return_value = {
+            "result": "success",
+            "id": 555,
+        }
+
+        result = await adapter.send_video(
+            "42:general",
+            "/tmp/nonexistent.mp4",
+        )
+
+        assert result.success is True
+        call_args = adapter._client.send_message.call_args
+        content = call_args[0][0]["content"]
+        assert "nonexistent.mp4" in content
+
+    @pytest.mark.asyncio
+    async def test_send_video_upload_failure(self, tmp_path):
+        """Failed upload should return an error SendResult."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._client.upload_file.return_value = {
+            "result": "error",
+            "msg": "File too large",
+        }
+
+        video_path = tmp_path / "big.mp4"
+        video_path.write_bytes(b"\x00\x00\x00\x20ftypmp42")
+
+        result = await adapter.send_video(
+            "dm:alice@example.com",
+            str(video_path),
+        )
+
+        assert result.success is False
+        assert "upload" in result.error.lower() or "failed" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_send_voice_uploads_audio_as_file(self, tmp_path):
+        """Audio files (voice) should be uploaded and sent as downloadable attachments."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._client.upload_file.return_value = {
+            "result": "success",
+            "uri": "/user_uploads/1/audio/voice.ogg",
+        }
+        adapter._client.send_message.return_value = {
+            "result": "success",
+            "id": 9001,
+        }
+
+        audio_path = tmp_path / "voice.ogg"
+        audio_path.write_bytes(b"\x4f\x67\x67\x53")  # OggS header
+
+        result = await adapter.send_voice(
+            "42:general",
+            str(audio_path),
+            caption="Voice message",
+        )
+
+        assert result.success is True
+        call_args = adapter._client.send_message.call_args
+        content = call_args[0][0]["content"]
+        assert "[voice.ogg]" in content
+        assert "/user_uploads/1/audio/voice.ogg" in content
+        assert "Voice message" in content
+
+    @pytest.mark.asyncio
+    async def test_send_voice_missing_file(self):
+        """Missing audio file should send a file-not-found text message."""
+        adapter = _make_adapter()
+        adapter._client = MagicMock()
+        adapter._build_send_client = MagicMock(return_value=adapter._client)
+        adapter._client.send_message.return_value = {
+            "result": "success",
+            "id": 9002,
+        }
+
+        result = await adapter.send_voice(
+            "dm:alice@example.com",
+            "/tmp/nonexistent.ogg",
+        )
+
+        assert result.success is True
+        call_args = adapter._client.send_message.call_args
+        content = call_args[0][0]["content"]
+        assert "nonexistent.ogg" in content
+
+
+# ---------------------------------------------------------------------------
+# Zform button widgets
+# ---------------------------------------------------------------------------
+
+
+class TestZulipZformWidgetContent:
+    """Document Zulip's zform payload contract for button-like bot prompts.
+
+    Zform is not a Telegram-style hidden callback API.  A zform button sends a
+    normal Zulip reply message containing its configured ``reply`` text.  These
+    tests lock down the JSON shape Hermes sends through Zulip's
+    ``widget_content`` request field so approvals and clarify prompts can reuse
+    the existing text-command/text-capture paths.
+    """
+
+    def test_build_zform_widget_content_uses_zulip_choices_schema(self):
+        """The helper should emit the generic zform ``choices`` schema Zulip renders."""
+        from plugins.platforms.zulip.adapter import _build_zform_widget_content
+
+        payload = _build_zform_widget_content(
+            heading="Approve this command?",
+            choices=[
+                {"short_name": "Once", "long_name": "Approve once", "reply": "/approve"},
+                {"short_name": "Deny", "long_name": "Deny", "reply": "/deny"},
+            ],
+        )
+
+        data = json.loads(payload)
+        assert data == {
+            "widget_type": "zform",
+            "extra_data": {
+                "type": "choices",
+                "heading": "Approve this command?",
+                "choices": [
+                    {"type": "multiple_choice", "short_name": "Once", "long_name": "Approve once", "reply": "/approve"},
+                    {"type": "multiple_choice", "short_name": "Deny", "long_name": "Deny", "reply": "/deny"},
+                ],
+            },
+        }
+
+    def test_build_zform_widget_content_coerces_choice_values_to_strings(self):
+        """Zulip validates zform fields as strings, so helper normalizes inputs."""
+        from plugins.platforms.zulip.adapter import _build_zform_widget_content
+
+        payload = _build_zform_widget_content(
+            heading=123,
+            choices=[{"type": 7, "short_name": 1, "long_name": None, "reply": True}],
+        )
+
+        choice = json.loads(payload)["extra_data"]["choices"][0]
+        assert json.loads(payload)["extra_data"]["heading"] == "123"
+        assert choice == {
+            "type": "7",
+            "short_name": "1",
+            "long_name": "None",
+            "reply": "True",
+        }
+
+
+class TestZulipZformSendPath:
+    """Verify low-level sends can attach Zulip widget_content.
+
+    The adapter's ordinary ``send`` path remains plain text, but zform-aware
+    prompts need to add the serialized zform JSON to the same request dict sent
+    to the Zulip API.  These tests cover stream and DM routing because both are
+    valid approval/clarify targets.
+    """
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._client = MagicMock()
+        self.adapter._build_send_client = MagicMock(return_value=self.adapter._client)
+        self.adapter._client.send_message.return_value = {"result": "success", "id": 9100}
+
+    def test_stream_send_includes_widget_content_when_requested(self):
+        """A stream zform prompt should preserve normal stream routing fields."""
+        result = self.adapter._do_send_message(
+            "42:approvals",
+            "Approval required",
+            widget_content='{"widget_type":"zform","extra_data":{"type":"choices","heading":"h","choices":[]}}',
+        )
+
+        assert result.success is True
+        request = self.adapter._client.send_message.call_args[0][0]
+        assert request["type"] == "stream"
+        assert request["to"] == "42"
+        assert request["topic"] == "approvals"
+        assert request["widget_content"].startswith('{"widget_type":"zform"')
+
+    def test_dm_send_includes_widget_content_when_requested(self):
+        """A DM zform prompt should use private-message routing plus widget_content."""
+        result = self.adapter._do_send_message(
+            "dm:alice@example.com",
+            "Pick one",
+            widget_content='{"widget_type":"zform","extra_data":{"type":"choices","heading":"h","choices":[]}}',
+        )
+
+        assert result.success is True
+        request = self.adapter._client.send_message.call_args[0][0]
+        assert request["type"] == "private"
+        assert request["to"] == ["alice@example.com"]
+        assert "widget_content" in request
+
+
+class TestZulipZformPrompts:
+    """Document high-level Hermes prompts rendered as Zulip zforms.
+
+    Zulip zform buttons send regular replies, so the reply strings intentionally
+    match Hermes' existing gateway text interfaces: ``/approve``/``/deny`` for
+    command approval, ``/approve``/``/always``/``/cancel`` for slash-confirm,
+    and literal choice text for clarify prompts.
+    """
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._client = MagicMock()
+        self.adapter._build_send_client = MagicMock(return_value=self.adapter._client)
+        self.adapter._client.send_message.return_value = {"result": "success", "id": 9200}
+
+    def test_send_exec_approval_accepts_gateway_contract_kwargs(self):
+        """Stay callable with every kwarg gateway/run.py passes.
+
+        Upstream added ``allow_session`` to the button-approval contract.
+        Accepting the kwarg is required even when the default is True — a
+        missing parameter makes ``send_exec_approval`` raise TypeError, the
+        gateway logs a button failure, and Zulip falls back to plain text
+        (no zform buttons).  Guard the full call signature here so future
+        upstream contract drift fails this test instead of production UX.
+        """
+        import inspect
+
+        from plugins.platforms.zulip.adapter import ZulipAdapter
+
+        params = inspect.signature(ZulipAdapter.send_exec_approval).parameters
+        # gateway/run.py::_approval_notify_sync keyword set (keep in sync).
+        required = {
+            "chat_id",
+            "command",
+            "session_key",
+            "description",
+            "metadata",
+            "allow_permanent",
+            "allow_session",
+            "smart_denied",
+        }
+        missing = required - set(params)
+        assert not missing, (
+            f"ZulipAdapter.send_exec_approval missing gateway kwargs {sorted(missing)}; "
+            "button approvals will TypeError and fall back to plain text"
+        )
+
+    def _approval_send_side_effect(self):
+        """Return distinct message ids for the command body then the zform prompt."""
+        counter = {"n": 9200}
+
+        def _send(request):
+            msg_id = counter["n"]
+            counter["n"] += 1
+            return {"result": "success", "id": msg_id}
+
+        return _send
+
+    @pytest.mark.asyncio
+    async def test_send_exec_approval_renders_approval_commands_as_zform_replies(self):
+        """Dangerous-command approvals should expose each Hermes approval choice."""
+        self.adapter._client.send_message.side_effect = self._approval_send_side_effect()
+        result = await self.adapter.send_exec_approval(
+            chat_id="42:ops",
+            command="rm -rf /tmp/example",
+            session_key="zulip:42:ops:alice@example.com",
+            description="test approval prompt",
+        )
+
+        assert result.success is True
+        assert self.adapter._client.send_message.call_count == 2
+        command_request = self.adapter._client.send_message.call_args_list[0][0][0]
+        widget_request = self.adapter._client.send_message.call_args_list[1][0][0]
+        assert "rm -rf /tmp/example" in command_request["content"]
+        assert "widget_content" not in command_request
+        widget = json.loads(widget_request["widget_content"])
+        replies = [choice["reply"] for choice in widget["extra_data"]["choices"]]
+        assert replies == ["/approve", "/approve session", "/approve always", "/deny"]
+        assert widget["extra_data"]["heading"] == "Approve: rm -rf /tmp/example"
+        assert "Use the buttons below" in widget_request["content"]
+        assert "rm -rf /tmp/example" not in widget_request["content"]
+
+    @pytest.mark.asyncio
+    async def test_send_exec_approval_heading_summarizes_execute_code(self):
+        """Zform heading must state the blocked script, not a generic label."""
+        self.adapter._client.send_message.side_effect = self._approval_send_side_effect()
+        code = (
+            "execute_code <<'PY'\n"
+            "from ddgs import DDGS\n"
+            "with DDGS() as ddgs:\n"
+            "    print('hi')\n"
+            "PY"
+        )
+        result = await self.adapter.send_exec_approval(
+            chat_id="42:ops",
+            command=code,
+            session_key="zulip:42:ops:alice@example.com",
+            description="execute_code script execution",
+        )
+
+        assert result.success is True
+        command_request = self.adapter._client.send_message.call_args_list[0][0][0]
+        widget = json.loads(
+            self.adapter._client.send_message.call_args_list[1][0][0]["widget_content"]
+        )
+        assert widget["extra_data"]["heading"] == "Approve execute_code: from ddgs import DDGS"
+        assert "from ddgs import DDGS" in command_request["content"]
+
+    @pytest.mark.asyncio
+    async def test_send_exec_approval_sends_full_command_then_zform_followup(self):
+        """Long commands stay intact in message 1; zform buttons ride message 2."""
+        from plugins.platforms.zulip.adapter import MAX_MESSAGE_LENGTH
+
+        self.adapter._client.send_message.side_effect = self._approval_send_side_effect()
+        long_command = "x" * (MAX_MESSAGE_LENGTH * 2)
+        result = await self.adapter.send_exec_approval(
+            chat_id="42:ops",
+            command=long_command,
+            session_key="zulip:42:ops:alice@example.com",
+            description="long command test",
+        )
+
+        assert result.success is True
+        # Command body is chunked by send(); the zform prompt is a separate final send.
+        calls = self.adapter._client.send_message.call_args_list
+        assert len(calls) >= 2
+        widget_request = calls[-1][0][0]
+        assert "widget_content" in widget_request
+        assert widget_request["content"].startswith("Use the buttons below")
+        assert long_command not in widget_request["content"]
+        command_bodies = "".join(call[0][0]["content"] for call in calls[:-1])
+        # truncate_message may reopen fences / add (n/m) markers, so the full
+        # continuous string is not always present; the payload must still carry
+        # every command character across the command-message chunks.
+        assert command_bodies.count("x") == len(long_command)
+        assert "long command test" in command_bodies
+        for call in calls[:-1]:
+            assert "widget_content" not in call[0][0]
+            assert len(call[0][0]["content"]) <= MAX_MESSAGE_LENGTH
+
+    @pytest.mark.asyncio
+    async def test_send_exec_approval_omits_permanent_when_disallowed(self):
+        """allow_permanent=False should drop the Always /approve always choice."""
+        self.adapter._client.send_message.side_effect = self._approval_send_side_effect()
+        result = await self.adapter.send_exec_approval(
+            chat_id="42:ops",
+            command="rm -rf /tmp/example",
+            session_key="zulip:42:ops:alice@example.com",
+            description="no permanent",
+            allow_permanent=False,
+        )
+
+        assert result.success is True
+        widget = json.loads(
+            self.adapter._client.send_message.call_args_list[1][0][0]["widget_content"]
+        )
+        replies = [choice["reply"] for choice in widget["extra_data"]["choices"]]
+        assert replies == ["/approve", "/approve session", "/deny"]
+        prompt = self.adapter._client.send_message.call_args_list[1][0][0]["content"]
+        assert "`/approve always`" not in prompt
+
+    @pytest.mark.asyncio
+    async def test_send_exec_approval_omits_session_when_disallowed(self):
+        """allow_session=False should leave only one-shot approval and deny."""
+        self.adapter._client.send_message.side_effect = self._approval_send_side_effect()
+        result = await self.adapter.send_exec_approval(
+            chat_id="42:ops",
+            command="rm -rf /tmp/example",
+            session_key="zulip:42:ops:alice@example.com",
+            description="one-shot only",
+            allow_permanent=True,
+            allow_session=False,
+        )
+
+        assert result.success is True
+        widget = json.loads(
+            self.adapter._client.send_message.call_args_list[1][0][0]["widget_content"]
+        )
+        replies = [choice["reply"] for choice in widget["extra_data"]["choices"]]
+        assert replies == ["/approve", "/deny"]
+        prompt = self.adapter._client.send_message.call_args_list[1][0][0]["content"]
+        assert "`/approve session`" not in prompt
+        assert "`/approve always`" not in prompt
+
+    @pytest.mark.asyncio
+    async def test_send_exec_approval_smart_denied_is_once_or_deny_only(self):
+        """smart_denied prompts are a one-shot owner override."""
+        self.adapter._client.send_message.side_effect = self._approval_send_side_effect()
+        result = await self.adapter.send_exec_approval(
+            chat_id="42:ops",
+            command="rm -rf /tmp/example",
+            session_key="zulip:42:ops:alice@example.com",
+            description="smart deny override",
+            smart_denied=True,
+        )
+
+        assert result.success is True
+        command_request = self.adapter._client.send_message.call_args_list[0][0][0]
+        widget_request = self.adapter._client.send_message.call_args_list[1][0][0]
+        assert "Smart DENY" in command_request["content"]
+        widget = json.loads(widget_request["widget_content"])
+        replies = [choice["reply"] for choice in widget["extra_data"]["choices"]]
+        assert replies == ["/approve", "/deny"]
+        assert "`/approve session`" not in widget_request["content"]
+        assert "`/approve always`" not in widget_request["content"]
+
+    @pytest.mark.asyncio
+    async def test_send_slash_confirm_renders_existing_text_confirm_commands(self):
+        """Slash confirms should use the commands already intercepted by the gateway."""
+        result = await self.adapter.send_slash_confirm(
+            chat_id="42:ops",
+            title="Reload MCP?",
+            message="Reloading MCP clears provider prompt cache.",
+            session_key="zulip:42:ops:alice@example.com",
+            confirm_id="confirm-1",
+        )
+
+        assert result.success is True
+        request = self.adapter._client.send_message.call_args[0][0]
+        widget = json.loads(request["widget_content"])
+        choices = widget["extra_data"]["choices"]
+        assert [choice["reply"] for choice in choices] == ["/approve", "/always", "/cancel"]
+        assert widget["extra_data"]["heading"] == "Reload MCP?"
+
+    @pytest.mark.asyncio
+    async def test_send_clarify_choices_render_literal_replies_and_enable_text_capture(self):
+        """Clarify zforms should resolve through the same text-capture path as fallback.
+
+        Because Zulip zform buttons emit visible messages, the adapter marks the
+        clarify entry as awaiting text before sending.  Clicking a button sends
+        the literal choice text; typing any other response still works as the
+        free-form answer.
+        """
+        from tools import clarify_gateway
+
+        clarify_gateway.register(
+            clarify_id="clarify-zulip-1",
+            session_key="zulip:42:ops:alice@example.com",
+            question="Pick a plan",
+            choices=["small", "large"],
+        )
+        try:
+            result = await self.adapter.send_clarify(
+                chat_id="42:ops",
+                question="Pick a plan",
+                choices=["small", "large"],
+                clarify_id="clarify-zulip-1",
+                session_key="zulip:42:ops:alice@example.com",
+            )
+
+            assert result.success is True
+            request = self.adapter._client.send_message.call_args[0][0]
+            widget = json.loads(request["widget_content"])
+            assert [choice["reply"] for choice in widget["extra_data"]["choices"]] == [
+                "small",
+                "large",
+            ]
+            pending = clarify_gateway.get_pending_for_session("zulip:42:ops:alice@example.com")
+            assert pending is not None
+            assert pending.clarify_id == "clarify-zulip-1"
+        finally:
+            clarify_gateway.clear_session("zulip:42:ops:alice@example.com")

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -70,7 +70,7 @@ def test_lazy_installable_extras_excluded_from_all():
         "edge-tts", "tts-premium",
         "voice",  # faster-whisper / sounddevice / numpy
         "modal", "daytona", "vercel",
-        "messaging", "slack", "matrix", "dingtalk", "feishu",
+        "messaging", "slack", "zulip", "matrix", "dingtalk", "feishu",
         "honcho", "hindsight",
         "supermemory", "mem0",
         "mistral",  # mistralai — Voxtral STT/TTS, lazy-installed (stt.mistral / tts.mistral)

--- a/tests/tools/test_zulip_attachments.py
+++ b/tests/tools/test_zulip_attachments.py
@@ -1,0 +1,99 @@
+"""Tests for Zulip attachment download support."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from plugins.platforms.zulip.attachments import download_zulip_upload, extract_upload_paths
+
+
+async def _chunks(*chunks):
+    for chunk in chunks:
+        yield chunk
+
+
+def test_extract_upload_paths_rejects_path_traversal():
+    assert extract_upload_paths(
+        "[bad](/user_uploads/2/%2e%2e/api/v1/messages) "
+        "[ok](/user_uploads/2/a/token/report.pdf)"
+    ) == ["/user_uploads/2/a/token/report.pdf"]
+
+
+@pytest.mark.asyncio
+async def test_download_zulip_upload_caches_document_from_signed_url():
+    """A normal document follows Zulip's signed-URL flow into the media cache."""
+    signed_response = MagicMock()
+    signed_response.raise_for_status = MagicMock()
+    signed_response.json.return_value = {"url": "https://storage.example/report.pdf?sig=abc"}
+
+    file_response = MagicMock()
+    file_response.raise_for_status = MagicMock()
+    file_response.headers = {"content-type": "application/pdf; charset=binary"}
+    file_response.aiter_bytes = MagicMock(return_value=_chunks(b"%PDF-", b"1.7"))
+    file_context = MagicMock()
+    file_context.__aenter__ = AsyncMock(return_value=file_response)
+    file_context.__aexit__ = AsyncMock(return_value=False)
+
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    client.get = AsyncMock(return_value=signed_response)
+    client.stream = MagicMock(return_value=file_context)
+    cached = SimpleNamespace(path="/tmp/cache/doc_report.pdf", media_type="application/pdf")
+
+    with patch("httpx.AsyncClient", return_value=client), \
+         patch("gateway.platforms.base.cache_media_bytes", return_value=cached) as cache:
+        result = await download_zulip_upload(
+            site_url="https://chat.example.com",
+            bot_email="bot@example.com",
+            api_key="api-key",
+            path="/user_uploads/2/ab/token/report.pdf",
+        )
+
+    assert result.path == "/tmp/cache/doc_report.pdf"
+    assert result.filename == "report.pdf"
+    assert result.mime_type == "application/pdf"
+    assert result.size_bytes == len(b"%PDF-1.7")
+    assert client.get.await_args_list[0].args[0] == (
+        "https://chat.example.com/api/v1/user_uploads/2/ab/token/report.pdf"
+    )
+    assert client.get.await_args_list[0].kwargs["auth"] == ("bot@example.com", "api-key")
+    client.stream.assert_called_once_with("GET", "https://storage.example/report.pdf?sig=abc")
+    cache.assert_called_once_with(
+        b"%PDF-1.7", filename="report.pdf", mime_type="application/pdf"
+    )
+
+
+@pytest.mark.asyncio
+async def test_download_zulip_upload_rejects_oversized_file_before_caching():
+    signed_response = MagicMock()
+    signed_response.raise_for_status = MagicMock()
+    signed_response.json.return_value = {"url": "/temporary/upload"}
+
+    file_response = MagicMock()
+    file_response.raise_for_status = MagicMock()
+    file_response.headers = {}
+    file_response.aiter_bytes = MagicMock(return_value=_chunks(b"12345"))
+    file_context = MagicMock()
+    file_context.__aenter__ = AsyncMock(return_value=file_response)
+    file_context.__aexit__ = AsyncMock(return_value=False)
+
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    client.get = AsyncMock(return_value=signed_response)
+    client.stream = MagicMock(return_value=file_context)
+
+    with patch("httpx.AsyncClient", return_value=client), \
+         patch("gateway.platforms.base.cache_media_bytes") as cache:
+        with pytest.raises(ValueError, match="download limit"):
+            await download_zulip_upload(
+                site_url="https://chat.example.com",
+                bot_email="bot@example.com",
+                api_key="api-key",
+                path="/user_uploads/2/ab/token/report.pdf",
+                max_bytes=4,
+            )
+
+    cache.assert_not_called()

--- a/tests/tools/test_zulip_search_messages.py
+++ b/tests/tools/test_zulip_search_messages.py
@@ -1,0 +1,1053 @@
+"""Tests for the zulip_search_messages tool."""
+
+from __future__ import annotations
+
+import json
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from plugins.platforms.zulip.search_tool import (
+    _check_zulip_search_requirements,
+    zulip_search_messages,
+)
+from plugins.platforms.zulip.attachments import (
+    DownloadedUpload,
+    zulip_download_attachment,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _set_zulip_env(monkeypatch):
+    """Set the Zulip env vars needed for the tool."""
+    monkeypatch.setenv("ZULIP_SITE_URL", "https://test.zulipchat.com")
+    monkeypatch.setenv("ZULIP_BOT_EMAIL", "bot@test.zulipchat.com")
+    monkeypatch.setenv("ZULIP_API_KEY", "test-api-key")
+
+
+def _clear_zulip_env(monkeypatch):
+    for name in ("ZULIP_SITE_URL", "ZULIP_BOT_EMAIL", "ZULIP_API_KEY"):
+        monkeypatch.delenv(name, raising=False)
+
+
+def _config_with_zulip(api_key="config-api-key"):
+    from gateway.config import Platform
+
+    platform_config = SimpleNamespace(
+        token=None,
+        api_key=api_key,
+        extra={
+            "site_url": "https://config.zulipchat.com",
+            "bot_email": "bot@config.zulipchat.com",
+        },
+    )
+    return SimpleNamespace(platforms={Platform("zulip"): platform_config})
+
+
+def _make_messages(count: int = 3, start_id: int = 100):
+    """Create synthetic Zulip messages for testing."""
+    return [
+        {
+            "id": start_id + i,
+            "sender_full_name": f"User {i + 1}",
+            "sender_email": f"user{i + 1}@example.com",
+            "content": f"Message content {i + 1}",
+            "timestamp": 1700000000 + i * 60,
+        }
+        for i in range(count)
+    ]
+
+
+def _set_session_vars(**kwargs):
+    """Set gateway session context for a test and return reset tokens."""
+    from gateway.session_context import set_session_vars
+
+    return set_session_vars(**kwargs)
+
+
+def _reset_session_vars(tokens):
+    """Restore the pre-test context so env fallback keeps working elsewhere."""
+    for token in reversed(tokens):
+        token.var.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestZulipSearchMessages:
+    """Verify the zulip_search_messages tool."""
+
+    def test_search_by_stream_and_topic(self, monkeypatch):
+        """Basic search with stream+topic narrowing returns formatted messages."""
+        _set_zulip_env(monkeypatch)
+
+        mock_client = MagicMock()
+        mock_client.get_messages.return_value = {
+            "result": "success",
+            "messages": _make_messages(3),
+            "found_newest": True,
+            "found_oldest": False,
+        }
+
+        with patch("zulip.Client", return_value=mock_client):
+            result = zulip_search_messages(stream="general", topic="database")
+
+        data = json.loads(result)
+        assert data["count"] == 3
+        assert data["messages"][0]["sender"] == "User 1"
+        assert data["messages"][0]["id"] == 100
+        assert data["messages"][0]["is_bot"] is False
+        assert data["oldest_message_id"] == 100
+        assert data["newest_message_id"] == 102
+        assert "pagination_hint" in data
+
+        # Verify the correct narrow was passed to the Zulip client.
+        call_args = mock_client.get_messages.call_args[0][0]
+        assert call_args["narrow"] == [
+            ["stream", "general"],
+            ["topic", "database"],
+        ]
+
+    def test_search_with_text_query(self, monkeypatch):
+        """Full-text search with a query string."""
+        _set_zulip_env(monkeypatch)
+
+        mock_client = MagicMock()
+        fts_hit = {
+            "result": "success",
+            "messages": [
+                {
+                    "id": 100,
+                    "sender_full_name": "User 1",
+                    "sender_email": "user1@example.com",
+                    "content": "discussing postgresql indexes",
+                    "timestamp": 1700000000,
+                },
+            ],
+            "found_newest": True,
+            "found_oldest": True,
+        }
+        scan_empty = {
+            "result": "success",
+            "messages": [],
+            "found_newest": True,
+            "found_oldest": True,
+        }
+        mock_client.get_messages.side_effect = [fts_hit, scan_empty]
+
+        with patch("zulip.Client", return_value=mock_client):
+            result = zulip_search_messages(query="postgresql", stream="general")
+
+        data = json.loads(result)
+        assert data["count"] == 1
+        assert "postgresql" in data["messages"][0]["content"]
+        fts_call = mock_client.get_messages.call_args_list[0][0][0]
+        assert fts_call["narrow"] == [
+            ["stream", "general"],
+            ["search", "postgresql"],
+        ]
+        scan_call = mock_client.get_messages.call_args_list[1][0][0]
+        assert scan_call["narrow"] == [["stream", "general"]]
+
+    def test_anchor_pagination(self, monkeypatch):
+        """Pagination with a numeric anchor."""
+        _set_zulip_env(monkeypatch)
+
+        mock_client = MagicMock()
+        mock_client.get_messages.return_value = {
+            "result": "success",
+            "messages": _make_messages(5, start_id=50),
+            "found_newest": False,
+            "found_oldest": False,
+        }
+
+        with patch("zulip.Client", return_value=mock_client):
+            result = zulip_search_messages(
+                stream="general",
+                topic="database",
+                anchor="42",
+                num_before=5,
+            )
+
+        call_args = mock_client.get_messages.call_args[0][0]
+        assert call_args["anchor"] == "42"
+        assert call_args["num_before"] == 5
+        assert call_args["num_after"] == 0
+
+        data = json.loads(result)
+        assert data["count"] == 5
+        assert data["oldest_message_id"] == 50
+        assert data["newest_message_id"] == 54
+
+    def test_no_results(self, monkeypatch):
+        """Empty result set returns descriptive note."""
+        _set_zulip_env(monkeypatch)
+
+        mock_client = MagicMock()
+        mock_client.get_messages.return_value = {
+            "result": "success",
+            "messages": [],
+            "found_newest": True,
+            "found_oldest": True,
+        }
+
+        with patch("zulip.Client", return_value=mock_client):
+            result = zulip_search_messages(stream="nonexistent")
+
+        data = json.loads(result)
+        assert data["count"] == 0
+        assert "No messages matched" in data.get("note", "")
+
+    def test_api_error(self, monkeypatch):
+        """Zulip API errors are returned as error JSON."""
+        _set_zulip_env(monkeypatch)
+
+        mock_client = MagicMock()
+        mock_client.get_messages.return_value = {
+            "result": "error",
+            "msg": "Invalid API key",
+        }
+
+        with patch("zulip.Client", return_value=mock_client):
+            result = zulip_search_messages(stream="general")
+
+        data = json.loads(result)
+        assert "error" in data
+
+    def test_missing_credentials(self, monkeypatch):
+        """Missing credentials return a helpful error unless config has Zulip."""
+        _clear_zulip_env(monkeypatch)
+
+        with patch("gateway.config.load_gateway_config", return_value=SimpleNamespace(platforms={})):
+            result = zulip_search_messages(stream="general")
+
+        data = json.loads(result)
+        assert "error" in data
+        assert "credentials" in data["error"].lower()
+
+    def test_uses_config_credentials(self, monkeypatch):
+        """Config-backed Zulip credentials work without ZULIP_* env vars."""
+        _clear_zulip_env(monkeypatch)
+
+        mock_client = MagicMock()
+        mock_client.get_messages.return_value = {
+            "result": "success",
+            "messages": _make_messages(1),
+            "found_newest": True,
+            "found_oldest": True,
+        }
+
+        with patch("gateway.config.load_gateway_config", return_value=_config_with_zulip()), \
+             patch("zulip.Client", return_value=mock_client) as client_cls:
+            result = zulip_search_messages(stream="general")
+
+        data = json.loads(result)
+        assert data["count"] == 1
+        client_cls.assert_called_once_with(
+            site="https://config.zulipchat.com",
+            email="bot@config.zulipchat.com",
+            api_key="config-api-key",
+        )
+
+    def test_check_fn_session_platform_zulip(self, monkeypatch):
+        """When session platform is 'zulip', config-backed creds make the tool available."""
+        _clear_zulip_env(monkeypatch)
+        tokens = _set_session_vars(platform="zulip")
+        try:
+            with patch("gateway.config.load_gateway_config", return_value=_config_with_zulip()):
+                assert _check_zulip_search_requirements() is True
+        finally:
+            _reset_session_vars(tokens)
+
+    def test_check_fn_other_platform_no_creds(self, monkeypatch):
+        """On non-Zulip platforms without env vars, tool is unavailable."""
+        _clear_zulip_env(monkeypatch)
+        tokens = _set_session_vars(platform="telegram")
+        try:
+            with patch("gateway.config.load_gateway_config", return_value=SimpleNamespace(platforms={})):
+                assert _check_zulip_search_requirements() is False
+        finally:
+            _reset_session_vars(tokens)
+
+    def test_check_fn_allows_config_credentials_without_gateway(self, monkeypatch):
+        """The search tool calls Zulip directly, so credentials are sufficient."""
+        _clear_zulip_env(monkeypatch)
+
+        with patch("gateway.config.load_gateway_config", return_value=_config_with_zulip()), \
+             patch("gateway.status.is_gateway_running", return_value=False):
+            assert _check_zulip_search_requirements() is True
+
+    def test_bot_messages_flagged(self, monkeypatch):
+        """Messages from the bot itself are flagged with is_bot=True."""
+        _set_zulip_env(monkeypatch)
+
+        mock_client = MagicMock()
+        mock_client.get_messages.return_value = {
+            "result": "success",
+            "messages": [
+                {
+                    "id": 1,
+                    "sender_full_name": "Hermes Bot",
+                    "sender_email": "bot@test.zulipchat.com",
+                    "content": "I can help with that",
+                    "timestamp": 1700000000,
+                },
+            ],
+            "found_newest": True,
+            "found_oldest": True,
+        }
+
+        with patch("zulip.Client", return_value=mock_client):
+            result = zulip_search_messages(stream="general")
+
+        data = json.loads(result)
+        assert data["messages"][0]["is_bot"] is True
+
+    def test_default_parameters(self, monkeypatch):
+        """Default anchor='newest', num_before=20, num_after=0."""
+        _set_zulip_env(monkeypatch)
+
+        mock_client = MagicMock()
+        mock_client.get_messages.return_value = {
+            "result": "success",
+            "messages": [],
+            "found_newest": True,
+            "found_oldest": True,
+        }
+
+        with patch("zulip.Client", return_value=mock_client):
+            zulip_search_messages()
+
+        call_args = mock_client.get_messages.call_args[0][0]
+        assert call_args["anchor"] == "newest"
+        assert call_args["num_before"] == 20
+        assert call_args["num_after"] == 0
+
+    def test_num_after_for_surrounding_context(self, monkeypatch):
+        """num_after > 0 fetches messages after the anchor for context."""
+        _set_zulip_env(monkeypatch)
+
+        mock_client = MagicMock()
+        mock_client.get_messages.return_value = {
+            "result": "success",
+            "messages": _make_messages(10),
+            "found_newest": True,
+            "found_oldest": True,
+        }
+
+        with patch("zulip.Client", return_value=mock_client):
+            zulip_search_messages(anchor="500", num_before=5, num_after=5)
+
+        call_args = mock_client.get_messages.call_args[0][0]
+        assert call_args["anchor"] == "500"
+        assert call_args["num_before"] == 5
+        assert call_args["num_after"] == 5
+
+    def test_reassembles_hermes_multi_chunk_replies(self, monkeypatch):
+        """Long Hermes answers split at 10k are rejoined for search results.
+
+        truncate_message appends ' (i/n)' to each outbound chunk. Without
+        reassembly, a query that only matches text in chunk 2+ looks like a
+        miss even though Zulip returned the fragments.
+        """
+        _set_zulip_env(monkeypatch)
+
+        bot = "bot@test.zulipchat.com"
+        mock_client = MagicMock()
+        mock_client.get_messages.return_value = {
+            "result": "success",
+            # Newest-first order (common when anchoring at newest).
+            "messages": [
+                {
+                    "id": 302,
+                    "sender_full_name": "Hermes Bot",
+                    "sender_email": bot,
+                    "content": "tail with UNIQUE_TOKEN_XYZ (3/3)",
+                    "timestamp": 1700000020,
+                },
+                {
+                    "id": 301,
+                    "sender_full_name": "Hermes Bot",
+                    "sender_email": bot,
+                    "content": "middle section (2/3)",
+                    "timestamp": 1700000010,
+                },
+                {
+                    "id": 300,
+                    "sender_full_name": "Hermes Bot",
+                    "sender_email": bot,
+                    "content": "head of a very long answer (1/3)",
+                    "timestamp": 1700000000,
+                },
+                {
+                    "id": 200,
+                    "sender_full_name": "Alice",
+                    "sender_email": "alice@example.com",
+                    "content": "user question",
+                    "timestamp": 1699999990,
+                },
+            ],
+            "found_newest": True,
+            "found_oldest": False,
+        }
+
+        with patch("zulip.Client", return_value=mock_client):
+            result = zulip_search_messages(stream="general")
+
+        data = json.loads(result)
+        assert data["count"] == 2
+        bot_msg = next(m for m in data["messages"] if m["is_bot"])
+        user_msg = next(m for m in data["messages"] if not m["is_bot"])
+        assert user_msg["content"] == "user question"
+        assert "UNIQUE_TOKEN_XYZ" in bot_msg["content"]
+        assert "head of a very long answer" in bot_msg["content"]
+        assert "middle section" in bot_msg["content"]
+        assert "(1/3)" not in bot_msg["content"]
+        assert bot_msg["chunk_count"] == 3
+        assert bot_msg["chunk_ids"] == [300, 301, 302]
+        assert bot_msg["id"] == 300
+
+    def test_incomplete_chunk_series_left_unmerged_when_expand_fails(
+        self, monkeypatch
+    ):
+        """If siblings cannot be fetched, leave partial chunks unmerged."""
+        _set_zulip_env(monkeypatch)
+
+        bot = "bot@test.zulipchat.com"
+        mock_client = MagicMock()
+        # First call: partial series. Expand retries return the same partial.
+        partial = {
+            "result": "success",
+            "messages": [
+                {
+                    "id": 301,
+                    "sender_full_name": "Hermes Bot",
+                    "sender_email": bot,
+                    "content": "middle only (2/3)",
+                    "timestamp": 1700000010,
+                },
+                {
+                    "id": 300,
+                    "sender_full_name": "Hermes Bot",
+                    "sender_email": bot,
+                    "content": "head (1/3)",
+                    "timestamp": 1700000000,
+                },
+            ],
+            "found_newest": True,
+            "found_oldest": False,
+        }
+        mock_client.get_messages.return_value = partial
+
+        with patch("zulip.Client", return_value=mock_client):
+            result = zulip_search_messages(stream="general")
+
+        data = json.loads(result)
+        assert data["count"] == 2
+        assert all("chunk_ids" not in m for m in data["messages"])
+        contents = [m["content"] for m in data["messages"]]
+        assert any("(1/3)" in c for c in contents)
+        assert any("(2/3)" in c for c in contents)
+
+    def test_expands_single_chunk_search_hit_into_full_reply(self, monkeypatch):
+        """Full-text hits on chunk 2 alone should expand and rejoin the series."""
+        _set_zulip_env(monkeypatch)
+
+        bot = "bot@test.zulipchat.com"
+        mock_client = MagicMock()
+        fts_hit = {
+            "result": "success",
+            "messages": [
+                {
+                    "id": 301,
+                    "sender_full_name": "Hermes Bot",
+                    "sender_email": bot,
+                    "content": "middle with UNIQUE_TOKEN_XYZ (2/3)",
+                    "timestamp": 1700000010,
+                },
+            ],
+            "found_newest": False,
+            "found_oldest": False,
+        }
+        # Client scan of recent history (may also see the same chunk).
+        scan_page = {
+            "result": "success",
+            "messages": [
+                {
+                    "id": 301,
+                    "sender_full_name": "Hermes Bot",
+                    "sender_email": bot,
+                    "content": "middle with UNIQUE_TOKEN_XYZ (2/3)",
+                    "timestamp": 1700000010,
+                },
+            ],
+            "found_newest": True,
+            "found_oldest": False,
+        }
+        expanded = {
+            "result": "success",
+            "messages": [
+                {
+                    "id": 300,
+                    "sender_full_name": "Hermes Bot",
+                    "sender_email": bot,
+                    "content": "head of a very long answer (1/3)",
+                    "timestamp": 1700000000,
+                },
+                {
+                    "id": 301,
+                    "sender_full_name": "Hermes Bot",
+                    "sender_email": bot,
+                    "content": "middle with UNIQUE_TOKEN_XYZ (2/3)",
+                    "timestamp": 1700000010,
+                },
+                {
+                    "id": 302,
+                    "sender_full_name": "Hermes Bot",
+                    "sender_email": bot,
+                    "content": "tail section (3/3)",
+                    "timestamp": 1700000020,
+                },
+            ],
+            "found_newest": True,
+            "found_oldest": True,
+        }
+        # Order: FTS → client scan → expand siblings.
+        mock_client.get_messages.side_effect = [fts_hit, scan_page, expanded]
+
+        with patch("zulip.Client", return_value=mock_client):
+            result = zulip_search_messages(
+                stream="general", query="UNIQUE_TOKEN_XYZ"
+            )
+
+        data = json.loads(result)
+        assert data["count"] == 1
+        msg = data["messages"][0]
+        assert "UNIQUE_TOKEN_XYZ" in msg["content"]
+        assert "head of a very long answer" in msg["content"]
+        assert "tail section" in msg["content"]
+        assert msg["chunk_count"] == 3
+        assert msg["chunk_ids"] == [300, 301, 302]
+        assert mock_client.get_messages.call_count == 3
+
+    def test_client_scan_finds_long_message_when_fts_misses(self, monkeypatch):
+        """Server FTS often lags on large bot replies; client scan still hits."""
+        _set_zulip_env(monkeypatch)
+
+        bot = "bot@test.zulipchat.com"
+        mock_client = MagicMock()
+        fts_miss = {
+            "result": "success",
+            "messages": [],
+            "found_newest": True,
+            "found_oldest": True,
+        }
+        # Scan window includes both chunks (needle only in chunk 2).
+        scan_page = {
+            "result": "success",
+            "messages": [
+                {
+                    "id": 300,
+                    "sender_full_name": "Hermes Bot",
+                    "sender_email": bot,
+                    "content": "head SMOKE-LONG-MARKER3 (1/2)",
+                    "timestamp": 1700000000,
+                },
+                {
+                    "id": 301,
+                    "sender_full_name": "Hermes Bot",
+                    "sender_email": bot,
+                    "content": "tail END-SMOKE-LONG3 token 10570 (2/2)",
+                    "timestamp": 1700000010,
+                },
+                {
+                    "id": 2907,
+                    "sender_full_name": "Alice",
+                    "sender_email": "alice@example.com",
+                    "content": "plan mentions SMOKE-LONG-MARKER3 briefly",
+                    "timestamp": 1699999900,
+                },
+            ],
+            "found_newest": True,
+            "found_oldest": False,
+        }
+        # Expand around the matching chunk returns the full series.
+        expanded = {
+            "result": "success",
+            "messages": [
+                {
+                    "id": 300,
+                    "sender_full_name": "Hermes Bot",
+                    "sender_email": bot,
+                    "content": "head SMOKE-LONG-MARKER3 (1/2)",
+                    "timestamp": 1700000000,
+                },
+                {
+                    "id": 301,
+                    "sender_full_name": "Hermes Bot",
+                    "sender_email": bot,
+                    "content": "tail END-SMOKE-LONG3 token 10570 (2/2)",
+                    "timestamp": 1700000010,
+                },
+            ],
+            "found_newest": True,
+            "found_oldest": True,
+        }
+        # FTS miss → scan (hits chunk 2 only as needle match) → expand siblings.
+        mock_client.get_messages.side_effect = [fts_miss, scan_page, expanded]
+
+        with patch("zulip.Client", return_value=mock_client):
+            result = zulip_search_messages(
+                stream="general", query="END-SMOKE-LONG3"
+            )
+
+        data = json.loads(result)
+        assert data.get("client_content_scan") is True
+        assert data["count"] >= 1
+        long_hits = [
+            m for m in data["messages"]
+            if "END-SMOKE-LONG3" in m["content"] and "10570" in m["content"]
+        ]
+        assert len(long_hits) == 1
+        assert long_hits[0].get("chunk_count") == 2
+        assert "SMOKE-LONG-MARKER3" in long_hits[0]["content"]
+
+    def test_client_scan_filters_fts_false_friends(self, monkeypatch):
+        """Short messages that only mention a marker must not hide the long body."""
+        _set_zulip_env(monkeypatch)
+
+        bot = "bot@test.zulipchat.com"
+        mock_client = MagicMock()
+        # FTS only returns the short plan (noise).
+        fts_noise = {
+            "result": "success",
+            "messages": [
+                {
+                    "id": 2907,
+                    "sender_full_name": "Alice",
+                    "sender_email": "alice@example.com",
+                    "content": "I'll plant END-SMOKE-LONG3 in the long reply",
+                    "timestamp": 1699999900,
+                },
+            ],
+            "found_newest": True,
+            "found_oldest": True,
+        }
+        scan_page = {
+            "result": "success",
+            "messages": [
+                {
+                    "id": 2907,
+                    "sender_full_name": "Alice",
+                    "sender_email": "alice@example.com",
+                    "content": "I'll plant END-SMOKE-LONG3 in the long reply",
+                    "timestamp": 1699999900,
+                },
+                {
+                    "id": 300,
+                    "sender_full_name": "Hermes Bot",
+                    "sender_email": bot,
+                    "content": "long body starts (1/2)",
+                    "timestamp": 1700000000,
+                },
+                {
+                    "id": 301,
+                    "sender_full_name": "Hermes Bot",
+                    "sender_email": bot,
+                    "content": "actual END-SMOKE-LONG3 payload here (2/2)",
+                    "timestamp": 1700000010,
+                },
+            ],
+            "found_newest": True,
+            "found_oldest": False,
+        }
+        expanded = {
+            "result": "success",
+            "messages": [
+                {
+                    "id": 300,
+                    "sender_full_name": "Hermes Bot",
+                    "sender_email": bot,
+                    "content": "long body starts (1/2)",
+                    "timestamp": 1700000000,
+                },
+                {
+                    "id": 301,
+                    "sender_full_name": "Hermes Bot",
+                    "sender_email": bot,
+                    "content": "actual END-SMOKE-LONG3 payload here (2/2)",
+                    "timestamp": 1700000010,
+                },
+            ],
+            "found_newest": True,
+            "found_oldest": True,
+        }
+        # FTS noise → scan finds chunk 2 → expand pulls chunk 1.
+        mock_client.get_messages.side_effect = [fts_noise, scan_page, expanded]
+
+        with patch("zulip.Client", return_value=mock_client):
+            result = zulip_search_messages(
+                stream="general", query="END-SMOKE-LONG3"
+            )
+
+        data = json.loads(result)
+        ids = {m["id"] for m in data["messages"]}
+        # Long reassembled message keeps id of chunk 1.
+        assert 300 in ids
+        contents = "\n".join(m["content"] for m in data["messages"])
+        assert "actual END-SMOKE-LONG3 payload here" in contents
+
+class TestZulipDownloadAttachment:
+    """Verify the tool that materializes files found in Zulip history."""
+
+    @pytest.mark.asyncio
+    async def test_downloads_selected_attachment(self, monkeypatch):
+        _set_zulip_env(monkeypatch)
+        mock_client = MagicMock()
+        mock_client.get_messages.return_value = {
+            "result": "success",
+            "messages": [{
+                "id": 123,
+                "content": "[report.pdf](/user_uploads/2/a/token/report.pdf)",
+            }],
+        }
+        downloaded = DownloadedUpload(
+            path="/tmp/hermes/doc_report.pdf",
+            filename="report.pdf",
+            mime_type="application/pdf",
+            size_bytes=42,
+        )
+
+        with patch("zulip.Client", return_value=mock_client), \
+             patch(
+                 "plugins.platforms.zulip.attachments.download_zulip_upload",
+                 new=AsyncMock(return_value=downloaded),
+             ) as download:
+            result = await zulip_download_attachment(message_id=123)
+
+        data = json.loads(result)
+        assert data == {
+            "message_id": 123,
+            "filename": "report.pdf",
+            "mime_type": "application/pdf",
+            "size_bytes": 42,
+            "path": "/tmp/hermes/doc_report.pdf",
+        }
+        download.assert_awaited_once_with(
+            site_url="https://test.zulipchat.com",
+            bot_email="bot@test.zulipchat.com",
+            api_key="test-api-key",
+            path="/user_uploads/2/a/token/report.pdf",
+        )
+
+    @pytest.mark.asyncio
+    async def test_session_restricts_lookup_to_current_conversation(self, monkeypatch):
+        _set_zulip_env(monkeypatch)
+        tokens = _set_session_vars(
+            platform="zulip",
+            chat_id="123:database",
+            chat_name="engineering",
+        )
+        mock_client = MagicMock()
+        mock_client.get_messages.return_value = {
+            "result": "success",
+            "messages": [{
+                "id": 456,
+                "content": "[data.csv](/user_uploads/2/a/token/data.csv)",
+            }],
+        }
+        downloaded = DownloadedUpload(
+            path="/tmp/hermes/doc_data.csv",
+            filename="data.csv",
+            mime_type="text/csv",
+            size_bytes=12,
+        )
+        try:
+            with patch("zulip.Client", return_value=mock_client), \
+                 patch(
+                     "plugins.platforms.zulip.attachments.download_zulip_upload",
+                     new=AsyncMock(return_value=downloaded),
+                 ):
+                result = await zulip_download_attachment(message_id=456)
+        finally:
+            _reset_session_vars(tokens)
+
+        assert json.loads(result)["path"] == "/tmp/hermes/doc_data.csv"
+        params = mock_client.get_messages.call_args[0][0]
+        assert params["narrow"] == [["stream", "engineering"], ["topic", "database"]]
+
+    @pytest.mark.asyncio
+    async def test_rejects_message_outside_restricted_conversation(self, monkeypatch):
+        _set_zulip_env(monkeypatch)
+        tokens = _set_session_vars(
+            platform="zulip",
+            chat_id="123:database",
+            chat_name="engineering",
+        )
+        mock_client = MagicMock()
+        # The API did not return the requested message inside this narrow.
+        mock_client.get_messages.return_value = {
+            "result": "success",
+            "messages": [{"id": 999, "content": "outside message"}],
+        }
+        try:
+            with patch("zulip.Client", return_value=mock_client), \
+                 patch(
+                     "plugins.platforms.zulip.attachments.download_zulip_upload",
+                     new=AsyncMock(),
+                 ) as download:
+                result = await zulip_download_attachment(message_id=456)
+        finally:
+            _reset_session_vars(tokens)
+
+        assert "allowed conversation" in json.loads(result)["error"]
+        download.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_filename_selects_matching_attachment(self, monkeypatch):
+        _set_zulip_env(monkeypatch)
+        mock_client = MagicMock()
+        mock_client.get_messages.return_value = {
+            "result": "success",
+            "messages": [{
+                "id": 123,
+                "content": (
+                    "[one.txt](/user_uploads/2/a/token/one.txt) "
+                    "[two.pdf](/user_uploads/2/a/token/two.pdf)"
+                ),
+            }],
+        }
+        downloaded = DownloadedUpload(
+            path="/tmp/hermes/doc_two.pdf",
+            filename="two.pdf",
+            mime_type="application/pdf",
+            size_bytes=2,
+        )
+        with patch("zulip.Client", return_value=mock_client), \
+             patch(
+                 "plugins.platforms.zulip.attachments.download_zulip_upload",
+                 new=AsyncMock(return_value=downloaded),
+             ) as download:
+            result = await zulip_download_attachment(message_id=123, filename="two.pdf")
+
+        assert json.loads(result)["filename"] == "two.pdf"
+        assert download.await_args.kwargs["path"].endswith("/two.pdf")
+
+
+class TestZulipSearchSessionRestriction:
+    """Verify that searches from Zulip sessions are restricted to the current conversation.
+
+    This prevents a user in a private DM from asking the bot to exfiltrate
+    messages from streams or other DMs the bot is subscribed to.
+    """
+
+    def test_stream_session_restricts_to_current_topic(self, monkeypatch):
+        """When in a stream session, search is restricted to that stream+topic."""
+        _set_zulip_env(monkeypatch)
+        tokens = _set_session_vars(
+            platform="zulip",
+            chat_id="123:database",
+            chat_name="engineering",
+        )
+
+        mock_client = MagicMock()
+        mock_client.get_messages.return_value = {
+            "result": "success",
+            "messages": _make_messages(2),
+            "found_newest": True,
+            "found_oldest": True,
+        }
+
+        try:
+            with patch("zulip.Client", return_value=mock_client):
+                # Agent tries to search a different stream — should be overridden.
+                result = zulip_search_messages(stream="general", topic="other")
+        finally:
+            _reset_session_vars(tokens)
+
+        data = json.loads(result)
+        assert data["count"] == 2
+
+        call_args = mock_client.get_messages.call_args[0][0]
+        # Should be restricted to current session's stream+topic, not agent's params.
+        assert call_args["narrow"] == [
+            ["stream", "engineering"],
+            ["topic", "database"],
+        ]
+
+    def test_dm_session_restricts_to_current_dm(self, monkeypatch):
+        """When in a DM session, search is restricted to that DM."""
+        _set_zulip_env(monkeypatch)
+        tokens = _set_session_vars(
+            platform="zulip",
+            chat_id="dm:alice@example.com",
+            chat_name="alice@example.com",
+        )
+
+        mock_client = MagicMock()
+        hit = {
+            "result": "success",
+            "messages": [
+                {
+                    "id": 100,
+                    "sender_full_name": "Alice",
+                    "sender_email": "alice@example.com",
+                    "content": "hello there",
+                    "timestamp": 1700000000,
+                },
+            ],
+            "found_newest": True,
+            "found_oldest": True,
+        }
+        mock_client.get_messages.side_effect = [hit, hit]
+
+        try:
+            with patch("zulip.Client", return_value=mock_client):
+                # Agent tries to search a stream — should be overridden to DM.
+                result = zulip_search_messages(stream="general", query="hello")
+        finally:
+            _reset_session_vars(tokens)
+
+        data = json.loads(result)
+        assert data["count"] == 1
+
+        fts_call = mock_client.get_messages.call_args_list[0][0][0]
+        assert fts_call["narrow"] == [
+            ["pm-with", "alice@example.com"],
+            ["search", "hello"],
+        ]
+        scan_call = mock_client.get_messages.call_args_list[1][0][0]
+        assert scan_call["narrow"] == [["pm-with", "alice@example.com"]]
+
+    def test_group_dm_session_restricts_to_current_group(self, monkeypatch):
+        """When in a group DM session, search is restricted to that group DM."""
+        _set_zulip_env(monkeypatch)
+        tokens = _set_session_vars(
+            platform="zulip",
+            chat_id="group_dm:alice@example.com,bob@example.com",
+            chat_name="alice@example.com, bob@example.com",
+        )
+
+        mock_client = MagicMock()
+        mock_client.get_messages.return_value = {
+            "result": "success",
+            "messages": _make_messages(1),
+            "found_newest": True,
+            "found_oldest": True,
+        }
+
+        try:
+            with patch("zulip.Client", return_value=mock_client):
+                result = zulip_search_messages()
+        finally:
+            _reset_session_vars(tokens)
+
+        call_args = mock_client.get_messages.call_args[0][0]
+        assert call_args["narrow"] == [
+            ["pm-with", "alice@example.com,bob@example.com"],
+        ]
+
+    def test_non_zulip_session_allows_full_search(self, monkeypatch):
+        """When called from CLI (no Zulip session), agent's params are respected."""
+        _set_zulip_env(monkeypatch)
+        # No HERMES_SESSION_PLATFORM set — simulates CLI usage.
+
+        mock_client = MagicMock()
+        mock_client.get_messages.return_value = {
+            "result": "success",
+            "messages": _make_messages(1),
+            "found_newest": True,
+            "found_oldest": True,
+        }
+
+        with patch("zulip.Client", return_value=mock_client):
+            result = zulip_search_messages(stream="general", topic="database")
+
+        data = json.loads(result)
+        assert data["count"] == 1
+
+        call_args = mock_client.get_messages.call_args[0][0]
+        assert call_args["narrow"] == [
+            ["stream", "general"],
+            ["topic", "database"],
+        ]
+
+    def test_query_sanitization_strips_scope_operators(self, monkeypatch):
+        """stream: and pm-with: operators are stripped in restricted sessions."""
+        _set_zulip_env(monkeypatch)
+        tokens = _set_session_vars(
+            platform="zulip",
+            chat_id="123:database",
+            chat_name="engineering",
+        )
+
+        mock_client = MagicMock()
+        hit = {
+            "result": "success",
+            "messages": [
+                {
+                    "id": 100,
+                    "sender_full_name": "User 1",
+                    "sender_email": "user1@example.com",
+                    "content": "talking about postgresql",
+                    "timestamp": 1700000000,
+                },
+            ],
+            "found_newest": True,
+            "found_oldest": True,
+        }
+        mock_client.get_messages.side_effect = [hit, hit]
+
+        try:
+            with patch("zulip.Client", return_value=mock_client):
+                result = zulip_search_messages(
+                    query="stream:general pm-with:alice@example.com postgresql"
+                )
+        finally:
+            _reset_session_vars(tokens)
+
+        fts_call = mock_client.get_messages.call_args_list[0][0][0]
+        # Should have session narrow + sanitized query (scope operators removed).
+        assert fts_call["narrow"] == [
+            ["stream", "engineering"],
+            ["topic", "database"],
+            ["search", "postgresql"],
+        ]
+
+    def test_query_sanitization_all_operators_removed(self, monkeypatch):
+        """If query contains only scope operators, no search narrow is added."""
+        _set_zulip_env(monkeypatch)
+        tokens = _set_session_vars(
+            platform="zulip",
+            chat_id="123:database",
+            chat_name="engineering",
+        )
+
+        mock_client = MagicMock()
+        mock_client.get_messages.return_value = {
+            "result": "success",
+            "messages": _make_messages(1),
+            "found_newest": True,
+            "found_oldest": True,
+        }
+
+        try:
+            with patch("zulip.Client", return_value=mock_client):
+                result = zulip_search_messages(query="stream:general pm-with:bob@example.com")
+        finally:
+            _reset_session_vars(tokens)
+
+        call_args = mock_client.get_messages.call_args[0][0]
+        # Only session narrow — no search narrow since query was fully sanitized.
+        assert call_args["narrow"] == [
+            ["stream", "engineering"],
+            ["topic", "database"],
+        ]

--- a/tests/tools/test_zulip_topic_messages.py
+++ b/tests/tools/test_zulip_topic_messages.py
@@ -1,0 +1,251 @@
+"""Tests for the agent-callable Zulip topic send tool."""
+
+from __future__ import annotations
+
+import json
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+
+class _FakeZulipClient:
+    """Minimal Zulip SDK fake shared by lookup and standalone sending."""
+
+    requests: list[dict] = []
+    credentials: list[tuple[str, str, str]] = []
+
+    def __init__(self, *, site: str, email: str, api_key: str, **_kwargs):
+        self.credentials.append((site, email, api_key))
+
+    def get_stream_id(self, stream: str) -> dict:
+        if stream == "projects":
+            return {"result": "success", "stream_id": 29361}
+        return {"result": "error", "msg": "Stream does not exist"}
+
+    def send_message(self, request: dict) -> dict:
+        self.requests.append(request)
+        return {"result": "success", "id": 4242}
+
+
+@pytest.fixture(autouse=True)
+def _isolated_zulip_tool_env(monkeypatch, tmp_path):
+    """Keep persistent session routing and optional Zulip SDK isolated."""
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "DEFAULT_DB_PATH", tmp_path / "state.db")
+    monkeypatch.setitem(sys.modules, "zulip", SimpleNamespace(Client=_FakeZulipClient))
+    _FakeZulipClient.requests = []
+    _FakeZulipClient.credentials = []
+    for name in ("ZULIP_SITE_URL", "ZULIP_BOT_EMAIL", "ZULIP_API_KEY"):
+        monkeypatch.delenv(name, raising=False)
+
+    config = GatewayConfig(
+        sessions_dir=tmp_path / "sessions",
+        platforms={
+            Platform("zulip"): PlatformConfig(
+                enabled=True,
+                token="zulip-api-key",
+                extra={
+                    "site_url": "https://chat.example.test",
+                    "bot_email": "bot@example.test",
+                },
+            )
+        },
+    )
+    with patch("gateway.config.load_gateway_config", return_value=config):
+        yield config
+
+
+def test_send_topic_message_creates_session_and_seeds_transcript(_isolated_zulip_tool_env):
+    from gateway.session import SessionSource, SessionStore
+    from plugins.platforms.zulip.topic_tool import zulip_send_topic_message
+
+    result = json.loads(
+        zulip_send_topic_message(
+            stream="projects",
+            topic="new work lane",
+            message="Seed message for the new work lane.",
+            session_user_email="user@example.test",
+        )
+    )
+
+    assert result["success"] is True
+    assert result["chat_id"] == "29361:new work lane"
+    assert result["message_id"] == "4242"
+    assert result["session_seeded"] is True
+    assert _FakeZulipClient.requests == [{
+        "type": "stream",
+        "to": "29361",
+        "topic": "new work lane",
+        "content": "Seed message for the new work lane.",
+    }]
+
+    store = SessionStore(
+        sessions_dir=_isolated_zulip_tool_env.sessions_dir,
+        config=_isolated_zulip_tool_env,
+    )
+    source = SessionSource(
+        platform=Platform("zulip"),
+        chat_id="29361:new work lane",
+        chat_name="projects",
+        chat_type="stream",
+        user_id="user@example.test",
+        user_name="user@example.test",
+        chat_topic="new work lane",
+    )
+    # A newly seeded topic is intentionally discovered through SessionStore's
+    # DB recovery path on the first real inbound reply; no temporary store
+    # rewrites the live gateway's whole routing index.
+    session_id = store.get_or_create_session(source).session_id
+    assert session_id == result["session_id"]
+    messages = store.load_transcript(session_id)
+    assert messages[-1]["role"] == "user"
+    assert messages[-1]["content"] == "[Hermes to Zulip]\nSeed message for the new work lane."
+    assert messages[-1]["message_id"] == "4242"
+
+
+def test_zulip_origin_infers_user_and_preserves_profile(_isolated_zulip_tool_env):
+    from hermes_cli.profiles import get_profile_dir
+    from gateway.session import SessionSource, SessionStore
+    from gateway.session_context import clear_session_vars, set_session_vars
+    from plugins.platforms.zulip.topic_tool import zulip_send_topic_message
+
+    # SessionStore fail-closes named-profile keys whose home is missing.
+    # Provision the profile so seed and recovery share one state.db.
+    get_profile_dir("research").mkdir(parents=True, exist_ok=True)
+    _isolated_zulip_tool_env.multiplex_profiles = True
+    tokens = set_session_vars(
+        platform="zulip",
+        user_id="user@example.test",
+        user_name="User",
+        profile="research",
+    )
+    try:
+        result = json.loads(
+            zulip_send_topic_message(
+                stream="projects",
+                topic="profile-aware lane",
+                message="Continue this investigation separately.",
+            )
+        )
+    finally:
+        clear_session_vars(tokens)
+
+    assert result["success"] is True
+    assert result["session_user_email"] == "user@example.test"
+    store = SessionStore(
+        sessions_dir=_isolated_zulip_tool_env.sessions_dir,
+        config=_isolated_zulip_tool_env,
+    )
+    source = SessionSource(
+        platform=Platform("zulip"),
+        chat_id="29361:profile-aware lane",
+        chat_name="projects",
+        chat_type="stream",
+        user_id="user@example.test",
+        user_name="User",
+        chat_topic="profile-aware lane",
+        profile="research",
+    )
+    assert store.get_or_create_session(source).session_id == result["session_id"]
+
+
+def test_non_zulip_origin_requires_session_owner_before_sending(_isolated_zulip_tool_env):
+    from plugins.platforms.zulip.topic_tool import zulip_send_topic_message
+
+    result = json.loads(
+        zulip_send_topic_message(
+            stream="projects", topic="new work lane", message="Do not send this."
+        )
+    )
+
+    assert "session_user_email" in result["error"]
+    assert _FakeZulipClient.requests == []
+
+
+def test_session_seed_failure_does_not_misreport_successful_send(
+    _isolated_zulip_tool_env,
+):
+    from plugins.platforms.zulip.topic_tool import zulip_send_topic_message
+
+    with patch(
+        "plugins.platforms.zulip.topic_tool._seed_topic_session",
+        side_effect=RuntimeError("state database unavailable"),
+    ):
+        result = json.loads(
+            zulip_send_topic_message(
+                stream="projects",
+                topic="seed outage",
+                message="The Zulip send still succeeds.",
+                session_user_email="user@example.test",
+            )
+        )
+
+    assert result["success"] is True
+    assert result["session_seeded"] is False
+    assert "state database unavailable" in result["session_error"]
+    assert _FakeZulipClient.requests[0]["topic"] == "seed outage"
+
+
+def test_topic_seed_does_not_replace_live_gateway_routing_index(_isolated_zulip_tool_env):
+    """Seeding a topic must not overwrite unrelated live gateway routing."""
+    from gateway.session import SessionSource, SessionStore
+    from plugins.platforms.zulip.topic_tool import zulip_send_topic_message
+
+    live_store = SessionStore(
+        sessions_dir=_isolated_zulip_tool_env.sessions_dir,
+        config=_isolated_zulip_tool_env,
+    )
+    existing_source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+        user_id="user-123",
+    )
+    existing = live_store.get_or_create_session(existing_source)
+    existing_key = live_store._generate_session_key(existing_source)
+
+    result = json.loads(
+        zulip_send_topic_message(
+            stream="projects",
+            topic="new work lane",
+            message="Keep the other routing entries intact.",
+            session_user_email="user@example.test",
+        )
+    )
+
+    assert result["session_seeded"] is True
+    fresh_store = SessionStore(
+        sessions_dir=_isolated_zulip_tool_env.sessions_dir,
+        config=_isolated_zulip_tool_env,
+    )
+    assert fresh_store.peek_session_id(existing_key) == existing.session_id
+
+
+def test_topic_tool_uses_one_resolved_credential_set_for_lookup_and_send(
+    _isolated_zulip_tool_env, monkeypatch
+):
+    from plugins.platforms.zulip.topic_tool import zulip_send_topic_message
+
+    monkeypatch.setenv("ZULIP_SITE_URL", "https://env-chat.example.test/")
+    monkeypatch.setenv("ZULIP_BOT_EMAIL", "env-bot@example.test")
+    monkeypatch.setenv("ZULIP_API_KEY", "env-zulip-api-key")
+
+    result = json.loads(
+        zulip_send_topic_message(
+            stream="projects",
+            topic="consistent credentials",
+            message="Lookup and send must use one Zulip account.",
+            session_user_email="user@example.test",
+        )
+    )
+
+    assert result["success"] is True
+    assert _FakeZulipClient.credentials == [
+        ("https://env-chat.example.test", "env-bot@example.test", "env-zulip-api-key"),
+        ("https://env-chat.example.test", "env-bot@example.test", "env-zulip-api-key"),
+    ]

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -130,6 +130,7 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
         "slack-sdk==3.43.0",
         "aiohttp==3.14.3",
     ),
+    "platform.zulip": ("zulip==0.9.1",),
     "platform.matrix": (
         "mautrix[encryption]==0.21.1",
         "aiosqlite==0.22.1",

--- a/uv.lock
+++ b/uv.lock
@@ -1910,6 +1910,9 @@ wecom = [
 youtube = [
     { name = "youtube-transcript-api" },
 ]
+zulip = [
+    { name = "zulip" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -2050,8 +2053,9 @@ requires-dist = [
     { name = "vercel", marker = "extra == 'vercel'", specifier = "==0.7.2" },
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
+    { name = "zulip", marker = "extra == 'zulip'", specifier = "==0.9.1" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "tts-premium", "voice", "wake", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "otlp", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "zulip", "matrix", "wecom", "tts-premium", "voice", "wake", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "otlp", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"
@@ -5130,4 +5134,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
+]
+
+[[package]]
+name = "zulip"
+version = "0.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "distro" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/74/3fbf8dab5035724f32c7c8c39a20f1e5b1a081fa8bfe4883d8f64d560999/zulip-0.9.1.tar.gz", hash = "sha256:abeba4147625107f690bb633143fdf36cd665fe037b3871011fd4b1e3dc081e8", size = 149751, upload-time = "2025-09-30T22:01:44.693Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/41/0507da59eae2ebb4641895a189eb6438b76610c06c65aa06310b755d3aa7/zulip-0.9.1-py3-none-any.whl", hash = "sha256:37682bad54714a53f9286586a534c2e13217b2bbddf0b4e71c60ef67d43b9043", size = 332200, upload-time = "2025-09-30T22:01:40.154Z" },
 ]

--- a/website/docs/user-guide/messaging/zulip.md
+++ b/website/docs/user-guide/messaging/zulip.md
@@ -1,0 +1,675 @@
+---
+sidebar_position: 12
+title: "Zulip"
+description: "Set up Hermes Agent as a Zulip bot"
+---
+
+# Zulip Setup
+
+Hermes Agent integrates with Zulip as a bundled platform plugin, letting you chat with your AI assistant through direct messages or stream topics. Zulip is an open-source team chat platform — you can use Zulip Cloud (hosted at zulipchat.com) or run it on your own infrastructure. The bot connects via the official `zulip` Python package using Zulip's REST API and long-polling event queue, processes messages through the Hermes Agent pipeline (including tool use, memory, and reasoning), and responds in real time. It supports text, images (including pasted/attached /user_uploads/ images, automatically fetched for vision-capable models), documents, video uploads, and typing indicators.
+
+The `zulip` Python package is optional and is only needed when you configure the
+Zulip plugin. You do not need to install it before running the setup wizard.
+After Zulip credentials are configured, Hermes installs the pinned Zulip SDK
+automatically on first use when `security.allow_lazy_installs` is enabled (the
+default).
+
+For locked-down or offline environments, preinstall the Zulip extra into the
+same environment that runs Hermes. From a source checkout created by
+`setup-hermes.sh`, use:
+
+```bash
+UV_PROJECT_ENVIRONMENT=venv uv sync --locked --extra all --extra zulip
+```
+
+If your checkout uses `.venv` instead, set `UV_PROJECT_ENVIRONMENT=.venv`.
+
+For a pip-installed Hermes package, use:
+
+```bash
+python -m pip install 'hermes-agent[zulip]'
+```
+
+`setup-hermes.sh` installs Hermes with the curated `all` extra. Zulip is not
+eager-installed by `all`; it is a lazy platform extra, like other optional
+platform SDKs.
+
+:::info
+The Zulip adapter lives under `plugins/platforms/zulip/`, so setup, status,
+authorization, cron delivery, and standalone sending are wired through the
+platform plugin registry instead of core gateway files.
+:::
+
+Before setup, here's the part most people want to know: how Hermes behaves once it's in your Zulip organization.
+
+## How Hermes Behaves
+
+| Context | Behavior |
+|---------|----------|
+| **DMs** | Hermes responds to every message. No `@mention` needed. Each DM has its own session. |
+| **Stream messages** | Hermes responds when you `@mention` it. Without a mention, Hermes ignores the message. |
+| **Topics** | Each stream+topic combination gets its own session. Changing the topic starts a fresh conversation. |
+| **Group DMs** | Hermes responds to every message in group DMs. Each group DM has its own session. |
+| **Shared streams with multiple users** | By default, Hermes isolates session history per user inside the stream. Two people talking in the same stream do not share one transcript unless you explicitly disable that. |
+
+:::tip
+If you want Hermes to respond in certain streams without an @mention, use `ZULIP_FREE_RESPONSE_STREAMS` to list stream names or IDs. This is useful for bot-dedicated channels.
+:::
+
+### Session Model in Zulip
+
+By default:
+
+- each DM gets its own session
+- each stream+topic gets its own session
+- each user in a shared stream gets their own session inside that stream+topic
+
+This is controlled by `config.yaml`:
+
+```yaml
+group_sessions_per_user: true
+```
+
+Set it to `false` only if you explicitly want one shared conversation for the entire stream:
+
+```yaml
+group_sessions_per_user: false
+```
+
+Shared sessions can be useful for a collaborative stream, but they also mean:
+
+- users share context growth and token costs
+- one person's long tool-heavy task can bloat everyone else's context
+- one person's in-flight run can interrupt another person's follow-up in the same stream
+
+### Agent-created topics
+
+Enable the `zulip-history` toolset to let Hermes use
+`zulip_send_topic_message`. It posts to any stream/topic the bot can access;
+Zulip creates the topic when it does not yet exist. Hermes also creates or
+reuses the matching topic session and records the sent seed message, so a later
+reply in that topic starts with the right context rather than an empty session.
+
+```text
+zulip_send_topic_message(
+  stream="projects",
+  topic="new work lane",
+  message="Let's investigate the deployment failure.",
+)
+```
+
+In a Zulip-origin conversation, Hermes automatically uses the current sender
+as the session owner. From the CLI, cron, or another messaging platform, pass
+`session_user_email` so Hermes knows whose per-user Zulip session to seed.
+
+This guide walks you through the full setup process — from creating your bot on Zulip to sending your first message.
+
+## Step 1: Create a Bot Account
+
+1. Log in to your Zulip organization (cloud or self-hosted).
+2. Go to **Settings** → **Your bots**.
+3. Click **Add a new bot**.
+4. Fill in the details:
+   - **Bot type**: choose **Generic bot**.
+   - **Bot email**: e.g., `hermes-bot@your-org.zulipchat.com`
+   - **Full name**: e.g., `Hermes Agent`
+   - **Role**: can be a normal user or admin, depending on your needs
+5. Click **Create bot**.
+6. Zulip will display the **bot's API key**. **Copy it immediately.**
+
+:::warning[API key shown only once]
+The bot's API key is only displayed once when you create the bot. If you lose it, you'll need to regenerate it from the bot's settings page. Never share your API key publicly or commit it to Git — anyone with this key has full control of the bot.
+:::
+
+:::info
+For self-hosted Zulip, make sure the bot is enabled after creation. Navigate to the bot in **Settings** → **Your bots** and verify its status.
+:::
+
+Store the API key somewhere safe (a password manager, for example). You'll need it in Step 3.
+
+## Step 2: Subscribe the Bot to Streams
+
+The bot needs to be subscribed to any stream where you want it to respond:
+
+1. Open the stream where you want the bot.
+2. Click the **stream name** → **Stream settings**.
+3. Go to the **Subscribers** tab.
+4. Search for the bot's email address and add it.
+
+For DMs, simply open a direct message with the bot — it will be able to respond immediately without subscribing to any streams.
+
+## Step 3: Configure Hermes Agent
+
+### Option A: Interactive Setup (Recommended)
+
+Run the guided setup command:
+
+```bash
+hermes gateway setup
+```
+
+Select **Zulip** when prompted, then enter your server URL, bot email, API key, and allowed user emails when asked.
+
+If the Zulip SDK is not already installed, the first configured gateway start
+will install it automatically unless lazy installs are disabled.
+
+### Option B: Manual Configuration
+
+Add the following to your `~/.hermes/.env` file:
+
+```bash
+# Required
+ZULIP_SITE_URL=https://your-org.zulipchat.com
+ZULIP_BOT_EMAIL=hermes-bot@your-org.zulipchat.com
+ZULIP_API_KEY=***
+
+# Required unless ZULIP_ALLOW_ALL_USERS=true
+ZULIP_ALLOWED_USERS=you@example.com
+
+# Multiple allowed users (comma-separated)
+# ZULIP_ALLOWED_USERS=you@example.com,colleague@example.com
+```
+
+Optional settings in `~/.hermes/.env`:
+
+```bash
+# Allow all users without an allowlist (NOT recommended for bots with terminal access)
+# ZULIP_ALLOW_ALL_USERS=true
+
+# Default stream for outbound messages
+ZULIP_DEFAULT_STREAM=general
+
+# Home topic for cron/reminder delivery when ZULIP_HOME_CHANNEL is not set
+# ZULIP_HOME_TOPIC=notifications
+
+# Mention gating (default: true)
+# ZULIP_REQUIRE_MENTION=false
+
+# TLS for self-hosted/local Zulip with private CA or self-signed certs
+# Preferred: trust your local CA explicitly
+# ZULIP_CERT_BUNDLE=/path/to/ca.pem
+# Temporary local-dev fallback only:
+# ZULIP_ALLOW_INSECURE=true   # disables TLS verification
+
+# Streams where @mention is not required (comma-separated names or IDs)
+# ZULIP_FREE_RESPONSE_STREAMS=bot-commands,42
+
+# Missed-message catch-up — back-fill messages that arrived while the gateway
+# was down (default: off). See "Missed-Message Catch-Up" below.
+# ZULIP_CATCHUP=true
+# ZULIP_CATCHUP_MAX_MESSAGES=100   # per-stream replay cap per (re-)register
+```
+
+Optional behavior settings in `~/.hermes/config.yaml`:
+
+```yaml
+group_sessions_per_user: true
+
+display:
+  platforms:
+    zulip:
+      # Enables live response streaming by editing Zulip messages in place.
+      # Before setting true, disable edit history in Zulip organization settings.
+      streaming: false
+```
+
+- `group_sessions_per_user: true` keeps each participant's context isolated inside shared streams and group DMs
+- `display.platforms.zulip.streaming: true` opts Zulip into edit-based live response streaming
+
+### Tool Progress Display
+
+Shared Zulip streams can get noisy if every tool call is echoed into the
+conversation. To keep tool progress quiet in Zulip while leaving final answers
+unchanged, set a per-platform display override:
+
+```yaml
+display:
+  platforms:
+    zulip:
+      tool_progress: off      # or log
+```
+
+Use `tool_progress: log` to keep chat silent while writing tool-call activity to
+Hermes logs. To show progress in chat, use `new`, `all`, or `verbose`.
+
+### Start the Gateway
+
+Once configured, start the gateway in the foreground:
+
+```bash
+hermes gateway run
+```
+
+The bot should connect to your Zulip server within a few seconds. You'll see a log message like:
+
+```
+Zulip: authenticated as hermes-bot@your-org.zulipchat.com (user_id=123) on https://your-org.zulipchat.com
+```
+
+Send it a DM or @mention it in a stream to test.
+
+:::tip
+Use `hermes gateway run` for a foreground test run. Once that works, you can install the systemd/launchd service for persistent operation.
+:::
+
+## Home Channel
+
+You can designate a "home stream+topic" where the bot sends proactive messages (such as cron job output, reminders, and notifications). There are two ways to set it.
+
+### Using the Slash Command
+
+Type `/sethome` in any Zulip stream or DM where the bot is present. That stream+topic becomes the home channel.
+
+### Manual Configuration
+
+Add either a combined stream+topic target:
+
+```bash
+ZULIP_HOME_CHANNEL=general:notifications
+```
+
+The format is `stream_name:topic`. Hermes resolves the stream name to the correct Zulip stream ID before sending, so manual config stays human-readable.
+
+Or use separate variables:
+
+```bash
+ZULIP_DEFAULT_STREAM=general
+ZULIP_HOME_TOPIC=notifications
+```
+
+`ZULIP_HOME_CHANNEL` takes precedence when both forms are set.
+
+## Known Core Follow-Ups
+
+The Zulip adapter is intentionally shipped through the plugin path, so this PR
+does not change core target parsing or cron bookkeeping. Two generic Hermes
+edges are worth tracking separately:
+
+- `hermes send --to zulip "message"` works when `ZULIP_HOME_CHANNEL` is set.
+  `hermes send --to "zulip:5:Sauve Cloud Status" "message"` currently goes
+  through the shared channel-name resolver before the Zulip adapter sees it.
+  A core follow-up can teach `send_message_tool` that Zulip `stream:topic` and
+  `dm:...` strings are explicit adapter-native targets.
+- `hermes cron run` for a finite `--repeat 1` smoke job can report failure
+  after the job removes itself, even when the script ran and delivery succeeded.
+  The saved output and gateway logs are authoritative for that edge case. Use
+  `--repeat 2` during manual smoke testing if you need the job to remain visible
+  after the first run.
+
+Candidate patch for the first follow-up:
+
+```diff
+diff --git a/tools/send_message_tool.py b/tools/send_message_tool.py
+@@
+     if platform_name == "ntfy":
+         topic = target_ref.strip()
+         if topic:
+             return topic, None, True
++    if platform_name == "zulip":
++        target = target_ref.strip()
++        if target.startswith("dm:") and len(target) > 3:
++            return target, None, True
++        if ":" in target:
++            return target, None, True
+     if platform_name == "email":
+```
+
+Candidate shape for the second follow-up:
+
+```diff
+diff --git a/cron/scheduler.py b/cron/scheduler.py
+@@
+         if success and not final_response.strip():
+             success = False
+             error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
++
++        # mark_job_run() removes finite one-shot jobs immediately after their
++        # repeat limit is reached. Preserve the run result in memory so
++        # manual callers can report the actual outcome after removal.
++        job["_execution_success"] = bool(success)
++        job["_execution_error"] = error
+
+         mark_job_run(job["id"], success, error, delivery_error=delivery_error)
+diff --git a/tools/cronjob_tools.py b/tools/cronjob_tools.py
+@@
+         processed = run_one_job(job)
+         refreshed = get_job(job_id) or {}
+-        ok = refreshed.get("last_status") == "ok"
++        ok = refreshed.get("last_status") == "ok" if refreshed else bool(job.get("_execution_success"))
++        error = refreshed.get("last_error") if refreshed else job.get("_execution_error")
+         return {
+             "claimed": True,
+             "success": bool(processed and ok),
+-            "error": refreshed.get("last_error"),
++            "error": error,
+         }
+```
+
+## Missed-Message Catch-Up
+
+The Zulip events API only delivers events from the moment the gateway registers
+its event queue onward. If the gateway is down — a restart, a `BAD_EVENT_QUEUE_ID`
+expiry after a long idle, or a network drop — any messages that arrive during the
+gap are never delivered, and the bot silently never sees them.
+
+Catch-up closes that gap. When enabled, on every (re-)register the adapter
+back-fills each stream from a persisted per-stream watermark and feeds the missed
+messages through the **same path live messages take** — so dedup, mention-gating,
+and per-topic sessions all behave identically to messages received in real time.
+
+It is **off by default**: enabling it on a bot that has been offline for a while
+replays the accumulated backlog (up to the per-stream cap), which is usually
+surprising. Turn it on deliberately.
+
+```bash
+ZULIP_CATCHUP=true                 # opt in (default: false)
+ZULIP_CATCHUP_MAX_MESSAGES=100     # per-stream replay cap per (re-)register
+```
+
+Or in `~/.hermes/config.yaml` under the Zulip platform's `extra`:
+
+```yaml
+catchup_enabled: true
+catchup_max_messages: 100
+```
+
+Behavior details:
+
+- **First run never floods.** The first time catch-up sees a stream (no stored
+  watermark) it records the newest message id as a baseline and replays nothing —
+  a clean start does not drag in history.
+- **Bounded.** At most `catchup_max_messages` messages per stream are replayed per
+  (re-)register, so even a long downtime can't trigger an unbounded replay.
+- **Exactly-once in practice.** Replayed messages flow through the same dedup the
+  live queue uses, so a message caught by both the sweep and the live queue is
+  processed once.
+- **Forward-only.** The watermark only advances; it is persisted next to the bot's
+  state and survives restarts.
+
+## Mention Gating
+
+By default, Hermes only responds in streams when it is @mentioned. This prevents the bot from processing every message in a busy stream.
+
+### Disabling Mention Requirement
+
+Set `ZULIP_REQUIRE_MENTION=false` in your `~/.hermes/.env` to make the bot respond to all messages in every stream:
+
+```bash
+ZULIP_REQUIRE_MENTION=false
+```
+
+### Per-Stream Exemptions
+
+Use `ZULIP_FREE_RESPONSE_STREAMS` to exempt specific streams from the mention requirement while keeping it active elsewhere:
+
+```bash
+ZULIP_FREE_RESPONSE_STREAMS=bot-commands,ai-assistant
+```
+
+You can use stream names or stream IDs (comma-separated). This is useful for dedicated bot channels where you want a conversational experience without the @mention overhead.
+
+### Historical Context on @mention
+
+By default, the bot only sees the message where it was @mentioned — it has no idea what was discussed beforehand. It's like walking into a room mid-conversation.
+
+Set `ZULIP_CONTEXT_DEPTH` in your `~/.hermes/.env` to instruct the bot to fetch recent messages from the same stream+topic when summoned:
+
+```bash
+ZULIP_CONTEXT_DEPTH=20
+```
+
+When someone types `@bot what do you think about the proposal above?`, the bot fetches the last 20 messages from Zulip's `/messages` REST API and injects them as context before the current message. The agent sees something like:
+
+```
+Recent messages in this topic:
+Alice: I think we should use PostgreSQL
+Bob: Agreed, but what about migrations?
+Charlie: We can use Alembic for that
+---
+@**Hermes Bot** what do you think about the proposal above?
+```
+
+**Key properties:**
+
+- **Survives disconnects** — uses Zulip as the source of truth via REST API, not the event queue. If the bot was offline for an hour, it still sees what happened.
+- **On-demand** — only fetches when @mentioned (or in free-response streams). Zero overhead on unmentioned messages.
+- **No local storage** — context is fetched fresh each time, never persisted between turns.
+- **Privacy-preserving** — the bot only reads the stream+topic when explicitly summoned. It never silently observes or stores messages.
+- **Bot's own messages skipped** — the bot filters itself out of the context so it doesn't see its own previous responses.
+
+Set it to `0` (the default) to disable context fetching:
+
+:::info
+DMs and group DMs always bypass mention gating — the bot responds to every message in private conversations.
+:::
+
+### Message History Search Tool
+
+The bot has access to a `zulip_search_messages` tool that lets it search and paginate through Zulip message history. This wraps Zulip's `/messages` API — the bot can use it to:
+
+- **Fetch context** around a specific message ID (e.g., a message someone replied to)
+- **Paginate** further back when the initial auto-fetched context isn't enough
+- **Search** for specific content (e.g., "find where we discussed PostgreSQL")
+- **Filter by sender** using Zulip's search operators
+
+**Tool parameters:**
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `stream` | Stream name | `"general"` |
+| `topic` | Topic name | `"database"` |
+| `query` | Full-text search (Zulip operators) | `"postgresql"`, `"sender:alice@example.com"` |
+| `anchor` | Message ID or `"newest"`/`"oldest"` | `"newest"`, `"42"` |
+| `num_before` | Messages to fetch before anchor | `20` |
+| `num_after` | Messages to fetch after anchor | `5` |
+
+**Common patterns the bot uses:**
+
+```python
+# Recent conversation context
+zulip_search_messages(stream="general", topic="database", anchor="newest", num_before=20)
+
+# Context around a specific message (e.g., a reply target)
+zulip_search_messages(stream="general", anchor="42", num_before=5, num_after=5)
+
+# Find where PostgreSQL was discussed
+zulip_search_messages(stream="general", query="postgresql")
+
+# Show older page of history
+zulip_search_messages(stream="general", topic="database", anchor="<oldest_message_id>", num_before=20)
+```
+
+:::warning[Search scope is restricted to the current conversation]
+When the bot is talking to you **through Zulip** (DM, group DM, or stream), the `zulip_search_messages` tool is automatically restricted to the **current conversation only**. A user in a private DM cannot ask the bot to search messages from streams or other DMs the bot is subscribed to. This prevents the bot from being used as a proxy to exfiltrate content from conversations you don't have access to.
+
+When the bot is invoked from the **CLI** or other platforms, the full search scope is available (subject to the bot's own Zulip permissions).
+:::
+
+The response includes pagination hints (`oldest_message_id`, `newest_message_id`) so the bot can continue browsing without guesswork.
+
+### Downloading historical attachments
+
+`zulip_search_messages` returns the original Markdown for historical messages.
+When it finds a `/user_uploads/...` link, the bot can call
+`zulip_download_attachment(message_id, filename?, attachment_index?)` to save
+that attachment into Hermes's local media cache. The tool returns a local path
+for `read_file` or terminal tools to inspect.
+
+In a Zulip conversation, the download tool has the same stream/topic or DM
+restriction as message-history search. It accepts a message ID rather than an
+arbitrary upload URL, so it cannot be used to retrieve a file from another
+conversation that the requesting user cannot access.
+
+:::tip
+If the bot says "I don't have enough context," tell it: "use zulip_search_messages to look further back in this topic." It will paginate until it finds what it needs.
+:::
+
+## Live Response Streaming Edits
+
+Zulip streaming uses message edits: Hermes sends the first partial response as a normal Zulip message, then edits that same message as more text is generated. This mode is disabled by default because Zulip may preserve every intermediate edit in message edit history.
+
+To enable it for Zulip only, use the standard per-platform gateway streaming switch in `~/.hermes/config.yaml`:
+
+```yaml
+streaming:
+  enabled: false
+  transport: auto
+  # Desktop Zulip can visibly repaint on each edit. A high threshold lets the
+  # interval control the cadence instead of flushing for every short segment.
+  edit_interval: 2.0
+  buffer_threshold: 10000
+
+display:
+  platforms:
+    zulip:
+      # First disable edit history in Zulip organization settings.
+      streaming: true
+```
+
+You can also enable streaming globally with `streaming.enabled: true`; `display.platforms.zulip.streaming: true` is the narrower opt-in for Zulip. Before enabling Zulip streaming, disable edit history in your Zulip organization settings. Otherwise intermediate streamed content, including partial assistant drafts, may remain visible in the message's edit history.
+
+Some Zulip desktop clients visibly repaint an edited message. If frequent
+updates look like blinking, set a 1–2 second `edit_interval` and a high
+`buffer_threshold`, as above: the interval is the minimum time between edits,
+while the threshold is a character-count force-flush. Restart the gateway after
+changing the setting.
+
+When Zulip streaming edits are first used, Hermes logs a warning once. With Zulip streaming unset or false, Zulip sends normal whole-message replies and does not log the warning.
+
+## Long responses
+
+Hermes sends a Zulip response as one message up to 10,000 Unicode code points,
+the standard Zulip message limit. Responses above that limit are split at
+natural text boundaries so that code blocks remain valid Markdown.
+
+For a self-hosted Zulip realm, make sure its `MAX_MESSAGE_LENGTH` in
+`/etc/zulip/settings.py` is at least `10000`, then restart the server. Docker
+deployments can set the equivalent `SETTING_MAX_MESSAGE_LENGTH=10000`. Zulip
+Cloud users cannot change this server setting. Zulip publishes the effective
+per-realm maximum through its registration API, so a lower realm limit will
+still reject a message that exceeds it.
+
+## Sending Messages Cross-Platform
+
+You can send messages to Zulip from other platforms using the `send_message` tool. The plugin registers a standalone sender, so `send_message` and cron delivery can work even when the gateway is not running in the same process.
+
+| Target | Description |
+|--------|-------------|
+| `zulip` | Sends to the home stream+topic |
+
+Out-of-process standalone sending is text-focused. Media attachments are supported by the live gateway adapter, but standalone cron/tool sends return a clear unsupported-media error when media files are provided. The standalone sender uses the same Zulip dependency check as the gateway adapter, so configured cron/status delivery can trigger the normal lazy install path.
+
+## Cron Delivery
+
+Cron jobs can deliver results to Zulip. Use `deliver="zulip"` to send to the configured home stream+topic:
+
+```
+deliver="zulip"
+```
+
+For cron-only deployments where the gateway is not running in the same process,
+make sure the Zulip credentials and home channel are available to the cron
+process. If runtime lazy installs are disabled, preinstall the Zulip extra before
+running cron jobs.
+
+## Media attachments
+
+The Zulip adapter supports uploading and sending media files:
+
+| Type | Behavior |
+|------|----------|
+| **Images** | Uploaded to Zulip and rendered inline using `![alt](/user_uploads/...)` |
+| **Documents** | Uploaded and sent as a clickable Markdown link `[filename](/user_uploads/...)` |
+| **Video** | Uploaded and sent as a downloadable link (Zulip does not inline video playback) |
+| **Voice/audio** | Uploaded and sent as a downloadable Markdown link. Zulip has no native voice bubble support. |
+
+Media delivery works in both streams and DMs.
+
+Incoming attachments from the triggering message are also downloaded
+automatically. Images go through the normal vision path; documents, archives,
+text files, audio, and video are cached locally and surfaced to the agent as
+paths it can inspect with its existing tools. The current-message download is
+automatic, so no model tool call is required.
+
+## Troubleshooting
+
+### Bot is not responding to messages
+
+**Cause**: The bot is not subscribed to the stream, or `ZULIP_ALLOWED_USERS` doesn't include your email.
+
+**Fix**: Subscribe the bot to the stream (stream settings → Subscribers → add the bot's email). Verify your email is in `ZULIP_ALLOWED_USERS`. Restart the gateway.
+
+### 401 Unauthorized errors
+
+**Cause**: The API key, bot email, or server URL is incorrect.
+
+**Fix**: Verify all three values in your `.env` file. Check that `ZULIP_SITE_URL` includes `https://` and has no trailing slash.
+
+Run `hermes gateway run` in the foreground and check for the authenticated log
+line.
+
+### Bot ignores stream messages
+
+**Cause**: `ZULIP_REQUIRE_MENTION` is `true` (the default) and the bot isn't @mentioned.
+
+**Fix**: Either @mention the bot (e.g., `@**Hermes Agent** hello`), or add the stream to `ZULIP_FREE_RESPONSE_STREAMS`, or set `ZULIP_REQUIRE_MENTION=false`.
+
+### "zulip package not installed" on startup
+
+**Cause**: The `zulip` Python package is not installed, and Hermes could not
+install it at runtime because lazy installs are disabled or the environment is
+offline.
+
+**Fix**: Normally Hermes installs this automatically on first configured use. If
+lazy installs are disabled, install the Zulip extra into the same environment
+that runs Hermes. From a source checkout created by `setup-hermes.sh`:
+
+```bash
+UV_PROJECT_ENVIRONMENT=venv uv sync --locked --extra all --extra zulip
+hermes gateway run
+```
+
+If your checkout uses `.venv` instead, set `UV_PROJECT_ENVIRONMENT=.venv`.
+
+For a pip-installed Hermes package:
+
+```bash
+python -m pip install 'hermes-agent[zulip]'
+hermes gateway run
+```
+
+### Event queue disconnects / reconnection loops
+
+**Cause**: Network instability, Zulip server restarts, or firewall issues with long-polling connections.
+
+**Fix**: The adapter automatically reconnects with exponential backoff (2s → 60s). Check your network connectivity. If you're behind a proxy, ensure it supports long-lived HTTP connections.
+
+### Bot is offline
+
+**Cause**: The Hermes gateway isn't running, or it failed to connect.
+
+**Fix**: Check that `hermes gateway run` is running. Look at the terminal output or `~/.hermes/logs/gateway.log` / `~/.hermes/logs/gateway.error.log` for error messages. Common issues: wrong server URL, stale API key, Zulip server unreachable, or self-signed TLS without `ZULIP_CERT_BUNDLE` / `ZULIP_ALLOW_INSECURE`.
+
+### "User not allowed" / Bot ignores you
+
+**Cause**: Your email isn't in `ZULIP_ALLOWED_USERS`.
+
+**Fix**: Add your email to `ZULIP_ALLOWED_USERS` in `~/.hermes/.env` and restart the gateway. Remember: this is your **email address**, not your Zulip username.
+
+## Security
+
+:::warning
+Always set `ZULIP_ALLOWED_USERS` to restrict who can interact with the bot. Without it, the gateway denies all users by default as a safety measure. Only add emails of people you trust — authorized users have full access to the agent's capabilities, including tool use and system access.
+:::
+
+If you want to allow all users in your Zulip organization, set `ZULIP_ALLOW_ALL_USERS=true`. This is only appropriate for private organizations where all members are trusted.
+
+For more information on securing your Hermes Agent deployment, see the [Security Guide](../security.md).
+
+## Notes
+
+- **Zulip Cloud and self-hosted**: Works with both zulipchat.com cloud organizations and self-hosted Zulip servers.
+- **Official client**: Uses the `zulip` Python package for reliable API access.
+- **Long-polling**: The event queue uses Zulip's long-polling mechanism — no WebSocket or incoming webhook needed.
+- **Stream topics**: Each topic in a stream gets its own session, which maps naturally to Zulip's topic-based conversation model.
+- **DM pairing**: Unknown users who DM the bot receive a one-time pairing code (see the [Messaging Gateway](index.md) docs for details on the pairing flow).

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -706,6 +706,7 @@ const sidebars: SidebarsConfig = {
             'user-guide/messaging/open-webui',
             'user-guide/messaging/relay',
             'user-guide/messaging/webhooks',
+            'user-guide/messaging/zulip',
           ],
         },
       ],


### PR DESCRIPTION
## What does this PR do?

  This PR adds Zulip support to Hermes as a bundled platform plugin under
  `plugins/platforms/zulip/`.

  The original branch predated the current platform plugin system and wired Zulip
  through several core gateway, CLI, scheduler, and tool files. This update moves
  the integration onto the current plugin path: platform registration, setup
  metadata, env/YAML configuration, auth validation, adapter construction, cron
  delivery metadata, standalone text delivery, and the Zulip search tool now live
  with the plugin.

  The goal is to keep Zulip support aligned with the current platform architecture
  while preserving the adapter behavior that has been tested by real users.

  ## Related Issue

  Related to the earlier Zulip PRs:

  - #16541
  - #54715

  This PR remains the canonical Zulip candidate per maintainer feedback on this
  thread.

  Fixes #

  ## Type of Change

  - [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [x] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [x] 📝 Documentation update
  - [x] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️ Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  ## Changes Made

  - `plugins/platforms/zulip/`
    - Adds the Zulip platform plugin, adapter, plugin metadata, standalone sender, setup/config
    hooks, and Zulip search tool.
    - Supports DMs, stream topics, mention/free-response handling, thread/session isolation, topic
    names containing `/`, media handling, typing/reactions where supported, and edit-based
    streaming.
  - `pyproject.toml`, `uv.lock`, `tools/lazy_deps.py`
    - Adds Zulip as an optional/lazy dependency through the `zulip` extra.
  - `website/docs/user-guide/messaging/zulip.md`
    - Adds Zulip setup, configuration, cron delivery, standalone send, search, and streaming docs.
  - `website/docs/user-guide/messaging/index.md`
    - Lists Zulip in the messaging platform docs.
  - `tests/gateway/test_zulip.py`
    - Adds gateway/plugin adapter coverage.
  - `tests/tools/test_zulip_search_messages.py`
    - Adds coverage for Zulip message search behavior.
  - `tests/test_project_metadata.py`
    - Adds coverage for Zulip dependency/plugin metadata wiring.

  This revision also incorporates updates from @slav's patches and @a6patch's
  branch work, manually integrated into the plugin structure to keep this PR
  reviewable:

  - Current-Hermes compatibility updates.
  - Zulip connected-state checking.
  - Platform registry support with standalone sender behavior.
  - Reconnect compatibility coverage.
  - Zulip message edit capability.
  - `edit_message(..., finalize=..., metadata=...)` support for gateway streaming.
  - Docs/tests for edit-based Zulip streaming.
  - Cron and standalone delivery validation.

  ## How to Test

  1. Install with the Zulip extra, or with all extras:

     ```bash
     UV_PROJECT_ENVIRONMENT=venv uv sync --locked --extra zulip
     ```

     or:

     ```bash
     UV_PROJECT_ENVIRONMENT=venv uv sync --locked --extra all
     ```

  2. Configure Zulip credentials and run setup/gateway:

     ```bash
     hermes setup
     hermes gateway
     ```

  3. Validate normal gateway behavior from Zulip:

     - Send the bot a DM.
     - Mention the bot in a stream topic.
     - Test a topic containing `/`, such as `some/topics/with/slashes`.
     - Attach an image and confirm the agent can see it.
     - Use `zulip_search_messages` from a Zulip conversation.

  4. Validate standalone send with a configured home channel:

     ```bash
     hermes send --to zulip "Standalone Zulip send smoke"
     ```

  5. Validate cron delivery:

     ```bash
     hermes cron create \
       --name zulip-cron-smoke \
       --deliver "zulip:5:Sauve Cloud Status" \
       --repeat 1 \
       --script zulip-cron-smoke.sh \
       --no-agent \
       "every 1d" \
       "Zulip cron smoke"

     hermes cron run zulip-cron-smoke
     ```

  6. Validate edit-based streaming by enabling both the global/root streaming flag
     and the Zulip platform streaming flag:

     ```yaml
     display:
       streaming: true
       platforms:
         zulip:
           streaming: true
     ```

  7. Run focused tests:

     ```bash
     pytest tests/gateway/test_zulip.py tests/tools/test_zulip_search_messages.py tests/
     test_project_metadata.py -q
     ```

  ## Checklist

  ### Code

  - [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/
  CONTRIBUTING.md)
  - [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
  (`fix(scope):`, `feat(scope):`, etc.)
  - [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make
  sure this isn't a duplicate. Related Zulip PRs are #16541 and #54715; this PR is the canonical
  Zulip candidate per maintainer feedback.
  - [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
  - [ ] I've run `pytest tests/ -q` and all tests pass
  - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - [x] I've tested on my platform: macOS

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
  - [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
  - [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/
  A
  - [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide]
  (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-
  compatibility) — or N/A
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

  ## Screenshots / Logs

  Manually validated:

  - Zulip gateway startup and connection.
  - Inbound DM handling.
  - Stream/topic handling.
  - Topics containing `/`.
  - Thread/session isolation.
  - Zulip message search.
  - Image reception and vision support.
  - Standalone send using the configured Zulip home channel.
  - Cron delivery to Zulip.
  - Edit-in-place streaming.

  Example standalone send result:

  ```text
  hermes send --to zulip "Standalone Zulip send smoke"
  Sent to zulip home channel (chat_id: 5:Sauve Cloud Status)
  ```

  ## Notes / Follow-Ups

  Edit-based streaming requires the global/root gateway streaming setting to be
  enabled in addition to the Zulip platform setting. Users should also be aware
  that Zulip may retain message edit history depending on the organization's Zulip
  settings.

  Two shared follow-ups were found while testing this PR:

  1. Direct CLI sends to a specific Zulip topic, such as
     `hermes send --to "zulip:stream:topic" ...`, need one small shared sender fix
     outside of the Zulip plugin. This will be proposed separately after the plugin
     PR lands.

  2. One-shot cron jobs using `--repeat 1` can sometimes deliver correctly but
     still print a failure status after completion. This appears to overlap with
     #57689, so it is not included here.