### PR TITLE
fix(cli): /reasoning wipes session token counters and cost tracking

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1929,7 +1929,7 @@ class HermesCLI:
         # AIAgent/OpenAI client holds auth at init time, so rebuild if key,
         # routing, or the effective model changed.
         if (credentials_changed or routing_changed or model_changed) and self.agent is not None:
-            self.agent = None
+            self._reinit_agent_preserve_counters()
             self._active_agent_route_signature = None
 
         return True
@@ -1951,6 +1951,36 @@ class HermesCLI:
                 "args": list(self.acp_args or []),
             },
         )
+
+    _SESSION_COUNTER_FIELDS = (
+        "session_total_tokens", "session_input_tokens", "session_output_tokens",
+        "session_prompt_tokens", "session_completion_tokens",
+        "session_cache_read_tokens", "session_cache_write_tokens",
+        "session_reasoning_tokens", "session_api_calls",
+        "session_estimated_cost_usd", "session_cost_status", "session_cost_source",
+    )
+
+    def _reinit_agent_preserve_counters(self) -> None:
+        """Destroy the agent to force re-init, preserving session usage counters.
+
+        Commands like /reasoning, /prompt, and /personality need to rebuild the
+        agent with new config, but should not wipe token counts and cost data.
+        """
+        saved = {}
+        if self.agent:
+            for field in self._SESSION_COUNTER_FIELDS:
+                saved[field] = getattr(self.agent, field, None)
+        self.agent = None
+        self._pending_counter_restore = saved
+
+    def _restore_counters_if_pending(self) -> None:
+        """Restore saved counters onto the newly created agent."""
+        saved = getattr(self, "_pending_counter_restore", None)
+        if saved and self.agent:
+            for field, value in saved.items():
+                if value is not None:
+                    setattr(self.agent, field, value)
+            self._pending_counter_restore = None
 
     def _init_agent(self, *, model_override: str = None, runtime_override: dict = None, route_label: str = None) -> bool:
         """
@@ -2178,6 +2208,7 @@ class HermesCLI:
         except Exception:
             pass
 
+        self._restore_counters_if_pending()
         return True
 
     def _display_resumed_history(self):
@@ -3186,14 +3217,14 @@ class HermesCLI:
             
             if new_prompt.lower() == "clear":
                 self.system_prompt = ""
-                self.agent = None  # Force re-init
+                self._reinit_agent_preserve_counters()
                 if save_config_value("agent.system_prompt", ""):
                     print("(^_^)b System prompt cleared (saved to config)")
                 else:
                     print("(^_^) System prompt cleared (session only)")
             else:
                 self.system_prompt = new_prompt
-                self.agent = None  # Force re-init
+                self._reinit_agent_preserve_counters()
                 if save_config_value("agent.system_prompt", new_prompt):
                     print("(^_^)b System prompt set (saved to config)")
                 else:
@@ -3253,7 +3284,7 @@ class HermesCLI:
             
             if personality_name in ("none", "default", "neutral"):
                 self.system_prompt = ""
-                self.agent = None  # Force re-init
+                self._reinit_agent_preserve_counters()
                 if save_config_value("agent.system_prompt", ""):
                     print("(^_^)b Personality cleared (saved to config)")
                 else:
@@ -3261,7 +3292,7 @@ class HermesCLI:
                 print("  No personality overlay — using base agent behavior.")
             elif personality_name in self.personalities:
                 self.system_prompt = self._resolve_personality_prompt(self.personalities[personality_name])
-                self.agent = None  # Force re-init
+                self._reinit_agent_preserve_counters()
                 if save_config_value("agent.system_prompt", self.system_prompt):
                     print(f"(^_^)b Personality set to '{personality_name}' (saved to config)")
                 else:
@@ -4415,7 +4446,11 @@ class HermesCLI:
             return
 
         self.reasoning_config = parsed
-        self.agent = None  # Force agent re-init with new reasoning config
+        if self.agent:
+            self.agent.reasoning_config = parsed
+            self.agent._invalidate_system_prompt()
+        else:
+            self._reinit_agent_preserve_counters()
 
         if save_config_value("agent.reasoning_effort", arg):
             _cprint(f"  {_GOLD}✓ Reasoning effort set to '{arg}' (saved to config){_RST}")

--- a/tests/test_cli_counter_preserve.py
+++ b/tests/test_cli_counter_preserve.py
@@ -1,0 +1,93 @@
+"""Tests for session counter preservation across agent re-init.
+
+Commands like /reasoning, /prompt, and /personality need to change agent
+config without wiping token counters and cost data. /reasoning updates
+the agent in place; /prompt and /personality use _reinit_agent_preserve_counters.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def _make_cli_stub():
+    """Build a minimal CLI object with the counter-preservation methods."""
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._pending_counter_restore = None
+
+    # Fake agent with some usage
+    agent = MagicMock()
+    agent.session_total_tokens = 5000
+    agent.session_input_tokens = 3000
+    agent.session_output_tokens = 2000
+    agent.session_prompt_tokens = 3000
+    agent.session_completion_tokens = 2000
+    agent.session_cache_read_tokens = 100
+    agent.session_cache_write_tokens = 500
+    agent.session_reasoning_tokens = 0
+    agent.session_api_calls = 3
+    agent.session_estimated_cost_usd = 0.25
+    agent.session_cost_status = "estimated"
+    agent.session_cost_source = "official_docs_snapshot"
+    agent.reasoning_config = None
+    cli.agent = agent
+    return cli
+
+
+class TestReasoningUpdatesInPlace:
+
+    def test_reasoning_config_set_on_existing_agent(self):
+        """When agent exists, /reasoning should update config in place, not destroy."""
+        cli = _make_cli_stub()
+        old_agent = cli.agent
+
+        # Simulate what the /reasoning handler does
+        parsed = {"enabled": True, "effort": "high"}
+        cli.reasoning_config = parsed
+        if cli.agent:
+            cli.agent.reasoning_config = parsed
+
+        assert cli.agent is old_agent  # same object, not destroyed
+        assert cli.agent.reasoning_config == {"enabled": True, "effort": "high"}
+        assert cli.agent.session_total_tokens == 5000  # counters preserved
+
+
+class TestReinitPreservesCounters:
+
+    def test_counters_saved_before_destroy(self):
+        cli = _make_cli_stub()
+        cli._reinit_agent_preserve_counters()
+
+        assert cli.agent is None
+        assert cli._pending_counter_restore["session_total_tokens"] == 5000
+        assert cli._pending_counter_restore["session_api_calls"] == 3
+
+    def test_counters_restored_onto_new_agent(self):
+        cli = _make_cli_stub()
+        cli._reinit_agent_preserve_counters()
+
+        cli.agent = SimpleNamespace(
+            session_total_tokens=0, session_input_tokens=0, session_output_tokens=0,
+            session_prompt_tokens=0, session_completion_tokens=0,
+            session_cache_read_tokens=0, session_cache_write_tokens=0,
+            session_reasoning_tokens=0, session_api_calls=0,
+            session_estimated_cost_usd=0.0, session_cost_status="unknown",
+            session_cost_source="none",
+        )
+        cli._restore_counters_if_pending()
+
+        assert cli.agent.session_total_tokens == 5000
+        assert cli.agent.session_api_calls == 3
+
+    def test_no_pending_restore_is_noop(self):
+        cli = _make_cli_stub()
+        cli._restore_counters_if_pending()
+        assert cli.agent.session_total_tokens == 5000
+
+    def test_restore_clears_pending(self):
+        cli = _make_cli_stub()
+        cli._reinit_agent_preserve_counters()
+        cli.agent = SimpleNamespace(**{f: 0 for f in cli._SESSION_COUNTER_FIELDS})
+        cli._restore_counters_if_pending()
+        assert cli._pending_counter_restore is None


### PR DESCRIPTION
## Summary

Typing `/reasoning high` (or any level) mid-session destroys the agent and resets all token counters to zero. `/usage` shows "No active agent" until the next message, and when it does come back, all prior usage is lost.

Same bug affects `/prompt` and `/personality`.

**Before — counters wiped after `/reasoning high`:**

![before fix](https://i.imgur.com/BD1madl.png)

**After — counters preserved:**

![after fix](https://i.imgur.com/X3teSt1.png)

## Root Cause

The `/reasoning` handler at `cli.py:4418` sets `self.agent = None` to force re-initialization with the new config. This destroys the `AIAgent` object, which holds all session counters (`session_input_tokens`, `session_output_tokens`, `session_api_calls`, `session_estimated_cost_usd`, etc.). The same pattern appears in `/prompt` (lines 3189, 3196) and `/personality` (lines 3256, 3264).

## Fix

**`/reasoning`** — update the agent's `reasoning_config` in place instead of destroying it. The reasoning config is just a dict on the agent — no need to rebuild the entire object.

```python
if self.agent:
    self.agent.reasoning_config = parsed
    self.agent._invalidate_system_prompt()
```

**`/prompt` and `/personality`** — these do need to rebuild the agent (system prompt is baked into construction). Added `_reinit_agent_preserve_counters()` that snapshots all counter fields before setting `self.agent = None`, and `_restore_counters_if_pending()` that writes them back after `_init_agent()` completes.

## Tests

5 new tests: reasoning updates in place, counters saved before destroy, counters restored onto new agent, no-op when no pending restore, pending cleared after restore.

```
5 passed
```