### PR TITLE
perf(ttft): move runtime metadata out of cached prompt

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -356,6 +356,26 @@ def _inject_honcho_turn_context(content, turn_context: str):
     return f"{text}\n\n{note}"
 
 
+def _inject_runtime_turn_context(content, runtime_context: str):
+    """Append runtime metadata to the current-turn user message only."""
+    if not runtime_context:
+        return content
+
+    note = (
+        "[System note: The following runtime metadata applies to this turn only. "
+        "It is not new user input.]\n\n"
+        f"{runtime_context}"
+    )
+
+    if isinstance(content, list):
+        return list(content) + [{"type": "text", "text": note}]
+
+    text = "" if content is None else str(content)
+    if not text.strip():
+        return note
+    return f"{text}\n\n{note}"
+
+
 class AIAgent:
     """
     AI Agent with tool calling capabilities.
@@ -2409,8 +2429,7 @@ class AIAgent:
         #   3. Persistent memory (frozen snapshot)
         #   4. Skills guidance (if skills tools are loaded)
         #   5. Context files (AGENTS.md, .cursorrules — SOUL.md excluded here when used as identity)
-        #   6. Current date & time (frozen at build time)
-        #   7. Platform-specific formatting hint
+        #   6. Platform-specific formatting hint
 
         # Try SOUL.md as primary identity (unless context files are skipped)
         _soul_loaded = False
@@ -2541,17 +2560,6 @@ class AIAgent:
             if context_files_prompt:
                 prompt_parts.append(context_files_prompt)
 
-        from hermes_time import now as _hermes_now
-        now = _hermes_now()
-        timestamp_line = f"Conversation started: {now.strftime('%A, %B %d, %Y %I:%M %p')}"
-        if self.pass_session_id and self.session_id:
-            timestamp_line += f"\nSession ID: {self.session_id}"
-        if self.model:
-            timestamp_line += f"\nModel: {self.model}"
-        if self.provider:
-            timestamp_line += f"\nProvider: {self.provider}"
-        prompt_parts.append(timestamp_line)
-
         # Alibaba Coding Plan API always returns "glm-4.7" as model name regardless
         # of the requested model. Inject explicit model identity into the system prompt
         # so the agent can correctly report which model it is (workaround for API bug).
@@ -2569,6 +2577,20 @@ class AIAgent:
             prompt_parts.append(PLATFORM_HINTS[platform_key])
 
         return "\n\n".join(prompt_parts)
+
+    def _build_runtime_context_note(self) -> str:
+        """Build per-turn runtime metadata outside the cached system prompt."""
+        from hermes_time import now as _hermes_now
+
+        now = _hermes_now()
+        lines = [f"Current date/time: {now.strftime('%A, %B %d, %Y %I:%M %p')}"]
+        if self.pass_session_id and self.session_id:
+            lines.append(f"Session ID: {self.session_id}")
+        if self.model:
+            lines.append(f"Model: {self.model}")
+        if self.provider:
+            lines.append(f"Provider: {self.provider}")
+        return "\n".join(lines)
 
     # =========================================================================
     # Pre/post-call guardrails (inspired by PR #1321 — @alireza78a)
@@ -5866,6 +5888,7 @@ class AIAgent:
                         logger.debug("Session DB update_system_prompt failed: %s", e)
 
         active_system_prompt = self._cached_system_prompt
+        runtime_turn_context = self._build_runtime_context_note()
 
         # ── Preflight context compression ──
         # Before entering the main loop, check if the loaded conversation
@@ -5979,9 +6002,13 @@ class AIAgent:
             for idx, msg in enumerate(messages):
                 api_msg = msg.copy()
 
-                if idx == current_turn_user_idx and msg.get("role") == "user" and self._honcho_turn_context:
-                    api_msg["content"] = _inject_honcho_turn_context(
-                        api_msg.get("content", ""), self._honcho_turn_context
+                if idx == current_turn_user_idx and msg.get("role") == "user":
+                    if self._honcho_turn_context:
+                        api_msg["content"] = _inject_honcho_turn_context(
+                            api_msg.get("content", ""), self._honcho_turn_context
+                        )
+                    api_msg["content"] = _inject_runtime_turn_context(
+                        api_msg.get("content", ""), runtime_turn_context
                     )
 
                 # For ALL assistant messages, pass reasoning back to the API

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -579,10 +579,16 @@ class TestBuildSystemPrompt:
         prompt = agent._build_system_prompt()
         assert MEMORY_GUIDANCE not in prompt
 
-    def test_includes_datetime(self, agent):
+    def test_cached_prompt_excludes_runtime_metadata(self, agent):
         prompt = agent._build_system_prompt()
-        # Should contain current date info like "Conversation started:"
-        assert "Conversation started:" in prompt
+        assert "Conversation started:" not in prompt
+        assert "Current date/time:" not in prompt
+
+    def test_runtime_context_note_includes_datetime(self, agent):
+        note = agent._build_runtime_context_note()
+        assert "Current date/time:" in note
+        assert f"Model: {agent.model}" in note
+        assert f"Provider: {agent.provider}" in note
 
 
 class TestInvalidateSystemPrompt:
@@ -1770,6 +1776,33 @@ class TestSystemPromptStability:
         assert "prior context" in current_user["content"]
         assert "Honcho memory was retrieved from prior sessions" in current_user["content"]
 
+    def test_runtime_context_stays_out_of_cached_system_prompt(self, agent):
+        captured = {}
+
+        def _fake_api_call(api_kwargs):
+            captured.update(api_kwargs)
+            return _mock_response(content="done", finish_reason="stop")
+
+        agent._use_prompt_caching = False
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_interruptible_api_call", side_effect=_fake_api_call),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        api_messages = captured["messages"]
+        assert api_messages[0]["role"] == "system"
+        assert "Current date/time:" not in api_messages[0]["content"]
+        current_user = api_messages[-1]
+        assert current_user["role"] == "user"
+        assert "hello" in current_user["content"]
+        assert "Current date/time:" in current_user["content"]
+        assert f"Model: {agent.model}" in current_user["content"]
+
     def test_honcho_prefetch_runs_on_first_turn(self):
         """Honcho prefetch should run when conversation_history is empty."""
         conversation_history = []
@@ -1804,7 +1837,7 @@ class TestSystemPromptStability:
             result = agent.run_conversation("synthetic flush turn", sync_honcho=False)
 
         assert result["completed"] is True
-        assert captured["messages"][-1]["content"] == "synthetic flush turn"
+        assert captured["messages"][-1]["content"].startswith("synthetic flush turn")
         mock_sync.assert_not_called()
         mock_prefetch.assert_not_called()
 


### PR DESCRIPTION
## What does this PR do?

Moves live runtime metadata out of the cached system prompt and into a per-turn runtime note on the current user message.

This is the atomic TTFT slice for keeping the cached prompt prefix stable across sessions.

## Related Issue

Fixes #3353

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Remove date/session/model/provider lines from `_build_system_prompt()` in `run_agent.py`
- Add a per-turn runtime note injector for the current user message only
- Add regression coverage proving runtime metadata stays out of the cached system prompt

## How to Test

1. `source /Users/kshitij/Projects/hermes-agent/.venv/bin/activate`
2. `python -m pytest -n 0 tests/test_run_agent.py::TestBuildSystemPrompt tests/test_run_agent.py::TestSystemPromptStability -q`
3. Confirm: `16 passed, 1 warning in 11.89s`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Live testing: `16 passed, 1 warning in 11.89s`
- Live TTFT note: the local timing delta is smaller here, but this stabilizes the provider-side cacheable prefix across sessions
