### PR TITLE
feat: persistent todo store with REST API endpoints

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -8,6 +8,10 @@ Exposes an HTTP server with endpoints:
 - DELETE /v1/responses/{response_id} — Delete a stored response
 - GET  /v1/models                  — lists hermes-agent as an available model
 - GET  /health                     — health check
+- GET  /api/todos                  — list all sessions with persisted todos
+- GET  /api/todos/{session_id}     — get todos for a specific session
+- PATCH /api/todos/{session_id}    — update todos for a session (merge or replace)
+- DELETE /api/todos/{session_id}   — delete a session's todos
 
 Any OpenAI-compatible frontend (Open WebUI, LobeChat, LibreChat,
 AnythingLLM, NextChat, ChatBox, etc.) can connect to hermes-agent
@@ -1231,6 +1235,114 @@ class APIServerAdapter(BasePlatformAdapter):
         return await loop.run_in_executor(None, _run)
 
     # ------------------------------------------------------------------
+    # Todo API handlers
+    # ------------------------------------------------------------------
+
+    async def _handle_list_todos(self, request: "web.Request") -> "web.Response":
+        """GET /api/todos — list all sessions with persisted todos."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        from tools.todo_store import list_all_sessions
+        sessions = list_all_sessions()
+        return web.json_response({"sessions": sessions})
+
+    async def _handle_get_todos(self, request: "web.Request") -> "web.Response":
+        """GET /api/todos/{session_id} — get todos for a specific session."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        session_id = request.match_info["session_id"]
+
+        from tools.todo_store import load_session_todos
+        doc = load_session_todos(session_id)
+        if doc is None:
+            return web.json_response(
+                {"error": {"message": f"No todos found for session: {session_id}", "type": "not_found"}},
+                status=404,
+            )
+
+        return web.json_response(doc)
+
+    async def _handle_update_todos(self, request: "web.Request") -> "web.Response":
+        """
+        PATCH /api/todos/{session_id} — update todos for a session.
+
+        Body:
+            {
+                "todos": [ {id, content, status}, ... ],
+                "merge": true|false  (default: true)
+            }
+        """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        session_id = request.match_info["session_id"]
+
+        try:
+            body = await request.json()
+        except (json.JSONDecodeError, Exception):
+            return web.json_response(
+                {"error": {"message": "Invalid JSON in request body", "type": "invalid_request_error"}},
+                status=400,
+            )
+
+        todos = body.get("todos")
+        if not todos or not isinstance(todos, list):
+            return web.json_response(
+                {"error": {"message": "Missing or invalid 'todos' array", "type": "invalid_request_error"}},
+                status=400,
+            )
+
+        merge = body.get("merge", True)
+
+        from tools.todo_store import PersistentTodoStore
+        store = PersistentTodoStore(session_id)
+        items = store.write(todos, merge=merge)
+
+        # Build summary
+        pending = sum(1 for i in items if i["status"] == "pending")
+        in_progress = sum(1 for i in items if i["status"] == "in_progress")
+        completed = sum(1 for i in items if i["status"] == "completed")
+        cancelled = sum(1 for i in items if i["status"] == "cancelled")
+
+        return web.json_response({
+            "session_id": session_id,
+            "todos": items,
+            "summary": {
+                "total": len(items),
+                "pending": pending,
+                "in_progress": in_progress,
+                "completed": completed,
+                "cancelled": cancelled,
+            },
+        })
+
+    async def _handle_delete_todos(self, request: "web.Request") -> "web.Response":
+        """DELETE /api/todos/{session_id} — delete a session's todos."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        session_id = request.match_info["session_id"]
+
+        from tools.todo_store import delete_session_todos
+        deleted = delete_session_todos(session_id)
+        if not deleted:
+            return web.json_response(
+                {"error": {"message": f"No todos found for session: {session_id}", "type": "not_found"}},
+                status=404,
+            )
+
+        return web.json_response({
+            "session_id": session_id,
+            "deleted": True,
+        })
+
+    # ------------------------------------------------------------------
     # BasePlatformAdapter interface
     # ------------------------------------------------------------------
 
@@ -1260,6 +1372,11 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_post("/api/jobs/{job_id}/pause", self._handle_pause_job)
             self._app.router.add_post("/api/jobs/{job_id}/resume", self._handle_resume_job)
             self._app.router.add_post("/api/jobs/{job_id}/run", self._handle_run_job)
+            # Todo API
+            self._app.router.add_get("/api/todos", self._handle_list_todos)
+            self._app.router.add_get("/api/todos/{session_id}", self._handle_get_todos)
+            self._app.router.add_patch("/api/todos/{session_id}", self._handle_update_todos)
+            self._app.router.add_delete("/api/todos/{session_id}", self._handle_delete_todos)
 
             self._runner = web.AppRunner(self._app)
             await self._runner.setup()

--- a/run_agent.py
+++ b/run_agent.py
@@ -1008,9 +1008,15 @@ class AIAgent:
                     "Session DB create_session failed (session_search still available): %s", e
                 )
         
-        # In-memory todo list for task planning (one per agent/session)
-        from tools.todo_tool import TodoStore
-        self._todo_store = TodoStore()
+        # Todo list for task planning (one per agent/session).
+        # Use persistent store when session_id is available so todos
+        # survive across sessions and can be queried via /api/todos.
+        if self.session_id:
+            from tools.todo_store import PersistentTodoStore
+            self._todo_store = PersistentTodoStore(self.session_id)
+        else:
+            from tools.todo_tool import TodoStore
+            self._todo_store = TodoStore()
         
         # Load config once for memory, skills, and compression sections
         try:

--- a/tests/tools/test_todo_store.py
+++ b/tests/tools/test_todo_store.py
@@ -1,0 +1,129 @@
+"""Tests for the persistent todo store module."""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tools.todo_tool import TodoStore
+from tools.todo_store import (
+    PersistentTodoStore,
+    delete_session_todos,
+    list_all_sessions,
+    load_session_todos,
+    save_session_todos,
+)
+
+
+@pytest.fixture(autouse=True)
+def tmp_todos_dir(tmp_path):
+    """Redirect TODOS_DIR to a temp directory for all tests."""
+    with patch("tools.todo_store.TODOS_DIR", tmp_path):
+        yield tmp_path
+
+
+class TestSaveAndLoad:
+    def test_round_trip(self):
+        todos = [{"id": "1", "content": "Task A", "status": "pending"}]
+        doc = save_session_todos("sess-1", todos)
+        assert doc["session_id"] == "sess-1"
+        assert doc["todos"] == todos
+        assert "created_at" in doc
+        assert "updated_at" in doc
+
+        loaded = load_session_todos("sess-1")
+        assert loaded is not None
+        assert loaded["todos"] == todos
+
+    def test_load_missing_returns_none(self):
+        assert load_session_todos("nonexistent") is None
+
+    def test_save_preserves_created_at(self):
+        original = "2024-01-01T00:00:00+00:00"
+        save_session_todos("sess-1", [], created_at=original)
+        loaded = load_session_todos("sess-1")
+        assert loaded["created_at"] == original
+
+
+class TestListAllSessions:
+    def test_empty_dir(self):
+        assert list_all_sessions() == []
+
+    def test_lists_sessions_with_summary(self):
+        save_session_todos("sess-1", [
+            {"id": "1", "content": "A", "status": "pending"},
+            {"id": "2", "content": "B", "status": "completed"},
+        ])
+        save_session_todos("sess-2", [
+            {"id": "1", "content": "C", "status": "in_progress"},
+        ])
+
+        sessions = list_all_sessions()
+        assert len(sessions) == 2
+        ids = {s["session_id"] for s in sessions}
+        assert ids == {"sess-1", "sess-2"}
+
+        # Check summary
+        s1 = next(s for s in sessions if s["session_id"] == "sess-1")
+        assert s1["summary"]["total"] == 2
+        assert s1["summary"]["pending"] == 1
+        assert s1["summary"]["completed"] == 1
+
+
+class TestDeleteSessionTodos:
+    def test_delete_existing(self):
+        save_session_todos("sess-1", [{"id": "1", "content": "X", "status": "pending"}])
+        assert delete_session_todos("sess-1") is True
+        assert load_session_todos("sess-1") is None
+
+    def test_delete_nonexistent(self):
+        assert delete_session_todos("ghost") is False
+
+
+class TestPersistentTodoStore:
+    def test_inherits_todostore(self):
+        store = PersistentTodoStore("sess-1")
+        assert isinstance(store, TodoStore)
+
+    def test_write_persists_to_disk(self):
+        store = PersistentTodoStore("sess-1")
+        store.write([{"id": "1", "content": "Task", "status": "pending"}])
+
+        loaded = load_session_todos("sess-1")
+        assert loaded is not None
+        assert len(loaded["todos"]) == 1
+        assert loaded["todos"][0]["content"] == "Task"
+
+    def test_loads_existing_on_init(self):
+        save_session_todos("sess-1", [
+            {"id": "1", "content": "Existing", "status": "in_progress"},
+        ])
+
+        store = PersistentTodoStore("sess-1")
+        items = store.read()
+        assert len(items) == 1
+        assert items[0]["content"] == "Existing"
+
+    def test_merge_persists(self):
+        store = PersistentTodoStore("sess-1")
+        store.write([{"id": "1", "content": "First", "status": "pending"}])
+        store.write(
+            [{"id": "1", "status": "completed"}],
+            merge=True,
+        )
+
+        loaded = load_session_todos("sess-1")
+        assert loaded["todos"][0]["status"] == "completed"
+        assert loaded["todos"][0]["content"] == "First"
+
+    def test_second_store_picks_up_changes(self):
+        store1 = PersistentTodoStore("sess-1")
+        store1.write([{"id": "1", "content": "Hello", "status": "pending"}])
+
+        store2 = PersistentTodoStore("sess-1")
+        items = store2.read()
+        assert len(items) == 1
+        assert items[0]["content"] == "Hello"

--- a/tools/todo_store.py
+++ b/tools/todo_store.py
@@ -1,0 +1,210 @@
+"""
+Persistent Todo Store — file-backed todo list storage.
+
+Wraps the in-memory TodoStore with JSON file persistence so that
+todo state survives across agent sessions and can be queried by
+external clients (e.g., the API server's /api/todos endpoints).
+
+Storage layout:
+    ~/.hermes/todos/{session_id}.json
+
+Each file contains:
+    {
+        "session_id": "...",
+        "created_at": "ISO8601",
+        "updated_at": "ISO8601",
+        "todos": [ {id, content, status}, ... ]
+    }
+"""
+
+import json
+import logging
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from tools.todo_tool import TodoStore, VALID_STATUSES
+
+logger = logging.getLogger(__name__)
+
+HERMES_DIR = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+TODOS_DIR = HERMES_DIR / "todos"
+
+
+def _secure_dir(path: Path):
+    """Set directory to owner-only access (0700). No-op on Windows."""
+    try:
+        os.chmod(path, 0o700)
+    except (OSError, NotImplementedError):
+        pass
+
+
+def _secure_file(path: Path):
+    """Set file to owner-only read/write (0600). No-op on Windows."""
+    try:
+        if path.exists():
+            os.chmod(path, 0o600)
+    except (OSError, NotImplementedError):
+        pass
+
+
+def ensure_dirs():
+    """Ensure todos directory exists with secure permissions."""
+    TODOS_DIR.mkdir(parents=True, exist_ok=True)
+    _secure_dir(TODOS_DIR)
+
+
+def _todos_file(session_id: str) -> Path:
+    """Return the path to a session's todo file."""
+    # Sanitize session_id for safe filesystem use
+    safe_id = "".join(c for c in session_id if c.isalnum() or c in "-_.")
+    return TODOS_DIR / f"{safe_id}.json"
+
+
+# =========================================================================
+# File-level CRUD (used by both PersistentTodoStore and API endpoints)
+# =========================================================================
+
+def load_session_todos(session_id: str) -> Optional[Dict[str, Any]]:
+    """Load a session's todo data from disk. Returns None if not found."""
+    path = _todos_file(session_id)
+    if not path.exists():
+        return None
+    try:
+        with open(path, "r") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning("Failed to load todos for session %s: %s", session_id, e)
+        return None
+
+
+def save_session_todos(session_id: str, todos: List[Dict[str, str]], created_at: Optional[str] = None) -> Dict[str, Any]:
+    """
+    Atomically save a session's todos to disk.
+
+    Returns the full stored document.
+    """
+    ensure_dirs()
+    now = datetime.now(timezone.utc).isoformat()
+
+    doc = {
+        "session_id": session_id,
+        "created_at": created_at or now,
+        "updated_at": now,
+        "todos": todos,
+    }
+
+    path = _todos_file(session_id)
+    # Atomic write: write to temp file then rename
+    fd, tmp_path = tempfile.mkstemp(dir=TODOS_DIR, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(doc, f, indent=2, ensure_ascii=False)
+        os.replace(tmp_path, path)
+        _secure_file(path)
+    except Exception:
+        # Clean up temp file on failure
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+    return doc
+
+
+def list_all_sessions() -> List[Dict[str, Any]]:
+    """
+    List all sessions that have persisted todos.
+
+    Returns a list of summary dicts (without full todo items) sorted by
+    updated_at descending.
+    """
+    ensure_dirs()
+    sessions = []
+    for path in TODOS_DIR.glob("*.json"):
+        try:
+            with open(path, "r") as f:
+                doc = json.load(f)
+            todos = doc.get("todos", [])
+            pending = sum(1 for t in todos if t.get("status") == "pending")
+            in_progress = sum(1 for t in todos if t.get("status") == "in_progress")
+            completed = sum(1 for t in todos if t.get("status") == "completed")
+            cancelled = sum(1 for t in todos if t.get("status") == "cancelled")
+            sessions.append({
+                "session_id": doc.get("session_id", path.stem),
+                "created_at": doc.get("created_at"),
+                "updated_at": doc.get("updated_at"),
+                "summary": {
+                    "total": len(todos),
+                    "pending": pending,
+                    "in_progress": in_progress,
+                    "completed": completed,
+                    "cancelled": cancelled,
+                },
+            })
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning("Skipping malformed todo file %s: %s", path, e)
+            continue
+
+    sessions.sort(key=lambda s: s.get("updated_at", ""), reverse=True)
+    return sessions
+
+
+def delete_session_todos(session_id: str) -> bool:
+    """Delete a session's todo file. Returns True if found and deleted."""
+    path = _todos_file(session_id)
+    if path.exists():
+        try:
+            path.unlink()
+            return True
+        except OSError as e:
+            logger.warning("Failed to delete todos for session %s: %s", session_id, e)
+    return False
+
+
+# =========================================================================
+# PersistentTodoStore — drop-in replacement for TodoStore
+# =========================================================================
+
+class PersistentTodoStore(TodoStore):
+    """
+    TodoStore subclass that persists state to disk after every write.
+
+    On init, loads any existing todos from disk for the given session_id.
+    On every write(), saves the updated list back to disk.
+    Read operations are served from memory (fast) and always consistent
+    because writes are the only mutation path.
+    """
+
+    def __init__(self, session_id: str):
+        super().__init__()
+        self._session_id = session_id
+        self._created_at: Optional[str] = None
+
+        # Load existing state from disk
+        existing = load_session_todos(session_id)
+        if existing:
+            self._created_at = existing.get("created_at")
+            for item in existing.get("todos", []):
+                validated = self._validate(item)
+                self._items.append(validated)
+
+    def write(self, todos: List[Dict[str, Any]], merge: bool = False) -> List[Dict[str, str]]:
+        """Write todos and persist to disk."""
+        result = super().write(todos, merge)
+        self._persist()
+        return result
+
+    def _persist(self):
+        """Save current state to disk."""
+        try:
+            save_session_todos(
+                self._session_id,
+                self.read(),
+                created_at=self._created_at,
+            )
+        except Exception as e:
+            logger.warning("Failed to persist todos for session %s: %s", self._session_id, e)


### PR DESCRIPTION
## Summary

- Adds **`/api/todos` REST endpoints** to the API server so external UIs (dashboards, mobile apps, web frontends) can consume and manage agent task lists
- Introduces **`PersistentTodoStore`** — a drop-in `TodoStore` subclass that persists todos to `~/.hermes/todos/{session_id}.json`, following the same atomic-write pattern used by the cron job system
- `AIAgent` now automatically uses the persistent store when `session_id` is available, falling back to the original in-memory `TodoStore` otherwise

### New Endpoints

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/api/todos` | List all sessions with persisted todos (with summary counts) |
| `GET` | `/api/todos/{session_id}` | Get full todo list for a specific session |
| `PATCH` | `/api/todos/{session_id}` | Update todos with merge or replace semantics |
| `DELETE` | `/api/todos/{session_id}` | Delete a session's todos |

All endpoints respect the existing Bearer token auth. CORS is handled by the existing middleware.

### Files Changed

- **`tools/todo_store.py`** (new) — `PersistentTodoStore` class + file CRUD functions
- **`gateway/platforms/api_server.py`** — 4 new handler methods + route registration
- **`run_agent.py`** — Wire `PersistentTodoStore` when session_id is present
- **`tests/tools/test_todo_store.py`** (new) — 12 tests covering persistence, listing, deletion, merge, and cross-session pickup

## Test plan

- [x] All 12 new `test_todo_store.py` tests pass
- [x] All 11 existing `test_todo_tool.py` tests pass (no regressions)
- [x] Existing API server tests unaffected (pre-existing async test infra issue, not related)
- [ ] Manual testing: start API server, `curl` the `/api/todos` endpoints
- [ ] Verify atomic writes don't corrupt on concurrent access

🤖 Generated with [Claude Code](https://claude.com/claude-code)