### PR TITLE
fix(tools): catch pkill/killall targeting hermes/gateway/cli.py process

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -40,6 +40,9 @@ DANGEROUS_PATTERNS = [
     (r'\bsystemctl\s+(stop|disable|mask)\b', "stop/disable system service"),
     (r'\bkill\s+-9\s+-1\b', "kill all processes"),
     (r'\bpkill\s+-9\b', "force kill processes"),
+    # Self-termination: pkill/killall targeting hermes/gateway/cli.py processes
+    # Catches 'pkill -f "cli.py --gateway"', 'killall hermes', 'pkill gateway', etc.
+    (r'\b(pkill|killall)\b.*\b(hermes|gateway|cli\.py)\b', "kill hermes/gateway process (self-termination)"),
     (r':\(\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:', "fork bomb"),
     # Any shell invocation via -c or combined flags like -lc, -ic, etc.
     (r'\b(bash|sh|zsh|ksh)\s+-[^\s]*c(\s+|$)', "shell command via -c/-lc flag"),


### PR DESCRIPTION
Fixes #3397

## Problem

The agent can self-terminate by running `pkill -f "cli.py --gateway"`,
which kills the gateway process from within itself.
This variant of #2617 but but uses process-name targeting instead of a known PID.

The existing `DANGEROUS_PATTERNS` catch `pkill -9` (force kill) but not `pkill -f` (filter by name pattern). Any `pkill`/`killall` targeting `hermes`, `gateway`, or `cli.py` bypasses all guards.

## Fix

Add a pattern that catches `pkill`/`killall` commands targeting hermes/gateway/cli.py processes:

```python
(r'\b(pkill|killall)\b.*\b(hermes|gateway|cli\.py)\b', "kill hermes/gateway process (self-termination)"),
```

This reuses the existing approval flow — in gateway mode it sends an approval request, to the user, in CLI mode it prompts interactively.

Note: placed immediately after the existing `pkill -9` pattern to ensure all pkill variants (with or without flags) are caught.

## Testing

Verified against the cases from the bug report:
- `pkill -f "cli.py --gateway"` → caught (pkill + cli.py)
- `pkill hermes` → caught
- `killall gateway` → caught
- `killall cli.py` → caught
- `echo gateway` → not caught
- `ps aux | grep hermes` → not caught (no pkill/killall)