### PR TITLE
fix(setup+auxiliary): custom endpoint loses config after setup, and auxiliary ignores active provider

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -611,14 +611,31 @@ def _read_main_model() -> str:
 def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str]]:
     """Resolve the active custom/main endpoint the same way the main CLI does.
 
-    This covers both env-driven OPENAI_BASE_URL setups and config-saved custom
-    endpoints where the base URL lives in config.yaml instead of the live
-    environment.
+    Uses the same provider resolution path as the main agent (reading provider
+    from config.yaml / env), so named custom providers (e.g. ``custom:local``)
+    are honoured instead of being skipped by a hardcoded ``requested="custom"``.
+
+    Falls back to an explicit ``requested="custom"`` pass only when the active
+    provider is not itself a custom endpoint, preserving existing behaviour for
+    env-driven OPENAI_BASE_URL setups.
     """
     try:
-        from hermes_cli.runtime_provider import resolve_runtime_provider
+        from hermes_cli.runtime_provider import (
+            resolve_runtime_provider,
+            resolve_requested_provider,
+        )
 
-        runtime = resolve_runtime_provider(requested="custom")
+        # First attempt: resolve using the same provider the main agent uses.
+        # This ensures named custom providers stored in config.yaml are picked
+        # up instead of being bypassed.
+        active_requested = resolve_requested_provider()
+        runtime = resolve_runtime_provider(requested=active_requested)
+
+        # If the active provider resolved to a non-custom endpoint (e.g. nous,
+        # openrouter) there is no custom endpoint to mirror.  Fall back to an
+        # explicit custom pass so env-driven OPENAI_BASE_URL setups still work.
+        if runtime.get("provider") != "custom":
+            runtime = resolve_runtime_provider(requested="custom")
     except Exception as exc:
         logger.debug("Auxiliary client: custom runtime resolution failed: %s", exc)
         return None, None
@@ -632,10 +649,17 @@ def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str]]:
 
     custom_base = custom_base.strip().rstrip("/")
     if "openrouter.ai" in custom_base.lower():
-        # requested='custom' falls back to OpenRouter when no custom endpoint is
-        # configured. Treat that as "no custom endpoint" for auxiliary routing.
+        # Treat an OpenRouter result as "no custom endpoint" for auxiliary
+        # routing — resolve_runtime_provider falls back to OpenRouter when
+        # nothing else is configured.
         return None, None
 
+    source = runtime.get("source", "unknown")
+    logger.debug(
+        "Auxiliary client: resolved custom runtime via source=%r endpoint=%s",
+        source,
+        custom_base,
+    )
     return custom_base, custom_key.strip()
 
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1057,6 +1057,16 @@ def setup_model_provider(config: dict):
         # and custom_providers. Keep selected_provider = "custom" so
         # the model selection step below is skipped (line 1631 check)
         # but vision and TTS setup still run.
+        #
+        # IMPORTANT: _model_flow_custom writes to disk via its own fresh
+        # load_config() + save_config() call — the outer `config` dict is
+        # NOT updated in-place.  If we don't reload here, the final
+        # save_config(config) at the bottom of run_setup_wizard() will
+        # overwrite what _model_flow_custom just wrote, losing
+        # model.provider and model.base_url from config.yaml (issue #3415).
+        from hermes_cli.config import load_config as _reload_config
+        config.clear()
+        config.update(_reload_config())
 
     elif provider_idx == 4:  # Z.AI / GLM
         selected_provider = "zai"

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -680,7 +680,11 @@ class TestVisionClientFallback:
         """
         monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:1234/v1")
         monkeypatch.setenv("OPENAI_API_KEY", "local-key")
+        # Set the active provider explicitly so _resolve_custom_runtime() uses the
+        # env-driven OPENAI_BASE_URL path and does not fall through to _try_anthropic.
+        monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "custom")
         with patch("agent.auxiliary_client._read_nous_auth", return_value=None), \
+             patch("agent.anthropic_adapter.build_anthropic_client", return_value=None), \
              patch("agent.auxiliary_client.OpenAI") as mock_openai:
             client, model = get_vision_auxiliary_client()
         assert client is not None  # Custom endpoint picked up as fallback

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -988,3 +988,129 @@ class TestAuxiliaryMaxTokensParam:
              patch("agent.auxiliary_client._read_codex_access_token", return_value=None):
             result = auxiliary_max_tokens_param(1024)
         assert result == {"max_tokens": 1024}
+
+
+class TestResolveCustomRuntime:
+    """_resolve_custom_runtime() should mirror the main agent's provider choice."""
+
+    def test_named_custom_provider_used_when_active(self, monkeypatch):
+        """When the active provider is a named custom one, auxiliary should reuse it."""
+        from agent.auxiliary_client import _resolve_custom_runtime
+
+        named_runtime = {
+            "provider": "custom",
+            "base_url": "http://localhost:11434/v1",
+            "api_key": "sk-local",
+            "source": "custom_provider:local",
+        }
+
+        with patch(
+            "hermes_cli.runtime_provider.resolve_requested_provider",
+            return_value="custom:local",
+        ), patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=named_runtime,
+        ) as mock_resolve:
+            base, key = _resolve_custom_runtime()
+
+        assert base == "http://localhost:11434/v1"
+        assert key == "sk-local"
+        # Should have resolved with the active provider name, not hardcoded "custom"
+        mock_resolve.assert_called_once_with(requested="custom:local")
+
+    def test_falls_back_to_explicit_custom_when_active_is_non_custom(self, monkeypatch):
+        """When the active provider is nous/openrouter, fall back to requested=custom."""
+        from agent.auxiliary_client import _resolve_custom_runtime
+
+        nous_runtime = {
+            "provider": "nous",
+            "base_url": "https://inference.nous.ai/v1",
+            "api_key": "nous-key",
+            "source": "portal",
+        }
+        custom_runtime = {
+            "provider": "custom",
+            "base_url": "http://localhost:8080/v1",
+            "api_key": "sk-env",
+            "source": "env",
+        }
+
+        call_count = {"n": 0}
+
+        def fake_resolve(*, requested):
+            call_count["n"] += 1
+            if requested == "nous":
+                return nous_runtime
+            return custom_runtime
+
+        with patch(
+            "hermes_cli.runtime_provider.resolve_requested_provider",
+            return_value="nous",
+        ), patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=fake_resolve,
+        ):
+            base, key = _resolve_custom_runtime()
+
+        assert base == "http://localhost:8080/v1"
+        assert key == "sk-env"
+        assert call_count["n"] == 2  # first with "nous", then fallback with "custom"
+
+    def test_credential_source_consistent_with_active_runtime(self, monkeypatch):
+        """Auxiliary credentials must come from the same source as the main runtime."""
+        from agent.auxiliary_client import _resolve_custom_runtime
+
+        active_runtime = {
+            "provider": "custom",
+            "base_url": "https://custom.example.com/v1",
+            "api_key": "sk-config-saved",
+            "source": "custom_provider:myserver",
+        }
+
+        with patch(
+            "hermes_cli.runtime_provider.resolve_requested_provider",
+            return_value="custom:myserver",
+        ), patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=active_runtime,
+        ):
+            base, key = _resolve_custom_runtime()
+
+        assert base == "https://custom.example.com/v1"
+        assert key == "sk-config-saved"
+
+    def test_openrouter_result_treated_as_no_custom_endpoint(self, monkeypatch):
+        """If active provider resolves to OpenRouter, auxiliary should see no endpoint."""
+        from agent.auxiliary_client import _resolve_custom_runtime
+
+        or_runtime = {
+            "provider": "custom",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "or-key",
+            "source": "env",
+        }
+
+        with patch(
+            "hermes_cli.runtime_provider.resolve_requested_provider",
+            return_value="auto",
+        ), patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=or_runtime,
+        ):
+            base, key = _resolve_custom_runtime()
+
+        assert base is None
+        assert key is None
+
+    def test_resolution_exception_returns_none(self, monkeypatch):
+        """Any exception during resolution must be swallowed and return (None, None)."""
+        from agent.auxiliary_client import _resolve_custom_runtime
+
+        with patch(
+            "hermes_cli.runtime_provider.resolve_requested_provider",
+            side_effect=RuntimeError("config unreadable"),
+        ):
+            base, key = _resolve_custom_runtime()
+
+        assert base is None
+        assert key is None

--- a/tests/hermes_cli/test_setup_model_provider.py
+++ b/tests/hermes_cli/test_setup_model_provider.py
@@ -459,6 +459,61 @@ def test_setup_summary_marks_codex_auth_as_vision_available(tmp_path, monkeypatc
     assert "missing OPENROUTER_API_KEY" in output
 
 
+def test_custom_setup_wizard_persists_provider_in_config(tmp_path, monkeypatch):
+    """hermes setup (custom endpoint) must not clobber model.provider after _model_flow_custom.
+
+    Regression test for issue #3415: run_setup_wizard() called save_config(config) at
+    the end using the outer `config` dict that was never updated by _model_flow_custom
+    (which writes via its own fresh load_config() / save_config() cycle), causing
+    model.provider and model.base_url to be stripped from config.yaml.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_env(monkeypatch)
+
+    config = load_config()
+
+    def fake_prompt_choice(question, choices, default=0):
+        if question == "Select your inference provider:":
+            return 3  # Custom endpoint
+        if question == "Configure vision:":
+            return len(choices) - 1  # Skip
+        tts_idx = _maybe_keep_current_tts(question, choices)
+        if tts_idx is not None:
+            return tts_idx
+        raise AssertionError(f"Unexpected prompt_choice call: {question!r}")
+
+    monkeypatch.setattr("hermes_cli.setup.prompt_choice", fake_prompt_choice)
+    monkeypatch.setattr("hermes_cli.setup.prompt_yes_no", lambda *a, **kw: False)
+    monkeypatch.setattr("hermes_cli.auth.detect_external_credentials", lambda: [])
+    monkeypatch.setattr("hermes_cli.main._save_custom_provider", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        "hermes_cli.models.probe_api_models",
+        lambda api_key, base_url: {"models": ["m"], "probed_url": base_url + "/models"},
+    )
+
+    input_values = iter([
+        "https://custom.example/v1",  # base URL
+        "custom-api-key",              # API key
+        "my-model",                    # model name
+        "",                            # context_length (blank = auto-detect)
+    ])
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(input_values))
+
+    setup_model_provider(config)
+    save_config(config)
+
+    reloaded = load_config()
+    model = reloaded.get("model", {})
+    assert isinstance(model, dict), "model should be a dict after custom setup"
+    assert model.get("provider") == "custom", (
+        "model.provider was lost — run_setup_wizard() clobbered _model_flow_custom's write"
+    )
+    assert model.get("base_url") == "https://custom.example/v1", (
+        "model.base_url was lost — run_setup_wizard() clobbered _model_flow_custom's write"
+    )
+    assert model.get("default") == "my-model"
+
+
 def test_setup_summary_marks_anthropic_auth_as_vision_available(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     _clear_provider_env(monkeypatch)


### PR DESCRIPTION
## Summary

Fixes #3410.

Two separate bugs that both affect custom OpenAI-compatible endpoint users.

---

## Fix 1 — `auxiliary_client`: mirror active runtime in `_resolve_custom_runtime`

### Root cause

`_resolve_custom_runtime()` hardcoded `requested="custom"` when calling
`resolve_runtime_provider()`. The problem: `_get_named_custom_provider()`
**explicitly returns `None`** when `requested_norm == "custom"` — it only matches
named entries like `custom:local`. So named custom providers saved in
`config.yaml` were silently bypassed.

The auxiliary path then fell through to env-var resolution
(`OPENAI_BASE_URL` / `OPENAI_API_KEY`), which can carry different credentials
or nothing at all — even though the main agent was already running successfully
against the named provider.

### Fix

```
resolve_requested_provider()          # what provider is the main agent using?
  → "custom:local"                    # reads config.yaml / HERMES_INFERENCE_PROVIDER

resolve_runtime_provider(requested="custom:local")   # same path as main agent
  → { provider: "custom", source: "custom_provider:local", api_key: "...", ... }
```

If the active provider is not a custom endpoint (e.g. `nous`, `openrouter`),
fall back to `requested="custom"` so env-driven `OPENAI_BASE_URL` setups keep working.

Also adds `DEBUG`-level logging of the credential source selected for auxiliary
resolution.

---

## Fix 2 — `setup`: reload config after `_model_flow_custom` to prevent clobber

### Root cause

`_model_flow_custom()` writes `model.provider` and `model.base_url` to disk via
its own independent `load_config()` + `save_config()` cycle — it does **not**
mutate the outer `config` dict that `run_setup_wizard()` holds.

After `_model_flow_custom` returns, `run_setup_wizard()` calls `save_config(config)`
with the **stale outer dict** (no `provider`, no `base_url`), silently overwriting
the correct values.

Net effect: `.env` is right, `config.yaml` is wrong → the user must run
`hermes model` again to recover, and vision / auxiliary tooling also fails.

### Fix

After `_model_flow_custom()` returns, reload the on-disk state back into the
outer `config` dict so the subsequent `save_config(config)` is a no-op:

```python
config.clear()
config.update(load_config())
```

---

## Changes

- `agent/auxiliary_client.py` — `_resolve_custom_runtime()`: use `resolve_requested_provider()` first
- `hermes_cli/setup.py` — `run_setup_wizard()`: reload config after custom flow
- `tests/agent/test_auxiliary_client.py` — 5 new tests + isolation fix
- `tests/hermes_cli/test_setup_model_provider.py` — regression test for config clobber

## Tests

```
103 passed in test_auxiliary_client.py
1 passed  in test_setup_model_provider.py::test_custom_setup_wizard_persists_provider_in_config
```