### PR TITLE
fix: parse <tool_call> XML from text content in main agent loop

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3895,6 +3895,25 @@ class AIAgent:
                         ),
                     ))
 
+            # Fallback: if no structured tool_calls were streamed but the
+            # accumulated content contains <tool_call> XML tags, parse them.
+            # This handles providers (e.g. Nous Portal) that stream tool
+            # calls as text content instead of tool_call deltas.
+            if not mock_tool_calls and full_content and "<tool_call>" in full_content:
+                try:
+                    from environments.tool_call_parsers import get_parser
+                    _fb_parser = get_parser("hermes")
+                    _fb_content, _fb_calls = _fb_parser.parse(full_content)
+                    if _fb_calls:
+                        mock_tool_calls = _fb_calls
+                        full_content = _fb_content
+                        logger.info(
+                            "Streaming fallback parser extracted %d tool call(s) from text",
+                            len(_fb_calls),
+                        )
+                except Exception:
+                    pass
+
             full_reasoning = "".join(reasoning_parts) or None
             mock_message = SimpleNamespace(
                 role=role,
@@ -7135,6 +7154,33 @@ class AIAgent:
                 elif hasattr(self, "_codex_incomplete_retries"):
                     self._codex_incomplete_retries = 0
                 
+                # Fallback: if response has no structured tool_calls but content
+                # contains raw <tool_call> XML tags, parse them using the Hermes
+                # parser.  This handles providers (e.g. Nous Portal) that return
+                # tool calls as text instead of structured API tool_calls.
+                if (
+                    not assistant_message.tool_calls
+                    and assistant_message.content
+                    and self.tools
+                    and "<tool_call>" in (assistant_message.content or "")
+                ):
+                    try:
+                        from environments.tool_call_parsers import get_parser
+                        fallback_parser = get_parser("hermes")
+                        parsed_content, parsed_calls = fallback_parser.parse(
+                            assistant_message.content
+                        )
+                        if parsed_calls:
+                            assistant_message.tool_calls = parsed_calls
+                            if parsed_content is not None:
+                                assistant_message.content = parsed_content
+                            logger.info(
+                                "Fallback parser extracted %d tool call(s) from text content",
+                                len(parsed_calls),
+                            )
+                    except Exception as e:
+                        logger.debug("Fallback tool call parsing failed: %s", e)
+
                 # Check for tool calls
                 if assistant_message.tool_calls:
                     if not self.quiet_mode:


### PR DESCRIPTION
## Summary

- Adds fallback `<tool_call>` XML parsing to the main agent loop in `run_agent.py`
- Fixes providers (e.g. Nous Portal with Hermes-4-405B) that return tool calls as text content instead of structured OpenAI `tool_calls`
- Reuses the existing `HermesToolCallParser` from `environments/tool_call_parsers/hermes_parser.py` — zero new dependencies, 46 lines added

## Problem

Models served via providers that don't translate tool calls into structured OpenAI `tool_calls` (e.g. `inference-api.nousresearch.com` with Hermes-4-405B) emit `<tool_call>` XML tags in the text content. The main agent loop only checks `assistant_message.tool_calls`, finds it empty, treats the response as a final text answer, and returns to the prompt — **tools are never executed**.

The RL training path (`environments/agent_loop.py:260-281`) already had a fallback parser for this exact case, but the main agent loop did not.

## Fix

Add the same fallback in two places:

1. **Streaming path** (~line 3898): After streaming chunks are accumulated into a mock response, if no structured `tool_calls` were received but the content contains `<tool_call>` tags, parse them with `HermesToolCallParser`.

2. **Main agent loop** (~line 7157): Before the `if assistant_message.tool_calls:` check, parse `<tool_call>` XML from text content when `tool_calls` is empty.

Both paths reuse the battle-tested `HermesToolCallParser` already in the codebase — no new files or abstractions needed.

## Related

- Closes #2936 — "Hermes-4 does not invoke tools via Telegram gateway despite tools being loaded"
- Alternative to #3175 — which solves a similar problem for Kimi K2 but via a new 539-line `response_adapters.py` module. This PR is a lighter approach that reuses existing infrastructure.

## Test plan

- [x] Verified `HermesToolCallParser` correctly extracts tool calls from `<tool_call>` XML
- [x] Tested with Hermes-4-405B via Nous Portal — tool calls now execute instead of being displayed as text
- [x] Existing parser tests pass (`tests/test_tool_call_parsers.py` — 27 passed)
- [ ] Gateway testing (Telegram/Discord) with Hermes-4-405B

🤖 Generated with [Claude Code](https://claude.com/claude-code)