### PR TITLE
fix: accept model key as alias for default in config.yaml model section

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -63,7 +63,10 @@ def _get_model_config() -> Dict[str, Any]:
     model_cfg = config.get("model")
     if isinstance(model_cfg, dict):
         cfg = dict(model_cfg)
-        default = cfg.get("default", "").strip()
+        # Accept both "default" and "model" keys for the model name so that
+        # config.yaml entries like ``model: { provider: x, model: y }`` work
+        # alongside the canonical ``model: { provider: x, default: y }`` form.
+        default = (cfg.get("default") or cfg.get("model") or "").strip()
         base_url = cfg.get("base_url", "").strip()
         is_local = "localhost" in base_url or "127.0.0.1" in base_url
         is_fallback = not default or default == "anthropic/claude-opus-4.6"


### PR DESCRIPTION
## Summary

- `_get_model_config()` in `runtime_provider.py` only read the `default` key from the `model:` config block, ignoring the `model` key
- Users configuring `model: { provider: kimi-coding, model: moonshot-v1-auto }` would silently fall back to the hardcoded `anthropic/claude-opus-4.6`, causing 404 errors on non-OpenRouter providers
- Now accepts both `default` and `model` keys, with `default` taking precedence for backwards compatibility

Fixes #3535

## Test plan

- [ ] Verify `model: { provider: kimi-coding, model: moonshot-v1-auto }` correctly sends `moonshot-v1-auto` to the Kimi API
- [ ] Verify `model: { provider: kimi-coding, default: moonshot-v1-auto }` still works as before
- [ ] Verify fallback to `anthropic/claude-opus-4.6` still works when neither key is present
- [ ] Run existing `test_runtime_provider_resolution.py` tests