### PR TITLE
feat(auth): add Ollama Cloud, Google/Gemini, xAI, and Ollama Local as built-in providers

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -125,6 +125,38 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "google": ProviderConfig(
+        id="google",
+        name="Google",
+        auth_type="api_key",
+        inference_base_url="https://generativelanguage.googleapis.com/v1beta/openai",
+        api_key_env_vars=("GOOGLE_API_KEY", "GEMINI_API_KEY"),
+        base_url_env_var="GOOGLE_BASE_URL",
+    ),
+    "xai": ProviderConfig(
+        id="xai",
+        name="xAI",
+        auth_type="api_key",
+        inference_base_url="https://api.x.ai/v1",
+        api_key_env_vars=("XAI_API_KEY",),
+        base_url_env_var="XAI_BASE_URL",
+    ),
+    "ollama-cloud": ProviderConfig(
+        id="ollama-cloud",
+        name="Ollama Cloud",
+        auth_type="api_key",
+        inference_base_url="https://ollama.com",
+        api_key_env_vars=("OLLAMA_CLOUD_API_KEY",),
+        base_url_env_var="OLLAMA_CLOUD_BASE_URL",
+    ),
+    "ollama-local": ProviderConfig(
+        id="ollama-local",
+        name="Ollama (Local)",
+        auth_type="api_key",
+        inference_base_url="http://localhost:11434/v1",
+        api_key_env_vars=("OLLAMA_API_KEY",),
+        base_url_env_var="OLLAMA_HOST",
+    ),
     "zai": ProviderConfig(
         id="zai",
         name="Z.AI / GLM",
@@ -696,6 +728,9 @@ def resolve_provider(
         "hf": "huggingface", "hugging-face": "huggingface", "huggingface-hub": "huggingface",
         "go": "opencode-go", "opencode-go-sub": "opencode-go",
         "kilo": "kilocode", "kilo-code": "kilocode", "kilo-gateway": "kilocode",
+        "gemini": "google", "google-ai": "google", "googleai": "google",
+        "grok": "xai",
+        "ollama_cloud": "ollama-cloud", "ollama-cloud-api": "ollama-cloud",
     }
     normalized = _PROVIDER_ALIASES.get(normalized, normalized)
 


### PR DESCRIPTION
## Summary

Adds 4 inference providers to `PROVIDER_REGISTRY` and corresponding aliases. These are popular providers that currently require manual patching after every update.

## Motivation

Hermes already supports 16 built-in providers (nous, openai-codex, anthropic, minimax, huggingface, etc.). Four widely-used providers are missing:

- **Ollama Cloud** (`ollama.com`) — Cloud-hosted open models (GLM-5, Qwen3.5, DeepSeek, MiniMax, etc.). Ollama launched cloud hosting in late 2025 and has a growing user base. Uses API keys, OpenAI-compatible endpoint.
- **Google/Gemini** (`generativelanguage.googleapis.com/v1beta/openai`) — Google's Gemini models via their OpenAI-compatible endpoint. Many users have free Gemini API credits.
- **xAI** (`api.x.ai/v1`) — Grok models. Standard OpenAI-compatible API with API key auth.
- **Ollama Local** (`localhost:11434/v1`) — Local Ollama instance. Many users run Ollama locally for development/testing.

Without these in the registry, users must either:
1. Patch `auth.py` after every `hermes update` (fragile, breaks on each update)
2. Use workarounds with custom base URLs (doesn't support env var API keys, must hardcode secrets)

## Changes

### `hermes_cli/auth.py`

Add to `PROVIDER_REGISTRY`:

- `google`
- `xai`
- `ollama-cloud`
- `ollama-local`

Add aliases:

- `gemini` → `google`
- `google-ai` → `google`
- `googleai` → `google`
- `grok` → `xai`
- `ollama_cloud` → `ollama-cloud`
- `ollama-cloud-api` → `ollama-cloud`

### No other files changed

The provider registry is self-contained. Model validation, provider selection, and API routing already read from `PROVIDER_REGISTRY` automatically.

## Test plan

- [x] `python3 -m py_compile hermes_cli/auth.py`
- [x] `git diff --check`
- [x] Only `hermes_cli/auth.py` changed
- [ ] `hermes config set model.provider ollama-cloud` → resolves to Ollama Cloud
- [ ] `hermes config set model.provider google` → resolves to Google
- [ ] `hermes config set model.provider xai` → resolves to xAI
- [ ] `hermes config set model.provider ollama-local` → resolves to local Ollama
- [ ] Aliases resolve: `gemini` → google, `grok` → xai, `ollama_cloud` → ollama-cloud
- [ ] API keys read from env vars: `OLLAMA_CLOUD_API_KEY`, `GEMINI_API_KEY`, `XAI_API_KEY`, `OLLAMA_API_KEY`
- [ ] Base URL overrides work via env vars
- [ ] Existing providers unaffected

## Context

These providers have been running via local patches in a multi-agent setup for months. The provider configs are stable and tested in daily use. Adding them upstream would eliminate a recurring post-update patch requirement.