### PR TITLE
feat(discord): DISCORD_IGNORE_NO_MENTION — skip messages that @mention others but not the bot

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -550,6 +550,22 @@ class DiscordAdapter(BasePlatformAdapter):
                             return
                     # "all" falls through to handle_message
                 
+                # If the message @mentions other users but NOT the bot, the
+                # sender is talking to someone else — stay silent.  Only
+                # applies in server channels; in DMs the user is always
+                # talking to the bot (mentions are just references).
+                # Controlled by DISCORD_IGNORE_NO_MENTION (default: true).
+                _ignore_no_mention = os.getenv(
+                    "DISCORD_IGNORE_NO_MENTION", "true"
+                ).lower() in ("true", "1", "yes")
+                if _ignore_no_mention and message.mentions and not isinstance(message.channel, discord.DMChannel):
+                    _bot_mentioned = (
+                        self._client.user is not None
+                        and self._client.user in message.mentions
+                    )
+                    if not _bot_mentioned:
+                        return  # Talking to someone else, don't interrupt
+
                 await self._handle_message(message)
 
             @self._client.event


### PR DESCRIPTION
Salvage of PR #3310 (luojiesi).

When `DISCORD_IGNORE_NO_MENTION=true` (default), if a Discord message mentions other users but not the bot, the bot stays silent. Prevents the bot from interrupting conversations between humans in shared channels.

### Fix over original PR

Scoped to server channels only — DMs are excluded. In the original PR, a DM like "tell @Alice about the project" would be silently dropped because `message.mentions` includes Alice but not the bot. In DMs the user is always talking to the bot, so mentions are just references.

### How it works

The check runs in `on_message` after bot filtering, before `_handle_message()`:

1. Read `DISCORD_IGNORE_NO_MENTION` env var (default: `true`)
2. If the message has mentions AND is NOT a DM AND the bot is NOT among the mentioned → skip
3. Otherwise, proceed to `_handle_message()` as normal

Complements the existing `DISCORD_REQUIRE_MENTION` gating (which requires the bot to be @mentioned to respond). This new check handles the inverse case: someone explicitly @mentioning *someone else*.

### Tests

1621 gateway tests pass, 0 failures.

Closes #3310