### PR TITLE
Başlık: fix: stabilize Copilot provider routing for GPT-5.4 #3388

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -677,7 +677,15 @@ class SessionStore:
 
             if session_key in self._entries and not force_new:
                 entry = self._entries[session_key]
+# ... mevcut kodlar ...
+if session_key in self._entries and not force_new:
+    entry = self._entries[session_key] # Entry burada tanımlanıyor
 
+    # ŞİMDİ BURAYA EKLE:
+    if self.config.provider == "copilot":
+        entry.base_url = "https://api.githubcopilot.com"
+        entry.api_mode = "codex_responses"
+        entry.model = self.config.model or "gpt-5.4"
                 reset_reason = self._should_reset(entry, source)
                 if not reset_reason:
                     entry.updated_at = now

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -45,11 +45,13 @@ Usage:
 
 import argparse
 import os
+from datetime import datetime
 import subprocess
 import sys
 from pathlib import Path
 from typing import Optional
-
+def get_timestamp():
+    return f"[{datetime.now().strftime('%H:%M:%S')}] "
 # Add project root to path
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 sys.path.insert(0, str(PROJECT_ROOT))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+dingtalk = ["dingtalk-stream>=1.0.0"]
 modal = ["modal>=1.0.0,<2"]
 daytona = ["daytona>=0.148.0,<1"]
 dev = ["pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "mcp>=1.2.0,<2"]
@@ -66,6 +67,7 @@ rl = [
 ]
 yc-bench = ["yc-bench @ git+https://github.com/collinear-ai/yc-bench.git ; python_version >= '3.12'"]
 all = [
+  "hermes-agent[dingtalk]",
   "hermes-agent[modal]",
   "hermes-agent[daytona]",
   "hermes-agent[messaging]",
@@ -77,6 +79,7 @@ all = [
   "hermes-agent[pty]",
   "hermes-agent[honcho]",
   "hermes-agent[mcp]",
+  "dingtalk = ["dingtalk-stream>=1.0.0"]
   "hermes-agent[homeassistant]",
   "hermes-agent[sms]",
   "hermes-agent[acp]",


### PR DESCRIPTION
This PR ensures that Copilot sessions strictly use the correct base_url and api_mode within gateway/session.py. This prevents intermittent routing drift to OpenRouter when using GPT-5.4. Fixes #3388