### PR TITLE
fix: session_search fallback preview on summarization failure (salvage #3413)

### DIFF
--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -392,21 +392,34 @@ def session_search(
             }, ensure_ascii=False)
 
         summaries = []
-        for (session_id, match_info, _, _), result in zip(tasks, results):
-            if isinstance(result, Exception):
+        for (session_id, match_info, conversation_text, _), result in zip(tasks, results):
+            when_str = _format_timestamp(match_info.get("session_started"))
+            source_str = match_info.get("source", "unknown")
+            model_str = match_info.get("model")
+            
+            if isinstance(result, Exception) or not result:
                 logging.warning(
-                    "Failed to summarize session %s: %s",
+                    "Summarization failed or returned empty for session %s. Using raw fallback preview.",
                     session_id,
-                    result,
-                    exc_info=True,
+                    exc_info=isinstance(result, Exception)
                 )
-                continue
-            if result:
+                # Fallback: Instead of dropping the result completely (which causes false negatives),
+                # return a raw preview from the conversation text.
+                preview_text = conversation_text[:500] + "\n...[truncated]" if conversation_text else "No preview available."
+                
                 summaries.append({
                     "session_id": session_id,
-                    "when": _format_timestamp(match_info.get("session_started")),
-                    "source": match_info.get("source", "unknown"),
-                    "model": match_info.get("model"),
+                    "when": when_str,
+                    "source": source_str,
+                    "model": model_str,
+                    "summary": f"[Summarization Failed] Raw match preview:\n{preview_text}",
+                })
+            else:
+                summaries.append({
+                    "session_id": session_id,
+                    "when": when_str,
+                    "source": source_str,
+                    "model": model_str,
                     "summary": result,
                 })
 

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -393,35 +393,29 @@ def session_search(
 
         summaries = []
         for (session_id, match_info, conversation_text, _), result in zip(tasks, results):
-            when_str = _format_timestamp(match_info.get("session_started"))
-            source_str = match_info.get("source", "unknown")
-            model_str = match_info.get("model")
-            
-            if isinstance(result, Exception) or not result:
+            if isinstance(result, Exception):
                 logging.warning(
-                    "Summarization failed or returned empty for session %s. Using raw fallback preview.",
-                    session_id,
-                    exc_info=isinstance(result, Exception)
+                    "Failed to summarize session %s: %s",
+                    session_id, result, exc_info=True,
                 )
-                # Fallback: Instead of dropping the result completely (which causes false negatives),
-                # return a raw preview from the conversation text.
-                preview_text = conversation_text[:500] + "\n...[truncated]" if conversation_text else "No preview available."
-                
-                summaries.append({
-                    "session_id": session_id,
-                    "when": when_str,
-                    "source": source_str,
-                    "model": model_str,
-                    "summary": f"[Summarization Failed] Raw match preview:\n{preview_text}",
-                })
+                result = None
+
+            entry = {
+                "session_id": session_id,
+                "when": _format_timestamp(match_info.get("session_started")),
+                "source": match_info.get("source", "unknown"),
+                "model": match_info.get("model"),
+            }
+
+            if result:
+                entry["summary"] = result
             else:
-                summaries.append({
-                    "session_id": session_id,
-                    "when": when_str,
-                    "source": source_str,
-                    "model": model_str,
-                    "summary": result,
-                })
+                # Fallback: raw preview so matched sessions aren't silently
+                # dropped when the summarizer is unavailable (fixes #3409).
+                preview = (conversation_text[:500] + "\n…[truncated]") if conversation_text else "No preview available."
+                entry["summary"] = f"[Raw preview — summarization unavailable]\n{preview}"
+
+            summaries.append(entry)
 
         return json.dumps({
             "success": True,


### PR DESCRIPTION
Salvage of #3413 by @devorun with cleaned up logic on top.

**Problem (#3409):** When `session_search` finds matching sessions via FTS5 but the LLM summarizer fails or returns empty, those sessions are silently dropped. The user gets an empty result — a false negative.

**Fix:** Instead of dropping, provide a raw 500-char conversation preview so the matched session is still surfaced. The user sees the session existed and gets enough context to decide relevance.

**Cleanup on top:** Restructured the loop — exception handling separated from fallback logic, entry dict built once, no duplicated field assignments.

Closes #3413. Fixes #3409.