### PR TITLE
[codex] Allow self-hosted Honcho without API key

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6070,7 +6070,7 @@ class HermesCLI:
             from honcho_integration.client import HonchoClientConfig
             from agent.display import honcho_session_line, write_tty
             hcfg = HonchoClientConfig.from_global_config()
-            if hcfg.enabled and hcfg.api_key and hcfg.explicitly_configured:
+            if hcfg.enabled and (hcfg.api_key or hcfg.base_url) and hcfg.explicitly_configured:
                 sname = hcfg.resolve_session_name(session_id=self.session_id)
                 if sname:
                     write_tty(honcho_session_line(hcfg.workspace_id, sname) + "\n")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -432,7 +432,7 @@ class GatewayRunner:
             from honcho_integration.session import HonchoSessionManager
 
             hcfg = HonchoClientConfig.from_global_config()
-            if not hcfg.enabled or not hcfg.api_key:
+            if not hcfg.enabled or not (hcfg.api_key or hcfg.base_url):
                 return None, hcfg
 
             client = get_honcho_client(hcfg)

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -56,7 +56,7 @@ def _honcho_is_configured_for_doctor() -> bool:
         from honcho_integration.client import HonchoClientConfig
 
         cfg = HonchoClientConfig.from_global_config()
-        return bool(cfg.enabled and cfg.api_key)
+        return bool(cfg.enabled and (cfg.api_key or cfg.base_url))
     except Exception:
         return False
 

--- a/honcho_integration/cli.py
+++ b/honcho_integration/cli.py
@@ -270,7 +270,7 @@ def cmd_status(args) -> None:
             print(f"    {peer}: {mode}")
     print(f"  Write freq:     {hcfg.write_frequency}")
 
-    if hcfg.enabled and hcfg.api_key:
+    if hcfg.enabled and (hcfg.api_key or hcfg.base_url):
         print("\n  Connection... ", end="", flush=True)
         try:
             get_honcho_client(hcfg)
@@ -278,7 +278,7 @@ def cmd_status(args) -> None:
         except Exception as e:
             print(f"FAILED ({e})\n")
     else:
-        reason = "disabled" if not hcfg.enabled else "no API key"
+        reason = "disabled" if not hcfg.enabled else "no API key or base URL"
         print(f"\n  Not connected ({reason})\n")
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -2187,8 +2187,14 @@ class AIAgent:
     # ── Honcho integration helpers ──
 
     def _honcho_should_activate(self, hcfg) -> bool:
-        """Return True when remote Honcho should be active."""
-        if not hcfg or not hcfg.enabled or not hcfg.api_key:
+        """Return True when Honcho should be active.
+
+        Self-hosted Honcho may be configured with a base_url and no API key,
+        so activation should accept either credential style.
+        """
+        if not hcfg or not hcfg.enabled:
+            return False
+        if not (hcfg.api_key or hcfg.base_url):
             return False
         return True
 


### PR DESCRIPTION
## What changed
- treat a configured Honcho `base_url` as sufficient to activate Honcho integration paths
- stop requiring an API key when Hermes is pointed at a self-hosted Honcho deployment
- update status and doctor messaging to reflect `base_url`-only self-hosted usage

## Why
Self-hosted Honcho can be reachable by base URL without an API key, but Hermes previously treated that setup as disabled. These checks now allow self-hosted deployments to work without fake credentials.

## User impact
Hermes CLI, gateway, doctor, and Honcho activation checks now work correctly for self-hosted Honcho setups configured with a base URL and no API key.

## Validation
- `python3 -m py_compile cli.py gateway/run.py hermes_cli/doctor.py honcho_integration/cli.py run_agent.py`
