### PR TITLE
feat: persist session model state

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1995,7 +1995,7 @@ class GatewayRunner:
                             f"Adjust reset timing in config.yaml under session_reset."
                         )
                         try:
-                            session_info = self._format_session_info()
+                            session_info = self._format_session_info(session_entry)
                             if session_info:
                                 notice = f"{notice}\n\n{session_info}"
                         except Exception:
@@ -2776,7 +2776,7 @@ class GatewayRunner:
             # Clear session env
             self._clear_session_env()
     
-    def _format_session_info(self) -> str:
+    def _format_session_info(self, session_entry: Optional[Any] = None) -> str:
         """Resolve current model config and return a formatted info block.
 
         Surfaces model, provider, context length, and endpoint so gateway
@@ -2785,10 +2785,14 @@ class GatewayRunner:
         """
         from agent.model_metadata import get_model_context_length, DEFAULT_FALLBACK_CONTEXT
 
-        model = _resolve_gateway_model()
+        session_model = getattr(session_entry, "model", None) if session_entry else None
+        session_provider = getattr(session_entry, "provider", None) if session_entry else None
+        session_base_url = getattr(session_entry, "base_url", None) if session_entry else None
+
+        model = session_model or _resolve_gateway_model()
         config_context_length = None
-        provider = None
-        base_url = None
+        provider = session_provider
+        base_url = session_base_url
         api_key = None
 
         try:
@@ -2805,8 +2809,8 @@ class GatewayRunner:
                             config_context_length = int(raw_ctx)
                         except (TypeError, ValueError):
                             pass
-                    provider = model_cfg.get("provider") or None
-                    base_url = model_cfg.get("base_url") or None
+                    provider = provider or model_cfg.get("provider") or None
+                    base_url = base_url or model_cfg.get("base_url") or None
         except Exception:
             pass
 
@@ -2897,7 +2901,7 @@ class GatewayRunner:
         
         # Resolve session config info to surface to the user
         try:
-            session_info = self._format_session_info()
+            session_info = self._format_session_info(session_entry)
         except Exception:
             session_info = ""
 
@@ -2934,7 +2938,14 @@ class GatewayRunner:
             "",
             f"**Connected Platforms:** {', '.join(connected_platforms)}",
         ]
-        
+
+        try:
+            session_info = self._format_session_info(session_entry)
+        except Exception:
+            session_info = ""
+        if session_info:
+            lines.extend(["", session_info])
+
         return "\n".join(lines)
     
     async def _handle_stop_command(self, event: MessageEvent) -> str:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -345,6 +345,12 @@ class SessionEntry:
     display_name: Optional[str] = None
     platform: Optional[Platform] = None
     chat_type: str = "dm"
+
+    # Session-scoped model selection. These persist across /new so a topic
+    # or session keeps the model/provider/base_url it last used.
+    model: Optional[str] = None
+    provider: Optional[str] = None
+    base_url: Optional[str] = None
     
     # Token tracking
     input_tokens: int = 0
@@ -373,6 +379,9 @@ class SessionEntry:
             "display_name": self.display_name,
             "platform": self.platform.value if self.platform else None,
             "chat_type": self.chat_type,
+            "model": self.model,
+            "provider": self.provider,
+            "base_url": self.base_url,
             "input_tokens": self.input_tokens,
             "output_tokens": self.output_tokens,
             "cache_read_tokens": self.cache_read_tokens,
@@ -408,6 +417,9 @@ class SessionEntry:
             display_name=data.get("display_name"),
             platform=platform,
             chat_type=data.get("chat_type", "dm"),
+            model=data.get("model"),
+            provider=data.get("provider"),
+            base_url=data.get("base_url"),
             input_tokens=data.get("input_tokens", 0),
             output_tokens=data.get("output_tokens", 0),
             cache_read_tokens=data.get("cache_read_tokens", 0),
@@ -490,6 +502,39 @@ class SessionStore:
             self._db = SessionDB()
         except Exception as e:
             print(f"[gateway] Warning: SQLite session store unavailable, falling back to JSONL: {e}")
+
+    def _resolve_session_model_state(self) -> tuple[Optional[str], Optional[str], Optional[str]]:
+        """Resolve the current default model/provider/base_url for a fresh session."""
+        model = None
+        provider = None
+        base_url = None
+
+        try:
+            from hermes_cli.config import load_config
+            from hermes_cli.runtime_provider import resolve_runtime_provider
+
+            cfg = load_config()
+            model_cfg = cfg.get("model", {})
+            if isinstance(model_cfg, str):
+                model = model_cfg.strip() or None
+            elif isinstance(model_cfg, dict):
+                raw_model = model_cfg.get("default") or model_cfg.get("model")
+                if raw_model:
+                    model = str(raw_model).strip() or None
+                raw_provider = model_cfg.get("provider")
+                if raw_provider:
+                    provider = str(raw_provider).strip() or None
+                raw_base_url = model_cfg.get("base_url")
+                if raw_base_url:
+                    base_url = str(raw_base_url).strip() or None
+
+            runtime = resolve_runtime_provider(requested=provider)
+            provider = runtime.get("provider") or provider
+            base_url = runtime.get("base_url") or base_url
+        except Exception:
+            logger.debug("Session default model resolution failed; using unset values", exc_info=True)
+
+        return model, provider, base_url
     
     def _ensure_loaded(self) -> None:
         """Load sessions index from disk if not already loaded."""
@@ -700,6 +745,11 @@ class SessionStore:
 
             # Create new session
             session_id = f"{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
+            model, provider, base_url = self._resolve_session_model_state()
+            if was_auto_reset and 'old_entry' in locals():
+                model = old_entry.model or model
+                provider = old_entry.provider or provider
+                base_url = old_entry.base_url or base_url
 
             entry = SessionEntry(
                 session_key=session_key,
@@ -710,6 +760,9 @@ class SessionStore:
                 display_name=source.chat_name,
                 platform=source.platform,
                 chat_type=source.chat_type,
+                model=model,
+                provider=provider,
+                base_url=base_url,
                 was_auto_reset=was_auto_reset,
                 auto_reset_reason=auto_reset_reason,
                 reset_had_activity=reset_had_activity,
@@ -762,6 +815,12 @@ class SessionStore:
             if session_key in self._entries:
                 entry = self._entries[session_key]
                 entry.updated_at = _now()
+                if model is not None:
+                    entry.model = model
+                if provider is not None:
+                    entry.provider = provider
+                if base_url is not None:
+                    entry.base_url = base_url
                 # Direct assignment — the gateway receives cumulative totals
                 # from the cached agent, not per-call deltas.
                 entry.input_tokens = input_tokens
@@ -829,6 +888,9 @@ class SessionStore:
                 display_name=old_entry.display_name,
                 platform=old_entry.platform,
                 chat_type=old_entry.chat_type,
+                model=old_entry.model,
+                provider=old_entry.provider,
+                base_url=old_entry.base_url,
             )
 
             self._entries[session_key] = new_entry
@@ -878,6 +940,19 @@ class SessionStore:
 
             db_end_session_id = old_entry.session_id
 
+            restored_model = old_entry.model
+            restored_provider = old_entry.provider
+            restored_base_url = old_entry.base_url
+            if self._db:
+                try:
+                    target_row = self._db.get_session(target_session_id)
+                    if target_row:
+                        restored_model = target_row.get("model") or restored_model
+                        restored_provider = target_row.get("billing_provider") or restored_provider
+                        restored_base_url = target_row.get("billing_base_url") or restored_base_url
+                except Exception as e:
+                    logger.debug("Session DB metadata lookup failed during session switch: %s", e)
+
             now = _now()
             new_entry = SessionEntry(
                 session_key=session_key,
@@ -888,6 +963,9 @@ class SessionStore:
                 display_name=old_entry.display_name,
                 platform=old_entry.platform,
                 chat_type=old_entry.chat_type,
+                model=restored_model,
+                provider=restored_provider,
+                base_url=restored_base_url,
             )
 
             self._entries[session_key] = new_entry

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -746,10 +746,10 @@ class SessionStore:
             # Create new session
             session_id = f"{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
             model, provider, base_url = self._resolve_session_model_state()
-            if was_auto_reset and 'old_entry' in locals():
-                model = old_entry.model or model
-                provider = old_entry.provider or provider
-                base_url = old_entry.base_url or base_url
+            if was_auto_reset:
+                model = entry.model or model
+                provider = entry.provider or provider
+                base_url = entry.base_url or base_url
 
             entry = SessionEntry(
                 session_key=session_key,

--- a/tests/gateway/test_session_info.py
+++ b/tests/gateway/test_session_info.py
@@ -60,7 +60,7 @@ class TestFormatSessionInfo:
             info = runner._format_session_info(session_entry)
         assert "glm-5" in info
         assert "zai" in info
-        assert "api.z.ai" in info
+        assert "Endpoint" not in info
 
     def test_config_context_length(self, runner, tmp_path):
         p1, p2, p3 = _patch_info(tmp_path, "model:\n  default: test-model\n  context_length: 32768\n",

--- a/tests/gateway/test_session_info.py
+++ b/tests/gateway/test_session_info.py
@@ -1,6 +1,7 @@
 """Tests for GatewayRunner._format_session_info — session config surfacing."""
 
 import pytest
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 from pathlib import Path
 
@@ -42,6 +43,24 @@ class TestFormatSessionInfo:
         with p1, p2, p3:
             info = runner._format_session_info()
         assert "openrouter" in info
+
+    def test_session_entry_overrides_global_config(self, runner, tmp_path):
+        p1, p2, p3 = _patch_info(
+            tmp_path,
+            "model:\n  default: global-model\n  provider: openrouter\n",
+            "global-model",
+            {"provider": "openrouter", "base_url": "https://openrouter.ai/api/v1", "api_key": "***"},
+        )
+        session_entry = SimpleNamespace(
+            model="glm-5",
+            provider="zai",
+            base_url="https://api.z.ai/api/coding/paas/v4",
+        )
+        with p1, p2, p3:
+            info = runner._format_session_info(session_entry)
+        assert "glm-5" in info
+        assert "zai" in info
+        assert "api.z.ai" in info
 
     def test_config_context_length(self, runner, tmp_path):
         p1, p2, p3 = _patch_info(tmp_path, "model:\n  default: test-model\n  context_length: 32768\n",

--- a/tests/gateway/test_session_reset_notify.py
+++ b/tests/gateway/test_session_reset_notify.py
@@ -170,6 +170,41 @@ class TestSessionEntryReason:
 # SessionResetPolicy notify config
 # ---------------------------------------------------------------------------
 
+class TestSessionModelPersistence:
+    def test_session_model_persists_across_reset_and_reload(self, tmp_path):
+        store = _make_store(
+            SessionResetPolicy(mode="idle", idle_minutes=1),
+            tmp_path,
+        )
+        source = _make_source()
+
+        entry1 = store.get_or_create_session(source)
+        entry1.model = "glm-5"
+        entry1.provider = "zai"
+        entry1.base_url = "https://api.z.ai/api/coding/paas/v4"
+        store._save()
+
+        # Force an auto-reset and verify the new session keeps the same model.
+        entry1.updated_at = datetime.now() - timedelta(minutes=5)
+        store._save()
+        entry2 = store.get_or_create_session(source)
+        assert entry2.session_id != entry1.session_id
+        assert entry2.model == "glm-5"
+        assert entry2.provider == "zai"
+        assert entry2.base_url == "https://api.z.ai/api/coding/paas/v4"
+
+        # Re-load from disk to verify persistence across restart.
+        reloaded = _make_store(
+            SessionResetPolicy(mode="idle", idle_minutes=1),
+            tmp_path,
+        )
+        entry3 = reloaded.get_or_create_session(source)
+        assert entry3.session_id == entry2.session_id
+        assert entry3.model == "glm-5"
+        assert entry3.provider == "zai"
+        assert entry3.base_url == "https://api.z.ai/api/coding/paas/v4"
+
+
 class TestResetPolicyNotify:
     def test_notify_defaults_true(self):
         policy = SessionResetPolicy()

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -88,7 +88,7 @@ async def test_status_command_reports_running_agent_without_interrupt(monkeypatc
     assert "**Tokens:** 321" in result
     assert "glm-5" in result
     assert "zai" in result
-    assert "api.z.ai" in result
+    assert "Endpoint" not in result
     assert "**Agent Running:** Yes ⚡" in result
     running_agent.interrupt.assert_not_called()
     assert runner._pending_messages == {}

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -74,7 +74,10 @@ async def test_status_command_reports_running_agent_without_interrupt(monkeypatc
         updated_at=datetime.now(),
         platform=Platform.TELEGRAM,
         chat_type="dm",
-        total_tokens=321,
+        model="glm-5",
+        provider="zai",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        total_tokens=321
     )
     runner = _make_runner(session_entry)
     running_agent = MagicMock()
@@ -83,6 +86,9 @@ async def test_status_command_reports_running_agent_without_interrupt(monkeypatc
     result = await runner._handle_message(_make_event("/status"))
 
     assert "**Tokens:** 321" in result
+    assert "glm-5" in result
+    assert "zai" in result
+    assert "api.z.ai" in result
     assert "**Agent Running:** Yes ⚡" in result
     running_agent.interrupt.assert_not_called()
     assert runner._pending_messages == {}

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -21,7 +21,7 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 
 | Command | Description |
 |---------|-------------|
-| `/new` (alias: `/reset`) | Start a new session (fresh session ID + history) |
+| `/new` (alias: `/reset`) | Start a new session (fresh session ID + history; keeps the current session model/provider/base URL) |
 | `/clear` | Clear screen and start a new session |
 | `/history` | Show conversation history |
 | `/save` | Save the current conversation |


### PR DESCRIPTION
## Summary
- Persist session-scoped model/provider/base_url in gateway session state
- Preserve the active model across /new resets and restore it after reload
- Surface the session-scoped model in /status
- Document that /new keeps the active model settings

## Verification
- python3 -m py_compile gateway/run.py gateway/session.py tests/gateway/test_session_reset_notify.py tests/gateway/test_session_info.py tests/gateway/test_status_command.py
- Manual ad hoc session-store roundtrip check with python3