### PR TITLE
fix(provider): allow MiniMax users to override to /v1 endpoint

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -407,12 +407,6 @@ def resolve_runtime_provider(
             # (e.g. https://api.minimax.io/anthropic, https://dashscope.../anthropic)
             elif base_url.rstrip("/").endswith("/anthropic"):
                 api_mode = "anthropic_messages"
-            # MiniMax providers always use Anthropic Messages API.
-            # Auto-correct stale /v1 URLs (from old .env or config) to /anthropic.
-            elif provider in ("minimax", "minimax-cn"):
-                api_mode = "anthropic_messages"
-                if base_url.rstrip("/").endswith("/v1"):
-                    base_url = base_url.rstrip("/")[:-3] + "/anthropic"
         return {
             "provider": provider,
             "api_mode": api_mode,

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -493,22 +493,22 @@ def test_minimax_default_url_uses_anthropic_messages(monkeypatch):
     assert resolved["base_url"] == "https://api.minimax.io/anthropic"
 
 
-def test_minimax_stale_v1_url_auto_corrected(monkeypatch):
-    """MiniMax with stale /v1 base URL should be auto-corrected to /anthropic."""
+def test_minimax_v1_url_uses_chat_completions(monkeypatch):
+    """MiniMax with /v1 base URL should use chat_completions (user override for regions where /anthropic 404s)."""
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "minimax")
     monkeypatch.setattr(rp, "_get_model_config", lambda: {})
     monkeypatch.setenv("MINIMAX_API_KEY", "test-minimax-key")
-    monkeypatch.setenv("MINIMAX_BASE_URL", "https://api.minimax.io/v1")
+    monkeypatch.setenv("MINIMAX_BASE_URL", "https://api.minimax.chat/v1")
 
     resolved = rp.resolve_runtime_provider(requested="minimax")
 
     assert resolved["provider"] == "minimax"
-    assert resolved["api_mode"] == "anthropic_messages"
-    assert resolved["base_url"] == "https://api.minimax.io/anthropic"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "https://api.minimax.chat/v1"
 
 
-def test_minimax_cn_stale_v1_url_auto_corrected(monkeypatch):
-    """MiniMax-CN with stale /v1 base URL should be auto-corrected to /anthropic."""
+def test_minimax_cn_v1_url_uses_chat_completions(monkeypatch):
+    """MiniMax-CN with /v1 base URL should use chat_completions (user override)."""
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "minimax-cn")
     monkeypatch.setattr(rp, "_get_model_config", lambda: {})
     monkeypatch.setenv("MINIMAX_CN_API_KEY", "test-minimax-cn-key")
@@ -517,8 +517,8 @@ def test_minimax_cn_stale_v1_url_auto_corrected(monkeypatch):
     resolved = rp.resolve_runtime_provider(requested="minimax-cn")
 
     assert resolved["provider"] == "minimax-cn"
-    assert resolved["api_mode"] == "anthropic_messages"
-    assert resolved["base_url"] == "https://api.minimaxi.com/anthropic"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "https://api.minimaxi.com/v1"
 
 
 def test_minimax_explicit_api_mode_respected(monkeypatch):


### PR DESCRIPTION
## Summary

Users in certain regions get nginx 404 on `api.minimax.io/anthropic` (confirmed by Talion and wenzani in Discord). The endpoint works from our server but appears to have geographic routing gaps.

The previous fix (`6bcec1ac`) added minimax-specific auto-correction that forced `/v1` URLs back to `/anthropic` and hardcoded `anthropic_messages` mode. This prevented users from overriding via `MINIMAX_BASE_URL` even when they needed to.

## Changes

- **Removed** the minimax-specific auto-correction in `runtime_provider.py` (lines 410-415)
- The generic URL-suffix detection at line 408 already handles `/anthropic` → `anthropic_messages`, so the default path is unaffected
- Users who need `/v1` can now set `MINIMAX_BASE_URL=https://api.minimax.chat/v1` and get `chat_completions` mode naturally
- Updated tests to verify both paths work

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Default (no override) | `/anthropic` + `anthropic_messages` | Same ✓ |
| User sets `MINIMAX_BASE_URL=.../v1` | Auto-corrected to `/anthropic` (broken) | `/v1` + `chat_completions` ✓ |
| User sets `MINIMAX_BASE_URL=.../anthropic` | `anthropic_messages` | Same ✓ |

Closes #3546 (different approach — respects user overrides instead of changing the default).