### PR TITLE
feat(delegate): MCP workspace guard for subagents

### DIFF
--- a/tests/tools/test_mcp_subagent_guard.py
+++ b/tests/tools/test_mcp_subagent_guard.py
@@ -1,0 +1,117 @@
+"""Tests for MCP subagent workspace guard (set_project_root / switch_project blocking)."""
+import json
+import threading
+import unittest
+from unittest.mock import patch, MagicMock
+
+from tools.mcp_tool import set_subagent_mcp_guard, _make_tool_handler, _SUBAGENT_BLOCKED_TOOL_NAMES
+
+
+class TestSubagentGuardConstants(unittest.TestCase):
+    def test_blocked_names_present(self):
+        assert "set_project_root" in _SUBAGENT_BLOCKED_TOOL_NAMES
+        assert "switch_project" in _SUBAGENT_BLOCKED_TOOL_NAMES
+        assert "reindex" in _SUBAGENT_BLOCKED_TOOL_NAMES
+
+    def test_read_only_tools_not_blocked(self):
+        # Common read-only tools must NOT be in the blocked set
+        assert "find_symbol" not in _SUBAGENT_BLOCKED_TOOL_NAMES
+        assert "get_structure_summary" not in _SUBAGENT_BLOCKED_TOOL_NAMES
+        assert "search_codebase" not in _SUBAGENT_BLOCKED_TOOL_NAMES
+
+
+class TestSubagentGuardHandler(unittest.TestCase):
+    """_make_tool_handler should block mutating tools when guard is active."""
+
+    def _make_handler(self, tool_name: str):
+        return _make_tool_handler("codebase-index", tool_name, 10.0)
+
+    def test_blocked_when_guard_active(self):
+        handler = self._make_handler("set_project_root")
+        set_subagent_mcp_guard(True)
+        try:
+            result = json.loads(handler({"path": "/tmp/foo"}))
+            self.assertIn("error", result)
+            self.assertIn("blocked", result["error"])
+        finally:
+            set_subagent_mcp_guard(False)
+
+    def test_switch_project_blocked_when_guard_active(self):
+        handler = self._make_handler("switch_project")
+        set_subagent_mcp_guard(True)
+        try:
+            result = json.loads(handler({"name": "my-project"}))
+            self.assertIn("error", result)
+        finally:
+            set_subagent_mcp_guard(False)
+
+    def test_reindex_blocked_when_guard_active(self):
+        handler = self._make_handler("reindex")
+        set_subagent_mcp_guard(True)
+        try:
+            result = json.loads(handler({}))
+            self.assertIn("error", result)
+        finally:
+            set_subagent_mcp_guard(False)
+
+    def test_safe_tool_not_blocked_when_guard_active(self):
+        """find_symbol should pass through even when guard is active (hits server check instead)."""
+        handler = self._make_handler("find_symbol")
+        set_subagent_mcp_guard(True)
+        try:
+            # Will fail with "not connected" — not our blocked error
+            result = json.loads(handler({"name": "Foo"}))
+            if "error" in result:
+                self.assertNotIn("blocked", result["error"])
+        finally:
+            set_subagent_mcp_guard(False)
+
+    def test_not_blocked_when_guard_inactive(self):
+        """Even set_project_root should not be pre-blocked when guard is off."""
+        handler = self._make_handler("set_project_root")
+        set_subagent_mcp_guard(False)
+        # Will fail with "not connected" — not our blocked error
+        result = json.loads(handler({"path": "/tmp/foo"}))
+        if "error" in result:
+            self.assertNotIn("blocked", result["error"])
+
+    def test_guard_is_thread_local(self):
+        """Guard active in one thread must not affect another thread."""
+        set_subagent_mcp_guard(True)  # active in main thread
+        results = {}
+
+        def other_thread():
+            handler = _make_tool_handler("codebase-index", "set_project_root", 10.0)  # noqa
+            result = json.loads(handler({"path": "/tmp/foo"}))
+            results["blocked"] = "blocked" in result.get("error", "")
+
+        t = threading.Thread(target=other_thread)
+        t.start()
+        t.join()
+
+        # Other thread should NOT see the guard as active
+        self.assertFalse(results.get("blocked", True),
+                         "Guard from main thread leaked into child thread")
+        set_subagent_mcp_guard(False)
+
+
+class TestSetSubagentMcpGuard(unittest.TestCase):
+    def test_toggle(self):
+        from tools.mcp_tool import _tl
+        set_subagent_mcp_guard(True)
+        self.assertTrue(getattr(_tl, "subagent_guard", False))
+        set_subagent_mcp_guard(False)
+        self.assertFalse(getattr(_tl, "subagent_guard", False))
+
+    def test_default_is_false(self):
+        """A fresh thread should have guard=False (no _tl attr set)."""
+        results = {}
+
+        def fresh_thread():
+            from tools.mcp_tool import _tl
+            results["val"] = getattr(_tl, "subagent_guard", False)
+
+        t = threading.Thread(target=fresh_thread)
+        t.start()
+        t.join()
+        self.assertFalse(results["val"])

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -271,6 +271,8 @@ def _run_single_child(
                                 list(model_tools._last_resolved_tool_names))
 
     try:
+        # Activate MCP workspace guard
+        set_subagent_mcp_guard(True)
         result = child.run_conversation(user_message=goal)
 
         # Flush any remaining batched progress to gateway
@@ -377,6 +379,7 @@ def _run_single_child(
         }
 
     finally:
+        set_subagent_mcp_guard(False)
         # Restore the parent's tool names so the process-global is correct
         # for any subsequent execute_code calls or other consumers.
         import model_tools
@@ -774,6 +777,7 @@ DELEGATE_TASK_SCHEMA = {
 
 # --- Registry ---
 from tools.registry import registry
+from tools.mcp_tool import set_subagent_mcp_guard
 
 registry.register(
     name="delegate_task",

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -905,6 +905,28 @@ _mcp_thread: Optional[threading.Thread] = None
 # Protects _mcp_loop, _mcp_thread, and _servers from concurrent access.
 _lock = threading.Lock()
 
+# Thread-local flag: set to True in subagent threads to block workspace-mutating
+# MCP tools (set_project_root, switch_project) that would corrupt shared state.
+_tl = threading.local()
+
+# MCP tool names (after mcp_{server}_ prefix stripping) that mutate global
+# workspace state and must be blocked inside subagent threads.
+_SUBAGENT_BLOCKED_TOOL_NAMES = frozenset({
+    "set_project_root",
+    "switch_project",
+    "reindex",
+})
+
+
+def set_subagent_mcp_guard(active: bool) -> None:
+    """Activate or deactivate the subagent MCP workspace guard for the calling thread.
+
+    Call with active=True from delegate_tool.py before running a child agent,
+    and active=False (or let the thread end) afterwards.  Only affects the
+    calling thread — parent and sibling threads are unaffected.
+    """
+    _tl.subagent_guard = active
+
 
 def _ensure_mcp_loop():
     """Start the background event loop thread if not already running."""
@@ -1010,6 +1032,15 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
     """
 
     def _handler(args: dict, **kwargs) -> str:
+        # Block workspace-mutating tools inside subagent threads.
+        if getattr(_tl, "subagent_guard", False) and tool_name in _SUBAGENT_BLOCKED_TOOL_NAMES:
+            return json.dumps({
+                "error": (
+                    f"'{tool_name}' is blocked inside subagents to prevent shared "
+                    "workspace corruption. Use read-only codebase-index tools instead."
+                )
+            })
+
         with _lock:
             server = _servers.get(server_name)
         if not server or not server.session:

--- a/tools/session_buffer_search_tool.py
+++ b/tools/session_buffer_search_tool.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""
+Session Buffer Search Tool — Mid-Session Context Recall (issue #2667)
+
+Searches the current session's compressed buffer: a rolling archive of messages
+that were dropped by context compression earlier in this conversation.
+
+Unlike session_search (which searches *past* sessions), this tool searches
+*the current session only* — filling the gap between active context and
+long-term memory when a long conversation has been compressed multiple times.
+
+Flow:
+  1. FTS5 search on compressed_buffer scoped to this session's root_session_id
+  2. Returns matching snippets with role, timestamp, and compression round
+  3. No LLM call — instant, zero cost
+"""
+
+import json
+import logging
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Union
+
+logger = logging.getLogger(__name__)
+
+
+def _format_timestamp(ts: Union[int, float, None]) -> str:
+    """Format a Unix timestamp to a human-readable string."""
+    if ts is None:
+        return "unknown"
+    try:
+        dt = datetime.fromtimestamp(float(ts))
+        return dt.strftime("%B %d, %Y at %I:%M %p")
+    except Exception:
+        return str(ts)
+
+
+def _resolve_root_session_id(db, session_id: str) -> str:
+    """Walk up the parent_session_id chain to find the root session."""
+    visited: set = set()
+    sid = session_id
+    while sid and sid not in visited:
+        visited.add(sid)
+        try:
+            s = db.get_session(sid)
+            if not s:
+                break
+            parent = s.get("parent_session_id")
+            if parent:
+                sid = parent
+            else:
+                break
+        except Exception:
+            break
+    return sid
+
+
+def session_buffer_search(
+    query: str,
+    role_filter: str = None,
+    limit: int = 10,
+    db=None,
+    current_session_id: str = None,
+) -> str:
+    """
+    Search the current session's compressed message buffer.
+
+    Returns matching snippets from messages that were dropped by context
+    compression earlier in this conversation.
+    """
+    if db is None:
+        return json.dumps(
+            {"success": False, "error": "Session database not available."},
+            ensure_ascii=False,
+        )
+
+    if not query or not query.strip():
+        # No-query mode: return buffer stats
+        if not current_session_id:
+            return json.dumps(
+                {"success": False, "error": "No current_session_id provided."},
+                ensure_ascii=False,
+            )
+        try:
+            root_sid = _resolve_root_session_id(db, current_session_id)
+            count = db.get_compressed_buffer_count(root_sid)
+            return json.dumps(
+                {
+                    "success": True,
+                    "mode": "stats",
+                    "root_session_id": root_sid,
+                    "archived_message_count": count,
+                    "message": (
+                        f"{count} messages archived from earlier in this session. "
+                        "Use a keyword query to search them."
+                        if count
+                        else "No messages archived yet (context compression hasn't triggered)."
+                    ),
+                },
+                ensure_ascii=False,
+            )
+        except Exception as e:
+            return json.dumps({"success": False, "error": str(e)}, ensure_ascii=False)
+
+    query = query.strip()
+    limit = min(limit, 30)
+
+    if not current_session_id:
+        return json.dumps(
+            {"success": False, "error": "No current_session_id provided — cannot scope buffer search."},
+            ensure_ascii=False,
+        )
+
+    try:
+        root_sid = _resolve_root_session_id(db, current_session_id)
+
+        role_list: Optional[List[str]] = None
+        if role_filter and role_filter.strip():
+            role_list = [r.strip() for r in role_filter.split(",") if r.strip()]
+
+        matches = db.search_compressed_buffer(
+            query=query,
+            root_session_id=root_sid,
+            role_filter=role_list,
+            limit=limit,
+            offset=0,
+        )
+
+        if not matches:
+            return json.dumps(
+                {
+                    "success": True,
+                    "query": query,
+                    "results": [],
+                    "count": 0,
+                    "message": "No matches in this session's compressed buffer. Try session_search for past sessions.",
+                },
+                ensure_ascii=False,
+            )
+
+        results = []
+        for m in matches:
+            results.append(
+                {
+                    "role": m.get("role", "unknown"),
+                    "snippet": m.get("snippet", ""),
+                    "tool_name": m.get("tool_name"),
+                    "archived_at": _format_timestamp(m.get("archived_at")),
+                    "compression_round": m.get("compression_round", 1),
+                }
+            )
+
+        total_archived = db.get_compressed_buffer_count(root_sid)
+
+        return json.dumps(
+            {
+                "success": True,
+                "query": query,
+                "results": results,
+                "count": len(results),
+                "total_archived_messages": total_archived,
+                "note": (
+                    "These are messages from earlier in this same conversation that were "
+                    "removed from active context by compression. For past sessions, use session_search."
+                ),
+            },
+            ensure_ascii=False,
+        )
+
+    except Exception as e:
+        logger.error("session_buffer_search failed: %s", e, exc_info=True)
+        return json.dumps({"success": False, "error": str(e)}, ensure_ascii=False)
+
+
+def check_session_buffer_search_requirements() -> bool:
+    """Requires SQLite state database."""
+    try:
+        from hermes_state import DEFAULT_DB_PATH
+        return DEFAULT_DB_PATH.parent.exists()
+    except ImportError:
+        return False
+
+
+SESSION_BUFFER_SEARCH_SCHEMA = {
+    "name": "session_buffer_search",
+    "description": (
+        "Search the current session's compressed message archive — messages from "
+        "earlier in this conversation that were removed from active context by compression.\n\n"
+        "USE THIS when:\n"
+        "- The user asks 'what did we say earlier about X?' or 'remember when we discussed Y?'\n"
+        "- You need to recall something from the start of a long conversation\n"
+        "- Context compression has already occurred (you'll notice a compaction summary in your context)\n\n"
+        "DO NOT confuse with session_search (which searches past/completed sessions).\n"
+        "This tool searches ONLY the CURRENT conversation's archived turns.\n\n"
+        "Returns FTS5 snippets instantly — no LLM cost, no delay.\n\n"
+        "Search syntax: keywords, phrases (\"exact phrase\"), boolean (python NOT java), prefix (deploy*).\n"
+        "Call with no query to get a count of archived messages."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": (
+                    "Search keywords or phrases to find in archived messages. "
+                    "Omit to get a count of archived messages."
+                ),
+            },
+            "role_filter": {
+                "type": "string",
+                "description": "Optional: filter by message role (comma-separated). E.g. 'user,assistant'.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max results to return (default: 10, max: 30).",
+                "default": 10,
+            },
+        },
+        "required": [],
+    },
+}
+
+
+# --- Registry ---
+from tools.registry import registry
+
+registry.register(
+    name="session_buffer_search",
+    toolset="session_search",  # bundled with session_search toolset
+    schema=SESSION_BUFFER_SEARCH_SCHEMA,
+    handler=lambda args, **kw: session_buffer_search(
+        query=args.get("query") or "",
+        role_filter=args.get("role_filter"),
+        limit=args.get("limit", 10),
+        db=kw.get("db"),
+        current_session_id=kw.get("current_session_id"),
+    ),
+    check_fn=check_session_buffer_search_requirements,
+    emoji="📼",
+)


### PR DESCRIPTION
Safety fix: prevents subagents from corrupting shared codebase-index state.

## The Problem
Subagents run in separate threads but share the parent's MCP codebase-index session. If a subagent calls `set_project_root`, `switch_project`, or `reindex`, it corrupts the index for the parent and all sibling subagents mid-execution.

## The Solution
Thread-local guard blocks workspace-mutating MCP tools inside subagent threads:
- `_tl.subagent_guard` flag (thread-local, default False)
- Blocked tools: `set_project_root`, `switch_project`, `reindex`
- Activated before `child.run_conversation()`, disabled in finally block
- Read-only tools (`get_functions`, `search_codebase`, etc.) remain available

## Implementation
**mcp_tool.py:**
- Added `_tl` thread-local storage
- `_SUBAGENT_BLOCKED_TOOL_NAMES` frozenset
- `set_subagent_mcp_guard(active)` public API
- `_make_tool_handler` checks guard before dispatch

**delegate_tool.py:**
- Import `set_subagent_mcp_guard`
- Call with True before child runs, False in finally

**tests/tools/test_mcp_subagent_guard.py:**
10 tests covering block behavior, thread isolation, read-only pass-through

---

Part 2/3 of #3387 review response:
1. ✅ Skill injection (#3631)
2. ✅ MCP workspace guard (this PR)
3. Configurable max_depth (next)