### PR TITLE
docs(discord): Fix Public Bot setting for Discord-provided invite link

### DIFF
--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -95,11 +95,15 @@ You'll land on the **General Information** page. Note the **Application ID** —
 1. In the left sidebar, click **Bot**.
 2. Discord automatically creates a bot user for your application. You'll see the bot's username, which you can customize.
 3. Under **Authorization Flow**:
-   - Set **Public Bot** to **OFF** — this prevents other people from inviting your bot to their servers.
+   - Set **Public Bot** to **ON** — required to use the Discord-provided invite link (recommended). This allows the Installation tab to generate a default authorization URL.
    - Leave **Require OAuth2 Code Grant** set to **OFF**.
 
 :::tip
 You can set a custom avatar and banner for your bot on this page. This is what users will see in Discord.
+:::
+
+:::info[Private Bot Alternative]
+If you prefer to keep your bot private (Public Bot = OFF), you **must** use the **Manual URL** method in Step 5 instead of the Installation tab. The Discord-provided link requires Public Bot to be enabled.
 :::
 
 ## Step 3: Enable Privileged Gateway Intents
@@ -148,6 +152,10 @@ Store the token somewhere safe (a password manager, for example). You'll need it
 You need an OAuth2 URL to invite the bot to your server. There are two ways to do this:
 
 ### Option A: Using the Installation Tab (Recommended)
+
+:::note[Requires Public Bot]
+This method requires **Public Bot** to be set to **ON** in Step 2. If you set Public Bot to OFF, use the Manual URL method below instead.
+:::
 
 1. In the left sidebar, click **Installation**.
 2. Under **Installation Contexts**, enable **Guild Install**.
@@ -361,3 +369,6 @@ Always set `DISCORD_ALLOWED_USERS` to restrict who can interact with the bot. Wi
 :::
 
 For more information on securing your Hermes Agent deployment, see the [Security Guide](../security.md).
+
+
+


### PR DESCRIPTION
## Problem

The Discord setup documentation incorrectly instructed users to set **Public Bot** to **OFF**, but this prevents using the **Discord-provided invite link** (the recommended method in Step 5).

When following the docs with Public Bot = OFF, users encounter this error:

> Private application cannot have a default authorization link.

## Solution

Three targeted fixes:

1. **Step 2 (line 98):** Changed from "Set Public Bot to OFF" → "Set Public Bot to ON" with explanation that it's required for the Discord-provided invite link

2. **Added info callout after Step 2:** Explains the Private Bot alternative - if users want Public Bot OFF, they must use the Manual URL method instead of the Installation tab

3. **Step 5 Option A:** Added note clarifying that Installation tab method requires Public Bot ON

## Files Changed
- `website/docs/user-guide/messaging/discord.md`

## Testing
- Verified Docusaurus admonition syntax is correct
- Changes align with Discord Developer Portal behavior

Fixes Discord bot setup flow for new users following the recommended path.