### PR TITLE
fix(cli): guard .strip() against None values from YAML config (salvage #3217)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1083,7 +1083,7 @@ class HermesCLI:
         self.model = model or _config_model or _FALLBACK_MODEL
         # Auto-detect model from local server if still on fallback
         if self.model == _FALLBACK_MODEL:
-            _base_url = _model_config.get("base_url", "") if isinstance(_model_config, dict) else ""
+            _base_url = (_model_config.get("base_url") or "") if isinstance(_model_config, dict) else ""
             if "localhost" in _base_url or "127.0.0.1" in _base_url:
                 from hermes_cli.runtime_provider import _auto_detect_local_model
                 _detected = _auto_detect_local_model(_base_url)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -832,8 +832,8 @@ def cmd_model(args):
         for entry in custom_providers_cfg:
             if not isinstance(entry, dict):
                 continue
-            name = entry.get("name", "").strip()
-            base_url = entry.get("base_url", "").strip()
+            name = (entry.get("name") or "").strip()
+            base_url = (entry.get("base_url") or "").strip()
             if not name or not base_url:
                 continue
             # Generate a stable key from the name

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -63,8 +63,8 @@ def _get_model_config() -> Dict[str, Any]:
     model_cfg = config.get("model")
     if isinstance(model_cfg, dict):
         cfg = dict(model_cfg)
-        default = cfg.get("default", "").strip()
-        base_url = cfg.get("base_url", "").strip()
+        default = (cfg.get("default") or "").strip()
+        base_url = (cfg.get("base_url") or "").strip()
         is_local = "localhost" in base_url or "127.0.0.1" in base_url
         is_fallback = not default or default == "anthropic/claude-opus-4.6"
         if is_local and is_fallback and base_url:


### PR DESCRIPTION
## Summary

`dict.get(key, default)` only returns the default when the key is **absent**. When YAML has `key:` with no value, it parses as `None` — `.get()` returns `None`, then `.strip()` crashes with `AttributeError`.

Changes 5 instances of `.get("key", "").strip()` to `(x or "").strip()` across:
- `cli.py` — `_model_config.get("base_url")` in local server auto-detection
- `hermes_cli/main.py` — custom provider `name` and `base_url` in `cmd_model()`
- `hermes_cli/runtime_provider.py` — `default` and `base_url` in `_get_model_config()`

## Attribution

Cherry-picked from PR #3217 by @erosika. Original authorship preserved.

## Test plan

- 658 tests pass (test_cli_init.py + hermes_cli/ suite)
- All three files compile clean