### PR TITLE
fix(signal): use FIFO eviction for sent-timestamp tracking

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -19,6 +19,7 @@ import os
 import random
 import re
 import time
+from collections import OrderedDict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Any
@@ -181,7 +182,7 @@ class SignalAdapter(BasePlatformAdapter):
 
         # Track recently sent message timestamps to prevent echo-back loops
         # in Note to Self / self-chat mode (mirrors WhatsApp recentlySentIds)
-        self._recent_sent_timestamps: set = set()
+        self._recent_sent_timestamps: OrderedDict = OrderedDict()
         self._max_recent_timestamps = 50
 
         logger.info("Signal adapter initialized: url=%s account=%s groups=%s",
@@ -379,7 +380,7 @@ class SignalAdapter(BasePlatformAdapter):
                     if dest == self._account_normalized:
                         # Check if this is an echo of our own outbound reply
                         if sent_ts and sent_ts in self._recent_sent_timestamps:
-                            self._recent_sent_timestamps.discard(sent_ts)
+                            self._recent_sent_timestamps.pop(sent_ts, None)
                             return
                         # Genuine user Note to Self — promote to dataMessage
                         is_note_to_self = True
@@ -621,9 +622,9 @@ class SignalAdapter(BasePlatformAdapter):
         """Record outbound message timestamp for echo-back filtering."""
         ts = rpc_result.get("timestamp") if isinstance(rpc_result, dict) else None
         if ts:
-            self._recent_sent_timestamps.add(ts)
+            self._recent_sent_timestamps[ts] = None
             if len(self._recent_sent_timestamps) > self._max_recent_timestamps:
-                self._recent_sent_timestamps.pop()
+                self._recent_sent_timestamps.popitem(last=False)
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Send a typing indicator."""

--- a/tests/gateway/test_signal_timestamp_eviction.py
+++ b/tests/gateway/test_signal_timestamp_eviction.py
@@ -1,0 +1,67 @@
+"""Tests for Signal adapter FIFO timestamp eviction."""
+import pytest
+from unittest.mock import patch
+from collections import OrderedDict
+
+
+@pytest.fixture
+def signal_adapter():
+    """Create a minimal SignalAdapter with mocked config."""
+    with patch.dict("os.environ", {
+        "SIGNAL_CLI_REST_URL": "http://localhost:8080",
+        "SIGNAL_ACCOUNT": "+15551234567",
+    }):
+        with patch("gateway.platforms.signal.SignalAdapter.__init__", lambda self: None):
+            from gateway.platforms.signal import SignalAdapter
+            adapter = SignalAdapter.__new__(SignalAdapter)
+            adapter._recent_sent_timestamps = OrderedDict()
+            adapter._max_recent_timestamps = 50
+            return adapter
+
+
+class TestTimestampEviction:
+    """Verify _recent_sent_timestamps uses FIFO eviction."""
+
+    def test_tracks_timestamp(self, signal_adapter):
+        signal_adapter._track_sent_timestamp({"timestamp": "ts_1"})
+        assert "ts_1" in signal_adapter._recent_sent_timestamps
+
+    def test_ignores_missing_timestamp(self, signal_adapter):
+        signal_adapter._track_sent_timestamp({})
+        assert len(signal_adapter._recent_sent_timestamps) == 0
+
+    def test_ignores_non_dict(self, signal_adapter):
+        signal_adapter._track_sent_timestamp("not a dict")
+        assert len(signal_adapter._recent_sent_timestamps) == 0
+
+    def test_evicts_oldest_first(self, signal_adapter):
+        """When exceeding max, the OLDEST timestamp must be evicted."""
+        signal_adapter._max_recent_timestamps = 5
+        for i in range(7):
+            signal_adapter._track_sent_timestamp({"timestamp": f"ts_{i}"})
+
+        assert len(signal_adapter._recent_sent_timestamps) == 5
+        # Oldest two (ts_0, ts_1) should be gone
+        assert "ts_0" not in signal_adapter._recent_sent_timestamps
+        assert "ts_1" not in signal_adapter._recent_sent_timestamps
+        # Newest five should remain
+        for i in range(2, 7):
+            assert f"ts_{i}" in signal_adapter._recent_sent_timestamps
+
+    def test_fifo_order_under_sustained_load(self, signal_adapter):
+        """Under sustained load, only the most recent N timestamps survive."""
+        signal_adapter._max_recent_timestamps = 50
+        for i in range(10000):
+            signal_adapter._track_sent_timestamp({"timestamp": f"ts_{i}"})
+
+        assert len(signal_adapter._recent_sent_timestamps) == 50
+        # Only the last 50 should survive
+        for i in range(9950, 10000):
+            assert f"ts_{i}" in signal_adapter._recent_sent_timestamps
+        # None of the old ones should remain
+        for i in range(100):
+            assert f"ts_{i}" not in signal_adapter._recent_sent_timestamps
+
+    def test_uses_ordered_dict_not_set(self, signal_adapter):
+        """The backing store must be OrderedDict for deterministic eviction."""
+        assert isinstance(signal_adapter._recent_sent_timestamps, OrderedDict)


### PR DESCRIPTION
## Summary

Signal's echo-back filter (`_recent_sent_timestamps`) uses `set.pop()` to evict old entries when the set exceeds 50 items. Since Python sets are unordered, `pop()` removes an arbitrary element — it might evict the newest timestamp while keeping a stale one from hours ago. Over time this degrades the echo-back filter: legitimate sent timestamps get evicted early, causing the adapter to re-process its own outbound messages as inbound.

Same class of bug as #3490 (email `_seen_uids` growing unbounded).

## Root Cause

`set.pop()` on line 626 of `gateway/platforms/signal.py` doesn't guarantee oldest-first eviction. Sets have no insertion order in their iteration/pop behavior, so the eviction is effectively random.

## Fix

Replace the plain `set` with `collections.OrderedDict` (used as an ordered set with `None` values):

- **gateway/platforms/signal.py:184** — `set()` → `OrderedDict()`
- **gateway/platforms/signal.py:382** — `.discard(ts)` → `.pop(ts, None)`
- **gateway/platforms/signal.py:624-626** — `.add(ts)` → `[ts] = None`, `.pop()` → `.popitem(last=False)`

`OrderedDict.popitem(last=False)` always removes the oldest entry — O(1), deterministic FIFO.

## Tests

6 new tests in `tests/gateway/test_signal_timestamp_eviction.py`:
- Tracks timestamps, ignores missing/non-dict input
- Verifies oldest-first eviction when exceeding max
- Verifies only newest 50 survive after 10k messages
- Asserts backing store is OrderedDict

38 pre-existing signal tests + 6 new = 44 passed.