### PR TITLE
fix(telegram): add channel_post and edited_channel_post handlers

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -526,7 +526,7 @@ class TelegramAdapter(BasePlatformAdapter):
             self._app = builder.build()
             self._bot = self._app.bot
             
-            # Register handlers
+            # Register handlers for regular messages
             self._app.add_handler(TelegramMessageHandler(
                 filters.TEXT & ~filters.COMMAND,
                 self._handle_text_message
@@ -542,6 +542,26 @@ class TelegramAdapter(BasePlatformAdapter):
             self._app.add_handler(TelegramMessageHandler(
                 filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
                 self._handle_media_message
+            ))
+            
+            # Register handlers for channel posts (messages in Telegram channels)
+            # Channel posts come through update.channel_post instead of update.message
+            self._app.add_handler(TelegramMessageHandler(
+                filters.UpdateType.CHANNEL_POST & filters.TEXT & ~filters.COMMAND,
+                self._handle_channel_text_message
+            ))
+            self._app.add_handler(TelegramMessageHandler(
+                filters.UpdateType.CHANNEL_POST & filters.COMMAND,
+                self._handle_channel_command
+            ))
+            self._app.add_handler(TelegramMessageHandler(
+                filters.UpdateType.CHANNEL_POST & (filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL),
+                self._handle_channel_media_message
+            ))
+            # Also handle edited channel posts
+            self._app.add_handler(TelegramMessageHandler(
+                filters.UpdateType.EDITED_CHANNEL_POST & filters.TEXT,
+                self._handle_channel_text_message
             ))
             
             # Start polling — retry initialize() for transient TLS resets
@@ -1552,6 +1572,175 @@ class TelegramAdapter(BasePlatformAdapter):
         event = self._build_message_event(update.message, MessageType.COMMAND)
         await self.handle_message(event)
     
+    async def _handle_channel_text_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle incoming text messages from channels.
+        
+        Channel posts come through update.channel_post (or update.edited_channel_post)
+        instead of update.message.
+        """
+        msg = update.channel_post or update.edited_channel_post
+        if not msg or not msg.text:
+            return
+
+        event = self._build_message_event(msg, MessageType.TEXT)
+        self._enqueue_text_event(event)
+    
+    async def _handle_channel_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle incoming command messages from channels."""
+        msg = update.channel_post or update.edited_channel_post
+        if not msg or not msg.text:
+            return
+        
+        event = self._build_message_event(msg, MessageType.COMMAND)
+        await self.handle_message(event)
+    
+    async def _handle_channel_media_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle incoming media messages from channels.
+        
+        Downloads images/audio/documents to local cache, same as regular messages.
+        """
+        msg = update.channel_post or update.edited_channel_post
+        if not msg:
+            return
+        
+        # Determine media type
+        if msg.photo:
+            msg_type = MessageType.PHOTO
+        elif msg.video:
+            msg_type = MessageType.VIDEO
+        elif msg.audio:
+            msg_type = MessageType.AUDIO
+        elif msg.voice:
+            msg_type = MessageType.VOICE
+        elif msg.document:
+            msg_type = MessageType.DOCUMENT
+        else:
+            msg_type = MessageType.DOCUMENT
+        
+        event = self._build_message_event(msg, msg_type)
+        
+        # Add caption as text
+        if msg.caption:
+            event.text = msg.caption
+        
+        # Download photo to local image cache
+        if msg.photo:
+            try:
+                photo = msg.photo[-1]
+                file_obj = await photo.get_file()
+                image_bytes = await file_obj.download_as_bytearray()
+                ext = ".jpg"
+                if file_obj.file_path:
+                    for candidate in [".png", ".webp", ".gif", ".jpeg", ".jpg"]:
+                        if file_obj.file_path.lower().endswith(candidate):
+                            ext = candidate
+                            break
+                cached_path = cache_image_from_bytes(bytes(image_bytes), ext=ext)
+                event.media_urls = [cached_path]
+                event.media_types = [f"image/{ext.lstrip('.')}" ]
+                logger.info("[Telegram] Cached channel photo at %s", cached_path)
+                
+                media_group_id = getattr(msg, "media_group_id", None)
+                if media_group_id:
+                    await self._queue_media_group_event(str(media_group_id), event)
+                else:
+                    batch_key = self._photo_batch_key(event, msg)
+                    self._enqueue_photo_event(batch_key, event)
+                return
+            except Exception as e:
+                logger.warning("[Telegram] Failed to cache channel photo: %s", e, exc_info=True)
+
+        # Download voice/audio messages
+        if msg.voice:
+            try:
+                file_obj = await msg.voice.get_file()
+                audio_bytes = await file_obj.download_as_bytearray()
+                cached_path = cache_audio_from_bytes(bytes(audio_bytes), ext=".ogg")
+                event.media_urls = [cached_path]
+                event.media_types = ["audio/ogg"]
+                logger.info("[Telegram] Cached channel voice at %s", cached_path)
+            except Exception as e:
+                logger.warning("[Telegram] Failed to cache channel voice: %s", e, exc_info=True)
+        elif msg.audio:
+            try:
+                file_obj = await msg.audio.get_file()
+                audio_bytes = await file_obj.download_as_bytearray()
+                cached_path = cache_audio_from_bytes(bytes(audio_bytes), ext=".mp3")
+                event.media_urls = [cached_path]
+                event.media_types = ["audio/mp3"]
+                logger.info("[Telegram] Cached channel audio at %s", cached_path)
+            except Exception as e:
+                logger.warning("[Telegram] Failed to cache channel audio: %s", e, exc_info=True)
+
+        # Download document files
+        elif msg.document:
+            doc = msg.document
+            try:
+                ext = ""
+                original_filename = doc.file_name or ""
+                if original_filename:
+                    _, ext = os.path.splitext(original_filename)
+                    ext = ext.lower()
+
+                if not ext and doc.mime_type:
+                    mime_to_ext = {v: k for k, v in SUPPORTED_DOCUMENT_TYPES.items()}
+                    ext = mime_to_ext.get(doc.mime_type, "")
+
+                if ext not in SUPPORTED_DOCUMENT_TYPES:
+                    supported_list = ", ".join(sorted(SUPPORTED_DOCUMENT_TYPES.keys()))
+                    event.text = (
+                        f"Unsupported document type '{ext or 'unknown'}'. "
+                        f"Supported types: {supported_list}"
+                    )
+                    logger.info("[Telegram] Unsupported channel document type: %s", ext or "unknown")
+                    await self.handle_message(event)
+                    return
+
+                MAX_DOC_BYTES = 20 * 1024 * 1024
+                if not doc.file_size or doc.file_size > MAX_DOC_BYTES:
+                    event.text = (
+                        "The document is too large or its size could not be verified. "
+                        "Maximum: 20 MB."
+                    )
+                    logger.info("[Telegram] Channel document too large: %s bytes", doc.file_size)
+                    await self.handle_message(event)
+                    return
+
+                file_obj = await doc.get_file()
+                doc_bytes = await file_obj.download_as_bytearray()
+                raw_bytes = bytes(doc_bytes)
+                cached_path = cache_document_from_bytes(raw_bytes, original_filename or f"document{ext}")
+                mime_type = SUPPORTED_DOCUMENT_TYPES[ext]
+                event.media_urls = [cached_path]
+                event.media_types = [mime_type]
+                logger.info("[Telegram] Cached channel document at %s", cached_path)
+
+                MAX_TEXT_INJECT_BYTES = 100 * 1024
+                if ext in (".md", ".txt") and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
+                    try:
+                        text_content = raw_bytes.decode("utf-8")
+                        display_name = original_filename or f"document{ext}"
+                        display_name = re.sub(r'[^\w.\- ]', '_', display_name)
+                        injection = f"[Content of {display_name}]:\n{text_content}"
+                        if event.text:
+                            event.text = f"{injection}\n\n{event.text}"
+                        else:
+                            event.text = injection
+                    except UnicodeDecodeError:
+                        logger.warning(
+                            "[Telegram] Could not decode channel text file as UTF-8",
+                            exc_info=True,
+                        )
+            except Exception as e:
+                logger.warning("[Telegram] Failed to cache channel document: %s", e, exc_info=True)
+
+        media_group_id = getattr(msg, "media_group_id", None)
+        if media_group_id:
+            await self._queue_media_group_event(str(media_group_id), event)
+            return
+
+        await self.handle_message(event)
+    
     async def _handle_location_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming location/venue pin messages."""
         if not update.message:
@@ -2066,9 +2255,14 @@ class TelegramAdapter(BasePlatformAdapter):
             )
 
     def _build_message_event(self, message: Message, msg_type: MessageType) -> MessageEvent:
-        """Build a MessageEvent from a Telegram message."""
+        """Build a MessageEvent from a Telegram message.
+        
+        Handles both regular messages (from users in DMs/groups) and channel posts
+        (where from_user is None but sender_chat indicates the channel).
+        """
         chat = message.chat
         user = message.from_user
+        sender_chat = getattr(message, "sender_chat", None)
         
         # Determine chat type
         chat_type = "dm"
@@ -2076,6 +2270,17 @@ class TelegramAdapter(BasePlatformAdapter):
             chat_type = "group"
         elif chat.type == ChatType.CHANNEL:
             chat_type = "channel"
+        
+        # For channel posts, extract sender info from sender_chat if no from_user
+        user_id = None
+        user_name = None
+        if user:
+            user_id = str(user.id)
+            user_name = user.full_name
+        elif sender_chat:
+            # Channel posts: use the channel ID as the "user" and channel title as name
+            user_id = str(sender_chat.id)
+            user_name = sender_chat.title or f"Channel {sender_chat.id}"
 
         # Resolve DM topic name and skill binding
         thread_id_raw = message.message_thread_id
@@ -2102,8 +2307,8 @@ class TelegramAdapter(BasePlatformAdapter):
             chat_id=str(chat.id),
             chat_name=chat.title or (chat.full_name if hasattr(chat, "full_name") else None),
             chat_type=chat_type,
-            user_id=str(user.id) if user else None,
-            user_name=user.full_name if user else None,
+            user_id=user_id,
+            user_name=user_name,
             thread_id=thread_id_str,
             chat_topic=chat_topic,
         )

--- a/tests/gateway/test_telegram_channel_posts.py
+++ b/tests/gateway/test_telegram_channel_posts.py
@@ -1,0 +1,219 @@
+"""Tests for Telegram channel post handling.
+
+Telegram channels post updates come through update.channel_post (and 
+update.edited_channel_post) rather than update.message. The adapter should
+handle these appropriately and route them like other messages.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, SessionSource
+
+
+def _make_adapter():
+    """Create a minimal TelegramAdapter for testing channel post handling."""
+    from gateway.platforms.telegram import TelegramAdapter
+
+    config = PlatformConfig(enabled=True, token="test-token")
+    adapter = object.__new__(TelegramAdapter)
+    adapter._platform = Platform.TELEGRAM
+    adapter.config = config
+    adapter._pending_text_batches = {}
+    adapter._pending_text_batch_tasks = {}
+    adapter._text_batch_delay_seconds = 0.1  # fast for tests
+    adapter._active_sessions = {}
+    adapter._pending_messages = {}
+    adapter._message_handler = AsyncMock()
+    adapter.handle_message = AsyncMock()
+    # Channel post handlers also need these
+    adapter._pending_photo_batches = {}
+    adapter._pending_photo_batch_tasks = {}
+    adapter._media_batch_delay_seconds = 0.1
+    adapter._media_group_events = {}
+    adapter._media_group_tasks = {}
+    adapter._dm_topics = {}
+    adapter._dm_topics_config = []
+    return adapter
+
+
+def _make_channel_message(text: str = "Hello from channel", channel_id: int = -1001234567890):
+    """Create a mock Telegram Message representing a channel post."""
+    msg = MagicMock()
+    msg.text = text
+    msg.caption = None
+    msg.message_id = 42
+    msg.date = None
+    msg.reply_to_message = None
+    msg.message_thread_id = None
+    msg.forum_topic_created = None
+    msg.photo = None
+    msg.video = None
+    msg.audio = None
+    msg.voice = None
+    msg.document = None
+    msg.sticker = None
+    msg.media_group_id = None
+    
+    # Channel posts have no from_user, but have sender_chat
+    msg.from_user = None
+    
+    # sender_chat is the channel itself
+    sender_chat = MagicMock()
+    sender_chat.id = channel_id
+    sender_chat.title = "Test Channel"
+    msg.sender_chat = sender_chat
+    
+    # Chat is the channel
+    chat = MagicMock()
+    chat.id = channel_id
+    chat.title = "Test Channel"
+    chat.type = "channel"
+    chat.full_name = None
+    msg.chat = chat
+    
+    return msg
+
+
+def _make_channel_update(msg):
+    """Create a mock Update with channel_post set."""
+    update = MagicMock()
+    update.message = None
+    update.channel_post = msg
+    update.edited_channel_post = None
+    return update
+
+
+def _make_edited_channel_update(msg):
+    """Create a mock Update with edited_channel_post set."""
+    update = MagicMock()
+    update.message = None
+    update.channel_post = None
+    update.edited_channel_post = msg
+    return update
+
+
+class TestChannelPostHandling:
+    @pytest.mark.asyncio
+    async def test_channel_text_message_processed(self):
+        """Channel text posts should be processed and dispatched."""
+        adapter = _make_adapter()
+        msg = _make_channel_message(text="Breaking news from the channel!")
+        update = _make_channel_update(msg)
+        context = MagicMock()
+
+        await adapter._handle_channel_text_message(update, context)
+
+        # Wait for flush (text batching)
+        await asyncio.sleep(0.2)
+
+        adapter.handle_message.assert_called_once()
+        dispatched = adapter.handle_message.call_args[0][0]
+        assert dispatched.text == "Breaking news from the channel!"
+        assert dispatched.source.chat_type == "channel"
+
+    @pytest.mark.asyncio
+    async def test_edited_channel_post_processed(self):
+        """Edited channel posts should also be processed."""
+        adapter = _make_adapter()
+        msg = _make_channel_message(text="Edited message")
+        update = _make_edited_channel_update(msg)
+        context = MagicMock()
+
+        await adapter._handle_channel_text_message(update, context)
+        await asyncio.sleep(0.2)
+
+        adapter.handle_message.assert_called_once()
+        dispatched = adapter.handle_message.call_args[0][0]
+        assert dispatched.text == "Edited message"
+
+    @pytest.mark.asyncio
+    async def test_channel_command_processed(self):
+        """Channel command posts should be processed immediately (no batching)."""
+        adapter = _make_adapter()
+        msg = _make_channel_message(text="/status check")
+        update = _make_channel_update(msg)
+        context = MagicMock()
+
+        await adapter._handle_channel_command(update, context)
+
+        # Commands don't use batching, should be immediate
+        adapter.handle_message.assert_called_once()
+        dispatched = adapter.handle_message.call_args[0][0]
+        assert dispatched.text == "/status check"
+        assert dispatched.message_type == MessageType.COMMAND
+
+    @pytest.mark.asyncio
+    async def test_channel_user_info_from_sender_chat(self):
+        """Channel posts should extract user info from sender_chat."""
+        adapter = _make_adapter()
+        msg = _make_channel_message(channel_id=-1009999888777)
+        msg.sender_chat.title = "My News Channel"
+        update = _make_channel_update(msg)
+        context = MagicMock()
+
+        await adapter._handle_channel_text_message(update, context)
+        await asyncio.sleep(0.2)
+
+        dispatched = adapter.handle_message.call_args[0][0]
+        # user_id should be the channel ID
+        assert dispatched.source.user_id == "-1009999888777"
+        # user_name should be the channel title
+        assert dispatched.source.user_name == "My News Channel"
+
+    @pytest.mark.asyncio
+    async def test_null_channel_post_ignored(self):
+        """Updates with null channel_post should be ignored gracefully."""
+        adapter = _make_adapter()
+        update = MagicMock()
+        update.channel_post = None
+        update.edited_channel_post = None
+        context = MagicMock()
+
+        await adapter._handle_channel_text_message(update, context)
+
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_channel_post_without_text_ignored(self):
+        """Channel posts without text should be ignored by text handler."""
+        adapter = _make_adapter()
+        msg = _make_channel_message(text=None)
+        msg.text = None
+        update = _make_channel_update(msg)
+        context = MagicMock()
+
+        await adapter._handle_channel_text_message(update, context)
+        await asyncio.sleep(0.2)
+
+        adapter.handle_message.assert_not_called()
+
+
+class TestBuildMessageEventForChannels:
+    def test_build_event_with_sender_chat(self):
+        """_build_message_event should handle channel posts with sender_chat."""
+        from gateway.platforms.telegram import TelegramAdapter
+        from telegram.constants import ChatType
+        
+        # Skip if telegram not available
+        try:
+            from telegram import Message
+        except ImportError:
+            pytest.skip("python-telegram-bot not installed")
+        
+        adapter = _make_adapter()
+        adapter.name = "telegram"
+        
+        msg = _make_channel_message(text="Channel content")
+        # Mock ChatType for the test
+        msg.chat.type = ChatType.CHANNEL
+        
+        event = adapter._build_message_event(msg, MessageType.TEXT)
+        
+        assert event.text == "Channel content"
+        assert event.source.chat_type == "channel"
+        assert event.source.user_id == str(msg.sender_chat.id)
+        assert event.source.user_name == msg.sender_chat.title

--- a/tests/gateway/test_telegram_channel_posts.py
+++ b/tests/gateway/test_telegram_channel_posts.py
@@ -20,7 +20,8 @@ def _make_adapter():
 
     config = PlatformConfig(enabled=True, token="test-token")
     adapter = object.__new__(TelegramAdapter)
-    adapter._platform = Platform.TELEGRAM
+    # Use 'platform' not '_platform' - that's what the base class defines
+    adapter.platform = Platform.TELEGRAM
     adapter.config = config
     adapter._pending_text_batches = {}
     adapter._pending_text_batch_tasks = {}
@@ -205,7 +206,8 @@ class TestBuildMessageEventForChannels:
             pytest.skip("python-telegram-bot not installed")
         
         adapter = _make_adapter()
-        adapter.name = "telegram"
+        # Note: adapter.name is a read-only property derived from platform.value.title()
+        # Since we set platform = Platform.TELEGRAM, adapter.name is automatically "Telegram"
         
         msg = _make_channel_message(text="Channel content")
         # Mock ChatType for the test


### PR DESCRIPTION
## Summary

Telegram channels post messages through `update.channel_post` instead of `update.message`. Previously the adapter only registered handlers for regular messages, causing channel content to be silently dropped even when the bot was a channel admin.

## Changes

- Add handlers for `channel_post` and `edited_channel_post` update types
- Handle text, command, and media messages from channels  
- Extract sender info from `sender_chat` (channels don't have `from_user`)
- Reuse existing batching/caching logic for consistency
- Add comprehensive test coverage for channel post handling

## Technical Details

The fix adds three new handlers that mirror the existing message handlers:
- `_handle_channel_text_message` - batched text message handling
- `_handle_channel_command` - immediate command processing
- `_handle_channel_media_message` - photo/video/audio/document handling with caching

The `_build_message_event` method was updated to extract user info from `sender_chat` when `from_user` is None (which is the case for channel posts).

## Testing

Added `test_telegram_channel_posts.py` with tests for:
- Channel text message processing
- Edited channel post handling  
- Command processing from channels
- User info extraction from sender_chat
- Edge cases (null posts, posts without text)

Fixes #3634