### PR TITLE
fix: auto-repair jobs.json with invalid control characters (salvage #3517)

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -327,7 +327,20 @@ def load_jobs() -> List[Dict[str, Any]]:
         with open(JOBS_FILE, 'r', encoding='utf-8') as f:
             data = json.load(f)
             return data.get("jobs", [])
-    except (json.JSONDecodeError, IOError):
+    except json.JSONDecodeError:
+        # Retry with strict=False to handle bare control chars in string values
+        try:
+            with open(JOBS_FILE, 'r', encoding='utf-8') as f:
+                data = json.loads(f.read(), strict=False)
+                jobs = data.get("jobs", [])
+                if jobs:
+                    # Auto-repair: rewrite with proper escaping
+                    save_jobs(jobs)
+                    logger.warning("Auto-repaired jobs.json (had invalid control characters)")
+                return jobs
+        except Exception:
+            return []
+    except IOError:
         return []
 
 


### PR DESCRIPTION
## Summary

Salvage of #3517 by @zicochaos.

`load_jobs()` uses strict `json.load()` which rejects bare control characters (literal newlines, tabs, etc.) inside JSON string values. When a cron job prompt contains such characters — which happens when LLM output with newlines gets saved — the parser throws `JSONDecodeError` and the catch-all returns `[]`. **All cron jobs silently stop firing** with no error logged.

### Fix

On `JSONDecodeError`, retry with `json.loads(strict=False)` which accepts bare control characters. If jobs are recovered, auto-rewrite `jobs.json` via `save_jobs()` (which properly escapes everything via `json.dump`) and log a warning. Only fall back to empty list if the JSON is truly unrecoverable.