### PR TITLE
fix: auto-repair jobs.json with invalid control characters

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -327,7 +327,20 @@ def load_jobs() -> List[Dict[str, Any]]:
         with open(JOBS_FILE, 'r', encoding='utf-8') as f:
             data = json.load(f)
             return data.get("jobs", [])
-    except (json.JSONDecodeError, IOError):
+    except json.JSONDecodeError:
+        # Retry with strict=False to handle bare control chars in string values
+        try:
+            with open(JOBS_FILE, 'r', encoding='utf-8') as f:
+                data = json.loads(f.read(), strict=False)
+                jobs = data.get("jobs", [])
+                if jobs:
+                    # Auto-repair: rewrite with proper escaping
+                    save_jobs(jobs)
+                    logger.warning("Auto-repaired jobs.json (had invalid control characters)")
+                return jobs
+        except Exception:
+            return []
+    except IOError:
         return []
 
 


### PR DESCRIPTION
## Problem

`load_jobs()` in `cron/jobs.py` uses strict `json.load()` which rejects bare control characters (e.g. literal newlines `\n`) inside JSON string values. When a cron job prompt happens to contain such characters — which can happen when LLM output with newlines gets saved into a job's prompt field — the parser throws `JSONDecodeError`.

The current error handler catches this and returns an empty list:

```python
except (json.JSONDecodeError, IOError):
    return []
```

This means **all scheduled jobs silently stop firing** with no error logged. The cron ticker keeps running but sees zero jobs. The only symptom is that nothing gets delivered to Telegram/Discord/etc — easy to miss for hours or days.

## Fix

On `JSONDecodeError`, retry parsing with `json.loads(strict=False)` which accepts bare control characters. If jobs are recovered:
1. Auto-rewrite `jobs.json` via `save_jobs()` (which uses `json.dump` and properly escapes everything)
2. Log a warning so the repair is visible

Only fall back to empty list if the JSON is truly unrecoverable (not just control character issues).

## Testing

Reproduced by inserting a literal newline into a job prompt in `jobs.json`:
- Before fix: `hermes cron list` shows "No scheduled jobs" (silent data loss)
- After fix: jobs load correctly, file is auto-repaired, warning logged