### PR TITLE
perf(ttft): reduce pre-request startup overhead

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -59,6 +59,7 @@ _OAUTH_ONLY_BETAS = [
 # The version must stay reasonably current — Anthropic rejects OAuth requests
 # when the spoofed user-agent version is too far behind the actual release.
 _CLAUDE_CODE_VERSION_FALLBACK = "2.1.74"
+_claude_code_version_cache: Optional[str] = None
 
 
 def _detect_claude_code_version() -> str:
@@ -86,9 +87,16 @@ def _detect_claude_code_version() -> str:
     return _CLAUDE_CODE_VERSION_FALLBACK
 
 
-_CLAUDE_CODE_VERSION = _detect_claude_code_version()
 _CLAUDE_CODE_SYSTEM_PREFIX = "You are Claude Code, Anthropic's official CLI for Claude."
 _MCP_TOOL_PREFIX = "mcp_"
+
+
+def _get_claude_code_version() -> str:
+    """Lazily detect the installed Claude Code version when OAuth headers need it."""
+    global _claude_code_version_cache
+    if _claude_code_version_cache is None:
+        _claude_code_version_cache = _detect_claude_code_version()
+    return _claude_code_version_cache
 
 
 def _is_oauth_token(key: str) -> bool:
@@ -132,7 +140,7 @@ def build_anthropic_client(api_key: str, base_url: str = None):
         kwargs["auth_token"] = api_key
         kwargs["default_headers"] = {
             "anthropic-beta": ",".join(all_betas),
-            "user-agent": f"claude-cli/{_CLAUDE_CODE_VERSION} (external, cli)",
+            "user-agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
             "x-app": "cli",
         }
     else:
@@ -241,7 +249,7 @@ def _refresh_oauth_token(creds: Dict[str, Any]) -> Optional[str]:
 
     headers = {
         "Content-Type": "application/json",
-        "User-Agent": f"claude-cli/{_CLAUDE_CODE_VERSION} (external, cli)",
+        "User-Agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
     }
 
     for endpoint in token_endpoints:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1137,7 +1137,13 @@ def resolve_vision_provider_client(
         return "custom", client, final_model
 
     if requested == "auto":
-        for candidate in get_available_vision_backends():
+        ordered = list(_VISION_AUTO_PROVIDER_ORDER)
+        preferred = _preferred_main_vision_provider()
+        if preferred in ordered:
+            ordered.remove(preferred)
+            ordered.insert(0, preferred)
+
+        for candidate in ordered:
             sync_client, default_model = _resolve_strict_vision_backend(candidate)
             if sync_client is not None:
                 return _finalize(candidate, sync_client, default_model)

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -5,12 +5,16 @@ assemble pieces, then combines them with memory and ephemeral prompts.
 """
 
 import logging
+import json
 import os
 import re
+import sys
+import threading
 from pathlib import Path
 
 from hermes_constants import get_hermes_home
 from typing import Optional
+from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
@@ -228,11 +232,255 @@ PLATFORM_HINTS = {
 CONTEXT_FILE_MAX_CHARS = 20_000
 CONTEXT_TRUNCATE_HEAD_RATIO = 0.7
 CONTEXT_TRUNCATE_TAIL_RATIO = 0.2
+_SKILL_PLATFORM_MAP = {
+    "macos": "darwin",
+    "linux": "linux",
+    "windows": "win32",
+}
+_SKILL_SCAN_EXCLUDED_DIRS = frozenset((".git", ".github", ".hub"))
+_SKILLS_PROMPT_CACHE_MAX_ENTRIES = 8
+_SKILLS_PROMPT_CACHE: dict[tuple[str, tuple[str, ...], tuple[str, ...]], str] = {}
+_SKILLS_PROMPT_CACHE_LOCK = threading.Lock()
+_SKILLS_PROMPT_SNAPSHOT_VERSION = 1
+_YAML_LOAD = None
 
 
 # =========================================================================
 # Skills index
 # =========================================================================
+
+def _parse_frontmatter_block(content: str) -> tuple[dict, str]:
+    """Parse YAML frontmatter from a markdown string without importing tools."""
+    frontmatter = {}
+    body = content
+
+    if not content.startswith("---"):
+        return frontmatter, body
+
+    end_match = re.search(r"\n---\s*\n", content[3:])
+    if not end_match:
+        return frontmatter, body
+
+    yaml_content = content[3 : end_match.start() + 3]
+    body = content[end_match.end() + 3 :]
+
+    try:
+        parsed = _yaml_load(yaml_content)
+        if isinstance(parsed, dict):
+            frontmatter = parsed
+    except Exception:
+        for line in yaml_content.strip().split("\n"):
+            if ":" not in line:
+                continue
+            key, value = line.split(":", 1)
+            frontmatter[key.strip()] = value.strip()
+
+    return frontmatter, body
+
+
+def _yaml_load(content: str):
+    global _YAML_LOAD
+    if _YAML_LOAD is None:
+        import yaml
+
+        loader = getattr(yaml, "CSafeLoader", None) or yaml.SafeLoader
+
+        def _load(value: str):
+            return yaml.load(value, Loader=loader)
+
+        _YAML_LOAD = _load
+    return _YAML_LOAD(content)
+
+
+def _skill_matches_platform(frontmatter: dict) -> bool:
+    """Return True when the skill is compatible with the current OS."""
+    platforms = frontmatter.get("platforms")
+    if not platforms:
+        return True
+    if not isinstance(platforms, list):
+        platforms = [platforms]
+    current = sys.platform
+    for platform in platforms:
+        normalized = str(platform).lower().strip()
+        mapped = _SKILL_PLATFORM_MAP.get(normalized, normalized)
+        if current.startswith(mapped):
+            return True
+    return False
+
+
+def _normalize_string_set(values) -> set[str]:
+    if values is None:
+        return set()
+    if isinstance(values, str):
+        values = [values]
+    return {str(value).strip() for value in values if str(value).strip()}
+
+
+def _get_disabled_skill_names() -> set[str]:
+    """Read disabled skills from ~/.hermes/config.yaml without importing CLI/tool code."""
+    config_path = get_hermes_home() / "config.yaml"
+    if not config_path.exists():
+        return set()
+    try:
+        parsed = _yaml_load(config_path.read_text(encoding="utf-8"))
+    except Exception as e:
+        logger.debug("Could not read skill config %s: %s", config_path, e)
+        return set()
+    if not isinstance(parsed, dict):
+        return set()
+
+    skills_cfg = parsed.get("skills")
+    if not isinstance(skills_cfg, dict):
+        return set()
+
+    resolved_platform = os.getenv("HERMES_PLATFORM")
+    if resolved_platform:
+        platform_disabled = (skills_cfg.get("platform_disabled") or {}).get(
+            resolved_platform
+        )
+        if platform_disabled is not None:
+            return _normalize_string_set(platform_disabled)
+    return _normalize_string_set(skills_cfg.get("disabled"))
+
+
+def _iter_skill_index_files(skills_dir: Path, filename: str):
+    matches = []
+    for root, dirs, files in os.walk(skills_dir):
+        dirs[:] = [d for d in dirs if d not in _SKILL_SCAN_EXCLUDED_DIRS]
+        if filename in files:
+            matches.append(Path(root) / filename)
+    for path in sorted(matches, key=lambda item: str(item.relative_to(skills_dir))):
+        yield path
+
+
+def _skills_prompt_snapshot_path() -> Path:
+    return get_hermes_home() / ".skills_prompt_snapshot.json"
+
+
+def clear_skills_system_prompt_cache(*, clear_snapshot: bool = False) -> None:
+    """Drop the in-process skills prompt cache after local skill changes."""
+    with _SKILLS_PROMPT_CACHE_LOCK:
+        _SKILLS_PROMPT_CACHE.clear()
+    if clear_snapshot:
+        try:
+            _skills_prompt_snapshot_path().unlink(missing_ok=True)
+        except OSError as e:
+            logger.debug("Could not remove skills prompt snapshot: %s", e)
+
+
+def _extract_skill_description(frontmatter: dict) -> str:
+    raw_desc = frontmatter.get("description", "")
+    if not raw_desc:
+        return ""
+    desc = str(raw_desc).strip().strip("'\"")
+    if len(desc) > 60:
+        return desc[:57] + "..."
+    return desc
+
+
+def _extract_skill_conditions(frontmatter: dict) -> dict:
+    hermes = (frontmatter.get("metadata") or {}).get("hermes") or {}
+    return {
+        "fallback_for_toolsets": hermes.get("fallback_for_toolsets", []),
+        "requires_toolsets": hermes.get("requires_toolsets", []),
+        "fallback_for_tools": hermes.get("fallback_for_tools", []),
+        "requires_tools": hermes.get("requires_tools", []),
+    }
+
+
+def _read_skill_frontmatter(skill_file: Path) -> tuple[dict, str]:
+    raw = skill_file.read_text(encoding="utf-8")[:2000]
+    frontmatter, _ = _parse_frontmatter_block(raw)
+    return frontmatter, _extract_skill_description(frontmatter)
+
+
+def _build_snapshot_entry(
+    skill_file: Path,
+    skills_dir: Path,
+    *,
+    frontmatter: Optional[dict] = None,
+    description: Optional[str] = None,
+) -> dict:
+    rel_path = skill_file.relative_to(skills_dir)
+    parts = rel_path.parts
+    if len(parts) >= 2:
+        skill_name = parts[-2]
+        category = "/".join(parts[:-2]) if len(parts) > 2 else parts[0]
+    else:
+        category = "general"
+        skill_name = skill_file.parent.name
+
+    if frontmatter is None or description is None:
+        try:
+            frontmatter, desc = _read_skill_frontmatter(skill_file)
+        except Exception as e:
+            logger.debug("Failed to parse skill file %s: %s", skill_file, e)
+            frontmatter = {}
+            desc = ""
+    else:
+        desc = description
+
+    platforms = frontmatter.get("platforms") or []
+    if isinstance(platforms, str):
+        platforms = [platforms]
+
+    return {
+        "skill_name": skill_name,
+        "category": category,
+        "frontmatter_name": str(frontmatter.get("name", skill_name)),
+        "description": desc,
+        "platforms": [str(platform).strip() for platform in platforms if str(platform).strip()],
+        "conditions": _extract_skill_conditions(frontmatter),
+    }
+
+
+def _build_skills_prompt_manifest(skills_dir: Path) -> dict[str, list[int]]:
+    manifest = {}
+    for filename in ("SKILL.md", "DESCRIPTION.md"):
+        for path in _iter_skill_index_files(skills_dir, filename):
+            try:
+                stat = path.stat()
+            except OSError:
+                continue
+            manifest[str(path.relative_to(skills_dir))] = [stat.st_mtime_ns, stat.st_size]
+    return manifest
+
+
+def _load_skills_prompt_snapshot(skills_dir: Path) -> Optional[dict]:
+    snapshot_path = _skills_prompt_snapshot_path()
+    if not snapshot_path.exists():
+        return None
+    try:
+        snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    except Exception as e:
+        logger.debug("Could not read skills prompt snapshot %s: %s", snapshot_path, e)
+        return None
+    if not isinstance(snapshot, dict):
+        return None
+    if snapshot.get("version") != _SKILLS_PROMPT_SNAPSHOT_VERSION:
+        return None
+    if snapshot.get("manifest") != _build_skills_prompt_manifest(skills_dir):
+        return None
+    return snapshot
+
+
+def _write_skills_prompt_snapshot(
+    skills_dir: Path,
+    manifest: dict[str, list[int]],
+    skill_entries: list[dict],
+    category_descriptions: dict[str, str],
+) -> None:
+    snapshot = {
+        "version": _SKILLS_PROMPT_SNAPSHOT_VERSION,
+        "manifest": manifest,
+        "skills": skill_entries,
+        "category_descriptions": category_descriptions,
+    }
+    try:
+        atomic_json_write(_skills_prompt_snapshot_path(), snapshot)
+    except Exception as e:
+        logger.debug("Could not write skills prompt snapshot: %s", e)
+
 
 def _parse_skill_file(skill_file: Path) -> tuple[bool, dict, str]:
     """Read a SKILL.md once and return platform compatibility, frontmatter, and description.
@@ -241,20 +489,10 @@ def _parse_skill_file(skill_file: Path) -> tuple[bool, dict, str]:
     (True, {}, "") to err on the side of showing the skill.
     """
     try:
-        from tools.skills_tool import _parse_frontmatter, skill_matches_platform
+        frontmatter, desc = _read_skill_frontmatter(skill_file)
 
-        raw = skill_file.read_text(encoding="utf-8")[:2000]
-        frontmatter, _ = _parse_frontmatter(raw)
-
-        if not skill_matches_platform(frontmatter):
-            return False, {}, ""
-
-        desc = ""
-        raw_desc = frontmatter.get("description", "")
-        if raw_desc:
-            desc = str(raw_desc).strip().strip("'\"")
-            if len(desc) > 60:
-                desc = desc[:57] + "..."
+        if not _skill_matches_platform(frontmatter):
+            return False, frontmatter, desc
 
         return True, frontmatter, desc
     except Exception as e:
@@ -265,16 +503,8 @@ def _parse_skill_file(skill_file: Path) -> tuple[bool, dict, str]:
 def _read_skill_conditions(skill_file: Path) -> dict:
     """Extract conditional activation fields from SKILL.md frontmatter."""
     try:
-        from tools.skills_tool import _parse_frontmatter
-        raw = skill_file.read_text(encoding="utf-8")[:2000]
-        frontmatter, _ = _parse_frontmatter(raw)
-        hermes = frontmatter.get("metadata", {}).get("hermes", {})
-        return {
-            "fallback_for_toolsets": hermes.get("fallback_for_toolsets", []),
-            "requires_toolsets": hermes.get("requires_toolsets", []),
-            "fallback_for_tools": hermes.get("fallback_for_tools", []),
-            "requires_tools": hermes.get("requires_tools", []),
-        }
+        frontmatter, _ = _read_skill_frontmatter(skill_file)
+        return _extract_skill_conditions(frontmatter)
     except Exception as e:
         logger.debug("Failed to read skill conditions from %s: %s", skill_file, e)
         return {}
@@ -328,64 +558,101 @@ def build_skills_system_prompt(
     if not skills_dir.exists():
         return ""
 
+    cache_key = (
+        str(skills_dir.resolve()),
+        tuple(sorted(str(tool) for tool in (available_tools or set()))),
+        tuple(sorted(str(toolset) for toolset in (available_toolsets or set()))),
+    )
+    with _SKILLS_PROMPT_CACHE_LOCK:
+        cached = _SKILLS_PROMPT_CACHE.get(cache_key)
+        if cached is not None:
+            return cached
+
     # Collect skills with descriptions, grouped by category.
     # Each entry: (skill_name, description)
     # Supports sub-categories: skills/mlops/training/axolotl/SKILL.md
     # -> category "mlops/training", skill "axolotl"
     # Load disabled skill names once for the entire scan
-    try:
-        from tools.skills_tool import _get_disabled_skill_names
-        disabled = _get_disabled_skill_names()
-    except Exception:
-        disabled = set()
+    disabled = _get_disabled_skill_names()
+    snapshot = _load_skills_prompt_snapshot(skills_dir)
 
     skills_by_category: dict[str, list[tuple[str, str]]] = {}
-    for skill_file in skills_dir.rglob("SKILL.md"):
-        is_compatible, frontmatter, desc = _parse_skill_file(skill_file)
-        if not is_compatible:
-            continue
-        rel_path = skill_file.relative_to(skills_dir)
-        parts = rel_path.parts
-        if len(parts) >= 2:
-            skill_name = parts[-2]
-            category = "/".join(parts[:-2]) if len(parts) > 2 else parts[0]
-        else:
-            category = "general"
-            skill_name = skill_file.parent.name
-        # Respect user's disabled skills config
-        fm_name = frontmatter.get("name", skill_name)
-        if fm_name in disabled or skill_name in disabled:
-            continue
-        # Extract conditions inline from already-parsed frontmatter
-        # (avoids redundant file re-read that _read_skill_conditions would do)
-        hermes_meta = (frontmatter.get("metadata") or {}).get("hermes") or {}
-        conditions = {
-            "fallback_for_toolsets": hermes_meta.get("fallback_for_toolsets", []),
-            "requires_toolsets": hermes_meta.get("requires_toolsets", []),
-            "fallback_for_tools": hermes_meta.get("fallback_for_tools", []),
-            "requires_tools": hermes_meta.get("requires_tools", []),
-        }
-        if not _skill_should_show(conditions, available_tools, available_toolsets):
-            continue
-        skills_by_category.setdefault(category, []).append((skill_name, desc))
-
-    if not skills_by_category:
-        return ""
-
-    # Read category-level descriptions from DESCRIPTION.md
-    # Checks both the exact category path and parent directories
     category_descriptions = {}
-    for category in skills_by_category:
-        cat_path = Path(category)
-        desc_file = skills_dir / cat_path / "DESCRIPTION.md"
-        if desc_file.exists():
+    if snapshot is not None:
+        for entry in snapshot.get("skills", []):
+            if not isinstance(entry, dict):
+                continue
+            skill_name = entry.get("skill_name") or ""
+            category = entry.get("category") or "general"
+            frontmatter_name = entry.get("frontmatter_name") or skill_name
+            platforms = entry.get("platforms") or []
+            if not _skill_matches_platform({"platforms": platforms}):
+                continue
+            if frontmatter_name in disabled or skill_name in disabled:
+                continue
+            if not _skill_should_show(
+                entry.get("conditions") or {},
+                available_tools,
+                available_toolsets,
+            ):
+                continue
+            skills_by_category.setdefault(category, []).append(
+                (skill_name, entry.get("description", ""))
+            )
+        category_descriptions = {
+            str(key): str(value)
+            for key, value in (snapshot.get("category_descriptions") or {}).items()
+        }
+    else:
+        skill_entries = []
+        for skill_file in _iter_skill_index_files(skills_dir, "SKILL.md"):
+            is_compatible, frontmatter, desc = _parse_skill_file(skill_file)
+            entry = _build_snapshot_entry(
+                skill_file,
+                skills_dir,
+                frontmatter=frontmatter,
+                description=desc,
+            )
+            skill_entries.append(entry)
+            if not is_compatible:
+                continue
+            skill_name = entry["skill_name"]
+            if entry["frontmatter_name"] in disabled or skill_name in disabled:
+                continue
+            if not _skill_should_show(
+                _extract_skill_conditions(frontmatter),
+                available_tools,
+                available_toolsets,
+            ):
+                continue
+            skills_by_category.setdefault(entry["category"], []).append(
+                (skill_name, entry["description"])
+            )
+
+        for desc_file in _iter_skill_index_files(skills_dir, "DESCRIPTION.md"):
             try:
                 content = desc_file.read_text(encoding="utf-8")
-                match = re.search(r"^---\s*\n.*?description:\s*(.+?)\s*\n.*?^---", content, re.MULTILINE | re.DOTALL)
-                if match:
-                    category_descriptions[category] = match.group(1).strip()
+                frontmatter, _ = _parse_frontmatter_block(content)
+                desc = frontmatter.get("description")
+                if not desc:
+                    continue
+                rel_path = desc_file.relative_to(skills_dir)
+                category = "/".join(rel_path.parts[:-1]) if len(rel_path.parts) > 1 else "general"
+                category_descriptions[category] = str(desc).strip().strip("'\"")
             except Exception as e:
                 logger.debug("Could not read skill description %s: %s", desc_file, e)
+
+        _write_skills_prompt_snapshot(
+            skills_dir,
+            _build_skills_prompt_manifest(skills_dir),
+            skill_entries,
+            category_descriptions,
+        )
+
+    if not skills_by_category:
+        with _SKILLS_PROMPT_CACHE_LOCK:
+            _SKILLS_PROMPT_CACHE[cache_key] = ""
+        return ""
 
     index_lines = []
     for category in sorted(skills_by_category.keys()):
@@ -405,7 +672,7 @@ def build_skills_system_prompt(
             else:
                 index_lines.append(f"    - {name}")
 
-    return (
+    result = (
         "## Skills (mandatory)\n"
         "Before replying, scan the skills below. If one clearly matches your task, "
         "load it with skill_view(name) and follow its instructions. "
@@ -420,6 +687,13 @@ def build_skills_system_prompt(
         "\n"
         "If none match, proceed normally without loading a skill."
     )
+
+    with _SKILLS_PROMPT_CACHE_LOCK:
+        _SKILLS_PROMPT_CACHE[cache_key] = result
+        while len(_SKILLS_PROMPT_CACHE) > _SKILLS_PROMPT_CACHE_MAX_ENTRIES:
+            _SKILLS_PROMPT_CACHE.pop(next(iter(_SKILLS_PROMPT_CACHE)))
+
+    return result
 
 
 # =========================================================================

--- a/findings.md
+++ b/findings.md
@@ -1,0 +1,285 @@
+# TTFT Findings
+
+Date: 2026-03-27
+Branch: `ttft-upstream-main`
+Base: `upstream/main` @ `b8b1f24fd755ae187a0fbaedf5c9657a2af1ef1e`
+
+## Goal
+
+Figure out whether bad TTFT was model latency or Hermes doing too much before the first request, then keep the wins and record what actually helped.
+
+## Follow-up Ideas Tested
+
+- Move volatile runtime metadata out of the cached system prompt
+- Add a disk-backed skills metadata snapshot for fresh processes
+- Benchmark startup parallelization instead of assuming it helps
+
+## Measurement Setup
+
+- Clean worktree from `upstream/main`
+- Python environment: `/Users/kshitij/Projects/hermes-agent/.venv`
+- Local harnesses measured:
+  - cold `AIAgent(...)` init
+  - `_build_system_prompt()`
+  - time from `run_conversation()` entry to the first outbound `chat.completions.create(...)` dispatch
+- Follow-up harnesses additionally used a copied `HERMES_HOME` with the current `skills/`, `config.yaml`, and `SOUL.md`
+  - copied skill inventory: `104` `SKILL.md` files
+  - snapshot benchmark compared the same copied home with and without `.skills_prompt_snapshot.json`
+
+## Baseline On Upstream Main
+
+- Cold `AIAgent` init: `5499.24 ms`
+- First outbound request dispatch: `1252.98 ms`
+- `_build_system_prompt()`: `1149.83 ms`
+
+Baseline hotspots:
+
+- `vision_analyze` requirements check: `3963.62 ms`
+- `_build_system_prompt()` sub-costs:
+  - `check_toolset_requirements`: `442.13 ms`
+  - `build_skills_system_prompt`: `659.61 ms`
+
+Conclusion: the worst latency was not just provider TTFT. Hermes was burning a lot of time before the request ever left the process.
+
+## Findings
+
+### 1. Tool availability checks were duplicated
+
+What we tried:
+
+- Cache shared `check_fn` results inside one `ToolRegistry.get_definitions()` call.
+
+What worked:
+
+- Repeated tools that shared the same availability probe stopped rerunning the same check during schema build.
+- This was one of the fixes that drove cold init from `5499 ms` down to `963 ms` in the first round.
+
+Files:
+
+- `tools/registry.py`
+- `tests/tools/test_registry.py`
+
+### 2. Vision auto-resolution was probing too many backends
+
+What we tried:
+
+- Stop calling the full “discover every vision backend” path for auto resolution.
+- Prefer the main configured provider first and short-circuit on the first working backend.
+
+What worked:
+
+- The `vision_analyze` gating check dropped from `3963.62 ms` to `76.61 ms`.
+- This removed the single biggest cold-start offender.
+
+Files:
+
+- `agent/auxiliary_client.py`
+- `tests/agent/test_auxiliary_client.py`
+
+### 3. Anthropic adapter had eager import-time work
+
+What we tried:
+
+- Remove eager Claude Code version detection at module import time.
+- Resolve and cache it lazily only when OAuth headers actually need it.
+
+What worked:
+
+- The import-time tax disappeared from the Anthropic path that vision fallback and other startup flows touched.
+
+Files:
+
+- `agent/anthropic_adapter.py`
+- `tests/test_anthropic_adapter.py`
+
+### 4. `_build_system_prompt()` was recomputing toolset availability
+
+What we tried:
+
+- Stop calling `check_toolset_requirements()` again during system prompt construction.
+- Derive available toolsets directly from already loaded `self.valid_tool_names`.
+
+What worked:
+
+- Removed the extra `442.13 ms` prompt-build pass from the hot path.
+- After the first four fixes, `_build_system_prompt()` dropped from `1149.83 ms` to `438.82 ms`.
+- In the same first-round harness, first outbound request dispatch dropped from `1252.98 ms` to `434.56 ms`.
+
+Files:
+
+- `run_agent.py`
+- `tests/test_run_agent.py`
+
+### 5. Skills prompt generation was still a repeat cost
+
+What we tried first:
+
+- A signature-validated cache for `build_skills_system_prompt()`.
+
+What happened:
+
+- It improved reuse, but validating the cache was still expensive enough that it hurt the cold path.
+- I did not keep that version.
+
+What we kept:
+
+- A lightweight in-process cache for the skills system prompt.
+- Explicit invalidation when `skill_manage(...)` modifies skills.
+- Prompt-builder-local parsing so this path does not need to import the heavy `tools` package just to read skill frontmatter.
+
+What worked:
+
+- In one Python process:
+  - `_build_system_prompt()` first fresh agent: `545.95 ms`
+  - `_build_system_prompt()` second fresh agent: `0.36 ms`
+- Standalone `build_skills_system_prompt()`:
+  - first call: `762.02 ms`
+  - second call: `0.19 ms`
+
+Interpretation:
+
+- This is a hot-path win for repeated new agents in the same Hermes process.
+- The remaining cold-path bottleneck is still skill frontmatter parsing across installed skills.
+
+Files:
+
+- `agent/prompt_builder.py`
+- `tools/skill_manager_tool.py`
+- `tests/agent/test_prompt_builder.py`
+- `tests/tools/test_skill_manager_tool.py`
+
+### 6. Remaining cold-path bottleneck
+
+Current dominant remaining pre-request work:
+
+- `build_skills_system_prompt()` still spends most of its time parsing `SKILL.md` frontmatter.
+- The integrated profile also showed non-trivial timestamp/timezone work via `hermes_time.now()` on the first prompt build.
+
+What this means:
+
+- The big avoidable structural regressions are fixed.
+- The next big step, if we want more cold-start improvement, is probably a maintained skill metadata index or startup snapshot instead of reparsing every skill file on the first new agent in a process.
+
+### 7. Runtime metadata belonged outside the cached system prompt
+
+What we tried:
+
+- Removed live runtime lines from `_build_system_prompt()`
+- Added a per-turn runtime note to the current user message instead:
+  - `Current date/time`
+  - `Session ID` when enabled
+  - `Model`
+  - `Provider`
+
+What worked:
+
+- The cached system prompt is now stable across new sessions instead of varying on timestamp/session metadata.
+- This aligns Hermes with the Claude Code style prompt-caching pattern from the comparison pass.
+- The local timing effect was smaller than the skills work, but the real value is improved provider-side prefix-cache reuse.
+
+Files:
+
+- `run_agent.py`
+- `tests/test_run_agent.py`
+
+### 8. Disk-backed skills metadata snapshot fixed the remaining fresh-process cost
+
+What we tried:
+
+- Kept the in-process skills prompt cache
+- Added `.skills_prompt_snapshot.json` under `HERMES_HOME`
+- Snapshot validity is checked from a manifest of `SKILL.md` and `DESCRIPTION.md` mtimes/sizes
+- `skill_manage(...)` now clears both the in-process cache and the disk snapshot after successful writes
+
+What worked:
+
+- On the copied `104`-skill benchmark home:
+  - fresh-process `_build_system_prompt()` without snapshot: `297.22 ms`
+  - fresh-process `_build_system_prompt()` with snapshot: `102.51 ms`
+  - fresh-process first outbound dispatch without snapshot: `368.42 ms`
+  - fresh-process first outbound dispatch with snapshot: `115.60 ms`
+- Same-process fresh-agent prompt build remained effectively hot:
+  - first agent: `85.34 ms`
+  - second agent: `0.88 ms`
+
+Interpretation:
+
+- This is the follow-up idea that materially moved fresh-process TTFT.
+- Relative to the original upstream baseline:
+  - `_build_system_prompt()` improved from `1149.83 ms` to `102.51 ms`
+  - first outbound dispatch improved from `1252.98 ms` to `115.60 ms`
+
+Files:
+
+- `agent/prompt_builder.py`
+- `tools/skill_manager_tool.py`
+- `tests/agent/test_prompt_builder.py`
+- `tests/tools/test_skill_manager_tool.py`
+
+### 9. Parallelizing the remaining startup work was not worth keeping
+
+What we tried:
+
+- Benchmarked the remaining post-snapshot prompt-assembly work both sequentially and with a small `ThreadPoolExecutor`
+- Compared:
+  - `load_soul_md()`
+  - `build_skills_system_prompt()`
+  - `build_context_files_prompt(...)`
+
+What happened:
+
+- On the copied benchmark home:
+  - sequential median: `99.80 ms`
+  - parallel median: `94.64 ms`
+- The gain was tiny and noisy, and the parallel version had a worse outlier (`156.82 ms`)
+
+Decision:
+
+- I did not keep a production parallel-startup patch.
+- After the snapshot work, there is not enough expensive independent work left to justify the complexity and variance.
+
+## Kept Results
+
+Measured wins from the clean-worktree investigation:
+
+- Cold `AIAgent` init: `5499 ms -> 963 ms`
+- First outbound request dispatch after the first four fixes: `1253 ms -> 435 ms`
+- `_build_system_prompt()` after the first four fixes: `1150 ms -> 439 ms`
+- Repeated same-process prompt builds after the skills cache: `545.95 ms -> 0.36 ms`
+- Fresh-process `_build_system_prompt()` on the copied skills home after the disk snapshot: `297.22 ms -> 102.51 ms`
+- Fresh-process first outbound dispatch on the copied skills home after the disk snapshot: `368.42 ms -> 115.60 ms`
+
+## Not Kept
+
+- Startup parallelization was tested directly and not kept.
+- Measured result on the copied benchmark home:
+  - sequential median: `99.80 ms`
+  - parallel median: `94.64 ms`
+- The delta was too small and noisy to justify thread-pool complexity, and the parallel version had a worse outlier (`156.82 ms`).
+
+## Comparative Patterns From Other Agent CLIs
+
+Patterns worth stealing or keeping in mind:
+
+- Codex: parallel startup tasks, startup tool snapshots, long-lived session client, connection prewarm
+- Claude Code: move date out of the cached system prompt, defer non-critical loading, cache MCP/auth discovery failures
+- Gemini CLI: dynamically import heavy interactive UI, emphasize context efficiency, cache expensive hook work
+- OpenCode: bootstrap parallel fetches, render partial state early, keep background loading separate from first paint
+- Aider: defer slow imports into background work, keep stable prompt regions cache-friendly
+
+Hermes follow-up ideas from that comparison:
+
+- Move the live date/time out of the cached system prompt to improve provider-side prompt cache reuse across new sessions
+- Maintain a skill metadata snapshot instead of reparsing every `SKILL.md` on the first agent in a process
+- Consider parallelizing non-critical startup work where correctness does not depend on sequencing
+
+## Sources
+
+- OpenAI latency optimization guide: https://developers.openai.com/api/docs/guides/latency-optimization
+- Anthropic prompt caching docs: https://platform.claude.com/docs/en/build-with-claude/prompt-caching
+- DeepWiki, `NousResearch/hermes-agent`: https://deepwiki.com/search/which-parts-of-aiagent-initial_10c46a12-abce-4d26-9e39-3d3668c3a1c5
+- DeepWiki, `openai/codex`: https://deepwiki.com/search/what-patterns-does-this-cli-us_d4c4a710-3be6-410e-a8a2-3191861df4d0
+- DeepWiki, `anthropics/claude-code`: https://deepwiki.com/search/what-patterns-does-this-cli-us_2e039217-d1fe-4a0f-9a2a-30446700cee7
+- DeepWiki, `google-gemini/gemini-cli`: https://deepwiki.com/search/what-patterns-does-this-cli-us_1272507f-3eda-4e81-bfdc-5166a36c76f4
+- DeepWiki, `sst/opencode`: https://deepwiki.com/search/what-patterns-does-this-cli-us_28bbda01-2d01-46f2-a683-4cdf60534862
+- DeepWiki, `Aider-AI/aider`: https://deepwiki.com/search/what-patterns-does-this-cli-us_485a9564-7cdd-4007-a0ca-4386a8eb5fa9

--- a/findings.md
+++ b/findings.md
@@ -267,11 +267,51 @@ Patterns worth stealing or keeping in mind:
 - OpenCode: bootstrap parallel fetches, render partial state early, keep background loading separate from first paint
 - Aider: defer slow imports into background work, keep stable prompt regions cache-friendly
 
-Hermes follow-up ideas from that comparison:
+### Patterns Hermes Already Stole
 
-- Move the live date/time out of the cached system prompt to improve provider-side prompt cache reuse across new sessions
-- Maintain a skill metadata snapshot instead of reparsing every `SKILL.md` on the first agent in a process
-- Consider parallelizing non-critical startup work where correctness does not depend on sequencing
+- Stable cached prompt prefix:
+  - We moved volatile runtime metadata out of `_build_system_prompt()` and into a per-turn runtime note.
+  - This follows the Claude Code / Aider style “keep the cacheable prefix stable” pattern.
+- Multi-layer skills caching:
+  - We now use both an in-process hot cache and a disk-backed snapshot for fresh processes.
+  - This is the same general idea as Codex/OpenCode style startup snapshots, adapted to Hermes skills metadata.
+- Lazy provider-specific work:
+  - We removed eager Anthropic Claude Code version detection and short-circuited vision backend probing.
+  - This matches the “do not pay optional-provider cost on the universal startup path” pattern seen across several other agent CLIs.
+- Shared startup state reuse:
+  - We stopped recomputing toolset availability during prompt building once the agent already knew which tools were valid.
+  - This is the Hermes version of “resolve once, reuse everywhere” for startup discovery.
+
+### Patterns Worth Prototyping Next
+
+- Persistent skill metadata index:
+  - The remaining cold-path bottleneck is still first-process `SKILL.md` frontmatter parsing.
+  - The next likely step is a maintained metadata index or more formal startup snapshot lifecycle.
+- Negative-result caching for discovery:
+  - Claude Code style caching of failed MCP/auth/provider probes is still attractive for Hermes optional integrations.
+  - This matters most when a machine has partially configured providers or broken local tooling.
+- Long-lived prewarmed clients:
+  - Codex/OpenCode style connection prewarm or shared long-lived provider clients may reduce first-dispatch variance further.
+  - This only makes sense if it does not complicate credential rotation or session isolation.
+- Keep the benchmark harnesses close to reality:
+  - The copied `HERMES_HOME` with `104` skills was materially more useful than synthetic microbenchmarks.
+  - Future TTFT work should keep using real skill inventories and fresh-process measurements.
+
+### Patterns We Explicitly Rejected
+
+- Startup parallelization after the snapshot work:
+  - We measured it directly instead of assuming it would help.
+  - The median gain was too small and the outliers got worse, so we did not keep it.
+- Heavy cache validation on the hot path:
+  - The first signature-validated skills cache design improved reuse but still cost enough on cold startup that it was the wrong trade-off.
+  - The lighter in-process cache plus disk snapshot was better.
+
+Remaining Hermes follow-up ideas from that comparison:
+
+- Replace first-process skill frontmatter reparsing with a more formal maintained metadata index
+- Cache negative discovery/probe results for optional providers, MCP servers, and auth paths
+- Evaluate long-lived prewarmed provider clients only if they preserve clean session isolation
+- Keep benchmarking with real copied `HERMES_HOME` state instead of only synthetic microbenchmarks
 
 ## Sources
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -62,7 +62,12 @@ else:
 
 
 # Import our tool system
-from model_tools import get_tool_definitions, handle_function_call, check_toolset_requirements
+from model_tools import (
+    get_tool_definitions,
+    get_toolset_for_tool,
+    handle_function_call,
+    check_toolset_requirements,
+)
 from tools.terminal_tool import cleanup_vm
 from tools.interrupt import set_interrupt as _set_interrupt
 from tools.browser_tool import cleanup_browser
@@ -345,6 +350,26 @@ def _inject_honcho_turn_context(content, turn_context: str):
         "sessions. It is continuity context for this turn only, not new user "
         "input.]\n\n"
         f"{turn_context}"
+    )
+
+    if isinstance(content, list):
+        return list(content) + [{"type": "text", "text": note}]
+
+    text = "" if content is None else str(content)
+    if not text.strip():
+        return note
+    return f"{text}\n\n{note}"
+
+
+def _inject_runtime_turn_context(content, runtime_context: str):
+    """Append runtime metadata to the current-turn user message only."""
+    if not runtime_context:
+        return content
+
+    note = (
+        "[System note: The following runtime metadata applies to this turn only. "
+        "It is not new user input.]\n\n"
+        f"{runtime_context}"
     )
 
     if isinstance(content, list):
@@ -2409,8 +2434,7 @@ class AIAgent:
         #   3. Persistent memory (frozen snapshot)
         #   4. Skills guidance (if skills tools are loaded)
         #   5. Context files (AGENTS.md, .cursorrules — SOUL.md excluded here when used as identity)
-        #   6. Current date & time (frozen at build time)
-        #   7. Platform-specific formatting hint
+        #   6. Platform-specific formatting hint
 
         # Try SOUL.md as primary identity (unless context files are skipped)
         _soul_loaded = False
@@ -2520,7 +2544,13 @@ class AIAgent:
 
         has_skills_tools = any(name in self.valid_tool_names for name in ['skills_list', 'skill_view', 'skill_manage'])
         if has_skills_tools:
-            avail_toolsets = {ts for ts, avail in check_toolset_requirements().items() if avail}
+            avail_toolsets = {
+                toolset
+                for toolset in (
+                    get_toolset_for_tool(tool_name) for tool_name in self.valid_tool_names
+                )
+                if toolset
+            }
             skills_prompt = build_skills_system_prompt(
                 available_tools=self.valid_tool_names,
                 available_toolsets=avail_toolsets,
@@ -2541,17 +2571,6 @@ class AIAgent:
             if context_files_prompt:
                 prompt_parts.append(context_files_prompt)
 
-        from hermes_time import now as _hermes_now
-        now = _hermes_now()
-        timestamp_line = f"Conversation started: {now.strftime('%A, %B %d, %Y %I:%M %p')}"
-        if self.pass_session_id and self.session_id:
-            timestamp_line += f"\nSession ID: {self.session_id}"
-        if self.model:
-            timestamp_line += f"\nModel: {self.model}"
-        if self.provider:
-            timestamp_line += f"\nProvider: {self.provider}"
-        prompt_parts.append(timestamp_line)
-
         # Alibaba Coding Plan API always returns "glm-4.7" as model name regardless
         # of the requested model. Inject explicit model identity into the system prompt
         # so the agent can correctly report which model it is (workaround for API bug).
@@ -2569,6 +2588,20 @@ class AIAgent:
             prompt_parts.append(PLATFORM_HINTS[platform_key])
 
         return "\n\n".join(prompt_parts)
+
+    def _build_runtime_context_note(self) -> str:
+        """Build per-turn runtime metadata outside the cached system prompt."""
+        from hermes_time import now as _hermes_now
+
+        now = _hermes_now()
+        lines = [f"Current date/time: {now.strftime('%A, %B %d, %Y %I:%M %p')}"]
+        if self.pass_session_id and self.session_id:
+            lines.append(f"Session ID: {self.session_id}")
+        if self.model:
+            lines.append(f"Model: {self.model}")
+        if self.provider:
+            lines.append(f"Provider: {self.provider}")
+        return "\n".join(lines)
 
     # =========================================================================
     # Pre/post-call guardrails (inspired by PR #1321 — @alireza78a)
@@ -5866,6 +5899,7 @@ class AIAgent:
                         logger.debug("Session DB update_system_prompt failed: %s", e)
 
         active_system_prompt = self._cached_system_prompt
+        runtime_turn_context = self._build_runtime_context_note()
 
         # ── Preflight context compression ──
         # Before entering the main loop, check if the loaded conversation
@@ -5979,9 +6013,13 @@ class AIAgent:
             for idx, msg in enumerate(messages):
                 api_msg = msg.copy()
 
-                if idx == current_turn_user_idx and msg.get("role") == "user" and self._honcho_turn_context:
-                    api_msg["content"] = _inject_honcho_turn_context(
-                        api_msg.get("content", ""), self._honcho_turn_context
+                if idx == current_turn_user_idx and msg.get("role") == "user":
+                    if self._honcho_turn_context:
+                        api_msg["content"] = _inject_honcho_turn_context(
+                            api_msg.get("content", ""), self._honcho_turn_context
+                        )
+                    api_msg["content"] = _inject_runtime_turn_context(
+                        api_msg.get("content", ""), runtime_turn_context
                     )
 
                 # For ALL assistant messages, pass reasoning back to the API

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -11,6 +11,7 @@ from agent.auxiliary_client import (
     get_text_auxiliary_client,
     get_vision_auxiliary_client,
     get_available_vision_backends,
+    resolve_vision_provider_client,
     resolve_provider_client,
     auxiliary_max_tokens_param,
     _read_codex_access_token,
@@ -637,6 +638,30 @@ class TestVisionClientFallback:
         assert client is not None
         assert client.__class__.__name__ == "AnthropicAuxiliaryClient"
         assert model == "claude-haiku-4-5-20251001"
+
+    def test_selected_codex_provider_short_circuits_vision_auto(self, monkeypatch):
+        def fake_load_config():
+            return {"model": {"provider": "openai-codex", "default": "gpt-5.2-codex"}}
+
+        codex_client = MagicMock()
+        with (
+            patch("hermes_cli.config.load_config", fake_load_config),
+            patch("agent.auxiliary_client._try_codex", return_value=(codex_client, "gpt-5.2-codex")) as mock_codex,
+            patch("agent.auxiliary_client._try_openrouter") as mock_openrouter,
+            patch("agent.auxiliary_client._try_nous") as mock_nous,
+            patch("agent.auxiliary_client._try_anthropic") as mock_anthropic,
+            patch("agent.auxiliary_client._try_custom_endpoint") as mock_custom,
+        ):
+            provider, client, model = resolve_vision_provider_client()
+
+        assert provider == "openai-codex"
+        assert client is codex_client
+        assert model == "gpt-5.2-codex"
+        mock_codex.assert_called_once()
+        mock_openrouter.assert_not_called()
+        mock_nous.assert_not_called()
+        mock_anthropic.assert_not_called()
+        mock_custom.assert_not_called()
 
     def test_vision_auto_includes_codex(self, codex_auth_dir):
         """Codex supports vision (gpt-5.3-codex), so auto mode should use it."""

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -4,6 +4,7 @@ import builtins
 import importlib
 import logging
 import sys
+import pytest
 
 from agent.prompt_builder import (
     _scan_context_content,
@@ -15,6 +16,7 @@ from agent.prompt_builder import (
     _find_git_root,
     _strip_yaml_frontmatter,
     build_skills_system_prompt,
+    clear_skills_system_prompt_cache,
     build_context_files_prompt,
     CONTEXT_FILE_MAX_CHARS,
     DEFAULT_AGENT_IDENTITY,
@@ -192,7 +194,7 @@ class TestParseSkillFile:
         )
         from unittest.mock import patch
 
-        with patch("tools.skills_tool.sys") as mock_sys:
+        with patch("agent.prompt_builder.sys") as mock_sys:
             mock_sys.platform = "linux"
             is_compat, _, _ = _parse_skill_file(skill_file)
         assert is_compat is False
@@ -283,7 +285,7 @@ class TestBuildSkillsSystemPrompt:
 
         from unittest.mock import patch
 
-        with patch("tools.skills_tool.sys") as mock_sys:
+        with patch("agent.prompt_builder.sys") as mock_sys:
             mock_sys.platform = "linux"
             result = build_skills_system_prompt()
 
@@ -302,12 +304,98 @@ class TestBuildSkillsSystemPrompt:
 
         from unittest.mock import patch
 
-        with patch("tools.skills_tool.sys") as mock_sys:
+        with patch("agent.prompt_builder.sys") as mock_sys:
             mock_sys.platform = "darwin"
             result = build_skills_system_prompt()
 
         assert "imessage" in result
         assert "Send iMessages" in result
+
+    def test_builds_index_without_importing_tools_package(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "coding" / "python-debug"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: python-debug\ndescription: Debug Python scripts\n---\n"
+        )
+
+        original_import = builtins.__import__
+
+        def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "tools" or name.startswith("tools."):
+                raise ModuleNotFoundError("simulated tools package import failure")
+            return original_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.delitem(sys.modules, "tools", raising=False)
+        monkeypatch.delitem(sys.modules, "tools.skills_tool", raising=False)
+        monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+        result = build_skills_system_prompt()
+
+        assert "python-debug" in result
+        assert "Debug Python scripts" in result
+
+    def test_reuses_cached_prompt_when_inputs_unchanged(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "coding" / "python-debug"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: python-debug\ndescription: Debug Python scripts\n---\n"
+        )
+
+        import agent.prompt_builder as prompt_builder
+
+        first = build_skills_system_prompt()
+
+        def fail_if_reparsed(*args, **kwargs):
+            raise AssertionError("expected cached skills prompt reuse")
+
+        monkeypatch.setattr(prompt_builder, "_parse_skill_file", fail_if_reparsed)
+
+        second = build_skills_system_prompt()
+
+        assert second == first
+
+    def test_clear_skills_prompt_cache_with_snapshot_clear_forces_reparse(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "coding" / "python-debug"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: python-debug\ndescription: Debug Python scripts\n---\n"
+        )
+
+        first = build_skills_system_prompt()
+        clear_skills_system_prompt_cache(clear_snapshot=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: python-debug\ndescription: Reparsed description\n---\n"
+        )
+
+        second = build_skills_system_prompt()
+
+        assert second != first
+        assert "Reparsed description" in second
+
+    def test_uses_disk_snapshot_after_process_cache_clear(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "coding" / "python-debug"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: python-debug\ndescription: Debug Python scripts\n---\n"
+        )
+
+        import agent.prompt_builder as prompt_builder
+
+        first = build_skills_system_prompt()
+        prompt_builder.clear_skills_system_prompt_cache()
+
+        def fail_if_reparsed(*args, **kwargs):
+            raise AssertionError("expected disk snapshot reuse")
+
+        monkeypatch.setattr(prompt_builder, "_parse_skill_file", fail_if_reparsed)
+
+        second = build_skills_system_prompt()
+
+        assert second == first
 
     def test_excludes_disabled_skills(self, monkeypatch, tmp_path):
         """Skills in the user's disabled list should not appear in the system prompt."""
@@ -330,7 +418,7 @@ class TestBuildSkillsSystemPrompt:
         from unittest.mock import patch
 
         with patch(
-            "tools.skills_tool._get_disabled_skill_names",
+            "agent.prompt_builder._get_disabled_skill_names",
             return_value={"old-tool"},
         ):
             result = build_skills_system_prompt()
@@ -561,10 +649,14 @@ class TestBuildContextFilesPrompt:
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert "Lowercase claude rules" in result
 
-    def test_claude_md_uppercase_takes_priority(self, tmp_path):
-        (tmp_path / "CLAUDE.md").write_text("From uppercase.")
-        (tmp_path / "claude.md").write_text("From lowercase.")
-        result = build_context_files_prompt(cwd=str(tmp_path))
+    def test_claude_md_uppercase_takes_priority(self, monkeypatch, tmp_path):
+        upper = tmp_path / "CLAUDE.md"
+        lower = tmp_path / "claude.md"
+        upper.write_text("From uppercase.")
+        if lower.exists():
+            pytest.skip("case-insensitive filesystem cannot distinguish CLAUDE.md from claude.md")
+        lower.write_text("From lowercase.")
+        result = build_context_files_prompt(cwd=str(tmp_path), skip_soul=True)
         assert "From uppercase" in result
         assert "From lowercase" not in result
 

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -579,10 +579,48 @@ class TestBuildSystemPrompt:
         prompt = agent._build_system_prompt()
         assert MEMORY_GUIDANCE not in prompt
 
-    def test_includes_datetime(self, agent):
+    def test_cached_prompt_excludes_runtime_metadata(self, agent):
         prompt = agent._build_system_prompt()
-        # Should contain current date info like "Conversation started:"
-        assert "Conversation started:" in prompt
+        assert "Conversation started:" not in prompt
+        assert "Current date/time:" not in prompt
+
+    def test_runtime_context_note_includes_datetime(self, agent):
+        note = agent._build_runtime_context_note()
+        assert "Current date/time:" in note
+        assert f"Model: {agent.model}" in note
+        assert f"Provider: {agent.provider}" in note
+
+    def test_skills_prompt_derives_available_toolsets_from_loaded_tools(self):
+        tools = _make_tool_defs("web_search", "skills_list", "skill_view", "skill_manage")
+        toolset_map = {
+            "web_search": "web",
+            "skills_list": "skills",
+            "skill_view": "skills",
+            "skill_manage": "skills",
+        }
+
+        with (
+            patch("run_agent.get_tool_definitions", return_value=tools),
+            patch(
+                "run_agent.check_toolset_requirements",
+                side_effect=AssertionError("should not re-check toolset requirements"),
+            ),
+            patch("run_agent.get_toolset_for_tool", create=True, side_effect=toolset_map.get),
+            patch("run_agent.build_skills_system_prompt", return_value="SKILLS_PROMPT") as mock_skills,
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-k...7890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+            prompt = agent._build_system_prompt()
+
+        assert "SKILLS_PROMPT" in prompt
+        assert mock_skills.call_args.kwargs["available_tools"] == set(toolset_map)
+        assert mock_skills.call_args.kwargs["available_toolsets"] == {"web", "skills"}
 
 
 class TestInvalidateSystemPrompt:
@@ -1770,6 +1808,33 @@ class TestSystemPromptStability:
         assert "prior context" in current_user["content"]
         assert "Honcho memory was retrieved from prior sessions" in current_user["content"]
 
+    def test_runtime_context_stays_out_of_cached_system_prompt(self, agent):
+        captured = {}
+
+        def _fake_api_call(api_kwargs):
+            captured.update(api_kwargs)
+            return _mock_response(content="done", finish_reason="stop")
+
+        agent._use_prompt_caching = False
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_interruptible_api_call", side_effect=_fake_api_call),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        api_messages = captured["messages"]
+        assert api_messages[0]["role"] == "system"
+        assert "Current date/time:" not in api_messages[0]["content"]
+        current_user = api_messages[-1]
+        assert current_user["role"] == "user"
+        assert "hello" in current_user["content"]
+        assert "Current date/time:" in current_user["content"]
+        assert f"Model: {agent.model}" in current_user["content"]
+
     def test_honcho_prefetch_runs_on_first_turn(self):
         """Honcho prefetch should run when conversation_history is empty."""
         conversation_history = []
@@ -1804,7 +1869,7 @@ class TestSystemPromptStability:
             result = agent.run_conversation("synthetic flush turn", sync_honcho=False)
 
         assert result["completed"] is True
-        assert captured["messages"][-1]["content"] == "synthetic flush turn"
+        assert captured["messages"][-1]["content"].startswith("synthetic flush turn")
         mock_sync.assert_not_called()
         mock_prefetch.assert_not_called()
 

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -81,6 +81,33 @@ class TestGetDefinitions:
         assert len(defs) == 1
         assert defs[0]["function"]["name"] == "available"
 
+    def test_reuses_shared_check_fn_once_per_call(self):
+        reg = ToolRegistry()
+        calls = {"count": 0}
+
+        def shared_check():
+            calls["count"] += 1
+            return True
+
+        reg.register(
+            name="first",
+            toolset="shared",
+            schema=_make_schema("first"),
+            handler=_dummy_handler,
+            check_fn=shared_check,
+        )
+        reg.register(
+            name="second",
+            toolset="shared",
+            schema=_make_schema("second"),
+            handler=_dummy_handler,
+            check_fn=shared_check,
+        )
+
+        defs = reg.get_definitions({"first", "second"})
+        assert len(defs) == 2
+        assert calls["count"] == 1
+
 
 class TestUnknownToolDispatch:
     def test_returns_error_json(self):

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -371,3 +371,17 @@ class TestSkillManageDispatcher:
             raw = skill_manage(action="create", name="test-skill", content=VALID_SKILL_CONTENT)
         result = json.loads(raw)
         assert result["success"] is True
+
+    def test_successful_write_clears_skills_prompt_cache(self, tmp_path):
+        with (
+            patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path),
+            patch("tools.skill_manager_tool._clear_skills_prompt_cache") as clear_cache,
+        ):
+            raw = skill_manage(
+                action="create",
+                name="test-skill",
+                content=VALID_SKILL_CONTENT,
+            )
+        result = json.loads(raw)
+        assert result["success"] is True
+        clear_cache.assert_called_once_with(clear_snapshot=True)

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -98,19 +98,22 @@ class ToolRegistry:
         are included.
         """
         result = []
+        check_results: Dict[Callable, bool] = {}
         for name in sorted(tool_names):
             entry = self._tools.get(name)
             if not entry:
                 continue
             if entry.check_fn:
-                try:
-                    if not entry.check_fn():
+                if entry.check_fn not in check_results:
+                    try:
+                        check_results[entry.check_fn] = bool(entry.check_fn())
+                    except Exception:
+                        check_results[entry.check_fn] = False
                         if not quiet:
-                            logger.debug("Tool %s unavailable (check failed)", name)
-                        continue
-                except Exception:
+                            logger.debug("Tool %s check raised; skipping", name)
+                if not check_results[entry.check_fn]:
                     if not quiet:
-                        logger.debug("Tool %s check raised; skipping", name)
+                        logger.debug("Tool %s unavailable (check failed)", name)
                     continue
             result.append({"type": "function", "function": entry.schema})
         return result

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -95,6 +95,15 @@ def check_skill_manage_requirements() -> bool:
     return True
 
 
+def _clear_skills_prompt_cache(*, clear_snapshot: bool = False) -> None:
+    try:
+        from agent.prompt_builder import clear_skills_system_prompt_cache
+
+        clear_skills_system_prompt_cache(clear_snapshot=clear_snapshot)
+    except Exception as e:
+        logger.debug("Could not clear skills prompt cache: %s", e)
+
+
 # =============================================================================
 # Validation helpers
 # =============================================================================
@@ -546,6 +555,9 @@ def skill_manage(
 
     else:
         result = {"success": False, "error": f"Unknown action '{action}'. Use: create, edit, patch, delete, write_file, remove_file"}
+
+    if result.get("success"):
+        _clear_skills_prompt_cache(clear_snapshot=True)
 
     return json.dumps(result, ensure_ascii=False)
 


### PR DESCRIPTION
## What does this PR do?

This PR reduces Hermes pre-request startup overhead and improves time to first token by cutting avoidable work before the first outbound model request.

It removes repeated tool availability checks, short-circuits expensive vision backend probing, makes Anthropic Claude Code version detection lazy, reuses already-loaded toolsets during prompt construction, and splits runtime metadata out of the cached system prompt so provider-side prefix caching can actually reuse the prefix.

It also adds in-process and disk-backed skills metadata caching so repeated agents and fresh processes stop reparsing installed skills on every first prompt build. The live benchmark/report for all of these experiments, including the startup parallelization experiment that was tested and intentionally not kept, is recorded in `findings.md`, which now also captures the reusable patterns Hermes should keep stealing from other agent CLIs.

## Related Issue

Fixes #3348
Fixes #3349
Fixes #3350
Fixes #3351
Fixes #3352
Fixes #3353
Fixes #3354
Fixes #3355
Refs #3356

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Deduped shared tool availability checks in [tools/registry.py](tools/registry.py) and reused resolved toolsets during system prompt construction in [run_agent.py](run_agent.py).
- Short-circuited vision backend auto-resolution in [agent/auxiliary_client.py](agent/auxiliary_client.py) and made Claude Code version detection lazy in [agent/anthropic_adapter.py](agent/anthropic_adapter.py).
- Split cached system prompt content from runtime metadata in [agent/prompt_builder.py](agent/prompt_builder.py) to preserve prompt-cache reuse across sessions.
- Added in-process and disk-backed skills metadata caching in [tools/skill_manager_tool.py](tools/skill_manager_tool.py).
- Added TTFT-focused regression coverage in `tests/tools/test_registry.py`, `tests/agent/test_auxiliary_client.py`, `tests/test_run_agent.py`, `tests/test_anthropic_adapter.py`, `tests/tools/test_skill_manager_tool.py`, and `tests/agent/test_prompt_builder.py`.
- Expanded `findings.md` with the live benchmark report, the patterns Hermes already adopted, the patterns worth prototyping next, and the experiments that were explicitly rejected.

## How to Test

1. `source /Users/kshitij/Projects/hermes-agent/.venv/bin/activate`
2. `python -m pytest -n 0 tests/tools/test_registry.py tests/agent/test_auxiliary_client.py tests/test_run_agent.py tests/test_anthropic_adapter.py tests/tools/test_vision_tools.py tests/tools/test_skill_manager_tool.py tests/agent/test_prompt_builder.py -q`
3. Confirm the targeted TTFT-sensitive suite passes: `575 passed, 1 skipped, 1 warning in 104.99s`.
4. Review `findings.md` for the live benchmark/report output, the patterns worth stealing, and the measured parallelization experiment that was not kept.
5. Optional repo-level check: `python -m pytest tests/ -q`. On this macOS 26.3.1 run it still reported unrelated upstream failures dominated by `OSError: [Errno 24] Too many open files` under parallel pytest, plus unrelated non-TTFT failures such as `tests/tools/test_transcription.py::TestTranscribeOpenAI::test_no_key`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Live benchmark/report highlights from `findings.md`:

- Fresh-process `_build_system_prompt()`: `297.22 ms -> 102.51 ms`
- Fresh-process first outbound dispatch: `368.42 ms -> 115.60 ms`
- Same-process fresh-agent prompt build: `85.34 ms -> 0.88 ms`
- Parallelization experiment: sequential median `99.80 ms`, parallel median `94.64 ms`, worse parallel outlier `156.82 ms`; not kept

Live verification on this branch:

- Targeted suite: `575 passed, 1 skipped, 1 warning in 104.99s`
- Full suite: `7 failed, 6155 passed, 187 skipped, 108 warnings, 226 errors in 162.94s (0:02:42)`
- Full-suite failures are unrelated to the TTFT files in this PR and are dominated by `OSError: [Errno 24] Too many open files` during parallel pytest setup/teardown.
