### PR TITLE
fix: ensure tool schema always includes name field (#3729)

### DIFF
--- a/tools/registry.py
+++ b/tools/registry.py
@@ -115,7 +115,9 @@ class ToolRegistry:
                     if not quiet:
                         logger.debug("Tool %s unavailable (check failed)", name)
                     continue
-            result.append({"type": "function", "function": entry.schema})
+            # Ensure schema always has a "name" field — use entry.name as fallback
+            schema_with_name = {**entry.schema, "name": entry.name}
+            result.append({"type": "function", "function": schema_with_name})
         return result
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix KeyError crash when a registered tool schema omits the name field.

## Fix

In tools/registry.py get_definitions(), always merge entry.name into the schema.

Closes #3729