### PR TITLE
fix: preserve threaded Slack delivery for cron updates

### DIFF
--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -117,6 +117,29 @@ class TestScheduleCronjob:
         ))
         assert result["repeat"] == "5 times"
 
+    def test_origin_preserves_thread_id_from_environment(self, monkeypatch):
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "slack")
+        monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "C123")
+        monkeypatch.setenv("HERMES_SESSION_CHAT_NAME", "trading-strategy")
+        monkeypatch.setenv("HERMES_SESSION_THREAD_ID", "1774555596.462009")
+
+        result = json.loads(schedule_cronjob(
+            prompt="Check server status",
+            schedule="30m",
+            name="Threaded Job",
+        ))
+        assert result["success"] is True
+
+        listing = json.loads(list_cronjobs(include_disabled=True))
+        job = next(j for j in listing["jobs"] if j["job_id"] == result["job_id"])
+        assert job["deliver"] == "origin"
+
+        from cron.jobs import load_jobs
+        stored_job = next(j for j in load_jobs() if j["id"] == result["job_id"])
+        assert stored_job["origin"]["platform"] == "slack"
+        assert stored_job["origin"]["chat_id"] == "C123"
+        assert stored_job["origin"]["thread_id"] == "1774555596.462009"
+
 
 # =========================================================================
 # list_cronjobs

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -2,11 +2,12 @@
 
 import asyncio
 import json
+import os
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 from gateway.config import Platform
-from tools.send_message_tool import send_message_tool
+from tools.send_message_tool import _send_slack, _send_to_platform, send_message_tool
 
 
 def _run_async_immediately(coro):
@@ -25,7 +26,8 @@ class TestSendMessageTool:
     def test_sends_to_explicit_telegram_topic_target(self):
         config, telegram_cfg = _make_config()
 
-        with patch("gateway.config.load_gateway_config", return_value=config), \
+        with patch.dict("os.environ", {"HERMES_SESSION_PLATFORM": "cli"}, clear=False), \
+             patch("gateway.config.load_gateway_config", return_value=config), \
              patch("tools.interrupt.is_interrupted", return_value=False), \
              patch("model_tools._run_async", side_effect=_run_async_immediately), \
              patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
@@ -65,3 +67,49 @@ class TestSendMessageTool:
 
         assert result["success"] is True
         send_mock.assert_awaited_once_with(Platform.TELEGRAM, telegram_cfg, "-1001", "hello", thread_id="17585")
+
+    def test_send_to_platform_passes_slack_thread_id(self):
+        slack_cfg = SimpleNamespace(token="xoxb-test", extra={})
+
+        with patch("tools.send_message_tool._send_slack", new=AsyncMock(return_value={"success": True})) as send_mock:
+            result = asyncio.run(_send_to_platform(Platform.SLACK, slack_cfg, "C123", "hello", thread_id="1774555596.462009"))
+
+        assert result == {"success": True}
+        send_mock.assert_awaited_once_with("xoxb-test", "C123", "hello", thread_id="1774555596.462009")
+
+    def test_send_slack_includes_thread_ts_when_present(self):
+        class FakeResponse:
+            async def json(self):
+                return {"ok": True, "ts": "1774555600.000100"}
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        class FakeSession:
+            def __init__(self):
+                self.calls = []
+
+            def post(self, url, headers=None, json=None):
+                self.calls.append({"url": url, "headers": headers, "json": json})
+                return FakeResponse()
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        fake_session = FakeSession()
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            result = asyncio.run(_send_slack("xoxb-test", "C123", "hello", thread_id="1774555596.462009"))
+
+        assert result["success"] is True
+        assert fake_session.calls[0]["json"] == {
+            "channel": "C123",
+            "text": "hello",
+            "thread_ts": "1774555596.462009",
+        }

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -124,6 +124,9 @@ def schedule_cronjob(
             "chat_id": origin_chat_id,
             "chat_name": os.getenv("HERMES_SESSION_CHAT_NAME"),
         }
+        origin_thread_id = os.getenv("HERMES_SESSION_THREAD_ID")
+        if origin_thread_id:
+            origin["thread_id"] = origin_thread_id
     
     try:
         job = create_job(

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -183,7 +183,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None)
     elif platform == Platform.DISCORD:
         return await _send_discord(pconfig.token, chat_id, message)
     elif platform == Platform.SLACK:
-        return await _send_slack(pconfig.token, chat_id, message)
+        return await _send_slack(pconfig.token, chat_id, message, thread_id=thread_id)
     elif platform == Platform.SIGNAL:
         return await _send_signal(pconfig.extra, chat_id, message)
     elif platform == Platform.EMAIL:
@@ -231,7 +231,7 @@ async def _send_discord(token, chat_id, message):
         return {"error": f"Discord send failed: {e}"}
 
 
-async def _send_slack(token, chat_id, message):
+async def _send_slack(token, chat_id, message, thread_id=None):
     """Send via Slack Web API."""
     try:
         import aiohttp
@@ -240,8 +240,11 @@ async def _send_slack(token, chat_id, message):
     try:
         url = "https://slack.com/api/chat.postMessage"
         headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+        payload = {"channel": chat_id, "text": message}
+        if thread_id is not None:
+            payload["thread_ts"] = thread_id
         async with aiohttp.ClientSession() as session:
-            async with session.post(url, headers=headers, json={"channel": chat_id, "text": message}) as resp:
+            async with session.post(url, headers=headers, json=payload) as resp:
                 data = await resp.json()
                 if data.get("ok"):
                     return {"success": True, "platform": "slack", "chat_id": chat_id, "message_id": data.get("ts")}


### PR DESCRIPTION
## Summary
- pass Slack thread IDs through the direct send path so cron deliveries use `thread_ts`
- preserve `HERMES_SESSION_THREAD_ID` when scheduling cronjobs with `deliver=origin`
- add regression tests for both the Slack sender and cronjob origin capture

## Root cause
There were two separate breaks affecting threaded Slack cron delivery:
1. `tools/send_message_tool.py` ignored `thread_id` for Slack direct sends, so scheduler deliveries posted to the channel root instead of the thread.
2. `tools/cronjob_tools.py` did not persist `HERMES_SESSION_THREAD_ID` into the stored cronjob origin, so new jobs created from a Slack thread lost the thread context immediately.

## Verification
- `source venv/bin/activate && python -m pytest tests/tools/test_send_message_tool.py tests/tools/test_cronjob_tools.py tests/cron/test_scheduler.py -q`
- Result: `37 passed`

## Notes
This was found while debugging Slack thread noise from recurring strategy-monitor cronjobs.
