### PR TITLE
Remove incorrect docker alternative for signal-cli

### DIFF
--- a/website/docs/user-guide/messaging/signal.md
+++ b/website/docs/user-guide/messaging/signal.md
@@ -36,22 +36,6 @@ brew install signal-cli
 # Extract and add to PATH
 ```
 
-### Alternative: Docker (signal-cli-rest-api)
-
-If you prefer Docker, use the [signal-cli-rest-api](https://github.com/bbernhard/signal-cli-rest-api) container:
-
-```bash
-docker run -d --name signal-cli \
-  -p 8080:8080 \
-  -v $HOME/.local/share/signal-cli:/home/.local/share/signal-cli \
-  -e MODE=json-rpc \
-  bbernhard/signal-cli-rest-api
-```
-
-:::tip
-Use `MODE=json-rpc` for best performance. The `normal` mode spawns a JVM per request and is much slower.
-:::
-
 ---
 
 ## Step 1: Link Your Signal Account


### PR DESCRIPTION
Removed docker alternative for signal-cli-rest-api from the documentation. It does not support the raw signal-cli http daemon. See https://github.com/bbernhard/signal-cli-rest-api/issues/720.

## What does this PR do?

"Fixes" #2409 by removing incorrect documentation. Technically you can use the bbernhard container by overwriting its entry point. Though you'd still need to register by starting that container normally and scanning the QR code which is enough headache that I wouldn't recommend a normal user do it.

Technical workaround, assuming you've registered your signal account with the signal-cli mount
```bash
docker run --name signal-cli \
  -p 8080:8080 \
  -v $HOME/.local/share/signal-cli:/home/.local/share/signal-cli \
  --entrypoint signal-cli \
  bbernhard/signal-cli-rest-api \
  -a +1234567890 --config /home/.local/share/signal-cli daemon --http 0.0.0.0:8080
```


## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #2409

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [X] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- Remove invalid doc section from website/docs/user-guide/messaging/signal.md

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

N/A, only a docs change.

## Checklist

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

N/A, just a simple delete.
