### PR TITLE
fix: prevent tool name/arg concatenation for Ollama-compatible endpoints

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3804,6 +3804,14 @@ class AIAgent:
             # Reset per-call reasoning tracking so _build_assistant_message
             # knows whether reasoning was already displayed during streaming.
             self._reasoning_deltas_fired = False
+            # Fix: sequential tool dispatch for Ollama-compatible endpoints
+            # (parallel tool call concatenation bug)
+            # Ollama reuses index 0 for every tool call in a parallel batch,
+            # causing names/args to be concatenated into one slot.
+            # Track the last seen id per raw index so we can detect a new tool
+            # call starting at the same index and redirect it to a fresh slot.
+            _last_id_at_idx: dict = {}    # raw_index -> last seen non-empty id
+            _active_slot_by_idx: dict = {}  # raw_index -> current slot in tool_calls_acc
 
             for chunk in stream:
                 last_chunk_time["t"] = time.time()
@@ -3841,10 +3849,31 @@ class AIAgent:
                 # Accumulate tool call deltas — notify display on first name
                 if delta and delta.tool_calls:
                     for tc_delta in delta.tool_calls:
-                        idx = tc_delta.index if tc_delta.index is not None else 0
+                        raw_idx = tc_delta.index if tc_delta.index is not None else 0
+                        delta_id = tc_delta.id or ""
+
+                        # Fix: sequential tool dispatch for Ollama-compatible endpoints
+                        # (parallel tool call concatenation bug)
+                        # Ollama sends every tool call in a parallel batch at the same
+                        # index (typically 0).  Detect a new tool call by watching for a
+                        # new non-empty id at an already-active index, then redirect it to
+                        # a fresh slot so names and arguments are never concatenated.
+                        if raw_idx not in _active_slot_by_idx:
+                            _active_slot_by_idx[raw_idx] = raw_idx
+                        if (
+                            delta_id
+                            and raw_idx in _last_id_at_idx
+                            and delta_id != _last_id_at_idx[raw_idx]
+                        ):
+                            new_slot = max(tool_calls_acc, default=-1) + 1
+                            _active_slot_by_idx[raw_idx] = new_slot
+                        if delta_id:
+                            _last_id_at_idx[raw_idx] = delta_id
+                        idx = _active_slot_by_idx[raw_idx]
+
                         if idx not in tool_calls_acc:
                             tool_calls_acc[idx] = {
-                                "id": tc_delta.id or "",
+                                "id": delta_id,
                                 "type": "function",
                                 "function": {"name": "", "arguments": ""},
                                 "extra_content": None,


### PR DESCRIPTION
## Problem

When using any model served via Ollama's OpenAI-compatible endpoint (`http://localhost:11434/v1`), Hermes produces malformed tool call requests that result in HTTP 400 errors and this log pattern:

```
⚠️  Unknown tool 'terminalterminal' — sending error to model for self-correction
⚠️  Unknown tool 'write_filewrite_filewrite_file' — sending error to model for self-correction
⚠️  API call failed: HTTP 400: invalid tool call arguments
```

## Root Cause

Ollama sends all parallel tool calls at the **same streaming index** (typically `0`) instead of incrementing per the OpenAI streaming spec. The existing accumulator in `_call_chat_completions` keys deltas by `tc_delta.index`, so every tool call lands in `tool_calls_acc[0]` — causing names and arguments to concatenate.

**Example:** a prompt asking to write 3 files causes Ollama to emit 3 tool calls all at `index=0`. The accumulator merges them into `name='write_filewrite_filewrite_file'` with three JSON objects concatenated in `arguments`.

Confirmed via live inspection of Ollama's streaming output:
```
chunk: index=0, id='call_function_xxx_1', name='write_file', args='{"path":"alpha.txt",...}'
chunk: index=0, id='call_function_xxx_2', name='write_file', args='{"path":"beta.txt",...}'
chunk: index=0, id='call_function_xxx_3', name='write_file', args='{"path":"gamma.txt",...}'
```

## Fix

Add two per-stream tracking dicts (`_last_id_at_idx`, `_active_slot_by_idx`) inside `_call_chat_completions`. Ollama always assigns a **distinct `id`** to each tool call in the batch (`call_function_xxx_1`, `_2`, `_3`, …). When a new non-empty `id` appears at an already-active index, the accumulator allocates a fresh slot and routes subsequent argument chunks there.

Changes are confined to `run_agent.py`, inside the streaming accumulator loop. No new dependencies.

## Compatibility

Providers that correctly increment `index` (OpenAI, Anthropic, OpenRouter) are **unaffected** — a new `id` at a *new* index never triggers the reallocation path.

## Testing

- Verified with **MiniMax M2.7 via Ollama**: full 13-test scorecard passes
- Existing test suite: **238 passed, 0 regressions** (`test_streaming.py`, `test_agent_loop_tool_calling.py`, `test_run_agent.py`)
- End-to-end simulation with live Ollama stream confirms 3 `write_file` calls produce `slots=3` (one per file) instead of 1 concatenated slot