### PR TITLE
feat(telegram): add native draft streaming for DMs

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -181,7 +181,7 @@ class PlatformConfig:
 class StreamingConfig:
     """Configuration for real-time token streaming to messaging platforms."""
     enabled: bool = False
-    transport: str = "edit"       # "edit" (progressive editMessageText) or "off"
+    transport: str = "auto"       # "auto", "draft", "edit", or "off"
     edit_interval: float = 0.3    # Seconds between message edits
     buffer_threshold: int = 40    # Chars before forcing an edit
     cursor: str = " ▉"           # Cursor shown during streaming
@@ -201,7 +201,7 @@ class StreamingConfig:
             return cls()
         return cls(
             enabled=data.get("enabled", False),
-            transport=data.get("transport", "edit"),
+            transport=data.get("transport", "auto"),
             edit_interval=float(data.get("edit_interval", 0.3)),
             buffer_threshold=int(data.get("buffer_threshold", 40)),
             cursor=data.get("cursor", " ▉"),

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -538,6 +538,25 @@ class BasePlatformAdapter(ABC):
         """
         return SendResult(success=False, error="Not supported")
 
+    @property
+    def supports_draft_streaming(self) -> bool:
+        """Whether the adapter supports a native draft/preview streaming API."""
+        return False
+
+    async def send_draft(
+        self,
+        chat_id: str,
+        draft_id: int,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Update a native draft/preview stream.
+
+        Platforms without native draft streaming should return False so the
+        caller can fall back to edit-based streaming.
+        """
+        return False
+
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """
         Send a typing indicator.

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -758,6 +758,34 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.error("[%s] Failed to send Telegram message: %s", self.name, e, exc_info=True)
             return SendResult(success=False, error=str(e))
 
+    @property
+    def supports_draft_streaming(self) -> bool:
+        return bool(self._bot and hasattr(self._bot, "send_message_draft"))
+
+    async def send_draft(
+        self,
+        chat_id: str,
+        draft_id: int,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Update a Telegram native streaming draft when supported."""
+        if not self._bot or not hasattr(self._bot, "send_message_draft"):
+            return False
+        try:
+            thread_id = metadata.get("thread_id") if metadata else None
+            await self._bot.send_message_draft(
+                chat_id=int(chat_id),
+                draft_id=int(draft_id),
+                text=content,
+                parse_mode=None,
+                message_thread_id=int(thread_id) if thread_id else None,
+            )
+            return True
+        except Exception as e:
+            logger.warning("[%s] Failed to update Telegram message draft: %s", self.name, e)
+            return False
+
     async def edit_message(
         self,
         chat_id: str,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5168,15 +5168,19 @@ class GatewayRunner:
                     _adapter = self.adapters.get(source.platform)
                     if _adapter:
                         _consumer_cfg = StreamConsumerConfig(
+                            transport=_scfg.transport,
                             edit_interval=_scfg.edit_interval,
                             buffer_threshold=_scfg.buffer_threshold,
                             cursor=_scfg.cursor,
                         )
+                        _stream_metadata = {"chat_type": source.chat_type}
+                        if _progress_thread_id:
+                            _stream_metadata["thread_id"] = _progress_thread_id
                         _stream_consumer = GatewayStreamConsumer(
                             adapter=_adapter,
                             chat_id=source.chat_id,
                             config=_consumer_cfg,
-                            metadata={"thread_id": _progress_thread_id} if _progress_thread_id else None,
+                            metadata=_stream_metadata,
                         )
                         _stream_delta_cb = _stream_consumer.on_delta
                         stream_consumer_holder[0] = _stream_consumer

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -31,6 +31,7 @@ _DONE = object()
 @dataclass
 class StreamConsumerConfig:
     """Runtime config for a single stream consumer instance."""
+    transport: str = "auto"
     edit_interval: float = 0.3
     buffer_threshold: int = 40
     cursor: str = " ▉"
@@ -69,6 +70,31 @@ class GatewayStreamConsumer:
         self._edit_supported = True  # Disabled on first edit failure (Signal/Email/HA)
         self._last_edit_time = 0.0
         self._last_sent_text = ""   # Track last-sent text to skip redundant edits
+        self._draft_id: Optional[int] = None
+        self._transport = self._resolve_transport()
+
+    def _resolve_transport(self) -> str:
+        requested = (self.cfg.transport or "auto").lower()
+        chat_type = (self.metadata or {}).get("chat_type")
+        draft_supported = bool(
+            chat_type == "dm"
+            and getattr(self.adapter, "supports_draft_streaming", False)
+        )
+
+        if requested == "off":
+            return "off"
+        if requested == "draft":
+            if draft_supported:
+                logger.info("Gateway stream consumer using native draft transport")
+                return "draft"
+            logger.info("Gateway draft transport requested but unavailable; falling back to edit transport")
+            return "edit"
+        if requested == "auto":
+            chosen = "draft" if draft_supported else "edit"
+            logger.info("Gateway stream consumer using %s transport", chosen)
+            return chosen
+        logger.info("Gateway stream consumer using edit transport")
+        return "edit"
 
     @property
     def already_sent(self) -> bool:
@@ -135,26 +161,66 @@ class GatewayStreamConsumer:
                     if not got_done:
                         display_text += self.cfg.cursor
 
-                    await self._send_or_edit(display_text)
+                    await self._send_progress(display_text)
                     self._last_edit_time = time.monotonic()
 
                 if got_done:
-                    # Final edit without cursor
-                    if self._accumulated and self._message_id:
-                        await self._send_or_edit(self._accumulated)
+                    # Final flush without cursor. In draft mode this updates the
+                    # preview one last time; the normal send path still delivers
+                    # the final message because already_sent remains False.
+                    if self._accumulated:
+                        await self._send_progress(self._accumulated)
                     return
 
                 await asyncio.sleep(0.05)  # Small yield to not busy-loop
 
         except asyncio.CancelledError:
-            # Best-effort final edit on cancellation
-            if self._accumulated and self._message_id:
+            # Best-effort final flush on cancellation
+            if self._accumulated:
                 try:
-                    await self._send_or_edit(self._accumulated)
+                    await self._send_progress(self._accumulated)
                 except Exception:
                     pass
         except Exception as e:
             logger.error("Stream consumer error: %s", e)
+
+    async def _send_progress(self, text: str) -> None:
+        """Deliver a streaming update using draft transport or edit fallback."""
+        if text == self._last_sent_text:
+            return
+
+        if self._transport == "draft":
+            if await self._send_draft(text):
+                return
+
+        await self._send_or_edit(text)
+
+    async def _send_draft(self, text: str) -> bool:
+        """Send a native draft update when supported by the adapter."""
+        if self._draft_id is None:
+            # Telegram requires a non-zero draft ID. Use the monotonic clock to
+            # generate a stable session-local identifier without extra imports.
+            self._draft_id = max(1, int(time.monotonic() * 1_000_000))
+
+        try:
+            ok = await self.adapter.send_draft(
+                chat_id=self.chat_id,
+                draft_id=self._draft_id,
+                content=text,
+                metadata=self.metadata,
+            )
+        except Exception as e:
+            logger.warning("Draft streaming failed; falling back to edit transport: %s", e)
+            ok = False
+
+        if ok:
+            self._last_sent_text = text
+            return True
+
+        logger.info("Draft streaming unavailable or failed; switching to edit transport for this response")
+        self._transport = "edit"
+        self._draft_id = None
+        return False
 
     async def _send_or_edit(self, text: str) -> None:
         """Send or edit the streaming message."""

--- a/tests/gateway/test_stream_consumer_draft.py
+++ b/tests/gateway/test_stream_consumer_draft.py
@@ -1,0 +1,109 @@
+"""Tests for Telegram native draft streaming fallback behavior."""
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+
+class StubAdapter(BasePlatformAdapter):
+    def __init__(self, *, draft_supported=False, draft_results=None):
+        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.TELEGRAM)
+        self._draft_supported = draft_supported
+        self.draft_results = list(draft_results or [])
+        self.sent = []
+        self.edited = []
+        self.drafts = []
+
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent.append((chat_id, content, metadata))
+        return SendResult(success=True, message_id="m1")
+
+    async def edit_message(self, chat_id, message_id, content):
+        self.edited.append((chat_id, message_id, content))
+        return SendResult(success=True, message_id=message_id)
+
+    async def send_typing(self, chat_id, metadata=None):
+        return None
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+    @property
+    def supports_draft_streaming(self):
+        return self._draft_supported
+
+    async def send_draft(self, chat_id, draft_id, content, metadata=None):
+        self.drafts.append((chat_id, draft_id, content, metadata))
+        if self.draft_results:
+            return self.draft_results.pop(0)
+        return True
+
+
+@pytest.mark.asyncio
+async def test_draft_transport_used_for_dm_and_final_message_not_marked_sent():
+    adapter = StubAdapter(draft_supported=True)
+    consumer = GatewayStreamConsumer(
+        adapter=adapter,
+        chat_id="123",
+        config=StreamConsumerConfig(transport="auto", edit_interval=0.01, buffer_threshold=1, cursor=" ▉"),
+        metadata={"chat_type": "dm"},
+    )
+
+    consumer.on_delta("Hel")
+    consumer.on_delta("lo")
+    consumer.finish()
+    await consumer.run()
+
+    assert consumer.already_sent is False
+    assert adapter.sent == []
+    assert adapter.edited == []
+    assert len(adapter.drafts) >= 1
+    assert all(call[3] == {"chat_type": "dm"} for call in adapter.drafts)
+    assert adapter.drafts[-1][2] == "Hello"
+
+
+@pytest.mark.asyncio
+async def test_group_chat_auto_mode_uses_edit_transport():
+    adapter = StubAdapter(draft_supported=True)
+    consumer = GatewayStreamConsumer(
+        adapter=adapter,
+        chat_id="456",
+        config=StreamConsumerConfig(transport="auto", edit_interval=0.01, buffer_threshold=1, cursor=" ▉"),
+        metadata={"chat_type": "group"},
+    )
+
+    consumer.on_delta("abc")
+    consumer.finish()
+    await consumer.run()
+
+    assert consumer.already_sent is True
+    assert adapter.drafts == []
+    assert len(adapter.sent) == 1
+
+
+@pytest.mark.asyncio
+async def test_draft_failure_falls_back_to_edit_transport():
+    adapter = StubAdapter(draft_supported=True, draft_results=[False])
+    consumer = GatewayStreamConsumer(
+        adapter=adapter,
+        chat_id="789",
+        config=StreamConsumerConfig(transport="draft", edit_interval=0.01, buffer_threshold=1, cursor=" ▉"),
+        metadata={"chat_type": "dm"},
+    )
+
+    consumer.on_delta("fallback")
+    consumer.finish()
+    await consumer.run()
+
+    assert adapter.drafts != []
+    assert consumer.already_sent is True
+    assert len(adapter.sent) == 1
+    assert adapter.sent[0][1] == "fallback"


### PR DESCRIPTION
## Summary
- add Telegram native `send_message_draft` streaming support for DM chats
- keep existing edit-based streaming as the fallback path for groups, topics, and unsupported runtimes
- route gateway streaming through `transport: auto|draft|edit|off`
- add focused gateway tests for draft transport selection and fallback behavior

## Why
Telegram now exposes a native draft streaming API that renders progressively in supported clients much better than repeated `editMessageText` updates. Hermes currently uses edit-based streaming only, which can appear as a single final chunk for Telegram users even when OpenClaw/native draft streaming works in the same client.

This patch adds the safer first step:
- enable native draft streaming only for Telegram DMs
- keep the final response delivery unchanged
- avoid breaking group chat/topic flows by falling back to the existing edit transport

## Implementation details
- `StreamingConfig.transport` now defaults to `auto`
- `GatewayStreamConsumer` chooses `draft` only when:
  - transport is `auto` or explicitly `draft`
  - the chat type is `dm`
  - the adapter reports native draft support
- draft updates do **not** mark `already_sent=true`, so the normal final send path still delivers the completed message
- any draft failure downgrades the active response back to edit transport

## Test plan
```bash
source /Users/alfred/.hermes/hermes-agent/venv/bin/activate && pytest tests/test_streaming.py tests/gateway/test_stream_consumer_draft.py -q
```

Result locally:
- 20 passed

## Risk / scope
This intentionally does **not** replace Hermes' global streaming implementation.
It adds a DM-only optimization with edit fallback, which keeps the blast radius modest while letting Telegram private chats take advantage of the newer API.
EOF; __hermes_rc=$?; printf '__HERMES_FENCE_a9f7b3__'; exit $__hermes_rc
