### PR TITLE
Default missing tool schema names in registry

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -2792,6 +2792,28 @@ class TestRegistryCollisionWarning:
 
         assert not any("collision" in r.message.lower() for r in caplog.records)
 
+    def test_missing_schema_name_is_filled_from_registry_name(self):
+        """Tools without schema['name'] should still produce valid definitions."""
+        from tools.registry import ToolRegistry
+
+        reg = ToolRegistry()
+        schema = {"description": "test", "parameters": {"type": "object", "properties": {}}}
+        handler = lambda args, **kw: "{}"
+
+        reg.register(name="my_tool", toolset="builtin", schema=schema, handler=handler)
+
+        defs = reg.get_definitions({"my_tool"})
+        assert defs == [
+            {
+                "type": "function",
+                "function": {
+                    "name": "my_tool",
+                    "description": "test",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+
 
 class TestMCPBuiltinCollisionGuard:
     """MCP tools that collide with built-in tool names are skipped."""

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -66,6 +66,11 @@ class ToolRegistry:
         emoji: str = "",
     ):
         """Register a tool.  Called at module-import time by each tool file."""
+        # External/plugin tools sometimes omit schema["name"]. The registry
+        # already has the canonical tool name, so normalize the schema here
+        # instead of letting downstream callers crash on startup.
+        if "name" not in schema:
+            schema = {**schema, "name": name}
         existing = self._tools.get(name)
         if existing and existing.toolset != toolset:
             logger.warning(


### PR DESCRIPTION
Fixes #3729.

## Summary
- fill in  from the registry tool name when external tools omit it
- keep downstream tool-definition consumers from crashing on startup
- add a regression test covering name-less schemas

## Verification
- bringing up nodes...
bringing up nodes...

..                                                                       [100%]
2 passed in 11.58s

## Security
- patch only touches registry/test code paths
- no secrets, env files, or local paths added to the diff