### PR TITLE
fix(tools): implement Mattermost direct send via REST API

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from gateway.config import Platform
-from tools.send_message_tool import _send_telegram, _send_to_platform, send_message_tool
+from tools.send_message_tool import _send_mattermost, _send_telegram, _send_to_platform, send_message_tool
 
 
 def _run_async_immediately(coro):
@@ -504,3 +504,98 @@ class TestSendTelegramHtmlDetection:
         assert bot.send_message.await_count == 2
         second_call = bot.send_message.await_args_list[1].kwargs
         assert second_call["parse_mode"] is None
+
+
+# ---------------------------------------------------------------------------
+# Mattermost direct send (_send_mattermost and _send_to_platform routing)
+# ---------------------------------------------------------------------------
+
+
+class TestSendMattermost:
+    def _make_pconfig(self, url="https://mattermost.example.com"):
+        return SimpleNamespace(
+            enabled=True,
+            token="xoxb-test-token",
+            api_key=None,
+            extra={"url": url},
+        )
+
+    def test_routes_to_send_mattermost(self):
+        """Platform.MATTERMOST routes through _send_mattermost, not the else branch."""
+        mock = AsyncMock(return_value={"success": True, "platform": "mattermost", "chat_id": "ch123", "message_id": "m1"})
+        with patch("tools.send_message_tool._send_mattermost", mock):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.MATTERMOST,
+                    self._make_pconfig(),
+                    "ch123",
+                    "hello",
+                )
+            )
+        assert result["success"] is True
+        mock.assert_awaited_once()
+
+    def test_send_mattermost_success(self):
+        """_send_mattermost returns success dict with message_id on HTTP 201."""
+        pconfig = self._make_pconfig()
+        fake_resp = AsyncMock()
+        fake_resp.status = 201
+        fake_resp.json = AsyncMock(return_value={"id": "post-abc"})
+
+        fake_session = MagicMock()
+        fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+        fake_session.__aexit__ = AsyncMock(return_value=False)
+        fake_session.post.return_value.__aenter__ = AsyncMock(return_value=fake_resp)
+        fake_session.post.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            result = asyncio.run(_send_mattermost(pconfig, "ch123", "hello"))
+
+        assert result == {"success": True, "platform": "mattermost", "chat_id": "ch123", "message_id": "post-abc"}
+
+    def test_send_mattermost_thread_id_sets_root_id(self):
+        """When thread_id is provided, payload includes root_id for threaded replies."""
+        pconfig = self._make_pconfig()
+        captured = {}
+
+        fake_resp = AsyncMock()
+        fake_resp.status = 201
+        fake_resp.json = AsyncMock(return_value={"id": "post-xyz"})
+
+        fake_cm = MagicMock()
+        fake_cm.__aenter__ = AsyncMock(return_value=fake_resp)
+        fake_cm.__aexit__ = AsyncMock(return_value=False)
+
+        fake_session = MagicMock()
+        fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+        fake_session.__aexit__ = AsyncMock(return_value=False)
+
+        def capturing_post(url, headers=None, json=None):
+            captured["payload"] = json
+            return fake_cm
+
+        fake_session.post = capturing_post
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            asyncio.run(_send_mattermost(pconfig, "ch123", "reply", thread_id="root-1"))
+
+        assert captured["payload"]["root_id"] == "root-1"
+
+    def test_send_mattermost_api_error(self):
+        """Non-2xx response returns an error dict with status and body."""
+        pconfig = self._make_pconfig()
+        fake_resp = AsyncMock()
+        fake_resp.status = 403
+        fake_resp.text = AsyncMock(return_value="Forbidden")
+
+        fake_session = MagicMock()
+        fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+        fake_session.__aexit__ = AsyncMock(return_value=False)
+        fake_session.post.return_value.__aenter__ = AsyncMock(return_value=fake_resp)
+        fake_session.post.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("aiohttp.ClientSession", return_value=fake_session):
+            result = asyncio.run(_send_mattermost(pconfig, "ch123", "hello"))
+
+        assert "error" in result
+        assert "403" in result["error"]

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -343,6 +343,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             result = await _send_email(pconfig.extra, chat_id, chunk)
         elif platform == Platform.SMS:
             result = await _send_sms(pconfig.api_key, chat_id, chunk)
+        elif platform == Platform.MATTERMOST:
+            result = await _send_mattermost(pconfig, chat_id, chunk, thread_id=thread_id)
         else:
             result = {"error": f"Direct sending not yet implemented for {platform.value}"}
 
@@ -664,6 +666,42 @@ async def _send_sms(auth_token, chat_id, message):
                 return {"success": True, "platform": "sms", "chat_id": chat_id, "message_id": msg_sid}
     except Exception as e:
         return {"error": f"SMS send failed: {e}"}
+
+
+async def _send_mattermost(pconfig, chat_id, message, thread_id=None):
+    """Send a single message to a Mattermost channel via REST API.
+
+    Uses a direct aiohttp POST to /api/v4/posts — no adapter instantiation
+    needed, matching the same pattern as _send_discord and _send_slack.
+    Chunking is handled by _send_to_platform() before this is called.
+    thread_id maps to Mattermost's root_id for threaded replies.
+    """
+    try:
+        import aiohttp
+    except ImportError:
+        return {"error": "aiohttp not installed. Run: pip install aiohttp"}
+    try:
+        base_url = pconfig.extra.get("url", "").rstrip("/")
+        token = pconfig.token or pconfig.api_key
+        url = f"{base_url}/api/v4/posts"
+        headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+        payload = {"channel_id": chat_id, "message": message}
+        if thread_id:
+            payload["root_id"] = thread_id
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as session:
+            async with session.post(url, headers=headers, json=payload) as resp:
+                if resp.status in (200, 201):
+                    data = await resp.json()
+                    return {
+                        "success": True,
+                        "platform": "mattermost",
+                        "chat_id": chat_id,
+                        "message_id": data.get("id"),
+                    }
+                body = await resp.text()
+                return {"error": f"Mattermost API error ({resp.status}): {body}"}
+    except Exception as e:
+        return {"error": f"Mattermost send failed: {e}"}
 
 
 def _check_send_message():


### PR DESCRIPTION
## What does this PR do?

`Platform.MATTERMOST` was fully registered and its config was parsed correctly, but `_send_to_platform()` had no handler for it — falling through to the `else` branch and returning `"Direct sending not yet implemented for mattermost"`.

This made every cron job or agent delivery targeting Mattermost silently fail. The root cause was that the only existing send path for Mattermost goes through `MattermostAdapter`, which requires `connect()` to be called before use (setting up `self._session`). The direct-send path (used outside the gateway, e.g. cron jobs) never called `connect()`, leaving `self._session = None` and raising `AttributeError: 'NoneType' object has no attribute 'post'`.

Fix: add `_send_mattermost()` using a direct `aiohttp` POST to `/api/v4/posts`, matching the same pattern already used by `_send_discord` and `_send_slack`. No new dependencies — `aiohttp` is already required by those handlers. Also wires `thread_id` → Mattermost's `root_id` for threaded replies.

Note: #3512 fixed platform registration (toolset config parsing). This PR fixes the complementary send-path bug — the platform was correctly registered but delivery was never implemented for the direct-send path used by cron jobs.

## Related Issue

Fixes — (no existing issue; discovered in production via cron job delivery failure)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `tools/send_message_tool.py` — add `_send_mattermost(pconfig, chat_id, message, thread_id=None)` implementing direct REST delivery via `aiohttp`
- `tools/send_message_tool.py` — wire `Platform.MATTERMOST` in the `_send_to_platform()` dispatch loop (was hitting `else` branch)
- `tests/tools/test_send_message_tool.py` — add `TestSendMattermost` class with 4 tests: routing, success (HTTP 201), `thread_id` → `root_id` mapping, API error (HTTP 403)

## How to Test

1. Configure Mattermost in `~/.hermes/config.yaml`:
   ```yaml
   platforms:
     mattermost:
       token: xoxb-your-bot-token
       extra:
         url: https://your-mattermost-instance.com
   ```
2. Schedule a cron job with `deliver: mattermost` and a channel ID as target, or call `send_message` with `platform: mattermost`
3. Before this fix: delivery returns `{"error": "Direct sending not yet implemented for mattermost"}`
4. After this fix: message appears in the Mattermost channel

Unit tests: `pytest tests/tools/test_send_message_tool.py::TestSendMattermost -v` — 4 passed

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(send_message): implement Mattermost direct send via REST API`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (2 files: the tool and its test)
- [x] I've run `pytest tests/ -q` and all tests pass (10 pre-existing failures on `main` unrelated to this PR, verified on clean `HEAD` before branching)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Apple M1)

### Documentation & Housekeeping
- [x] I've updated relevant documentation — N/A (no config keys added; Mattermost was already documented)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (pure Python/aiohttp, no OS calls)
- [x] I've updated tool descriptions/schemas — N/A (no schema change, behavior fix only)

## Screenshots / Logs

Before (cron job delivery to Mattermost):
```
{"error": "Direct sending not yet implemented for mattermost"}
```

After:
```
{"success": true, "platform": "mattermost", "chat_id": "...", "message_id": "..."}
```