### PR TITLE
fix: placeholder api_key for custom providers without credentials (salvage #3543)

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -203,7 +203,7 @@ def _resolve_named_custom_runtime(
         or _detect_api_mode_for_url(base_url)
         or "chat_completions",
         "base_url": base_url,
-        "api_key": api_key,
+        "api_key": api_key or "no-key-required",
         "source": f"custom_provider:{custom_provider.get('name', requested_provider)}",
     }
 


### PR DESCRIPTION
## Summary

Local/custom OpenAI-compatible providers (Ollama, LM Studio, vLLM) that don't require auth hit empty api_key rejections from the OpenAI SDK when used as smart model routing targets.

One-line fix: `api_key or "no-key-required"` in `_resolve_named_custom_runtime()`, matching the identical pattern already in `_resolve_openrouter_runtime()` (line 288).

## Attribution

Cherry-picked from PR #3543 by @scottlowry. Adjusted placeholder from `"na-key"` to `"no-key-required"` for consistency with existing code.

## Tests

670 hermes_cli tests pass.