### PR TITLE
feat(skills): load native skill launcher metadata

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -8,6 +8,7 @@ can invoke skills via /skill-name commands and prompt-only built-ins like
 import json
 import logging
 import re
+import shlex
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -148,6 +149,60 @@ def _build_skill_message(
     return "\n".join(parts)
 
 
+def _normalize_native_launcher(frontmatter: dict[str, Any]) -> dict[str, Any] | None:
+    """Extract optional Hermes native-launch metadata from SKILL frontmatter."""
+    metadata = frontmatter.get("metadata")
+    hermes_meta = metadata.get("hermes") if isinstance(metadata, dict) else None
+    native = None
+    if isinstance(hermes_meta, dict):
+        native = hermes_meta.get("native_launcher") or hermes_meta.get("native_app")
+    if not isinstance(native, dict):
+        return None
+
+    executable = str(native.get("executable") or "").strip()
+    if not executable:
+        return None
+
+    def _normalize_shellish_list(value: Any) -> list[str]:
+        if value is None:
+            return []
+        if isinstance(value, str):
+            try:
+                return [str(item) for item in shlex.split(value) if str(item).strip()]
+            except ValueError:
+                return [value]
+        if isinstance(value, (list, tuple)):
+            return [str(item).strip() for item in value if str(item).strip()]
+        return [str(value).strip()]
+
+    terminal = str(native.get("terminal") or ("tmux" if native.get("separate_terminal") else "system")).strip().lower()
+    if terminal not in {"tmux", "system"}:
+        terminal = "system"
+
+    setup_command = str(native.get("setup_command") or "").strip() or None
+    setup_sentinel = str(native.get("setup_sentinel") or executable).strip() or executable
+    default_args = _normalize_shellish_list(native.get("default_args"))
+    interactive_subcommands = _normalize_shellish_list(native.get("interactive_subcommands"))
+    global_options_with_values = _normalize_shellish_list(native.get("global_options_with_values"))
+    global_flag_options = _normalize_shellish_list(native.get("global_flag_options"))
+    default_subcommand = str(native.get("default_subcommand") or "").strip() or None
+    terminal_name = str(native.get("terminal_name") or frontmatter.get("name") or "skill").strip()
+
+    return {
+        "executable": executable,
+        "setup_command": setup_command,
+        "setup_sentinel": setup_sentinel,
+        "terminal": terminal,
+        "terminal_name": terminal_name,
+        "hold_on_failure": bool(native.get("hold_on_failure", True)),
+        "default_args": default_args,
+        "default_subcommand": default_subcommand,
+        "interactive_subcommands": interactive_subcommands,
+        "global_options_with_values": global_options_with_values,
+        "global_flag_options": global_flag_options,
+    }
+
+
 def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     """Scan ~/.hermes/skills/ and return a mapping of /command -> skill info.
 
@@ -187,6 +242,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     "description": description or f"Invoke the {name} skill",
                     "skill_md_path": str(skill_md),
                     "skill_dir": str(skill_md.parent),
+                    "native_launcher": _normalize_native_launcher(frontmatter),
                 }
             except Exception:
                 continue

--- a/cli.py
+++ b/cli.py
@@ -3898,12 +3898,15 @@ class HermesCLI:
                         _cprint(f"\033[1;31mPlugin command error: {e}{_RST}")
             # Check for skill slash commands (/gif-search, /axolotl, etc.)
             elif base_cmd in _skill_commands:
+                skill_info = _skill_commands[base_cmd]
+                if self._maybe_launch_native_skill(base_cmd, skill_info, cmd_original):
+                    return True
                 user_instruction = cmd_original[len(base_cmd):].strip()
                 msg = build_skill_invocation_message(
                     base_cmd, user_instruction, task_id=self.session_id
                 )
                 if msg:
-                    skill_name = _skill_commands[base_cmd]["name"]
+                    skill_name = skill_info["name"]
                     print(f"\n⚡ Loading skill: {skill_name}")
                     if hasattr(self, '_pending_input'):
                         self._pending_input.put(msg)
@@ -3978,6 +3981,118 @@ class HermesCLI:
         else:
             self.console.print("[bold red]Plan mode unavailable: input queue not initialized[/]")
     
+    def _maybe_launch_native_skill(self, cmd_key: str, skill_info: dict, cmd_original: str) -> bool:
+        native = skill_info.get("native_launcher")
+        if not isinstance(native, dict):
+            return False
+        self._launch_native_skill(cmd_key, skill_info, cmd_original)
+        return True
+
+    def _effective_native_skill_subcommand(self, tokens: list[str], native: dict) -> str | None:
+        options_with_values = {str(item) for item in native.get("global_options_with_values") or []}
+        flag_options = {str(item) for item in native.get("global_flag_options") or []}
+        skip_next = False
+        saw_flag = False
+        for token in tokens:
+            if skip_next:
+                skip_next = False
+                continue
+            if token in flag_options:
+                saw_flag = True
+                break
+            if token in options_with_values:
+                skip_next = True
+                continue
+            if token.startswith("-"):
+                continue
+            return token
+        if saw_flag:
+            return None
+        default_subcommand = str(native.get("default_subcommand") or "").strip()
+        return default_subcommand or None
+
+    def _build_native_skill_shell(self, skill_dir: Path, native: dict, tokens: list[str]) -> str:
+        import shlex
+
+        executable_rel = str(native.get("executable") or "").strip()
+        setup_sentinel = str(native.get("setup_sentinel") or executable_rel).strip() or executable_rel
+        setup_command = str(native.get("setup_command") or "").strip()
+        argv = [executable_rel, *tokens]
+
+        lines = [f"cd {shlex.quote(str(skill_dir))}"]
+        if setup_command:
+            lines.append(
+                "if [ ! -x "
+                + shlex.quote(setup_sentinel)
+                + " ]; then printf '%s\\n' 'Bootstrapping native skill runtime...'; "
+                + setup_command
+                + "; fi"
+            )
+        lines.append(
+            "if [ ! -x "
+            + shlex.quote(executable_rel)
+            + " ]; then printf '%s\\n' 'Native skill executable is still missing after setup.'; exit 1; fi"
+        )
+        lines.append("exec " + " ".join(shlex.quote(part) for part in argv))
+        return " && ".join(lines)
+
+    def _launch_native_skill(self, cmd_key: str, skill_info: dict, cmd_original: str) -> None:
+        """Launch an installed native skill declared via SKILL.md metadata."""
+        import shlex
+        import subprocess
+
+        skill_name = str(skill_info.get("name") or cmd_key.lstrip("/"))
+        native = skill_info.get("native_launcher") or {}
+        skill_dir_value = skill_info.get("skill_dir")
+        skill_dir = Path(str(skill_dir_value)).expanduser() if skill_dir_value else None
+        if skill_dir is None or not skill_dir.exists():
+            self.console.print(f"[bold red]{skill_name} is not installed correctly.[/]")
+            self.console.print("[dim]Expected an installed skill directory with SKILL.md metadata.[/]")
+            return
+
+        arg_text = cmd_original[len(cmd_key):].strip()
+        try:
+            tokens = shlex.split(arg_text) if arg_text else list(native.get("default_args") or [])
+        except ValueError as exc:
+            self.console.print(f"[bold red]Could not parse {cmd_key} arguments: {exc}[/]")
+            return
+
+        effective_subcommand = self._effective_native_skill_subcommand(tokens, native)
+        inner_command = self._build_native_skill_shell(skill_dir, native, tokens)
+
+        interactive_subcommands = {str(item) for item in native.get("interactive_subcommands") or []}
+        terminal_mode = str(native.get("terminal") or "system").strip().lower()
+        use_tmux = terminal_mode == "tmux" and (
+            not interactive_subcommands or effective_subcommand in interactive_subcommands
+        )
+
+        tmux_executable = shutil.which("tmux")
+        if use_tmux and tmux_executable:
+            tmux_name = str(native.get("terminal_name") or skill_name).strip().lower().replace(" ", "-") or "skill"
+            tmux_wrapped_command = f"bash -lc {shlex.quote(inner_command)}"
+            tmux_command = [tmux_executable]
+            if os.environ.get("TMUX"):
+                tmux_command += ["new-window", "-n", tmux_name, tmux_wrapped_command]
+            else:
+                tmux_command += ["new-session", "-A", "-s", tmux_name, tmux_wrapped_command]
+            try:
+                subprocess.run(tmux_command, check=False)
+            except Exception as exc:
+                self.console.print(f"[bold red]Failed to launch {skill_name} in tmux: {exc}[/]")
+            return
+
+        if use_tmux:
+            try:
+                subprocess.run(inner_command, shell=True, check=False)
+            except Exception as exc:
+                self.console.print(f"[bold red]Failed to launch {skill_name}: {exc}[/]")
+            return
+
+        try:
+            subprocess.run(["bash", "-lc", inner_command], check=False)
+        except Exception as exc:
+            self.console.print(f"[bold red]Failed to launch {skill_name}: {exc}[/]")
+
     def _handle_background_command(self, cmd: str):
         """Handle /background <prompt> — run a prompt in a separate background session.
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -106,6 +106,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("skills", "Search, install, inspect, or manage skills",
                "Tools & Skills", cli_only=True,
                subcommands=("search", "browse", "inspect", "install")),
+    CommandDef("hermes-network", "Launch the installed Hermes Network skill with auto-bootstrap and its own dedicated chat space",
+               "Tools & Skills", cli_only=True),
     CommandDef("cron", "Manage scheduled tasks", "Tools & Skills",
                cli_only=True, args_hint="[subcommand]",
                subcommands=("list", "add", "create", "edit", "pause", "resume", "run", "remove")),

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -100,6 +100,36 @@ class TestScanSkillCommands:
         assert "/enabled-skill" in result
         assert "/disabled-skill" not in result
 
+    def test_parses_native_launcher_metadata(self, tmp_path):
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(
+                tmp_path,
+                "native-skill",
+                frontmatter_extra=(
+                    "metadata:\n"
+                    "  hermes:\n"
+                    "    native_launcher:\n"
+                    "      executable: .venv/bin/native-skill\n"
+                    "      setup_command: python3 scripts/install_runtime.py\n"
+                    "      terminal: tmux\n"
+                    "      default_subcommand: app\n"
+                    "      interactive_subcommands: [app, host, join]\n"
+                    "      global_options_with_values: [--data-dir]\n"
+                    "      global_flag_options: [--help, -h]\n"
+                ),
+            )
+            result = scan_skill_commands()
+
+        launcher = result["/native-skill"]["native_launcher"]
+        assert launcher is not None
+        assert launcher["executable"] == ".venv/bin/native-skill"
+        assert launcher["setup_command"] == "python3 scripts/install_runtime.py"
+        assert launcher["terminal"] == "tmux"
+        assert launcher["default_subcommand"] == "app"
+        assert launcher["interactive_subcommands"] == ["app", "host", "join"]
+        assert launcher["global_options_with_values"] == ["--data-dir"]
+        assert launcher["global_flag_options"] == ["--help", "-h"]
+
 
 class TestBuildPreloadedSkillsPrompt:
     def test_builds_prompt_for_multiple_named_skills(self, tmp_path):

--- a/tests/test_cli_hermes_network_command.py
+++ b/tests/test_cli_hermes_network_command.py
@@ -1,0 +1,99 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from cli import HermesCLI
+
+
+def _make_cli():
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.config = {}
+    cli_obj.console = MagicMock()
+    cli_obj.agent = None
+    cli_obj.conversation_history = []
+    cli_obj._app = MagicMock()
+    return cli_obj
+
+
+def _make_native_skill(tmp_path: Path):
+    skill_dir = tmp_path / "skills" / "networking" / "hermes-network"
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text("name: hermes-network\n")
+    return skill_dir
+
+
+def _native_launcher(skill_dir: Path):
+    return {
+        "/hermes-network": {
+            "name": "hermes-network",
+            "description": "Chat-only network skill",
+            "skill_dir": str(skill_dir),
+            "native_launcher": {
+                "executable": ".venv/bin/hermes-network",
+                "setup_command": "python3 scripts/install_runtime.py",
+                "setup_sentinel": ".venv/bin/hermes-network",
+                "terminal": "tmux",
+                "terminal_name": "hermes-network",
+                "default_args": ["app"],
+                "default_subcommand": "app",
+                "interactive_subcommands": ["app", "host", "join", "chat"],
+                "global_options_with_values": ["--data-dir"],
+                "global_flag_options": ["--help", "-h"],
+                "hold_on_failure": True,
+            },
+        }
+    }
+
+
+class TestCLIHermesNetworkCommand:
+    def test_default_launch_bootstraps_and_opens_tmux(self, tmp_path):
+        cli_obj = _make_cli()
+        skill_dir = _make_native_skill(tmp_path)
+
+        with (
+            patch("cli._skill_commands", _native_launcher(skill_dir)),
+            patch("cli.shutil.which", return_value="/usr/bin/tmux"),
+            patch.dict("cli.os.environ", {"TMUX": "1"}, clear=False),
+            patch("subprocess.run") as mock_run,
+        ):
+            result = cli_obj.process_command("/hermes-network")
+
+        assert result is True
+        cli_obj._app.run_system_command.assert_not_called()
+        mock_run.assert_called_once()
+        args = mock_run.call_args[0][0]
+        assert args[:3] == ["/usr/bin/tmux", "new-window", "-n"]
+        assert args[3] == "hermes-network"
+        command = args[4]
+        assert "python3 scripts/install_runtime.py" in command
+        assert ".venv/bin/hermes-network app" in command
+        assert "Bootstrapping native skill runtime" in command
+
+    def test_noninteractive_subcommand_runs_via_bash_inline(self, tmp_path):
+        cli_obj = _make_cli()
+        skill_dir = _make_native_skill(tmp_path)
+
+        with (
+            patch("cli._skill_commands", _native_launcher(skill_dir)),
+            patch("cli.shutil.which", return_value="/usr/bin/tmux"),
+            patch("subprocess.run") as mock_run,
+        ):
+            cli_obj.process_command("/hermes-network demo-local-mesh")
+
+        cli_obj._app.run_system_command.assert_not_called()
+        mock_run.assert_called_once()
+        args = mock_run.call_args[0][0]
+        assert args[:2] == ["bash", "-lc"]
+        command = args[2]
+        assert "python3 scripts/install_runtime.py" in command
+        assert ".venv/bin/hermes-network demo-local-mesh" in command
+
+    def test_missing_skill_dir_shows_error(self, tmp_path):
+        cli_obj = _make_cli()
+        missing_dir = tmp_path / "skills" / "networking" / "hermes-network"
+
+        with patch("cli._skill_commands", _native_launcher(missing_dir)):
+            cli_obj.process_command("/hermes-network")
+
+        cli_obj.console.print.assert_called()
+        printed = "\n".join(str(call.args[0]) for call in cli_obj.console.print.call_args_list)
+        assert "not installed correctly" in printed.lower()


### PR DESCRIPTION
## Summary
- add native launcher metadata parsing to skill slash-command registration
- let installed skills bootstrap and launch local runtimes directly from `/skill-name`
- cover the flow with Hermes Network launcher + metadata tests

## Why
This makes "just send a skill" viable for installable local apps. A skill can declare its executable, setup command, and preferred terminal surface in `SKILL.md`, and Hermes can launch it without a hardcoded one-off slash command.

## Test Plan
- `/home/main/.hermes/hermes-agent/venv/bin/python -m py_compile cli.py agent/skill_commands.py hermes_cli/commands.py tests/test_cli_hermes_network_command.py tests/agent/test_skill_commands.py`
- `/home/main/.hermes/hermes-agent/venv/bin/pytest -q tests/test_cli_hermes_network_command.py tests/agent/test_skill_commands.py`
