### PR TITLE
fix: set api_mode when switching providers via hermes model

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -980,6 +980,7 @@ def _model_flow_openrouter(config, current_model=""):
             cfg["model"] = model
         model["provider"] = "openrouter"
         model["base_url"] = OPENROUTER_BASE_URL
+        model["api_mode"] = "chat_completions"
         save_config(cfg)
         deactivate_provider()
         print(f"Default model set to: {selected} (via OpenRouter)")
@@ -1203,6 +1204,7 @@ def _model_flow_custom(config):
             cfg["model"] = model
         model["provider"] = "custom"
         model["base_url"] = effective_url
+        model["api_mode"] = "chat_completions"
         save_config(cfg)
         deactivate_provider()
 
@@ -1984,6 +1986,7 @@ def _model_flow_kimi(config, current_model=""):
             cfg["model"] = model
         model["provider"] = provider_id
         model["base_url"] = effective_base
+        model["api_mode"] = "chat_completions"
         save_config(cfg)
         deactivate_provider()
 
@@ -2090,6 +2093,7 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
             cfg["model"] = model
         model["provider"] = provider_id
         model["base_url"] = effective_base
+        model["api_mode"] = "chat_completions"
         save_config(cfg)
         deactivate_provider()
 


### PR DESCRIPTION
## Summary

When switching providers via `hermes model`, the previous provider's `api_mode` persisted in config.yaml. Switching from Copilot (`codex_responses`) to a chat_completions provider like Z.AI would leave the stale api_mode, causing 404s.

Salvaged from #3686 by @HenkDz with authorship preserved. Fixes #3685.

## Changes
- `hermes_cli/main.py`: add `model["api_mode"] = "chat_completions"` in 4 provider flows (OpenRouter, custom, Kimi, api_key_provider)

## Live test
Verified with isolated HERMES_HOME: stale `codex_responses` correctly overwritten to `chat_completions` after provider switch, runtime resolver picks up the new value.