### PR TITLE
feat: add ephemeral /btw command for side questions

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1266,6 +1266,8 @@ class HermesCLI:
         # Background task tracking: {task_id: threading.Thread}
         self._background_tasks: Dict[str, threading.Thread] = {}
         self._background_task_counter = 0
+        self._btw_tasks: Dict[str, threading.Thread] = {}
+        self._btw_task_counter = 0
 
     def _invalidate(self, min_interval: float = 0.25) -> None:
         """Throttled UI repaint — prevents terminal blinking on slow/SSH connections."""
@@ -3829,6 +3831,8 @@ class HermesCLI:
             self._handle_rollback_command(cmd_original)
         elif canonical == "stop":
             self._handle_stop_command()
+        elif canonical == "btw":
+            self._handle_btw_command(cmd_original)
         elif canonical == "background":
             self._handle_background_command(cmd_original)
         elif canonical == "queue":
@@ -4101,6 +4105,127 @@ class HermesCLI:
 
         thread = threading.Thread(target=run_background, daemon=True, name=f"bg-task-{task_id}")
         self._background_tasks[task_id] = thread
+        thread.start()
+
+    def _handle_btw_command(self, cmd: str):
+        """Handle /btw <question> — ask an ephemeral side question without tools."""
+        parts = cmd.strip().split(maxsplit=1)
+        if len(parts) < 2 or not parts[1].strip():
+            _cprint("  Usage: /btw <question>")
+            _cprint("  Example: /btw remind me what module owns session titles")
+            _cprint("  This runs as an ephemeral side question and does not alter the main session history.")
+            return
+
+        question = parts[1].strip()
+        self._btw_task_counter += 1
+        task_num = self._btw_task_counter
+        task_id = f"btw_{datetime.now().strftime('%H%M%S')}_{uuid.uuid4().hex[:6]}"
+
+        if not self._ensure_runtime_credentials():
+            _cprint("  (>_<) Cannot start /btw: no valid credentials.")
+            return
+
+        turn_route = self._resolve_turn_agent_config(question)
+        history_snapshot = list(self.conversation_history)
+        btw_prompt = (
+            "[Ephemeral /btw side question. You are answering a quick follow-up using the current "
+            "session context. Do not call tools. Do not modify files. Answer directly and concisely.]\n\n"
+            f"{question}"
+        )
+
+        _cprint(f"  💬 /btw #{task_num} started: \"{question[:60]}{'...' if len(question) > 60 else ''}\"")
+        _cprint("  Side answer will appear here without interrupting the main session.\n")
+
+        def run_btw():
+            try:
+                btw_agent = AIAgent(
+                    model=turn_route["model"],
+                    api_key=turn_route["runtime"].get("api_key"),
+                    base_url=turn_route["runtime"].get("base_url"),
+                    provider=turn_route["runtime"].get("provider"),
+                    api_mode=turn_route["runtime"].get("api_mode"),
+                    acp_command=turn_route["runtime"].get("command"),
+                    acp_args=turn_route["runtime"].get("args"),
+                    max_iterations=max(1, min(self.max_turns, 8)),
+                    enabled_toolsets=["__btw_no_tools__"],
+                    quiet_mode=True,
+                    verbose_logging=False,
+                    session_id=task_id,
+                    platform="cli",
+                    reasoning_config=self.reasoning_config,
+                    providers_allowed=self._providers_only,
+                    providers_ignored=self._providers_ignore,
+                    providers_order=self._providers_order,
+                    provider_sort=self._provider_sort,
+                    provider_require_parameters=self._provider_require_params,
+                    provider_data_collection=self._provider_data_collection,
+                    fallback_model=self._fallback_model,
+                    session_db=None,
+                    skip_memory=True,
+                    persist_session=False,
+                )
+
+                result = btw_agent.run_conversation(
+                    user_message=btw_prompt,
+                    conversation_history=history_snapshot,
+                    task_id=task_id,
+                    sync_honcho=False,
+                )
+
+                response = result.get("final_response", "") if result else ""
+                if not response and result and result.get("error"):
+                    response = f"Error: {result['error']}"
+
+                if self._app:
+                    self._app.invalidate()
+                    import time as _tmod
+                    _tmod.sleep(0.05)
+                print()
+                ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
+                _cprint(f"  💬 /btw #{task_num}")
+                _cprint(f"  Question: \"{question[:60]}{'...' if len(question) > 60 else ''}\"")
+                ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
+                if response:
+                    try:
+                        from hermes_cli.skin_engine import get_active_skin
+                        _skin = get_active_skin()
+                        _resp_color = _skin.get_color("response_border", "#4F6D4A")
+                        _resp_text = _skin.get_color("banner_text", "#FFF8DC")
+                    except Exception:
+                        _resp_color = "#4F6D4A"
+                        _resp_text = "#FFF8DC"
+
+                    _chat_console = ChatConsole()
+                    _chat_console.print(Panel(
+                        _rich_text_from_ansi(response),
+                        title=f"[{_resp_color} bold]⚕ Hermes (/btw #{task_num})[/]",
+                        title_align="left",
+                        border_style=_resp_color,
+                        style=_resp_text,
+                        box=rich_box.HORIZONTALS,
+                        padding=(1, 2),
+                    ))
+                else:
+                    _cprint("  (No response generated)")
+
+                if self.bell_on_complete:
+                    sys.stdout.write("\a")
+                    sys.stdout.flush()
+
+            except Exception as e:
+                if self._app:
+                    self._app.invalidate()
+                    import time as _tmod
+                    _tmod.sleep(0.05)
+                print()
+                _cprint(f"  ❌ /btw #{task_num} failed: {e}")
+            finally:
+                self._btw_tasks.pop(task_id, None)
+                if self._app:
+                    self._invalidate(min_interval=0)
+
+        thread = threading.Thread(target=run_btw, daemon=True, name=f"btw-task-{task_id}")
+        self._btw_tasks[task_id] = thread
         thread.start()
 
     @staticmethod

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24,6 +24,7 @@ import signal
 import tempfile
 import threading
 import time
+import uuid
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from datetime import datetime
@@ -416,6 +417,7 @@ class GatewayRunner:
 
         # Track background tasks to prevent garbage collection mid-execution
         self._background_tasks: set = set()
+        self._active_btw_tasks: Dict[str, asyncio.Task] = {}
 
     def _get_or_create_gateway_honcho(self, session_key: str):
         """Return a persistent Honcho manager/config pair for this gateway session."""
@@ -1650,6 +1652,10 @@ class GatewayRunner:
                     adapter._pending_messages[_quick_key] = queued_event
                 return "Queued for the next turn."
 
+            # /btw <question> — run an ephemeral side-question without interrupting
+            if _cmd_def_inner and _cmd_def_inner.name == "btw":
+                return await self._handle_btw_command(event)
+
             if event.message_type == MessageType.PHOTO:
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key[:20])
                 adapter = self.adapters.get(source.platform)
@@ -1800,6 +1806,9 @@ class GatewayRunner:
 
         if canonical == "background":
             return await self._handle_background_command(event)
+
+        if canonical == "btw":
+            return await self._handle_btw_command(event)
 
         if canonical == "voice":
             return await self._handle_voice_command(event)
@@ -3806,6 +3815,170 @@ class GatewayRunner:
                 await adapter.send(
                     chat_id=source.chat_id,
                     content=f"❌ Background task {task_id} failed: {e}",
+                    metadata=_thread_metadata,
+                )
+            except Exception:
+                pass
+
+    async def _handle_btw_command(self, event: MessageEvent) -> str:
+        """Handle /btw <question> — answer an ephemeral side question in chat."""
+        question = event.get_command_args().strip()
+        if not question:
+            return (
+                "Usage: /btw <question>\n"
+                "Example: /btw what module owns session title sanitization?\n\n"
+                "Runs an ephemeral no-tools side question in the same chat/thread."
+            )
+
+        source = event.source
+        session_key = self._session_key_for_source(source)
+        existing = self._active_btw_tasks.get(session_key)
+        if existing and not existing.done():
+            return "A /btw side question is already running for this chat. Wait for it to finish, then send another."
+
+        task_id = f"btw_{datetime.now().strftime('%H%M%S')}_{uuid.uuid4().hex[:6]}"
+        _task = asyncio.create_task(self._run_btw_task(question, source, session_key, task_id))
+        self._background_tasks.add(_task)
+        self._active_btw_tasks[session_key] = _task
+
+        def _cleanup(task):
+            self._background_tasks.discard(task)
+            current = self._active_btw_tasks.get(session_key)
+            if current is task:
+                self._active_btw_tasks.pop(session_key, None)
+
+        _task.add_done_callback(_cleanup)
+
+        preview = question[:60] + ("..." if len(question) > 60 else "")
+        return f'💬 /btw started: "{preview}"\nReply will appear here without interrupting the main session.'
+
+    async def _run_btw_task(
+        self, question: str, source: "SessionSource", session_key: str, task_id: str
+    ) -> None:
+        """Execute an ephemeral /btw side-question and deliver the answer."""
+        from run_agent import AIAgent
+
+        adapter = self.adapters.get(source.platform)
+        if not adapter:
+            logger.warning("No adapter for platform %s in /btw task %s", source.platform, task_id)
+            return
+
+        _thread_metadata = {"thread_id": source.thread_id} if source.thread_id else None
+
+        try:
+            runtime_kwargs = _resolve_runtime_agent_kwargs()
+            if not runtime_kwargs.get("api_key"):
+                await adapter.send(
+                    source.chat_id,
+                    "❌ /btw failed: no provider credentials configured.",
+                    metadata=_thread_metadata,
+                )
+                return
+
+            user_config = _load_gateway_config()
+            model = _resolve_gateway_model(user_config)
+            platform_key = _platform_config_key(source.platform)
+
+            pr = self._provider_routing
+            reasoning_config = self._load_reasoning_config()
+            self._reasoning_config = reasoning_config
+            turn_route = self._resolve_turn_agent_config(question, model, runtime_kwargs)
+
+            running_agent = self._running_agents.get(session_key)
+            if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
+                history_snapshot = list(getattr(running_agent, "_session_messages", []) or [])
+            else:
+                session_entry = self.session_store.get_or_create_session(source)
+                history_snapshot = self.session_store.load_transcript(session_entry.session_id)
+
+            btw_prompt = (
+                "[Ephemeral /btw side question. You are answering a quick follow-up using the current "
+                "session context. Do not call tools. Do not modify files. Answer directly and concisely.]\n\n"
+                f"{question}"
+            )
+
+            def run_sync():
+                agent = AIAgent(
+                    model=turn_route["model"],
+                    **turn_route["runtime"],
+                    max_iterations=8,
+                    quiet_mode=True,
+                    verbose_logging=False,
+                    enabled_toolsets=["__btw_no_tools__"],
+                    reasoning_config=reasoning_config,
+                    providers_allowed=pr.get("only"),
+                    providers_ignored=pr.get("ignore"),
+                    providers_order=pr.get("order"),
+                    provider_sort=pr.get("sort"),
+                    provider_require_parameters=pr.get("require_parameters", False),
+                    provider_data_collection=pr.get("data_collection"),
+                    session_id=task_id,
+                    platform=platform_key,
+                    session_db=None,
+                    fallback_model=self._fallback_model,
+                    skip_memory=True,
+                    persist_session=False,
+                )
+
+                return agent.run_conversation(
+                    user_message=btw_prompt,
+                    conversation_history=history_snapshot,
+                    task_id=task_id,
+                    sync_honcho=False,
+                )
+
+            loop = asyncio.get_event_loop()
+            result = await loop.run_in_executor(None, run_sync)
+
+            response = result.get("final_response", "") if result else ""
+            if not response and result and result.get("error"):
+                response = f"Error: {result['error']}"
+            if not response:
+                response = "(No response generated)"
+
+            media_files, response = adapter.extract_media(response)
+            images, text_content = adapter.extract_images(response)
+            preview = question[:60] + ("..." if len(question) > 60 else "")
+            header = f'💬 /btw\nQuestion: "{preview}"\n\n'
+
+            if text_content:
+                await adapter.send(
+                    chat_id=source.chat_id,
+                    content=header + text_content,
+                    metadata=_thread_metadata,
+                )
+            elif not images and not media_files:
+                await adapter.send(
+                    chat_id=source.chat_id,
+                    content=header + "(No response generated)",
+                    metadata=_thread_metadata,
+                )
+
+            for image_url, alt_text in (images or []):
+                try:
+                    await adapter.send_image(
+                        chat_id=source.chat_id,
+                        image_url=image_url,
+                        caption=alt_text,
+                    )
+                except Exception:
+                    pass
+
+            for media_path in (media_files or []):
+                try:
+                    await adapter.send_file(
+                        chat_id=source.chat_id,
+                        file_path=media_path,
+                    )
+                except Exception:
+                    pass
+
+        except Exception as e:
+            logger.exception("/btw task %s failed", task_id)
+            try:
+                await adapter.send(
+                    chat_id=source.chat_id,
+                    content=f"❌ /btw failed: {e}",
                     metadata=_thread_metadata,
                 )
             except Exception:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -65,6 +65,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True, args_hint="[session|always]"),
     CommandDef("deny", "Deny a pending dangerous command", "Session",
                gateway_only=True),
+    CommandDef("btw", "Ask an ephemeral side question without interrupting", "Session",
+               args_hint="<question>"),
     CommandDef("background", "Run a prompt in the background", "Session",
                aliases=("bg",), args_hint="<prompt>"),
     CommandDef("queue", "Queue a prompt for the next turn (doesn't interrupt)", "Session",

--- a/run_agent.py
+++ b/run_agent.py
@@ -429,6 +429,7 @@ class AIAgent:
         checkpoints_enabled: bool = False,
         checkpoint_max_snapshots: int = 50,
         pass_session_id: bool = False,
+        persist_session: bool = True,
     ):
         """
         Initialize the AI Agent.
@@ -468,6 +469,8 @@ class AIAgent:
             skip_context_files (bool): If True, skip auto-injection of SOUL.md, AGENTS.md, and .cursorrules
                 into the system prompt. Use this for batch processing and data generation to avoid
                 polluting trajectories with user-specific persona or project instructions.
+            persist_session (bool): When False, skip session log and SQLite persistence for this
+                agent run. Useful for ephemeral helper flows like side questions.
             honcho_session_key (str): Session key for Honcho integration (e.g., "telegram:123456" or CLI session_id).
                 When provided and Honcho is enabled in config, enables persistent cross-session user modeling.
             honcho_manager: Optional shared HonchoSessionManager owned by the caller.
@@ -493,6 +496,7 @@ class AIAgent:
         self._print_fn = None
         self.background_review_callback = None  # Optional sync callback for gateway delivery
         self.skip_context_files = skip_context_files
+        self.persist_session = persist_session
         self.pass_session_id = pass_session_id
         self.log_prefix_chars = log_prefix_chars
         self.log_prefix = f"{log_prefix} " if log_prefix else ""
@@ -1582,6 +1586,8 @@ class AIAgent:
 
         Ensures conversations are never lost, even on errors or early returns.
         """
+        if not self.persist_session:
+            return
         self._apply_persist_user_message_override(messages)
         self._session_messages = messages
         self._save_session_log(messages)

--- a/tests/gateway/test_btw_command.py
+++ b/tests/gateway/test_btw_command.py
@@ -1,0 +1,151 @@
+"""Tests for /btw gateway slash command."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_event(text="/btw", platform=Platform.TELEGRAM, user_id="12345", chat_id="67890"):
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._session_db = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner._background_tasks = set()
+    runner._active_btw_tasks = {}
+
+    mock_store = MagicMock()
+    mock_store.get_or_create_session.return_value = MagicMock(session_id="sess_123")
+    mock_store.load_transcript.return_value = [{"role": "user", "content": "main context"}]
+    runner.session_store = mock_store
+
+    from gateway.hooks import HookRegistry
+    runner.hooks = HookRegistry()
+
+    return runner
+
+
+class TestHandleBtwCommand:
+    @pytest.mark.asyncio
+    async def test_no_question_shows_usage(self):
+        runner = _make_runner()
+        event = _make_event(text="/btw")
+        result = await runner._handle_btw_command(event)
+        assert "Usage:" in result
+        assert "/btw" in result
+
+    @pytest.mark.asyncio
+    async def test_valid_question_starts_task(self):
+        runner = _make_runner()
+        created_tasks = []
+
+        def capture_task(coro, *args, **kwargs):
+            coro.close()
+            mock_task = MagicMock()
+            mock_task.done.return_value = False
+            created_tasks.append(mock_task)
+            return mock_task
+
+        with patch("gateway.run.asyncio.create_task", side_effect=capture_task):
+            event = _make_event(text="/btw what owns titles?")
+            result = await runner._handle_btw_command(event)
+
+        assert "💬 /btw started" in result
+        assert "what owns titles?" in result
+        assert len(created_tasks) == 1
+        assert len(runner._active_btw_tasks) == 1
+
+    @pytest.mark.asyncio
+    async def test_rejects_second_active_btw_for_same_session(self):
+        runner = _make_runner()
+        task = MagicMock()
+        task.done.return_value = False
+        session_key = runner._session_key_for_source(_make_event().source)
+        runner._active_btw_tasks[session_key] = task
+
+        result = await runner._handle_btw_command(_make_event(text="/btw another one"))
+        assert "already running" in result
+
+
+class TestRunBtwTask:
+    @pytest.mark.asyncio
+    async def test_no_credentials_sends_error(self):
+        runner = _make_runner()
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = _make_event().source
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": None}):
+            await runner._run_btw_task("what owns titles?", source, "telegram:12345:67890", "btw_test")
+
+        mock_adapter.send.assert_called_once()
+        call_args = mock_adapter.send.call_args
+        sent = call_args[1].get("content", call_args[0][1] if len(call_args[0]) > 1 else "")
+        assert "/btw failed" in sent
+
+    @pytest.mark.asyncio
+    async def test_successful_task_sends_prefixed_result(self):
+        runner = _make_runner()
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([], "Session titles live in hermes_state.py"))
+        mock_adapter.extract_images = MagicMock(return_value=([], "Session titles live in hermes_state.py"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = _make_event().source
+        mock_result = {"final_response": "Session titles live in hermes_state.py", "messages": []}
+
+        fake_loop = MagicMock()
+        fake_loop.run_in_executor = AsyncMock(return_value=mock_result)
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+             patch("gateway.run._load_gateway_config", return_value={}), \
+             patch("gateway.run._resolve_gateway_model", return_value="anthropic/claude-opus-4.6"), \
+             patch("gateway.run.asyncio.get_event_loop", return_value=fake_loop), \
+             patch("run_agent.AIAgent") as MockAgent:
+            mock_agent_instance = MagicMock()
+            mock_agent_instance.run_conversation.return_value = mock_result
+            MockAgent.return_value = mock_agent_instance
+
+            await runner._run_btw_task("what owns titles?", source, "telegram:12345:67890", "btw_test")
+
+        mock_adapter.send.assert_called_once()
+        content = mock_adapter.send.call_args[1].get("content", "")
+        assert "💬 /btw" in content
+        assert "what owns titles?" in content
+        assert "Session titles live in hermes_state.py" in content
+
+
+class TestBtwRegistry:
+    def test_btw_is_known_gateway_command(self):
+        from hermes_cli.commands import GATEWAY_KNOWN_COMMANDS
+        assert "btw" in GATEWAY_KNOWN_COMMANDS
+
+    def test_btw_in_commands_dict(self):
+        from hermes_cli.commands import COMMANDS
+        assert "/btw" in COMMANDS
+
+    def test_btw_in_session_category(self):
+        from hermes_cli.commands import COMMANDS_BY_CATEGORY
+        assert "/btw" in COMMANDS_BY_CATEGORY["Session"]

--- a/tests/test_cli_btw_command.py
+++ b/tests/test_cli_btw_command.py
@@ -1,0 +1,53 @@
+"""Tests for the /btw CLI slash command."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+from tests.test_cli_init import _make_cli
+
+
+_CLI_IMPORT_STUBS = {
+    "fire": MagicMock(),
+    "openai": MagicMock(),
+    "firecrawl": MagicMock(),
+    "fal_client": MagicMock(),
+}
+
+
+class TestBtwCommand:
+    def test_btw_requires_question(self):
+        with patch.dict(sys.modules, _CLI_IMPORT_STUBS):
+            cli = _make_cli()
+            cli._handle_btw_command("/btw")
+
+        assert cli._pending_input.empty()
+        assert cli._btw_tasks == {}
+
+    def test_btw_starts_ephemeral_thread_without_touching_pending_input(self):
+        with patch.dict(sys.modules, _CLI_IMPORT_STUBS):
+            cli = _make_cli()
+            cli.conversation_history = [{"role": "user", "content": "Current context"}]
+
+            fake_thread = MagicMock()
+
+            with patch.object(cli, "_ensure_runtime_credentials", return_value=True), \
+                 patch.object(cli, "_resolve_turn_agent_config", return_value={
+                     "model": cli.model,
+                     "runtime": {
+                         "api_key": "key",
+                         "base_url": "https://openrouter.ai/api/v1",
+                         "provider": "openrouter",
+                         "api_mode": "chat_completions",
+                         "command": None,
+                         "args": None,
+                     },
+                 }), \
+                 patch("cli.threading.Thread", return_value=fake_thread) as mock_thread:
+                cli.process_command("/btw what owns titles?")
+
+        assert cli._pending_input.empty()
+        assert len(cli._btw_tasks) == 1
+        fake_thread.start.assert_called_once()
+        kwargs = mock_thread.call_args.kwargs
+        assert kwargs["daemon"] is True
+        assert kwargs["name"].startswith("btw-task-")

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -31,6 +31,7 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 | `/compress` | Manually compress conversation context (flush memories + summarize) |
 | `/rollback` | List or restore filesystem checkpoints (usage: /rollback [number]) |
 | `/stop` | Kill all running background processes |
+| `/btw <question>` | Ask an ephemeral side question in parallel with the main session. Hermes snapshots the current conversation context, answers with a no-tools helper agent, and does not write the exchange back into the main session history. |
 | `/queue <prompt>` (alias: `/q`) | Queue a prompt for the next turn (doesn't interrupt the current agent response) |
 | `/resume [name]` | Resume a previously-named session |
 | `/statusbar` (alias: `/sb`) | Toggle the context/model status bar on or off |
@@ -115,6 +116,7 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 | `/voice [on\|off\|tts\|join\|channel\|leave\|status]` | Control spoken replies in chat. `join`/`channel`/`leave` manage Discord voice-channel mode. |
 | `/rollback [number]` | List or restore filesystem checkpoints. |
 | `/background <prompt>` | Run a prompt in a separate background session. Results are delivered back to the same chat when the task finishes. See [Messaging Background Sessions](/docs/user-guide/messaging/#background-sessions). |
+| `/btw <question>` | Ask an ephemeral side question in the same chat/thread. Hermes snapshots the current session context, answers with a no-tools helper agent, and does not write the `/btw` exchange back into the main session history. |
 | `/plan [request]` | Load the bundled `plan` skill to write a markdown plan instead of executing the work. Plans are saved under `.hermes/plans/` relative to the active workspace/backend working directory. |
 | `/reload-mcp` | Reload MCP servers from config. |
 | `/approve [session\|always]` | Approve and execute a pending dangerous command. `session` approves for this session only; `always` adds to permanent allowlist. |
@@ -128,5 +130,5 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 - `/skin`, `/tools`, `/toolsets`, `/browser`, `/config`, `/prompt`, `/cron`, `/skills`, `/platforms`, `/paste`, `/statusbar`, and `/plugins` are **CLI-only** commands.
 - `/verbose` is **CLI-only by default**, but can be enabled for messaging platforms by setting `display.tool_progress_command: true` in `config.yaml`. When enabled, it cycles the `display.tool_progress` mode and saves to config.
 - `/status`, `/sethome`, `/update`, `/approve`, and `/deny` are **messaging-only** commands.
-- `/background`, `/voice`, `/reload-mcp`, and `/rollback` work in **both** the CLI and the messaging gateway.
+- `/background`, `/btw`, `/voice`, `/reload-mcp`, and `/rollback` work in **both** the CLI and the messaging gateway.
 - `/voice join`, `/voice channel`, and `/voice leave` are only meaningful on Discord.


### PR DESCRIPTION
  ## What does this PR do?

  Adds an ephemeral /btw side-question command to Hermes.

  /btw lets users ask a quick follow-up without interrupting the main session. It snapshots the current session context, answers with a separate no-tools helper agent, and does not persist the /btw exchange back into the main session
  history.

  This is implemented for both the interactive CLI and the messaging gateway.

  ## Related Issue

  No tracked issue.

  ## Type of Change

  - [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [x] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [ ] 📝 Documentation update
  - [x] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️ Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  ## Changes Made

  - Added /btw <question> to the central slash-command registry
  - Implemented CLI /btw as an ephemeral side-question flow that runs in parallel without interrupting the main session
  - Added a persist_session switch to AIAgent so ephemeral helper flows can avoid writing session logs and DB history
  - Implemented gateway /btw support for same-chat/thread replies
  - Added a per-session gateway guard so only one /btw runs at a time per chat/session
  - Updated slash-command reference docs
  - Added CLI and gateway tests for /btw

  ## How to Test

  1. Run the targeted test suites:
     python -m pytest tests/test_cli_btw_command.py
     python -m pytest tests/gateway/test_btw_command.py
     python -m pytest tests/hermes_cli/test_commands.py
  2. In the CLI, start a task and run /btw <question>.
     Verify the /btw reply appears separately and does not interrupt the main task.
  3. In a messaging chat/thread, send /btw <question>.
     Verify the reply appears in the same chat/thread, does not interrupt the main run, and does not persist into main session history.

  ## Checklist

  ### Code

  - [x] I've read the Contributing Guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit messages follow Conventional Commits (https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
  - [x] I searched for existing PRs (https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - [x] My PR contains only changes related to this fix/feature (no unrelated commits)
  - [ ] I've run pytest tests/ -q and all tests pass
  - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - [x] I've tested on my platform: Ubuntu/Linux

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
  - [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
  - [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
  - [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

  ## Screenshots / Logs

  Targeted test results:

  - tests/test_cli_btw_command.py: passed
  - tests/gateway/test_btw_command.py: passed
  - tests/hermes_cli/test_commands.py: passed
