### PR TITLE
fix: write models.dev disk cache atomically

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -15,6 +15,8 @@ import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from utils import atomic_json_write
+
 import requests
 
 logger = logging.getLogger(__name__)
@@ -64,12 +66,10 @@ def _load_disk_cache() -> Dict[str, Any]:
 
 
 def _save_disk_cache(data: Dict[str, Any]) -> None:
-    """Save models.dev data to disk cache."""
+    """Save models.dev data to disk cache atomically."""
     try:
         cache_path = _get_cache_path()
-        cache_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(cache_path, "w", encoding="utf-8") as f:
-            json.dump(data, f, separators=(",", ":"))
+        atomic_json_write(cache_path, data, indent=None, separators=(",", ":"))
     except Exception as e:
         logger.debug("Failed to save models.dev disk cache: %s", e)
 


### PR DESCRIPTION
Salvage of #3429 by @memosr — uses the existing `atomic_json_write()` utility from `utils.py` instead of hand-rolling the same tempfile + fsync + os.replace pattern inline.

## What changed

`_save_disk_cache()` in `agent/models_dev.py` now calls `atomic_json_write()` instead of plain `open()`/`json.dump()`. Prevents corrupted cache JSON if the process is killed mid-write — `_load_disk_cache()` silently returns `{}` on corrupt JSON, losing all model metadata (context lengths, pricing, provider info) until the next successful API fetch.

## Changes

- `agent/models_dev.py`: Import `atomic_json_write`, replace 4 lines with 1-line call

## Tests

- 19 models_dev tests pass
- 89 atomic_json_write + model_metadata tests pass