### PR TITLE
feat(plugins): add llm-switch example plugin for local server management

### DIFF
--- a/docs/llm-switch-plugin-example/README.md
+++ b/docs/llm-switch-plugin-example/README.md
@@ -1,0 +1,137 @@
+# llm-switch — Local LLM Server Manager Plugin
+
+Auto-manage a local LLM server (llama.cpp, vLLM, etc.) from within Hermes.
+Define your models in a YAML file and the plugin handles the server lifecycle.
+
+## Motivation
+
+Many users run local models alongside cloud providers — using llama.cpp for
+drafting, coding, or research while keeping cloud models for complex tasks.
+Today this requires manually starting/stopping the server outside of Hermes.
+
+This plugin bridges that gap: configure your local models in a YAML file,
+and Hermes handles the server lifecycle transparently.
+
+## How it works
+
+The plugin uses two lifecycle hooks (activated in #3542):
+
+- **`pre_llm_call`** — fires before each conversation turn. If the active
+  model matches a locally configured model and the correct server isn't
+  running, the plugin starts it automatically.
+- **`on_session_end`** — kills the server when you exit Hermes.
+
+It also registers a **`switch_local_llm` tool** so the agent can switch
+models mid-session. This is the primary mid-session switching mechanism —
+the user tells the agent "switch to the code model" and the tool swaps
+the server behind the scenes.
+
+## Setup
+
+1. Copy the plugin to your Hermes plugins directory:
+
+   ```bash
+   cp -r docs/llm-switch-plugin-example ~/.hermes/plugins/llm-switch
+   ```
+
+2. Create your model config:
+
+   ```bash
+   cd ~/.hermes/plugins/llm-switch
+   cp models.yaml.example models.yaml
+   # Edit models.yaml with your GGUF paths, context sizes, sampling params
+   ```
+
+3. Add a custom provider for your local endpoint in `~/.hermes/config.yaml`:
+
+   ```yaml
+   custom_providers:
+     - name: local
+       base_url: http://localhost:8080/v1
+       api_key: "sk-local"
+   ```
+
+4. Select the local provider before starting a session:
+
+   ```bash
+   hermes model
+   # Select your custom provider → pick model name matching a models.yaml key
+   ```
+
+## Usage
+
+### Startup — auto-start on first message
+
+After selecting a local model via `hermes model`, the `pre_llm_call` hook
+detects the model name on your first message and starts the server:
+
+```
+$ hermes
+> Write me a blog post about...
+  Starting local model: write (SEO articles and content briefs)
+  Ready on http://localhost:8080/v1
+[model responds...]
+```
+
+### Mid-session — switch via the agent
+
+Tell the agent to switch models. It calls the `switch_local_llm` tool:
+
+```
+> This task needs the code model, switch to it
+  Switching to: code (Agentic coding and tool calling)
+[agent continues with new model]
+```
+
+### Switch to cloud and back
+
+Use `hermes model` (in a separate terminal or before starting) to switch
+between local and cloud providers. Within a session, the agent can handle
+local model swaps via the tool.
+
+### Exit — auto-cleanup
+
+When you exit Hermes, the `on_session_end` hook kills the server automatically.
+
+## Configuration
+
+See `models.yaml.example` for the full schema. Key sections:
+
+### `server` — shared server settings
+
+| Field             | Default          | Description                    |
+|-------------------|------------------|--------------------------------|
+| `binary`          | `llama-server`   | Server binary name or path     |
+| `models_dir`      | `~/llama-models` | Base directory for model files |
+| `host`            | `0.0.0.0`        | Listen address                 |
+| `port`            | `8080`           | Listen port                    |
+| `gpu_layers`      | `99`             | GPU offload layers (-ngl)      |
+| `flash_attention` | `true`           | Flash attention (-fa)          |
+| `parallel`        | `1`              | Concurrent slots (-np)         |
+| `jinja`           | `true`           | Chat templates (--jinja)       |
+
+### `models.<name>` — per-model settings
+
+| Field         | Required | Description                              |
+|---------------|----------|------------------------------------------|
+| `gguf`        | yes      | Path to GGUF file (relative to models_dir) |
+| `description` | no       | Human-readable purpose                   |
+| `context`     | no       | Context size in tokens (default: 8192)   |
+| `kv_cache`    | no       | `{key: q8_0, value: q4_0}` quantization  |
+| `sampling`    | no       | Default sampling: temp, top_p, top_k, etc. |
+| `alias`       | no       | Name reported by /v1/models              |
+
+## Environment variables
+
+| Variable             | Description                                  |
+|----------------------|----------------------------------------------|
+| `LLM_SWITCH_MODELS`  | Custom path to models.yaml (default: plugin dir) |
+
+## Complementary PRs
+
+This plugin works best with in-session model switching. See:
+- **#3360** — restores `/model` slash command for CLI and gateway
+- **#3548** — CLI-only `/model` restoration
+
+Once `/model` is restored, `/model custom:write` would trigger the
+`pre_llm_call` hook to auto-start the right server on the next message.

--- a/docs/llm-switch-plugin-example/__init__.py
+++ b/docs/llm-switch-plugin-example/__init__.py
@@ -1,0 +1,199 @@
+"""llm-switch plugin — auto-manage local LLM servers when switching models.
+
+Uses the pre_llm_call hook to detect when the active model matches a locally
+configured model, and starts/swaps the server automatically.  Also registers
+a switch_local_llm tool so the agent can switch models autonomously.
+
+Works with any OpenAI-compatible server (llama.cpp, vLLM, etc.).  Model
+configurations are defined in a declarative YAML file (models.yaml).
+
+Hook signatures match the upstream implementation from PR #3542.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+_PLUGIN_DIR = Path(__file__).parent
+_config: Optional[Dict[str, Any]] = None
+
+
+def _load_config() -> Optional[Dict[str, Any]]:
+    """Load models.yaml from plugin dir or LLM_SWITCH_MODELS env var."""
+    global _config
+    if _config is not None:
+        return _config
+
+    config_path = os.getenv(
+        "LLM_SWITCH_MODELS", str(_PLUGIN_DIR / "models.yaml")
+    )
+    try:
+        import yaml
+    except ImportError:
+        logger.warning("llm-switch: PyYAML not installed, plugin disabled")
+        return None
+
+    path = Path(config_path)
+    if not path.exists():
+        logger.info(
+            "llm-switch: No models.yaml at %s — copy models.yaml.example",
+            path,
+        )
+        return None
+
+    with open(path, encoding="utf-8") as f:
+        _config = yaml.safe_load(f)
+    return _config
+
+
+# ---------------------------------------------------------------------------
+# Hooks
+# ---------------------------------------------------------------------------
+
+def _on_pre_llm_call(
+    session_id: str,
+    user_message: str,
+    conversation_history: list,
+    is_first_turn: bool,
+    model: str,
+    platform: str,
+    **kwargs: Any,
+) -> None:
+    """Auto-start the right local server before each turn.
+
+    If the current model name matches a key in models.yaml and the correct
+    server isn't already running, kill any existing server and start the
+    right one.  This makes model switching seamless — the server spins up
+    automatically when hermes is configured with a local model name.
+
+    If /model is restored (PR #3360), this also enables:
+      /model custom:write → next turn → hook starts write server → seamless
+    """
+    from . import server
+
+    config = _load_config()
+    if not config or model not in config.get("models", {}):
+        return  # not a local model — nothing to do
+
+    status = server.get_status(config)
+    if status.get("running") and status.get("model") == model:
+        return  # correct model already running
+
+    desc = config["models"][model].get("description", model)
+    print(f"  Starting local model: {model} ({desc})")
+
+    if server.start_server(model, config):
+        port = config.get("server", {}).get("port", 8080)
+        print(f"  Ready on http://localhost:{port}/v1")
+    else:
+        print(f"  WARNING: Server timed out — check /tmp/llama-server.log")
+
+
+def _on_session_end(
+    session_id: str,
+    completed: bool,
+    interrupted: bool,
+    model: str,
+    platform: str,
+    **kwargs: Any,
+) -> None:
+    """Kill the local server when the session ends."""
+    config = _load_config()
+    if not config:
+        return
+    try:
+        from . import server
+
+        status = server.get_status(config)
+        if status.get("running"):
+            binary = config.get("server", {}).get("binary", "llama-server")
+            server.kill_server(binary=binary)
+            logger.info("llm-switch: Stopped server on session end")
+    except Exception as exc:
+        logger.debug("llm-switch: Error stopping server: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Tool handler
+# ---------------------------------------------------------------------------
+
+def _handle_switch(args: dict, **kwargs: Any) -> str:
+    """Handle the switch_local_llm tool call.
+
+    This is the primary mid-session switching mechanism.  The user tells
+    the agent "switch to the research model" and the agent calls this tool.
+    The server is swapped behind the scenes — subsequent LLM calls go to
+    the new model automatically since the endpoint (localhost:port) stays
+    the same.
+    """
+    from . import server
+
+    model = args.get("model", "").strip()
+
+    config = _load_config()
+    if not config:
+        return json.dumps({"error": "No models.yaml configured"})
+
+    if model == "status":
+        return json.dumps(server.get_status(config))
+
+    if model == "stop":
+        binary = config.get("server", {}).get("binary", "llama-server")
+        server.kill_server(binary=binary)
+        return json.dumps({"status": "stopped"})
+
+    if model == "list":
+        models = {
+            k: v.get("description", "")
+            for k, v in config.get("models", {}).items()
+        }
+        return json.dumps({"models": models})
+
+    if model not in config.get("models", {}):
+        available = list(config.get("models", {}).keys())
+        return json.dumps(
+            {"error": f"Unknown model '{model}'", "available": available}
+        )
+
+    desc = config["models"][model].get("description", model)
+    print(f"  Switching to: {model} ({desc})")
+    ok = server.start_server(model, config)
+    port = config.get("server", {}).get("port", 8080)
+
+    if ok:
+        return json.dumps({
+            "status": "ready",
+            "model": model,
+            "description": desc,
+            "endpoint": f"http://localhost:{port}/v1",
+        })
+    return json.dumps({
+        "status": "starting",
+        "model": model,
+        "note": "Server still loading — check /tmp/llama-server.log",
+    })
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+def register(ctx: Any) -> None:
+    """Wire schemas to handlers and register lifecycle hooks."""
+    from . import schemas
+
+    ctx.register_tool(
+        name="switch_local_llm",
+        toolset="llm-switch",
+        schema=schemas.SWITCH_LOCAL_LLM,
+        handler=_handle_switch,
+        description="Switch local LLM model",
+    )
+    ctx.register_hook("pre_llm_call", _on_pre_llm_call)
+    ctx.register_hook("on_session_end", _on_session_end)

--- a/docs/llm-switch-plugin-example/models.yaml.example
+++ b/docs/llm-switch-plugin-example/models.yaml.example
@@ -1,0 +1,75 @@
+# Local LLM server configuration for the llm-switch plugin.
+# Copy to models.yaml and edit to match your setup.
+#
+# Supports any OpenAI-compatible server (llama.cpp, vLLM, etc.)
+# The plugin auto-starts/stops the server when you switch models.
+#
+# Usage:
+#   Tell the agent: "switch to the write model"
+#   Or: "use the code model for this task"
+#   On exit, the server is stopped automatically.
+#
+# If /model is restored (PR #3360), you can also use:
+#   /model custom:write   — triggers pre_llm_call hook → auto-starts server
+
+server:
+  binary: llama-server             # Server binary name or absolute path
+  models_dir: ~/llama-models       # Base directory for model files (GGUF, etc.)
+  host: 0.0.0.0                    # Listen address
+  port: 8080                       # Listen port
+  gpu_layers: 99                   # -ngl flag (-1 for all layers)
+  flash_attention: true            # -fa flag (recommended for Ampere+)
+  parallel: 1                      # -np flag (concurrent request slots)
+  jinja: true                      # --jinja flag (enable chat templates)
+
+models:
+  # Each key becomes a model name the plugin recognizes.
+  #
+  # Required fields:
+  #   gguf          — path to model file, relative to server.models_dir
+  #
+  # Optional fields:
+  #   description   — human-readable purpose (shown in status messages)
+  #   context       — context window size in tokens (default: 8192)
+  #   kv_cache      — KV cache quantization: {key: q8_0, value: q4_0}
+  #   sampling      — default sampling params (client can override per-request)
+  #     temp, top_p, top_k, min_p, presence_penalty, repeat_penalty
+  #   alias         — model name reported by /v1/models (default: key name)
+
+  write:
+    description: "SEO articles and content briefs"
+    gguf: qwen3.5-9b/Qwen3.5-9B-UD-Q6_K_XL.gguf
+    context: 49152
+    kv_cache:
+      key: q8_0
+      value: q4_0
+    sampling:
+      temp: 0.7
+      top_p: 0.8
+      top_k: 20
+      presence_penalty: 1.5
+
+  research:
+    description: "Long research with max context"
+    gguf: qwen3.5-9b/Qwen3.5-9B-UD-Q4_K_XL.gguf
+    context: 65536
+    kv_cache:
+      key: q4_0
+      value: q4_0
+    sampling:
+      temp: 0.7
+      top_p: 0.8
+      top_k: 20
+      presence_penalty: 1.5
+
+  code:
+    description: "Agentic coding and tool calling"
+    gguf: omnicoder-9b/omnicoder-9b-q4_k_m.gguf
+    context: 65536
+    kv_cache:
+      key: q4_0
+      value: q4_0
+    sampling:
+      temp: 0.6
+      top_p: 0.95
+      top_k: 20

--- a/docs/llm-switch-plugin-example/plugin.yaml
+++ b/docs/llm-switch-plugin-example/plugin.yaml
@@ -1,0 +1,7 @@
+name: llm-switch
+version: 1.0.0
+description: Auto-manage local LLM servers (llama.cpp, vLLM) when switching models
+author: community
+provides:
+  tools: true
+  hooks: true

--- a/docs/llm-switch-plugin-example/schemas.py
+++ b/docs/llm-switch-plugin-example/schemas.py
@@ -1,0 +1,27 @@
+"""Tool schemas for the llm-switch plugin."""
+
+SWITCH_LOCAL_LLM = {
+    "name": "switch_local_llm",
+    "description": (
+        "Switch the local LLM server to a different model. "
+        "Only one model can run at a time on a single GPU. "
+        "The server is automatically managed — calling this tool kills the "
+        "current server (if any) and starts a new one with the requested model. "
+        "Available actions: provide a model name to switch, 'status' to check "
+        "what's running, 'stop' to kill the server, or 'list' to see available models."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "model": {
+                "type": "string",
+                "description": (
+                    "Model name to switch to (must match a key in models.yaml), "
+                    "or 'status' to check current server, 'stop' to kill it, "
+                    "'list' to show available models."
+                ),
+            },
+        },
+        "required": ["model"],
+    },
+}

--- a/docs/llm-switch-plugin-example/server.py
+++ b/docs/llm-switch-plugin-example/server.py
@@ -1,0 +1,152 @@
+"""Server lifecycle management for local LLM servers.
+
+Pure Python — no shell or OS-specific dependencies beyond subprocess and /proc.
+Works with any OpenAI-compatible server (llama.cpp, vLLM, etc.).
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Map from YAML sampling key names to llama-server CLI flags
+_SAMPLING_FLAGS = {
+    "temp": "--temp",
+    "top_p": "--top-p",
+    "top_k": "--top-k",
+    "min_p": "--min-p",
+    "presence_penalty": "--presence-penalty",
+    "repeat_penalty": "--repeat-penalty",
+    "frequency_penalty": "--frequency-penalty",
+}
+
+
+def kill_server(binary: str = "llama-server", timeout: float = 5.0) -> None:
+    """Kill any running server process and wait for it to exit."""
+    subprocess.run(["pkill", "-f", binary], capture_output=True)
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = subprocess.run(["pgrep", "-f", binary], capture_output=True)
+        if result.returncode != 0:
+            return  # process gone
+        time.sleep(0.2)
+    # Force kill if still alive
+    subprocess.run(["pkill", "-9", "-f", binary], capture_output=True)
+
+
+def build_command(model_key: str, config: Dict[str, Any]) -> List[str]:
+    """Build the server command line from a models.yaml config."""
+    server_cfg = config.get("server", {})
+    model_cfg = config["models"][model_key]
+    models_dir = Path(server_cfg.get("models_dir", "~/llama-models")).expanduser()
+
+    cmd = [
+        server_cfg.get("binary", "llama-server"),
+        "-m", str(models_dir / model_cfg["gguf"]),
+        "-c", str(model_cfg.get("context", 8192)),
+        "-ngl", str(server_cfg.get("gpu_layers", 99)),
+        "-np", str(server_cfg.get("parallel", 1)),
+        "--host", server_cfg.get("host", "0.0.0.0"),
+        "--port", str(server_cfg.get("port", 8080)),
+    ]
+
+    if server_cfg.get("flash_attention"):
+        cmd += ["-fa", "on"]
+    if server_cfg.get("jinja"):
+        cmd.append("--jinja")
+
+    # KV cache quantization
+    kv = model_cfg.get("kv_cache", {})
+    if kv.get("key"):
+        cmd += ["-ctk", str(kv["key"])]
+    if kv.get("value"):
+        cmd += ["-ctv", str(kv["value"])]
+
+    # Sampling defaults
+    sampling = model_cfg.get("sampling", {})
+    for param, flag in _SAMPLING_FLAGS.items():
+        if param in sampling:
+            cmd += [flag, str(sampling[param])]
+
+    # Model alias (reported by /v1/models)
+    alias = model_cfg.get("alias", model_key)
+    cmd += ["--alias", alias]
+
+    return cmd
+
+
+def start_server(
+    model_key: str,
+    config: Dict[str, Any],
+    timeout: int = 60,
+) -> bool:
+    """Kill existing server, start a new one, and wait for it to be healthy.
+
+    Returns True if the server is ready, False if it timed out.
+    """
+    binary = config.get("server", {}).get("binary", "llama-server")
+    kill_server(binary=binary)
+
+    cmd = build_command(model_key, config)
+    logger.info("Starting server: %s", " ".join(cmd))
+
+    log_path = Path("/tmp/llama-server.log")
+    log_file = log_path.open("w")
+    subprocess.Popen(cmd, stdout=log_file, stderr=log_file)
+
+    port = config.get("server", {}).get("port", 8080)
+    health_url = f"http://localhost:{port}/health"
+
+    for _ in range(timeout):
+        try:
+            import urllib.request
+            with urllib.request.urlopen(health_url, timeout=2) as resp:
+                if resp.status == 200:
+                    return True
+        except Exception:
+            pass
+        time.sleep(1)
+
+    return False
+
+
+def get_status(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Check if the server is running and which model is loaded."""
+    binary = config.get("server", {}).get("binary", "llama-server")
+    result = subprocess.run(
+        ["pgrep", "-f", binary], capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        return {"running": False}
+
+    pid_str = result.stdout.strip().split("\n")[0]
+    try:
+        pid = int(pid_str)
+    except ValueError:
+        return {"running": False}
+
+    # Extract --alias from /proc/<pid>/cmdline
+    alias = None
+    try:
+        cmdline = Path(f"/proc/{pid}/cmdline").read_bytes()
+        parts = cmdline.decode(errors="replace").split("\0")
+        for i, part in enumerate(parts):
+            if part == "--alias" and i + 1 < len(parts):
+                alias = parts[i + 1]
+                break
+    except Exception:
+        pass
+
+    port = config.get("server", {}).get("port", 8080)
+    return {
+        "running": True,
+        "pid": pid,
+        "alias": alias,
+        "model": alias,  # convenience alias
+        "endpoint": f"http://localhost:{port}/v1",
+    }


### PR DESCRIPTION
## Summary

Example plugin demonstrating the lifecycle hooks activated in #3542. Auto-manages a local llama-server (or any OpenAI-compatible server) when the active model matches a locally configured model name.

**This is a plugin-only PR — no core changes.** All hook infrastructure was already merged in #3542.

Supersedes #2930 (which included core hook patches before #3542 was merged).

## What it does

- **`pre_llm_call` hook**: Detects when the active model name matches a key in `models.yaml`. If the correct server isn't running, starts it automatically before the LLM call proceeds.
- **`on_session_end` hook**: Kills the server when the session ends.
- **`switch_local_llm` tool**: Mid-session model switching — the agent calls this when asked "switch to the code model". Swaps the server behind the scenes while the endpoint stays the same.
- **Declarative YAML config**: Define models with GGUF paths, context sizes, KV cache quantization, and sampling params. Replaces shell scripts.

## Example `models.yaml`

```yaml
server:
  binary: llama-server
  models_dir: ~/llama-models
  port: 8080
  gpu_layers: 99
  flash_attention: true

models:
  write:
    description: "SEO articles and content briefs"
    gguf: qwen3.5-9b/Qwen3.5-9B-UD-Q6_K_XL.gguf
    context: 49152
    kv_cache: { key: q8_0, value: q4_0 }
    sampling: { temp: 0.7, top_p: 0.8, top_k: 20 }

  code:
    description: "Agentic coding and tool calling"
    gguf: omnicoder-9b/omnicoder-9b-q4_k_m.gguf
    context: 65536
    sampling: { temp: 0.6, top_p: 0.95 }
```

## User flow

1. `hermes model` → select custom provider → pick model name matching `models.yaml` key
2. Start chatting → `pre_llm_call` hook auto-starts the server on first message
3. Mid-session: "switch to the code model" → agent calls `switch_local_llm` tool → server swaps
4. Exit → `on_session_end` kills server

## Relationship to other PRs

- **Builds on #3542** — uses the lifecycle hooks activated there
- **Complements #3360 / #3548** — once `/model` is restored as a slash command, `/model custom:write` would trigger the `pre_llm_call` hook to auto-start the right server seamlessly

## Changes

6 new files in `docs/llm-switch-plugin-example/`:

| File | Purpose |
|------|---------|
| `plugin.yaml` | Manifest |
| `__init__.py` | Registration, hook handlers, tool handler |
| `schemas.py` | Tool schema for `switch_local_llm` |
| `server.py` | Pure Python server lifecycle (start, stop, health check) |
| `models.yaml.example` | Example config with full schema documentation |
| `README.md` | Setup instructions, usage, and config reference |

## Testing

- Plugin is self-contained — copy to `~/.hermes/plugins/llm-switch/`, add `models.yaml`, verify with `/plugins`
- No existing code is modified — zero regression risk

## Platforms tested

- Linux (Arch)