### PR TITLE
fix(api-server): cancel orphaned agent task when SSE client disconnects

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -570,7 +570,11 @@ class APIServerAdapter(BasePlatformAdapter):
         self, request: "web.Request", completion_id: str, model: str,
         created: int, stream_q, agent_task,
     ) -> "web.StreamResponse":
-        """Write real streaming SSE from agent's stream_delta_callback queue."""
+        """Write real streaming SSE from agent's stream_delta_callback queue.
+
+        If the client disconnects mid-stream (network drop, browser tab close),
+        the agent task is cancelled so it stops consuming API tokens and memory.
+        """
         import queue as _q
 
         response = web.StreamResponse(
@@ -579,69 +583,80 @@ class APIServerAdapter(BasePlatformAdapter):
         )
         await response.prepare(request)
 
-        # Role chunk
-        role_chunk = {
-            "id": completion_id, "object": "chat.completion.chunk",
-            "created": created, "model": model,
-            "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}],
-        }
-        await response.write(f"data: {json.dumps(role_chunk)}\n\n".encode())
-
-        # Stream content chunks as they arrive from the agent
-        loop = asyncio.get_event_loop()
-        while True:
-            try:
-                delta = await loop.run_in_executor(None, lambda: stream_q.get(timeout=0.5))
-            except _q.Empty:
-                if agent_task.done():
-                    # Drain any remaining items
-                    while True:
-                        try:
-                            delta = stream_q.get_nowait()
-                            if delta is None:
-                                break
-                            content_chunk = {
-                                "id": completion_id, "object": "chat.completion.chunk",
-                                "created": created, "model": model,
-                                "choices": [{"index": 0, "delta": {"content": delta}, "finish_reason": None}],
-                            }
-                            await response.write(f"data: {json.dumps(content_chunk)}\n\n".encode())
-                        except _q.Empty:
-                            break
-                    break
-                continue
-
-            if delta is None:  # End of stream sentinel
-                break
-
-            content_chunk = {
+        try:
+            # Role chunk
+            role_chunk = {
                 "id": completion_id, "object": "chat.completion.chunk",
                 "created": created, "model": model,
-                "choices": [{"index": 0, "delta": {"content": delta}, "finish_reason": None}],
+                "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}],
             }
-            await response.write(f"data: {json.dumps(content_chunk)}\n\n".encode())
+            await response.write(f"data: {json.dumps(role_chunk)}\n\n".encode())
 
-        # Get usage from completed agent
-        usage = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
-        try:
-            result, agent_usage = await agent_task
-            usage = agent_usage or usage
-        except Exception:
-            pass
+            # Stream content chunks as they arrive from the agent
+            loop = asyncio.get_event_loop()
+            while True:
+                try:
+                    delta = await loop.run_in_executor(None, lambda: stream_q.get(timeout=0.5))
+                except _q.Empty:
+                    if agent_task.done():
+                        # Drain any remaining items
+                        while True:
+                            try:
+                                delta = stream_q.get_nowait()
+                                if delta is None:
+                                    break
+                                content_chunk = {
+                                    "id": completion_id, "object": "chat.completion.chunk",
+                                    "created": created, "model": model,
+                                    "choices": [{"index": 0, "delta": {"content": delta}, "finish_reason": None}],
+                                }
+                                await response.write(f"data: {json.dumps(content_chunk)}\n\n".encode())
+                            except _q.Empty:
+                                break
+                        break
+                    continue
 
-        # Finish chunk
-        finish_chunk = {
-            "id": completion_id, "object": "chat.completion.chunk",
-            "created": created, "model": model,
-            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
-            "usage": {
-                "prompt_tokens": usage.get("input_tokens", 0),
-                "completion_tokens": usage.get("output_tokens", 0),
-                "total_tokens": usage.get("total_tokens", 0),
-            },
-        }
-        await response.write(f"data: {json.dumps(finish_chunk)}\n\n".encode())
-        await response.write(b"data: [DONE]\n\n")
+                if delta is None:  # End of stream sentinel
+                    break
+
+                content_chunk = {
+                    "id": completion_id, "object": "chat.completion.chunk",
+                    "created": created, "model": model,
+                    "choices": [{"index": 0, "delta": {"content": delta}, "finish_reason": None}],
+                }
+                await response.write(f"data: {json.dumps(content_chunk)}\n\n".encode())
+
+            # Get usage from completed agent
+            usage = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+            try:
+                result, agent_usage = await agent_task
+                usage = agent_usage or usage
+            except Exception:
+                pass
+
+            # Finish chunk
+            finish_chunk = {
+                "id": completion_id, "object": "chat.completion.chunk",
+                "created": created, "model": model,
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                "usage": {
+                    "prompt_tokens": usage.get("input_tokens", 0),
+                    "completion_tokens": usage.get("output_tokens", 0),
+                    "total_tokens": usage.get("total_tokens", 0),
+                },
+            }
+            await response.write(f"data: {json.dumps(finish_chunk)}\n\n".encode())
+            await response.write(b"data: [DONE]\n\n")
+        except (ConnectionResetError, ConnectionAbortedError, BrokenPipeError, OSError):
+            # Client disconnected mid-stream — cancel the orphaned agent task
+            # so it stops consuming API tokens and memory.
+            if not agent_task.done():
+                agent_task.cancel()
+                try:
+                    await agent_task
+                except (asyncio.CancelledError, Exception):
+                    pass
+                logger.info("SSE client disconnected; cancelled agent task %s", completion_id)
 
         return response
 

--- a/tests/gateway/test_sse_agent_cancel.py
+++ b/tests/gateway/test_sse_agent_cancel.py
@@ -1,0 +1,197 @@
+"""Tests for SSE client disconnect → agent task cancellation.
+
+When a streaming /v1/chat/completions client disconnects mid-stream
+(network drop, browser tab close), the agent task must be cancelled
+so it stops consuming API tokens and memory.
+"""
+
+import asyncio
+import json
+import queue
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_adapter():
+    """Build a minimal APIServerAdapter with mocked internals."""
+    from gateway.platforms.api_server import APIServerAdapter
+    from gateway.config import PlatformConfig
+
+    config = PlatformConfig(enabled=True, token="test-key")
+    adapter = APIServerAdapter(config)
+    return adapter
+
+
+def _make_request():
+    """Build a mock aiohttp request."""
+    req = MagicMock()
+    req.headers = {}
+    return req
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestSSEAgentCancelOnDisconnect:
+    """gateway/platforms/api_server.py — _write_sse_chat_completion()"""
+
+    def test_agent_task_cancelled_on_client_disconnect(self):
+        """When response.write raises ConnectionResetError (client dropped),
+        the agent task must be cancelled."""
+        adapter = _make_adapter()
+
+        stream_q = queue.Queue()
+        stream_q.put("hello ")  # Some data already queued
+
+        # Agent task that runs forever (simulates a long LLM call)
+        agent_done = asyncio.Event()
+
+        async def fake_agent():
+            await agent_done.wait()
+            return {"final_response": "done"}, {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+
+        async def run():
+            from aiohttp import web
+
+            agent_task = asyncio.ensure_future(fake_agent())
+
+            # Mock response that raises ConnectionResetError on second write
+            mock_response = AsyncMock(spec=web.StreamResponse)
+            call_count = 0
+
+            async def write_side_effect(data):
+                nonlocal call_count
+                call_count += 1
+                if call_count >= 2:
+                    raise ConnectionResetError("client disconnected")
+
+            mock_response.write = AsyncMock(side_effect=write_side_effect)
+            mock_response.prepare = AsyncMock()
+
+            with patch.object(type(adapter), '_write_sse_chat_completion',
+                              adapter._write_sse_chat_completion):
+                # Patch StreamResponse creation
+                with patch("gateway.platforms.api_server.web.StreamResponse",
+                           return_value=mock_response):
+                    await adapter._write_sse_chat_completion(
+                        _make_request(), "cmpl-123", "gpt-4", 1234567890,
+                        stream_q, agent_task,
+                    )
+
+            # The critical assertion: agent_task must be cancelled
+            assert agent_task.cancelled() or agent_task.done()
+            # Clean up
+            agent_done.set()
+
+        asyncio.run(run())
+
+    def test_agent_task_not_cancelled_on_normal_completion(self):
+        """On normal stream completion, agent task should NOT be cancelled."""
+        adapter = _make_adapter()
+
+        stream_q = queue.Queue()
+        stream_q.put("hello")
+        stream_q.put(None)  # End-of-stream sentinel
+
+        async def fake_agent():
+            return {"final_response": "done"}, {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+
+        async def run():
+            from aiohttp import web
+
+            agent_task = asyncio.ensure_future(fake_agent())
+            await asyncio.sleep(0)  # Let agent complete
+
+            mock_response = AsyncMock(spec=web.StreamResponse)
+            mock_response.write = AsyncMock()
+            mock_response.prepare = AsyncMock()
+
+            with patch("gateway.platforms.api_server.web.StreamResponse",
+                       return_value=mock_response):
+                await adapter._write_sse_chat_completion(
+                    _make_request(), "cmpl-456", "gpt-4", 1234567890,
+                    stream_q, agent_task,
+                )
+
+            # Agent should have completed normally, not been cancelled
+            assert agent_task.done()
+            assert not agent_task.cancelled()
+
+        asyncio.run(run())
+
+    def test_broken_pipe_also_cancels_agent(self):
+        """BrokenPipeError (another disconnect variant) also cancels the task."""
+        adapter = _make_adapter()
+
+        stream_q = queue.Queue()
+
+        async def fake_agent():
+            await asyncio.sleep(999)  # Never completes
+            return {}, {}
+
+        async def run():
+            from aiohttp import web
+
+            agent_task = asyncio.ensure_future(fake_agent())
+
+            mock_response = AsyncMock(spec=web.StreamResponse)
+            mock_response.write = AsyncMock(side_effect=BrokenPipeError("pipe broken"))
+            mock_response.prepare = AsyncMock()
+
+            with patch("gateway.platforms.api_server.web.StreamResponse",
+                       return_value=mock_response):
+                await adapter._write_sse_chat_completion(
+                    _make_request(), "cmpl-789", "gpt-4", 1234567890,
+                    stream_q, agent_task,
+                )
+
+            assert agent_task.cancelled() or agent_task.done()
+
+        asyncio.run(run())
+
+    def test_already_done_task_not_cancelled_on_disconnect(self):
+        """If agent already finished before disconnect, don't try to cancel."""
+        adapter = _make_adapter()
+
+        stream_q = queue.Queue()
+        stream_q.put("data")
+
+        async def fake_agent():
+            return {"final_response": "done"}, {}
+
+        async def run():
+            from aiohttp import web
+
+            agent_task = asyncio.ensure_future(fake_agent())
+            await asyncio.sleep(0)  # Let agent complete
+
+            mock_response = AsyncMock(spec=web.StreamResponse)
+            call_count = 0
+
+            async def write_side_effect(data):
+                nonlocal call_count
+                call_count += 1
+                if call_count >= 2:
+                    raise ConnectionResetError("late disconnect")
+
+            mock_response.write = AsyncMock(side_effect=write_side_effect)
+            mock_response.prepare = AsyncMock()
+
+            with patch("gateway.platforms.api_server.web.StreamResponse",
+                       return_value=mock_response):
+                await adapter._write_sse_chat_completion(
+                    _make_request(), "cmpl-done", "gpt-4", 1234567890,
+                    stream_q, agent_task,
+                )
+
+            # Task was already done — should not be cancelled
+            assert agent_task.done()
+            assert not agent_task.cancelled()
+
+        asyncio.run(run())


### PR DESCRIPTION
When a streaming `/v1/chat/completions` client disconnects mid-stream (network drop, browser tab close, Open WebUI navigation), `response.write()` raises `ConnectionResetError` but the `agent_task` created via `asyncio.ensure_future` is never cancelled. The orphaned agent keeps running — making LLM API calls, consuming tokens and memory — with no reference held to it. This repeats on every dropped streaming client.

## Changes Made

Wrapped the SSE write loop in `_write_sse_chat_completion` with `try/except` to catch disconnect errors (`ConnectionResetError`, `BrokenPipeError`, `ConnectionAbortedError`, `OSError`). On disconnect, if the agent task is still running, it's cancelled and awaited. If the agent already finished before the disconnect, it's left alone.

## How to Test

```bash
python3 -m pytest tests/gateway/test_sse_agent_cancel.py -v
```

4 tests covering:
- Agent task cancelled on `ConnectionResetError`
- Agent task cancelled on `BrokenPipeError`
- Normal completion — agent NOT cancelled
- Already-done agent — NOT cancelled on late disconnect

## Checklist

- [x] Tests added (4 tests)
- [x] Full test suite run — no regressions
- [x] Tested on Linux (Ubuntu 22.04)