### PR TITLE
feat: support service_tier in responses api requests

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -921,6 +921,18 @@ class AIAgent:
         except Exception:
             _agent_cfg = {}
 
+        # Optional Responses API execution tier for OpenAI-compatible endpoints.
+        # Currently used only on the codex_responses path.
+        _model_cfg_for_tier = _agent_cfg.get("model", {})
+        if isinstance(_model_cfg_for_tier, dict):
+            _service_tier = _model_cfg_for_tier.get("service_tier")
+            if isinstance(_service_tier, str) and _service_tier.strip():
+                self.service_tier = _service_tier.strip()
+            else:
+                self.service_tier = None
+        else:
+            self.service_tier = None
+
         # Persistent memory (MEMORY.md + USER.md) -- loaded from disk
         self._memory_store = None
         self._memory_enabled = False
@@ -3062,6 +3074,7 @@ class AIAgent:
             "model", "instructions", "input", "tools", "store",
             "reasoning", "include", "max_output_tokens", "temperature",
             "tool_choice", "parallel_tool_calls", "prompt_cache_key",
+            "service_tier",
         }
         normalized: Dict[str, Any] = {
             "model": model,
@@ -3092,6 +3105,10 @@ class AIAgent:
             val = api_kwargs.get(passthrough_key)
             if val is not None:
                 normalized[passthrough_key] = val
+
+        service_tier = api_kwargs.get("service_tier")
+        if isinstance(service_tier, str) and service_tier.strip():
+            normalized["service_tier"] = service_tier.strip()
 
         if allow_stream:
             stream = api_kwargs.get("stream")
@@ -4445,6 +4462,9 @@ class AIAgent:
 
             if self.max_tokens is not None:
                 kwargs["max_output_tokens"] = self.max_tokens
+
+            if isinstance(getattr(self, "service_tier", None), str) and self.service_tier.strip():
+                kwargs["service_tier"] = self.service_tier.strip()
 
             return kwargs
 

--- a/tests/test_provider_parity.py
+++ b/tests/test_provider_parity.py
@@ -286,6 +286,18 @@ class TestBuildApiKwargsCodex:
         assert "name" in tools[0]
         assert "function" not in tools[0]
 
+    def test_includes_service_tier_when_configured(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"model": {"service_tier": "fast"}},
+            raising=False,
+        )
+        agent = _make_agent(monkeypatch, "openai-codex", api_mode="codex_responses",
+                            base_url="https://chatgpt.com/backend-api/codex")
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["service_tier"] == "fast"
+
 
 # ── Message conversion tests ────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Add `service_tier` support to the Responses API request path.

This change:
- reads `model.service_tier` from config
- allows `service_tier` through codex/responses preflight validation
- forwards `service_tier` in Responses API kwargs when configured

## Why

Some OpenAI-compatible Responses endpoints support execution tiers such as `service_tier: "fast"`, but Hermes previously rejected or omitted this field.

## Testing

- Added a focused parity test covering `service_tier` propagation on the `codex_responses` path
- Passed:
  `./venv/bin/python -m pytest tests/test_provider_parity.py -q -k service_tier`
