### PR TITLE
fix(doctor): add model context length compatibility check

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2205,7 +2205,111 @@ def run_doctor(args):
             issues.append("Run 'hermes setup' to configure missing API keys for full tool access")
     except Exception as e:
         check_warn("Could not check tool availability", f"({e})")
-    
+
+    # =========================================================================
+    # Check: Model context length (local servers)
+    # =========================================================================
+    _section("Model Compatibility")
+
+    try:
+        from agent.model_metadata import (
+            MINIMUM_CONTEXT_LENGTH,
+            get_model_context_length,
+            is_local_endpoint,
+        )
+        from hermes_cli.config import (
+            get_compatible_custom_providers,
+            get_custom_provider_context_length,
+            load_config,
+        )
+
+        _cfg = load_config()
+        _model_cfg = _cfg.get("model", {}) or {}
+        _model = str(_model_cfg.get("default") or "").strip()
+        _provider = str(_model_cfg.get("provider") or "").strip()
+        _base_url = str(_model_cfg.get("base_url") or "").strip()
+        _inference_cfg = _cfg.get("inference", {}) or {}
+        if not _base_url:
+            _base_url = str(_inference_cfg.get("api_base") or _inference_cfg.get("base_url") or "").strip()
+
+        if not _model or not _base_url:
+            if _model:
+                check_info(f"Model: {_model} (no base_url configured — skipping context check)")
+            else:
+                check_warn("No model configured", "(set model.default in config.yaml)")
+        elif not is_local_endpoint(_base_url):
+            check_info(f"Model: {_model} (remote provider — context length managed by provider)")
+        else:
+            # Resolve effective config_context_length the same way the agent does
+            _config_context_length: int | None = None
+            if isinstance(_model_cfg, dict):
+                _raw_ctx = _model_cfg.get("context_length")
+                if _raw_ctx is not None:
+                    try:
+                        _config_context_length = int(_raw_ctx)
+                    except (TypeError, ValueError):
+                        pass
+
+            # Resolve custom_providers for per-model context_length overrides
+            _custom_providers: list = []
+            try:
+                _custom_providers = get_compatible_custom_providers(_cfg)
+            except Exception:
+                pass
+
+            # Resolve custom-provider per-model override if no explicit config context_length
+            if _config_context_length is None and _custom_providers:
+                try:
+                    _cp_ctx = get_custom_provider_context_length(
+                        model=_model,
+                        base_url=_base_url,
+                        custom_providers=_custom_providers,
+                    )
+                    if _cp_ctx:
+                        _config_context_length = int(_cp_ctx)
+                except Exception:
+                    pass
+
+            _ctx = get_model_context_length(
+                _model,
+                base_url=_base_url,
+                provider=_provider,
+                config_context_length=_config_context_length,
+                custom_providers=_custom_providers,
+            )
+
+            if _ctx >= MINIMUM_CONTEXT_LENGTH:
+                check_ok(f"Model context length: {_ctx:,} tokens")
+            else:
+                check_fail(
+                    f"Model context length: {_ctx:,} tokens",
+                    f"(minimum {MINIMUM_CONTEXT_LENGTH:,} needed)",
+                )
+                issues.append(
+                    f"Model '{_model}' has insufficient context ({_ctx:,} tokens). "
+                    f"Hermes requires at least {MINIMUM_CONTEXT_LENGTH:,} tokens. "
+                    f"Load the model with context_length >= {MINIMUM_CONTEXT_LENGTH:,} "
+                    f"or set model.context_length in config.yaml to the real value."
+                )
+
+            # Also check inference.model if configured separately
+            _inf_model = str(_inference_cfg.get("model") or "").strip()
+            if _inf_model and _inf_model != _model:
+                _inf_ctx = get_model_context_length(
+                    _inf_model,
+                    base_url=_base_url,
+                    provider=_provider,
+                    config_context_length=_config_context_length,
+                    custom_providers=_custom_providers,
+                )
+                if _inf_ctx < MINIMUM_CONTEXT_LENGTH:
+                    check_warn(
+                        f"Inference model context: {_inf_ctx:,} tokens",
+                        f"(below {MINIMUM_CONTEXT_LENGTH:,} minimum)",
+                    )
+    except Exception as e:
+        check_warn("Model compatibility check", f"(could not verify: {e})")
+
     _section("Skills Hub")
     hub_dir = HERMES_HOME / "skills" / ".hub"
     if hub_dir.exists():

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2773,7 +2773,111 @@ def run_doctor(args):
             issues.append("Run 'hermes setup' to configure missing API keys for full tool access")
     except Exception as e:
         check_warn("Could not check tool availability", f"({e})")
-    
+
+    # =========================================================================
+    # Check: Model context length (local servers)
+    # =========================================================================
+    _section("Model Compatibility")
+
+    try:
+        from agent.model_metadata import (
+            MINIMUM_CONTEXT_LENGTH,
+            get_model_context_length,
+            is_local_endpoint,
+        )
+        from hermes_cli.config import (
+            get_compatible_custom_providers,
+            get_custom_provider_context_length,
+            load_config,
+        )
+
+        _cfg = load_config()
+        _model_cfg = _cfg.get("model", {}) or {}
+        _model = str(_model_cfg.get("default") or "").strip()
+        _provider = str(_model_cfg.get("provider") or "").strip()
+        _base_url = str(_model_cfg.get("base_url") or "").strip()
+        _inference_cfg = _cfg.get("inference", {}) or {}
+        if not _base_url:
+            _base_url = str(_inference_cfg.get("api_base") or _inference_cfg.get("base_url") or "").strip()
+
+        if not _model or not _base_url:
+            if _model:
+                check_info(f"Model: {_model} (no base_url configured — skipping context check)")
+            else:
+                check_warn("No model configured", "(set model.default in config.yaml)")
+        elif not is_local_endpoint(_base_url):
+            check_info(f"Model: {_model} (remote provider — context length managed by provider)")
+        else:
+            # Resolve effective config_context_length the same way the agent does
+            _config_context_length: int | None = None
+            if isinstance(_model_cfg, dict):
+                _raw_ctx = _model_cfg.get("context_length")
+                if _raw_ctx is not None:
+                    try:
+                        _config_context_length = int(_raw_ctx)
+                    except (TypeError, ValueError):
+                        pass
+
+            # Resolve custom_providers for per-model context_length overrides
+            _custom_providers: list = []
+            try:
+                _custom_providers = get_compatible_custom_providers(_cfg)
+            except Exception:
+                pass
+
+            # Resolve custom-provider per-model override if no explicit config context_length
+            if _config_context_length is None and _custom_providers:
+                try:
+                    _cp_ctx = get_custom_provider_context_length(
+                        model=_model,
+                        base_url=_base_url,
+                        custom_providers=_custom_providers,
+                    )
+                    if _cp_ctx:
+                        _config_context_length = int(_cp_ctx)
+                except Exception:
+                    pass
+
+            _ctx = get_model_context_length(
+                _model,
+                base_url=_base_url,
+                provider=_provider,
+                config_context_length=_config_context_length,
+                custom_providers=_custom_providers,
+            )
+
+            if _ctx >= MINIMUM_CONTEXT_LENGTH:
+                check_ok(f"Model context length: {_ctx:,} tokens")
+            else:
+                check_fail(
+                    f"Model context length: {_ctx:,} tokens",
+                    f"(minimum {MINIMUM_CONTEXT_LENGTH:,} needed)",
+                )
+                issues.append(
+                    f"Model '{_model}' has insufficient context ({_ctx:,} tokens). "
+                    f"Hermes requires at least {MINIMUM_CONTEXT_LENGTH:,} tokens. "
+                    f"Load the model with context_length >= {MINIMUM_CONTEXT_LENGTH:,} "
+                    f"or set model.context_length in config.yaml to the real value."
+                )
+
+            # Also check inference.model if configured separately
+            _inf_model = str(_inference_cfg.get("model") or "").strip()
+            if _inf_model and _inf_model != _model:
+                _inf_ctx = get_model_context_length(
+                    _inf_model,
+                    base_url=_base_url,
+                    provider=_provider,
+                    config_context_length=_config_context_length,
+                    custom_providers=_custom_providers,
+                )
+                if _inf_ctx < MINIMUM_CONTEXT_LENGTH:
+                    check_warn(
+                        f"Inference model context: {_inf_ctx:,} tokens",
+                        f"(below {MINIMUM_CONTEXT_LENGTH:,} minimum)",
+                    )
+    except Exception as e:
+        check_warn("Model compatibility check", f"(could not verify: {e})")
+
     _section("Skills Hub")
     hub_dir = HERMES_HOME / "skills" / ".hub"
     if hub_dir.exists():

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1488,3 +1488,275 @@ def test_npm_audit_fix_hint_avoids_crashing_workspace_flag(monkeypatch, tmp_path
     assert "build-time tooling" in out
     assert "known npm bug" in out
     assert "lockfile bump" in out
+
+
+# ---------------------------------------------------------------------------
+# ◆ Model Compatibility context length checks
+# ---------------------------------------------------------------------------
+
+
+class TestDoctorModelCompatibility:
+    """The ◆ Model Compatibility section must validate local model context length.
+
+    Regression for PR #3375: the original implementation used a hardcoded 16K
+    threshold instead of MINIMUM_CONTEXT_LENGTH (64K) from agent.model_metadata,
+    and it did not pass the full effective configuration (config_context_length,
+    custom_providers) to get_model_context_length().
+    """
+
+    MIN_CTX: int
+
+    @classmethod
+    def setup_class(cls):
+        from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+        cls.MIN_CTX = MINIMUM_CONTEXT_LENGTH
+
+    def _make_config(self, tmp_path, model="local-model", base_url="http://localhost:1234/v1",
+                     provider="custom", context_length=None, inference_model=None):
+        """Create a minimal HERMES_HOME with config.yaml for the test."""
+        home = tmp_path / ".hermes"
+        home.mkdir(parents=True, exist_ok=True)
+        cfg = {
+            "model": {
+                "default": model,
+                "provider": provider,
+                "base_url": base_url,
+            }
+        }
+        if context_length is not None:
+            cfg["model"]["context_length"] = context_length
+        if inference_model:
+            cfg.setdefault("inference", {})["model"] = inference_model
+        import yaml
+        (home / "config.yaml").write_text(yaml.dump(cfg), encoding="utf-8")
+        return home
+
+    def _run_doctor_compat(self, monkeypatch, tmp_path, home, ctx_length_return=128_000,
+                           is_local=True, ctx_side_effect=None):
+        """Run doctor and return stdout, short-circuiting at the Skills Hub section.
+
+        Mocks get_model_context_length() and is_local_endpoint() so the
+        Model Compatibility section returns controlled values.
+        """
+        from unittest import mock
+
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+        monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        (tmp_path / "project").mkdir(exist_ok=True)
+
+        # Stub tool availability so doctor runs past Tool Availability
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+        # Stub auth checks to avoid real API calls
+        try:
+            from hermes_cli import auth as _auth_mod
+            monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+        except Exception:
+            pass
+
+        # Mock model_metadata functions
+        import agent.model_metadata as _mm
+        if ctx_side_effect is not None:
+            monkeypatch.setattr(_mm, "get_model_context_length", mock.Mock(side_effect=ctx_side_effect))
+        else:
+            monkeypatch.setattr(_mm, "get_model_context_length", mock.Mock(return_value=ctx_length_return))
+        monkeypatch.setattr(_mm, "is_local_endpoint", mock.Mock(return_value=is_local))
+
+        import io, contextlib
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            doctor_mod.run_doctor(Namespace(fix=False))
+        return buf.getvalue()
+
+    def _model_compat_lines(self, output):
+        """Return lines from the ◆ Model Compatibility section."""
+        lines = output.splitlines()
+        start = None
+        end = None
+        for i, line in enumerate(lines):
+            if "◆ Model Compatibility" in line:
+                start = i
+            elif start is not None and line.startswith("◆"):
+                end = i
+                break
+        if start is None:
+            return []
+        return lines[start:end]
+
+    def test_sufficient_context_passes(self, monkeypatch, tmp_path):
+        """Exactly MINIMUM_CONTEXT_LENGTH should pass (64K)."""
+        from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+        home = self._make_config(tmp_path)
+        out = self._run_doctor_compat(monkeypatch, tmp_path, home,
+                                      ctx_length_return=MINIMUM_CONTEXT_LENGTH)
+        compat_lines = self._model_compat_lines(out)
+        joined = "\n".join(compat_lines)
+        assert "✓ Model context length" in joined
+        assert "✗" not in joined
+
+    def test_insufficient_context_fails(self, monkeypatch, tmp_path):
+        """Below MINIMUM_CONTEXT_LENGTH should fail."""
+        from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+        low_ctx = MINIMUM_CONTEXT_LENGTH - 1
+        home = self._make_config(tmp_path)
+        out = self._run_doctor_compat(monkeypatch, tmp_path, home,
+                                      ctx_length_return=low_ctx)
+        compat_lines = self._model_compat_lines(out)
+        joined = "\n".join(compat_lines)
+        assert "✗ Model context length" in joined
+        assert f"{low_ctx:,}" in joined
+
+    def test_remote_provider_skipped(self, monkeypatch, tmp_path):
+        """Remote endpoints should be skipped with an info message."""
+        home = self._make_config(tmp_path, base_url="https://api.openai.com/v1")
+        out = self._run_doctor_compat(monkeypatch, tmp_path, home, is_local=False)
+        compat_lines = self._model_compat_lines(out)
+        joined = "\n".join(compat_lines)
+        assert "remote provider" in joined
+        assert "✓" not in joined
+        assert "✗" not in joined
+
+    def test_no_model_configured(self, monkeypatch, tmp_path):
+        """No model.default should show a warning."""
+        home = self._make_config(tmp_path, model="")
+        out = self._run_doctor_compat(monkeypatch, tmp_path, home)
+        compat_lines = self._model_compat_lines(out)
+        joined = "\n".join(compat_lines)
+        assert "No model configured" in joined
+
+    def test_config_context_length_override(self, monkeypatch, tmp_path):
+        """A model.context_length override must be passed to get_model_context_length."""
+        from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+        from unittest import mock
+
+        home = self._make_config(tmp_path, context_length=MINIMUM_CONTEXT_LENGTH)
+
+        import agent.model_metadata as _mm
+        mock_fn = mock.Mock(return_value=MINIMUM_CONTEXT_LENGTH)
+        monkeypatch.setattr(_mm, "get_model_context_length", mock_fn)
+        monkeypatch.setattr(_mm, "is_local_endpoint", mock.Mock(return_value=True))
+
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+        monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        (tmp_path / "project").mkdir(exist_ok=True)
+
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+        try:
+            from hermes_cli import auth as _auth_mod
+            monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+        except Exception:
+            pass
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            doctor_mod.run_doctor(Namespace(fix=False))
+
+        # Verify config_context_length was passed to get_model_context_length
+        assert mock_fn.called
+        call_kwargs = mock_fn.call_args[1]
+        assert call_kwargs.get("config_context_length") == MINIMUM_CONTEXT_LENGTH
+
+    def test_custom_provider_context_length_override(self, monkeypatch, tmp_path):
+        """A custom_providers per-model context_length must be passed to get_model_context_length."""
+        from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+        from unittest import mock
+
+        home = tmp_path / ".hermes"
+        home.mkdir(parents=True, exist_ok=True)
+        cfg = {
+            "model": {
+                "default": "local-model",
+                "provider": "custom:my-server",
+                "base_url": "http://localhost:1234/v1",
+            },
+            "custom_providers": [
+                {
+                    "name": "my-server",
+                    "base_url": "http://localhost:1234/v1",
+                    "models": {
+                        "local-model": {"context_length": MINIMUM_CONTEXT_LENGTH}
+                    },
+                }
+            ],
+        }
+        import yaml
+        (home / "config.yaml").write_text(yaml.dump(cfg), encoding="utf-8")
+
+        import agent.model_metadata as _mm
+        mock_fn = mock.Mock(return_value=MINIMUM_CONTEXT_LENGTH)
+        monkeypatch.setattr(_mm, "get_model_context_length", mock_fn)
+        monkeypatch.setattr(_mm, "is_local_endpoint", mock.Mock(return_value=True))
+
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+        monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        (tmp_path / "project").mkdir(exist_ok=True)
+
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+        try:
+            from hermes_cli import auth as _auth_mod
+            monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+        except Exception:
+            pass
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            doctor_mod.run_doctor(Namespace(fix=False))
+
+        # Verify custom_providers was passed to get_model_context_length
+        assert mock_fn.called
+        call_kwargs = mock_fn.call_args[1]
+        assert call_kwargs.get("custom_providers") is not None
+        assert len(call_kwargs["custom_providers"]) == 1
+
+    def test_insufficient_context_appends_issue(self, monkeypatch, tmp_path):
+        """A failing context check must append a fix instruction to issues."""
+        from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+        low_ctx = MINIMUM_CONTEXT_LENGTH - 1
+        home = self._make_config(tmp_path, model="test-model")
+        out = self._run_doctor_compat(monkeypatch, tmp_path, home,
+                                      ctx_length_return=low_ctx)
+        # The issues list is printed at the end of doctor output
+        assert f"test-model" in out
+        assert f"{low_ctx:,}" in out
+        assert f"context_length >= {MINIMUM_CONTEXT_LENGTH:,}" in out
+
+    def test_inference_model_separately_checked(self, monkeypatch, tmp_path):
+        """If inference.model differs from model.default, both are checked."""
+        from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+        low_ctx = MINIMUM_CONTEXT_LENGTH - 1
+        home = self._make_config(tmp_path, model="main-model", inference_model="inf-model")
+        # First call returns OK (main model), second returns low (inference model)
+        out = self._run_doctor_compat(monkeypatch, tmp_path, home,
+                                      ctx_side_effect=[MINIMUM_CONTEXT_LENGTH, low_ctx])
+        compat_lines = self._model_compat_lines(out)
+        joined = "\n".join(compat_lines)
+        assert "✓ Model context length" in joined
+        assert "Inference model context" in joined
+        assert f"{low_ctx:,}" in joined

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1457,3 +1457,274 @@ class TestDoctorDeprecatedConfigAndEnv:
         assert "Deprecated: delegation.max_async_children" in out
         assert "Deprecated: HERMES_TOOL_PROGRESS_MODE" in out
         assert "⚠" in out or "Deprecated" in out
+
+# ---------------------------------------------------------------------------
+# ◆ Model Compatibility context length checks
+# ---------------------------------------------------------------------------
+
+
+class TestDoctorModelCompatibility:
+    """The ◆ Model Compatibility section must validate local model context length.
+
+    Regression for PR #3375: the original implementation used a hardcoded 16K
+    threshold instead of MINIMUM_CONTEXT_LENGTH (64K) from agent.model_metadata,
+    and it did not pass the full effective configuration (config_context_length,
+    custom_providers) to get_model_context_length().
+    """
+
+    MIN_CTX: int
+
+    @classmethod
+    def setup_class(cls):
+        from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+        cls.MIN_CTX = MINIMUM_CONTEXT_LENGTH
+
+    def _make_config(self, tmp_path, model="local-model", base_url="http://localhost:1234/v1",
+                     provider="custom", context_length=None, inference_model=None):
+        """Create a minimal HERMES_HOME with config.yaml for the test."""
+        home = tmp_path / ".hermes"
+        home.mkdir(parents=True, exist_ok=True)
+        cfg = {
+            "model": {
+                "default": model,
+                "provider": provider,
+                "base_url": base_url,
+            }
+        }
+        if context_length is not None:
+            cfg["model"]["context_length"] = context_length
+        if inference_model:
+            cfg.setdefault("inference", {})["model"] = inference_model
+        import yaml
+        (home / "config.yaml").write_text(yaml.dump(cfg), encoding="utf-8")
+        return home
+
+    def _run_doctor_compat(self, monkeypatch, tmp_path, home, ctx_length_return=128_000,
+                           is_local=True, ctx_side_effect=None):
+        """Run doctor and return stdout, short-circuiting at the Skills Hub section.
+
+        Mocks get_model_context_length() and is_local_endpoint() so the
+        Model Compatibility section returns controlled values.
+        """
+        from unittest import mock
+
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+        monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        (tmp_path / "project").mkdir(exist_ok=True)
+
+        # Stub tool availability so doctor runs past Tool Availability
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+        # Stub auth checks to avoid real API calls
+        try:
+            from hermes_cli import auth as _auth_mod
+            monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+        except Exception:
+            pass
+
+        # Mock model_metadata functions
+        import agent.model_metadata as _mm
+        if ctx_side_effect is not None:
+            monkeypatch.setattr(_mm, "get_model_context_length", mock.Mock(side_effect=ctx_side_effect))
+        else:
+            monkeypatch.setattr(_mm, "get_model_context_length", mock.Mock(return_value=ctx_length_return))
+        monkeypatch.setattr(_mm, "is_local_endpoint", mock.Mock(return_value=is_local))
+
+        import io, contextlib
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            doctor_mod.run_doctor(Namespace(fix=False))
+        return buf.getvalue()
+
+    def _model_compat_lines(self, output):
+        """Return lines from the ◆ Model Compatibility section."""
+        lines = output.splitlines()
+        start = None
+        end = None
+        for i, line in enumerate(lines):
+            if "◆ Model Compatibility" in line:
+                start = i
+            elif start is not None and line.startswith("◆"):
+                end = i
+                break
+        if start is None:
+            return []
+        return lines[start:end]
+
+    def test_sufficient_context_passes(self, monkeypatch, tmp_path):
+        """Exactly MINIMUM_CONTEXT_LENGTH should pass (64K)."""
+        from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+        home = self._make_config(tmp_path)
+        out = self._run_doctor_compat(monkeypatch, tmp_path, home,
+                                      ctx_length_return=MINIMUM_CONTEXT_LENGTH)
+        compat_lines = self._model_compat_lines(out)
+        joined = "\n".join(compat_lines)
+        assert "✓ Model context length" in joined
+        assert "✗" not in joined
+
+    def test_insufficient_context_fails(self, monkeypatch, tmp_path):
+        """Below MINIMUM_CONTEXT_LENGTH should fail."""
+        from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+        low_ctx = MINIMUM_CONTEXT_LENGTH - 1
+        home = self._make_config(tmp_path)
+        out = self._run_doctor_compat(monkeypatch, tmp_path, home,
+                                      ctx_length_return=low_ctx)
+        compat_lines = self._model_compat_lines(out)
+        joined = "\n".join(compat_lines)
+        assert "✗ Model context length" in joined
+        assert f"{low_ctx:,}" in joined
+
+    def test_remote_provider_skipped(self, monkeypatch, tmp_path):
+        """Remote endpoints should be skipped with an info message."""
+        home = self._make_config(tmp_path, base_url="https://api.openai.com/v1")
+        out = self._run_doctor_compat(monkeypatch, tmp_path, home, is_local=False)
+        compat_lines = self._model_compat_lines(out)
+        joined = "\n".join(compat_lines)
+        assert "remote provider" in joined
+        assert "✓" not in joined
+        assert "✗" not in joined
+
+    def test_no_model_configured(self, monkeypatch, tmp_path):
+        """No model.default should show a warning."""
+        home = self._make_config(tmp_path, model="")
+        out = self._run_doctor_compat(monkeypatch, tmp_path, home)
+        compat_lines = self._model_compat_lines(out)
+        joined = "\n".join(compat_lines)
+        assert "No model configured" in joined
+
+    def test_config_context_length_override(self, monkeypatch, tmp_path):
+        """A model.context_length override must be passed to get_model_context_length."""
+        from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+        from unittest import mock
+
+        home = self._make_config(tmp_path, context_length=MINIMUM_CONTEXT_LENGTH)
+
+        import agent.model_metadata as _mm
+        mock_fn = mock.Mock(return_value=MINIMUM_CONTEXT_LENGTH)
+        monkeypatch.setattr(_mm, "get_model_context_length", mock_fn)
+        monkeypatch.setattr(_mm, "is_local_endpoint", mock.Mock(return_value=True))
+
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+        monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        (tmp_path / "project").mkdir(exist_ok=True)
+
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+        try:
+            from hermes_cli import auth as _auth_mod
+            monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+        except Exception:
+            pass
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            doctor_mod.run_doctor(Namespace(fix=False))
+
+        # Verify config_context_length was passed to get_model_context_length
+        assert mock_fn.called
+        call_kwargs = mock_fn.call_args[1]
+        assert call_kwargs.get("config_context_length") == MINIMUM_CONTEXT_LENGTH
+
+    def test_custom_provider_context_length_override(self, monkeypatch, tmp_path):
+        """A custom_providers per-model context_length must be passed to get_model_context_length."""
+        from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+        from unittest import mock
+
+        home = tmp_path / ".hermes"
+        home.mkdir(parents=True, exist_ok=True)
+        cfg = {
+            "model": {
+                "default": "local-model",
+                "provider": "custom:my-server",
+                "base_url": "http://localhost:1234/v1",
+            },
+            "custom_providers": [
+                {
+                    "name": "my-server",
+                    "base_url": "http://localhost:1234/v1",
+                    "models": {
+                        "local-model": {"context_length": MINIMUM_CONTEXT_LENGTH}
+                    },
+                }
+            ],
+        }
+        import yaml
+        (home / "config.yaml").write_text(yaml.dump(cfg), encoding="utf-8")
+
+        import agent.model_metadata as _mm
+        mock_fn = mock.Mock(return_value=MINIMUM_CONTEXT_LENGTH)
+        monkeypatch.setattr(_mm, "get_model_context_length", mock_fn)
+        monkeypatch.setattr(_mm, "is_local_endpoint", mock.Mock(return_value=True))
+
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+        monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        (tmp_path / "project").mkdir(exist_ok=True)
+
+        fake_model_tools = types.SimpleNamespace(
+            check_tool_availability=lambda *a, **kw: ([], []),
+            TOOLSET_REQUIREMENTS={},
+        )
+        monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+        try:
+            from hermes_cli import auth as _auth_mod
+            monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_minimax_oauth_auth_status", lambda: {})
+            monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+        except Exception:
+            pass
+
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            doctor_mod.run_doctor(Namespace(fix=False))
+
+        # Verify custom_providers was passed to get_model_context_length
+        assert mock_fn.called
+        call_kwargs = mock_fn.call_args[1]
+        assert call_kwargs.get("custom_providers") is not None
+        assert len(call_kwargs["custom_providers"]) == 1
+
+    def test_insufficient_context_appends_issue(self, monkeypatch, tmp_path):
+        """A failing context check must append a fix instruction to issues."""
+        from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+        low_ctx = MINIMUM_CONTEXT_LENGTH - 1
+        home = self._make_config(tmp_path, model="test-model")
+        out = self._run_doctor_compat(monkeypatch, tmp_path, home,
+                                      ctx_length_return=low_ctx)
+        # The issues list is printed at the end of doctor output
+        assert f"test-model" in out
+        assert f"{low_ctx:,}" in out
+        assert f"context_length >= {MINIMUM_CONTEXT_LENGTH:,}" in out
+
+    def test_inference_model_separately_checked(self, monkeypatch, tmp_path):
+        """If inference.model differs from model.default, both are checked."""
+        from agent.model_metadata import MINIMUM_CONTEXT_LENGTH
+        low_ctx = MINIMUM_CONTEXT_LENGTH - 1
+        home = self._make_config(tmp_path, model="main-model", inference_model="inf-model")
+        # First call returns OK (main model), second returns low (inference model)
+        out = self._run_doctor_compat(monkeypatch, tmp_path, home,
+                                      ctx_side_effect=[MINIMUM_CONTEXT_LENGTH, low_ctx])
+        compat_lines = self._model_compat_lines(out)
+        joined = "\n".join(compat_lines)
+        assert "✓ Model context length" in joined
+        assert "Inference model context" in joined
+        assert f"{low_ctx:,}" in joined


### PR DESCRIPTION
## What

Adds a "Model Compatibility" section to `hermes doctor` that validates the configured model's context length is sufficient for Hermes system prompts.

## Why

The most common crash for users running local models (LM Studio, Ollama) is `Compute error` or `n_keep >= n_ctx`. This happens because:
- Hermes system prompts are ~8-15K tokens (persona + tools + memory + skills)
- Models loaded with context < system prompt tokens can't even start a conversation
- Users don't know this until the first message crashes

`hermes doctor` should catch this proactively.

## Changes

New "Model Compatibility" section in `run_doctor()` that:
1. Reads `model.default` and `model.base_url` from config
2. Only runs for local endpoints (localhost, private IPs) — remote providers manage context automatically
3. Resolves the model's context length via `get_model_context_length()`
4. Checks against 16,384 minimum (Hermes system prompt size)
5. Fails with clear guidance: `"Load model 'X' with context_length >= 16384 (current: 8192)"`
6. Also checks `inference.model` if configured separately

## How to test

```bash
# Load a model with insufficient context
curl http://localhost:1234/api/v1/models/load -H "Content-Type: application/json" \
  -d '{"model": "mistralai/ministral-3-3b", "context_length": 8192}'

# Run doctor — should fail with clear message
hermes doctor

# Fix by loading with correct context
curl http://localhost:1234/api/v1/models/load -H "Content-Type: application/json" \
  -d '{"model": "mistralai/ministral-3-3b", "context_length": 16384}'

# Run doctor again — should pass
hermes doctor
```

## Platform

macOS (Apple Silicon M1, 8GB RAM) with LM Studio local server.