### PR TITLE
fix(whatsapp): add **kwargs to media sending methods (salvage #3144)

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -526,6 +526,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
         image_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        **kwargs,
     ) -> SendResult:
         """Send a local image file natively via bridge."""
         return await self._send_media_to_bridge(chat_id, image_path, "image", caption)
@@ -536,6 +537,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
         video_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        **kwargs,
     ) -> SendResult:
         """Send a video natively via bridge — plays inline in WhatsApp."""
         return await self._send_media_to_bridge(chat_id, video_path, "video", caption)
@@ -547,6 +549,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
         reply_to: Optional[str] = None,
+        **kwargs,
     ) -> SendResult:
         """Send a document/file as a downloadable attachment via bridge."""
         return await self._send_media_to_bridge(


### PR DESCRIPTION
## Summary

The base orchestrator in `base.py` passes `metadata=_thread_metadata` to `send_image_file`, `send_video`, and `send_document`. WhatsApp was the only platform adapter missing this parameter, causing `TypeError: got an unexpected keyword argument 'metadata'` crashes when sending any media.

Extended the original PR's fix from just `send_image_file` to all three methods.

## Attribution

Cherry-picked from PR #3144 by @afifai, extended to cover `send_video` and `send_document`.

## Test plan

- 1607 gateway tests pass (0 failures)
- Verified all three methods accept `**kwargs` via signature inspection
- Compile clean