### PR TITLE
fix(update): switch to main before pulling local-only branches

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2721,7 +2721,8 @@ def cmd_update(args):
             text=True,
             check=True
         )
-        branch = result.stdout.strip()
+        current_branch = result.stdout.strip()
+        branch = current_branch
 
         # Fall back to main if the current branch doesn't exist on the remote
         verify = subprocess.run(
@@ -2751,8 +2752,12 @@ def cmd_update(args):
         auto_stash_ref = _stash_local_changes_if_needed(git_cmd, PROJECT_ROOT)
         prompt_for_restore = auto_stash_ref is not None and sys.stdin.isatty() and sys.stdout.isatty()
 
-        print("→ Pulling updates...")
         try:
+            if current_branch != branch:
+                print(f"→ Current branch '{current_branch}' is local-only; switching to '{branch}' for update...")
+                subprocess.run(git_cmd + ["checkout", branch], cwd=PROJECT_ROOT, check=True)
+
+            print("→ Pulling updates...")
             subprocess.run(git_cmd + ["pull", "--ff-only", "origin", branch], cwd=PROJECT_ROOT, check=True)
         finally:
             if auto_stash_ref is not None:

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -68,6 +68,65 @@ class TestCmdUpdateBranchFallback:
 
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")
+    def test_update_checks_out_main_before_pulling_when_branch_not_on_remote(
+        self, mock_run, _mock_which, mock_args, capsys
+    ):
+        mock_run.side_effect = _make_run_side_effect(
+            branch="fix/stoicneko", verify_ok=False, commit_count="3"
+        )
+
+        cmd_update(mock_args)
+
+        commands = [c.args[0] for c in mock_run.call_args_list]
+
+        checkout_cmds = [
+            i for i, cmd in enumerate(commands) if cmd[-2:] == ["checkout", "main"]
+        ]
+        pull_cmds = [i for i, cmd in enumerate(commands) if "pull" in cmd]
+
+        assert len(checkout_cmds) == 1
+        assert len(pull_cmds) == 1
+        assert checkout_cmds[0] < pull_cmds[0]
+
+    @patch("shutil.which", return_value=None)
+    @patch("hermes_cli.main._restore_stashed_changes")
+    @patch("hermes_cli.main._stash_local_changes_if_needed", return_value="stash123")
+    @patch("subprocess.run")
+    def test_update_restores_stash_when_checkout_fails(
+        self,
+        mock_run,
+        _mock_stash,
+        mock_restore,
+        _mock_which,
+        mock_args,
+        capsys,
+    ):
+        def side_effect(cmd, **kwargs):
+            joined = " ".join(str(c) for c in cmd)
+            if "rev-parse" in joined and "--abbrev-ref" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="fix/stoicneko\n", stderr="")
+            if "rev-parse" in joined and "--verify" in joined:
+                return subprocess.CompletedProcess(cmd, 128, stdout="", stderr="")
+            if "rev-list" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="3\n", stderr="")
+            if cmd[-2:] == ["checkout", "main"]:
+                raise subprocess.CalledProcessError(1, cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        mock_run.side_effect = side_effect
+
+        with pytest.raises(SystemExit, match="1"):
+            cmd_update(mock_args)
+
+        mock_restore.assert_called_once_with(
+            ["git"],
+            PROJECT_ROOT,
+            "stash123",
+            prompt_user=False,
+        )
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
     def test_update_uses_current_branch_when_on_remote(
         self, mock_run, _mock_which, mock_args, capsys
     ):


### PR DESCRIPTION
## Summary
- keep `current_branch` separate from the update target branch in `cmd_update`
- when the current branch does not exist on origin, explicitly `git checkout main` before `git pull --ff-only origin main`
- restore any autostashed local changes even if the fallback checkout fails
- add regression coverage for checkout-before-pull and stash restore on checkout failure

## Problem
Updating from a local-only branch could fall back to `main` logically, but still attempt to fast-forward from the local branch context. That leads to update failures like:

```text
fatal: Not possible to fast-forward, aborting.
```

## Test Plan
- `uv run --extra dev pytest -o addopts= tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_update_autostash.py tests/hermes_cli/test_update_gateway_restart.py tests/hermes_cli/test_update_check.py -q`
