### PR TITLE
feat(api-server): derive stable chat session IDs for chat completions

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -18,6 +18,7 @@ Requires:
 """
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -279,6 +280,58 @@ def _make_request_fingerprint(body: Dict[str, Any], keys: List[str]) -> str:
     return sha256(repr(subset).encode("utf-8")).hexdigest()
 
 
+def _normalize_openai_content(content: Any) -> str:
+    """Normalize OpenAI-style message content into plain text."""
+    if content is None:
+        return ""
+
+    if isinstance(content, str):
+        return content
+
+    if isinstance(content, list):
+        parts: List[str] = []
+        for item in content:
+            if isinstance(item, str):
+                if item:
+                    parts.append(item)
+                continue
+            if isinstance(item, dict):
+                item_type = item.get("type")
+                if item_type in ("text", "input_text", "output_text"):
+                    text = item.get("text", "")
+                    if isinstance(text, str) and text:
+                        parts.append(text)
+        return "\n".join(parts)
+
+    return str(content)
+
+
+def _derive_chat_session_id(request: "web.Request", body: Dict[str, Any], messages: List[Dict[str, Any]]) -> str:
+    """Derive a stable session_id for chat completions requests."""
+    header_chat_id = request.headers.get("X-Chat-ID", "").strip()
+    if header_chat_id:
+        return f"api-server-chat-{header_chat_id}"
+
+    conversation = body.get("conversation")
+    if isinstance(conversation, str) and conversation.strip():
+        return f"api-server-chat-{conversation.strip()}"
+
+    normalized_messages: List[Dict[str, str]] = []
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        normalized_messages.append(
+            {
+                "role": str(msg.get("role", "")),
+                "content": _normalize_openai_content(msg.get("content", "")),
+            }
+        )
+
+    payload = json.dumps(normalized_messages, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:24]
+    return f"api-server-chat-{digest}"
+
+
 class APIServerAdapter(BasePlatformAdapter):
     """
     OpenAI-compatible HTTP API server adapter.
@@ -471,7 +524,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         for msg in messages:
             role = msg.get("role", "")
-            content = msg.get("content", "")
+            content = _normalize_openai_content(msg.get("content", ""))
             if role == "system":
                 # Accumulate system messages
                 if system_prompt is None:
@@ -494,7 +547,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=400,
             )
 
-        session_id = str(uuid.uuid4())
+        session_id = _derive_chat_session_id(request, body, messages)
         completion_id = f"chatcmpl-{uuid.uuid4().hex[:29]}"
         model_name = body.get("model", "hermes-agent")
         created = int(time.time())

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -12,6 +12,7 @@ Tests cover:
 - Error handling (invalid JSON, missing fields)
 """
 
+import hashlib
 import json
 import time
 import uuid
@@ -529,6 +530,69 @@ class TestChatCompletionsEndpoint:
             assert len(call_kwargs["conversation_history"]) == 2
             assert call_kwargs["conversation_history"][0] == {"role": "user", "content": "1+1=?"}
             assert call_kwargs["conversation_history"][1] == {"role": "assistant", "content": "2"}
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_uses_x_chat_id_as_session_id(self, adapter):
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [{"role": "user", "content": "Hello"}],
+                    },
+                    headers={"X-Chat-ID": "webui-thread-123"},
+                )
+
+            assert resp.status == 200
+            assert mock_run.call_args.kwargs["session_id"] == "api-server-chat-webui-thread-123"
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_uses_conversation_field_as_session_id(self, adapter):
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "conversation": "conv-abc",
+                        "messages": [{"role": "user", "content": "Hello"}],
+                    },
+                )
+
+            assert resp.status == 200
+            assert mock_run.call_args.kwargs["session_id"] == "api-server-chat-conv-abc"
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_fallback_session_id_is_deterministic(self, adapter):
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+
+        expected_messages = [{"role": "user", "content": "Hello"}]
+        payload = json.dumps(expected_messages, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        expected_digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()[:24]
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [{"role": "user", "content": "Hello"}],
+                    },
+                )
+
+            assert resp.status == 200
+            assert mock_run.call_args.kwargs["session_id"] == f"api-server-chat-{expected_digest}"
 
     @pytest.mark.asyncio
     async def test_agent_error_returns_500(self, adapter):


### PR DESCRIPTION
## Summary

This PR makes `/v1/chat/completions` derive a stable Hermes `session_id` instead of generating a random UUID on every request.

## Problem

The API server currently creates a fresh random `session_id` for every Chat Completions request. That breaks session continuity for WebUI-style clients, since repeated requests from the same chat thread do not map to the same Hermes session.

## Solution

For `/v1/chat/completions`, derive `session_id` using this precedence:

1. `X-Chat-ID` request header
2. `conversation` field in the request body
3. deterministic hash of normalized `messages`

Also normalize OpenAI-style message content so structured content arrays can participate in deterministic session ID generation.

## Why this helps

This is a low-risk step toward WebUI session persistence and cross-request continuity:
- same chat thread can reuse the same Hermes session
- repeated requests no longer always start a brand new session
- behavior is deterministic and test-covered

## Tests

Added tests covering:
- `X-Chat-ID` precedence
- `conversation` fallback
- deterministic hash fallback

Local result:
- `python -m pytest tests/gateway/test_api_server.py -q`
- `91 passed`