### PR TITLE
fix: add async_is_safe_url() to avoid blocking event loop on DNS lookup

### DIFF
--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -15,6 +15,7 @@ Limitations (documented, not fixable at pre-flight level):
     SDKs (Firecrawl/Tavily) where redirect handling is on their servers.
 """
 
+import asyncio
 import ipaddress
 import logging
 import socket
@@ -47,11 +48,73 @@ def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     return False
 
 
+def _check_hostname(hostname: str, url: str) -> bool:
+    """Resolve hostname and verify it is not a private/internal address.
+
+    This is the synchronous core used by both is_safe_url() and
+    async_is_safe_url(). Callers in async contexts should use
+    async_is_safe_url() to avoid blocking the event loop during DNS lookup.
+    """
+    # Block known internal hostnames
+    if hostname in _BLOCKED_HOSTNAMES:
+        logger.warning("Blocked request to internal hostname: %s", hostname)
+        return False
+
+    # Try to resolve and check IP
+    try:
+        addr_info = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+    except socket.gaierror:
+        # DNS resolution failed — fail closed. If DNS can't resolve it,
+        # the HTTP client will also fail, so blocking loses nothing.
+        logger.warning("Blocked request — DNS resolution failed for: %s", hostname)
+        return False
+
+    for family, _, _, _, sockaddr in addr_info:
+        ip_str = sockaddr[0]
+        try:
+            ip = ipaddress.ip_address(ip_str)
+        except ValueError:
+            continue
+
+        if _is_blocked_ip(ip):
+            logger.warning(
+                "Blocked request to private/internal address: %s -> %s",
+                hostname, ip_str,
+            )
+            return False
+
+    return True
+
+
 def is_safe_url(url: str) -> bool:
     """Return True if the URL target is not a private/internal address.
 
     Resolves the hostname to an IP and checks against private ranges.
     Fails closed: DNS errors and unexpected exceptions block the request.
+
+    WARNING: This function calls socket.getaddrinfo() which is synchronous
+    and will block the calling thread during DNS resolution. In async
+    contexts (e.g. inside async def functions), use async_is_safe_url()
+    instead to avoid blocking the event loop.
+    """
+    try:
+        parsed = urlparse(url)
+        hostname = (parsed.hostname or "").strip().lower()
+        if not hostname:
+            return False
+        return _check_hostname(hostname, url)
+    except Exception as exc:
+        logger.warning("Blocked request — URL safety check error for %s: %s", url, exc)
+        return False
+
+
+async def async_is_safe_url(url: str) -> bool:
+    """Async-safe version of is_safe_url() for use in async contexts.
+
+    Runs the blocking socket.getaddrinfo() DNS lookup in a thread pool
+    executor so the event loop is not blocked during DNS resolution.
+    This is important in the gateway where a slow DNS response would
+    otherwise freeze all message handling for all users.
     """
     try:
         parsed = urlparse(url)
@@ -59,38 +122,15 @@ def is_safe_url(url: str) -> bool:
         if not hostname:
             return False
 
-        # Block known internal hostnames
+        # Block known internal hostnames without DNS (no I/O needed)
         if hostname in _BLOCKED_HOSTNAMES:
             logger.warning("Blocked request to internal hostname: %s", hostname)
             return False
 
-        # Try to resolve and check IP
-        try:
-            addr_info = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
-        except socket.gaierror:
-            # DNS resolution failed — fail closed. If DNS can't resolve it,
-            # the HTTP client will also fail, so blocking loses nothing.
-            logger.warning("Blocked request — DNS resolution failed for: %s", hostname)
-            return False
-
-        for family, _, _, _, sockaddr in addr_info:
-            ip_str = sockaddr[0]
-            try:
-                ip = ipaddress.ip_address(ip_str)
-            except ValueError:
-                continue
-
-            if _is_blocked_ip(ip):
-                logger.warning(
-                    "Blocked request to private/internal address: %s -> %s",
-                    hostname, ip_str,
-                )
-                return False
-
-        return True
+        # Run blocking DNS resolution in thread pool to avoid blocking event loop
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, _check_hostname, hostname, url)
 
     except Exception as exc:
-        # Fail closed on unexpected errors — don't let parsing edge cases
-        # become SSRF bypass vectors
         logger.warning("Blocked request — URL safety check error for %s: %s", url, exc)
         return False


### PR DESCRIPTION
is_safe_url() calls socket.getaddrinfo() which is synchronous and blocks the calling thread. It is called from web_extract_tool() and web_crawl_tool() which are both async. On a slow or unresponsive DNS server this freezes the entire asyncio event loop — blocking all gateway message handling for all users until DNS responds.

Fix extracts the hostname check into _check_hostname() and adds async_is_safe_url() which runs the blocking DNS call in a thread pool executor via loop.run_in_executor(). The original is_safe_url() is preserved for sync callers (vision_tools.py redirect hook).

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

