### PR TITLE
fix(api-server): add CORS headers to streaming SSE responses

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -568,7 +568,11 @@ class APIServerAdapter(BasePlatformAdapter):
 
         response = web.StreamResponse(
             status=200,
-            headers={"Content-Type": "text/event-stream", "Cache-Control": "no-cache"},
+            headers={
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                **_CORS_HEADERS,  # add CORS headers to streaming responses
+            },
         )
         await response.prepare(request)
 


### PR DESCRIPTION
Fixes #3378

## Problem
CORS headers were only added to non-streaming responses via aiohttp's cors_middleware. StreamResponse objects are prepared before the middleware can add headers, so streaming SSE responses were missing CORS headers.

## Fix
Explicitly include _CORS_HEADERS in the StreamResponse headers dict at creation time. One-line fix.
