### PR TITLE
fix(gateway): strip @botname suffix from Telegram slash command parsing

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -333,7 +333,11 @@ class MessageEvent:
             return None
         # Split on space and get first word, strip the /
         parts = self.text.split(maxsplit=1)
-        return parts[0][1:].lower() if parts else None
+        cmd = parts[0][1:].lower() if parts else None
+        # Strip @botname suffix (Telegram appends it in groups, e.g. /model@MyBot_bot)
+        if cmd and '@' in cmd:
+            cmd = cmd.split('@')[0]
+        return cmd
     
     def get_command_args(self) -> str:
         """Get the arguments after a command."""


### PR DESCRIPTION
## Summary

Telegram clients append the bot username to slash commands (e.g. `/model@MyBot_bot`). `get_command()` does not strip this suffix, so `resolve_command()` fails to match and the command falls through to the agent as plain text.

**This affects both group chats and DMs:**
- **Group chats / Supergroups**: Telegram Bot API **always** appends `@botname` to disambiguate between multiple bots
- **DMs**: Some Telegram clients also append `@botname` in private chats (observed on Telegram Desktop and certain mobile client versions)

All slash commands are affected — including the new `/models` command proposed in #3500 (#3502, #3503), which would also fail in group chats and DMs without this fix.

## Root cause

`MessageEvent.get_command()` in `gateway/platforms/base.py` extracts the command with `text.split()[0][1:]` — this returns `model@mybot_bot` instead of `model`. Since `resolve_command("model@mybot_bot")` returns `None`, the message bypasses command dispatch entirely.

The `@username` suffix is a standard Telegram Bot API convention — it is guaranteed in group chats and common in DMs depending on client implementation.

## Fix

**gateway/platforms/base.py**: Strip everything after `@` in the extracted command name (3-line change in `get_command()`).

```python
cmd = parts[0][1:].lower()
if cmd and "@" in cmd:
    cmd = cmd.split("@")[0]
```

This is safe for all platforms — only Telegram uses the `@suffix` convention, and no valid command name contains `@`.

## How to test

1. In a **group chat**: send `/model@YourBot_bot` — should now be recognized as `/model`
2. In a **DM**: send `/help@YourBot_bot` — should show help
3. Verify commands without `@botname` suffix still work normally in both chat types

## Platform tested

Linux, Telegram gateway (group chats and DMs)

Related to #3500