### PR TITLE
fix(matrix): add missing matrix entry in PLATFORMS dict (salvage #3314)

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -135,6 +135,7 @@ PLATFORMS = {
     "signal":   {"label": "📡 Signal",     "default_toolset": "hermes-signal"},
     "homeassistant": {"label": "🏠 Home Assistant", "default_toolset": "hermes-homeassistant"},
     "email":    {"label": "📧 Email",      "default_toolset": "hermes-email"},
+    "matrix":   {"label": "💬 Matrix",     "default_toolset": "hermes-matrix"},
     "dingtalk": {"label": "💬 DingTalk",   "default_toolset": "hermes-dingtalk"},
     "api_server": {"label": "🌐 API Server", "default_toolset": "hermes-api-server"},
 }


### PR DESCRIPTION
Salvage of #3314 by @williamtwomey. Cherry-picked clean.

Matrix platform was missing from the `PLATFORMS` dict in `tools_config.py`, causing a `KeyError: 'matrix'` in `_get_platform_tools()` on every Matrix message. One-liner — adds the entry matching the pattern of all other platforms.

Closes #3314.