### PR TITLE
fix(api-server): add CORS headers to streaming SSE responses

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -582,10 +582,14 @@ class APIServerAdapter(BasePlatformAdapter):
         """
         import queue as _q
 
-        response = web.StreamResponse(
-            status=200,
-            headers={"Content-Type": "text/event-stream", "Cache-Control": "no-cache"},
-        )
+        sse_headers = {"Content-Type": "text/event-stream", "Cache-Control": "no-cache"}
+        # CORS middleware can't inject headers into StreamResponse after
+        # prepare() flushes them, so resolve CORS headers up front.
+        origin = request.headers.get("Origin", "")
+        cors = self._cors_headers_for_origin(origin) if origin else None
+        if cors:
+            sse_headers.update(cors)
+        response = web.StreamResponse(status=200, headers=sse_headers)
         await response.prepare(request)
 
         try:


### PR DESCRIPTION
## Summary

The CORS middleware adds headers `after` the handler returns, but `StreamResponse` flushes headers on `prepare()` — so SSE streaming responses were missing all CORS headers. Browser clients hitting the streaming endpoint from a different origin would get blocked.

Improved over #3381's approach: instead of spreading the static `_CORS_HEADERS` (which lacks `Access-Control-Allow-Origin`), this calls `_cors_headers_for_origin()` to resolve the full dynamic CORS header set including the origin.

Salvaged from #3381 by @ygd58 with authorship preserved.

## Changes
- `gateway/platforms/api_server.py`: resolve CORS headers before `prepare()` on the SSE `StreamResponse`

## Test plan
```
python -m pytest tests/gateway/test_api_server.py -n0 -q  # 86 passed
```