### PR TITLE
feat(signal): add read receipt support

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -692,6 +692,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             "http_url": signal_url,
             "account": signal_account,
             "ignore_stories": os.getenv("SIGNAL_IGNORE_STORIES", "true").lower() in ("true", "1", "yes"),
+            "send_read_receipts": os.getenv("SIGNAL_SEND_READ_RECEIPTS", "true").lower() in ("true", "1", "yes"),
         })
     signal_home = os.getenv("SIGNAL_HOME_CHANNEL")
     if signal_home and Platform.SIGNAL in config.platforms:

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -160,6 +160,7 @@ class SignalAdapter(BasePlatformAdapter):
         self.http_url = extra.get("http_url", "http://127.0.0.1:8080").rstrip("/")
         self.account = extra.get("account", "")
         self.ignore_stories = extra.get("ignore_stories", True)
+        self.send_read_receipts = extra.get("send_read_receipts", False)
 
         # Parse allowlists — group policy is derived from presence of group allowlist
         group_allowed_str = os.getenv("SIGNAL_GROUP_ALLOWED_USERS", "")
@@ -545,6 +546,22 @@ class SignalAdapter(BasePlatformAdapter):
                       _redact_phone(sender), chat_id[:20], (text or "")[:50])
 
         await self.handle_message(event)
+
+        # Send read receipt if enabled
+        if self.send_read_receipts and sender and ts_ms:
+            await self._send_read_receipt(sender, ts_ms)
+
+    async def _send_read_receipt(self, sender: str, timestamp: int) -> None:
+        """Send a read receipt for a message."""
+        try:
+            await self._rpc("sendReceipt", {
+                "account": self.account,
+                "recipient": sender,
+                "type": "read",
+                "targetTimestamp": timestamp,
+            }, rpc_id="receipt")
+        except Exception:
+            logger.debug("Signal: failed to send read receipt to %s", _redact_phone(sender))
 
     # ------------------------------------------------------------------
     # Attachment Handling


### PR DESCRIPTION
## Summary
- Send read receipts after handling inbound Signal messages
- Controlled by `SIGNAL_SEND_READ_RECEIPTS` env var (defaults to `true`) or `send_read_receipts` in signal platform config

## Motivation
Signal shows messages as unread/undelivered when the recipient doesn't send read receipts. This makes hermes-agent behave like a proper Signal client.

## Test plan
- [ ] Send a message to hermes via Signal — verify blue double-tick (read) appears on sender's device
- [ ] Set `SIGNAL_SEND_READ_RECEIPTS=false` — verify no read receipts are sent