### PR TITLE
feat: per-call model/provider override on delegate_task

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -668,6 +668,15 @@ delegation:
   # provider: "openrouter"                    # Override provider for subagents (empty = inherit parent)
   #                                           # Resolves full credentials (base_url, api_key) automatically.
   #                                           # Supported: openrouter, nous, zai, kimi-coding, minimax
+  #
+  # Task-type model routing — map task categories to specific models.
+  # When delegate_task is called with task_type="coding", the model is looked
+  # up from this map. Any key is valid; common types: coding, research, reasoning.
+  # Resolution order: per-call model > task_models[type] > delegation.model > parent model
+  # task_models:
+  #   coding: "glm-5.1"
+  #   research: "glm-5"
+  #   reasoning: "glm-5"
 
 # =============================================================================
 # Honcho Integration (Cross-Session User Modeling)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -359,6 +359,12 @@ DEFAULT_CONFIG = {
         "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
         "max_iterations": 50,  # per-subagent iteration cap (each subagent gets its own budget,
                                # independent of the parent's max_iterations)
+        # Task-type model routing — map task categories to specific models.
+        # When delegate_task is called with task_type="coding", the model is
+        # resolved from this map. Per-call model param still takes top precedence.
+        # Provider is always delegation.provider (or parent's if unconfigured).
+        # Resolution: per-call model > task_models[task_type] > delegation.model > parent model
+        "task_models": {},  # e.g. {"coding": "glm-5.1", "research": "glm-5", "reasoning": "glm-5"}
     },
 
     # Ephemeral prefill messages file — JSON list of {role, content} dicts

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -405,6 +405,12 @@ def _run_single_child(
             except (ValueError, UnboundLocalError) as e:
                 logger.debug("Could not remove child from active_children: %s", e)
 
+# Well-known task types for task_models routing.
+# Not enforced — any key in task_models is valid. These are hints for
+# documentation, config examples, and the tool description shown to the LLM.
+KNOWN_TASK_TYPES = ("coding", "research", "reasoning", "writing", "review", "testing")
+
+
 def delegate_task(
     goal: Optional[str] = None,
     context: Optional[str] = None,
@@ -413,14 +419,25 @@ def delegate_task(
     max_iterations: Optional[int] = None,
     model: Optional[str] = None,
     provider: Optional[str] = None,
+    task_type: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks.
 
     Supports two modes:
-      - Single: provide goal (+ optional context, toolsets)
-      - Batch:  provide tasks array [{goal, context, toolsets}, ...]
+      - Single: provide goal (+ optional context, toolsets, task_type)
+      - Batch:  provide tasks array [{goal, context, toolsets, task_type}, ...]
+
+    Model resolution per task (highest to lowest precedence):
+      1. Per-call ``model`` param (top-level, applies to all tasks)
+      2. Per-task ``model`` field (batch mode only)
+      3. ``delegation.task_models[task_type]`` from config
+      4. ``delegation.model`` from config (fallback default)
+      5. Parent agent's model (inherit)
+
+    Provider resolution is separate — ``delegation.provider`` (or per-call
+    ``provider``) always applies. ``task_models`` only selects the model name.
 
     Returns JSON with results array, one entry per task.
     """
@@ -439,29 +456,51 @@ def delegate_task(
 
     # Load config
     cfg = _load_config()
-    # Per-call model/provider override (from tool params) takes precedence
-    if model:
-        cfg["model"] = model
+    # Per-call provider override (from tool params) takes precedence
     if provider:
         cfg["provider"] = provider
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
     effective_max_iter = max_iterations or default_max_iter
 
-    # Resolve delegation credentials (provider:model pair).
-    # When delegation.provider is configured, this resolves the full credential
-    # bundle (base_url, api_key, api_mode) via the same runtime provider system
-    # used by CLI/gateway startup.  When unconfigured, returns None values so
-    # children inherit from the parent.
+    # Load task_models map from config for task-type routing
+    task_models = cfg.get("task_models") or {}
+
+    # Resolve delegation credentials (provider + base fallback model).
+    # The base model here is delegation.model (or None if unconfigured).
+    # Per-task model resolution (via task_type or per-task model) happens
+    # below after we have the credential bundle.
     try:
         creds = _resolve_delegation_credentials(cfg, parent_agent)
     except ValueError as exc:
         return json.dumps({"error": str(exc)})
 
+    # --- Helper: resolve the effective model for a single task ---
+    def _resolve_model_for_task(task: Dict[str, Any]) -> Optional[str]:
+        """Resolve model: per-call model > per-task model > task_models > delegation.model."""
+        # 1. Per-call model override (top-level param, applies to all tasks)
+        if model:
+            return model
+        # 2. Per-task model override (batch mode only)
+        task_model = str(task.get("model") or "").strip()
+        if task_model:
+            return task_model
+        # 3. Task-type model from config
+        tt = str(task.get("task_type") or task_type or "").strip()
+        if tt and task_models:
+            mapped = str(task_models.get(tt) or "").strip()
+            if mapped:
+                logger.debug(
+                    "task_models routing: task_type=%s -> model=%s", tt, mapped
+                )
+                return mapped
+        # 4. delegation.model from config (already in creds["model"])
+        return None  # signals "use creds model" (which may also be None → parent inherit)
+
     # Normalize to task list
     if tasks and isinstance(tasks, list):
         task_list = tasks[:MAX_CONCURRENT_CHILDREN]
     elif goal and isinstance(goal, str) and goal.strip():
-        task_list = [{"goal": goal, "context": context, "toolsets": toolsets}]
+        task_list = [{"goal": goal, "context": context, "toolsets": toolsets, "task_type": task_type}]
     else:
         return json.dumps({"error": "Provide either 'goal' (single task) or 'tasks' (batch)."})
 
@@ -492,9 +531,13 @@ def delegate_task(
     children = []
     try:
         for i, t in enumerate(task_list):
+            # Resolve model for this specific task
+            task_model = _resolve_model_for_task(t)
+            effective_model = task_model or creds["model"]
+
             child = _build_child_agent(
                 task_index=i, goal=t["goal"], context=t.get("context"),
-                toolsets=t.get("toolsets") or toolsets, model=creds["model"],
+                toolsets=t.get("toolsets") or toolsets, model=effective_model,
                 max_iterations=effective_max_iter, parent_agent=parent_agent,
                 override_provider=creds["provider"], override_base_url=creds["base_url"],
                 override_api_key=creds["api_key"],
@@ -724,6 +767,7 @@ DELEGATE_TASK_SCHEMA = {
         "- Single tool call -> just call the tool directly\n"
         "- Tasks needing user interaction -> subagents cannot use clarify\n\n"
         "IMPORTANT:\n"
+        "- Always set task_type (coding/research/reasoning/etc) for correct model routing.\n"
         "- Subagents have NO memory of your conversation. Pass all relevant "
         "info (file paths, error messages, constraints) via the 'context' field.\n"
         "- Subagents CANNOT call: delegate_task, clarify, memory, send_message, "
@@ -773,6 +817,20 @@ DELEGATE_TASK_SCHEMA = {
                             "items": {"type": "string"},
                             "description": "Toolsets for this specific task",
                         },
+                        "task_type": {
+                            "type": "string",
+                            "description": (
+                                "Task category for model routing via task_models config. "
+                                "Overrides top-level task_type. Common: coding, research, reasoning."
+                            ),
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": (
+                                "Override model for this specific task only. "
+                                "Takes precedence over task_type routing."
+                            ),
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -793,8 +851,9 @@ DELEGATE_TASK_SCHEMA = {
             "model": {
                 "type": "string",
                 "description": (
-                    "Override model for this delegation. "
-                    "Takes precedence over delegation.model in config."
+                    "Override model for ALL tasks in this delegation. "
+                    "Takes highest precedence — overrides task_models routing "
+                    "and delegation.model. Use for one-off model overrides."
                 ),
             },
             "provider": {
@@ -803,6 +862,17 @@ DELEGATE_TASK_SCHEMA = {
                     "Override provider for this delegation. "
                     "Takes precedence over delegation.provider in config. "
                     "Resolves full credentials (base_url, api_key) automatically."
+                ),
+            },
+            "task_type": {
+                "type": "string",
+                "description": (
+                    "IMPORTANT: Always provide this for correct model routing. "
+                    "Task category for model routing via delegation.task_models "
+                    "in config. Common types: coding, research, reasoning, "
+                    "writing, review, testing. Any key in task_models works. "
+                    "Ignored when per-call 'model' is set (it takes precedence). "
+                    "In batch mode, per-task task_type overrides this."
                 ),
             },
         },
@@ -826,6 +896,7 @@ registry.register(
         max_iterations=args.get("max_iterations"),
         model=args.get("model"),
         provider=args.get("provider"),
+        task_type=args.get("task_type"),
         parent_agent=kw.get("parent_agent")),
     check_fn=check_delegate_requirements,
     emoji="🔀",

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -261,6 +261,14 @@ def _run_single_child(
     """
     child_start = time.monotonic()
 
+    # Log the model/provider the subagent is running on
+    _child_model = getattr(child, "model", None)
+    _child_provider = getattr(child, "provider", None)
+    if _child_model:
+        provider_tag = f" ({_child_provider})" if _child_provider else ""
+        logger.info("[subagent-%d] spawning with model=%s%s", task_index, _child_model, provider_tag)
+        print(f"  [subagent-{task_index}] model={_child_model}{provider_tag}")
+
     # Get the progress callback from the child agent
     child_progress_cb = getattr(child, 'tool_progress_callback', None)
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -403,6 +403,8 @@ def delegate_task(
     toolsets: Optional[List[str]] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -429,6 +431,11 @@ def delegate_task(
 
     # Load config
     cfg = _load_config()
+    # Per-call model/provider override (from tool params) takes precedence
+    if model:
+        cfg["model"] = model
+    if provider:
+        cfg["provider"] = provider
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
     effective_max_iter = max_iterations or default_max_iter
 
@@ -590,28 +597,37 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             or os.getenv("OPENAI_API_KEY", "").strip()
         )
         if not api_key:
-            raise ValueError(
-                "Delegation base_url is configured but no API key was found. "
-                "Set delegation.api_key or OPENAI_API_KEY."
-            )
+            if configured_provider:
+                # base_url set but no api_key — fall through to provider
+                # resolution which checks provider-specific env vars.
+                logger.debug(
+                    "delegation base_url set but no api_key; "
+                    "falling through to provider resolution (%s)",
+                    configured_provider,
+                )
+            else:
+                raise ValueError(
+                    "Delegation base_url is configured but no API key was found. "
+                    "Set delegation.api_key, delegation.provider, or OPENAI_API_KEY."
+                )
+        else:
+            base_lower = configured_base_url.lower()
+            provider = "custom"
+            api_mode = "chat_completions"
+            if "chatgpt.com/backend-api/codex" in base_lower:
+                provider = "openai-codex"
+                api_mode = "codex_responses"
+            elif "api.anthropic.com" in base_lower:
+                provider = "anthropic"
+                api_mode = "anthropic_messages"
 
-        base_lower = configured_base_url.lower()
-        provider = "custom"
-        api_mode = "chat_completions"
-        if "chatgpt.com/backend-api/codex" in base_lower:
-            provider = "openai-codex"
-            api_mode = "codex_responses"
-        elif "api.anthropic.com" in base_lower:
-            provider = "anthropic"
-            api_mode = "anthropic_messages"
-
-        return {
-            "model": configured_model,
-            "provider": provider,
-            "base_url": configured_base_url,
-            "api_key": api_key,
-            "api_mode": api_mode,
-        }
+            return {
+                "model": configured_model,
+                "provider": provider,
+                "base_url": configured_base_url,
+                "api_key": api_key,
+                "api_mode": api_mode,
+            }
 
     if not configured_provider:
         # No provider override — child inherits everything from parent
@@ -766,6 +782,21 @@ DELEGATE_TASK_SCHEMA = {
                     "Only set lower for simple tasks."
                 ),
             },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Override model for this delegation. "
+                    "Takes precedence over delegation.model in config."
+                ),
+            },
+            "provider": {
+                "type": "string",
+                "description": (
+                    "Override provider for this delegation. "
+                    "Takes precedence over delegation.provider in config. "
+                    "Resolves full credentials (base_url, api_key) automatically."
+                ),
+            },
         },
         "required": [],
     },
@@ -785,6 +816,8 @@ registry.register(
         toolsets=args.get("toolsets"),
         tasks=args.get("tasks"),
         max_iterations=args.get("max_iterations"),
+        model=args.get("model"),
+        provider=args.get("provider"),
         parent_agent=kw.get("parent_agent")),
     check_fn=check_delegate_requirements,
     emoji="🔀",

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1557,6 +1557,45 @@ The delegation provider uses the same credential resolution as CLI/gateway start
 
 **Precedence:** `delegation.base_url` in config → `delegation.provider` in config → parent provider (inherited). `delegation.model` in config → parent model (inherited). Setting just `model` without `provider` changes only the model name while keeping the parent's credentials (useful for switching models within the same provider like OpenRouter).
 
+### Task-Type Model Routing
+
+Route different task categories to different models without per-call overrides. Set `delegation.task_models` to map task types to model names:
+
+```yaml
+delegation:
+  provider: zai
+  model: glm-5-turbo           # Fallback when no task_type matches
+  task_models:
+    coding: glm-5.1            # Code generation, debugging, implementation
+    research: glm-5            # Web research, documentation, analysis
+    reasoning: glm-5           # Math, logic, complex problem-solving
+    writing: glm-5-turbo       # Content creation, editing
+```
+
+Then use `delegate_task(task_type="coding", goal="...")` — or in batch mode, set `task_type` per task:
+
+```json
+{
+  "tasks": [
+    {"goal": "Implement auth middleware", "task_type": "coding", "toolsets": ["terminal", "file"]},
+    {"goal": "Research WebGPU adoption trends", "task_type": "research", "toolsets": ["web"]}
+  ]
+}
+```
+
+**Resolution order (highest to lowest precedence):**
+
+1. Per-call `model` param — overrides everything, applies to all tasks
+2. Per-task `model` field (batch mode only) — overrides for that specific task
+3. `delegation.task_models[task_type]` — looked up from config
+4. `delegation.model` — fallback default from config
+5. Parent agent's model — inherited when nothing is configured
+
+**Key points:**
+- `task_models` only selects the model name. The provider is always `delegation.provider` (or the per-call `provider`, or parent's provider).
+- Any key is valid in `task_models` — `coding`, `research`, `reasoning` are common conventions, not enforced types.
+- Per-call `model` always wins — use it for one-off overrides when you need a specific model regardless of task type.
+
 ## Clarify
 
 Configure the clarification prompt behavior:


### PR DESCRIPTION
## Summary

Add `model` and `provider` parameters to the `delegate_task` tool, allowing per-delegation model routing. The LLM can now specify which model/provider to use for each delegation call, overriding the static `delegation.model`/`delegation.provider` config.

## Changes

1. **Schema**: Added `model` and `provider` string fields to `DELEGATE_TASK_SCHEMA`
2. **Handler**: Wired new params through registry handler to `delegate_task()`
3. **Signature**: Added `model` and `provider` optional params to function
4. **Config override**: Per-call values override `delegation` config section
5. **Credential fix**: When `delegation.base_url` is set but no api_key found AND a provider is configured, fall through to provider resolution instead of erroring

## Use case

```
delegate_task(
  goal="Write a Python function...",
  toolsets=["terminal", "file"],
  model="glm-5.1",
  provider="zai"
)
```

Routes this specific subagent to `glm-5.1` on provider `zai`, while the parent runs on a different model.