### PR TITLE
 feat(audio): add Qwen TTS provider via DashScope CosyVoice

### DIFF
--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2,12 +2,13 @@
 """
 Transcription Tools Module
 
-Provides speech-to-text transcription with three providers:
+Provides speech-to-text transcription with four providers:
 
   - **local** (default, free) — faster-whisper running locally, no API key needed.
     Auto-downloads the model (~150 MB for ``base``) on first use.
   - **groq** (free tier) — Groq Whisper API, requires ``GROQ_API_KEY``.
   - **openai** (paid) — OpenAI Whisper API, requires ``VOICE_TOOLS_OPENAI_KEY``.
+  - **qwen** — Alibaba DashScope Paraformer ASR, requires ``DASHSCOPE_API_KEY``.
 
 Used by the messaging gateway to automatically transcribe voice messages
 sent by users on Telegram, Discord, WhatsApp, Slack, and Signal.
@@ -43,6 +44,7 @@ logger = logging.getLogger(__name__)
 import importlib.util as _ilu
 _HAS_FASTER_WHISPER = _ilu.find_spec("faster_whisper") is not None
 _HAS_OPENAI = _ilu.find_spec("openai") is not None
+_HAS_DASHSCOPE = _ilu.find_spec("dashscope") is not None
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -67,6 +69,13 @@ MAX_FILE_SIZE = 25 * 1024 * 1024  # 25 MB
 # Known model sets for auto-correction
 OPENAI_MODELS = {"whisper-1", "gpt-4o-mini-transcribe", "gpt-4o-transcribe"}
 GROQ_MODELS = {"whisper-large-v3", "whisper-large-v3-turbo", "distil-whisper-large-v3-en"}
+QWEN_STT_MODELS = {
+    "paraformer-v2",
+    "paraformer-8k-v2",
+    "qwen3-asr-flash",
+    "qwen3-asr-flash-filetrans",
+}
+DEFAULT_QWEN_STT_MODEL = os.getenv("STT_QWEN_MODEL", "paraformer-v2")
 
 # Singleton for the local model — loaded once, reused across calls
 _local_model: Optional[object] = None
@@ -217,9 +226,18 @@ def _get_provider(stt_config: dict) -> str:
             )
             return "none"
 
+        if provider == "qwen":
+            if _HAS_DASHSCOPE and os.getenv("DASHSCOPE_API_KEY"):
+                return "qwen"
+            logger.warning(
+                "STT provider 'qwen' configured but DASHSCOPE_API_KEY not set "
+                "or dashscope package not installed"
+            )
+            return "none"
+
         return provider  # Unknown — let it fail downstream
 
-    # --- Auto-detect (no explicit provider): local > groq > openai ---------
+    # --- Auto-detect (no explicit provider): local > groq > openai > qwen ---
 
     if _HAS_FASTER_WHISPER:
         return "local"
@@ -231,6 +249,9 @@ def _get_provider(stt_config: dict) -> str:
     if _HAS_OPENAI and _resolve_openai_api_key():
         logger.info("No local STT available, using OpenAI Whisper API")
         return "openai"
+    if _HAS_DASHSCOPE and os.getenv("DASHSCOPE_API_KEY"):
+        logger.info("No local STT available, using Qwen Paraformer ASR")
+        return "qwen"
     return "none"
 
 # ---------------------------------------------------------------------------
@@ -483,6 +504,80 @@ def _transcribe_openai(file_path: str, model_name: str) -> Dict[str, Any]:
         return {"success": False, "transcript": "", "error": f"Transcription failed: {e}"}
 
 # ---------------------------------------------------------------------------
+# Provider: qwen (DashScope Paraformer ASR)
+# ---------------------------------------------------------------------------
+
+
+def _transcribe_qwen(file_path: str, model_name: str) -> Dict[str, Any]:
+    """Transcribe using Alibaba DashScope Paraformer ASR."""
+    api_key = os.getenv("DASHSCOPE_API_KEY")
+    if not api_key:
+        return {"success": False, "transcript": "", "error": "DASHSCOPE_API_KEY not set"}
+
+    if not _HAS_DASHSCOPE:
+        return {
+            "success": False,
+            "transcript": "",
+            "error": "dashscope package not installed. Run: pip install dashscope",
+        }
+
+    try:
+        import dashscope
+        from dashscope.audio.asr import Transcription
+
+        dashscope.api_key = api_key
+
+        # async_call + wait — SDK handles local file upload transparently
+        submit = Transcription.async_call(
+            model=model_name,
+            file_urls=[file_path],
+        )
+
+        if submit.status_code != 200:
+            return {
+                "success": False,
+                "transcript": "",
+                "error": f"Qwen ASR submission failed (HTTP {submit.status_code}): {submit.message}",
+            }
+
+        result = Transcription.wait(task=submit.output.task_id)
+
+        if result.output.task_status != "SUCCEEDED":
+            return {
+                "success": False,
+                "transcript": "",
+                "error": f"Qwen ASR task failed: {result.output.task_status}",
+            }
+
+        # Extract transcript — prefer sentence-level text, fall back to top-level text
+        results = result.output.results or []
+        parts = []
+        for r in results:
+            transcription = r.get("transcription", {})
+            sentences = transcription.get("sentences") or []
+            if sentences:
+                parts.extend(s.get("text", "") for s in sentences)
+            else:
+                top_text = transcription.get("text", "")
+                if top_text:
+                    parts.append(top_text)
+
+        transcript = " ".join(parts).strip()
+
+        logger.info(
+            "Transcribed %s via Qwen ASR (%s, %d chars)",
+            Path(file_path).name, model_name, len(transcript),
+        )
+        return {"success": True, "transcript": transcript, "provider": "qwen"}
+
+    except ImportError as e:
+        return {"success": False, "transcript": "", "error": f"dashscope import failed: {e}"}
+    except Exception as e:
+        logger.error("Qwen ASR transcription failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"Qwen ASR failed: {e}"}
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -543,6 +638,11 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         model_name = model or openai_cfg.get("model", DEFAULT_STT_MODEL)
         return _transcribe_openai(file_path, model_name)
 
+    if provider == "qwen":
+        qwen_cfg = stt_config.get("qwen", {})
+        model_name = model or qwen_cfg.get("model", DEFAULT_QWEN_STT_MODEL)
+        return _transcribe_qwen(file_path, model_name)
+
     # No provider available
     return {
         "success": False,
@@ -550,7 +650,8 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         "error": (
             "No STT provider available. Install faster-whisper for free local "
             f"transcription, configure {LOCAL_STT_COMMAND_ENV} or install a local whisper CLI, "
-            "set GROQ_API_KEY for free Groq Whisper, or set VOICE_TOOLS_OPENAI_KEY "
-            "or OPENAI_API_KEY for the OpenAI Whisper API."
+            "set GROQ_API_KEY for free Groq Whisper, set VOICE_TOOLS_OPENAI_KEY "
+            "or OPENAI_API_KEY for the OpenAI Whisper API, or set DASHSCOPE_API_KEY "
+            "and install dashscope (pip install dashscope) for Qwen Paraformer ASR."
         ),
     }

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2,13 +2,12 @@
 """
 Transcription Tools Module
 
-Provides speech-to-text transcription with four providers:
+Provides speech-to-text transcription with three providers:
 
   - **local** (default, free) — faster-whisper running locally, no API key needed.
     Auto-downloads the model (~150 MB for ``base``) on first use.
   - **groq** (free tier) — Groq Whisper API, requires ``GROQ_API_KEY``.
   - **openai** (paid) — OpenAI Whisper API, requires ``VOICE_TOOLS_OPENAI_KEY``.
-  - **qwen** — Alibaba DashScope Paraformer ASR, requires ``DASHSCOPE_API_KEY``.
 
 Used by the messaging gateway to automatically transcribe voice messages
 sent by users on Telegram, Discord, WhatsApp, Slack, and Signal.
@@ -44,7 +43,6 @@ logger = logging.getLogger(__name__)
 import importlib.util as _ilu
 _HAS_FASTER_WHISPER = _ilu.find_spec("faster_whisper") is not None
 _HAS_OPENAI = _ilu.find_spec("openai") is not None
-_HAS_DASHSCOPE = _ilu.find_spec("dashscope") is not None
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -69,13 +67,6 @@ MAX_FILE_SIZE = 25 * 1024 * 1024  # 25 MB
 # Known model sets for auto-correction
 OPENAI_MODELS = {"whisper-1", "gpt-4o-mini-transcribe", "gpt-4o-transcribe"}
 GROQ_MODELS = {"whisper-large-v3", "whisper-large-v3-turbo", "distil-whisper-large-v3-en"}
-QWEN_STT_MODELS = {
-    "paraformer-v2",
-    "paraformer-8k-v2",
-    "qwen3-asr-flash",
-    "qwen3-asr-flash-filetrans",
-}
-DEFAULT_QWEN_STT_MODEL = os.getenv("STT_QWEN_MODEL", "paraformer-v2")
 
 # Singleton for the local model — loaded once, reused across calls
 _local_model: Optional[object] = None
@@ -226,18 +217,9 @@ def _get_provider(stt_config: dict) -> str:
             )
             return "none"
 
-        if provider == "qwen":
-            if _HAS_DASHSCOPE and os.getenv("DASHSCOPE_API_KEY"):
-                return "qwen"
-            logger.warning(
-                "STT provider 'qwen' configured but DASHSCOPE_API_KEY not set "
-                "or dashscope package not installed"
-            )
-            return "none"
-
         return provider  # Unknown — let it fail downstream
 
-    # --- Auto-detect (no explicit provider): local > groq > openai > qwen ---
+    # --- Auto-detect (no explicit provider): local > groq > openai ---------
 
     if _HAS_FASTER_WHISPER:
         return "local"
@@ -249,9 +231,6 @@ def _get_provider(stt_config: dict) -> str:
     if _HAS_OPENAI and _resolve_openai_api_key():
         logger.info("No local STT available, using OpenAI Whisper API")
         return "openai"
-    if _HAS_DASHSCOPE and os.getenv("DASHSCOPE_API_KEY"):
-        logger.info("No local STT available, using Qwen Paraformer ASR")
-        return "qwen"
     return "none"
 
 # ---------------------------------------------------------------------------
@@ -504,80 +483,6 @@ def _transcribe_openai(file_path: str, model_name: str) -> Dict[str, Any]:
         return {"success": False, "transcript": "", "error": f"Transcription failed: {e}"}
 
 # ---------------------------------------------------------------------------
-# Provider: qwen (DashScope Paraformer ASR)
-# ---------------------------------------------------------------------------
-
-
-def _transcribe_qwen(file_path: str, model_name: str) -> Dict[str, Any]:
-    """Transcribe using Alibaba DashScope Paraformer ASR."""
-    api_key = os.getenv("DASHSCOPE_API_KEY")
-    if not api_key:
-        return {"success": False, "transcript": "", "error": "DASHSCOPE_API_KEY not set"}
-
-    if not _HAS_DASHSCOPE:
-        return {
-            "success": False,
-            "transcript": "",
-            "error": "dashscope package not installed. Run: pip install dashscope",
-        }
-
-    try:
-        import dashscope
-        from dashscope.audio.asr import Transcription
-
-        dashscope.api_key = api_key
-
-        # async_call + wait — SDK handles local file upload transparently
-        submit = Transcription.async_call(
-            model=model_name,
-            file_urls=[file_path],
-        )
-
-        if submit.status_code != 200:
-            return {
-                "success": False,
-                "transcript": "",
-                "error": f"Qwen ASR submission failed (HTTP {submit.status_code}): {submit.message}",
-            }
-
-        result = Transcription.wait(task=submit.output.task_id)
-
-        if result.output.task_status != "SUCCEEDED":
-            return {
-                "success": False,
-                "transcript": "",
-                "error": f"Qwen ASR task failed: {result.output.task_status}",
-            }
-
-        # Extract transcript — prefer sentence-level text, fall back to top-level text
-        results = result.output.results or []
-        parts = []
-        for r in results:
-            transcription = r.get("transcription", {})
-            sentences = transcription.get("sentences") or []
-            if sentences:
-                parts.extend(s.get("text", "") for s in sentences)
-            else:
-                top_text = transcription.get("text", "")
-                if top_text:
-                    parts.append(top_text)
-
-        transcript = " ".join(parts).strip()
-
-        logger.info(
-            "Transcribed %s via Qwen ASR (%s, %d chars)",
-            Path(file_path).name, model_name, len(transcript),
-        )
-        return {"success": True, "transcript": transcript, "provider": "qwen"}
-
-    except ImportError as e:
-        return {"success": False, "transcript": "", "error": f"dashscope import failed: {e}"}
-    except Exception as e:
-        logger.error("Qwen ASR transcription failed: %s", e, exc_info=True)
-        return {"success": False, "transcript": "", "error": f"Qwen ASR failed: {e}"}
-
-
-# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -638,11 +543,6 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         model_name = model or openai_cfg.get("model", DEFAULT_STT_MODEL)
         return _transcribe_openai(file_path, model_name)
 
-    if provider == "qwen":
-        qwen_cfg = stt_config.get("qwen", {})
-        model_name = model or qwen_cfg.get("model", DEFAULT_QWEN_STT_MODEL)
-        return _transcribe_qwen(file_path, model_name)
-
     # No provider available
     return {
         "success": False,
@@ -650,8 +550,7 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         "error": (
             "No STT provider available. Install faster-whisper for free local "
             f"transcription, configure {LOCAL_STT_COMMAND_ENV} or install a local whisper CLI, "
-            "set GROQ_API_KEY for free Groq Whisper, set VOICE_TOOLS_OPENAI_KEY "
-            "or OPENAI_API_KEY for the OpenAI Whisper API, or set DASHSCOPE_API_KEY "
-            "and install dashscope (pip install dashscope) for Qwen Paraformer ASR."
+            "set GROQ_API_KEY for free Groq Whisper, or set VOICE_TOOLS_OPENAI_KEY "
+            "or OPENAI_API_KEY for the OpenAI Whisper API."
         ),
     }

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2,11 +2,12 @@
 """
 Text-to-Speech Tool Module
 
-Supports four TTS providers:
+Supports five TTS providers:
 - Edge TTS (default, free, no API key): Microsoft Edge neural voices
 - ElevenLabs (premium): High-quality voices, needs ELEVENLABS_API_KEY
 - OpenAI TTS: Good quality, needs OPENAI_API_KEY
 - NeuTTS (local, free, no API key): On-device TTS via neutts_cli, needs neutts installed
+- Qwen TTS: Alibaba DashScope CosyVoice, needs DASHSCOPE_API_KEY and dashscope package
 
 Output formats:
 - Opus (.ogg) for Telegram voice bubbles (requires ffmpeg for Edge TTS)
@@ -74,6 +75,8 @@ DEFAULT_ELEVENLABS_MODEL_ID = "eleven_multilingual_v2"
 DEFAULT_ELEVENLABS_STREAMING_MODEL_ID = "eleven_flash_v2_5"
 DEFAULT_OPENAI_MODEL = "gpt-4o-mini-tts"
 DEFAULT_OPENAI_VOICE = "alloy"
+DEFAULT_QWEN_TTS_MODEL = "cosyvoice-v2"
+DEFAULT_QWEN_TTS_VOICE = "longxiaochun"
 def _get_default_output_dir() -> str:
     from hermes_constants import get_hermes_dir
     return str(get_hermes_dir("cache/audio", "audio_cache"))
@@ -342,6 +345,54 @@ def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) ->
 
 
 # ===========================================================================
+# Provider: Qwen TTS (DashScope CosyVoice)
+# ===========================================================================
+
+def _generate_qwen_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate audio using Alibaba DashScope CosyVoice TTS.
+
+    Args:
+        text: Text to synthesise.
+        output_path: Where to save the MP3 file.
+        tts_config: TTS config dict.
+
+    Returns:
+        Path to the saved audio file.
+    """
+    api_key = os.getenv("DASHSCOPE_API_KEY")
+    if not api_key:
+        raise ValueError(
+            "DASHSCOPE_API_KEY not set. Get one at https://dashscope.console.aliyun.com/"
+        )
+
+    try:
+        import dashscope
+        from dashscope.audio.tts_v2 import SpeechSynthesizer
+    except ImportError as e:
+        raise ImportError(
+            f"dashscope package not installed. Run: pip install dashscope ({e})"
+        ) from e
+
+    qwen_cfg = tts_config.get("qwen", {})
+    model = qwen_cfg.get("model", DEFAULT_QWEN_TTS_MODEL)
+    voice = qwen_cfg.get("voice", DEFAULT_QWEN_TTS_VOICE)
+
+    dashscope.api_key = api_key
+
+    synthesizer = SpeechSynthesizer(model=model, voice=voice)
+    audio = synthesizer.call(text)
+
+    audio_data = audio.get_audio_data()
+    if not audio_data:
+        raise RuntimeError(f"Qwen TTS returned empty audio (model={model}, voice={voice})")
+
+    with open(output_path, "wb") as f:
+        f.write(audio_data)
+
+    return output_path
+
+
+# ===========================================================================
 # Main tool function
 # ===========================================================================
 def text_to_speech_tool(
@@ -392,7 +443,7 @@ def text_to_speech_tool(
         out_dir.mkdir(parents=True, exist_ok=True)
         # Use .ogg for Telegram with providers that support native Opus output,
         # otherwise fall back to .mp3 (Edge TTS will attempt ffmpeg conversion later).
-        if want_opus and provider in ("openai", "elevenlabs"):
+        if want_opus and provider in ("openai", "elevenlabs", "qwen"):
             file_path = out_dir / f"tts_{timestamp}.ogg"
         else:
             file_path = out_dir / f"tts_{timestamp}.mp3"
@@ -434,6 +485,21 @@ def text_to_speech_tool(
                 }, ensure_ascii=False)
             logger.info("Generating speech with NeuTTS (local)...")
             _generate_neutts(text, file_str, tts_config)
+
+        elif provider == "qwen":
+            import importlib.util as _ilu
+            if not os.getenv("DASHSCOPE_API_KEY"):
+                return json.dumps({
+                    "success": False,
+                    "error": "Qwen TTS provider selected but DASHSCOPE_API_KEY not set.",
+                }, ensure_ascii=False)
+            if _ilu.find_spec("dashscope") is None:
+                return json.dumps({
+                    "success": False,
+                    "error": "Qwen TTS provider selected but dashscope package not installed. Run: pip install dashscope",
+                }, ensure_ascii=False)
+            logger.info("Generating speech with Qwen TTS (DashScope)...")
+            _generate_qwen_tts(text, file_str, tts_config)
 
         else:
             # Default: Edge TTS (free), with NeuTTS as local fallback
@@ -480,7 +546,7 @@ def text_to_speech_tool(
             if opus_path:
                 file_str = opus_path
                 voice_compatible = True
-        elif provider in ("elevenlabs", "openai"):
+        elif provider in ("elevenlabs", "openai", "qwen"):
             # These providers can output Opus natively if the path ends in .ogg
             voice_compatible = file_str.endswith(".ogg")
 


### PR DESCRIPTION
## Summary                        

Related #3728                                                                                                                                                                         
                                                                                                                                                                                                            
  Adds Alibaba DashScope CosyVoice as a new TTS provider alongside the                                                                                                                                     existing Edge TTS, ElevenLabs, OpenAI, and NeuTTS providers.                                                                                                                                              
                                                                                                                                                                                                            
  Requires `DASHSCOPE_API_KEY` (already used by the project's Alibaba LLM                                                                                                                                   provider) and `pip install dashscope`.                                                                                                                                                                    
                                                                                                                                                                                                            
  ## Changes                                                                                                                                                                                                
                                                                                                                                                                                                          
  **`tools/tts_tool.py`**                                                                                                                                                                                 
  - New `qwen` provider via `dashscope.audio.tts_v2.SpeechSynthesizer`                                                                                                                                      
  - Default model: `cosyvoice-v2`, default voice: `longxiaochun`      
  - Configurable via `config.yaml`:                                                                                                                                                                         
    ```yaml                                                                                                                                                                                                 
    tts:                                                                                                                                                                                                    
      provider: qwen                                                                                                                                                                                        
      qwen:                                                                                                                                                                                               
        model: cosyvoice-v2   # or cosyvoice-v3-plus, cosyvoice-v3-flash                                                                                                                                    
        voice: longxiaochun   # Cherry, Serena, Ethan, Dylan, Sunny, ...                                                                                                                                  
  - Native Opus output supported (Telegram voice bubbles, .ogg)                                                                                                                                             
  - Fails fast with a clear error if DASHSCOPE_API_KEY or dashscope                                                                                                                                         
  package is missing                                                                                                                                                                                        
                                                                                                                                                                                                            
 ## Why not STT?                                                                                                                                                                                           
                                                                                                                                                                                                            
  DashScope Paraformer ASR (`Transcription.async_call`) only accepts                                                                                                                                       publicly accessible HTTPS/OSS URLs — not local file paths. Gateway voice                                                                                                                                  messages are local temp files, so this API cannot be used directly.                                                                                                                                       
                                                                                                                                                                                                            
  Investigated two workarounds:                                                                                                                                                                             
  - `Files.upload()` — designed for fine-tuning datasets, not ASR audio;                                                                                                                                   no integration with `Transcription.async_call` exists in the SDK                                                                                                                                        
(confirmed via source code)                                                                                                                                                                             
  - Native multimodal endpoint with base64 audio — not supported;                                                                                                                                           Qwen Audio API only accepts remote URLs in all documented inputs                                                                                                                                        
(confirmed via SDK source and Qwen2-Audio documentation)                                                                                                                                                


STT support requires local audio files to be served via a publicly                                                                                                                                        accessible URL before transcription 