### PR TITLE
feat: per-call model/provider override on delegate_task

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -174,8 +174,10 @@ def _build_child_agent(
 
     # When no explicit toolsets given, inherit from parent's enabled toolsets
     # so disabled tools (e.g. web) don't leak to subagents.
+    parent_toolsets = set(getattr(parent_agent, "enabled_toolsets", None) or DEFAULT_TOOLSETS)
     if toolsets:
-        child_toolsets = _strip_blocked_tools(toolsets)
+        # Intersect with parent — subagent must not gain tools the parent lacks
+        child_toolsets = _strip_blocked_tools([t for t in toolsets if t in parent_toolsets])
     elif parent_agent and getattr(parent_agent, "enabled_toolsets", None):
         child_toolsets = _strip_blocked_tools(parent_agent.enabled_toolsets)
     else:
@@ -258,6 +260,14 @@ def _run_single_child(
     Returns a structured result dict.
     """
     child_start = time.monotonic()
+
+    # Log the model/provider the subagent is running on
+    _child_model = getattr(child, "model", None)
+    _child_provider = getattr(child, "provider", None)
+    if _child_model:
+        provider_tag = f" ({_child_provider})" if _child_provider else ""
+        logger.info("[subagent-%d] spawning with model=%s%s", task_index, _child_model, provider_tag)
+        print(f"  [subagent-{task_index}] model={_child_model}{provider_tag}")
 
     # Get the progress callback from the child agent
     child_progress_cb = getattr(child, 'tool_progress_callback', None)
@@ -401,19 +411,14 @@ def delegate_task(
     toolsets: Optional[List[str]] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
-    model: Optional[str] = None,
-    provider: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks.
 
     Supports two modes:
-      - Single: provide goal (+ optional context, toolsets, model, provider)
-      - Batch:  provide tasks array [{goal, context, toolsets, model, provider}, ...]
-
-    Model/provider resolution (per-task in batch, top-level in single):
-      per-call model/provider → config delegation.model/provider → inherit parent
+      - Single: provide goal (+ optional context, toolsets)
+      - Batch:  provide tasks array [{goal, context, toolsets}, ...]
 
     Returns JSON with results array, one entry per task.
     """
@@ -435,14 +440,21 @@ def delegate_task(
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
     effective_max_iter = max_iterations or default_max_iter
 
-    # Normalize to task list, including top-level model/provider
+    # Resolve delegation credentials (provider:model pair).
+    # When delegation.provider is configured, this resolves the full credential
+    # bundle (base_url, api_key, api_mode) via the same runtime provider system
+    # used by CLI/gateway startup.  When unconfigured, returns None values so
+    # children inherit from the parent.
+    try:
+        creds = _resolve_delegation_credentials(cfg, parent_agent)
+    except ValueError as exc:
+        return json.dumps({"error": str(exc)})
+
+    # Normalize to task list
     if tasks and isinstance(tasks, list):
         task_list = tasks[:MAX_CONCURRENT_CHILDREN]
     elif goal and isinstance(goal, str) and goal.strip():
-        task_list = [{
-            "goal": goal, "context": context, "toolsets": toolsets,
-            "model": model, "provider": provider,
-        }]
+        task_list = [{"goal": goal, "context": context, "toolsets": toolsets}]
     else:
         return json.dumps({"error": "Provide either 'goal' (single task) or 'tasks' (batch)."})
 
@@ -473,24 +485,13 @@ def delegate_task(
     children = []
     try:
         for i, t in enumerate(task_list):
-            # Resolve credentials per-task: per-call override → config → parent
-            task_model = t.get("model")
-            task_provider = t.get("provider")
-            try:
-                task_creds = _resolve_call_credentials(
-                    task_model, task_provider, cfg, parent_agent,
-                )
-            except ValueError as exc:
-                return json.dumps({"error": str(exc)})
-
             child = _build_child_agent(
                 task_index=i, goal=t["goal"], context=t.get("context"),
-                toolsets=t.get("toolsets") or toolsets, model=task_creds["model"],
+                toolsets=t.get("toolsets") or toolsets, model=creds["model"],
                 max_iterations=effective_max_iter, parent_agent=parent_agent,
-                override_provider=task_creds["provider"],
-                override_base_url=task_creds["base_url"],
-                override_api_key=task_creds["api_key"],
-                override_api_mode=task_creds["api_mode"],
+                override_provider=creds["provider"], override_base_url=creds["base_url"],
+                override_api_key=creds["api_key"],
+                override_api_mode=creds["api_mode"],
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
@@ -569,69 +570,6 @@ def delegate_task(
         "results": results,
         "total_duration_seconds": total_duration,
     }, ensure_ascii=False)
-
-
-def _resolve_call_credentials(
-    call_model: Optional[str],
-    call_provider: Optional[str],
-    cfg: dict,
-    parent_agent,
-) -> dict:
-    """Resolve credentials for a single delegation call.
-
-    Priority: per-call model/provider → config delegation.model/provider → parent inherit.
-
-    When per-call provider differs from config provider (or config has none),
-    resolves the full credential bundle via the runtime provider system.
-    Otherwise returns config-resolved credentials with per-call model override.
-    """
-    # Start with config-level credentials
-    try:
-        config_creds = _resolve_delegation_credentials(cfg, parent_agent)
-    except ValueError:
-        config_creds = {
-            "model": None, "provider": None,
-            "base_url": None, "api_key": None, "api_mode": None,
-        }
-
-    # Per-call provider override — re-resolve if different from config
-    call_provider_stripped = str(call_provider or "").strip() or None
-    if call_provider_stripped and call_provider_stripped != config_creds.get("provider"):
-        try:
-            from hermes_cli.runtime_provider import resolve_runtime_provider
-            runtime = resolve_runtime_provider(requested=call_provider_stripped)
-        except Exception as exc:
-            raise ValueError(
-                f"Cannot resolve per-call delegation provider "
-                f"'{call_provider_stripped}': {exc}. "
-                f"Check that the provider is configured (API key set)."
-            ) from exc
-        api_key = runtime.get("api_key", "")
-        if not api_key:
-            raise ValueError(
-                f"Per-call delegation provider '{call_provider_stripped}' "
-                f"resolved but has no API key. "
-                f"Set the appropriate environment variable or run 'hermes login'."
-            )
-        return {
-            "model": call_model or config_creds.get("model"),
-            "provider": runtime.get("provider"),
-            "base_url": runtime.get("base_url"),
-            "api_key": api_key,
-            "api_mode": runtime.get("api_mode"),
-            "command": runtime.get("command"),
-            "args": list(runtime.get("args") or []),
-        }
-
-    # Same provider as config (or no per-call provider) — use config creds
-    # with per-call model override
-    return {
-        "model": call_model or config_creds.get("model"),
-        "provider": config_creds.get("provider"),
-        "base_url": config_creds.get("base_url"),
-        "api_key": config_creds.get("api_key"),
-        "api_mode": config_creds.get("api_mode"),
-    }
 
 
 def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
@@ -756,29 +694,25 @@ DELEGATE_TASK_SCHEMA = {
         "Spawn one or more subagents to work on tasks in isolated contexts. "
         "Each subagent gets its own conversation, terminal session, and toolset. "
         "Only the final summary is returned -- intermediate tool results "
-        "never enter your context window.\\n\\n"
-        "TWO MODES (one of 'goal' or 'tasks' is required):\\n"
-        "1. Single task: provide 'goal' (+ optional context, toolsets, model, provider)\\n"
+        "never enter your context window.\n\n"
+        "TWO MODES (one of 'goal' or 'tasks' is required):\n"
+        "1. Single task: provide 'goal' (+ optional context, toolsets)\n"
         "2. Batch (parallel): provide 'tasks' array with up to 3 items. "
-        "All run concurrently and results are returned together.\\n\\n"
-        "MODEL/PROVIDER ROUTING:\\n"
-        "You can specify 'model' and/or 'provider' per task to route subagents "
-        "to different models. Priority: per-call override > config delegation.* > parent. "
-        "Use this to assign code tasks to a fast model and reasoning tasks to a stronger model.\\n\\n"
-        "WHEN TO USE delegate_task:\\n"
-        "- Reasoning-heavy subtasks (debugging, code review, research synthesis)\\n"
-        "- Tasks that would flood your context with intermediate data\\n"
-        "- Parallel independent workstreams (research A and B simultaneously)\\n\\n"
-        "WHEN NOT TO USE (use these instead):\\n"
-        "- Mechanical multi-step work with no reasoning needed -> use execute_code\\n"
-        "- Single tool call -> just call the tool directly\\n"
-        "- Tasks needing user interaction -> subagents cannot use clarify\\n\\n"
-        "IMPORTANT:\\n"
+        "All run concurrently and results are returned together.\n\n"
+        "WHEN TO USE delegate_task:\n"
+        "- Reasoning-heavy subtasks (debugging, code review, research synthesis)\n"
+        "- Tasks that would flood your context with intermediate data\n"
+        "- Parallel independent workstreams (research A and B simultaneously)\n\n"
+        "WHEN NOT TO USE (use these instead):\n"
+        "- Mechanical multi-step work with no reasoning needed -> use execute_code\n"
+        "- Single tool call -> just call the tool directly\n"
+        "- Tasks needing user interaction -> subagents cannot use clarify\n\n"
+        "IMPORTANT:\n"
         "- Subagents have NO memory of your conversation. Pass all relevant "
-        "info (file paths, error messages, constraints) via the 'context' field.\\n"
+        "info (file paths, error messages, constraints) via the 'context' field.\n"
         "- Subagents CANNOT call: delegate_task, clarify, memory, send_message, "
-        "execute_code.\\n"
-        "- Each subagent gets its own terminal session (separate working directory and state).\\n"
+        "execute_code.\n"
+        "- Each subagent gets its own terminal session (separate working directory and state).\n"
         "- Results are always returned as an array, one entry per task."
     ),
     "parameters": {
@@ -811,22 +745,6 @@ DELEGATE_TASK_SCHEMA = {
                     "full-stack tasks."
                 ),
             },
-            "model": {
-                "type": "string",
-                "description": (
-                    "Override the model for this subagent. "
-                    "Example: 'glm-5.1' for code tasks, 'glm-5' for reasoning. "
-                    "Overrides config delegation.model. Falls back to parent model if omitted."
-                ),
-            },
-            "provider": {
-                "type": "string",
-                "description": (
-                    "Override the provider for this subagent. "
-                    "Example: 'zai', 'openrouter', 'nous'. "
-                    "Overrides config delegation.provider. Falls back to parent provider if omitted."
-                ),
-            },
             "tasks": {
                 "type": "array",
                 "items": {
@@ -838,14 +756,6 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "array",
                             "items": {"type": "string"},
                             "description": "Toolsets for this specific task",
-                        },
-                        "model": {
-                            "type": "string",
-                            "description": "Override model for this specific task",
-                        },
-                        "provider": {
-                            "type": "string",
-                            "description": "Override provider for this specific task",
                         },
                     },
                     "required": ["goal"],
@@ -883,8 +793,6 @@ registry.register(
         toolsets=args.get("toolsets"),
         tasks=args.get("tasks"),
         max_iterations=args.get("max_iterations"),
-        model=args.get("model"),
-        provider=args.get("provider"),
         parent_agent=kw.get("parent_agent")),
     check_fn=check_delegate_requirements,
     emoji="🔀",

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -401,14 +401,19 @@ def delegate_task(
     toolsets: Optional[List[str]] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks.
 
     Supports two modes:
-      - Single: provide goal (+ optional context, toolsets)
-      - Batch:  provide tasks array [{goal, context, toolsets}, ...]
+      - Single: provide goal (+ optional context, toolsets, model, provider)
+      - Batch:  provide tasks array [{goal, context, toolsets, model, provider}, ...]
+
+    Model/provider resolution (per-task in batch, top-level in single):
+      per-call model/provider → config delegation.model/provider → inherit parent
 
     Returns JSON with results array, one entry per task.
     """
@@ -430,21 +435,14 @@ def delegate_task(
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
     effective_max_iter = max_iterations or default_max_iter
 
-    # Resolve delegation credentials (provider:model pair).
-    # When delegation.provider is configured, this resolves the full credential
-    # bundle (base_url, api_key, api_mode) via the same runtime provider system
-    # used by CLI/gateway startup.  When unconfigured, returns None values so
-    # children inherit from the parent.
-    try:
-        creds = _resolve_delegation_credentials(cfg, parent_agent)
-    except ValueError as exc:
-        return json.dumps({"error": str(exc)})
-
-    # Normalize to task list
+    # Normalize to task list, including top-level model/provider
     if tasks and isinstance(tasks, list):
         task_list = tasks[:MAX_CONCURRENT_CHILDREN]
     elif goal and isinstance(goal, str) and goal.strip():
-        task_list = [{"goal": goal, "context": context, "toolsets": toolsets}]
+        task_list = [{
+            "goal": goal, "context": context, "toolsets": toolsets,
+            "model": model, "provider": provider,
+        }]
     else:
         return json.dumps({"error": "Provide either 'goal' (single task) or 'tasks' (batch)."})
 
@@ -475,13 +473,24 @@ def delegate_task(
     children = []
     try:
         for i, t in enumerate(task_list):
+            # Resolve credentials per-task: per-call override → config → parent
+            task_model = t.get("model")
+            task_provider = t.get("provider")
+            try:
+                task_creds = _resolve_call_credentials(
+                    task_model, task_provider, cfg, parent_agent,
+                )
+            except ValueError as exc:
+                return json.dumps({"error": str(exc)})
+
             child = _build_child_agent(
                 task_index=i, goal=t["goal"], context=t.get("context"),
-                toolsets=t.get("toolsets") or toolsets, model=creds["model"],
+                toolsets=t.get("toolsets") or toolsets, model=task_creds["model"],
                 max_iterations=effective_max_iter, parent_agent=parent_agent,
-                override_provider=creds["provider"], override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
+                override_provider=task_creds["provider"],
+                override_base_url=task_creds["base_url"],
+                override_api_key=task_creds["api_key"],
+                override_api_mode=task_creds["api_mode"],
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
@@ -560,6 +569,69 @@ def delegate_task(
         "results": results,
         "total_duration_seconds": total_duration,
     }, ensure_ascii=False)
+
+
+def _resolve_call_credentials(
+    call_model: Optional[str],
+    call_provider: Optional[str],
+    cfg: dict,
+    parent_agent,
+) -> dict:
+    """Resolve credentials for a single delegation call.
+
+    Priority: per-call model/provider → config delegation.model/provider → parent inherit.
+
+    When per-call provider differs from config provider (or config has none),
+    resolves the full credential bundle via the runtime provider system.
+    Otherwise returns config-resolved credentials with per-call model override.
+    """
+    # Start with config-level credentials
+    try:
+        config_creds = _resolve_delegation_credentials(cfg, parent_agent)
+    except ValueError:
+        config_creds = {
+            "model": None, "provider": None,
+            "base_url": None, "api_key": None, "api_mode": None,
+        }
+
+    # Per-call provider override — re-resolve if different from config
+    call_provider_stripped = str(call_provider or "").strip() or None
+    if call_provider_stripped and call_provider_stripped != config_creds.get("provider"):
+        try:
+            from hermes_cli.runtime_provider import resolve_runtime_provider
+            runtime = resolve_runtime_provider(requested=call_provider_stripped)
+        except Exception as exc:
+            raise ValueError(
+                f"Cannot resolve per-call delegation provider "
+                f"'{call_provider_stripped}': {exc}. "
+                f"Check that the provider is configured (API key set)."
+            ) from exc
+        api_key = runtime.get("api_key", "")
+        if not api_key:
+            raise ValueError(
+                f"Per-call delegation provider '{call_provider_stripped}' "
+                f"resolved but has no API key. "
+                f"Set the appropriate environment variable or run 'hermes login'."
+            )
+        return {
+            "model": call_model or config_creds.get("model"),
+            "provider": runtime.get("provider"),
+            "base_url": runtime.get("base_url"),
+            "api_key": api_key,
+            "api_mode": runtime.get("api_mode"),
+            "command": runtime.get("command"),
+            "args": list(runtime.get("args") or []),
+        }
+
+    # Same provider as config (or no per-call provider) — use config creds
+    # with per-call model override
+    return {
+        "model": call_model or config_creds.get("model"),
+        "provider": config_creds.get("provider"),
+        "base_url": config_creds.get("base_url"),
+        "api_key": config_creds.get("api_key"),
+        "api_mode": config_creds.get("api_mode"),
+    }
 
 
 def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
@@ -684,25 +756,29 @@ DELEGATE_TASK_SCHEMA = {
         "Spawn one or more subagents to work on tasks in isolated contexts. "
         "Each subagent gets its own conversation, terminal session, and toolset. "
         "Only the final summary is returned -- intermediate tool results "
-        "never enter your context window.\n\n"
-        "TWO MODES (one of 'goal' or 'tasks' is required):\n"
-        "1. Single task: provide 'goal' (+ optional context, toolsets)\n"
+        "never enter your context window.\\n\\n"
+        "TWO MODES (one of 'goal' or 'tasks' is required):\\n"
+        "1. Single task: provide 'goal' (+ optional context, toolsets, model, provider)\\n"
         "2. Batch (parallel): provide 'tasks' array with up to 3 items. "
-        "All run concurrently and results are returned together.\n\n"
-        "WHEN TO USE delegate_task:\n"
-        "- Reasoning-heavy subtasks (debugging, code review, research synthesis)\n"
-        "- Tasks that would flood your context with intermediate data\n"
-        "- Parallel independent workstreams (research A and B simultaneously)\n\n"
-        "WHEN NOT TO USE (use these instead):\n"
-        "- Mechanical multi-step work with no reasoning needed -> use execute_code\n"
-        "- Single tool call -> just call the tool directly\n"
-        "- Tasks needing user interaction -> subagents cannot use clarify\n\n"
-        "IMPORTANT:\n"
+        "All run concurrently and results are returned together.\\n\\n"
+        "MODEL/PROVIDER ROUTING:\\n"
+        "You can specify 'model' and/or 'provider' per task to route subagents "
+        "to different models. Priority: per-call override > config delegation.* > parent. "
+        "Use this to assign code tasks to a fast model and reasoning tasks to a stronger model.\\n\\n"
+        "WHEN TO USE delegate_task:\\n"
+        "- Reasoning-heavy subtasks (debugging, code review, research synthesis)\\n"
+        "- Tasks that would flood your context with intermediate data\\n"
+        "- Parallel independent workstreams (research A and B simultaneously)\\n\\n"
+        "WHEN NOT TO USE (use these instead):\\n"
+        "- Mechanical multi-step work with no reasoning needed -> use execute_code\\n"
+        "- Single tool call -> just call the tool directly\\n"
+        "- Tasks needing user interaction -> subagents cannot use clarify\\n\\n"
+        "IMPORTANT:\\n"
         "- Subagents have NO memory of your conversation. Pass all relevant "
-        "info (file paths, error messages, constraints) via the 'context' field.\n"
+        "info (file paths, error messages, constraints) via the 'context' field.\\n"
         "- Subagents CANNOT call: delegate_task, clarify, memory, send_message, "
-        "execute_code.\n"
-        "- Each subagent gets its own terminal session (separate working directory and state).\n"
+        "execute_code.\\n"
+        "- Each subagent gets its own terminal session (separate working directory and state).\\n"
         "- Results are always returned as an array, one entry per task."
     ),
     "parameters": {
@@ -735,6 +811,22 @@ DELEGATE_TASK_SCHEMA = {
                     "full-stack tasks."
                 ),
             },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Override the model for this subagent. "
+                    "Example: 'glm-5.1' for code tasks, 'glm-5' for reasoning. "
+                    "Overrides config delegation.model. Falls back to parent model if omitted."
+                ),
+            },
+            "provider": {
+                "type": "string",
+                "description": (
+                    "Override the provider for this subagent. "
+                    "Example: 'zai', 'openrouter', 'nous'. "
+                    "Overrides config delegation.provider. Falls back to parent provider if omitted."
+                ),
+            },
             "tasks": {
                 "type": "array",
                 "items": {
@@ -746,6 +838,14 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "array",
                             "items": {"type": "string"},
                             "description": "Toolsets for this specific task",
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": "Override model for this specific task",
+                        },
+                        "provider": {
+                            "type": "string",
+                            "description": "Override provider for this specific task",
                         },
                     },
                     "required": ["goal"],
@@ -783,6 +883,8 @@ registry.register(
         toolsets=args.get("toolsets"),
         tasks=args.get("tasks"),
         max_iterations=args.get("max_iterations"),
+        model=args.get("model"),
+        provider=args.get("provider"),
         parent_agent=kw.get("parent_agent")),
     check_fn=check_delegate_requirements,
     emoji="🔀",


### PR DESCRIPTION
Closes #3719

## Summary

Add `model` and `provider` parameters to `delegate_task` (top-level and per-task in batch mode) so the parent agent can dynamically route subagents to different models based on task type.

## Motivation

Currently subagent model selection is static via `delegation.model`/`delegation.provider` in config.yaml — all subagents use the same model. Different tasks benefit from different models (code → fast model, research → strong reasoning model).

## Changes

**`tools/delegate_tool.py`** (136 insertions, 34 deletions)

1. **Schema**: Added `model` and `provider` as top-level params + inside batch task items
2. **`_resolve_call_credentials()`**: New helper that merges per-call overrides with config-level credentials via `resolve_runtime_provider()`
3. **`delegate_task()`**: Refactored to resolve credentials **per-task** instead of once globally. Top-level `model`/`provider` flow into single-task mode; batch mode uses each task's own overrides
4. **Registry handler**: Wires `model`/`provider` through the lambda

## Resolution Priority

```
per-call model/provider  →  config delegation.model/provider  →  inherit parent
```

Fully backward compatible — omitting `model`/`provider` preserves existing behavior.

## Example Usage

**Single task:**
```json
delegate_task({
  "goal": "Implement auth middleware",
  "model": "glm-5.1",
  "provider": "zai"
})
```

**Batch with per-task routing:**
```json
delegate_task({
  "tasks": [
    {"goal": "Research competitors", "model": "glm-5", "provider": "zai"},
    {"goal": "Write integration tests", "model": "glm-5.1"}
  ]
})
```