### PR TITLE
perf(ttft): cache skills prompt metadata across agents and processes

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -5,12 +5,16 @@ assemble pieces, then combines them with memory and ephemeral prompts.
 """
 
 import logging
+import json
 import os
 import re
+import sys
+import threading
 from pathlib import Path
 
 from hermes_constants import get_hermes_home
 from typing import Optional
+from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
@@ -228,11 +232,255 @@ PLATFORM_HINTS = {
 CONTEXT_FILE_MAX_CHARS = 20_000
 CONTEXT_TRUNCATE_HEAD_RATIO = 0.7
 CONTEXT_TRUNCATE_TAIL_RATIO = 0.2
+_SKILL_PLATFORM_MAP = {
+    "macos": "darwin",
+    "linux": "linux",
+    "windows": "win32",
+}
+_SKILL_SCAN_EXCLUDED_DIRS = frozenset((".git", ".github", ".hub"))
+_SKILLS_PROMPT_CACHE_MAX_ENTRIES = 8
+_SKILLS_PROMPT_CACHE: dict[tuple[str, tuple[str, ...], tuple[str, ...]], str] = {}
+_SKILLS_PROMPT_CACHE_LOCK = threading.Lock()
+_SKILLS_PROMPT_SNAPSHOT_VERSION = 1
+_YAML_LOAD = None
 
 
 # =========================================================================
 # Skills index
 # =========================================================================
+
+def _parse_frontmatter_block(content: str) -> tuple[dict, str]:
+    """Parse YAML frontmatter from a markdown string without importing tools."""
+    frontmatter = {}
+    body = content
+
+    if not content.startswith("---"):
+        return frontmatter, body
+
+    end_match = re.search(r"\n---\s*\n", content[3:])
+    if not end_match:
+        return frontmatter, body
+
+    yaml_content = content[3 : end_match.start() + 3]
+    body = content[end_match.end() + 3 :]
+
+    try:
+        parsed = _yaml_load(yaml_content)
+        if isinstance(parsed, dict):
+            frontmatter = parsed
+    except Exception:
+        for line in yaml_content.strip().split("\n"):
+            if ":" not in line:
+                continue
+            key, value = line.split(":", 1)
+            frontmatter[key.strip()] = value.strip()
+
+    return frontmatter, body
+
+
+def _yaml_load(content: str):
+    global _YAML_LOAD
+    if _YAML_LOAD is None:
+        import yaml
+
+        loader = getattr(yaml, "CSafeLoader", None) or yaml.SafeLoader
+
+        def _load(value: str):
+            return yaml.load(value, Loader=loader)
+
+        _YAML_LOAD = _load
+    return _YAML_LOAD(content)
+
+
+def _skill_matches_platform(frontmatter: dict) -> bool:
+    """Return True when the skill is compatible with the current OS."""
+    platforms = frontmatter.get("platforms")
+    if not platforms:
+        return True
+    if not isinstance(platforms, list):
+        platforms = [platforms]
+    current = sys.platform
+    for platform in platforms:
+        normalized = str(platform).lower().strip()
+        mapped = _SKILL_PLATFORM_MAP.get(normalized, normalized)
+        if current.startswith(mapped):
+            return True
+    return False
+
+
+def _normalize_string_set(values) -> set[str]:
+    if values is None:
+        return set()
+    if isinstance(values, str):
+        values = [values]
+    return {str(value).strip() for value in values if str(value).strip()}
+
+
+def _get_disabled_skill_names() -> set[str]:
+    """Read disabled skills from ~/.hermes/config.yaml without importing CLI/tool code."""
+    config_path = get_hermes_home() / "config.yaml"
+    if not config_path.exists():
+        return set()
+    try:
+        parsed = _yaml_load(config_path.read_text(encoding="utf-8"))
+    except Exception as e:
+        logger.debug("Could not read skill config %s: %s", config_path, e)
+        return set()
+    if not isinstance(parsed, dict):
+        return set()
+
+    skills_cfg = parsed.get("skills")
+    if not isinstance(skills_cfg, dict):
+        return set()
+
+    resolved_platform = os.getenv("HERMES_PLATFORM")
+    if resolved_platform:
+        platform_disabled = (skills_cfg.get("platform_disabled") or {}).get(
+            resolved_platform
+        )
+        if platform_disabled is not None:
+            return _normalize_string_set(platform_disabled)
+    return _normalize_string_set(skills_cfg.get("disabled"))
+
+
+def _iter_skill_index_files(skills_dir: Path, filename: str):
+    matches = []
+    for root, dirs, files in os.walk(skills_dir):
+        dirs[:] = [d for d in dirs if d not in _SKILL_SCAN_EXCLUDED_DIRS]
+        if filename in files:
+            matches.append(Path(root) / filename)
+    for path in sorted(matches, key=lambda item: str(item.relative_to(skills_dir))):
+        yield path
+
+
+def _skills_prompt_snapshot_path() -> Path:
+    return get_hermes_home() / ".skills_prompt_snapshot.json"
+
+
+def clear_skills_system_prompt_cache(*, clear_snapshot: bool = False) -> None:
+    """Drop the in-process skills prompt cache after local skill changes."""
+    with _SKILLS_PROMPT_CACHE_LOCK:
+        _SKILLS_PROMPT_CACHE.clear()
+    if clear_snapshot:
+        try:
+            _skills_prompt_snapshot_path().unlink(missing_ok=True)
+        except OSError as e:
+            logger.debug("Could not remove skills prompt snapshot: %s", e)
+
+
+def _extract_skill_description(frontmatter: dict) -> str:
+    raw_desc = frontmatter.get("description", "")
+    if not raw_desc:
+        return ""
+    desc = str(raw_desc).strip().strip("'\"")
+    if len(desc) > 60:
+        return desc[:57] + "..."
+    return desc
+
+
+def _extract_skill_conditions(frontmatter: dict) -> dict:
+    hermes = (frontmatter.get("metadata") or {}).get("hermes") or {}
+    return {
+        "fallback_for_toolsets": hermes.get("fallback_for_toolsets", []),
+        "requires_toolsets": hermes.get("requires_toolsets", []),
+        "fallback_for_tools": hermes.get("fallback_for_tools", []),
+        "requires_tools": hermes.get("requires_tools", []),
+    }
+
+
+def _read_skill_frontmatter(skill_file: Path) -> tuple[dict, str]:
+    raw = skill_file.read_text(encoding="utf-8")[:2000]
+    frontmatter, _ = _parse_frontmatter_block(raw)
+    return frontmatter, _extract_skill_description(frontmatter)
+
+
+def _build_snapshot_entry(
+    skill_file: Path,
+    skills_dir: Path,
+    *,
+    frontmatter: Optional[dict] = None,
+    description: Optional[str] = None,
+) -> dict:
+    rel_path = skill_file.relative_to(skills_dir)
+    parts = rel_path.parts
+    if len(parts) >= 2:
+        skill_name = parts[-2]
+        category = "/".join(parts[:-2]) if len(parts) > 2 else parts[0]
+    else:
+        category = "general"
+        skill_name = skill_file.parent.name
+
+    if frontmatter is None or description is None:
+        try:
+            frontmatter, desc = _read_skill_frontmatter(skill_file)
+        except Exception as e:
+            logger.debug("Failed to parse skill file %s: %s", skill_file, e)
+            frontmatter = {}
+            desc = ""
+    else:
+        desc = description
+
+    platforms = frontmatter.get("platforms") or []
+    if isinstance(platforms, str):
+        platforms = [platforms]
+
+    return {
+        "skill_name": skill_name,
+        "category": category,
+        "frontmatter_name": str(frontmatter.get("name", skill_name)),
+        "description": desc,
+        "platforms": [str(platform).strip() for platform in platforms if str(platform).strip()],
+        "conditions": _extract_skill_conditions(frontmatter),
+    }
+
+
+def _build_skills_prompt_manifest(skills_dir: Path) -> dict[str, list[int]]:
+    manifest = {}
+    for filename in ("SKILL.md", "DESCRIPTION.md"):
+        for path in _iter_skill_index_files(skills_dir, filename):
+            try:
+                stat = path.stat()
+            except OSError:
+                continue
+            manifest[str(path.relative_to(skills_dir))] = [stat.st_mtime_ns, stat.st_size]
+    return manifest
+
+
+def _load_skills_prompt_snapshot(skills_dir: Path) -> Optional[dict]:
+    snapshot_path = _skills_prompt_snapshot_path()
+    if not snapshot_path.exists():
+        return None
+    try:
+        snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    except Exception as e:
+        logger.debug("Could not read skills prompt snapshot %s: %s", snapshot_path, e)
+        return None
+    if not isinstance(snapshot, dict):
+        return None
+    if snapshot.get("version") != _SKILLS_PROMPT_SNAPSHOT_VERSION:
+        return None
+    if snapshot.get("manifest") != _build_skills_prompt_manifest(skills_dir):
+        return None
+    return snapshot
+
+
+def _write_skills_prompt_snapshot(
+    skills_dir: Path,
+    manifest: dict[str, list[int]],
+    skill_entries: list[dict],
+    category_descriptions: dict[str, str],
+) -> None:
+    snapshot = {
+        "version": _SKILLS_PROMPT_SNAPSHOT_VERSION,
+        "manifest": manifest,
+        "skills": skill_entries,
+        "category_descriptions": category_descriptions,
+    }
+    try:
+        atomic_json_write(_skills_prompt_snapshot_path(), snapshot)
+    except Exception as e:
+        logger.debug("Could not write skills prompt snapshot: %s", e)
+
 
 def _parse_skill_file(skill_file: Path) -> tuple[bool, dict, str]:
     """Read a SKILL.md once and return platform compatibility, frontmatter, and description.
@@ -241,20 +489,10 @@ def _parse_skill_file(skill_file: Path) -> tuple[bool, dict, str]:
     (True, {}, "") to err on the side of showing the skill.
     """
     try:
-        from tools.skills_tool import _parse_frontmatter, skill_matches_platform
+        frontmatter, desc = _read_skill_frontmatter(skill_file)
 
-        raw = skill_file.read_text(encoding="utf-8")[:2000]
-        frontmatter, _ = _parse_frontmatter(raw)
-
-        if not skill_matches_platform(frontmatter):
-            return False, {}, ""
-
-        desc = ""
-        raw_desc = frontmatter.get("description", "")
-        if raw_desc:
-            desc = str(raw_desc).strip().strip("'\"")
-            if len(desc) > 60:
-                desc = desc[:57] + "..."
+        if not _skill_matches_platform(frontmatter):
+            return False, frontmatter, desc
 
         return True, frontmatter, desc
     except Exception as e:
@@ -265,16 +503,8 @@ def _parse_skill_file(skill_file: Path) -> tuple[bool, dict, str]:
 def _read_skill_conditions(skill_file: Path) -> dict:
     """Extract conditional activation fields from SKILL.md frontmatter."""
     try:
-        from tools.skills_tool import _parse_frontmatter
-        raw = skill_file.read_text(encoding="utf-8")[:2000]
-        frontmatter, _ = _parse_frontmatter(raw)
-        hermes = frontmatter.get("metadata", {}).get("hermes", {})
-        return {
-            "fallback_for_toolsets": hermes.get("fallback_for_toolsets", []),
-            "requires_toolsets": hermes.get("requires_toolsets", []),
-            "fallback_for_tools": hermes.get("fallback_for_tools", []),
-            "requires_tools": hermes.get("requires_tools", []),
-        }
+        frontmatter, _ = _read_skill_frontmatter(skill_file)
+        return _extract_skill_conditions(frontmatter)
     except Exception as e:
         logger.debug("Failed to read skill conditions from %s: %s", skill_file, e)
         return {}
@@ -328,64 +558,101 @@ def build_skills_system_prompt(
     if not skills_dir.exists():
         return ""
 
+    cache_key = (
+        str(skills_dir.resolve()),
+        tuple(sorted(str(tool) for tool in (available_tools or set()))),
+        tuple(sorted(str(toolset) for toolset in (available_toolsets or set()))),
+    )
+    with _SKILLS_PROMPT_CACHE_LOCK:
+        cached = _SKILLS_PROMPT_CACHE.get(cache_key)
+        if cached is not None:
+            return cached
+
     # Collect skills with descriptions, grouped by category.
     # Each entry: (skill_name, description)
     # Supports sub-categories: skills/mlops/training/axolotl/SKILL.md
     # -> category "mlops/training", skill "axolotl"
     # Load disabled skill names once for the entire scan
-    try:
-        from tools.skills_tool import _get_disabled_skill_names
-        disabled = _get_disabled_skill_names()
-    except Exception:
-        disabled = set()
+    disabled = _get_disabled_skill_names()
+    snapshot = _load_skills_prompt_snapshot(skills_dir)
 
     skills_by_category: dict[str, list[tuple[str, str]]] = {}
-    for skill_file in skills_dir.rglob("SKILL.md"):
-        is_compatible, frontmatter, desc = _parse_skill_file(skill_file)
-        if not is_compatible:
-            continue
-        rel_path = skill_file.relative_to(skills_dir)
-        parts = rel_path.parts
-        if len(parts) >= 2:
-            skill_name = parts[-2]
-            category = "/".join(parts[:-2]) if len(parts) > 2 else parts[0]
-        else:
-            category = "general"
-            skill_name = skill_file.parent.name
-        # Respect user's disabled skills config
-        fm_name = frontmatter.get("name", skill_name)
-        if fm_name in disabled or skill_name in disabled:
-            continue
-        # Extract conditions inline from already-parsed frontmatter
-        # (avoids redundant file re-read that _read_skill_conditions would do)
-        hermes_meta = (frontmatter.get("metadata") or {}).get("hermes") or {}
-        conditions = {
-            "fallback_for_toolsets": hermes_meta.get("fallback_for_toolsets", []),
-            "requires_toolsets": hermes_meta.get("requires_toolsets", []),
-            "fallback_for_tools": hermes_meta.get("fallback_for_tools", []),
-            "requires_tools": hermes_meta.get("requires_tools", []),
-        }
-        if not _skill_should_show(conditions, available_tools, available_toolsets):
-            continue
-        skills_by_category.setdefault(category, []).append((skill_name, desc))
-
-    if not skills_by_category:
-        return ""
-
-    # Read category-level descriptions from DESCRIPTION.md
-    # Checks both the exact category path and parent directories
     category_descriptions = {}
-    for category in skills_by_category:
-        cat_path = Path(category)
-        desc_file = skills_dir / cat_path / "DESCRIPTION.md"
-        if desc_file.exists():
+    if snapshot is not None:
+        for entry in snapshot.get("skills", []):
+            if not isinstance(entry, dict):
+                continue
+            skill_name = entry.get("skill_name") or ""
+            category = entry.get("category") or "general"
+            frontmatter_name = entry.get("frontmatter_name") or skill_name
+            platforms = entry.get("platforms") or []
+            if not _skill_matches_platform({"platforms": platforms}):
+                continue
+            if frontmatter_name in disabled or skill_name in disabled:
+                continue
+            if not _skill_should_show(
+                entry.get("conditions") or {},
+                available_tools,
+                available_toolsets,
+            ):
+                continue
+            skills_by_category.setdefault(category, []).append(
+                (skill_name, entry.get("description", ""))
+            )
+        category_descriptions = {
+            str(key): str(value)
+            for key, value in (snapshot.get("category_descriptions") or {}).items()
+        }
+    else:
+        skill_entries = []
+        for skill_file in _iter_skill_index_files(skills_dir, "SKILL.md"):
+            is_compatible, frontmatter, desc = _parse_skill_file(skill_file)
+            entry = _build_snapshot_entry(
+                skill_file,
+                skills_dir,
+                frontmatter=frontmatter,
+                description=desc,
+            )
+            skill_entries.append(entry)
+            if not is_compatible:
+                continue
+            skill_name = entry["skill_name"]
+            if entry["frontmatter_name"] in disabled or skill_name in disabled:
+                continue
+            if not _skill_should_show(
+                _extract_skill_conditions(frontmatter),
+                available_tools,
+                available_toolsets,
+            ):
+                continue
+            skills_by_category.setdefault(entry["category"], []).append(
+                (skill_name, entry["description"])
+            )
+
+        for desc_file in _iter_skill_index_files(skills_dir, "DESCRIPTION.md"):
             try:
                 content = desc_file.read_text(encoding="utf-8")
-                match = re.search(r"^---\s*\n.*?description:\s*(.+?)\s*\n.*?^---", content, re.MULTILINE | re.DOTALL)
-                if match:
-                    category_descriptions[category] = match.group(1).strip()
+                frontmatter, _ = _parse_frontmatter_block(content)
+                desc = frontmatter.get("description")
+                if not desc:
+                    continue
+                rel_path = desc_file.relative_to(skills_dir)
+                category = "/".join(rel_path.parts[:-1]) if len(rel_path.parts) > 1 else "general"
+                category_descriptions[category] = str(desc).strip().strip("'\"")
             except Exception as e:
                 logger.debug("Could not read skill description %s: %s", desc_file, e)
+
+        _write_skills_prompt_snapshot(
+            skills_dir,
+            _build_skills_prompt_manifest(skills_dir),
+            skill_entries,
+            category_descriptions,
+        )
+
+    if not skills_by_category:
+        with _SKILLS_PROMPT_CACHE_LOCK:
+            _SKILLS_PROMPT_CACHE[cache_key] = ""
+        return ""
 
     index_lines = []
     for category in sorted(skills_by_category.keys()):
@@ -405,7 +672,7 @@ def build_skills_system_prompt(
             else:
                 index_lines.append(f"    - {name}")
 
-    return (
+    result = (
         "## Skills (mandatory)\n"
         "Before replying, scan the skills below. If one clearly matches your task, "
         "load it with skill_view(name) and follow its instructions. "
@@ -420,6 +687,13 @@ def build_skills_system_prompt(
         "\n"
         "If none match, proceed normally without loading a skill."
     )
+
+    with _SKILLS_PROMPT_CACHE_LOCK:
+        _SKILLS_PROMPT_CACHE[cache_key] = result
+        while len(_SKILLS_PROMPT_CACHE) > _SKILLS_PROMPT_CACHE_MAX_ENTRIES:
+            _SKILLS_PROMPT_CACHE.pop(next(iter(_SKILLS_PROMPT_CACHE)))
+
+    return result
 
 
 # =========================================================================

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -4,6 +4,7 @@ import builtins
 import importlib
 import logging
 import sys
+import pytest
 
 from agent.prompt_builder import (
     _scan_context_content,
@@ -15,6 +16,7 @@ from agent.prompt_builder import (
     _find_git_root,
     _strip_yaml_frontmatter,
     build_skills_system_prompt,
+    clear_skills_system_prompt_cache,
     build_context_files_prompt,
     CONTEXT_FILE_MAX_CHARS,
     DEFAULT_AGENT_IDENTITY,
@@ -192,7 +194,7 @@ class TestParseSkillFile:
         )
         from unittest.mock import patch
 
-        with patch("tools.skills_tool.sys") as mock_sys:
+        with patch("agent.prompt_builder.sys") as mock_sys:
             mock_sys.platform = "linux"
             is_compat, _, _ = _parse_skill_file(skill_file)
         assert is_compat is False
@@ -283,7 +285,7 @@ class TestBuildSkillsSystemPrompt:
 
         from unittest.mock import patch
 
-        with patch("tools.skills_tool.sys") as mock_sys:
+        with patch("agent.prompt_builder.sys") as mock_sys:
             mock_sys.platform = "linux"
             result = build_skills_system_prompt()
 
@@ -302,12 +304,98 @@ class TestBuildSkillsSystemPrompt:
 
         from unittest.mock import patch
 
-        with patch("tools.skills_tool.sys") as mock_sys:
+        with patch("agent.prompt_builder.sys") as mock_sys:
             mock_sys.platform = "darwin"
             result = build_skills_system_prompt()
 
         assert "imessage" in result
         assert "Send iMessages" in result
+
+    def test_builds_index_without_importing_tools_package(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "coding" / "python-debug"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: python-debug\ndescription: Debug Python scripts\n---\n"
+        )
+
+        original_import = builtins.__import__
+
+        def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "tools" or name.startswith("tools."):
+                raise ModuleNotFoundError("simulated tools package import failure")
+            return original_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.delitem(sys.modules, "tools", raising=False)
+        monkeypatch.delitem(sys.modules, "tools.skills_tool", raising=False)
+        monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+        result = build_skills_system_prompt()
+
+        assert "python-debug" in result
+        assert "Debug Python scripts" in result
+
+    def test_reuses_cached_prompt_when_inputs_unchanged(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "coding" / "python-debug"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: python-debug\ndescription: Debug Python scripts\n---\n"
+        )
+
+        import agent.prompt_builder as prompt_builder
+
+        first = build_skills_system_prompt()
+
+        def fail_if_reparsed(*args, **kwargs):
+            raise AssertionError("expected cached skills prompt reuse")
+
+        monkeypatch.setattr(prompt_builder, "_parse_skill_file", fail_if_reparsed)
+
+        second = build_skills_system_prompt()
+
+        assert second == first
+
+    def test_clear_skills_prompt_cache_with_snapshot_clear_forces_reparse(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "coding" / "python-debug"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: python-debug\ndescription: Debug Python scripts\n---\n"
+        )
+
+        first = build_skills_system_prompt()
+        clear_skills_system_prompt_cache(clear_snapshot=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: python-debug\ndescription: Reparsed description\n---\n"
+        )
+
+        second = build_skills_system_prompt()
+
+        assert second != first
+        assert "Reparsed description" in second
+
+    def test_uses_disk_snapshot_after_process_cache_clear(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "coding" / "python-debug"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: python-debug\ndescription: Debug Python scripts\n---\n"
+        )
+
+        import agent.prompt_builder as prompt_builder
+
+        first = build_skills_system_prompt()
+        prompt_builder.clear_skills_system_prompt_cache()
+
+        def fail_if_reparsed(*args, **kwargs):
+            raise AssertionError("expected disk snapshot reuse")
+
+        monkeypatch.setattr(prompt_builder, "_parse_skill_file", fail_if_reparsed)
+
+        second = build_skills_system_prompt()
+
+        assert second == first
 
     def test_excludes_disabled_skills(self, monkeypatch, tmp_path):
         """Skills in the user's disabled list should not appear in the system prompt."""
@@ -330,7 +418,7 @@ class TestBuildSkillsSystemPrompt:
         from unittest.mock import patch
 
         with patch(
-            "tools.skills_tool._get_disabled_skill_names",
+            "agent.prompt_builder._get_disabled_skill_names",
             return_value={"old-tool"},
         ):
             result = build_skills_system_prompt()
@@ -561,10 +649,14 @@ class TestBuildContextFilesPrompt:
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert "Lowercase claude rules" in result
 
-    def test_claude_md_uppercase_takes_priority(self, tmp_path):
-        (tmp_path / "CLAUDE.md").write_text("From uppercase.")
-        (tmp_path / "claude.md").write_text("From lowercase.")
-        result = build_context_files_prompt(cwd=str(tmp_path))
+    def test_claude_md_uppercase_takes_priority(self, monkeypatch, tmp_path):
+        upper = tmp_path / "CLAUDE.md"
+        lower = tmp_path / "claude.md"
+        upper.write_text("From uppercase.")
+        if lower.exists():
+            pytest.skip("case-insensitive filesystem cannot distinguish CLAUDE.md from claude.md")
+        lower.write_text("From lowercase.")
+        result = build_context_files_prompt(cwd=str(tmp_path), skip_soul=True)
         assert "From uppercase" in result
         assert "From lowercase" not in result
 

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -371,3 +371,17 @@ class TestSkillManageDispatcher:
             raw = skill_manage(action="create", name="test-skill", content=VALID_SKILL_CONTENT)
         result = json.loads(raw)
         assert result["success"] is True
+
+    def test_successful_write_clears_skills_prompt_cache(self, tmp_path):
+        with (
+            patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path),
+            patch("tools.skill_manager_tool._clear_skills_prompt_cache") as clear_cache,
+        ):
+            raw = skill_manage(
+                action="create",
+                name="test-skill",
+                content=VALID_SKILL_CONTENT,
+            )
+        result = json.loads(raw)
+        assert result["success"] is True
+        clear_cache.assert_called_once_with(clear_snapshot=True)

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -95,6 +95,15 @@ def check_skill_manage_requirements() -> bool:
     return True
 
 
+def _clear_skills_prompt_cache(*, clear_snapshot: bool = False) -> None:
+    try:
+        from agent.prompt_builder import clear_skills_system_prompt_cache
+
+        clear_skills_system_prompt_cache(clear_snapshot=clear_snapshot)
+    except Exception as e:
+        logger.debug("Could not clear skills prompt cache: %s", e)
+
+
 # =============================================================================
 # Validation helpers
 # =============================================================================
@@ -546,6 +555,9 @@ def skill_manage(
 
     else:
         result = {"success": False, "error": f"Unknown action '{action}'. Use: create, edit, patch, delete, write_file, remove_file"}
+
+    if result.get("success"):
+        _clear_skills_prompt_cache(clear_snapshot=True)
 
     return json.dumps(result, ensure_ascii=False)
 


### PR DESCRIPTION
## What does this PR do?

Adds multi-layer skills prompt caching: an in-process hot cache for repeated agents and a disk-backed snapshot for fresh processes, with invalidation through `skill_manage(...)`.

This combines the tightly coupled skills-cache issues into one atomic PR.

## Related Issue

Fixes #3352
Fixes #3354

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Move skills frontmatter parsing into `agent.prompt_builder` so prompt construction no longer imports the heavy `tools` package
- Add an in-process skills prompt cache keyed by skills directory and tool/toolset availability
- Add a disk-backed `.skills_prompt_snapshot.json` for fresh-process reuse
- Clear both caches after successful `skill_manage(...)` writes
- Add regression coverage in `tests/agent/test_prompt_builder.py` and `tests/tools/test_skill_manager_tool.py`

## How to Test

1. `source /Users/kshitij/Projects/hermes-agent/.venv/bin/activate`
2. `python -m pytest -n 0 tests/agent/test_prompt_builder.py tests/tools/test_skill_manager_tool.py -q`
3. Confirm: `148 passed, 1 skipped, 1 warning in 7.17s`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Live testing: `148 passed, 1 skipped, 1 warning in 7.17s`
- Live measurement: same-process prompt build `545.95 ms -> 0.36 ms`
- Live measurement: fresh-process `_build_system_prompt()` `297.22 ms -> 102.51 ms`
- Live measurement: fresh-process first outbound dispatch `368.42 ms -> 115.60 ms`
