### PR TITLE
fix: mattermost configuration parsing bugs

### DIFF
--- a/hermes_cli/skills_config.py
+++ b/hermes_cli/skills_config.py
@@ -24,6 +24,9 @@ PLATFORMS = {
     "whatsapp": "📱 WhatsApp",
     "signal":   "📡 Signal",
     "email":    "📧 Email",
+    "mattermost": "💬 Mattermost",
+    "matrix":   "💬 Matrix",
+    "dingtalk": "💬 DingTalk",
 }
 
 # ─── Config Helpers ───────────────────────────────────────────────────────────

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -138,6 +138,7 @@ PLATFORMS = {
     "matrix":   {"label": "💬 Matrix",     "default_toolset": "hermes-matrix"},
     "dingtalk": {"label": "💬 DingTalk",   "default_toolset": "hermes-dingtalk"},
     "api_server": {"label": "🌐 API Server", "default_toolset": "hermes-api-server"},
+    "mattermost": {"label": "💬 Mattermost", "default_toolset": "hermes-mattermost"},
 }
 
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -333,6 +333,24 @@ TOOLSETS = {
         "includes": []
     },
 
+    "hermes-mattermost": {
+        "description": "Mattermost bot toolset - self-hosted team messaging (full access)",
+        "tools": _HERMES_CORE_TOOLS,
+        "includes": []
+    },
+
+    "hermes-matrix": {
+        "description": "Matrix bot toolset - decentralized encrypted messaging (full access)",
+        "tools": _HERMES_CORE_TOOLS,
+        "includes": []
+    },
+
+    "hermes-dingtalk": {
+        "description": "DingTalk bot toolset - enterprise messaging platform (full access)",
+        "tools": _HERMES_CORE_TOOLS,
+        "includes": []
+    },
+
     "hermes-sms": {
         "description": "SMS bot toolset - interact with Hermes via SMS (Twilio)",
         "tools": _HERMES_CORE_TOOLS,
@@ -342,7 +360,7 @@ TOOLSETS = {
     "hermes-gateway": {
         "description": "Gateway toolset - union of all messaging platform tools",
         "tools": [],
-        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-homeassistant", "hermes-email", "hermes-sms"]
+        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk"]
     }
 }
 


### PR DESCRIPTION
## What does this PR do?

Mattermost (and probably Matrix and Dingtalk) configuration parsing was failing with:

```
Traceback (most recent call last):
  File "/home/green/hermes-agent/gateway/run.py", line 2481, in _handle_message_with_agent
    agent_result = await self._run_agent(
                   ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/green/hermes-agent/gateway/run.py", line 4908, in _run_agent
    enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/green/hermes-agent/hermes_cli/tools_config.py", line 416, in _get_platform_tools
    default_ts = PLATFORMS[platform]["default_toolset"]
 ```



## Related Issue

Fixes #3511

## Type of Change


- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

hermes_cli/skills_config.py
hermes_cli/tools_config.py
toolsets.py


- 

## How to Test

1. Configure Mattermost
2. Send message to agent
3. Agent receives message, and works nominally

## Checklist


### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->
