### PR TITLE
fix(api-server): improve CORS headers

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -166,7 +166,8 @@ class ResponseStore:
 
 _CORS_HEADERS = {
     "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
-    "Access-Control-Allow-Headers": "Authorization, Content-Type",
+    # Include Idempotency-Key so browser clients can use request deduplication safely.
+    "Access-Control-Allow-Headers": "Authorization, Content-Type, Idempotency-Key",
 }
 
 
@@ -185,10 +186,14 @@ if AIOHTTP_AVAILABLE:
         if request.method == "OPTIONS":
             if cors_headers is None:
                 return web.Response(status=403)
+            # Ensure downstream caches do not serve one origin's CORS response to another.
+            cors_headers.setdefault("Vary", "Origin")
             return web.Response(status=200, headers=cors_headers)
 
         response = await handler(request)
         if cors_headers is not None:
+            # Ensure downstream caches do not serve one origin's CORS response to another.
+            cors_headers.setdefault("Vary", "Origin")
             response.headers.update(cors_headers)
         return response
 else:

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1301,6 +1301,33 @@ class TestCORS:
             assert "DELETE" in resp.headers.get("Access-Control-Allow-Methods", "")
 
     @pytest.mark.asyncio
+
+
+    @pytest.mark.asyncio
+    async def test_cors_allows_idempotency_key_header(self):
+        adapter = _make_adapter(cors_origins=["http://localhost:3000"])
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.options(
+                "/v1/chat/completions",
+                headers={
+                    "Origin": "http://localhost:3000",
+                    "Access-Control-Request-Method": "POST",
+                    "Access-Control-Request-Headers": "Idempotency-Key",
+                },
+            )
+            assert resp.status == 200
+            assert "Idempotency-Key" in resp.headers.get("Access-Control-Allow-Headers", "")
+
+    @pytest.mark.asyncio
+    async def test_cors_sets_vary_origin_header(self):
+        adapter = _make_adapter(cors_origins=["http://localhost:3000"])
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/health", headers={"Origin": "http://localhost:3000"})
+            assert resp.status == 200
+            assert resp.headers.get("Vary") == "Origin"
+
     async def test_cors_options_preflight_allowed_for_configured_origin(self):
         """Configured origins can complete browser preflight."""
         adapter = _make_adapter(cors_origins=["http://localhost:3000"])

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1328,6 +1328,7 @@ class TestCORS:
             assert resp.status == 200
             assert resp.headers.get("Vary") == "Origin"
 
+    @pytest.mark.asyncio
     async def test_cors_options_preflight_allowed_for_configured_origin(self):
         """Configured origins can complete browser preflight."""
         adapter = _make_adapter(cors_origins=["http://localhost:3000"])


### PR DESCRIPTION
This PR makes two small, high-impact CORS improvements for the API server:

- Allow `Idempotency-Key` in `Access-Control-Allow-Headers` so browser clients can use idempotency safely.
- Ensure `Vary: Origin` is set for CORS responses to prevent cache/proxy mix-ups between different origins.

Tests:
- Add unit tests that assert `Idempotency-Key` is allowed on preflight and `Vary: Origin` is returned for allowed origins.