### PR TITLE
fix(honcho): use placeholder API key for local instances that don't require auth

### DIFF
--- a/honcho_integration/client.py
+++ b/honcho_integration/client.py
@@ -417,9 +417,18 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
     else:
         logger.info("Initializing Honcho client (host: %s, workspace: %s)", config.host, config.workspace_id)
 
+    # Local Honcho instances don't require an API key.
+    # The SDK still expects a non-empty string, so use a placeholder.
+    _is_local = resolved_base_url and (
+        "localhost" in resolved_base_url
+        or "127.0.0.1" in resolved_base_url
+        or "::1" in resolved_base_url
+    )
+    effective_api_key = config.api_key or ("local" if _is_local else None)
+
     kwargs: dict = {
         "workspace_id": config.workspace_id,
-        "api_key": config.api_key,
+        "api_key": effective_api_key,
         "environment": config.environment,
     }
     if resolved_base_url:


### PR DESCRIPTION
## Summary

The Honcho SDK requires a non-empty `api_key` string, but self-hosted local instances (localhost/127.0.0.1/::1) don't need authentication. This uses `"local"` as a placeholder when no key is configured and the base URL points to a local server.

Salvaged from #3570 by @ygd58 with authorship preserved. #3560 by @devorun is a duplicate.

## Changes
- `honcho_integration/client.py`: detect local URLs, use placeholder key

## Test plan
```
python -m pytest tests/ -n0 -q -k honcho  # 145 passed
```