### PR TITLE
fix(session_search): exclude entire session lineage from recent sessions list

### DIFF
--- a/tests/test_session_search_lineage.py
+++ b/tests/test_session_search_lineage.py
@@ -1,0 +1,88 @@
+"""Tests for session lineage exclusion in _list_recent_sessions.
+
+After context compression, the current conversation has a parent→child
+chain. All sessions in that chain must be excluded from "recent sessions"
+results, otherwise the agent sees its own conversation as a separate
+recent session.
+"""
+
+from unittest.mock import MagicMock
+from tools.session_search_tool import _list_recent_sessions
+
+
+def _mock_db(sessions, parent_map=None):
+    """Build a mock SessionDB with get_session and list_sessions_rich."""
+    parent_map = parent_map or {}
+    db = MagicMock()
+    db.list_sessions_rich.return_value = sessions
+
+    def get_session(sid):
+        parent = parent_map.get(sid)
+        return {"id": sid, "parent_session_id": parent} if sid in parent_map or any(s.get("id") == sid for s in sessions) else None
+
+    db.get_session.side_effect = get_session
+    return db
+
+
+class TestLineageExclusion:
+
+    def test_parent_excluded_from_recent(self):
+        """Parent session of current conversation must not appear in results."""
+        sessions = [
+            {"id": "parent-aaa", "title": "Old convo"},
+            {"id": "child-bbb", "title": None, "parent_session_id": "parent-aaa"},
+            {"id": "unrelated-ccc", "title": "Other work"},
+        ]
+        parent_map = {"child-bbb": "parent-aaa", "parent-aaa": None}
+        db = _mock_db(sessions, parent_map)
+
+        result = _list_recent_sessions(db, limit=10, current_session_id="child-bbb")
+
+        assert "unrelated-ccc" in result
+        assert "parent-aaa" not in result
+        assert "child-bbb" not in result
+
+    def test_deep_lineage_all_excluded(self):
+        """A→B→C chain: all three excluded when current is C."""
+        sessions = [
+            {"id": "root-a", "title": "Session A"},
+            {"id": "mid-b", "title": None, "parent_session_id": "root-a"},
+            {"id": "leaf-c", "title": None, "parent_session_id": "mid-b"},
+            {"id": "other-d", "title": "Unrelated"},
+        ]
+        parent_map = {"leaf-c": "mid-b", "mid-b": "root-a", "root-a": None}
+        db = _mock_db(sessions, parent_map)
+
+        result = _list_recent_sessions(db, limit=10, current_session_id="leaf-c")
+
+        assert "other-d" in result
+        assert "root-a" not in result
+        assert "mid-b" not in result
+        assert "leaf-c" not in result
+
+    def test_no_compression_still_works(self):
+        """Session with no parent chain should just exclude itself."""
+        sessions = [
+            {"id": "current-x", "title": "My session"},
+            {"id": "other-y", "title": "Other"},
+        ]
+        parent_map = {"current-x": None}
+        db = _mock_db(sessions, parent_map)
+
+        result = _list_recent_sessions(db, limit=10, current_session_id="current-x")
+
+        assert "other-y" in result
+        assert "current-x" not in result
+
+    def test_no_current_session_returns_all(self):
+        """When current_session_id is None, nothing is excluded."""
+        sessions = [
+            {"id": "aaa", "title": "First"},
+            {"id": "bbb", "title": "Second"},
+        ]
+        db = _mock_db(sessions)
+
+        result = _list_recent_sessions(db, limit=10, current_session_id=None)
+
+        assert "aaa" in result
+        assert "bbb" in result

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -199,23 +199,29 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str
 
         # Resolve current session lineage to exclude it
         current_root = None
+        current_lineage = set()
         if current_session_id:
             try:
                 sid = current_session_id
-                visited = set()
-                while sid and sid not in visited:
-                    visited.add(sid)
+                while sid:
+                    current_lineage.add(sid)
                     s = db.get_session(sid)
                     parent = s.get("parent_session_id") if s else None
-                    sid = parent if parent else None
-                current_root = max(visited, key=len) if visited else current_session_id
+                    if parent and parent not in current_lineage:
+                        sid = parent
+                    else:
+                        current_root = sid
+                        break
+                if not current_root:
+                    current_root = current_session_id
             except Exception:
                 current_root = current_session_id
+                current_lineage = {current_session_id}
 
         results = []
         for s in sessions:
             sid = s.get("id", "")
-            if current_root and (sid == current_root or sid == current_session_id):
+            if sid in current_lineage:
                 continue
             # Skip child/delegation sessions (they have parent_session_id)
             if s.get("parent_session_id"):


### PR DESCRIPTION
## Summary

After context compression, `session_search` with no query (browsing recent sessions) shows the current conversation's parent session in the results. The agent sees its own conversation as a separate "recent session" and may waste tokens recalling from itself.

## Root Cause

`_list_recent_sessions` at `session_search_tool.py:211` uses `max(visited, key=len)` to find the root session of the current lineage. This picks the session ID with the **longest string**, not the actual root parent. If the child ID is longer than the parent ID, the wrong session is identified as root and the real parent leaks into results.

The correct pattern already exists in the same file — `_resolve_to_parent` at line 298 walks the chain and returns the last `sid` reached. But `_list_recent_sessions` uses a different, broken approach.

Additionally, line 218 only excludes `current_root` and `current_session_id` — but intermediate sessions in a deep chain (grandparent→parent→child) are not excluded.

## Fix

Replaced the `max(visited, key=len)` approach with a proper parent-chain walk that captures the actual root. Changed the exclusion check from comparing two IDs to checking membership in the full `current_lineage` set — so all sessions in the chain (root, intermediate, current) are excluded.

```python
current_lineage = set()
sid = current_session_id
while sid:
    current_lineage.add(sid)
    parent = db.get_session(sid).get("parent_session_id")
    if parent and parent not in current_lineage:
        sid = parent
    else:
        break
```

## Tests

4 new tests: parent excluded after compression, deep A→B→C chain all excluded, no-compression session excluded, None current_session returns all.

```
4 passed
```