### PR TITLE
perf(ttft): dedupe shared tool availability checks

### DIFF
--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -81,6 +81,33 @@ class TestGetDefinitions:
         assert len(defs) == 1
         assert defs[0]["function"]["name"] == "available"
 
+    def test_reuses_shared_check_fn_once_per_call(self):
+        reg = ToolRegistry()
+        calls = {"count": 0}
+
+        def shared_check():
+            calls["count"] += 1
+            return True
+
+        reg.register(
+            name="first",
+            toolset="shared",
+            schema=_make_schema("first"),
+            handler=_dummy_handler,
+            check_fn=shared_check,
+        )
+        reg.register(
+            name="second",
+            toolset="shared",
+            schema=_make_schema("second"),
+            handler=_dummy_handler,
+            check_fn=shared_check,
+        )
+
+        defs = reg.get_definitions({"first", "second"})
+        assert len(defs) == 2
+        assert calls["count"] == 1
+
 
 class TestUnknownToolDispatch:
     def test_returns_error_json(self):

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -98,19 +98,22 @@ class ToolRegistry:
         are included.
         """
         result = []
+        check_results: Dict[Callable, bool] = {}
         for name in sorted(tool_names):
             entry = self._tools.get(name)
             if not entry:
                 continue
             if entry.check_fn:
-                try:
-                    if not entry.check_fn():
+                if entry.check_fn not in check_results:
+                    try:
+                        check_results[entry.check_fn] = bool(entry.check_fn())
+                    except Exception:
+                        check_results[entry.check_fn] = False
                         if not quiet:
-                            logger.debug("Tool %s unavailable (check failed)", name)
-                        continue
-                except Exception:
+                            logger.debug("Tool %s check raised; skipping", name)
+                if not check_results[entry.check_fn]:
                     if not quiet:
-                        logger.debug("Tool %s check raised; skipping", name)
+                        logger.debug("Tool %s unavailable (check failed)", name)
                     continue
             result.append({"type": "function", "function": entry.schema})
         return result


### PR DESCRIPTION
## What does this PR do?

Dedupes shared tool availability checks inside `ToolRegistry.get_definitions()` so Hermes stops rerunning identical `check_fn` probes during one schema-build pass.

This is the atomic TTFT slice for the registry-level startup duplication fix.

## Related Issue

Fixes #3348

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Cache `check_fn` results per `get_definitions()` call in `tools/registry.py`
- Skip duplicate availability probes for tools that share the same readiness check
- Add regression coverage in `tests/tools/test_registry.py`

## How to Test

1. `source /Users/kshitij/Projects/hermes-agent/.venv/bin/activate`
2. `python -m pytest -n 0 tests/tools/test_registry.py -q`
3. Confirm: `21 passed, 1 warning in 4.73s`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Live testing: `21 passed, 1 warning in 4.73s`
- Live TTFT note: this registry dedupe was part of the first-round cold-init reduction from `5499 ms` to `963 ms`
