### PR TITLE
feat(cli): show resume-by-title command in exit summary

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5891,10 +5891,22 @@ class HermesCLI:
             else:
                 duration_str = f"{seconds}s"
             
+            # Look up session title for resume-by-name hint
+            session_title = None
+            if self._session_db:
+                try:
+                    session_title = self._session_db.get_session_title(self.session_id)
+                except Exception:
+                    pass
+
             print("Resume this session with:")
             print(f"  hermes --resume {self.session_id}")
+            if session_title:
+                print(f"  hermes -c \"{session_title}\"")
             print()
             print(f"Session:        {self.session_id}")
+            if session_title:
+                print(f"Title:          {session_title}")
             print(f"Duration:       {duration_str}")
             print(f"Messages:       {msg_count} ({user_msgs} user, {tool_calls} tool calls)")
         else:


### PR DESCRIPTION
## Summary
When exiting a CLI session that has a title (auto-generated or manually set), the exit summary now shows the `hermes -c "Title"` command alongside the existing `hermes --resume <id>`.

## Before
```
Resume this session with:
  hermes --resume 20260328_132400_abc123

Session:        20260328_132400_abc123
Duration:       12m 34s
Messages:       47 (8 user, 31 tool calls)
```

## After
```
Resume this session with:
  hermes --resume 20260328_132400_abc123
  hermes -c "Review PR 3514 CORS Preflight"

Session:        20260328_132400_abc123
Title:          Review PR 3514 CORS Preflight
Duration:       12m 34s
Messages:       47 (8 user, 31 tool calls)
```

When no title exists, output is unchanged.

## Changes
- `cli.py`: `_print_exit_summary()` — look up session title from DB, show `hermes -c` hint and title row

## Testing
- 691 CLI/hermes_cli tests pass
- Compile-checked