### PR TITLE
Fix KeyError when tool schema missing 'name' field

### DIFF
--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -17,6 +17,13 @@ def _make_schema(name="test_tool"):
     }
 
 
+def _make_schema_without_name():
+    return {
+        "description": "A tool without name in schema",
+        "parameters": {"type": "object", "properties": {}},
+    }
+
+
 class TestRegisterAndDispatch:
     def test_register_and_dispatch(self):
         reg = ToolRegistry()
@@ -309,3 +316,64 @@ class TestSecretCaptureResultContract:
             "validated": False,
         }
         assert "secret" not in json.dumps(result).lower()
+
+
+class TestSchemaNameNormalization:
+    def test_schema_missing_name_gets_canonical_name(self):
+        reg = ToolRegistry()
+        reg.register(
+            name="my_tool",
+            toolset="core",
+            schema=_make_schema_without_name(),
+            handler=_dummy_handler,
+        )
+        defs = reg.get_definitions({"my_tool"})
+        assert defs[0]["function"]["name"] == "my_tool"
+
+    def test_schema_missing_name_no_keyerror_in_comprehension(self):
+        reg = ToolRegistry()
+        reg.register(
+            name="bare_tool",
+            toolset="core",
+            schema=_make_schema_without_name(),
+            handler=_dummy_handler,
+        )
+        defs = reg.get_definitions({"bare_tool"})
+        names = {t["function"]["name"] for t in defs}
+        assert "bare_tool" in names
+
+    def test_existing_schema_name_preserved_when_present(self):
+        reg = ToolRegistry()
+        reg.register(
+            name="different_canonical",
+            toolset="core",
+            schema=_make_schema("existing_name"),
+            handler=_dummy_handler,
+        )
+        defs = reg.get_definitions({"different_canonical"})
+        assert defs[0]["function"]["name"] == "existing_name"
+
+    def test_mixed_tools_some_missing_name(self):
+        reg = ToolRegistry()
+        reg.register(
+            name="tool_a",
+            toolset="core",
+            schema=_make_schema("tool_a"),
+            handler=_dummy_handler,
+        )
+        reg.register(
+            name="tool_b",
+            toolset="core",
+            schema=_make_schema_without_name(),
+            handler=_dummy_handler,
+        )
+        reg.register(
+            name="tool_c",
+            toolset="core",
+            schema=_make_schema_without_name(),
+            handler=_dummy_handler,
+            check_fn=lambda: False,
+        )
+        defs = reg.get_definitions({"tool_a", "tool_b", "tool_c"})
+        assert len(defs) == 2
+        assert {d["function"]["name"] for d in defs} == {"tool_a", "tool_b"}

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -73,6 +73,11 @@ class ToolRegistry:
                 "overwritten by toolset '%s'",
                 name, existing.toolset, toolset,
             )
+        # Ensure schema always carries the canonical tool name so that
+        # downstream code (e.g. get_definitions → available_tool_names) can
+        # rely on t["function"]["name"] existing.
+        if "name" not in schema:
+            schema["name"] = name
         self._tools[name] = ToolEntry(
             name=name,
             toolset=toolset,

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -303,20 +303,20 @@ class GitHubSource(SkillSource):
     def fetch(self, identifier: str) -> Optional[SkillBundle]:
         """
         Download a skill from GitHub.
-        identifier format: "owner/repo/path/to/skill-dir" or "owner/repo" (root skill)
+        identifier format: "owner/repo/path/to/skill-dir"
         """
         parts = identifier.split("/", 2)
-        if len(parts) < 2:
+        if len(parts) < 3:
             return None
 
         repo = f"{parts[0]}/{parts[1]}"
-        skill_path = parts[2] if len(parts) >= 3 else ""
+        skill_path = parts[2]
 
         files = self._download_directory(repo, skill_path)
         if not files or "SKILL.md" not in files:
             return None
 
-        skill_name = skill_path.rstrip("/").split("/")[-1] if skill_path else parts[1]
+        skill_name = skill_path.rstrip("/").split("/")[-1]
         trust = self.trust_level_for(identifier)
 
         return SkillBundle(
@@ -330,19 +330,19 @@ class GitHubSource(SkillSource):
     def inspect(self, identifier: str) -> Optional[SkillMeta]:
         """Fetch just the SKILL.md metadata for preview."""
         parts = identifier.split("/", 2)
-        if len(parts) < 2:
+        if len(parts) < 3:
             return None
 
         repo = f"{parts[0]}/{parts[1]}"
-        skill_path = parts[2].rstrip("/") if len(parts) >= 3 else ""
-        skill_md_path = f"{skill_path}/SKILL.md" if skill_path else "SKILL.md"
+        skill_path = parts[2].rstrip("/")
+        skill_md_path = f"{skill_path}/SKILL.md"
 
         content = self._fetch_file_content(repo, skill_md_path)
         if not content:
             return None
 
         fm = self._parse_frontmatter_quick(content)
-        skill_name = fm.get("name", skill_path.split("/")[-1] if skill_path else parts[1])
+        skill_name = fm.get("name", skill_path.split("/")[-1])
         description = fm.get("description", "")
 
         tags = []
@@ -452,13 +452,13 @@ class GitHubSource(SkillSource):
             return None
 
         # Filter to blobs under our target path and fetch content
-        prefix = f"{path}/" if path else ""
+        prefix = f"{path}/"
         files: Dict[str, str] = {}
         for item in tree_data.get("tree", []):
             if item.get("type") != "blob":
                 continue
             item_path = item.get("path", "")
-            if prefix and not item_path.startswith(prefix):
+            if not item_path.startswith(prefix):
                 continue
             rel_path = item_path[len(prefix):]
             content = self._fetch_file_content(repo, item_path)

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -303,20 +303,20 @@ class GitHubSource(SkillSource):
     def fetch(self, identifier: str) -> Optional[SkillBundle]:
         """
         Download a skill from GitHub.
-        identifier format: "owner/repo/path/to/skill-dir"
+        identifier format: "owner/repo/path/to/skill-dir" or "owner/repo" (root skill)
         """
         parts = identifier.split("/", 2)
-        if len(parts) < 3:
+        if len(parts) < 2:
             return None
 
         repo = f"{parts[0]}/{parts[1]}"
-        skill_path = parts[2]
+        skill_path = parts[2] if len(parts) >= 3 else ""
 
         files = self._download_directory(repo, skill_path)
         if not files or "SKILL.md" not in files:
             return None
 
-        skill_name = skill_path.rstrip("/").split("/")[-1]
+        skill_name = skill_path.rstrip("/").split("/")[-1] if skill_path else parts[1]
         trust = self.trust_level_for(identifier)
 
         return SkillBundle(
@@ -330,19 +330,19 @@ class GitHubSource(SkillSource):
     def inspect(self, identifier: str) -> Optional[SkillMeta]:
         """Fetch just the SKILL.md metadata for preview."""
         parts = identifier.split("/", 2)
-        if len(parts) < 3:
+        if len(parts) < 2:
             return None
 
         repo = f"{parts[0]}/{parts[1]}"
-        skill_path = parts[2].rstrip("/")
-        skill_md_path = f"{skill_path}/SKILL.md"
+        skill_path = parts[2].rstrip("/") if len(parts) >= 3 else ""
+        skill_md_path = f"{skill_path}/SKILL.md" if skill_path else "SKILL.md"
 
         content = self._fetch_file_content(repo, skill_md_path)
         if not content:
             return None
 
         fm = self._parse_frontmatter_quick(content)
-        skill_name = fm.get("name", skill_path.split("/")[-1])
+        skill_name = fm.get("name", skill_path.split("/")[-1] if skill_path else parts[1])
         description = fm.get("description", "")
 
         tags = []
@@ -452,13 +452,13 @@ class GitHubSource(SkillSource):
             return None
 
         # Filter to blobs under our target path and fetch content
-        prefix = f"{path}/"
+        prefix = f"{path}/" if path else ""
         files: Dict[str, str] = {}
         for item in tree_data.get("tree", []):
             if item.get("type") != "blob":
                 continue
             item_path = item.get("path", "")
-            if not item_path.startswith(prefix):
+            if prefix and not item_path.startswith(prefix):
                 continue
             rel_path = item_path[len(prefix):]
             content = self._fetch_file_content(repo, item_path)


### PR DESCRIPTION
## Summary
- Fix `KeyError: 'name'` crash in `get_tool_definitions()` when a registered tool's schema dict omits the `"name"` key
- `ToolRegistry.register()` now ensures `schema["name"]` is always set using the canonical `name` argument

Fixes #3729

## Root Cause
`register()` stores the schema as-is without guaranteeing it contains `"name"`. When `get_definitions()` wraps it as `{"type": "function", "function": schema}`, downstream code at `model_tools.py:308` assumes `t["function"]["name"]` exists and crashes if it doesn't.

## Change
Added a guard in `register()` to set `schema["name"] = name` when missing (~2 lines).

## Test plan
- [ ] Verify hermes starts without error after the fix
- [ ] Register a tool with a schema that omits `"name"` and confirm no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)