### PR TITLE
[codex] Add local MLX and KittenTTS voice backends

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -540,7 +540,7 @@ platform_toolsets:
 #   todo         - Task planning and tracking for multi-step work
 #   memory       - Persistent memory across sessions (personal notes + user profile)
 #   session_search - Search and recall past conversations (FTS5 + Gemini Flash summarization)
-#   tts          - Text-to-speech (Edge TTS free, ElevenLabs, OpenAI)
+#   tts          - Text-to-speech (Edge TTS free, ElevenLabs, OpenAI, KittenTTS, MLX Audio Server)
 #   cronjob      - Schedule and manage automated tasks (CLI-only)
 #   rl           - RL training tools (Tinker-Atropos)
 #

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -967,17 +967,27 @@ class BasePlatformAdapter(ABC):
 
                 # Play TTS audio before text (voice-first experience)
                 if _tts_path and Path(_tts_path).exists():
+                    _tts_sent_with_caption = False
                     try:
-                        await self.play_tts(
+                        _tts_result = await self.play_tts(
                             chat_id=event.source.chat_id,
                             audio_path=_tts_path,
+                            caption=text_content if getattr(self, "name", "").lower() == "signal" else None,
                             metadata=_thread_metadata,
                         )
+                        if (
+                            getattr(self, "name", "").lower() == "signal"
+                            and getattr(_tts_result, "success", False)
+                            and event.message_type == MessageType.VOICE
+                        ):
+                            _tts_sent_with_caption = True
                     finally:
                         try:
                             os.remove(_tts_path)
                         except OSError:
                             pass
+                    if _tts_sent_with_caption:
+                        text_content = ""
 
                 # Send the text portion
                 if text_content:

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -22,7 +22,7 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Any
-from urllib.parse import unquote
+from urllib.parse import unquote, quote
 
 import httpx
 
@@ -85,7 +85,10 @@ def _guess_extension(data: bytes) -> str:
         return ".webp"
     if data[:4] == b"%PDF":
         return ".pdf"
-    if len(data) >= 8 and data[4:8] == b"ftyp":
+    if len(data) >= 12 and data[4:8] == b"ftyp":
+        brand = data[8:12]
+        if brand in (b"M4A ", b"M4B ", b"M4P "):
+            return ".m4a"
         return ".mp4"
     if data[:4] == b"OggS":
         return ".ogg"
@@ -116,6 +119,35 @@ _EXT_TO_MIME = {
 def _ext_to_mime(ext: str) -> str:
     """Map file extension to MIME type."""
     return _EXT_TO_MIME.get(ext.lower(), "application/octet-stream")
+
+
+def _resolve_signal_attachment_path(att: Any) -> Optional[str]:
+    """Best-effort resolution of a locally stored Signal attachment path."""
+    candidates: list[str] = []
+    attachment_root = Path.home() / ".local" / "share" / "signal-cli" / "attachments"
+
+    if isinstance(att, str):
+        candidates.append(att)
+    elif isinstance(att, dict):
+        for key in (
+            "path", "file", "filePath", "localPath",
+            "storedFilename", "storedFileName", "storedFile",
+            "filename", "fileName",
+        ):
+            value = att.get(key)
+            if not value or not isinstance(value, str):
+                continue
+            candidates.append(value)
+            if not os.path.isabs(value):
+                candidates.append(str(attachment_root / value))
+
+    for candidate in candidates:
+        try:
+            if candidate and Path(candidate).exists() and Path(candidate).is_file():
+                return candidate
+        except OSError:
+            continue
+    return None
 
 
 def _render_mentions(text: str, mentions: list) -> str:
@@ -253,7 +285,8 @@ class SignalAdapter(BasePlatformAdapter):
 
     async def _sse_listener(self) -> None:
         """Listen for SSE events from signal-cli daemon."""
-        url = f"{self.http_url}/api/v1/events?account={self.account}"
+        encoded_account = quote(self.account, safe="")
+        url = f"{self.http_url}/api/v1/events?account={encoded_account}"
         backoff = SSE_RETRY_DELAY_INITIAL
 
         while self._running:
@@ -446,18 +479,33 @@ class SignalAdapter(BasePlatformAdapter):
 
         if attachments_data and not getattr(self, "ignore_attachments", False):
             for att in attachments_data:
-                att_id = att.get("id")
-                att_size = att.get("size", 0)
+                att_dict = att if isinstance(att, dict) else {}
+                att_id = att_dict.get("id")
+                att_size = att_dict.get("size", 0)
+
+                direct_path = _resolve_signal_attachment_path(att)
+                if direct_path:
+                    ext = Path(direct_path).suffix.lower()
+                    content_type = att_dict.get("contentType") or _ext_to_mime(ext)
+                    media_urls.append(direct_path)
+                    media_types.append(content_type)
+                    continue
+
                 if not att_id:
+                    logger.debug("Signal: attachment missing id/path, skipping: %r", att)
                     continue
                 if att_size > SIGNAL_MAX_ATTACHMENT_SIZE:
                     logger.warning("Signal: attachment too large (%d bytes), skipping", att_size)
                     continue
                 try:
-                    cached_path, ext = await self._fetch_attachment(att_id)
+                    cached_path, ext = await self._fetch_attachment(
+                        att_id,
+                        sender=sender if not is_group else None,
+                        group_id=group_id if is_group else None,
+                    )
                     if cached_path:
                         # Use contentType from Signal if available, else map from extension
-                        content_type = att.get("contentType") or _ext_to_mime(ext)
+                        content_type = att_dict.get("contentType") or _ext_to_mime(ext)
                         media_urls.append(cached_path)
                         media_types.append(content_type)
                 except Exception:
@@ -511,12 +559,23 @@ class SignalAdapter(BasePlatformAdapter):
     # Attachment Handling
     # ------------------------------------------------------------------
 
-    async def _fetch_attachment(self, attachment_id: str) -> tuple:
+    async def _fetch_attachment(
+        self,
+        attachment_id: str,
+        sender: Optional[str] = None,
+        group_id: Optional[str] = None,
+    ) -> tuple:
         """Fetch an attachment via JSON-RPC and cache it. Returns (path, ext)."""
-        result = await self._rpc("getAttachment", {
+        params: Dict[str, Any] = {
             "account": self.account,
-            "attachmentId": attachment_id,
-        })
+            "id": attachment_id,
+        }
+        if group_id:
+            params["groupId"] = group_id
+        elif sender:
+            params["recipient"] = sender
+
+        result = await self._rpc("getAttachment", params)
 
         if not result:
             return None, ""
@@ -618,6 +677,42 @@ class SignalAdapter(BasePlatformAdapter):
             self._recent_sent_timestamps.add(ts)
             if len(self._recent_sent_timestamps) > self._max_recent_timestamps:
                 self._recent_sent_timestamps.pop()
+
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send an audio attachment (used for TTS replies on Signal)."""
+        await self._stop_typing_indicator(chat_id)
+
+        if not audio_path or not Path(audio_path).exists():
+            return SendResult(success=False, error="Audio file not found")
+
+        file_size = Path(audio_path).stat().st_size
+        if file_size > SIGNAL_MAX_ATTACHMENT_SIZE:
+            return SendResult(success=False, error=f"Audio too large ({file_size} bytes)")
+
+        params: Dict[str, Any] = {
+            "account": self.account,
+            "message": caption or "",
+            "attachments": [audio_path],
+        }
+
+        if chat_id.startswith("group:"):
+            params["groupId"] = chat_id[6:]
+        else:
+            params["recipient"] = [chat_id]
+
+        result = await self._rpc("send", params)
+        if result is not None:
+            self._track_sent_timestamp(result)
+            return SendResult(success=True)
+        return SendResult(success=False, error="RPC send voice failed")
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Send a typing indicator."""

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -169,6 +169,18 @@ TOOL_CATEGORIES = {
                 ],
                 "tts_provider": "elevenlabs",
             },
+            {
+                "name": "KittenTTS",
+                "tag": "Local - lightweight ONNX voice synthesis",
+                "env_vars": [],
+                "tts_provider": "kitten",
+            },
+            {
+                "name": "MLX Audio Server",
+                "tag": "Local/self-hosted - custom voices like Samantha and Judy",
+                "env_vars": [],
+                "tts_provider": "mlx",
+            },
         ],
     },
     "web": {

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1,8 +1,16 @@
 """Tests for gateway/platforms/base.py — MessageEvent, media extraction, message truncation."""
 
+import asyncio
+import json
 import os
+from pathlib import Path
+import sys
+import types
 from unittest.mock import patch
 
+import pytest
+
+from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
     GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE,
@@ -280,6 +288,76 @@ class TestExtractMedia:
         assert media == [("/tmp/my image.png", False)]
         assert "Here" in cleaned
         assert "After" in cleaned
+
+
+class DummySignalAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True), Platform.SIGNAL)
+        self.sent = []
+        self.voice_sent = []
+
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent.append({
+            "chat_id": chat_id,
+            "content": content,
+            "reply_to": reply_to,
+            "metadata": metadata,
+        })
+        return type("R", (), {"success": True, "message_id": "m1"})()
+
+    async def send_voice(self, chat_id, audio_path, caption=None, reply_to=None, metadata=None, **kwargs):
+        self.voice_sent.append({
+            "chat_id": chat_id,
+            "audio_path": audio_path,
+            "caption": caption,
+            "reply_to": reply_to,
+            "metadata": metadata,
+        })
+        return type("R", (), {"success": True, "message_id": "v1"})()
+
+    async def send_typing(self, chat_id, metadata=None):
+        return None
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+
+class TestSignalSingleMessageVoiceReplies:
+    @pytest.mark.asyncio
+    async def test_signal_voice_reply_sends_audio_with_caption_and_skips_followup_text(self, tmp_path, monkeypatch):
+        adapter = DummySignalAdapter()
+        adapter.set_message_handler(lambda event: asyncio.sleep(0, result="Reply in one message"))
+
+        tts_path = tmp_path / "reply.ogg"
+        tts_path.write_bytes(b"voice-bytes")
+
+        event = MessageEvent(
+            text="",
+            message_type=MessageType.VOICE,
+            source=type("S", (), {"chat_id": "+15551234567", "thread_id": None})(),
+            message_id="orig-1",
+        )
+
+        fake_tools_pkg = types.ModuleType("tools")
+        fake_tools_pkg.__path__ = []
+        fake_tts_module = types.ModuleType("tools.tts_tool")
+        fake_tts_module.check_tts_requirements = lambda: True
+        fake_tts_module.text_to_speech_tool = lambda text: json.dumps({"file_path": str(tts_path)})
+        monkeypatch.setitem(sys.modules, "tools", fake_tools_pkg)
+        monkeypatch.setitem(sys.modules, "tools.tts_tool", fake_tts_module)
+
+        await adapter._process_message_background(event, "session-key")
+
+        assert len(adapter.voice_sent) == 1
+        assert adapter.voice_sent[0]["caption"] == "Reply in one message"
+        assert adapter.sent == []
+        assert not Path(tts_path).exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -1,4 +1,5 @@
 """Tests for Signal messenger platform adapter."""
+import base64
 import json
 import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
@@ -145,6 +146,10 @@ class TestSignalHelpers:
         from gateway.platforms.signal import _guess_extension
         assert _guess_extension(b"\x00\x00\x00\x18ftypisom" + b"\x00" * 100) == ".mp4"
 
+    def test_guess_extension_m4a(self):
+        from gateway.platforms.signal import _guess_extension
+        assert _guess_extension(b"\x00\x00\x00\x1cftypM4A " + b"\x00" * 100) == ".m4a"
+
     def test_guess_extension_unknown(self):
         from gateway.platforms.signal import _guess_extension
         assert _guess_extension(b"\x00\x01\x02\x03" * 10) == ".bin"
@@ -161,6 +166,15 @@ class TestSignalHelpers:
         assert _is_audio_ext(".mp3") is True
         assert _is_audio_ext(".ogg") is True
         assert _is_audio_ext(".png") is False
+
+    def test_resolve_signal_attachment_path_prefers_existing_local_file(self, tmp_path):
+        from gateway.platforms.signal import _resolve_signal_attachment_path
+
+        attachment = tmp_path / "voice-note.m4a"
+        attachment.write_bytes(b"audio")
+
+        resolved = _resolve_signal_attachment_path({"path": str(attachment)})
+        assert resolved == str(attachment)
 
     def test_check_requirements(self, monkeypatch):
         from gateway.platforms.signal import check_signal_requirements
@@ -222,6 +236,57 @@ class TestSignalSessionSource:
         assert restored.user_id_alt == "uuid:abc"
         assert restored.chat_id_alt == "xyz"
         assert restored.platform == Platform.SIGNAL
+
+
+class TestSignalAttachmentRpc:
+    @pytest.mark.asyncio
+    async def test_fetch_attachment_uses_openclaw_style_rpc_params_for_dm(self, monkeypatch):
+        from gateway.platforms.signal import SignalAdapter
+
+        config = PlatformConfig(enabled=True)
+        config.extra = {"http_url": "http://localhost:8080", "account": "+15550001111"}
+        adapter = SignalAdapter(config)
+
+        recorded = {}
+
+        async def fake_rpc(method, params, rpc_id=None):
+            recorded["method"] = method
+            recorded["params"] = params
+            return {"data": base64.b64encode(b"OggS" + b"\x00" * 32).decode()}
+
+        monkeypatch.setattr(adapter, "_rpc", fake_rpc)
+
+        path, ext = await adapter._fetch_attachment("att-123", sender="+15551234567")
+
+        assert recorded["method"] == "getAttachment"
+        assert recorded["params"]["account"] == "+15550001111"
+        assert recorded["params"]["id"] == "att-123"
+        assert recorded["params"]["recipient"] == "+15551234567"
+        assert "attachmentId" not in recorded["params"]
+        assert path is not None
+        assert ext == ".ogg"
+
+    @pytest.mark.asyncio
+    async def test_fetch_attachment_uses_group_id_for_groups(self, monkeypatch):
+        from gateway.platforms.signal import SignalAdapter
+
+        config = PlatformConfig(enabled=True)
+        config.extra = {"http_url": "http://localhost:8080", "account": "+15550001111"}
+        adapter = SignalAdapter(config)
+
+        recorded = {}
+
+        async def fake_rpc(method, params, rpc_id=None):
+            recorded["params"] = params
+            return {"data": base64.b64encode(b"ID3" + b"\x00" * 32).decode()}
+
+        monkeypatch.setattr(adapter, "_rpc", fake_rpc)
+
+        await adapter._fetch_attachment("att-456", group_id="group-789")
+
+        assert recorded["params"]["id"] == "att-456"
+        assert recorded["params"]["groupId"] == "group-789"
+        assert "recipient" not in recorded["params"]
 
 
 # ---------------------------------------------------------------------------
@@ -291,8 +356,6 @@ class TestSignalAuthorization:
 
 class TestSignalSendMessage:
     def test_signal_in_platform_map(self):
-        """Signal should be in the send_message tool's platform map."""
-        from tools.send_message_tool import send_message_tool
-        # Just verify the import works and Signal is a valid platform
+        """Signal should remain a valid outbound platform."""
         from gateway.config import Platform
         assert Platform.SIGNAL.value == "signal"

--- a/tools/kitten_tts_synth.py
+++ b/tools/kitten_tts_synth.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Small helper that synthesizes speech with kittentts."""
+
+import argparse
+import sys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Synthesize speech with KittenTTS")
+    parser.add_argument("--text", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--voice", default="Rosie")
+    parser.add_argument("--model-name", default="KittenML/kitten-tts-nano-0.8")
+    parser.add_argument("--speed", type=float, default=1.0)
+    parser.add_argument("--cache-dir", default=None)
+    parser.add_argument("--clean-text", action="store_true")
+    args = parser.parse_args()
+
+    from kittentts import KittenTTS
+
+    model = KittenTTS(model_name=args.model_name, cache_dir=args.cache_dir)
+    model.generate_to_file(
+        args.text,
+        args.out,
+        voice=args.voice,
+        speed=args.speed,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -29,6 +29,7 @@ import shlex
 import shutil
 import subprocess
 import tempfile
+import json
 from pathlib import Path
 from typing import Optional, Dict, Any
 
@@ -465,6 +466,15 @@ def _transcribe_openai(file_path: str, model_name: str) -> Dict[str, Any]:
             )
 
         transcript_text = str(transcription).strip()
+        # Some OpenAI-compatible local servers return JSON even when
+        # response_format="text". Accept {"text": "..."} as a friendly fallback.
+        if transcript_text.startswith("{"):
+            try:
+                parsed = json.loads(transcript_text)
+                if isinstance(parsed, dict) and isinstance(parsed.get("text"), str):
+                    transcript_text = parsed["text"].strip()
+            except Exception:
+                pass
         logger.info("Transcribed %s via OpenAI API (%s, %d chars)",
                      Path(file_path).name, model_name, len(transcript_text))
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2,11 +2,13 @@
 """
 Text-to-Speech Tool Module
 
-Supports four TTS providers:
+Supports TTS providers:
 - Edge TTS (default, free, no API key): Microsoft Edge neural voices
 - ElevenLabs (premium): High-quality voices, needs ELEVENLABS_API_KEY
 - OpenAI TTS: Good quality, needs OPENAI_API_KEY
 - NeuTTS (local, free, no API key): On-device TTS via neutts_cli, needs neutts installed
+- KittenTTS (local, free, no API key): Local ONNX TTS via kittentts, supports Rosie
+- MLX TTS (local/self-hosted): OpenClaw-compatible MLX audio server with custom voices
 
 Output formats:
 - Opus (.ogg) for Telegram voice bubbles (requires ffmpeg for Edge TTS)
@@ -22,6 +24,7 @@ Usage:
 """
 
 import asyncio
+import base64
 import datetime
 import json
 import logging
@@ -35,6 +38,8 @@ import threading
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Callable, Dict, Any, Optional
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
 
 logger = logging.getLogger(__name__)
 
@@ -338,6 +343,143 @@ def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) ->
 
 
 # ===========================================================================
+# KittenTTS (local, on-device TTS via kittentts)
+# ===========================================================================
+
+def _check_kitten_available(python_bin: str) -> bool:
+    """Check if the configured Python can import kittentts."""
+    try:
+        result = subprocess.run(
+            [python_bin, "-c", "import kittentts"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+def _generate_kitten(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate speech using KittenTTS in a separate Python interpreter."""
+    import sys
+
+    kitten_config = tts_config.get("kitten", {})
+    python_bin = kitten_config.get("python_bin", "").strip() or sys.executable
+    voice = kitten_config.get("voice", "Rosie")
+    model_name = kitten_config.get("model_name", "KittenML/kitten-tts-nano-0.8")
+    speed = float(kitten_config.get("speed", 1.0))
+    cache_dir = kitten_config.get("cache_dir", "").strip()
+    clean_text = bool(kitten_config.get("clean_text", True))
+
+    wav_path = output_path
+    if not output_path.endswith(".wav"):
+        wav_path = output_path.rsplit(".", 1)[0] + ".wav"
+
+    synth_script = str(Path(__file__).parent / "kitten_tts_synth.py")
+    cmd = [
+        python_bin,
+        synth_script,
+        "--text",
+        text,
+        "--out",
+        wav_path,
+        "--voice",
+        voice,
+        "--model-name",
+        model_name,
+        "--speed",
+        str(speed),
+    ]
+    if cache_dir:
+        cmd.extend(["--cache-dir", cache_dir])
+    if clean_text:
+        cmd.append("--clean-text")
+
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=180)
+    if result.returncode != 0:
+        stderr = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(f"KittenTTS synthesis failed: {stderr or 'unknown error'}")
+
+    if wav_path != output_path:
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg:
+            conv_cmd = [ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path]
+            subprocess.run(conv_cmd, check=True, timeout=30)
+            os.remove(wav_path)
+        else:
+            os.rename(wav_path, output_path)
+
+    return output_path
+
+
+# ===========================================================================
+# MLX TTS (local/self-hosted OpenClaw-compatible audio server)
+# ===========================================================================
+
+def _generate_mlx(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate speech using a local/self-hosted MLX audio server."""
+    mlx_config = tts_config.get("mlx", {})
+    base_url = mlx_config.get("base_url", "").strip()
+    if not base_url:
+        raise ValueError("tts.mlx.base_url is not configured")
+
+    voice = str(mlx_config.get("voice", "samantha")).strip() or "samantha"
+    speed = float(mlx_config.get("speed", 1.0))
+    timeout = float(mlx_config.get("timeout", 60))
+    model = str(mlx_config.get("model", "mlx-community/Qwen3-TTS-12Hz-1.7B-Base-4bit")).strip()
+    base_url = base_url.rstrip("/")
+
+    if voice.lower() in {"samantha", "judy"}:
+        query = urlencode({"text": text, "speed": speed})
+        url = f"{base_url}/v1/audio/{voice.lower()}?{query}"
+        request = Request(url, method="POST")
+    else:
+        url = f"{base_url}/v1/audio/speech"
+        payload = json.dumps(
+            {
+                "text": text,
+                "model": model,
+                "voice": voice,
+                "speed": speed,
+            }
+        ).encode("utf-8")
+        request = Request(
+            url,
+            data=payload,
+            method="POST",
+            headers={"Content-Type": "application/json"},
+        )
+
+    with urlopen(request, timeout=timeout) as response:
+        body = response.read().decode("utf-8")
+
+    data = json.loads(body)
+    audio_b64 = data.get("audio")
+    if not isinstance(audio_b64, str) or not audio_b64:
+        raise RuntimeError("MLX TTS response missing audio field")
+
+    source_format = str(data.get("format", "mp3")).lower()
+    source_path = output_path
+    if not source_path.endswith(f".{source_format}"):
+        source_path = output_path.rsplit(".", 1)[0] + f".{source_format}"
+
+    with open(source_path, "wb") as f:
+        f.write(base64.b64decode(audio_b64))
+
+    if source_path != output_path:
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg:
+            conv_cmd = [ffmpeg, "-i", source_path, "-y", "-loglevel", "error", output_path]
+            subprocess.run(conv_cmd, check=True, timeout=30)
+            os.remove(source_path)
+        else:
+            os.rename(source_path, output_path)
+
+    return output_path
+
+
+# ===========================================================================
 # Main tool function
 # ===========================================================================
 def text_to_speech_tool(
@@ -431,6 +573,22 @@ def text_to_speech_tool(
             logger.info("Generating speech with NeuTTS (local)...")
             _generate_neutts(text, file_str, tts_config)
 
+        elif provider == "kitten":
+            kitten_config = tts_config.get("kitten", {})
+            python_bin = kitten_config.get("python_bin", "").strip() or shutil.which("python3") or "python3"
+            if not _check_kitten_available(python_bin):
+                return json.dumps({
+                    "success": False,
+                    "error": f"KittenTTS provider selected but 'kittentts' is not importable via {python_bin}. "
+                             "Set tts.kitten.python_bin to a Python with kittentts installed."
+                }, ensure_ascii=False)
+            logger.info("Generating speech with KittenTTS (local)...")
+            _generate_kitten(text, file_str, tts_config)
+
+        elif provider == "mlx":
+            logger.info("Generating speech with MLX TTS...")
+            _generate_mlx(text, file_str, tts_config)
+
         else:
             # Default: Edge TTS (free), with NeuTTS as local fallback
             edge_available = True
@@ -471,7 +629,7 @@ def text_to_speech_tool(
         # Try Opus conversion for Telegram compatibility
         # Edge TTS outputs MP3, NeuTTS outputs WAV — both need ffmpeg conversion
         voice_compatible = False
-        if provider in ("edge", "neutts") and not file_str.endswith(".ogg"):
+        if provider in ("edge", "neutts", "kitten", "mlx") and not file_str.endswith(".ogg"):
             opus_path = _convert_to_opus(file_str)
             if opus_path:
                 file_str = opus_path
@@ -544,6 +702,16 @@ def check_tts_requirements() -> bool:
     except ImportError:
         pass
     if _check_neutts_available():
+        return True
+    mlx_base_url = _load_tts_config().get("mlx", {}).get("base_url", "").strip()
+    if mlx_base_url:
+        return True
+    kitten_python = (
+        _load_tts_config().get("kitten", {}).get("python_bin", "").strip()
+        or shutil.which("python3")
+        or "python3"
+    )
+    if _check_kitten_available(kitten_python):
         return True
     return False
 


### PR DESCRIPTION
## What changed
- add a local `kitten` TTS provider for Hermes
- add a local/self-hosted `mlx` TTS provider that can call OpenClaw-compatible MLX audio servers
- add `KittenTTS` and `MLX Audio Server` to the Hermes TTS setup menu and config docs
- accept JSON `{\"text\": ...}` responses from OpenAI-compatible STT servers when Hermes requests text transcription

## Why
This makes it easier to run Hermes fully against local audio infrastructure on Apple Silicon, including self-hosted MLX speech services and lightweight local TTS options.

## User impact
- Hermes can now use a self-hosted MLX speech server for TTS voices such as Samantha and Judy
- Hermes can now use KittenTTS as a local voice backend
- OpenAI-compatible local STT servers that return JSON text payloads work more reliably with Hermes

## Validation
- `python3 -m py_compile tools/transcription_tools.py tools/tts_tool.py tools/kitten_tts_synth.py`
- local smoke tests against a running MLX server for STT and TTS
