### PR TITLE
feat(telegram): add inbound topic allowlists for multi-bot groups

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -91,12 +91,11 @@ def _build_skill_message(
     parts = [activation_note, "", content.strip()]
 
     if loaded_skill.get("setup_skipped"):
-        parts.extend(
-            [
-                "",
-                "[Skill setup note: Required environment setup was skipped. Continue loading the skill and explain any reduced functionality if it matters.]",
-            ]
-        )
+        note_text = "[Skill setup note: Required environment setup was skipped. Continue loading the skill and explain any reduced functionality if it matters.]"
+        # For remote backends, also append the remote-specific guidance
+        if loaded_skill.get("setup_note"):
+            note_text = f"{note_text} {loaded_skill['setup_note']}"
+        parts.extend(["", note_text])
     elif loaded_skill.get("gateway_setup_hint"):
         parts.extend(
             [

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -123,6 +123,11 @@ class TelegramAdapter(BasePlatformAdapter):
         self._app: Optional[Application] = None
         self._bot: Optional[Bot] = None
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
+        self._allowed_inbound_targets = self._parse_allowed_inbound_targets(
+            self.config.extra.get("allowed_inbound_targets", [])
+            if getattr(self.config, "extra", None)
+            else []
+        )
         # Buffer rapid/album photo updates so Telegram image bursts are handled
         # as a single MessageEvent instead of self-interrupting multiple turns.
         self._media_batch_delay_seconds = float(os.getenv("HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS", "0.8"))
@@ -144,6 +149,93 @@ class TelegramAdapter(BasePlatformAdapter):
         self._dm_topics: Dict[str, int] = {}
         # DM Topics config from extra.dm_topics
         self._dm_topics_config: List[Dict[str, Any]] = self.config.extra.get("dm_topics", [])
+
+    @staticmethod
+    def _parse_allowed_inbound_targets(raw_targets: Any) -> set[tuple[str, Optional[str]]]:
+        """Normalize inbound allowlist config into {(chat_id, thread_id)} tuples."""
+        if raw_targets is None:
+            return set()
+
+        if isinstance(raw_targets, (str, int, dict)):
+            raw_targets = [raw_targets]
+
+        normalized: set[tuple[str, Optional[str]]] = set()
+        for item in raw_targets:
+            chat_id: Optional[str] = None
+            thread_id: Optional[str] = None
+
+            if isinstance(item, dict):
+                chat_val = item.get("chat_id")
+                thread_val = item.get("thread_id")
+                if chat_val is None:
+                    continue
+                chat_id = str(chat_val).strip()
+                thread_id = str(thread_val).strip() if thread_val is not None else None
+            elif isinstance(item, int) and not isinstance(item, bool):
+                chat_id = str(item)
+            elif isinstance(item, str):
+                target = item.strip()
+                if not target:
+                    continue
+                if target.startswith("telegram:"):
+                    target = target.split(":", 1)[1]
+                if ":" in target:
+                    chat_part, thread_part = target.rsplit(":", 1)
+                    chat_id = chat_part.strip()
+                    thread_id = thread_part.strip() or None
+                else:
+                    chat_id = target
+            else:
+                continue
+
+            if not chat_id:
+                continue
+            normalized.add((chat_id, thread_id or None))
+
+        return normalized
+
+    def _is_inbound_target_allowed(
+        self,
+        *,
+        chat_id: str,
+        chat_type: str,
+        thread_id: Optional[str],
+    ) -> bool:
+        """Return whether an inbound Telegram message should be processed."""
+        if not self._allowed_inbound_targets:
+            return True
+        if chat_type == "dm":
+            return True
+
+        for allowed_chat_id, allowed_thread_id in self._allowed_inbound_targets:
+            if allowed_chat_id != chat_id:
+                continue
+            if allowed_thread_id is None or allowed_thread_id == thread_id:
+                return True
+        return False
+
+    def _is_inbound_message_allowed(self, message: Message) -> bool:
+        """Convenience wrapper around _is_inbound_target_allowed for PTB Message."""
+        chat = message.chat
+        chat_type = "dm"
+        if chat.type in (ChatType.GROUP, ChatType.SUPERGROUP):
+            chat_type = "group"
+        elif chat.type == ChatType.CHANNEL:
+            chat_type = "channel"
+        thread_id = str(message.message_thread_id) if getattr(message, "message_thread_id", None) else None
+        allowed = self._is_inbound_target_allowed(
+            chat_id=str(chat.id),
+            chat_type=chat_type,
+            thread_id=thread_id,
+        )
+        if not allowed:
+            logger.info(
+                "[%s] Ignoring inbound Telegram message outside allowlist: chat=%s thread=%s",
+                self.name,
+                chat.id,
+                thread_id or "-",
+            )
+        return allowed
 
     def _fallback_ips(self) -> list[str]:
         """Return validated fallback IPs from config (populated by _apply_env_overrides)."""
@@ -1324,6 +1416,8 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         if not update.message or not update.message.text:
             return
+        if not self._is_inbound_message_allowed(update.message):
+            return
 
         event = self._build_message_event(update.message, MessageType.TEXT)
         self._enqueue_text_event(event)
@@ -1332,6 +1426,8 @@ class TelegramAdapter(BasePlatformAdapter):
         """Handle incoming command messages."""
         if not update.message or not update.message.text:
             return
+        if not self._is_inbound_message_allowed(update.message):
+            return
         
         event = self._build_message_event(update.message, MessageType.COMMAND)
         await self.handle_message(event)
@@ -1339,6 +1435,8 @@ class TelegramAdapter(BasePlatformAdapter):
     async def _handle_location_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming location/venue pin messages."""
         if not update.message:
+            return
+        if not self._is_inbound_message_allowed(update.message):
             return
 
         msg = update.message
@@ -1482,6 +1580,8 @@ class TelegramAdapter(BasePlatformAdapter):
     async def _handle_media_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming media messages, downloading images to local cache."""
         if not update.message:
+            return
+        if not self._is_inbound_message_allowed(update.message):
             return
         
         msg = update.message

--- a/tests/gateway/test_telegram_inbound_allowlist.py
+++ b/tests/gateway/test_telegram_inbound_allowlist.py
@@ -1,0 +1,132 @@
+"""Tests for Telegram inbound target allowlists."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.telegram import TelegramAdapter
+
+
+class TestParseAllowedInboundTargets:
+    def test_supports_string_and_dict_forms(self):
+        parsed = TelegramAdapter._parse_allowed_inbound_targets(
+            [
+                "telegram:-100111:7",
+                "-100222:9",
+                {"chat_id": -100333, "thread_id": 11},
+                {"chat_id": -100444},
+                -100555,
+            ]
+        )
+
+        assert parsed == {
+            ("-100111", "7"),
+            ("-100222", "9"),
+            ("-100333", "11"),
+            ("-100444", None),
+            ("-100555", None),
+        }
+
+    def test_none_and_bool_values_are_ignored(self):
+        parsed = TelegramAdapter._parse_allowed_inbound_targets([None, True, False, "", {"thread_id": 7}])
+        assert parsed == set()
+
+
+class TestInboundTargetFiltering:
+    def _make_adapter(self, extra=None):
+        config = PlatformConfig(enabled=True, token="***")
+        if extra:
+            config.extra.update(extra)
+        return TelegramAdapter(config)
+
+    def test_empty_allowlist_allows_everything(self):
+        adapter = self._make_adapter()
+        assert adapter._is_inbound_target_allowed(chat_id="-1001", chat_type="group", thread_id="7") is True
+
+    def test_matching_thread_is_allowed(self):
+        adapter = self._make_adapter(
+            {"allowed_inbound_targets": ["-1001:7"]}
+        )
+        assert adapter._is_inbound_target_allowed(chat_id="-1001", chat_type="group", thread_id="7") is True
+        assert adapter._is_inbound_target_allowed(chat_id="-1001", chat_type="group", thread_id="8") is False
+        assert adapter._is_inbound_target_allowed(chat_id="-1002", chat_type="group", thread_id="7") is False
+
+    def test_chat_level_entry_allows_all_topics_in_chat(self):
+        adapter = self._make_adapter(
+            {"allowed_inbound_targets": [{"chat_id": -1001}]}
+        )
+        assert adapter._is_inbound_target_allowed(chat_id="-1001", chat_type="group", thread_id="7") is True
+        assert adapter._is_inbound_target_allowed(chat_id="-1001", chat_type="group", thread_id="99") is True
+        assert adapter._is_inbound_target_allowed(chat_id="-1002", chat_type="group", thread_id="7") is False
+
+    def test_dms_remain_allowed_even_with_group_allowlist(self):
+        adapter = self._make_adapter(
+            {"allowed_inbound_targets": ["-1001:7"]}
+        )
+        assert adapter._is_inbound_target_allowed(chat_id="693180290", chat_type="dm", thread_id=None) is True
+
+
+class TestInboundHandlers:
+    @pytest.mark.asyncio
+    async def test_handle_text_message_ignores_disallowed_target(self, monkeypatch):
+        adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+        monkeypatch.setattr(adapter, "_is_inbound_message_allowed", lambda _message: False)
+        enqueue = MagicMock()
+        monkeypatch.setattr(adapter, "_enqueue_text_event", enqueue)
+        build = MagicMock()
+        monkeypatch.setattr(adapter, "_build_message_event", build)
+
+        update = SimpleNamespace(message=SimpleNamespace(text="hello"))
+        await adapter._handle_text_message(update, None)
+
+        enqueue.assert_not_called()
+        build.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_command_ignores_disallowed_target(self, monkeypatch):
+        adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+        monkeypatch.setattr(adapter, "_is_inbound_message_allowed", lambda _message: False)
+        handle = AsyncMock()
+        monkeypatch.setattr(adapter, "handle_message", handle)
+        build = MagicMock()
+        monkeypatch.setattr(adapter, "_build_message_event", build)
+
+        update = SimpleNamespace(message=SimpleNamespace(text="/status"))
+        await adapter._handle_command(update, None)
+
+        handle.assert_not_awaited()
+        build.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_media_message_ignores_disallowed_target(self, monkeypatch):
+        adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+        monkeypatch.setattr(adapter, "_is_inbound_message_allowed", lambda _message: False)
+        handle = AsyncMock()
+        monkeypatch.setattr(adapter, "handle_message", handle)
+        build = MagicMock()
+        monkeypatch.setattr(adapter, "_build_message_event", build)
+
+        update = SimpleNamespace(message=SimpleNamespace(photo=None, video=None, audio=None, voice=None, document=None, sticker=None))
+        await adapter._handle_media_message(update, None)
+
+        handle.assert_not_awaited()
+        build.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handle_location_message_ignores_disallowed_target(self, monkeypatch):
+        adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+        monkeypatch.setattr(adapter, "_is_inbound_message_allowed", lambda _message: False)
+        handle = AsyncMock()
+        monkeypatch.setattr(adapter, "handle_message", handle)
+
+        update = SimpleNamespace(
+            message=SimpleNamespace(
+                venue=None,
+                location=SimpleNamespace(latitude=1.0, longitude=2.0),
+            )
+        )
+        await adapter._handle_location_message(update, None)
+
+        handle.assert_not_awaited()

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -165,6 +165,42 @@ Hermes Agent works in Telegram group chats with a few considerations:
 - When privacy mode is off (or bot is admin), the bot sees all messages and can participate naturally
 - `TELEGRAM_ALLOWED_USERS` still applies — only authorized users can trigger the bot, even in groups
 
+## Inbound Topic Allowlists
+
+If you run multiple Hermes bots in the same Telegram supergroup, privacy-off mode means every bot can see every topic it has access to. To pin a bot to just one topic (or a small set of topics), add an inbound allowlist under `platforms.telegram.extra.allowed_inbound_targets`:
+
+```yaml
+platforms:
+  telegram:
+    extra:
+      allowed_inbound_targets:
+        - chat_id: -1003502111905
+          thread_id: 2
+        - chat_id: -1003502111905
+          thread_id: 7
+```
+
+You can also use compact strings:
+
+```yaml
+platforms:
+  telegram:
+    extra:
+      allowed_inbound_targets:
+        - "-1003502111905:2"
+        - "telegram:-1003502111905:7"
+```
+
+Behavior:
+
+- If `allowed_inbound_targets` is empty or omitted, Hermes accepts inbound messages from any Telegram chat/topic it can see
+- A `chat_id` + `thread_id` entry allows exactly one forum topic
+- A `chat_id` entry with no `thread_id` allows the whole chat
+- Direct messages remain allowed even when a group/topic allowlist is configured
+- This only filters inbound message handling — explicit outbound delivery targets like `telegram:-1003502111905:2` still work as usual
+
+This is useful for "bot swarm" setups where, for example, `m2` should only answer in topic 2 while `m4` should only answer in topic 7.
+
 ## Private Chat Topics (Bot API 9.4)
 
 Telegram Bot API 9.4 (February 2026) introduced **Private Chat Topics** — bots can create forum-style topic threads directly in 1-on-1 DM chats, no supergroup needed. This lets you run multiple isolated workspaces within your existing DM with Hermes.

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -199,7 +199,7 @@ Behavior:
 - Direct messages remain allowed even when a group/topic allowlist is configured
 - This only filters inbound message handling — explicit outbound delivery targets like `telegram:-1003502111905:2` still work as usual
 
-This is useful for "bot swarm" setups where, for example, `m2` should only answer in topic 2 while `m4` should only answer in topic 7.
+This is useful for "bot swarm" setups where, for example, `hermes2` should only answer in topic 2 while `hermes7` should only answer in topic 7.
 
 ## Private Chat Topics (Bot API 9.4)
 


### PR DESCRIPTION
## Summary
- add `platforms.telegram.extra.allowed_inbound_targets` to restrict which Telegram chats/topics a bot responds to
- support both dict and compact string target formats like `-1001234567890:7`
- keep DMs allowed while filtering group/channel inbound traffic
- document the multi-bot supergroup workflow and add targeted adapter tests

## Why
When Telegram privacy mode is off, multiple Hermes bots in the same supergroup can all see and respond in every topic they have access to. This makes "bot swarm" setups awkward because `/new` isolates session state but does not bind a specific bot to a specific topic.

This change adds an inbound allowlist so each bot instance can be pinned to one or more assigned topics while still sharing the same parent supergroup.

## Config example
```yaml
platforms:
  telegram:
    extra:
      allowed_inbound_targets:
        - chat_id: -1003502111905
          thread_id: 2
        - "-1003502111905:7"
```

## Behavior
- empty/omitted allowlist preserves current behavior
- `chat_id + thread_id` allows one topic
- `chat_id` with no thread allows the entire chat
- DMs remain allowed
- outbound delivery is unchanged

## Test plan
- `./venv/bin/pytest -q tests/gateway/test_telegram_inbound_allowlist.py`
- `./venv/bin/pytest -q tests/gateway/test_base_topic_sessions.py tests/gateway/test_telegram_network.py tests/gateway/test_telegram_reply_mode.py`
EOF; __hermes_rc=$?; printf '__HERMES_FENCE_a9f7b3__'; exit $__hermes_rc
