### PR TITLE
fix(config): preserve raw user config across updates

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1082,33 +1082,41 @@ def save_config_value(key_path: str, value: any) -> bool:
     try:
         # Ensure parent directory exists (for ~/.hermes/config.yaml on first use)
         config_path.parent.mkdir(parents=True, exist_ok=True)
-        
-        # Load existing config
-        if config_path.exists():
-            with open(config_path, 'r') as f:
-                config = yaml.safe_load(f) or {}
+
+        if config_path == user_config_path:
+            from hermes_cli.config import load_raw_config, save_raw_config
+
+            config = load_raw_config(config_path=config_path)
+            keys = key_path.split('.')
+            current = config
+            for key in keys[:-1]:
+                if key not in current or not isinstance(current[key], dict):
+                    current[key] = {}
+                current = current[key]
+            current[keys[-1]] = value
+            save_raw_config(config, config_path=config_path)
         else:
-            config = {}
-        
-        # Navigate to the key and set value
-        keys = key_path.split('.')
-        current = config
-        for key in keys[:-1]:
-            if key not in current or not isinstance(current[key], dict):
-                current[key] = {}
-            current = current[key]
-        current[keys[-1]] = value
-        
-        # Save back atomically — write to temp file + fsync + os.replace
-        # so an interrupt never leaves config.yaml truncated or empty.
-        from utils import atomic_yaml_write
-        atomic_yaml_write(config_path, config)
-        
-        # Enforce owner-only permissions on config files (contain API keys)
-        try:
-            os.chmod(config_path, 0o600)
-        except (OSError, NotImplementedError):
-            pass
+            if config_path.exists():
+                with open(config_path, 'r') as f:
+                    config = yaml.safe_load(f) or {}
+            else:
+                config = {}
+
+            keys = key_path.split('.')
+            current = config
+            for key in keys[:-1]:
+                if key not in current or not isinstance(current[key], dict):
+                    current[key] = {}
+                current = current[key]
+            current[keys[-1]] = value
+
+            from utils import atomic_yaml_write
+            atomic_yaml_write(config_path, config)
+
+            try:
+                os.chmod(config_path, 0o600)
+            except (OSError, NotImplementedError):
+                pass
         
         return True
     except Exception as e:

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -358,9 +358,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 logger.warning("[%s] Config file not found at %s, cannot persist thread_id", self.name, config_path)
                 return
 
-            import yaml as _yaml
-            with open(config_path, "r") as f:
-                config = _yaml.safe_load(f) or {}
+            from hermes_cli.config import load_raw_config, save_user_config
+            config = load_raw_config(config_path=config_path)
 
             # Navigate to platforms.telegram.extra.dm_topics
             dm_topics = (
@@ -383,8 +382,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         break
 
             if changed:
-                with open(config_path, "w") as f:
-                    _yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+                save_user_config(config, config_path=config_path)
                 logger.info(
                     "[%s] Persisted thread_id=%s for topic '%s' in config.yaml",
                     self.name, thread_id, topic_name,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -417,6 +417,42 @@ def _load_gateway_config() -> dict:
     return {}
 
 
+def _load_gateway_raw_config() -> dict:
+    """Load the raw gateway config.yaml without merging defaults."""
+    try:
+        from hermes_cli.config import load_raw_config
+
+        return load_raw_config(config_path=_hermes_home / "config.yaml")
+    except Exception:
+        logger.debug("Could not load raw gateway config from %s", _hermes_home / "config.yaml")
+        return {}
+
+
+def _save_gateway_user_config(config: dict) -> None:
+    """Save raw gateway config through the shared user-config writer."""
+    from hermes_cli.config import save_user_config
+
+    save_user_config(config, config_path=_hermes_home / "config.yaml")
+
+
+def _save_gateway_config_key(key_path: str, value) -> bool:
+    """Save a dot-separated key to gateway config using the shared writer."""
+    try:
+        user_config = _load_gateway_raw_config()
+        keys = key_path.split(".")
+        current = user_config
+        for key in keys[:-1]:
+            if key not in current or not isinstance(current.get(key), dict):
+                current[key] = {}
+            current = current[key]
+        current[keys[-1]] = value
+        _save_gateway_user_config(user_config)
+        return True
+    except Exception as e:
+        logger.error("Failed to save config key %s: %s", key_path, e)
+        return False
+
+
 def _resolve_gateway_model(config: dict | None = None) -> str:
     """Read model from config.yaml — single source of truth.
 
@@ -3658,19 +3694,11 @@ class GatewayRunner:
     
     async def _handle_personality_command(self, event: MessageEvent) -> str:
         """Handle /personality command - list or set a personality."""
-        import yaml
-
         args = event.get_command_args().strip().lower()
-        config_path = _hermes_home / 'config.yaml'
 
         try:
-            if config_path.exists():
-                with open(config_path, 'r', encoding="utf-8") as f:
-                    config = yaml.safe_load(f) or {}
-                personalities = config.get("agent", {}).get("personalities", {})
-            else:
-                config = {}
-                personalities = {}
+            config = _load_gateway_raw_config()
+            personalities = config.get("agent", {}).get("personalities", {})
         except Exception:
             config = {}
             personalities = {}
@@ -3702,10 +3730,8 @@ class GatewayRunner:
 
         if args in ("none", "default", "neutral"):
             try:
-                if "agent" not in config or not isinstance(config.get("agent"), dict):
-                    config["agent"] = {}
-                config["agent"]["system_prompt"] = ""
-                atomic_yaml_write(config_path, config)
+                if not _save_gateway_config_key("agent.system_prompt", ""):
+                    raise RuntimeError("could not save config")
             except Exception as e:
                 return f"⚠️ Failed to save personality change: {e}"
             self._ephemeral_system_prompt = ""
@@ -3713,12 +3739,9 @@ class GatewayRunner:
         elif args in personalities:
             new_prompt = _resolve_prompt(personalities[args])
 
-            # Write to config.yaml, same pattern as CLI save_config_value.
             try:
-                if "agent" not in config or not isinstance(config.get("agent"), dict):
-                    config["agent"] = {}
-                config["agent"]["system_prompt"] = new_prompt
-                atomic_yaml_write(config_path, config)
+                if not _save_gateway_config_key("agent.system_prompt", new_prompt):
+                    raise RuntimeError("could not save config")
             except Exception as e:
                 return f"⚠️ Failed to save personality change: {e}"
 
@@ -3799,16 +3822,9 @@ class GatewayRunner:
         
         env_key = f"{platform_name.upper()}_HOME_CHANNEL"
         
-        # Save to config.yaml
         try:
-            import yaml
-            config_path = _hermes_home / 'config.yaml'
-            user_config = {}
-            if config_path.exists():
-                with open(config_path, encoding="utf-8") as f:
-                    user_config = yaml.safe_load(f) or {}
-            user_config[env_key] = chat_id
-            atomic_yaml_write(config_path, user_config)
+            if not _save_gateway_config_key(env_key, chat_id):
+                raise RuntimeError("could not save config")
             # Also set in the current environment so it takes effect immediately
             os.environ[env_key] = str(chat_id)
         except Exception as e:
@@ -4615,32 +4631,9 @@ class GatewayRunner:
             /reasoning show|on      Show model reasoning in responses
             /reasoning hide|off     Hide model reasoning from responses
         """
-        import yaml
-
         args = event.get_command_args().strip().lower()
-        config_path = _hermes_home / "config.yaml"
         self._reasoning_config = self._load_reasoning_config()
         self._show_reasoning = self._load_show_reasoning()
-
-        def _save_config_key(key_path: str, value):
-            """Save a dot-separated key to config.yaml."""
-            try:
-                user_config = {}
-                if config_path.exists():
-                    with open(config_path, encoding="utf-8") as f:
-                        user_config = yaml.safe_load(f) or {}
-                keys = key_path.split(".")
-                current = user_config
-                for k in keys[:-1]:
-                    if k not in current or not isinstance(current[k], dict):
-                        current[k] = {}
-                    current = current[k]
-                current[keys[-1]] = value
-                atomic_yaml_write(config_path, user_config)
-                return True
-            except Exception as e:
-                logger.error("Failed to save config key %s: %s", key_path, e)
-                return False
 
         if not args:
             # Show current state
@@ -4662,12 +4655,12 @@ class GatewayRunner:
         # Display toggle
         if args in ("show", "on"):
             self._show_reasoning = True
-            _save_config_key("display.show_reasoning", True)
+            _save_gateway_config_key("display.show_reasoning", True)
             return "🧠 ✓ Reasoning display: **ON**\nModel thinking will be shown before each response."
 
         if args in ("hide", "off"):
             self._show_reasoning = False
-            _save_config_key("display.show_reasoning", False)
+            _save_gateway_config_key("display.show_reasoning", False)
             return "🧠 ✓ Reasoning display: **OFF**"
 
         # Effort level change
@@ -4684,7 +4677,7 @@ class GatewayRunner:
             )
 
         self._reasoning_config = parsed
-        if _save_config_key("agent.reasoning_effort", effort):
+        if _save_gateway_config_key("agent.reasoning_effort", effort):
             return f"🧠 ✓ Reasoning effort set to `{effort}` (saved to config)\n_(takes effect on next message)_"
         else:
             return f"🧠 ✓ Reasoning effort set to `{effort}` (this session only)"
@@ -4706,16 +4699,9 @@ class GatewayRunner:
         When enabled, cycles the tool progress mode through off → new → all →
         verbose → off, same as the CLI.
         """
-        import yaml
-
-        config_path = _hermes_home / "config.yaml"
-
         # --- check config gate ------------------------------------------------
         try:
-            user_config = {}
-            if config_path.exists():
-                with open(config_path, encoding="utf-8") as f:
-                    user_config = yaml.safe_load(f) or {}
+            user_config = _load_gateway_raw_config()
             gate_enabled = user_config.get("display", {}).get("tool_progress_command", False)
         except Exception:
             gate_enabled = False
@@ -4749,12 +4735,9 @@ class GatewayRunner:
         idx = (cycle.index(current) + 1) % len(cycle)
         new_mode = cycle[idx]
 
-        # Save to config.yaml
         try:
-            if "display" not in user_config or not isinstance(user_config.get("display"), dict):
-                user_config["display"] = {}
-            user_config["display"]["tool_progress"] = new_mode
-            atomic_yaml_write(config_path, user_config)
+            if not _save_gateway_config_key("display.tool_progress", new_mode):
+                raise RuntimeError("could not save config")
             return f"{descriptions[new_mode]}\n_(saved to config — takes effect on next message)_"
         except Exception as e:
             logger.warning("Failed to save tool_progress mode: %s", e)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -35,9 +35,12 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import httpx
-import yaml
-
-from hermes_cli.config import get_hermes_home, get_config_path
+from hermes_cli.config import (
+    get_hermes_home,
+    get_config_path,
+    load_raw_config,
+    save_user_config,
+)
 from hermes_constants import OPENROUTER_BASE_URL
 
 logger = logging.getLogger(__name__)
@@ -2111,15 +2114,7 @@ def _update_config_for_provider(
     # Update config.yaml model section
     config_path = get_config_path()
     config_path.parent.mkdir(parents=True, exist_ok=True)
-
-    config: Dict[str, Any] = {}
-    if config_path.exists():
-        try:
-            loaded = yaml.safe_load(config_path.read_text()) or {}
-            if isinstance(loaded, dict):
-                config = loaded
-        except Exception:
-            config = {}
+    config = load_raw_config()
 
     current_model = config.get("model")
     if isinstance(current_model, dict):
@@ -2146,7 +2141,7 @@ def _update_config_for_provider(
 
     config["model"] = model_cfg
 
-    config_path.write_text(yaml.safe_dump(config, sort_keys=False))
+    save_user_config(config)
     return config_path
 
 
@@ -2156,20 +2151,14 @@ def _reset_config_provider() -> Path:
     if not config_path.exists():
         return config_path
 
-    try:
-        config = yaml.safe_load(config_path.read_text()) or {}
-    except Exception:
-        return config_path
-
-    if not isinstance(config, dict):
-        return config_path
+    config = load_raw_config()
 
     model = config.get("model")
     if isinstance(model, dict):
         model["provider"] = "auto"
         if "base_url" in model:
             model["base_url"] = OPENROUTER_BASE_URL
-    config_path.write_text(yaml.safe_dump(config, sort_keys=False))
+    save_user_config(config)
     return config_path
 
 
@@ -2313,7 +2302,7 @@ def _save_model_choice(model_id: str) -> None:
     The model is stored in config.yaml only — NOT in .env.  This avoids
     conflicts in multi-agent setups where env vars would stomp each other.
     """
-    from hermes_cli.config import save_config, load_config
+    from hermes_cli.config import load_config, save_user_config
 
     config = load_config()
     # Always use dict format so provider/base_url can be stored alongside
@@ -2321,7 +2310,7 @@ def _save_model_choice(model_id: str) -> None:
         config["model"]["default"] = model_id
     else:
         config["model"] = {"default": model_id}
-    save_config(config)
+    save_user_config(config)
 
 
 def login_command(args) -> None:

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -464,14 +464,14 @@ def _interactive_strategy() -> None:
         print("Invalid choice.")
         return
 
-    from hermes_cli.config import load_config, save_config
-    cfg = load_config()
+    from hermes_cli.config import load_raw_config, save_user_config
+    cfg = load_raw_config()
     pool_strategies = cfg.get("credential_pool_strategies") or {}
     if not isinstance(pool_strategies, dict):
         pool_strategies = {}
     pool_strategies[provider] = strategy
     cfg["credential_pool_strategies"] = pool_strategies
-    save_config(cfg)
+    save_user_config(cfg)
     print(f"Set {provider} strategy to: {strategy}")
 
 

--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -15,7 +15,7 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
-from hermes_cli.config import get_hermes_home, get_config_path, load_config, save_config
+from hermes_cli.config import get_hermes_home, get_config_path, load_config, save_user_config
 from hermes_constants import get_optional_skills_dir
 from hermes_cli.setup import (
     Colors,
@@ -262,7 +262,7 @@ def _cmd_migrate(args):
     # Ensure config.yaml exists before migration tries to read it
     config_path = get_config_path()
     if not config_path.exists():
-        save_config(load_config())
+        save_user_config(load_config())
 
     # Load and run the migration
     try:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -20,6 +20,7 @@ import subprocess
 import sys
 import tempfile
 from dataclasses import dataclass
+import copy
 from pathlib import Path
 from typing import Dict, Any, Optional, List, Tuple
 
@@ -1463,7 +1464,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
                 display["tool_progress"] = "all"
                 results["config_added"].append("display.tool_progress=all (default)")
             config["display"] = display
-            save_config(config)
+            save_user_config(config)
             if not quiet:
                 print(f"  ✓ Migrated tool progress to config.yaml: {display['tool_progress']}")
     
@@ -1478,7 +1479,7 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             else:
                 config["timezone"] = ""
                 results["config_added"].append("timezone= (empty, uses server-local)")
-            save_config(config)
+            save_user_config(config)
             if not quiet:
                 tz_display = config["timezone"] or "(server-local)"
                 print(f"  ✓ Added timezone to config.yaml: {tz_display}")
@@ -1657,12 +1658,12 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
         
         # Update version and save
         config["_config_version"] = latest_ver
-        save_config(config)
+        save_user_config(config)
     elif current_ver < latest_ver:
         # Just update version
         config = load_config()
         config["_config_version"] = latest_ver
-        save_config(config)
+        save_user_config(config)
     
     return results
 
@@ -1753,30 +1754,144 @@ def _normalize_max_turns_config(config: Dict[str, Any]) -> Dict[str, Any]:
     return config
 
 
+def load_raw_config(config_path: Optional[Path] = None) -> Dict[str, Any]:
+    """Load the user-authored config.yaml without merging defaults."""
+    ensure_hermes_home()
+    config_path = config_path or get_config_path()
+
+    if not config_path.exists():
+        return {}
+
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            loaded = yaml.safe_load(f) or {}
+        return loaded if isinstance(loaded, dict) else {}
+    except Exception as e:
+        print(f"Warning: Failed to load config: {e}")
+        return {}
+
+
+def _prune_default_values(current, defaults):
+    """Return only values that differ from defaults, preserving unknown keys."""
+    if isinstance(current, dict) and isinstance(defaults, dict):
+        pruned = {}
+        for key, value in current.items():
+            if key == "_config_version":
+                pruned[key] = value
+                continue
+            if key not in defaults:
+                pruned[key] = value
+                continue
+            default_value = defaults[key]
+            if isinstance(value, dict) and isinstance(default_value, dict):
+                nested = _prune_default_values(value, default_value)
+                if nested:
+                    pruned[key] = nested
+            elif value != default_value:
+                pruned[key] = value
+        return pruned
+    return current if current != defaults else None
+
+
+def _preserve_raw_existing_values(
+    desired: Any,
+    raw_existing: Any,
+    expanded_existing: Any,
+) -> Any:
+    """Preserve raw user-authored values when the effective value is unchanged.
+
+    This keeps placeholders like ``${GLM_API_KEY}`` intact on disk even when a
+    caller mutates an env-expanded config object returned by ``load_config()``.
+    """
+    if desired == expanded_existing:
+        return copy.deepcopy(raw_existing)
+
+    if (
+        isinstance(desired, dict)
+        and isinstance(raw_existing, dict)
+        and isinstance(expanded_existing, dict)
+    ):
+        preserved = {}
+        for key, value in desired.items():
+            if key in raw_existing and key in expanded_existing:
+                preserved[key] = _preserve_raw_existing_values(
+                    value,
+                    raw_existing[key],
+                    expanded_existing[key],
+                )
+            else:
+                preserved[key] = value
+        return preserved
+
+    if (
+        isinstance(desired, list)
+        and isinstance(raw_existing, list)
+        and isinstance(expanded_existing, list)
+        and len(desired) == len(raw_existing) == len(expanded_existing)
+    ):
+        return [
+            _preserve_raw_existing_values(value, raw_existing[i], expanded_existing[i])
+            for i, value in enumerate(desired)
+        ]
+
+    return desired
+
+
+def _commented_config_sections(normalized: Dict[str, Any]) -> Optional[str]:
+    """Return optional commented config sections to append to the YAML file."""
+    parts = []
+    sec = normalized.get("security", {})
+    if not sec or sec.get("redact_secrets") is None:
+        parts.append(_SECURITY_COMMENT)
+    fb = normalized.get("fallback_model", {})
+    if not fb or not (fb.get("provider") and fb.get("model")):
+        parts.append(_FALLBACK_COMMENT)
+    return "".join(parts) if parts else None
+
+
+def _write_config_yaml(
+    config: Dict[str, Any],
+    *,
+    commented_from: Optional[Dict[str, Any]] = None,
+    config_path: Optional[Path] = None,
+) -> None:
+    """Write a config mapping to ~/.hermes/config.yaml with standard comments."""
+    if is_managed():
+        managed_error("save configuration")
+        return
+    from utils import atomic_yaml_write
+
+    ensure_hermes_home()
+    config_path = config_path or get_config_path()
+    normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
+    comment_source = _normalize_root_model_keys(
+        _normalize_max_turns_config(commented_from or config)
+    )
+
+    atomic_yaml_write(
+        config_path,
+        normalized,
+        extra_content=_commented_config_sections(comment_source),
+    )
+    _secure_file(config_path)
+
+
 
 def load_config() -> Dict[str, Any]:
     """Load configuration from ~/.hermes/config.yaml."""
     import copy
-    ensure_hermes_home()
-    config_path = get_config_path()
     
     config = copy.deepcopy(DEFAULT_CONFIG)
-    
-    if config_path.exists():
-        try:
-            with open(config_path, encoding="utf-8") as f:
-                user_config = yaml.safe_load(f) or {}
 
-            if "max_turns" in user_config:
-                agent_user_config = dict(user_config.get("agent") or {})
-                if agent_user_config.get("max_turns") is None:
-                    agent_user_config["max_turns"] = user_config["max_turns"]
-                user_config["agent"] = agent_user_config
-                user_config.pop("max_turns", None)
+    user_config = load_raw_config()
+    if "max_turns" in user_config:
+        agent_user_config = dict(user_config.get("agent") or {})
+        if agent_user_config.get("max_turns") is None:
+            agent_user_config["max_turns"] = user_config["max_turns"]
+        user_config["agent"] = agent_user_config
+        user_config.pop("max_turns", None)
 
-            config = _deep_merge(config, user_config)
-        except Exception as e:
-            print(f"Warning: Failed to load config: {e}")
+    config = _deep_merge(config, user_config)
     
     return _expand_env_vars(_normalize_root_model_keys(_normalize_max_turns_config(config)))
 
@@ -1876,33 +1991,28 @@ _COMMENTED_SECTIONS = """
 """
 
 
-def save_config(config: Dict[str, Any]):
+def save_config(config: Dict[str, Any], *, config_path: Optional[Path] = None):
     """Save configuration to ~/.hermes/config.yaml."""
-    if is_managed():
-        managed_error("save configuration")
-        return
-    from utils import atomic_yaml_write
+    _write_config_yaml(config, config_path=config_path)
 
-    ensure_hermes_home()
-    config_path = get_config_path()
+def save_raw_config(config: Dict[str, Any], *, config_path: Optional[Path] = None) -> None:
+    """Save raw user config without default pruning, but with standard formatting."""
+    _write_config_yaml(config, commented_from=config, config_path=config_path)
+
+def save_user_config(config: Dict[str, Any], *, config_path: Optional[Path] = None):
+    """Save only user-authored overrides to ~/.hermes/config.yaml."""
     normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
-
-    # Build optional commented-out sections for features that are off by
-    # default or only relevant when explicitly configured.
-    parts = []
-    sec = normalized.get("security", {})
-    if not sec or sec.get("redact_secrets") is None:
-        parts.append(_SECURITY_COMMENT)
-    fb = normalized.get("fallback_model", {})
-    if not fb or not (fb.get("provider") and fb.get("model")):
-        parts.append(_FALLBACK_COMMENT)
-
-    atomic_yaml_write(
-        config_path,
-        normalized,
-        extra_content="".join(parts) if parts else None,
+    raw_existing = _normalize_root_model_keys(
+        _normalize_max_turns_config(load_raw_config(config_path=config_path))
     )
-    _secure_file(config_path)
+    expanded_existing = _expand_env_vars(copy.deepcopy(raw_existing))
+    preserved = _preserve_raw_existing_values(
+        normalized,
+        raw_existing,
+        expanded_existing,
+    )
+    user_config = _prune_default_values(preserved, DEFAULT_CONFIG) or {}
+    _write_config_yaml(user_config, commented_from=preserved, config_path=config_path)
 
 
 def load_env() -> Dict[str, str]:
@@ -2334,7 +2444,7 @@ def edit_config():
     
     # Ensure config exists
     if not config_path.exists():
-        save_config(DEFAULT_CONFIG)
+        save_user_config(load_config())
         print(f"Created {config_path}")
     
     # Find editor
@@ -2381,17 +2491,10 @@ def set_config_value(key: str, value: str):
         print(f"✓ Set {key} in {get_env_path()}")
         return
     
-    # Otherwise it goes to config.yaml
-    # Read the raw user config (not merged with defaults) to avoid
-    # dumping all default values back to the file
+    # Otherwise it goes to config.yaml. Preserve the exact raw file shape for
+    # explicit CLI edits, including default-valued keys like model="".
     config_path = get_config_path()
-    user_config = {}
-    if config_path.exists():
-        try:
-            with open(config_path, encoding="utf-8") as f:
-                user_config = yaml.safe_load(f) or {}
-        except Exception:
-            user_config = {}
+    user_config = load_raw_config(config_path=config_path)
     
     # Handle nested keys (e.g., "tts.provider")
     parts = key.split('.')
@@ -2414,10 +2517,7 @@ def set_config_value(key: str, value: str):
     
     current[parts[-1]] = value
     
-    # Write only user config back (not the full merged defaults)
-    ensure_hermes_home()
-    with open(config_path, 'w', encoding="utf-8") as f:
-        yaml.dump(user_config, f, default_flow_style=False, sort_keys=False)
+    save_raw_config(user_config, config_path=config_path)
     
     # Keep .env in sync for keys that terminal_tool reads directly from env vars.
     # config.yaml is authoritative, but terminal_tool only reads TERMINAL_ENV etc.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1099,7 +1099,7 @@ def _model_flow_openrouter(config, current_model=""):
         _save_model_choice(selected)
 
         # Update config provider and deactivate any OAuth provider
-        from hermes_cli.config import load_config, save_config
+        from hermes_cli.config import load_config, save_user_config as save_config
         cfg = load_config()
         model = cfg.get("model")
         if not isinstance(model, dict):
@@ -1123,7 +1123,7 @@ def _model_flow_nous(config, current_model="", args=None):
         fetch_nous_models, AuthError, format_auth_error,
         _login_nous, PROVIDER_REGISTRY,
     )
-    from hermes_cli.config import get_env_value, save_config, save_env_value
+    from hermes_cli.config import get_env_value, save_user_config as save_config, save_env_value
     from hermes_cli.nous_subscription import (
         apply_nous_provider_defaults,
         get_nous_subscription_explainer_lines,
@@ -1286,7 +1286,12 @@ def _model_flow_custom(config):
     so it appears in the provider menu on subsequent runs.
     """
     from hermes_cli.auth import _save_model_choice, deactivate_provider
-    from hermes_cli.config import get_env_value, save_env_value, load_config, save_config
+    from hermes_cli.config import (
+        get_env_value,
+        save_env_value,
+        load_config,
+        save_user_config as save_config,
+    )
 
     current_url = get_env_value("OPENAI_BASE_URL") or ""
     current_key = get_env_value("OPENAI_API_KEY") or ""
@@ -1430,7 +1435,7 @@ def _save_custom_provider(base_url, api_key="", model="", context_length=None):
     model name and context_length but doesn't add a duplicate entry.
     Auto-generates a display name from the URL hostname.
     """
-    from hermes_cli.config import load_config, save_config
+    from hermes_cli.config import load_config, save_user_config as save_config
 
     cfg = load_config()
     providers = cfg.get("custom_providers") or []
@@ -1487,7 +1492,7 @@ def _save_custom_provider(base_url, api_key="", model="", context_length=None):
 
 def _remove_custom_provider(config):
     """Let the user remove a saved custom provider from config.yaml."""
-    from hermes_cli.config import load_config, save_config
+    from hermes_cli.config import load_config, save_user_config as save_config
 
     cfg = load_config()
     providers = cfg.get("custom_providers") or []
@@ -1547,7 +1552,11 @@ def _model_flow_named_custom(config, provider_info):
     Otherwise probes the endpoint's /models API to let the user pick one.
     """
     from hermes_cli.auth import _save_model_choice, deactivate_provider
-    from hermes_cli.config import save_env_value, load_config, save_config
+    from hermes_cli.config import (
+        save_env_value,
+        load_config,
+        save_user_config as save_config,
+    )
     from hermes_cli.models import fetch_api_models
 
     name = provider_info["name"]
@@ -1757,7 +1766,12 @@ def _model_flow_copilot(config, current_model=""):
         deactivate_provider,
         resolve_api_key_provider_credentials,
     )
-    from hermes_cli.config import get_env_value, save_env_value, load_config, save_config
+    from hermes_cli.config import (
+        get_env_value,
+        save_env_value,
+        load_config,
+        save_user_config as save_config,
+    )
     from hermes_cli.models import (
         fetch_api_models,
         fetch_github_model_catalog,
@@ -1934,7 +1948,7 @@ def _model_flow_copilot_acp(config, current_model=""):
         fetch_github_model_catalog,
         normalize_copilot_model_id,
     )
-    from hermes_cli.config import load_config, save_config
+    from hermes_cli.config import load_config, save_user_config as save_config
 
     del config
 
@@ -2032,7 +2046,12 @@ def _model_flow_kimi(config, current_model=""):
         PROVIDER_REGISTRY, KIMI_CODE_BASE_URL, _prompt_model_selection,
         _save_model_choice, deactivate_provider,
     )
-    from hermes_cli.config import get_env_value, save_env_value, load_config, save_config
+    from hermes_cli.config import (
+        get_env_value,
+        save_env_value,
+        load_config,
+        save_user_config as save_config,
+    )
 
     provider_id = "kimi-coding"
     pconfig = PROVIDER_REGISTRY[provider_id]
@@ -2126,7 +2145,12 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
         PROVIDER_REGISTRY, _prompt_model_selection, _save_model_choice,
         deactivate_provider,
     )
-    from hermes_cli.config import get_env_value, save_env_value, load_config, save_config
+    from hermes_cli.config import (
+        get_env_value,
+        save_env_value,
+        load_config,
+        save_user_config as save_config,
+    )
     from hermes_cli.models import fetch_api_models, opencode_model_api_mode, normalize_opencode_model_id
 
     pconfig = PROVIDER_REGISTRY[provider_id]
@@ -2325,7 +2349,10 @@ def _model_flow_anthropic(config, current_model=""):
         deactivate_provider,
     )
     from hermes_cli.config import (
-        get_env_value, save_env_value, load_config, save_config,
+        get_env_value,
+        save_env_value,
+        load_config,
+        save_user_config as save_config,
         save_anthropic_api_key,
     )
     from hermes_cli.models import _PROVIDER_MODELS
@@ -4778,7 +4805,7 @@ For more help on a command:
     def cmd_memory(args):
         sub = getattr(args, "memory_command", None)
         if sub == "off":
-            from hermes_cli.config import load_config, save_config
+            from hermes_cli.config import load_config, save_user_config as save_config
             config = load_config()
             if not isinstance(config.get("memory"), dict):
                 config["memory"] = {}

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_cli.config import (
     load_config,
-    save_config,
+    save_user_config as save_config,
     get_env_value,
     save_env_value,
     get_hermes_home,  # noqa: F401 — used by test mocks

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -252,7 +252,7 @@ def _get_available_providers() -> list:
 
 def cmd_setup_provider(provider_name: str) -> None:
     """Run memory setup for a specific provider, skipping the picker."""
-    from hermes_cli.config import load_config, save_config
+    from hermes_cli.config import load_raw_config, save_user_config
 
     providers = _get_available_providers()
     match = None
@@ -270,7 +270,7 @@ def cmd_setup_provider(provider_name: str) -> None:
 
     _install_dependencies(name)
 
-    config = load_config()
+    config = load_raw_config()
     if not isinstance(config.get("memory"), dict):
         config["memory"] = {}
 
@@ -281,14 +281,14 @@ def cmd_setup_provider(provider_name: str) -> None:
 
     # Fallback: generic schema-based setup (same as cmd_setup)
     config["memory"]["provider"] = name
-    save_config(config)
+    save_user_config(config)
     print(f"\n  Memory provider: {name}")
     print(f"  Activation saved to config.yaml\n")
 
 
 def cmd_setup(args) -> None:
     """Interactive memory provider setup wizard."""
-    from hermes_cli.config import load_config, save_config
+    from hermes_cli.config import load_raw_config, save_user_config
 
     providers = _get_available_providers()
 
@@ -306,14 +306,14 @@ def cmd_setup(args) -> None:
     builtin_idx = len(items) - 1
     selected = _curses_select("Memory provider setup", items, default=builtin_idx)
 
-    config = load_config()
+    config = load_raw_config()
     if not isinstance(config.get("memory"), dict):
         config["memory"] = {}
 
     # Built-in only
     if selected >= len(providers) or selected < 0:
         config["memory"]["provider"] = ""
-        save_config(config)
+        save_user_config(config)
         print("\n  ✓ Memory provider: built-in only")
         print("  Saved to config.yaml\n")
         return
@@ -397,7 +397,7 @@ def cmd_setup(args) -> None:
 
     # Write activation key to config.yaml
     config["memory"]["provider"] = name
-    save_config(config)
+    save_user_config(config)
 
     # Write non-secret config to provider's native location
     hermes_home = str(Path(os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes"))))

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -397,12 +397,13 @@ def _get_disabled_set() -> set:
 
 def _save_disabled_set(disabled: set) -> None:
     """Write the disabled plugins list to config.yaml."""
-    from hermes_cli.config import load_config, save_config
-    config = load_config()
+    from hermes_cli.config import load_raw_config, save_user_config
+
+    config = load_raw_config()
     if "plugins" not in config:
         config["plugins"] = {}
     config["plugins"]["disabled"] = sorted(disabled)
-    save_config(config)
+    save_user_config(config)
 
 
 def cmd_enable(name: str) -> None:

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -338,7 +338,9 @@ from hermes_cli.config import (
     get_config_path,
     get_env_path,
     load_config,
+    load_raw_config,
     save_config,
+    save_user_config,
     save_env_value,
     get_env_value,
     ensure_hermes_home,
@@ -898,8 +900,6 @@ def setup_model_provider(config: dict):
     This ensures a single code path for all provider setup — any new
     provider added to ``hermes model`` is automatically available here.
     """
-    from hermes_cli.config import load_config, save_config
-
     print_header("Inference Provider")
     print_info("Choose how to connect to your main chat model.")
     print_info(f"   Guide: {_DOCS_BASE}/integrations/providers")
@@ -920,7 +920,7 @@ def setup_model_provider(config: dict):
 
     # Re-sync the wizard's config dict from what cmd_model saved to disk.
     # This is critical: cmd_model writes to disk via its own load/save cycle,
-    # and the wizard's final save_config(config) must not overwrite those
+    # and the wizard's final save_user_config(config) must not overwrite those
     # changes with stale values (#4172).
     _refreshed = load_config()
     config["model"] = _refreshed.get("model", config.get("model"))
@@ -1107,7 +1107,7 @@ def setup_model_provider(config: dict):
         else:
             print_info(f"Keeping your existing TTS provider: {current_tts}")
 
-    save_config(config)
+    save_user_config(config)
 
     # Offer TTS provider selection at the end of model setup, except when
     # Nous subscription defaults are already being applied.
@@ -1292,7 +1292,7 @@ def _setup_tts_provider(config: dict):
     if "tts" not in config:
         config["tts"] = {}
     config["tts"]["provider"] = selected
-    save_config(config)
+    save_user_config(config)
     print_success(f"TTS provider set to: {provider_labels.get(selected, selected)}")
 
 
@@ -1641,7 +1641,7 @@ def setup_terminal_backend(config: dict):
     save_env_value("TERMINAL_ENV", selected_backend)
     if selected_backend == "modal":
         save_env_value("TERMINAL_MODAL_MODE", config["terminal"].get("modal_mode", "auto"))
-    save_config(config)
+    save_user_config(config)
     print()
     print_success(f"Terminal backend set to: {selected_backend}")
 
@@ -1692,7 +1692,7 @@ def setup_agent_settings(config: dict):
         if "display" not in config:
             config["display"] = {}
         config["display"]["tool_progress"] = mode.lower()
-        save_config(config)
+        save_user_config(config)
         print_success(f"Tool progress set to: {mode.lower()}")
     else:
         print_warning(f"Unknown mode '{mode}', keeping '{current_mode}'")
@@ -1703,8 +1703,6 @@ def setup_agent_settings(config: dict):
     print_info(
         "Higher threshold = compress later (use more context). Lower = compress sooner."
     )
-
-    config.setdefault("compression", {})["enabled"] = True
 
     current_threshold = config.get("compression", {}).get("threshold", 0.50)
     threshold_str = prompt("Compression threshold (0.5-0.95)", str(current_threshold))
@@ -1813,7 +1811,7 @@ def setup_agent_settings(config: dict):
         )
     # else: keep current (idx == 4)
 
-    save_config(config)
+    save_user_config(config)
 
 
 # =============================================================================
@@ -2588,7 +2586,7 @@ def _offer_openclaw_migration(hermes_home: Path) -> bool:
     # Ensure config.yaml exists before migration tries to read it
     config_path = get_config_path()
     if not config_path.exists():
-        save_config(load_config())
+        save_user_config(load_config())
 
     # Dynamically load the migration script
     try:
@@ -2730,7 +2728,7 @@ def run_setup_wizard(args):
                     )
                 )
                 func(config)
-                save_config(config)
+                save_user_config(config)
                 print()
                 print_success(f"{label} configuration complete!")
                 return
@@ -2833,7 +2831,7 @@ def run_setup_wizard(args):
             if section:
                 _, label, func = section
                 func(config)
-                save_config(config)
+                save_user_config(config)
                 _print_setup_summary(config, hermes_home)
             return
     else:
@@ -2895,7 +2893,7 @@ def run_setup_wizard(args):
         setup_tools(config, first_install=not is_existing)
 
     # Save and show summary
-    save_config(config)
+    save_user_config(config)
     _print_setup_summary(config, hermes_home)
 
 
@@ -3059,7 +3057,7 @@ def _run_quick_setup(config: dict, hermes_home):
 
         # Update config version
         config["_config_version"] = latest_ver
-        save_config(config)
+        save_user_config(config)
 
     # Jump to summary
     _print_setup_summary(config, hermes_home)

--- a/hermes_cli/skills_config.py
+++ b/hermes_cli/skills_config.py
@@ -13,7 +13,7 @@ Config stored in ~/.hermes/config.yaml under:
 """
 from typing import List, Optional, Set
 
-from hermes_cli.config import load_config, save_config
+from hermes_cli.config import load_config, save_user_config as save_config
 from hermes_cli.colors import Colors, color
 
 PLATFORMS = {

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -17,7 +17,10 @@ from typing import Dict, List, Optional, Set
 
 
 from hermes_cli.config import (
-    load_config, save_config, get_env_value, save_env_value,
+    get_env_value,
+    load_config,
+    save_env_value,
+    save_user_config as save_config,
 )
 from hermes_cli.colors import Colors, color
 from hermes_cli.nous_subscription import (
@@ -1108,11 +1111,11 @@ def _configure_simple_requirements(ts_key: str):
             if api_key and api_key.strip():
                 save_env_value("OPENAI_API_KEY", api_key.strip())
                 # Save vision base URL to config (not .env — only secrets go there)
-                from hermes_cli.config import load_config, save_config
-                _cfg = load_config()
+                from hermes_cli.config import load_raw_config, save_user_config
+                _cfg = load_raw_config()
                 _aux = _cfg.setdefault("auxiliary", {}).setdefault("vision", {})
                 _aux["base_url"] = base_url
-                save_config(_cfg)
+                save_user_config(_cfg)
                 if "api.openai.com" in base_url.lower():
                     save_env_value("AUXILIARY_VISION_MODEL", "gpt-4o-mini")
                 _print_success("    Saved")
@@ -1306,7 +1309,7 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
             prompt for API keys on all enabled tools that need them.
         config: Optional config dict to use.  When called from the setup
             wizard, the wizard passes its own dict so that platform_toolsets
-            are written into it and survive the wizard's final save_config().
+            are written into it and survive the wizard's final raw-preserving save.
     """
     if config is None:
         config = load_config()

--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -130,17 +130,13 @@ class HolographicMemoryProvider(MemoryProvider):
     def save_config(self, values, hermes_home):
         """Write config to config.yaml under plugins.hermes-memory-store."""
         from pathlib import Path
+        from hermes_cli.config import load_raw_config, save_user_config
         config_path = Path(hermes_home) / "config.yaml"
         try:
-            import yaml
-            existing = {}
-            if config_path.exists():
-                with open(config_path) as f:
-                    existing = yaml.safe_load(f) or {}
+            existing = load_raw_config(config_path=config_path)
             existing.setdefault("plugins", {})
             existing["plugins"]["hermes-memory-store"] = values
-            with open(config_path, "w") as f:
-                yaml.dump(existing, f, default_flow_style=False)
+            save_user_config(existing, config_path=config_path)
         except Exception:
             pass
 

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -459,10 +459,10 @@ def cmd_setup(args) -> None:
 
     # --- Auto-enable Honcho as memory provider in config.yaml ---
     try:
-        from hermes_cli.config import load_config, save_config
-        hermes_config = load_config()
+        from hermes_cli.config import load_raw_config, save_user_config
+        hermes_config = load_raw_config()
         hermes_config.setdefault("memory", {})["provider"] = "honcho"
-        save_config(hermes_config)
+        save_user_config(hermes_config)
         print("  Memory provider set to 'honcho' in config.yaml")
     except Exception as e:
         print(f"  Could not auto-enable in config.yaml: {e}")

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1,8 +1,10 @@
 """Tests for the memory provider interface, manager, and builtin provider."""
 
 import json
-import pytest
 from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
 
 from agent.memory_provider import MemoryProvider
 from agent.memory_manager import MemoryManager
@@ -542,6 +544,191 @@ class TestPluginMemoryDiscovery:
         assert p is not None
         assert p.name == "holographic"
         assert p.is_available()
+
+    def test_holographic_save_config_preserves_raw_user_config(self, tmp_path, monkeypatch):
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("GLM_API_KEY", "secret-key-123")
+
+        config_path = home / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "mcp_servers": {
+                        "zread": {
+                            "config": {
+                                "headers": {
+                                    "Authorization": "Bearer ${GLM_API_KEY}",
+                                }
+                            }
+                        }
+                    },
+                    "custom_section": {"keep": True},
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+        from plugins.memory import load_memory_provider
+
+        provider = load_memory_provider("holographic")
+        assert provider is not None
+
+        provider.save_config({"db_path": "memory_store.db"}, str(home))
+
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        assert saved["plugins"]["hermes-memory-store"]["db_path"] == "memory_store.db"
+        assert saved["custom_section"] == {"keep": True}
+        assert (
+            saved["mcp_servers"]["zread"]["config"]["headers"]["Authorization"]
+            == "Bearer ${GLM_API_KEY}"
+        )
+        assert "browser" not in saved
+
+    def test_memory_setup_builtin_preserves_raw_user_config(self, tmp_path, monkeypatch):
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("GLM_API_KEY", "secret-key-123")
+
+        config_path = home / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "compression": {"threshold": 0.8},
+                    "mcp_servers": {
+                        "zread": {
+                            "config": {
+                                "headers": {
+                                    "Authorization": "Bearer ${GLM_API_KEY}",
+                                }
+                            }
+                        }
+                    },
+                    "custom_section": {"keep": True},
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+        import hermes_cli.memory_setup as memory_setup
+
+        class _Provider:
+            pass
+
+        monkeypatch.setattr(
+            memory_setup,
+            "_get_available_providers",
+            lambda: [("dummy", "desc", _Provider())],
+        )
+        monkeypatch.setattr(memory_setup, "_curses_select", lambda *a, **kw: 1)
+
+        memory_setup.cmd_setup(None)
+
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        assert saved["custom_section"] == {"keep": True}
+        assert saved.get("memory", {}) == {}
+        assert (
+            saved["mcp_servers"]["zread"]["config"]["headers"]["Authorization"]
+            == "Bearer ${GLM_API_KEY}"
+        )
+        assert "terminal" not in saved
+
+    def test_honcho_setup_auto_enable_preserves_raw_user_config(self, tmp_path, monkeypatch):
+        home = tmp_path / ".hermes"
+        home.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("GLM_API_KEY", "secret-key-123")
+
+        config_path = home / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "compression": {"threshold": 0.8},
+                    "mcp_servers": {
+                        "zread": {
+                            "config": {
+                                "headers": {
+                                    "Authorization": "Bearer ${GLM_API_KEY}",
+                                }
+                            }
+                        }
+                    },
+                    "custom_section": {"keep": True},
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+        import plugins.memory.honcho.cli as honcho_cli
+
+        prompt_values = iter(
+            [
+                "local",
+                "http://localhost:8000",
+                "user",
+                "hermes",
+                "hermes",
+                "directional",
+                "async",
+                "hybrid",
+                "per-directory",
+            ]
+        )
+        fake_cfg = {
+            "host": {
+                "peerName": "user",
+                "aiPeer": "hermes",
+                "workspace": "hermes",
+                "observationMode": "directional",
+                "writeFrequency": "async",
+                "recallMode": "hybrid",
+                "sessionStrategy": "per-directory",
+            }
+        }
+        fake_client_cfg = type(
+            "FakeHonchoClientConfig",
+            (),
+            {
+                "resolve_session_name": lambda self: "s",
+                "workspace_id": "w",
+                "peer_name": "u",
+                "ai_peer": "a",
+                "observation_mode": "o",
+                "write_frequency": "async",
+                "recall_mode": "hybrid",
+                "session_strategy": "per-directory",
+            },
+        )
+
+        monkeypatch.setattr(honcho_cli, "_read_config", lambda: fake_cfg)
+        monkeypatch.setattr(
+            honcho_cli,
+            "_prompt",
+            lambda *a, **kw: next(prompt_values),
+        )
+        monkeypatch.setattr(honcho_cli, "_write_config", lambda cfg: None)
+        monkeypatch.setattr("plugins.memory.honcho.client.reset_honcho_client", lambda: None)
+        monkeypatch.setattr("plugins.memory.honcho.client.get_honcho_client", lambda cfg: object())
+        monkeypatch.setattr(
+            "plugins.memory.honcho.client.HonchoClientConfig.from_global_config",
+            lambda host=None: fake_client_cfg(),
+        )
+
+        honcho_cli.cmd_setup(type("Args", (), {})())
+
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        assert saved["custom_section"] == {"keep": True}
+        assert saved["memory"]["provider"] == "honcho"
+        assert (
+            saved["mcp_servers"]["zread"]["config"]["headers"]["Authorization"]
+            == "Bearer ${GLM_API_KEY}"
+        )
+        assert "terminal" not in saved
 
     def test_load_nonexistent_returns_none(self):
         """load_memory_provider returns None for unknown names."""

--- a/tests/gateway/test_config_persistence.py
+++ b/tests/gateway/test_config_persistence.py
@@ -1,0 +1,94 @@
+"""Tests for gateway config mutation commands using the shared config writer."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import yaml
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_event(text="/personality pirate", platform=Platform.TELEGRAM, user_id="12345", chat_id="67890"):
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._show_reasoning = False
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.hooks.loaded_hooks = []
+    runner._session_db = None
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_personality_command_uses_shared_config_writer(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text(
+        "agent:\n"
+        "  personalities:\n"
+        "    pirate: Arrr\n"
+        "mcp_servers:\n"
+        "  zread:\n"
+        "    headers:\n"
+        "      Authorization: Bearer ${GLM_API_KEY}\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+    runner = _make_runner()
+    result = await runner._handle_personality_command(_make_event("/personality pirate"))
+
+    saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    saved_text = config_path.read_text(encoding="utf-8")
+    assert saved["agent"]["system_prompt"] == "Arrr"
+    assert "Authorization: Bearer ${GLM_API_KEY}" in saved_text
+    assert "# ── Security" in saved_text
+    assert "takes effect on next message" in result
+
+
+@pytest.mark.asyncio
+async def test_sethome_command_uses_shared_config_writer(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text(
+        "mcp_servers:\n"
+        "  zread:\n"
+        "    headers:\n"
+        "      Authorization: Bearer ${GLM_API_KEY}\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+    runner = _make_runner()
+    result = await runner._handle_set_home_command(_make_event("/sethome"))
+
+    saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    saved_text = config_path.read_text(encoding="utf-8")
+    assert saved["TELEGRAM_HOME_CHANNEL"] == "67890"
+    assert "Authorization: Bearer ${GLM_API_KEY}" in saved_text
+    assert "# ── Security" in saved_text
+    assert "Home channel set" in result

--- a/tests/gateway/test_dm_topics.py
+++ b/tests/gateway/test_dm_topics.py
@@ -270,7 +270,8 @@ def test_persist_dm_topic_thread_id_skips_if_already_set(tmp_path):
 
     adapter = _make_adapter()
 
-    with patch.object(Path, "home", return_value=tmp_path):
+    with patch.object(Path, "home", return_value=tmp_path), \
+         patch.dict(os.environ, {"HERMES_HOME": str(tmp_path / ".hermes")}):
         adapter._persist_dm_topic_thread_id(111, "General", 999)
 
     with open(config_file) as f:
@@ -278,6 +279,50 @@ def test_persist_dm_topic_thread_id_skips_if_already_set(tmp_path):
 
     topics = result["platforms"]["telegram"]["extra"]["dm_topics"][0]["topics"]
     assert topics[0]["thread_id"] == 500  # unchanged
+
+
+def test_persist_dm_topic_thread_id_uses_shared_config_writer(tmp_path):
+    """Persisting topic IDs should keep the shared config scaffold."""
+    import yaml
+
+    config_data = {
+        "platforms": {
+            "telegram": {
+                "extra": {
+                    "dm_topics": [
+                        {
+                            "chat_id": 111,
+                            "topics": [
+                                {"name": "General", "icon_color": 123},
+                            ],
+                        }
+                    ]
+                }
+            }
+        },
+        "mcp_servers": {
+            "zread": {
+                "headers": {
+                    "Authorization": "Bearer ${GLM_API_KEY}",
+                }
+            }
+        },
+    }
+
+    config_file = tmp_path / ".hermes" / "config.yaml"
+    config_file.parent.mkdir(parents=True)
+    with open(config_file, "w") as f:
+        yaml.dump(config_data, f)
+
+    adapter = _make_adapter()
+
+    with patch.object(Path, "home", return_value=tmp_path), \
+         patch.dict(os.environ, {"HERMES_HOME": str(tmp_path / ".hermes")}):
+        adapter._persist_dm_topic_thread_id(111, "General", 999)
+
+    saved_text = config_file.read_text(encoding="utf-8")
+    assert "Authorization: Bearer ${GLM_API_KEY}" in saved_text
+    assert "# ── Security" in saved_text
 
 
 # ── _get_dm_topic_info ──

--- a/tests/gateway/test_reasoning_command.py
+++ b/tests/gateway/test_reasoning_command.py
@@ -120,6 +120,33 @@ class TestReasoningCommand:
         assert runner._reasoning_config == {"enabled": True, "effort": "low"}
         assert "takes effect on next message" in result
 
+    @pytest.mark.asyncio
+    async def test_handle_reasoning_command_uses_shared_config_writer(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "agent:\n"
+            "  reasoning_effort: medium\n"
+            "mcp_servers:\n"
+            "  zread:\n"
+            "    headers:\n"
+            "      Authorization: Bearer ${GLM_API_KEY}\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+        monkeypatch.delenv("HERMES_REASONING_EFFORT", raising=False)
+
+        runner = _make_runner()
+        runner._reasoning_config = {"enabled": True, "effort": "medium"}
+
+        await runner._handle_reasoning_command(_make_event("/reasoning high"))
+
+        saved_text = config_path.read_text(encoding="utf-8")
+        assert "Authorization: Bearer ${GLM_API_KEY}" in saved_text
+        assert "# ── Security" in saved_text
+
     def test_run_agent_reloads_reasoning_config_per_message(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir()

--- a/tests/gateway/test_verbose_command.py
+++ b/tests/gateway/test_verbose_command.py
@@ -85,6 +85,32 @@ class TestVerboseCommand:
         assert saved["display"]["tool_progress"] == "verbose"
 
     @pytest.mark.asyncio
+    async def test_enabled_cycles_mode_uses_shared_config_writer(self, tmp_path, monkeypatch):
+        """Gateway verbose saves should keep the shared config scaffold."""
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "display:\n"
+            "  tool_progress_command: true\n"
+            "  tool_progress: all\n"
+            "mcp_servers:\n"
+            "  zread:\n"
+            "    headers:\n"
+            "      Authorization: Bearer ${GLM_API_KEY}\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+        await runner._handle_verbose_command(_make_event())
+
+        saved_text = config_path.read_text(encoding="utf-8")
+        assert "Authorization: Bearer ${GLM_API_KEY}" in saved_text
+        assert "# ── Security" in saved_text
+
+    @pytest.mark.asyncio
     async def test_cycles_through_all_modes(self, tmp_path, monkeypatch):
         """Calling /verbose repeatedly cycles through all four modes."""
         hermes_home = tmp_path / "hermes"

--- a/tests/hermes_cli/test_claw.py
+++ b/tests/hermes_cli/test_claw.py
@@ -5,6 +5,7 @@ from types import ModuleType
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 
 from hermes_cli import claw as claw_mod
 
@@ -255,7 +256,7 @@ class TestCmdMigrate:
             patch.object(claw_mod, "_find_migration_script", return_value=script),
             patch.object(claw_mod, "_load_migration_module", return_value=fake_mod),
             patch.object(claw_mod, "get_config_path", return_value=tmp_path / "config.yaml"),
-            patch.object(claw_mod, "save_config"),
+            patch.object(claw_mod, "save_user_config"),
             patch.object(claw_mod, "load_config", return_value={}),
         ):
             claw_mod._cmd_migrate(args)
@@ -263,6 +264,39 @@ class TestCmdMigrate:
         captured = capsys.readouterr()
         assert "Dry Run Results" in captured.out
         assert "5 skipped" in captured.out
+
+    def test_bootstraps_minimal_user_config_when_missing(self, tmp_path):
+        openclaw_dir = tmp_path / ".openclaw"
+        openclaw_dir.mkdir()
+        config_path = tmp_path / "config.yaml"
+
+        fake_mod = ModuleType("openclaw_to_hermes")
+        fake_mod.resolve_selected_options = MagicMock(return_value=set())
+        fake_migrator = MagicMock()
+        fake_migrator.migrate.return_value = {
+            "summary": {"migrated": 0, "skipped": 0, "conflict": 0, "error": 0},
+            "items": [],
+        }
+        fake_mod.Migrator = MagicMock(return_value=fake_migrator)
+
+        args = Namespace(
+            source=str(openclaw_dir),
+            dry_run=True, preset="full", overwrite=False,
+            migrate_secrets=False, workspace_target=None,
+            skill_conflict="skip", yes=False,
+        )
+
+        with (
+            patch.dict("os.environ", {"HERMES_HOME": str(tmp_path)}, clear=False),
+            patch.object(claw_mod, "_find_migration_script", return_value=tmp_path / "s.py"),
+            patch.object(claw_mod, "_load_migration_module", return_value=fake_mod),
+        ):
+            claw_mod._cmd_migrate(args)
+
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert "_config_version" in saved
+        assert "terminal" not in saved
+        assert "browser" not in saved
 
     def test_execute_with_confirmation(self, tmp_path, capsys):
         openclaw_dir = tmp_path / ".openclaw"
@@ -329,7 +363,7 @@ class TestCmdMigrate:
             patch.object(claw_mod, "_find_migration_script", return_value=tmp_path / "s.py"),
             patch.object(claw_mod, "_load_migration_module", return_value=fake_mod),
             patch.object(claw_mod, "get_config_path", return_value=tmp_path / "config.yaml"),
-            patch.object(claw_mod, "save_config"),
+            patch.object(claw_mod, "save_user_config"),
             patch.object(claw_mod, "load_config", return_value={}),
             patch.object(claw_mod, "_offer_source_archival") as mock_archival,
         ):
@@ -363,7 +397,7 @@ class TestCmdMigrate:
             patch.object(claw_mod, "_find_migration_script", return_value=tmp_path / "s.py"),
             patch.object(claw_mod, "_load_migration_module", return_value=fake_mod),
             patch.object(claw_mod, "get_config_path", return_value=tmp_path / "config.yaml"),
-            patch.object(claw_mod, "save_config"),
+            patch.object(claw_mod, "save_user_config"),
             patch.object(claw_mod, "load_config", return_value={}),
             patch.object(claw_mod, "_offer_source_archival") as mock_archival,
         ):
@@ -442,7 +476,7 @@ class TestCmdMigrate:
             patch.object(claw_mod, "_find_migration_script", return_value=tmp_path / "s.py"),
             patch.object(claw_mod, "_load_migration_module", side_effect=RuntimeError("boom")),
             patch.object(claw_mod, "get_config_path", return_value=config_path),
-            patch.object(claw_mod, "save_config"),
+            patch.object(claw_mod, "save_user_config"),
             patch.object(claw_mod, "load_config", return_value={}),
         ):
             claw_mod._cmd_migrate(args)
@@ -476,7 +510,7 @@ class TestCmdMigrate:
             patch.object(claw_mod, "_find_migration_script", return_value=tmp_path / "s.py"),
             patch.object(claw_mod, "_load_migration_module", return_value=fake_mod),
             patch.object(claw_mod, "get_config_path", return_value=tmp_path / "config.yaml"),
-            patch.object(claw_mod, "save_config"),
+            patch.object(claw_mod, "save_user_config"),
             patch.object(claw_mod, "load_config", return_value={}),
         ):
             claw_mod._cmd_migrate(args)

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1,5 +1,6 @@
 """Tests for hermes_cli configuration management."""
 
+import importlib
 import os
 from pathlib import Path
 from unittest.mock import patch, MagicMock
@@ -8,6 +9,7 @@ import yaml
 
 from hermes_cli.config import (
     DEFAULT_CONFIG,
+    edit_config,
     get_hermes_home,
     ensure_hermes_home,
     load_config,
@@ -15,6 +17,8 @@ from hermes_cli.config import (
     migrate_config,
     remove_env_value,
     save_config,
+    save_user_config,
+    set_config_value,
     save_env_value,
     save_env_value_secure,
     sanitize_env_file,
@@ -111,6 +115,133 @@ class TestSaveAndLoadRoundtrip:
 
             reloaded = load_config()
             assert reloaded["terminal"]["timeout"] == 999
+
+    def test_migrate_config_preserves_user_overrides_without_materializing_defaults(
+        self, tmp_path
+    ):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config_path = tmp_path / "config.yaml"
+            config_path.write_text(
+                yaml.safe_dump(
+                    {
+                        "_config_version": 4,
+                        "compression": {"threshold": 0.8},
+                        "custom_section": {"keep": True},
+                    },
+                    sort_keys=False,
+                ),
+                encoding="utf-8",
+            )
+
+            migrate_config(interactive=False, quiet=True)
+
+            saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+            assert saved["compression"]["threshold"] == 0.8
+            assert saved["custom_section"] == {"keep": True}
+            assert "terminal" not in saved
+
+    def test_edit_config_bootstraps_minimal_user_config(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("EDITOR", "fake-editor")
+
+        with patch("hermes_cli.config.subprocess.run") as mock_run:
+            edit_config()
+
+        mock_run.assert_called_once()
+        saved = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+        assert "_config_version" in saved
+        assert "terminal" not in saved
+        assert "browser" not in saved
+
+    def test_set_config_value_uses_shared_user_config_writer(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config_path = tmp_path / "config.yaml"
+            config_path.write_text(
+                yaml.safe_dump(
+                    {
+                        "custom_section": {"keep": True},
+                        "compression": {"enabled": False},
+                    },
+                    sort_keys=False,
+                ),
+                encoding="utf-8",
+            )
+
+            set_config_value("model.default", "new-model")
+
+            saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+            assert saved["custom_section"] == {"keep": True}
+            assert saved["compression"] == {"enabled": False}
+            assert saved["model"] == {"default": "new-model"}
+            assert saved["agent"]["max_turns"] == DEFAULT_CONFIG["agent"]["max_turns"]
+
+            raw_text = config_path.read_text(encoding="utf-8")
+            assert "# ── Security" in raw_text
+
+    def test_save_user_config_preserves_raw_env_placeholders(self, tmp_path):
+        with patch.dict(
+            os.environ,
+            {"HERMES_HOME": str(tmp_path), "GLM_API_KEY": "secret-key-123"},
+            clear=False,
+        ):
+            config_path = tmp_path / "config.yaml"
+            config_path.write_text(
+                yaml.safe_dump(
+                    {
+                        "mcp_servers": {
+                            "zread": {
+                                "url": "https://example.com",
+                                "headers": {"Authorization": "Bearer ${GLM_API_KEY}"},
+                            }
+                        }
+                    },
+                    sort_keys=False,
+                ),
+                encoding="utf-8",
+            )
+
+            config = load_config()
+            save_user_config(config)
+
+            saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+            assert (
+                saved["mcp_servers"]["zread"]["headers"]["Authorization"]
+                == "Bearer ${GLM_API_KEY}"
+            )
+
+    def test_cli_save_config_value_preserves_raw_env_placeholders(self, tmp_path):
+        with patch.dict(
+            os.environ,
+            {"HERMES_HOME": str(tmp_path), "GLM_API_KEY": "secret-key-123"},
+            clear=False,
+        ):
+            import cli as cli_mod
+
+            cli_mod = importlib.reload(cli_mod)
+            config_path = tmp_path / "config.yaml"
+            config_path.write_text(
+                yaml.safe_dump(
+                    {
+                        "model": {"default": "old-model"},
+                        "mcp_servers": {
+                            "zread": {
+                                "url": "https://example.com",
+                                "headers": {"Authorization": "Bearer ${GLM_API_KEY}"},
+                            }
+                        },
+                        "custom_section": {"keep": True},
+                    },
+                    sort_keys=False,
+                ),
+                encoding="utf-8",
+            )
+
+            assert cli_mod.save_config_value("display.skin", "slate") is True
+
+            saved = config_path.read_text(encoding="utf-8")
+            assert "Bearer ${GLM_API_KEY}" in saved
+            assert "skin: slate" in saved
+            assert "# ── Security" in saved
 
 
 class TestSaveEnvValueSecure:

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List
 from unittest.mock import MagicMock, patch, PropertyMock
 
 import pytest
+import yaml
 
 
 # ---------------------------------------------------------------------------
@@ -384,6 +385,29 @@ class TestConfigHelpers:
 
         assert _env_key_for_server("ink") == "MCP_INK_API_KEY"
         assert _env_key_for_server("my-server") == "MCP_MY_SERVER_API_KEY"
+
+    def test_save_mcp_server_preserves_raw_user_config(self, tmp_path):
+        from hermes_cli.mcp_config import _save_mcp_server
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "custom_section": {"keep": True},
+                    "compression": {"enabled": False},
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+        _save_mcp_server("exa", {"url": "https://mcp.exa.ai/mcp"})
+
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert saved["custom_section"] == {"keep": True}
+        assert saved["compression"] == {"enabled": False}
+        assert saved["mcp_servers"]["exa"]["url"] == "https://mcp.exa.ai/mcp"
+        assert "terminal" not in saved
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -3,10 +3,11 @@ select_provider_and_model() and config dict sync."""
 import json
 import sys
 import types
+import yaml
 
-from hermes_cli.auth import get_active_provider
-from hermes_cli.config import load_config, save_config
-from hermes_cli.setup import setup_model_provider
+from hermes_cli.auth import _reset_config_provider, _update_config_for_provider, get_active_provider
+from hermes_cli.config import get_config_path, load_config, save_config
+from hermes_cli.setup import setup_agent_settings, setup_model_provider
 
 
 def _maybe_keep_current_tts(question, choices):
@@ -305,3 +306,99 @@ def test_modal_setup_persists_direct_mode_when_user_chooses_their_own_account(tm
 
     assert config["terminal"]["backend"] == "modal"
     assert config["terminal"]["modal_mode"] == "direct"
+
+
+def test_setup_agent_settings_preserves_raw_user_config_without_enabling_defaults(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    config_path = get_config_path()
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "_config_version": 10,
+                "compression": {"threshold": 0.8, "enabled": False},
+                "custom_section": {"keep": True},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_config()
+
+    prompt_values = iter(["90", "all", "0.8"])
+
+    monkeypatch.setattr(
+        "hermes_cli.setup.prompt",
+        lambda *args, **kwargs: next(prompt_values),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.setup.prompt_choice",
+        lambda question, choices, default=0: 4 if question == "Session reset mode:" else default,
+    )
+
+    setup_agent_settings(config)
+
+    saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert saved["compression"]["threshold"] == 0.8
+    assert saved["compression"]["enabled"] is False
+    assert saved["custom_section"] == {"keep": True}
+    assert "browser" not in saved
+
+
+def test_update_config_for_provider_preserves_raw_user_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    config_path = get_config_path()
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "model": "old-model",
+                "compression": {"threshold": 0.8},
+                "custom_section": {"keep": True},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    _update_config_for_provider("nous", "https://inference.example.com/v1")
+
+    saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert saved["model"]["provider"] == "nous"
+    assert saved["model"]["base_url"] == "https://inference.example.com/v1"
+    assert saved["model"]["default"] == "old-model"
+    assert saved["compression"]["threshold"] == 0.8
+    assert saved["custom_section"] == {"keep": True}
+    assert "browser" not in saved
+
+
+def test_reset_config_provider_preserves_raw_user_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    config_path = get_config_path()
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "provider": "nous",
+                    "base_url": "https://inference.example.com/v1",
+                    "default": "gemini-3-flash",
+                },
+                "custom_section": {"keep": True},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    _reset_config_provider()
+
+    saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert saved["model"]["provider"] == "auto"
+    assert saved["model"]["base_url"] == "https://openrouter.ai/api/v1"
+    assert saved["model"]["default"] == "gemini-3-flash"
+    assert saved["custom_section"] == {"keep": True}
+    assert "browser" not in saved

--- a/tests/hermes_cli/test_setup_openclaw_migration.py
+++ b/tests/hermes_cli/test_setup_openclaw_migration.py
@@ -143,7 +143,7 @@ class TestOfferOpenclawMigration:
             patch.object(setup_mod, "prompt_yes_no", return_value=True),
             patch.object(setup_mod, "get_config_path", return_value=config_path),
             patch.object(setup_mod, "load_config", return_value={"agent": {}}),
-            patch.object(setup_mod, "save_config") as mock_save,
+            patch.object(setup_mod, "save_user_config") as mock_save,
             patch(
                 "importlib.util.spec_from_file_location",
                 side_effect=RuntimeError("stop early"),
@@ -151,7 +151,7 @@ class TestOfferOpenclawMigration:
         ):
             setup_mod._offer_openclaw_migration(hermes_home)
 
-        # save_config should have been called to bootstrap the file
+        # save_user_config should have been called to bootstrap the file
         mock_save.assert_called_once_with({"agent": {}})
 
 

--- a/tests/hermes_cli/test_skills_config.py
+++ b/tests/hermes_cli/test_skills_config.py
@@ -1,4 +1,5 @@
 """Tests for hermes_cli/skills_config.py and skills_tool disabled filtering."""
+import yaml
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -74,6 +75,31 @@ class TestSaveDisabledSkills:
         save_disabled_skills(config, {"skill-x"})
         assert "skills" in config
         assert "disabled" in config["skills"]
+
+    def test_save_disabled_skills_preserves_raw_user_config(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        from hermes_cli.config import load_config
+        from hermes_cli.skills_config import save_disabled_skills
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "custom_section": {"keep": True},
+                    "compression": {"enabled": False},
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+        save_disabled_skills(load_config(), {"skill-a"})
+
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert saved["custom_section"] == {"keep": True}
+        assert saved["compression"] == {"enabled": False}
+        assert saved["skills"]["disabled"] == ["skill-a"]
+        assert "terminal" not in saved
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -1,9 +1,11 @@
 """Tests for hermes_cli.tools_config platform tool persistence."""
 
+import yaml
 from unittest.mock import patch
 
 from hermes_cli.tools_config import (
     _configure_provider,
+    _configure_simple_requirements,
     _get_platform_tools,
     _platform_toolset_summary,
     _save_platform_tools,
@@ -141,6 +143,69 @@ def test_save_platform_tools_handles_invalid_existing_config():
 
     saved_toolsets = config["platform_toolsets"]["cli"]
     assert "web" in saved_toolsets
+
+
+def test_save_platform_tools_preserves_raw_user_config(tmp_path, monkeypatch):
+    """Saving tool selections must not rewrite unrelated defaults into config.yaml."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from hermes_cli.config import load_config
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "custom_section": {"keep": True},
+                "compression": {"enabled": False},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_config()
+    _save_platform_tools(config, "cli", {"web", "terminal"})
+
+    saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert saved["custom_section"] == {"keep": True}
+    assert saved["compression"] == {"enabled": False}
+    assert saved["platform_toolsets"]["cli"] == ["terminal", "web"]
+    assert "browser" not in saved
+    assert "display" not in saved
+    assert "terminal" not in saved
+
+
+def test_save_platform_tools_preserves_raw_env_placeholders(tmp_path, monkeypatch):
+    """Saving tool selections must not expand unrelated env placeholders."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("GLM_API_KEY", "secret-key-123")
+
+    from hermes_cli.config import load_config
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "mcp_servers": {
+                    "zread": {
+                        "url": "https://example.com",
+                        "headers": {"Authorization": "Bearer ${GLM_API_KEY}"},
+                    }
+                }
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_config()
+    _save_platform_tools(config, "cli", {"web", "terminal"})
+
+    saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert (
+        saved["mcp_servers"]["zread"]["headers"]["Authorization"]
+        == "Bearer ${GLM_API_KEY}"
+    )
 
 
 def test_save_platform_tools_does_not_preserve_platform_default_toolsets():
@@ -314,6 +379,7 @@ def test_first_install_nous_auto_configures_managed_defaults(monkeypatch):
         "hermes_cli.tools_config._prompt_toolset_checklist",
         lambda *args, **kwargs: {"web", "image_gen", "tts", "browser"},
     )
+    monkeypatch.setattr("hermes_cli.tools_config._get_enabled_platforms", lambda: ["cli"])
     monkeypatch.setattr("hermes_cli.tools_config.save_config", lambda config: None)
     monkeypatch.setattr(
         "hermes_cli.nous_subscription.get_nous_auth_status",
@@ -333,6 +399,49 @@ def test_first_install_nous_auto_configures_managed_defaults(monkeypatch):
     assert config["browser"]["cloud_provider"] == "browserbase"
     assert configured == []
 
+
+def test_vision_reconfig_preserves_raw_user_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("GLM_API_KEY", "secret-key-123")
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "mcp_servers": {
+                    "zread": {
+                        "config": {
+                            "headers": {
+                                "Authorization": "Bearer ${GLM_API_KEY}",
+                            }
+                        }
+                    }
+                },
+                "custom_section": {"keep": True},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr("hermes_cli.tools_config._toolset_has_keys", lambda _ts: False)
+    monkeypatch.setattr("hermes_cli.tools_config._prompt_choice", lambda *_args, **_kwargs: 1)
+    prompt_values = iter(["https://custom.example/v1", "api-key"])
+    monkeypatch.setattr(
+        "hermes_cli.tools_config._prompt",
+        lambda *_args, **_kwargs: next(prompt_values),
+    )
+
+    _configure_simple_requirements("vision")
+
+    saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert saved["auxiliary"]["vision"]["base_url"] == "https://custom.example/v1"
+    assert saved["custom_section"] == {"keep": True}
+    assert (
+        saved["mcp_servers"]["zread"]["config"]["headers"]["Authorization"]
+        == "Bearer ${GLM_API_KEY}"
+    )
+    assert "browser" not in saved
 # ── Platform / toolset consistency ────────────────────────────────────────────
 
 

--- a/tests/test_auth_commands.py
+++ b/tests/test_auth_commands.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import json
 from datetime import datetime, timezone
+import yaml
 
 import pytest
 
@@ -657,3 +658,46 @@ def test_auth_remove_manual_entry_does_not_touch_env(tmp_path, monkeypatch):
 
     # .env should be untouched
     assert env_path.read_text() == "SOME_KEY=some-value\n"
+
+
+def test_interactive_strategy_preserves_raw_user_config(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("GLM_API_KEY", "secret-key-123")
+
+    config_path = hermes_home / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "mcp_servers": {
+                    "zread": {
+                        "config": {
+                            "headers": {
+                                "Authorization": "Bearer ${GLM_API_KEY}",
+                            }
+                        }
+                    }
+                },
+                "custom_section": {"keep": True},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    from hermes_cli.auth_commands import _interactive_strategy
+
+    monkeypatch.setattr("hermes_cli.auth_commands._pick_provider", lambda _prompt: "openrouter")
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "1")
+
+    _interactive_strategy()
+
+    saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert saved["credential_pool_strategies"]["openrouter"] == "fill_first"
+    assert saved["custom_section"] == {"keep": True}
+    assert (
+        saved["mcp_servers"]["zread"]["config"]["headers"]["Authorization"]
+        == "Bearer ${GLM_API_KEY}"
+    )
+    assert "browser" not in saved

--- a/tests/test_model_provider_persistence.py
+++ b/tests/test_model_provider_persistence.py
@@ -7,9 +7,12 @@ falling back to auto-detection.
 """
 
 import os
+import sys
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 import pytest
+import yaml
 
 
 @pytest.fixture
@@ -53,7 +56,6 @@ class TestSaveModelChoiceAlwaysDict:
 
     def test_dict_model_stays_dict(self, config_home):
         """When config.model is already a dict, _save_model_choice preserves it."""
-        import yaml
         (config_home / "config.yaml").write_text(
             "model:\n  default: old-model\n  provider: openrouter\n"
         )
@@ -66,6 +68,227 @@ class TestSaveModelChoiceAlwaysDict:
         assert isinstance(model, dict)
         assert model["default"] == "new-model"
         assert model["provider"] == "openrouter"  # preserved
+
+    def test_save_model_choice_preserves_raw_user_config(self, config_home):
+        """Saving a model choice must not rewrite unrelated defaults into config.yaml."""
+        (config_home / "config.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "model": "old-model",
+                    "compression": {"threshold": 0.8, "enabled": False},
+                    "custom_section": {"keep": True},
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+        from hermes_cli.auth import _save_model_choice
+
+        _save_model_choice("new-model")
+
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        assert config["model"]["default"] == "new-model"
+        assert config["compression"] == {"threshold": 0.8, "enabled": False}
+        assert config["custom_section"] == {"keep": True}
+        assert "terminal" not in config
+        assert "browser" not in config
+
+    def test_save_model_choice_preserves_raw_env_placeholders(self, config_home, monkeypatch):
+        """Saving a model choice must not expand unrelated env placeholders."""
+        monkeypatch.setenv("GLM_API_KEY", "secret-key-123")
+        (config_home / "config.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "model": "old-model",
+                    "mcp_servers": {
+                        "zread": {
+                            "url": "https://example.com",
+                            "headers": {"Authorization": "Bearer ${GLM_API_KEY}"},
+                        }
+                    },
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+        from hermes_cli.auth import _save_model_choice
+
+        _save_model_choice("new-model")
+
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        assert config["model"]["default"] == "new-model"
+        assert (
+            config["mcp_servers"]["zread"]["headers"]["Authorization"]
+            == "Bearer ${GLM_API_KEY}"
+        )
+
+    def test_model_flow_openrouter_preserves_raw_user_config(self, config_home, monkeypatch):
+        """OpenRouter model selection must not rewrite unrelated defaults."""
+        (config_home / "config.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "model": "old-model",
+                    "compression": {"enabled": False},
+                    "custom_section": {"keep": True},
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+
+        from hermes_cli.config import load_config
+        from hermes_cli.main import _model_flow_openrouter
+
+        with patch("hermes_cli.models.model_ids", return_value=["new-model"]), patch(
+            "hermes_cli.auth._prompt_model_selection", return_value="new-model"
+        ), patch("hermes_cli.auth.deactivate_provider"):
+            _model_flow_openrouter(load_config(), current_model="old-model")
+
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        assert config["model"]["default"] == "new-model"
+        assert config["model"]["provider"] == "openrouter"
+        assert config["compression"] == {"enabled": False}
+        assert config["custom_section"] == {"keep": True}
+        assert "terminal" not in config
+
+    def test_save_custom_provider_preserves_raw_user_config(self, config_home):
+        """Saving a named custom provider must not rewrite unrelated defaults."""
+        (config_home / "config.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "custom_section": {"keep": True},
+                    "compression": {"enabled": False},
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+        from hermes_cli.main import _save_custom_provider
+
+        _save_custom_provider("https://example.com/v1", model="my-model", context_length=1234)
+
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        assert config["custom_section"] == {"keep": True}
+        assert config["compression"] == {"enabled": False}
+        assert config["custom_providers"][0]["base_url"] == "https://example.com/v1"
+        assert config["custom_providers"][0]["model"] == "my-model"
+        assert "terminal" not in config
+
+    def test_model_flow_nous_preserves_raw_env_placeholders(self, config_home, monkeypatch):
+        """Logged-in Nous model selection must not expand unrelated env placeholders."""
+        monkeypatch.setenv("GLM_API_KEY", "secret-key-123")
+        (config_home / "config.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "model": {"default": "old-model"},
+                    "mcp_servers": {
+                        "zread": {
+                            "url": "https://example.com",
+                            "headers": {"Authorization": "Bearer ${GLM_API_KEY}"},
+                        }
+                    },
+                    "custom_section": {"keep": True},
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+        from hermes_cli.config import load_config
+        from hermes_cli.main import _model_flow_nous
+
+        config = load_config()
+
+        with patch("hermes_cli.auth.get_provider_auth_state", return_value={"access_token": "tok"}), patch(
+            "hermes_cli.auth._prompt_model_selection",
+            return_value="nous-model",
+        ), patch(
+            "hermes_cli.auth._save_model_choice",
+            lambda *_a, **_k: None,
+        ), patch(
+            "hermes_cli.auth._update_config_for_provider",
+            lambda *_a, **_k: None,
+        ), patch(
+            "hermes_cli.auth.resolve_nous_runtime_credentials",
+            return_value={"base_url": "https://inference.example.com/v1"},
+        ), patch(
+            "hermes_cli.nous_subscription.apply_nous_provider_defaults",
+            return_value=set(),
+        ), patch(
+            "hermes_cli.nous_subscription.get_nous_subscription_explainer_lines",
+            return_value=[],
+        ), patch(
+            "hermes_cli.config.get_env_value",
+            return_value="",
+        ), patch(
+            "hermes_cli.config.save_env_value",
+            lambda *_a, **_k: None,
+        ):
+            _model_flow_nous(
+                config,
+                current_model="old-model",
+                args=SimpleNamespace(
+                    portal_url=None,
+                    inference_url=None,
+                    client_id=None,
+                    scope=None,
+                    no_browser=False,
+                    timeout=15.0,
+                    ca_bundle=None,
+                    insecure=False,
+                ),
+            )
+
+        saved = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        assert saved["model"]["default"] == "nous-model"
+        assert saved["model"]["provider"] == "nous"
+        assert saved["custom_section"] == {"keep": True}
+        assert (
+            saved["mcp_servers"]["zread"]["headers"]["Authorization"]
+            == "Bearer ${GLM_API_KEY}"
+        )
+        assert "browser" not in saved
+
+    def test_memory_off_preserves_raw_env_placeholders(self, config_home, monkeypatch):
+        """`hermes memory off` must not expand unrelated env placeholders."""
+        monkeypatch.setenv("GLM_API_KEY", "secret-key-123")
+        (config_home / "config.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "memory": {"provider": "honcho"},
+                    "mcp_servers": {
+                        "zread": {
+                            "url": "https://example.com",
+                            "headers": {"Authorization": "Bearer ${GLM_API_KEY}"},
+                        }
+                    },
+                    "custom_section": {"keep": True},
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+        from hermes_cli import main as hermes_main
+
+        original_argv = sys.argv[:]
+        try:
+            sys.argv = ["hermes", "memory", "off"]
+            hermes_main.main()
+        finally:
+            sys.argv = original_argv
+
+        saved = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        if "memory" in saved:
+            assert saved["memory"].get("provider", "") == ""
+        assert saved["custom_section"] == {"keep": True}
+        assert (
+            saved["mcp_servers"]["zread"]["headers"]["Authorization"]
+            == "Bearer ${GLM_API_KEY}"
+        )
+        assert "browser" not in saved
 
 
 class TestProviderPersistsAfterModelSave:

--- a/tests/test_plugins_cmd.py
+++ b/tests/test_plugins_cmd.py
@@ -384,6 +384,44 @@ class TestCmdList:
         cmd_list()
 
 
+# ── config preservation regression ───────────────────────────────────────
+
+
+class TestPluginConfigPersistence:
+    """Plugin enable/disable should preserve raw user config values."""
+
+    def test_cmd_disable_preserves_raw_placeholders(self, tmp_path, monkeypatch):
+        from hermes_cli.plugins_cmd import cmd_disable
+
+        hermes_home = tmp_path / ".hermes"
+        plugins_dir = hermes_home / "plugins"
+        plugin_dir = plugins_dir / "demo-plugin"
+        plugin_dir.mkdir(parents=True)
+
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "custom_section:\n"
+            "  keep: true\n"
+            "mcp_servers:\n"
+            "  zread:\n"
+            "    headers:\n"
+            "      Authorization: Bearer ${GLM_API_KEY}\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("GLM_API_KEY", "secret-key-123")
+
+        cmd_disable("demo-plugin")
+
+        saved = config_path.read_text(encoding="utf-8")
+        assert "Authorization: Bearer ${GLM_API_KEY}" in saved
+        assert "terminal:" not in saved
+        assert "plugins:" in saved
+        assert "disabled:" in saved
+        assert "- demo-plugin" in saved
+
+
 # ── _copy_example_files tests ─────────────────────────────────────────────────
 
 

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -4,6 +4,8 @@ import ast
 from pathlib import Path
 from unittest.mock import patch as mock_patch
 
+from hermes_cli.config import get_config_path
+
 import tools.approval as approval_module
 from tools.approval import (
     _get_approval_mode,
@@ -15,6 +17,7 @@ from tools.approval import (
     load_permanent,
     pop_pending,
     prompt_dangerous_approval,
+    save_permanent_allowlist,
     submit_pending,
 )
 
@@ -221,6 +224,29 @@ class TestSessionKeyContext:
 
         assert pop_pending("alice") is not None
         assert pop_pending("bob") is None
+
+
+class TestPermanentAllowlistPersistence:
+    def test_save_permanent_allowlist_preserves_raw_placeholders(self, monkeypatch):
+        monkeypatch.setenv("GLM_API_KEY", "secret-key-123")
+        config_path = get_config_path()
+        config_path.write_text(
+            "custom_section:\n"
+            "  keep: true\n"
+            "mcp_servers:\n"
+            "  zread:\n"
+            "    headers:\n"
+            "      Authorization: Bearer ${GLM_API_KEY}\n",
+            encoding="utf-8",
+        )
+
+        save_permanent_allowlist({"git status"})
+
+        saved = config_path.read_text(encoding="utf-8")
+        assert "Authorization: Bearer ${GLM_API_KEY}" in saved
+        assert "command_allowlist:" in saved
+        assert "- git status" in saved
+        assert "terminal:" not in saved
 
 
 class TestRmFalsePositiveFix:
@@ -714,5 +740,3 @@ class TestNormalizationBypass:
         cmd = "\uff4c\uff53 -\uff4c\uff41 /tmp"
         dangerous, key, desc = detect_dangerous_command(cmd)
         assert dangerous is False
-
-

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -349,10 +349,10 @@ def load_permanent_allowlist() -> set:
 def save_permanent_allowlist(patterns: set):
     """Save permanently allowed command patterns to config."""
     try:
-        from hermes_cli.config import load_config, save_config
+        from hermes_cli.config import load_config, save_user_config
         config = load_config()
         config["command_allowlist"] = list(patterns)
-        save_config(config)
+        save_user_config(config)
     except Exception as e:
         logger.warning("Could not save allowlist: %s", e)
 


### PR DESCRIPTION
## What does this PR do?

  Fixes config persistence so Hermes stops silently rewriting user-authored `~/.hermes/config.yaml` when setup or other config-changing flows run.

  Before this change, several commands loaded the effective runtime config, which already had defaults merged in and environment variables expanded, then saved that object back to disk. That could:
  - reset user overrides like `compression.threshold`
  - expand a small config file into a large default-filled one
  - replace raw placeholders like `${GLM_API_KEY}` with resolved secret values

  This PR fixes that by separating the two config views clearly:
  - runtime code can still use the effective merged config
  - anything that writes `config.yaml` now patches and saves the raw user config instead

  That keeps the file minimal, preserves existing user overrides, and avoids writing expanded secrets back into `config.yaml`.

  ## Related Issue

  Fixes #4775 #3596 

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [ ] 📝 Documentation update
  - [x] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️ Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  ## Changes Made

  - Added a raw-preserving config save path in `hermes_cli/config.py` and centralized config writing through a shared writer.
  - Updated setup and migration flows in `hermes_cli/setup.py` and `hermes_cli/claw.py` so they preserve existing user config instead of regenerating the whole file.
  - Updated model/provider/config mutation flows in `hermes_cli/main.py`, `hermes_cli/auth.py`, `hermes_cli/mcp_config.py`, `hermes_cli/skills_config.py`, `hermes_cli/tools_config.py`, and `cli.py` to use the raw-preserving writer.
  - Updated permanent allowlist persistence in `tools/approval.py` to preserve raw placeholders and unrelated user config.
  - Updated gateway-side config writes in `gateway/run.py` and `gateway/platforms/telegram.py` to use the same shared config writer.
  - Added regression coverage in:
    - `tests/hermes_cli/test_config.py`
    - `tests/hermes_cli/test_setup.py`
    - `tests/hermes_cli/test_setup_openclaw_migration.py`
    - `tests/hermes_cli/test_claw.py`
    - `tests/hermes_cli/test_tools_config.py`
    - `tests/hermes_cli/test_mcp_config.py`
    - `tests/hermes_cli/test_skills_config.py`
    - `tests/test_model_provider_persistence.py`
    - `tests/tools/test_approval.py`
    - `tests/gateway/test_reasoning_command.py`
    - `tests/gateway/test_verbose_command.py`
    - `tests/gateway/test_dm_topics.py`
    - `tests/gateway/test_config_persistence.py`

  ## How to Test

  1. Create a minimal `~/.hermes/config.yaml` with a custom override like:
     ```yaml
     compression:
       threshold: 0.80
     mcp_servers:
       zread:
         config:
           headers:
             Authorization: Bearer ${GLM_API_KEY}

  2. Run config-changing flows such as hermes setup, hermes model, hermes tools, hermes mcp, hermes skills, or the gateway config commands, then confirm:
      - compression.threshold stays 0.80
      - ${GLM_API_KEY} stays raw in config.yaml
      - Hermes does not rewrite the file into a full default-expanded config
  3. Run:

     source .venv/bin/activate
     python -m pytest tests/hermes_cli/test_config.py tests/hermes_cli/test_setup.py tests/hermes_cli/test_tools_config.py tests/hermes_cli/test_mcp_config.py tests/hermes_cli/test_skills_config.py tests/test_model_provider_persistence.py tests/
  tools/test_approval.py tests/gateway/test_reasoning_command.py tests/gateway/test_verbose_command.py tests/gateway/test_dm_topics.py tests/gateway/test_config_persistence.py -q
     Expected result:
      - 243 passed, 24 warnings

  ## Checklist

  ### Code

  - [ ] I've read the Contributing Guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit messages follow Conventional Commits (https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
  - [x] I searched for existing PRs (https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - [x] My PR contains only changes related to this fix/feature (no unrelated commits)
  - [ ] I've run pytest tests/ -q and all tests pass
  - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - [x] I've tested on my platform: Ubuntu Linux

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A: N/A
  - [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A: N/A
  - [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A: N/A
  - [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A: N/A

  ## Screenshots / Logs

  Focused verification:

  $ source .venv/bin/activate
  $ python -m pytest tests/hermes_cli/test_config.py tests/hermes_cli/test_setup.py tests/hermes_cli/test_tools_config.py tests/hermes_cli/test_mcp_config.py tests/hermes_cli/test_skills_config.py tests/test_model_provider_persistence.py tests/
  tools/test_approval.py tests/gateway/test_reasoning_command.py tests/gateway/test_verbose_command.py tests/gateway/test_dm_topics.py tests/gateway/test_config_persistence.py -q
  243 passed, 24 warnings in 8.14s

  Full suite note:

  - pytest tests/ -q was run during development in this environment, but it still has unrelated pre-existing failures/errors outside this PR, so that checklist item is left unchecked.