### PR TITLE
feat(telegram): add configurable regex wake-word gating for group text and media

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -507,6 +507,10 @@ def load_gateway_config() -> GatewayConfig:
                     )
                 if "reply_prefix" in platform_cfg:
                     bridged["reply_prefix"] = platform_cfg["reply_prefix"]
+                if "require_mention" in platform_cfg:
+                    bridged["require_mention"] = platform_cfg["require_mention"]
+                if "mention_patterns" in platform_cfg:
+                    bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if not bridged:
                     continue
                 plat_data = platforms_data.setdefault(plat.value, {})
@@ -531,6 +535,17 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["DISCORD_FREE_RESPONSE_CHANNELS"] = str(frc)
                 if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
                     os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
+
+            # Telegram settings → env vars (env vars take precedence)
+            telegram_cfg = yaml_cfg.get("telegram", {})
+            if isinstance(telegram_cfg, dict):
+                if "require_mention" in telegram_cfg and not os.getenv("TELEGRAM_REQUIRE_MENTION"):
+                    os.environ["TELEGRAM_REQUIRE_MENTION"] = str(telegram_cfg["require_mention"]).lower()
+                mention_patterns = telegram_cfg.get("mention_patterns")
+                if mention_patterns is not None and not os.getenv("TELEGRAM_MENTION_PATTERNS"):
+                    if isinstance(mention_patterns, list):
+                        mention_patterns = "\n".join(str(v) for v in mention_patterns)
+                    os.environ["TELEGRAM_MENTION_PATTERNS"] = str(mention_patterns)
     except Exception as e:
         logger.warning(
             "Failed to process config.yaml — falling back to .env / gateway.json values. "

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1314,6 +1314,55 @@ class TelegramAdapter(BasePlatformAdapter):
 
         return text
     
+    @staticmethod
+    def _require_mention_enabled() -> bool:
+        """Whether group messages require an explicit mention/prefix to be processed."""
+        return os.getenv("TELEGRAM_REQUIRE_MENTION", "false").lower() in ("true", "1", "yes")
+
+    @staticmethod
+    def _mention_patterns() -> List[str]:
+        """Configured Telegram mention regex patterns."""
+        raw = os.getenv("TELEGRAM_MENTION_PATTERNS", "")
+        if not raw:
+            return []
+        return [line.strip() for line in raw.splitlines() if line.strip()]
+
+    @classmethod
+    def _strip_leading_mention(cls, text: str) -> str:
+        """Remove the first matching mention/prefix from the start of the message."""
+        cleaned = text or ""
+        for pattern in cls._mention_patterns():
+            try:
+                updated = re.sub(pattern, "", cleaned, count=1, flags=re.IGNORECASE).lstrip(" ,:-\t")
+            except re.error:
+                continue
+            if updated != cleaned:
+                return updated.strip()
+        return cleaned.strip()
+
+    def _message_mentions_bot(self, message: Message) -> bool:
+        """Return True if a Telegram group message explicitly invokes the bot."""
+        text = (message.text or message.caption or "").strip()
+        if not text:
+            return False
+
+        for pattern in self._mention_patterns():
+            try:
+                if re.search(pattern, text, flags=re.IGNORECASE):
+                    return True
+            except re.error:
+                logger.warning("[Telegram] Invalid mention pattern ignored: %s", pattern)
+
+        bot = getattr(self, "_bot", None)
+        bot_id = str(getattr(bot, "id", "")) if bot else ""
+        reply_to = getattr(message, "reply_to_message", None)
+        reply_user = getattr(reply_to, "from_user", None) if reply_to else None
+        reply_user_id = str(getattr(reply_user, "id", "")) if reply_user else ""
+        if bot_id and reply_user_id and reply_user_id == bot_id:
+            return True
+
+        return False
+
     async def _handle_text_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming text messages.
 
@@ -1324,7 +1373,18 @@ class TelegramAdapter(BasePlatformAdapter):
         if not update.message or not update.message.text:
             return
 
-        event = self._build_message_event(update.message, MessageType.TEXT)
+        message = update.message
+        chat = getattr(message, "chat", None)
+        is_group = bool(chat and chat.type in (ChatType.GROUP, ChatType.SUPERGROUP))
+        cleaned_text = message.text
+        if is_group and self._require_mention_enabled():
+            if not self._message_mentions_bot(message):
+                logger.debug("[Telegram] Skipping group message without required mention/prefix")
+                return
+            cleaned_text = self._strip_leading_mention(message.text)
+
+        event = self._build_message_event(message, MessageType.TEXT)
+        event.text = cleaned_text
         self._enqueue_text_event(event)
     
     async def _handle_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -1482,8 +1542,14 @@ class TelegramAdapter(BasePlatformAdapter):
         """Handle incoming media messages, downloading images to local cache."""
         if not update.message:
             return
-        
+
         msg = update.message
+        chat = getattr(msg, "chat", None)
+        is_group = bool(chat and chat.type in (ChatType.GROUP, ChatType.SUPERGROUP))
+        if is_group and self._require_mention_enabled():
+            if not self._message_mentions_bot(msg):
+                logger.debug("[Telegram] Skipping group media without required mention/prefix")
+                return
         
         # Determine media type
         if msg.sticker:
@@ -1505,7 +1571,7 @@ class TelegramAdapter(BasePlatformAdapter):
         
         # Add caption as text
         if msg.caption:
-            event.text = msg.caption
+            event.text = self._strip_leading_mention(msg.caption) if is_group and self._require_mention_enabled() else msg.caption
         
         # Handle stickers: describe via vision tool with caching
         if msg.sticker:

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -1,0 +1,121 @@
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from gateway.config import Platform, PlatformConfig, load_gateway_config
+
+
+def _make_adapter(require_mention=None, mention_patterns=None):
+    from gateway.platforms.telegram import TelegramAdapter
+
+    extra = {}
+    if require_mention is not None:
+        extra["require_mention"] = require_mention
+    if mention_patterns is not None:
+        extra["mention_patterns"] = mention_patterns
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter.config = PlatformConfig(enabled=True, token="***", extra=extra)
+    adapter._bot = SimpleNamespace(id=999, username="example_bot")
+    adapter._message_handler = AsyncMock()
+    adapter._pending_text_batches = {}
+    adapter._pending_text_batch_tasks = {}
+    adapter._text_batch_delay_seconds = 0.01
+    if mention_patterns is not None:
+        os.environ["TELEGRAM_MENTION_PATTERNS"] = "\n".join(mention_patterns)
+    else:
+        os.environ.pop("TELEGRAM_MENTION_PATTERNS", None)
+    if require_mention is not None:
+        os.environ["TELEGRAM_REQUIRE_MENTION"] = str(require_mention).lower()
+    else:
+        os.environ.pop("TELEGRAM_REQUIRE_MENTION", None)
+    return adapter
+
+
+def _group_message(text="hello", *, caption=None, reply_to_bot=False):
+    reply_to_message = None
+    if reply_to_bot:
+        reply_to_message = SimpleNamespace(from_user=SimpleNamespace(id=999))
+    return SimpleNamespace(
+        text=text,
+        caption=caption,
+        entities=[],
+        caption_entities=[],
+        chat=SimpleNamespace(id=-100, type="group"),
+        reply_to_message=reply_to_message,
+    )
+
+
+def _dm_message(text="hello"):
+    return SimpleNamespace(
+        text=text,
+        caption=None,
+        entities=[],
+        caption_entities=[],
+        chat=SimpleNamespace(id=123, type="private"),
+        reply_to_message=None,
+    )
+
+
+def test_group_message_without_mention_is_skipped():
+    adapter = _make_adapter(require_mention=True, mention_patterns=[r"^\s*wakeword\b"])
+
+    assert adapter._message_mentions_bot(_group_message("hello everyone")) is False
+
+
+def test_group_message_with_prefix_is_detected_and_stripped():
+    adapter = _make_adapter(require_mention=True, mention_patterns=[r"^\s*wakeword\b"])
+    msg = _group_message("wakeword hi there")
+
+    assert adapter._message_mentions_bot(msg) is True
+    assert adapter._strip_leading_mention(msg.text) == "hi there"
+
+
+def test_reply_to_bot_is_detected():
+    adapter = _make_adapter(require_mention=True, mention_patterns=[r"^\s*wakeword\b"])
+
+    assert adapter._message_mentions_bot(_group_message("whatever", reply_to_bot=True)) is True
+
+
+def test_dm_bypasses_group_gating_logic():
+    adapter = _make_adapter(require_mention=True, mention_patterns=[r"^\s*wakeword\b"])
+
+    assert adapter._message_mentions_bot(_dm_message("hello")) is False
+
+
+def test_media_caption_prefix_is_stripped():
+    adapter = _make_adapter(require_mention=True, mention_patterns=[r"^\s*wakeword\b"])
+    msg = _group_message(text=None, caption="wakeword what is this")
+
+    assert adapter._message_mentions_bot(msg) is True
+    assert adapter._strip_leading_mention(msg.caption) == "what is this"
+
+
+def test_group_media_without_caption_or_reply_is_skipped():
+    adapter = _make_adapter(require_mention=True, mention_patterns=[r"^\s*wakeword\b"])
+    msg = _group_message(text=None, caption=None)
+
+    assert adapter._message_mentions_bot(msg) is False
+
+
+def test_config_bridges_telegram_group_settings(monkeypatch, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "telegram:\n"
+        "  require_mention: true\n"
+        "  mention_patterns:\n"
+        "    - \"^\\\\s*wakeword\\\\b\"\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("TELEGRAM_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("TELEGRAM_MENTION_PATTERNS", raising=False)
+
+    config = load_gateway_config()
+
+    assert config is not None
+    assert __import__("os").environ["TELEGRAM_REQUIRE_MENTION"] == "true"
+    assert __import__("os").environ["TELEGRAM_MENTION_PATTERNS"].splitlines() == [r"^\s*wakeword\b"]


### PR DESCRIPTION
## What does this PR do?

This PR adds Telegram-specific group invocation gating with configurable regex wake words.

The goal is to let Hermes ignore ambient group chatter while still responding to explicit Telegram group triggers. It adds Hermes-side gating for Telegram group messages and captions so the bot only responds when explicitly invoked.

## Changes Made

- Added Telegram config bridging in `gateway/config.py` for:
  - `telegram.require_mention`
  - `telegram.mention_patterns`
- Added Telegram group invocation handling in `gateway/platforms/telegram.py`
- Group messages are now processed when they:
  - match a configured regex wake word
  - reply to one of the bot’s messages
- Strips the matched wake-word prefix from the beginning of the text/caption before dispatching to the model
- Applies the same invocation gating to media/caption messages, not just plain text
- Avoids mutating Telegram `Message` objects directly when cleaning invocation prefixes
- Added focused Telegram gating tests in:
  - `tests/gateway/test_telegram_group_gating.py`

## Example config

```yaml
telegram:
  require_mention: true
  mention_patterns:
    - "^\\s*wakeword\\b"
```

With the example above:
- `wakeword hi` in a group is processed
- a plain uninvoked group message is ignored
- an image with caption `wakeword what is this` is processed
- a plain image with no caption is ignored
- replies to the bot are processed

## How to Test

Run:

- `pytest -q tests/gateway/test_telegram_group_gating.py tests/gateway/test_telegram_text_batching.py`

Then verify in a Telegram group where the bot receives group messages:

- plain text with no invocation is ignored
- `wakeword hi` is processed
- reply-to-bot is processed
- plain image with no caption is ignored
- image with a wake-word caption is processed

## Notes

- This is Telegram-specific behavior and does not change Discord or other platform adapters.
- The tests use generic placeholder names/patterns rather than user-specific wake words.

## Checklist

- [x] Code changes tested
- [x] Group text invocation gating works
- [x] Group media invocation gating works
- [x] No private/local config included
- [x] No user-specific bot names or wake words used in tests