### PR TITLE
feat(providers): add Google Vertex AI provider for Claude

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -298,6 +298,58 @@ def build_anthropic_client(api_key: str, base_url: str = None):
     return _anthropic_sdk.Anthropic(**kwargs)
 
 
+def build_vertex_client(project: str, region: str = "us-east5"):
+    """Build an AnthropicVertex client using GCP Application Default Credentials.
+
+    Uses the same Messages API as Anthropic direct, but authenticated via
+    GCP IAM (attached service account, ADC, or explicit key file).
+
+    Args:
+        project: GCP project ID (required)
+        region: GCP region where Claude on Vertex AI is generally available
+            (default: us-east5)
+
+    Returns:
+        AnthropicVertex client instance (same interface as Anthropic)
+    """
+    try:
+        from anthropic import AnthropicVertex
+    except ImportError:
+        raise ImportError(
+            "anthropic[vertex] is required for Vertex AI provider. "
+            "Install with: pip install 'anthropic[vertex]'"
+        )
+
+    from httpx import Timeout
+
+    kwargs = {
+        "project_id": project,
+        "region": region,
+        "timeout": Timeout(timeout=900.0, connect=10.0),
+    }
+
+    return AnthropicVertex(**kwargs)
+
+
+def resolve_vertex_credentials():
+    """Resolve Vertex AI credentials from environment.
+
+    Returns:
+        Tuple of (project_id, region) or (None, None) if not configured.
+    """
+    project = (
+        os.environ.get("VERTEX_PROJECT")
+        or os.environ.get("GOOGLE_CLOUD_PROJECT")
+        or os.environ.get("GCP_PROJECT_ID")
+    )
+    region = os.environ.get("VERTEX_REGION", "us-east5")
+
+    if not project:
+        return None, None
+
+    return project, region
+
+
 def read_claude_code_credentials() -> Optional[Dict[str, Any]]:
     """Read refreshable Claude Code OAuth credentials from ~/.claude/.credentials.json.
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -105,6 +105,7 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "minimax": "MiniMax-M2.7",
     "minimax-cn": "MiniMax-M2.7",
     "anthropic": "claude-haiku-4-5-20251001",
+    "vertex-ai": "claude-haiku-4-5",
     "ai-gateway": "google/gemini-3-flash",
     "opencode-zen": "gemini-3-flash",
     "opencode-go": "glm-5",
@@ -700,6 +701,8 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
             except ImportError:
                 pass
             return _try_anthropic()
+        if provider_id == "vertex-ai":
+            return _try_vertex()
 
         pool_present, entry = _select_pool_entry(provider_id)
         if pool_present:
@@ -1005,6 +1008,24 @@ def _try_anthropic() -> Tuple[Optional[Any], Optional[str]]:
         # when _anthropic_sdk is None.  Treat as unavailable.
         return None, None
     return AnthropicAuxiliaryClient(real_client, model, token, base_url, is_oauth=is_oauth), model
+
+
+def _try_vertex() -> Tuple[Optional[Any], Optional[str]]:
+    """Try to build a Vertex AI auxiliary client (Claude via GCP)."""
+    try:
+        from agent.anthropic_adapter import build_vertex_client, resolve_vertex_credentials
+    except ImportError:
+        return None, None
+
+    project, region = resolve_vertex_credentials()
+    if not project:
+        return None, None
+
+    model = _API_KEY_PROVIDER_AUX_MODELS.get("vertex-ai", "claude-haiku-4-5")
+    logger.debug("Auxiliary client: Vertex AI (%s) project=%s region=%s", model, project, region)
+    real_client = build_vertex_client(project, region)
+    return AnthropicAuxiliaryClient(real_client, model, "", ""), model
+
 
 
 _AUTO_PROVIDER_LABELS = {
@@ -1464,6 +1485,14 @@ def resolve_provider_client(
                 logger.warning("resolve_provider_client: anthropic requested but no Anthropic credentials found")
                 return None, None
             final_model = _normalize_resolved_model(model or default_model, provider)
+            return (_to_async_client(client, final_model) if async_mode else (client, final_model))
+
+        if provider == "vertex-ai":
+            client, default_model = _try_vertex()
+            if client is None:
+                logger.warning("resolve_provider_client: vertex-ai requested but no GCP credentials found (set VERTEX_PROJECT)")
+                return None, None
+            final_model = model or default_model
             return (_to_async_client(client, final_model) if async_mode else (client, final_model))
 
         creds = resolve_api_key_provider_credentials(provider)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -174,6 +174,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url="https://api.anthropic.com",
         api_key_env_vars=("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"),
     ),
+    "vertex-ai": ProviderConfig(
+        id="vertex-ai",
+        name="Google Vertex AI (Claude)",
+        auth_type="api_key",
+        inference_base_url="",
+        api_key_env_vars=("VERTEX_PROJECT",),
+    ),
     "alibaba": ProviderConfig(
         id="alibaba",
         name="Alibaba Cloud (DashScope)",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -165,6 +165,8 @@ def _resolve_runtime_from_pool_entry(
         base_url = base_url or OPENROUTER_BASE_URL
     elif provider == "nous":
         api_mode = "chat_completions"
+    elif provider == "vertex-ai":
+        api_mode = "anthropic_messages"
     elif provider == "copilot":
         api_mode = _copilot_runtime_api_mode(model_cfg, getattr(entry, "runtime_api_key", ""))
     else:
@@ -740,6 +742,23 @@ def resolve_runtime_provider(
             "command": creds.get("command", ""),
             "args": list(creds.get("args") or []),
             "source": creds.get("source", "process"),
+            "requested_provider": requested_provider,
+        }
+
+    # Vertex AI (Claude via GCP)
+    if provider == "vertex-ai":
+        from agent.anthropic_adapter import resolve_vertex_credentials
+        project, region = resolve_vertex_credentials()
+        if not project:
+            raise AuthError(
+                "VERTEX_PROJECT env var required for vertex-ai provider"
+            )
+        return {
+            "provider": "vertex-ai",
+            "api_mode": "anthropic_messages",
+            "base_url": "",
+            "api_key": project,
+            "source": "VERTEX_PROJECT",
             "requested_provider": requested_provider,
         }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ pty = [
   "ptyprocess>=0.7.0,<1; sys_platform != 'win32'",
   "pywinpty>=2.0.0,<3; sys_platform == 'win32'",
 ]
+vertex = ["anthropic[vertex]>=0.39.0,<1"]
 honcho = ["honcho-ai>=2.0.1,<3"]
 mcp = ["mcp>=1.2.0,<2"]
 homeassistant = ["aiohttp>=3.9.0,<4"]
@@ -99,6 +100,7 @@ all = [
   "hermes-agent[slack]",
   "hermes-agent[pty]",
   "hermes-agent[honcho]",
+  "hermes-agent[vertex]",
   "hermes-agent[mcp]",
   "hermes-agent[homeassistant]",
   "hermes-agent[sms]",

--- a/run_agent.py
+++ b/run_agent.py
@@ -678,6 +678,8 @@ class AIAgent:
         elif (provider_name is None) and "chatgpt.com/backend-api/codex" in self._base_url_lower:
             self.api_mode = "codex_responses"
             self.provider = "openai-codex"
+        elif self.provider == "vertex-ai":
+            self.api_mode = "anthropic_messages"
         elif self.provider == "anthropic" or (provider_name is None and "api.anthropic.com" in self._base_url_lower):
             self.api_mode = "anthropic_messages"
             self.provider = "anthropic"
@@ -846,7 +848,21 @@ class AIAgent:
         self._anthropic_client = None
         self._is_anthropic_oauth = False
 
-        if self.api_mode == "anthropic_messages":
+        if self.api_mode == "anthropic_messages" and self.provider == "vertex-ai":
+            from agent.anthropic_adapter import build_vertex_client, resolve_vertex_credentials
+            project, region = resolve_vertex_credentials()
+            if not project:
+                raise ValueError("VERTEX_PROJECT environment variable is required for vertex-ai provider")
+            self._anthropic_client = build_vertex_client(project, region)
+            self._anthropic_api_key = ""
+            self._anthropic_base_url = ""
+            self._is_anthropic_oauth = False
+            self.client = None
+            self._client_kwargs = {}
+            if not self.quiet_mode:
+                print(f"🤖 AI Agent initialized with model: {self.model} (Vertex AI)")
+                print(f"☁️  GCP project: {project}, region: {region}")
+        elif self.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
             # Only fall back to ANTHROPIC_TOKEN when the provider is actually Anthropic.
             # Other anthropic_messages providers (MiniMax, Alibaba, etc.) must use their own API key.


### PR DESCRIPTION
## Summary

Adds `vertex-ai` as a first-class provider, enabling Claude models via Google Cloud Vertex AI with Application Default Credentials (ADC).

- Uses `AnthropicVertex` from `anthropic[vertex]` SDK
- Reuses the existing Anthropic Messages API adapter — zero new adapters needed
- Supports main agent, auxiliary tasks, compression, delegation, and credential pool routing

## Configuration

```yaml
provider: vertex-ai
model: claude-sonnet-4-6
```

```bash
# Environment
export VERTEX_PROJECT=my-gcp-project   # required
export VERTEX_REGION=us-east5           # optional, default: us-east5

# Auth (any of these):
# 1. Attached service account on GCP VMs (ADC) — zero config
# 2. GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json
# 3. gcloud auth application-default login (local dev)
```

## Changes

| File | Lines | What |
|------|-------|------|
| `agent/anthropic_adapter.py` | +52 | `build_vertex_client()` + `resolve_vertex_credentials()` |
| `agent/auxiliary_client.py` | +34 | `_try_vertex()`, auto-resolver guard, `resolve_provider_client` routing, aux model entry |
| `hermes_cli/auth.py` | +7 | Provider registry entry |
| `hermes_cli/runtime_provider.py` | +19 | Vertex-ai resolution + credential pool `api_mode` fix |
| `run_agent.py` | +18 | Provider detection + client init |
| `pyproject.toml` | +2 | `vertex` optional extra |

## What changed since v1

- Added `hermes_cli/runtime_provider.py` — vertex-ai resolution was missing, causing the credential pool to fall back to `chat_completions` and create an OpenAI client instead of `AnthropicVertex`
- Added credential pool `api_mode` fix in `_resolve_runtime_from_pool_entry()`
- Rebased onto current main (resolved `auxiliary_client.py` conflict from upstream's `_resolve_forced_provider` removal)

## Tested

Locally and on GCP with a Vertex AI service account using ADC.

## Install

```bash
pip install 'hermes-agent[vertex]'
```