### PR TITLE
fix: use placeholder api_key for custom providers without credentials

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -203,7 +203,7 @@ def _resolve_named_custom_runtime(
         or _detect_api_mode_for_url(base_url)
         or "chat_completions",
         "base_url": base_url,
-        "api_key": api_key,
+        "api_key": api_key or "na-key",
         "source": f"custom_provider:{custom_provider.get('name', requested_provider)}",
     }
 


### PR DESCRIPTION
## Problem

Smart model routing silently fails when using local/custom OpenAI-compatible providers (e.g. Ollama) that do not require an API key. The `OpenAI` SDK client rejects a `None` `api_key`, causing the cheap-model route to fail without surfacing a clear error.

## Fix

In `_resolve_named_custom_runtime()`, fall back to a placeholder value `"na-key"` when no API key is configured:

```python
# before
"api_key": api_key,

# after
"api_key": api_key or "na-key",
```

This matches the pattern already used in `_resolve_openrouter_runtime()` for the same scenario (line ~270).

## Impact

- No change in behaviour for providers that supply a real key
- Custom/local providers (Ollama, LM Studio, etc.) can now be used as `cheap_model` targets in smart model routing without error
- One-line, surgical change with clear precedent in the existing codebase