### PR TITLE
feat(discord): add channel-based routing prefixes from config

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -531,6 +531,15 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["DISCORD_FREE_RESPONSE_CHANNELS"] = str(frc)
                 if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
                     os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
+                channel_routing = discord_cfg.get("channel_routing")
+                if (
+                    isinstance(channel_routing, dict)
+                    and channel_routing
+                    and not os.getenv("DISCORD_CHANNEL_ROUTING")
+                ):
+                    os.environ["DISCORD_CHANNEL_ROUTING"] = json.dumps(
+                        {str(k): str(v) for k, v in channel_routing.items() if str(v)}
+                    )
     except Exception as e:
         logger.warning(
             "Failed to process config.yaml — falling back to .env / gateway.json values. "

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -430,6 +430,7 @@ class DiscordAdapter(BasePlatformAdapter):
         self._client: Optional[commands.Bot] = None
         self._ready_event = asyncio.Event()
         self._allowed_user_ids: set = set()  # For button approval authorization
+        self._channel_routing: Dict[str, str] = self._load_channel_routing()
         # Voice channel state (per-guild)
         self._voice_clients: Dict[int, Any] = {}  # guild_id -> VoiceClient
         self._voice_text_channels: Dict[int, int] = {}  # guild_id -> text_channel_id
@@ -448,6 +449,62 @@ class DiscordAdapter(BasePlatformAdapter):
         self._typing_tasks: Dict[str, asyncio.Task] = {}
         # Cap to prevent unbounded growth (Discord threads get archived).
         self._MAX_TRACKED_THREADS = 500
+
+    def _load_channel_routing(self) -> Dict[str, str]:
+        """Load channel->prefix routing from config.extra and env var."""
+        routing: Dict[str, str] = {}
+
+        from_config = self.config.extra.get("channel_routing", {})
+        if isinstance(from_config, dict):
+            for channel_id, prefix in from_config.items():
+                channel_key = str(channel_id).strip()
+                if not channel_key:
+                    continue
+                if isinstance(prefix, str) and prefix:
+                    routing[channel_key] = prefix
+        elif from_config:
+            logger.warning(
+                "[%s] Ignoring invalid discord channel_routing in platform extra (expected dict)",
+                self.name,
+            )
+
+        routing_env = os.getenv("DISCORD_CHANNEL_ROUTING", "").strip()
+        if routing_env:
+            try:
+                parsed = json.loads(routing_env)
+                if not isinstance(parsed, dict):
+                    raise ValueError("must be a JSON object")
+                for channel_id, prefix in parsed.items():
+                    channel_key = str(channel_id).strip()
+                    if not channel_key:
+                        continue
+                    if isinstance(prefix, str) and prefix:
+                        routing[channel_key] = prefix
+            except Exception as e:
+                logger.warning(
+                    "[%s] Invalid DISCORD_CHANNEL_ROUTING JSON, ignoring value: %s",
+                    self.name,
+                    e,
+                )
+
+        if routing:
+            logger.info("[%s] Loaded Discord channel routing for %d channel(s)", self.name, len(routing))
+        return routing
+
+    def _get_routing_prefix(self, message: DiscordMessage) -> str:
+        """Return a routing prefix based on channel or parent thread channel."""
+        if not self._channel_routing:
+            return ""
+
+        channel_id = str(getattr(message.channel, "id", "")).strip()
+        if channel_id and channel_id in self._channel_routing:
+            return self._channel_routing[channel_id]
+
+        parent_channel_id = self._get_parent_channel_id(message.channel)
+        if parent_channel_id and parent_channel_id in self._channel_routing:
+            return self._channel_routing[parent_channel_id]
+
+        return ""
     
     async def connect(self) -> bool:
         """Connect to Discord and start receiving events."""
@@ -2094,6 +2151,9 @@ class DiscordAdapter(BasePlatformAdapter):
         event_text = message.content
         if pending_text_injection:
             event_text = f"{pending_text_injection}\n\n{event_text}" if event_text else pending_text_injection
+        routing_prefix = self._get_routing_prefix(message)
+        if routing_prefix:
+            event_text = f"{routing_prefix}{event_text}" if event_text else routing_prefix
 
         event = MessageEvent(
             text=event_text,

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -358,3 +358,37 @@ async def test_discord_thread_participation_tracked_on_dispatch(adapter, monkeyp
     await adapter._handle_message(message)
 
     assert "777" in adapter._bot_participated_threads
+
+
+@pytest.mark.asyncio
+async def test_discord_channel_routing_prefix_from_env(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    monkeypatch.setenv("DISCORD_CHANNEL_ROUTING", '{"123":"You are Quill.\\n\\n"}')
+
+    adapter._channel_routing = adapter._load_channel_routing()
+    message = make_message(channel=FakeTextChannel(channel_id=123), content="write a poem")
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "You are Quill.\n\nwrite a poem"
+
+
+@pytest.mark.asyncio
+async def test_discord_channel_routing_prefix_applies_via_parent_for_thread(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+    monkeypatch.setenv("DISCORD_CHANNEL_ROUTING", '{"222":"You are Intel.\\n\\n"}')
+
+    adapter._channel_routing = adapter._load_channel_routing()
+    parent = FakeTextChannel(channel_id=222)
+    thread = FakeThread(channel_id=333, parent=parent)
+    message = make_message(channel=thread, content="investigate this")
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "You are Intel.\n\ninvestigate this"


### PR DESCRIPTION
﻿## Related Issue
Fixes #3423

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made
- Added config/env-driven Discord channel routing for persona/context prefix injection in `gateway/platforms/discord.py`.
- Added bridge from `discord.channel_routing` in `config.yaml` to `DISCORD_CHANNEL_ROUTING` (only when env var is not already set) in `gateway/config.py`.
- Added tests for direct channel routing and thread parent-channel fallback in `tests/gateway/test_discord_free_response.py`.

## How to Test
1. Set `DISCORD_REQUIRE_MENTION=false` and `DISCORD_AUTO_THREAD=false`.
2. Set `DISCORD_CHANNEL_ROUTING='{"123":"You are Quill.\\n\\n","456":"You are Intel.\\n\\n"}'`.
3. Send messages in mapped channels (and in threads under mapped parent channels) and verify the prefix is prepended before dispatch.
4. Run:
   - `python -m pytest tests/gateway/test_discord_free_response.py -q`
   - `python -m pytest tests/gateway/test_discord_free_response.py tests/gateway/test_discord_thread_persistence.py -q`

## Checklist
### Code
- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping
- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs
- `python -m pytest tests/gateway/test_discord_free_response.py -q` (passed)
- `python -m pytest tests/gateway/test_discord_free_response.py tests/gateway/test_discord_thread_persistence.py -q` (passed)
