### PR TITLE
feat(discord): register /approve and /deny as native Discord slash commands

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1525,6 +1525,14 @@ class DiscordAdapter(BasePlatformAdapter):
             event = self._build_slash_event(interaction, f"/voice {mode}".strip())
             await self.handle_message(event)
 
+        @tree.command(name="approve", description="Approve a pending dangerous command")
+        async def slash_approve(interaction: discord.Interaction):
+            await self._run_simple_slash(interaction, "/approve")
+
+        @tree.command(name="deny", description="Deny a pending dangerous command")
+        async def slash_deny(interaction: discord.Interaction):
+            await self._run_simple_slash(interaction, "/deny")
+
         @tree.command(name="update", description="Update Hermes Agent to the latest version")
         async def slash_update(interaction: discord.Interaction):
             await self._run_simple_slash(interaction, "/update", "Update initiated~")


### PR DESCRIPTION
Fixes #3614

## Problem
/approve and /deny were missing from Discord's native slash command registry. In multi-bot servers, Discord routes slash interactions to whichever bot has the command registered — without registration, another bot wins and Hermes never sees the approval.

## Fix
Added /approve and /deny slash command handlers using the existing _run_simple_slash helper, consistent with all other Hermes Discord slash commands.
