### PR TITLE
fix(delegate_task): send empty list instead of None for tools

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4706,7 +4706,7 @@ class AIAgent:
         api_kwargs = {
             "model": self.model,
             "messages": sanitized_messages,
-            "tools": self.tools if self.tools else None,
+            "tools": self.tools if self.tools else [],
             "timeout": float(os.getenv("HERMES_API_TIMEOUT", 1800.0)),
         }
 


### PR DESCRIPTION
## Problem

`delegate_task` fails with Fireworks AI (and other strict OpenAI-compatible providers) when a subagent has no valid tools after filtering blocked ones:

```
HTTP 400: Input should be a valid list, field: 'tools', value: None
```

## Root Cause

In `_build_api_kwargs()`, when `self.tools` is an empty list `[]` (falsy in Python), the code was converting it to `None`:

```python
"tools": self.tools if self.tools else None,
```

Fireworks AI rejects `tools=None` — it requires either a valid list or the parameter omitted entirely.

## Fix

Changed to always send a valid list:

```python
"tools": self.tools if self.tools else [],
```

## Testing

- Subagent with tools (terminal): ✅ Works  
- Subagent without tools (empty list): ✅ Works (previously failed)

---

**Note:** This is a minimal one-line fix with no breaking changes.