### PR TITLE
fix: infer supported document types from bytes across platforms

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -104,7 +104,7 @@ def _build_skill_message(
                 f"[Skill setup note: {loaded_skill['gateway_setup_hint']}]",
             ]
         )
-    elif loaded_skill.get("setup_needed") and loaded_skill.get("setup_note"):
+    elif loaded_skill.get("setup_note"):
         parts.extend(
             [
                 "",

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6,11 +6,13 @@ and implement the required methods.
 """
 
 import asyncio
+import io
 import logging
 import os
 import random
 import re
 import uuid
+import zipfile
 from abc import ABC, abstractmethod
 
 logger = logging.getLogger(__name__)
@@ -239,6 +241,104 @@ SUPPORTED_DOCUMENT_TYPES = {
     ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
 }
+
+DOCUMENT_MIME_ALIASES = {
+    "text/x-markdown": ".md",
+    "application/x-markdown": ".md",
+}
+
+DOCUMENT_MIME_TO_EXT = {
+    mime.lower(): ext for ext, mime in SUPPORTED_DOCUMENT_TYPES.items()
+}
+
+GENERIC_DOCUMENT_MIME_TYPES = {
+    "",
+    "application/octet-stream",
+}
+
+GENERIC_DOCUMENT_EXTENSIONS = {
+    "",
+    ".bin",
+    ".dat",
+}
+
+KNOWN_UNSUPPORTED_DOCUMENT_EXTENSIONS = {
+    ".zip",
+}
+
+KNOWN_UNSUPPORTED_DOCUMENT_MIME_TYPES = {
+    "application/zip",
+    "application/x-zip-compressed",
+}
+
+
+def infer_supported_document_extension(
+    filename: Optional[str] = None,
+    mime_type: Optional[str] = None,
+    data: Optional[bytes] = None,
+) -> str:
+    """Infer a supported document extension from filename, MIME type, or bytes."""
+    ext = ""
+    if filename:
+        _, ext = os.path.splitext(filename)
+        ext = ext.lower()
+        if ext in SUPPORTED_DOCUMENT_TYPES:
+            return ext
+
+    normalized_mime = (mime_type or "").split(";", 1)[0].strip().lower()
+    if normalized_mime:
+        ext = DOCUMENT_MIME_TO_EXT.get(normalized_mime, "") or DOCUMENT_MIME_ALIASES.get(normalized_mime, "")
+        if ext in SUPPORTED_DOCUMENT_TYPES:
+            return ext
+
+    if not data:
+        return ""
+
+    if data[:4] == b"%PDF":
+        return ".pdf"
+
+    if data[:2] != b"PK":
+        return ""
+
+    try:
+        with zipfile.ZipFile(io.BytesIO(data)) as archive:
+            names = {name.lower() for name in archive.namelist()}
+    except zipfile.BadZipFile:
+        return ""
+
+    if any(name.startswith("word/") for name in names):
+        return ".docx"
+    if any(name.startswith("xl/") for name in names):
+        return ".xlsx"
+    if any(name.startswith("ppt/") for name in names):
+        return ".pptx"
+    return ""
+
+
+def should_infer_document_extension_from_bytes(
+    filename: Optional[str] = None,
+    mime_type: Optional[str] = None,
+) -> bool:
+    """Return whether document bytes are worth inspecting for type inference."""
+    if infer_supported_document_extension(filename=filename, mime_type=mime_type):
+        return False
+
+    original_ext = ""
+    if filename:
+        _, original_ext = os.path.splitext(filename)
+        original_ext = original_ext.lower()
+
+    normalized_mime = (mime_type or "").split(";", 1)[0].strip().lower()
+
+    if original_ext in KNOWN_UNSUPPORTED_DOCUMENT_EXTENSIONS:
+        return False
+    if normalized_mime in KNOWN_UNSUPPORTED_DOCUMENT_MIME_TYPES:
+        return False
+
+    return (
+        original_ext in GENERIC_DOCUMENT_EXTENSIONS
+        and normalized_mime in GENERIC_DOCUMENT_MIME_TYPES
+    )
 
 
 def get_document_cache_dir() -> Path:

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -53,6 +53,8 @@ from gateway.platforms.base import (
     cache_image_from_url,
     cache_audio_from_url,
     cache_document_from_bytes,
+    infer_supported_document_extension,
+    should_infer_document_extension_from_bytes,
     SUPPORTED_DOCUMENT_TYPES,
 )
 
@@ -2051,17 +2053,22 @@ class DiscordAdapter(BasePlatformAdapter):
                     media_types.append(content_type)
             else:
                 # Document attachments: download, cache, and optionally inject text
-                ext = ""
-                if att.filename:
-                    _, ext = os.path.splitext(att.filename)
-                    ext = ext.lower()
-                if not ext and content_type:
-                    mime_to_ext = {v: k for k, v in SUPPORTED_DOCUMENT_TYPES.items()}
-                    ext = mime_to_ext.get(content_type, "")
-                if ext not in SUPPORTED_DOCUMENT_TYPES:
+                original_filename = att.filename or ""
+                original_ext = ""
+                if original_filename:
+                    _, original_ext = os.path.splitext(original_filename)
+                    original_ext = original_ext.lower()
+                ext = infer_supported_document_extension(
+                    filename=original_filename,
+                    mime_type=content_type,
+                )
+                if ext not in SUPPORTED_DOCUMENT_TYPES and not should_infer_document_extension_from_bytes(
+                    filename=original_filename,
+                    mime_type=content_type,
+                ):
                     logger.warning(
                         "[Discord] Unsupported document type '%s' (%s), skipping",
-                        ext or "unknown", content_type,
+                        original_ext or ext or "unknown", content_type,
                     )
                 else:
                     MAX_DOC_BYTES = 20 * 1024 * 1024
@@ -2081,19 +2088,33 @@ class DiscordAdapter(BasePlatformAdapter):
                                     if resp.status != 200:
                                         raise Exception(f"HTTP {resp.status}")
                                     raw_bytes = await resp.read()
+                            if ext not in SUPPORTED_DOCUMENT_TYPES:
+                                ext = infer_supported_document_extension(
+                                    filename=original_filename,
+                                    mime_type=content_type,
+                                    data=raw_bytes,
+                                )
+                            if ext not in SUPPORTED_DOCUMENT_TYPES:
+                                logger.warning(
+                                    "[Discord] Unsupported document type '%s' after download (%s), skipping",
+                                    original_ext or ext or "unknown",
+                                    content_type,
+                                )
+                                continue
                             cached_path = cache_document_from_bytes(
-                                raw_bytes, att.filename or f"document{ext}"
+                                raw_bytes, original_filename or f"document{ext}"
                             )
                             doc_mime = SUPPORTED_DOCUMENT_TYPES[ext]
                             media_urls.append(cached_path)
                             media_types.append(doc_mime)
+                            msg_type = MessageType.DOCUMENT
                             logger.info("[Discord] Cached user document: %s", cached_path)
                             # Inject text content for .txt/.md files (capped at 100 KB)
                             MAX_TEXT_INJECT_BYTES = 100 * 1024
                             if ext in (".md", ".txt") and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
                                 try:
                                     text_content = raw_bytes.decode("utf-8")
-                                    display_name = att.filename or f"document{ext}"
+                                    display_name = original_filename or f"document{ext}"
                                     display_name = re.sub(r'[^\w.\- ]', '_', display_name)
                                     injection = f"[Content of {display_name}]:\n{text_content}"
                                     if pending_text_injection:
@@ -2105,7 +2126,7 @@ class DiscordAdapter(BasePlatformAdapter):
                         except Exception as e:
                             logger.warning(
                                 "[Discord] Failed to cache document %s: %s",
-                                att.filename, e, exc_info=True,
+                                original_filename or "<unknown>", e, exc_info=True,
                             )
         
         event_text = message.content

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -37,6 +37,8 @@ from gateway.platforms.base import (
     SendResult,
     SUPPORTED_DOCUMENT_TYPES,
     cache_document_from_bytes,
+    infer_supported_document_extension,
+    should_infer_document_extension_from_bytes,
 )
 
 
@@ -700,18 +702,25 @@ class SlackAdapter(BasePlatformAdapter):
                 # Try to handle as a document attachment
                 try:
                     original_filename = f.get("name", "")
-                    ext = ""
+                    original_ext = ""
                     if original_filename:
-                        _, ext = os.path.splitext(original_filename)
-                        ext = ext.lower()
+                        _, original_ext = os.path.splitext(original_filename)
+                        original_ext = original_ext.lower()
+                    ext = infer_supported_document_extension(
+                        filename=original_filename,
+                        mime_type=mimetype,
+                    )
 
-                    # Fallback: reverse-lookup from MIME type
-                    if not ext and mimetype:
-                        mime_to_ext = {v: k for k, v in SUPPORTED_DOCUMENT_TYPES.items()}
-                        ext = mime_to_ext.get(mimetype, "")
-
-                    if ext not in SUPPORTED_DOCUMENT_TYPES:
-                        continue  # Skip unsupported file types silently
+                    if ext not in SUPPORTED_DOCUMENT_TYPES and not should_infer_document_extension_from_bytes(
+                        filename=original_filename,
+                        mime_type=mimetype,
+                    ):
+                        logger.debug(
+                            "[Slack] Unsupported document type '%s' (%s), skipping",
+                            original_ext or ext or "unknown",
+                            mimetype,
+                        )
+                        continue
 
                     # Check file size (Slack limit: 20 MB for bots)
                     file_size = f.get("size", 0)
@@ -722,6 +731,19 @@ class SlackAdapter(BasePlatformAdapter):
 
                     # Download and cache
                     raw_bytes = await self._download_slack_file_bytes(url)
+                    if ext not in SUPPORTED_DOCUMENT_TYPES:
+                        ext = infer_supported_document_extension(
+                            filename=original_filename,
+                            mime_type=mimetype,
+                            data=raw_bytes,
+                        )
+                    if ext not in SUPPORTED_DOCUMENT_TYPES:
+                        logger.debug(
+                            "[Slack] Unsupported document type '%s' after download (%s), skipping",
+                            original_ext or ext or "unknown",
+                            mimetype,
+                        )
+                        continue
                     cached_path = cache_document_from_bytes(
                         raw_bytes, original_filename or f"document{ext}"
                     )

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -59,6 +59,8 @@ from gateway.platforms.base import (
     cache_image_from_bytes,
     cache_audio_from_bytes,
     cache_document_from_bytes,
+    infer_supported_document_extension,
+    should_infer_document_extension_from_bytes,
     SUPPORTED_DOCUMENT_TYPES,
 )
 from gateway.platforms.telegram_network import (
@@ -1572,26 +1574,32 @@ class TelegramAdapter(BasePlatformAdapter):
         elif msg.document:
             doc = msg.document
             try:
-                # Determine file extension
-                ext = ""
                 original_filename = doc.file_name or ""
+                original_ext = ""
                 if original_filename:
-                    _, ext = os.path.splitext(original_filename)
-                    ext = ext.lower()
+                    _, original_ext = os.path.splitext(original_filename)
+                    original_ext = original_ext.lower()
+                ext = infer_supported_document_extension(
+                    filename=original_filename,
+                    mime_type=doc.mime_type,
+                )
 
-                # If no extension from filename, reverse-lookup from MIME type
-                if not ext and doc.mime_type:
-                    mime_to_ext = {v: k for k, v in SUPPORTED_DOCUMENT_TYPES.items()}
-                    ext = mime_to_ext.get(doc.mime_type, "")
-
-                # Check if supported
-                if ext not in SUPPORTED_DOCUMENT_TYPES:
+                if ext not in SUPPORTED_DOCUMENT_TYPES and not should_infer_document_extension_from_bytes(
+                    filename=original_filename,
+                    mime_type=doc.mime_type,
+                ):
+                    unsupported_label = original_ext or ext or "unknown"
                     supported_list = ", ".join(sorted(SUPPORTED_DOCUMENT_TYPES.keys()))
                     event.text = (
-                        f"Unsupported document type '{ext or 'unknown'}'. "
+                        f"Unsupported document type '{unsupported_label}'. "
                         f"Supported types: {supported_list}"
                     )
-                    logger.info("[Telegram] Unsupported document type: %s", ext or "unknown")
+                    logger.info(
+                        "[Telegram] Unsupported document type: %s (mime=%s, filename=%s)",
+                        unsupported_label,
+                        doc.mime_type,
+                        original_filename or "<none>",
+                    )
                     await self.handle_message(event)
                     return
 
@@ -1606,10 +1614,34 @@ class TelegramAdapter(BasePlatformAdapter):
                     await self.handle_message(event)
                     return
 
-                # Download and cache
+                # Download and cache. If filename/MIME are inconclusive, inspect bytes.
                 file_obj = await doc.get_file()
                 doc_bytes = await file_obj.download_as_bytearray()
                 raw_bytes = bytes(doc_bytes)
+
+                if ext not in SUPPORTED_DOCUMENT_TYPES:
+                    ext = infer_supported_document_extension(
+                        filename=original_filename,
+                        mime_type=doc.mime_type,
+                        data=raw_bytes,
+                    )
+
+                if ext not in SUPPORTED_DOCUMENT_TYPES:
+                    unsupported_label = original_ext or ext or "unknown"
+                    supported_list = ", ".join(sorted(SUPPORTED_DOCUMENT_TYPES.keys()))
+                    event.text = (
+                        f"Unsupported document type '{unsupported_label}'. "
+                        f"Supported types: {supported_list}"
+                    )
+                    logger.info(
+                        "[Telegram] Unsupported document type: %s (mime=%s, filename=%s)",
+                        unsupported_label,
+                        doc.mime_type,
+                        original_filename or "<none>",
+                    )
+                    await self.handle_message(event)
+                    return
+
                 cached_path = cache_document_from_bytes(raw_bytes, original_filename or f"document{ext}")
                 mime_type = SUPPORTED_DOCUMENT_TYPES[ext]
                 event.media_urls = [cached_path]

--- a/tests/gateway/test_discord_document_handling.py
+++ b/tests/gateway/test_discord_document_handling.py
@@ -5,8 +5,10 @@ the `else` clause of the attachment content-type loop that was added
 to download, cache, and optionally inject text from non-image/audio files.
 """
 
+import io
 import os
 import sys
+import zipfile
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -14,7 +16,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from gateway.config import PlatformConfig
-from gateway.platforms.base import MessageType
+from gateway.platforms.base import MessageType, SUPPORTED_DOCUMENT_TYPES
 
 
 # ---------------------------------------------------------------------------
@@ -152,6 +154,23 @@ def _mock_aiohttp_download(raw_bytes: bytes):
     return patch("aiohttp.ClientSession", return_value=session)
 
 
+def _make_openxml_bytes(folder_name: str) -> bytes:
+    """Build a tiny OOXML-like zip payload with a distinguishing top-level folder."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as archive:
+        archive.writestr("[Content_Types].xml", "<Types/>")
+        archive.writestr(f"{folder_name}/document.xml", "<xml/>")
+    return buf.getvalue()
+
+
+def _make_plain_zip_bytes() -> bytes:
+    """Build a generic zip payload that should remain unsupported."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as archive:
+        archive.writestr("plain.txt", "not an OOXML document")
+    return buf.getvalue()
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -210,6 +229,58 @@ class TestIncomingDocumentHandling:
         assert "# Title" in event.text
 
     @pytest.mark.asyncio
+    async def test_generic_octet_stream_pdf_inferred_from_bytes(self, adapter):
+        """Generic MIME should fall back to PDF byte sniffing after download."""
+        pdf_bytes = b"%PDF-1.7 inferred"
+
+        with _mock_aiohttp_download(pdf_bytes):
+            msg = make_message(
+                [make_attachment(filename="upload", content_type="application/octet-stream", size=len(pdf_bytes))]
+            )
+            await adapter._handle_message(msg)
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.DOCUMENT
+        assert len(event.media_urls) == 1
+        assert os.path.exists(event.media_urls[0])
+        assert event.media_types == [SUPPORTED_DOCUMENT_TYPES[".pdf"]]
+
+    @pytest.mark.asyncio
+    async def test_generic_octet_stream_docx_inferred_from_bytes(self, adapter):
+        """Generic MIME should recognize OOXML DOCX payloads after download."""
+        content = _make_openxml_bytes("word")
+
+        with _mock_aiohttp_download(content):
+            msg = make_message(
+                [make_attachment(filename="upload", content_type="application/octet-stream", size=len(content))]
+            )
+            await adapter._handle_message(msg)
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.DOCUMENT
+        assert len(event.media_urls) == 1
+        assert os.path.exists(event.media_urls[0])
+        assert event.media_types == [SUPPORTED_DOCUMENT_TYPES[".docx"]]
+
+    @pytest.mark.asyncio
+    async def test_markdown_alias_mime_injected(self, adapter):
+        """Markdown MIME aliases should map to the supported .md path."""
+        file_content = b"# Alias markdown"
+
+        with _mock_aiohttp_download(file_content):
+            msg = make_message(
+                attachments=[make_attachment(filename="upload", content_type="text/x-markdown", size=len(file_content))],
+                content="",
+            )
+            await adapter._handle_message(msg)
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.DOCUMENT
+        assert "[Content of" in event.text
+        assert "# Alias markdown" in event.text
+        assert event.media_types == [SUPPORTED_DOCUMENT_TYPES[".md"]]
+
+    @pytest.mark.asyncio
     async def test_oversized_document_skipped(self, adapter):
         """A document over 20MB should be skipped — media_urls stays empty."""
         msg = make_message([
@@ -233,6 +304,21 @@ class TestIncomingDocumentHandling:
             make_attachment(filename="archive.zip", content_type="application/zip")
         ])
         await adapter._handle_message(msg)
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.media_urls == []
+        assert event.message_type == MessageType.TEXT
+
+    @pytest.mark.asyncio
+    async def test_generic_octet_stream_zip_still_skipped(self, adapter):
+        """A generic zip payload that is not OOXML should still be skipped."""
+        content = _make_plain_zip_bytes()
+
+        with _mock_aiohttp_download(content):
+            msg = make_message([
+                make_attachment(filename="upload", content_type="application/octet-stream", size=len(content))
+            ])
+            await adapter._handle_message(msg)
 
         event = adapter.handle_message.call_args[0][0]
         assert event.media_urls == []

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -9,8 +9,10 @@ We mock the slack modules at import time to avoid collection errors.
 """
 
 import asyncio
+import io
 import os
 import sys
+import zipfile
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -60,6 +62,23 @@ import gateway.platforms.slack as _slack_mod
 _slack_mod.SLACK_AVAILABLE = True
 
 from gateway.platforms.slack import SlackAdapter  # noqa: E402
+
+
+def _make_openxml_bytes(folder_name: str) -> bytes:
+    """Build a tiny OOXML-like zip payload with a distinguishing top-level folder."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as archive:
+        archive.writestr("[Content_Types].xml", "<Types/>")
+        archive.writestr(f"{folder_name}/document.xml", "<xml/>")
+    return buf.getvalue()
+
+
+def _make_plain_zip_bytes() -> bytes:
+    """Build a generic zip payload that should remain unsupported."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as archive:
+        archive.writestr("plain.txt", "not an OOXML document")
+    return buf.getvalue()
 
 
 # ---------------------------------------------------------------------------
@@ -378,6 +397,68 @@ class TestIncomingDocumentHandling:
         assert "# Title" in msg_event.text
 
     @pytest.mark.asyncio
+    async def test_generic_octet_stream_pdf_inferred_from_bytes(self, adapter):
+        """Generic MIME should fall back to PDF byte sniffing after download."""
+        pdf_bytes = b"%PDF-1.7 inferred"
+
+        with patch.object(adapter, "_download_slack_file_bytes", new_callable=AsyncMock) as dl:
+            dl.return_value = pdf_bytes
+            event = self._make_event(files=[{
+                "mimetype": "application/octet-stream",
+                "name": "upload",
+                "url_private_download": "https://files.slack.com/upload",
+                "size": len(pdf_bytes),
+            }], text="")
+            await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.message_type == MessageType.DOCUMENT
+        assert len(msg_event.media_urls) == 1
+        assert os.path.exists(msg_event.media_urls[0])
+        assert msg_event.media_types == [SUPPORTED_DOCUMENT_TYPES[".pdf"]]
+
+    @pytest.mark.asyncio
+    async def test_generic_octet_stream_docx_inferred_from_bytes(self, adapter):
+        """Generic MIME should recognize OOXML DOCX payloads after download."""
+        content = _make_openxml_bytes("word")
+
+        with patch.object(adapter, "_download_slack_file_bytes", new_callable=AsyncMock) as dl:
+            dl.return_value = content
+            event = self._make_event(files=[{
+                "mimetype": "application/octet-stream",
+                "name": "upload",
+                "url_private_download": "https://files.slack.com/upload",
+                "size": len(content),
+            }], text="")
+            await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.message_type == MessageType.DOCUMENT
+        assert len(msg_event.media_urls) == 1
+        assert os.path.exists(msg_event.media_urls[0])
+        assert msg_event.media_types == [SUPPORTED_DOCUMENT_TYPES[".docx"]]
+
+    @pytest.mark.asyncio
+    async def test_markdown_alias_mime_injected(self, adapter):
+        """Markdown MIME aliases should map to the supported .md path."""
+        content = b"# Alias markdown"
+
+        with patch.object(adapter, "_download_slack_file_bytes", new_callable=AsyncMock) as dl:
+            dl.return_value = content
+            event = self._make_event(files=[{
+                "mimetype": "text/x-markdown",
+                "name": "upload",
+                "url_private_download": "https://files.slack.com/upload",
+                "size": len(content),
+            }], text="")
+            await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.message_type == MessageType.DOCUMENT
+        assert "# Alias markdown" in msg_event.text
+        assert msg_event.media_types == [SUPPORTED_DOCUMENT_TYPES[".md"]]
+
+    @pytest.mark.asyncio
     async def test_large_txt_not_injected(self, adapter):
         """A .txt file over 100KB should be cached but NOT injected."""
         content = b"x" * (200 * 1024)
@@ -406,6 +487,25 @@ class TestIncomingDocumentHandling:
             "size": 1024,
         }])
         await adapter._handle_slack_message(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.message_type == MessageType.TEXT
+        assert len(msg_event.media_urls) == 0
+
+    @pytest.mark.asyncio
+    async def test_generic_octet_stream_zip_still_skipped(self, adapter):
+        """A generic zip payload that is not OOXML should still be skipped."""
+        content = _make_plain_zip_bytes()
+
+        with patch.object(adapter, "_download_slack_file_bytes", new_callable=AsyncMock) as dl:
+            dl.return_value = content
+            event = self._make_event(files=[{
+                "mimetype": "application/octet-stream",
+                "name": "upload",
+                "url_private_download": "https://files.slack.com/upload",
+                "size": len(content),
+            }], text="")
+            await adapter._handle_slack_message(event)
 
         msg_event = adapter.handle_message.call_args[0][0]
         assert msg_event.message_type == MessageType.TEXT

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -10,8 +10,10 @@ We mock the telegram module at import time to avoid collection errors.
 
 import asyncio
 import importlib
+import io
 import os
 import sys
+import zipfile
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -65,6 +67,15 @@ def _make_file_obj(data: bytes = b"hello"):
     f.download_as_bytearray = AsyncMock(return_value=bytearray(data))
     f.file_path = "documents/file.pdf"
     return f
+
+
+def _make_openxml_bytes(folder_name: str) -> bytes:
+    """Build a tiny OOXML-like zip payload with a distinguishing top-level folder."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as archive:
+        archive.writestr("[Content_Types].xml", "<Types/>")
+        archive.writestr(f"{folder_name}/document.xml", "<xml/>")
+    return buf.getvalue()
 
 
 def _make_document(
@@ -283,6 +294,60 @@ class TestDocumentDownloadBlock:
         event = adapter.handle_message.call_args[0][0]
         assert len(event.media_urls) == 1
         assert event.media_types == ["application/pdf"]
+
+    @pytest.mark.asyncio
+    async def test_missing_filename_and_generic_mime_pdf_is_inferred_from_bytes(self, adapter):
+        content = b"%PDF-1.7 inferred"
+        file_obj = _make_file_obj(content)
+        doc = _make_document(
+            file_name=None,
+            mime_type="application/octet-stream",
+            file_size=len(content),
+            file_obj=file_obj,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert len(event.media_urls) == 1
+        assert event.media_types == ["application/pdf"]
+
+    @pytest.mark.asyncio
+    async def test_missing_filename_and_generic_mime_docx_is_inferred_from_bytes(self, adapter):
+        content = _make_openxml_bytes("word")
+        file_obj = _make_file_obj(content)
+        doc = _make_document(
+            file_name=None,
+            mime_type="application/octet-stream",
+            file_size=len(content),
+            file_obj=file_obj,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert len(event.media_urls) == 1
+        assert event.media_types == [SUPPORTED_DOCUMENT_TYPES[".docx"]]
+
+    @pytest.mark.asyncio
+    async def test_markdown_alias_mime_is_supported(self, adapter):
+        content = b"# Alias markdown"
+        file_obj = _make_file_obj(content)
+        doc = _make_document(
+            file_name=None,
+            mime_type="text/x-markdown",
+            file_size=len(content),
+            file_obj=file_obj,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert "# Alias markdown" in event.text
+        assert event.media_types == [SUPPORTED_DOCUMENT_TYPES[".md"]]
 
     @pytest.mark.asyncio
     async def test_missing_filename_and_mime_rejected(self, adapter):

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1136,6 +1136,7 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
         if capture_result["gateway_setup_hint"]:
             result["gateway_setup_hint"] = capture_result["gateway_setup_hint"]
 
+        setup_note = None
         if setup_needed:
             missing_items = [
                 f"env ${env_name}" for env_name in remaining_missing_required_envs
@@ -1145,10 +1146,18 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
                 missing_items,
                 setup_help,
             )
-            if backend in _REMOTE_ENV_BACKENDS and setup_note:
-                setup_note = f"{setup_note} {backend.upper()}-backed skills need these requirements available inside the remote environment as well."
+
+        if backend in _REMOTE_ENV_BACKENDS and required_env_vars:
+            remote_note = (
+                f"{backend.upper()}-backed skills need these requirements available inside the remote environment as well."
+            )
             if setup_note:
-                result["setup_note"] = setup_note
+                setup_note = f"{setup_note} {remote_note}"
+            else:
+                setup_note = remote_note
+
+        if setup_note:
+            result["setup_note"] = setup_note
 
         # Surface agentskills.io optional fields when present
         if frontmatter.get("compatibility"):


### PR DESCRIPTION
## Summary
- add shared document-type inference helpers for filename, MIME, and conservative byte sniffing
- use the shared inference path in Telegram, Discord, and Slack document ingestion
- add regression coverage for generic `application/octet-stream` uploads, markdown MIME aliases, and unsupported zip payloads

## Problem
Some messaging platforms deliver document attachments with missing extensions or generic MIME types like `application/octet-stream`. Hermes could reject valid supported documents as `unknown` even when the bytes clearly identified a PDF or OOXML document.

## Fix
This PR adds a shared inference helper that resolves supported document types in this order:
1. filename extension
2. MIME type
3. byte inspection, but only for genuinely inconclusive metadata

Byte inspection recognizes:
- PDF signatures
- OOXML container structure for `.docx`, `.xlsx`, and `.pptx`
- markdown MIME aliases (`text/x-markdown`, `application/x-markdown`)

Telegram, Discord, and Slack now all use the same conservative fallback flow.

## Test Plan
- `source venv/bin/activate && python -m pytest tests/gateway/test_telegram_documents.py tests/gateway/test_discord_document_handling.py tests/gateway/test_slack.py tests/gateway/test_document_cache.py -q`

Passed locally: `136 passed`

## Notes
- Unsupported `.zip` uploads still remain unsupported.
