### PR TITLE
fix: guard LLM response content against None before calling .strip()

### DIFF
--- a/tests/tools/test_llm_content_none_guard.py
+++ b/tests/tools/test_llm_content_none_guard.py
@@ -1,0 +1,218 @@
+"""Tests for None guard on response.choices[0].message.content.strip().
+
+OpenAI-compatible APIs return ``message.content = None`` when the model
+responds with tool calls only or reasoning-only output (e.g. DeepSeek-R1,
+Qwen-QwQ via OpenRouter with ``reasoning.enabled = True``).  Calling
+``.strip()`` on ``None`` raises ``AttributeError``.
+
+These tests verify that every call site handles ``content is None`` safely.
+"""
+
+import asyncio
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+def _make_response(content):
+    """Build a minimal OpenAI-compatible ChatCompletion response stub."""
+    message = types.SimpleNamespace(content=content, tool_calls=None)
+    choice = types.SimpleNamespace(message=message)
+    return types.SimpleNamespace(choices=[choice])
+
+
+def _run(coro):
+    """Run an async coroutine synchronously."""
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ── mixture_of_agents_tool — reference model (line 146) ───────────────────
+
+class TestMoAReferenceModelContentNone:
+    """tools/mixture_of_agents_tool.py — _query_model()"""
+
+    def test_none_content_raises_before_fix(self):
+        """Demonstrate that None content from a reasoning model crashes."""
+        response = _make_response(None)
+
+        # Simulate the exact line: response.choices[0].message.content.strip()
+        with pytest.raises(AttributeError):
+            response.choices[0].message.content.strip()
+
+    def test_none_content_safe_with_or_guard(self):
+        """The ``or ""`` guard should convert None to empty string."""
+        response = _make_response(None)
+
+        content = (response.choices[0].message.content or "").strip()
+        assert content == ""
+
+    def test_normal_content_unaffected(self):
+        """Regular string content should pass through unchanged."""
+        response = _make_response("  Hello world  ")
+
+        content = (response.choices[0].message.content or "").strip()
+        assert content == "Hello world"
+
+
+# ── mixture_of_agents_tool — aggregator (line 214) ────────────────────────
+
+class TestMoAAggregatorContentNone:
+    """tools/mixture_of_agents_tool.py — _run_aggregator()"""
+
+    def test_none_content_raises_before_fix(self):
+        response = _make_response(None)
+
+        with pytest.raises(AttributeError):
+            response.choices[0].message.content.strip()
+
+    def test_none_content_safe_with_or_guard(self):
+        response = _make_response(None)
+
+        content = (response.choices[0].message.content or "").strip()
+        assert content == ""
+
+
+# ── web_tools — LLM content processor (line 419) ─────────────────────────
+
+class TestWebToolsProcessorContentNone:
+    """tools/web_tools.py — _process_with_llm() return line"""
+
+    def test_none_content_raises_before_fix(self):
+        response = _make_response(None)
+
+        with pytest.raises(AttributeError):
+            response.choices[0].message.content.strip()
+
+    def test_none_content_safe_with_or_guard(self):
+        response = _make_response(None)
+
+        content = (response.choices[0].message.content or "").strip()
+        assert content == ""
+
+
+# ── web_tools — synthesis/summarization (line 538) ────────────────────────
+
+class TestWebToolsSynthesisContentNone:
+    """tools/web_tools.py — synthesize_content() final_summary line"""
+
+    def test_none_content_raises_before_fix(self):
+        response = _make_response(None)
+
+        with pytest.raises(AttributeError):
+            response.choices[0].message.content.strip()
+
+    def test_none_content_safe_with_or_guard(self):
+        response = _make_response(None)
+
+        content = (response.choices[0].message.content or "").strip()
+        assert content == ""
+
+
+# ── vision_tools (line 350) ───────────────────────────────────────────────
+
+class TestVisionToolsContentNone:
+    """tools/vision_tools.py — analyze_image() analysis extraction"""
+
+    def test_none_content_raises_before_fix(self):
+        response = _make_response(None)
+
+        with pytest.raises(AttributeError):
+            response.choices[0].message.content.strip()
+
+    def test_none_content_safe_with_or_guard(self):
+        response = _make_response(None)
+
+        content = (response.choices[0].message.content or "").strip()
+        assert content == ""
+
+
+# ── skills_guard (line 963) ───────────────────────────────────────────────
+
+class TestSkillsGuardContentNone:
+    """tools/skills_guard.py — _llm_audit_skill() llm_text extraction"""
+
+    def test_none_content_raises_before_fix(self):
+        response = _make_response(None)
+
+        with pytest.raises(AttributeError):
+            response.choices[0].message.content.strip()
+
+    def test_none_content_safe_with_or_guard(self):
+        response = _make_response(None)
+
+        content = (response.choices[0].message.content or "").strip()
+        assert content == ""
+
+
+# ── session_search_tool (line 164) ────────────────────────────────────────
+
+class TestSessionSearchContentNone:
+    """tools/session_search_tool.py — _summarize_session() return line"""
+
+    def test_none_content_raises_before_fix(self):
+        response = _make_response(None)
+
+        with pytest.raises(AttributeError):
+            response.choices[0].message.content.strip()
+
+    def test_none_content_safe_with_or_guard(self):
+        response = _make_response(None)
+
+        content = (response.choices[0].message.content or "").strip()
+        assert content == ""
+
+
+# ── integration: verify the actual source lines are guarded ───────────────
+
+class TestSourceLinesAreGuarded:
+    """Read the actual source files and verify the fix is applied.
+
+    These tests will FAIL before the fix (bare .content.strip()) and
+    PASS after ((.content or "").strip()).
+    """
+
+    @staticmethod
+    def _read_file(rel_path: str) -> str:
+        import os
+        base = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        with open(os.path.join(base, rel_path)) as f:
+            return f.read()
+
+    def test_mixture_of_agents_reference_model_guarded(self):
+        src = self._read_file("tools/mixture_of_agents_tool.py")
+        # The unguarded pattern should NOT exist
+        assert ".message.content.strip()" not in src, (
+            "tools/mixture_of_agents_tool.py still has unguarded "
+            ".content.strip() — apply `(... or \"\").strip()` guard"
+        )
+
+    def test_web_tools_guarded(self):
+        src = self._read_file("tools/web_tools.py")
+        assert ".message.content.strip()" not in src, (
+            "tools/web_tools.py still has unguarded "
+            ".content.strip() — apply `(... or \"\").strip()` guard"
+        )
+
+    def test_vision_tools_guarded(self):
+        src = self._read_file("tools/vision_tools.py")
+        assert ".message.content.strip()" not in src, (
+            "tools/vision_tools.py still has unguarded "
+            ".content.strip() — apply `(... or \"\").strip()` guard"
+        )
+
+    def test_skills_guard_guarded(self):
+        src = self._read_file("tools/skills_guard.py")
+        assert ".message.content.strip()" not in src, (
+            "tools/skills_guard.py still has unguarded "
+            ".content.strip() — apply `(... or \"\").strip()` guard"
+        )
+
+    def test_session_search_tool_guarded(self):
+        src = self._read_file("tools/session_search_tool.py")
+        assert ".message.content.strip()" not in src, (
+            "tools/session_search_tool.py still has unguarded "
+            ".content.strip() — apply `(... or \"\").strip()` guard"
+        )

--- a/tools/mixture_of_agents_tool.py
+++ b/tools/mixture_of_agents_tool.py
@@ -143,7 +143,7 @@ async def _run_reference_model_safe(
             
             response = await _get_openrouter_client().chat.completions.create(**api_params)
             
-            content = response.choices[0].message.content.strip()
+            content = (response.choices[0].message.content or "").strip()
             logger.info("%s responded (%s characters)", model, len(content))
             return model, content, True
             
@@ -211,7 +211,7 @@ async def _run_aggregator_model(
 
     response = await _get_openrouter_client().chat.completions.create(**api_params)
 
-    content = response.choices[0].message.content.strip()
+    content = (response.choices[0].message.content or "").strip()
     logger.info("Aggregation complete (%s characters)", len(content))
     return content
 

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -161,7 +161,7 @@ async def _summarize_session(
                 temperature=0.1,
                 max_tokens=MAX_SUMMARY_TOKENS,
             )
-            return response.choices[0].message.content.strip()
+            return (response.choices[0].message.content or "").strip()
         except RuntimeError:
             logging.warning("No auxiliary model available for session summarization")
             return None

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -960,7 +960,7 @@ def llm_audit_skill(skill_path: Path, static_result: ScanResult,
             temperature=0,
             max_tokens=1000,
         )
-        llm_text = response.choices[0].message.content.strip()
+        llm_text = (response.choices[0].message.content or "").strip()
     except Exception:
         # LLM audit is best-effort — don't block install if the call fails
         return static_result

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -347,7 +347,7 @@ async def vision_analyze_tool(
         response = await async_call_llm(**call_kwargs)
         
         # Extract the analysis
-        analysis = response.choices[0].message.content.strip()
+        analysis = (response.choices[0].message.content or "").strip()
         analysis_length = len(analysis)
         
         logger.info("Image analysis completed (%s characters)", analysis_length)

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -416,7 +416,7 @@ Create a markdown summary that captures all key information in a well-organized,
             if model:
                 call_kwargs["model"] = model
             response = await async_call_llm(**call_kwargs)
-            return response.choices[0].message.content.strip()
+            return (response.choices[0].message.content or "").strip()
         except RuntimeError:
             logger.warning("No auxiliary model available for web content processing")
             return None
@@ -535,7 +535,7 @@ Create a single, unified markdown summary."""
         if model:
             call_kwargs["model"] = model
         response = await async_call_llm(**call_kwargs)
-        final_summary = response.choices[0].message.content.strip()
+        final_summary = (response.choices[0].message.content or "").strip()
         
         # Enforce hard cap
         if len(final_summary) > max_output_size:


### PR DESCRIPTION
OpenAI-compatible APIs return `message.content = None` when a model responds with tool calls only or reasoning-only output — for example DeepSeek-R1 or Qwen-QwQ via OpenRouter with `reasoning.enabled = True`. Several tool files call `.strip()` directly on the content without a None check, which crashes with `AttributeError: 'NoneType' object has no attribute 'strip'`.

## Changes Made

Applied `(response.choices[0].message.content or "").strip()` at all 7 unguarded call sites:

| File | Lines |
|------|-------|
| `tools/mixture_of_agents_tool.py` | 146, 214 |
| `tools/web_tools.py` | 419, 538 |
| `tools/vision_tools.py` | 350 |
| `tools/skills_guard.py` | 963 |
| `tools/session_search_tool.py` | 164 |

This is the same `or ""` coalescing pattern already used in `trajectory_compressor.py` (merged in #1327).

## How to Test

```bash
python3 -m pytest tests/tools/test_llm_content_none_guard.py -v
```

**Before fix** — 5 source-guard tests fail, confirming the unguarded `.content.strip()`:

![before fix](https://iili.io/qt89IhG.png)

**After fix** — all 20 tests pass:

![after fix](https://iili.io/qt8HgDu.png)

## Checklist

- [x] Tests added (20 tests covering all 7 sites)
- [x] Full test suite run — no regressions
- [x] Tested on Linux (Ubuntu 22.04)