### PR TITLE
fix(gateway): implement message queuing to prevent overwriting during interrupts  

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -19,6 +19,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Any, Callable, Awaitable, Tuple
 from enum import Enum
+from collections import defaultdict, deque
 
 import sys
 from pathlib import Path as _Path
@@ -398,7 +399,7 @@ class BasePlatformAdapter(ABC):
         # Track active message handlers per session for interrupt support
         # Key: session_key (e.g., chat_id), Value: (event, asyncio.Event for interrupt)
         self._active_sessions: Dict[str, asyncio.Event] = {}
-        self._pending_messages: Dict[str, MessageEvent] = {}
+        self._pending_messages: Dict[str, deque[MessageEvent]] = defaultdict(deque)
         # Background message-processing tasks spawned by handle_message().
         # Gateway shutdown cancels these so an old gateway instance doesn't keep
         # working on a task after --replace or manual restarts.
@@ -980,7 +981,7 @@ class BasePlatformAdapter(ABC):
             # then process them immediately after the current task finishes.
             if event.message_type == MessageType.PHOTO:
                 print(f"[{self.name}] 🖼️ Queuing photo follow-up for session {session_key} without interrupt")
-                existing = self._pending_messages.get(session_key)
+                existing = self._pending_messages[session_key][-1] if self._pending_messages[session_key] else None
                 if existing and existing.message_type == MessageType.PHOTO:
                     existing.media_urls.extend(event.media_urls)
                     existing.media_types.extend(event.media_types)
@@ -990,12 +991,12 @@ class BasePlatformAdapter(ABC):
                         elif event.text not in existing.text:
                             existing.text = f"{existing.text}\n\n{event.text}".strip()
                 else:
-                    self._pending_messages[session_key] = event
+                    self._pending_messages[session_key].append(event)
                 return  # Don't interrupt now - will run after current task completes
 
             # Default behavior for non-photo follow-ups: interrupt the running agent
             print(f"[{self.name}] ⚡ New message while session {session_key} is active - triggering interrupt")
-            self._pending_messages[session_key] = event
+            self._pending_messages[session_key].append(event)
             # Signal the interrupt (the processing task checks this)
             self._active_sessions[session_key].set()
             return  # Don't process now - will be handled after current task finishes
@@ -1286,7 +1287,9 @@ class BasePlatformAdapter(ABC):
     
     def get_pending_message(self, session_key: str) -> Optional[MessageEvent]:
         """Get and clear any pending message for a session."""
-        return self._pending_messages.pop(session_key, None)
+        if self._pending_messages[session_key]:
+            return self._pending_messages[session_key].popleft()
+        return None
     
     def build_source(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -28,6 +28,7 @@ from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from datetime import datetime
 from typing import Dict, Optional, Any, List
+from collections import defaultdict, deque
 
 # ---------------------------------------------------------------------------
 # SSL certificate auto-detection for NixOS and other non-standard systems.
@@ -357,7 +358,7 @@ class GatewayRunner:
         # Track running agents per session for interrupt support
         # Key: session_key, Value: AIAgent instance
         self._running_agents: Dict[str, Any] = {}
-        self._pending_messages: Dict[str, str] = {}  # Queued messages during interrupt
+        self._pending_messages: Dict[str, deque[str]] = defaultdict(deque)
 
         # Cache AIAgent instances per session to preserve prompt caching.
         # Without this, a new AIAgent is created per message, rebuilding the
@@ -1647,7 +1648,7 @@ class GatewayRunner:
                         source=event.source,
                         message_id=event.message_id,
                     )
-                    adapter._pending_messages[_quick_key] = queued_event
+                    adapter._pending_messages[_quick_key].append(queued_event)
                 return "Queued for the next turn."
 
             if event.message_type == MessageType.PHOTO:
@@ -1655,8 +1656,8 @@ class GatewayRunner:
                 adapter = self.adapters.get(source.platform)
                 if adapter:
                     # Reuse adapter queue semantics so photo bursts merge cleanly.
-                    if _quick_key in adapter._pending_messages:
-                        existing = adapter._pending_messages[_quick_key]
+                    if adapter._pending_messages[_quick_key]:
+                        existing = adapter._pending_messages[_quick_key][-1]
                         if getattr(existing, "message_type", None) == MessageType.PHOTO:
                             existing.media_urls.extend(event.media_urls)
                             existing.media_types.extend(event.media_types)
@@ -1666,9 +1667,9 @@ class GatewayRunner:
                                 elif event.text not in existing.text:
                                     existing.text = f"{existing.text}\n\n{event.text}".strip()
                         else:
-                            adapter._pending_messages[_quick_key] = event
+                            adapter._pending_messages[_quick_key].append(event)
                     else:
-                        adapter._pending_messages[_quick_key] = event
+                        adapter._pending_messages[_quick_key].append(event)
                 return None
 
             running_agent = self._running_agents.get(_quick_key)
@@ -1684,14 +1685,11 @@ class GatewayRunner:
                 # agent starts.
                 adapter = self.adapters.get(source.platform)
                 if adapter:
-                    adapter._pending_messages[_quick_key] = event
+                    adapter._pending_messages[_quick_key].append(event)
                 return None
             logger.debug("PRIORITY interrupt for session %s", _quick_key[:20])
             running_agent.interrupt(event.text)
-            if _quick_key in self._pending_messages:
-                self._pending_messages[_quick_key] += "\n" + event.text
-            else:
-                self._pending_messages[_quick_key] = event.text
+            self._pending_messages[_quick_key].append(event.text)
             return None
 
         # Check for commands


### PR DESCRIPTION
## What does this PR do?

Fixes #3505

### Problem
The current implementation of `_pending_messages` uses a simple dictionary assignment, which causes messages to overwrite each other if multiple inputs arrive during an interrupt or while the agent is busy.

### Solution
- Switched `_pending_messages` to `defaultdict(deque)` in both `base.py` and `run.py` to support multi-message queuing.
- Replaced direct assignments with `.append()` to preserve all incoming messages.
- Updated message retrieval logic to use `.popleft()` for FIFO processing.
- Maintained compatibility with photo-burst logic.

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

