### PR TITLE
fix: tag cron auto replies and force utf8 env

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -164,14 +164,17 @@ def _deliver_result(job: dict, content: str) -> None:
         logger.warning("Job '%s': platform '%s' not configured/enabled", job["id"], platform_name)
         return
 
-    # Wrap the content so the user knows this is a cron delivery and that
-    # the interactive agent has no visibility into it.
+    # Wrap the content so the user knows this is a cron delivery from a
+    # fresh session. The cron agent cannot see follow-up chat messages unless
+    # they are included in the job prompt, but it can still act on external
+    # systems when the prompt provides the required details.
     task_name = job.get("name", job["id"])
     wrapped = (
+        f"[CRONJOB AUTO-REPLY]\n"
         f"Cronjob Response: {task_name}\n"
         f"-------------\n\n"
         f"{content}\n\n"
-        f"Note: The agent cannot see this message, and therefore cannot respond to it."
+        f"Note: This cron run executed in a fresh session. It cannot see messages from this chat unless they were included in the job prompt, but it can still perform requested actions, such as posting to GitHub, when the prompt includes the necessary details."
     )
 
     # Run the async send in a fresh event loop (safe from any thread)
@@ -291,6 +294,18 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         os.environ["HERMES_SESSION_CHAT_ID"] = str(origin["chat_id"])
         if origin.get("chat_name"):
             os.environ["HERMES_SESSION_CHAT_NAME"] = origin["chat_name"]
+
+    # Force UTF-8 process I/O for cron runs so external replies posted via
+    # terminal/gh/curl are consistently encoded even on hosts with odd locale
+    # inheritance. Restore the previous environment after the run.
+    encoding_env_overrides = {
+        "LANG": "C.UTF-8",
+        "LC_ALL": "C.UTF-8",
+        "PYTHONIOENCODING": "utf-8",
+        "PYTHONUTF8": "1",
+    }
+    previous_encoding_env = {key: os.environ.get(key) for key in encoding_env_overrides}
+    os.environ.update(encoding_env_overrides)
 
     try:
         # Re-read .env and config.yaml fresh every run so provider/key
@@ -471,6 +486,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             "HERMES_CRON_AUTO_DELIVER_THREAD_ID",
         ):
             os.environ.pop(key, None)
+        for key, previous_value in previous_encoding_env.items():
+            if previous_value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = previous_value
         if _session_db:
             try:
                 _session_db.end_session(_cron_session_id, "cron_complete")

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -120,8 +120,8 @@ class TestResolveDeliveryTarget:
 class TestDeliverResultWrapping:
     """Verify that cron deliveries are wrapped with header/footer and no longer mirrored."""
 
-    def test_delivery_wraps_content_with_header_and_footer(self):
-        """Delivered content should include task name header and agent-invisible note."""
+    def test_delivery_wraps_content_with_header_and_fresh_session_note(self):
+        """Delivered content should include task name header and fresh-session note."""
         from gateway.config import Platform
 
         pconfig = MagicMock()
@@ -141,10 +141,13 @@ class TestDeliverResultWrapping:
 
         send_mock.assert_called_once()
         sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
+        assert sent_content.startswith("[CRONJOB AUTO-REPLY]\n")
         assert "Cronjob Response: daily-report" in sent_content
         assert "-------------" in sent_content
         assert "Here is today's summary." in sent_content
-        assert "The agent cannot see this message" in sent_content
+        assert "executed in a fresh session" in sent_content
+        assert "cannot see messages from this chat" in sent_content
+        assert "posting to GitHub" in sent_content
 
     def test_delivery_uses_job_id_when_no_name(self):
         """When a job has no name, the wrapper should fall back to job id."""
@@ -165,6 +168,7 @@ class TestDeliverResultWrapping:
             _deliver_result(job, "Output.")
 
         sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
+        assert sent_content.startswith("[CRONJOB AUTO-REPLY]\n")
         assert "Cronjob Response: abc-123" in sent_content
 
     def test_no_mirror_to_session_call(self):
@@ -258,6 +262,62 @@ class TestRunJobSessionPersistence:
         call_args = fake_db.end_session.call_args
         assert call_args[0][0].startswith("cron_test-job_")
         assert call_args[0][1] == "cron_complete"
+        fake_db.close.assert_called_once()
+
+    def test_run_job_forces_utf8_encoding_env_and_restores_afterward(self, tmp_path, monkeypatch):
+        job = {
+            "id": "encoding-job",
+            "name": "encoding test",
+            "prompt": "hello",
+        }
+        fake_db = MagicMock()
+        seen = {}
+
+        monkeypatch.setenv("LANG", "ja_JP.UTF-8")
+        monkeypatch.setenv("LC_ALL", "ja_JP.UTF-8")
+        monkeypatch.setenv("PYTHONIOENCODING", "cp932")
+        monkeypatch.setenv("PYTHONUTF8", "0")
+
+        class FakeAgent:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def run_conversation(self, *args, **kwargs):
+                seen["LANG"] = os.getenv("LANG")
+                seen["LC_ALL"] = os.getenv("LC_ALL")
+                seen["PYTHONIOENCODING"] = os.getenv("PYTHONIOENCODING")
+                seen["PYTHONUTF8"] = os.getenv("PYTHONUTF8")
+                return {"final_response": "ok"}
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent", FakeAgent):
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+        assert seen == {
+            "LANG": "C.UTF-8",
+            "LC_ALL": "C.UTF-8",
+            "PYTHONIOENCODING": "utf-8",
+            "PYTHONUTF8": "1",
+        }
+        assert os.getenv("LANG") == "ja_JP.UTF-8"
+        assert os.getenv("LC_ALL") == "ja_JP.UTF-8"
+        assert os.getenv("PYTHONIOENCODING") == "cp932"
+        assert os.getenv("PYTHONUTF8") == "0"
         fake_db.close.assert_called_once()
 
     def test_run_job_empty_response_returns_empty_not_placeholder(self, tmp_path):


### PR DESCRIPTION
## Summary
- prepend `[CRONJOB AUTO-REPLY]` to delivered cron messages and clarify the fresh-session behavior in the wrapper note
- force UTF-8-related environment variables during cron job execution, then restore the previous values afterward
- add scheduler tests covering the wrapper text and UTF-8 env override/restore behavior

## Testing
- source venv/bin/activate && python -m pytest tests/cron/test_scheduler.py -q