### PR TITLE
fix(tests): CI skill remote-setup assertion and related test hygiene

### DIFF
--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -5,6 +5,8 @@ import importlib
 import logging
 import sys
 
+import pytest
+
 from agent.prompt_builder import (
     _scan_context_content,
     _truncate_content,
@@ -194,7 +196,7 @@ class TestParseSkillFile:
         )
         from unittest.mock import patch
 
-        with patch("tools.skills_tool.sys") as mock_sys:
+        with patch("agent.skill_utils.sys") as mock_sys:
             mock_sys.platform = "linux"
             is_compat, _, _ = _parse_skill_file(skill_file)
         assert is_compat is False
@@ -232,9 +234,6 @@ class TestPromptBuilderImports:
 # =========================================================================
 # Skills system prompt builder
 # =========================================================================
-
-
-import pytest
 
 
 class TestBuildSkillsSystemPrompt:
@@ -296,7 +295,7 @@ class TestBuildSkillsSystemPrompt:
 
         from unittest.mock import patch
 
-        with patch("tools.skills_tool.sys") as mock_sys:
+        with patch("agent.skill_utils.sys") as mock_sys:
             mock_sys.platform = "linux"
             result = build_skills_system_prompt()
 
@@ -574,6 +573,10 @@ class TestBuildContextFilesPrompt:
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert "Lowercase claude rules" in result
 
+    @pytest.mark.skipif(
+        sys.platform == "darwin",
+        reason="APFS default volume is case-insensitive; CLAUDE.md and claude.md alias the same path",
+    )
     def test_claude_md_uppercase_takes_priority(self, tmp_path):
         (tmp_path / "CLAUDE.md").write_text("From uppercase.")
         (tmp_path / "claude.md").write_text("From lowercase.")

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -246,20 +246,10 @@ Generate some audio.
     def test_preserves_remaining_remote_setup_warning(self, tmp_path, monkeypatch):
         monkeypatch.setenv("TERMINAL_ENV", "ssh")
         monkeypatch.delenv("TENOR_API_KEY", raising=False)
-
-        def fake_secret_callback(var_name, prompt, metadata=None):
-            os.environ[var_name] = "stored-in-test"
-            return {
-                "success": True,
-                "stored_as": var_name,
-                "validated": False,
-                "skipped": False,
-            }
-
         monkeypatch.setattr(
             skills_tool_module,
             "_secret_capture_callback",
-            fake_secret_callback,
+            None,
             raising=False,
         )
 


### PR DESCRIPTION
## What failed on CI (e.g. PR #3676)

`tests/agent/test_skill_commands.py::TestBuildSkillInvocationMessage::test_preserves_remaining_remote_setup_warning` — the test installed a secret-capture callback that **filled** `TENOR_API_KEY`, so `skill_view` cleared `setup_needed` and never built `setup_note` (including the SSH `remote environment` suffix). Production behavior is correct; the fixture was contradictory.

## Duplicate PR check

- [#2625](https://github.com/NousResearch/hermes-agent/pull/2625) fixes optional-dep mocks / env pollution (parallel, whisper, HA websocket, etc.) — **different** failures.
- [#2785](https://github.com/NousResearch/hermes-agent/pull/2785) clears `TERMINAL_ENV` in conftest for xdist flakes — **orthogonal**.

No open PR targets this skill-invocation / `remote environment` assertion.

## Other fixes (local + CI consistency)

- Platform tests: patch `agent.skill_utils.sys` (where `skill_matches_platform` reads `sys.platform`), not `tools.skills_tool.sys`.
- `test_invoke_tool_dispatches_to_handle_function_call`: expect `tool_call_id=None` passed to `handle_function_call`.
- `test_claude_md_uppercase_takes_priority`: `@pytest.mark.skipif(darwin)` — default macOS APFS cannot represent `CLAUDE.md` and `claude.md` as two files (CI remains Linux and still runs the test).

## Verification

```bash
env OPENAI_API_KEY= OPENROUTER_API_KEY= NOUS_API_KEY= ANTHROPIC_API_KEY= python -m pytest tests/ -q
```

6731 passed, 165 skipped.