### PR TITLE
fix(terminal): prevent heredoc fence wrapper leak in oneshot execution (salvage #3508)

### DIFF
--- a/tests/tools/test_local_persistent.py
+++ b/tests/tools/test_local_persistent.py
@@ -63,6 +63,18 @@ class TestLocalOneShotRegression:
         assert r["output"].strip() == ""
         env.cleanup()
 
+    def test_oneshot_heredoc_does_not_leak_fence_wrapper(self):
+        """Heredoc closing line must not be merged with the fence wrapper tail."""
+        env = LocalEnvironment(persistent=False)
+        cmd = "cat <<'H_EOF'\nheredoc body line\nH_EOF"
+        r = env.execute(cmd)
+        env.cleanup()
+        assert r["returncode"] == 0
+        assert "heredoc body line" in r["output"]
+        assert "__hermes_rc" not in r["output"]
+        assert "printf '" not in r["output"]
+        assert "exit $" not in r["output"]
+
 
 class TestLocalPersistent:
     @pytest.fixture

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -391,12 +391,17 @@ class LocalEnvironment(PersistentShellMixin, BaseEnvironment):
             effective_stdin = stdin_data
 
         user_shell = _find_bash()
+        # Newline-separated wrapper (not `cmd; __hermes_rc=...` on one line).
+        # A trailing `; __hermes_rc` glued to `<<EOF` / a closing `EOF` line breaks
+        # heredoc parsing: the delimiter must be alone on its line, otherwise the
+        # rest of this script becomes heredoc body and leaks into stdout (e.g. gh
+        # issue/PR flows that use here-documents for bodies).
         fenced_cmd = (
-            f"printf '{_OUTPUT_FENCE}';"
-            f" {exec_command};"
-            f" __hermes_rc=$?;"
-            f" printf '{_OUTPUT_FENCE}';"
-            f" exit $__hermes_rc"
+            f"printf '{_OUTPUT_FENCE}'\n"
+            f"{exec_command}\n"
+            f"__hermes_rc=$?\n"
+            f"printf '{_OUTPUT_FENCE}'\n"
+            f"exit $__hermes_rc\n"
         )
         run_env = _make_run_env(self.env)
 


### PR DESCRIPTION
## Summary
Salvage of #3508 by @kshitijk4poor. Cherry-picked onto current main with authorship preserved.

The oneshot terminal wrapper in `LocalEnvironment._execute_oneshot` joined the user command with fence markers using `;` on a single line. When the user command ends with a heredoc (e.g. `gh issue create --body <<'EOF'...EOF`), the closing delimiter must be alone on its line — the trailing `; __hermes_rc=$?` broke the delimiter, causing bash to treat the rest of the wrapper script as heredoc body. This leaked `__hermes_rc`, `__HERMES_FENCE`, and `exit` text into captured stdout.

Fix: switch from `;` separators to `\n` separators so the post-command trailer always starts on its own line.

## Changes
- `tools/environments/local.py`: newline-separated wrapper instead of semicolon-joined
- New test: `test_oneshot_heredoc_does_not_leak_fence_wrapper`

## Verification
- Unit tests: 26/26 pass in `test_local_persistent.py`
- Live PTY test: heredoc commands produce clean output with no fence leakage
- Regression: regular (non-heredoc) commands unaffected

## Credit
Original work by @kshitijk4poor in #3508.