### PR TITLE
feat(setup): add provider-linked MCP setup presets

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1427,32 +1427,51 @@ def _normalize_max_turns_config(config: Dict[str, Any]) -> Dict[str, Any]:
     return config
 
 
+def _load_user_config_file() -> Dict[str, Any]:
+    """Load the raw user config file without applying defaults or env expansion."""
+    ensure_hermes_home()
+    config_path = get_config_path()
+    if not config_path.exists():
+        return {}
+
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            user_config = yaml.safe_load(f) or {}
+    except Exception as e:
+        print(f"Warning: Failed to load config: {e}")
+        return {}
+
+    return user_config if isinstance(user_config, dict) else {}
+
+
+def load_raw_config() -> Dict[str, Any]:
+    """Load raw configuration from ~/.hermes/config.yaml without env expansion."""
+    return _load_user_config_file()
+
+
 
 def load_config() -> Dict[str, Any]:
     """Load configuration from ~/.hermes/config.yaml."""
     import copy
     ensure_hermes_home()
-    config_path = get_config_path()
-    
-    config = copy.deepcopy(DEFAULT_CONFIG)
-    
-    if config_path.exists():
-        try:
-            with open(config_path, encoding="utf-8") as f:
-                user_config = yaml.safe_load(f) or {}
 
-            if "max_turns" in user_config:
-                agent_user_config = dict(user_config.get("agent") or {})
-                if agent_user_config.get("max_turns") is None:
-                    agent_user_config["max_turns"] = user_config["max_turns"]
-                user_config["agent"] = agent_user_config
-                user_config.pop("max_turns", None)
+    default_config = copy.deepcopy(DEFAULT_CONFIG)
+    try:
+        user_config = _load_user_config_file()
+        if "max_turns" in user_config:
+            agent_user_config = dict(user_config.get("agent") or {})
+            if agent_user_config.get("max_turns") is None:
+                agent_user_config["max_turns"] = user_config["max_turns"]
+            user_config["agent"] = agent_user_config
+            user_config.pop("max_turns", None)
 
-            config = _deep_merge(config, user_config)
-        except Exception as e:
-            print(f"Warning: Failed to load config: {e}")
-    
-    return _expand_env_vars(_normalize_root_model_keys(_normalize_max_turns_config(config)))
+        config = _deep_merge(default_config, user_config)
+        return _expand_env_vars(_normalize_root_model_keys(_normalize_max_turns_config(config)))
+    except Exception as e:
+        print(f"Warning: Failed to load config: {e}")
+        return _expand_env_vars(
+            _normalize_root_model_keys(_normalize_max_turns_config(default_config))
+        )
 
 
 _SECURITY_COMMENT = """

--- a/hermes_cli/mcp_presets.py
+++ b/hermes_cli/mcp_presets.py
@@ -1,0 +1,755 @@
+"""Provider-linked MCP preset resolution for setup-time convenience flows."""
+
+from __future__ import annotations
+
+import copy
+import shutil
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+_PRESET_DATA_PATH: Path | None = None
+_SUPPORTED_DEFAULT_CHECKED_WHEN_KEYS = frozenset({"command_available"})
+
+
+def _normalize_runtime_server_name(name: str) -> str:
+    return name.replace("-", "_").replace(".", "_")
+
+
+def _config_transport_kind(config: Any) -> str | None:
+    if not isinstance(config, dict):
+        return None
+
+    has_url = isinstance(config.get("url"), str) and bool(config["url"].strip())
+    has_command = isinstance(config.get("command"), str) and bool(
+        config["command"].strip()
+    )
+    if has_url and has_command:
+        return "mixed"
+    if has_url:
+        return "http"
+    if has_command:
+        return "stdio"
+    return None
+
+
+def _freeze_config_value(value: Any) -> Any:
+    if isinstance(value, dict):
+        return tuple(
+            (str(key), _freeze_config_value(val))
+            for key, val in sorted(value.items(), key=lambda item: str(item[0]))
+        )
+    if isinstance(value, list):
+        return tuple(_freeze_config_value(item) for item in value)
+    return value
+
+
+def _server_transport_identity(server_config: Any) -> tuple[str, Any] | None:
+    if not isinstance(server_config, dict):
+        return None
+
+    url = server_config.get("url")
+    if isinstance(url, str) and url.strip():
+        return (
+            "http",
+            _freeze_config_value(
+                {
+                    "url": url.strip(),
+                    "headers": server_config.get("headers"),
+                    "auth": server_config.get("auth"),
+                }
+            ),
+        )
+
+    command = server_config.get("command")
+    if isinstance(command, str) and command.strip():
+        return (
+            "stdio",
+            _freeze_config_value(
+                {
+                    "command": command.strip(),
+                    "args": server_config.get("args") or [],
+                    "env": server_config.get("env"),
+                    "auth": server_config.get("auth"),
+                }
+            ),
+        )
+
+    return None
+
+
+def _server_transport_identity_variants(server_config: Any) -> list[tuple[str, Any]]:
+    identities: list[tuple[str, Any]] = []
+    raw_identity = _server_transport_identity(server_config)
+    if raw_identity is not None:
+        identities.append(raw_identity)
+
+    try:
+        from hermes_cli.config import _expand_env_vars
+
+        expanded_config = _expand_env_vars(server_config)
+    except Exception:
+        expanded_config = server_config
+
+    expanded_identity = _server_transport_identity(expanded_config)
+    if expanded_identity is not None and expanded_identity not in identities:
+        identities.append(expanded_identity)
+
+    return identities
+
+
+def _read_preset_data_text() -> str:
+    if _PRESET_DATA_PATH is not None:
+        return _PRESET_DATA_PATH.read_text(encoding="utf-8")
+    return (
+        resources.files("hermes_cli")
+        .joinpath("mcp_provider_presets.yaml")
+        .read_text(encoding="utf-8")
+    )
+
+
+def snapshot_existing_mcp_servers_raw(
+    config: dict[str, Any],
+    *,
+    raw_config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a raw MCP snapshot that preserves disk placeholders and in-memory edits."""
+
+    snapshot: dict[str, Any] = {}
+    raw_mcp_servers = raw_config.get("mcp_servers") if isinstance(raw_config, dict) else None
+    if isinstance(raw_mcp_servers, dict):
+        snapshot = copy.deepcopy(raw_mcp_servers)
+
+    current_mcp_servers = config.get("mcp_servers")
+    if isinstance(current_mcp_servers, dict):
+        for name, server in current_mcp_servers.items():
+            snapshot.setdefault(name, copy.deepcopy(server))
+
+    return snapshot
+
+
+def _match_key(entry: dict[str, Any]) -> tuple[str, str | None]:
+    match = entry.get("match", {})
+    provider = match.get("provider")
+    model = match.get("model")
+    return provider, model
+
+
+def _format_match_desc(provider: str, model: str | None) -> str:
+    provider_desc = f"provider '{provider}'"
+    if model:
+        provider_desc += f" model '{model}'"
+    return provider_desc
+
+
+def _entry_match_key(entry: Any) -> tuple[str, str | None] | None:
+    if not isinstance(entry, dict):
+        return None
+    match = entry.get("match")
+    if not isinstance(match, dict):
+        return None
+    provider = match.get("provider")
+    if not isinstance(provider, str) or not provider.strip():
+        return None
+    model = match.get("model")
+    if model is None:
+        return provider.strip(), None
+    if not isinstance(model, str) or not model.strip():
+        return None
+    return provider.strip(), model.strip()
+
+
+def _validate_server_entry(
+    server_name: str,
+    server_data: Any,
+    match_desc: str,
+) -> None:
+    if not isinstance(server_data, dict):
+        raise ValueError(
+            f"MCP preset server '{server_name}' for {match_desc} must be a mapping"
+        )
+
+    config = server_data.get("config")
+    if not isinstance(config, dict) or not config:
+        raise ValueError(
+            f"MCP preset server '{server_name}' for {match_desc} must include a non-empty config mapping"
+        )
+    if _config_transport_kind(config) == "mixed":
+        raise ValueError(
+            f"MCP preset server '{server_name}' for {match_desc} cannot define both 'url' and 'command'"
+        )
+
+    if "default_checked" in server_data and not isinstance(server_data["default_checked"], bool):
+        raise ValueError(
+            f"MCP preset server '{server_name}' for {match_desc} has invalid default_checked"
+        )
+
+    when = server_data.get("default_checked_when")
+    if when is not None:
+        if not isinstance(when, dict):
+            raise ValueError(
+                f"MCP preset server '{server_name}' for {match_desc} has invalid default_checked_when"
+            )
+        unsupported_keys = set(when) - _SUPPORTED_DEFAULT_CHECKED_WHEN_KEYS
+        if unsupported_keys:
+            raise ValueError(
+                "Unsupported default_checked_when keys for "
+                f"MCP preset server '{server_name}' for {match_desc}: "
+                + ", ".join(sorted(unsupported_keys))
+            )
+        command = when.get("command_available")
+        if command is not None and (not isinstance(command, str) or not command.strip()):
+            raise ValueError(
+                f"MCP preset server '{server_name}' for {match_desc} has invalid command_available"
+            )
+
+    note = server_data.get("note_when_unchecked")
+    if note is not None and not isinstance(note, str):
+        raise ValueError(
+            f"MCP preset server '{server_name}' for {match_desc} has invalid note_when_unchecked"
+        )
+
+
+def _validate_preset_entry(entry: Any, index: int) -> tuple[str, str | None]:
+    if not isinstance(entry, dict):
+        raise ValueError(f"MCP preset entry #{index + 1} must be a mapping")
+
+    match = entry.get("match")
+    if not isinstance(match, dict):
+        raise ValueError(f"MCP preset entry #{index + 1} is missing a match mapping")
+
+    provider = match.get("provider")
+    if not isinstance(provider, str) or not provider.strip():
+        raise ValueError(
+            f"MCP preset entry #{index + 1} must include a non-empty match.provider"
+        )
+    model = match.get("model")
+    if model is not None and (not isinstance(model, str) or not model.strip()):
+        raise ValueError(
+            f"MCP preset entry #{index + 1} has invalid match.model"
+        )
+
+    prompt = entry.get("prompt", {})
+    if not isinstance(prompt, dict):
+        raise ValueError(
+            f"MCP preset entry #{index + 1} prompt must be a mapping"
+        )
+    default_value = prompt.get("default")
+    if default_value is not None and not isinstance(default_value, bool):
+        raise ValueError(
+            f"MCP preset entry #{index + 1} prompt.default must be a boolean"
+        )
+
+    servers = entry.get("servers")
+    if not isinstance(servers, dict) or not servers:
+        raise ValueError(
+            f"MCP preset entry #{index + 1} must include a non-empty servers mapping"
+        )
+
+    match_desc = f"provider '{provider}'" if model is None else f"provider '{provider}' model '{model}'"
+    for server_name, server_data in servers.items():
+        if not isinstance(server_name, str) or not server_name.strip():
+            raise ValueError(
+                f"MCP preset entry #{index + 1} has an invalid server name"
+            )
+        _validate_server_entry(server_name, server_data, match_desc)
+
+    return provider, model.strip() if isinstance(model, str) else None
+
+
+def _load_presets() -> list[dict[str, Any]]:
+    try:
+        raw = yaml.safe_load(_read_preset_data_text()) or {}
+    except yaml.YAMLError as exc:
+        raise ValueError("Invalid MCP preset YAML") from exc
+    if not isinstance(raw, dict):
+        raise ValueError("MCP preset data must be a mapping")
+    presets = raw.get("presets", [])
+    if not isinstance(presets, list):
+        raise ValueError("MCP preset data 'presets' must be a list")
+    return _validate_preset_catalog(presets)
+
+
+def _matches(entry: dict[str, Any], provider: str, model: str | None) -> bool:
+    match = entry.get("match", {})
+    if not isinstance(match, dict):
+        return False
+    if match.get("provider") != provider:
+        return False
+    entry_model = match.get("model")
+    if entry_model is None:
+        return True
+    return entry_model == model
+
+
+def _deep_merge_mappings(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    merged = copy.deepcopy(base)
+    for key, value in override.items():
+        existing = merged.get(key)
+        if isinstance(existing, dict) and isinstance(value, dict):
+            merged[key] = _deep_merge_mappings(existing, value)
+        else:
+            merged[key] = copy.deepcopy(value)
+    return merged
+
+
+def _merge_server_config(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    base_transport = _config_transport_kind(base)
+    override_transport = _config_transport_kind(override)
+    if (
+        base_transport in {"http", "stdio"}
+        and override_transport in {"http", "stdio"}
+        and base_transport != override_transport
+    ):
+        return copy.deepcopy(override)
+    return _deep_merge_mappings(base, override)
+
+
+def _merge_server_entry(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    merged = copy.deepcopy(base)
+    for key, value in override.items():
+        existing = merged.get(key)
+        if key == "config" and isinstance(existing, dict) and isinstance(value, dict):
+            merged[key] = _merge_server_config(existing, value)
+        elif isinstance(existing, dict) and isinstance(value, dict):
+            merged[key] = _deep_merge_mappings(existing, value)
+        else:
+            merged[key] = copy.deepcopy(value)
+    return merged
+
+
+def _get_selected_model_name(config: dict[str, Any]) -> str | None:
+    current_model = config.get("model")
+    if isinstance(current_model, dict):
+        model_name = current_model.get("default")
+        if isinstance(model_name, str):
+            return model_name.strip() or None
+        return None
+    if isinstance(current_model, str):
+        return current_model.strip() or None
+    return None
+
+
+def _validate_runtime_server_name_uniqueness(
+    servers: dict[str, Any],
+    *,
+    provider: str,
+    model: str | None,
+) -> None:
+    seen: dict[str, str] = {}
+    for server_name in servers:
+        normalized_name = _normalize_runtime_server_name(server_name)
+        existing_name = seen.get(normalized_name)
+        if existing_name is None:
+            seen[normalized_name] = server_name
+            continue
+
+        raise ValueError(
+            "MCP preset bundle for "
+            f"{_format_match_desc(provider, model)} contains servers '{existing_name}' and "
+            f"'{server_name}' with the same runtime name"
+        )
+
+
+def _build_resolved_bundle(
+    presets: list[dict[str, Any]],
+    provider: str,
+    model: str | None,
+) -> dict[str, Any] | None:
+    provider_entries: list[dict[str, Any]] = []
+    model_entries: list[dict[str, Any]] = []
+
+    for entry in presets:
+        entry_match = _match_key(entry)
+        if entry_match[0] != provider:
+            continue
+
+        if not _matches(entry, provider, model):
+            continue
+
+        if entry_match[1] is None:
+            provider_entries.append(entry)
+        else:
+            model_entries.append(entry)
+
+    if not provider_entries and not model_entries:
+        return None
+
+    merged: dict[str, Any] = {
+        "prompt": {},
+        "servers": {},
+    }
+    for entry in provider_entries + model_entries:
+        prompt = entry.get("prompt", {})
+        if isinstance(prompt, dict):
+            merged["prompt"].update(copy.deepcopy(prompt))
+        servers = entry.get("servers", {})
+        if isinstance(servers, dict):
+            for server_name, server_data in servers.items():
+                if isinstance(server_data, dict) and isinstance(
+                    merged["servers"].get(server_name), dict
+                ):
+                    merged["servers"][server_name] = _merge_server_entry(
+                        merged["servers"][server_name],
+                        server_data,
+                    )
+                else:
+                    merged["servers"][server_name] = copy.deepcopy(server_data)
+
+    return merged
+
+
+def _validate_resolved_bundle(
+    bundle: dict[str, Any],
+    *,
+    provider: str,
+    model: str | None,
+) -> None:
+    servers = bundle.get("servers", {})
+    if not isinstance(servers, dict) or not servers:
+        raise ValueError(
+            f"MCP preset bundle for {_format_match_desc(provider, model)} has no servers"
+        )
+
+    _validate_runtime_server_name_uniqueness(
+        servers,
+        provider=provider,
+        model=model,
+    )
+    for server_name, server_data in servers.items():
+        if not isinstance(server_data, dict):
+            raise ValueError(
+                f"MCP preset bundle for {_format_match_desc(provider, model)} has invalid server '{server_name}'"
+            )
+        config = server_data.get("config")
+        if not isinstance(config, dict) or not config:
+            raise ValueError(
+                f"MCP preset bundle for {_format_match_desc(provider, model)} has invalid config for server '{server_name}'"
+            )
+        if _config_transport_kind(config) == "mixed":
+            raise ValueError(
+                f"MCP preset bundle for {_format_match_desc(provider, model)} has server '{server_name}' with both 'url' and 'command'"
+            )
+
+    prompt = bundle.get("prompt")
+    if (
+        not isinstance(prompt, dict)
+        or not prompt.get("question")
+        or not prompt.get("checklist_title")
+    ):
+        raise ValueError(
+            f"MCP preset bundle for {_format_match_desc(provider, model)} is missing prompt text"
+        )
+
+
+def _validate_preset_catalog(presets: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    validated_presets: list[dict[str, Any]] = []
+    seen_matches: set[tuple[str, str | None]] = set()
+    ordered_matches: list[tuple[str, str | None]] = []
+
+    for idx, entry in enumerate(presets):
+        validated_match = _validate_preset_entry(entry, idx)
+        if validated_match in seen_matches:
+            provider, entry_model = validated_match
+            if entry_model is None:
+                raise ValueError(f"Duplicate MCP preset match for provider '{provider}'")
+            raise ValueError(
+                f"Duplicate MCP preset match for provider '{provider}' model '{entry_model}'"
+            )
+        seen_matches.add(validated_match)
+        ordered_matches.append(validated_match)
+        validated_presets.append(entry)
+
+    for provider, model in ordered_matches:
+        bundle = _build_resolved_bundle(validated_presets, provider, model)
+        if bundle is None:
+            raise ValueError(
+                f"MCP preset bundle for {_format_match_desc(provider, model)} could not be resolved"
+            )
+        _validate_resolved_bundle(
+            bundle,
+            provider=provider,
+            model=model,
+        )
+
+    return validated_presets
+
+
+def resolve_provider_mcp_bundle(provider: str, model: str | None = None) -> dict[str, Any] | None:
+    """Resolve one setup-time MCP bundle for a provider and optional model.
+
+    Resolution order:
+    1. provider-only entries
+    2. provider+model exact matches
+
+    Later matches override earlier matches on prompt fields and server keys.
+    """
+
+    presets = _load_presets()
+    bundle = _build_resolved_bundle(presets, provider, model)
+    if bundle is None:
+        return None
+
+    _validate_resolved_bundle(
+        bundle,
+        provider=provider,
+        model=model,
+    )
+    return bundle
+
+
+def configure_provider_mcp_bundle(
+    config: dict[str, Any],
+    selected_provider: str | None,
+    *,
+    existing_mcp_servers_raw: dict[str, Any] | None = None,
+    prompt_yes_no,
+    prompt_checklist,
+    print_warning,
+    print_success,
+    logger,
+) -> None:
+    if not selected_provider:
+        return
+
+    bundle_model = _get_selected_model_name(config)
+    try:
+        provider_bundle = resolve_provider_mcp_bundle(
+            selected_provider,
+            model=bundle_model,
+        )
+    except Exception:
+        logger.exception(
+            "Failed to resolve provider-linked MCP presets for provider=%s model=%s",
+            selected_provider,
+            bundle_model,
+        )
+        print_warning(
+            "Failed to resolve provider-linked MCP presets; continuing without them."
+        )
+        return
+
+    if not provider_bundle:
+        return
+
+    prompt_cfg = provider_bundle.get("prompt", {})
+    enable_provider_mcp = prompt_yes_no(
+        prompt_cfg.get("question", "Enable MCP servers during setup?"),
+        default=bool(prompt_cfg.get("default", True)),
+    )
+    if not enable_provider_mcp:
+        return
+
+    bundle_server_names = list(provider_bundle.get("servers", {}))
+    default_checked, notes = get_bundle_default_checked_servers(provider_bundle)
+    default_checked_set = set(default_checked)
+    for note in notes:
+        print_warning(note)
+
+    pre_selected = [
+        idx
+        for idx, server_name in enumerate(bundle_server_names)
+        if server_name in default_checked_set
+    ]
+    selected_indices = prompt_checklist(
+        prompt_cfg.get("checklist_title", "Select MCP servers to enable:"),
+        bundle_server_names,
+        pre_selected,
+    )
+    selected_names = [
+        bundle_server_names[idx]
+        for idx in selected_indices
+        if isinstance(idx, int) and 0 <= idx < len(bundle_server_names)
+    ]
+    summary = merge_selected_provider_mcp_servers(
+        config,
+        provider_bundle,
+        selected_names,
+        existing_mcp_servers_raw=existing_mcp_servers_raw,
+    )
+    added = sorted(summary.get("added", []))
+    skipped = sorted(summary.get("skipped_existing", []))
+    skipped_runtime_collisions = summary.get("skipped_runtime_collisions", [])
+    skipped_equivalent_existing = summary.get("skipped_equivalent_existing", [])
+    if added:
+        print_success(f"MCP servers added: {', '.join(added)}")
+    if skipped:
+        print_warning(
+            "MCP servers already configured (not overwritten): "
+            + ", ".join(skipped)
+        )
+    if skipped_runtime_collisions:
+        collision_desc = ", ".join(
+            f"{item['requested']} (matches existing {item['existing']})"
+            for item in skipped_runtime_collisions
+            if isinstance(item, dict)
+            and isinstance(item.get("requested"), str)
+            and isinstance(item.get("existing"), str)
+        )
+        if collision_desc:
+            print_warning(
+                "MCP servers skipped because an equivalent server is already configured: "
+                + collision_desc
+            )
+    if skipped_equivalent_existing:
+        equivalent_desc = ", ".join(
+            f"{item['requested']} (matches existing {item['existing']})"
+            for item in skipped_equivalent_existing
+            if isinstance(item, dict)
+            and isinstance(item.get("requested"), str)
+            and isinstance(item.get("existing"), str)
+        )
+        if equivalent_desc:
+            print_warning(
+                "MCP servers already configured under a different name (not duplicated): "
+                + equivalent_desc
+            )
+
+
+def get_bundle_default_checked_servers(bundle: dict[str, Any]) -> tuple[list[str], list[str]]:
+    """Return default-checked server names and explanatory notes."""
+
+    checked: list[str] = []
+    notes: list[str] = []
+
+    servers = bundle.get("servers", {})
+    if not isinstance(servers, dict):
+        return checked, notes
+
+    for server_name, server_data in servers.items():
+        if not isinstance(server_data, dict):
+            continue
+
+        if server_data.get("default_checked") is True:
+            checked.append(server_name)
+            continue
+
+        when = server_data.get("default_checked_when")
+        if not isinstance(when, dict):
+            continue
+
+        command = when.get("command_available")
+        if isinstance(command, str) and command.strip():
+            if shutil.which(command.strip()) is not None:
+                checked.append(server_name)
+            else:
+                note = server_data.get("note_when_unchecked")
+                if isinstance(note, str) and note.strip():
+                    notes.append(note.strip())
+
+    return checked, notes
+
+
+def merge_selected_provider_mcp_servers(
+    config: dict[str, Any],
+    bundle: dict[str, Any],
+    selected_servers: list[str],
+    *,
+    existing_mcp_servers_raw: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Merge selected bundle servers into config without overwriting user config."""
+
+    if not selected_servers:
+        return {
+            "added": [],
+            "skipped_existing": [],
+            "skipped_runtime_collisions": [],
+            "skipped_equivalent_existing": [],
+        }
+
+    servers = bundle.get("servers", {})
+    if not isinstance(servers, dict):
+        return {
+            "added": [],
+            "skipped_existing": [],
+            "skipped_runtime_collisions": [],
+            "skipped_equivalent_existing": [],
+        }
+
+    existing_mcp_servers = config.get("mcp_servers")
+    if not isinstance(existing_mcp_servers, dict):
+        existing_mcp_servers = {}
+    raw_existing_mcp_servers = (
+        existing_mcp_servers_raw
+        if isinstance(existing_mcp_servers_raw, dict)
+        else existing_mcp_servers
+    )
+
+    mcp_servers = None
+    summary = {
+        "added": [],
+        "skipped_existing": [],
+        "skipped_runtime_collisions": [],
+        "skipped_equivalent_existing": [],
+    }
+    normalized_existing_names = {
+        _normalize_runtime_server_name(existing_name): existing_name
+        for existing_name in existing_mcp_servers
+    }
+    existing_transport_identities: dict[tuple[str, Any], str] = {}
+    for existing_source in (raw_existing_mcp_servers, existing_mcp_servers):
+        for existing_name, existing_config in existing_source.items():
+            for identity in _server_transport_identity_variants(existing_config):
+                existing_transport_identities.setdefault(identity, existing_name)
+
+    for server_name in selected_servers:
+        if server_name in existing_mcp_servers:
+            summary["skipped_existing"].append(server_name)
+            continue
+
+        normalized_name = _normalize_runtime_server_name(server_name)
+        existing_collision = normalized_existing_names.get(normalized_name)
+        if existing_collision is not None:
+            summary["skipped_runtime_collisions"].append(
+                {
+                    "requested": server_name,
+                    "existing": existing_collision,
+                }
+            )
+            continue
+
+        server_payload = servers.get(server_name)
+        if not isinstance(server_payload, dict):
+            continue
+
+        server_config = server_payload.get("config")
+        if not isinstance(server_config, dict):
+            continue
+
+        transport_identities = _server_transport_identity_variants(server_config)
+        existing_equivalent = next(
+            (
+                existing_transport_identities[identity]
+                for identity in transport_identities
+                if identity in existing_transport_identities
+            ),
+            None,
+        )
+        if existing_equivalent is not None:
+            summary["skipped_equivalent_existing"].append(
+                {
+                    "requested": server_name,
+                    "existing": existing_equivalent,
+                }
+            )
+            continue
+
+        if mcp_servers is None:
+            current_mcp_servers = config.get("mcp_servers")
+            if not isinstance(current_mcp_servers, dict):
+                current_mcp_servers = {}
+                config["mcp_servers"] = current_mcp_servers
+            mcp_servers = current_mcp_servers
+
+        merged_entry = copy.deepcopy(server_config)
+        merged_entry["enabled"] = True
+        mcp_servers[server_name] = merged_entry
+        summary["added"].append(server_name)
+        normalized_existing_names[normalized_name] = server_name
+        for identity in transport_identities:
+            existing_transport_identities.setdefault(identity, server_name)
+
+    return summary

--- a/hermes_cli/mcp_provider_presets.yaml
+++ b/hermes_cli/mcp_provider_presets.yaml
@@ -1,0 +1,39 @@
+presets:
+  - match:
+      provider: zai
+    prompt:
+      question: "Enable z.ai MCP servers during setup?"
+      default: true
+      checklist_title: "Select z.ai MCP servers to enable:"
+    servers:
+      web-search-prime:
+        default_checked: true
+        config:
+          url: "https://api.z.ai/api/mcp/web_search_prime/mcp"
+          headers:
+            Authorization: "Bearer ${GLM_API_KEY}"
+
+      web-reader:
+        default_checked: true
+        config:
+          url: "https://api.z.ai/api/mcp/web_reader/mcp"
+          headers:
+            Authorization: "Bearer ${GLM_API_KEY}"
+
+      zread:
+        default_checked: true
+        config:
+          url: "https://api.z.ai/api/mcp/zread/mcp"
+          headers:
+            Authorization: "Bearer ${GLM_API_KEY}"
+
+      zai-vision:
+        default_checked_when:
+          command_available: "npx"
+        note_when_unchecked: "`zai-vision` was not preselected because `npx` is unavailable."
+        config:
+          command: "npx"
+          args: ["-y", "@z_ai/mcp-server@latest"]
+          env:
+            Z_AI_API_KEY: "${GLM_API_KEY}"
+            Z_AI_MODE: "ZAI"

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -840,7 +840,11 @@ def setup_model_provider(config: dict):
     This ensures a single code path for all provider setup — any new
     provider added to ``hermes model`` is automatically available here.
     """
-    from hermes_cli.config import load_config, save_config
+    from hermes_cli.config import load_config, load_raw_config, save_config
+    from hermes_cli.mcp_presets import (
+        configure_provider_mcp_bundle,
+        snapshot_existing_mcp_servers_raw,
+    )
 
     print_header("Inference Provider")
     print_info("Choose how to connect to your main chat model.")
@@ -1038,6 +1042,19 @@ def setup_model_provider(config: dict):
         else:
             print_info("Skipped — add later with 'hermes setup' or configure AUXILIARY_VISION_* settings")
 
+    configure_provider_mcp_bundle(
+        config,
+        selected_provider,
+        existing_mcp_servers_raw=snapshot_existing_mcp_servers_raw(
+            config,
+            raw_config=load_raw_config(),
+        ),
+        prompt_yes_no=prompt_yes_no,
+        prompt_checklist=prompt_checklist,
+        print_warning=print_warning,
+        print_success=print_success,
+        logger=logger,
+    )
 
     save_config(config)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,9 @@ py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajector
 [tool.setuptools.packages.find]
 include = ["agent", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "cron", "honcho_integration", "acp_adapter"]
 
+[tool.setuptools.package-data]
+hermes_cli = ["mcp_provider_presets.yaml"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 markers = [

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -77,6 +77,20 @@ class TestLoadConfigDefaults:
             assert config["agent"]["max_turns"] == 42
             assert "max_turns" not in config
 
+    def test_malformed_but_parseable_shape_warns_and_falls_back_to_defaults(
+        self, tmp_path, capsys
+    ):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config_path = tmp_path / "config.yaml"
+            config_path.write_text("agent: bad-value\n", encoding="utf-8")
+
+            config = load_config()
+
+            assert config["agent"]["max_turns"] == DEFAULT_CONFIG["agent"]["max_turns"]
+            assert config["model"] == DEFAULT_CONFIG["model"]
+            out = capsys.readouterr().out
+            assert "Warning: Failed to load config:" in out
+
 
 class TestSaveAndLoadRoundtrip:
     def test_roundtrip(self, tmp_path):

--- a/tests/hermes_cli/test_mcp_presets.py
+++ b/tests/hermes_cli/test_mcp_presets.py
@@ -1,0 +1,666 @@
+import copy
+import textwrap
+from pathlib import Path
+
+import hermes_cli.mcp_presets as mcp_presets
+import pytest
+
+
+def _set_test_preset_data(monkeypatch, tmp_path: Path, yaml_text: str) -> Path:
+    preset_path = tmp_path / "mcp_provider_presets.yaml"
+    preset_path.write_text(textwrap.dedent(yaml_text).strip() + "\n", encoding="utf-8")
+    monkeypatch.setattr(mcp_presets, "_PRESET_DATA_PATH", preset_path)
+    return preset_path
+
+
+def test_shipped_zai_bundle_resolves_from_real_yaml():
+    bundle = mcp_presets.resolve_provider_mcp_bundle("zai")
+
+    assert bundle["prompt"] == {
+        "question": "Enable z.ai MCP servers during setup?",
+        "default": True,
+        "checklist_title": "Select z.ai MCP servers to enable:",
+    }
+    assert set(bundle["servers"]) == {
+        "web-search-prime",
+        "web-reader",
+        "zread",
+        "zai-vision",
+    }
+    assert (
+        bundle["servers"]["web-search-prime"]["config"]["headers"]["Authorization"]
+        == "Bearer ${GLM_API_KEY}"
+    )
+    assert bundle["servers"]["zai-vision"]["config"]["command"] == "npx"
+    assert bundle["servers"]["zai-vision"]["config"]["env"] == {
+        "Z_AI_API_KEY": "${GLM_API_KEY}",
+        "Z_AI_MODE": "ZAI",
+    }
+
+
+def test_shipped_preset_catalog_validates_as_a_whole():
+    presets = mcp_presets._load_presets()
+
+    assert isinstance(presets, list)
+    assert presets
+
+
+def test_provider_only_resolution_uses_matching_provider_entry(monkeypatch, tmp_path):
+    _set_test_preset_data(
+        monkeypatch,
+        tmp_path,
+        """
+        presets:
+          - match:
+              provider: alpha
+            prompt:
+              question: "Enable Alpha MCP?"
+              default: false
+              checklist_title: "Alpha servers"
+            servers:
+              alpha-core:
+                default_checked: true
+                config:
+                  url: "https://alpha.example/core"
+        """,
+    )
+
+    bundle = mcp_presets.resolve_provider_mcp_bundle("alpha", model="alpha-fast")
+
+    assert bundle["prompt"] == {
+        "question": "Enable Alpha MCP?",
+        "default": False,
+        "checklist_title": "Alpha servers",
+    }
+    assert set(bundle["servers"]) == {"alpha-core"}
+    assert bundle["servers"]["alpha-core"]["config"]["url"] == "https://alpha.example/core"
+
+
+def test_provider_model_resolution_overrides_provider_prompt_and_server(monkeypatch, tmp_path):
+    _set_test_preset_data(
+        monkeypatch,
+        tmp_path,
+        """
+        presets:
+          - match:
+              provider: alpha
+            prompt:
+              question: "Enable Alpha MCP?"
+              default: false
+              checklist_title: "Alpha servers"
+            servers:
+              shared:
+                default_checked: true
+                config:
+                  url: "https://alpha.example/shared"
+              alpha-core:
+                config:
+                  url: "https://alpha.example/core"
+          - match:
+              provider: alpha
+              model: alpha-fast
+            prompt:
+              question: "Enable Alpha Fast MCP?"
+              default: true
+            servers:
+              shared:
+                default_checked_when:
+                  command_available: "uvx"
+                note_when_unchecked: "`shared` was not preselected because `uvx` is unavailable."
+                config:
+                  command: "uvx"
+                  args: ["alpha-fast-shared"]
+              alpha-fast-only:
+                config:
+                  url: "https://alpha.example/fast"
+        """,
+    )
+
+    bundle = mcp_presets.resolve_provider_mcp_bundle("alpha", model="alpha-fast")
+
+    assert bundle["prompt"] == {
+        "question": "Enable Alpha Fast MCP?",
+        "default": True,
+        "checklist_title": "Alpha servers",
+    }
+    assert set(bundle["servers"]) == {"shared", "alpha-core", "alpha-fast-only"}
+    assert bundle["servers"]["shared"]["config"] == {
+        "command": "uvx",
+        "args": ["alpha-fast-shared"],
+    }
+    assert bundle["servers"]["alpha-core"]["config"]["url"] == "https://alpha.example/core"
+    assert bundle["servers"]["alpha-fast-only"]["config"]["url"] == "https://alpha.example/fast"
+
+
+def test_provider_model_resolution_deep_merges_server_entry(monkeypatch, tmp_path):
+    _set_test_preset_data(
+        monkeypatch,
+        tmp_path,
+        """
+        presets:
+          - match:
+              provider: alpha
+            prompt:
+              question: "Enable Alpha MCP?"
+              default: false
+              checklist_title: "Alpha servers"
+            servers:
+              shared:
+                default_checked_when:
+                  command_available: "npx"
+                note_when_unchecked: "provider note"
+                config:
+                  command: "npx"
+                  args: ["provider-shared"]
+                  env:
+                    ALPHA_MODE: "provider"
+                    ALPHA_REGION: "global"
+          - match:
+              provider: alpha
+              model: alpha-fast
+            prompt:
+              question: "Enable Alpha Fast MCP?"
+              default: true
+            servers:
+              shared:
+                config:
+                  env:
+                    ALPHA_MODE: "fast"
+        """,
+    )
+
+    bundle = mcp_presets.resolve_provider_mcp_bundle("alpha", model="alpha-fast")
+
+    assert bundle["servers"]["shared"] == {
+        "default_checked_when": {"command_available": "npx"},
+        "note_when_unchecked": "provider note",
+        "config": {
+            "command": "npx",
+            "args": ["provider-shared"],
+            "env": {
+                "ALPHA_MODE": "fast",
+                "ALPHA_REGION": "global",
+            },
+        },
+    }
+
+
+def test_provider_model_resolution_requires_exact_model_match(monkeypatch, tmp_path):
+    _set_test_preset_data(
+        monkeypatch,
+        tmp_path,
+        """
+        presets:
+          - match:
+              provider: alpha
+            prompt:
+              question: "Enable Alpha MCP?"
+              default: false
+              checklist_title: "Alpha servers"
+            servers:
+              alpha-core:
+                config:
+                  url: "https://alpha.example/core"
+          - match:
+              provider: alpha
+              model: alpha-fast
+            prompt:
+              question: "Enable Alpha Fast MCP?"
+              default: true
+            servers:
+              alpha-fast-only:
+                config:
+                  url: "https://alpha.example/fast"
+        """,
+    )
+
+    bundle = mcp_presets.resolve_provider_mcp_bundle("alpha", model="alpha-slow")
+
+    assert bundle["prompt"] == {
+        "question": "Enable Alpha MCP?",
+        "default": False,
+        "checklist_title": "Alpha servers",
+    }
+    assert set(bundle["servers"]) == {"alpha-core"}
+
+
+def test_duplicate_match_entries_raise_validation_error(monkeypatch, tmp_path):
+    _set_test_preset_data(
+        monkeypatch,
+        tmp_path,
+        """
+        presets:
+          - match:
+              provider: alpha
+            prompt:
+              question: "Enable Alpha MCP?"
+              default: false
+              checklist_title: "Alpha servers"
+            servers:
+              alpha-core:
+                config:
+                  url: "https://alpha.example/core"
+          - match:
+              provider: alpha
+            prompt:
+              question: "Enable duplicate Alpha MCP?"
+              default: true
+              checklist_title: "Alpha duplicate servers"
+            servers:
+              alpha-extra:
+                config:
+                  url: "https://alpha.example/extra"
+        """,
+    )
+
+    with pytest.raises(ValueError, match="Duplicate MCP preset match"):
+        mcp_presets.resolve_provider_mcp_bundle("alpha")
+
+
+def test_runtime_name_collision_in_resolved_bundle_raises_validation_error(monkeypatch, tmp_path):
+    _set_test_preset_data(
+        monkeypatch,
+        tmp_path,
+        """
+        presets:
+          - match:
+              provider: alpha
+            prompt:
+              question: "Enable Alpha MCP?"
+              default: false
+              checklist_title: "Alpha servers"
+            servers:
+              alpha-core:
+                config:
+                  url: "https://alpha.example/core"
+          - match:
+              provider: alpha
+              model: alpha-fast
+            prompt:
+              question: "Enable Alpha Fast MCP?"
+              default: true
+            servers:
+              alpha_core:
+                config:
+                  url: "https://alpha.example/core-fast"
+        """,
+    )
+
+    with pytest.raises(ValueError, match="same runtime name"):
+        mcp_presets.resolve_provider_mcp_bundle("alpha", model="alpha-fast")
+
+
+def test_invalid_yaml_raises_validation_error(monkeypatch, tmp_path):
+    _set_test_preset_data(monkeypatch, tmp_path, "presets: [")
+
+    with pytest.raises(ValueError, match="Invalid MCP preset YAML"):
+        mcp_presets.resolve_provider_mcp_bundle("alpha")
+
+
+def test_invalid_server_entry_raises_validation_error(monkeypatch, tmp_path):
+    _set_test_preset_data(
+        monkeypatch,
+        tmp_path,
+        """
+        presets:
+          - match:
+              provider: alpha
+            prompt:
+              question: "Enable Alpha MCP?"
+              default: false
+              checklist_title: "Alpha servers"
+            servers:
+              alpha-core: "https://alpha.example/core"
+        """,
+    )
+
+    with pytest.raises(ValueError, match="must be a mapping"):
+        mcp_presets.resolve_provider_mcp_bundle("alpha")
+
+
+def test_server_config_with_both_transports_raises_validation_error(monkeypatch, tmp_path):
+    _set_test_preset_data(
+        monkeypatch,
+        tmp_path,
+        """
+        presets:
+          - match:
+              provider: alpha
+            prompt:
+              question: "Enable Alpha MCP?"
+              default: false
+              checklist_title: "Alpha servers"
+            servers:
+              alpha-core:
+                config:
+                  url: "https://alpha.example/core"
+                  command: "uvx"
+        """,
+    )
+
+    with pytest.raises(ValueError, match="cannot define both 'url' and 'command'"):
+        mcp_presets.resolve_provider_mcp_bundle("alpha")
+
+
+def test_unsupported_default_checked_when_key_raises_validation_error(monkeypatch, tmp_path):
+    _set_test_preset_data(
+        monkeypatch,
+        tmp_path,
+        """
+        presets:
+          - match:
+              provider: alpha
+            prompt:
+              question: "Enable Alpha MCP?"
+              default: false
+              checklist_title: "Alpha servers"
+            servers:
+              alpha-core:
+                default_checked_when:
+                  env_var_present: "ALPHA_KEY"
+                config:
+                  url: "https://alpha.example/core"
+        """,
+    )
+
+    with pytest.raises(ValueError, match="Unsupported default_checked_when keys"):
+        mcp_presets.resolve_provider_mcp_bundle("alpha")
+
+
+def test_unrelated_invalid_preset_breaks_catalog_validation(monkeypatch, tmp_path):
+    _set_test_preset_data(
+        monkeypatch,
+        tmp_path,
+        """
+        presets:
+          - match:
+              provider: alpha
+            prompt:
+              question: "Enable Alpha MCP?"
+              default: false
+              checklist_title: "Alpha servers"
+            servers:
+              alpha-core: "https://alpha.example/core"
+          - match:
+              provider: zai
+            prompt:
+              question: "Enable z.ai MCP servers during setup?"
+              default: true
+              checklist_title: "Select z.ai MCP servers to enable:"
+            servers:
+              web-reader:
+                default_checked: true
+                config:
+                  url: "https://api.z.ai/api/mcp/web_reader/mcp"
+        """,
+    )
+
+    with pytest.raises(ValueError, match="must be a mapping"):
+        mcp_presets.resolve_provider_mcp_bundle("zai", model="glm-5")
+
+
+def test_get_bundle_default_checked_servers_marks_command_gated_server_when_available(monkeypatch):
+    bundle = mcp_presets.resolve_provider_mcp_bundle("zai")
+    monkeypatch.setattr(
+        mcp_presets.shutil,
+        "which",
+        lambda cmd: f"/usr/bin/{cmd}" if cmd == "npx" else None,
+    )
+
+    checked, notes = mcp_presets.get_bundle_default_checked_servers(bundle)
+
+    assert checked == ["web-search-prime", "web-reader", "zread", "zai-vision"]
+    assert notes == []
+
+
+def test_get_bundle_default_checked_servers_emits_note_when_command_is_missing(monkeypatch):
+    bundle = mcp_presets.resolve_provider_mcp_bundle("zai")
+    monkeypatch.setattr(mcp_presets.shutil, "which", lambda _cmd: None)
+
+    checked, notes = mcp_presets.get_bundle_default_checked_servers(bundle)
+
+    assert checked == ["web-search-prime", "web-reader", "zread"]
+    assert notes == ["`zai-vision` was not preselected because `npx` is unavailable."]
+
+
+def test_merge_selected_provider_mcp_servers_preserves_existing_entries():
+    bundle = mcp_presets.resolve_provider_mcp_bundle("zai")
+    existing_entry = {
+        "url": "https://example.invalid/mcp",
+        "enabled": False,
+        "tools": {"exclude": ["foo"]},
+    }
+    config = {"mcp_servers": {"web-search-prime": copy.deepcopy(existing_entry)}}
+
+    summary = mcp_presets.merge_selected_provider_mcp_servers(
+        config,
+        bundle,
+        ["web-search-prime", "zread"],
+    )
+
+    assert config["mcp_servers"]["web-search-prime"] == existing_entry
+    assert config["mcp_servers"]["zread"]["enabled"] is True
+    assert summary == {
+        "added": ["zread"],
+        "skipped_existing": ["web-search-prime"],
+        "skipped_runtime_collisions": [],
+        "skipped_equivalent_existing": [],
+    }
+
+
+def test_merge_selected_provider_mcp_servers_tolerates_malformed_existing_mcp_servers():
+    bundle = mcp_presets.resolve_provider_mcp_bundle("zai")
+    config = {"mcp_servers": ["not", "a", "mapping"]}
+
+    summary = mcp_presets.merge_selected_provider_mcp_servers(config, bundle, ["zread"])
+
+    assert config["mcp_servers"] == {
+        "zread": {
+            "url": "https://api.z.ai/api/mcp/zread/mcp",
+            "headers": {"Authorization": "Bearer ${GLM_API_KEY}"},
+            "enabled": True,
+        }
+    }
+    assert summary == {
+        "added": ["zread"],
+        "skipped_existing": [],
+        "skipped_runtime_collisions": [],
+        "skipped_equivalent_existing": [],
+    }
+
+
+def test_merge_selected_provider_mcp_servers_skips_existing_runtime_name_collision():
+    bundle = mcp_presets.resolve_provider_mcp_bundle("zai")
+    config = {
+        "mcp_servers": {
+            "zai_vision": {
+                "command": "npx",
+                "args": ["-y", "old-server"],
+            }
+        }
+    }
+
+    summary = mcp_presets.merge_selected_provider_mcp_servers(
+        config,
+        bundle,
+        ["zai-vision"],
+    )
+
+    assert config["mcp_servers"] == {
+        "zai_vision": {
+            "command": "npx",
+            "args": ["-y", "old-server"],
+        }
+    }
+    assert summary == {
+        "added": [],
+        "skipped_existing": [],
+        "skipped_runtime_collisions": [
+            {
+                "requested": "zai-vision",
+                "existing": "zai_vision",
+            }
+        ],
+        "skipped_equivalent_existing": [],
+    }
+
+
+def test_merge_selected_provider_mcp_servers_skips_existing_equivalent_server():
+    bundle = mcp_presets.resolve_provider_mcp_bundle("zai")
+    config = {
+        "mcp_servers": {
+            "custom-zread": {
+                "url": "https://api.z.ai/api/mcp/zread/mcp",
+                "headers": {"Authorization": "Bearer ${GLM_API_KEY}"},
+                "enabled": False,
+                "tools": {"exclude": ["foo"]},
+                "timeout": 120,
+            }
+        }
+    }
+
+    summary = mcp_presets.merge_selected_provider_mcp_servers(
+        config,
+        bundle,
+        ["zread"],
+    )
+
+    assert config["mcp_servers"] == {
+        "custom-zread": {
+            "url": "https://api.z.ai/api/mcp/zread/mcp",
+            "headers": {"Authorization": "Bearer ${GLM_API_KEY}"},
+            "enabled": False,
+            "tools": {"exclude": ["foo"]},
+            "timeout": 120,
+        }
+    }
+    assert summary == {
+        "added": [],
+        "skipped_existing": [],
+        "skipped_runtime_collisions": [],
+        "skipped_equivalent_existing": [
+            {
+                "requested": "zread",
+                "existing": "custom-zread",
+            }
+        ],
+    }
+
+
+def test_merge_selected_provider_mcp_servers_matches_raw_existing_config_for_equivalence():
+    bundle = mcp_presets.resolve_provider_mcp_bundle("zai")
+    config = {
+        "mcp_servers": {
+            "custom-zread": {
+                "url": "https://api.z.ai/api/mcp/zread/mcp",
+                "headers": {"Authorization": "Bearer zai-key"},
+                "enabled": False,
+            }
+        }
+    }
+    raw_existing_mcp_servers = {
+        "custom-zread": {
+            "url": "https://api.z.ai/api/mcp/zread/mcp",
+            "headers": {"Authorization": "Bearer ${GLM_API_KEY}"},
+            "enabled": False,
+        }
+    }
+
+    summary = mcp_presets.merge_selected_provider_mcp_servers(
+        config,
+        bundle,
+        ["zread"],
+        existing_mcp_servers_raw=raw_existing_mcp_servers,
+    )
+
+    assert config["mcp_servers"] == {
+        "custom-zread": {
+            "url": "https://api.z.ai/api/mcp/zread/mcp",
+            "headers": {"Authorization": "Bearer zai-key"},
+            "enabled": False,
+        }
+    }
+    assert summary == {
+        "added": [],
+        "skipped_existing": [],
+        "skipped_runtime_collisions": [],
+        "skipped_equivalent_existing": [
+            {
+                "requested": "zread",
+                "existing": "custom-zread",
+            }
+        ],
+    }
+
+
+def test_merge_selected_provider_mcp_servers_matches_expanded_in_memory_config_for_equivalence(
+    monkeypatch,
+):
+    bundle = mcp_presets.resolve_provider_mcp_bundle("zai")
+    config = {
+        "mcp_servers": {
+            "custom-zread": {
+                "url": "https://api.z.ai/api/mcp/zread/mcp",
+                "headers": {"Authorization": "Bearer zai-key"},
+                "enabled": False,
+            }
+        }
+    }
+    monkeypatch.setenv("GLM_API_KEY", "zai-key")
+
+    summary = mcp_presets.merge_selected_provider_mcp_servers(
+        config,
+        bundle,
+        ["zread"],
+    )
+
+    assert config["mcp_servers"] == {
+        "custom-zread": {
+            "url": "https://api.z.ai/api/mcp/zread/mcp",
+            "headers": {"Authorization": "Bearer zai-key"},
+            "enabled": False,
+        }
+    }
+    assert summary == {
+        "added": [],
+        "skipped_existing": [],
+        "skipped_runtime_collisions": [],
+        "skipped_equivalent_existing": [
+            {
+                "requested": "zread",
+                "existing": "custom-zread",
+            }
+        ],
+    }
+
+
+def test_merge_selected_provider_mcp_servers_is_noop_for_empty_and_unknown_selections():
+    bundle = mcp_presets.resolve_provider_mcp_bundle("zai")
+
+    empty_config = {}
+    empty_before = copy.deepcopy(empty_config)
+    empty_summary = mcp_presets.merge_selected_provider_mcp_servers(empty_config, bundle, [])
+
+    assert empty_config == empty_before
+    assert empty_summary == {
+        "added": [],
+        "skipped_existing": [],
+        "skipped_runtime_collisions": [],
+        "skipped_equivalent_existing": [],
+    }
+
+    unknown_config = {}
+    unknown_before = copy.deepcopy(unknown_config)
+    unknown_summary = mcp_presets.merge_selected_provider_mcp_servers(
+        unknown_config,
+        bundle,
+        ["does-not-exist"],
+    )
+
+    assert unknown_config == unknown_before
+    assert unknown_summary == {
+        "added": [],
+        "skipped_existing": [],
+        "skipped_runtime_collisions": [],
+        "skipped_equivalent_existing": [],
+    }

--- a/tests/hermes_cli/test_setup_model_provider.py
+++ b/tests/hermes_cli/test_setup_model_provider.py
@@ -113,6 +113,57 @@ def test_setup_keep_current_config_provider_uses_provider_specific_model_menu(
     assert reloaded["model"]["provider"] == "zai"
 
 
+def test_setup_invokes_provider_mcp_bundle_after_shared_model_flow(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_env(monkeypatch)
+
+    config = load_config()
+    captured = {}
+
+    def fake_select():
+        _write_model_config("zai", "https://api.z.ai/api/paas/v4", "glm-5")
+
+    def fake_snapshot(config_arg, *, raw_config=None):
+        captured["snapshot_raw"] = raw_config
+        return {"existing-zread": {"url": "https://example.invalid/mcp"}}
+
+    def fake_bundle(
+        config_arg,
+        selected_provider,
+        *,
+        existing_mcp_servers_raw,
+        prompt_yes_no,
+        prompt_checklist,
+        print_warning,
+        print_success,
+        logger,
+    ):
+        captured["selected_provider"] = selected_provider
+        captured["existing_mcp_servers_raw"] = existing_mcp_servers_raw
+        config_arg.setdefault("mcp_servers", {})["zread"] = {
+            "url": "https://api.z.ai/api/mcp/zread/mcp",
+        }
+
+    monkeypatch.setattr("hermes_cli.main.select_provider_and_model", fake_select)
+    _stub_tts(monkeypatch)
+    monkeypatch.setattr("agent.auxiliary_client.get_available_vision_backends", lambda: [])
+    monkeypatch.setattr("hermes_cli.mcp_presets.snapshot_existing_mcp_servers_raw", fake_snapshot)
+    monkeypatch.setattr("hermes_cli.mcp_presets.configure_provider_mcp_bundle", fake_bundle)
+
+    setup_model_provider(config)
+
+    reloaded = load_config()
+    assert captured["selected_provider"] == "zai"
+    assert captured["existing_mcp_servers_raw"] == {
+        "existing-zread": {"url": "https://example.invalid/mcp"}
+    }
+    assert captured["snapshot_raw"]["model"]["provider"] == "zai"
+    assert captured["snapshot_raw"]["model"]["default"] == "glm-5"
+    assert reloaded["model"]["provider"] == "zai"
+    assert reloaded["model"]["default"] == "glm-5"
+    assert reloaded["mcp_servers"]["zread"]["url"] == "https://api.z.ai/api/mcp/zread/mcp"
+
+
 def test_setup_same_provider_rotation_strategy_saved_for_multi_credential_pool(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     _clear_provider_env(monkeypatch)

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -155,7 +155,7 @@ Use the full wizard or jump into one section:
 
 | Section | Description |
 |---------|-------------|
-| `model` | Provider and model setup. |
+| `model` | Provider and model setup. Matching providers can offer a provider-linked MCP checklist during setup. |
 | `terminal` | Terminal backend and sandbox setup. |
 | `gateway` | Messaging platform setup. |
 | `tools` | Enable/disable tools per platform. |
@@ -167,6 +167,8 @@ Options:
 |--------|-------------|
 | `--non-interactive` | Use defaults / environment values without prompts. |
 | `--reset` | Reset configuration to defaults before setup. |
+
+For provider-linked MCP behavior details, see the [MCP feature guide](../user-guide/features/mcp.md#provider-linked-mcp-setup-in-model-setup).
 
 ## `hermes whatsapp`
 

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -52,6 +52,22 @@ List the files in /home/user/projects and summarize the repo structure.
 
 Hermes will discover the MCP server's tools and use them like any other tool.
 
+## Provider-linked MCP setup in model setup
+
+`hermes setup model` can offer MCP bundles during setup when the selected `provider`/`provider:model` has linked preset data.
+
+This is a setup-only, explicit flow:
+
+- It is not a background auto-run; setup prompts you directly in the wizard.
+- A checklist is shown so you can opt into only the MCP entries you want.
+- New MCP entries are additive: existing `mcp_servers` entries are preserved and not overwritten.
+
+The only shipped provider-linked example today is z.ai, which uses the z.ai preset bundle when z.ai is selected.
+
+After setup, MCP remains managed the normal way via `~/.hermes/config.yaml` and `hermes mcp ...` commands.
+
+Provider switching does not auto-disable MCP entries; changing provider/model does not clear or disable MCP servers.
+
 ## Two kinds of MCP servers
 
 ### Stdio servers


### PR DESCRIPTION
## What does this PR do?

  Adds a provider-linked MCP preset system to `hermes setup model`.

  This PR introduces a generic data-driven flow for add recommended MCP servers for a specific provider[:model]:

  - MCP bundles can be linked to an exact `provider`
  - MCP bundles can also be linked to an exact `provider:model`
  - when setup resolves a matching bundle, Hermes shows an explicit prompt and checklist
  - selected MCP servers are added to `mcp_servers` without overwriting existing user config

  The first built-in example is z.ai, but the real change is the extension point. Future provider-linked MCP bundles can now be added mostly by editing preset data instead of adding more provider-specific setup code.

I think this is the best approach because
  - keeps setup behavior explicit and user-controlled
  - avoids one-off branching in `setup.py` for every provider
  - supports provider-wide bundles plus model-specific add-ons
  - preserves existing `mcp_servers` entries instead of mutating user config destructively

  ## Related Issue

  Fixes #3392 

  ## Type of Change

  - [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [x] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [x] 📝 Documentation update
  - [x] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️ Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  ## Changes Made

  - Added YAML-backed provider-linked MCP preset data in `hermes_cli/mcp_provider_presets.yaml`
  - Added `hermes_cli/mcp_presets.py` as a generic preset engine:
    - resolves exact `provider` and exact `provider:model` matches
    - merges provider-level and model-level bundles
    - computes default-checked checklist entries and explanatory notes
    - merges selected MCP servers into `mcp_servers` without overwriting existing entries
  - Add to `hermes_cli/setup.py` to use the generic preset engine 
  - Added `tests/hermes_cli/test_mcp_presets.py` to cover generic engine behavior:
    - shipped z.ai bundle resolution
    - provider-only resolution
    - exact provider:model resolution
    - precedence rules
    - default-checked behavior
    - non-destructive merge behavior
  - Updated `tests/hermes_cli/test_setup_model_provider.py` to verify generic setup integration using z.ai as the shipped example
  - Updated docs:
    - `website/docs/user-guide/features/mcp.md`
    - `website/docs/reference/cli-commands.md`
  - Added package-data wiring for the YAML file in `pyproject.toml`

  ## How to Test

  1. Run the focused regression slice:
     ```bash
     source .venv/bin/activate
     python -m pytest tests/hermes_cli/test_mcp_presets.py tests/hermes_cli/test_setup_model_provider.py tests/hermes_cli/test_mcp_config.py -q

  Expected result:

  - 46 passed

  2. Test the setup flow manually:

     source .venv/bin/activate
     hermes setup model
     Then:
      - choose Z.AI / GLM or Keep current (Z.AI / GLM)
      - keep your current model
      - confirm the MCP prompt appears
      - confirm the checklist appears
      - confirm the 3 HTTP MCP servers are preselected
      - confirm zai-vision is only preselected when npx is available
  3. Verify config behavior:
      - selected servers are added under mcp_servers
      - existing MCP servers are preserved and not duplicated, including same-name entries, runtime-name aliases, and equivalent servers already configured under a different name
      - later MCP management still works through hermes mcp ... and ~/.hermes/config.yaml

  ## Checklist

  ### Code

  - [x] I've read the Contributing Guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit messages follow Conventional Commits (https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
  - [x] I searched for existing PRs (https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - [x] My PR contains only changes related to this fix/feature (no unrelated commits)
  - [ ] I've run pytest tests/ -q and all tests pass
  - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - [x] I've tested on my platform: Ubuntu Linux

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
  - [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
  - [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
  - [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

  ## Screenshots / Logs

  Focused verification:

  $ source .venv/bin/activate
  $ python -m pytest tests/hermes_cli/test_mcp_presets.py tests/hermes_cli/test_setup_model_provider.py tests/hermes_cli/test_mcp_config.py -q
  46 passed, 24 warnings in 2.80s
  
<img width="587" height="216" alt="image" src="https://github.com/user-attachments/assets/59e04e98-9c46-43b5-afab-27fa999b7803" />
<img width="610" height="208" alt="image" src="https://github.com/user-attachments/assets/6d358818-5a8e-4fe2-b47b-181111f7a03d" />
