### PR TITLE
fix(mcp): handle EmbeddedResource content blocks in tool results

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1067,11 +1067,20 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     )
                 })
 
-            # Collect text from content blocks
+            # Collect text from content blocks.
+            # MCP tools may return TextContent (block.text) or
+            # EmbeddedResource (block.resource.text).  Handle both.
             parts: List[str] = []
             for block in (result.content or []):
                 if hasattr(block, "text"):
                     parts.append(block.text)
+                elif hasattr(block, "resource"):
+                    res = block.resource
+                    text = getattr(res, "text", None)
+                    if text:
+                        parts.append(text)
+                    elif hasattr(res, "blob"):
+                        parts.append(f"[binary resource: {getattr(res, 'uri', 'unknown')}]")
             return json.dumps({"result": "\n".join(parts) if parts else ""})
 
         try:


### PR DESCRIPTION
## Problem

MCP tools may return content blocks with `type: 'resource'` ([EmbeddedResource](https://spec.modelcontextprotocol.io/specification/2024-11-05/server/resources/#embedded-resources)) in addition to `type: 'text'` (TextContent). The `_make_tool_handler` in `tools/mcp_tool.py` only extracts TextContent blocks (`block.text`), silently dropping EmbeddedResource content and returning empty strings to the agent.

## Impact

Any MCP server that returns documents as EmbeddedResource is affected. For example, [qmd](https://github.com/nicobailon/qmd)'s `get` and `multi_get` tools return markdown documents as EmbeddedResource with URI metadata — these return empty results through Hermes despite the MCP server responding correctly.

The bug is in the content extraction loop at line ~1070:
```python
for block in (result.content or []):
    if hasattr(block, "text"):
        parts.append(block.text)
```

EmbeddedResource blocks have `block.resource.text`, not `block.text`, so they're silently skipped.

## Fix

Extract text from both content block types:
- `block.text` for TextContent (existing behavior)
- `block.resource.text` for EmbeddedResource (new)
- Placeholder for binary resources (`block.resource.blob`)

Minimal change — 10 lines added, no new dependencies.