### PR TITLE
fix: add missing mattermost/matrix/dingtalk toolsets + platform consistency tests (salvage #3512)

### DIFF
--- a/hermes_cli/skills_config.py
+++ b/hermes_cli/skills_config.py
@@ -24,6 +24,9 @@ PLATFORMS = {
     "whatsapp": "📱 WhatsApp",
     "signal":   "📡 Signal",
     "email":    "📧 Email",
+    "mattermost": "💬 Mattermost",
+    "matrix":   "💬 Matrix",
+    "dingtalk": "💬 DingTalk",
 }
 
 # ─── Config Helpers ───────────────────────────────────────────────────────────

--- a/hermes_cli/skills_config.py
+++ b/hermes_cli/skills_config.py
@@ -24,6 +24,7 @@ PLATFORMS = {
     "whatsapp": "📱 WhatsApp",
     "signal":   "📡 Signal",
     "email":    "📧 Email",
+    "homeassistant": "🏠 Home Assistant",
     "mattermost": "💬 Mattermost",
     "matrix":   "💬 Matrix",
     "dingtalk": "💬 DingTalk",

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -138,6 +138,7 @@ PLATFORMS = {
     "matrix":   {"label": "💬 Matrix",     "default_toolset": "hermes-matrix"},
     "dingtalk": {"label": "💬 DingTalk",   "default_toolset": "hermes-dingtalk"},
     "api_server": {"label": "🌐 API Server", "default_toolset": "hermes-api-server"},
+    "mattermost": {"label": "💬 Mattermost", "default_toolset": "hermes-mattermost"},
 }
 
 

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -237,3 +237,53 @@ def test_save_platform_tools_still_preserves_mcp_with_platform_default_present()
 
     # Deselected configurable toolset removed
     assert "terminal" not in saved
+
+
+# ── Platform / toolset consistency ────────────────────────────────────────────
+
+
+class TestPlatformToolsetConsistency:
+    """Every platform in tools_config.PLATFORMS must have a matching toolset."""
+
+    def test_all_platforms_have_toolset_definitions(self):
+        """Each platform's default_toolset must exist in TOOLSETS."""
+        from hermes_cli.tools_config import PLATFORMS
+        from toolsets import TOOLSETS
+
+        for platform, meta in PLATFORMS.items():
+            ts_name = meta["default_toolset"]
+            assert ts_name in TOOLSETS, (
+                f"Platform {platform!r} references toolset {ts_name!r} "
+                f"which is not defined in toolsets.py"
+            )
+
+    def test_gateway_toolset_includes_all_messaging_platforms(self):
+        """hermes-gateway includes list should cover all messaging platforms."""
+        from hermes_cli.tools_config import PLATFORMS
+        from toolsets import TOOLSETS
+
+        gateway_includes = set(TOOLSETS["hermes-gateway"]["includes"])
+        # Exclude non-messaging platforms from the check
+        non_messaging = {"cli", "api_server"}
+        for platform, meta in PLATFORMS.items():
+            if platform in non_messaging:
+                continue
+            ts_name = meta["default_toolset"]
+            assert ts_name in gateway_includes, (
+                f"Platform {platform!r} toolset {ts_name!r} missing from "
+                f"hermes-gateway includes"
+            )
+
+    def test_skills_config_covers_tools_config_platforms(self):
+        """skills_config.PLATFORMS should have entries for all gateway platforms."""
+        from hermes_cli.tools_config import PLATFORMS as TOOLS_PLATFORMS
+        from hermes_cli.skills_config import PLATFORMS as SKILLS_PLATFORMS
+
+        non_messaging = {"api_server"}
+        for platform in TOOLS_PLATFORMS:
+            if platform in non_messaging:
+                continue
+            assert platform in SKILLS_PLATFORMS, (
+                f"Platform {platform!r} in tools_config but missing from "
+                f"skills_config PLATFORMS"
+            )

--- a/toolsets.py
+++ b/toolsets.py
@@ -333,6 +333,24 @@ TOOLSETS = {
         "includes": []
     },
 
+    "hermes-mattermost": {
+        "description": "Mattermost bot toolset - self-hosted team messaging (full access)",
+        "tools": _HERMES_CORE_TOOLS,
+        "includes": []
+    },
+
+    "hermes-matrix": {
+        "description": "Matrix bot toolset - decentralized encrypted messaging (full access)",
+        "tools": _HERMES_CORE_TOOLS,
+        "includes": []
+    },
+
+    "hermes-dingtalk": {
+        "description": "DingTalk bot toolset - enterprise messaging platform (full access)",
+        "tools": _HERMES_CORE_TOOLS,
+        "includes": []
+    },
+
     "hermes-sms": {
         "description": "SMS bot toolset - interact with Hermes via SMS (Twilio)",
         "tools": _HERMES_CORE_TOOLS,
@@ -342,7 +360,7 @@ TOOLSETS = {
     "hermes-gateway": {
         "description": "Gateway toolset - union of all messaging platform tools",
         "tools": [],
-        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-homeassistant", "hermes-email", "hermes-sms"]
+        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk"]
     }
 }
 


### PR DESCRIPTION
## Summary

Mattermost users crash with `KeyError` on every message because `"mattermost"` was missing from `tools_config.py` PLATFORMS. Matrix and dingtalk had PLATFORMS entries but no toolset definitions in `toolsets.py`, and all three were missing from `skills_config.py`.

Cherry-picked from PR #3512 by @MPavleski (authorship preserved).

### Follow-up additions:
- Added `homeassistant` to `skills_config.py` PLATFORMS (was in tools_config but missing from skills_config)
- Added 3 consistency tests that cross-check all platforms have matching toolset definitions, gateway includes, and skills_config entries — prevents this class of bug from recurring

## Test plan
- `pytest tests/hermes_cli/test_tools_config.py` — 15 passed (3 new)