### PR TITLE
fix(email): skip automated senders

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -51,6 +51,47 @@ MAX_MESSAGE_LENGTH = 50_000
 # Supported image extensions for inline detection
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
 
+# Local-part patterns that indicate automated/noreply senders.
+# Checked as exact match or as the base before a '+' subaddress.
+_NOREPLY_LOCAL_PARTS = frozenset({
+    "noreply", "no-reply", "no_reply",
+    "donotreply", "do-not-reply", "do_not_reply",
+    "mailer-daemon", "mailer_daemon",
+    "postmaster", "bounce", "bounces", "daemon",
+})
+
+
+def _is_automated_sender(sender_addr: str, headers: Dict[str, str]) -> bool:
+    """Return True if this email is from an automated/noreply sender.
+
+    Checks both the sender address local-part and common RFC headers used by
+    mailing lists, bulk mailers, and auto-responders.
+    """
+    local = sender_addr.lower().split("@")[0] if "@" in sender_addr else sender_addr.lower()
+    # Strip subaddress (e.g. bounce+hash123 → bounce)
+    base_local = local.split("+")[0]
+    if base_local in _NOREPLY_LOCAL_PARTS or local in _NOREPLY_LOCAL_PARTS:
+        return True
+
+    # Precedence: bulk / list / junk  (RFC 2076)
+    if headers.get("precedence", "").lower().strip() in ("bulk", "list", "junk"):
+        return True
+
+    # Auto-Submitted: anything other than "no" means automated  (RFC 3834)
+    auto_submitted = headers.get("auto_submitted", "").lower().strip()
+    if auto_submitted and auto_submitted != "no":
+        return True
+
+    # List-Unsubscribe presence means mailing-list / bulk mail  (RFC 2369)
+    if headers.get("list_unsubscribe", "").strip():
+        return True
+
+    # X-Auto-Response-Suppress is set by Exchange/O365 to block auto-replies
+    if headers.get("x_auto_response_suppress", "").strip():
+        return True
+
+    return False
+
 
 def check_email_requirements() -> bool:
     """Check if email platform dependencies are available."""
@@ -334,6 +375,11 @@ class EmailAdapter(BasePlatformAdapter):
                     "body": body,
                     "attachments": attachments,
                     "date": msg.get("Date", ""),
+                    # Automation-detection headers
+                    "precedence": msg.get("Precedence", ""),
+                    "auto_submitted": msg.get("Auto-Submitted", ""),
+                    "list_unsubscribe": msg.get("List-Unsubscribe", ""),
+                    "x_auto_response_suppress": msg.get("X-Auto-Response-Suppress", ""),
                 })
 
             imap.logout()
@@ -347,6 +393,17 @@ class EmailAdapter(BasePlatformAdapter):
 
         # Skip self-messages
         if sender_addr == self._address.lower():
+            return
+
+        # Skip automated senders (noreply addresses, bulk mail, auto-responders)
+        automation_headers = {
+            "precedence": msg_data.get("precedence", ""),
+            "auto_submitted": msg_data.get("auto_submitted", ""),
+            "list_unsubscribe": msg_data.get("list_unsubscribe", ""),
+            "x_auto_response_suppress": msg_data.get("x_auto_response_suppress", ""),
+        }
+        if _is_automated_sender(sender_addr, automation_headers):
+            logger.info("[Email] Skipping automated sender: %s", sender_addr)
             return
 
         subject = msg_data["subject"]

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1057,5 +1057,186 @@ class TestSendEmailStandalone(unittest.TestCase):
         self.assertIn("not configured", result["error"])
 
 
+class TestIsAutomatedSender(unittest.TestCase):
+    """Unit tests for the _is_automated_sender() helper."""
+
+    def _check(self, addr, headers=None):
+        from gateway.platforms.email import _is_automated_sender
+        return _is_automated_sender(addr, headers or {})
+
+    # ── Address-based detection ──────────────────────────────────────────────
+
+    def test_noreply_exact(self):
+        self.assertTrue(self._check("noreply@example.com"))
+
+    def test_no_reply_hyphen(self):
+        self.assertTrue(self._check("no-reply@service.io"))
+
+    def test_no_reply_underscore(self):
+        self.assertTrue(self._check("no_reply@service.io"))
+
+    def test_donotreply(self):
+        self.assertTrue(self._check("donotreply@company.com"))
+
+    def test_mailer_daemon(self):
+        self.assertTrue(self._check("mailer-daemon@mailhost.net"))
+
+    def test_postmaster(self):
+        self.assertTrue(self._check("postmaster@example.org"))
+
+    def test_bounce_exact(self):
+        self.assertTrue(self._check("bounce@mail.example.com"))
+
+    def test_bounce_subaddress(self):
+        """bounce+hash123@ pattern used by many ESPs."""
+        self.assertTrue(self._check("bounce+abc123@em.example.com"))
+
+    def test_regular_user_not_filtered(self):
+        self.assertFalse(self._check("alice@example.com"))
+
+    def test_admin_not_filtered(self):
+        self.assertFalse(self._check("admin@example.com"))
+
+    # ── Header-based detection ───────────────────────────────────────────────
+
+    def test_precedence_bulk(self):
+        self.assertTrue(self._check("news@example.com", {"precedence": "bulk"}))
+
+    def test_precedence_list(self):
+        self.assertTrue(self._check("list@example.com", {"precedence": "list"}))
+
+    def test_precedence_junk(self):
+        self.assertTrue(self._check("junk@example.com", {"precedence": "junk"}))
+
+    def test_precedence_normal_not_filtered(self):
+        self.assertFalse(self._check("user@example.com", {"precedence": "normal"}))
+
+    def test_auto_submitted_auto_generated(self):
+        self.assertTrue(self._check(
+            "alerts@system.com",
+            {"auto_submitted": "auto-generated"},
+        ))
+
+    def test_auto_submitted_auto_replied(self):
+        self.assertTrue(self._check(
+            "vacation@example.com",
+            {"auto_submitted": "auto-replied"},
+        ))
+
+    def test_auto_submitted_no_passes(self):
+        """auto-submitted: no means a real human wrote it."""
+        self.assertFalse(self._check(
+            "user@example.com",
+            {"auto_submitted": "no"},
+        ))
+
+    def test_list_unsubscribe_present(self):
+        self.assertTrue(self._check(
+            "newsletter@company.com",
+            {"list_unsubscribe": "<mailto:unsub@company.com>"},
+        ))
+
+    def test_x_auto_response_suppress(self):
+        """Exchange / O365 suppress header should block auto-reply."""
+        self.assertTrue(self._check(
+            "alerts@corp.com",
+            {"x_auto_response_suppress": "All"},
+        ))
+
+    def test_empty_headers_regular_user(self):
+        self.assertFalse(self._check("bob@example.com", {
+            "precedence": "",
+            "auto_submitted": "",
+            "list_unsubscribe": "",
+            "x_auto_response_suppress": "",
+        }))
+
+
+class TestDispatchAutomatedFiltering(unittest.TestCase):
+    """Integration tests: _dispatch_message() must skip automated senders."""
+
+    def _make_adapter(self):
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        }):
+            from gateway.platforms.email import EmailAdapter
+            adapter = EmailAdapter(PlatformConfig(enabled=True))
+        return adapter
+
+    def _msg(self, sender, **extra_headers):
+        base = {
+            "uid": b"99",
+            "sender_addr": sender,
+            "sender_name": "Bot",
+            "subject": "Test",
+            "message_id": "<bot@test.com>",
+            "in_reply_to": "",
+            "body": "automated content",
+            "attachments": [],
+            "date": "",
+            "precedence": "",
+            "auto_submitted": "",
+            "list_unsubscribe": "",
+            "x_auto_response_suppress": "",
+        }
+        base.update(extra_headers)
+        return base
+
+    def test_noreply_address_not_dispatched(self):
+        import asyncio
+        adapter = self._make_adapter()
+        adapter.handle_message = AsyncMock()
+
+        asyncio.run(adapter._dispatch_message(self._msg("noreply@service.com")))
+        adapter.handle_message.assert_not_called()
+
+    def test_precedence_bulk_not_dispatched(self):
+        import asyncio
+        adapter = self._make_adapter()
+        adapter.handle_message = AsyncMock()
+
+        asyncio.run(adapter._dispatch_message(
+            self._msg("news@example.com", precedence="bulk")
+        ))
+        adapter.handle_message.assert_not_called()
+
+    def test_auto_submitted_not_dispatched(self):
+        import asyncio
+        adapter = self._make_adapter()
+        adapter.handle_message = AsyncMock()
+
+        asyncio.run(adapter._dispatch_message(
+            self._msg("alerts@system.com", auto_submitted="auto-generated")
+        ))
+        adapter.handle_message.assert_not_called()
+
+    def test_list_unsubscribe_not_dispatched(self):
+        import asyncio
+        adapter = self._make_adapter()
+        adapter.handle_message = AsyncMock()
+
+        asyncio.run(adapter._dispatch_message(
+            self._msg("news@company.com", list_unsubscribe="<mailto:unsub@company.com>")
+        ))
+        adapter.handle_message.assert_not_called()
+
+    def test_regular_sender_still_dispatched(self):
+        import asyncio
+        adapter = self._make_adapter()
+        captured = []
+
+        async def capture(event):
+            captured.append(event)
+
+        adapter.handle_message = capture
+
+        asyncio.run(adapter._dispatch_message(self._msg("alice@example.com")))
+        self.assertEqual(len(captured), 1)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION

  ## What does this PR do?

  The email adapter was replying to every inbound message, including noreply addresses, bounce notifications, mailing lists, and auto-responders. This created a feedback loop where the agent would send unwanted replies to automated systems — in the worst case, 64+ unsolicited messages before the user noticed and disabled the adapter (reported in #3453).

  This PR adds `_is_automated_sender()`, a filtering function that runs before any message is dispatched to the agent. It blocks automated senders based on:

  - **Address patterns** — `noreply@`, `no-reply@`, `mailer-daemon@`,`postmaster@`, `bounce@`, `bounce+hash@`, etc.
  - **`Precedence: bulk / list / junk`** (RFC 2076) — mailing lists and bulk mailers
  - **`Auto-Submitted:`** anything other than `no` (RFC 3834) — vacation replies, system notifications
  - **`List-Unsubscribe:`** header presence (RFC 2369) — newsletters and marketing mail
  - **`X-Auto-Response-Suppress:`** (Exchange / O365) — corporate auto-reply suppression

  Legitimate senders are unaffected.

  ## Related Issue

  Fixes #3453

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)

  ## Changes Made

  - `gateway/platforms/email.py` — Added `_NOREPLY_LOCAL_PARTS` frozenset and`_is_automated_sender()` helper; extended `_fetch_new_messages()` to capture `Precedence`, `Auto-Submitted`, `List-Unsubscribe`, and `X-Auto-Response-Suppress` headers; added automated-sender guard in`_dispatch_message()` before `handle_message()` is called
  - `tests/gateway/test_email.py` — Added `TestIsAutomatedSender` (unit tests for the helper function) and `TestDispatchAutomatedFiltering` (integration tests verifying `_dispatch_message()` skips automated senders while passing through real users)

  ## How to Test

  1. Configure the email adapter with valid IMAP/SMTP credentials
  2. Send an email from `noreply@github.com` to the agent's inbox — no reply should be sent
  3. Subscribe the agent's address to any mailing list — bulk emails should be silently dropped
  4. Set up an out-of-office auto-reply to the agent — the `Auto-Submitted` header should block the loop
  5. Send a normal email from your personal address — the agent should respond as usual
  6. Run `pytest tests/gateway/test_email.py -v` — all 90 tests should pass

  ## Checklist

  - [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
  - [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)                                                                                                                                                                                          
  - [x] I've run `pytest tests/ -q` and all tests pass — 6204 tests collected, 1 pre-existing collection error in `tests/tools/test_mcp_tool.py` (unrelated to this change) 
  - [x] I've added tests for my changes
  - [x] I've tested on my platform: macOS 

  ### Documentation & Housekeeping

  - [ ] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
  - [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
  - [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
  - [x] I've considered cross-platform impact (Windows, macOS) — no platform-specific code introduced
  - [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

                                                                                                                                            
                                     