### PR TITLE
fix: setup wizard overwrites custom endpoint config with OpenRouter defaults

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1054,10 +1054,12 @@ def setup_model_provider(config: dict):
         # env saving, config.yaml updates, and custom_providers persistence.
         from hermes_cli.main import _model_flow_custom
         _model_flow_custom(config)
-        # _model_flow_custom handles model selection, config, env vars,
-        # and custom_providers. Keep selected_provider = "custom" so
-        # the model selection step below is skipped (line 1631 check)
-        # but vision and TTS setup still run.
+        # _model_flow_custom saves config independently (loads its own copy).
+        # Reload here so the final save_config(config) below doesn't overwrite it.
+        from hermes_cli.config import load_config as _reload_config
+        config.update(_reload_config())
+        # Keep selected_provider = "custom" so the model selection step below is
+        # skipped (line 1631 check) but vision and TTS setup still run.
 
     elif provider_idx == 4:  # Z.AI / GLM
         selected_provider = "zai"


### PR DESCRIPTION
## Problem

When selecting **Custom OpenAI-compatible endpoint** in the setup wizard, the settings entered by the user (base URL, model name) are silently overwritten by the OpenRouter defaults after the wizard completes.

**Symptoms:** `~/.hermes/config.yaml` ends up with:
```yaml
model:
  base_url: https://openrouter.ai/api/v1
  default: anthropic/claude-opus-4.6
```
instead of the user-provided values (e.g. `http://localhost:11434/v1` + local model).

## Root Cause

`_model_flow_custom()` (`main.py`) loads its own independent copy of config via `load_config()`, applies the custom endpoint settings, and saves it. However, the caller `setup_model_provider()` (`setup.py`) holds a separate `config` dict loaded at wizard startup. The final `save_config(config)` call at line 1802 of `setup.py` overwrites everything `_model_flow_custom()` just saved.

## Fix

Reload config in `setup.py` immediately after `_model_flow_custom()` returns, so the caller's copy reflects the saved changes before the final write.

```python
from hermes_cli.main import _model_flow_custom
_model_flow_custom(config)
# _model_flow_custom saves config independently (loads its own copy).
# Reload here so the final save_config(config) below doesn't overwrite it.
from hermes_cli.config import load_config as _reload_config
config.update(_reload_config())
```

One line added, no refactoring. `_model_flow_custom()` logic is untouched.

## Reproduction

1. Run `hermes setup`
2. Select **Custom OpenAI-compatible endpoint**
3. Enter `http://localhost:11434/v1` as base URL, `ollama` as API key, `qwen2.5-coder:14b` as model
4. Complete the wizard
5. `cat ~/.hermes/config.yaml` → `model.base_url` is still `https://openrouter.ai/api/v1`

Tested with Ollama on WSL2.