### PR TITLE
fix(patch): reject truncated file reads before applying patch

### DIFF
--- a/tests/tools/test_patch_parser.py
+++ b/tests/tools/test_patch_parser.py
@@ -253,3 +253,42 @@ class TestAdditionOnlyHunks:
         assert result.success is True
         assert file_ops.written.endswith("def new_func():\n    return True\n")
         assert "existing = True" in file_ops.written
+
+class TestTruncatedFileSafeguard:
+    """patch_parser should refuse to patch files that were read truncated."""
+
+    def test_truncated_read_returns_error_and_does_not_write(self):
+        patch = """*** Begin Patch
+*** Update File: big.py
+@@ some_func @@
+ def some_func():
+-    return 1
++    return 2
+*** End Patch"""
+        ops, err = parse_v4a_patch(patch)
+        assert err is None
+
+        class FakeFileOps:
+            def __init__(self):
+                self.write_called = False
+
+            def read_file(self, path, offset=1, limit=500):
+                # Simulate a file that has more lines than the read limit returned
+                return SimpleNamespace(
+                    content="def some_func():\n    return 1",
+                    error=None,
+                    truncated=True,
+                    total_lines=3500,
+                )
+
+            def write_file(self, path, content):
+                self.write_called = True
+                return SimpleNamespace(error=None)
+
+        file_ops = FakeFileOps()
+        result = apply_v4a_operations(ops, file_ops)
+
+        assert result.success is False
+        assert "3500" in result.error
+        assert "capped" in result.error
+        assert file_ops.write_called is False

--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -355,7 +355,15 @@ def _apply_update(op: PatchOperation, file_ops: Any) -> Tuple[bool, str]:
     
     if read_result.error:
         return False, f"Cannot read file: {read_result.error}"
-    
+
+    if getattr(read_result, 'truncated', False):
+        total = getattr(read_result, 'total_lines', '?')
+        return False, (
+            f"{op.file_path} has {total} lines but the read was capped before the end. "
+            "Patching a partial view would destroy the rest of the file. "
+            "Split the patch into smaller hunks targeting specific sections."
+        )
+
     # Parse content (remove line numbers)
     current_lines = []
     for line in read_result.content.split('\n'):


### PR DESCRIPTION
## Summary
Prevent patch application from running on truncated file reads.

## Problem
`patch_parser` could keep applying a patch after reading only a truncated view of a large file. Because the result is written back as a full overwrite, this could drop the rest of the file.

## Fix
Return an error early when `read_file()` reports a truncated result, instead of applying the patch to partial content.

## Tests
Added a test that simulates a truncated read and verifies that:
- patch application fails
- an error is returned
- `write_file` is not called