### PR TITLE
fix(terminal): prevent heredoc + output fence wrapper from leaking into stdout

### DIFF
--- a/tests/tools/test_local_persistent.py
+++ b/tests/tools/test_local_persistent.py
@@ -63,6 +63,18 @@ class TestLocalOneShotRegression:
         assert r["output"].strip() == ""
         env.cleanup()
 
+    def test_oneshot_heredoc_does_not_leak_fence_wrapper(self):
+        """Heredoc closing line must not be merged with the fence wrapper tail."""
+        env = LocalEnvironment(persistent=False)
+        cmd = "cat <<'H_EOF'\nheredoc body line\nH_EOF"
+        r = env.execute(cmd)
+        env.cleanup()
+        assert r["returncode"] == 0
+        assert "heredoc body line" in r["output"]
+        assert "__hermes_rc" not in r["output"]
+        assert "printf '" not in r["output"]
+        assert "exit $" not in r["output"]
+
 
 class TestLocalPersistent:
     @pytest.fixture

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -391,12 +391,17 @@ class LocalEnvironment(PersistentShellMixin, BaseEnvironment):
             effective_stdin = stdin_data
 
         user_shell = _find_bash()
+        # Newline-separated wrapper (not `cmd; __hermes_rc=...` on one line).
+        # A trailing `; __hermes_rc` glued to `<<EOF` / a closing `EOF` line breaks
+        # heredoc parsing: the delimiter must be alone on its line, otherwise the
+        # rest of this script becomes heredoc body and leaks into stdout (e.g. gh
+        # issue/PR flows that use here-documents for bodies).
         fenced_cmd = (
-            f"printf '{_OUTPUT_FENCE}';"
-            f" {exec_command};"
-            f" __hermes_rc=$?;"
-            f" printf '{_OUTPUT_FENCE}';"
-            f" exit $__hermes_rc"
+            f"printf '{_OUTPUT_FENCE}'\n"
+            f"{exec_command}\n"
+            f"__hermes_rc=$?\n"
+            f"printf '{_OUTPUT_FENCE}'\n"
+            f"exit $__hermes_rc\n"
         )
         run_env = _make_run_env(self.env)
 


### PR DESCRIPTION
## Summary

Fixes a bug where **one-shot local terminal** output could end with leaked shell trailer text such as \`EOF; __hermes_rc=\$?; printf '__HERMES_FENCE_a9f7b3__'; exit \$__hermes_rc\`, especially when the model runs **GitHub CLI** commands that use **here-documents** for issue/PR bodies.

## Context

\`LocalEnvironment._execute_oneshot\` wraps each command in \`tools/environments/local.py\` so Hermes can strip login-shell noise: it prints a unique fence marker before and after the user command, then captures stdout between those markers.

The wrapper was previously built as a **single line** with **semicolons**:

\`\`\`bash
printf 'FENCE'; <user_command>; __hermes_rc=\$?; printf 'FENCE'; exit \$__hermes_rc
\`\`\`

That is safe for simple one-liners, but it breaks when \`<user_command>\` ends with a **heredoc**. The closing delimiter (commonly \`EOF\`) must appear **alone** on its line. Appending \`; __hermes_rc=...\` on the same line as \`EOF\` produces an invalid delimiter, so bash never terminates the heredoc and treats the **rest of the wrapper script** as heredoc body. That text is then fed to the foreground command (e.g. \`gh\`) or otherwise surfaces in captured output—exactly the garbage users saw at the end of successful \`gh issue create\` / \`gh pr create\` flows.

## Fix

Build the wrapper as a **newline-separated** mini-script so the post-command trailer always starts on its **own** line after the heredoc closes:

\`\`\`bash
printf 'FENCE'
<user_command>
__hermes_rc=\$?
printf 'FENCE'
exit \$__hermes_rc
\`\`\`

No change to the fence marker or extraction logic—only how the wrapper is glued to arbitrary (including multiline) user commands.

## Testing

- Added \`test_oneshot_heredoc_does_not_leak_fence_wrapper\` in \`tests/tools/test_local_persistent.py\`.
- \`python -m pytest tests/tools/test_local_persistent.py -q\` — all green.
