### PR TITLE
fix(skills): stop marking persisted env vars missing on remote backends

### DIFF
--- a/tests/tools/test_skill_env_passthrough.py
+++ b/tests/tools/test_skill_env_passthrough.py
@@ -63,6 +63,35 @@ class TestSkillViewRegistersPassthrough:
         assert result["success"] is True
         assert is_env_passthrough("TENOR_API_KEY")
 
+    def test_remote_backend_persisted_env_vars_registered(self, tmp_path, monkeypatch):
+        """Remote-backed skills still register locally available env vars."""
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        _create_skill(
+            tmp_path,
+            "test-skill",
+            frontmatter_extra=(
+                "required_environment_variables:\n"
+                "  - name: TENOR_API_KEY\n"
+                "    prompt: Enter your Tenor API key\n"
+            ),
+        )
+        monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", tmp_path)
+
+        from hermes_cli.config import save_env_value
+
+        save_env_value("TENOR_API_KEY", "persisted-value-123")
+        monkeypatch.delenv("TENOR_API_KEY", raising=False)
+
+        with patch("tools.skills_tool._secret_capture_callback", None):
+            from tools.skills_tool import skill_view
+
+            result = json.loads(skill_view(name="test-skill"))
+
+        assert result["success"] is True
+        assert result["setup_needed"] is False
+        assert result["missing_required_environment_variables"] == []
+        assert is_env_passthrough("TENOR_API_KEY")
+
     def test_missing_env_vars_not_registered(self, tmp_path, monkeypatch):
         """When a skill declares required_environment_variables but the var is NOT set,
         it should NOT be registered in the passthrough."""

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -813,6 +813,29 @@ class TestSkillViewPrerequisites:
         assert result["setup_needed"] is False
         assert result["missing_required_environment_variables"] == []
 
+    def test_remote_backend_treats_persisted_env_as_available(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "remote-ready",
+                frontmatter_extra="prerequisites:\n  env_vars: [PERSISTED_REMOTE_KEY]\n",
+            )
+            from hermes_cli.config import save_env_value
+
+            save_env_value("PERSISTED_REMOTE_KEY", "persisted-value")
+            monkeypatch.delenv("PERSISTED_REMOTE_KEY", raising=False)
+            raw = skill_view("remote-ready")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["setup_needed"] is False
+        assert result["missing_required_environment_variables"] == []
+        assert result["readiness_status"] == "available"
+
     def test_no_setup_metadata_when_no_required_envs(self, tmp_path):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             _make_skill(tmp_path, "plain-skill")
@@ -878,17 +901,11 @@ class TestSkillViewPrerequisites:
         assert result["setup_needed"] is True
 
     @pytest.mark.parametrize(
-        "backend,expected_note",
-        [
-            ("ssh", "remote environment"),
-            ("daytona", "remote environment"),
-            ("docker", "docker-backed skills"),
-            ("singularity", "singularity-backed skills"),
-            ("modal", "modal-backed skills"),
-        ],
+        "backend",
+        ["ssh", "daytona", "docker", "singularity", "modal"],
     )
-    def test_remote_backend_keeps_setup_needed_after_local_secret_capture(
-        self, tmp_path, monkeypatch, backend, expected_note
+    def test_remote_backend_becomes_available_after_local_secret_capture(
+        self, tmp_path, monkeypatch, backend
     ):
         monkeypatch.setenv("TERMINAL_ENV", backend)
         monkeypatch.delenv("TENOR_API_KEY", raising=False)
@@ -926,10 +943,10 @@ class TestSkillViewPrerequisites:
         result = json.loads(raw)
         assert result["success"] is True
         assert len(calls) == 1
-        assert result["setup_needed"] is True
-        assert result["readiness_status"] == "setup_needed"
-        assert result["missing_required_environment_variables"] == ["TENOR_API_KEY"]
-        assert expected_note in result["setup_note"].lower()
+        assert result["setup_needed"] is False
+        assert result["readiness_status"] == "available"
+        assert result["missing_required_environment_variables"] == []
+        assert "setup_note" not in result
 
     def test_skill_view_surfaces_skill_read_errors(self, tmp_path, monkeypatch):
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -360,8 +360,6 @@ def _remaining_required_environment_names(
     if backend is None:
         backend = _get_terminal_backend_name()
     missing_names = set(capture_result["missing_names"])
-    if backend in _REMOTE_ENV_BACKENDS:
-        return [entry["name"] for entry in required_env_vars]
 
     if env_snapshot is None:
         env_snapshot = load_env()
@@ -1076,8 +1074,7 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
         missing_required_env_vars = [
             e
             for e in required_env_vars
-            if backend in _REMOTE_ENV_BACKENDS
-            or not _is_env_var_persisted(e["name"], env_snapshot)
+            if not _is_env_var_persisted(e["name"], env_snapshot)
         ]
         capture_result = _capture_required_environment_variables(
             skill_name,

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -355,10 +355,7 @@ def _remaining_required_environment_names(
     capture_result: Dict[str, Any],
     *,
     env_snapshot: Dict[str, str] | None = None,
-    backend: str | None = None,
 ) -> List[str]:
-    if backend is None:
-        backend = _get_terminal_backend_name()
     missing_names = set(capture_result["missing_names"])
 
     if env_snapshot is None:
@@ -1086,7 +1083,6 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
             required_env_vars,
             capture_result,
             env_snapshot=env_snapshot,
-            backend=backend,
         )
         setup_needed = bool(remaining_missing_required_envs)
 


### PR DESCRIPTION
 ## What does this PR do?

  Stops remote backends from marking persisted required environment variables as missing during skill readiness checks.

  Today, `skill_view(...)` can report a skill as not ready on remote backends even when the required env var already exists in
  `HERMES_HOME/.env` or `os.environ`. This PR makes readiness depend on whether the var is actually persisted, regardless of backend.

  This is intentionally scoped to the maintainer-approved `tools/skills_tool.py` fix. It does not change remote backend command injection
  behavior.

  ## Related Issue

  Fixes #3433

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [x] ✅ Tests (adding or improving test coverage)

  ## Changes Made

  - removed the remote-backend short-circuit from the initial missing env var computation in `skill_view(...)`
  - removed the remote-backend short-circuit from `_remaining_required_environment_names(...)`
  - kept the existing remote-backend guidance text for vars that are genuinely missing
  - updated regression tests so remotely loaded skills treat persisted vars as available
  - updated regression tests so remote secret capture no longer leaves `setup_needed=true`
  - added passthrough registration coverage for remotely loaded skills with locally available env vars

  ## How to Test

  1. Run:
     `uv run --extra dev python -m pytest tests/tools/test_skills_tool.py tests/tools/test_skill_env_passthrough.py -q`
  2. Set a remote backend, for example:
     `TERMINAL_ENV=docker`
  3. Persist a required env var in `HERMES_HOME/.env`
  4. Load a skill that declares that var in `required_environment_variables`
  5. Confirm:
     - `setup_needed` is `false`
     - `missing_required_environment_variables` is empty
     - `readiness_status` is `available`

  ## Test Results

  - `81 passed in 5.63s`

  ## Platform Tested

  - macOS