### PR TITLE
fix: route /bg spinner through TUI widget to prevent status bar collision

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -284,11 +284,11 @@ class KawaiiSpinner:
         The CLI already drives a TUI widget (_spinner_text) for spinner display,
         so KawaiiSpinner's \\r-based animation is redundant under StdoutProxy.
         """
-        out = self._out
-        # StdoutProxy has a 'raw' attribute (bool) that plain file objects lack.
-        if hasattr(out, 'raw') and type(out).__name__ == 'StdoutProxy':
-            return True
-        return False
+        try:
+            from prompt_toolkit.patch_stdout import StdoutProxy
+            return isinstance(self._out, StdoutProxy)
+        except ImportError:
+            return False
 
     def _animate(self):
         # When stdout is not a real terminal (e.g. Docker, systemd, pipe),

--- a/cli.py
+++ b/cli.py
@@ -4034,6 +4034,17 @@ class HermesCLI:
                     provider_data_collection=self._provider_data_collection,
                     fallback_model=self._fallback_model,
                 )
+                # Silence raw spinner; route thinking through TUI widget when no foreground agent is active.
+                bg_agent._print_fn = lambda *_a, **_kw: None
+
+                def _bg_thinking(text: str) -> None:
+                    # Concurrent bg tasks may race on _spinner_text; acceptable for best-effort UI.
+                    if not self._agent_running:
+                        self._spinner_text = text
+                        if self._app:
+                            self._app.invalidate()
+
+                bg_agent.thinking_callback = _bg_thinking
 
                 result = bg_agent.run_conversation(
                     user_message=prompt,
@@ -4096,6 +4107,9 @@ class HermesCLI:
                 _cprint(f"  ❌ Background task #{task_num} failed: {e}")
             finally:
                 self._background_tasks.pop(task_id, None)
+                # Clear spinner only if no foreground agent owns it
+                if not self._agent_running:
+                    self._spinner_text = ""
                 if self._app:
                     self._invalidate(min_interval=0)
 


### PR DESCRIPTION
Salvage of #3493 by @kshitijk4poor. Cherry-picked cleanly onto current main.

## Problem

When running `/bg <prompt>`, the background agent's `KawaiiSpinner` writes `\r`-based animation and `stop()` final messages directly through prompt_toolkit's `StdoutProxy`. StdoutProxy injects newlines around each flush, so spinner frames land on the status bar row — garbling both the spinner and the prompt.

## Fix (2 files, +19/-5)

**`agent/display.py`** — Improved `_is_patch_stdout_proxy()` detection:
- Old: `hasattr(out, 'raw') and type(out).__name__ == 'StdoutProxy'` — fragile heuristic that can break across prompt_toolkit versions
- New: `isinstance(self._out, StdoutProxy)` with try/except ImportError guard

**`cli.py`** — Background agent spinner routing:
- `bg_agent._print_fn = lambda *_a, **_kw: None` — silences all raw spinner output (both `_animate()` and `stop()` paths)
- `bg_agent.thinking_callback = _bg_thinking` — routes thinking updates through TUI widget (`_spinner_text`) only when no foreground agent is active
- `finally` block clears spinner text with same foreground guard

## Tests

- 146 spinner/background/display tests pass (2 skipped)

Closes #2718