### PR TITLE
fix(gateway): resolve 403 on custom OpenAI endpoints by applying prov…

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -289,6 +289,9 @@ def _resolve_gateway_model(config: dict | None = None) -> str:
         model = model_cfg
     elif isinstance(model_cfg, dict):
         model = model_cfg.get("default") or model_cfg.get("model") or model
+        provider = model_cfg.get("provider")
+        if provider and model and "/" not in model:
+            model = f"{provider}/{model}"
     return model
 
 


### PR DESCRIPTION
…ider prefix

Ensure _resolve_gateway_model correctly prefixes the model name with the provider (e.g., openai/qwen3.5-plus) so LiteLLM uses the correct Bearer auth flow.

## What does this PR do?

Fixes #3717

Root Cause:
The CLI correctly prefixes model names (e.g., `openai/qwen3.5-plus`), which signals LiteLLM to use the OpenAI API flow and properly send the `Authorization: Bearer` token. However, the Gateway's `_resolve_gateway_model` bypassed this normalisation and returned the raw model name. When LiteLLM receives a raw string like `qwen3.5-plus`, it auto-routes to native provider logic (like DashScope), expecting a different API key format and dropping the custom `base_url` Bearer auth, resulting in a 403.

Fix:
Updated `_resolve_gateway_model` in `gateway/run.py` to correctly append the `provider/` prefix to the model name if it's defined in `config.yaml` and not already prefixed. This aligns the Gateway's behaviour with the CLI and ensures LiteLLM handles custom endpoints accurately.

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

