### PR TITLE
fix: add self-termination guard for pkill/killall targeting hermes/gateway

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -512,6 +512,30 @@ class TestGatewayProtection:
         dangerous, key, desc = detect_dangerous_command(cmd)
         assert dangerous is False
 
+    def test_pkill_hermes_detected(self):
+        """pkill targeting hermes/gateway processes must be caught (#3397)."""
+        cmd = 'pkill -f "cli.py --gateway"'
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
+    def test_killall_hermes_detected(self):
+        cmd = "killall hermes"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
+    def test_pkill_gateway_detected(self):
+        cmd = "pkill -f gateway"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_pkill_unrelated_not_flagged(self):
+        """pkill targeting unrelated processes should not be flagged."""
+        cmd = "pkill -f nginx"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is False
+
 
 class TestNormalizationBypass:
     """Obfuscation techniques must not bypass dangerous command detection."""

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -53,6 +53,8 @@ DANGEROUS_PATTERNS = [
     # Gateway protection: never start gateway outside systemd management
     (r'gateway\s+run\b.*(&\s*$|&\s*;|\bdisown\b|\bsetsid\b)', "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')"),
     (r'\bnohup\b.*gateway\s+run\b', "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')"),
+    # Self-termination protection: prevent agent from killing its own process (#3397)
+    (r'\b(pkill|killall)\b.*\b(hermes|gateway|cli\.py)\b', "kill hermes/gateway process (self-termination)"),
 ]
 
 


### PR DESCRIPTION
## Problem

A Telegram gateway agent ran `pkill -f "cli.py --gateway"` and killed its own process. This command is not caught by any existing `DANGEROUS_PATTERNS` entry — the current `pkill` pattern only matches `pkill -9` (force kill), not `pkill -f` (filter by name).

This is a variant of #2617, where the agent killed the gateway via `kill PID` + `&disown`.

Closes #3397

## Changes

**`tools/approval.py`** — Add one pattern to `DANGEROUS_PATTERNS`:
```python
(r'\b(pkill|killall)\b.*\b(hermes|gateway|cli\.py)\b', "kill hermes/gateway process (self-termination)")
```

**`tests/tools/test_approval.py`** — 4 new tests:
- `pkill -f "cli.py --gateway"` → detected
- `killall hermes` → detected
- `pkill -f gateway` → detected
- `pkill -f nginx` → not flagged (unrelated process)

## Test plan

- [x] `python -m pytest tests/tools/test_approval.py -q` — 91 passed, 0 failed