### PR TITLE
fix(gateway): exit with failure when all platforms fail with retryable errors

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -745,10 +745,22 @@ class GatewayRunner:
                 logger.error("No connected messaging platforms remain. Shutting down gateway cleanly.")
             await self.stop()
         elif not self.adapters and self._failed_platforms:
-            logger.warning(
-                "No connected messaging platforms remain, but %d platform(s) queued for reconnection",
-                len(self._failed_platforms),
-            )
+            # All platforms are down and queued for background reconnection.
+            # If the error is retryable, exit with failure so systemd Restart=on-failure
+            # can restart the process. Otherwise stay alive and keep retrying in background.
+            if adapter.fatal_error_retryable:
+                self._exit_reason = adapter.fatal_error_message or "All messaging platforms failed with retryable errors"
+                self._exit_with_failure = True
+                logger.error(
+                    "All messaging platforms failed with retryable errors. "
+                    "Shutting down gateway for service restart (systemd will retry)."
+                )
+                await self.stop()
+            else:
+                logger.warning(
+                    "No connected messaging platforms remain, but %d platform(s) queued for reconnection",
+                    len(self._failed_platforms),
+                )
 
     def _request_clean_exit(self, reason: str) -> None:
         self._exit_cleanly = True


### PR DESCRIPTION
## Problem

When Telegram Bot API returned "Bad Gateway" errors, the gateway's Telegram adapter:
1. Exhausted its 10 network retry attempts (exponential backoff up to ~60s each)
2. Called `_set_fatal_error(... retryable=True)` → `_notify_fatal_error()`
3. The adapter was removed from `self.adapters` but remained in `_failed_platforms` for background reconnection
4. The gateway stayed alive with no functional messaging platforms but exit code 0

Since `systemd Restart=on-failure` only triggers on non-zero exit codes, the gateway was never restarted automatically.

## Fix

In `_handle_adapter_fatal_error`, when all platforms are down and queued for background reconnection, check if the error is retryable. If so, set `_exit_with_failure = True` and call `await self.stop()`. This causes the gateway to exit with code 1, triggering systemd's restart policy.



## Testing

Verified via log analysis — the gateway was confirmed to have stayed alive after Mar 25 and Mar 27 Bad Gateway events, rather than restarting.

## Related

The `Restart=on-failure` systemd policy was already configured but was ineffective because the gateway never produced a non-zero exit code in this scenario.