### PR TITLE
Fix hermes launcher to use local venv and package entrypoint

### DIFF
--- a/hermes
+++ b/hermes
@@ -6,7 +6,70 @@ This is a convenience wrapper to launch the Hermes CLI.
 Usage: ./hermes [options]
 """
 
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def _project_root() -> Path:
+    return Path(__file__).resolve().parent
+
+
+def _find_local_venv_python(project_root: Path) -> Path | None:
+    """Prefer the repo-local venv (if present), then re-exec in it."""
+    for venv_dir in (project_root / "venv", project_root / ".venv"):
+        if not venv_dir.exists():
+            continue
+        candidate = venv_dir / "bin" / "python3"
+        if candidate.exists():
+            return candidate
+        candidate = venv_dir / "bin" / "python"
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _ensure_local_venv_if_available() -> None:
+    if os.environ.get("HERMES_LAUNCHER_REEXEC") == "1":
+        return
+
+    local_python = _find_local_venv_python(_project_root())
+    if local_python is None:
+        return
+
+    current = Path(sys.executable).resolve()
+    if current == local_python.resolve():
+        return
+
+    os.environ["HERMES_LAUNCHER_REEXEC"] = "1"
+    os.execv(str(local_python), [str(local_python), *sys.argv])
+
+
+def _format_dependency_message(module_name: str | None) -> str:
+    if not module_name:
+        return (
+            "Hermes dependencies are not installed in the active Python environment.\n"
+            "Run `pip install -e \".[all]\"` from the repo root, then retry."
+        )
+    return (
+        f"Failed to import required module `{module_name}`.\n"
+        "This usually means the Hermes dependencies are not installed in the active environment.\n"
+        "From the repo root, run:\n"
+        "  source venv/bin/activate\n"
+        "  pip install -e \".[all]\"\n"
+        "Then run `./hermes` again."
+    )
+
+
 if __name__ == "__main__":
-    from cli import main
-    import fire
-    fire.Fire(main)
+    _ensure_local_venv_if_available()
+
+    try:
+        from hermes_cli.main import main
+    except ModuleNotFoundError as exc:
+        print(_format_dependency_message(exc.name))
+        raise SystemExit(1) from exc
+
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- re-exec the repo launcher into the local venv Python when one exists
- use the packaged hermes CLI entrypoint instead of importing cli.py directly
- print a clearer dependency/setup error when required modules are missing

## Verification
- ran \usage: hermes [-h] [--version] [--resume SESSION] [--continue [SESSION_NAME]]
              [--worktree] [--skills SKILLS] [--yolo] [--pass-session-id]
              {chat,model,gateway,setup,whatsapp,login,logout,status,cron,webhook,doctor,config,pairing,skills,plugins,honcho,tools,mcp,sessions,insights,claw,version,update,uninstall,acp}
              ...

Hermes Agent - AI assistant with tool-calling capabilities

positional arguments:
  {chat,model,gateway,setup,whatsapp,login,logout,status,cron,webhook,doctor,config,pairing,skills,plugins,honcho,tools,mcp,sessions,insights,claw,version,update,uninstall,acp}
                        Command to run
    chat                Interactive chat with the agent
    model               Select default model and provider
    gateway             Messaging gateway management
    setup               Interactive setup wizard
    whatsapp            Set up WhatsApp integration
    login               Authenticate with an inference provider
    logout              Clear authentication for an inference provider
    status              Show status of all components
    cron                Cron job management
    webhook             Manage dynamic webhook subscriptions
    doctor              Check configuration and dependencies
    config              View and edit configuration
    pairing             Manage DM pairing codes for user authorization
    skills              Search, install, configure, and manage skills
    plugins             Manage plugins — install, update, remove, list
    honcho              Manage Honcho AI memory integration
    tools               Configure which tools are enabled per platform
    mcp                 Manage MCP server connections
    sessions            Manage session history (list, rename, export, prune,
                        delete)
    insights            Show usage insights and analytics
    claw                OpenClaw migration tools
    version             Show version information
    update              Update Hermes Agent to the latest version
    uninstall           Uninstall Hermes Agent
    acp                 Run Hermes Agent as an ACP (Agent Client Protocol)
                        server

options:
  -h, --help            show this help message and exit
  --version, -V         Show version and exit
  --resume SESSION, -r SESSION
                        Resume a previous session by ID or title
  --continue [SESSION_NAME], -c [SESSION_NAME]
                        Resume a session by name, or the most recent if no
                        name given
  --worktree, -w        Run in an isolated git worktree (for parallel agents)
  --skills SKILLS, -s SKILLS
                        Preload one or more skills for the session (repeat
                        flag or comma-separate)
  --yolo                Bypass all dangerous command approval prompts (use at
                        your own risk)
  --pass-session-id     Include the session ID in the agent's system prompt

Examples:
    hermes                        Start interactive chat
    hermes chat -q "Hello"        Single query mode
    hermes -c                     Resume the most recent session
    hermes -c "my project"        Resume a session by name (latest in lineage)
    hermes --resume <session_id>  Resume a specific session by ID
    hermes setup                  Run setup wizard
    hermes logout                 Clear stored authentication
    hermes model                  Select default model
    hermes config                 View configuration
    hermes config edit            Edit config in $EDITOR
    hermes config set model gpt-4 Set a config value
    hermes gateway                Run messaging gateway
    hermes -s hermes-agent-dev,github-auth
    hermes -w                     Start in isolated git worktree
    hermes gateway install        Install gateway background service
    hermes sessions list          List past sessions
    hermes sessions browse        Interactive session picker
    hermes sessions rename ID T   Rename/title a session
    hermes update                 Update to latest version

For more help on a command:
    hermes <command> --help from the repo root without manually activating the venv
- confirmed the CLI now starts and prints usage successfully