### PR TITLE
feat(skills): add garrytan/gstack as default Skills Hub tap

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -251,6 +251,7 @@ class GitHubSource(SkillSource):
         {"repo": "openai/skills", "path": "skills/"},
         {"repo": "anthropics/skills", "path": "skills/"},
         {"repo": "VoltAgent/awesome-agent-skills", "path": "skills/"},
+        {"repo": "garrytan/gstack", "path": ""},
     ]
 
     def __init__(self, auth: GitHubAuth, extra_taps: Optional[List[Dict]] = None):
@@ -395,7 +396,8 @@ class GitHubSource(SkillSource):
             if dir_name.startswith(".") or dir_name.startswith("_"):
                 continue
 
-            skill_identifier = f"{repo}/{path.rstrip('/')}/{dir_name}"
+            prefix = path.rstrip("/")
+            skill_identifier = f"{repo}/{prefix}/{dir_name}" if prefix else f"{repo}/{dir_name}"
             meta = self.inspect(skill_identifier)
             if meta:
                 skills.append(meta)


### PR DESCRIPTION
## Summary

Add the [gstack](https://github.com/garrytan/gstack) community skills repo to the default Skills Hub tap list. Also fixes skill identifier construction for repos with an empty `path` prefix (avoids double-slash).

Salvaged from #3386 by @tugrulguner with authorship preserved. (Previous merge attempt lost this change — re-applying cleanly.)

## Changes
- `tools/skills_hub.py`: add gstack tap + fix empty-path identifier construction