### PR TITLE
fix(telegram): honor proxy env vars in fallback transport (salvage #3411)

### DIFF
--- a/gateway/platforms/telegram_network.py
+++ b/gateway/platforms/telegram_network.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import ipaddress
 import logging
+import os
 import socket
 from typing import Iterable, Optional
 
@@ -43,6 +44,14 @@ _DOH_PROVIDERS: list[dict] = [
 _SEED_FALLBACK_IPS: list[str] = ["149.154.167.220"]
 
 
+def _resolve_proxy_url() -> str | None:
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY", "https_proxy", "http_proxy", "all_proxy"):
+        value = (os.environ.get(key) or "").strip()
+        if value:
+            return value
+    return None
+
+
 class TelegramFallbackTransport(httpx.AsyncBaseTransport):
     """Retry Telegram Bot API requests via fallback IPs while preserving TLS/SNI.
 
@@ -54,6 +63,9 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
 
     def __init__(self, fallback_ips: Iterable[str], **transport_kwargs):
         self._fallback_ips = [ip for ip in dict.fromkeys(_normalize_fallback_ips(fallback_ips))]
+        proxy_url = _resolve_proxy_url()
+        if proxy_url and "proxy" not in transport_kwargs:
+            transport_kwargs["proxy"] = proxy_url
         self._primary = httpx.AsyncHTTPTransport(**transport_kwargs)
         self._fallbacks = {
             ip: httpx.AsyncHTTPTransport(**transport_kwargs) for ip in self._fallback_ips

--- a/tests/gateway/test_telegram_network.py
+++ b/tests/gateway/test_telegram_network.py
@@ -315,6 +315,24 @@ class TestFallbackTransportInit:
         transport = tnet.TelegramFallbackTransport(["149.154.167.220", "not-an-ip"])
         assert transport._fallback_ips == ["149.154.167.220"]
 
+    def test_uses_proxy_env_for_primary_and_fallback_transports(self, monkeypatch):
+        seen_kwargs = []
+
+        def factory(**kwargs):
+            seen_kwargs.append(kwargs.copy())
+            return FakeTransport([], {})
+
+        for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY", "https_proxy", "http_proxy", "all_proxy"):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:8080")
+        monkeypatch.setattr(tnet.httpx, "AsyncHTTPTransport", factory)
+
+        transport = tnet.TelegramFallbackTransport(["149.154.167.220"])
+
+        assert transport._fallback_ips == ["149.154.167.220"]
+        assert len(seen_kwargs) == 2
+        assert all(kwargs["proxy"] == "http://proxy.example:8080" for kwargs in seen_kwargs)
+
 
 class TestFallbackTransportClose:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Salvage of #3411 by kufufu9. Cherry-picked onto current main with authorship preserved.

Makes `TelegramFallbackTransport` read standard proxy env vars (`HTTPS_PROXY`, `HTTP_PROXY`, `ALL_PROXY`) and pass them to the underlying `httpx.AsyncHTTPTransport` instances. Without this, users behind corporate proxies can't reach Telegram through our custom transport — httpx only auto-resolves proxy env vars at the `AsyncClient` level, not the transport level.

No-op when proxy env vars aren't set.

## Changes
- New `_resolve_proxy_url()` helper reads proxy env vars in standard precedence order
- Injects `proxy=url` into transport kwargs (respects explicit caller overrides)
- Test verifies both primary and fallback transports receive the proxy

## Credit
Original work by @kufufu9 in #3411.