### PR TITLE
fix: increase API timeout default from 900s to 1800s for slow-thinking models

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3772,7 +3772,7 @@ class AIAgent:
         def _call_chat_completions():
             """Stream a chat completions response."""
             import httpx as _httpx
-            _base_timeout = float(os.getenv("HERMES_API_TIMEOUT", 900.0))
+            _base_timeout = float(os.getenv("HERMES_API_TIMEOUT", 1800.0))
             _stream_read_timeout = float(os.getenv("HERMES_STREAM_READ_TIMEOUT", 60.0))
             stream_kwargs = {
                 **api_kwargs,
@@ -4497,7 +4497,7 @@ class AIAgent:
             "model": self.model,
             "messages": sanitized_messages,
             "tools": self.tools if self.tools else None,
-            "timeout": float(os.getenv("HERMES_API_TIMEOUT", 900.0)),
+            "timeout": float(os.getenv("HERMES_API_TIMEOUT", 1800.0)),
         }
 
         if self.max_tokens is not None:

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -637,7 +637,7 @@ class TestBuildApiKwargs:
         kwargs = agent._build_api_kwargs(messages)
         assert kwargs["model"] == agent.model
         assert kwargs["messages"] is messages
-        assert kwargs["timeout"] == 900.0
+        assert kwargs["timeout"] == 1800.0
 
     def test_provider_preferences_injected(self, agent):
         agent.providers_allowed = ["Anthropic"]


### PR DESCRIPTION
## Problem

Models like GLM-5/5.1 can think for 15+ minutes. The previous `HERMES_API_TIMEOUT` default of 900s (15 min) killed legitimate requests mid-thinking.

## Fix

Raise `HERMES_API_TIMEOUT` default from 900s to 1800s (30 min) in both places that read the env var:
- `_build_api_kwargs()` — non-streaming total timeout
- `_call_chat_completions()` — streaming connection write timeout

Still configurable via `HERMES_API_TIMEOUT` env var.

### Unchanged

- Stream per-chunk read timeout (60s) — appropriate for inter-chunk timing
- Stale stream detector (180-300s) — already scales for large contexts

## Test results

200 passed, 0 failures.