### PR TITLE
fix: recover updater when venv pip is missing

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2450,8 +2450,18 @@ def _update_via_zip(args):
             )
     else:
         # Use sys.executable to explicitly call the venv's pip module,
-        # avoiding PEP 668 'externally-managed-environment' errors on Debian/Ubuntu
+        # avoiding PEP 668 'externally-managed-environment' errors on Debian/Ubuntu.
+        # Some environments lose pip inside the venv; bootstrap it back with
+        # ensurepip before trying the editable install.
         pip_cmd = [sys.executable, "-m", "pip"]
+        try:
+            subprocess.run(pip_cmd + ["--version"], cwd=PROJECT_ROOT, check=True, capture_output=True)
+        except subprocess.CalledProcessError:
+            subprocess.run(
+                [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
+                cwd=PROJECT_ROOT,
+                check=True,
+            )
         try:
             subprocess.run(pip_cmd + ["install", "-e", ".[all]", "--quiet"], cwd=PROJECT_ROOT, check=True)
         except subprocess.CalledProcessError:
@@ -2764,8 +2774,18 @@ def cmd_update(args):
                 )
         else:
             # Use sys.executable to explicitly call the venv's pip module,
-            # avoiding PEP 668 'externally-managed-environment' errors on Debian/Ubuntu
+            # avoiding PEP 668 'externally-managed-environment' errors on Debian/Ubuntu.
+            # Some environments lose pip inside the venv; bootstrap it back with
+            # ensurepip before trying the editable install.
             pip_cmd = [sys.executable, "-m", "pip"]
+            try:
+                subprocess.run(pip_cmd + ["--version"], cwd=PROJECT_ROOT, check=True, capture_output=True)
+            except subprocess.CalledProcessError:
+                subprocess.run(
+                    [sys.executable, "-m", "ensurepip", "--upgrade", "--default-pip"],
+                    cwd=PROJECT_ROOT,
+                    check=True,
+                )
             try:
                 subprocess.run(pip_cmd + ["install", "-e", ".[all]", "--quiet"], cwd=PROJECT_ROOT, check=True)
             except subprocess.CalledProcessError:


### PR DESCRIPTION
## Summary
- recover the updater when the venv's `pip` module is missing
- bootstrap `pip` with `python -m ensurepip --upgrade --default-pip` before editable installs in the non-`uv` update path
- keep the existing `.[all]` -> `.` fallback behavior unchanged

## Problem
On my machine, `hermes update` failed during dependency reinstall because the venv Python existed but `pip` had disappeared:

```text
/Users/dazheng/.hermes/hermes-agent/venv/bin/python: No module named pip
✗ Update failed: Command '['/Users/dazheng/.hermes/hermes-agent/venv/bin/python', '-m', 'pip', 'install', '-e', '.', '--quiet']' returned non-zero exit status 1.
```

The updater currently assumes `pip` is always available inside the venv.

## Fix
Before invoking `python -m pip` in the non-`uv` update flow, check `pip --version`. If that fails, recover with `ensurepip`, then continue with the existing install flow.

## Validation
- reproduced the failure locally with a venv missing `pip`
- repaired the venv with `ensurepip`
- verified the previously failing editable install succeeds afterward
- verified the updater code now includes the same self-healing fallback in both update code paths
