### PR TITLE
fix(tools): use non-deprecated streamable_http_client for MCP HTTP transport

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -94,7 +94,7 @@ try:
     from mcp.client.stdio import stdio_client
     _MCP_AVAILABLE = True
     try:
-        from mcp.client.streamable_http import streamablehttp_client
+        from mcp.client.streamable_http import streamablehttp_client, streamable_http_client
         _MCP_HTTP_AVAILABLE = True
     except ImportError:
         _MCP_HTTP_AVAILABLE = False
@@ -748,6 +748,8 @@ class MCPServerTask:
                 "Upgrade the mcp package to get HTTP support."
             )
 
+        import httpx
+
         url = config["url"]
         headers = dict(config.get("headers") or {})
         connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
@@ -762,13 +764,19 @@ class MCPServerTask:
                 logger.warning("MCP OAuth setup failed for '%s': %s", self.name, exc)
 
         sampling_kwargs = self._sampling.session_kwargs() if self._sampling else {}
-        _http_kwargs: dict = {
-            "headers": headers,
-            "timeout": float(connect_timeout),
+
+        # Build httpx client with auth headers (new non-deprecated API)
+        http_kwargs: dict = {
+            "follow_redirects": True,
+            "timeout": httpx.Timeout(float(connect_timeout), read=300.0),
         }
+        if headers:
+            http_kwargs["headers"] = headers
         if _oauth_auth is not None:
-            _http_kwargs["auth"] = _oauth_auth
-        async with streamablehttp_client(url, **_http_kwargs) as (
+            http_kwargs["auth"] = _oauth_auth
+
+        http_client = httpx.AsyncClient(**http_kwargs)
+        async with streamable_http_client(url, http_client=http_client) as (
             read_stream, write_stream, _get_session_id,
         ):
             async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:


### PR DESCRIPTION
## What changed

`tools/mcp_tool.py` — switched MCP HTTP transport from the deprecated `streamablehttp_client()` to the new `streamable_http_client()` API that accepts a pre-built `httpx.AsyncClient`.

## Why

The `mcp` Python package deprecated `streamablehttp_client()` in favor of `streamable_http_client()`. The old API accepted raw kwargs (`headers`, `timeout`) that it internally mapped to an httpx client. The new API requires the caller to build the `httpx.AsyncClient` explicitly, giving better control over timeouts, redirects, and auth.

Using the deprecated API produces warnings today and will break when the `mcp` package removes it in a future release.

## Changes

- Import `streamable_http_client` alongside the legacy `streamablehttp_client` (kept for fallback detection)
- Build an explicit `httpx.AsyncClient` with:
  - `follow_redirects=True`
  - `httpx.Timeout(connect_timeout, read=300.0)` — generous read timeout for long-running MCP tool calls
  - Auth headers from config
  - OAuth auth when configured
- Pass the pre-built client via `http_client=` kwarg

## How to test

1. Configure an HTTP-based MCP server (e.g. Z.AI, any StreamableHTTP endpoint) in `~/.hermes/config.yaml`
2. Run `hermes chat -q "list available MCP tools"` — verify the server connects without deprecation warnings
3. Exercise an MCP tool call — verify it completes successfully

Unit tests: `pytest tests/tools/test_mcp_tool.py tests/tools/test_mcp_oauth.py tests/tools/test_mcp_probe.py` — all 176 pass.

## Tested on

- Ubuntu 22.04 (WSL2), Python 3.11, mcp>=1.2.0, httpx>=0.28.1

## Checklist

- [x] One logical change per PR
- [x] Tests pass
- [x] Conventional commit message
- [x] No new dependencies (httpx already required)