### PR TITLE
 feat(gateway): Add log option to tool_progress setting

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -685,6 +685,8 @@ display:
   #   new:     Show a tool indicator only when the tool changes (skip repeats)
   #   all:     Show every tool call with a short preview (default)
   #   verbose: Full args, results, and debug logs (same as /verbose)
+  #   log:     Write tool calls to ~/.hermes/logs/tool_progress.log instead of
+  #            sending them to the gateway provider (gateway-only audit mode)
   # Toggle at runtime with /verbose in the CLI
   tool_progress: all
 

--- a/cli.py
+++ b/cli.py
@@ -4219,8 +4219,8 @@ class HermesCLI:
             print("  Prompt + TUI colors updated.")
 
     def _toggle_verbose(self):
-        """Cycle tool progress mode: off → new → all → verbose → off."""
-        cycle = ["off", "new", "all", "verbose"]
+        """Cycle tool progress mode: off → new → all → verbose → log → off."""
+        cycle = ["off", "new", "all", "verbose", "log"]
         try:
             idx = cycle.index(self.tool_progress_mode)
         except ValueError:
@@ -4247,6 +4247,7 @@ class HermesCLI:
             "new": f"{_Colors.YELLOW}Tool progress: NEW{_Colors.RESET} — show each new tool (skip repeats).",
             "all": f"{_Colors.GREEN}Tool progress: ALL{_Colors.RESET} — show every tool call.",
             "verbose": f"{_Colors.BOLD}{_Colors.GREEN}Tool progress: VERBOSE{_Colors.RESET} — full args, results, think blocks, and debug logs.",
+            "log": f"{_Colors.DIM}Tool progress: LOG{_Colors.RESET} — write tool calls to ~/.hermes/logs/tool_progress.log (gateway audit mode).",
         }
         _cprint(labels.get(self.tool_progress_mode, ""))
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4925,27 +4925,46 @@ class GatewayRunner:
             or "all"
         )
         tool_progress_enabled = progress_mode != "off"
-        
-        # Queue for progress messages (thread-safe)
-        progress_queue = queue.Queue() if tool_progress_enabled else None
+        tool_progress_log_mode = progress_mode == "log"
+
+        # Queue for progress messages (thread-safe).
+        # Not needed in log mode — events go directly to file.
+        progress_queue = queue.Queue() if (tool_progress_enabled and not tool_progress_log_mode) else None
         last_tool = [None]  # Mutable container for tracking in closure
         last_progress_msg = [None]  # Track last message for dedup
         repeat_count = [0]  # How many times the same message repeated
-        
+
+        # Log-mode file writer
+        if tool_progress_log_mode:
+            import threading as _tp_threading
+            _tp_log_lock = _tp_threading.Lock()
+            _tp_log_path = _hermes_home / "logs" / "tool_progress.log"
+
+            def _append_tool_log(msg: str):
+                try:
+                    _tp_log_path.parent.mkdir(parents=True, exist_ok=True)
+                    from datetime import datetime as _dt
+                    ts = _dt.now().strftime("%Y-%m-%d %H:%M:%S")
+                    with _tp_log_lock:
+                        with open(_tp_log_path, "a", encoding="utf-8") as _lf:
+                            _lf.write(f"[{ts}] {msg}\n")
+                except Exception:
+                    pass
+
         def progress_callback(tool_name: str, preview: str = None, args: dict = None):
             """Callback invoked by agent when a tool is called."""
-            if not progress_queue:
+            if not tool_progress_enabled:
                 return
-            
+
             # "new" mode: only report when tool changes
             if progress_mode == "new" and tool_name == last_tool[0]:
                 return
             last_tool[0] = tool_name
-            
+
             # Build progress message with primary argument preview
             from agent.display import get_tool_emoji
             emoji = get_tool_emoji(tool_name, default="⚙️")
-            
+
             # Verbose mode: show detailed arguments
             if progress_mode == "verbose" and args:
                 import json as _json
@@ -4955,7 +4974,7 @@ class GatewayRunner:
                 msg = f"{emoji} {tool_name}({list(args.keys())})\n{args_str}"
                 progress_queue.put(msg)
                 return
-            
+
             if preview:
                 # Truncate preview to keep messages clean
                 if len(preview) > 80:
@@ -4963,7 +4982,12 @@ class GatewayRunner:
                 msg = f"{emoji} {tool_name}: \"{preview}\""
             else:
                 msg = f"{emoji} {tool_name}..."
-            
+
+            # Log mode: write to file instead of sending to provider
+            if tool_progress_log_mode:
+                _append_tool_log(msg)
+                return
+
             # Dedup: collapse consecutive identical progress messages.
             # Common with execute_code where models iterate with the same
             # code (same boilerplate imports → identical previews).
@@ -4975,7 +4999,7 @@ class GatewayRunner:
                 return
             last_progress_msg[0] = msg
             repeat_count[0] = 0
-            
+
             progress_queue.put(msg)
         
         # Background task to send progress messages
@@ -5419,9 +5443,9 @@ class GatewayRunner:
                 "session_id": effective_session_id,
             }
         
-        # Start progress message sender if enabled
+        # Start progress message sender if enabled (not needed in log mode)
         progress_task = None
-        if tool_progress_enabled:
+        if progress_queue:
             progress_task = asyncio.create_task(send_progress_messages())
 
         # Start stream consumer task — polls for consumer creation since it

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2282,10 +2282,11 @@ def setup_agent_settings(config: dict):
     print_info("  new     — Show tool name only when it changes (less noise)")
     print_info("  all     — Show every tool call with a short preview")
     print_info("  verbose — Full args, results, and debug logs")
+    print_info("  log     — Write tool calls to ~/.hermes/logs/tool_progress.log (gateway audit mode)")
 
     current_mode = config.get("display", {}).get("tool_progress", "all")
     mode = prompt("Tool progress mode", current_mode)
-    if mode.lower() in ("off", "new", "all", "verbose"):
+    if mode.lower() in ("off", "new", "all", "verbose", "log"):
         if "display" not in config:
             config["display"] = {}
         config["display"]["tool_progress"] = mode.lower()

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -133,3 +133,51 @@ async def test_run_agent_progress_stays_in_originating_topic(monkeypatch, tmp_pa
     ]
     assert adapter.edits
     assert all(call["metadata"] == {"thread_id": "17585"} for call in adapter.typing)
+
+
+@pytest.mark.asyncio
+async def test_log_mode_writes_to_file_not_provider(monkeypatch, tmp_path):
+    """log mode must write tool calls to a file and send nothing to the provider."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "log")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"})
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        thread_id="17585",
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-1",
+        session_key="agent:main:telegram:group:-1001:17585",
+    )
+
+    assert result["final_response"] == "done"
+
+    # Nothing sent to the provider
+    assert adapter.sent == []
+    assert adapter.edits == []
+
+    # Tool calls written to log file
+    log_file = tmp_path / "logs" / "tool_progress.log"
+    assert log_file.exists(), "tool_progress.log should be created in log mode"
+    content = log_file.read_text(encoding="utf-8")
+    assert 'terminal: "pwd"' in content
+    assert 'browser_navigate: "https://example.com"' in content


### PR DESCRIPTION
  ## What does this PR do?

  Adds a new `log` option to the existing `display.tool_progress` setting.

  When set to `log`, tool progress events are written to `~/.hermes/logs/tool_progress.log` with timestamps instead of being sent to the gateway provider (Telegram, Discord, etc.). This enables full audit/monitoring of agent tool activity without cluttering the chat with progress messages.

  This is particularly useful for production or shared gateway deployments where you want visibility into what the agent is doing, but don't want intermediate tool updates appearing in the conversation.                
  
 ## Related Issue

 #3450 

  ## Type of Change

  - [x] ✨ New feature (non-breaking change that adds functionality)

  ## Changes Made

  - `gateway/run.py` — Added `tool_progress_log_mode` flag; `progress_queue` is skipped in log mode; added `_append_tool_log()` closure that writes timestamped entries to
  `~/.hermes/logs/tool_progress.log`; `progress_task` only started when there is an active queue (not in log mode)
  - `cli.py` — Added `log` to the `/verbose` cycle (`off → new → all → verbose → log → off`) with a descriptive label
  - `cli-config.yaml.example` — Documented the new `log` option under `display.tool_progress`
  - `hermes_cli/setup.py` — Added `log` to the valid modes list and help text in the interactive setup wizard

  ## How to Test

  1. Set `display.tool_progress: log` in `~/.hermes/config.yaml`
  2. Start the gateway and send a message that triggers tool use (e.g. ask the agent to read a file)
  3. Verify **no** tool progress messages appear in the chat (Telegram/Discord/etc.)
  4. Check `~/.hermes/logs/tool_progress.log` — each tool call should appear with a timestamp and preview
  5. Alternatively, cycle to `log` mode via `/verbose` in the CLI and confirm the label reads `Tool progress: LOG`

  ## Checklist

  - [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
  - [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
  - [x] I've run `pytest tests/ -q` and all tests pass
  6180 tests collected, 1 pre-existing collection error in `tests/tools/test_mcp_tool.py` (unrelated to this change)                                                                                                                                                                                                   
  - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - [x] I've tested on my platform: macOS 

  ### Documentation & Housekeeping

  - [x] I've updated `cli-config.yaml.example` if I added/changed config keys
  - [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — `Path.mkdir(parents=True, exist_ok=True)` is cross-platform safe


