### PR TITLE
fix: include remote setup note even when setup is skipped

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -91,12 +91,11 @@ def _build_skill_message(
     parts = [activation_note, "", content.strip()]
 
     if loaded_skill.get("setup_skipped"):
-        parts.extend(
-            [
-                "",
-                "[Skill setup note: Required environment setup was skipped. Continue loading the skill and explain any reduced functionality if it matters.]",
-            ]
-        )
+        note_text = "[Skill setup note: Required environment setup was skipped. Continue loading the skill and explain any reduced functionality if it matters.]"
+        # For remote backends, also append the remote-specific guidance
+        if loaded_skill.get("setup_note"):
+            note_text = f"{note_text} {loaded_skill['setup_note']}"
+        parts.extend(["", note_text])
     elif loaded_skill.get("gateway_setup_hint"):
         parts.extend(
             [


### PR DESCRIPTION
## Summary
- Fix test `test_preserves_remaining_remote_setup_warning` that was failing on main
- When `setup_skipped` is True and a remote backend is detected, include both the generic skipped message AND the remote-specific `setup_note`
- This preserves the "remote environment" guidance that the test expects

## Root cause
Commit 9916e555 added logic to show `setup_note` for remote backends but didn't account for the `setup_skipped` case. The code was showing a generic "Required environment setup was skipped" message instead of including the remote-specific guidance.

## Test plan
- ✅ The failing test now passes: `tests/agent/test_skill_commands.py::TestBuildSkillInvocationMessage::test_preserves_remaining_remote_setup_warning`
- Verified locally that the message contains "remote environment" as expected