### PR TITLE
fix: plugin toolsets invisible in hermes tools and standalone processes

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -108,7 +108,8 @@ def _get_effective_configurable_toolsets():
     """
     result = list(CONFIGURABLE_TOOLSETS)
     try:
-        from hermes_cli.plugins import get_plugin_toolsets
+        from hermes_cli.plugins import discover_plugins, get_plugin_toolsets
+        discover_plugins()  # idempotent — ensures plugins are loaded
         result.extend(get_plugin_toolsets())
     except Exception:
         pass
@@ -118,7 +119,8 @@ def _get_effective_configurable_toolsets():
 def _get_plugin_toolset_keys() -> set:
     """Return the set of toolset keys provided by plugins."""
     try:
-        from hermes_cli.plugins import get_plugin_toolsets
+        from hermes_cli.plugins import discover_plugins, get_plugin_toolsets
+        discover_plugins()  # idempotent — ensures plugins are loaded
         return {ts_key for ts_key, _, _ in get_plugin_toolsets()}
     except Exception:
         return set()


### PR DESCRIPTION
## Summary

Plugin toolsets never appeared in the `hermes tools` TUI or any standalone process that reads plugin state without first importing `model_tools.py`.

**Root cause:** `discover_plugins()` only runs as a side effect of importing `model_tools.py` (line 181-182). The `hermes tools` command and `_get_platform_tools()` call `get_plugin_toolsets()` / `_get_plugin_toolset_keys()` without ensuring plugins have been discovered first. The plugin manager singleton exists but has never scanned `~/.hermes/plugins/`, so `_plugin_tool_names` is empty and all plugin queries return `[]`.

**Impact:**
- `hermes tools` TUI never shows plugin toolsets — users can't see or toggle them
- Any standalone process that reads plugin state before `model_tools.py` is imported misses plugin toolsets

**Fix:** Call `discover_plugins()` (idempotent — checks `_discovered` flag) in both `_get_plugin_toolset_keys()` and `_get_effective_configurable_toolsets()` before accessing plugin state. In the gateway/CLI where `model_tools.py` is already imported, the call is a no-op.

## Context

Reported by community member (pistrie) on Discord — installed two plugins (brave-search, web-extract), `/plugins` showed them loaded, but they never appeared in `hermes tools` output or in the agent's tool list.

## Test plan

- `python3 -m pytest tests/hermes_cli/test_tools_config.py tests/test_plugins.py -o 'addopts=' -q` — 29 passed