### PR TITLE
fix(gateway): include ~/.local/bin in systemd unit PATH for uvx/pipx tools

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -434,6 +434,11 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
         resolved_node_dir = str(Path(resolved_node).resolve().parent)
         if resolved_node_dir not in path_entries:
             path_entries.append(resolved_node_dir)
+    # Include ~/.local/bin so tools installed via `uv` / `pipx` (e.g. uvx)
+    # are discoverable by MCP servers started from the systemd unit.
+    local_bin = str(Path.home() / ".local" / "bin")
+    if local_bin not in path_entries:
+        path_entries.append(local_bin)
     path_entries.extend(["/usr/local/sbin", "/usr/local/bin", "/usr/sbin", "/usr/bin", "/sbin", "/bin"])
     sane_path = ":".join(path_entries)
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1,6 +1,7 @@
 """Tests for gateway service management helpers."""
 
 import os
+from pathlib import Path
 from types import SimpleNamespace
 
 import hermes_cli.gateway as gateway_cli
@@ -352,6 +353,20 @@ class TestGeneratedUnitUsesDetectedVenv:
         assert f"{dot_venv}/bin" in unit
         # Must NOT contain a hardcoded /venv/ path
         assert "/venv/" not in unit or "/.venv/" in unit
+
+
+class TestGeneratedUnitIncludesLocalBin:
+    """~/.local/bin must be in PATH so uvx/pipx tools are discoverable."""
+
+    def test_user_unit_includes_local_bin_in_path(self):
+        unit = gateway_cli.generate_systemd_unit(system=False)
+        home = str(Path.home())
+        assert f"{home}/.local/bin" in unit
+
+    def test_system_unit_includes_local_bin_in_path(self):
+        unit = gateway_cli.generate_systemd_unit(system=True)
+        home = str(Path.home())
+        assert f"{home}/.local/bin" in unit
 
 
 class TestEnsureUserSystemdEnv:


### PR DESCRIPTION
## Summary

Fixes #3327 — Hermes gateway installed as a systemd user unit cannot find `uvx` (or other tools installed via `uv`/`pipx`) to start MCP servers.

## Problem

`generate_systemd_unit()` constructs a `PATH` from the venv bin, node bin, resolved node directory, and standard system paths. However, `~/.local/bin` is not included.

The default Hermes installation script installs `uv` to `~/.local/bin`. When the gateway runs as a systemd unit, MCP servers that depend on `uvx` fail because the binary is not on the unit's PATH.

`hermes chat` works fine because it inherits the user's shell PATH (which typically includes `~/.local/bin`), but the systemd unit constructs its own PATH from scratch.

## Changes

- **`hermes_cli/gateway.py`**: Added `~/.local/bin` to `path_entries` (before system paths, after tool-specific paths). Includes a guard to avoid duplicates.
- **`tests/hermes_cli/test_gateway_service.py`**: Added 2 tests verifying `~/.local/bin` appears in both user and system unit PATH.

## Testing

```
$ python -m pytest tests/hermes_cli/test_gateway_service.py -v -o 'addopts=' 
28 passed in 0.14s
```

Closes #3327