### PR TITLE
feat(skills): add optional mail auto-draft skill

### DIFF
--- a/optional-skills/email/mail-auto-draft/SKILL.md
+++ b/optional-skills/email/mail-auto-draft/SKILL.md
@@ -14,12 +14,14 @@ prerequisites:
 
 # Mail Auto-Draft with Himalaya
 
-Build a local inbound email automation workflow that:
+Build a practical local inbound email automation workflow that:
 - reads new mail from INBOX via Himalaya
 - classifies simple inbound requests
 - automatically replies only to safe standard cases
 - avoids self-reply loops
 - runs continuously via systemd user timers
+
+This skill is intentionally optional. It is highly useful for users who want mailbox automation, but it depends on local mail account setup, machine-specific deployment choices, and provider-specific operational details.
 
 ## When to Use
 
@@ -32,6 +34,15 @@ Typical requests:
 - "Make it safe enough for production"
 
 This skill is for user-owned mailboxes, not agent-owned inboxes like AgentMail.
+
+## Quick Reference
+
+Typical flow:
+1. configure Himalaya for the mailbox
+2. create or adapt `process_inbox.py` and `config.yaml`
+3. test in draft mode
+4. enable auto-send only for safe whitelisted categories
+5. run continuously with a `systemd --user` timer
 
 ## Requirements
 
@@ -228,6 +239,14 @@ Manual run:
 python3 process_inbox.py --limit 1
 ```
 
+## Example Workflow
+
+Example use case:
+- a user wants automatic replies for simple inbound messages such as information requests, lightweight appointment requests, or simple acknowledgements
+- Hermes helps configure Himalaya and the local processing script
+- the workflow only auto-sends safe standard categories
+- anything uncertain stays out of the auto-send path
+
 ## Troubleshooting
 
 ### It replies to itself repeatedly
@@ -265,3 +284,4 @@ A successful setup should show:
 ## References
 
 - `references/production-checklist.md`
+- `references/setup-commands.md`

--- a/optional-skills/email/mail-auto-draft/SKILL.md
+++ b/optional-skills/email/mail-auto-draft/SKILL.md
@@ -1,0 +1,267 @@
+---
+name: mail-auto-draft
+description: Build and deploy a Himalaya-based inbound email auto-reply workflow with self-reply protection, Reply-To aware recipient selection, and systemd user timers.
+version: 1.0.0
+author: jozrftamson
+license: MIT
+metadata:
+  hermes:
+    tags: [email, himalaya, imap, smtp, automation, systemd, gmail]
+    category: email
+prerequisites:
+  commands: [himalaya, python3, systemctl]
+---
+
+# Mail Auto-Draft with Himalaya
+
+Build a local inbound email automation workflow that:
+- reads new mail from INBOX via Himalaya
+- classifies simple inbound requests
+- automatically replies only to safe standard cases
+- avoids self-reply loops
+- runs continuously via systemd user timers
+
+## When to Use
+
+Use this skill when the user wants to automate replies to inbound email on their own mailbox, especially on Ubuntu/Linux with Himalaya.
+
+Typical requests:
+- "Automatically answer simple incoming emails"
+- "Set up a local email auto-responder with Gmail and Himalaya"
+- "Keep it running in the background every minute"
+- "Make it safe enough for production"
+
+This skill is for user-owned mailboxes, not agent-owned inboxes like AgentMail.
+
+## Requirements
+
+1. Himalaya CLI installed
+2. Python 3 with `pyyaml` and `requests`
+3. A working IMAP/SMTP account in `~/.config/himalaya/config.toml`
+4. A local project directory containing:
+   - `process_inbox.py`
+   - `config.yaml`
+   - `prompts/system_prompt.txt`
+   - `prompts/user_prompt.txt`
+
+## Recommended Project Files
+
+Minimum structure:
+- `process_inbox.py`
+- `config.yaml`
+- `config.example.yaml`
+- `README.md`
+- `SCHNELLSTART_AND_INSTALLATION.md`
+- `deploy/systemd/mail-auto-draft.service`
+- `deploy/systemd/mail-auto-draft.timer`
+- `prompts/`
+
+Local runtime dirs:
+- `drafts/`
+- `logs/`
+- `data/`
+- `runtime/`
+
+## Safe Defaults
+
+For production, prefer:
+- `require_unseen: true`
+- `require_new_in_inbox: true`
+- `require_whitelist: true`
+- `require_high_confidence: true`
+- `confidence_threshold` around `70` to `85`
+- `forbid_sensitive_categories` includes:
+  - `sensibel`
+  - `individuell`
+  - `unklar`
+  - `ignorieren`
+
+## Critical Safety Rules
+
+### 1. Always define own addresses
+
+In `config.yaml`:
+
+```yaml
+own_addresses:
+  - your-address@example.com
+```
+
+This prevents self-reply loops when your own replies appear in INBOX.
+
+### 2. Prefer Reply-To over From
+
+When selecting the reply recipient:
+1. use `Reply-To` if present
+2. otherwise use `From`
+3. if the generated reply template has empty `To:`, backfill it before sending
+
+### 3. Ignore own-sender mail
+
+Any inbound mail whose sender matches `own_addresses` should be ignored with a reason like `self_sender`.
+
+### 4. Do not auto-send uncertain categories
+
+Keep these as draft-only or blocked:
+- `sensibel`
+- `individuell`
+- `unklar`
+- `ignorieren`
+
+### 5. Treat Gmail Sent append failures carefully
+
+On Gmail, SMTP may succeed while Himalaya still exits non-zero because append to Sent fails.
+If stderr includes both:
+- `cannot add IMAP message`
+- `Folder doesn't exist`
+
+then treat it as likely sent and avoid duplicate resend.
+
+## Himalaya Config Notes
+
+For Gmail, use an app password, not the normal password.
+
+Recommended pattern:
+- keep the app password out of the project repo
+- store it in a local secret file such as:
+  `~/.config/mail-auto-draft/secrets.env`
+
+Example local secret file:
+
+```bash
+GMAIL_APP_PASSWORD='YOUR_APP_PASSWORD'
+```
+
+Example auth command in `~/.config/himalaya/config.toml`:
+
+```toml
+backend.auth.cmd = "sh -lc '. /home/USER/.config/mail-auto-draft/secrets.env && printf %s \"$GMAIL_APP_PASSWORD\"'"
+message.send.backend.auth.cmd = "sh -lc '. /home/USER/.config/mail-auto-draft/secrets.env && printf %s \"$GMAIL_APP_PASSWORD\"'"
+```
+
+## Continuous Background Processing
+
+Prefer a `systemd --user` oneshot service plus timer over an infinite Python loop.
+
+Example service template:
+
+```ini
+[Unit]
+Description=Process inbox and auto-reply via Himalaya
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=__PROJECT_DIR__
+ExecStart=/usr/bin/flock -n __PROJECT_DIR__/runtime/process_inbox.lock /usr/bin/python3 __PROJECT_DIR__/process_inbox.py --limit 5
+```
+
+Example timer template:
+
+```ini
+[Unit]
+Description=Run mail auto-draft every minute
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=60s
+Persistent=true
+Unit=mail-auto-draft.service
+
+[Install]
+WantedBy=timers.target
+```
+
+## Procedure
+
+### 1. Verify dependencies
+
+```bash
+himalaya --version
+python3 -c "import yaml, requests"
+python3 -m py_compile process_inbox.py
+```
+
+### 2. Test in draft mode first
+
+```bash
+python3 process_inbox.py --mode draft --limit 5
+```
+
+Review:
+- generated drafts
+- `logs/mail_actions.jsonl`
+
+### 3. Switch to auto mode only after review
+
+```bash
+python3 process_inbox.py --mode auto --limit 1
+```
+
+### 4. Enable timer-based background processing
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now mail-auto-draft.timer
+systemctl --user start mail-auto-draft.service
+```
+
+## Useful Runtime Commands
+
+Status:
+
+```bash
+systemctl --user status mail-auto-draft.timer --no-pager
+systemctl --user status mail-auto-draft.service --no-pager
+```
+
+Logs:
+
+```bash
+journalctl --user -u mail-auto-draft.service -n 50 --no-pager
+```
+
+Manual run:
+
+```bash
+python3 process_inbox.py --limit 1
+```
+
+## Troubleshooting
+
+### It replies to itself repeatedly
+Check:
+- `own_addresses` is configured
+- self-sender mail is ignored
+- only new/unseen mail is processed
+
+### Replies go to the wrong recipient
+Check:
+- recipient selection prefers `Reply-To`
+- fallback uses `From`
+- empty `To:` in reply templates is repaired before send
+
+### It sends to newsletters or bulk mail
+Tighten:
+- subject keyword filters
+- header ignore rules
+- whitelist-only auto-send
+- high confidence requirement
+
+### Himalaya says send failed but recipient got the email
+This is often the Gmail IMAP append issue after SMTP success.
+Verify recipient delivery before resending.
+
+## Verification
+
+A successful setup should show:
+- inbound external mail gets processed
+- `chosen_reply_recipient` is logged correctly
+- own mail is ignored with `self_sender`
+- background timer runs every minute
+- no repeated self-reply loops
+
+## References
+
+- `references/production-checklist.md`

--- a/optional-skills/email/mail-auto-draft/references/production-checklist.md
+++ b/optional-skills/email/mail-auto-draft/references/production-checklist.md
@@ -1,0 +1,38 @@
+# Production Checklist
+
+Use this checklist before enabling automatic replies in production.
+
+## Mail Safety
+
+- [ ] `own_addresses` contains the mailbox's real sender address
+- [ ] self-sender mail is ignored
+- [ ] `Reply-To` is preferred over `From`
+- [ ] empty `To:` gets backfilled before sending
+- [ ] only new/unseen inbound mail is processed
+
+## Classification Safety
+
+- [ ] whitelist-only auto-send is enabled
+- [ ] confidence threshold is not set too low
+- [ ] `sensibel`, `individuell`, `unklar`, `ignorieren` are blocked from auto-send
+- [ ] newsletter/system-mail filters are active
+
+## Secrets
+
+- [ ] no app password is committed to the repository
+- [ ] local secret file permissions are restricted (for example `chmod 600`)
+- [ ] Himalaya uses a local secret command instead of hardcoded plaintext in the repo
+
+## Runtime
+
+- [ ] `python3 -m py_compile process_inbox.py` passes
+- [ ] draft mode test passed
+- [ ] auto mode test passed with an external sender
+- [ ] systemd timer is active
+- [ ] JSONL log shows `chosen_reply_recipient`
+
+## Gmail-specific
+
+- [ ] Gmail app password is used
+- [ ] team understands that SMTP may succeed even if IMAP append to Sent fails
+- [ ] no duplicate resend logic is triggered on Gmail append failure

--- a/optional-skills/email/mail-auto-draft/references/setup-commands.md
+++ b/optional-skills/email/mail-auto-draft/references/setup-commands.md
@@ -1,0 +1,105 @@
+# Setup Commands
+
+Concrete command sequence for setting up a local Himalaya-based mail auto-reply workflow.
+
+## 1. Verify tools
+
+```bash
+himalaya --version
+python3 --version
+systemctl --user --version
+python3 -c "import yaml, requests"
+```
+
+## 2. Create project directories
+
+```bash
+PROJECT_DIR="$HOME/Projekte/Automation/mail-auto-draft"
+mkdir -p "$PROJECT_DIR"/{drafts,logs,data,runtime,prompts,deploy/systemd}
+```
+
+## 3. Create local secrets file
+
+```bash
+mkdir -p "$HOME/.config/mail-auto-draft"
+chmod 700 "$HOME/.config/mail-auto-draft"
+cat > "$HOME/.config/mail-auto-draft/secrets.env" <<'EOF'
+GMAIL_APP_PASSWORD='YOUR_APP_PASSWORD'
+EOF
+chmod 600 "$HOME/.config/mail-auto-draft/secrets.env"
+```
+
+## 4. Configure Himalaya for Gmail
+
+Example auth commands inside `~/.config/himalaya/config.toml`:
+
+```toml
+backend.auth.cmd = "sh -lc '. $HOME/.config/mail-auto-draft/secrets.env && printf %s \"$GMAIL_APP_PASSWORD\"'"
+message.send.backend.auth.cmd = "sh -lc '. $HOME/.config/mail-auto-draft/secrets.env && printf %s \"$GMAIL_APP_PASSWORD\"'"
+```
+
+## 5. Validate script syntax
+
+```bash
+cd "$PROJECT_DIR"
+python3 -m py_compile process_inbox.py
+```
+
+## 6. Test in draft mode
+
+```bash
+cd "$PROJECT_DIR"
+python3 process_inbox.py --mode draft --limit 5
+```
+
+Review:
+- drafts in `drafts/`
+- logs in `logs/mail_actions.jsonl`
+
+## 7. Test in auto mode with one mail
+
+```bash
+cd "$PROJECT_DIR"
+python3 process_inbox.py --mode auto --limit 1
+```
+
+## 8. Install systemd user units
+
+```bash
+PROJECT_DIR="$HOME/Projekte/Automation/mail-auto-draft"
+mkdir -p "$HOME/.config/systemd/user"
+sed "s|__PROJECT_DIR__|$PROJECT_DIR|g" "$PROJECT_DIR/deploy/systemd/mail-auto-draft.service" > "$HOME/.config/systemd/user/mail-auto-draft.service"
+cp "$PROJECT_DIR/deploy/systemd/mail-auto-draft.timer" "$HOME/.config/systemd/user/mail-auto-draft.timer"
+systemctl --user daemon-reload
+systemctl --user enable --now mail-auto-draft.timer
+```
+
+## 9. Start and inspect background processing
+
+```bash
+systemctl --user start mail-auto-draft.service
+systemctl --user status mail-auto-draft.timer --no-pager
+systemctl --user status mail-auto-draft.service --no-pager
+journalctl --user -u mail-auto-draft.service -n 50 --no-pager
+```
+
+## 10. Day-to-day commands
+
+Manual run:
+
+```bash
+cd "$PROJECT_DIR"
+python3 process_inbox.py --limit 1
+```
+
+Stop timer:
+
+```bash
+systemctl --user stop mail-auto-draft.timer
+```
+
+Restart timer:
+
+```bash
+systemctl --user restart mail-auto-draft.timer
+```


### PR DESCRIPTION
## Summary
- add an optional email skill for Himalaya-based inbound auto-reply workflows
- document self-reply protection, Reply-To-aware recipient selection, and Gmail append-failure behavior
- include a production checklist reference for safe deployment

## Why this matters
Many users want lightweight email automation on their own mailbox without introducing a hosted SaaS inbox or building a full custom integration from scratch. This skill gives Hermes a practical path for handling simple inbound email workflows with tools many Linux users already have: Himalaya, Python, and systemd.

It also emphasizes safety patterns that are easy to get wrong in email automation:
- self-reply loop prevention via own_addresses
- Reply-To-aware recipient selection
- safe handling of Gmail SMTP-success / IMAP-append-failure edge cases
- conservative production defaults for auto-send

## Example workflow
A user wants Hermes to monitor a Gmail inbox for new inbound messages and automatically respond to simple categories such as:
- information requests
- basic appointment requests
- simple acknowledgement emails

With this skill, Hermes can guide the setup of:
1. Himalaya IMAP/SMTP account configuration
2. a local Python-based inbound processing script
3. safe config defaults for whitelist-only auto-send
4. a systemd user timer for continuous background processing
5. checks to avoid replying to the user’s own outbound mail

## Why optional instead of bundled
This is intentionally proposed under optional-skills/email rather than bundled default skills because it is useful but not universal.

It requires:
- a locally configured mailbox
- Himalaya CLI
- Python dependencies
- machine-specific deployment decisions
- provider-specific operational knowledge such as Gmail behavior

That makes it a strong fit for an official optional skill: valuable, practical, and reusable, but not something every Hermes installation should enable or surface by default.

## Testing
- skill content written in fork under optional-skills/email/mail-auto-draft/
- structure matches existing optional skill layout
- references file included for production safety checklist
