### PR TITLE
feat(api-server): add /v1/health alias for OpenAI compatibility

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1222,6 +1222,7 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app = web.Application(middlewares=mws)
             self._app["api_server_adapter"] = self
             self._app.router.add_get("/health", self._handle_health)
+            self._app.router.add_get("/v1/health", self._handle_health)
             self._app.router.add_get("/v1/models", self._handle_models)
             self._app.router.add_post("/v1/chat/completions", self._handle_chat_completions)
             self._app.router.add_post("/v1/responses", self._handle_responses)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -217,6 +217,7 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app = web.Application(middlewares=[cors_middleware])
     app["api_server_adapter"] = adapter
     app.router.add_get("/health", adapter._handle_health)
+    app.router.add_get("/v1/health", adapter._handle_health)
     app.router.add_get("/v1/models", adapter._handle_models)
     app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
     app.router.add_post("/v1/responses", adapter._handle_responses)
@@ -246,6 +247,17 @@ class TestHealthEndpoint:
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.get("/health")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["status"] == "ok"
+            assert data["platform"] == "hermes-agent"
+
+    @pytest.mark.asyncio
+    async def test_v1_health_alias_returns_ok(self, adapter):
+        """GET /v1/health should return the same response as /health."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/health")
             assert resp.status == 200
             data = await resp.json()
             assert data["status"] == "ok"


### PR DESCRIPTION
## Summary

Add `GET /v1/health` as an alias to the existing `/health` endpoint for OpenAI-compatible health checks.

Salvaged from #3515 by @aydnOktay — cherry-picked onto current main with authorship preserved, added regression test.

## Changes
- `gateway/platforms/api_server.py`: add `/v1/health` route pointing to the same handler
- `tests/gateway/test_api_server.py`: add `/v1/health` route to test helper + new test

## Test plan
```
python -m pytest tests/gateway/test_api_server.py -n0 -q  # 86 passed
```