### PR TITLE
fix(honcho): use placeholder API key for local instances that don't require auth

### DIFF
--- a/honcho_integration/client.py
+++ b/honcho_integration/client.py
@@ -417,9 +417,18 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
     else:
         logger.info("Initializing Honcho client (host: %s, workspace: %s)", config.host, config.workspace_id)
 
+    # Local Honcho instances don't require an API key.
+    # The SDK still expects a non-empty string, so use a placeholder.
+    _is_local = resolved_base_url and (
+        "localhost" in resolved_base_url
+        or "127.0.0.1" in resolved_base_url
+        or "::1" in resolved_base_url
+    )
+    effective_api_key = config.api_key or ("local" if _is_local else None)
+
     kwargs: dict = {
         "workspace_id": config.workspace_id,
-        "api_key": config.api_key,
+        "api_key": effective_api_key,
         "environment": config.environment,
     }
     if resolved_base_url:


### PR DESCRIPTION
Fixes #3555

## Problem
Local Honcho instances don't require an API key, but the Honcho SDK expects a non-empty string, causing "Invalid API key" errors.

## Fix vs #3560
PR #3560 adds a dummy key in __post_init__ (dataclass level). This PR applies the fix at the client initialization level in get_honcho_client(), where the URL context is available to detect local instances.

Detects localhost, 127.0.0.1, and ::1 as local. Uses "local" as placeholder key only when no real key is configured.
