### PR TITLE
fix(cli): sync session_id after context compression to prevent orphaned sessions

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4479,6 +4479,9 @@ class HermesCLI:
                     self.agent._honcho.flush_all()
                 except Exception:
                     pass
+            # Sync session_id — compression creates a child session on the agent
+            if hasattr(self, '_session_db') and self.agent:
+                self.session_id = self.agent.session_id
         except Exception as e:
             print(f"  ❌ Compression failed: {e}")
 
@@ -5723,6 +5726,10 @@ class HermesCLI:
 
             # Update history with full conversation
             self.conversation_history = result.get("messages", self.conversation_history) if result else self.conversation_history
+
+            # Sync session_id — auto-compression may have created a child session
+            if self.agent and self.agent.session_id != getattr(self, 'session_id', None):
+                self.session_id = self.agent.session_id
 
             # Get the final response
             response = result.get("final_response", "") if result else ""

--- a/tests/test_session_id_compression_sync.py
+++ b/tests/test_session_id_compression_sync.py
@@ -1,0 +1,85 @@
+"""Tests for session_id sync between CLI and agent after compression.
+
+When context compression fires, the agent creates a child session in the
+DB and updates self.session_id. The CLI must sync its own session_id to
+match, otherwise /new ends the wrong session and the child session is
+orphaned.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def _make_cli_with_agent():
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "original-session-123"
+    cli.conversation_history = [{"role": "user", "content": "hi"}] * 5
+    cli._session_db = MagicMock()
+
+    agent = MagicMock()
+    agent.session_id = "original-session-123"
+    agent.compression_enabled = True
+    agent._cached_system_prompt = "You are helpful."
+    agent._compress_context = MagicMock(return_value=(
+        [{"role": "user", "content": "compressed"}],
+        "You are helpful.",
+    ))
+    agent._honcho = None
+    cli.agent = agent
+    return cli
+
+
+class TestManualCompressSync:
+
+    def test_session_id_synced_after_manual_compress(self):
+        """After /compress, CLI session_id should match agent's new child session."""
+        cli = _make_cli_with_agent()
+
+        # Simulate what _compress_context does: agent gets a new session_id
+        def fake_compress(messages, system, approx_tokens=0):
+            cli.agent.session_id = "child-session-456"
+            return [{"role": "user", "content": "compressed"}], system
+
+        cli.agent._compress_context = fake_compress
+
+        with patch("agent.model_metadata.estimate_messages_tokens_rough", return_value=5000):
+            cli._manual_compress()
+
+        assert cli.session_id == "child-session-456"
+
+    def test_session_id_unchanged_when_compression_fails(self):
+        """If compression throws, CLI session_id stays the same."""
+        cli = _make_cli_with_agent()
+        cli.agent._compress_context = MagicMock(side_effect=RuntimeError("fail"))
+
+        with patch("agent.model_metadata.estimate_messages_tokens_rough", return_value=5000):
+            cli._manual_compress()
+
+        assert cli.session_id == "original-session-123"
+
+
+class TestAutoCompressSync:
+
+    def test_session_id_synced_after_auto_compression(self):
+        """After run_conversation triggers compression, CLI syncs session_id."""
+        cli = _make_cli_with_agent()
+
+        # Simulate agent's session_id changing during run_conversation
+        cli.agent.session_id = "auto-child-789"
+
+        # The sync logic that runs after run_conversation
+        if cli.agent and cli.agent.session_id != cli.session_id:
+            cli.session_id = cli.agent.session_id
+
+        assert cli.session_id == "auto-child-789"
+
+    def test_session_id_unchanged_when_no_compression(self):
+        """When no compression happens, session_id stays the same."""
+        cli = _make_cli_with_agent()
+
+        if cli.agent and cli.agent.session_id != cli.session_id:
+            cli.session_id = cli.agent.session_id
+
+        assert cli.session_id == "original-session-123"


### PR DESCRIPTION
## Summary

After context compression fires (auto or `/compress`), the CLI's `session_id` desyncs from the agent's. The agent creates a child session in the DB, but the CLI never picks up the new ID. Subsequent `/new` or exit ends the wrong (already-ended parent) session, and the child session is orphaned forever.

## Reproduce

Tested on hermes v0.4.0 with GPT-5.4:

1. Start `hermes` and send 4+ messages to build conversation context
2. Type `/compress` — compression creates a child session on the agent
3. Type `/new` — CLI ends the old parent session, not the child
4. Exit and query the DB:

```sql
SELECT id, parent_session_id, ended_at FROM sessions WHERE parent_session_id IS NOT NULL;
```

Result:
```
Found 1 compression child session(s):
  20260328_213154_4944f2
    parent: 20260328_212826_76282a
    status: ORPHANED (no ended_at)

BUG CONFIRMED — orphaned child session found
```

The child session `20260328_213154_4944f2` created during compression was never ended. It stays open in the DB indefinitely, invisible to `hermes sessions prune` and accumulating stale entries over time.

## Root Cause

`_compress_context` at `run_agent.py:4950` ends the current session, creates a child session, and updates `self.session_id` on the agent. But the CLI holds its own `self.session_id` that's never synced:

- `_manual_compress` at `cli.py:4464` — no sync after `_compress_context` returns
- Post-`run_conversation` handler at `cli.py:5728` — no sync for auto-compression

So when `/new` calls `end_session(self.session_id)`, it targets the parent session (already ended by compression), and the child session is never closed.

## Fix

**Manual compress** — sync after compression succeeds:
```python
if hasattr(self, '_session_db') and self.agent:
    self.session_id = self.agent.session_id
```

**Auto compress** — sync after `run_conversation` returns:
```python
if self.agent and self.agent.session_id != self.session_id:
    self.session_id = self.agent.session_id
```

## Tests

4 new tests: manual compress syncs, failure preserves original, auto compress syncs, no-compression is no-op.

```
4 passed
```