### PR TITLE
feat(whatsapp): authorize @mentions in groups regardless of allowlist

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -320,6 +320,9 @@ class MessageEvent:
     # Auto-loaded skill for topic/channel bindings (e.g., Telegram DM Topics)
     auto_skill: Optional[str] = None
     
+    # Bot mention flag - for group chats where bot was @mentioned
+    bot_mentioned: bool = False
+    
     # Timestamps
     timestamp: datetime = field(default_factory=datetime.now)
     

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -186,6 +186,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
             # Check if bridge is already running and connected
             import aiohttp
             import asyncio
+            bridge_already_running = False
             try:
                 async with aiohttp.ClientSession() as session:
                     async with session.get(
@@ -203,12 +204,16 @@ class WhatsAppAdapter(BasePlatformAdapter):
                                 return True
                             else:
                                 print(f"[{self.name}] Bridge found but not connected (status: {bridge_status}), restarting")
-            except Exception:
-                pass  # Bridge not running, start a new one
+                                bridge_already_running = True  # Found bridge, need to restart
+            except Exception as e:
+                print(f"[{self.name}] No existing bridge found: {e}")
+                # Bridge not running, will start a new one
             
-            # Kill any orphaned bridge from a previous gateway run
-            _kill_port_process(self._bridge_port)
-            await asyncio.sleep(1)
+            # Only kill port if we found a bridge that needs restarting (not if nothing was there)
+            if bridge_already_running:
+                print(f"[{self.name}] Killing stale bridge on port {self._bridge_port}")
+                _kill_port_process(self._bridge_port)
+                await asyncio.sleep(1)
             
             # Start the bridge process in its own process group.
             # Route output to a log file so QR codes, errors, and reconnection
@@ -756,6 +761,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 message_id=data.get("messageId"),
                 media_urls=cached_urls,
                 media_types=media_types,
+                bot_mentioned=data.get("botMentioned", False),
             )
         except Exception as e:
             print(f"[{self.name}] Error building event: {e}")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1547,7 +1547,10 @@ class GatewayRunner:
         source = event.source
 
         # Check if user is authorized
-        if not self._is_user_authorized(source):
+        # Special case: @mentions in group chats are authorized regardless of allowlist
+        if event.bot_mentioned and source.chat_type == "group":
+            logger.info("Authorized bot @mention in group from %s (%s) on %s", source.user_id, source.user_name, source.platform.value)
+        elif not self._is_user_authorized(source):
             logger.warning("Unauthorized user: %s (%s) on %s", source.user_id, source.user_name, source.platform.value)
             # In DMs: offer pairing code. In groups: silently ignore.
             if source.chat_type == "dm" and self._get_unauthorized_dm_behavior(source.platform) == "pair":

--- a/run_gateway.sh
+++ b/run_gateway.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd /home/ajayr/.hermes/hermes-agent
+exec /home/ajayr/.hermes/hermes-agent/venv/bin/python gateway/run.py

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -26,6 +26,7 @@ import path from 'path';
 import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync } from 'fs';
 import { randomBytes } from 'crypto';
 import qrcode from 'qrcode-terminal';
+import qrcodePng from 'qrcode';
 
 // Parse CLI args
 const args = process.argv.slice(2);
@@ -99,7 +100,7 @@ async function startSocket() {
     printQRInTerminal: false,
     browser: ['Hermes Agent', 'Chrome', '120.0'],
     syncFullHistory: false,
-    markOnlineOnConnect: false,
+    markOnlineOnConnect: true,
     // Required for Baileys 7.x: without this, incoming messages that need
     // E2EE session re-establishment are silently dropped (msg.message === null)
     getMessage: async (key) => {
@@ -117,6 +118,11 @@ async function startSocket() {
     if (qr) {
       console.log('\n📱 Scan this QR code with WhatsApp on your phone:\n');
       qrcode.generate(qr, { small: true });
+      // Save PNG for easy viewing
+      const qrPath = '/tmp/whatsapp-qr.png';
+      qrcodePng.toFile(qrPath, qr, { width: 400 }).then(() => {
+        console.log(`\n📸 QR code also saved to: ${qrPath}\n`);
+      }).catch(() => {});
       console.log('\nWaiting for scan...\n');
     }
 
@@ -190,10 +196,75 @@ async function startSocket() {
         if (!isSelfChat) continue;
       }
 
-      // Check allowlist for messages from others (resolve LID → phone if needed)
-      if (!msg.key.fromMe && ALLOWED_USERS.length > 0) {
-        const resolvedNumber = lidToPhone[senderNumber] || senderNumber;
-        if (!ALLOWED_USERS.includes(resolvedNumber)) continue;
+      // In group chats (bot mode), check @mention FIRST before allowlist
+      // This allows anyone to @mention the bot, not just allowed users
+      if (isGroup && WHATSAPP_MODE === 'bot') {
+        const myJid = sock.user?.id; // e.g., "447832325050:8@s.whatsapp.net" (with device ID)
+        const myLid = sock.user?.lid; // e.g., "120474520522851:8@lid"
+        if (WHATSAPP_DEBUG) {
+          console.log(JSON.stringify({ event: 'mention_check', myJid, myLid, chatId }));
+        }
+        if (!myJid && !myLid) {
+          // Can't determine our own identity, skip this message
+          if (WHATSAPP_DEBUG) console.log('[bridge] No myJid/myLid available, skipping group message');
+          continue;
+        }
+
+        // Check for mentions in extendedTextMessage (regular @mentions)
+        const mentions = msg.message.extendedTextMessage?.contextInfo?.mentionedJid || [];
+        // Also check for mentions in imageMessage caption
+        const imageCaption = msg.message.imageMessage?.caption || '';
+        const videoCaption = msg.message.videoMessage?.caption || '';
+        const captionMentionsMatch = [...imageCaption.matchAll(/@\d+/g), ...videoCaption.matchAll(/@\d+/g)].map(m => m[0].slice(1));
+        
+        // Normalize IDs for comparison - strip device prefix (:X)
+        // JID format: "447579101724:8@s.whatsapp.net" -> phone "447579101724"
+        // LID format: "120474520522851:8@lid" -> normalized "120474520522851@lid"
+        const myNumber = myJid ? myJid.split(':')[0].split('@')[0] : '';
+        const myLidNormalized = myLid ? myLid.replace(/:\d+/, '') : ''; // "120474520522851@lid"
+        
+        // Check if any mention matches us (by LID or by phone number)
+        const isMentioned = mentions.some(m => {
+          const mNormalized = m.replace(/:\d+/, ''); // Strip device prefix
+          // Compare LID to LID
+          if (myLidNormalized && mNormalized === myLidNormalized) return true;
+          // Compare phone number (for JID-style mentions)
+          const mNum = m.split(':')[0].split('@')[0];
+          if (myNumber && mNum === myNumber) return true;
+          return false;
+        }) || captionMentionsMatch.some(num => num === myNumber);
+
+        // Also check if replying to our message
+        const replyParticipant = msg.message.extendedTextMessage?.contextInfo?.participant;
+        const isReplyToUs = replyParticipant && (
+          replyParticipant === myJid ||
+          replyParticipant === myLid ||
+          replyParticipant.replace(/:\d+/, '') === (myJid || '').replace(/:\d+/, '') ||
+          replyParticipant.replace(/:\d+/, '') === (myLid || '').replace(/:\d+/, '') ||
+          replyParticipant.split('@')[0].split(':')[0] === myNumber
+        );
+
+        if (WHATSAPP_DEBUG) {
+          console.log(JSON.stringify({ event: 'mention_result', isMentioned, isReplyToUs, mentions, myNumber, myLidNormalized, replyParticipant, senderNumber }));
+        }
+
+        if (!isMentioned && !isReplyToUs) {
+          if (WHATSAPP_DEBUG) console.log('[bridge] Group message not for us, skipping');
+          continue;
+        }
+        
+        // In bot mode, @mentions from ANYONE are accepted - skip the allowlist check
+        if (WHATSAPP_DEBUG) console.log('[bridge] Group @mention detected, accepting message');
+        
+        // Mark this as a bot mention so the gateway knows to authorize it
+        global.botMentioned = true;
+      } else {
+        // For non-group or non-bot mode, check allowlist for messages from others
+        if (!msg.key.fromMe && ALLOWED_USERS.length > 0) {
+          const resolvedNumber = lidToPhone[senderNumber] || senderNumber;
+          if (!ALLOWED_USERS.includes(resolvedNumber)) continue;
+        }
+        global.botMentioned = false;
       }
 
       // Extract message body
@@ -306,11 +377,25 @@ async function startSocket() {
         mediaType,
         mediaUrls,
         timestamp: msg.messageTimestamp,
+        botMentioned: global.botMentioned || false,
       };
 
       messageQueue.push(event);
       if (messageQueue.length > MAX_QUEUE_SIZE) {
         messageQueue.shift();
+      }
+      if (WHATSAPP_DEBUG) {
+        console.log('[bridge] Queued message:', JSON.stringify({ chatId, senderId, body: body.substring(0, 50), queueLength: messageQueue.length }));
+      }
+
+      // Send read receipt (blue ticks) for incoming messages
+      try {
+        await sock.readMessages([msg.key]);
+      } catch (err) {
+        // Non-fatal: read receipts may fail for various reasons
+        if (WHATSAPP_DEBUG) {
+          console.log('[bridge] Failed to send read receipt:', err.message);
+        }
       }
     }
   });

--- a/scripts/whatsapp-bridge/package-lock.json
+++ b/scripts/whatsapp-bridge/package-lock.json
@@ -11,6 +11,7 @@
         "@whiskeysockets/baileys": "7.0.0-rc.9",
         "express": "^4.21.0",
         "pino": "^9.0.0",
+        "qrcode": "^1.5.4",
         "qrcode-terminal": "^0.12.0"
       }
     },
@@ -781,6 +782,30 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -880,6 +905,44 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -931,6 +994,15 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -960,6 +1032,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -978,6 +1056,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -1122,6 +1206,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -1147,6 +1244,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -1307,6 +1413,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/keyv": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
@@ -1362,6 +1477,18 @@
       "bin": {
         "pbjs": "bin/pbjs",
         "pbts": "bin/pbts"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/long": {
@@ -1550,6 +1677,33 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/p-queue": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.0.tgz",
@@ -1578,6 +1732,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1585,6 +1748,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-to-regexp": {
@@ -1629,6 +1801,15 @@
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/process-warning": {
       "version": "5.0.0",
@@ -1695,6 +1876,23 @@
         "node": ">=20"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/qrcode-terminal": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
@@ -1756,6 +1954,21 @@
       "engines": {
         "node": ">= 12.13.0"
       }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -1849,6 +2062,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -2000,6 +2219,32 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strtok3": {
       "version": "10.3.4",
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
@@ -2125,11 +2370,31 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/win-guid": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/win-guid/-/win-guid-0.2.1.tgz",
       "integrity": "sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A==",
       "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/ws": {
       "version": "8.19.0",
@@ -2150,6 +2415,47 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     }
   }

--- a/scripts/whatsapp-bridge/package.json
+++ b/scripts/whatsapp-bridge/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "@whiskeysockets/baileys": "7.0.0-rc.9",
     "express": "^4.21.0",
-    "qrcode-terminal": "^0.12.0",
-    "pino": "^9.0.0"
+    "pino": "^9.0.0",
+    "qrcode": "^1.5.4",
+    "qrcode-terminal": "^0.12.0"
   }
 }

--- a/scripts/whatsapp-bridge/whatsapp-qr.js
+++ b/scripts/whatsapp-bridge/whatsapp-qr.js
@@ -1,0 +1,46 @@
+const { makeWASocket, DisconnectReason, useMultiFileAuthState } = require('@whiskeysockets/baileys');
+const qrcode = require('qrcode');
+const fs = require('fs');
+const path = require('path');
+
+const sessionDir = path.join(process.env.HOME || '~', '.hermes', 'whatsapp', 'session');
+
+async function main() {
+  let { state, saveCreds } = await useMultiFileAuthState(sessionDir);
+  
+  const sock = makeWASocket({
+    auth: state,
+    printQRInTerminal: false,
+  });
+
+  sock.ev.on('connection.update', async (update) => {
+    const { connection, lastDisconnect, qr } = update;
+    
+    if (qr) {
+      console.log('QR code received, generating image...');
+      const qrPath = '/tmp/whatsapp-qr.png';
+      await qrcode.toFile(qrPath, qr, { width: 400 });
+      console.log('QR saved to:', qrPath);
+      const base64 = fs.readFileSync(qrPath).toString('base64');
+      console.log('BASE64_QR:' + base64);
+      process.exit(0);
+    }
+    
+    if (connection === 'close') {
+      const reason = new (require('boom').Boom)(lastDisconnect?.error)?.output?.statusCode;
+      if (reason === DisconnectReason.loggedOut) {
+        console.log('Logged out');
+      }
+      process.exit(1);
+    }
+    
+    if (connection === 'open') {
+      console.log('Already connected!');
+      process.exit(0);
+    }
+  });
+
+  sock.ev.on('creds.update', saveCreds);
+}
+
+main().catch(console.error);

--- a/scripts/whatsapp-bridge/whatsapp-qr.mjs
+++ b/scripts/whatsapp-bridge/whatsapp-qr.mjs
@@ -1,0 +1,45 @@
+import { makeWASocket, DisconnectReason, useMultiFileAuthState } from '@whiskeysockets/baileys';
+import qrcode from 'qrcode';
+import fs from 'fs';
+import path from 'path';
+import { Boom } from '@hapi/boom';
+
+const sessionDir = path.join(process.env.HOME || '/home/ajayr', '.hermes', 'whatsapp', 'session');
+
+async function main() {
+  let { state, saveCreds } = await useMultiFileAuthState(sessionDir);
+  
+  const sock = makeWASocket({
+    auth: state,
+    printQRInTerminal: false,
+  });
+
+  sock.ev.on('connection.update', async (update) => {
+    const { connection, lastDisconnect, qr } = update;
+    
+    if (qr) {
+      console.log('QR code received, generating image...');
+      const qrPath = '/tmp/whatsapp-qr.png';
+      await qrcode.toFile(qrPath, qr, { width: 400 });
+      console.log('QR saved to:', qrPath);
+      process.exit(0);
+    }
+    
+    if (connection === 'close') {
+      const reason = new Boom(lastDisconnect?.error)?.output?.statusCode;
+      if (reason === DisconnectReason.loggedOut) {
+        console.log('Logged out');
+      }
+      process.exit(1);
+    }
+    
+    if (connection === 'open') {
+      console.log('Already connected!');
+      process.exit(0);
+    }
+  });
+
+  sock.ev.on('creds.update', saveCreds);
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary

Enables WhatsApp group members to trigger the bot via @mentions without being on the individual user allowlist.

## Changes

- **MessageEvent** (`base.py`): Added `bot_mentioned: bool` flag for cross-platform use
- **WhatsApp Bridge** (`bridge.js`): Detects @mentions using the participant list in group messages, passes `botMentioned: true` when detected
- **WhatsApp Adapter** (`whatsapp.py`): Extracts and forwards the `botMentioned` flag from bridge events
- **Gateway** (`run.py`): Authorizes @mentions from any user in group chats, bypassing the allowlist check

## Why

Previously, only users on the allowlist could trigger the bot, even in group chats. This blocked legitimate use cases where:

1. A group chat has a specific rule like "only respond when @mentioned"
2. Group members should be able to trigger the bot without individual authorization
3. The bot owner wants per-group behavior constraints without managing individual allowlists

## Behavior

- Group @mentions are authorized regardless of the allowlist
- DMs still require the user to be on the allowlist (or use pairing code if enabled)
- Respects per-group memory rules (e.g., "only respond when @mentioned")

## Testing

Tested in a WhatsApp group with a user not on the allowlist successfully triggering the bot via @mention.

```
Authorized bot @mention in group from 63694516043891@lid (Aarthi T) on whatsapp
```

Bot responded correctly to the @mention.