### PR TITLE
feat(agent): configurable timeouts for auxiliary LLM calls and context compression

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1407,7 +1407,7 @@ def _build_call_kwargs(
     temperature: Optional[float] = None,
     max_tokens: Optional[int] = None,
     tools: Optional[list] = None,
-    timeout: float = 30.0,
+    timeout: float = float(os.environ.get("HERMES_AUX_TIMEOUT", 90.0)),
     extra_body: Optional[dict] = None,
     base_url: Optional[str] = None,
 ) -> dict:
@@ -1457,7 +1457,7 @@ def call_llm(
     temperature: float = None,
     max_tokens: int = None,
     tools: list = None,
-    timeout: float = 30.0,
+    timeout: float = float(os.environ.get("HERMES_AUX_TIMEOUT", 90.0)),
     extra_body: dict = None,
 ) -> Any:
     """Centralized synchronous LLM call.
@@ -1569,7 +1569,7 @@ async def async_call_llm(
     temperature: float = None,
     max_tokens: int = None,
     tools: list = None,
-    timeout: float = 30.0,
+    timeout: float = float(os.environ.get("HERMES_AUX_TIMEOUT", 90.0)),
     extra_body: dict = None,
 ) -> Any:
     """Centralized asynchronous LLM call.

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -14,6 +14,7 @@ Improvements over v1:
 """
 
 import logging
+import os
 from typing import Any, Dict, List, Optional
 
 from agent.auxiliary_client import call_llm
@@ -347,7 +348,7 @@ Write only the summary body. Do not include any preamble or prefix."""
                 "messages": [{"role": "user", "content": prompt}],
                 "temperature": 0.3,
                 "max_tokens": summary_budget * 2,
-                "timeout": 45.0,
+                "timeout": float(os.environ.get("HERMES_COMPRESSION_TIMEOUT", 120.0)),
             }
             if self.summary_model:
                 call_kwargs["model"] = self.summary_model

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -5,6 +5,7 @@ adds latency to the user-facing reply.
 """
 
 import logging
+import os
 import threading
 from typing import Optional
 
@@ -19,7 +20,7 @@ _TITLE_PROMPT = (
 )
 
 
-def generate_title(user_message: str, assistant_response: str, timeout: float = 15.0) -> Optional[str]:
+def generate_title(user_message: str, assistant_response: str, timeout: float = float(os.environ.get("HERMES_AUX_TIMEOUT", 90.0))) -> Optional[str]:
     """Generate a session title from the first exchange.
 
     Uses the auxiliary LLM client (cheapest/fastest available model).


### PR DESCRIPTION
## Summary

- Add `HERMES_AUX_TIMEOUT` env var (default 90s) for auxiliary `call_llm`/`async_call_llm` and title generation (was hardcoded 30s/15s)
- Add `HERMES_COMPRESSION_TIMEOUT` env var (default 120s) for context compression (was hardcoded 45s)
- Follows the existing `HERMES_API_TIMEOUT` and `HERMES_STREAM_STALE_TIMEOUT` patterns

## Motivation

On local setups (Ollama, oMLX, llama.cpp) running a single model for both main and auxiliary tasks, auxiliary requests queue behind the main generation. The 30s default fires before prefill completes, causing compression failures, title generation timeouts, and session search loops. Previously addressed for the main client (#1010) and vision (#2107) but not for auxiliary calls or compression.

Closes #3404

## Test plan

- [ ] Set `HERMES_AUX_TIMEOUT=90` and `HERMES_COMPRESSION_TIMEOUT=120`, run Hermes with a local model, verify auxiliary calls no longer time out during main generation
- [ ] Verify defaults work without env vars set (90s for aux, 120s for compression)
- [ ] `pytest tests/ -v` passes

## Files changed

- `agent/auxiliary_client.py` — 3 timeout defaults read from `HERMES_AUX_TIMEOUT`
- `agent/context_compressor.py` — compression timeout reads from `HERMES_COMPRESSION_TIMEOUT`
- `agent/title_generator.py` — title timeout reads from `HERMES_AUX_TIMEOUT`

Tested on macOS M1 Max, oMLX with Qwen3.5-35B-A3B-4bit.