### PR TITLE
fix: strip @botname suffix from Telegram slash commands (salvage #3550)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -333,7 +333,10 @@ class MessageEvent:
             return None
         # Split on space and get first word, strip the /
         parts = self.text.split(maxsplit=1)
-        return parts[0][1:].lower() if parts else None
+        raw = parts[0][1:].lower() if parts else None
+        if raw and "@" in raw:
+            raw = raw.split("@", 1)[0]
+        return raw
     
     def get_command_args(self) -> str:
         """Get the arguments after a command."""

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -62,6 +62,18 @@ class TestMessageEventGetCommand:
         event = MessageEvent(text="/")
         assert event.get_command() == ""
 
+    def test_command_with_at_botname(self):
+        event = MessageEvent(text="/new@TigerNanoBot")
+        assert event.get_command() == "new"
+
+    def test_command_with_at_botname_and_args(self):
+        event = MessageEvent(text="/compress@TigerNanoBot")
+        assert event.get_command() == "compress"
+
+    def test_command_mixed_case_with_at_botname(self):
+        event = MessageEvent(text="/RESET@TigerNanoBot")
+        assert event.get_command() == "reset"
+
 
 class TestMessageEventGetCommandArgs:
     def test_command_with_args(self):


### PR DESCRIPTION
## Summary

Telegram appends `@BotName` to slash commands in group chats (e.g. `/reset@TigerNanoBot`). `get_command()` returned `"reset@tigernanobot"` which didn't match any registered command, so commands were silently ignored in groups.

Fix: strip the `@...` suffix in `get_command()` via `split("@", 1)[0]`.

Cherry-picked from PR #3550 by @MacroAnarchy (authorship preserved). #3541 by @Kathie-yu is a duplicate of the same fix (submitted first, but without tests).

## Test plan
- `pytest tests/gateway/test_platform_base.py` — 56 passed (3 new test cases)