### PR TITLE
feat(delegate): skill inheritance for subagents

### DIFF
--- a/tests/tools/test_delegate_skills.py
+++ b/tests/tools/test_delegate_skills.py
@@ -1,0 +1,36 @@
+import sys
+sys.path.insert(0, '/root/hermes-agent')
+
+def test_load_skill_content_returns_none_for_unknown():
+    from tools.delegate_tool import _load_skill_content
+    assert _load_skill_content('this-skill-does-not-exist-xyz') is None
+
+def test_load_skill_content_finds_existing_skill():
+    from pathlib import Path
+    from tools.delegate_tool import _load_skill_content
+    skills_dir = Path('/root/hermes-agent/skills')
+    skill_names = [p.parent.name for p in skills_dir.rglob('SKILL.md')]
+    if not skill_names:
+        return
+    content = _load_skill_content(skill_names[0])
+    assert content is not None and len(content) > 0
+
+def test_skill_injected_in_prompt(monkeypatch):
+    import tools.delegate_tool as dt
+    monkeypatch.setattr(dt, '_load_skill_content', lambda name: f'SKILL_CONTENT_{name}')
+    from tools.delegate_tool import _build_child_system_prompt
+    prompt = _build_child_system_prompt('do something', None, skills=['my-skill'])
+    assert 'SKILL_CONTENT_my-skill' in prompt
+
+def test_missing_skill_silently_skipped(monkeypatch):
+    import tools.delegate_tool as dt
+    monkeypatch.setattr(dt, '_load_skill_content', lambda name: None)
+    from tools.delegate_tool import _build_child_system_prompt
+    prompt = _build_child_system_prompt('goal', None, skills=['nonexistent'])
+    assert 'SKILL_CONTENT' not in prompt
+
+def test_no_skills_does_not_crash():
+    from tools.delegate_tool import _build_child_system_prompt
+    p1 = _build_child_system_prompt('goal', None, skills=None)
+    p2 = _build_child_system_prompt('goal', None, skills=[])
+    assert 'goal' in p1

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -21,6 +21,7 @@ import logging
 logger = logging.getLogger(__name__)
 import os
 import time
+from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, List, Optional
 
@@ -45,7 +46,23 @@ def check_delegate_requirements() -> bool:
     return True
 
 
-def _build_child_system_prompt(goal: str, context: Optional[str] = None) -> str:
+def _load_skill_content(name: str) -> str | None:
+    search_bases = [
+        Path(__file__).parent.parent / 'skills',
+        Path.home() / '.hermes' / 'skills',
+    ]
+    for base in search_bases:
+        if not base.exists():
+            continue
+        for skill_md in base.rglob(f'{name}/SKILL.md'):
+            try:
+                return skill_md.read_text(encoding='utf-8')
+            except OSError:
+                pass
+    return None
+
+
+def _build_child_system_prompt(goal: str, context: Optional[str] = None, skills: list | None = None) -> str:
     """Build a focused system prompt for a child agent."""
     parts = [
         "You are a focused subagent working on a specific delegated task.",
@@ -54,6 +71,14 @@ def _build_child_system_prompt(goal: str, context: Optional[str] = None) -> str:
     ]
     if context and context.strip():
         parts.append(f"\nCONTEXT:\n{context}")
+    if skills:
+        skill_sections = []
+        for skill_name in skills:
+            content = _load_skill_content(skill_name)
+            if content:
+                skill_sections.append(f'\n--- Skill: {skill_name} ---\n{content}')
+        if skill_sections:
+            parts.append('\nLoaded skills:' + ''.join(skill_sections))
     parts.append(
         "\nComplete this task using the tools available to you. "
         "When finished, provide a clear, concise summary of:\n"
@@ -160,6 +185,8 @@ def _build_child_agent(
     override_base_url: Optional[str] = None,
     override_api_key: Optional[str] = None,
     override_api_mode: Optional[str] = None,
+
+    skills: list | None = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -183,7 +210,7 @@ def _build_child_agent(
     else:
         child_toolsets = _strip_blocked_tools(DEFAULT_TOOLSETS)
 
-    child_prompt = _build_child_system_prompt(goal, context)
+    child_prompt = _build_child_system_prompt(goal, context, skills=skills)
     # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
     parent_api_key = getattr(parent_agent, "api_key", None)
     if (not parent_api_key) and hasattr(parent_agent, "_client_kwargs"):
@@ -484,6 +511,7 @@ def delegate_task(
                 override_provider=creds["provider"], override_base_url=creds["base_url"],
                 override_api_key=creds["api_key"],
                 override_api_mode=creds["api_mode"],
+                skills=t.get("skills"),
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names


### PR DESCRIPTION
Enables passing `skills=["skill-name"]` in the task dict to inject skill content into subagent system prompts.

## What this does
- Subagents can now load skills — closes a real gap where parent knowledge doesn't transfer
- Skill content is injected into the child system prompt under a "Loaded skills" section
- Gracefully skips missing skills (no crash)

## Implementation
- `_load_skill_content(name)` searches `skills/` and `~/.hermes/skills/` for `SKILL.md`
- `_build_child_system_prompt()` accepts optional `skills` list
- `delegate_task()` passes `t.get("skills")` through to child agent construction

## Tests
5 tests covering:
- Skill content lookup (found/not found)
- Prompt injection
- Missing skills silently skipped
- No crash when skills omitted

All existing delegate tests still pass.

---

This PR addresses one of the three items requested in #3387 review. Two more PRs coming:
1. ✅ Skill injection (this PR)
2. MCP workspace guard
3. Configurable max_depth