### PR TITLE
fix(matrix): download non-image MXC files and recover text MIME type                                                                                                                                                                                

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -715,23 +715,29 @@ class MatrixAdapter(BasePlatformAdapter):
         elif event_mimetype:
             media_type = event_mimetype
 
-        # For images, download and cache locally so vision tools can access them.
-        # Matrix MXC URLs require authentication, so direct URL access fails.
+        # Download and cache media locally — Matrix MXC URLs require authentication
+        # so direct URL access fails for all file types.
         cached_path = None
-        if msg_type == MessageType.PHOTO and url:
+        if url:
             try:
-                ext_map = {
-                    "image/jpeg": ".jpg", "image/png": ".png",
-                    "image/gif": ".gif", "image/webp": ".webp",
-                }
-                ext = ext_map.get(event_mimetype, ".jpg")
                 download_resp = await self._client.download(url)
                 if isinstance(download_resp, nio.DownloadResponse):
-                    from gateway.platforms.base import cache_image_from_bytes
-                    cached_path = cache_image_from_bytes(download_resp.body, ext=ext)
-                    logger.info("[Matrix] Cached user image at %s", cached_path)
+                    if msg_type == MessageType.PHOTO:
+                        ext_map = {
+                            "image/jpeg": ".jpg", "image/png": ".png",
+                            "image/gif": ".gif", "image/webp": ".webp",
+                        }
+                        ext = ext_map.get(event_mimetype, ".jpg")
+                        from gateway.platforms.base import cache_image_from_bytes
+                        cached_path = cache_image_from_bytes(download_resp.body, ext=ext)
+                        logger.info("[Matrix] Cached user image at %s", cached_path)
+                    else:
+                        filename = body or "file"
+                        from gateway.platforms.base import cache_document_from_bytes
+                        cached_path = cache_document_from_bytes(download_resp.body, filename=filename)
+                        logger.info("[Matrix] Cached user file at %s", cached_path)
             except Exception as e:
-                logger.warning("[Matrix] Failed to cache image: %s", e)
+                logger.warning("[Matrix] Failed to cache media: %s", e)
 
         is_dm = self._dm_rooms.get(room.room_id, False)
         if not is_dm and room.member_count == 2:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2398,8 +2398,20 @@ class GatewayRunner:
         # Enrich document messages with context notes for the agent
         # -----------------------------------------------------------------
         if event.media_urls and event.message_type == MessageType.DOCUMENT:
+            import mimetypes as _mimetypes
+            _TEXT_EXTENSIONS = {".txt", ".md", ".csv", ".log", ".json", ".xml", ".yaml", ".yml", ".toml", ".ini", ".cfg"}
             for i, path in enumerate(event.media_urls):
                 mtype = event.media_types[i] if i < len(event.media_types) else ""
+                # Fall back to extension-based detection when MIME type is unreliable.
+                if mtype in ("", "application/octet-stream"):
+                    import os as _os2
+                    _ext = _os2.path.splitext(path)[1].lower()
+                    if _ext in _TEXT_EXTENSIONS:
+                        mtype = "text/plain"
+                    else:
+                        guessed, _ = _mimetypes.guess_type(path)
+                        if guessed:
+                            mtype = guessed
                 if not (mtype.startswith("application/") or mtype.startswith("text/")):
                     continue
                 # Extract display filename by stripping the doc_{uuid12}_ prefix


### PR DESCRIPTION
 ## What does this PR do?
                                                                                                                                                                                                            
  Fixes two runtime bugs in the Matrix gateway that occur after a successful setup.
                                                                                                                                                                                                            
  1. Non-image MXC downloads failing — the download block in gateway/platforms/matrix.py was gated on msg_type == MessageType.PHOTO, so PDFs, text files, and other non-image uploads were only passed as an
   authenticated MXC HTTP URL that the agent cannot access. All file types are now downloaded via self._client.download() and cached locally.                                                               
  2. Text files not injected into agent context — gateway/run.py only detected text files when the MIME type was already text/*. When MIME detection returned application/octet-stream (common for Matrix   
  uploads), the file fell through to the generic "document saved at" branch and its content was never injected. A fallback now uses file extension and mimetypes.guess_type to recover the correct type.    

 NOT: The third (missing "matrix" entry in PLATFORMS) was already resolved upstream.       
  
  ## Related Issue                                                                                                                                                                                             
                                                            
  Fixes #3487                                                                                                                                                                                         
                                                            
 ## Type of Change

  - 🐛 Bug fix (non-breaking change that fixes an issue)

 ## Changes Made                                                                                                                                                                                              
  
  - gateway/platforms/matrix.py — extended MXC download block to cover all file types; non-image files cached via cache_document_from_bytes                                                                 
  - gateway/run.py — added extension-based and mimetypes.guess_type fallback when media_type is empty or application/octet-stream
                                                                                                                                                                                                           
  Checklist

  - I've read the https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md
  - My commit messages follow https://www.conventionalcommits.org/ (fix(scope):, feat(scope):, etc.)
  - I searched for https://github.com/NousResearch/hermes-agent/pulls to make sure this isn't a duplicate
  - My PR contains only changes related to this fix/feature (no unrelated commits)

