### PR TITLE
fix(api-server): allow Idempotency-Key in CORS headers (salvage #3384)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -166,7 +166,7 @@ class ResponseStore:
 
 _CORS_HEADERS = {
     "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
-    "Access-Control-Allow-Headers": "Authorization, Content-Type",
+    "Access-Control-Allow-Headers": "Authorization, Content-Type, Idempotency-Key",
 }
 
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1301,6 +1301,31 @@ class TestCORS:
             assert "DELETE" in resp.headers.get("Access-Control-Allow-Methods", "")
 
     @pytest.mark.asyncio
+    async def test_cors_allows_idempotency_key_header(self):
+        adapter = _make_adapter(cors_origins=["http://localhost:3000"])
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.options(
+                "/v1/chat/completions",
+                headers={
+                    "Origin": "http://localhost:3000",
+                    "Access-Control-Request-Method": "POST",
+                    "Access-Control-Request-Headers": "Idempotency-Key",
+                },
+            )
+            assert resp.status == 200
+            assert "Idempotency-Key" in resp.headers.get("Access-Control-Allow-Headers", "")
+
+    @pytest.mark.asyncio
+    async def test_cors_sets_vary_origin_header(self):
+        adapter = _make_adapter(cors_origins=["http://localhost:3000"])
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/health", headers={"Origin": "http://localhost:3000"})
+            assert resp.status == 200
+            assert resp.headers.get("Vary") == "Origin"
+
+    @pytest.mark.asyncio
     async def test_cors_options_preflight_allowed_for_configured_origin(self):
         """Configured origins can complete browser preflight."""
         adapter = _make_adapter(cors_origins=["http://localhost:3000"])


### PR DESCRIPTION
## Summary

Salvage of #3384 by @aydnOktay onto current main.

The API server already reads `Idempotency-Key` from requests for deduplication, but the CORS `Access-Control-Allow-Headers` didn't include it — browser clients would fail preflight when sending this header.

### Changes
- Add `Idempotency-Key` to `_CORS_HEADERS` allow-list
- Add test for `Idempotency-Key` preflight allowance
- Add test for existing `Vary: Origin` behavior

### What was dropped from #3384
The `Vary: Origin` middleware changes were redundant — `_cors_headers_for_origin()` already sets `Vary: Origin` on line 317 (added after #3384 branched).

Closes #3384