### PR TITLE
fix(cli): add missing subprocess.run() timeouts in gateway

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -42,7 +42,7 @@ def find_gateway_pids() -> list:
             # Windows: use wmic to search command lines
             result = subprocess.run(
                 ["wmic", "process", "get", "ProcessId,CommandLine", "/FORMAT:LIST"],
-                capture_output=True, text=True
+                capture_output=True, text=True, timeout=10
             )
             # Parse WMIC LIST output: blocks of "CommandLine=...\nProcessId=...\n"
             current_cmd = ""
@@ -64,7 +64,8 @@ def find_gateway_pids() -> list:
             result = subprocess.run(
                 ["ps", "aux"],
                 capture_output=True,
-                text=True
+                text=True,
+                timeout=10,
             )
             for line in result.stdout.split('\n'):
                 # Skip grep and current process
@@ -361,6 +362,7 @@ def get_systemd_linger_status() -> tuple[bool | None, str]:
             capture_output=True,
             text=True,
             check=False,
+            timeout=5,
         )
     except Exception as e:
         return None, str(e)
@@ -569,7 +571,7 @@ def refresh_systemd_unit_if_needed(system: bool = False) -> bool:
 
     expected_user = _read_systemd_user_from_unit(unit_path) if system else None
     unit_path.write_text(generate_systemd_unit(system=system, run_as_user=expected_user), encoding="utf-8")
-    subprocess.run(_systemctl_cmd(system) + ["daemon-reload"], check=True)
+    subprocess.run(_systemctl_cmd(system) + ["daemon-reload"], check=True, timeout=30)
     print(f"↻ Updated gateway {_service_scope_label(system)} service definition to match the current Hermes install")
     return True
 
@@ -620,6 +622,7 @@ def _ensure_linger_enabled() -> None:
             capture_output=True,
             text=True,
             check=False,
+            timeout=10,
         )
     except Exception as e:
         _print_linger_enable_warning(username, str(e))
@@ -650,7 +653,7 @@ def systemd_install(force: bool = False, system: bool = False, run_as_user: str 
         if not systemd_unit_is_current(system=system):
             print(f"↻ Repairing outdated {_service_scope_label(system)} systemd service at: {unit_path}")
             refresh_systemd_unit_if_needed(system=system)
-            subprocess.run(_systemctl_cmd(system) + ["enable", get_service_name()], check=True)
+            subprocess.run(_systemctl_cmd(system) + ["enable", get_service_name()], check=True, timeout=30)
             print(f"✓ {_service_scope_label(system).capitalize()} service definition updated")
             return
         print(f"Service already installed at: {unit_path}")
@@ -661,8 +664,8 @@ def systemd_install(force: bool = False, system: bool = False, run_as_user: str 
     print(f"Installing {_service_scope_label(system)} systemd service to: {unit_path}")
     unit_path.write_text(generate_systemd_unit(system=system, run_as_user=run_as_user), encoding="utf-8")
 
-    subprocess.run(_systemctl_cmd(system) + ["daemon-reload"], check=True)
-    subprocess.run(_systemctl_cmd(system) + ["enable", get_service_name()], check=True)
+    subprocess.run(_systemctl_cmd(system) + ["daemon-reload"], check=True, timeout=30)
+    subprocess.run(_systemctl_cmd(system) + ["enable", get_service_name()], check=True, timeout=30)
 
     print()
     print(f"✓ {_service_scope_label(system).capitalize()} service installed and enabled!")
@@ -688,15 +691,15 @@ def systemd_uninstall(system: bool = False):
     if system:
         _require_root_for_system_service("uninstall")
 
-    subprocess.run(_systemctl_cmd(system) + ["stop", get_service_name()], check=False)
-    subprocess.run(_systemctl_cmd(system) + ["disable", get_service_name()], check=False)
+    subprocess.run(_systemctl_cmd(system) + ["stop", get_service_name()], check=False, timeout=30)
+    subprocess.run(_systemctl_cmd(system) + ["disable", get_service_name()], check=False, timeout=30)
 
     unit_path = get_systemd_unit_path(system=system)
     if unit_path.exists():
         unit_path.unlink()
         print(f"✓ Removed {unit_path}")
 
-    subprocess.run(_systemctl_cmd(system) + ["daemon-reload"], check=True)
+    subprocess.run(_systemctl_cmd(system) + ["daemon-reload"], check=True, timeout=30)
     print(f"✓ {_service_scope_label(system).capitalize()} service uninstalled")
 
 
@@ -705,7 +708,7 @@ def systemd_start(system: bool = False):
     if system:
         _require_root_for_system_service("start")
     refresh_systemd_unit_if_needed(system=system)
-    subprocess.run(_systemctl_cmd(system) + ["start", get_service_name()], check=True)
+    subprocess.run(_systemctl_cmd(system) + ["start", get_service_name()], check=True, timeout=30)
     print(f"✓ {_service_scope_label(system).capitalize()} service started")
 
 
@@ -714,7 +717,7 @@ def systemd_stop(system: bool = False):
     system = _select_systemd_scope(system)
     if system:
         _require_root_for_system_service("stop")
-    subprocess.run(_systemctl_cmd(system) + ["stop", get_service_name()], check=True)
+    subprocess.run(_systemctl_cmd(system) + ["stop", get_service_name()], check=True, timeout=30)
     print(f"✓ {_service_scope_label(system).capitalize()} service stopped")
 
 
@@ -724,7 +727,7 @@ def systemd_restart(system: bool = False):
     if system:
         _require_root_for_system_service("restart")
     refresh_systemd_unit_if_needed(system=system)
-    subprocess.run(_systemctl_cmd(system) + ["restart", get_service_name()], check=True)
+    subprocess.run(_systemctl_cmd(system) + ["restart", get_service_name()], check=True, timeout=30)
     print(f"✓ {_service_scope_label(system).capitalize()} service restarted")
 
 
@@ -751,12 +754,14 @@ def systemd_status(deep: bool = False, system: bool = False):
     subprocess.run(
         _systemctl_cmd(system) + ["status", get_service_name(), "--no-pager"],
         capture_output=False,
+        timeout=10,
     )
 
     result = subprocess.run(
         _systemctl_cmd(system) + ["is-active", get_service_name()],
         capture_output=True,
         text=True,
+        timeout=5,
     )
 
     status = result.stdout.strip()
@@ -793,7 +798,7 @@ def systemd_status(deep: bool = False, system: bool = False):
     if deep:
         print()
         print("Recent logs:")
-        subprocess.run(_journalctl_cmd(system) + ["-u", get_service_name(), "-n", "20", "--no-pager"])
+        subprocess.run(_journalctl_cmd(system) + ["-u", get_service_name(), "-n", "20", "--no-pager"], timeout=10)
 
 
 # =============================================================================
@@ -906,8 +911,8 @@ def refresh_launchd_plist_if_needed() -> bool:
 
     plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
     # Unload/reload so launchd picks up the new definition
-    subprocess.run(["launchctl", "unload", str(plist_path)], check=False)
-    subprocess.run(["launchctl", "load", str(plist_path)], check=False)
+    subprocess.run(["launchctl", "unload", str(plist_path)], check=False, timeout=30)
+    subprocess.run(["launchctl", "load", str(plist_path)], check=False, timeout=30)
     print("↻ Updated gateway launchd service definition to match the current Hermes install")
     return True
 
@@ -929,8 +934,8 @@ def launchd_install(force: bool = False):
     print(f"Installing launchd service to: {plist_path}")
     plist_path.write_text(generate_launchd_plist())
     
-    subprocess.run(["launchctl", "load", str(plist_path)], check=True)
-    
+    subprocess.run(["launchctl", "load", str(plist_path)], check=True, timeout=30)
+
     print()
     print("✓ Service installed and loaded!")
     print()
@@ -940,7 +945,7 @@ def launchd_install(force: bool = False):
 
 def launchd_uninstall():
     plist_path = get_launchd_plist_path()
-    subprocess.run(["launchctl", "unload", str(plist_path)], check=False)
+    subprocess.run(["launchctl", "unload", str(plist_path)], check=False, timeout=30)
     
     if plist_path.exists():
         plist_path.unlink()
@@ -957,25 +962,25 @@ def launchd_start():
         print("↻ launchd plist missing; regenerating service definition")
         plist_path.parent.mkdir(parents=True, exist_ok=True)
         plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
-        subprocess.run(["launchctl", "load", str(plist_path)], check=True)
-        subprocess.run(["launchctl", "start", label], check=True)
+        subprocess.run(["launchctl", "load", str(plist_path)], check=True, timeout=30)
+        subprocess.run(["launchctl", "start", label], check=True, timeout=30)
         print("✓ Service started")
         return
 
     refresh_launchd_plist_if_needed()
     try:
-        subprocess.run(["launchctl", "start", label], check=True)
+        subprocess.run(["launchctl", "start", label], check=True, timeout=30)
     except subprocess.CalledProcessError as e:
         if e.returncode != 3:
             raise
         print("↻ launchd job was unloaded; reloading service definition")
-        subprocess.run(["launchctl", "load", str(plist_path)], check=True)
-        subprocess.run(["launchctl", "start", label], check=True)
+        subprocess.run(["launchctl", "load", str(plist_path)], check=True, timeout=30)
+        subprocess.run(["launchctl", "start", label], check=True, timeout=30)
     print("✓ Service started")
 
 def launchd_stop():
     label = get_launchd_label()
-    subprocess.run(["launchctl", "stop", label], check=True)
+    subprocess.run(["launchctl", "stop", label], check=True, timeout=30)
     print("✓ Service stopped")
 
 def _wait_for_gateway_exit(timeout: float = 10.0, force_after: float = 5.0):
@@ -1031,11 +1036,18 @@ def launchd_restart():
 def launchd_status(deep: bool = False):
     plist_path = get_launchd_plist_path()
     label = get_launchd_label()
-    result = subprocess.run(
-        ["launchctl", "list", label],
-        capture_output=True,
-        text=True
-    )
+    try:
+        result = subprocess.run(
+            ["launchctl", "list", label],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        loaded = result.returncode == 0
+        loaded_output = result.stdout
+    except subprocess.TimeoutExpired:
+        loaded = False
+        loaded_output = ""
 
     print(f"Launchd plist: {plist_path}")
     if launchd_plist_is_current():
@@ -1043,21 +1055,21 @@ def launchd_status(deep: bool = False):
     else:
         print("⚠ Service definition is stale relative to the current Hermes install")
         print("  Run: hermes gateway start")
-    
-    if result.returncode == 0:
+
+    if loaded:
         print("✓ Gateway service is loaded")
-        print(result.stdout)
+        print(loaded_output)
     else:
         print("✗ Gateway service is not loaded")
         print("  Service definition exists locally but launchd has not loaded it.")
         print("  Run: hermes gateway start")
-    
+
     if deep:
         log_file = get_hermes_home() / "logs" / "gateway.log"
         if log_file.exists():
             print()
             print("Recent logs:")
-            subprocess.run(["tail", "-20", str(log_file)])
+            subprocess.run(["tail", "-20", str(log_file)], timeout=10)
 
 
 # =============================================================================
@@ -1519,28 +1531,37 @@ def _is_service_running() -> bool:
         system_unit_exists = get_systemd_unit_path(system=True).exists()
 
         if user_unit_exists:
-            result = subprocess.run(
-                _systemctl_cmd(False) + ["is-active", get_service_name()],
-                capture_output=True, text=True
-            )
-            if result.stdout.strip() == "active":
-                return True
+            try:
+                result = subprocess.run(
+                    _systemctl_cmd(False) + ["is-active", get_service_name()],
+                    capture_output=True, text=True, timeout=5,
+                )
+                if result.stdout.strip() == "active":
+                    return True
+            except subprocess.TimeoutExpired:
+                pass
 
         if system_unit_exists:
-            result = subprocess.run(
-                _systemctl_cmd(True) + ["is-active", get_service_name()],
-                capture_output=True, text=True
-            )
-            if result.stdout.strip() == "active":
-                return True
+            try:
+                result = subprocess.run(
+                    _systemctl_cmd(True) + ["is-active", get_service_name()],
+                    capture_output=True, text=True, timeout=5,
+                )
+                if result.stdout.strip() == "active":
+                    return True
+            except subprocess.TimeoutExpired:
+                pass
 
         return False
     elif is_macos() and get_launchd_plist_path().exists():
-        result = subprocess.run(
-            ["launchctl", "list", get_launchd_label()],
-            capture_output=True, text=True
-        )
-        return result.returncode == 0
+        try:
+            result = subprocess.run(
+                ["launchctl", "list", get_launchd_label()],
+                capture_output=True, text=True, timeout=5,
+            )
+            return result.returncode == 0
+        except subprocess.TimeoutExpired:
+            return False
     # Check for manual processes
     return len(find_gateway_pids()) > 0
 


### PR DESCRIPTION
 ## Summary

  All `subprocess.run()` calls in `hermes_cli/gateway.py` lacked a `timeout` parameter. If systemctl, launchctl, loginctl, wmic, or ps blocks — e.g. D-Bus socket unavailable, WMI service stuck on Windows, or launchd momentarily unresponsive — `hermes gateway start/stop/restart/status/install/uninstall` hangs indefinitely with no feedback or escape other than Ctrl+C.

  Same class of bug as #3469 (context_references subprocess calls) and #3693 doctor/status subprocess calls). `gateway.py` was not covered by either.

  ## Root cause

  `subprocess.run()` defaults to `timeout=None` — waits forever. The rest of the CLI already uses timeouts consistently (`clipboard.py`, `banner.py`, `doctor.py`, `status.py`). `gateway.py` was the remaining gap.

  ## Fix

  Timeout values applied across all 32 call sites:

  | Call type | timeout |
  |---|---|
  | Lifecycle: `start`, `stop`, `restart`, `enable`, `disable`, `daemon-reload`, `launchctl load/unload` | `30s` |
  | Query: `is-active`, `systemctl status`, `launchctl list`, `loginctl show-user`, `journalctl`, `tail`, `ps aux`, `wmic` | `5–10s` |
  | `loginctl enable-linger` | `10s` |

  For `_is_service_running()` and `launchd_status()`, `TimeoutExpired` is caught explicitly and treated as not-running — consistent with how non-zero return codes are already handled in those functions.

  All other call sites are either already inside `try/except Exception` blocks (`find_gateway_pids`, `get_systemd_linger_status`, `_enable_systemd_linger`) or propagate `TimeoutExpired` as a clear exception instead of hanging forever.

  ## Verification

  AST-based check confirms zero remaining `subprocess.run()` calls without
  `timeout=` in `gateway.py`:

  ```python
  python3 -c "
  import ast, sys
  source = open('hermes_cli/gateway.py').read()
  tree = ast.parse(source)
  missing = [n.lineno for n in ast.walk(tree)
             if isinstance(n, ast.Call)
             and isinstance(n.func, ast.Attribute)
             and n.func.attr == 'run'
             and isinstance(n.func.value, ast.Name)
             and n.func.value.id == 'subprocess'
             and not any(kw.arg == 'timeout' for kw in n.keywords)]
  assert not missing, f'missing timeout at lines: {missing}'
  print('ok')
  "
