### PR TITLE
fix(async): prevent 'Event loop is closed' GC crashes mid-session

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -777,7 +777,9 @@ def _to_async_client(sync_client, model: str):
         async_kwargs["default_headers"] = copilot_default_headers()
     elif "api.kimi.com" in base_lower:
         async_kwargs["default_headers"] = {"User-Agent": "KimiCLI/1.0"}
-    return AsyncOpenAI(**async_kwargs), model
+    async_client = AsyncOpenAI(**async_kwargs)
+    _track_async_client(async_client)
+    return async_client, model
 
 
 def resolve_provider_client(
@@ -1203,6 +1205,34 @@ def auxiliary_max_tokens_param(value: int) -> dict:
 _client_cache: Dict[tuple, tuple] = {}
 _client_cache_lock = threading.Lock()
 
+# Weak-reference registry for ALL async clients created anywhere (including
+# those returned by resolve_provider_client that bypass _client_cache).
+# Used by _force_close_all_async_clients() during shutdown and by the
+# prompt_toolkit exception-handler safety net.
+import weakref as _weakref
+_all_async_clients: list = []
+_all_async_clients_lock = threading.Lock()
+
+
+def _track_async_client(client: Any) -> None:
+    """Register an async client so it will be neutered on shutdown."""
+    with _all_async_clients_lock:
+        _all_async_clients.append(_weakref.ref(client))
+
+
+def _force_close_all_async_clients() -> None:
+    """Mark ALL tracked async clients as closed to prevent __del__ crashes.
+
+    Covers clients created via resolve_provider_client (not in _client_cache)
+    as well as any client manually registered with _track_async_client.
+    """
+    with _all_async_clients_lock:
+        for ref in _all_async_clients:
+            client = ref()
+            if client is not None:
+                _force_close_async_httpx(client)
+        _all_async_clients.clear()
+
 
 def _force_close_async_httpx(client: Any) -> None:
     """Mark the httpx AsyncClient inside an AsyncOpenAI client as closed.
@@ -1229,6 +1259,8 @@ def shutdown_cached_clients() -> None:
 
     Call this during CLI shutdown, *before* the event loop is closed, to
     avoid ``AsyncHttpxClientWrapper.__del__`` raising on a dead loop.
+    Covers both _client_cache entries and clients tracked via
+    _track_async_client (e.g. those from resolve_provider_client).
     """
     import inspect
 
@@ -1249,6 +1281,9 @@ def shutdown_cached_clients() -> None:
             except Exception:
                 pass
         _client_cache.clear()
+
+    # Also neuter any async clients that bypassed _client_cache.
+    _force_close_all_async_clients()
 
 
 def _get_cached_client(

--- a/cli.py
+++ b/cli.py
@@ -502,6 +502,9 @@ def _run_cleanup():
     # Close cached auxiliary LLM clients (sync + async) so that
     # AsyncHttpxClientWrapper.__del__ doesn't fire on a closed event loop
     # and trigger prompt_toolkit's "Press ENTER to continue..." handler.
+    # shutdown_cached_clients() also calls _force_close_all_async_clients()
+    # which covers clients created via resolve_provider_client that bypass
+    # _client_cache (e.g. openrouter_client._client).
     try:
         from agent.auxiliary_client import shutdown_cached_clients
         shutdown_cached_clients()
@@ -6973,6 +6976,33 @@ class HermesCLI:
             **({'cursor': _STEADY_CURSOR} if _STEADY_CURSOR is not None else {}),
         )
         self._app = app  # Store reference for clarify_callback
+
+        # Defense-in-depth: suppress "RuntimeError: Event loop is closed" that
+        # originates from AsyncHttpxClientWrapper.__del__ scheduling aclose()
+        # on prompt_toolkit's loop when a stale async client is GC'd mid-session.
+        # Without this, prompt_toolkit's default exception handler prints the
+        # traceback and halts with "Press ENTER to continue...".
+        _pt_loop = asyncio.get_event_loop()
+        _original_exc_handler = _pt_loop.get_exception_handler()
+
+        def _safe_exc_handler(loop, context):
+            exc = context.get("exception")
+            if isinstance(exc, RuntimeError) and "Event loop is closed" in str(exc):
+                # Harmless GC cleanup failure from a stale httpx/openai/anthropic
+                # async client whose transport references a closed tool loop.
+                # The OS will drop the connections; no action needed.
+                import logging as _logging
+                _logging.debug(
+                    "Suppressed 'Event loop is closed' from async client GC: %s",
+                    context.get("message", ""),
+                )
+                return
+            if _original_exc_handler is not None:
+                _original_exc_handler(loop, context)
+            else:
+                loop.default_exception_handler(context)
+
+        _pt_loop.set_exception_handler(_safe_exc_handler)
 
         def spinner_loop():
             import time as _time

--- a/tools/openrouter_client.py
+++ b/tools/openrouter_client.py
@@ -20,10 +20,14 @@ def get_async_client():
     """
     global _client
     if _client is None:
-        from agent.auxiliary_client import resolve_provider_client
+        from agent.auxiliary_client import resolve_provider_client, _track_async_client
         client, _model = resolve_provider_client("openrouter", async_mode=True)
         if client is None:
             raise ValueError("OPENROUTER_API_KEY environment variable not set")
+        # resolve_provider_client tracks AsyncOpenAI clients created via
+        # _to_async_client, but register explicitly here too in case the
+        # client bypassed that path (e.g. a non-OpenAI async adapter).
+        _track_async_client(client)
         _client = client
     return _client
 


### PR DESCRIPTION
## What does this PR do?                                                                                                                                                                                     
                                                                                                                                                                                                            
  Fixes a bug where stale AsyncOpenAI/AsyncAnthropic clients getting garbage-collected mid-session would trigger RuntimeError: Event loop is closed, which caused prompt_toolkit to halt the CLI with "Press ENTER to continue...". This could happen repeatedly during heavy tool use.
                                                                                                                                                                                                            
  Three-layer fix:                                                                                                                                                                                          
  1. A global weakref registry tracks every async client created anywhere — not just those in _client_cache
  2. shutdown_cached_clients() now also drains the registry, covering clients from resolve_provider_client and openrouter_client that previously escaped cleanup                                            
  3. A safe exception handler is installed on prompt_toolkit's event loop at startup to suppress any remaining Event loop is closed noise from third-party code 
                                                                                                                                                                                                            
 ## Related Issue                                                                                                                                                                                             
                                                                                                                                                                                                            
  Fixes #3436                                                                                                                                                                                               
                                                            
  ## Type of Change

  - 🐛 Bug fix (non-breaking change that fixes an issue)                                                                                                                                                    
  
  ## Changes Made                                                                                                                                                                                              
                                                            
  - agent/auxiliary_client.py — add _all_async_clients weakref registry, _track_async_client(), _force_close_all_async_clients(); call _track_async_client inside _to_async_client (single choke-point for all AsyncOpenAI creation); update shutdown_cached_clients() to drain registry after clearing cache
  - tools/openrouter_client.py — explicitly call _track_async_client on the lazy singleton as defense against non-OpenAI async adapters that bypass _to_async_client                                        
  - cli.py — install _safe_exc_handler on prompt_toolkit's event loop after Application is created; silently drops RuntimeError: Event loop is closed from stale httpx GC paths, delegates everything else to the original handler                                                                                                                                                                                   
                                                                                                                                                                                                            
  ## How to Test                                                                                                                                                                                               
                                                            
  1. Start a CLI session                                                                                                                                                                                    
  2. Run several tool calls that create async HTTP clients in rapid succession (e.g. image_generate, mixture_of_agents, vision_analyze)
  3. Wait for GC to run — previously this would print the traceback and show "Press ENTER to continue..."                                                                                                   
  4. With the fix: no interruption, session continues normally                                                                                                                                              
                                                                                                                                                                                                            
 ## Checklist                                                                                                                                                                                                 
                                                                                                                                                                                                            
  - My commit messages follow Conventional Commits                                                                                                                                                          
  - My PR contains only changes related to this fix
  - I've run pytest tests/ -q and all tests pass — N/A                                                                                                                                                   
  - I've updated relevant documentation (README, docs/, docstrings) — N/A
  - I've updated cli-config.yaml.example if I added/changed config keys — N/A                                                                                                                               
  - I've considered cross-platform impact (Windows, macOS) — fix is pure Python stdlib, no platform-specific code
