### PR TITLE
fix(gateway): Add some commonly seen user local paths to PATH env var of systemd unit file

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -434,13 +434,20 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
         resolved_node_dir = str(Path(resolved_node).resolve().parent)
         if resolved_node_dir not in path_entries:
             path_entries.append(resolved_node_dir)
-    path_entries.extend(["/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin", "/sbin", "/bin"])
-    sane_path = ":".join(path_entries)
 
     hermes_home = str(get_hermes_home().resolve())
 
     if system:
         username, group_name, home_dir = _system_service_identity(run_as_user)
+        user_local_bin = str(Path(home_dir) / ".local" / "bin")
+        path_entries.append(user_local_bin)
+    else:
+        path_entries.append(str(Path.home() / ".local" / "bin"))
+
+    path_entries.extend(["/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin", "/sbin", "/bin"])
+    sane_path = ":".join(path_entries)
+
+    if system:
         return f"""[Unit]
 Description={SERVICE_DESCRIPTION}
 After=network-online.target

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -434,6 +434,23 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
         resolved_node_dir = str(Path(resolved_node).resolve().parent)
         if resolved_node_dir not in path_entries:
             path_entries.append(resolved_node_dir)
+
+    # Include common user-local binary directories so MCP servers launched
+    # by the systemd service can find tools like uvx, cargo, go, etc.
+    # The shell PATH is available at install time but not in the service unit.
+    home = Path.home()
+    user_local_paths = [
+        str(home / ".local" / "bin"),    # uv, uvx, pip-installed CLIs
+        str(home / ".cargo" / "bin"),    # Rust/cargo tools
+        str(home / "go" / "bin"),        # Go tools
+        str(home / ".npm-global" / "bin"),  # npm global packages
+        "/opt/homebrew/bin",             # macOS Homebrew (Apple Silicon)
+        "/usr/local/homebrew/bin",       # macOS Homebrew (Intel)
+    ]
+    for p in user_local_paths:
+        if p not in path_entries and Path(p).exists():
+            path_entries.append(p)
+
     path_entries.extend(["/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin", "/sbin", "/bin"])
     sane_path = ":".join(path_entries)
 


### PR DESCRIPTION
## What does this PR do?

Add a few commonly seen user local paths to the `PATH` env var of the systemd unit file for the Hermes gateway. This allows the Hermes gateway process to start MCP servers that depend on executables from these paths.

This PR combines the best of these two PRs:
- #3328
- #3330

#3330 originally added two path patterns found on macOS, but I don't think that's useful because we're talking about fixing Linux with systemd here, so I have omitted those two path patterns.

## Related Issue

Fixes #3327

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a `_build_user_local_paths` helper function to `hermes_cli/gateway.py` to correct build the user local paths regardless of whether the hermes gateway is installed as a user service or as a system service.
- Changed `generate_systemd_unit` so that it extends the `path_entries` list with the commonly seen user local paths.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. On a systemd-based Linux distro, install Hermes agent using the official installation script, _without_ installing the `uv` tool ahead of time - this ensures that the `uv` tool will be installed by the Hermes installation script to `~/.local/bin`.
2. Configure Hermes and ensure to include:
    - an MCP server that depends on `uvx`
    - a gateway (let's say Discord)
3. Run `hermes chat` and ask Hermes to list all the MCP servers and tools that it sees. It will list the MCP server that depends on `uvx`, so we know it found the `uvx` executable.
4. Run `hermes gateway install`.
5. Run `hermes gateway start`.
6. On Discord, ask Hermes again to list all the MCP servers and tools that it sees. You shall see the same MCP server.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've tested on my platform: Ubuntu 24.04 in WSL2, with systemd enabled, Windows 11 Pro
