### PR TITLE
fix(config): accept 'model' key as alias for 'default' in config.yaml model section

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -63,6 +63,11 @@ def _get_model_config() -> Dict[str, Any]:
     model_cfg = config.get("model")
     if isinstance(model_cfg, dict):
         cfg = dict(model_cfg)
+        # Accept "model" as an alias for "default" so both config spellings work:
+        #   model: { default: my-model }  (documented)
+        #   model: { model: my-model }    (intuitive but previously silently ignored)
+        if not cfg.get("default") and cfg.get("model"):
+            cfg["default"] = cfg["model"]
         default = cfg.get("default", "").strip()
         base_url = cfg.get("base_url", "").strip()
         is_local = "localhost" in base_url or "127.0.0.1" in base_url
@@ -82,7 +87,7 @@ def _copilot_runtime_api_mode(model_cfg: Dict[str, Any], api_key: str) -> str:
     if configured_mode:
         return configured_mode
 
-    model_name = str(model_cfg.get("default") or "").strip()
+    model_name = str(model_cfg.get("default") or model_cfg.get("model") or "").strip()
     if not model_name:
         return "chat_completions"
 


### PR DESCRIPTION
Fixes #3535

## Problem
model.model in config.yaml was silently ignored. _get_model_config() only read cfg.get("default"), causing fallback to hardcoded anthropic/claude-opus-4.6 for providers like kimi-coding.

## Fix
Two places updated:
1. _get_model_config(): normalize "model" → "default" early, so all downstream code benefits automatically
2. Line 85: added model_cfg.get("model") fallback alongside model_cfg.get("default")

Both spellings now work:
- model: { default: moonshot-v1-auto }  ✅ (documented)  
- model: { model: moonshot-v1-auto }    ✅ (now fixed)
