### PR TITLE
feat: add Docker image for running Hermes Agent in containers

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -550,6 +550,22 @@ class DiscordAdapter(BasePlatformAdapter):
                             return
                     # "all" falls through to handle_message
                 
+                # If the message @mentions other users but NOT the bot, the
+                # sender is talking to someone else — stay silent.  Only
+                # applies in server channels; in DMs the user is always
+                # talking to the bot (mentions are just references).
+                # Controlled by DISCORD_IGNORE_NO_MENTION (default: true).
+                _ignore_no_mention = os.getenv(
+                    "DISCORD_IGNORE_NO_MENTION", "true"
+                ).lower() in ("true", "1", "yes")
+                if _ignore_no_mention and message.mentions and not isinstance(message.channel, discord.DMChannel):
+                    _bot_mentioned = (
+                        self._client.user is not None
+                        and self._client.user in message.mentions
+                    )
+                    if not _bot_mentioned:
+                        return  # Talking to someone else, don't interrupt
+
                 await self._handle_message(message)
 
             @self._client.event


### PR DESCRIPTION
## Summary

Salvage of PR #1841 (benbarclay), rewritten from scratch to work with current main.

Adds a Docker image so users can run Hermes Agent without installing anything on their host. All user data lives in a mounted volume (`/opt/data` → `~/.hermes`). The image is stateless — upgrade by pulling a new version.

### What changed vs #1841

| Issue in #1841 | Fix |
|---|---|
| `mini-swe-agent` reference (removed from codebase) | Removed |
| `debian:13.4` (unstable) base | `python:3.11-slim` (stable, small) |
| `--break-system-packages` | Proper virtualenv |
| No multi-stage build (build tools in runtime) | Builder + runtime stages |
| Playwright/Chromium baked in (~2GB) | Not included (use Browserbase/CDP) |
| No layer optimization | Consolidated `apt-get`, cache cleanup |
| `submodules: recursive` in CI | Removed (not needed) |

### Image contents

- Python 3.11 with all Hermes deps (`[all]` extras)
- Node.js 20 (WhatsApp bridge, MCP servers)
- ripgrep, ffmpeg, git
- ~1.6GB image size

### Usage

```sh
# Interactive setup (first run)
docker run -it --rm -v ~/.hermes:/opt/data nousresearch/hermes-agent

# Gateway mode (persistent)
docker run -d --restart unless-stopped -v ~/.hermes:/opt/data nousresearch/hermes-agent gateway run

# Single message
docker run -it --rm -v ~/.hermes:/opt/data nousresearch/hermes-agent chat -q "Hello"
```

### CI

GitHub Actions workflow builds on every push to main → publishes to DockerHub as `nousresearch/hermes-agent:latest`. PR builds only trigger when Dockerfile, docker/, or pyproject.toml change.

**Note:** Requires `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` GitHub Action secrets to be configured for publishing.

### Live tested

- `docker build` succeeds ✓
- `--version` reports correctly ✓
- Skills sync runs (96 bundled skills) ✓
- Config bootstrapping works ✓

Closes #850, closes #913, closes #1841.

## Credit

- **benbarclay** (PR #1841) — original concept, entrypoint design, CI workflow, docs