### PR TITLE
fix(gateway): preserve full transcript on /compress instead of overwriting

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3998,16 +3998,25 @@ class GatewayRunner:
             loop = asyncio.get_event_loop()
             compressed, _ = await loop.run_in_executor(
                 None,
-                lambda: tmp_agent._compress_context(msgs, "", approx_tokens=approx_tokens),
+                lambda: tmp_agent._compress_context(msgs, "", approx_tokens=approx_tokens)
             )
 
-            self.session_store.rewrite_transcript(session_entry.session_id, compressed)
+            # _compress_context already calls end_session() on the old session
+            # (preserving its full transcript in SQLite) and creates a new
+            # session_id for the continuation.  Write the compressed messages
+            # into the NEW session so the original history stays searchable.
+            new_session_id = tmp_agent.session_id
+            if new_session_id != session_entry.session_id:
+                session_entry.session_id = new_session_id
+                self.session_store._save()
+
+            self.session_store.rewrite_transcript(new_session_id, compressed)
             # Reset stored token count — transcript changed, old value is stale
             self.session_store.update_session(
-                session_entry.session_key, last_prompt_tokens=0,
+                session_entry.session_key, last_prompt_tokens=0
             )
             new_count = len(compressed)
-            new_tokens = estimate_messages_tokens_rough(compressed)
+            new_tokens=estimate_messages_tokens_rough(compressed)
 
             return (
                 f"🗜️ Compressed: {original_count} → {new_count} messages\n"


### PR DESCRIPTION
## What does this PR do?

Fixes `/compress` silently destroying the original session transcript. After this fix, `/compress` preserves full searchable history — same as `/new` and auto-compression already do.

## The Bug

`/compress` calls `_compress_context()` which correctly:
1. Ends the old session via `end_session()` (preserves transcript in SQLite)
2. Creates a new `session_id` for the continuation

But then the handler immediately calls `rewrite_transcript()` on the **old** session ID — overwriting the preserved transcript with the compressed version. The full conversation history is lost and no longer searchable via `session_search`.

**Auto-compression does NOT have this bug** — the gateway already handles the session_id swap after `_run_agent_sync` (lines 5684-5692). Only the manual `/compress` command path was affected.

## Impact

- Every `/compress` destroys original messages permanently
- `session_search` cannot find details from compressed portions
- Users who prefer `/compress` over `/new` lose all detailed history
- Auto-compression users are unaffected

## Fix

After `_compress_context` creates the new session, write the compressed messages into the **new** session ID and update the session store pointer. The old session stays intact in SQLite with its full transcript.

**Before:** `/compress` overwrites history — details gone forever
**After:** `/compress` behaves like `/new` — full transcript preserved, compressed context for the live session

## Type of Change
🐛 Bug fix (non-breaking change that fixes an issue)

## How to Test

1. Start a conversation with 20+ messages
2. Run `/compress`
3. Use `session_search` to find specific details from early in the conversation
4. **Before fix:** search returns nothing for compressed messages
5. **After fix:** search finds the original messages in the preserved session

## Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs before opening this one
- [x] Single file changed, minimal diff (13 lines added, 4 removed)