### PR TITLE
fix(acp): advertise slash commands

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -13,6 +13,8 @@ from acp.schema import (
     AgentCapabilities,
     AuthenticateResponse,
     AuthMethod,
+    AvailableCommand,
+    AvailableCommandsUpdate,
     ClientCapabilities,
     EmbeddedResourceContentBlock,
     ForkSessionResponse,
@@ -31,6 +33,7 @@ from acp.schema import (
     SessionListCapabilities,
     SessionInfo,
     TextContentBlock,
+    UnstructuredCommandInput,
     Usage,
 )
 
@@ -77,6 +80,48 @@ def _extract_text(
 
 class HermesACPAgent(acp.Agent):
     """ACP Agent implementation wrapping Hermes AIAgent."""
+
+    _SLASH_COMMANDS = {
+        "help": "Show available commands",
+        "model": "Show or change current model",
+        "tools": "List available tools",
+        "context": "Show conversation context info",
+        "reset": "Clear conversation history",
+        "compact": "Compress conversation context",
+        "version": "Show Hermes version",
+    }
+
+    _ADVERTISED_COMMANDS = (
+        {
+            "name": "help",
+            "description": "List available commands",
+        },
+        {
+            "name": "model",
+            "description": "Show current model and provider, or switch models",
+            "input_hint": "model name to switch to",
+        },
+        {
+            "name": "tools",
+            "description": "List available tools with descriptions",
+        },
+        {
+            "name": "context",
+            "description": "Show conversation message counts by role",
+        },
+        {
+            "name": "reset",
+            "description": "Clear conversation history",
+        },
+        {
+            "name": "compact",
+            "description": "Compress conversation context",
+        },
+        {
+            "name": "version",
+            "description": "Show Hermes version",
+        },
+    )
 
     def __init__(self, session_manager: SessionManager | None = None):
         super().__init__()
@@ -140,6 +185,7 @@ class HermesACPAgent(acp.Agent):
     ) -> NewSessionResponse:
         state = self.session_manager.create_session(cwd=cwd)
         logger.info("New session %s (cwd=%s)", state.session_id, cwd)
+        self._schedule_available_commands_update(state.session_id)
         return NewSessionResponse(session_id=state.session_id)
 
     async def load_session(
@@ -154,6 +200,7 @@ class HermesACPAgent(acp.Agent):
             logger.warning("load_session: session %s not found", session_id)
             return None
         logger.info("Loaded session %s", session_id)
+        self._schedule_available_commands_update(session_id)
         return LoadSessionResponse()
 
     async def resume_session(
@@ -168,6 +215,7 @@ class HermesACPAgent(acp.Agent):
             logger.warning("resume_session: session %s not found, creating new", session_id)
             state = self.session_manager.create_session(cwd=cwd)
         logger.info("Resumed session %s", state.session_id)
+        self._schedule_available_commands_update(state.session_id)
         return ResumeSessionResponse()
 
     async def cancel(self, session_id: str, **kwargs: Any) -> None:
@@ -191,6 +239,8 @@ class HermesACPAgent(acp.Agent):
         state = self.session_manager.fork_session(session_id, cwd=cwd)
         new_id = state.session_id if state else ""
         logger.info("Forked session %s -> %s", session_id, new_id)
+        if new_id:
+            self._schedule_available_commands_update(new_id)
         return ForkSessionResponse(session_id=new_id)
 
     async def list_sessions(
@@ -328,15 +378,50 @@ class HermesACPAgent(acp.Agent):
 
     # ---- Slash commands (headless) -------------------------------------------
 
-    _SLASH_COMMANDS = {
-        "help": "Show available commands",
-        "model": "Show or change current model",
-        "tools": "List available tools",
-        "context": "Show conversation context info",
-        "reset": "Clear conversation history",
-        "compact": "Compress conversation context",
-        "version": "Show Hermes version",
-    }
+    @classmethod
+    def _available_commands(cls) -> list[AvailableCommand]:
+        commands: list[AvailableCommand] = []
+        for spec in cls._ADVERTISED_COMMANDS:
+            input_hint = spec.get("input_hint")
+            commands.append(
+                AvailableCommand(
+                    name=spec["name"],
+                    description=spec["description"],
+                    input=UnstructuredCommandInput(hint=input_hint)
+                    if input_hint
+                    else None,
+                )
+            )
+        return commands
+
+    async def _send_available_commands_update(self, session_id: str) -> None:
+        """Advertise supported slash commands to the connected ACP client."""
+        if not self._conn:
+            return
+
+        try:
+            await self._conn.session_update(
+                session_id=session_id,
+                update=AvailableCommandsUpdate(
+                    sessionUpdate="available_commands_update",
+                    availableCommands=self._available_commands(),
+                ),
+            )
+        except Exception:
+            logger.warning(
+                "Failed to advertise ACP slash commands for session %s",
+                session_id,
+                exc_info=True,
+            )
+
+    def _schedule_available_commands_update(self, session_id: str) -> None:
+        """Send the command advertisement after the session response is queued."""
+        if not self._conn:
+            return
+        loop = asyncio.get_running_loop()
+        loop.call_soon(
+            asyncio.create_task, self._send_available_commands_update(session_id)
+        )
 
     def _handle_slash_command(self, text: str, state: SessionState) -> str | None:
         """Dispatch a slash command and return the response text.
@@ -456,11 +541,39 @@ class HermesACPAgent(acp.Agent):
             return "Nothing to compress — conversation is empty."
         try:
             agent = state.agent
-            if hasattr(agent, "compress_context"):
-                agent.compress_context(state.history)
-                self.session_manager.save_session(state.session_id)
-                return f"Context compressed. Messages: {len(state.history)}"
-            return "Context compression not available for this agent."
+            if not getattr(agent, "compression_enabled", True):
+                return "Context compression is disabled for this agent."
+            if not hasattr(agent, "_compress_context"):
+                return "Context compression not available for this agent."
+
+            from agent.model_metadata import estimate_messages_tokens_rough
+
+            original_count = len(state.history)
+            approx_tokens = estimate_messages_tokens_rough(state.history)
+            original_session_db = getattr(agent, "_session_db", None)
+
+            try:
+                # ACP sessions must keep a stable session id, so avoid the
+                # SQLite session-splitting side effect inside _compress_context.
+                agent._session_db = None
+                compressed, _ = agent._compress_context(
+                    state.history,
+                    getattr(agent, "_cached_system_prompt", "") or "",
+                    approx_tokens=approx_tokens,
+                    task_id=state.session_id,
+                )
+            finally:
+                agent._session_db = original_session_db
+
+            state.history = compressed
+            self.session_manager.save_session(state.session_id)
+
+            new_count = len(state.history)
+            new_tokens = estimate_messages_tokens_rough(state.history)
+            return (
+                f"Context compressed: {original_count} -> {new_count} messages\n"
+                f"~{approx_tokens:,} -> ~{new_tokens:,} tokens"
+            )
         except Exception as e:
             return f"Compression failed: {e}"
 

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -11,6 +11,7 @@ import acp
 from acp.schema import (
     AgentCapabilities,
     AuthenticateResponse,
+    AvailableCommandsUpdate,
     Implementation,
     InitializeResponse,
     ListSessionsResponse,
@@ -111,6 +112,53 @@ class TestSessionOps:
         assert state.cwd == "/home/user/project"
 
     @pytest.mark.asyncio
+    async def test_available_commands_include_help(self, agent):
+        help_cmd = next(
+            (cmd for cmd in agent._available_commands() if cmd.name == "help"),
+            None,
+        )
+
+        assert help_cmd is not None
+        assert help_cmd.description == "List available commands"
+        assert help_cmd.input is None
+
+    @pytest.mark.asyncio
+    async def test_send_available_commands_update(self, agent):
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        agent._conn = mock_conn
+
+        await agent._send_available_commands_update("session-123")
+
+        mock_conn.session_update.assert_awaited_once()
+        call = mock_conn.session_update.await_args
+        assert call.kwargs["session_id"] == "session-123"
+        update = call.kwargs["update"]
+        assert isinstance(update, AvailableCommandsUpdate)
+        assert update.session_update == "available_commands_update"
+        assert [cmd.name for cmd in update.available_commands] == [
+            "help",
+            "model",
+            "tools",
+            "context",
+            "reset",
+            "compact",
+            "version",
+        ]
+        model_cmd = next(
+            cmd for cmd in update.available_commands if cmd.name == "model"
+        )
+        assert model_cmd.input is not None
+        assert model_cmd.input.root.hint == "model name to switch to"
+
+    @pytest.mark.asyncio
+    async def test_new_session_schedules_available_commands_update(self, agent):
+        with patch.object(agent, "_schedule_available_commands_update") as mock_schedule:
+            resp = await agent.new_session(cwd="/home/user/project")
+
+        mock_schedule.assert_called_once_with(resp.session_id)
+
+    @pytest.mark.asyncio
     async def test_cancel_sets_event(self, agent):
         resp = await agent.new_session(cwd=".")
         state = agent.session_manager.get_session(resp.session_id)
@@ -130,6 +178,15 @@ class TestSessionOps:
         assert isinstance(load_resp, LoadSessionResponse)
 
     @pytest.mark.asyncio
+    async def test_load_session_schedules_available_commands_update(self, agent):
+        resp = await agent.new_session(cwd="/tmp")
+        with patch.object(agent, "_schedule_available_commands_update") as mock_schedule:
+            load_resp = await agent.load_session(cwd="/tmp", session_id=resp.session_id)
+
+        assert isinstance(load_resp, LoadSessionResponse)
+        mock_schedule.assert_called_once_with(resp.session_id)
+
+    @pytest.mark.asyncio
     async def test_load_session_not_found_returns_none(self, agent):
         resp = await agent.load_session(cwd="/tmp", session_id="bogus")
         assert resp is None
@@ -139,6 +196,15 @@ class TestSessionOps:
         resp = await agent.new_session(cwd="/tmp")
         resume_resp = await agent.resume_session(cwd="/tmp", session_id=resp.session_id)
         assert isinstance(resume_resp, ResumeSessionResponse)
+
+    @pytest.mark.asyncio
+    async def test_resume_session_schedules_available_commands_update(self, agent):
+        resp = await agent.new_session(cwd="/tmp")
+        with patch.object(agent, "_schedule_available_commands_update") as mock_schedule:
+            resume_resp = await agent.resume_session(cwd="/tmp", session_id=resp.session_id)
+
+        assert isinstance(resume_resp, ResumeSessionResponse)
+        mock_schedule.assert_called_once_with(resp.session_id)
 
     @pytest.mark.asyncio
     async def test_resume_session_creates_new_if_missing(self, agent):
@@ -166,6 +232,15 @@ class TestListAndFork:
         fork_resp = await agent.fork_session(cwd="/forked", session_id=new_resp.session_id)
         assert fork_resp.session_id
         assert fork_resp.session_id != new_resp.session_id
+
+    @pytest.mark.asyncio
+    async def test_fork_session_schedules_available_commands_update(self, agent):
+        new_resp = await agent.new_session(cwd="/original")
+        with patch.object(agent, "_schedule_available_commands_update") as mock_schedule:
+            fork_resp = await agent.fork_session(cwd="/forked", session_id=new_resp.session_id)
+
+        assert fork_resp.session_id
+        mock_schedule.assert_called_once_with(fork_resp.session_id)
 
 
 # ---------------------------------------------------------------------------
@@ -356,6 +431,55 @@ class TestSlashCommands:
         result = agent._handle_slash_command("/version", state)
         assert HERMES_VERSION in result
 
+    def test_compact_compresses_context(self, agent, mock_manager):
+        state = self._make_state(mock_manager)
+        state.history = [
+            {"role": "user", "content": "one"},
+            {"role": "assistant", "content": "two"},
+            {"role": "user", "content": "three"},
+            {"role": "assistant", "content": "four"},
+        ]
+        state.agent.compression_enabled = True
+        state.agent._cached_system_prompt = "system"
+        original_session_db = object()
+        state.agent._session_db = original_session_db
+
+        def _compress_context(messages, system_prompt, *, approx_tokens, task_id):
+            assert state.agent._session_db is None
+            assert messages == state.history
+            assert system_prompt == "system"
+            assert approx_tokens == 40
+            assert task_id == state.session_id
+            return [{"role": "user", "content": "summary"}], "new-system"
+
+        state.agent._compress_context = MagicMock(side_effect=_compress_context)
+
+        with (
+            patch.object(agent.session_manager, "save_session") as mock_save,
+            patch(
+                "agent.model_metadata.estimate_messages_tokens_rough",
+                side_effect=[40, 12],
+            ),
+        ):
+            result = agent._handle_slash_command("/compact", state)
+
+        assert "Context compressed: 4 -> 1 messages" in result
+        assert "~40 -> ~12 tokens" in result
+        assert state.history == [{"role": "user", "content": "summary"}]
+        assert state.agent._session_db is original_session_db
+        state.agent._compress_context.assert_called_once_with(
+            [
+                {"role": "user", "content": "one"},
+                {"role": "assistant", "content": "two"},
+                {"role": "user", "content": "three"},
+                {"role": "assistant", "content": "four"},
+            ],
+            "system",
+            approx_tokens=40,
+            task_id=state.session_id,
+        )
+        mock_save.assert_called_once_with(state.session_id)
+
     def test_unknown_command_returns_none(self, agent, mock_manager):
         state = self._make_state(mock_manager)
         result = agent._handle_slash_command("/nonexistent", state)
@@ -365,7 +489,8 @@ class TestSlashCommands:
     async def test_slash_command_intercepted_in_prompt(self, agent, mock_manager):
         """Slash commands should be handled without calling the LLM."""
         new_resp = await agent.new_session(cwd="/tmp")
-        mock_conn = AsyncMock(spec=acp.Client)
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
         agent._conn = mock_conn
 
         prompt = [TextContentBlock(type="text", text="/help")]
@@ -378,7 +503,9 @@ class TestSlashCommands:
     async def test_unknown_slash_falls_through_to_llm(self, agent, mock_manager):
         """Unknown /commands should be sent to the LLM, not intercepted."""
         new_resp = await agent.new_session(cwd="/tmp")
-        mock_conn = AsyncMock(spec=acp.Client)
+        mock_conn = MagicMock(spec=acp.Client)
+        mock_conn.session_update = AsyncMock()
+        mock_conn.request_permission = AsyncMock(return_value=None)
         agent._conn = mock_conn
 
         # Mock run_in_executor to avoid actually running the agent


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

ACP slash commands current do not work, since they exist but are not advertising correctly

see https://github.com/zed-industries/zed/issues/41405#issuecomment-3501853287
> In order for slash commands to work in Gemini/Qwen-Code, etc., the agents need to advertise them to Zed from their end as described in the docs

the docs to Advertising commands in acp https://agentclientprotocol.com/protocol/slash-commands

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. install zed and add fixed zed acp config see #2222
2. open agent panel and go to hermes agent
3. type and send /version or /help or any other slash command, just typing slash should also have a popup of all commands


## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

### Before
see no popup
<img width="846" height="1066" alt="image" src="https://github.com/user-attachments/assets/1a07e91b-4434-4e9b-b222-f131bf218ecb" />

<img width="850" height="1059" alt="image" src="https://github.com/user-attachments/assets/fc3815fb-9aeb-4e4b-b5e5-f13abb4fb292" />

### After
<img width="844" height="1032" alt="image" src="https://github.com/user-attachments/assets/819e80b8-b4bf-44b4-8a41-e7ed78740559" />
<img width="833" height="1019" alt="image" src="https://github.com/user-attachments/assets/badd50e9-53ee-4cbe-99fe-86ac10e4f269" />

