### PR TITLE
fix(skills): /skills install soft-locks in TUI due to blocking input() call  

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1075,9 +1075,9 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
             return
         identifier = args[0]
         category = ""
-        # --yes / -y bypasses confirmation prompt (needed in TUI mode)
-        # --force handles reinstall override
-        skip_confirm = any(flag in args for flag in ("--yes", "-y"))
+        # Slash command handler always runs in TUI mode where input() hangs.
+        # Confirmation is skipped by default; --no-confirm is kept for symmetry.
+        skip_confirm = "--no-confirm" not in args
         force = "--force" in args
         for i, a in enumerate(args):
             if a == "--category" and i + 1 < len(args):
@@ -1115,7 +1115,7 @@ def handle_skills_slash(cmd: str, console: Optional[Console] = None) -> None:
         if not args:
             c.print("[bold red]Usage:[/] /skills uninstall <name> [--yes]\n")
             return
-        skip_confirm = any(flag in args for flag in ("--yes", "-y"))
+        skip_confirm = "--no-confirm" not in args
         do_uninstall(args[0], console=c, skip_confirm=skip_confirm)
 
     elif action == "publish":


### PR DESCRIPTION
## What does this PR do?                                                                                                                                                                                     
                                                                                                                                                                                                            
  Fixes a soft-lock that occurs when running /skills install or /skills uninstall from the interactive chat.                                                                                                
                                                                                                                                                                                                            
  The slash command handler calls do_install / do_uninstall with skip_confirm=False unless the user explicitly passes --yes. This causes input("Confirm [y/N]: ") to block indefinitely in TUI mode where stdin is not a real terminal — the agent freezes with no recovery path other than killing the process.                                                                                                    
                                                                                                                                                                                                            
  Since the slash command handler exclusively runs in interactive chat context (the user typing the command is already an implicit confirmation), skip_confirm is now True by default. --no-confirm is available as an opt-out for edge cases.
                                                                                                                                                                                                            
  The CLI path (hermes skills install) is unaffected — it uses argparse --yes correctly.                                                                                                                    
  
 ## Related Issue                                                                                                                                                                                             
                                                            
  Fixes #3474

 ## Type of Change

  - 🐛 Bug fix (non-breaking change that fixes an issue)                                                                                                                                                    
  
 ## Changes Made                                                                                                                                                                                              
                                                            
  - hermes_cli/skills_hub.py — /skills install: changed skip_confirm from opt-in (--yes/-y) to opt-out (--no-confirm) in the slash command handler                                                          
  - hermes_cli/skills_hub.py — /skills uninstall: same fix
                                                                                                                                                                                                            
  ## How to Test                                               
                                                                                                                                                                                                            
  1. Launch Hermes in interactive chat mode.                                                                                                                                                                
  2. Run /skills install obsidian-cli (no --yes flag).
  3. Confirm the skill installs without hanging.                                                                                                                                                            
  4. Run /skills uninstall obsidian-cli and verify the same.
                                                                                                                                                                                                            
 ## Checklist                                                 
                                                                                                                                                                                                            
  - I've read the https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md                                                                                                                    
  - My commit messages follow https://www.conventionalcommits.org/ (fix(scope):, feat(scope):, etc.)
  - I searched for https://github.com/NousResearch/hermes-agent/pulls to make sure this isn't a duplicate                                                                                                   
  - My PR contains only changes related to this fix/feature (no unrelated commits)                                                                                                                          
    