### PR TITLE
fix: set api_mode when switching providers via hermes model

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -980,6 +980,7 @@ def _model_flow_openrouter(config, current_model=""):
             cfg["model"] = model
         model["provider"] = "openrouter"
         model["base_url"] = OPENROUTER_BASE_URL
+        model["api_mode"] = "chat_completions"
         save_config(cfg)
         deactivate_provider()
         print(f"Default model set to: {selected} (via OpenRouter)")
@@ -1203,6 +1204,7 @@ def _model_flow_custom(config):
             cfg["model"] = model
         model["provider"] = "custom"
         model["base_url"] = effective_url
+        model["api_mode"] = "chat_completions"
         save_config(cfg)
         deactivate_provider()
 
@@ -1984,6 +1986,7 @@ def _model_flow_kimi(config, current_model=""):
             cfg["model"] = model
         model["provider"] = provider_id
         model["base_url"] = effective_base
+        model["api_mode"] = "chat_completions"
         save_config(cfg)
         deactivate_provider()
 
@@ -2090,6 +2093,7 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
             cfg["model"] = model
         model["provider"] = provider_id
         model["base_url"] = effective_base
+        model["api_mode"] = "chat_completions"
         save_config(cfg)
         deactivate_provider()
 


### PR DESCRIPTION
## Summary

`hermes model` does not update `api_mode` in `~/.hermes/config.yaml` when switching to most providers. The previous provider's `api_mode` persists, causing requests to the wrong endpoint.

## The bug

Switching from Copilot (`api_mode: codex_responses`) to Z.AI leaves the stale `api_mode: codex_responses` in config. Z.AI doesn't support `/v4/responses`, so every request fails with 404.

## The fix

Set `model.api_mode = "chat_completions"` in all provider flows that use the chat completions API surface:

| Flow | Before | After |
|------|--------|-------|
| OpenRouter | no api_mode set | `chat_completions` |
| Custom endpoint | no api_mode set | `chat_completions` |
| Kimi / Moonshot | no api_mode set | `chat_completions` |
| Z.AI / MiniMax | no api_mode set | `chat_completions` |
| Copilot | already correct | unchanged |
| Copilot-ACP | already correct | unchanged |

## Testing

- Verified that `resolveProvider()` in the Paperclip adapter correctly falls back to model-name inference when config model doesn't match requested model
- Confirmed the 4 new lines match the existing pattern used by Copilot-ACP (line 1887)

Fixes #3685