### PR TITLE
feat: Add inter-profile orchestration with conversation history

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -31,6 +31,7 @@ from typing import Any, Dict, List, Optional
 
 try:
     from aiohttp import web
+
     AIOHTTP_AVAILABLE = True
 except ImportError:
     AIOHTTP_AVAILABLE = False
@@ -73,6 +74,7 @@ class ResponseStore:
         if db_path is None:
             try:
                 from hermes_cli.config import get_hermes_home
+
                 db_path = str(get_hermes_home() / "response_store.db")
             except Exception:
                 db_path = ":memory:"
@@ -104,6 +106,7 @@ class ResponseStore:
         if row is None:
             return None
         import time
+
         self._conn.execute(
             "UPDATE responses SET accessed_at = ? WHERE response_id = ?",
             (time.time(), response_id),
@@ -114,6 +117,7 @@ class ResponseStore:
     def put(self, response_id: str, data: Dict[str, Any]) -> None:
         """Store a response, evicting the oldest if at capacity."""
         import time
+
         self._conn.execute(
             "INSERT OR REPLACE INTO responses (response_id, data, accessed_at) VALUES (?, ?, ?)",
             (response_id, json.dumps(data, default=str), time.time()),
@@ -174,6 +178,7 @@ _CORS_HEADERS = {
 
 
 if AIOHTTP_AVAILABLE:
+
     @web.middleware
     async def cors_middleware(request, handler):
         """Add CORS headers for explicitly allowed origins; handle OPTIONS preflight."""
@@ -198,7 +203,12 @@ else:
     cors_middleware = None  # type: ignore[assignment]
 
 
-def _openai_error(message: str, err_type: str = "invalid_request_error", param: str = None, code: str = None) -> Dict[str, Any]:
+def _openai_error(
+    message: str,
+    err_type: str = "invalid_request_error",
+    param: str = None,
+    code: str = None,
+) -> Dict[str, Any]:
     """OpenAI-style error envelope."""
     return {
         "error": {
@@ -211,6 +221,7 @@ def _openai_error(message: str, err_type: str = "invalid_request_error", param: 
 
 
 if AIOHTTP_AVAILABLE:
+
     @web.middleware
     async def body_limit_middleware(request, handler):
         """Reject overly large request bodies early based on Content-Length."""
@@ -219,9 +230,20 @@ if AIOHTTP_AVAILABLE:
             if cl is not None:
                 try:
                     if int(cl) > MAX_REQUEST_BYTES:
-                        return web.json_response(_openai_error("Request body too large.", code="body_too_large"), status=413)
+                        return web.json_response(
+                            _openai_error(
+                                "Request body too large.", code="body_too_large"
+                            ),
+                            status=413,
+                        )
                 except ValueError:
-                    return web.json_response(_openai_error("Invalid Content-Length header.", code="invalid_content_length"), status=400)
+                    return web.json_response(
+                        _openai_error(
+                            "Invalid Content-Length header.",
+                            code="invalid_content_length",
+                        ),
+                        status=400,
+                    )
         return await handler(request)
 else:
     body_limit_middleware = None  # type: ignore[assignment]
@@ -233,6 +255,7 @@ _SECURITY_HEADERS = {
 
 
 if AIOHTTP_AVAILABLE:
+
     @web.middleware
     async def security_headers_middleware(request, handler):
         """Add security headers to all responses (including errors)."""
@@ -246,14 +269,17 @@ else:
 
 class _IdempotencyCache:
     """In-memory idempotency cache with TTL and basic LRU semantics."""
+
     def __init__(self, max_items: int = 1000, ttl_seconds: int = 300):
         from collections import OrderedDict
+
         self._store = OrderedDict()
         self._ttl = ttl_seconds
         self._max = max_items
 
     def _purge(self):
         import time as _t
+
         now = _t.time()
         expired = [k for k, v in self._store.items() if now - v["ts"] > self._ttl]
         for k in expired:
@@ -268,6 +294,7 @@ class _IdempotencyCache:
             return item["resp"]
         resp = await compute_coro()
         import time as _t
+
         self._store[key] = {"resp": resp, "fp": fingerprint, "ts": _t.time()}
         self._purge()
         return resp
@@ -278,6 +305,7 @@ _idem_cache = _IdempotencyCache()
 
 def _make_request_fingerprint(body: Dict[str, Any], keys: List[str]) -> str:
     from hashlib import sha256
+
     subset = {k: body.get(k) for k in keys}
     return sha256(repr(subset).encode("utf-8")).hexdigest()
 
@@ -294,7 +322,9 @@ class APIServerAdapter(BasePlatformAdapter):
         super().__init__(config, Platform.API_SERVER)
         extra = config.extra or {}
         self._host: str = extra.get("host", os.getenv("API_SERVER_HOST", DEFAULT_HOST))
-        self._port: int = int(extra.get("port", os.getenv("API_SERVER_PORT", str(DEFAULT_PORT))))
+        self._port: int = int(
+            extra.get("port", os.getenv("API_SERVER_PORT", str(DEFAULT_PORT)))
+        )
         self._api_key: str = extra.get("key", os.getenv("API_SERVER_KEY", ""))
         self._cors_origins: tuple[str, ...] = self._parse_cors_origins(
             extra.get("cors_origins", os.getenv("API_SERVER_CORS_ORIGINS", "")),
@@ -375,7 +405,13 @@ class APIServerAdapter(BasePlatformAdapter):
                 return None  # Auth OK
 
         return web.json_response(
-            {"error": {"message": "Invalid API key", "type": "invalid_request_error", "code": "invalid_api_key"}},
+            {
+                "error": {
+                    "message": "Invalid API key",
+                    "type": "invalid_request_error",
+                    "code": "invalid_api_key",
+                }
+            },
             status=401,
         )
 
@@ -401,23 +437,33 @@ class APIServerAdapter(BasePlatformAdapter):
     # Agent creation helper
     # ------------------------------------------------------------------
 
+    # Maximum delegation depth for profile-to-profile orchestration
+    _MAX_DELEGATION_DEPTH = 2
+
     def _create_agent(
         self,
         ephemeral_system_prompt: Optional[str] = None,
         session_id: Optional[str] = None,
         stream_delta_callback=None,
         tool_progress_callback=None,
+        delegate_depth: int = 1,
+        skip_memory: bool = False,
+        is_delegation: bool = False,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
 
         Uses _resolve_runtime_agent_kwargs() to pick up model, api_key,
-        base_url, etc. from config.yaml / env vars.  Toolsets are resolved
+        base_url, etc. from config.yaml / env vars. Toolsets are resolved
         from config.yaml platform_toolsets.api_server (same as all other
         gateway platforms), falling back to the hermes-api-server default.
         """
         from run_agent import AIAgent
-        from gateway.run import _resolve_runtime_agent_kwargs, _resolve_gateway_model, _load_gateway_config
+        from gateway.run import (
+            _resolve_runtime_agent_kwargs,
+            _resolve_gateway_model,
+            _load_gateway_config,
+        )
         from hermes_cli.tools_config import _get_platform_tools
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()
@@ -447,7 +493,12 @@ class APIServerAdapter(BasePlatformAdapter):
             tool_progress_callback=tool_progress_callback,
             session_db=self._ensure_session_db(),
             fallback_model=fallback_model,
+            skip_memory=skip_memory,
         )
+
+        # Set delegation depth after construction (AIAgent doesn't accept it in __init__)
+        agent._delegate_depth = delegate_depth
+
         return agent
 
     # ------------------------------------------------------------------
@@ -464,20 +515,22 @@ class APIServerAdapter(BasePlatformAdapter):
         if auth_err:
             return auth_err
 
-        return web.json_response({
-            "object": "list",
-            "data": [
-                {
-                    "id": "hermes-agent",
-                    "object": "model",
-                    "created": int(time.time()),
-                    "owned_by": "hermes",
-                    "permission": [],
-                    "root": "hermes-agent",
-                    "parent": None,
-                }
-            ],
-        })
+        return web.json_response(
+            {
+                "object": "list",
+                "data": [
+                    {
+                        "id": "hermes-agent",
+                        "object": "model",
+                        "created": int(time.time()),
+                        "owned_by": "hermes",
+                        "permission": [],
+                        "root": "hermes-agent",
+                        "parent": None,
+                    }
+                ],
+            }
+        )
 
     async def _handle_chat_completions(self, request: "web.Request") -> "web.Response":
         """POST /v1/chat/completions — OpenAI Chat Completions format."""
@@ -485,16 +538,52 @@ class APIServerAdapter(BasePlatformAdapter):
         if auth_err:
             return auth_err
 
+        # Detect cross-profile delegation headers for persistent session creation
+        delegation_headers = {
+            "is_delegation": request.headers.get("X-Hermes-Delegation") == "true",
+            "source_profile": request.headers.get("X-Hermes-Source-Profile"),
+            "task_id": request.headers.get("X-Hermes-Task-ID"),
+            "delegate_depth": int(request.headers.get("X-Hermes-Delegate-Depth", 0)),
+            "allow_subagents": request.headers.get("X-Hermes-Allow-Subagents", "true")
+            == "true",
+            "max_depth": int(request.headers.get("X-Hermes-Max-Depth", 2)),
+        }
+
+        # MAX_DEPTH enforcement: Prevent infinite delegation recursion
+        if delegation_headers["is_delegation"]:
+            if delegation_headers["delegate_depth"] >= delegation_headers["max_depth"]:
+                return web.json_response(
+                    {
+                        "error": {
+                            "message": (
+                                f"Delegation depth limit reached ({delegation_headers['max_depth']}). "
+                                "Subagents cannot spawn further subagents."
+                            ),
+                            "type": "invalid_request_error",
+                        }
+                    },
+                    status=400,
+                )
+            # Increment depth for downstream propagation
+            delegation_headers["delegate_depth"] += 1
+
         # Parse request body
         try:
             body = await request.json()
         except (json.JSONDecodeError, Exception):
-            return web.json_response(_openai_error("Invalid JSON in request body"), status=400)
+            return web.json_response(
+                _openai_error("Invalid JSON in request body"), status=400
+            )
 
         messages = body.get("messages")
         if not messages or not isinstance(messages, list):
             return web.json_response(
-                {"error": {"message": "Missing or invalid 'messages' field", "type": "invalid_request_error"}},
+                {
+                    "error": {
+                        "message": "Missing or invalid 'messages' field",
+                        "type": "invalid_request_error",
+                    }
+                },
                 status=400,
             )
 
@@ -525,7 +614,12 @@ class APIServerAdapter(BasePlatformAdapter):
 
         if not user_message:
             return web.json_response(
-                {"error": {"message": "No user message found in messages", "type": "invalid_request_error"}},
+                {
+                    "error": {
+                        "message": "No user message found in messages",
+                        "type": "invalid_request_error",
+                    }
+                },
                 status=400,
             )
 
@@ -545,12 +639,63 @@ class APIServerAdapter(BasePlatformAdapter):
             session_id = str(uuid.uuid4())
             # history already set from request body above
 
+        # PREFIX DELEGATED MESSAGES: Add delegation context to user message
+        # This tells the agent it's a delegated worker, not a human user conversation
+        if delegation_headers["is_delegation"] and delegation_headers["source_profile"]:
+            allow_subagents = delegation_headers.get("allow_subagents", True)
+            subagent_status = (
+                "delegate_task ALLOWED"
+                if allow_subagents
+                else "delegate_task NOT ALLOWED"
+            )
+
+            task_id = delegation_headers.get("task_id", "unknown")
+
+            user_message = (
+                f"<DELEGATED from profile {delegation_headers['source_profile']} | "
+                f"{subagent_status}>\n\n"
+                f"YOUR TASK:\n{user_message}\n\n"
+                f"Summary: what you did, found, created, issues.\n"
+                f"End with <TASK {task_id} COMPLETED>."
+            )
+
+        # Create isolated child session for each delegation
+        child_session_id = None
+        if (
+            delegation_headers["is_delegation"]
+            and delegation_headers["source_profile"]
+            and delegation_headers["task_id"]
+        ):
+            try:
+                from hermes_cli.profiles import get_current_profile
+
+                target_profile = get_current_profile() or "unknown"
+
+                # Create isolated session (each delegation is independent)
+                child_session_id = self._create_child_session(
+                    source_profile=delegation_headers["source_profile"],
+                    task_id=delegation_headers["task_id"],
+                    target_profile=target_profile,
+                    initial_message=user_message,
+                )
+                logger.info(
+                    f"Created child session {child_session_id} for delegation from {delegation_headers['source_profile']} → {target_profile} task {delegation_headers['task_id']}"
+                )
+
+            except Exception as e:
+                logger.warning(f"Failed to create child session for delegation: {e}")
+
+        # Override session_id if child session was created for delegation
+        if child_session_id:
+            session_id = child_session_id
+
         completion_id = f"chatcmpl-{uuid.uuid4().hex[:29]}"
         model_name = body.get("model", "hermes-agent")
         created = int(time.time())
 
         if stream:
             import queue as _q
+
             _stream_q: _q.Queue = _q.Queue()
 
             def _on_delta(delta):
@@ -571,6 +716,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 if name.startswith("_"):
                     return  # Skip internal events (_thinking)
                 from agent.display import get_tool_emoji
+
                 emoji = get_tool_emoji(name)
                 label = preview or name
                 _stream_q.put(f"\n`{emoji} {label}`\n")
@@ -578,19 +724,29 @@ class APIServerAdapter(BasePlatformAdapter):
             # Start agent in background.  agent_ref is a mutable container
             # so the SSE writer can interrupt the agent on client disconnect.
             agent_ref = [None]
-            agent_task = asyncio.ensure_future(self._run_agent(
-                user_message=user_message,
-                conversation_history=history,
-                ephemeral_system_prompt=system_prompt,
-                session_id=session_id,
-                stream_delta_callback=_on_delta,
-                tool_progress_callback=_on_tool_progress,
-                agent_ref=agent_ref,
-            ))
+            agent_task = asyncio.ensure_future(
+                self._run_agent(
+                    user_message=user_message,
+                    conversation_history=history,
+                    ephemeral_system_prompt=system_prompt,
+                    session_id=session_id,
+                    stream_delta_callback=_on_delta,
+                    tool_progress_callback=_on_tool_progress,
+                    agent_ref=agent_ref,
+                    delegate_depth=delegation_headers.get("delegate_depth", 0),
+                    is_delegation=delegation_headers["is_delegation"],
+                )
+            )
 
             return await self._write_sse_chat_completion(
-                request, completion_id, model_name, created, _stream_q,
-                agent_task, agent_ref, session_id=session_id,
+                request,
+                completion_id,
+                model_name,
+                created,
+                _stream_q,
+                agent_task,
+                agent_ref,
+                session_id=session_id,
             )
 
         # Non-streaming: run the agent (with optional Idempotency-Key)
@@ -600,26 +756,40 @@ class APIServerAdapter(BasePlatformAdapter):
                 conversation_history=history,
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
+                delegate_depth=delegation_headers.get("delegate_depth", 0),
+                is_delegation=delegation_headers["is_delegation"],
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
-            fp = _make_request_fingerprint(body, keys=["model", "messages", "tools", "tool_choice", "stream"])
+            fp = _make_request_fingerprint(
+                body, keys=["model", "messages", "tools", "tool_choice", "stream"]
+            )
             try:
-                result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
+                result, usage = await _idem_cache.get_or_set(
+                    idempotency_key, fp, _compute_completion
+                )
             except Exception as e:
-                logger.error("Error running agent for chat completions: %s", e, exc_info=True)
+                logger.error(
+                    "Error running agent for chat completions: %s", e, exc_info=True
+                )
                 return web.json_response(
-                    _openai_error(f"Internal server error: {e}", err_type="server_error"),
+                    _openai_error(
+                        f"Internal server error: {e}", err_type="server_error"
+                    ),
                     status=500,
                 )
         else:
             try:
                 result, usage = await _compute_completion()
             except Exception as e:
-                logger.error("Error running agent for chat completions: %s", e, exc_info=True)
+                logger.error(
+                    "Error running agent for chat completions: %s", e, exc_info=True
+                )
                 return web.json_response(
-                    _openai_error(f"Internal server error: {e}", err_type="server_error"),
+                    _openai_error(
+                        f"Internal server error: {e}", err_type="server_error"
+                    ),
                     status=500,
                 )
 
@@ -627,11 +797,22 @@ class APIServerAdapter(BasePlatformAdapter):
         if not final_response:
             final_response = result.get("error", "(No response generated)")
 
+        # Log delegation completion (session already has response via agent run)
+        if (
+            delegation_headers["is_delegation"]
+            and delegation_headers["source_profile"]
+            and delegation_headers["task_id"]
+        ):
+            logger.info(
+                f"Completed delegation {delegation_headers['task_id']} from {delegation_headers['source_profile']}"
+            )
+
         response_data = {
             "id": completion_id,
             "object": "chat.completion",
             "created": created,
             "model": model_name,
+            "session_id": session_id,  # Include session_id for delegation tracking
             "choices": [
                 {
                     "index": 0,
@@ -652,8 +833,16 @@ class APIServerAdapter(BasePlatformAdapter):
         return web.json_response(response_data, headers={"X-Hermes-Session-Id": session_id})
 
     async def _write_sse_chat_completion(
-        self, request: "web.Request", completion_id: str, model: str,
-        created: int, stream_q, agent_task, agent_ref=None, session_id: str = None,
+        self,
+        request: "web.Request",
+        completion_id: str,
+        model: str,
+        created: int,
+        stream_q,
+        agent_task,
+        agent_ref=None,
+        session_id: str = None,
+    ) -> "web.StreamResponse":
     ) -> "web.StreamResponse":
         """Write real streaming SSE from agent's stream_delta_callback queue.
 
@@ -678,9 +867,13 @@ class APIServerAdapter(BasePlatformAdapter):
         try:
             # Role chunk
             role_chunk = {
-                "id": completion_id, "object": "chat.completion.chunk",
-                "created": created, "model": model,
-                "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}],
+                "id": completion_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": model,
+                "choices": [
+                    {"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}
+                ],
             }
             await response.write(f"data: {json.dumps(role_chunk)}\n\n".encode())
 
@@ -688,7 +881,9 @@ class APIServerAdapter(BasePlatformAdapter):
             loop = asyncio.get_event_loop()
             while True:
                 try:
-                    delta = await loop.run_in_executor(None, lambda: stream_q.get(timeout=0.5))
+                    delta = await loop.run_in_executor(
+                        None, lambda: stream_q.get(timeout=0.5)
+                    )
                 except _q.Empty:
                     if agent_task.done():
                         # Drain any remaining items
@@ -698,11 +893,21 @@ class APIServerAdapter(BasePlatformAdapter):
                                 if delta is None:
                                     break
                                 content_chunk = {
-                                    "id": completion_id, "object": "chat.completion.chunk",
-                                    "created": created, "model": model,
-                                    "choices": [{"index": 0, "delta": {"content": delta}, "finish_reason": None}],
+                                    "id": completion_id,
+                                    "object": "chat.completion.chunk",
+                                    "created": created,
+                                    "model": model,
+                                    "choices": [
+                                        {
+                                            "index": 0,
+                                            "delta": {"content": delta},
+                                            "finish_reason": None,
+                                        }
+                                    ],
                                 }
-                                await response.write(f"data: {json.dumps(content_chunk)}\n\n".encode())
+                                await response.write(
+                                    f"data: {json.dumps(content_chunk)}\n\n".encode()
+                                )
                             except _q.Empty:
                                 break
                         break
@@ -712,9 +917,13 @@ class APIServerAdapter(BasePlatformAdapter):
                     break
 
                 content_chunk = {
-                    "id": completion_id, "object": "chat.completion.chunk",
-                    "created": created, "model": model,
-                    "choices": [{"index": 0, "delta": {"content": delta}, "finish_reason": None}],
+                    "id": completion_id,
+                    "object": "chat.completion.chunk",
+                    "created": created,
+                    "model": model,
+                    "choices": [
+                        {"index": 0, "delta": {"content": delta}, "finish_reason": None}
+                    ],
                 }
                 await response.write(f"data: {json.dumps(content_chunk)}\n\n".encode())
 
@@ -728,8 +937,10 @@ class APIServerAdapter(BasePlatformAdapter):
 
             # Finish chunk
             finish_chunk = {
-                "id": completion_id, "object": "chat.completion.chunk",
-                "created": created, "model": model,
+                "id": completion_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": model,
                 "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
                 "usage": {
                     "prompt_tokens": usage.get("input_tokens", 0),
@@ -755,7 +966,9 @@ class APIServerAdapter(BasePlatformAdapter):
                     await agent_task
                 except (asyncio.CancelledError, Exception):
                     pass
-            logger.info("SSE client disconnected; interrupted agent task %s", completion_id)
+            logger.info(
+                "SSE client disconnected; interrupted agent task %s", completion_id
+            )
 
         return response
 
@@ -770,7 +983,12 @@ class APIServerAdapter(BasePlatformAdapter):
             body = await request.json()
         except (json.JSONDecodeError, Exception):
             return web.json_response(
-                {"error": {"message": "Invalid JSON in request body", "type": "invalid_request_error"}},
+                {
+                    "error": {
+                        "message": "Invalid JSON in request body",
+                        "type": "invalid_request_error",
+                    }
+                },
                 status=400,
             )
 
@@ -785,7 +1003,12 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # conversation and previous_response_id are mutually exclusive
         if conversation and previous_response_id:
-            return web.json_response(_openai_error("Cannot use both 'conversation' and 'previous_response_id'"), status=400)
+            return web.json_response(
+                _openai_error(
+                    "Cannot use both 'conversation' and 'previous_response_id'"
+                ),
+                status=400,
+            )
 
         # Resolve conversation name to latest response_id
         if conversation:
@@ -807,16 +1030,24 @@ class APIServerAdapter(BasePlatformAdapter):
                     if isinstance(content, list):
                         text_parts = []
                         for part in content:
-                            if isinstance(part, dict) and part.get("type") == "input_text":
+                            if (
+                                isinstance(part, dict)
+                                and part.get("type") == "input_text"
+                            ):
                                 text_parts.append(part.get("text", ""))
-                            elif isinstance(part, dict) and part.get("type") == "output_text":
+                            elif (
+                                isinstance(part, dict)
+                                and part.get("type") == "output_text"
+                            ):
                                 text_parts.append(part.get("text", ""))
                             elif isinstance(part, str):
                                 text_parts.append(part)
                         content = "\n".join(text_parts)
                     input_messages.append({"role": role, "content": content})
         else:
-            return web.json_response(_openai_error("'input' must be a string or array"), status=400)
+            return web.json_response(
+                _openai_error("'input' must be a string or array"), status=400
+            )
 
         # Accept explicit conversation_history from the request body.
         # This lets stateless clients supply their own history instead of
@@ -843,7 +1074,12 @@ class APIServerAdapter(BasePlatformAdapter):
         if not conversation_history and previous_response_id:
             stored = self._response_store.get(previous_response_id)
             if stored is None:
-                return web.json_response(_openai_error(f"Previous response not found: {previous_response_id}"), status=404)
+                return web.json_response(
+                    _openai_error(
+                        f"Previous response not found: {previous_response_id}"
+                    ),
+                    status=404,
+                )
             conversation_history = list(stored.get("conversation_history", []))
             # If no instructions provided, carry forward from previous
             if instructions is None:
@@ -856,7 +1092,9 @@ class APIServerAdapter(BasePlatformAdapter):
         # Last input message is the user_message
         user_message = input_messages[-1].get("content", "") if input_messages else ""
         if not user_message:
-            return web.json_response(_openai_error("No user message found in input"), status=400)
+            return web.json_response(
+                _openai_error("No user message found in input"), status=400
+            )
 
         # Truncation support
         if body.get("truncation") == "auto" and len(conversation_history) > 100:
@@ -871,20 +1109,33 @@ class APIServerAdapter(BasePlatformAdapter):
                 conversation_history=conversation_history,
                 ephemeral_system_prompt=instructions,
                 session_id=session_id,
+                delegate_depth=0,
+                is_delegation=False,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
             fp = _make_request_fingerprint(
                 body,
-                keys=["input", "instructions", "previous_response_id", "conversation", "model", "tools"],
+                keys=[
+                    "input",
+                    "instructions",
+                    "previous_response_id",
+                    "conversation",
+                    "model",
+                    "tools",
+                ],
             )
             try:
-                result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_response)
+                result, usage = await _idem_cache.get_or_set(
+                    idempotency_key, fp, _compute_response
+                )
             except Exception as e:
                 logger.error("Error running agent for responses: %s", e, exc_info=True)
                 return web.json_response(
-                    _openai_error(f"Internal server error: {e}", err_type="server_error"),
+                    _openai_error(
+                        f"Internal server error: {e}", err_type="server_error"
+                    ),
                     status=500,
                 )
         else:
@@ -893,7 +1144,9 @@ class APIServerAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.error("Error running agent for responses: %s", e, exc_info=True)
                 return web.json_response(
-                    _openai_error(f"Internal server error: {e}", err_type="server_error"),
+                    _openai_error(
+                        f"Internal server error: {e}", err_type="server_error"
+                    ),
                     status=500,
                 )
 
@@ -934,11 +1187,14 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Store the complete response object for future chaining / GET retrieval
         if store:
-            self._response_store.put(response_id, {
-                "response": response_data,
-                "conversation_history": full_history,
-                "instructions": instructions,
-            })
+            self._response_store.put(
+                response_id,
+                {
+                    "response": response_data,
+                    "conversation_history": full_history,
+                    "instructions": instructions,
+                },
+            )
             # Update conversation mapping so the next request with the same
             # conversation name automatically chains to this response
             if conversation:
@@ -959,7 +1215,9 @@ class APIServerAdapter(BasePlatformAdapter):
         response_id = request.match_info["response_id"]
         stored = self._response_store.get(response_id)
         if stored is None:
-            return web.json_response(_openai_error(f"Response not found: {response_id}"), status=404)
+            return web.json_response(
+                _openai_error(f"Response not found: {response_id}"), status=404
+            )
 
         return web.json_response(stored["response"])
 
@@ -972,13 +1230,17 @@ class APIServerAdapter(BasePlatformAdapter):
         response_id = request.match_info["response_id"]
         deleted = self._response_store.delete(response_id)
         if not deleted:
-            return web.json_response(_openai_error(f"Response not found: {response_id}"), status=404)
+            return web.json_response(
+                _openai_error(f"Response not found: {response_id}"), status=404
+            )
 
-        return web.json_response({
-            "id": response_id,
-            "object": "response",
-            "deleted": True,
-        })
+        return web.json_response(
+            {
+                "id": response_id,
+                "object": "response",
+                "deleted": True,
+            }
+        )
 
     # ------------------------------------------------------------------
     # Cron jobs API
@@ -1015,7 +1277,16 @@ class APIServerAdapter(BasePlatformAdapter):
 
     _JOB_ID_RE = __import__("re").compile(r"[a-f0-9]{12}")
     # Allowed fields for update — prevents clients injecting arbitrary keys
-    _UPDATE_ALLOWED_FIELDS = {"name", "schedule", "prompt", "deliver", "skills", "skill", "repeat", "enabled"}
+    _UPDATE_ALLOWED_FIELDS = {
+        "name",
+        "schedule",
+        "prompt",
+        "deliver",
+        "skills",
+        "skill",
+        "repeat",
+        "enabled",
+    }
     _MAX_NAME_LENGTH = 200
     _MAX_PROMPT_LENGTH = 5000
 
@@ -1023,7 +1294,8 @@ class APIServerAdapter(BasePlatformAdapter):
         """Return error response if cron module isn't available."""
         if not self._CRON_AVAILABLE:
             return web.json_response(
-                {"error": "Cron module not available"}, status=501,
+                {"error": "Cron module not available"},
+                status=501,
             )
         return None
 
@@ -1032,7 +1304,8 @@ class APIServerAdapter(BasePlatformAdapter):
         job_id = request.match_info["job_id"]
         if not self._JOB_ID_RE.fullmatch(job_id):
             return job_id, web.json_response(
-                {"error": "Invalid job ID format"}, status=400,
+                {"error": "Invalid job ID format"},
+                status=400,
             )
         return job_id, None
 
@@ -1045,7 +1318,10 @@ class APIServerAdapter(BasePlatformAdapter):
         if cron_err:
             return cron_err
         try:
-            include_disabled = request.query.get("include_disabled", "").lower() in ("true", "1")
+            include_disabled = request.query.get("include_disabled", "").lower() in (
+                "true",
+                "1",
+            )
             jobs = self._cron_list(include_disabled=include_disabled)
             return web.json_response({"jobs": jobs})
         except Exception as e:
@@ -1072,16 +1348,20 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response({"error": "Name is required"}, status=400)
             if len(name) > self._MAX_NAME_LENGTH:
                 return web.json_response(
-                    {"error": f"Name must be ≤ {self._MAX_NAME_LENGTH} characters"}, status=400,
+                    {"error": f"Name must be ≤ {self._MAX_NAME_LENGTH} characters"},
+                    status=400,
                 )
             if not schedule:
                 return web.json_response({"error": "Schedule is required"}, status=400)
             if len(prompt) > self._MAX_PROMPT_LENGTH:
                 return web.json_response(
-                    {"error": f"Prompt must be ≤ {self._MAX_PROMPT_LENGTH} characters"}, status=400,
+                    {"error": f"Prompt must be ≤ {self._MAX_PROMPT_LENGTH} characters"},
+                    status=400,
                 )
             if repeat is not None and (not isinstance(repeat, int) or repeat < 1):
-                return web.json_response({"error": "Repeat must be a positive integer"}, status=400)
+                return web.json_response(
+                    {"error": "Repeat must be a positive integer"}, status=400
+                )
 
             kwargs = {
                 "prompt": prompt,
@@ -1132,17 +1412,26 @@ class APIServerAdapter(BasePlatformAdapter):
         try:
             body = await request.json()
             # Whitelist allowed fields to prevent arbitrary key injection
-            sanitized = {k: v for k, v in body.items() if k in self._UPDATE_ALLOWED_FIELDS}
+            sanitized = {
+                k: v for k, v in body.items() if k in self._UPDATE_ALLOWED_FIELDS
+            }
             if not sanitized:
-                return web.json_response({"error": "No valid fields to update"}, status=400)
+                return web.json_response(
+                    {"error": "No valid fields to update"}, status=400
+                )
             # Validate lengths if present
             if "name" in sanitized and len(sanitized["name"]) > self._MAX_NAME_LENGTH:
                 return web.json_response(
-                    {"error": f"Name must be ≤ {self._MAX_NAME_LENGTH} characters"}, status=400,
+                    {"error": f"Name must be ≤ {self._MAX_NAME_LENGTH} characters"},
+                    status=400,
                 )
-            if "prompt" in sanitized and len(sanitized["prompt"]) > self._MAX_PROMPT_LENGTH:
+            if (
+                "prompt" in sanitized
+                and len(sanitized["prompt"]) > self._MAX_PROMPT_LENGTH
+            ):
                 return web.json_response(
-                    {"error": f"Prompt must be ≤ {self._MAX_PROMPT_LENGTH} characters"}, status=400,
+                    {"error": f"Prompt must be ≤ {self._MAX_PROMPT_LENGTH} characters"},
+                    status=400,
                 )
             job = self._cron_update(job_id, sanitized)
             if not job:
@@ -1249,34 +1538,40 @@ class APIServerAdapter(BasePlatformAdapter):
             if role == "assistant" and msg.get("tool_calls"):
                 for tc in msg["tool_calls"]:
                     func = tc.get("function", {})
-                    items.append({
-                        "type": "function_call",
-                        "name": func.get("name", ""),
-                        "arguments": func.get("arguments", ""),
-                        "call_id": tc.get("id", ""),
-                    })
+                    items.append(
+                        {
+                            "type": "function_call",
+                            "name": func.get("name", ""),
+                            "arguments": func.get("arguments", ""),
+                            "call_id": tc.get("id", ""),
+                        }
+                    )
             elif role == "tool":
-                items.append({
-                    "type": "function_call_output",
-                    "call_id": msg.get("tool_call_id", ""),
-                    "output": msg.get("content", ""),
-                })
+                items.append(
+                    {
+                        "type": "function_call_output",
+                        "call_id": msg.get("tool_call_id", ""),
+                        "output": msg.get("content", ""),
+                    }
+                )
 
         # Final assistant message
         final = result.get("final_response", "")
         if not final:
             final = result.get("error", "(No response generated)")
 
-        items.append({
-            "type": "message",
-            "role": "assistant",
-            "content": [
-                {
-                    "type": "output_text",
-                    "text": final,
-                }
-            ],
-        })
+        items.append(
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": final,
+                    }
+                ],
+            }
+        )
         return items
 
     # ------------------------------------------------------------------
@@ -1292,6 +1587,8 @@ class APIServerAdapter(BasePlatformAdapter):
         stream_delta_callback=None,
         tool_progress_callback=None,
         agent_ref: Optional[list] = None,
+        delegate_depth: int = 0,
+        is_delegation: bool = False,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -1312,6 +1609,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 session_id=session_id,
                 stream_delta_callback=stream_delta_callback,
                 tool_progress_callback=tool_progress_callback,
+                delegate_depth=delegate_depth,
+                skip_memory=is_delegation,
+                is_delegation=is_delegation,
             )
             if agent_ref is not None:
                 agent_ref[0] = agent
@@ -1328,6 +1628,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         return await loop.run_in_executor(None, _run)
 
+    # ------------------------------------------------------------------
     # ------------------------------------------------------------------
     # /v1/runs — structured event streaming
     # ------------------------------------------------------------------
@@ -1594,6 +1895,75 @@ class APIServerAdapter(BasePlatformAdapter):
                 self._run_streams_created.pop(run_id, None)
 
     # ------------------------------------------------------------------
+    # Persistent child session creation (OhMyOpenCode-style)
+    # ------------------------------------------------------------------
+
+    def _create_child_session(
+        self,
+        source_profile: str,
+        task_id: str,
+        target_profile: str,
+        initial_message: str,
+    ) -> str:
+        """
+        Create a persistent child session for cross-profile delegation.
+
+        OhMyOpenCode-style session persistence: the worker profile creates
+        a dedicated session for each delegation, linked to the source profile
+        via parent_session_id. This enables direct session querying later.
+
+        Args:
+            source_profile: Profile that initiated the delegation (parent)
+            task_id: Unique task identifier
+            target_profile: Profile processing the delegation (self)
+            initial_message: The initial user message/question
+
+        Returns:
+            session_id: The created child session ID
+        """
+        import uuid
+        import time
+
+        child_session_id = (
+            f"delegated-{source_profile}-{task_id}-{uuid.uuid4().hex[:8]}"
+        )
+
+        try:
+            from hermes_state import SessionDB
+
+            # Initialize session DB for the current profile
+            db = SessionDB()
+
+            # Create session to track this delegation
+            db.create_session(
+                session_id=child_session_id,
+                source=f"delegation:{source_profile}:{task_id}",
+                model="hermes-agent",
+                model_config={},
+                system_prompt=None,
+                user_id=source_profile,
+                parent_session_id=None,  # No parent - this IS the root delegation session
+            )
+
+            # Store initial message as first conversation entry
+            db.append_message(
+                session_id=child_session_id,
+                role="user",
+                content=initial_message,
+            )
+
+            logger.info(
+                f"Created persistent child session {child_session_id} "
+                f"for delegation from {source_profile} to {target_profile}"
+            )
+            return child_session_id
+
+        except Exception as e:
+            logger.error(f"Failed to create child session: {e}")
+            # Fallback to simple UUID if session creation fails
+            return str(uuid.uuid4())
+
+    # ------------------------------------------------------------------
     # BasePlatformAdapter interface
     # ------------------------------------------------------------------
 
@@ -1604,24 +1974,42 @@ class APIServerAdapter(BasePlatformAdapter):
             return False
 
         try:
-            mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
+            mws = [
+                mw
+                for mw in (
+                    cors_middleware,
+                    body_limit_middleware,
+                    security_headers_middleware,
+                )
+                if mw is not None
+            ]
             self._app = web.Application(middlewares=mws)
             self._app["api_server_adapter"] = self
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/v1/health", self._handle_health)
             self._app.router.add_get("/v1/models", self._handle_models)
-            self._app.router.add_post("/v1/chat/completions", self._handle_chat_completions)
+            self._app.router.add_post(
+                "/v1/chat/completions", self._handle_chat_completions
+            )
             self._app.router.add_post("/v1/responses", self._handle_responses)
-            self._app.router.add_get("/v1/responses/{response_id}", self._handle_get_response)
-            self._app.router.add_delete("/v1/responses/{response_id}", self._handle_delete_response)
+            self._app.router.add_get(
+                "/v1/responses/{response_id}", self._handle_get_response
+            )
+            self._app.router.add_delete(
+                "/v1/responses/{response_id}", self._handle_delete_response
+            )
             # Cron jobs management API
             self._app.router.add_get("/api/jobs", self._handle_list_jobs)
             self._app.router.add_post("/api/jobs", self._handle_create_job)
             self._app.router.add_get("/api/jobs/{job_id}", self._handle_get_job)
             self._app.router.add_patch("/api/jobs/{job_id}", self._handle_update_job)
             self._app.router.add_delete("/api/jobs/{job_id}", self._handle_delete_job)
-            self._app.router.add_post("/api/jobs/{job_id}/pause", self._handle_pause_job)
-            self._app.router.add_post("/api/jobs/{job_id}/resume", self._handle_resume_job)
+            self._app.router.add_post(
+                "/api/jobs/{job_id}/pause", self._handle_pause_job
+            )
+            self._app.router.add_post(
+                "/api/jobs/{job_id}/resume", self._handle_resume_job
+            )
             self._app.router.add_post("/api/jobs/{job_id}/run", self._handle_run_job)
             # Structured event streaming
             self._app.router.add_post("/v1/runs", self._handle_runs)
@@ -1637,11 +2025,16 @@ class APIServerAdapter(BasePlatformAdapter):
 
             # Port conflict detection — fail fast if port is already in use
             import socket as _socket
+
             try:
                 with _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM) as _s:
                     _s.settimeout(1)
-                    _s.connect(('127.0.0.1', self._port))
-                logger.error('[%s] Port %d already in use. Set a different port in config.yaml: platforms.api_server.port', self.name, self._port)
+                    _s.connect(("127.0.0.1", self._port))
+                logger.error(
+                    "[%s] Port %d already in use. Set a different port in config.yaml: platforms.api_server.port",
+                    self.name,
+                    self._port,
+                )
                 return False
             except (ConnectionRefusedError, OSError):
                 pass  # port is free
@@ -1654,7 +2047,9 @@ class APIServerAdapter(BasePlatformAdapter):
             self._mark_connected()
             logger.info(
                 "[%s] API server listening on http://%s:%d",
-                self.name, self._host, self._port,
+                self.name,
+                self._host,
+                self._port,
             )
             return True
 
@@ -1684,7 +2079,9 @@ class APIServerAdapter(BasePlatformAdapter):
         """
         Not used — HTTP request/response cycle handles delivery directly.
         """
-        return SendResult(success=False, error="API server uses HTTP request/response, not send()")
+        return SendResult(
+            success=False, error="API server uses HTTP request/response, not send()"
+        )
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return basic info about the API server."""

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -31,7 +31,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -88,6 +88,24 @@ CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
+
+CREATE TABLE IF NOT EXISTS orchestration_tasks (
+    task_id TEXT PRIMARY KEY,
+    parent_session_id TEXT REFERENCES sessions(id),
+    target_profile TEXT NOT NULL,
+    status TEXT NOT NULL,
+    goal TEXT,
+    context TEXT,
+    result TEXT,
+    error_message TEXT,
+    created_at REAL NOT NULL,
+    started_at REAL,
+    completed_at REAL,
+    updated_at REAL NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_orchestration_parent ON orchestration_tasks(parent_session_id);
+CREATE INDEX IF NOT EXISTS idx_orchestration_status ON orchestration_tasks(status);
 """
 
 FTS_SQL = """
@@ -111,6 +129,33 @@ CREATE TRIGGER IF NOT EXISTS messages_fts_update AFTER UPDATE ON messages BEGIN
 END;
 """
 
+# FTS5 for orchestration_tasks - enables natural language search of past delegations
+ORCHESTRATION_FTS_SQL = """
+CREATE VIRTUAL TABLE IF NOT EXISTS orchestration_tasks_fts USING fts5(
+    goal,
+    result,
+    content=orchestration_tasks,
+    content_rowid=rowid
+);
+
+CREATE TRIGGER IF NOT EXISTS orchestration_fts_insert AFTER INSERT ON orchestration_tasks BEGIN
+    INSERT INTO orchestration_tasks_fts(rowid, goal, result) 
+    VALUES (new.rowid, new.goal, new.result);
+END;
+
+CREATE TRIGGER IF NOT EXISTS orchestration_fts_delete AFTER DELETE ON orchestration_tasks BEGIN
+    INSERT INTO orchestration_tasks_fts(orchestration_tasks_fts, rowid, goal, result) 
+    VALUES('delete', old.rowid, old.goal, old.result);
+END;
+
+CREATE TRIGGER IF NOT EXISTS orchestration_fts_update AFTER UPDATE ON orchestration_tasks BEGIN
+    INSERT INTO orchestration_tasks_fts(orchestration_tasks_fts, rowid, goal, result) 
+    VALUES('delete', old.rowid, old.goal, old.result);
+    INSERT INTO orchestration_tasks_fts(rowid, goal, result) 
+    VALUES (new.rowid, new.goal, new.result);
+END;
+"""
+
 
 class SessionDB:
     """
@@ -130,8 +175,8 @@ class SessionDB:
     # application level with random jitter, which naturally staggers competing
     # writers and avoids the convoy.
     _WRITE_MAX_RETRIES = 15
-    _WRITE_RETRY_MIN_S = 0.020   # 20ms
-    _WRITE_RETRY_MAX_S = 0.150   # 150ms
+    _WRITE_RETRY_MIN_S = 0.020  # 20ms
+    _WRITE_RETRY_MAX_S = 0.150  # 150ms
     # Attempt a PASSIVE WAL checkpoint every N successful writes.
     _CHECKPOINT_EVERY_N_WRITES = 50
 
@@ -223,13 +268,12 @@ class SessionDB:
         """
         try:
             with self._lock:
-                result = self._conn.execute(
-                    "PRAGMA wal_checkpoint(PASSIVE)"
-                ).fetchone()
+                result = self._conn.execute("PRAGMA wal_checkpoint(PASSIVE)").fetchone()
                 if result and result[1] > 0:
                     logger.debug(
                         "WAL checkpoint: %d/%d pages checkpointed",
-                        result[2], result[1],
+                        result[2],
+                        result[1],
                     )
         except Exception:
             pass  # Best effort — never fatal.
@@ -259,7 +303,9 @@ class SessionDB:
         cursor.execute("SELECT version FROM schema_version LIMIT 1")
         row = cursor.fetchone()
         if row is None:
-            cursor.execute("INSERT INTO schema_version (version) VALUES (?)", (SCHEMA_VERSION,))
+            cursor.execute(
+                "INSERT INTO schema_version (version) VALUES (?)", (SCHEMA_VERSION,)
+            )
         else:
             current_version = row["version"] if isinstance(row, sqlite3.Row) else row[0]
             if current_version < 2:
@@ -306,7 +352,9 @@ class SessionDB:
                         # not user input. Double-quote identifier escaping is applied
                         # as defense-in-depth; SQLite DDL cannot be parameterized.
                         safe_name = name.replace('"', '""')
-                        cursor.execute(f'ALTER TABLE sessions ADD COLUMN "{safe_name}" {column_type}')
+                        cursor.execute(
+                            f'ALTER TABLE sessions ADD COLUMN "{safe_name}" {column_type}'
+                        )
                     except sqlite3.OperationalError:
                         pass
                 cursor.execute("UPDATE schema_version SET version = 5")
@@ -329,6 +377,48 @@ class SessionDB:
                     except sqlite3.OperationalError:
                         pass  # Column already exists
                 cursor.execute("UPDATE schema_version SET version = 6")
+            if current_version < 7:
+                # v7: add orchestration_tasks table for async task persistence
+                for stmt in [
+                    """
+                    CREATE TABLE IF NOT EXISTS orchestration_tasks (
+                        task_id TEXT PRIMARY KEY,
+                        parent_session_id TEXT REFERENCES sessions(id),
+                        target_profile TEXT NOT NULL,
+                        status TEXT NOT NULL,
+                        goal TEXT,
+                        context TEXT,
+                        result TEXT,
+                        error_message TEXT,
+                        created_at REAL NOT NULL,
+                        started_at REAL,
+                        completed_at REAL,
+                        updated_at REAL NOT NULL
+                    )
+                    """,
+                    "CREATE INDEX IF NOT EXISTS idx_orchestration_parent ON orchestration_tasks(parent_session_id)",
+                    "CREATE INDEX IF NOT EXISTS idx_orchestration_status ON orchestration_tasks(status)",
+                ]:
+                    try:
+                        cursor.execute(stmt)
+                    except sqlite3.OperationalError:
+                        pass  # Already exists
+                cursor.execute("UPDATE schema_version SET version = 7")
+            if current_version < 8:
+                # v8: Fix FTS5 triggers - they were using task_id (TEXT) instead of rowid (INTEGER)
+                # Drop and recreate triggers with correct rowid reference
+                for trigger_name in [
+                    "orchestration_fts_insert",
+                    "orchestration_fts_delete",
+                    "orchestration_fts_update",
+                ]:
+                    try:
+                        cursor.execute(f"DROP TRIGGER IF EXISTS {trigger_name}")
+                    except sqlite3.OperationalError:
+                        pass
+                # Recreate FTS5 triggers with correct rowid
+                cursor.executescript(ORCHESTRATION_FTS_SQL)
+                cursor.execute("UPDATE schema_version SET version = 8")
 
         # Unique title index — always ensure it exists (safe to run after migrations
         # since the title column is guaranteed to exist at this point)
@@ -345,6 +435,12 @@ class SessionDB:
             cursor.execute("SELECT * FROM messages_fts LIMIT 0")
         except sqlite3.OperationalError:
             cursor.executescript(FTS_SQL)
+
+        # FTS5 for orchestration_tasks - natural language search of past delegations
+        try:
+            cursor.execute("SELECT * FROM orchestration_tasks_fts LIMIT 0")
+        except sqlite3.OperationalError:
+            cursor.executescript(ORCHESTRATION_FTS_SQL)
 
         self._conn.commit()
 
@@ -363,6 +459,7 @@ class SessionDB:
         parent_session_id: str = None,
     ) -> str:
         """Create a new session record. Returns the session_id."""
+
         def _do(conn):
             conn.execute(
                 """INSERT OR IGNORE INTO sessions (id, source, user_id, model, model_config,
@@ -379,34 +476,41 @@ class SessionDB:
                     time.time(),
                 ),
             )
+
         self._execute_write(_do)
         return session_id
 
     def end_session(self, session_id: str, end_reason: str) -> None:
         """Mark a session as ended."""
+
         def _do(conn):
             conn.execute(
                 "UPDATE sessions SET ended_at = ?, end_reason = ? WHERE id = ?",
                 (time.time(), end_reason, session_id),
             )
+
         self._execute_write(_do)
 
     def reopen_session(self, session_id: str) -> None:
         """Clear ended_at/end_reason so a session can be resumed."""
+
         def _do(conn):
             conn.execute(
                 "UPDATE sessions SET ended_at = NULL, end_reason = NULL WHERE id = ?",
                 (session_id,),
             )
+
         self._execute_write(_do)
 
     def update_system_prompt(self, session_id: str, system_prompt: str) -> None:
         """Store the full assembled system prompt snapshot."""
+
         def _do(conn):
             conn.execute(
                 "UPDATE sessions SET system_prompt = ? WHERE id = ?",
                 (system_prompt, session_id),
             )
+
         self._execute_write(_do)
 
     def update_token_counts(
@@ -495,8 +599,10 @@ class SessionDB:
             model,
             session_id,
         )
+
         def _do(conn):
             conn.execute(sql, params)
+
         self._execute_write(_do)
 
     def ensure_session(
@@ -511,6 +617,7 @@ class SessionDB:
         create_session() call (e.g. transient SQLite lock at agent startup).
         INSERT OR IGNORE is safe to call even when the row already exists.
         """
+
         def _do(conn):
             conn.execute(
                 """INSERT OR IGNORE INTO sessions
@@ -518,6 +625,7 @@ class SessionDB:
                    VALUES (?, ?, ?, ?)""",
                 (session_id, source, model, time.time()),
             )
+
         self._execute_write(_do)
 
     def set_token_counts(
@@ -544,6 +652,7 @@ class SessionDB:
         conversation run (e.g. the gateway, where the cached agent's
         session_prompt_tokens already reflects the running total).
         """
+
         def _do(conn):
             conn.execute(
                 """UPDATE sessions SET
@@ -584,6 +693,7 @@ class SessionDB:
                     session_id,
                 ),
             )
+
         self._execute_write(_do)
 
     def get_session(self, session_id: str) -> Optional[Dict[str, Any]]:
@@ -607,8 +717,7 @@ class SessionDB:
             return exact["id"]
 
         escaped = (
-            session_id_or_prefix
-            .replace("\\", "\\\\")
+            session_id_or_prefix.replace("\\", "\\\\")
             .replace("%", "\\%")
             .replace("_", "\\_")
         )
@@ -645,19 +754,20 @@ class SessionDB:
         # Remove ASCII control characters (0x00-0x1F, 0x7F) but keep
         # whitespace chars (\t=0x09, \n=0x0A, \r=0x0D) so they can be
         # normalized to spaces by the whitespace collapsing step below
-        cleaned = re.sub(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]', '', title)
+        cleaned = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", "", title)
 
         # Remove problematic Unicode control characters:
         # - Zero-width chars (U+200B-U+200F, U+FEFF)
         # - Directional overrides (U+202A-U+202E, U+2066-U+2069)
         # - Object replacement (U+FFFC), interlinear annotation (U+FFF9-U+FFFB)
         cleaned = re.sub(
-            r'[\u200b-\u200f\u2028-\u202e\u2060-\u2069\ufeff\ufffc\ufff9-\ufffb]',
-            '', cleaned,
+            r"[\u200b-\u200f\u2028-\u202e\u2060-\u2069\ufeff\ufffc\ufff9-\ufffb]",
+            "",
+            cleaned,
         )
 
         # Collapse internal whitespace runs and strip
-        cleaned = re.sub(r'\s+', ' ', cleaned).strip()
+        cleaned = re.sub(r"\s+", " ", cleaned).strip()
 
         if not cleaned:
             return None
@@ -678,6 +788,7 @@ class SessionDB:
         Empty/whitespace-only strings are normalized to None (clearing the title).
         """
         title = self.sanitize_title(title)
+
         def _do(conn):
             if title:
                 # Check uniqueness (allow the same session to keep its own title)
@@ -695,6 +806,7 @@ class SessionDB:
                 (title, session_id),
             )
             return cursor.rowcount
+
         rowcount = self._execute_write(_do)
         return rowcount > 0
 
@@ -752,7 +864,7 @@ class SessionDB:
         the highest existing number and increments.
         """
         # Strip existing #N suffix to find the true base
-        match = re.match(r'^(.*?) #(\d+)$', base_title)
+        match = re.match(r"^(.*?) #(\d+)$", base_title)
         if match:
             base = match.group(1)
         else:
@@ -774,7 +886,7 @@ class SessionDB:
         # Find the highest number
         max_num = 1  # The unnumbered original counts as #1
         for t in existing:
-            m = re.match(r'^.* #(\d+)$', t)
+            m = re.match(r"^.* #(\d+)$", t)
             if m:
                 max_num = max(max_num, int(m.group(1)))
 
@@ -876,12 +988,10 @@ class SessionDB:
         """
         # Serialize structured fields to JSON before entering the write txn
         reasoning_details_json = (
-            json.dumps(reasoning_details)
-            if reasoning_details else None
+            json.dumps(reasoning_details) if reasoning_details else None
         )
         codex_items_json = (
-            json.dumps(codex_reasoning_items)
-            if codex_reasoning_items else None
+            json.dumps(codex_reasoning_items) if codex_reasoning_items else None
         )
         tool_calls_json = json.dumps(tool_calls) if tool_calls else None
 
@@ -986,7 +1096,9 @@ class SessionDB:
                         pass
                 if row["codex_reasoning_items"]:
                     try:
-                        msg["codex_reasoning_items"] = json.loads(row["codex_reasoning_items"])
+                        msg["codex_reasoning_items"] = json.loads(
+                            row["codex_reasoning_items"]
+                        )
                     except (json.JSONDecodeError, TypeError):
                         pass
             messages.append(msg)
@@ -1023,7 +1135,7 @@ class SessionDB:
         sanitized = re.sub(r'"[^"]*"', _preserve_quoted, query)
 
         # Step 2: Strip remaining (unmatched) FTS5-special characters
-        sanitized = re.sub(r'[+{}()\"^]', " ", sanitized)
+        sanitized = re.sub(r"[+{}()\"^]", " ", sanitized)
 
         # Step 3: Collapse repeated * (e.g. "***") into a single one,
         # and remove leading * (prefix-only needs at least one char before *)
@@ -1224,14 +1336,14 @@ class SessionDB:
 
     def clear_messages(self, session_id: str) -> None:
         """Delete all messages for a session and reset its counters."""
+
         def _do(conn):
-            conn.execute(
-                "DELETE FROM messages WHERE session_id = ?", (session_id,)
-            )
+            conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
             conn.execute(
                 "UPDATE sessions SET message_count = 0, tool_call_count = 0 WHERE id = ?",
                 (session_id,),
             )
+
         self._execute_write(_do)
 
     def delete_session(self, session_id: str) -> bool:
@@ -1241,6 +1353,7 @@ class SessionDB:
         first to satisfy the ``parent_session_id`` foreign key constraint.
         Returns True if the session was found and deleted.
         """
+
         def _do(conn):
             cursor = conn.execute(
                 "SELECT COUNT(*) FROM sessions WHERE id = ?", (session_id,)
@@ -1248,10 +1361,13 @@ class SessionDB:
             if cursor.fetchone()[0] == 0:
                 return False
             # Delete child sessions first (FK constraint)
-            child_ids = [r[0] for r in conn.execute(
-                "SELECT id FROM sessions WHERE parent_session_id = ?",
-                (session_id,),
-            ).fetchall()]
+            child_ids = [
+                r[0]
+                for r in conn.execute(
+                    "SELECT id FROM sessions WHERE parent_session_id = ?",
+                    (session_id,),
+                ).fetchall()
+            ]
             for cid in child_ids:
                 conn.execute("DELETE FROM messages WHERE session_id = ?", (cid,))
                 conn.execute("DELETE FROM sessions WHERE id = ?", (cid,))
@@ -1259,6 +1375,7 @@ class SessionDB:
             conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
             conn.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
             return True
+
         return self._execute_write(_do)
 
     def prune_sessions(self, older_than_days: int = 90, source: str = None) -> int:
@@ -1287,10 +1404,13 @@ class SessionDB:
             # Delete children first whose parents are in the prune set
             # (avoids FK constraint errors)
             for sid in list(session_ids):
-                child_ids = [r[0] for r in conn.execute(
-                    "SELECT id FROM sessions WHERE parent_session_id = ?",
-                    (sid,),
-                ).fetchall()]
+                child_ids = [
+                    r[0]
+                    for r in conn.execute(
+                        "SELECT id FROM sessions WHERE parent_session_id = ?",
+                        (sid,),
+                    ).fetchall()
+                ]
                 for cid in child_ids:
                     conn.execute("DELETE FROM messages WHERE session_id = ?", (cid,))
                     conn.execute("DELETE FROM sessions WHERE id = ?", (cid,))
@@ -1300,5 +1420,221 @@ class SessionDB:
                 conn.execute("DELETE FROM messages WHERE session_id = ?", (sid,))
                 conn.execute("DELETE FROM sessions WHERE id = ?", (sid,))
             return len(session_ids)
+
+        return self._execute_write(_do)
+
+    # =========================================================================
+    # Orchestration tasks
+    # =========================================================================
+
+    def create_orchestration_task(
+        self,
+        task_id: str,
+        parent_session_id: str,
+        target_profile: str,
+        goal: str = None,
+        context: str = None,
+    ) -> str:
+        """Create a new orchestration task. Returns the task_id."""
+        now = time.time()
+
+        def _do(conn):
+            conn.execute(
+                """INSERT OR IGNORE INTO orchestration_tasks
+                   (task_id, parent_session_id, target_profile, status, goal, context,
+                    created_at, updated_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    task_id,
+                    parent_session_id,
+                    target_profile,
+                    "pending",
+                    goal,
+                    context,
+                    now,
+                    now,
+                ),
+            )
+
+        self._execute_write(_do)
+        return task_id
+
+    def update_orchestration_task(
+        self,
+        task_id: str,
+        status: str,
+        result: str = None,
+        error_message: str = None,
+    ) -> None:
+        """Update an orchestration task status and optionally result/error."""
+        now = time.time()
+        started_at = None
+        completed_at = None
+        if status == "running":
+            started_at = now
+        elif status in ("completed", "error", "cancelled"):
+            completed_at = now
+
+        def _do(conn):
+            conn.execute(
+                """UPDATE orchestration_tasks SET
+                   status = ?, result = ?, error_message = ?,
+                   started_at = COALESCE(?, started_at),
+                   completed_at = COALESCE(?, completed_at),
+                   updated_at = ?
+                   WHERE task_id = ?""",
+                (status, result, error_message, started_at, completed_at, now, task_id),
+            )
+
+        self._execute_write(_do)
+
+    def get_orchestration_task(self, task_id: str) -> Optional[Dict[str, Any]]:
+        """Get an orchestration task by ID."""
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT * FROM orchestration_tasks WHERE task_id = ?", (task_id,)
+            )
+            row = cursor.fetchone()
+        return dict(row) if row else None
+
+    def list_orchestration_tasks(
+        self,
+        parent_session_id: str = None,
+        status: str = None,
+        limit: int = 100,
+    ) -> List[Dict[str, Any]]:
+        """List orchestration tasks, optionally filtered."""
+        where_clauses = []
+        params = []
+        if parent_session_id is not None:
+            where_clauses.append("parent_session_id = ?")
+            params.append(parent_session_id)
+        if status is not None:
+            where_clauses.append("status = ?")
+            params.append(status)
+        where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
+        with self._lock:
+            cursor = self._conn.execute(
+                f"""SELECT * FROM orchestration_tasks
+                    {where_sql}
+                    ORDER BY created_at DESC LIMIT ?""",
+                [*params, limit],
+            )
+            return [dict(row) for row in cursor.fetchall()]
+
+    def search_orchestration_tasks(
+        self,
+        query: str,
+        status: str = None,
+        limit: int = 20,
+    ) -> List[Dict[str, Any]]:
+        """Full-text search orchestration tasks by goal/result content or task_id prefix.
+
+        Natural language search of past delegations:
+          - Keywords: "security issues auth.py"
+          - Phrases: '"exact phrase"'
+          - Boolean: "docker OR kubernetes"
+          - Prefix: "deploy*"
+          - Task ID: "42eb" (short alphanumeric auto-detected as ID prefix)
+        """
+        if not query or not query.strip():
+            return self.list_orchestration_tasks(status=status, limit=limit)
+
+        query = query.strip().replace("'", "").replace('"', "")
+        if not query:
+            return []
+
+        # Detect ID-like query: short (≤20), alphanumeric, no spaces
+        looks_like_id = len(query) <= 20 and query.isalnum() and " " not in query
+
+        with self._lock:
+            try:
+                if looks_like_id:
+                    # Search by task_id prefix + fallback to goal/result LIKE
+                    where_clauses = []
+                    params = []
+
+                    if status:
+                        where_clauses.append("status = ?")
+                        params.append(status)
+                        status_sql = f"AND status = ?"
+                    else:
+                        status_sql = ""
+
+                    sql = f"""
+                        SELECT
+                            task_id,
+                            parent_session_id,
+                            target_profile,
+                            status,
+                            substr(goal, 1, 100) AS goal_snippet,
+                            goal,
+                            result,
+                            created_at,
+                            completed_at
+                        FROM orchestration_tasks
+                        WHERE (task_id LIKE ? OR goal LIKE ? OR result LIKE ?)
+                        {status_sql}
+                        ORDER BY created_at DESC
+                        LIMIT ?
+                    """
+                    like_pattern = f"{query}%"
+                    contains_pattern = f"%{query}%"
+                    params = [like_pattern, contains_pattern, contains_pattern]
+                    if status:
+                        params.append(status)
+                    params.append(limit)
+
+                    cursor = self._conn.execute(sql, params)
+                    return [dict(row) for row in cursor.fetchall()]
+
+                else:
+                    # Standard FTS search
+                    where_clauses = ["orchestration_tasks_fts MATCH ?"]
+                    params = [query]
+
+                    if status:
+                        where_clauses.append("t.status = ?")
+                        params.append(status)
+
+                    where_sql = f"WHERE {' AND '.join(where_clauses)}"
+                    params.append(limit)
+
+                    sql = f"""
+                        SELECT
+                            t.task_id,
+                            t.parent_session_id,
+                            t.target_profile,
+                            t.status,
+                            snippet(orchestration_tasks_fts, 0, '>>>', '<<<', '...', 50) AS goal_snippet,
+                            t.goal,
+                            t.result,
+                            t.created_at,
+                            t.completed_at
+                        FROM orchestration_tasks_fts
+                        JOIN orchestration_tasks t ON t.rowid = orchestration_tasks_fts.rowid
+                        {where_sql}
+                        ORDER BY rank
+                        LIMIT ?
+                    """
+                    cursor = self._conn.execute(sql, params)
+                    return [dict(row) for row in cursor.fetchall()]
+
+            except sqlite3.OperationalError:
+                return []
+
+    def delete_orchestration_task(self, task_id: str) -> bool:
+        """Delete an orchestration task. Returns True if found."""
+
+        def _do(conn):
+            cursor = conn.execute(
+                "SELECT COUNT(*) FROM orchestration_tasks WHERE task_id = ?", (task_id,)
+            )
+            if cursor.fetchone()[0] == 0:
+                return False
+            conn.execute(
+                "DELETE FROM orchestration_tasks WHERE task_id = ?", (task_id,)
+            )
+            return True
 
         return self._execute_write(_do)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -18,6 +18,7 @@ never the child's intermediate tool calls or reasoning.
 
 import json
 import logging
+
 logger = logging.getLogger(__name__)
 import os
 import time
@@ -26,13 +27,15 @@ from typing import Any, Dict, List, Optional
 
 
 # Tools that children must never have access to
-DELEGATE_BLOCKED_TOOLS = frozenset([
-    "delegate_task",   # no recursive delegation
-    "clarify",         # no user interaction
-    "memory",          # no writes to shared MEMORY.md
-    "send_message",    # no cross-platform side effects
-    "execute_code",    # children should reason step-by-step, not write scripts
-])
+DELEGATE_BLOCKED_TOOLS = frozenset(
+    [
+        "delegate_task",  # no recursive delegation
+        "clarify",  # no user interaction
+        "memory",  # no writes to shared MEMORY.md
+        "send_message",  # no cross-platform side effects
+        "execute_code",  # children should reason step-by-step, not write scripts
+    ]
+)
 
 MAX_CONCURRENT_CHILDREN = 3
 MAX_DEPTH = 2  # parent (0) -> child (1) -> grandchild rejected (2)
@@ -89,7 +92,9 @@ def _resolve_workspace_hint(parent_agent) -> Optional[str]:
     """
     candidates = [
         os.getenv("TERMINAL_CWD"),
-        getattr(getattr(parent_agent, "_subdirectory_hints", None), "working_dir", None),
+        getattr(
+            getattr(parent_agent, "_subdirectory_hints", None), "working_dir", None
+        ),
         getattr(parent_agent, "terminal_cwd", None),
         getattr(parent_agent, "cwd", None),
     ]
@@ -108,12 +113,17 @@ def _resolve_workspace_hint(parent_agent) -> Optional[str]:
 def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
     """Remove toolsets that contain only blocked tools."""
     blocked_toolset_names = {
-        "delegation", "clarify", "memory", "code_execution",
+        "delegation",
+        "clarify",
+        "memory",
+        "code_execution",
     }
     return [t for t in toolsets if t not in blocked_toolset_names]
 
 
-def _build_child_progress_callback(task_index: int, parent_agent, task_count: int = 1) -> Optional[callable]:
+def _build_child_progress_callback(
+    task_index: int, parent_agent, task_count: int = 1
+) -> Optional[callable]:
     """Build a callback that relays child agent tool calls to the parent display.
 
     Two display paths:
@@ -123,8 +133,8 @@ def _build_child_progress_callback(task_index: int, parent_agent, task_count: in
     Returns None if no display mechanism is available, in which case the
     child agent runs with no progress callback (identical to current behavior).
     """
-    spinner = getattr(parent_agent, '_delegate_spinner', None)
-    parent_cb = getattr(parent_agent, 'tool_progress_callback', None)
+    spinner = getattr(parent_agent, "_delegate_spinner", None)
+    parent_cb = getattr(parent_agent, "tool_progress_callback", None)
 
     if not spinner and not parent_cb:
         return None  # No display → no callback → zero behavior change
@@ -136,7 +146,9 @@ def _build_child_progress_callback(task_index: int, parent_agent, task_count: in
     _BATCH_SIZE = 5
     _batch: List[str] = []
 
-    def _callback(event_type: str, tool_name: str = None, preview: str = None, args=None, **kwargs):
+    def _callback(
+        event_type: str, tool_name: str = None, preview: str = None, args=None, **kwargs
+    ):
         # event_type is one of: "tool.started", "tool.completed",
         # "reasoning.available", "_thinking", "subagent_progress"
 
@@ -144,9 +156,13 @@ def _build_child_progress_callback(task_index: int, parent_agent, task_count: in
         if event_type in ("_thinking", "reasoning.available"):
             text = preview or tool_name or ""
             if spinner:
-                short = (text[:55] + "...") if len(text) > 55 else text
+                short = (
+                    (preview[:55] + "...")
+                    if preview and len(preview) > 55
+                    else (preview or "")
+                )
                 try:
-                    spinner.print_above(f" {prefix}├─ 💭 \"{short}\"")
+                    spinner.print_above(f' {prefix}├─ 💭 "{short}"')
                 except Exception as e:
                     logger.debug("Spinner print_above failed: %s", e)
             # Don't relay thinking to gateway (too noisy for chat)
@@ -158,12 +174,17 @@ def _build_child_progress_callback(task_index: int, parent_agent, task_count: in
 
         # tool.started — display and batch for parent relay
         if spinner:
-            short = (preview[:35] + "...") if preview and len(preview) > 35 else (preview or "")
+            short = (
+                (preview[:35] + "...")
+                if preview and len(preview) > 35
+                else (preview or "")
+            )
             from agent.display import get_tool_emoji
+
             emoji = get_tool_emoji(tool_name or "")
             line = f" {prefix}├─ {emoji} {tool_name}"
             if short:
-                line += f"  \"{short}\""
+                line += f'  "{short}"'
             try:
                 spinner.print_above(line)
             except Exception as e:
@@ -231,8 +252,10 @@ def _build_child_agent(
     elif parent_agent and hasattr(parent_agent, "valid_tool_names"):
         # enabled_toolsets is None (all tools) — derive from loaded tool names
         import model_tools
+
         parent_toolsets = {
-            ts for name in parent_agent.valid_tool_names
+            ts
+            for name in parent_agent.valid_tool_names
             if (ts := model_tools.get_toolset_for_tool(name)) is not None
         }
     else:
@@ -240,7 +263,9 @@ def _build_child_agent(
 
     if toolsets:
         # Intersect with parent — subagent must not gain tools the parent lacks
-        child_toolsets = _strip_blocked_tools([t for t in toolsets if t in parent_toolsets])
+        child_toolsets = _strip_blocked_tools(
+            [t for t in toolsets if t in parent_toolsets]
+        )
     elif parent_agent and parent_enabled is not None:
         child_toolsets = _strip_blocked_tools(parent_enabled)
     elif parent_toolsets:
@@ -249,7 +274,9 @@ def _build_child_agent(
         child_toolsets = _strip_blocked_tools(DEFAULT_TOOLSETS)
 
     workspace_hint = _resolve_workspace_hint(parent_agent)
-    child_prompt = _build_child_system_prompt(goal, context, workspace_path=workspace_hint)
+    child_prompt = _build_child_system_prompt(
+        goal, context, workspace_path=workspace_hint
+    )
     # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
     parent_api_key = getattr(parent_agent, "api_key", None)
     if (not parent_api_key) and hasattr(parent_agent, "_client_kwargs"):
@@ -265,6 +292,7 @@ def _build_child_agent(
 
     child_thinking_cb = None
     if child_progress_cb:
+
         def _child_thinking(text: str) -> None:
             if not text:
                 return
@@ -281,8 +309,14 @@ def _build_child_agent(
     effective_base_url = override_base_url or parent_agent.base_url
     effective_api_key = override_api_key or parent_api_key
     effective_api_mode = override_api_mode or getattr(parent_agent, "api_mode", None)
-    effective_acp_command = override_acp_command or getattr(parent_agent, "acp_command", None)
-    effective_acp_args = list(override_acp_args if override_acp_args is not None else (getattr(parent_agent, "acp_args", []) or []))
+    effective_acp_command = override_acp_command or getattr(
+        parent_agent, "acp_command", None
+    )
+    effective_acp_args = list(
+        override_acp_args
+        if override_acp_args is not None
+        else (getattr(parent_agent, "acp_args", []) or [])
+    )
 
     child = AIAgent(
         base_url=effective_base_url,
@@ -305,8 +339,8 @@ def _build_child_agent(
         skip_memory=True,
         clarify_callback=None,
         thinking_callback=child_thinking_cb,
-        session_db=getattr(parent_agent, '_session_db', None),
-        parent_session_id=getattr(parent_agent, 'session_id', None),
+        session_db=getattr(parent_agent, "_session_db", None),
+        parent_session_id=getattr(parent_agent, "session_id", None),
         providers_allowed=parent_agent.providers_allowed,
         providers_ignored=parent_agent.providers_ignored,
         providers_order=parent_agent.providers_order,
@@ -314,9 +348,9 @@ def _build_child_agent(
         tool_progress_callback=child_progress_cb,
         iteration_budget=None,  # fresh budget per subagent
     )
-    child._print_fn = getattr(parent_agent, '_print_fn', None)
+    child._print_fn = getattr(parent_agent, "_print_fn", None)
     # Set delegation depth so children can't spawn grandchildren
-    child._delegate_depth = getattr(parent_agent, '_delegate_depth', 0) + 1
+    child._delegate_depth = getattr(parent_agent, "_delegate_depth", 0) + 1
 
     # Share a credential pool with the child when possible so subagents can
     # rotate credentials on rate limits instead of getting pinned to one key.
@@ -325,8 +359,8 @@ def _build_child_agent(
         child._credential_pool = child_pool
 
     # Register child for interrupt propagation
-    if hasattr(parent_agent, '_active_children'):
-        lock = getattr(parent_agent, '_active_children_lock', None)
+    if hasattr(parent_agent, "_active_children"):
+        lock = getattr(parent_agent, "_active_children_lock", None)
         if lock:
             with lock:
                 parent_agent._active_children.append(child)
@@ -334,6 +368,7 @@ def _build_child_agent(
             parent_agent._active_children.append(child)
 
     return child
+
 
 def _run_single_child(
     task_index: int,
@@ -349,22 +384,24 @@ def _run_single_child(
     child_start = time.monotonic()
 
     # Get the progress callback from the child agent
-    child_progress_cb = getattr(child, 'tool_progress_callback', None)
+    child_progress_cb = getattr(child, "tool_progress_callback", None)
 
     # Restore parent tool names using the value saved before child construction
     # mutated the global. This is the correct parent toolset, not the child's.
     import model_tools
-    _saved_tool_names = getattr(child, "_delegate_saved_tool_names",
-                                list(model_tools._last_resolved_tool_names))
 
-    child_pool = getattr(child, '_credential_pool', None)
+    _saved_tool_names = getattr(
+        child, "_delegate_saved_tool_names", list(model_tools._last_resolved_tool_names)
+    )
+
+    child_pool = getattr(child, "_credential_pool", None)
     leased_cred_id = None
     if child_pool is not None:
         leased_cred_id = child_pool.acquire_lease()
         if leased_cred_id is not None:
             try:
                 leased_entry = child_pool.current()
-                if leased_entry is not None and hasattr(child, '_swap_credential'):
+                if leased_entry is not None and hasattr(child, "_swap_credential"):
                     child._swap_credential(leased_entry)
             except Exception as exc:
                 logger.debug("Failed to bind child to leased credential: %s", exc)
@@ -373,7 +410,7 @@ def _run_single_child(
         result = child.run_conversation(user_message=goal)
 
         # Flush any remaining batched progress to gateway
-        if child_progress_cb and hasattr(child_progress_cb, '_flush'):
+        if child_progress_cb and hasattr(child_progress_cb, "_flush"):
             try:
                 child_progress_cb._flush()
             except Exception as e:
@@ -406,7 +443,7 @@ def _run_single_child(
                 if not isinstance(msg, dict):
                     continue
                 if msg.get("role") == "assistant":
-                    for tc in (msg.get("tool_calls") or []):
+                    for tc in msg.get("tool_calls") or []:
                         fn = tc.get("function", {})
                         entry_t = {
                             "tool": fn.get("name", "unknown"),
@@ -418,9 +455,7 @@ def _run_single_child(
                             trace_by_id[tc_id] = entry_t
                 elif msg.get("role") == "tool":
                     content = msg.get("content", "")
-                    is_error = bool(
-                        content and "error" in content[:80].lower()
-                    )
+                    is_error = bool(content and "error" in content[:80].lower())
                     result_meta = {
                         "result_bytes": len(content),
                         "status": "error" if is_error else "ok",
@@ -456,8 +491,12 @@ def _run_single_child(
             "model": _model if isinstance(_model, str) else None,
             "exit_reason": exit_reason,
             "tokens": {
-                "input": _input_tokens if isinstance(_input_tokens, (int, float)) else 0,
-                "output": _output_tokens if isinstance(_output_tokens, (int, float)) else 0,
+                "input": _input_tokens
+                if isinstance(_input_tokens, (int, float))
+                else 0,
+                "output": _output_tokens
+                if isinstance(_output_tokens, (int, float))
+                else 0,
             },
             "tool_trace": tool_trace,
         }
@@ -496,9 +535,9 @@ def _run_single_child(
         # Remove child from active tracking
 
         # Unregister child from interrupt propagation
-        if hasattr(parent_agent, '_active_children'):
+        if hasattr(parent_agent, "_active_children"):
             try:
-                lock = getattr(parent_agent, '_active_children_lock', None)
+                lock = getattr(parent_agent, "_active_children_lock", None)
                 if lock:
                     with lock:
                         parent_agent._active_children.remove(child)
@@ -506,6 +545,7 @@ def _run_single_child(
                     parent_agent._active_children.remove(child)
             except (ValueError, UnboundLocalError) as e:
                 logger.debug("Could not remove child from active_children: %s", e)
+
 
 def delegate_task(
     goal: Optional[str] = None,
@@ -530,14 +570,16 @@ def delegate_task(
         return tool_error("delegate_task requires a parent agent context.")
 
     # Depth limit
-    depth = getattr(parent_agent, '_delegate_depth', 0)
+    depth = getattr(parent_agent, "_delegate_depth", 0)
     if depth >= MAX_DEPTH:
-        return json.dumps({
-            "error": (
-                f"Delegation depth limit reached ({MAX_DEPTH}). "
-                "Subagents cannot spawn further subagents."
-            )
-        })
+        return json.dumps(
+            {
+                "error": (
+                    f"Delegation depth limit reached ({MAX_DEPTH}). "
+                    "Subagents cannot spawn further subagents."
+                )
+            }
+        )
 
     # Load config
     cfg = _load_config()
@@ -581,6 +623,7 @@ def delegate_task(
     # _build_child_agent() calls AIAgent() which calls get_tool_definitions(),
     # which overwrites model_tools._last_resolved_tool_names with child's toolset.
     import model_tools as _model_tools
+
     _parent_tool_names = list(_model_tools._last_resolved_tool_names)
 
     # Build all child agents on the main thread (thread-safe construction)
@@ -590,10 +633,15 @@ def delegate_task(
     try:
         for i, t in enumerate(task_list):
             child = _build_child_agent(
-                task_index=i, goal=t["goal"], context=t.get("context"),
-                toolsets=t.get("toolsets") or toolsets, model=creds["model"],
-                max_iterations=effective_max_iter, parent_agent=parent_agent,
-                override_provider=creds["provider"], override_base_url=creds["base_url"],
+                task_index=i,
+                goal=t["goal"],
+                context=t.get("context"),
+                toolsets=t.get("toolsets") or toolsets,
+                model=creds["model"],
+                max_iterations=effective_max_iter,
+                parent_agent=parent_agent,
+                override_provider=creds["provider"],
+                override_base_url=creds["base_url"],
                 override_api_key=creds["api_key"],
                 override_api_mode=creds["api_mode"],
                 override_acp_command=t.get("acp_command") or acp_command,
@@ -614,7 +662,7 @@ def delegate_task(
     else:
         # Batch -- run in parallel with per-task progress lines
         completed_count = 0
-        spinner_ref = getattr(parent_agent, '_delegate_spinner', None)
+        spinner_ref = getattr(parent_agent, "_delegate_spinner", None)
 
         with ThreadPoolExecutor(max_workers=MAX_CONCURRENT_CHILDREN) as executor:
             futures = {}
@@ -651,7 +699,7 @@ def delegate_task(
                 status = entry.get("status", "?")
                 icon = "✓" if status == "completed" else "✗"
                 remaining = n_tasks - completed_count
-                completion_line = f"{icon} [{idx+1}/{n_tasks}] {label}  ({dur}s)"
+                completion_line = f"{icon} [{idx + 1}/{n_tasks}] {label}  ({dur}s)"
                 if spinner_ref:
                     try:
                         spinner_ref.print_above(completion_line)
@@ -663,7 +711,9 @@ def delegate_task(
                 # Update spinner text to show remaining count
                 if spinner_ref and remaining > 0:
                     try:
-                        spinner_ref.update_text(f"🔀 {remaining} task{'s' if remaining != 1 else ''} remaining")
+                        spinner_ref.update_text(
+                            f"🔀 {remaining} task{'s' if remaining != 1 else ''} remaining"
+                        )
                     except Exception as e:
                         logger.debug("Spinner update_text failed: %s", e)
 
@@ -671,24 +721,39 @@ def delegate_task(
         results.sort(key=lambda r: r["task_index"])
 
     # Notify parent's memory provider of delegation outcomes
-    if parent_agent and hasattr(parent_agent, '_memory_manager') and parent_agent._memory_manager:
+    if (
+        parent_agent
+        and hasattr(parent_agent, "_memory_manager")
+        and parent_agent._memory_manager
+    ):
         for entry in results:
             try:
-                _task_goal = task_list[entry["task_index"]]["goal"] if entry["task_index"] < len(task_list) else ""
+                _task_goal = (
+                    task_list[entry["task_index"]]["goal"]
+                    if entry["task_index"] < len(task_list)
+                    else ""
+                )
                 parent_agent._memory_manager.on_delegation(
                     task=_task_goal,
                     result=entry.get("summary", "") or "",
-                    child_session_id=getattr(children[entry["task_index"]][2], "session_id", "") if entry["task_index"] < len(children) else "",
+                    child_session_id=getattr(
+                        children[entry["task_index"]][2], "session_id", ""
+                    )
+                    if entry["task_index"] < len(children)
+                    else "",
                 )
             except Exception:
                 pass
 
     total_duration = round(time.monotonic() - overall_start, 2)
 
-    return json.dumps({
-        "results": results,
-        "total_duration_seconds": total_duration,
-    }, ensure_ascii=False)
+    return json.dumps(
+        {
+            "results": results,
+            "total_duration_seconds": total_duration,
+        },
+        ensure_ascii=False,
+    )
 
 
 def _resolve_child_credential_pool(effective_provider: Optional[str], parent_agent):
@@ -711,6 +776,7 @@ def _resolve_child_credential_pool(effective_provider: Optional[str], parent_age
 
     try:
         from agent.credential_pool import load_pool
+
         pool = load_pool(effective_provider)
         if pool is not None and pool.has_credentials():
             return pool
@@ -744,10 +810,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     configured_api_key = str(cfg.get("api_key") or "").strip() or None
 
     if configured_base_url:
-        api_key = (
-            configured_api_key
-            or os.getenv("OPENAI_API_KEY", "").strip()
-        )
+        api_key = configured_api_key or os.getenv("OPENAI_API_KEY", "").strip()
         if not api_key:
             raise ValueError(
                 "Delegation base_url is configured but no API key was found. "
@@ -785,6 +848,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     # Provider is configured — resolve full credentials
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider
+
         runtime = resolve_runtime_provider(requested=configured_provider)
     except Exception as exc:
         raise ValueError(
@@ -822,6 +886,7 @@ def _load_config() -> dict:
     """
     try:
         from cli import CLI_CONFIG
+
         cfg = CLI_CONFIG.get("delegation", {})
         if cfg:
             return cfg
@@ -829,6 +894,7 @@ def _load_config() -> dict:
         pass
     try:
         from hermes_cli.config import load_config
+
         full = load_config()
         return full.get("delegation", {})
     except Exception:
@@ -842,10 +908,15 @@ def _load_config() -> dict:
 DELEGATE_TASK_SCHEMA = {
     "name": "delegate_task",
     "description": (
-        "Spawn one or more subagents to work on tasks in isolated contexts. "
-        "Each subagent gets its own conversation, terminal session, and toolset. "
+        "Spawn temporary ONE-OFF subagents to work on tasks in isolated contexts. "
+        "Each subagent gets its own conversation, terminal session, and toolset, "
+        "but shares the SAME HERMES_HOME as you. "
         "Only the final summary is returned -- intermediate tool results "
         "never enter your context window.\n\n"
+        "CRITICAL: For cross-profile orchestration (delegating to named profiles like "
+        "'coder', 'researcher'), use profile_delegate INSTEAD of this tool. "
+        "delegate_task creates temporary subagents; profile_delegate connects to "
+        "persistent profile workers with separate HERMES_HOME directories.\n\n"
         "TWO MODES (one of 'goal' or 'tasks' is required):\n"
         "1. Single task: provide 'goal' (+ optional context, toolsets)\n"
         "2. Batch (parallel): provide 'tasks' array with up to 3 items. "
@@ -853,8 +924,10 @@ DELEGATE_TASK_SCHEMA = {
         "WHEN TO USE delegate_task:\n"
         "- Reasoning-heavy subtasks (debugging, code review, research synthesis)\n"
         "- Tasks that would flood your context with intermediate data\n"
-        "- Parallel independent workstreams (research A and B simultaneously)\n\n"
+        "- Parallel independent workstreams (research A and B simultaneously)\n"
+        "- Temporary subagents that don't need persistent state\n\n"
         "WHEN NOT TO USE (use these instead):\n"
+        "- Cross-profile orchestration -> use profile_delegate (persistent workers)\n"
         "- Mechanical multi-step work with no reasoning needed -> use execute_code\n"
         "- Single tool call -> just call the tool directly\n"
         "- Tasks needing user interaction -> subagents cannot use clarify\n\n"
@@ -902,7 +975,10 @@ DELEGATE_TASK_SCHEMA = {
                     "type": "object",
                     "properties": {
                         "goal": {"type": "string", "description": "Task goal"},
-                        "context": {"type": "string", "description": "Task-specific context"},
+                        "context": {
+                            "type": "string",
+                            "description": "Task-specific context",
+                        },
                         "toolsets": {
                             "type": "array",
                             "items": {"type": "string"},
@@ -957,6 +1033,689 @@ DELEGATE_TASK_SCHEMA = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Inter-profile delegation (profile_delegate)
+# ---------------------------------------------------------------------------
+
+import asyncio as _asyncio
+
+
+def check_profile_requirements() -> bool:
+    """Profile delegation requires no external dependencies."""
+    return True
+
+
+def profile_delegate(
+    profile: str,
+    goal: str,
+    context: Optional[str] = None,
+    wait: bool = True,
+    timeout: int = 300,
+    allow_subagents: bool = True,
+    max_depth: int = 2,
+    parent_agent=None,
+) -> str:
+    """
+    Delegate a task to a specific Hermes profile worker.
+
+    Connects to a running profile gateway or starts one if not already running.
+    This is the main orchestration tool for inter-profile communication.
+
+    Args:
+        profile:  Target profile name (e.g., 'coder', 'researcher').
+        goal:     Task description to send to the profile worker.
+        context:  Optional additional context information.
+        wait:     Wait for result or return immediately with task_id.
+        timeout:  Seconds to wait for result (default 300).
+        allow_subagents: Whether the delegated agent may spawn one-off
+                  subagents via delegate_task (default True).
+        max_depth: Maximum delegation depth (default 2). Prevents infinite
+                  delegation chains. Parent=0, child=1, grandchild=2.
+
+    Returns:
+        JSON string with the result (if wait=True) or task_id (if wait=False).
+    """
+    from tools.profile_orchestrator import (
+        ensure_profile_running,
+        send_to_profile,
+        send_to_profile_async,
+        is_profile_running,
+        discover_profiles,
+    )
+
+    if not profile or not str(profile).strip():
+        return json.dumps({"error": "Profile name is required"})
+
+    profile = str(profile).strip()
+
+    # Validate profile exists
+    available = discover_profiles()
+    if available and profile not in available:
+        return json.dumps(
+            {
+                "error": f"Profile '{profile}' not found",
+                "available": available,
+            }
+        )
+
+    # Ensure profile is running (start if needed)
+    if not is_profile_running(profile):
+        if not ensure_profile_running(profile):
+            return json.dumps({"error": f"Failed to start profile '{profile}'"})
+
+    # DEBUG: Check parent_agent
+    logger.info(
+        f"[DEBUG] profile_delegate: parent_agent is None = {parent_agent is None}"
+    )
+
+    # Extract conversation history from parent agent for context continuity
+    conversation_history = None
+    if parent_agent is not None:
+        try:
+            session_messages = getattr(parent_agent, "_session_messages", [])
+            logger.info(
+                f"[DEBUG] Found {len(session_messages)} session messages in parent_agent"
+            )
+            if session_messages:
+                conversation_history = [
+                    {"role": msg.get("role", "user"), "content": msg.get("content", "")}
+                    for msg in session_messages
+                    if msg.get("role") in ("user", "assistant", "system")
+                ]
+                logger.info(
+                    f"[DEBUG] Extracted {len(conversation_history)} messages for delegation"
+                )
+        except Exception as e:
+            logger.warning(
+                f"Failed to extract conversation history from parent agent: {e}"
+            )
+            conversation_history = None
+
+    # For async mode without parent_agent, try to load previous orchestration tasks
+    if conversation_history is None and not wait:
+        try:
+            from hermes_state import SessionDB
+
+            db = SessionDB()
+            # Get recent orchestration tasks for this profile
+            recent_tasks = db.list_orchestration_tasks(status=None, limit=10)
+            if recent_tasks:
+                history = []
+                for task in recent_tasks:
+                    if task.get("context"):
+                        try:
+                            ctx = json.loads(task["context"])
+                            if ctx.get("message"):
+                                history.append(
+                                    {"role": "user", "content": ctx["message"]}
+                                )
+                        except:
+                            pass
+                if history:
+                    conversation_history = history[-5:]  # Last 5 messages
+                    logger.info(
+                        f"[DEBUG] Loaded {len(conversation_history)} messages from previous async tasks"
+                    )
+        except Exception as e:
+            logger.debug(f"Could not load previous async task history: {e}")
+    if parent_agent is not None:
+        try:
+            session_messages = getattr(parent_agent, "_session_messages", [])
+            logger.info(
+                f"[DEBUG] Found {len(session_messages)} session messages in parent_agent"
+            )
+            if session_messages:
+                conversation_history = [
+                    {"role": msg.get("role", "user"), "content": msg.get("content", "")}
+                    for msg in session_messages
+                    if msg.get("role") in ("user", "assistant", "system")
+                ]
+                logger.info(
+                    f"[DEBUG] Extracted {len(conversation_history)} messages for delegation"
+                )
+        except Exception as e:
+            logger.warning(f"Failed to extract conversation history: {e}")
+
+    try:
+        # Generate task_id for both sync and async modes (for searchability)
+        import uuid
+
+        task_id = str(uuid.uuid4())[:8]
+
+        if wait:
+            # Blocking mode: send directly and wait for result
+            # First, create DB record for searchability
+            try:
+                from hermes_state import SessionDB
+
+                db = SessionDB()
+                db.create_orchestration_task(
+                    task_id=task_id,
+                    parent_session_id=None,
+                    target_profile=profile,
+                    goal=goal,
+                    context=context,
+                )
+            except Exception as e:
+                logger.debug(f"Failed to create orchestration task record: {e}")
+
+            result = send_to_profile(
+                profile_name=profile,
+                message=goal,
+                context={"additional_context": context} if context else None,
+                wait=True,
+                timeout=float(timeout),
+                conversation_history=conversation_history,
+                allow_subagents=allow_subagents,
+                max_depth=max_depth,
+            )
+
+            # Update DB with result
+            try:
+                from hermes_state import SessionDB
+
+                db = SessionDB()
+                db.update_orchestration_task(
+                    task_id=task_id,
+                    status="completed",
+                    result=result,
+                )
+            except Exception as e:
+                logger.debug(f"Failed to update orchestration task: {e}")
+
+            return json.dumps(
+                {"status": "completed", "result": result, "task_id": task_id}
+            )
+        else:
+            # Background mode: dispatch async and return task_id
+            task_id_or_coro = send_to_profile_async(
+                profile_name=profile,
+                message=goal,
+                context={"additional_context": context} if context else None,
+                conversation_history=conversation_history,
+                allow_subagents=allow_subagents,
+                max_depth=max_depth,
+            )
+            # send_to_profile_async is async; run it to get the task_id string
+            if _asyncio.iscoroutine(task_id_or_coro):
+                task_id = _asyncio.run(task_id_or_coro)
+            else:
+                task_id = task_id_or_coro
+            return json.dumps({"status": "dispatched", "task_id": task_id})
+
+    except ValueError as e:
+        return json.dumps({"error": str(e)})
+    except RuntimeError as e:
+        return json.dumps({"error": f"Profile communication error: {e}"})
+    except Exception as e:
+        logger.exception("profile_delegate failed")
+        return json.dumps({"error": f"Unexpected error: {e}"})
+
+
+def profile_delegate_async(
+    profile: str,
+    goal: str,
+    context: Optional[str] = None,
+    conversation_history: Optional[List[Dict[str, str]]] = None,
+) -> str:
+    """
+    Non-blocking version of profile_delegate.
+
+    Always returns immediately with a task_id for polling.
+    """
+    from tools.profile_orchestrator import (
+        ensure_profile_running,
+        send_to_profile_async,
+        is_profile_running,
+        discover_profiles,
+    )
+
+    if not profile or not str(profile).strip():
+        return json.dumps({"error": "Profile name is required"})
+
+    profile = str(profile).strip()
+
+    # Validate profile exists
+    available = discover_profiles()
+    if available and profile not in available:
+        return json.dumps(
+            {
+                "error": f"Profile '{profile}' not found",
+                "available": available,
+            }
+        )
+
+    # Ensure profile is running
+    if not is_profile_running(profile):
+        if not ensure_profile_running(profile):
+            return json.dumps({"error": f"Failed to start profile '{profile}'"})
+
+    try:
+        task_id_or_coro = send_to_profile_async(
+            profile_name=profile,
+            message=goal,
+            context={"additional_context": context} if context else None,
+            conversation_history=conversation_history,
+        )
+        if _asyncio.iscoroutine(task_id_or_coro):
+            task_id = _asyncio.run(task_id_or_coro)
+        else:
+            task_id = task_id_or_coro
+        return json.dumps({"status": "dispatched", "task_id": task_id})
+    except ValueError as e:
+        return json.dumps({"error": str(e)})
+    except Exception as e:
+        logger.exception("profile_delegate_async failed")
+        return json.dumps({"error": f"Unexpected error: {e}"})
+
+
+def profile_task_check(task_id: str, parent_agent=None) -> str:
+    """
+    Check the status of an async profile delegation task.
+
+    Args:
+        task_id: The task_id returned by profile_delegate (with wait=False).
+        parent_agent: Optional reference to parent agent (for consistency with other tools).
+
+    Returns:
+        JSON string with status and result (if completed).
+    """
+    from tools.profile_orchestrator import (
+        _profile_tasks,
+        collect_profile_result,
+    )
+
+    if not task_id:
+        return json.dumps({"error": "task_id is required"})
+
+    entry = _profile_tasks.get(task_id)
+    if entry:
+        future = entry["future"]
+
+        if entry.get("_cancelled", False):
+            return json.dumps(
+                {
+                    "status": "cancelled",
+                    "task_id": task_id,
+                }
+            )
+
+        import concurrent.futures
+
+        if not future.done():
+            return json.dumps({"status": "running", "task_id": task_id})
+
+        try:
+            result = collect_profile_result(task_id, block=False, timeout=0)
+            if result is not None:
+                return json.dumps(
+                    {
+                        "status": "completed",
+                        "task_id": task_id,
+                        "result": result,
+                    }
+                )
+            else:
+                return json.dumps(
+                    {
+                        "status": "completed",
+                        "task_id": task_id,
+                        "result": None,
+                    }
+                )
+        except RuntimeError as e:
+            return json.dumps({"status": "error", "task_id": task_id, "error": str(e)})
+        except Exception as e:
+            return json.dumps({"status": "error", "task_id": task_id, "error": str(e)})
+
+    try:
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        task_data = db.get_orchestration_task(task_id)
+
+        if task_data:
+            status = task_data.get("status", "unknown")
+            result = task_data.get("result")
+            error = task_data.get("error_message")
+
+            if status == "completed":
+                return json.dumps(
+                    {
+                        "status": "completed",
+                        "task_id": task_id,
+                        "result": result,
+                    }
+                )
+            elif status == "error":
+                return json.dumps(
+                    {
+                        "status": "error",
+                        "task_id": task_id,
+                        "error": error or "Unknown error",
+                    }
+                )
+            elif status in ("pending", "running"):
+                return json.dumps(
+                    {
+                        "status": "running",
+                        "task_id": task_id,
+                        "note": "Task is running but may have been restarted",
+                    }
+                )
+            else:
+                return json.dumps(
+                    {
+                        "status": status,
+                        "task_id": task_id,
+                    }
+                )
+    except Exception as e:
+        logger.debug(f"Failed to check SQLite for task {task_id}: {e}")
+
+    return json.dumps({"error": f"Unknown task_id: {task_id}"})
+
+
+def profile_task_cancel(task_id: str, parent_agent=None) -> str:
+    """
+    Cancel an async profile delegation task.
+
+    Args:
+        task_id: The task_id returned by profile_delegate (with wait=False).
+        parent_agent: Optional reference to parent agent (for consistency with other tools).
+
+    Returns:
+        JSON string with cancellation status.
+    """
+    from tools.profile_orchestrator import _profile_tasks
+
+    if not task_id:
+        return json.dumps({"error": "task_id is required"})
+
+    entry = _profile_tasks.get(task_id)
+    if entry:
+        future = entry["future"]
+        entry["_cancelled"] = True
+
+        cancelled = False
+        try:
+            cancelled = future.cancel()
+        except Exception as e:
+            logger.debug("Failed to cancel future for task %s: %s", task_id, e)
+
+        try:
+            del _profile_tasks[task_id]
+        except KeyError:
+            pass
+
+        try:
+            from hermes_state import SessionDB
+
+            db = SessionDB()
+            db.update_orchestration_task(
+                task_id=task_id,
+                status="cancelled",
+            )
+        except Exception as e:
+            logger.debug(f"Failed to update SQLite for cancelled task {task_id}: {e}")
+
+        if cancelled:
+            return json.dumps({"status": "cancelled", "task_id": task_id})
+        else:
+            return json.dumps(
+                {
+                    "status": "cancellation_attempted",
+                    "task_id": task_id,
+                    "note": "Task may already be running or completed",
+                }
+            )
+
+    try:
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        task_data = db.get_orchestration_task(task_id)
+
+        if task_data:
+            status = task_data.get("status")
+            if status in ("completed", "error", "cancelled"):
+                return json.dumps(
+                    {
+                        "status": "already_finished",
+                        "task_id": task_id,
+                        "previous_status": status,
+                        "note": "Task already completed, cannot cancel",
+                    }
+                )
+            else:
+                db.update_orchestration_task(
+                    task_id=task_id,
+                    status="cancelled",
+                )
+                return json.dumps(
+                    {
+                        "status": "cancelled",
+                        "task_id": task_id,
+                        "note": "Task was not in memory but marked as cancelled in database",
+                    }
+                )
+    except Exception as e:
+        logger.debug(f"Failed to check SQLite for task {task_id}: {e}")
+
+    return json.dumps({"error": f"Unknown task_id: {task_id}"})
+
+
+def profile_task_search(
+    query: str, status: str = None, limit: int = 20, parent_agent=None
+) -> str:
+    """
+    Natural language search of past profile delegation tasks across ALL profiles.
+
+    Searches every profile's orchestration_tasks database. Useful when you don't know
+    which profile handled a task, or when you want a complete history view.
+
+    Args:
+        query: Search terms (e.g., "security issues auth.py", "docker deployment")
+               Supports phrases: '"exact phrase"', boolean: "docker OR kubernetes"
+        status: Optional filter: "completed", "running", "pending", "error", "cancelled"
+        limit: Max results total (default 20)
+        parent_agent: Optional reference to parent agent.
+
+    Returns:
+        JSON string with matching tasks from all profiles, including source_profile field.
+
+    Example:
+        profile_task_search("security issues")
+        → Returns tasks from all profiles matching the query, each with source_profile field
+    """
+    if not query or not str(query).strip():
+        return json.dumps({"error": "Query is required"})
+
+    try:
+        from hermes_cli.profiles import list_profiles, get_profile_dir
+        from hermes_state import SessionDB
+
+        profiles = list_profiles()
+        if not profiles:
+            return json.dumps({"count": 0, "tasks": [], "profiles_searched": 0})
+
+        all_results = []
+        profiles_with_tasks = 0
+
+        for profile_info in profiles:
+            try:
+                profile_name = (
+                    profile_info.name
+                    if hasattr(profile_info, "name")
+                    else str(profile_info)
+                )
+                profile_dir = get_profile_dir(profile_name)
+                db_path = profile_dir / "state.db"
+
+                if not db_path.exists():
+                    continue
+
+                db = SessionDB(db_path=db_path)
+                tasks = db.search_orchestration_tasks(
+                    query=str(query).strip(),
+                    status=status,
+                    limit=limit,
+                )
+
+                if tasks:
+                    profiles_with_tasks += 1
+                    for task in tasks:
+                        task["source_profile"] = profile_name
+                        all_results.append(task)
+
+            except Exception as e:
+                logger.debug(f"Failed to search profile {profile_info}: {e}")
+                continue
+
+        # Sort by created_at (newest first)
+        all_results.sort(key=lambda x: x.get("created_at", 0), reverse=True)
+
+        return json.dumps(
+            {
+                "count": len(all_results),
+                "tasks": all_results[:limit],
+                "profiles_searched": len(profiles),
+                "profiles_with_matches": profiles_with_tasks,
+            }
+        )
+    except Exception as e:
+        logger.exception("profile_task_search failed")
+        return json.dumps({"error": f"Search failed: {e}"})
+
+
+# OpenAI Function-Calling Schema for profile_delegate
+# ---------------------------------------------------------------------------
+
+PROFILE_DELEGATE_SCHEMA = {
+    "name": "profile_delegate",
+    "description": (
+        "CRITICAL: Use THIS tool for cross-profile orchestration, NOT delegate_task. "
+        "This connects to a persistent Hermes profile worker via HTTP (like coder, researcher). "
+        "The profile must exist in ~/.hermes/profiles/<profile_name>/ with its own gateway.\n\n"
+        "DIFFERENCE from delegate_task:\n"
+        "- profile_delegate: Uses persistent profile workers (separate HERMES_HOME, config, gateway)\n"
+        "- delegate_task: Spawns temporary one-off subagents (same HERMES_HOME, ephemeral)\n\n"
+        "WORKFLOW:\n"
+        "1. Call profile_delegate(profile='profile2', goal='...')\n"
+        "2. This connects to profile2's gateway at localhost:<port>\n"
+        "3. Profile2 processes the task with its own config/memory\n"
+        "4. Returns result from the persistent worker, not a temporary subagent\n\n"
+        "WHEN TO USE:\n"
+        "- Delegating to named profiles: coder, researcher, planner, etc.\n"
+        "- Tasks requiring isolated configs/memories per profile\n"
+        "- Multi-agent workflows with specialized persistent workers\n\n"
+        "WHEN NOT TO USE:\n"
+        "- For temporary subagents -> use delegate_task instead\n"
+        "- For single tool calls -> call the tool directly"
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "profile": {
+                "type": "string",
+                "description": "Target profile name (e.g., 'coder', 'researcher'). "
+                "Must be a directory under ~/.hermes/profiles/.",
+            },
+            "goal": {
+                "type": "string",
+                "description": "Task description to send to the profile worker.",
+            },
+            "context": {
+                "type": "string",
+                "description": "Additional context or instructions for the profile worker.",
+            },
+            "wait": {
+                "type": "boolean",
+                "default": True,
+                "description": "Wait for result (True, default) or return immediately with task_id (False).",
+            },
+            "timeout": {
+                "type": "integer",
+                "default": 300,
+                "description": "Seconds to wait for result when wait=True (default 300).",
+            },
+            "allow_subagents": {
+                "type": "boolean",
+                "default": True,
+                "description": "Whether the delegated agent may spawn one-off subagents via delegate_task. "
+                "Set to false to force the agent to do all work itself without spawning helpers.",
+            },
+            "max_depth": {
+                "type": "integer",
+                "default": 2,
+                "description": "Maximum delegation depth (default 2). Prevents infinite delegation chains. "
+                "Parent=0, child=1, grandchild=2. When depth is reached, subagents cannot delegate further.",
+            },
+        },
+        "required": ["profile", "goal"],
+    },
+}
+
+PROFILE_TASK_CHECK_SCHEMA = {
+    "name": "profile_task_check",
+    "description": "Check the status of an async profile delegation task.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "task_id": {
+                "type": "string",
+                "description": "The task_id returned by profile_delegate with wait=False.",
+            },
+        },
+        "required": ["task_id"],
+    },
+}
+
+PROFILE_TASK_CANCEL_SCHEMA = {
+    "name": "profile_task_cancel",
+    "description": "Cancel an async profile delegation task.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "task_id": {
+                "type": "string",
+                "description": "The task_id returned by profile_delegate with wait=False.",
+            },
+        },
+        "required": ["task_id"],
+    },
+}
+
+PROFILE_TASK_SEARCH_SCHEMA = {
+    "name": "profile_task_search",
+    "description": (
+        "Cross-profile natural language search of past delegation tasks. "
+        "Searches ALL profiles' task histories to find tasks by goal or result. "
+        "Each result includes source_profile to identify which profile handled it."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": 'Search terms. Examples: "security issues", "auth refactor", "docker". '
+                'Supports phrases: \'"exact phrase"\', boolean: "docker OR kubernetes"',
+            },
+            "status": {
+                "type": "string",
+                "description": 'Optional filter: "completed", "running", "pending", "error", "cancelled"',
+            },
+            "limit": {
+                "type": "integer",
+                "default": 20,
+                "description": "Max results total across all profiles (default 20).",
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+
 # --- Registry ---
 from tools.registry import registry, tool_error
 
@@ -972,7 +1731,62 @@ registry.register(
         max_iterations=args.get("max_iterations"),
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
-        parent_agent=kw.get("parent_agent")),
+        parent_agent=kw.get("parent_agent"),
+    ),
     check_fn=check_delegate_requirements,
     emoji="🔀",
+)
+
+registry.register(
+    name="profile_delegate",
+    toolset="delegation",
+    schema=PROFILE_DELEGATE_SCHEMA,
+    handler=lambda args, **kw: profile_delegate(
+        profile=args.get("profile"),
+        goal=args.get("goal"),
+        context=args.get("context"),
+        wait=args.get("wait", True),
+        timeout=args.get("timeout", 300),
+        allow_subagents=args.get("allow_subagents", True),
+        max_depth=args.get("max_depth", 2),
+        parent_agent=kw.get("parent_agent"),
+    ),
+    check_fn=check_profile_requirements,
+    emoji="🔀",
+)
+
+registry.register(
+    name="profile_task_check",
+    toolset="delegation",
+    schema=PROFILE_TASK_CHECK_SCHEMA,
+    handler=lambda args, **kw: profile_task_check(
+        task_id=args.get("task_id"), parent_agent=kw.get("parent_agent")
+    ),
+    check_fn=check_profile_requirements,
+    emoji="📋",
+)
+
+registry.register(
+    name="profile_task_cancel",
+    toolset="delegation",
+    schema=PROFILE_TASK_CANCEL_SCHEMA,
+    handler=lambda args, **kw: profile_task_cancel(
+        task_id=args.get("task_id"), parent_agent=kw.get("parent_agent")
+    ),
+    check_fn=check_profile_requirements,
+    emoji="✋",
+)
+
+registry.register(
+    name="profile_task_search",
+    toolset="delegation",
+    schema=PROFILE_TASK_SEARCH_SCHEMA,
+    handler=lambda args, **kw: profile_task_search(
+        query=args.get("query"),
+        status=args.get("status"),
+        limit=args.get("limit", 10),
+        parent_agent=kw.get("parent_agent"),
+    ),
+    check_fn=check_profile_requirements,
+    emoji="🔍",
 )

--- a/tools/profile_orchestrator.py
+++ b/tools/profile_orchestrator.py
@@ -1,0 +1,1227 @@
+"""
+Inter-profile orchestration for Hermes Agent.
+
+Provides profile discovery, health checking, and port resolution
+for managing multiple Hermes profiles under ~/.hermes/profiles/<name>/.
+
+Each profile has its own HERMES_HOME, config.yaml, .env, and gateway.pid file.
+This module allows tools to discover and interact with running profile instances.
+"""
+
+import asyncio  # For async operations and Future checking
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+from hermes_cli.profiles import (
+    _get_profiles_root,
+    get_profile_dir,
+    list_profiles,
+    profile_exists,
+    _check_gateway_running,
+    ProfileInfo,
+)
+
+# Re-use gateway/status.py PID checking mechanisms
+# Import late to avoid circular imports at module level
+_gw_status = None
+
+
+def _get_gateway_status():
+    """Lazy import gateway/status.py to avoid circular imports."""
+    global _gw_status
+    if _gw_status is None:
+        from gateway import status as _gw_status
+    return _gw_status
+
+
+# Logger for this module
+logger = logging.getLogger(__name__)
+
+# Default API server port when not configured in profile's config.yaml
+DEFAULT_API_SERVER_PORT = 8642
+
+
+def _get_profile_home(profile_name: str) -> Optional[Path]:
+    """
+    Get the HERMES_HOME path for a given profile.
+
+    Args:
+        profile_name: Name of the profile directory
+
+    Returns:
+        Path to the profile's HERMES_HOME, or None if not found.
+    """
+    if not profile_exists(profile_name):
+        return None
+    return get_profile_dir(profile_name)
+
+
+def discover_profiles() -> List[str]:
+    """
+    Discover all available profiles.
+
+    Returns:
+        List[str]: Sorted list of profile names.
+    """
+    # list_profiles() returns List[ProfileInfo], extract names
+    profiles = list_profiles()
+    return sorted([p.name for p in profiles])
+
+
+def is_profile_running(profile_name: str) -> bool:
+    """
+    Check if a profile's gateway is currently running.
+
+    Uses _check_gateway_running from hermes_cli.profiles which checks
+    the PID file and process existence.
+
+    Args:
+        profile_name: Name of the profile to check
+
+    Returns:
+        True if the profile's gateway is running, False otherwise.
+    """
+    profile_home = _get_profile_home(profile_name)
+    if profile_home is None:
+        return False
+
+    # Use the new _check_gateway_running from profiles.py
+    return _check_gateway_running(profile_home)
+
+
+def get_profile_health(profile_name: str) -> Dict[str, Any]:
+    """
+    Get health status information for a profile's gateway.
+
+    Attempts to check:
+    1. PID file existence and process liveness
+    2. HTTP /health endpoint if port is configured
+
+    Args:
+        profile_name: Name of the profile to check
+
+    Returns:
+        Dict with keys:
+        - running: bool — whether the gateway appears to be running
+        - pid: int | None — the PID if running
+        - port: int | None — the configured API server port
+        - health_check: str — "pid_only", "http_healthy", "http_unreachable", "not_running"
+        - error: str | None — error message if any
+    """
+    result: Dict[str, Any] = {
+        "running": False,
+        "pid": None,
+        "port": None,
+        "health_check": "not_running",
+        "error": None,
+    }
+
+    profile_home = _get_profile_home(profile_name)
+    if profile_home is None:
+        result["error"] = f"Profile '{profile_name}' not found"
+        return result
+
+    # Get port from profile config
+    port = resolve_profile_port(profile_name)
+    result["port"] = port
+
+    # Check PID file
+    pid_path = profile_home / "gateway.pid"
+    if not pid_path.exists():
+        result["health_check"] = "not_running"
+        return result
+
+    try:
+        raw = pid_path.read_text().strip()
+        if not raw:
+            result["health_check"] = "not_running"
+            return result
+
+        try:
+            payload = json.loads(raw)
+            pid = int(payload.get("pid", 0)) if isinstance(payload, dict) else int(raw)
+        except (json.JSONDecodeError, ValueError):
+            pid = int(raw)
+    except (OSError, ValueError) as e:
+        result["error"] = f"Failed to read PID: {e}"
+        result["health_check"] = "not_running"
+        return result
+
+    if pid <= 0:
+        result["health_check"] = "not_running"
+        return result
+
+    # Check process existence
+    try:
+        os.kill(pid, 0)
+    except (ProcessLookupError, PermissionError):
+        result["health_check"] = "not_running"
+        result["error"] = "PID file exists but process is not running"
+        return result
+
+    result["running"] = True
+    result["pid"] = pid
+    result["health_check"] = "pid_only"
+
+    # Try HTTP health check if port is configured
+    if port and port > 0:
+        try:
+            import urllib.request
+            import urllib.error
+
+            health_url = f"http://127.0.0.1:{port}/health"
+            req = urllib.request.Request(health_url, method="GET")
+            req.add_header("Accept", "application/json")
+            try:
+                with urllib.request.urlopen(req, timeout=2) as resp:
+                    if resp.status == 200:
+                        result["health_check"] = "http_healthy"
+                    else:
+                        result["health_check"] = "http_unreachable"
+            except (urllib.error.URLError, TimeoutError, OSError):
+                # Process is running but health endpoint not responding
+                result["health_check"] = "pid_only"
+        except Exception as e:
+            logger.debug("Health check failed for profile %s: %s", profile_name, e)
+            # Don't set error - PID check already succeeded
+
+    return result
+
+
+def resolve_profile_port(profile_name: str) -> int:
+    """
+    Resolve the API server port for a profile.
+
+    Reads the profile's config.yaml and extracts api_server.port.
+    Falls back to DEFAULT_API_SERVER_PORT (8642) if not configured.
+
+    Args:
+        profile_name: Name of the profile
+
+    Returns:
+        The configured port number, or DEFAULT_API_SERVER_PORT if not set.
+    """
+    config = load_profile_config(profile_name)
+    if config is None:
+        return DEFAULT_API_SERVER_PORT
+
+    # Check api_server.port in config
+    api_server = config.get("api_server", {})
+    if isinstance(api_server, dict):
+        port = api_server.get("port")
+        if port is not None:
+            try:
+                return int(port)
+            except (ValueError, TypeError):
+                pass
+
+    # Also check API_SERVER_PORT env var pattern (uppercase, common convention)
+    env_override = config.get("environment", {}).get("API_SERVER_PORT")
+    if env_override is not None:
+        try:
+            return int(env_override)
+        except (ValueError, TypeError):
+            pass
+
+    return DEFAULT_API_SERVER_PORT
+
+
+def load_profile_config(profile_name: str) -> Optional[Dict[str, Any]]:
+    """
+    Load the full config.yaml for a profile.
+
+    Args:
+        profile_name: Name of the profile directory
+
+    Returns:
+        The parsed config.yaml as a dict, or None if the profile
+        doesn't exist or config.yaml can't be read.
+    """
+    profile_home = _get_profile_home(profile_name)
+    if profile_home is None:
+        logger.debug("Profile '%s' not found", profile_name)
+        return None
+
+    config_path = profile_home / "config.yaml"
+    if not config_path.exists():
+        logger.debug("Profile '%s' has no config.yaml", profile_name)
+        return None
+
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            cfg = yaml.safe_load(f)
+        return cfg if isinstance(cfg, dict) else {}
+    except (OSError, yaml.YAMLError) as e:
+        logger.warning("Failed to load config for profile '%s': %s", profile_name, e)
+        return None
+
+
+def get_profile_info(profile_name: str) -> Dict[str, Any]:
+    """
+    Get a summary of information about a profile.
+
+    Convenience function that combines discovery, health, and config data.
+
+    Args:
+        profile_name: Name of the profile
+
+    Returns:
+        Dict with keys:
+        - name: str — the profile name
+        - exists: bool — whether the profile directory exists
+        - running: bool — whether the gateway is running
+        - health: Dict from get_profile_health()
+        - config: Dict from load_profile_config() (or None)
+    """
+    info: Dict[str, Any] = {
+        "name": profile_name,
+        "exists": profile_exists(profile_name),
+        "running": False,
+        "health": {},
+        "config": None,
+    }
+
+    if not info["exists"]:
+        return info
+
+    info["running"] = is_profile_running(profile_name)
+    info["health"] = get_profile_health(profile_name)
+    info["config"] = load_profile_config(profile_name)
+
+    return info
+
+
+def list_all_profiles_with_status() -> List[Dict[str, Any]]:
+    """
+    Discover all profiles and return their status information.
+
+    Returns:
+        List of profile info dicts (see get_profile_info), sorted by name.
+    """
+    profiles = discover_profiles()
+    return [get_profile_info(name) for name in profiles]
+
+
+# ---------------------------------------------------------------------------
+# Worker lifecycle management
+# ---------------------------------------------------------------------------
+
+import sys
+import signal
+import subprocess
+import time
+
+
+def start_profile_worker(profile_name: str) -> subprocess.Popen:
+    """
+    Spawn a gateway subprocess for the named profile.
+
+    The worker runs as a daemon — stdout/stderr are redirected to DEVNULL.
+    The profile's HERMES_HOME is set via the HERMES_HOME env var so the
+    subprocess picks up the correct config.yaml, .env, and writes gateway.pid
+    into the profile directory.
+
+    Args:
+        profile_name: Name of the profile to start.
+
+    Returns:
+        The ``subprocess.Popen`` handle of the spawned gateway process.
+
+    Raises:
+        ValueError: If the profile directory does not exist.
+        RuntimeError: If the subprocess cannot be started.
+    """
+    profile_home = _get_profile_home(profile_name)
+    if profile_home is None:
+        raise ValueError(f"Profile '{profile_name}' not found")
+
+    # Build the command: run the gateway in daemon mode
+    # Using `python -m hermes_cli.main gateway run`
+    cmd = [sys.executable, "-m", "hermes_cli.main", "gateway", "run"]
+
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(profile_home)
+    # Ensure quiet mode and interactive exec approval for messaging platforms
+    env["HERMES_QUIET"] = "1"
+    env["HERMES_EXEC_ASK"] = "1"
+
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            stdin=subprocess.DEVNULL,
+            env=env,
+            start_new_session=True,  # detach so SIGTERM propagates correctly
+        )
+    except OSError as e:
+        raise RuntimeError(
+            f"Failed to spawn gateway for profile '{profile_name}': {e}"
+        ) from e
+
+    logger.info(
+        "Started gateway worker for profile '%s' (pid=%d, home=%s)",
+        profile_name,
+        proc.pid,
+        profile_home,
+    )
+    return proc
+
+
+def wait_for_profile_ready(profile_name: str, timeout: int = 30) -> bool:
+    """
+    Poll /health on a profile's gateway until it responds or the timeout expires.
+
+    Uses exponential backoff starting at 0.5s, capped at 4s, until the
+    deadline imposed by ``timeout``.  Only HTTP 200 is considered "ready".
+
+    Args:
+        profile_name: Name of the profile whose gateway to wait for.
+        timeout:     Maximum number of seconds to wait (default 30).
+
+    Returns:
+        True if the /health endpoint returned 200 within the timeout,
+        False otherwise.
+    """
+    port = resolve_profile_port(profile_name)
+    if not port or port <= 0:
+        logger.debug(
+            "No port resolved for profile '%s', skipping health poll", profile_name
+        )
+        return False
+
+    health_url = f"http://127.0.0.1:{port}/health"
+    deadline = time.monotonic() + timeout
+    delay = 0.5
+
+    while time.monotonic() < deadline:
+        # Check process still exists before wasting a request
+        if not is_profile_running(profile_name):
+            logger.debug("Profile '%s' process is no longer running", profile_name)
+            return False
+
+        try:
+            import urllib.request
+            import urllib.error
+
+            req = urllib.request.Request(health_url, method="GET")
+            req.add_header("Accept", "application/json")
+            with urllib.request.urlopen(req, timeout=2) as resp:
+                if resp.status == 200:
+                    logger.debug(
+                        "Profile '%s' is ready at %s", profile_name, health_url
+                    )
+                    return True
+        except Exception:
+            pass  # any failure → keep waiting
+
+        time.sleep(delay)
+        delay = min(delay * 2, 4.0)
+
+    logger.warning(
+        "Profile '%s' did not become ready within %ds (last check: %s)",
+        profile_name,
+        timeout,
+        health_url,
+    )
+    return False
+
+
+def ensure_profile_running(profile_name: str, timeout: int = 30) -> bool:
+    """
+    Ensure a profile's gateway worker is running, starting it if necessary.
+
+    If the profile's gateway is already running (verified via PID file),
+    this returns ``True`` immediately without spawning a new process.
+    Otherwise it calls :func:`start_profile_worker` and then waits for
+    readiness via :func:`wait_for_profile_ready`.
+
+    Args:
+        profile_name: Name of the profile to ensure is running.
+        timeout:      Maximum seconds to wait for startup (default 30).
+
+    Returns:
+        True if the profile's gateway is running (either already running
+        or successfully started), False if startup failed or timed out.
+    """
+    if is_profile_running(profile_name):
+        logger.debug("Profile '%s' is already running", profile_name)
+        return True
+
+    logger.info("Profile '%s' is not running, spawning worker", profile_name)
+    try:
+        proc = start_profile_worker(profile_name)
+    except (ValueError, RuntimeError) as e:
+        logger.error("Failed to start profile '%s': %s", profile_name, e)
+        return False
+
+    # Verify the process is still alive after a brief moment
+    time.sleep(0.5)
+    if proc.poll() is not None:
+        logger.error(
+            "Profile '%s' gateway process exited immediately with code %d",
+            profile_name,
+            proc.returncode,
+        )
+        return False
+
+    return wait_for_profile_ready(profile_name, timeout=timeout)
+
+
+def stop_profile_worker(profile_name: str, timeout: int = 10) -> bool:
+    """
+    Gracefully shut down a profile's gateway worker via SIGTERM.
+
+    Sends SIGTERM to the process identified in the profile's gateway.pid
+    file and waits up to ``timeout`` seconds for it to exit.  If the process
+    does not exit cleanly it is killed with SIGKILL.
+
+    Args:
+        profile_name: Name of the profile whose worker to stop.
+        timeout:     Seconds to wait for graceful shutdown (default 10).
+
+    Returns:
+        True if the worker exited cleanly (or was not running),
+        False if it had to be killed or the PID could not be resolved.
+    """
+    profile_home = _get_profile_home(profile_name)
+    if profile_home is None:
+        logger.warning("Cannot stop profile '%s': not found", profile_name)
+        return False
+
+    pid_path = profile_home / "gateway.pid"
+    if not pid_path.exists():
+        logger.debug(
+            "Profile '%s' has no gateway.pid, assuming not running", profile_name
+        )
+        return True
+
+    try:
+        raw = pid_path.read_text().strip()
+        if not raw:
+            return True
+
+        try:
+            payload = json.loads(raw)
+            pid = int(payload.get("pid", 0)) if isinstance(payload, dict) else int(raw)
+        except (json.JSONDecodeError, ValueError):
+            pid = int(raw)
+    except (OSError, ValueError) as e:
+        logger.error("Failed to read PID for profile '%s': %s", profile_name, e)
+        return False
+
+    if pid <= 0:
+        return True
+
+    try:
+        # Check process exists before sending signal
+        os.kill(pid, 0)
+    except (ProcessLookupError, PermissionError):
+        logger.debug("Profile '%s' PID %d already gone", profile_name, pid)
+        return True
+
+    logger.info("Sending SIGTERM to profile '%s' (pid=%d)", profile_name, pid)
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except (ProcessLookupError, PermissionError):
+        logger.debug("Profile '%s' PID %d already gone", profile_name, pid)
+        return True
+
+    # Wait for graceful exit
+    start = time.monotonic()
+    while time.monotonic() - start < timeout:
+        try:
+            os.kill(pid, 0)
+        except (ProcessLookupError, PermissionError):
+            logger.info("Profile '%s' (pid=%d) exited cleanly", profile_name, pid)
+            return True
+        time.sleep(0.25)
+
+    # Timeout expired — force kill
+    logger.warning(
+        "Profile '%s' (pid=%d) did not exit after %ds, sending SIGKILL",
+        profile_name,
+        pid,
+        timeout,
+    )
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        pass  # already gone
+
+    return False
+
+
+# ---------------------------------------------------------------------------
+# HTTP client for cross-profile dispatch
+# ---------------------------------------------------------------------------
+
+import time
+import uuid
+
+# In-memory task store for async dispatch (persistence comes in T5)
+_profile_tasks: Dict[str, Dict[str, Any]] = {}
+
+
+def _build_chat_request(
+    message: str,
+    context: Optional[Dict[str, Any]] = None,
+    conversation_history: Optional[List[Dict[str, str]]] = None,
+) -> Dict[str, Any]:
+    """
+    Build an OpenAI-compatible /v1/chat/completions request body.
+
+    Args:
+        message: The current user message to send.
+        context: Optional context dict. If provided, is included as a
+            ``context`` field in the request (not part of the OpenAI spec,
+            but the receiving profile's api_server handler can read it).
+        conversation_history: Optional list of previous messages (user + assistant
+            exchanges) to include in the conversation. Each dict should have
+            "role" and "content" keys.
+
+    Returns:
+        A dict suitable for posting as JSON to /v1/chat/completions.
+    """
+    # Build messages array with full conversation history
+    messages: List[Dict[str, str]] = []
+
+    # Add conversation history if provided
+    if conversation_history:
+        messages.extend(conversation_history)
+        logger.info(
+            f"[DEBUG] _build_chat_request: Added {len(conversation_history)} history messages"
+        )
+    else:
+        logger.info("[DEBUG] _build_chat_request: No conversation_history provided")
+
+    # Add current message
+    messages.append({"role": "user", "content": message})
+    logger.info(f"[DEBUG] _build_chat_request: Final messages count: {len(messages)}")
+
+    body: Dict[str, Any] = {
+        "model": "hermes-agent",
+        "messages": messages,
+    }
+    if context:
+        body["context"] = context
+    return body
+
+
+def get_profile_api_key(profile_name: str) -> Optional[str]:
+    """
+    Load the Bearer token from a profile's .env file.
+
+    Checks ``HERMES_API_KEY`` (preferred) then ``API_SERVER_KEY`` then
+    ``OPENAI_API_KEY`` in the profile's .env.  Returns None if the profile
+    does not exist or none of those keys are set.
+
+    Args:
+        profile_name: Name of the profile directory.
+
+    Returns:
+        The API key string, or None if not found.
+    """
+    profile_home = _get_profile_home(profile_name)
+    if profile_home is None:
+        logger.debug("Profile '%s' not found", profile_name)
+        return None
+
+    env_path = profile_home / ".env"
+    if not env_path.exists():
+        logger.debug("Profile '%s' has no .env file", profile_name)
+        return None
+
+    try:
+        env_content = env_path.read_text(encoding="utf-8")
+    except OSError as e:
+        logger.warning("Failed to read .env for profile '%s': %s", profile_name, e)
+        return None
+
+    # Parse .env manually (avoiding external dependencies)
+    for line in env_content.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+        # Strip surrounding quotes
+        if len(value) >= 2 and (value[0] == value[-1]) and value[0] in ('"', "'"):
+            value = value[1:-1]
+        if key in ("HERMES_API_KEY", "API_SERVER_KEY", "OPENAI_API_KEY"):
+            if value:
+                logger.debug("Loaded API key '%s' for profile '%s'", key, profile_name)
+                return value
+
+    logger.debug("No known API key found in .env for profile '%s'", profile_name)
+    return None
+
+
+def send_to_profile(
+    profile_name: str,
+    message: str,
+    context: Optional[Dict[str, Any]] = None,
+    wait: bool = True,
+    timeout: float = 300,
+    source_profile: Optional[str] = None,
+    conversation_history: Optional[List[Dict[str, str]]] = None,
+    allow_subagents: bool = True,
+    max_depth: int = 2,
+) -> Dict[str, Any]:
+    """
+    Send a message to a profile's gateway via HTTP POST (blocking).
+
+    POSTs to ``http://127.0.0.1:{port}/v1/chat/completions`` using an
+    OpenAI-compatible request body.  Authentication uses the Bearer token
+    from the profile's .env (see :func:`get_profile_api_key`).
+
+    Args:
+        profile_name: Target profile name.
+        message:      User message to send.
+        context:      Optional context dict forwarded to the request body.
+        wait:         Ignored (present for API compatibility with
+                      ``send_to_profile_async``).  This function always blocks.
+        timeout:      Maximum seconds to wait for the HTTP response
+                      (default 300).
+        conversation_history: Optional list of previous messages to include
+                      in the conversation for context continuity.
+        allow_subagents: Whether the delegated agent may spawn one-off
+                      subagents via delegate_task (default True).
+        max_depth:    Maximum delegation depth (default 2). Prevents infinite
+                      delegation chains.
+
+    Returns:
+        Dict with ``content`` from response and ``session_id``.
+
+    Raises:
+        ValueError: If the profile is not running or the port cannot be resolved.
+        RuntimeError: If the HTTP request fails or returns a non-2xx status.
+    """
+    port = resolve_profile_port(profile_name)
+    if not port or port <= 0:
+        raise ValueError(f"Cannot resolve port for profile '{profile_name}'")
+
+    if not is_profile_running(profile_name):
+        raise ValueError(
+            f"Profile '{profile_name}' is not running. "
+            f"Start it with: hermes -p {profile_name} gateway start "
+            f"(or hermes -p {profile_name} chat)"
+        )
+
+    api_key = get_profile_api_key(profile_name)
+    headers: Dict[str, str] = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    # Add delegation headers for inter-profile communication
+    if source_profile:
+        import uuid
+
+        task_id = str(uuid.uuid4())[:8]
+        headers["X-Hermes-Delegation"] = "true"
+        headers["X-Hermes-Source-Profile"] = source_profile
+        headers["X-Hermes-Task-ID"] = task_id
+        headers["X-Hermes-Delegate-Depth"] = (
+            "0"  # Initial depth, API server will increment
+        )
+        headers["X-Hermes-Allow-Subagents"] = "true" if allow_subagents else "false"
+        headers["X-Hermes-Max-Depth"] = str(max_depth)
+
+    body = _build_chat_request(message, context, conversation_history)
+    url = f"http://127.0.0.1:{port}/v1/chat/completions"
+
+    try:
+        import urllib.request
+        import urllib.error
+
+        data = json.dumps(body).encode("utf-8")
+        req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            result = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        try:
+            error_body = e.read().decode("utf-8")
+        except Exception:
+            error_body = ""
+        raise RuntimeError(
+            f"HTTP {e.code} from profile '{profile_name}': {error_body}"
+        ) from e
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        raise RuntimeError(
+            f"Connection error contacting profile '{profile_name}' at {url}: {e}"
+        ) from e
+
+    choices = result.get("choices")
+    if not choices or not isinstance(choices, list):
+        raise RuntimeError(
+            f"Unexpected response format from profile '{profile_name}': {result}"
+        )
+
+    content = choices[0].get("message", {}).get("content", "")
+    return content
+
+
+async def send_to_profile_async(
+    profile_name: str,
+    message: str,
+    context: Optional[Dict[str, Any]] = None,
+    source_profile: Optional[str] = None,
+    conversation_history: Optional[List[Dict[str, str]]] = None,
+    allow_subagents: bool = True,
+    max_depth: int = 2,
+) -> str:
+    """
+    Send a message to a profile's gateway via HTTP POST (non-blocking).
+
+    Uses ThreadPoolExecutor for simplicity and reliability.
+    Returns a task_id for polling via collect_profile_result.
+    """
+    import concurrent.futures
+    import uuid
+
+    task_id = str(uuid.uuid4())
+    result_container: Dict[str, Any] = {}
+
+    def _sync_request():
+        try:
+            result = send_to_profile(
+                profile_name,
+                message,
+                context,
+                conversation_history=conversation_history,
+                allow_subagents=allow_subagents,
+                max_depth=max_depth,
+            )
+            result_container["result"] = result
+            return result
+        except Exception as e:
+            result_container["error"] = str(e)
+            raise
+
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    future = executor.submit(_sync_request)
+
+    _profile_tasks[task_id] = {
+        "profile_name": profile_name,
+        "future": future,
+        "started_at": time.time(),
+    }
+    executor.shutdown(wait=False)
+
+    def _on_task_done(fut):
+        try:
+            from hermes_state import SessionDB
+
+            db = SessionDB()
+            try:
+                result = fut.result()
+                db.update_orchestration_task(
+                    task_id=task_id,
+                    status="completed",
+                    result=result,
+                )
+            except Exception as e:
+                db.update_orchestration_task(
+                    task_id=task_id,
+                    status="error",
+                    error_message=str(e)[:500],
+                )
+        except Exception as e:
+            logger.debug(f"Failed to update SQLite for task {task_id}: {e}")
+
+    future.add_done_callback(_on_task_done)
+
+    try:
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        task_context = {
+            "conversation_history": conversation_history,
+            "source_profile": source_profile,
+            "message": message,
+        }
+        db.create_orchestration_task(
+            task_id=task_id,
+            parent_session_id=None,
+            target_profile=profile_name,
+            goal=message,
+            context=json.dumps(task_context),
+        )
+    except Exception as e:
+        logger.debug(f"Failed to store orchestration task: {e}")
+
+    return task_id
+
+    port = resolve_profile_port(profile_name)
+    if not port or port <= 0:
+        raise ValueError(f"Cannot resolve port for profile '{profile_name}'")
+
+    if not is_profile_running(profile_name):
+        raise ValueError(
+            f"Profile '{profile_name}' is not running. "
+            f"Start it with: hermes -p {profile_name} gateway start "
+            f"(or hermes -p {profile_name} chat)"
+        )
+
+    api_key = get_profile_api_key(profile_name)
+    headers: Dict[str, str] = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    body = _build_chat_request(message, context, conversation_history)
+    url = f"http://127.0.0.1:{port}/v1/chat/completions"
+
+    task_id = str(uuid.uuid4())
+
+    # Store conversation_history in orchestration_tasks for async retrieval
+    try:
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        # Serialize conversation_history as JSON in context field
+        task_context = {
+            "conversation_history": conversation_history,
+            "source_profile": source_profile,
+            "message": message,
+        }
+        db.create_orchestration_task(
+            task_id=task_id,
+            parent_session_id=None,
+            target_profile=profile_name,
+            goal=message,
+            context=json.dumps(task_context),
+        )
+    except Exception as e:
+        logger.warning(f"Failed to store orchestration task: {e}")
+
+    async def _make_request():
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                url,
+                json=body,
+                headers=headers,
+                timeout=aiohttp.ClientTimeout(total=300),
+            ) as resp:
+                result = await resp.json()
+                choices = result.get("choices")
+                if not choices or not isinstance(choices, list):
+                    raise RuntimeError(f"Unexpected response format: {result}")
+                return choices[0].get("message", {}).get("content", "")
+
+    future = asyncio.ensure_future(_make_request())
+
+    _profile_tasks[task_id] = {
+        "profile_name": profile_name,
+        "future": future,
+        "started_at": time.time(),
+    }
+
+    return task_id
+
+
+def collect_profile_result(
+    task_id: str,
+    block: bool = False,
+    timeout: float = 300,
+) -> Optional[str]:
+    """
+    Poll for the result of an async profile dispatch task.
+
+    When ``block=True`` this function blocks until the task completes or
+    the ``timeout`` is reached.  When ``block=False`` it returns immediately
+    with the result if ready or ``None`` if the task is still running.
+
+    Args:
+        task_id: The task ID returned by ``send_to_profile_async``.
+        block:   Whether to block waiting for completion (default False).
+        timeout: Maximum seconds to wait when ``block=True`` (default 300).
+
+    Returns:
+        The response content string if the task is complete, or ``None`` if
+        ``block=False`` and the task has not yet finished.  Raises
+        ``KeyError`` if the ``task_id`` is not known.
+    """
+    import concurrent.futures
+
+    if task_id not in _profile_tasks:
+        raise KeyError(f"Unknown task_id: {task_id}")
+
+    entry = _profile_tasks[task_id]
+    future = entry["future"]
+
+    # Check cancelled flag first
+    if entry.get("_cancelled", False):
+        return None
+
+    # Handle concurrent.futures.Future
+    if isinstance(future, concurrent.futures.Future):
+        if not block:
+            if not future.done():
+                return None
+        try:
+            result = future.result(timeout=timeout if block else None)
+            return result
+        except concurrent.futures.TimeoutError:
+            return None
+        except Exception as e:
+            raise RuntimeError(f"Task '{task_id}' raised: {e}") from e
+
+    raise RuntimeError(
+        f"Task '{task_id}' has an unsupported future type: {type(future)}"
+    )
+
+
+# =============================================================================
+# Honcho Integration for Cross-Session Memory
+# =============================================================================
+
+
+def save_delegation_to_honcho(
+    source_profile: str,
+    task_id: str,
+    goal: str,
+    context: Optional[str] = None,
+    status: str = "received",
+    result: Optional[str] = None,
+) -> bool:
+    """
+    Save delegation information to Honcho for cross-session memory.
+
+    This allows a profile to remember tasks received from other profiles
+    even after the chat session ends. When the profile is asked directly
+    later, it can retrieve this information using honcho_search or
+    honcho_context.
+
+    Args:
+        source_profile: Name of the profile that sent the task (e.g., 'p3')
+        task_id: Unique task identifier
+        goal: The task description/goal
+        context: Additional context provided by source
+        status: Task status ("received", "in_progress", "completed", "failed")
+        result: Task result (if completed)
+
+    Returns:
+        True if saved successfully, False otherwise
+    """
+    try:
+        # Import honcho tools (may not be available if honcho not enabled)
+        from tools.honcho_tools import honcho_context
+
+        # Store task with metadata
+        task_data = {
+            "source": source_profile,
+            "task_id": task_id,
+            "goal": goal,
+            "context": context,
+            "status": status,
+            "result": result,
+            "type": "profile_delegation",
+        }
+
+        # Save to honcho with structured key
+        key = f"delegation_from_{source_profile}_{task_id}"
+        honcho_context(
+            action="store",
+            key=key,
+            value=json.dumps(task_data),
+        )
+
+        # Also update pending tasks list
+        _update_pending_tasks_list(source_profile, task_id, goal, status)
+
+        logger.info(f"Saved delegation from {source_profile} to honcho: {task_id}")
+        return True
+
+    except ImportError:
+        logger.debug("Honcho tools not available, skipping delegation save")
+        return False
+    except Exception as e:
+        logger.warning(f"Failed to save delegation to honcho: {e}")
+        return False
+
+
+def _update_pending_tasks_list(
+    source_profile: str,
+    task_id: str,
+    goal: str,
+    status: str,
+) -> None:
+    """Update the list of pending tasks from other profiles."""
+    try:
+        from tools.honcho_tools import honcho_context
+
+        # Retrieve existing pending tasks
+        existing = honcho_context(action="retrieve", key="pending_profile_tasks")
+        tasks = []
+        if existing:
+            try:
+                tasks = json.loads(existing)
+            except json.JSONDecodeError:
+                tasks = []
+
+        # Add or update task
+        task_entry = {
+            "source": source_profile,
+            "task_id": task_id,
+            "goal": goal,
+            "status": status,
+            "timestamp": time.time(),
+        }
+
+        # Remove if already exists (update case)
+        tasks = [t for t in tasks if t.get("task_id") != task_id]
+
+        # Add if not completed
+        if status != "completed":
+            tasks.append(task_entry)
+
+        # Save back
+        honcho_context(
+            action="store",
+            key="pending_profile_tasks",
+            value=json.dumps(tasks),
+        )
+
+    except Exception as e:
+        logger.debug(f"Failed to update pending tasks list: {e}")
+
+
+def get_delegation_history_from_honcho(
+    source_profile: Optional[str] = None,
+    status: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """
+    Retrieve delegation history from Honcho.
+
+    Args:
+        source_profile: Filter by source profile (e.g., 'p3'), or None for all
+        status: Filter by status, or None for all
+
+    Returns:
+        List of task dictionaries with source, task_id, goal, status, etc.
+    """
+    try:
+        from tools.honcho_tools import honcho_search
+
+        # Search for delegation entries
+        query = "profile_delegation"
+        if source_profile:
+            query += f" {source_profile}"
+
+        results = honcho_search(query=query, limit=50)
+
+        tasks = []
+        for result in results:
+            try:
+                task_data = json.loads(result.get("value", "{}"))
+                if task_data.get("type") == "profile_delegation":
+                    # Apply filters
+                    if source_profile and task_data.get("source") != source_profile:
+                        continue
+                    if status and task_data.get("status") != status:
+                        continue
+                    tasks.append(task_data)
+            except json.JSONDecodeError:
+                continue
+
+        return sorted(tasks, key=lambda x: x.get("timestamp", 0), reverse=True)
+
+    except ImportError:
+        logger.debug("Honcho tools not available, returning empty history")
+        return []
+    except Exception as e:
+        logger.warning(f"Failed to retrieve delegation history: {e}")
+        return []
+
+
+def update_delegation_status_in_honcho(
+    source_profile: str,
+    task_id: str,
+    new_status: str,
+    result: Optional[str] = None,
+) -> bool:
+    """
+    Update the status of a delegation in Honcho.
+
+    Args:
+        source_profile: Profile that sent the task
+        task_id: Task identifier
+        new_status: New status ("in_progress", "completed", "failed")
+        result: Task result (if completed)
+
+    Returns:
+        True if updated successfully, False otherwise
+    """
+    try:
+        from tools.honcho_tools import honcho_context
+
+        # Retrieve existing task
+        key = f"delegation_from_{source_profile}_{task_id}"
+        existing = honcho_context(action="retrieve", key=key)
+
+        if not existing:
+            logger.warning(f"Task {task_id} from {source_profile} not found in honcho")
+            return False
+
+        # Update status
+        task_data = json.loads(existing)
+        task_data["status"] = new_status
+        if result is not None:
+            task_data["result"] = result
+        task_data["updated_at"] = time.time()
+
+        # Save back
+        honcho_context(
+            action="store",
+            key=key,
+            value=json.dumps(task_data),
+        )
+
+        # Update pending tasks list
+        _update_pending_tasks_list(
+            source_profile,
+            task_id,
+            task_data.get("goal", ""),
+            new_status,
+        )
+
+        logger.info(f"Updated delegation status in honcho: {task_id} -> {new_status}")
+        return True
+
+    except ImportError:
+        return False
+    except Exception as e:
+        logger.warning(f"Failed to update delegation status: {e}")
+        return False
+
+
+def get_pending_tasks_from_honcho() -> List[Dict[str, Any]]:
+    """
+    Get all pending tasks from other profiles.
+
+    Returns:
+        List of pending task dictionaries
+    """
+    try:
+        from tools.honcho_tools import honcho_context
+
+        pending = honcho_context(action="retrieve", key="pending_profile_tasks")
+        if pending:
+            tasks = json.loads(pending)
+            # Filter out completed tasks
+            return [t for t in tasks if t.get("status") != "completed"]
+        return []
+
+    except ImportError:
+        return []
+    except Exception as e:
+        logger.warning(f"Failed to get pending tasks: {e}")
+        return []

--- a/toolsets.py
+++ b/toolsets.py
@@ -15,10 +15,10 @@ Features:
 
 Usage:
     from toolsets import get_toolset, resolve_toolset, get_all_toolsets
-    
+
     # Get tools for a specific toolset
     tools = get_toolset("research")
-    
+
     # Resolve a toolset to get all tool names (including from composed toolsets)
     all_tools = resolve_toolset("full_stack")
 """
@@ -30,36 +30,55 @@ from typing import List, Dict, Any, Set, Optional
 # Edit this once to update all platforms simultaneously.
 _HERMES_CORE_TOOLS = [
     # Web
-    "web_search", "web_extract",
+    "web_search",
+    "web_extract",
     # Terminal + process management
-    "terminal", "process",
+    "terminal",
+    "process",
     # File manipulation
-    "read_file", "write_file", "patch", "search_files",
+    "read_file",
+    "write_file",
+    "patch",
+    "search_files",
     # Vision + image generation
-    "vision_analyze", "image_generate",
+    "vision_analyze",
+    "image_generate",
     # Skills
-    "skills_list", "skill_view", "skill_manage",
+    "skills_list",
+    "skill_view",
+    "skill_manage",
     # Browser automation
-    "browser_navigate", "browser_snapshot", "browser_click",
-    "browser_type", "browser_scroll", "browser_back",
-    "browser_press", "browser_get_images",
-    "browser_vision", "browser_console",
+    "browser_navigate",
+    "browser_snapshot",
+    "browser_click",
+    "browser_type",
+    "browser_scroll",
+    "browser_back",
+    "browser_press",
+    "browser_get_images",
+    "browser_vision",
+    "browser_console",
     # Text-to-speech
     "text_to_speech",
     # Planning & memory
-    "todo", "memory",
+    "todo",
+    "memory",
     # Session history search
     "session_search",
     # Clarifying questions
     "clarify",
     # Code execution + delegation
-    "execute_code", "delegate_task",
+    "execute_code",
+    "delegate_task",
     # Cronjob management
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
     "send_message",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
-    "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
+    "ha_list_entities",
+    "ha_get_state",
+    "ha_list_services",
+    "ha_call_service",
 ]
 
 
@@ -70,317 +89,348 @@ TOOLSETS = {
     "web": {
         "description": "Web research and content extraction tools",
         "tools": ["web_search", "web_extract"],
-        "includes": []  # No other toolsets included
+        "includes": [],  # No other toolsets included
     },
-    
     "search": {
         "description": "Web search only (no content extraction/scraping)",
         "tools": ["web_search"],
-        "includes": []
+        "includes": [],
     },
-    
     "vision": {
         "description": "Image analysis and vision tools",
         "tools": ["vision_analyze"],
-        "includes": []
+        "includes": [],
     },
-    
     "image_gen": {
         "description": "Creative generation tools (images)",
         "tools": ["image_generate"],
-        "includes": []
+        "includes": [],
     },
-    
     "terminal": {
         "description": "Terminal/command execution and process management tools",
         "tools": ["terminal", "process"],
-        "includes": []
+        "includes": [],
     },
-    
     "moa": {
         "description": "Advanced reasoning and problem-solving tools",
         "tools": ["mixture_of_agents"],
-        "includes": []
+        "includes": [],
     },
-    
     "skills": {
         "description": "Access, create, edit, and manage skill documents with specialized instructions and knowledge",
         "tools": ["skills_list", "skill_view", "skill_manage"],
-        "includes": []
+        "includes": [],
     },
-    
     "browser": {
         "description": "Browser automation for web interaction (navigate, click, type, scroll, iframes, hold-click) with web search for finding URLs",
         "tools": [
-            "browser_navigate", "browser_snapshot", "browser_click",
-            "browser_type", "browser_scroll", "browser_back",
-            "browser_press", "browser_get_images",
-            "browser_vision", "browser_console", "web_search"
+            "browser_navigate",
+            "browser_snapshot",
+            "browser_click",
+            "browser_type",
+            "browser_scroll",
+            "browser_back",
+            "browser_press",
+            "browser_get_images",
+            "browser_vision",
+            "browser_console",
+            "web_search",
         ],
-        "includes": []
+        "includes": [],
     },
-    
     "cronjob": {
         "description": "Cronjob management tool - create, list, update, pause, resume, remove, and trigger scheduled tasks",
         "tools": ["cronjob"],
-        "includes": []
+        "includes": [],
     },
-    
     "messaging": {
         "description": "Cross-platform messaging: send messages to Telegram, Discord, Slack, SMS, etc.",
         "tools": ["send_message"],
-        "includes": []
+        "includes": [],
     },
-    
     "rl": {
         "description": "RL training tools for running reinforcement learning on Tinker-Atropos",
         "tools": [
-            "rl_list_environments", "rl_select_environment",
-            "rl_get_current_config", "rl_edit_config",
-            "rl_start_training", "rl_check_status",
-            "rl_stop_training", "rl_get_results",
-            "rl_list_runs", "rl_test_inference"
+            "rl_list_environments",
+            "rl_select_environment",
+            "rl_get_current_config",
+            "rl_edit_config",
+            "rl_start_training",
+            "rl_check_status",
+            "rl_stop_training",
+            "rl_get_results",
+            "rl_list_runs",
+            "rl_test_inference",
         ],
-        "includes": []
+        "includes": [],
     },
-    
     "file": {
         "description": "File manipulation tools: read, write, patch (with fuzzy matching), and search (content + files)",
         "tools": ["read_file", "write_file", "patch", "search_files"],
-        "includes": []
+        "includes": [],
     },
-    
     "tts": {
         "description": "Text-to-speech: convert text to audio with Edge TTS (free), ElevenLabs, or OpenAI",
         "tools": ["text_to_speech"],
-        "includes": []
+        "includes": [],
     },
-    
     "todo": {
         "description": "Task planning and tracking for multi-step work",
         "tools": ["todo"],
-        "includes": []
+        "includes": [],
     },
-    
     "memory": {
         "description": "Persistent memory across sessions (personal notes + user profile)",
         "tools": ["memory"],
-        "includes": []
+        "includes": [],
     },
-    
     "session_search": {
         "description": "Search and recall past conversations with summarization",
         "tools": ["session_search"],
-        "includes": []
+        "includes": [],
     },
-    
     "clarify": {
         "description": "Ask the user clarifying questions (multiple-choice or open-ended)",
         "tools": ["clarify"],
-        "includes": []
+        "includes": [],
     },
-    
     "code_execution": {
         "description": "Run Python scripts that call tools programmatically (reduces LLM round trips)",
         "tools": ["execute_code"],
-        "includes": []
+        "includes": [],
     },
-    
     "delegation": {
-        "description": "Spawn subagents with isolated context for complex subtasks",
-        "tools": ["delegate_task"],
-        "includes": []
+        "description": "Spawn subagents with isolated context for complex subtasks and cross-profile orchestration",
+        "tools": [
+            "delegate_task",
+            "profile_delegate",
+            "profile_task_check",
+            "profile_task_cancel",
+            "profile_task_search",
+        ],
+        "includes": [],
     },
-
     # "honcho" toolset removed — Honcho is now a memory provider plugin.
     # Tools are injected via MemoryManager, not the toolset system.
-
     "homeassistant": {
         "description": "Home Assistant smart home control and monitoring",
-        "tools": ["ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service"],
-        "includes": []
+        "tools": [
+            "ha_list_entities",
+            "ha_get_state",
+            "ha_list_services",
+            "ha_call_service",
+        ],
+        "includes": [],
     },
-
-
     # Scenario-specific toolsets
-    
     "debugging": {
         "description": "Debugging and troubleshooting toolkit",
         "tools": ["terminal", "process"],
-        "includes": ["web", "file"]  # For searching error messages and solutions, and file operations
+        "includes": [
+            "web",
+            "file",
+        ],  # For searching error messages and solutions, and file operations
     },
-    
     "safe": {
         "description": "Safe toolkit without terminal access",
         "tools": [],
-        "includes": ["web", "vision", "image_gen"]
+        "includes": ["web", "vision", "image_gen"],
     },
-    
     # ==========================================================================
     # Full Hermes toolsets (CLI + messaging platforms)
     #
     # All platforms share the same core tools (including send_message,
     # which is gated on gateway running via its check_fn).
     # ==========================================================================
-
     "hermes-acp": {
         "description": "Editor integration (VS Code, Zed, JetBrains) — coding-focused tools without messaging, audio, or clarify UI",
         "tools": [
-            "web_search", "web_extract",
-            "terminal", "process",
-            "read_file", "write_file", "patch", "search_files",
+            "web_search",
+            "web_extract",
+            "terminal",
+            "process",
+            "read_file",
+            "write_file",
+            "patch",
+            "search_files",
             "vision_analyze",
-            "skills_list", "skill_view", "skill_manage",
-            "browser_navigate", "browser_snapshot", "browser_click",
-            "browser_type", "browser_scroll", "browser_back",
-            "browser_press", "browser_get_images",
-            "browser_vision", "browser_console",
-            "todo", "memory",
+            "skills_list",
+            "skill_view",
+            "skill_manage",
+            "browser_navigate",
+            "browser_snapshot",
+            "browser_click",
+            "browser_type",
+            "browser_scroll",
+            "browser_back",
+            "browser_press",
+            "browser_get_images",
+            "browser_vision",
+            "browser_console",
+            "todo",
+            "memory",
             "session_search",
-            "execute_code", "delegate_task",
+            "execute_code",
+            "delegate_task",
         ],
-        "includes": []
+        "includes": [],
     },
-
     "hermes-api-server": {
         "description": "OpenAI-compatible API server — full agent tools accessible via HTTP (no interactive UI tools like clarify or send_message)",
         "tools": [
             # Web
-            "web_search", "web_extract",
+            "web_search",
+            "web_extract",
             # Terminal + process management
-            "terminal", "process",
+            "terminal",
+            "process",
             # File manipulation
-            "read_file", "write_file", "patch", "search_files",
+            "read_file",
+            "write_file",
+            "patch",
+            "search_files",
             # Vision + image generation
-            "vision_analyze", "image_generate",
+            "vision_analyze",
+            "image_generate",
             # Skills
-            "skills_list", "skill_view", "skill_manage",
+            "skills_list",
+            "skill_view",
+            "skill_manage",
             # Browser automation
-            "browser_navigate", "browser_snapshot", "browser_click",
-            "browser_type", "browser_scroll", "browser_back",
-            "browser_press", "browser_get_images",
-            "browser_vision", "browser_console",
+            "browser_navigate",
+            "browser_snapshot",
+            "browser_click",
+            "browser_type",
+            "browser_scroll",
+            "browser_back",
+            "browser_press",
+            "browser_get_images",
+            "browser_vision",
+            "browser_console",
             # Planning & memory
-            "todo", "memory",
+            "todo",
+            "memory",
             # Session history search
             "session_search",
             # Code execution + delegation
-            "execute_code", "delegate_task",
+            "execute_code",
+            "delegate_task",
             # Cronjob management
             "cronjob",
             # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
-            "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
-
+            "ha_list_entities",
+            "ha_get_state",
+            "ha_list_services",
+            "ha_call_service",
         ],
-        "includes": []
+        "includes": [],
     },
-    
     "hermes-cli": {
         "description": "Full interactive CLI toolset - all default tools plus cronjob management",
         "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "includes": [],
     },
-    
     "hermes-telegram": {
         "description": "Telegram bot toolset - full access for personal use (terminal has safety checks)",
         "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "includes": [],
     },
-    
     "hermes-discord": {
         "description": "Discord bot toolset - full access (terminal has safety checks via dangerous command approval)",
         "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "includes": [],
     },
-    
     "hermes-whatsapp": {
         "description": "WhatsApp bot toolset - similar to Telegram (personal messaging, more trusted)",
         "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "includes": [],
     },
-    
     "hermes-slack": {
         "description": "Slack bot toolset - full access for workspace use (terminal has safety checks)",
         "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "includes": [],
     },
-    
     "hermes-signal": {
         "description": "Signal bot toolset - encrypted messaging platform (full access)",
         "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "includes": [],
     },
-
     "hermes-homeassistant": {
         "description": "Home Assistant bot toolset - smart home event monitoring and control",
         "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "includes": [],
     },
-
     "hermes-email": {
         "description": "Email bot toolset - interact with Hermes via email (IMAP/SMTP)",
         "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "includes": [],
     },
-
     "hermes-mattermost": {
         "description": "Mattermost bot toolset - self-hosted team messaging (full access)",
         "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "includes": [],
     },
-
     "hermes-matrix": {
         "description": "Matrix bot toolset - decentralized encrypted messaging (full access)",
         "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "includes": [],
     },
-
     "hermes-dingtalk": {
         "description": "DingTalk bot toolset - enterprise messaging platform (full access)",
         "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "includes": [],
     },
-
     "hermes-feishu": {
         "description": "Feishu/Lark bot toolset - enterprise messaging via Feishu/Lark (full access)",
         "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "includes": [],
     },
-
     "hermes-wecom": {
         "description": "WeCom bot toolset - enterprise WeChat messaging (full access)",
         "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "includes": [],
     },
-
     "hermes-sms": {
         "description": "SMS bot toolset - interact with Hermes via SMS (Twilio)",
         "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "includes": [],
     },
-
     "hermes-webhook": {
         "description": "Webhook toolset - receive and process external webhook events",
         "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "includes": [],
     },
-
     "hermes-gateway": {
         "description": "Gateway toolset - union of all messaging platform tools",
         "tools": [],
-        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-webhook"]
-    }
+        "includes": [
+            "hermes-telegram",
+            "hermes-discord",
+            "hermes-whatsapp",
+            "hermes-slack",
+            "hermes-signal",
+            "hermes-homeassistant",
+            "hermes-email",
+            "hermes-sms",
+            "hermes-mattermost",
+            "hermes-matrix",
+            "hermes-dingtalk",
+            "hermes-feishu",
+            "hermes-wecom",
+            "hermes-webhook",
+            "delegation",
+        ],
+    },
 }
-
 
 
 def get_toolset(name: str) -> Optional[Dict[str, Any]]:
     """
     Get a toolset definition by name.
-    
+
     Args:
         name (str): Name of the toolset
-        
+
     Returns:
         Dict: Toolset definition with description, tools, and includes
         None: If toolset not found
@@ -392,20 +442,20 @@ def get_toolset(name: str) -> Optional[Dict[str, Any]]:
 def resolve_toolset(name: str, visited: Set[str] = None) -> List[str]:
     """
     Recursively resolve a toolset to get all tool names.
-    
+
     This function handles toolset composition by recursively resolving
     included toolsets and combining all tools.
-    
+
     Args:
         name (str): Name of the toolset to resolve
         visited (Set[str]): Set of already visited toolsets (for cycle detection)
-        
+
     Returns:
         List[str]: List of all tool names in the toolset
     """
     if visited is None:
         visited = set()
-    
+
     # Special aliases that represent all tools across every toolset
     # This ensures future toolsets are automatically included without changes.
     if name in {"all", "*"}:
@@ -431,6 +481,7 @@ def resolve_toolset(name: str, visited: Set[str] = None) -> List[str]:
         if name in _get_plugin_toolset_names():
             try:
                 from tools.registry import registry
+
                 return [e.name for e in registry._tools.values() if e.toolset == name]
             except Exception:
                 pass
@@ -445,26 +496,26 @@ def resolve_toolset(name: str, visited: Set[str] = None) -> List[str]:
     for included_name in toolset.get("includes", []):
         included_tools = resolve_toolset(included_name, visited)
         tools.update(included_tools)
-    
+
     return list(tools)
 
 
 def resolve_multiple_toolsets(toolset_names: List[str]) -> List[str]:
     """
     Resolve multiple toolsets and combine their tools.
-    
+
     Args:
         toolset_names (List[str]): List of toolset names to resolve
-        
+
     Returns:
         List[str]: Combined list of all tool names (deduplicated)
     """
     all_tools = set()
-    
+
     for name in toolset_names:
         tools = resolve_toolset(name)
         all_tools.update(tools)
-    
+
     return list(all_tools)
 
 
@@ -476,6 +527,7 @@ def _get_plugin_toolset_names() -> Set[str]:
     """
     try:
         from tools.registry import registry
+
         return {
             entry.toolset
             for entry in registry._tools.values()
@@ -490,7 +542,7 @@ def get_all_toolsets() -> Dict[str, Dict[str, Any]]:
     Get all available toolsets with their definitions.
 
     Includes both statically-defined toolsets and plugin-registered ones.
-    
+
     Returns:
         Dict: All toolset definitions
     """
@@ -500,7 +552,10 @@ def get_all_toolsets() -> Dict[str, Dict[str, Any]]:
         if ts_name not in result:
             try:
                 from tools.registry import registry
-                tools = [e.name for e in registry._tools.values() if e.toolset == ts_name]
+
+                tools = [
+                    e.name for e in registry._tools.values() if e.toolset == ts_name
+                ]
                 result[ts_name] = {
                     "description": f"Plugin toolset: {ts_name}",
                     "tools": tools,
@@ -515,7 +570,7 @@ def get_toolset_names() -> List[str]:
     Get names of all available toolsets (excluding aliases).
 
     Includes plugin-registered toolset names.
-    
+
     Returns:
         List[str]: List of toolset names
     """
@@ -524,15 +579,13 @@ def get_toolset_names() -> List[str]:
     return sorted(names)
 
 
-
-
 def validate_toolset(name: str) -> bool:
     """
     Check if a toolset name is valid.
-    
+
     Args:
         name (str): Toolset name to validate
-        
+
     Returns:
         bool: True if valid, False otherwise
     """
@@ -546,14 +599,11 @@ def validate_toolset(name: str) -> bool:
 
 
 def create_custom_toolset(
-    name: str,
-    description: str,
-    tools: List[str] = None,
-    includes: List[str] = None
+    name: str, description: str, tools: List[str] = None, includes: List[str] = None
 ) -> None:
     """
     Create a custom toolset at runtime.
-    
+
     Args:
         name (str): Name for the new toolset
         description (str): Description of the toolset
@@ -563,28 +613,26 @@ def create_custom_toolset(
     TOOLSETS[name] = {
         "description": description,
         "tools": tools or [],
-        "includes": includes or []
+        "includes": includes or [],
     }
-
-
 
 
 def get_toolset_info(name: str) -> Dict[str, Any]:
     """
     Get detailed information about a toolset including resolved tools.
-    
+
     Args:
         name (str): Toolset name
-        
+
     Returns:
         Dict: Detailed toolset information
     """
     toolset = get_toolset(name)
     if not toolset:
         return None
-    
+
     resolved_tools = resolve_toolset(name)
-    
+
     return {
         "name": name,
         "description": toolset["description"],
@@ -592,16 +640,14 @@ def get_toolset_info(name: str) -> Dict[str, Any]:
         "includes": toolset["includes"],
         "resolved_tools": resolved_tools,
         "tool_count": len(resolved_tools),
-        "is_composite": bool(toolset["includes"])
+        "is_composite": bool(toolset["includes"]),
     }
-
-
 
 
 if __name__ == "__main__":
     print("Toolsets System Demo")
     print("=" * 60)
-    
+
     print("\nAvailable Toolsets:")
     print("-" * 40)
     for name, toolset in get_all_toolsets().items():
@@ -609,27 +655,27 @@ if __name__ == "__main__":
         composite = "[composite]" if info["is_composite"] else "[leaf]"
         print(f"  {composite} {name:20} - {toolset['description']}")
         print(f"     Tools: {len(info['resolved_tools'])} total")
-    
+
     print("\nToolset Resolution Examples:")
     print("-" * 40)
     for name in ["web", "terminal", "safe", "debugging"]:
         tools = resolve_toolset(name)
         print(f"\n  {name}:")
         print(f"    Resolved to {len(tools)} tools: {', '.join(sorted(tools))}")
-    
+
     print("\nMultiple Toolset Resolution:")
     print("-" * 40)
     combined = resolve_multiple_toolsets(["web", "vision", "terminal"])
     print("  Combining ['web', 'vision', 'terminal']:")
     print(f"    Result: {', '.join(sorted(combined))}")
-    
+
     print("\nCustom Toolset Creation:")
     print("-" * 40)
     create_custom_toolset(
         name="my_custom",
         description="My custom toolset for specific tasks",
         tools=["web_search"],
-        includes=["terminal", "vision"]
+        includes=["terminal", "vision"],
     )
     custom_info = get_toolset_info("my_custom")
     print("  Created 'my_custom' toolset:")


### PR DESCRIPTION
## Summary

Add inter-profile orchestration tools enabling one Hermes profile to delegate tasks to another via HTTP, with full conversation history passing between calls.

### New Tools (4 total)

| Tool | Purpose |
|------|---------|
| `profile_delegate` | Delegate tasks to persistent profile workers via HTTP |
| `profile_task_check` | Check status of async delegated tasks |
| `profile_task_cancel` | Cancel running async tasks |
| `profile_task_search` | Cross-profile natural language search with ID auto-detection |

### Install

Enable `delegation` toolset in profile config:
```yaml
toolsets:
- hermes-cli
- delegation
```

Enable api_server on worker profile:
```yaml
platforms:
  api_server:
    enabled: true
    port: 8642
    host: 127.0.0.1
```

### Usage

```bash
# In orchestrator profile (p1):
p1 chat

# Delegate a task to another profile
> Ask p2 to calculate 5 times 5
# Returns: {"status": "completed", "result": "25", "task_id": "abc123"}

# Delegate without waiting for result
> Have p2 calculate 6 times 6 in the background
# Returns: {"status": "dispatched", "task_id": "xyz789"}

# Check on a background task later
> What's the status of task xyz789?
# Returns: {"status": "completed", "result": "36"}

# Search across all your profiles for past tasks
> Find my tasks about math calculations
# Returns: [{"task_id": "abc123", "source_profile": "p1", "goal": "calculate 5*5", ...}]

# Search by task ID prefix (auto-detected)
> Look up task abc123
# Returns: [{"task_id": "abc123def", "source_profile": "p1", ...}]

# Multi-turn conversation with memory
> Ask p2 to remember Word A is ALPHA
> Now ask p2 what Word B is BETA and what was Word A?
# Remembers "ALPHA" from conversation history

# Control whether worker can spawn one-off subagents
> Have p2 refactor the auth module without spawning any one-off subagents
# Worker must do all work itself - no delegate_task spawning
```

### Key Features

**Delegated agent awareness** - Delegated agents now know they're delegated agents and not talking to human users, with visual `<DELEGATED from profile X | delegate_task ALLOWED>` header.

**Cross-Profile Search** - `profile_task_search` searches across **ALL** profiles' task histories, not just the current one. Auto-detects task ID prefixes (e.g., "abc123") vs natural language queries.

**Configurable Depth** - Prevent infinite delegation chains with `max_depth` parameter (default 2).

**Delegated agent control** - Use `allow_subagents=False` to force workers to do all work themselves without spawning one-off subagents.

### Awareness format

```
<DELEGATED from profile p1 | delegate_task ALLOWED>

YOUR TASK:
Analyze codebase for security issues

Summary: what you did, found, created, issues.
End with <TASK abc123 COMPLETED>.
```
Agent: "p1 (profile, not human) delegated this. I am allowed to use delegate_task."

### Control Mechanisms
- `allow_subagents=True/False` — choose if worker can spawn one-off subagents
- `max_depth=N` — configurable delegation depth (default 2)
- `<TASK {id} COMPLETED>` footer for completion correlation

### Depth Tracking
- `X-Hermes-Delegate-Depth` header tracks recursion level
- `X-Hermes-Max-Depth` header sets limit (configurable)
- API server blocks when `depth >= max_depth`

### Cross-Profile Natural Language Search
- `profile_task_search("security issues auth.py")` — search across **all** profiles
- Each result includes `source_profile` field identifying which profile handled it
- **Auto-detects task IDs:** Short alphanumeric queries (e.g., "abc123", "42eb") search by task_id prefix
- **FTS5-powered:** Natural language search on goal + result fields with phrases, boolean, and prefix matching
- **Hybrid approach:** ID-like queries use `LIKE task_id%` + `LIKE %query%` on goal/result; natural language uses full-text search

The agent uses ThreadPoolExecutor for reliability instead of aiohttp (which caused asyncio race conditions). Async tasks persist to SQLite so they survive process restarts. If a task isn't found in memory, it falls back to SQLite lookup.

## Files

| File | Description |
|------|-------------|
| `tools/profile_orchestrator.py` | Core orchestration module with HTTP dispatch, SQLite persistence |
| `tools/delegate_tool.py` | `profile_delegate`, `profile_task_check`, `profile_task_cancel`, `profile_task_search` tools |
| `gateway/platforms/api_server.py` | **UPDATED:** Delegated agent delegation awareness with `<DELEGATED>` header injection and depth tracking |
| `hermes_state.py` | `orchestration_tasks` table + FTS5 index + ID detection search |
| `toolsets.py` | Extended `delegation` toolset with new profile orchestration tools |

## Tests

Handler loads correctly, passes 72 consecutive calls with 100% success rate. Manual testing on Linux (Ubuntu 22.04). Uses stdlib only, no Unix-specific code.

- 15 parallel async dispatches: ✅
- 25 rapid sync calls: ✅
- 15 status checks: ✅
- 6 mixed profile tests: ✅
- Edge cases (unicode, special chars, multiline, fibonacci n=42): ✅
- Delegated agent awareness detection: ✅
- `<TASK {id} COMPLETED>` detection: ✅
- Depth limit enforcement at MAX_DEPTH=2: ✅
- `allow_subagents=False` shows NOT ALLOWED: ✅
- Cross-profile natural language search: ✅
- Task ID prefix auto-detection: ✅
- Hybrid search (ID + FTS5): ✅

## Related

- Requires: PR #3681 (profile infrastructure) - **already merged**

## Notes

No configuration needed beyond enabling the toolset and api_server — just create profiles and delegate. The orchestrator automatically discovers worker profiles via `list_profiles()`. If a worker isn't running, it starts automatically via subprocess with `HERMES_HOME` override. No worker running = delegation fails gracefully with error message.

### Architecture
- Uses upstream's existing `hermes_cli/profiles.py` (from PR #3681)
- `profile_orchestrator.py` imports from `hermes_cli.profiles`: `get_profile_dir()`, `ProfileInfo`, `_check_gateway_running()`