### PR TITLE
feat(skills): add garrytan/gstack as default Skills Hub tap

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -251,6 +251,7 @@ class GitHubSource(SkillSource):
         {"repo": "openai/skills", "path": "skills/"},
         {"repo": "anthropics/skills", "path": "skills/"},
         {"repo": "VoltAgent/awesome-agent-skills", "path": "skills/"},
+        {"repo": "garrytan/gstack", "path": ""},
     ]
 
     def __init__(self, auth: GitHubAuth, extra_taps: Optional[List[Dict]] = None):
@@ -395,7 +396,8 @@ class GitHubSource(SkillSource):
             if dir_name.startswith(".") or dir_name.startswith("_"):
                 continue
 
-            skill_identifier = f"{repo}/{path.rstrip('/')}/{dir_name}"
+            prefix = path.rstrip("/")
+            skill_identifier = f"{repo}/{prefix}/{dir_name}" if prefix else f"{repo}/{dir_name}"
             meta = self.inspect(skill_identifier)
             if meta:
                 skills.append(meta)


### PR DESCRIPTION
## What

Adds `garrytan/gstack` to `GitHubSource.DEFAULT_TAPS` in `tools/skills_hub.py` so that gstack skills are discoverable via `hermes skills search`.

Also fixes a minor bug in `_list_skills_in_repo` where an empty `path` in a tap would produce double-slash identifiers (e.g. `garrytan/gstack//review` instead of `garrytan/gstack/review`).

## Why

gstack (51k+ stars, 6.6k forks) is a popular collection of opinionated agent skills by Garry Tan. Individual skills can already be installed via `hermes skills install garrytan/gstack/<skill>`, but without a tap entry, users cannot discover them through `hermes skills search gstack` or `hermes skills browse`.

This was requested in #3224, and as noted by @Mibayy in the issue comments, adding the tap is a one-liner — the existing `GitHubSource` machinery handles the rest.

## Changes

- **`tools/skills_hub.py` line 251**: Added `{"repo": "garrytan/gstack", "path": ""}` to `DEFAULT_TAPS` (skills live at the repo root, not in a `skills/` subdirectory)
- **`tools/skills_hub.py` line 399**: Fixed `skill_identifier` construction to avoid double slashes when tap path is empty

## How to test

1. Run `hermes skills search gstack` — gstack skills (review, ship, qa, design-review, etc.) should appear in results
2. Run `hermes skills install garrytan/gstack/review` — should install successfully
3. Existing taps (openai/skills, anthropics/skills, VoltAgent) should continue working

### Verified

- GitHub API confirms 28 out of 36 gstack root directories contain valid SKILL.md files
- Non-skill directories (agents, bin, docs, lib, scripts, etc.) are correctly filtered
- Clean identifiers: `garrytan/gstack/review` (not `garrytan/gstack//review`)

## Platform tested

- Linux (Ubuntu, Python 3.11)

## Test results

```
86 passed in 40.90s (tests/tools/test_skills_hub.py + tests/hermes_cli/test_skills_hub.py)
```

Closes #3224