### PR TITLE
feat(gateway): add iMessage platform adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ hermes-agent/
 ├── gateway/              # Messaging platform gateway
 │   ├── run.py            # Main loop, slash commands, message dispatch
 │   ├── session.py        # SessionStore — conversation persistence
-│   └── platforms/        # Adapters: telegram, discord, slack, whatsapp, homeassistant, signal
+│   └── platforms/        # Adapters: telegram, discord, slack, whatsapp, homeassistant, signal, imessage
 ├── acp_adapter/          # ACP server (VS Code / Zed / JetBrains integration)
 ├── cron/                 # Scheduler (jobs.py, scheduler.py)
 ├── environments/         # RL training environments (Atropos)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,7 @@ hermes-agent/
 │   ├── config.py                 # Platform configuration resolution
 │   ├── session.py                # Session store, context prompts, reset policies
 │   └── platforms/                # Platform adapters
-│       ├── telegram.py, discord_adapter.py, slack.py, whatsapp.py
+│       ├── telegram.py, discord_adapter.py, slack.py, whatsapp.py, imessage.py
 │
 ├── scripts/                  # Installer and bridge scripts
 │   ├── install.sh                # Linux/macOS installer

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Use any model you want — [Nous Portal](https://portal.nousresearch.com), [Open
 
 <table>
 <tr><td><b>A real terminal interface</b></td><td>Full TUI with multiline editing, slash-command autocomplete, conversation history, interrupt-and-redirect, and streaming tool output.</td></tr>
-<tr><td><b>Lives where you do</b></td><td>Telegram, Discord, Slack, WhatsApp, Signal, and CLI — all from a single gateway process. Voice memo transcription, cross-platform conversation continuity.</td></tr>
+<tr><td><b>Lives where you do</b></td><td>Telegram, Discord, Slack, WhatsApp, Signal, iMessage, and CLI — all from a single gateway process. Voice memo transcription, cross-platform conversation continuity.</td></tr>
 <tr><td><b>A closed learning loop</b></td><td>Agent-curated memory with periodic nudges. Autonomous skill creation after complex tasks. Skills self-improve during use. FTS5 session search with LLM summarization for cross-session recall. <a href="https://github.com/plastic-labs/honcho">Honcho</a> dialectic user modeling. Compatible with the <a href="https://agentskills.io">agentskills.io</a> open standard.</td></tr>
 <tr><td><b>Scheduled automations</b></td><td>Built-in cron scheduler with delivery to any platform. Daily reports, nightly backups, weekly audits — all in natural language, running unattended.</td></tr>
 <tr><td><b>Delegates and parallelizes</b></td><td>Spawn isolated subagents for parallel workstreams. Write Python scripts that call tools via RPC, collapsing multi-step pipelines into zero-context-cost turns.</td></tr>
@@ -64,7 +64,7 @@ hermes doctor       # Diagnose any issues
 
 ## CLI vs Messaging Quick Reference
 
-Hermes has two entry points: start the terminal UI with `hermes`, or run the gateway and talk to it from Telegram, Discord, Slack, WhatsApp, Signal, or Email. Once you're in a conversation, many slash commands are shared across both interfaces.
+Hermes has two entry points: start the terminal UI with `hermes`, or run the gateway and talk to it from Telegram, Discord, Slack, WhatsApp, Signal, iMessage, or Email. Once you're in a conversation, many slash commands are shared across both interfaces.
 
 | Action | CLI | Messaging platforms |
 |---------|-----|---------------------|
@@ -91,7 +91,7 @@ All documentation lives at **[hermes-agent.nousresearch.com/docs](https://hermes
 | [Quickstart](https://hermes-agent.nousresearch.com/docs/getting-started/quickstart) | Install → setup → first conversation in 2 minutes |
 | [CLI Usage](https://hermes-agent.nousresearch.com/docs/user-guide/cli) | Commands, keybindings, personalities, sessions |
 | [Configuration](https://hermes-agent.nousresearch.com/docs/user-guide/configuration) | Config file, providers, models, all options |
-| [Messaging Gateway](https://hermes-agent.nousresearch.com/docs/user-guide/messaging) | Telegram, Discord, Slack, WhatsApp, Signal, Home Assistant |
+| [Messaging Gateway](https://hermes-agent.nousresearch.com/docs/user-guide/messaging) | Telegram, Discord, Slack, WhatsApp, Signal, iMessage, Home Assistant |
 | [Security](https://hermes-agent.nousresearch.com/docs/user-guide/security) | Command approval, DM pairing, container isolation |
 | [Tools & Toolsets](https://hermes-agent.nousresearch.com/docs/user-guide/features/tools) | 40+ tools, toolset system, terminal backends |
 | [Skills System](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills) | Procedural memory, Skills Hub, creating skills |

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -256,6 +256,12 @@ PLATFORM_HINTS = {
         "only — no markdown, no formatting. SMS messages are limited to ~1600 "
         "characters, so be brief and direct."
     ),
+    "imessage": (
+        "You are on iMessage (Apple Messages). Do not use markdown — it "
+        "does not render. Keep responses conversational and mobile-friendly. "
+        "Supported actions include tapbacks, message effects, typing "
+        "indicators, and message search."
+    ),
 }
 
 CONTEXT_FILE_MAX_CHARS = 20_000

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -146,7 +146,7 @@ def redact_sensitive_text(text: str) -> str:
     # Database connection string passwords
     text = _DB_CONNSTR_RE.sub(lambda m: f"{m.group(1)}***{m.group(3)}", text)
 
-    # E.164 phone numbers (Signal, WhatsApp)
+    # E.164 phone numbers (Signal, WhatsApp, iMessage)
     def _redact_phone(m):
         phone = m.group(1)
         if len(phone) <= 8:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -166,6 +166,7 @@ def _deliver_result(job: dict, content: str) -> None:
         "wecom": Platform.WECOM,
         "email": Platform.EMAIL,
         "sms": Platform.SMS,
+        "imessage": Platform.IMESSAGE,
     }
     platform = platform_map.get(platform_name.lower())
     if not platform:

--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -62,7 +62,7 @@ def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
             logger.warning("Channel directory: failed to build %s: %s", platform.value, e)
 
     # Telegram, WhatsApp & Signal can't enumerate chats -- pull from session history
-    for plat_name in ("telegram", "whatsapp", "signal", "email", "sms"):
+    for plat_name in ("telegram", "whatsapp", "signal", "email", "sms", "imessage"):
         if plat_name not in platforms:
             platforms[plat_name] = _build_from_sessions(plat_name)
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -11,6 +11,7 @@ Handles loading and validating configuration for:
 import logging
 import os
 import json
+import platform as platform_mod
 from pathlib import Path
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Any
@@ -62,6 +63,7 @@ class Platform(Enum):
     EMAIL = "email"
     SMS = "sms"
     DINGTALK = "dingtalk"
+    IMESSAGE = "imessage"
     API_SERVER = "api_server"
     WEBHOOK = "webhook"
     FEISHU = "feishu"
@@ -277,6 +279,14 @@ class GatewayConfig:
             # SMS uses api_key (Twilio auth token) — SID checked via env
             elif platform == Platform.SMS and os.getenv("TWILIO_ACCOUNT_SID"):
                 connected.append(platform)
+            # iMessage — local needs macOS; remote needs server_url + api_key
+            elif platform == Platform.IMESSAGE:
+                extra = config.extra or {}
+                is_local = _coerce_bool(extra.get("local"), True)
+                if is_local and platform_mod.system() == "Darwin":
+                    connected.append(platform)
+                elif not is_local and extra.get("server_url") and config.api_key:
+                    connected.append(platform)
             # API Server uses enabled flag only (no token needed)
             elif platform == Platform.API_SERVER:
                 connected.append(platform)
@@ -802,6 +812,28 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             chat_id=sms_home,
             name=os.getenv("SMS_HOME_CHANNEL_NAME", "Home"),
         )
+
+    # iMessage (macOS local or remote via advanced-imessage-http-proxy)
+    imessage_enabled = os.getenv("IMESSAGE_ENABLED", "").lower() in ("true", "1", "yes")
+    imessage_server = os.getenv("IMESSAGE_SERVER_URL", "")
+    imessage_key = os.getenv("IMESSAGE_API_KEY", "")
+    imessage_home = os.getenv("IMESSAGE_HOME_CHANNEL", "")
+    if imessage_enabled or imessage_server or imessage_key or imessage_home:
+        if Platform.IMESSAGE not in config.platforms:
+            config.platforms[Platform.IMESSAGE] = PlatformConfig()
+        if imessage_enabled or imessage_server:
+            config.platforms[Platform.IMESSAGE].enabled = True
+        if imessage_server:
+            config.platforms[Platform.IMESSAGE].extra["server_url"] = imessage_server
+            config.platforms[Platform.IMESSAGE].extra["local"] = False
+        if imessage_key:
+            config.platforms[Platform.IMESSAGE].api_key = imessage_key
+        if imessage_home:
+            config.platforms[Platform.IMESSAGE].home_channel = HomeChannel(
+                platform=Platform.IMESSAGE,
+                chat_id=imessage_home,
+                name="iMessage",
+            )
 
     # API Server
     api_server_enabled = os.getenv("API_SERVER_ENABLED", "").lower() in ("true", "1", "yes")

--- a/gateway/platforms/imessage.py
+++ b/gateway/platforms/imessage.py
@@ -1,0 +1,1010 @@
+"""iMessage platform adapter.
+
+Supports two modes:
+
+  **Local** (default, macOS only): Reads the native iMessage SQLite
+  database for inbound messages and sends via AppleScript.  Pure Python,
+  no external dependencies beyond macOS system frameworks.  Requires
+  Full Disk Access granted to the terminal running Hermes.
+
+  **Remote**: Talks to a Photon ``advanced-imessage-http-proxy`` server
+  over HTTP.  Works from any OS.  Provides file/image/audio sending,
+  tapbacks, typing indicators, message effects, message queries, chat
+  history, attachment download, and iMessage availability checks.
+
+  API reference: https://github.com/photon-hq/advanced-imessage-http-proxy
+
+Environment variables (remote — just your Photon credentials):
+  IMESSAGE_SERVER_URL   — Photon endpoint from photon.codes
+  IMESSAGE_API_KEY      — Photon API key from photon.codes
+
+Environment variables (local — macOS only, no Photon account):
+  IMESSAGE_ENABLED      — set to "true"
+
+Config (config.yaml platforms section):
+  imessage:
+    enabled: true
+    extra:
+      local: true                       # false for remote mode
+      server_url: ""                    # Photon endpoint from photon.codes
+      poll_interval: 2.0                # seconds between polls
+      database_path: ~/Library/Messages/chat.db
+      group_policy: "open"              # "open" or "ignore"
+      react_tapback: "love"             # tapback on inbound (remote only)
+      done_tapback: ""                  # tapback after reply (remote only)
+"""
+
+import asyncio
+import base64
+import binascii
+import json
+import logging
+import mimetypes
+import os
+import platform as platform_mod
+import random
+import sqlite3
+import subprocess
+import time
+from collections import OrderedDict
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+    cache_image_from_bytes,
+    cache_audio_from_bytes,
+    cache_document_from_bytes,
+)
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_DB_PATH = str(Path.home() / "Library" / "Messages" / "chat.db")
+_DEFAULT_PROXY_URL = "https://imessage-swagger.photon.codes"
+_REMOTE_POLL_INTERVAL = 2.0
+_BACKOFF_INITIAL = 2.0
+_BACKOFF_MAX = 60.0
+MAX_MESSAGE_LENGTH = 20000
+
+_AUDIO_EXTENSIONS = frozenset({".m4a", ".mp3", ".wav", ".aac", ".ogg", ".caf", ".opus"})
+
+_VALID_EFFECTS = frozenset({
+    "confetti", "fireworks", "balloon", "heart", "sparkles", "echo", "spotlight",
+})
+_VALID_TAPBACKS = frozenset({"love", "like", "dislike", "laugh", "emphasize", "question"})
+
+
+def check_imessage_requirements() -> bool:
+    """Check platform-level requirements (dependencies are stdlib + httpx)."""
+    try:
+        import httpx  # noqa: F401
+        return True
+    except ImportError:
+        logger.warning("iMessage remote mode requires httpx: pip install httpx")
+        return False
+
+
+def _make_bearer_token(server_url: str, api_key: str) -> str:
+    """Build the Bearer token expected by advanced-imessage-http-proxy.
+
+    Token format: base64(server_url|api_key).
+    If the key already decodes to a ``url|key`` pair it is used as-is.
+    """
+    try:
+        decoded = base64.b64decode(api_key, validate=True).decode()
+        if "|" in decoded:
+            return api_key
+    except (binascii.Error, UnicodeDecodeError, ValueError):
+        pass
+    raw = f"{server_url}|{api_key}"
+    return base64.b64encode(raw.encode()).decode()
+
+
+def _extract_address(chat_id: str) -> str:
+    """Convert a chatGuid to the proxy's address format.
+
+    ``iMessage;-;+1234567890`` -> ``+1234567890``
+    ``iMessage;+;chat123``     -> ``group:chat123``
+    ``+1234567890``            -> ``+1234567890`` (passthrough)
+    """
+    if ";-;" in chat_id:
+        return chat_id.split(";-;", 1)[1]
+    if ";+;" in chat_id:
+        return "group:" + chat_id.split(";+;", 1)[1]
+    return chat_id
+
+
+def _split_paragraphs(text: str) -> List[str]:
+    """Split text on paragraph boundaries, respecting max length."""
+    parts: List[str] = []
+    for para in text.split("\n\n"):
+        stripped = para.strip()
+        if stripped:
+            if len(stripped) <= MAX_MESSAGE_LENGTH:
+                parts.append(stripped)
+            else:
+                parts.extend(
+                    BasePlatformAdapter.truncate_message(stripped, MAX_MESSAGE_LENGTH)
+                )
+    return parts or [text]
+
+
+class IMessageAdapter(BasePlatformAdapter):
+    """iMessage adapter with local (macOS) and remote (Photon proxy) modes.
+
+    Remote mode supports: send text (replies, effects), send files
+    (images, documents, audio), tapbacks, typing indicators, mark
+    read/unread, message queries/search, chat listing, attachment
+    download, and iMessage availability checks.
+    """
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform.IMESSAGE)
+        extra = config.extra or {}
+        self._local = extra.get("local", True)
+        self._server_url = extra.get("server_url", "")
+        self._api_key = config.api_key or ""
+        self._poll_interval = float(extra.get("poll_interval", _REMOTE_POLL_INTERVAL))
+        self._db_path = str(Path(extra.get("database_path", _DEFAULT_DB_PATH)).expanduser())
+        self._group_policy = extra.get("group_policy", "open")
+        self._react_tapback = extra.get("react_tapback", "love")
+        self._done_tapback = extra.get("done_tapback", "")
+
+        self._poll_task: Optional[asyncio.Task] = None
+        self._http: Optional[httpx.AsyncClient] = None
+        self._processed_ids: OrderedDict[str, None] = OrderedDict()
+        self._last_rowid: int = 0
+        self._consecutive_errors: int = 0
+        self._typing_chats: set[str] = set()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def connect(self) -> bool:
+        if self._local:
+            return await self._connect_local()
+        return await self._connect_remote()
+
+    async def disconnect(self):
+        self._mark_disconnected()
+        if self._poll_task and not self._poll_task.done():
+            self._poll_task.cancel()
+            try:
+                await self._poll_task
+            except asyncio.CancelledError:
+                pass
+        for chat_id in list(self._typing_chats):
+            await self._api_stop_typing(chat_id)
+        self._typing_chats.clear()
+        if self._http:
+            await self._http.aclose()
+            self._http = None
+
+    def _backoff_delay(self) -> float:
+        """Exponential backoff with jitter for poll error recovery."""
+        base = min(_BACKOFF_INITIAL * (2 ** (self._consecutive_errors - 1)), _BACKOFF_MAX)
+        return base * (0.5 + random.random() * 0.5)
+
+    async def send(self, chat_id: str, content: str, reply_to: Optional[str] = None,
+                   metadata: Optional[Dict[str, Any]] = None) -> SendResult:
+        if self._local:
+            return await self._send_local(chat_id, content)
+        return await self._send_remote(chat_id, content, reply_to=reply_to, metadata=metadata)
+
+    async def send_typing(self, chat_id: str, metadata=None):
+        if not self._local and self._http:
+            try:
+                await self._http.post(f"/chats/{chat_id}/typing")
+            except httpx.HTTPError:
+                pass
+
+    async def send_image(self, chat_id: str, image_url: str, caption: Optional[str] = None,
+                         reply_to: Optional[str] = None, **kwargs) -> SendResult:
+        local_path = await self._download_to_cache(image_url)
+        if self._local:
+            if local_path:
+                try:
+                    await self._applescript_send_file(chat_id, local_path)
+                except Exception as exc:
+                    logger.warning("iMessage local send_image AppleScript failed: %s", exc)
+                    return SendResult(success=False, error=str(exc))
+            elif not caption:
+                return SendResult(success=False, error=f"Failed to download image: {image_url[:80]}")
+        else:
+            if local_path:
+                result = await self._api_send_file(chat_id, local_path)
+                if result:
+                    if caption:
+                        await self.send(chat_id, caption)
+                    return SendResult(success=True)
+            logger.debug("iMessage remote: file upload failed, sending URL/caption as text")
+            if not caption and image_url:
+                await self.send(chat_id, image_url)
+                return SendResult(success=True)
+        if caption:
+            await self.send(chat_id, caption)
+        return SendResult(success=True)
+
+    async def _download_to_cache(self, url: str) -> Optional[str]:
+        """Download URL to image cache, return local path or None."""
+        try:
+            from gateway.platforms.base import get_image_cache_dir
+            cache_dir = get_image_cache_dir()
+            async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+                resp = await client.get(url)
+                resp.raise_for_status()
+            ext = mimetypes.guess_extension(resp.headers.get("content-type", "")) or ".jpg"
+            import hashlib
+            name = hashlib.sha256(url.encode()).hexdigest()[:16] + ext
+            dest = cache_dir / name
+            dest.write_bytes(resp.content)
+            return str(dest)
+        except (httpx.HTTPError, OSError) as e:
+            logger.warning("Failed to download image %s: %s", url[:80], e)
+            return None
+
+    async def send_document(self, chat_id: str, file_path: str, caption: Optional[str] = None,
+                            file_name: Optional[str] = None, reply_to: Optional[str] = None,
+                            **kwargs) -> SendResult:
+        if self._local:
+            try:
+                await self._applescript_send_file(chat_id, file_path)
+            except Exception as exc:
+                logger.warning("iMessage local send_document AppleScript failed: %s", exc)
+                return SendResult(success=False, error=str(exc))
+        else:
+            result = await self._api_send_file(chat_id, file_path)
+            if not result:
+                logger.warning("iMessage remote: file upload failed for %s", Path(file_path).name)
+                return SendResult(success=False, error=f"File upload failed: {Path(file_path).name}")
+        if caption:
+            await self.send(chat_id, caption)
+        return SendResult(success=True)
+
+    async def send_image_file(self, chat_id: str, file_path: str, caption: Optional[str] = None) -> SendResult:
+        return await self.send_document(chat_id, file_path, caption)
+
+    async def send_voice(self, chat_id: str, file_path: str) -> SendResult:
+        if self._local:
+            try:
+                await self._applescript_send_file(chat_id, file_path)
+            except Exception as exc:
+                logger.warning("iMessage local send_voice AppleScript failed: %s", exc)
+                return SendResult(success=False, error=str(exc))
+        else:
+            result = await self._api_send_file(chat_id, file_path, audio=True)
+            if not result:
+                logger.warning("iMessage remote: voice upload failed for %s", Path(file_path).name)
+                return SendResult(success=False, error=f"Voice upload failed: {Path(file_path).name}")
+        return SendResult(success=True)
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        is_group = chat_id.startswith("group:") or ";+;" in chat_id
+        if not self._local and self._http:
+            data = await self._api_get(f"/chats/{chat_id}")
+            if isinstance(data, dict):
+                return {
+                    "name": data.get("displayName") or chat_id,
+                    "type": "group" if is_group else "dm",
+                    "chat_id": chat_id,
+                }
+        return {
+            "name": chat_id,
+            "type": "group" if is_group else "dm",
+            "chat_id": chat_id,
+        }
+
+    # ==================================================================
+    # LOCAL MODE  (macOS — sqlite3 + AppleScript)
+    # ==================================================================
+
+    async def _connect_local(self) -> bool:
+        if platform_mod.system() != "Darwin":
+            logger.error("iMessage local mode requires macOS")
+            return False
+
+        db_path = self._db_path
+        if not Path(db_path).exists():
+            logger.error(
+                "iMessage database not found at %s. "
+                "Ensure Full Disk Access is granted to your terminal.",
+                db_path,
+            )
+            return False
+
+        self._last_rowid = self._get_max_rowid(db_path)
+        self._mark_connected()
+        logger.info("iMessage local watcher started (polling %s)", db_path)
+        self._poll_task = asyncio.create_task(self._local_poll_loop())
+        return True
+
+    async def _local_poll_loop(self):
+        while self._running:
+            try:
+                await self._poll_local_db()
+                self._consecutive_errors = 0
+            except (sqlite3.Error, OSError) as e:
+                self._consecutive_errors += 1
+                delay = self._backoff_delay()
+                logger.warning("iMessage local poll error (retry in %.1fs): %s", delay, e, exc_info=True)
+                await asyncio.sleep(delay)
+                continue
+            except Exception as e:
+                self._consecutive_errors += 1
+                delay = self._backoff_delay()
+                logger.error("iMessage local poll unexpected error (retry in %.1fs): %s", delay, e, exc_info=True)
+                await asyncio.sleep(delay)
+                continue
+            await asyncio.sleep(max(0.5, self._poll_interval))
+
+    def _get_max_rowid(self, db_path: str) -> int:
+        try:
+            with sqlite3.connect(db_path, uri=True) as conn:
+                cur = conn.execute("SELECT MAX(ROWID) FROM message")
+                row = cur.fetchone()
+                return row[0] or 0
+        except (sqlite3.Error, OSError):
+            return 0
+
+    async def _poll_local_db(self):
+        loop = asyncio.get_running_loop()
+        rows = await loop.run_in_executor(None, self._fetch_new_messages)
+        for row in rows:
+            await self._handle_local_message(row)
+            self._last_rowid = max(self._last_rowid, int(row["ROWID"]))
+
+    def _fetch_new_messages(self) -> List[Dict[str, Any]]:
+        with sqlite3.connect(self._db_path, uri=True) as conn:
+            conn.row_factory = sqlite3.Row
+            cur = conn.execute(
+                """
+                SELECT
+                    m.ROWID,
+                    m.guid,
+                    m.text,
+                    m.is_from_me,
+                    m.date AS msg_date,
+                    m.service,
+                    h.id AS sender,
+                    c.chat_identifier,
+                    c.style AS chat_style,
+                    a.ROWID AS att_rowid,
+                    a.filename AS att_filename,
+                    a.mime_type AS att_mime,
+                    a.transfer_name AS att_transfer_name
+                FROM message m
+                LEFT JOIN handle h ON m.handle_id = h.ROWID
+                LEFT JOIN chat_message_join cmj ON m.ROWID = cmj.message_id
+                LEFT JOIN chat c ON cmj.chat_id = c.ROWID
+                LEFT JOIN message_attachment_join maj ON m.ROWID = maj.message_id
+                LEFT JOIN attachment a ON maj.attachment_id = a.ROWID
+                WHERE m.ROWID > ?
+                ORDER BY m.ROWID ASC
+                """,
+                (self._last_rowid,),
+            )
+            msg_map: Dict[int, Dict[str, Any]] = {}
+            for row in cur:
+                d = dict(row)
+                rowid = d["ROWID"]
+                if rowid not in msg_map:
+                    msg_map[rowid] = {**d, "attachments": []}
+                if d.get("att_rowid"):
+                    raw_path = d.get("att_filename") or ""
+                    resolved = (
+                        raw_path.replace("~", str(Path.home()), 1)
+                        if raw_path.startswith("~")
+                        else raw_path
+                    )
+                    msg_map[rowid]["attachments"].append({
+                        "filename": resolved,
+                        "mime_type": d.get("att_mime") or "",
+                        "transfer_name": d.get("att_transfer_name") or "",
+                    })
+        return list(msg_map.values())
+
+    async def _handle_local_message(self, row: Dict[str, Any]):
+        if row.get("is_from_me"):
+            return
+        if (row.get("service") or "").lower() != "imessage":
+            return
+
+        message_id = row.get("guid", "")
+        if self._is_seen(message_id):
+            return
+
+        sender = row.get("sender") or ""
+        chat_id = row.get("chat_identifier") or sender
+        content = row.get("text") or ""
+        is_group = (row.get("chat_style") or 0) == 43
+
+        if is_group and self._group_policy == "ignore":
+            return
+
+        image_paths: List[str] = []
+        for att in row.get("attachments") or []:
+            file_path = att.get("filename", "")
+            if not file_path or not Path(file_path).exists():
+                continue
+
+            mime = att.get("mime_type") or ""
+            ext = Path(file_path).suffix.lower()
+
+            try:
+                file_bytes = Path(file_path).read_bytes()
+            except OSError as exc:
+                logger.warning("iMessage local: cannot read attachment %s: %s", file_path, exc)
+                continue
+
+            if ext in _AUDIO_EXTENSIONS or mime.startswith("audio/"):
+                cached = cache_audio_from_bytes(file_bytes, ext or ".m4a")
+                content = f"{content}\n[Voice message: {cached}]" if content else f"[Voice message: {cached}]"
+                continue
+
+            if mime.startswith("image/"):
+                cached = cache_image_from_bytes(file_bytes, ext or ".jpg")
+                image_paths.append(cached)
+            else:
+                cached = cache_document_from_bytes(file_bytes, ext or ".bin")
+                content = f"{content}\n[File: {cached}]" if content else f"[File: {cached}]"
+
+        chat_type = "group" if is_group else "dm"
+        source = self.build_source(
+            chat_id=chat_id,
+            chat_type=chat_type,
+            user_id=sender,
+        )
+        msg_type = MessageType.PHOTO if image_paths else MessageType.TEXT
+        event = MessageEvent(
+            text=content,
+            message_type=msg_type,
+            source=source,
+            media_urls=image_paths or [],
+            media_types=["image/jpeg"] * len(image_paths) if image_paths else [],
+            message_id=message_id,
+            raw_message=row,
+        )
+        await self.handle_message(event)
+        self._mark_seen(message_id)
+
+    async def _send_local(self, chat_id: str, content: str) -> SendResult:
+        try:
+            for chunk in _split_paragraphs(content):
+                await self._applescript_send_text(chat_id, chunk)
+            return SendResult(success=True)
+        except (subprocess.SubprocessError, OSError) as e:
+            return SendResult(success=False, error=str(e))
+
+    @staticmethod
+    def _escape_applescript(s: str) -> str:
+        return s.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
+
+    async def _applescript_send_text(self, recipient: str, text: str):
+        escaped_recipient = self._escape_applescript(recipient)
+        escaped_text = self._escape_applescript(text)
+        script = (
+            f'tell application "Messages"\n'
+            f"  set targetService to 1st account whose service type = iMessage\n"
+            f'  set targetBuddy to participant "{escaped_recipient}" of targetService\n'
+            f'  send "{escaped_text}" to targetBuddy\n'
+            f"end tell"
+        )
+        await self._run_osascript(script)
+
+    async def _applescript_send_file(self, recipient: str, file_path: str):
+        escaped_recipient = self._escape_applescript(recipient)
+        escaped_path = self._escape_applescript(file_path)
+        script = (
+            f'tell application "Messages"\n'
+            f"  set targetService to 1st account whose service type = iMessage\n"
+            f'  set targetBuddy to participant "{escaped_recipient}" of targetService\n'
+            f'  send POSIX file "{escaped_path}" to targetBuddy\n'
+            f"end tell"
+        )
+        await self._run_osascript(script)
+
+    async def _run_osascript(self, script: str):
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            None,
+            lambda: subprocess.run(
+                ["osascript", "-e", script],
+                check=True,
+                capture_output=True,
+                timeout=15,
+            ),
+        )
+
+    # ==================================================================
+    # REMOTE MODE  (advanced-imessage-http-proxy)
+    # https://github.com/photon-hq/advanced-imessage-http-proxy
+    # ==================================================================
+
+    async def _connect_remote(self) -> bool:
+        if not self._server_url:
+            logger.error("iMessage remote mode requires IMESSAGE_SERVER_URL")
+            return False
+        if not self._api_key:
+            logger.error("iMessage remote mode requires IMESSAGE_API_KEY")
+            return False
+
+        token = _make_bearer_token(self._server_url, self._api_key)
+        self._http = httpx.AsyncClient(
+            base_url=_DEFAULT_PROXY_URL,
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=30.0,
+        )
+        logger.info("iMessage remote: endpoint=%s", self._server_url)
+
+        if not await self._api_health():
+            logger.warning("iMessage server health check failed — will retry in poll loop")
+
+        await self._seed_existing_ids()
+        self._mark_connected()
+        self._poll_task = asyncio.create_task(self._remote_poll_loop())
+        logger.info("iMessage remote polling started (%ss interval)", self._poll_interval)
+        return True
+
+    async def _seed_existing_ids(self):
+        """Mark existing messages so we only process new ones after startup."""
+        try:
+            resp = await self._api_get_messages(limit=100)
+            for msg in resp:
+                msg_id = msg.get("id") or msg.get("guid", "")
+                if msg_id:
+                    self._mark_seen(msg_id)
+            logger.info("Seeded %d existing message IDs", len(self._processed_ids))
+        except httpx.HTTPError as e:
+            logger.debug("Could not seed existing message IDs: %s", e, exc_info=True)
+
+    async def _remote_poll_loop(self):
+        while self._running:
+            try:
+                await self._poll_remote()
+                self._consecutive_errors = 0
+            except httpx.HTTPError as e:
+                self._consecutive_errors += 1
+                delay = self._backoff_delay()
+                logger.warning("iMessage remote poll error (retry in %.1fs): %s", delay, e, exc_info=True)
+                await asyncio.sleep(delay)
+                continue
+            except Exception as e:
+                self._consecutive_errors += 1
+                delay = self._backoff_delay()
+                logger.error("iMessage remote poll unexpected error (retry in %.1fs): %s", delay, e, exc_info=True)
+                await asyncio.sleep(delay)
+                continue
+            await asyncio.sleep(max(0.5, self._poll_interval))
+
+    async def _poll_remote(self):
+        if not self._http:
+            return
+        messages = await self._api_get_messages(limit=50)
+        for msg in reversed(messages):
+            await self._handle_remote_message(msg)
+
+    async def _handle_remote_message(self, data: Dict[str, Any]):
+        sender_raw = data.get("from") or ""
+        if sender_raw == "me" or data.get("isFromMe"):
+            return
+
+        message_id = data.get("id") or data.get("guid", "")
+        if self._is_seen(message_id):
+            return
+
+        sender = sender_raw
+        if not sender:
+            handle = data.get("handle")
+            if isinstance(handle, dict):
+                sender = handle.get("address", "")
+
+        address = data.get("chat") or sender
+        if not address:
+            chats = data.get("chats") or []
+            chat_guid = chats[0].get("guid", "") if chats else ""
+            address = _extract_address(chat_guid) if chat_guid else sender
+
+        content = data.get("text") or ""
+        is_group = address.startswith("group:") or (";+;" in address)
+
+        if is_group and self._group_policy == "ignore":
+            return
+
+        image_paths: List[str] = []
+        for att in data.get("attachments") or []:
+            att_guid = att.get("id") or att.get("guid", "")
+            name = att.get("name") or att.get("transferName") or att.get("filename") or ""
+            if not att_guid or not self._http:
+                continue
+
+            local_path = await self._api_download_attachment(att_guid, name)
+            if not local_path:
+                continue
+
+            mime, _ = mimetypes.guess_type(local_path)
+            ext = Path(local_path).suffix.lower()
+
+            if ext in _AUDIO_EXTENSIONS or (mime and mime.startswith("audio/")):
+                cached = cache_audio_from_bytes(Path(local_path).read_bytes(), ext or ".m4a")
+                content = f"{content}\n[Voice message: {cached}]" if content else f"[Voice message: {cached}]"
+                continue
+
+            if mime and mime.startswith("image/"):
+                image_paths.append(local_path)
+            else:
+                content = f"{content}\n[File: {local_path}]" if content else f"[File: {local_path}]"
+
+        chat_type = "group" if is_group else "dm"
+        source = self.build_source(
+            chat_id=address,
+            chat_type=chat_type,
+            user_id=sender,
+        )
+        msg_type = MessageType.PHOTO if image_paths else MessageType.TEXT
+        ts_raw = data.get("sentAt") or data.get("dateCreated")
+        ts = datetime.now()
+        if isinstance(ts_raw, (int, float)):
+            ts = datetime.fromtimestamp(ts_raw / 1000 if ts_raw > 1e12 else ts_raw)
+        elif isinstance(ts_raw, str):
+            try:
+                ts = datetime.fromisoformat(ts_raw)
+            except ValueError:
+                pass
+        event = MessageEvent(
+            text=content,
+            message_type=msg_type,
+            source=source,
+            media_urls=image_paths or [],
+            media_types=["image/jpeg"] * len(image_paths) if image_paths else [],
+            message_id=message_id,
+            timestamp=ts,
+            raw_message=data,
+        )
+        await self.handle_message(event)
+        self._mark_seen(message_id)
+
+        if self._react_tapback and self._react_tapback in _VALID_TAPBACKS:
+            await self._api_react(address, message_id, self._react_tapback)
+        await self._api_mark_read(address)
+
+    async def _send_remote(self, chat_id: str, content: str,
+                           reply_to: Optional[str] = None,
+                           metadata: Optional[Dict[str, Any]] = None) -> SendResult:
+        if not self._http:
+            return SendResult(success=False, error="HTTP client not initialised")
+
+        effect = (metadata or {}).get("effect", "")
+        await self._api_start_typing(chat_id)
+        try:
+            for i, chunk in enumerate(_split_paragraphs(content)):
+                body: Dict[str, Any] = {"to": chat_id, "text": chunk, "service": "iMessage"}
+                if i == 0 and reply_to:
+                    body["replyTo"] = reply_to
+                if i == 0 and effect and effect in _VALID_EFFECTS:
+                    body["effect"] = effect
+                resp = await self._api_send(body)
+                if resp is None:
+                    return SendResult(success=False, error=f"Text delivery failed for {chat_id}")
+        finally:
+            await self._api_stop_typing(chat_id)
+
+        message_id = (metadata or {}).get("message_id")
+        if message_id and self._react_tapback:
+            await self._api_remove_react(chat_id, message_id, self._react_tapback)
+            if self._done_tapback and self._done_tapback in _VALID_TAPBACKS:
+                await self._api_react(chat_id, message_id, self._done_tapback)
+
+        return SendResult(success=True)
+
+    # ==================================================================
+    # PROXY API  (advanced-imessage-http-proxy)
+    # https://github.com/photon-hq/advanced-imessage-http-proxy
+    #
+    # All responses follow: {"ok": true, "data": ...} envelope.
+    # ==================================================================
+
+    # ---- messaging (POST /send, POST /send/file, POST /send/sticker) --
+
+    async def _api_send(self, body: Dict[str, Any]) -> Optional[Dict]:
+        """POST /send — send text with optional effect/reply.
+
+        The upstream may return HTTP 500 with "Message sent with an error"
+        but still include a message ID.  We try to extract data even from
+        error responses so callers can use the ID for edit/unsend/tapback.
+        """
+        if not self._http:
+            return None
+        try:
+            resp = await self._http.post("/send", json=body)
+            if not resp.is_success:
+                logger.warning("iMessage POST /send HTTP %s: %s", resp.status_code, resp.text[:200])
+            try:
+                parsed = resp.json()
+            except (json.JSONDecodeError, ValueError):
+                return None
+            if isinstance(parsed, dict):
+                if "data" in parsed:
+                    return parsed["data"]
+                if parsed.get("id"):
+                    return parsed
+            return None
+        except httpx.HTTPError as e:
+            logger.warning("iMessage POST /send failed: %s", e, exc_info=True)
+            return None
+
+    async def _api_send_file(
+        self, to: str, file_path: str, audio: bool = False,
+    ) -> Optional[Dict]:
+        """POST /send/file — send an image, document, or audio file.
+
+        Uses multipart/form-data. May timeout on some Kit servers behind
+        the centralized proxy (Cloudflare 60s limit).
+        """
+        if not self._http:
+            return None
+        try:
+            mime, _ = mimetypes.guess_type(file_path)
+            fname = Path(file_path).name
+            data: Dict[str, Any] = {"to": to}
+            if audio:
+                data["audio"] = "true"
+            with open(file_path, "rb") as f:
+                resp = await self._http.post(
+                    "/send/file",
+                    data=data,
+                    files={"file": (fname, f, mime or "application/octet-stream")},
+                    timeout=120.0,
+                )
+            if not resp.is_success:
+                logger.warning("iMessage POST /send/file HTTP %s: %s", resp.status_code, resp.text[:200])
+                return None
+            return self._unwrap(resp)
+        except (httpx.HTTPError, OSError) as e:
+            logger.warning("iMessage POST /send/file failed: %s", e, exc_info=True)
+            return None
+
+    # ---- tapbacks (POST/DELETE /messages/:id/react) --------------------
+
+    async def _api_react(self, chat: str, message_id: str, tapback: str):
+        """POST /messages/:id/react — add tapback (love, like, dislike, laugh, emphasize, question)."""
+        if not self._http or not tapback:
+            return
+        try:
+            await self._http.post(
+                f"/messages/{message_id}/react",
+                json={"chat": chat, "type": tapback},
+            )
+        except httpx.HTTPError:
+            pass
+
+    async def _api_remove_react(self, chat: str, message_id: str, tapback: str):
+        """DELETE /messages/:id/react — remove tapback."""
+        if not self._http or not tapback:
+            return
+        try:
+            await self._http.request(
+                "DELETE", f"/messages/{message_id}/react",
+                json={"chat": chat, "type": tapback},
+            )
+        except httpx.HTTPError:
+            pass
+
+    # ---- messages (GET /messages, GET /messages/search, GET /messages/:id)
+
+    async def _api_get_messages(
+        self, limit: int = 50, chat: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """GET /messages — query messages, optionally filtered by chat."""
+        params: Dict[str, Any] = {"limit": limit}
+        if chat:
+            params["chat"] = chat
+        data = await self._api_get("/messages", params=params)
+        return data if isinstance(data, list) else []
+
+    async def _api_search_messages(
+        self, query: str, chat: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """GET /messages/search — full-text search."""
+        params: Dict[str, Any] = {"q": query}
+        if chat:
+            params["chat"] = chat
+        data = await self._api_get("/messages/search", params=params)
+        return data if isinstance(data, list) else []
+
+    async def _api_get_message(self, message_id: str) -> Optional[Dict]:
+        """GET /messages/:id — single message details."""
+        data = await self._api_get(f"/messages/{message_id}")
+        return data if isinstance(data, dict) else None
+
+    # ---- chats (GET /chats, GET /chats/:id, mark-read, typing) --------
+
+    async def _api_get_chats(self) -> List[Dict[str, Any]]:
+        """GET /chats — list all conversations."""
+        data = await self._api_get("/chats")
+        return data if isinstance(data, list) else []
+
+    async def _api_get_chat(self, address: str) -> Optional[Dict]:
+        """GET /chats/:id — chat details."""
+        data = await self._api_get(f"/chats/{address}")
+        return data if isinstance(data, dict) else None
+
+    async def _api_get_chat_messages(
+        self, address: str, limit: int = 50,
+    ) -> List[Dict[str, Any]]:
+        """GET /chats/:id/messages — message history for a chat."""
+        data = await self._api_get(f"/chats/{address}/messages", params={"limit": limit})
+        return data if isinstance(data, list) else []
+
+    async def _api_get_chat_participants(self, address: str) -> List[Dict[str, Any]]:
+        """GET /chats/:id/participants — group participants."""
+        data = await self._api_get(f"/chats/{address}/participants")
+        return data if isinstance(data, list) else []
+
+    async def _api_mark_read(self, address: str):
+        """POST /chats/:id/read — clear unread badge."""
+        if not self._http:
+            return
+        try:
+            await self._http.post(f"/chats/{address}/read")
+        except httpx.HTTPError:
+            pass
+
+    async def _api_mark_unread(self, address: str):
+        """POST /chats/:id/unread — mark as unread."""
+        if not self._http:
+            return
+        try:
+            await self._http.post(f"/chats/{address}/unread")
+        except httpx.HTTPError:
+            pass
+
+    async def _api_start_typing(self, address: str):
+        """POST /chats/:id/typing — show typing indicator."""
+        if not self._http:
+            return
+        try:
+            await self._http.post(f"/chats/{address}/typing")
+            self._typing_chats.add(address)
+        except httpx.HTTPError:
+            pass
+
+    async def _api_stop_typing(self, address: str):
+        """DELETE /chats/:id/typing — stop typing indicator."""
+        if not self._http:
+            return
+        try:
+            await self._http.request("DELETE", f"/chats/{address}/typing")
+        except httpx.HTTPError:
+            pass
+        self._typing_chats.discard(address)
+
+    # ---- attachments ---------------------------------------------------
+
+    async def _api_download_attachment(self, att_guid: str, filename: str) -> Optional[str]:
+        """GET /attachments/:id — download to local cache."""
+        if not self._http:
+            return None
+        try:
+            resp = await self._http.get(f"/attachments/{att_guid}")
+            if not resp.is_success:
+                return None
+            from hermes_cli.config import get_hermes_home
+            media_dir = get_hermes_home() / "image_cache"
+            media_dir.mkdir(parents=True, exist_ok=True)
+            sanitized_guid = att_guid.replace("/", "_").replace("\\", "_").replace("\x00", "")
+            raw_name = Path(filename).name.replace("\x00", "") if filename else ""
+            safe_name = f"{sanitized_guid}_{raw_name}" if raw_name else f"{sanitized_guid}.bin"
+            dest = (media_dir / safe_name).resolve()
+            if not dest.is_relative_to(media_dir.resolve()):
+                dest = (media_dir / f"{sanitized_guid}.bin").resolve()
+            dest.write_bytes(resp.content)
+            return str(dest)
+        except (httpx.HTTPError, OSError) as e:
+            logger.warning("Failed to download iMessage attachment %s: %s", att_guid, e, exc_info=True)
+            return None
+
+    async def _api_attachment_info(self, att_guid: str) -> Optional[Dict]:
+        """GET /attachments/:id/info — file metadata (name, size, MIME type)."""
+        data = await self._api_get(f"/attachments/{att_guid}/info")
+        return data if isinstance(data, dict) else None
+
+    # ---- contacts & handles --------------------------------------------
+
+    async def _api_check_imessage(self, address: str) -> bool:
+        """GET /check/:address — check if address uses iMessage."""
+        data = await self._api_get(f"/check/{address}")
+        if isinstance(data, dict):
+            return bool(data.get("available") or data.get("imessage"))
+        return False
+
+    # ---- server --------------------------------------------------------
+
+    async def _api_server_info(self) -> Optional[Dict]:
+        """GET /server — server info."""
+        data = await self._api_get("/server")
+        return data if isinstance(data, dict) else None
+
+    async def _api_health(self) -> bool:
+        """GET /health — basic health check (no auth required)."""
+        if not self._http:
+            return False
+        try:
+            resp = await self._http.get("/health")
+            if resp.is_success:
+                logger.info("iMessage server health check passed")
+                return True
+            logger.warning("iMessage health check HTTP %s", resp.status_code)
+        except httpx.HTTPError as e:
+            logger.warning("iMessage health check failed: %s", e, exc_info=True)
+        return False
+
+    # ---- HTTP helpers --------------------------------------------------
+
+    async def _api_get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Any:
+        if not self._http:
+            return None
+        try:
+            resp = await self._http.get(path, params=params)
+            return self._unwrap(resp)
+        except httpx.HTTPError as e:
+            logger.warning("iMessage GET %s failed: %s", path, e, exc_info=True)
+            return None
+
+    async def _api_post(self, path: str, body: Dict[str, Any]) -> Optional[Dict]:
+        if not self._http:
+            return None
+        try:
+            resp = await self._http.post(path, json=body)
+            if not resp.is_success:
+                logger.warning(
+                    "iMessage POST %s HTTP %s: %s", path, resp.status_code, resp.text[:200]
+                )
+            return self._unwrap(resp)
+        except httpx.HTTPError as e:
+            logger.warning("iMessage POST %s failed: %s", path, e, exc_info=True)
+            raise
+
+    async def _api_delete(self, path: str, body: Optional[Dict[str, Any]] = None) -> Optional[Dict]:
+        if not self._http:
+            return None
+        try:
+            resp = await self._http.request("DELETE", path, json=body)
+            return self._unwrap(resp)
+        except httpx.HTTPError as e:
+            logger.warning("iMessage DELETE %s failed: %s", path, e, exc_info=True)
+            return None
+
+    @staticmethod
+    def _unwrap(resp: httpx.Response) -> Any:
+        """Unwrap the proxy's ``{"ok": true, "data": ...}`` envelope."""
+        if not resp.is_success:
+            return None
+        try:
+            body = resp.json()
+        except (json.JSONDecodeError, ValueError):
+            return None
+        if isinstance(body, dict) and "data" in body:
+            return body["data"]
+        return body
+
+    # ---- dedup ---------------------------------------------------------
+
+    def _is_seen(self, message_id: str) -> bool:
+        if not message_id:
+            return False
+        return message_id in self._processed_ids
+
+    def _mark_seen(self, message_id: str):
+        if not message_id:
+            return
+        self._processed_ids[message_id] = None
+        while len(self._processed_ids) > 1000:
+            self._processed_ids.popitem(last=False)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1073,6 +1073,7 @@ class GatewayRunner:
                        "MATRIX_ALLOWED_USERS", "DINGTALK_ALLOWED_USERS",
                        "FEISHU_ALLOWED_USERS",
                        "WECOM_ALLOWED_USERS",
+                       "IMESSAGE_ALLOWED_USERS",
                        "GATEWAY_ALLOWED_USERS")
         )
         _allow_all = os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes") or any(
@@ -1083,7 +1084,8 @@ class GatewayRunner:
                        "SMS_ALLOW_ALL_USERS", "MATTERMOST_ALLOW_ALL_USERS",
                        "MATRIX_ALLOW_ALL_USERS", "DINGTALK_ALLOW_ALL_USERS",
                        "FEISHU_ALLOW_ALL_USERS",
-                       "WECOM_ALLOW_ALL_USERS")
+                       "WECOM_ALLOW_ALL_USERS",
+                       "IMESSAGE_ALLOW_ALL_USERS")
         )
         if not _any_allowlist and not _allow_all:
             logger.warning(
@@ -1554,6 +1556,13 @@ class GatewayRunner:
                 return None
             return MatrixAdapter(config)
 
+        elif platform == Platform.IMESSAGE:
+            from gateway.platforms.imessage import IMessageAdapter, check_imessage_requirements
+            if not check_imessage_requirements():
+                logger.warning("iMessage: requirements not met")
+                return None
+            return IMessageAdapter(config)
+
         elif platform == Platform.API_SERVER:
             from gateway.platforms.api_server import APIServerAdapter, check_api_server_requirements
             if not check_api_server_requirements():
@@ -1608,6 +1617,7 @@ class GatewayRunner:
             Platform.DINGTALK: "DINGTALK_ALLOWED_USERS",
             Platform.FEISHU: "FEISHU_ALLOWED_USERS",
             Platform.WECOM: "WECOM_ALLOWED_USERS",
+            Platform.IMESSAGE: "IMESSAGE_ALLOWED_USERS",
         }
         platform_allow_all_map = {
             Platform.TELEGRAM: "TELEGRAM_ALLOW_ALL_USERS",
@@ -1622,6 +1632,7 @@ class GatewayRunner:
             Platform.DINGTALK: "DINGTALK_ALLOW_ALL_USERS",
             Platform.FEISHU: "FEISHU_ALLOW_ALL_USERS",
             Platform.WECOM: "WECOM_ALLOW_ALL_USERS",
+            Platform.IMESSAGE: "IMESSAGE_ALLOW_ALL_USERS",
         }
 
         # Per-platform allow-all flag (e.g., DISCORD_ALLOW_ALL_USERS=true)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -193,6 +193,7 @@ _PII_SAFE_PLATFORMS = frozenset({
     Platform.WHATSAPP,
     Platform.SIGNAL,
     Platform.TELEGRAM,
+    Platform.IMESSAGE,
 })
 """Platforms where user IDs can be safely redacted (no in-message mention system
 that requires raw IDs).  Discord is excluded because mentions use ``<@user_id>``

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1375,6 +1375,31 @@ _PLATFORMS = [
              "help": "Chat ID for scheduled results and notifications."},
         ],
     },
+    {
+        "key": "imessage",
+        "label": "iMessage",
+        "emoji": "💬",
+        "token_var": "IMESSAGE_ENABLED",
+        "setup_instructions": [
+            "Enter your Photon endpoint and API key from photon.codes.",
+            "Hermes connects to iMessage automatically via the Photon proxy.",
+            "",
+            "LOCAL MODE (macOS only, no Photon account needed):",
+            "  Leave endpoint blank, set IMESSAGE_ENABLED=true instead.",
+            "  Requires Full Disk Access (System Settings -> Privacy).",
+        ],
+        "vars": [
+            {"name": "IMESSAGE_ENABLED", "prompt": "Enable iMessage", "password": False,
+             "help": "Set to 'true' to enable iMessage.", "default": "true"},
+            {"name": "IMESSAGE_SERVER_URL", "prompt": "Photon endpoint (leave blank for local macOS mode)", "password": False,
+             "help": "e.g., https://abc123.imsgd.photon.codes"},
+            {"name": "IMESSAGE_API_KEY", "prompt": "Photon API key (leave blank for local macOS mode)", "password": True,
+             "help": "API key from photon.codes"},
+            {"name": "IMESSAGE_ALLOWED_USERS", "prompt": "Allowed phone numbers / Apple IDs (comma-separated)", "password": False,
+             "is_allowlist": True,
+             "help": "Phone numbers (e.g., +15551234567) or Apple ID emails allowed to talk to Hermes."},
+        ],
+    },
 ]
 
 
@@ -1418,6 +1443,15 @@ def _platform_status(platform: dict) -> str:
             return f"configured{suffix}"
         if val or password or homeserver:
             return "partially configured"
+        return "not configured"
+    if platform.get("key") == "imessage":
+        enabled = (val or "").lower() in ("true", "1", "yes")
+        server_url = get_env_value("IMESSAGE_SERVER_URL")
+        api_key = get_env_value("IMESSAGE_API_KEY")
+        if server_url and api_key:
+            return "configured (remote)"
+        if enabled:
+            return "configured (local)"
         return "not configured"
     if val:
         return "configured"

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3753,7 +3753,7 @@ For more help on a command:
     gateway_parser = subparsers.add_parser(
         "gateway",
         help="Messaging gateway management",
-        description="Manage the messaging gateway (Telegram, Discord, WhatsApp)"
+        description="Manage the messaging gateway (Telegram, Discord, WhatsApp, Signal, iMessage)"
     )
     gateway_subparsers = gateway_parser.add_subparsers(dest="gateway_command")
     
@@ -3942,7 +3942,7 @@ For more help on a command:
     cron_create.add_argument("schedule", help="Schedule like '30m', 'every 2h', or '0 9 * * *'")
     cron_create.add_argument("prompt", nargs="?", help="Optional self-contained prompt or task instruction")
     cron_create.add_argument("--name", help="Optional human-friendly job name")
-    cron_create.add_argument("--deliver", help="Delivery target: origin, local, telegram, discord, signal, or platform:chat_id")
+    cron_create.add_argument("--deliver", help="Delivery target: origin, local, telegram, discord, signal, whatsapp, imessage, or platform:chat_id")
     cron_create.add_argument("--repeat", type=int, help="Optional repeat count")
     cron_create.add_argument("--skill", dest="skills", action="append", help="Attach a skill. Repeat to add multiple skills.")
 
@@ -4074,7 +4074,7 @@ For more help on a command:
     pairing_list_parser = pairing_sub.add_parser("list", help="Show pending + approved users")
 
     pairing_approve_parser = pairing_sub.add_parser("approve", help="Approve a pairing code")
-    pairing_approve_parser.add_argument("platform", help="Platform name (telegram, discord, slack, whatsapp)")
+    pairing_approve_parser.add_argument("platform", help="Platform name (telegram, discord, slack, whatsapp, signal, imessage)")
     pairing_approve_parser.add_argument("code", help="Pairing code to approve")
 
     pairing_revoke_parser = pairing_sub.add_parser("revoke", help="Revoke user access")
@@ -4614,7 +4614,7 @@ For more help on a command:
             msgs = db.message_count()
             print(f"Total sessions: {total}")
             print(f"Total messages: {msgs}")
-            for src in ["cli", "telegram", "discord", "whatsapp", "slack"]:
+            for src in ["cli", "telegram", "discord", "whatsapp", "slack", "signal", "imessage"]:
                 c = db.session_count(source=src)
                 if c > 0:
                     print(f"  {src}: {c} sessions")

--- a/hermes_cli/skills_config.py
+++ b/hermes_cli/skills_config.py
@@ -23,6 +23,7 @@ PLATFORMS = {
     "slack":    "💼 Slack",
     "whatsapp": "📱 WhatsApp",
     "signal":   "📡 Signal",
+    "imessage": "💬 iMessage",
     "email":    "📧 Email",
     "homeassistant": "🏠 Home Assistant",
     "mattermost": "💬 Mattermost",

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -257,11 +257,17 @@ def show_status(args):
         "DingTalk": ("DINGTALK_CLIENT_ID", None),
         "Feishu": ("FEISHU_APP_ID", "FEISHU_HOME_CHANNEL"),
         "WeCom": ("WECOM_BOT_ID", "WECOM_HOME_CHANNEL"),
+        "iMessage": ("IMESSAGE_ENABLED", "IMESSAGE_HOME_CHANNEL"),
     }
     
     for name, (token_var, home_var) in platforms.items():
         token = os.getenv(token_var, "")
         has_token = bool(token)
+
+        if name == "iMessage":
+            enabled = os.getenv("IMESSAGE_ENABLED", "").lower() in ("true", "1", "yes")
+            has_remote = bool(os.getenv("IMESSAGE_SERVER_URL", "")) and bool(os.getenv("IMESSAGE_API_KEY", ""))
+            has_token = enabled or has_remote
         
         home_channel = ""
         if home_var:

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -140,9 +140,11 @@ PLATFORMS = {
     "homeassistant": {"label": "🏠 Home Assistant", "default_toolset": "hermes-homeassistant"},
     "email":    {"label": "📧 Email",      "default_toolset": "hermes-email"},
     "matrix":   {"label": "💬 Matrix",     "default_toolset": "hermes-matrix"},
- "dingtalk": {"label": "💬 DingTalk", "default_toolset": "hermes-dingtalk"},
-    "feishu": {"label": "🪽 Feishu", "default_toolset": "hermes-feishu"},
-    "wecom": {"label": "💬 WeCom", "default_toolset": "hermes-wecom"},
+    "dingtalk": {"label": "💬 DingTalk",   "default_toolset": "hermes-dingtalk"},
+    "feishu": {"label": "🪽 Feishu",      "default_toolset": "hermes-feishu"},
+    "wecom": {"label": "💬 WeCom",        "default_toolset": "hermes-wecom"},
+    "feishu": {"label": "🪽 Feishu",      "default_toolset": "hermes-feishu"},
+    "imessage": {"label": "💬 iMessage",   "default_toolset": "hermes-imessage"},
     "api_server": {"label": "🌐 API Server", "default_toolset": "hermes-api-server"},
     "mattermost": {"label": "💬 Mattermost", "default_toolset": "hermes-mattermost"},
 }
@@ -412,6 +414,8 @@ def _get_enabled_platforms() -> List[str]:
         enabled.append("slack")
     if get_env_value("WHATSAPP_ENABLED"):
         enabled.append("whatsapp")
+    if (get_env_value("IMESSAGE_ENABLED") or "").lower() in ("true", "1", "yes") or get_env_value("IMESSAGE_SERVER_URL"):
+        enabled.append("imessage")
     return enabled
 
 

--- a/tests/gateway/test_imessage.py
+++ b/tests/gateway/test_imessage.py
@@ -1,0 +1,424 @@
+"""Tests for iMessage platform adapter."""
+import base64
+import json
+import pytest
+from unittest.mock import MagicMock, patch, AsyncMock
+
+from gateway.config import Platform, PlatformConfig
+
+
+# ---------------------------------------------------------------------------
+# Platform & Config
+# ---------------------------------------------------------------------------
+
+class TestIMessagePlatformEnum:
+    def test_imessage_enum_exists(self):
+        assert Platform.IMESSAGE.value == "imessage"
+
+    def test_imessage_in_platform_list(self):
+        platforms = [p.value for p in Platform]
+        assert "imessage" in platforms
+
+
+class TestIMessageConfigLoading:
+    def test_apply_env_overrides_local_mode(self, monkeypatch):
+        monkeypatch.setenv("IMESSAGE_ENABLED", "true")
+
+        from gateway.config import GatewayConfig, _apply_env_overrides
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+
+        assert Platform.IMESSAGE in config.platforms
+        pc = config.platforms[Platform.IMESSAGE]
+        assert pc.enabled is True
+        assert pc.extra.get("local", True) is True
+
+    def test_apply_env_overrides_remote_mode(self, monkeypatch):
+        monkeypatch.setenv("IMESSAGE_SERVER_URL", "https://imessage.example.com")
+        monkeypatch.setenv("IMESSAGE_API_KEY", "test-key")
+
+        from gateway.config import GatewayConfig, _apply_env_overrides
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+
+        assert Platform.IMESSAGE in config.platforms
+        pc = config.platforms[Platform.IMESSAGE]
+        assert pc.enabled is True
+        assert pc.extra.get("local") is False
+        assert pc.extra.get("server_url") == "https://imessage.example.com"
+        assert pc.api_key == "test-key"
+
+    def test_not_loaded_without_env(self, monkeypatch):
+        monkeypatch.delenv("IMESSAGE_ENABLED", raising=False)
+        monkeypatch.delenv("IMESSAGE_SERVER_URL", raising=False)
+        monkeypatch.delenv("IMESSAGE_API_KEY", raising=False)
+
+        from gateway.config import GatewayConfig, _apply_env_overrides
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+
+        assert Platform.IMESSAGE not in config.platforms
+
+    def test_connected_platforms_includes_imessage(self, monkeypatch):
+        monkeypatch.setenv("IMESSAGE_ENABLED", "true")
+        import gateway.config as gw_config
+        monkeypatch.setattr(gw_config, "platform_mod", type("_FakePlatform", (), {"system": staticmethod(lambda: "Darwin")})())
+
+        from gateway.config import GatewayConfig, _apply_env_overrides
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+
+        connected = config.get_connected_platforms()
+        assert Platform.IMESSAGE in connected
+
+    def test_home_channel_from_env(self, monkeypatch):
+        monkeypatch.setenv("IMESSAGE_ENABLED", "true")
+        monkeypatch.setenv("IMESSAGE_HOME_CHANNEL", "+15551234567")
+
+        from gateway.config import GatewayConfig, _apply_env_overrides
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+
+        pc = config.platforms[Platform.IMESSAGE]
+        assert pc.home_channel is not None
+        assert pc.home_channel.chat_id == "+15551234567"
+
+
+# ---------------------------------------------------------------------------
+# Adapter Init & Helpers
+# ---------------------------------------------------------------------------
+
+class TestIMessageAdapterInit:
+    def _make_config(self, local=True, **extra):
+        config = PlatformConfig()
+        config.enabled = True
+        config.extra = {"local": local, **extra}
+        return config
+
+    def test_init_local_mode(self):
+        from gateway.platforms.imessage import IMessageAdapter
+        adapter = IMessageAdapter(self._make_config(local=True))
+        assert adapter._local is True
+        assert adapter._server_url == ""
+
+    def test_init_remote_mode(self):
+        from gateway.platforms.imessage import IMessageAdapter
+        config = self._make_config(
+            local=False,
+            server_url="https://imessage.example.com",
+        )
+        config.api_key = "test-key"
+        adapter = IMessageAdapter(config)
+        assert adapter._local is False
+        assert adapter._server_url == "https://imessage.example.com"
+        assert adapter._api_key == "test-key"
+
+    def test_init_default_poll_interval(self):
+        from gateway.platforms.imessage import IMessageAdapter
+        adapter = IMessageAdapter(self._make_config())
+        assert adapter._poll_interval == 2.0
+
+    def test_init_custom_poll_interval(self):
+        from gateway.platforms.imessage import IMessageAdapter
+        adapter = IMessageAdapter(self._make_config(poll_interval=5.0))
+        assert adapter._poll_interval == 5.0
+
+    def test_init_group_policy_default(self):
+        from gateway.platforms.imessage import IMessageAdapter
+        adapter = IMessageAdapter(self._make_config())
+        assert adapter._group_policy == "open"
+
+    def test_init_group_policy_ignore(self):
+        from gateway.platforms.imessage import IMessageAdapter
+        adapter = IMessageAdapter(self._make_config(group_policy="ignore"))
+        assert adapter._group_policy == "ignore"
+
+    def test_init_consecutive_errors_zero(self):
+        from gateway.platforms.imessage import IMessageAdapter
+        adapter = IMessageAdapter(self._make_config())
+        assert adapter._consecutive_errors == 0
+
+
+class TestIMessageHelpers:
+    def test_check_requirements(self):
+        from gateway.platforms.imessage import check_imessage_requirements
+        assert check_imessage_requirements() is True
+
+    def test_make_bearer_token(self):
+        from gateway.platforms.imessage import _make_bearer_token
+        token = _make_bearer_token("https://example.com", "my-key")
+        decoded = base64.b64decode(token).decode()
+        assert decoded == "https://example.com|my-key"
+
+    def test_make_bearer_token_passthrough(self):
+        from gateway.platforms.imessage import _make_bearer_token
+        pre_encoded = base64.b64encode(b"https://s.com|key123").decode()
+        token = _make_bearer_token("https://s.com", pre_encoded)
+        assert token == pre_encoded
+
+    def test_extract_address_dm(self):
+        from gateway.platforms.imessage import _extract_address
+        assert _extract_address("iMessage;-;+1234567890") == "+1234567890"
+
+    def test_extract_address_group(self):
+        from gateway.platforms.imessage import _extract_address
+        assert _extract_address("iMessage;+;chat123") == "group:chat123"
+
+    def test_extract_address_passthrough_phone(self):
+        from gateway.platforms.imessage import _extract_address
+        assert _extract_address("+1234567890") == "+1234567890"
+
+    def test_extract_address_passthrough_email(self):
+        from gateway.platforms.imessage import _extract_address
+        assert _extract_address("user@icloud.com") == "user@icloud.com"
+
+    def test_split_paragraphs(self):
+        from gateway.platforms.imessage import _split_paragraphs
+        result = _split_paragraphs("Hello\n\nWorld\n\nFoo")
+        assert result == ["Hello", "World", "Foo"]
+
+    def test_split_paragraphs_single(self):
+        from gateway.platforms.imessage import _split_paragraphs
+        result = _split_paragraphs("Hello world")
+        assert result == ["Hello world"]
+
+    def test_split_paragraphs_empty(self):
+        from gateway.platforms.imessage import _split_paragraphs
+        result = _split_paragraphs("")
+        assert result == [""]
+
+    def test_dedup_tracking(self):
+        from gateway.platforms.imessage import IMessageAdapter
+        config = PlatformConfig()
+        config.enabled = True
+        config.extra = {"local": True}
+        adapter = IMessageAdapter(config)
+
+        assert adapter._is_seen("msg-1") is False
+        adapter._mark_seen("msg-1")
+        assert adapter._is_seen("msg-1") is True
+
+    def test_dedup_eviction(self):
+        from gateway.platforms.imessage import IMessageAdapter
+        config = PlatformConfig()
+        config.enabled = True
+        config.extra = {"local": True}
+        adapter = IMessageAdapter(config)
+
+        for i in range(1100):
+            adapter._mark_seen(f"msg-{i}")
+
+        assert adapter._is_seen("msg-0") is False
+        assert adapter._is_seen("msg-1099") is True
+        assert len(adapter._processed_ids) == 1000
+
+    def test_backoff_delay_increases(self):
+        from gateway.platforms.imessage import IMessageAdapter, _BACKOFF_MAX
+        config = PlatformConfig()
+        config.enabled = True
+        config.extra = {"local": True}
+        adapter = IMessageAdapter(config)
+
+        adapter._consecutive_errors = 1
+        d1 = adapter._backoff_delay()
+        adapter._consecutive_errors = 5
+        d5 = adapter._backoff_delay()
+        assert d5 > d1
+        assert d5 <= _BACKOFF_MAX
+
+
+# ---------------------------------------------------------------------------
+# PII Redaction
+# ---------------------------------------------------------------------------
+
+class TestIMessageRedaction:
+    @pytest.fixture(autouse=True)
+    def _ensure_redaction_enabled(self, monkeypatch):
+        monkeypatch.delenv("HERMES_REDACT_SECRETS", raising=False)
+
+    def test_phone_number_redacted(self):
+        from agent.redact import redact_sensitive_text
+        result = redact_sensitive_text("iMessage from +15551234567")
+        assert "+15551234567" not in result
+        assert "****" in result
+
+    def test_api_key_in_env_assignment_redacted(self):
+        from agent.redact import redact_sensitive_text
+        fake_key = "X" * 24
+        result = redact_sensitive_text(f"IMESSAGE_API_KEY={fake_key}")
+        assert fake_key not in result
+
+    def test_bearer_token_redacted(self):
+        from agent.redact import redact_sensitive_text
+        import base64
+        fake_token = base64.b64encode(b"https://test.example.com|fake-key-000").decode()
+        result = redact_sensitive_text(f"Authorization: Bearer {fake_token}")
+        assert fake_token not in result
+
+
+# ---------------------------------------------------------------------------
+# PII Safe Platform
+# ---------------------------------------------------------------------------
+
+class TestIMessagePIISafe:
+    def test_imessage_in_pii_safe(self):
+        from gateway.session import _PII_SAFE_PLATFORMS
+        assert Platform.IMESSAGE in _PII_SAFE_PLATFORMS
+
+
+# ---------------------------------------------------------------------------
+# Authorization in run.py
+# ---------------------------------------------------------------------------
+
+class TestIMessageAuthorization:
+    def test_imessage_in_allowlist_maps(self):
+        from gateway.run import GatewayRunner
+        from gateway.config import GatewayConfig
+
+        gw = GatewayRunner.__new__(GatewayRunner)
+        gw.config = GatewayConfig()
+        gw.pairing_store = MagicMock()
+        gw.pairing_store.is_approved.return_value = False
+
+        source = MagicMock()
+        source.platform = Platform.IMESSAGE
+        source.user_id = "+15559999999"
+
+        with patch.dict("os.environ", {}, clear=True):
+            result = gw._is_user_authorized(source)
+            assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Send Message Tool
+# ---------------------------------------------------------------------------
+
+class TestIMessageSendMessage:
+    def test_imessage_in_send_message_source(self):
+        """Check source text for imessage routing (avoids transitive import issues)."""
+        from pathlib import Path
+        src = (Path(__file__).resolve().parents[2] / "tools" / "send_message_tool.py").read_text()
+        assert '"imessage"' in src
+        assert "Platform.IMESSAGE" in src
+        assert "_send_imessage" in src
+
+    def test_imessage_enum_value(self):
+        assert Platform.IMESSAGE.value == "imessage"
+
+
+# ---------------------------------------------------------------------------
+# Toolset
+# ---------------------------------------------------------------------------
+
+class TestIMessageToolset:
+    def test_hermes_imessage_toolset_exists(self):
+        from toolsets import TOOLSETS
+        assert "hermes-imessage" in TOOLSETS
+
+    def test_hermes_gateway_includes_imessage(self):
+        from toolsets import TOOLSETS
+        gw = TOOLSETS.get("hermes-gateway", {})
+        includes = gw.get("includes", [])
+        assert "hermes-imessage" in includes
+
+
+# ---------------------------------------------------------------------------
+# Platform Hint
+# ---------------------------------------------------------------------------
+
+class TestIMessagePlatformHint:
+    def test_imessage_hint_exists(self):
+        from agent.prompt_builder import PLATFORM_HINTS
+        assert "imessage" in PLATFORM_HINTS
+        assert "iMessage" in PLATFORM_HINTS["imessage"]
+
+
+# ---------------------------------------------------------------------------
+# Cron Delivery
+# ---------------------------------------------------------------------------
+
+class TestIMessageCronDelivery:
+    def test_imessage_in_cron_platform_map(self):
+        from cron.scheduler import _deliver_result
+        import inspect
+        source = inspect.getsource(_deliver_result)
+        assert '"imessage"' in source or "'imessage'" in source
+
+    def test_platform_map_has_imessage(self):
+        """Verify the cron scheduler platform_map dict includes imessage."""
+        import cron.scheduler as sched
+        import inspect
+        src = inspect.getsource(sched)
+        assert "Platform.IMESSAGE" in src
+
+
+# ---------------------------------------------------------------------------
+# Channel Directory
+# ---------------------------------------------------------------------------
+
+class TestIMessageChannelDirectory:
+    def test_imessage_in_channel_directory(self):
+        import gateway.channel_directory as chdir
+        import inspect
+        src = inspect.getsource(chdir)
+        assert '"imessage"' in src or "'imessage'" in src
+
+
+# ---------------------------------------------------------------------------
+# CLI parity
+# ---------------------------------------------------------------------------
+
+class TestIMessageCLIParity:
+    def test_imessage_in_tools_config_platforms(self):
+        from hermes_cli.tools_config import PLATFORMS
+        assert "imessage" in PLATFORMS
+
+    def test_imessage_in_skills_config_platforms(self):
+        from hermes_cli.skills_config import PLATFORMS
+        assert "imessage" in PLATFORMS
+
+    def test_imessage_in_session_stats_loop(self):
+        import hermes_cli.main as main_mod
+        import inspect
+        src = inspect.getsource(main_mod)
+        assert '"imessage"' in src
+
+
+# ---------------------------------------------------------------------------
+# MessageEvent contract
+# ---------------------------------------------------------------------------
+
+class TestIMessageEventContract:
+    """Verify adapter builds MessageEvent with the correct field names."""
+
+    def test_message_type_photo_exists(self):
+        from gateway.platforms.base import MessageType
+        assert hasattr(MessageType, "PHOTO")
+
+    def test_message_type_image_not_used(self):
+        """Adapter must use PHOTO, not IMAGE (which doesn't exist)."""
+        from gateway.platforms.base import MessageType
+        assert not hasattr(MessageType, "IMAGE")
+
+    def test_message_event_has_media_urls(self):
+        from gateway.platforms.base import MessageEvent
+        import dataclasses
+        field_names = {f.name for f in dataclasses.fields(MessageEvent)}
+        assert "media_urls" in field_names
+        assert "media_types" in field_names
+        assert "images" not in field_names
+        assert "metadata" not in field_names
+
+    def test_message_event_has_reply_to_message_id(self):
+        from gateway.platforms.base import MessageEvent
+        import dataclasses
+        field_names = {f.name for f in dataclasses.fields(MessageEvent)}
+        assert "reply_to_message_id" in field_names
+
+    def test_adapter_source_uses_correct_fields(self):
+        """Spot-check that adapter code uses media_urls not images."""
+        from gateway.platforms import imessage
+        import inspect
+        src = inspect.getsource(imessage)
+        assert "images=image_paths" not in src
+        assert "media_urls=" in src

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -372,7 +372,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "deliver": {
                 "type": "string",
-                "description": "Delivery target: origin, local, telegram, discord, slack, whatsapp, signal, matrix, mattermost, homeassistant, dingtalk, feishu, wecom, email, sms, or platform:chat_id or platform:chat_id:thread_id for Telegram topics. Examples: 'origin', 'local', 'telegram', 'telegram:-1001234567890:17585', 'discord:#engineering'"
+                "description": "Delivery target: origin, local, telegram, discord, slack, whatsapp, signal, matrix, mattermost, homeassistant, dingtalk, feishu, wecom, email, sms, imessage, or platform:chat_id or platform:chat_id:thread_id for Telegram topics. Examples: 'origin', 'local', 'telegram', 'telegram:-1001234567890:17585', 'discord:#engineering', 'imessage:+15551234567'"
             },
             "model": {
                 "type": "string",

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -42,7 +42,7 @@ SEND_MESSAGE_SCHEMA = {
             },
             "target": {
                 "type": "string",
-                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or Telegram topic 'telegram:chat_id:thread_id'. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:#bot-home', 'slack:#engineering', 'signal:+15551234567'"
+                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or Telegram topic 'telegram:chat_id:thread_id'. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:#bot-home', 'slack:#engineering', 'signal:+15551234567', 'imessage:+15551234567'"
             },
             "message": {
                 "type": "string",
@@ -133,6 +133,7 @@ def _handle_send(args):
         "wecom": Platform.WECOM,
         "email": Platform.EMAIL,
         "sms": Platform.SMS,
+        "imessage": Platform.IMESSAGE,
     }
     platform = platform_map.get(platform_name)
     if not platform:
@@ -205,6 +206,8 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         match = _FEISHU_TARGET_RE.fullmatch(target_ref)
         if match:
             return match.group(1), match.group(2), True
+    if platform_name == "imessage" and (target_ref.startswith("+") or "@" in target_ref):
+        return target_ref, None, True
     if target_ref.lstrip("-").isdigit():
         return target_ref, None, True
     return None, None, False
@@ -371,6 +374,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             result = await _send_feishu(pconfig, chat_id, chunk, thread_id=thread_id)
         elif platform == Platform.WECOM:
             result = await _send_wecom(pconfig.extra, chat_id, chunk)
+        elif platform == Platform.IMESSAGE:
+            result = await _send_imessage(pconfig.extra, pconfig.api_key, chat_id, chunk)
         else:
             result = {"error": f"Direct sending not yet implemented for {platform.value}"}
 
@@ -879,6 +884,75 @@ async def _send_feishu(pconfig, chat_id, message, media_files=None, thread_id=No
         }
     except Exception as e:
         return {"error": f"Feishu send failed: {e}"}
+
+
+async def _send_imessage(extra, api_key, chat_id, message):
+    """Send via iMessage — AppleScript locally or HTTP proxy remotely.
+
+    Chunking is handled by _send_to_platform() before this is called.
+    """
+    import platform as platform_mod
+
+    local = extra.get("local", True)
+    server_url = extra.get("server_url", "")
+
+    if local:
+        if platform_mod.system() != "Darwin":
+            return {"error": "iMessage local mode requires macOS"}
+        import subprocess
+        def _escape_applescript(s: str) -> str:
+            return s.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t")
+        escaped_recipient = _escape_applescript(chat_id)
+        escaped_text = _escape_applescript(message)
+        script = (
+            f'tell application "Messages"\n'
+            f"  set targetService to 1st account whose service type = iMessage\n"
+            f'  set targetBuddy to participant "{escaped_recipient}" of targetService\n'
+            f'  send "{escaped_text}" to targetBuddy\n'
+            f"end tell"
+        )
+        try:
+            subprocess.run(
+                ["osascript", "-e", script],
+                check=True, capture_output=True, timeout=15,
+            )
+            return {"success": True, "platform": "imessage", "chat_id": chat_id}
+        except Exception as e:
+            return {"error": f"AppleScript send failed: {e}"}
+
+    if not server_url or not api_key:
+        return {"error": "iMessage remote mode requires IMESSAGE_SERVER_URL and IMESSAGE_API_KEY"}
+
+    import base64 as b64
+    try:
+        decoded = b64.b64decode(api_key, validate=True).decode()
+        token = api_key if "|" in decoded else b64.b64encode(f"{server_url}|{api_key}".encode()).decode()
+    except Exception:
+        token = b64.b64encode(f"{server_url}|{api_key}".encode()).decode()
+
+    try:
+        import httpx
+    except ImportError:
+        return {"error": "httpx not installed. Run: pip install httpx"}
+
+    try:
+        async with httpx.AsyncClient(
+            base_url="https://imessage-swagger.photon.codes",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=30.0,
+        ) as client:
+            resp = await client.post("/send", json={"to": chat_id, "text": message, "service": "iMessage"})
+            try:
+                parsed = resp.json()
+            except (json.JSONDecodeError, ValueError):
+                parsed = {}
+            if isinstance(parsed, dict) and (parsed.get("data", {}).get("id") or parsed.get("id")):
+                return {"success": True, "platform": "imessage", "chat_id": chat_id}
+            if not resp.is_success:
+                return {"error": f"iMessage proxy error ({resp.status_code}): {resp.text[:200]}"}
+            return {"success": True, "platform": "imessage", "chat_id": chat_id}
+    except Exception as e:
+        return {"error": f"iMessage send failed: {e}"}
 
 
 def _check_send_message():

--- a/toolsets.py
+++ b/toolsets.py
@@ -369,10 +369,16 @@ TOOLSETS = {
         "includes": []
     },
 
+    "hermes-imessage": {
+        "description": "iMessage bot toolset - interact with Hermes via Apple Messages (macOS local or remote proxy)",
+        "tools": _HERMES_CORE_TOOLS,
+        "includes": []
+    },
+
     "hermes-gateway": {
         "description": "Gateway toolset - union of all messaging platform tools",
         "tools": [],
-        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom"]
+        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-imessage"]
     }
 }
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -186,6 +186,12 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `SMS_ALLOW_ALL_USERS` | Allow all SMS senders without an allowlist |
 | `SMS_HOME_CHANNEL` | Phone number for cron job / notification delivery |
 | `SMS_HOME_CHANNEL_NAME` | Display name for the SMS home channel |
+| `IMESSAGE_SERVER_URL` | Photon endpoint from photon.codes (e.g. `https://abc123.imsgd.photon.codes`) |
+| `IMESSAGE_API_KEY` | Photon API key from photon.codes |
+| `IMESSAGE_ENABLED` | Set to `true` for local macOS mode (no Photon account needed) |
+| `IMESSAGE_ALLOWED_USERS` | Comma-separated phone numbers or Apple ID emails |
+| `IMESSAGE_ALLOW_ALL_USERS` | Allow all iMessage senders without an allowlist |
+| `IMESSAGE_HOME_CHANNEL` | Phone number or Apple ID for cron job / notification delivery |
 | `EMAIL_ADDRESS` | Email address for the Email gateway adapter |
 | `EMAIL_PASSWORD` | Password or app password for the email account |
 | `EMAIL_IMAP_HOST` | IMAP hostname for the email adapter |

--- a/website/docs/user-guide/messaging/imessage.md
+++ b/website/docs/user-guide/messaging/imessage.md
@@ -1,0 +1,198 @@
+---
+sidebar_position: 12
+title: "iMessage"
+description: "Set up Hermes Agent as an iMessage bot — local macOS mode or remote via HTTP proxy"
+---
+
+# iMessage Setup
+
+Hermes connects to iMessage through two modes:
+
+- **Local mode** (macOS only): Reads the native iMessage SQLite database (`~/Library/Messages/chat.db`) for inbound messages and sends via AppleScript. Pure Python, no external dependencies.
+- **Remote mode** (any OS): Connects to an [advanced-imessage-http-proxy](https://github.com/photon-hq/advanced-imessage-http-proxy) server via HTTP polling. Supports sending files/images/audio, tapback reactions, typing indicators, message effects, message queries, chat history, attachment download, and iMessage availability checks.
+
+:::info No Extra Python Dependencies
+Both modes use only stdlib and `httpx` (already a core Hermes dependency). No additional packages are required.
+:::
+
+---
+
+## Local Mode (macOS)
+
+The simplest setup — Hermes runs directly on your Mac and talks to Messages.app.
+
+### Prerequisites
+
+- **macOS** with Messages.app signed in to iMessage
+- **Full Disk Access** granted to your terminal application
+
+### Step 1: Grant Full Disk Access
+
+1. Open **System Settings → Privacy & Security → Full Disk Access**
+2. Add your terminal application (Terminal, iTerm2, Warp, etc.)
+3. Restart the terminal
+
+### Step 2: Configure
+
+Add to `~/.hermes/.env`:
+
+```bash
+IMESSAGE_ENABLED=true
+IMESSAGE_ALLOWED_USERS=+15551234567,user@icloud.com
+```
+
+Or use `hermes gateway setup` and select **iMessage**.
+
+### Step 3: Start
+
+```bash
+hermes gateway run
+```
+
+Hermes polls `chat.db` every 2 seconds for new messages and responds via AppleScript.
+
+---
+
+## Remote Mode
+
+Run Hermes on any machine — iMessage is managed by [Photon](https://photon.codes).
+
+### Configure
+
+You only need your **Photon endpoint** and **API key** (provided by photon.codes). Add to `~/.hermes/.env`:
+
+```bash
+IMESSAGE_SERVER_URL=https://abc123.imsgd.photon.codes
+IMESSAGE_API_KEY=your-photon-api-key
+IMESSAGE_ALLOWED_USERS=+15551234567,user@icloud.com
+```
+
+Or run `hermes gateway setup` and select **iMessage**.
+
+### Start
+
+```bash
+hermes gateway run
+```
+
+Hermes polls for new messages (default: every 2 seconds) and sends replies automatically.
+
+---
+
+## Access Control
+
+DM access follows the standard Hermes pattern:
+
+1. **`IMESSAGE_ALLOWED_USERS` set** — only those users can message
+2. **No allowlist set** — unknown users get a DM pairing code
+3. **`IMESSAGE_ALLOW_ALL_USERS=true`** — anyone can message
+
+### Group Chat Policy
+
+| Value | Behavior |
+|-------|----------|
+| `open` (default) | Process all group messages |
+| `ignore` | Ignore groups, only respond to DMs |
+
+```yaml
+platforms:
+  imessage:
+    extra:
+      group_policy: "ignore"
+```
+
+---
+
+## Remote Mode Features
+
+These features are available when using the [advanced-imessage-http-proxy](https://github.com/photon-hq/advanced-imessage-http-proxy):
+
+### Messaging
+
+| Feature | Description |
+|---------|-------------|
+| Send messages | Text with automatic multi-paragraph splitting |
+| Reply to messages | Inline replies to specific messages |
+| Message effects | Full-screen animations: `confetti`, `fireworks`, `balloon`, `heart`, `sparkles`, `echo`, `spotlight` |
+| Message search | Full-text search across message history |
+| Get message details | Retrieve a single message by ID |
+| Chat history | List messages in a specific conversation |
+
+### Reactions & Typing
+
+| Feature | Description |
+|---------|-------------|
+| Tapback reactions | `love`, `like`, `dislike`, `laugh`, `emphasize`, `question` — add and remove |
+| Typing indicators | Shown while generating a response |
+| Mark read / unread | Manage read state on conversations |
+
+Hermes reacts to incoming messages with a configurable tapback, then swaps it for a "done" tapback after replying:
+
+```yaml
+platforms:
+  imessage:
+    extra:
+      react_tapback: "love"     # on receive (empty string to disable)
+      done_tapback: ""          # after reply (empty string to disable)
+```
+
+### Attachments
+
+| Feature | Description |
+|---------|-------------|
+| Send files | Images, documents, audio via proxy or AppleScript |
+| Send audio messages | Audio files sent as voice messages (`audio=true`) |
+| Download attachments | Retrieve received files and media |
+| Attachment info | File name, size, MIME type metadata |
+
+> **Note:** File uploads may timeout on some Kit servers behind the centralized proxy (Cloudflare 60s limit). If this happens, the adapter falls back to sending the URL or caption as text.
+
+### Utilities
+
+| Feature | Description |
+|---------|-------------|
+| Check iMessage availability | Verify if an address uses iMessage |
+| Server info / health | OS version, server version, connectivity status |
+
+---
+
+## Full Configuration
+
+```yaml
+platforms:
+  imessage:
+    enabled: true
+    extra:
+      local: true                                    # false for remote mode
+      server_url: ""                                 # Photon endpoint (remote only)
+      poll_interval: 2.0                             # seconds between polls
+      database_path: "~/Library/Messages/chat.db"    # local mode DB path
+      group_policy: "open"                           # "open" or "ignore"
+      react_tapback: "love"                          # tapback on inbound (remote)
+      done_tapback: ""                               # tapback after reply (remote)
+```
+
+---
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| **"iMessage database not found"** | Grant Full Disk Access to your terminal in System Settings |
+| **"iMessage local mode requires macOS"** | Local mode only works on macOS — use remote mode on other OS |
+| **Messages not received** | Check `IMESSAGE_ALLOWED_USERS` includes the sender |
+| **AppleScript send failures** | Ensure Messages.app is signed in and recipient is a valid iMessage contact |
+| **Remote health check fails** | Verify proxy URL: `curl https://your-proxy/health` |
+
+---
+
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `IMESSAGE_SERVER_URL` | Yes (remote) | Photon endpoint from photon.codes |
+| `IMESSAGE_API_KEY` | Yes (remote) | Photon API key from photon.codes |
+| `IMESSAGE_ENABLED` | Yes (local) | Set to `true` for local macOS mode (no Photon account needed) |
+| `IMESSAGE_ALLOWED_USERS` | Recommended | Comma-separated phone numbers or Apple ID emails |
+| `IMESSAGE_ALLOW_ALL_USERS` | No | Allow any user to interact |
+| `IMESSAGE_HOME_CHANNEL` | No | Default delivery target for cron jobs |

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 1
 title: "Messaging Gateway"
-description: "Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Webhooks, or any OpenAI-compatible frontend via the API server — architecture and setup overview"
+description: "Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, iMessage, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Webhooks, or any OpenAI-compatible frontend via the API server — architecture and setup overview"
 ---
 
 # Messaging Gateway
 
-Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Feishu/Lark, WeCom, or your browser. The gateway is a single background process that connects to all your configured platforms, handles sessions, runs cron jobs, and delivers voice messages.
+Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, iMessage, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Feishu/Lark, WeCom, or your browser. The gateway is a single background process that connects to all your configured platforms, handles sessions, runs cron jobs, and delivers voice messages.
 
 For the full voice feature set — including CLI microphone mode, spoken replies in messaging, and Discord voice-channel conversations — see [Voice Mode](/docs/user-guide/features/voice-mode) and [Use Voice Mode with Hermes](/docs/guides/use-voice-mode-with-hermes).
 
@@ -41,6 +41,7 @@ flowchart TB
             wa[WhatsApp]
             sl[Slack]
             sig[Signal]
+            im[iMessage]
             sms[SMS]
             em[Email]
             ha[Home Assistant]
@@ -166,6 +167,7 @@ TELEGRAM_ALLOWED_USERS=123456789,987654321
 DISCORD_ALLOWED_USERS=123456789012345678
 SIGNAL_ALLOWED_USERS=+155****4567,+155****6543
 SMS_ALLOWED_USERS=+155****4567,+155****6543
+IMESSAGE_ALLOWED_USERS=+155****4567,user@icloud.com
 EMAIL_ALLOWED_USERS=trusted@example.com,colleague@work.com
 MATTERMOST_ALLOWED_USERS=3uo8dkh1p7g1mfk49ear5fzs5c
 MATRIX_ALLOWED_USERS=@alice:matrix.org
@@ -345,6 +347,7 @@ Each platform has its own toolset:
 | Slack | `hermes-slack` | Full tools including terminal |
 | Signal | `hermes-signal` | Full tools including terminal |
 | SMS | `hermes-sms` | Full tools including terminal |
+| iMessage | `hermes-imessage` | Full tools including terminal |
 | Email | `hermes-email` | Full tools including terminal |
 | Home Assistant | `hermes-homeassistant` | Full tools + HA device control (ha_list_entities, ha_get_state, ha_call_service, ha_list_services) |
 | Mattermost | `hermes-mattermost` | Full tools including terminal |
@@ -362,6 +365,7 @@ Each platform has its own toolset:
 - [Slack Setup](slack.md)
 - [WhatsApp Setup](whatsapp.md)
 - [Signal Setup](signal.md)
+- [iMessage Setup](imessage.md)
 - [SMS Setup (Twilio)](sms.md)
 - [Email Setup](email.md)
 - [Home Assistant Integration](homeassistant.md)


### PR DESCRIPTION
## Summary

### What
Adds iMessage as a first-class messaging platform in the Hermes gateway, supporting both **local macOS mode** (SQLite polling + AppleScript) and **remote mode** via the [Photon](https://photon.codes) `advanced-imessage-http-proxy`.

- **Local mode**: Polls `~/Library/Messages/chat.db` for inbound messages, sends via AppleScript. macOS only, no external dependencies.
- **Remote mode**: Communicates with a Photon Kit server through a centralized HTTP proxy. Works from any OS. Supports text, files, images, audio, tapbacks, typing indicators, message effects, message queries, chat history, attachment download, and iMessage availability checks.

### Why
Hermes supports Telegram, Discord, Slack, WhatsApp, Signal, and SMS — but not iMessage, despite it being the default messaging platform for hundreds of millions of Apple users. This gap means macOS users can't interact with their Hermes agent through the app they use most. Adding iMessage brings Hermes to the platform where many users already spend their time, and the remote mode via Photon makes it accessible without requiring the user to run Hermes on a Mac.

### Changes across 23 files

| Area | Files | What |
|------|-------|------|
| **Adapter** | `gateway/platforms/imessage.py` | Full `IMessageAdapter` implementation (~1000 lines) |
| **Config** | `gateway/config.py` | `Platform.IMESSAGE` enum, env var overrides, connectivity gating |
| **Gateway** | `gateway/run.py`, `gateway/session.py`, `gateway/channel_directory.py` | Adapter creation, authorization maps, PII-safe list, session discovery |
| **Agent** | `agent/prompt_builder.py`, `agent/redact.py` | Platform hints, redaction patterns |
| **Tools** | `tools/send_message_tool.py`, `tools/cronjob_tools.py`, `toolsets.py` | Send routing, cron delivery, `hermes-imessage` toolset |
| **CLI** | `hermes_cli/gateway.py`, `hermes_cli/status.py`, `hermes_cli/main.py`, `hermes_cli/tools_config.py`, `hermes_cli/skills_config.py` | Setup wizard, status display, CLI parity |
| **Tests** | `tests/gateway/test_imessage.py` | 48 unit tests covering config, helpers, integration points, CLI parity, event contract |
| **Docs** | `website/docs/user-guide/messaging/imessage.md`, `website/docs/user-guide/messaging/index.md`, `website/docs/reference/environment-variables.md`, `README.md`, `AGENTS.md`, `CONTRIBUTING.md` | Full setup guide, env var reference, platform listings |

## How to test

### Remote mode (any OS)
```bash
# Add to ~/.hermes/.env
IMESSAGE_SERVER_URL=https://<your-id>.imsgd.photon.codes
IMESSAGE_API_KEY=<your-photon-api-key>
IMESSAGE_ALLOWED_USERS=+15551234567

hermes gateway run
# Send a message from the allowed number — Hermes will respond
```

### Local mode (macOS only)
```bash
# Add to ~/.hermes/.env
IMESSAGE_ENABLED=true
IMESSAGE_ALLOWED_USERS=+15551234567

# Grant Full Disk Access to Terminal in System Settings → Privacy
hermes gateway run
```

### Unit tests
```bash
pytest tests/gateway/test_imessage.py -v
```

## Platforms tested

- macOS (remote mode with Photon Kit server)
- macOS (local mode)