### PR TITLE
Handle hermes status when systemctl is unavailable

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -5,6 +5,7 @@ Shows the status of all Hermes Agent components.
 """
 
 import os
+import shutil
 import sys
 import subprocess
 from pathlib import Path
@@ -282,14 +283,19 @@ def show_status(args):
             _gw_svc = get_service_name()
         except Exception:
             _gw_svc = "hermes-gateway"
-        result = subprocess.run(
-            ["systemctl", "--user", "is-active", _gw_svc],
-            capture_output=True,
-            text=True
-        )
-        is_active = result.stdout.strip() == "active"
-        print(f"  Status:       {check_mark(is_active)} {'running' if is_active else 'stopped'}")
-        print("  Manager:      systemd (user)")
+        systemctl_path = shutil.which("systemctl")
+        if systemctl_path:
+            result = subprocess.run(
+                [systemctl_path, "--user", "is-active", _gw_svc],
+                capture_output=True,
+                text=True
+            )
+            is_active = result.stdout.strip() == "active"
+            print(f"  Status:       {check_mark(is_active)} {'running' if is_active else 'stopped'}")
+            print("  Manager:      systemd (user)")
+        else:
+            print(f"  Status:       {color('N/A', Colors.DIM)}")
+            print("  Manager:      systemd unavailable in this runtime")
         
     elif sys.platform == 'darwin':
         from hermes_cli.gateway import get_launchd_label

--- a/tests/hermes_cli/test_status_model_provider.py
+++ b/tests/hermes_cli/test_status_model_provider.py
@@ -22,6 +22,7 @@ def _patch_common_status_deps(monkeypatch, status_mod, tmp_path, *, openai_base_
         "run",
         lambda *args, **kwargs: SimpleNamespace(stdout="inactive\n", returncode=3),
     )
+    monkeypatch.setattr(status_mod.shutil, "which", lambda _name: "/bin/systemctl")
 
 
 def test_show_status_displays_configured_dict_model_and_provider_label(monkeypatch, capsys, tmp_path):
@@ -59,3 +60,21 @@ def test_show_status_displays_legacy_string_model_and_custom_endpoint(monkeypatc
     out = capsys.readouterr().out
     assert "Model:        qwen3:latest" in out
     assert "Provider:     Custom endpoint" in out
+
+
+def test_show_status_handles_linux_without_systemctl(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+
+    _patch_common_status_deps(monkeypatch, status_mod, tmp_path)
+    monkeypatch.setattr(status_mod, "load_config", lambda: {}, raising=False)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "auto", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openrouter", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: provider, raising=False)
+    monkeypatch.setattr(status_mod.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(status_mod.sys, "platform", "linux")
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+
+    out = capsys.readouterr().out
+    assert "Status:       N/A" in out
+    assert "Manager:      systemd unavailable in this runtime" in out


### PR DESCRIPTION
Fixes #3724.

## Summary
- check for  before invoking it on Linux
- show a graceful  status when systemd is unavailable in the runtime
- add coverage for the no-systemctl path

## Verification
- bringing up nodes...
bringing up nodes...

..                                                                       [100%]
2 passed in 5.24s

## Security
- patch only changes local status display logic and tests
- no credentials,  data, or host-specific secrets included