### PR TITLE
fix: add self-termination guard for pkill/killall targeting hermes/gateway

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -512,6 +512,30 @@ class TestGatewayProtection:
         dangerous, key, desc = detect_dangerous_command(cmd)
         assert dangerous is False
 
+    def test_pkill_hermes_detected(self):
+        """pkill targeting hermes/gateway processes must be caught."""
+        cmd = 'pkill -f "cli.py --gateway"'
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
+    def test_killall_hermes_detected(self):
+        cmd = "killall hermes"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
+    def test_pkill_gateway_detected(self):
+        cmd = "pkill -f gateway"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+
+    def test_pkill_unrelated_not_flagged(self):
+        """pkill targeting unrelated processes should not be flagged."""
+        cmd = "pkill -f nginx"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is False
+
 
 class TestNormalizationBypass:
     """Obfuscation techniques must not bypass dangerous command detection."""

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -53,6 +53,8 @@ DANGEROUS_PATTERNS = [
     # Gateway protection: never start gateway outside systemd management
     (r'gateway\s+run\b.*(&\s*$|&\s*;|\bdisown\b|\bsetsid\b)', "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')"),
     (r'\bnohup\b.*gateway\s+run\b', "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')"),
+    # Self-termination protection: prevent agent from killing its own process
+    (r'\b(pkill|killall)\b.*\b(hermes|gateway|cli\.py)\b', "kill hermes/gateway process (self-termination)"),
 ]
 
 


### PR DESCRIPTION
## Summary

Prevent the agent from accidentally killing its own process with `pkill -f gateway`, `killall hermes`, `pkill -f "cli.py --gateway"`, etc. Adds a dangerous command pattern to `DANGEROUS_PATTERNS` that triggers the approval flow before execution.

Salvaged from #3400 by @arasovic with authorship preserved. #3402 is a duplicate (3 lines, no tests) — should be closed.

## Changes
- `tools/approval.py`: add self-termination regex pattern
- `tests/tools/test_approval.py`: 4 tests (pkill hermes, killall hermes, pkill gateway, pkill unrelated not flagged)

## Test plan
```
python -m pytest tests/tools/test_approval.py -n0 -q  # 91 passed
```