### PR TITLE
feat: restore session-scoped /model switching in CLI and gateway

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1101,6 +1101,7 @@ class HermesCLI:
 
         self._explicit_api_key = api_key
         self._explicit_base_url = base_url
+        self._session_base_url_override: Optional[str] = None
 
         # Provider selection is resolved lazily at use-time via _ensure_runtime_credentials().
         self.requested_provider = (
@@ -1885,7 +1886,11 @@ class HermesCLI:
             runtime = resolve_runtime_provider(
                 requested=self.requested_provider,
                 explicit_api_key=self._explicit_api_key,
-                explicit_base_url=self._explicit_base_url,
+                explicit_base_url=(
+                    self._session_base_url_override
+                    if self._session_base_url_override is not None
+                    else self._explicit_base_url
+                ),
             )
         except Exception as exc:
             message = format_runtime_provider_error(exc)
@@ -1996,6 +2001,7 @@ class HermesCLI:
                 _cprint(f"\033[1;31mSession not found: {self.session_id}{_RST}")
                 _cprint(f"{_DIM}Use a session ID from a previous CLI run (hermes sessions list).{_RST}")
                 return False
+            self._restore_session_runtime_settings(session_meta)
             restored = self._session_db.get_messages_as_conversation(self.session_id)
             if restored:
                 self.conversation_history = restored
@@ -2080,6 +2086,7 @@ class HermesCLI:
                 runtime.get("command"),
                 tuple(runtime.get("args") or ()),
             )
+            self._persist_session_runtime_settings()
 
             if self._pending_title and self._session_db:
                 try:
@@ -2159,6 +2166,7 @@ class HermesCLI:
             )
             return False
 
+        self._restore_session_runtime_settings(session_meta)
         restored = self._session_db.get_messages_as_conversation(self.session_id)
         if restored:
             self.conversation_history = restored
@@ -2191,6 +2199,80 @@ class HermesCLI:
             pass
 
         return True
+
+    def _build_session_model_config(self) -> Dict[str, Any]:
+        """Return per-session runtime metadata we want to persist in SessionDB."""
+        return {
+            "max_iterations": self.max_turns,
+            "reasoning_config": self.reasoning_config,
+            "provider": self.requested_provider,
+            "base_url": self._session_base_url_override or self.base_url,
+        }
+
+    def _persist_session_runtime_settings(self) -> None:
+        """Persist the current session-scoped model/provider/base_url to SessionDB."""
+        if not self._session_db or not self.session_id:
+            return
+
+        session_meta = self._session_db.get_session(self.session_id)
+        model_config = self._build_session_model_config()
+        try:
+            if session_meta is None:
+                self._session_db.create_session(
+                    session_id=self.session_id,
+                    source=os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                    model=self.model,
+                    model_config=model_config,
+                    billing_provider=self.requested_provider or self.provider,
+                    billing_base_url=self._session_base_url_override or self.base_url,
+                )
+                return
+
+            self._session_db.update_session_model_state(
+                self.session_id,
+                model=self.model,
+                provider=self.requested_provider or self.provider,
+                base_url=self._session_base_url_override or self.base_url,
+            )
+        except Exception:
+            logger.debug("Failed to persist session-scoped model settings", exc_info=True)
+
+    def _restore_session_runtime_settings(self, session_meta: Optional[Dict[str, Any]]) -> None:
+        """Restore model/provider/base_url from a resumed session's metadata."""
+        if not session_meta:
+            return
+
+        restored_model = session_meta.get("model")
+        if isinstance(restored_model, str) and restored_model.strip():
+            self.model = restored_model.strip()
+
+        raw_model_config = session_meta.get("model_config")
+        model_config = None
+        if isinstance(raw_model_config, str) and raw_model_config.strip():
+            try:
+                model_config = json.loads(raw_model_config)
+            except Exception:
+                logger.debug("Failed to decode session model_config for %s", self.session_id, exc_info=True)
+
+        restored_provider = session_meta.get("billing_provider")
+        if not (isinstance(restored_provider, str) and restored_provider.strip()):
+            restored_provider = model_config.get("provider") if isinstance(model_config, dict) else None
+        if isinstance(restored_provider, str) and restored_provider.strip():
+            restored_provider = restored_provider.strip()
+            self.requested_provider = restored_provider
+            self.provider = restored_provider
+
+        restored_base_url = session_meta.get("billing_base_url")
+        if not (isinstance(restored_base_url, str) and restored_base_url.strip()):
+            restored_base_url = model_config.get("base_url") if isinstance(model_config, dict) else None
+        if isinstance(restored_base_url, str) and restored_base_url.strip():
+            self.base_url = restored_base_url.strip()
+            self._session_base_url_override = self.base_url
+            if not (isinstance(restored_provider, str) and restored_provider.strip()) and "openrouter.ai" not in self.base_url:
+                self.requested_provider = "custom"
+                self.provider = "custom"
+        else:
+            self._session_base_url_override = None
 
     def _display_resumed_history(self):
         """Render a compact recap of previous conversation messages.
@@ -2950,16 +3032,16 @@ class HermesCLI:
                         session_id=self.session_id,
                         source=os.environ.get("HERMES_SESSION_SOURCE", "cli"),
                         model=self.model,
-                        model_config={
-                            "max_iterations": self.max_turns,
-                            "reasoning_config": self.reasoning_config,
-                        },
+                        model_config=self._build_session_model_config(),
+                        billing_provider=self.requested_provider or self.provider,
+                        billing_base_url=self._session_base_url_override or self.base_url,
                     )
                 except Exception:
                     pass
 
         if not silent:
             print("(^_^)v New session started!")
+            print(f"  Current model: {self.model} [provider: {self.provider or self.requested_provider or 'auto'}]")
 
     def _handle_resume_command(self, cmd_original: str) -> None:
         """Handle /resume <session_id_or_title> — switch to a previous session mid-conversation."""
@@ -3000,6 +3082,7 @@ class HermesCLI:
         self.session_id = target_id
         self._resumed = True
         self._pending_title = None
+        self._restore_session_runtime_settings(session_meta)
 
         # Load conversation history
         restored = self._session_db.get_messages_as_conversation(target_id)
@@ -3013,18 +3096,8 @@ class HermesCLI:
 
         # Sync the agent if already initialised
         if self.agent:
-            self.agent.session_id = target_id
-            self.agent.reset_session_state()
-            if hasattr(self.agent, "_last_flushed_db_idx"):
-                self.agent._last_flushed_db_idx = len(self.conversation_history)
-            if hasattr(self.agent, "_todo_store"):
-                try:
-                    from tools.todo_tool import TodoStore
-                    self.agent._todo_store = TodoStore()
-                except Exception:
-                    pass
-            if hasattr(self.agent, "_invalidate_system_prompt"):
-                self.agent._invalidate_system_prompt()
+            self.agent = None
+            self._active_agent_route_signature = None
 
         title_part = f" \"{session_meta['title']}\"" if session_meta.get("title") else ""
         msg_count = len([m for m in self.conversation_history if m.get("role") == "user"])
@@ -3141,7 +3214,11 @@ class HermesCLI:
                 current = _resolve_provider(
                     self.requested_provider,
                     explicit_api_key=self._explicit_api_key,
-                    explicit_base_url=self._explicit_base_url,
+                    explicit_base_url=(
+                        self._session_base_url_override
+                        if self._session_base_url_override is not None
+                        else self._explicit_base_url
+                    ),
                 )
             except Exception:
                 current = "openrouter"
@@ -3773,13 +3850,13 @@ class HermesCLI:
                         self.provider = "custom"
                         self.api_key = result.api_key
                         self.base_url = result.base_url
+                        self._session_base_url_override = result.base_url
                         self.agent = None
-                        save_config_value("model.default", result.model)
-                        save_config_value("model.provider", "custom")
-                        save_config_value("model.base_url", result.base_url)
-                        print(f"(^_^)b Model changed to: {result.model} [provider: Custom]")
+                        self._persist_session_runtime_settings()
+                        print(f"(^_^) Model changed to: {result.model} [provider: Custom] (this session only)")
                         print(f"  Endpoint: {result.base_url}")
-                        print(f"  Status: connected (model auto-detected)")
+                        print("  Status: connected (model auto-detected)")
+                        print("  Global default unchanged. Use `hermes model` to change it globally.")
                     else:
                         print(f"(>_<) {result.error_message}")
                     return True
@@ -3808,28 +3885,14 @@ class HermesCLI:
                         self.provider = result.target_provider
                         self.api_key = result.api_key
                         self.base_url = result.base_url
+                        self._session_base_url_override = result.base_url or None
 
                     provider_note = f" [provider: {result.provider_label}]" if result.provider_changed else ""
-
-                    if result.persist:
-                        saved_model = save_config_value("model.default", result.new_model)
-                        if result.provider_changed:
-                            save_config_value("model.provider", result.target_provider)
-                            # Persist base_url for custom endpoints; clear
-                            # when switching away from custom.
-                            if result.base_url and "openrouter.ai" not in (result.base_url or ""):
-                                save_config_value("model.base_url", result.base_url)
-                            else:
-                                save_config_value("model.base_url", None)
-                        if saved_model:
-                            print(f"(^_^)b Model changed to: {result.new_model}{provider_note} (saved to config)")
-                        else:
-                            print(f"(^_^) Model changed to: {result.new_model}{provider_note} (this session only)")
-                    else:
-                        print(f"(^_^) Model changed to: {result.new_model}{provider_note} (this session only)")
-                        if result.warning_message:
-                            print(f"  Reason: {result.warning_message}")
-                        print("  Note: Model will revert on restart. Use a verified model to save to config.")
+                    self._persist_session_runtime_settings()
+                    print(f"(^_^) Model changed to: {result.new_model}{provider_note} (this session only)")
+                    if result.warning_message:
+                        print(f"  Note: {result.warning_message}")
+                    print("  Global default unchanged. Use `hermes model` to change it globally.")
 
                     # Show endpoint info for custom providers
                     if result.is_custom_target:

--- a/cli.py
+++ b/cli.py
@@ -3755,6 +3755,91 @@ class HermesCLI:
                     _cprint("  Session database not available.")
         elif canonical == "new":
             self.new_session()
+        elif canonical == "model":
+            # Use original case so model names like "Anthropic/Claude-Opus-4" are preserved
+            parts = cmd_original.split(maxsplit=1)
+            if len(parts) > 1:
+                from hermes_cli.model_switch import switch_model, switch_to_custom_provider
+
+                raw_input = parts[1].strip()
+
+                # Handle bare "/model custom" — switch to custom provider
+                # and auto-detect the model from the endpoint.
+                if raw_input.strip().lower() == "custom":
+                    result = switch_to_custom_provider()
+                    if result.success:
+                        self.model = result.model
+                        self.requested_provider = "custom"
+                        self.provider = "custom"
+                        self.api_key = result.api_key
+                        self.base_url = result.base_url
+                        self.agent = None
+                        save_config_value("model.default", result.model)
+                        save_config_value("model.provider", "custom")
+                        save_config_value("model.base_url", result.base_url)
+                        print(f"(^_^)b Model changed to: {result.model} [provider: Custom]")
+                        print(f"  Endpoint: {result.base_url}")
+                        print(f"  Status: connected (model auto-detected)")
+                    else:
+                        print(f"(>_<) {result.error_message}")
+                    return True
+
+                # Core model-switching pipeline (shared with gateway)
+                current_provider = self.provider or self.requested_provider or "openrouter"
+                result = switch_model(
+                    raw_input,
+                    current_provider,
+                    current_base_url=self.base_url or "",
+                    current_api_key=self.api_key or "",
+                )
+
+                if not result.success:
+                    print(f"(>_<) {result.error_message}")
+                    if "Did you mean" not in result.error_message:
+                        print(f"  Model unchanged: {self.model}")
+                        if "credentials" not in result.error_message.lower():
+                            print("  Tip: Use /model to see available models, /provider to see providers")
+                else:
+                    self.model = result.new_model
+                    self.agent = None  # Force re-init
+
+                    if result.provider_changed:
+                        self.requested_provider = result.target_provider
+                        self.provider = result.target_provider
+                        self.api_key = result.api_key
+                        self.base_url = result.base_url
+
+                    provider_note = f" [provider: {result.provider_label}]" if result.provider_changed else ""
+
+                    if result.persist:
+                        saved_model = save_config_value("model.default", result.new_model)
+                        if result.provider_changed:
+                            save_config_value("model.provider", result.target_provider)
+                            # Persist base_url for custom endpoints; clear
+                            # when switching away from custom.
+                            if result.base_url and "openrouter.ai" not in (result.base_url or ""):
+                                save_config_value("model.base_url", result.base_url)
+                            else:
+                                save_config_value("model.base_url", None)
+                        if saved_model:
+                            print(f"(^_^)b Model changed to: {result.new_model}{provider_note} (saved to config)")
+                        else:
+                            print(f"(^_^) Model changed to: {result.new_model}{provider_note} (this session only)")
+                    else:
+                        print(f"(^_^) Model changed to: {result.new_model}{provider_note} (this session only)")
+                        if result.warning_message:
+                            print(f"  Reason: {result.warning_message}")
+                        print("  Note: Model will revert on restart. Use a verified model to save to config.")
+
+                    # Show endpoint info for custom providers
+                    if result.is_custom_target:
+                        endpoint = result.base_url or self.base_url or "custom endpoint"
+                        print(f"  Endpoint: {endpoint}")
+                        if not result.provider_changed:
+                            print("  Tip: To switch providers, use /model provider:model")
+                            print("       e.g. /model openai-codex:gpt-5.2-codex")
+            else:
+                self._show_model_and_providers()
         elif canonical == "resume":
             self._handle_resume_command(cmd_original)
         elif canonical == "provider":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2904,7 +2904,7 @@ class GatewayRunner:
         
         # Resolve session config info to surface to the user
         try:
-            session_info = self._format_session_info(session_entry)
+            session_info = self._format_session_info(new_entry)
         except Exception:
             session_info = ""
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3069,7 +3069,7 @@ class GatewayRunner:
         session_key = session_entry.session_key
         args = event.get_command_args().strip()
 
-        current_model = session_entry.model or self._resolve_gateway_model()
+        current_model = session_entry.model or _resolve_gateway_model()
         current_provider = session_entry.provider
         current_base_url = session_entry.base_url or ""
         current_api_key = ""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1740,6 +1740,9 @@ class GatewayRunner:
         if canonical == "reasoning":
             return await self._handle_reasoning_command(event)
 
+        if canonical == "model":
+            return await self._handle_model_command(event)
+
         if canonical == "verbose":
             return await self._handle_verbose_command(event)
 
@@ -3053,36 +3056,36 @@ class GatewayRunner:
     async def _handle_model_command(self, event: MessageEvent) -> str:
         """Handle /model command - switch model for this session."""
         from hermes_cli.model_switch import switch_model
-        from hermes_cli.models import _PROVIDER_LABELS
-        from gateway.session import SessionStore
+        from hermes_cli.models import (
+            _PROVIDER_LABELS,
+            _PROVIDER_MODELS,
+            curated_models_for_provider,
+            list_available_providers,
+        )
         from hermes_cli.runtime_provider import resolve_runtime_provider
-        import os
-        
+
+        source = event.source or self._get_event_source(event)
+        session_entry = self.session_store.get_or_create_session(source)
+        session_key = session_entry.session_key
         args = event.get_command_args().strip()
-        source = self._get_event_source(event)
-        session_key = self._session_key_from_source(source)
-        
-        # No args - show current model
+
+        current_model = session_entry.model or self._resolve_gateway_model()
+        current_provider = session_entry.provider
+        current_base_url = session_entry.base_url or ""
+        current_api_key = ""
+
+        try:
+            runtime = resolve_runtime_provider(requested=current_provider or "auto")
+            if not current_base_url:
+                current_base_url = runtime.get("base_url", "")
+            current_api_key = runtime.get("api_key", "")
+            current_provider = current_provider or runtime.get("provider")
+        except Exception:
+            pass
+
+        # No args - show current model and configured provider/model choices
         if not args:
-            session_entry = self.session_store.get_session(session_key)
-            if not session_entry:
-                return "No active session"
-            
-            # Get current session model info
-            current_model = session_entry.model or self._resolve_gateway_model()
-            current_provider = session_entry.provider
-            current_base_url = session_entry.base_url
-            
-            # Resolve current provider info
-            try:
-                runtime = resolve_runtime_provider(requested=current_provider or "auto")
-                if not current_base_url:
-                    current_base_url = runtime.get("base_url", "")
-            except Exception:
-                pass
-            
             provider_label = _PROVIDER_LABELS.get(current_provider, current_provider or "auto")
-            
             lines = [
                 f"**Current model:** `{current_model}`",
                 f"  Provider: {provider_label}",
@@ -3090,74 +3093,87 @@ class GatewayRunner:
             if current_base_url and "openrouter" not in current_base_url:
                 lines.append(f"  Base URL: {current_base_url}")
             lines.append("")
-            lines.append("Switch: `/model provider:model-name` or `/model model-name`")
-            lines.append("Examples: `/model zai:glm-5.1`, `/model claude-sonnet-4`")
+
+            providers = list_available_providers()
+            authed = [p for p in providers if p.get("authenticated")]
+            unauthed = [p for p in providers if not p.get("authenticated")]
+
+            if authed:
+                lines.append("**Configured providers & models:**")
+                for provider in authed:
+                    marker = " ← active" if provider["id"] == current_provider else ""
+                    lines.append(f"• `{provider['id']}` — {provider['label']}{marker}")
+                    curated = curated_models_for_provider(provider["id"])
+                    if curated:
+                        for model_id, _desc in curated:
+                            current_marker = " ← current" if provider["id"] == current_provider and model_id == current_model else ""
+                            lines.append(f"    - `{model_id}`{current_marker}")
+                    elif provider["id"] == "custom":
+                        endpoint = current_base_url or "configured endpoint"
+                        lines.append(f"    - endpoint: {endpoint}")
+                        if provider["id"] == current_provider:
+                            lines.append(f"    - model: `{current_model}` ← current")
+                    else:
+                        lines.append("    - use `hermes model` in CLI to browse/change globally")
+            if unauthed:
+                labels = ", ".join(p["label"] for p in unauthed)
+                lines.extend(["", f"**Not configured:** {labels}", "Run: `hermes setup`"])
+
+            lines.extend([
+                "",
+                "Switch: `/model provider:model-name` or `/model model-name`",
+                "Examples: `/model zai:glm-5.1`, `/model claude-sonnet-4`",
+                "This changes only this chat/topic session.",
+            ])
             return "\n".join(lines)
-        
+
         # Check for z-ai/glm models special case
         if args.lower().startswith("z-ai") or args.lower().startswith("zai:"):
-            # List GLM models for Z.AI provider
             if args.lower() in ("z-ai", "zai"):
-                from hermes_cli.models import _PROVIDER_MODELS
                 glm_models = _PROVIDER_MODELS.get("zai", [])
                 lines = ["**GLM Models (Z.AI)**", ""]
-                for m in glm_models:
-                    if "glm" in m.lower():
-                        lines.append(f"  • {m}")
+                for model_name in glm_models:
+                    if "glm" in model_name.lower():
+                        lines.append(f"  • {model_name}")
                 lines.append("")
                 lines.append("Usage: `/model zai:glm-5.1` or `/model z-ai/glm-5.1`")
                 return "\n".join(lines)
-        
-        # Get current session state for switch_model
-        session_entry = self.session_store.get_session(session_key)
-        current_provider = session_entry.provider if session_entry else None
-        current_base_url = session_entry.base_url if session_entry else ""
-        current_api_key = ""
-        
-        # Resolve current credentials
-        try:
-            runtime = resolve_runtime_provider(requested=current_provider or "auto")
-            if not current_base_url:
-                current_base_url = runtime.get("base_url", "")
-            current_api_key = runtime.get("api_key", "")
-        except Exception:
-            pass
-        
-        # Call switch_model
+
         result = switch_model(
             args,
             current_provider=current_provider or "auto",
             current_base_url=current_base_url,
             current_api_key=current_api_key,
         )
-        
+
         if not result.success:
             return f"Failed: {result.error_message}"
-        
-        # Update session with new model info
+
         self.session_store.update_session(
             session_key,
+            input_tokens=session_entry.input_tokens,
+            output_tokens=session_entry.output_tokens,
+            cache_read_tokens=session_entry.cache_read_tokens,
+            cache_write_tokens=session_entry.cache_write_tokens,
+            estimated_cost_usd=session_entry.estimated_cost_usd,
+            cost_status=session_entry.cost_status,
             model=result.new_model,
             provider=result.target_provider,
             base_url=result.base_url,
         )
-        
-        # Evict cached agent so next message uses new model
         self._evict_cached_agent(session_key)
-        
-        # Build response
-        provider_label = result.provider_label
+
         lines = [f"Switched to `{result.new_model}`"]
-        lines.append(f"  Provider: {provider_label}")
+        lines.append(f"  Provider: {result.provider_label}")
         if result.base_url and "openrouter" not in result.base_url:
             lines.append(f"  Base URL: {result.base_url}")
         if result.warning_message:
             lines.append(f"  Note: {result.warning_message}")
         lines.append("")
         lines.append("This change applies to this session only.")
-        lines.append("Use /status to see current model.")
+        lines.append("Use /status or /new to confirm the active model for this chat/topic.")
         return "\n".join(lines)
-    
+
     async def _handle_personality_command(self, event: MessageEvent) -> str:
         """Handle /personality command - list or set a personality."""
         import yaml

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1995,7 +1995,7 @@ class GatewayRunner:
                             f"Adjust reset timing in config.yaml under session_reset."
                         )
                         try:
-                            session_info = self._format_session_info()
+                            session_info = self._format_session_info(session_entry)
                             if session_info:
                                 notice = f"{notice}\n\n{session_info}"
                         except Exception:
@@ -2776,7 +2776,7 @@ class GatewayRunner:
             # Clear session env
             self._clear_session_env()
     
-    def _format_session_info(self) -> str:
+    def _format_session_info(self, session_entry: Optional[Any] = None) -> str:
         """Resolve current model config and return a formatted info block.
 
         Surfaces model, provider, context length, and endpoint so gateway
@@ -2785,10 +2785,14 @@ class GatewayRunner:
         """
         from agent.model_metadata import get_model_context_length, DEFAULT_FALLBACK_CONTEXT
 
-        model = _resolve_gateway_model()
+        session_model = getattr(session_entry, "model", None) if session_entry else None
+        session_provider = getattr(session_entry, "provider", None) if session_entry else None
+        session_base_url = getattr(session_entry, "base_url", None) if session_entry else None
+
+        model = session_model or _resolve_gateway_model()
         config_context_length = None
-        provider = None
-        base_url = None
+        provider = session_provider
+        base_url = session_base_url
         api_key = None
 
         try:
@@ -2805,8 +2809,8 @@ class GatewayRunner:
                             config_context_length = int(raw_ctx)
                         except (TypeError, ValueError):
                             pass
-                    provider = model_cfg.get("provider") or None
-                    base_url = model_cfg.get("base_url") or None
+                    provider = provider or model_cfg.get("provider") or None
+                    base_url = base_url or model_cfg.get("base_url") or None
         except Exception:
             pass
 
@@ -2897,7 +2901,7 @@ class GatewayRunner:
         
         # Resolve session config info to surface to the user
         try:
-            session_info = self._format_session_info()
+            session_info = self._format_session_info(session_entry)
         except Exception:
             session_info = ""
 
@@ -2934,7 +2938,14 @@ class GatewayRunner:
             "",
             f"**Connected Platforms:** {', '.join(connected_platforms)}",
         ]
-        
+
+        try:
+            session_info = self._format_session_info(session_entry)
+        except Exception:
+            session_info = ""
+        if session_info:
+            lines.extend(["", session_info])
+
         return "\n".join(lines)
     
     async def _handle_stop_command(self, event: MessageEvent) -> str:
@@ -3037,6 +3048,114 @@ class GatewayRunner:
         lines.append("")
         lines.append("Switch: `/model provider:model-name`")
         lines.append("Setup: `hermes setup`")
+        return "\n".join(lines)
+    
+    async def _handle_model_command(self, event: MessageEvent) -> str:
+        """Handle /model command - switch model for this session."""
+        from hermes_cli.model_switch import switch_model
+        from hermes_cli.models import _PROVIDER_LABELS
+        from gateway.session import SessionStore
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+        import os
+        
+        args = event.get_command_args().strip()
+        source = self._get_event_source(event)
+        session_key = self._session_key_from_source(source)
+        
+        # No args - show current model
+        if not args:
+            session_entry = self.session_store.get_session(session_key)
+            if not session_entry:
+                return "No active session"
+            
+            # Get current session model info
+            current_model = session_entry.model or self._resolve_gateway_model()
+            current_provider = session_entry.provider
+            current_base_url = session_entry.base_url
+            
+            # Resolve current provider info
+            try:
+                runtime = resolve_runtime_provider(requested=current_provider or "auto")
+                if not current_base_url:
+                    current_base_url = runtime.get("base_url", "")
+            except Exception:
+                pass
+            
+            provider_label = _PROVIDER_LABELS.get(current_provider, current_provider or "auto")
+            
+            lines = [
+                f"**Current model:** `{current_model}`",
+                f"  Provider: {provider_label}",
+            ]
+            if current_base_url and "openrouter" not in current_base_url:
+                lines.append(f"  Base URL: {current_base_url}")
+            lines.append("")
+            lines.append("Switch: `/model provider:model-name` or `/model model-name`")
+            lines.append("Examples: `/model zai:glm-5.1`, `/model claude-sonnet-4`")
+            return "\n".join(lines)
+        
+        # Check for z-ai/glm models special case
+        if args.lower().startswith("z-ai") or args.lower().startswith("zai:"):
+            # List GLM models for Z.AI provider
+            if args.lower() in ("z-ai", "zai"):
+                from hermes_cli.models import _PROVIDER_MODELS
+                glm_models = _PROVIDER_MODELS.get("zai", [])
+                lines = ["**GLM Models (Z.AI)**", ""]
+                for m in glm_models:
+                    if "glm" in m.lower():
+                        lines.append(f"  • {m}")
+                lines.append("")
+                lines.append("Usage: `/model zai:glm-5.1` or `/model z-ai/glm-5.1`")
+                return "\n".join(lines)
+        
+        # Get current session state for switch_model
+        session_entry = self.session_store.get_session(session_key)
+        current_provider = session_entry.provider if session_entry else None
+        current_base_url = session_entry.base_url if session_entry else ""
+        current_api_key = ""
+        
+        # Resolve current credentials
+        try:
+            runtime = resolve_runtime_provider(requested=current_provider or "auto")
+            if not current_base_url:
+                current_base_url = runtime.get("base_url", "")
+            current_api_key = runtime.get("api_key", "")
+        except Exception:
+            pass
+        
+        # Call switch_model
+        result = switch_model(
+            args,
+            current_provider=current_provider or "auto",
+            current_base_url=current_base_url,
+            current_api_key=current_api_key,
+        )
+        
+        if not result.success:
+            return f"Failed: {result.error_message}"
+        
+        # Update session with new model info
+        self.session_store.update_session(
+            session_key,
+            model=result.new_model,
+            provider=result.target_provider,
+            base_url=result.base_url,
+        )
+        
+        # Evict cached agent so next message uses new model
+        self._evict_cached_agent(session_key)
+        
+        # Build response
+        provider_label = result.provider_label
+        lines = [f"Switched to `{result.new_model}`"]
+        lines.append(f"  Provider: {provider_label}")
+        if result.base_url and "openrouter" not in result.base_url:
+            lines.append(f"  Base URL: {result.base_url}")
+        if result.warning_message:
+            lines.append(f"  Note: {result.warning_message}")
+        lines.append("")
+        lines.append("This change applies to this session only.")
+        lines.append("Use /status to see current model.")
         return "\n".join(lines)
     
     async def _handle_personality_command(self, event: MessageEvent) -> str:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -698,6 +698,12 @@ class SessionStore:
             self._ensure_loaded_locked()
             return len(self._entries) > 1
 
+    def get_session(self, session_key: str) -> Optional[SessionEntry]:
+        """Get the active session entry for a session key."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            return self._entries.get(session_key)
+
     def get_or_create_session(
         self,
         source: SessionSource,
@@ -774,6 +780,9 @@ class SessionStore:
                 "session_id": session_id,
                 "source": source.platform.value,
                 "user_id": source.user_id,
+                "model": entry.model,
+                "billing_provider": entry.provider,
+                "billing_base_url": entry.base_url,
             }
 
         # SQLite operations outside the lock
@@ -844,6 +853,13 @@ class SessionStore:
 
         if self._db and db_session_id:
             try:
+                if model is not None or provider is not None or base_url is not None:
+                    self._db.update_session_model_state(
+                        db_session_id,
+                        model=model,
+                        provider=provider,
+                        base_url=base_url,
+                    )
                 self._db.set_token_counts(
                     db_session_id,
                     input_tokens=input_tokens,
@@ -899,6 +915,9 @@ class SessionStore:
                 "session_id": session_id,
                 "source": old_entry.platform.value if old_entry.platform else "unknown",
                 "user_id": old_entry.origin.user_id if old_entry.origin else None,
+                "model": new_entry.model,
+                "billing_provider": new_entry.provider,
+                "billing_base_url": new_entry.base_url,
             }
 
         if self._db and db_end_session_id:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -345,6 +345,12 @@ class SessionEntry:
     display_name: Optional[str] = None
     platform: Optional[Platform] = None
     chat_type: str = "dm"
+
+    # Session-scoped model selection. These persist across /new so a topic
+    # or session keeps the model/provider/base_url it last used.
+    model: Optional[str] = None
+    provider: Optional[str] = None
+    base_url: Optional[str] = None
     
     # Token tracking
     input_tokens: int = 0
@@ -373,6 +379,9 @@ class SessionEntry:
             "display_name": self.display_name,
             "platform": self.platform.value if self.platform else None,
             "chat_type": self.chat_type,
+            "model": self.model,
+            "provider": self.provider,
+            "base_url": self.base_url,
             "input_tokens": self.input_tokens,
             "output_tokens": self.output_tokens,
             "cache_read_tokens": self.cache_read_tokens,
@@ -408,6 +417,9 @@ class SessionEntry:
             display_name=data.get("display_name"),
             platform=platform,
             chat_type=data.get("chat_type", "dm"),
+            model=data.get("model"),
+            provider=data.get("provider"),
+            base_url=data.get("base_url"),
             input_tokens=data.get("input_tokens", 0),
             output_tokens=data.get("output_tokens", 0),
             cache_read_tokens=data.get("cache_read_tokens", 0),
@@ -490,6 +502,39 @@ class SessionStore:
             self._db = SessionDB()
         except Exception as e:
             print(f"[gateway] Warning: SQLite session store unavailable, falling back to JSONL: {e}")
+
+    def _resolve_session_model_state(self) -> tuple[Optional[str], Optional[str], Optional[str]]:
+        """Resolve the current default model/provider/base_url for a fresh session."""
+        model = None
+        provider = None
+        base_url = None
+
+        try:
+            from hermes_cli.config import load_config
+            from hermes_cli.runtime_provider import resolve_runtime_provider
+
+            cfg = load_config()
+            model_cfg = cfg.get("model", {})
+            if isinstance(model_cfg, str):
+                model = model_cfg.strip() or None
+            elif isinstance(model_cfg, dict):
+                raw_model = model_cfg.get("default") or model_cfg.get("model")
+                if raw_model:
+                    model = str(raw_model).strip() or None
+                raw_provider = model_cfg.get("provider")
+                if raw_provider:
+                    provider = str(raw_provider).strip() or None
+                raw_base_url = model_cfg.get("base_url")
+                if raw_base_url:
+                    base_url = str(raw_base_url).strip() or None
+
+            runtime = resolve_runtime_provider(requested=provider)
+            provider = runtime.get("provider") or provider
+            base_url = runtime.get("base_url") or base_url
+        except Exception:
+            logger.debug("Session default model resolution failed; using unset values", exc_info=True)
+
+        return model, provider, base_url
     
     def _ensure_loaded(self) -> None:
         """Load sessions index from disk if not already loaded."""
@@ -700,6 +745,11 @@ class SessionStore:
 
             # Create new session
             session_id = f"{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
+            model, provider, base_url = self._resolve_session_model_state()
+            if was_auto_reset:
+                model = entry.model or model
+                provider = entry.provider or provider
+                base_url = entry.base_url or base_url
 
             entry = SessionEntry(
                 session_key=session_key,
@@ -710,6 +760,9 @@ class SessionStore:
                 display_name=source.chat_name,
                 platform=source.platform,
                 chat_type=source.chat_type,
+                model=model,
+                provider=provider,
+                base_url=base_url,
                 was_auto_reset=was_auto_reset,
                 auto_reset_reason=auto_reset_reason,
                 reset_had_activity=reset_had_activity,
@@ -762,6 +815,12 @@ class SessionStore:
             if session_key in self._entries:
                 entry = self._entries[session_key]
                 entry.updated_at = _now()
+                if model is not None:
+                    entry.model = model
+                if provider is not None:
+                    entry.provider = provider
+                if base_url is not None:
+                    entry.base_url = base_url
                 # Direct assignment — the gateway receives cumulative totals
                 # from the cached agent, not per-call deltas.
                 entry.input_tokens = input_tokens
@@ -829,6 +888,9 @@ class SessionStore:
                 display_name=old_entry.display_name,
                 platform=old_entry.platform,
                 chat_type=old_entry.chat_type,
+                model=old_entry.model,
+                provider=old_entry.provider,
+                base_url=old_entry.base_url,
             )
 
             self._entries[session_key] = new_entry
@@ -878,6 +940,19 @@ class SessionStore:
 
             db_end_session_id = old_entry.session_id
 
+            restored_model = old_entry.model
+            restored_provider = old_entry.provider
+            restored_base_url = old_entry.base_url
+            if self._db:
+                try:
+                    target_row = self._db.get_session(target_session_id)
+                    if target_row:
+                        restored_model = target_row.get("model") or restored_model
+                        restored_provider = target_row.get("billing_provider") or restored_provider
+                        restored_base_url = target_row.get("billing_base_url") or restored_base_url
+                except Exception as e:
+                    logger.debug("Session DB metadata lookup failed during session switch: %s", e)
+
             now = _now()
             new_entry = SessionEntry(
                 session_key=session_key,
@@ -888,6 +963,9 @@ class SessionStore:
                 display_name=old_entry.display_name,
                 platform=old_entry.platform,
                 chat_type=old_entry.chat_type,
+                model=restored_model,
+                provider=restored_provider,
+                base_url=restored_base_url,
             )
 
             self._entries[session_key] = new_entry

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -129,7 +129,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         id="zai",
         name="Z.AI / GLM",
         auth_type="api_key",
-        inference_base_url="https://api.z.ai/api/paas/v4",
+        inference_base_url="https://api.z.ai/api/coding/paas/v4",
         api_key_env_vars=("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"),
         base_url_env_var="GLM_BASE_URL",
     ),

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -79,6 +79,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     # Configuration
     CommandDef("config", "Show current configuration", "Configuration",
                cli_only=True),
+    CommandDef("model", "Switch model for this session (format: provider:model or just model)",
+               "Configuration", args_hint="[provider:model|model]"),
     CommandDef("provider", "Show available providers and current provider",
                "Configuration"),
     CommandDef("prompt", "View/set custom system prompt", "Configuration",

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -563,7 +563,7 @@ def run_doctor(args):
     # Tuple: (name, env_vars, default_url, base_env, supports_models_endpoint)
     # If supports_models_endpoint is False, we skip the health check and just show "configured"
     _apikey_providers = [
-        ("Z.AI / GLM",      ("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"), "https://api.z.ai/api/paas/v4/models", "GLM_BASE_URL", True),
+        ("Z.AI / GLM",      ("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"), "https://api.z.ai/api/coding/paas/v4/models", "GLM_BASE_URL", True),
         ("Kimi / Moonshot",  ("KIMI_API_KEY",),                              "https://api.moonshot.ai/v1/models",   "KIMI_BASE_URL", True),
         # MiniMax APIs don't support /models endpoint — https://github.com/NousResearch/hermes-agent/issues/811
         ("MiniMax",          ("MINIMAX_API_KEY",),                            None,                                  "MINIMAX_BASE_URL", False),

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -70,6 +70,7 @@ def switch_model(
     """
     from hermes_cli.models import (
         parse_model_input,
+        input_uses_explicit_provider,
         detect_provider_for_model,
         validate_requested_model,
         _PROVIDER_LABELS,
@@ -77,6 +78,7 @@ def switch_model(
     from hermes_cli.runtime_provider import resolve_runtime_provider
 
     # Step 1: Parse provider:model syntax
+    explicit_provider = input_uses_explicit_provider(raw_input)
     target_provider, new_model = parse_model_input(raw_input, current_provider)
 
     # Step 2: Detect if we're currently on a custom endpoint
@@ -88,7 +90,7 @@ def switch_model(
     # Step 3: Auto-detect provider when no explicit provider:model syntax
     # was used.  Skip for custom providers — the model name might
     # coincidentally match a known provider's catalog.
-    if target_provider == current_provider and not is_custom:
+    if (not explicit_provider) and target_provider == current_provider and not is_custom:
         detected = detect_provider_for_model(new_model, current_provider)
         if detected:
             target_provider, new_model = detected

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -19,6 +19,8 @@ COPILOT_MODELS_URL = f"{COPILOT_BASE_URL}/models"
 COPILOT_EDITOR_VERSION = "vscode/1.104.1"
 COPILOT_REASONING_EFFORTS_GPT5 = ["minimal", "low", "medium", "high"]
 COPILOT_REASONING_EFFORTS_O_SERIES = ["low", "medium", "high"]
+CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
+CODEX_MODELS_URL = f"{CODEX_BASE_URL}/models?client_version=1.0.0"
 
 # Backward-compatible aliases for the earlier GitHub Models-backed Copilot work.
 GITHUB_MODELS_BASE_URL = COPILOT_BASE_URL
@@ -1012,6 +1014,43 @@ def probe_api_models(
             "suggested_base_url": None,
             "used_fallback": False,
         }
+
+    if normalized.startswith(CODEX_BASE_URL):
+        headers: dict[str, str] = {}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        req = urllib.request.Request(CODEX_MODELS_URL, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                data = json.loads(resp.read().decode())
+                models = []
+                for item in data.get("models", []) if isinstance(data, dict) else []:
+                    if not isinstance(item, dict):
+                        continue
+                    slug = item.get("slug")
+                    if not isinstance(slug, str) or not slug.strip():
+                        continue
+                    if item.get("supported_in_api") is False:
+                        continue
+                    visibility = item.get("visibility", "")
+                    if isinstance(visibility, str) and visibility.strip().lower() in ("hide", "hidden"):
+                        continue
+                    models.append(slug.strip())
+                return {
+                    "models": models,
+                    "probed_url": CODEX_MODELS_URL,
+                    "resolved_base_url": CODEX_BASE_URL,
+                    "suggested_base_url": None,
+                    "used_fallback": False,
+                }
+        except Exception:
+            return {
+                "models": None,
+                "probed_url": CODEX_MODELS_URL,
+                "resolved_base_url": CODEX_BASE_URL,
+                "suggested_base_url": None,
+                "used_fallback": False,
+            }
 
     if normalized.endswith("/v1"):
         alternate_base = normalized[:-3].rstrip("/")

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -40,6 +40,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("stepfun/step-3.5-flash",          ""),
     ("minimax/minimax-m2.7",            ""),
     ("minimax/minimax-m2.5",            ""),
+    ("z-ai/glm-5.1",                    ""),
     ("z-ai/glm-5",                      ""),
     ("z-ai/glm-5-turbo",                ""),
     ("moonshotai/kimi-k2.5",            ""),
@@ -67,6 +68,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "stepfun/step-3.5-flash",
         "minimax/minimax-m2.7",
         "minimax/minimax-m2.5",
+        "z-ai/glm-5.1",
         "z-ai/glm-5",
         "z-ai/glm-5-turbo",
         "moonshotai/kimi-k2.5",
@@ -103,6 +105,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "grok-code-fast-1",
     ],
     "zai": [
+        "glm-5.1",
         "glm-5",
         "glm-5-turbo",
         "glm-4.7",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -320,6 +320,71 @@ _KNOWN_PROVIDER_NAMES: set[str] = (
     | {"openrouter", "custom"}
 )
 
+# Narrow slash-compat syntax for direct providers where users commonly type
+# provider/model by habit. This intentionally excludes common OpenRouter
+# namespaces like anthropic/openai/google so those slugs keep their existing
+# meaning.
+_SLASH_PROVIDER_NAMES: set[str] = {
+    "openai-codex",
+    "nous",
+    "copilot",
+    "copilot-acp",
+    "zai",
+    "glm",
+    "z-ai",
+    "z.ai",
+    "zhipu",
+    "kimi-coding",
+    "kimi",
+    "moonshot",
+    "minimax",
+    "minimax-cn",
+    "minimax-china",
+    "minimax_cn",
+    "kilocode",
+    "kilo",
+    "kilo-code",
+    "kilo-gateway",
+    "opencode-zen",
+    "opencode",
+    "zen",
+    "opencode-go",
+    "opencode-go-sub",
+    "ai-gateway",
+    "aigateway",
+    "vercel",
+    "vercel-ai-gateway",
+    "huggingface",
+    "hf",
+    "hugging-face",
+    "huggingface-hub",
+    "alibaba",
+    "dashscope",
+    "aliyun",
+    "custom",
+}
+
+
+def input_uses_explicit_provider(raw: str) -> bool:
+    """Return True when the model input explicitly names a provider."""
+    stripped = raw.strip()
+
+    colon = stripped.find(":")
+    if colon > 0:
+        provider_part = stripped[:colon].strip().lower()
+        model_part = stripped[colon + 1:].strip()
+        if provider_part and model_part and provider_part in _KNOWN_PROVIDER_NAMES:
+            return True
+
+    slash = stripped.find("/")
+    if slash > 0:
+        provider_part = stripped[:slash].strip().lower()
+        model_part = stripped[slash + 1:].strip()
+        if provider_part and model_part and provider_part in _SLASH_PROVIDER_NAMES:
+            return True
+
+    return False
+
 
 def list_available_providers() -> list[dict[str, str]]:
     """Return info about all providers the user could use with ``provider:model``.
@@ -399,6 +464,14 @@ def parse_model_input(raw: str, current_provider: str) -> tuple[str, str]:
                 if custom_name and actual_model:
                     return (f"custom:{custom_name}", actual_model)
             return (normalize_provider(provider_part), model_part)
+
+    slash = stripped.find("/")
+    if slash > 0:
+        provider_part = stripped[:slash].strip().lower()
+        model_part = stripped[slash + 1:].strip()
+        if provider_part and model_part and provider_part in _SLASH_PROVIDER_NAMES:
+            return (normalize_provider(provider_part), model_part)
+
     return (current_provider, stripped)
 
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -74,7 +74,7 @@ _DEFAULT_PROVIDER_MODELS = {
         "gemini-2.5-pro",
         "grok-code-fast-1",
     ],
-    "zai": ["glm-5", "glm-4.7", "glm-4.5", "glm-4.5-flash"],
+    "zai": ["glm-5.1", "glm-5", "glm-4.7", "glm-4.5", "glm-4.5-flash"],
     "kimi-coding": ["kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],
     "minimax": ["MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"],
     "minimax-cn": ["MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"],

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -369,22 +369,34 @@ class SessionDB:
         system_prompt: str = None,
         user_id: str = None,
         parent_session_id: str = None,
+        billing_provider: Optional[str] = None,
+        billing_base_url: Optional[str] = None,
     ) -> str:
         """Create a new session record. Returns the session_id."""
+        stored_model_config = dict(model_config) if isinstance(model_config, dict) else None
+        if stored_model_config is not None:
+            if billing_provider and not stored_model_config.get("provider"):
+                stored_model_config["provider"] = billing_provider
+            if billing_base_url and not stored_model_config.get("base_url"):
+                stored_model_config["base_url"] = billing_base_url
+
         def _do(conn):
             conn.execute(
                 """INSERT OR IGNORE INTO sessions (id, source, user_id, model, model_config,
-                   system_prompt, parent_session_id, started_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                   system_prompt, parent_session_id, started_at, billing_provider,
+                   billing_base_url)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     source,
                     user_id,
                     model,
-                    json.dumps(model_config) if model_config else None,
+                    json.dumps(stored_model_config) if stored_model_config else None,
                     system_prompt,
                     parent_session_id,
                     time.time(),
+                    billing_provider,
+                    billing_base_url,
                 ),
             )
         self._execute_write(_do)
@@ -592,6 +604,56 @@ class SessionDB:
                     session_id,
                 ),
             )
+        self._execute_write(_do)
+
+    def update_session_model_state(
+        self,
+        session_id: str,
+        model: Optional[str] = None,
+        provider: Optional[str] = None,
+        base_url: Optional[str] = None,
+    ) -> None:
+        """Persist session-scoped model/provider/base_url metadata."""
+
+        def _do(conn):
+            row = conn.execute(
+                "SELECT model_config FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+
+            model_config: Dict[str, Any] = {}
+            if row and row["model_config"]:
+                try:
+                    loaded = json.loads(row["model_config"])
+                    if isinstance(loaded, dict):
+                        model_config = loaded
+                except (json.JSONDecodeError, TypeError):
+                    model_config = {}
+
+            if provider is not None:
+                model_config["provider"] = provider
+            if base_url is not None:
+                model_config["base_url"] = base_url
+
+            conn.execute(
+                """UPDATE sessions SET
+                   model = CASE WHEN ? IS NULL THEN model ELSE ? END,
+                   billing_provider = CASE WHEN ? IS NULL THEN billing_provider ELSE ? END,
+                   billing_base_url = CASE WHEN ? IS NULL THEN billing_base_url ELSE ? END,
+                   model_config = ?
+                   WHERE id = ?""",
+                (
+                    model,
+                    model,
+                    provider,
+                    provider,
+                    base_url,
+                    base_url,
+                    json.dumps(model_config) if model_config else None,
+                    session_id,
+                ),
+            )
+
         self._execute_write(_do)
 
     def get_session(self, session_id: str) -> Optional[Dict[str, Any]]:

--- a/run_agent.py
+++ b/run_agent.py
@@ -994,8 +994,12 @@ class AIAgent:
                         "max_iterations": self.max_iterations,
                         "reasoning_config": reasoning_config,
                         "max_tokens": max_tokens,
+                        "provider": self.provider,
+                        "base_url": self.base_url,
                     },
                     user_id=None,
+                    billing_provider=self.provider,
+                    billing_base_url=self.base_url,
                 )
             except Exception as e:
                 # Transient SQLite lock contention (e.g. CLI and gateway writing
@@ -5172,6 +5176,12 @@ class AIAgent:
                     source=self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
                     model=self.model,
                     parent_session_id=old_session_id,
+                    model_config={
+                        "provider": self.provider,
+                        "base_url": self.base_url,
+                    },
+                    billing_provider=self.provider,
+                    billing_base_url=self.base_url,
                 )
                 # Auto-number the title for the continuation session
                 if old_title:

--- a/tests/gateway/test_honcho_lifecycle.py
+++ b/tests/gateway/test_honcho_lifecycle.py
@@ -91,18 +91,33 @@ class TestGatewayHonchoLifecycle:
         event = _make_event()
         runner._shutdown_gateway_honcho = MagicMock()
         runner._async_flush_memories = AsyncMock()
+        runner._evict_cached_agent = MagicMock()
+        runner._background_tasks = set()
+        runner._format_session_info = MagicMock(return_value="◆ Model: `gpt-5.4-mini`\n◆ Provider: openai-codex")
         runner.session_store = MagicMock()
         runner.session_store._generate_session_key.return_value = "gateway-key"
         runner.session_store._entries = {
-            "gateway-key": SimpleNamespace(session_id="old-session"),
+            "gateway-key": SimpleNamespace(
+                session_id="old-session",
+                model="gpt-5.4-mini",
+                provider="openai-codex",
+                base_url="https://chatgpt.com/backend-api/codex",
+            ),
         }
-        runner.session_store.reset_session.return_value = SimpleNamespace(session_id="new-session")
+        runner.session_store.reset_session.return_value = SimpleNamespace(
+            session_id="new-session",
+            model="gpt-5.4-mini",
+            provider="openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+        )
 
         result = await runner._handle_reset_command(event)
 
         runner._shutdown_gateway_honcho.assert_called_once_with("gateway-key")
         runner._async_flush_memories.assert_called_once_with("old-session", "gateway-key")
         assert "Session reset" in result
+        assert "◆ Model: `gpt-5.4-mini`" in result
+        runner._format_session_info.assert_called_once_with(runner.session_store.reset_session.return_value)
 
     def test_flush_memories_reuses_gateway_session_key_and_skips_honcho_sync(self):
         runner = _make_runner()

--- a/tests/gateway/test_model_command.py
+++ b/tests/gateway/test_model_command.py
@@ -1,0 +1,182 @@
+"""Tests for gateway /model command behavior."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _make_runner(session_entry: SessionEntry):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="tok")}
+    )
+    runner.adapters = {Platform.TELEGRAM: MagicMock(send=AsyncMock())}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner._send_voice_reply = AsyncMock()
+    runner._capture_gateway_honcho_if_configured = lambda *args, **kwargs: None
+    runner._emit_gateway_run_progress = AsyncMock()
+    runner._evict_cached_agent = MagicMock()
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_handle_message_dispatches_model_command():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    runner._handle_model_command = AsyncMock(return_value="model-ok")
+
+    result = await runner._handle_message(_make_event("/model"))
+
+    assert result == "model-ok"
+    runner._handle_model_command.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_model_command_lists_current_and_configured_models():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        model="glm-5.1",
+        provider="zai",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+    )
+    runner = _make_runner(session_entry)
+
+    with patch(
+        "hermes_cli.models.list_available_providers",
+        return_value=[
+            {"id": "zai", "label": "Z.AI", "authenticated": True, "aliases": []},
+            {"id": "openai-codex", "label": "OpenAI Codex", "authenticated": True, "aliases": []},
+            {"id": "openrouter", "label": "OpenRouter", "authenticated": False, "aliases": []},
+        ],
+    ), patch(
+        "hermes_cli.models.curated_models_for_provider",
+        side_effect=lambda provider: [
+            ("glm-5.1", "latest"),
+            ("glm-5", "stable"),
+        ] if provider == "zai" else [("gpt-5.4", "default")],
+    ), patch(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        return_value={
+            "provider": "zai",
+            "base_url": "https://api.z.ai/api/coding/paas/v4",
+            "api_key": "z-key",
+        },
+    ):
+        result = await runner._handle_model_command(_make_event("/model"))
+
+    assert "Current model" in result
+    assert "glm-5.1" in result
+    assert "Configured providers & models" in result
+    assert "openai-codex" in result
+    assert "Not configured" in result
+    runner.session_store.get_or_create_session.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_model_command_preserves_existing_token_totals_when_switching():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        model="glm-5.1",
+        provider="zai",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        input_tokens=111,
+        output_tokens=222,
+        cache_read_tokens=333,
+        cache_write_tokens=444,
+        estimated_cost_usd=1.23,
+        cost_status="estimated",
+    )
+    runner = _make_runner(session_entry)
+
+    with patch(
+        "hermes_cli.model_switch.switch_model",
+        return_value=SimpleNamespace(
+            success=True,
+            new_model="gpt-5.4",
+            target_provider="openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            provider_label="OpenAI Codex",
+            warning_message="",
+        ),
+    ), patch(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        return_value={
+            "provider": "zai",
+            "base_url": "https://api.z.ai/api/coding/paas/v4",
+            "api_key": "z-key",
+        },
+    ):
+        await runner._handle_model_command(_make_event("/model openai-codex:gpt-5.4"))
+
+    runner.session_store.update_session.assert_called_once_with(
+        session_entry.session_key,
+        input_tokens=111,
+        output_tokens=222,
+        cache_read_tokens=333,
+        cache_write_tokens=444,
+        estimated_cost_usd=1.23,
+        cost_status="estimated",
+        model="gpt-5.4",
+        provider="openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+    )

--- a/tests/gateway/test_model_command.py
+++ b/tests/gateway/test_model_command.py
@@ -128,6 +128,46 @@ async def test_model_command_lists_current_and_configured_models():
 
 
 @pytest.mark.asyncio
+async def test_model_command_falls_back_to_gateway_default_model_when_session_has_none():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        model=None,
+        provider="zai",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+    )
+    runner = _make_runner(session_entry)
+
+    with patch(
+        "gateway.run._resolve_gateway_model",
+        return_value="glm-5.1",
+    ), patch(
+        "hermes_cli.models.list_available_providers",
+        return_value=[
+            {"id": "zai", "label": "Z.AI", "authenticated": True, "aliases": []},
+        ],
+    ), patch(
+        "hermes_cli.models.curated_models_for_provider",
+        return_value=[("glm-5.1", "latest")],
+    ), patch(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        return_value={
+            "provider": "zai",
+            "base_url": "https://api.z.ai/api/coding/paas/v4",
+            "api_key": "***",
+        },
+    ):
+        result = await runner._handle_model_command(_make_event("/model"))
+
+    assert "Current model" in result
+    assert "glm-5.1" in result
+
+
+@pytest.mark.asyncio
 async def test_model_command_preserves_existing_token_totals_when_switching():
     session_entry = SessionEntry(
         session_key=build_session_key(_make_source()),

--- a/tests/gateway/test_session_info.py
+++ b/tests/gateway/test_session_info.py
@@ -1,6 +1,7 @@
 """Tests for GatewayRunner._format_session_info — session config surfacing."""
 
 import pytest
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 from pathlib import Path
 
@@ -42,6 +43,24 @@ class TestFormatSessionInfo:
         with p1, p2, p3:
             info = runner._format_session_info()
         assert "openrouter" in info
+
+    def test_session_entry_overrides_global_config(self, runner, tmp_path):
+        p1, p2, p3 = _patch_info(
+            tmp_path,
+            "model:\n  default: global-model\n  provider: openrouter\n",
+            "global-model",
+            {"provider": "openrouter", "base_url": "https://openrouter.ai/api/v1", "api_key": "***"},
+        )
+        session_entry = SimpleNamespace(
+            model="glm-5",
+            provider="zai",
+            base_url="https://api.z.ai/api/coding/paas/v4",
+        )
+        with p1, p2, p3:
+            info = runner._format_session_info(session_entry)
+        assert "glm-5" in info
+        assert "zai" in info
+        assert "Endpoint" not in info
 
     def test_config_context_length(self, runner, tmp_path):
         p1, p2, p3 = _patch_info(tmp_path, "model:\n  default: test-model\n  context_length: 32768\n",

--- a/tests/gateway/test_session_reset_notify.py
+++ b/tests/gateway/test_session_reset_notify.py
@@ -170,6 +170,41 @@ class TestSessionEntryReason:
 # SessionResetPolicy notify config
 # ---------------------------------------------------------------------------
 
+class TestSessionModelPersistence:
+    def test_session_model_persists_across_reset_and_reload(self, tmp_path):
+        store = _make_store(
+            SessionResetPolicy(mode="idle", idle_minutes=1),
+            tmp_path,
+        )
+        source = _make_source()
+
+        entry1 = store.get_or_create_session(source)
+        entry1.model = "glm-5"
+        entry1.provider = "zai"
+        entry1.base_url = "https://api.z.ai/api/coding/paas/v4"
+        store._save()
+
+        # Force an auto-reset and verify the new session keeps the same model.
+        entry1.updated_at = datetime.now() - timedelta(minutes=5)
+        store._save()
+        entry2 = store.get_or_create_session(source)
+        assert entry2.session_id != entry1.session_id
+        assert entry2.model == "glm-5"
+        assert entry2.provider == "zai"
+        assert entry2.base_url == "https://api.z.ai/api/coding/paas/v4"
+
+        # Re-load from disk to verify persistence across restart.
+        reloaded = _make_store(
+            SessionResetPolicy(mode="idle", idle_minutes=1),
+            tmp_path,
+        )
+        entry3 = reloaded.get_or_create_session(source)
+        assert entry3.session_id == entry2.session_id
+        assert entry3.model == "glm-5"
+        assert entry3.provider == "zai"
+        assert entry3.base_url == "https://api.z.ai/api/coding/paas/v4"
+
+
 class TestResetPolicyNotify:
     def test_notify_defaults_true(self):
         policy = SessionResetPolicy()

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -74,7 +74,10 @@ async def test_status_command_reports_running_agent_without_interrupt(monkeypatc
         updated_at=datetime.now(),
         platform=Platform.TELEGRAM,
         chat_type="dm",
-        total_tokens=321,
+        model="glm-5",
+        provider="zai",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        total_tokens=321
     )
     runner = _make_runner(session_entry)
     running_agent = MagicMock()
@@ -83,6 +86,9 @@ async def test_status_command_reports_running_agent_without_interrupt(monkeypatc
     result = await runner._handle_message(_make_event("/status"))
 
     assert "**Tokens:** 321" in result
+    assert "glm-5" in result
+    assert "zai" in result
+    assert "Endpoint" not in result
     assert "**Agent Running:** Yes ⚡" in result
     running_agent.interrupt.assert_not_called()
     assert runner._pending_messages == {}

--- a/tests/hermes_cli/test_model_switch.py
+++ b/tests/hermes_cli/test_model_switch.py
@@ -1,0 +1,53 @@
+"""Regression tests for explicit provider switching behavior."""
+
+from unittest.mock import patch
+
+from hermes_cli.model_switch import switch_model
+
+
+def test_switch_model_slash_provider_syntax_switches_to_zai_without_autodetect():
+    with patch(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        return_value={
+            "provider": "zai",
+            "base_url": "https://api.z.ai/api/coding/paas/v4",
+            "api_key": "glm-key",
+        },
+    ), patch(
+        "hermes_cli.models.validate_requested_model",
+        return_value={"accepted": True, "persist": True, "recognized": True, "message": None},
+    ):
+        result = switch_model(
+            "zai/glm-5.1",
+            current_provider="openai-codex",
+            current_base_url="https://chatgpt.com/backend-api/codex",
+        )
+
+    assert result.success is True
+    assert result.target_provider == "zai"
+    assert result.new_model == "glm-5.1"
+    assert result.warning_message == ""
+
+
+def test_switch_model_explicit_provider_keeps_current_provider_without_autodetect():
+    with patch(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        return_value={
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": "codex-token",
+        },
+    ), patch(
+        "hermes_cli.models.validate_requested_model",
+        return_value={"accepted": True, "persist": True, "recognized": True, "message": None},
+    ):
+        result = switch_model(
+            "openai-codex:gpt-5.4-mini",
+            current_provider="openai-codex",
+            current_base_url="https://chatgpt.com/backend-api/codex",
+        )
+
+    assert result.success is True
+    assert result.target_provider == "openai-codex"
+    assert result.new_model == "gpt-5.4-mini"
+    assert result.warning_message == ""

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -61,6 +61,16 @@ class TestParseModelInput:
         assert provider == "zai"
         assert model == "glm-5"
 
+    def test_provider_slash_syntax_for_zai(self):
+        provider, model = parse_model_input("zai/glm-5.1", "openai-codex")
+        assert provider == "zai"
+        assert model == "glm-5.1"
+
+    def test_provider_slash_syntax_for_openai_codex(self):
+        provider, model = parse_model_input("openai-codex/gpt-5.4-mini", "zai")
+        assert provider == "openai-codex"
+        assert model == "gpt-5.4-mini"
+
     def test_no_slash_no_colon_keeps_provider(self):
         provider, model = parse_model_input("gpt-5.4", "openrouter")
         assert provider == "openrouter"

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -252,6 +252,28 @@ class TestFetchApiModels:
         assert probe["resolved_base_url"] == "https://api.githubcopilot.com"
         assert probe["used_fallback"] is False
 
+    def test_probe_api_models_uses_codex_catalog_endpoint(self):
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return b'{"models": [{"slug": "gpt-5.4-mini", "supported_in_api": true}]}'
+
+        with patch("hermes_cli.models.urllib.request.urlopen", return_value=_Resp()) as mock_urlopen:
+            probe = probe_api_models("codex-token", "https://chatgpt.com/backend-api/codex")
+
+        assert (
+            mock_urlopen.call_args[0][0].full_url
+            == "https://chatgpt.com/backend-api/codex/models?client_version=1.0.0"
+        )
+        assert probe["models"] == ["gpt-5.4-mini"]
+        assert probe["resolved_base_url"] == "https://chatgpt.com/backend-api/codex"
+        assert probe["used_fallback"] is False
+
     def test_fetch_github_model_catalog_filters_non_chat_models(self):
         class _Resp:
             def __enter__(self):

--- a/tests/test_api_key_providers.py
+++ b/tests/test_api_key_providers.py
@@ -96,7 +96,7 @@ class TestProviderRegistry:
     def test_base_urls(self):
         assert PROVIDER_REGISTRY["copilot"].inference_base_url == "https://api.githubcopilot.com"
         assert PROVIDER_REGISTRY["copilot-acp"].inference_base_url == "acp://copilot"
-        assert PROVIDER_REGISTRY["zai"].inference_base_url == "https://api.z.ai/api/paas/v4"
+        assert PROVIDER_REGISTRY["zai"].inference_base_url == "https://api.z.ai/api/coding/paas/v4"
         assert PROVIDER_REGISTRY["kimi-coding"].inference_base_url == "https://api.moonshot.ai/v1"
         assert PROVIDER_REGISTRY["minimax"].inference_base_url == "https://api.minimax.io/anthropic"
         assert PROVIDER_REGISTRY["minimax-cn"].inference_base_url == "https://api.minimaxi.com/anthropic"
@@ -352,7 +352,7 @@ class TestResolveApiKeyProviderCredentials:
         creds = resolve_api_key_provider_credentials("zai")
         assert creds["provider"] == "zai"
         assert creds["api_key"] == "glm-secret-key"
-        assert creds["base_url"] == "https://api.z.ai/api/paas/v4"
+        assert creds["base_url"] == "https://api.z.ai/api/coding/paas/v4"
         assert creds["source"] == "GLM_API_KEY"
 
     def test_resolve_copilot_with_github_token(self, monkeypatch):
@@ -701,9 +701,9 @@ class TestKimiCodeCredentialAutoDetect:
 
     def test_non_kimi_providers_unaffected(self, monkeypatch):
         """Ensure the auto-detect logic doesn't leak to other providers."""
-        monkeypatch.setenv("GLM_API_KEY", "sk-kimi-looks-like-kimi-but-isnt")
+        monkeypatch.setenv("GLM_API_KEY", "sk-kim...isnt")
         creds = resolve_api_key_provider_credentials("zai")
-        assert creds["base_url"] == "https://api.z.ai/api/paas/v4"
+        assert creds["base_url"] == "https://api.z.ai/api/coding/paas/v4"
 
 
 # =============================================================================

--- a/tests/test_cli_new_session.py
+++ b/tests/test_cli_new_session.py
@@ -7,6 +7,7 @@ import os
 import sys
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
+import json
 
 from hermes_state import SessionDB
 from tools.todo_tool import TodoStore
@@ -220,3 +221,105 @@ def test_new_session_resets_token_counters(tmp_path):
     assert comp.last_total_tokens == 0
     assert comp.compression_count == 0
     assert comp._context_probed is False
+
+
+def test_model_switch_stays_session_scoped_across_new_session(tmp_path):
+    from hermes_cli.model_switch import ModelSwitchResult
+
+    cli = _prepare_cli_with_active_session(tmp_path)
+
+    with patch(
+        "hermes_cli.model_switch.switch_model",
+        return_value=ModelSwitchResult(
+            success=True,
+            new_model="glm-5.1",
+            target_provider="zai",
+            provider_changed=True,
+            api_key="z-key",
+            base_url="https://api.z.ai/api/coding/paas/v4",
+            persist=True,
+            provider_label="Z.AI",
+        ),
+    ), patch("cli.save_config_value") as mock_save:
+        cli.process_command("/model zai:glm-5.1")
+
+    assert cli.model == "glm-5.1"
+    assert cli.provider == "zai"
+    assert cli.requested_provider == "zai"
+    assert cli.base_url == "https://api.z.ai/api/coding/paas/v4"
+    mock_save.assert_not_called()
+
+    current_row = cli._session_db.get_session(cli.session_id)
+    current_config = json.loads(current_row["model_config"])
+    assert current_row["model"] == "glm-5.1"
+    assert current_config["provider"] == "zai"
+    assert current_config["base_url"] == "https://api.z.ai/api/coding/paas/v4"
+
+    cli.process_command("/new")
+
+    assert cli.model == "glm-5.1"
+    assert cli.provider == "zai"
+    assert cli.requested_provider == "zai"
+    assert cli.base_url == "https://api.z.ai/api/coding/paas/v4"
+
+    new_row = cli._session_db.get_session(cli.session_id)
+    if new_row is not None:
+        new_config = json.loads(new_row["model_config"])
+        assert new_row["model"] == "glm-5.1"
+        assert new_config["provider"] == "zai"
+        assert new_config["base_url"] == "https://api.z.ai/api/coding/paas/v4"
+
+
+def test_preload_resumed_session_restores_model_provider_and_base_url(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(
+        session_id="resume_me",
+        source="cli",
+        model="glm-5.1",
+        model_config={
+            "provider": "zai",
+            "base_url": "https://api.z.ai/api/coding/paas/v4",
+        },
+    )
+    db.append_message("resume_me", role="user", content="hello")
+    db.append_message("resume_me", role="assistant", content="hi")
+
+    cli = _make_cli(resume="resume_me")
+    cli._session_db = db
+
+    assert cli._preload_resumed_session() is True
+    assert cli.model == "glm-5.1"
+    assert cli.provider == "zai"
+    assert cli.requested_provider == "zai"
+    assert cli.base_url == "https://api.z.ai/api/coding/paas/v4"
+    assert len(cli.conversation_history) == 2
+
+
+def test_model_switch_clears_stale_session_base_url_override(tmp_path):
+    from hermes_cli.model_switch import ModelSwitchResult
+
+    cli = _prepare_cli_with_active_session(tmp_path)
+    cli._session_base_url_override = "http://old.local/v1"
+    cli.base_url = "http://old.local/v1"
+    cli.requested_provider = "custom"
+    cli.provider = "custom"
+
+    with patch(
+        "hermes_cli.model_switch.switch_model",
+        return_value=ModelSwitchResult(
+            success=True,
+            new_model="gpt-5.4",
+            target_provider="openai-codex",
+            provider_changed=True,
+            api_key="new-key",
+            base_url="https://chatgpt.com/backend-api/codex",
+            provider_label="OpenAI Codex",
+        ),
+    ):
+        cli.process_command("/model openai-codex:gpt-5.4")
+
+    assert cli._session_base_url_override == "https://chatgpt.com/backend-api/codex"
+
+    row = cli._session_db.get_session(cli.session_id)
+    config = json.loads(row["model_config"])
+    assert config["base_url"] == "https://chatgpt.com/backend-api/codex"

--- a/tests/test_cli_prefix_matching.py
+++ b/tests/test_cli_prefix_matching.py
@@ -92,6 +92,17 @@ class TestSlashCommandPrefixMatching:
             cli_obj.process_command("/help")
         mock_help.assert_called_once()
 
+    def test_model_command_dispatches_exact_branch(self):
+        """/model should hit the CLI model branch instead of falling through as unknown."""
+        cli_obj = _make_cli()
+        with patch.object(cli_obj, "_show_model_and_providers") as mock_show, \
+             patch("cli._cprint") as mock_cprint:
+            cli_obj.process_command("/model")
+
+        mock_show.assert_called_once()
+        printed = " ".join(str(c) for c in mock_cprint.call_args_list)
+        assert "Unknown command" not in printed
+
     def test_skill_command_prefix_matches(self):
         """A prefix that uniquely matches a skill command should dispatch it."""
         cli_obj = _make_cli()

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -21,7 +21,7 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 
 | Command | Description |
 |---------|-------------|
-| `/new` (alias: `/reset`) | Start a new session (fresh session ID + history) |
+| `/new` (alias: `/reset`) | Start a new session (fresh session ID + history; keeps the current session model/provider/base URL) |
 | `/clear` | Clear screen and start a new session |
 | `/history` | Show conversation history |
 | `/save` | Save the current conversation |


### PR DESCRIPTION
## Summary
- restore the `/model` command in the CLI and gateway, and keep model/provider/base_url overrides scoped to the active session
- preserve the active session model across `/new`, show it in session info/status output, and keep gateway fallback behavior sane
- accept explicit `provider/model` inputs for direct providers like Codex and Z.AI, add GLM 5.1 support, and fix Z.AI's coding API base URL

## Test Plan
- `/Users/dazheng/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_model_command.py tests/gateway/test_session_info.py tests/gateway/test_session_reset_notify.py tests/gateway/test_status_command.py tests/test_cli_prefix_matching.py tests/test_cli_new_session.py tests/hermes_cli/test_model_validation.py tests/hermes_cli/test_model_switch.py tests/test_api_key_providers.py tests/gateway/test_honcho_lifecycle.py`

## Notes
- This branch was built in a clean worktree from `origin/main` and cherry-picks the relevant model-picker improvements from my own fork of hermes
- This doesn't change the `hermes model` global config change behavior