### PR TITLE
fix(test): update streaming test to match PR #3566 behavior change

### DIFF
--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -362,9 +362,11 @@ class TestStreamingCallbacks:
 
         # Text before tool call IS fired (we don't know yet it will have tools)
         assert "thinking..." in deltas
-        # Text after tool call is NOT fired
-        assert " more text" not in deltas
-        # But content is still accumulated in the response
+        # Text after tool call IS still routed to stream_delta_callback so that
+        # reasoning tag extraction can fire (PR #3566).  Display-level suppression
+        # of non-reasoning text happens in the CLI's _stream_delta, not here.
+        assert " more text" in deltas
+        # Content is still accumulated in the response
         assert response.choices[0].message.content == "thinking... more text"
 
 


### PR DESCRIPTION
## Summary

PR #3566 intentionally changed the streaming behavior: content deltas are now routed to `stream_delta_callback` even when tool calls are present, so reasoning tag extraction can fire during streaming. The display-level suppression of non-reasoning text happens in the CLI's `_stream_delta`, not at the callback level.

The test `test_text_suppressed_when_tool_calls_present` was still asserting the old behavior where ` more text` was NOT in the callback deltas. Updated to match the new design.

## Test plan
- `pytest tests/test_streaming.py -q` — 19 passed
- Full suite: 6596 passed (only failures are integration tests excluded from CI)