### PR TITLE
fix(update): skip config migration prompts in non-interactive sessions

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2824,11 +2824,15 @@ def cmd_update(args):
                 print(f"  ℹ️  {len(missing_config)} new config option(s) available")
             
             print()
-            if sys.stdin.isatty():
-                response = input("Would you like to configure them now? [Y/n]: ").strip().lower()
-            else:
+            if not (sys.stdin.isatty() and sys.stdout.isatty()):
+                print("  ℹ Non-interactive session — skipping config migration prompt.")
+                print("    Run 'hermes config migrate' later to apply any new config/env options.")
                 response = "n"
-            
+            else:
+                try:
+                    response = input("Would you like to configure them now? [Y/n]: ").strip().lower()
+                except EOFError:
+                    response = "n"
             if response in ('', 'y', 'yes'):
                 print()
                 results = migrate_config(interactive=True, quiet=False)

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -105,3 +105,22 @@ class TestCmdUpdateBranchFallback:
         commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
         pull_cmds = [c for c in commands if "pull" in c]
         assert len(pull_cmds) == 0
+
+    def test_update_non_interactive_skips_migration_prompt(self, mock_args, capsys):
+        with patch("shutil.which", return_value=None), patch(
+            "subprocess.run"
+        ) as mock_run, patch("builtins.input") as mock_input, patch(
+            "hermes_cli.config.get_missing_env_vars", return_value=["MISSING_KEY"]
+        ), patch("hermes_cli.config.get_missing_config_fields", return_value=[]), patch(
+            "hermes_cli.config.check_config_version", return_value=(1, 2)
+        ), patch("hermes_cli.main.sys.stdin.isatty", return_value=False), patch(
+            "hermes_cli.main.sys.stdout.isatty", return_value=False):
+            mock_run.side_effect = _make_run_side_effect(
+                branch="main", verify_ok=True, commit_count="1"
+            )
+
+            cmd_update(mock_args)
+
+            mock_input.assert_not_called()
+            captured = capsys.readouterr()
+            assert "Non-interactive session — skipping config migration prompt." in captured.out


### PR DESCRIPTION
Title: fix(update): skip config migration prompts in non-interactive sessions

Branch: upstream/noninteractive-update-prompt-guard
Commit: 7c7f7100

Summary
Prevent `hermes update` from hanging or crashing in non-interactive contexts when config migration questions are pending.

Why
`hermes update` can run under automation, cron, CI, or other non-TTY contexts. In those environments, prompting for config migration is the wrong behavior and can cause blocked or failed updates.

What changed
- Detect non-interactive stdin/stdout before prompting
- Skip the migration prompt automatically in non-interactive sessions
- Fall back safely on `EOFError`
- Add regression coverage for the non-interactive path

Tests
- `python -m pytest -o addopts='' tests/hermes_cli/test_cmd_update.py -q`

Result
- 4 passed

Notes
This keeps automated update flows predictable while still allowing manual migration later via `hermes config migrate`.
