### PR TITLE
[codex] add Fireworks provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **The self-improving AI agent built by [Nous Research](https://nousresearch.com).** It's the only agent with a built-in learning loop — it creates skills from experience, improves them during use, nudges itself to persist knowledge, searches its own past conversations, and builds a deepening model of who you are across sessions. Run it on a $5 VPS, a GPU cluster, or serverless infrastructure that costs nearly nothing when idle. It's not tied to your laptop — talk to it from Telegram while it works on a cloud VM.
 
-Use any model you want — [Nous Portal](https://portal.nousresearch.com), [OpenRouter](https://openrouter.ai) (200+ models), [z.ai/GLM](https://z.ai), [Kimi/Moonshot](https://platform.moonshot.ai), [MiniMax](https://www.minimax.io), OpenAI, or your own endpoint. Switch with `hermes model` — no code changes, no lock-in.
+Use any model you want — [Nous Portal](https://portal.nousresearch.com), [OpenRouter](https://openrouter.ai) (200+ models), [z.ai/GLM](https://z.ai), [Kimi/Moonshot](https://platform.moonshot.ai), [MiniMax](https://www.minimax.io), [Fireworks AI](https://docs.fireworks.ai/tools-sdks/openai-compatibility), OpenAI, or your own endpoint. Switch with `hermes model` — no code changes, no lock-in.
 
 <table>
 <tr><td><b>A real terminal interface</b></td><td>Full TUI with multiline editing, slash-command autocomplete, conversation history, interrupt-and-redirect, and streaming tool output.</td></tr>

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -20,8 +20,9 @@ Resolution order for vision/multimodal tasks (auto mode):
   3. Nous Portal
   4. Codex OAuth (gpt-5.3-codex supports vision via Responses API)
   5. Native Anthropic
-  6. Custom endpoint (for local vision models: Qwen-VL, LLaVA, Pixtral, etc.)
-  7. None
+  6. Fireworks AI (Kimi K2.5)
+  7. Custom endpoint (for local vision models: Qwen-VL, LLaVA, Pixtral, etc.)
+  8. None
 
 Per-task provider overrides (e.g. AUXILIARY_VISION_PROVIDER,
 CONTEXT_COMPRESSION_PROVIDER) can force a specific provider for each task.
@@ -64,6 +65,13 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "opencode-zen": "gemini-3-flash",
     "opencode-go": "glm-5",
     "kilocode": "google/gemini-3-flash-preview",
+}
+
+# Known-good multimodal defaults for providers Hermes can auto-route for vision.
+# Fire Pass users can override this with
+# AUXILIARY_VISION_MODEL=accounts/fireworks/routers/kimi-k2p5-turbo.
+_VISION_PROVIDER_MODELS: Dict[str, str] = {
+    "fireworks": "accounts/fireworks/models/kimi-k2p5",
 }
 
 # OpenRouter app attribution headers
@@ -1032,6 +1040,7 @@ _VISION_AUTO_PROVIDER_ORDER = (
     "nous",
     "openai-codex",
     "anthropic",
+    "fireworks",
     "custom",
 )
 
@@ -1042,6 +1051,8 @@ def _normalize_vision_provider(provider: Optional[str]) -> str:
         return "openai-codex"
     if provider == "main":
         return "custom"
+    if provider in ("fireworks-ai", "fireworksai", "fw"):
+        return "fireworks"
     return provider
 
 
@@ -1055,6 +1066,11 @@ def _resolve_strict_vision_backend(provider: str) -> Tuple[Optional[Any], Option
         return _try_codex()
     if provider == "anthropic":
         return _try_anthropic()
+    if provider == "fireworks":
+        return resolve_provider_client(
+            "fireworks",
+            model=_VISION_PROVIDER_MODELS["fireworks"],
+        )
     if provider == "custom":
         return _try_custom_endpoint()
     return None, None

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -11,7 +11,7 @@ Resolution order for text tasks (auto mode):
   4. Codex OAuth (Responses API via chatgpt.com with gpt-5.3-codex,
      wrapped to look like a chat.completions client)
   5. Native Anthropic
-  6. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, MiniMax-CN)
+  6. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, Fireworks, etc.)
   7. None
 
 Resolution order for vision/multimodal tasks (auto mode):
@@ -60,6 +60,7 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "minimax-cn": "MiniMax-M2.7-highspeed",
     "anthropic": "claude-haiku-4-5-20251001",
     "ai-gateway": "google/gemini-3-flash",
+    "fireworks": "accounts/fireworks/models/qwen3-8b",
     "opencode-zen": "gemini-3-flash",
     "opencode-go": "glm-5",
     "kilocode": "google/gemini-3-flash-preview",
@@ -804,7 +805,7 @@ def resolve_provider_client(
     Args:
         provider: Provider identifier.  One of:
             "openrouter", "nous", "openai-codex" (or "codex"),
-            "zai", "kimi-coding", "minimax", "minimax-cn",
+            "zai", "kimi-coding", "minimax", "minimax-cn", "fireworks",
             "custom" (OPENAI_BASE_URL + OPENAI_API_KEY),
             "auto" (full auto-detection chain).
         model: Model slug override.  If None, uses the provider's default

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -25,11 +25,13 @@ logger = logging.getLogger(__name__)
 _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
     "zai", "kimi-coding", "minimax", "minimax-cn", "anthropic", "deepseek",
+    "fireworks",
     "opencode-zen", "opencode-go", "ai-gateway", "kilocode", "alibaba",
     "custom", "local",
     # Common aliases
     "glm", "z-ai", "z.ai", "zhipu", "github", "github-copilot",
     "github-models", "kimi", "moonshot", "claude", "deep-seek",
+    "fireworks-ai", "fw",
     "opencode", "zen", "go", "vercel", "kilo", "dashscope", "aliyun", "qwen",
 })
 
@@ -113,6 +115,14 @@ DEFAULT_CONTEXT_LENGTHS = {
     "glm": 202752,
     # Kimi
     "kimi": 262144,
+    # Fireworks AI curated defaults
+    "accounts/fireworks/models/kimi-k2p5": 256000,
+    "accounts/fireworks/models/kimi-k2-thinking": 256000,
+    "accounts/fireworks/models/deepseek-v3p2": 160000,
+    "accounts/fireworks/models/minimax-m2p5": 196608,
+    "accounts/fireworks/models/glm-5": 202752,
+    "accounts/fireworks/models/gpt-oss-120b": 131072,
+    "accounts/fireworks/models/qwen3-8b": 40000,
     # Hugging Face Inference Providers — model IDs use org/name format
     "Qwen/Qwen3.5-397B-A17B": 131072,
     "Qwen/Qwen3.5-35B-A3B": 131072,
@@ -173,6 +183,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "openrouter.ai": "openrouter",
     "inference-api.nousresearch.com": "nous",
     "api.deepseek.com": "deepseek",
+    "api.fireworks.ai": "fireworks",
     "api.githubcopilot.com": "copilot",
     "models.github.ai": "copilot",
 }

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -40,6 +40,7 @@ PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "alibaba": "alibaba",
     "copilot": "github-copilot",
     "ai-gateway": "vercel",
+    "fireworks": "fireworks-ai",
     "opencode-zen": "opencode",
     "opencode-go": "opencode-go",
     "kilocode": "kilo",

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -188,6 +188,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("AI_GATEWAY_API_KEY",),
         base_url_env_var="AI_GATEWAY_BASE_URL",
     ),
+    "fireworks": ProviderConfig(
+        id="fireworks",
+        name="Fireworks AI",
+        auth_type="api_key",
+        inference_base_url="https://api.fireworks.ai/inference/v1",
+        api_key_env_vars=("FIREWORKS_API_KEY",),
+        base_url_env_var="FIREWORKS_BASE_URL",
+    ),
     "opencode-zen": ProviderConfig(
         id="opencode-zen",
         name="OpenCode Zen",
@@ -692,6 +700,7 @@ def resolve_provider(
         "github-models": "copilot", "github-model": "copilot",
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
         "aigateway": "ai-gateway", "vercel": "ai-gateway", "vercel-ai-gateway": "ai-gateway",
+        "fireworks-ai": "fireworks", "fireworksai": "fireworks", "fw": "fireworks",
         "opencode": "opencode-zen", "zen": "opencode-zen",
         "hf": "huggingface", "hugging-face": "huggingface", "huggingface-hub": "huggingface",
         "go": "opencode-go", "opencode-go-sub": "opencode-go",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -581,6 +581,22 @@ OPTIONAL_ENV_VARS = {
         "category": "provider",
         "advanced": True,
     },
+    "FIREWORKS_API_KEY": {
+        "description": "Fireworks AI API key for serverless open models",
+        "prompt": "Fireworks API key",
+        "url": "https://app.fireworks.ai/settings/users/api-keys",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "FIREWORKS_BASE_URL": {
+        "description": "Fireworks AI base URL override",
+        "prompt": "Fireworks base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
     "OPENCODE_ZEN_API_KEY": {
         "description": "OpenCode Zen API key (pay-as-you-go access to curated models)",
         "prompt": "OpenCode Zen API key",

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -559,7 +559,7 @@ def run_doctor(args):
         except Exception as e:
             print(f"\r  {color('⚠', Colors.YELLOW)} Anthropic API {color(f'({e})', Colors.DIM)}                 ")
 
-    # -- API-key providers (Z.AI/GLM, Kimi, MiniMax, MiniMax-CN) --
+    # -- API-key providers (Z.AI/GLM, Kimi, MiniMax, Fireworks, etc.) --
     # Tuple: (name, env_vars, default_url, base_env, supports_models_endpoint)
     # If supports_models_endpoint is False, we skip the health check and just show "configured"
     _apikey_providers = [
@@ -569,6 +569,7 @@ def run_doctor(args):
         ("MiniMax",          ("MINIMAX_API_KEY",),                            None,                                  "MINIMAX_BASE_URL", False),
         ("MiniMax (China)",  ("MINIMAX_CN_API_KEY",),                         None,                                  "MINIMAX_CN_BASE_URL", False),
         ("AI Gateway",       ("AI_GATEWAY_API_KEY",),                          "https://ai-gateway.vercel.sh/v1/models", "AI_GATEWAY_BASE_URL", True),
+        ("Fireworks AI",     ("FIREWORKS_API_KEY",),                           "https://api.fireworks.ai/inference/v1/models", "FIREWORKS_BASE_URL", True),
         ("Kilo Code",        ("KILOCODE_API_KEY",),                            "https://api.kilo.ai/api/gateway/models",  "KILOCODE_BASE_URL", True),
     ]
     for _pname, _env_vars, _default_url, _base_env, _supports_health_check in _apikey_providers:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -793,6 +793,7 @@ def cmd_model(args):
         "opencode-zen": "OpenCode Zen",
         "opencode-go": "OpenCode Go",
         "ai-gateway": "AI Gateway",
+        "fireworks": "Fireworks AI",
         "kilocode": "Kilo Code",
         "alibaba": "Alibaba Cloud (DashScope)",
         "huggingface": "Hugging Face",
@@ -823,6 +824,7 @@ def cmd_model(args):
         ("ai-gateway", "AI Gateway (Vercel — 200+ models, pay-per-use)"),
         ("alibaba", "Alibaba Cloud / DashScope Coding (Qwen + multi-provider)"),
         ("huggingface", "Hugging Face Inference Providers (20+ open models)"),
+        ("fireworks", "Fireworks AI (serverless open models via OpenAI-compatible API)"),
     ]
 
     # Add user-defined custom providers from config.yaml
@@ -895,7 +897,7 @@ def cmd_model(args):
         _model_flow_anthropic(config, current_model)
     elif selected_provider == "kimi-coding":
         _model_flow_kimi(config, current_model)
-    elif selected_provider in ("zai", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface"):
+    elif selected_provider in ("zai", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface", "fireworks"):
         _model_flow_api_key_provider(config, selected_provider, current_model)
 
 
@@ -1505,6 +1507,15 @@ _PROVIDER_MODELS = {
         "openai/gpt-5.4",
         "google/gemini-3-pro-preview",
         "google/gemini-3-flash-preview",
+    ],
+    "fireworks": [
+        "accounts/fireworks/models/kimi-k2p5",
+        "accounts/fireworks/models/kimi-k2-thinking",
+        "accounts/fireworks/models/deepseek-v3p2",
+        "accounts/fireworks/models/minimax-m2p5",
+        "accounts/fireworks/models/glm-5",
+        "accounts/fireworks/models/gpt-oss-120b",
+        "accounts/fireworks/models/qwen3-8b",
     ],
     # Curated HF model list — only agentic models that map to OpenRouter defaults.
     # Format: HF model ID → OpenRouter equivalent noted in comment
@@ -3253,7 +3264,7 @@ For more help on a command:
     )
     chat_parser.add_argument(
         "--provider",
-        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode"],
+        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "fireworks"],
         default=None,
         help="Inference provider (default: auto)"
     )

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -201,6 +201,15 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "google/gemini-2.5-flash",
         "deepseek/deepseek-v3.2",
     ],
+    "fireworks": [
+        "accounts/fireworks/models/kimi-k2p5",
+        "accounts/fireworks/models/kimi-k2-thinking",
+        "accounts/fireworks/models/deepseek-v3p2",
+        "accounts/fireworks/models/minimax-m2p5",
+        "accounts/fireworks/models/glm-5",
+        "accounts/fireworks/models/gpt-oss-120b",
+        "accounts/fireworks/models/qwen3-8b",
+    ],
     "kilocode": [
         "anthropic/claude-opus-4.6",
         "anthropic/claude-sonnet-4.6",
@@ -251,6 +260,7 @@ _PROVIDER_LABELS = {
     "opencode-zen": "OpenCode Zen",
     "opencode-go": "OpenCode Go",
     "ai-gateway": "AI Gateway",
+    "fireworks": "Fireworks AI",
     "kilocode": "Kilo Code",
     "alibaba": "Alibaba Cloud (DashScope)",
     "huggingface": "Hugging Face",
@@ -282,6 +292,9 @@ _PROVIDER_ALIASES = {
     "aigateway": "ai-gateway",
     "vercel": "ai-gateway",
     "vercel-ai-gateway": "ai-gateway",
+    "fireworks-ai": "fireworks",
+    "fireworksai": "fireworks",
+    "fw": "fireworks",
     "kilo": "kilocode",
     "kilo-code": "kilocode",
     "kilo-gateway": "kilocode",
@@ -326,6 +339,7 @@ def list_available_providers() -> list[dict[str, str]]:
     _PROVIDER_ORDER = [
         "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
         "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "anthropic", "alibaba",
+        "fireworks",
         "opencode-zen", "opencode-go",
         "ai-gateway", "deepseek", "custom",
     ]

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -80,6 +80,15 @@ _DEFAULT_PROVIDER_MODELS = {
     "minimax-cn": ["MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"],
     "ai-gateway": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5", "google/gemini-3-flash"],
     "kilocode": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5.4", "google/gemini-3-pro-preview", "google/gemini-3-flash-preview"],
+    "fireworks": [
+        "accounts/fireworks/models/kimi-k2p5",
+        "accounts/fireworks/models/kimi-k2-thinking",
+        "accounts/fireworks/models/deepseek-v3p2",
+        "accounts/fireworks/models/minimax-m2p5",
+        "accounts/fireworks/models/glm-5",
+        "accounts/fireworks/models/gpt-oss-120b",
+        "accounts/fireworks/models/qwen3-8b",
+    ],
     "huggingface": [
         "Qwen/Qwen3.5-397B-A17B", "Qwen/Qwen3-235B-A22B-Thinking-2507",
         "Qwen/Qwen3-Coder-480B-A35B-Instruct", "deepseek-ai/DeepSeek-R1-0528",
@@ -891,6 +900,7 @@ def setup_model_provider(config: dict):
         "GitHub Copilot (uses GITHUB_TOKEN or gh auth token)",
         "GitHub Copilot ACP (spawns `copilot --acp --stdio`)",
         "Hugging Face Inference Providers (20+ open models)",
+        "Fireworks AI (serverless open models via OpenAI-compatible API)",
     ]
     if keep_label:
         provider_choices.append(keep_label)
@@ -1554,7 +1564,39 @@ def setup_model_provider(config: dict):
         _set_model_provider(config, "huggingface", pconfig.inference_base_url)
         selected_base_url = pconfig.inference_base_url
 
-    # else: provider_idx == 17 (Keep current) — only shown when a provider already exists
+    elif provider_idx == 17:  # Fireworks AI
+        selected_provider = "fireworks"
+        print()
+        print_header("Fireworks API Key")
+        pconfig = PROVIDER_REGISTRY["fireworks"]
+        print_info(f"Provider: {pconfig.name}")
+        print_info("Get your API key at: https://app.fireworks.ai/settings/users/api-keys")
+        print_info("Uses Fireworks' OpenAI-compatible endpoint by default.")
+        print()
+
+        existing_key = get_env_value("FIREWORKS_API_KEY")
+        if existing_key:
+            print_info(f"Current: {existing_key[:8]}... (configured)")
+            if prompt_yes_no("Update API key?", False):
+                api_key = prompt("  Fireworks API key", password=True)
+                if api_key:
+                    save_env_value("FIREWORKS_API_KEY", api_key)
+                    print_success("Fireworks API key updated")
+        else:
+            api_key = prompt("  Fireworks API key", password=True)
+            if api_key:
+                save_env_value("FIREWORKS_API_KEY", api_key)
+                print_success("Fireworks API key saved")
+            else:
+                print_warning("Skipped - agent won't work without an API key")
+
+        if existing_custom:
+            save_env_value("OPENAI_BASE_URL", "")
+            save_env_value("OPENAI_API_KEY", "")
+        _set_model_provider(config, "fireworks", pconfig.inference_base_url)
+        selected_base_url = pconfig.inference_base_url
+
+    # else: provider_idx == 18 (Keep current) — only shown when a provider already exists
     # Normalize "keep current" to an explicit provider so downstream logic
     # doesn't fall back to the generic OpenRouter/static-model path.
     if selected_provider is None:
@@ -1594,6 +1636,7 @@ def setup_model_provider(config: dict):
             "minimax-cn": "MiniMax CN",
             "anthropic": "Anthropic",
             "ai-gateway": "AI Gateway",
+            "fireworks": "Fireworks AI",
             "custom": "your custom endpoint",
         }
         _prov_display = _prov_names.get(selected_provider, selected_provider or "your provider")
@@ -1735,7 +1778,7 @@ def setup_model_provider(config: dict):
             model_cfg = _model_config_dict(config)
             model_cfg["api_mode"] = "chat_completions"
             config["model"] = model_cfg
-        elif selected_provider in ("copilot", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "ai-gateway", "opencode-zen", "opencode-go", "alibaba"):
+        elif selected_provider in ("copilot", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "ai-gateway", "opencode-zen", "opencode-go", "alibaba", "fireworks"):
             _setup_provider_model_selection(
                 config, selected_provider, current_model,
                 prompt_choice, prompt,
@@ -1796,7 +1839,7 @@ def setup_model_provider(config: dict):
     # Write provider+base_url to config.yaml only after model selection is complete.
     # This prevents a race condition where the gateway picks up a new provider
     # before the model name has been updated to match.
-    if selected_provider in ("copilot-acp", "copilot", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "anthropic") and selected_base_url is not None:
+    if selected_provider in ("copilot-acp", "copilot", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "anthropic", "fireworks") and selected_base_url is not None:
         _update_config_for_provider(selected_provider, selected_base_url)
 
     save_config(config)

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -197,6 +197,7 @@ def show_status(args):
         "Kimi / Moonshot":  ("KIMI_API_KEY",),
         "MiniMax":          ("MINIMAX_API_KEY",),
         "MiniMax (China)":  ("MINIMAX_CN_API_KEY",),
+        "Fireworks AI":     ("FIREWORKS_API_KEY",),
     }
     for pname, env_vars in apikey_providers.items():
         key_val = ""

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -28,6 +28,7 @@ def _clean_env(monkeypatch):
         "OPENROUTER_API_KEY", "OPENAI_BASE_URL", "OPENAI_API_KEY",
         "OPENAI_MODEL", "LLM_MODEL", "NOUS_INFERENCE_BASE_URL",
         "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN",
+        "FIREWORKS_API_KEY", "FIREWORKS_BASE_URL",
         # Per-task provider/model/direct-endpoint overrides
         "AUXILIARY_VISION_PROVIDER", "AUXILIARY_VISION_MODEL",
         "AUXILIARY_VISION_BASE_URL", "AUXILIARY_VISION_API_KEY",
@@ -618,6 +619,56 @@ class TestVisionClientFallback:
         assert client is not None
         assert client.__class__.__name__ == "AnthropicAuxiliaryClient"
         assert model == "claude-haiku-4-5-20251001"
+
+    def test_vision_auto_includes_fireworks_when_configured(self, monkeypatch):
+        monkeypatch.setenv("FIREWORKS_API_KEY", "fw-key")
+        with (
+            patch("agent.auxiliary_client._read_nous_auth", return_value=None),
+            patch("agent.auxiliary_client._read_codex_access_token", return_value=None),
+            patch("agent.auxiliary_client._try_anthropic", return_value=(None, None)),
+            patch("agent.auxiliary_client.OpenAI") as mock_openai,
+        ):
+            backends = get_available_vision_backends()
+            client, model = get_vision_auxiliary_client()
+
+        assert "fireworks" in backends
+        assert client is not None
+        assert model == "accounts/fireworks/models/kimi-k2p5"
+        assert "api.fireworks.ai/inference/v1" in mock_openai.call_args.kwargs["base_url"]
+
+    def test_selected_fireworks_provider_is_preferred_for_vision_auto(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        monkeypatch.setenv("FIREWORKS_API_KEY", "fw-key")
+
+        def fake_load_config():
+            return {"model": {"provider": "fireworks", "default": "accounts/fireworks/models/kimi-k2p5"}}
+
+        with (
+            patch("agent.auxiliary_client._read_nous_auth", return_value=None),
+            patch("agent.auxiliary_client._read_codex_access_token", return_value=None),
+            patch("agent.auxiliary_client._try_anthropic", return_value=(None, None)),
+            patch("agent.auxiliary_client.OpenAI") as mock_openai,
+            patch("hermes_cli.config.load_config", fake_load_config),
+        ):
+            provider, client, model = resolve_vision_provider_client()
+
+        assert provider == "fireworks"
+        assert client is not None
+        assert model == "accounts/fireworks/models/kimi-k2p5"
+        assert "api.fireworks.ai/inference/v1" in mock_openai.call_args.kwargs["base_url"]
+
+    def test_forced_fireworks_alias_can_use_fire_pass_router_for_vision(self, monkeypatch):
+        monkeypatch.setenv("AUXILIARY_VISION_PROVIDER", "fw")
+        monkeypatch.setenv("AUXILIARY_VISION_MODEL", "accounts/fireworks/routers/kimi-k2p5-turbo")
+        monkeypatch.setenv("FIREWORKS_API_KEY", "fw-key")
+
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            provider, client, model = resolve_vision_provider_client()
+
+        assert provider == "fireworks"
+        assert client is not None
+        assert model == "accounts/fireworks/routers/kimi-k2p5-turbo"
+        assert "api.fireworks.ai/inference/v1" in mock_openai.call_args.kwargs["base_url"]
 
     def test_selected_anthropic_provider_is_preferred_for_vision_auto(self, monkeypatch):
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -60,6 +60,16 @@ SAMPLE_REGISTRY = {
             },
         },
     },
+    "fireworks-ai": {
+        "id": "fireworks-ai",
+        "name": "Fireworks AI",
+        "models": {
+            "accounts/fireworks/models/kimi-k2p5": {
+                "id": "accounts/fireworks/models/kimi-k2p5",
+                "limit": {"context": 256000, "output": 256000},
+            },
+        },
+    },
     "audio-only": {
         "id": "audio-only",
         "models": {
@@ -83,6 +93,7 @@ class TestProviderMapping:
         assert PROVIDER_TO_MODELS_DEV["copilot"] == "github-copilot"
         assert PROVIDER_TO_MODELS_DEV["kilocode"] == "kilo"
         assert PROVIDER_TO_MODELS_DEV["ai-gateway"] == "vercel"
+        assert PROVIDER_TO_MODELS_DEV["fireworks"] == "fireworks-ai"
 
     def test_unmapped_provider_not_in_dict(self):
         assert "nous" not in PROVIDER_TO_MODELS_DEV
@@ -138,6 +149,11 @@ class TestLookupModelsDevContext:
         assert lookup_models_dev_context("anthropic", "claude-opus-4-6") == 1000000
         # GitHub Copilot: only 128K for same model
         assert lookup_models_dev_context("copilot", "claude-opus-4.6") == 128000
+
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_fireworks_lookup(self, mock_fetch):
+        mock_fetch.return_value = SAMPLE_REGISTRY
+        assert lookup_models_dev_context("fireworks", "accounts/fireworks/models/kimi-k2p5") == 256000
 
     @patch("agent.models_dev.fetch_models_dev")
     def test_zero_context_filtered(self, mock_fetch):

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -130,6 +130,10 @@ class TestCuratedModelsForProvider:
         models = curated_models_for_provider("zai")
         assert any("glm" in m[0] for m in models)
 
+    def test_fireworks_returns_curated_models(self):
+        models = curated_models_for_provider("fireworks")
+        assert any("accounts/fireworks/models/" in m[0] for m in models)
+
     def test_unknown_provider_returns_empty(self):
         assert curated_models_for_provider("totally-unknown") == []
 
@@ -146,6 +150,7 @@ class TestNormalizeProvider:
         assert normalize_provider("kimi") == "kimi-coding"
         assert normalize_provider("moonshot") == "kimi-coding"
         assert normalize_provider("github-copilot") == "copilot"
+        assert normalize_provider("fireworks-ai") == "fireworks"
 
     def test_case_insensitive(self):
         assert normalize_provider("OpenRouter") == "openrouter"
@@ -157,6 +162,7 @@ class TestProviderLabel:
         assert provider_label("kimi") == "Kimi / Moonshot"
         assert provider_label("copilot") == "GitHub Copilot"
         assert provider_label("copilot-acp") == "GitHub Copilot ACP"
+        assert provider_label("fireworks") == "Fireworks AI"
         assert provider_label("auto") == "Auto"
 
     def test_unknown_provider_preserves_original_name(self):
@@ -176,6 +182,9 @@ class TestProviderModelIds:
 
     def test_zai_returns_glm_models(self):
         assert "glm-5" in provider_model_ids("zai")
+
+    def test_fireworks_returns_fireworks_models(self):
+        assert "accounts/fireworks/models/kimi-k2p5" in provider_model_ids("fireworks")
 
     def test_copilot_prefers_live_catalog(self):
         with patch("hermes_cli.auth.resolve_api_key_provider_credentials", return_value={"api_key": "gh-token"}), \

--- a/tests/test_api_key_providers.py
+++ b/tests/test_api_key_providers.py
@@ -1,4 +1,4 @@
-"""Tests for API-key provider support (z.ai/GLM, Kimi, MiniMax, AI Gateway)."""
+"""Tests for API-key provider support (z.ai/GLM, Kimi, MiniMax, Fireworks, AI Gateway)."""
 
 import os
 import sys
@@ -44,6 +44,7 @@ class TestProviderRegistry:
         ("minimax", "MiniMax", "api_key"),
         ("minimax-cn", "MiniMax (China)", "api_key"),
         ("ai-gateway", "AI Gateway", "api_key"),
+        ("fireworks", "Fireworks AI", "api_key"),
         ("kilocode", "Kilo Code", "api_key"),
     ])
     def test_provider_registered(self, provider_id, name, auth_type):
@@ -83,6 +84,11 @@ class TestProviderRegistry:
         assert pconfig.api_key_env_vars == ("AI_GATEWAY_API_KEY",)
         assert pconfig.base_url_env_var == "AI_GATEWAY_BASE_URL"
 
+    def test_fireworks_env_vars(self):
+        pconfig = PROVIDER_REGISTRY["fireworks"]
+        assert pconfig.api_key_env_vars == ("FIREWORKS_API_KEY",)
+        assert pconfig.base_url_env_var == "FIREWORKS_BASE_URL"
+
     def test_kilocode_env_vars(self):
         pconfig = PROVIDER_REGISTRY["kilocode"]
         assert pconfig.api_key_env_vars == ("KILOCODE_API_KEY",)
@@ -101,6 +107,7 @@ class TestProviderRegistry:
         assert PROVIDER_REGISTRY["minimax"].inference_base_url == "https://api.minimax.io/anthropic"
         assert PROVIDER_REGISTRY["minimax-cn"].inference_base_url == "https://api.minimaxi.com/anthropic"
         assert PROVIDER_REGISTRY["ai-gateway"].inference_base_url == "https://ai-gateway.vercel.sh/v1"
+        assert PROVIDER_REGISTRY["fireworks"].inference_base_url == "https://api.fireworks.ai/inference/v1"
         assert PROVIDER_REGISTRY["kilocode"].inference_base_url == "https://api.kilo.ai/api/gateway"
         assert PROVIDER_REGISTRY["huggingface"].inference_base_url == "https://router.huggingface.co/v1"
 
@@ -122,6 +129,7 @@ PROVIDER_ENV_VARS = (
     "GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY",
     "KIMI_API_KEY", "KIMI_BASE_URL", "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY",
     "AI_GATEWAY_API_KEY", "AI_GATEWAY_BASE_URL",
+    "FIREWORKS_API_KEY", "FIREWORKS_BASE_URL",
     "KILOCODE_API_KEY", "KILOCODE_BASE_URL",
     "DASHSCOPE_API_KEY", "OPENCODE_ZEN_API_KEY", "OPENCODE_GO_API_KEY",
     "NOUS_API_KEY", "GITHUB_TOKEN", "GH_TOKEN",
@@ -155,6 +163,9 @@ class TestResolveProvider:
     def test_explicit_ai_gateway(self):
         assert resolve_provider("ai-gateway") == "ai-gateway"
 
+    def test_explicit_fireworks(self):
+        assert resolve_provider("fireworks") == "fireworks"
+
     def test_alias_glm(self):
         assert resolve_provider("glm") == "zai"
 
@@ -178,6 +189,12 @@ class TestResolveProvider:
 
     def test_alias_vercel(self):
         assert resolve_provider("vercel") == "ai-gateway"
+
+    def test_alias_fireworks_ai(self):
+        assert resolve_provider("fireworks-ai") == "fireworks"
+
+    def test_alias_fw(self):
+        assert resolve_provider("fw") == "fireworks"
 
     def test_explicit_kilocode(self):
         assert resolve_provider("kilocode") == "kilocode"
@@ -250,6 +267,10 @@ class TestResolveProvider:
         monkeypatch.setenv("AI_GATEWAY_API_KEY", "test-gw-key")
         assert resolve_provider("auto") == "ai-gateway"
 
+    def test_auto_detects_fireworks_key(self, monkeypatch):
+        monkeypatch.setenv("FIREWORKS_API_KEY", "test-fireworks-key")
+        assert resolve_provider("auto") == "fireworks"
+
     def test_auto_detects_kilocode_key(self, monkeypatch):
         monkeypatch.setenv("KILOCODE_API_KEY", "test-kilo-key")
         assert resolve_provider("auto") == "kilocode"
@@ -314,6 +335,14 @@ class TestApiKeyProviderStatus:
         status = get_auth_status("minimax")
         assert status["configured"] is True
         assert status["provider"] == "minimax"
+
+    def test_fireworks_status(self, monkeypatch):
+        monkeypatch.setenv("FIREWORKS_API_KEY", "fw-key")
+        status = get_api_key_provider_status("fireworks")
+        assert status["configured"] is True
+        assert status["logged_in"] is True
+        assert status["key_source"] == "FIREWORKS_API_KEY"
+        assert status["base_url"] == "https://api.fireworks.ai/inference/v1"
 
     def test_copilot_acp_status_detects_local_cli(self, monkeypatch):
         monkeypatch.setenv("HERMES_COPILOT_ACP_ARGS", "--acp --stdio --debug")
@@ -438,6 +467,20 @@ class TestResolveApiKeyProviderCredentials:
         assert creds["api_key"] == "gw-secret-key"
         assert creds["base_url"] == "https://ai-gateway.vercel.sh/v1"
 
+    def test_resolve_fireworks_with_key(self, monkeypatch):
+        monkeypatch.setenv("FIREWORKS_API_KEY", "fw-secret-key")
+        creds = resolve_api_key_provider_credentials("fireworks")
+        assert creds["provider"] == "fireworks"
+        assert creds["api_key"] == "fw-secret-key"
+        assert creds["base_url"] == "https://api.fireworks.ai/inference/v1"
+        assert creds["source"] == "FIREWORKS_API_KEY"
+
+    def test_resolve_fireworks_custom_base_url(self, monkeypatch):
+        monkeypatch.setenv("FIREWORKS_API_KEY", "fw-secret-key")
+        monkeypatch.setenv("FIREWORKS_BASE_URL", "https://proxy.fireworks.example/v1")
+        creds = resolve_api_key_provider_credentials("fireworks")
+        assert creds["base_url"] == "https://proxy.fireworks.example/v1"
+
     def test_resolve_kilocode_with_key(self, monkeypatch):
         monkeypatch.setenv("KILOCODE_API_KEY", "kilo-secret-key")
         creds = resolve_api_key_provider_credentials("kilocode")
@@ -520,6 +563,15 @@ class TestRuntimeProviderResolution:
         assert result["api_mode"] == "chat_completions"
         assert result["api_key"] == "gw-key"
         assert "ai-gateway.vercel.sh" in result["base_url"]
+
+    def test_runtime_fireworks(self, monkeypatch):
+        monkeypatch.setenv("FIREWORKS_API_KEY", "fw-key")
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+        result = resolve_runtime_provider(requested="fireworks")
+        assert result["provider"] == "fireworks"
+        assert result["api_mode"] == "chat_completions"
+        assert result["api_key"] == "fw-key"
+        assert "api.fireworks.ai" in result["base_url"]
 
     def test_runtime_kilocode(self, monkeypatch):
         monkeypatch.setenv("KILOCODE_API_KEY", "kilo-key")
@@ -783,3 +835,46 @@ class TestHuggingFaceModels:
         from hermes_cli.models import _PROVIDER_LABELS
         assert "huggingface" in _PROVIDER_LABELS
         assert _PROVIDER_LABELS["huggingface"] == "Hugging Face"
+
+
+# =============================================================================
+# Fireworks provider model list tests
+# =============================================================================
+
+class TestFireworksModels:
+    """Verify Fireworks model lists are consistent across all locations."""
+
+    def test_main_provider_models_has_fireworks(self):
+        from hermes_cli.main import _PROVIDER_MODELS
+        assert "fireworks" in _PROVIDER_MODELS
+        models = _PROVIDER_MODELS["fireworks"]
+        assert len(models) >= 6
+
+    def test_models_py_has_fireworks(self):
+        from hermes_cli.models import _PROVIDER_MODELS
+        assert "fireworks" in _PROVIDER_MODELS
+        models = _PROVIDER_MODELS["fireworks"]
+        assert len(models) >= 6
+
+    def test_model_lists_match(self):
+        from hermes_cli.main import _PROVIDER_MODELS as main_models
+        from hermes_cli.models import _PROVIDER_MODELS as models_models
+        assert main_models["fireworks"] == models_models["fireworks"]
+
+    def test_model_metadata_has_context_lengths(self):
+        from hermes_cli.models import _PROVIDER_MODELS
+        from agent.model_metadata import DEFAULT_CONTEXT_LENGTHS
+        for model in _PROVIDER_MODELS["fireworks"]:
+            assert model in DEFAULT_CONTEXT_LENGTHS, (
+                f"Fireworks model {model!r} missing from DEFAULT_CONTEXT_LENGTHS"
+            )
+
+    def test_provider_aliases_in_models_py(self):
+        from hermes_cli.models import _PROVIDER_ALIASES
+        assert _PROVIDER_ALIASES.get("fireworks-ai") == "fireworks"
+        assert _PROVIDER_ALIASES.get("fw") == "fireworks"
+
+    def test_provider_label(self):
+        from hermes_cli.models import _PROVIDER_LABELS
+        assert "fireworks" in _PROVIDER_LABELS
+        assert _PROVIDER_LABELS["fireworks"] == "Fireworks AI"

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -40,6 +40,20 @@ def test_resolve_runtime_provider_ai_gateway(monkeypatch):
     assert resolved["requested_provider"] == "ai-gateway"
 
 
+def test_resolve_runtime_provider_fireworks(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "fireworks")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setenv("FIREWORKS_API_KEY", "test-fireworks-key")
+
+    resolved = rp.resolve_runtime_provider(requested="fireworks")
+
+    assert resolved["provider"] == "fireworks"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "https://api.fireworks.ai/inference/v1"
+    assert resolved["api_key"] == "test-fireworks-key"
+    assert resolved["requested_provider"] == "fireworks"
+
+
 def test_resolve_runtime_provider_openrouter_explicit(monkeypatch):
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
     monkeypatch.setattr(rp, "_get_model_config", lambda: {})

--- a/tests/test_setup_model_selection.py
+++ b/tests/test_setup_model_selection.py
@@ -22,6 +22,7 @@ def mock_provider_registry():
         "kimi-coding": FakePConfig("Kimi Coding", ["KIMI_API_KEY"], "KIMI_BASE_URL", "https://api.kimi.example"),
         "minimax": FakePConfig("MiniMax", ["MINIMAX_API_KEY"], "MINIMAX_BASE_URL", "https://api.minimax.example"),
         "minimax-cn": FakePConfig("MiniMax CN", ["MINIMAX_API_KEY"], "MINIMAX_CN_BASE_URL", "https://api.minimax-cn.example"),
+        "fireworks": FakePConfig("Fireworks AI", ["FIREWORKS_API_KEY"], "FIREWORKS_BASE_URL", "https://api.fireworks.ai/inference/v1"),
     }
 
 
@@ -34,6 +35,7 @@ class TestSetupProviderModelSelection:
         ("kimi-coding", ["kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"]),
         ("minimax", ["MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"]),
         ("minimax-cn", ["MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"]),
+        ("fireworks", ["accounts/fireworks/models/kimi-k2p5", "accounts/fireworks/models/kimi-k2-thinking", "accounts/fireworks/models/deepseek-v3p2"]),
     ])
     @patch("hermes_cli.models.fetch_api_models", return_value=[])
     @patch("hermes_cli.config.get_env_value", return_value="fake-key")

--- a/website/docs/developer-guide/provider-runtime.md
+++ b/website/docs/developer-guide/provider-runtime.md
@@ -47,6 +47,7 @@ Current provider families include:
 - Kimi / Moonshot
 - MiniMax
 - MiniMax China
+- Fireworks AI
 - Custom (`provider: custom`) — first-class provider for any OpenAI-compatible endpoint
 - Named custom providers (`custom_providers` list in config.yaml)
 
@@ -75,14 +76,19 @@ This resolver is the main reason Hermes can share auth/runtime logic between:
 
 Set `AI_GATEWAY_API_KEY` in `~/.hermes/.env` and run with `--provider ai-gateway`. Hermes fetches available models from the gateway's `/models` endpoint, filtering to language models with tool-use support.
 
-## OpenRouter, AI Gateway, and custom OpenAI-compatible base URLs
+## Fireworks AI
 
-Hermes contains logic to avoid leaking the wrong API key to a custom endpoint when multiple provider keys exist (e.g. `OPENROUTER_API_KEY`, `AI_GATEWAY_API_KEY`, and `OPENAI_API_KEY`).
+Set `FIREWORKS_API_KEY` in `~/.hermes/.env` and run with `--provider fireworks`. Hermes uses Fireworks' OpenAI-compatible endpoint at `https://api.fireworks.ai/inference/v1` and supports `FIREWORKS_BASE_URL` for explicit overrides.
+
+## OpenRouter, AI Gateway, Fireworks, and custom OpenAI-compatible base URLs
+
+Hermes contains logic to avoid leaking the wrong API key to a custom endpoint when multiple provider keys exist (e.g. `OPENROUTER_API_KEY`, `AI_GATEWAY_API_KEY`, `FIREWORKS_API_KEY`, and `OPENAI_API_KEY`).
 
 Each provider's API key is scoped to its own base URL:
 
 - `OPENROUTER_API_KEY` is only sent to `openrouter.ai` endpoints
 - `AI_GATEWAY_API_KEY` is only sent to `ai-gateway.vercel.sh` endpoints
+- `FIREWORKS_API_KEY` is only sent to `api.fireworks.ai` endpoints
 - `OPENAI_API_KEY` is used for custom endpoints and as a fallback
 
 Hermes also distinguishes between:

--- a/website/docs/developer-guide/provider-runtime.md
+++ b/website/docs/developer-guide/provider-runtime.md
@@ -80,6 +80,11 @@ Set `AI_GATEWAY_API_KEY` in `~/.hermes/.env` and run with `--provider ai-gateway
 
 Set `FIREWORKS_API_KEY` in `~/.hermes/.env` and run with `--provider fireworks`. Hermes uses Fireworks' OpenAI-compatible endpoint at `https://api.fireworks.ai/inference/v1` and supports `FIREWORKS_BASE_URL` for explicit overrides.
 
+For auxiliary vision routing, Hermes treats Fireworks as a known-good
+multimodal backend and defaults to `accounts/fireworks/models/kimi-k2p5`.
+Fire Pass remains a model-level override: users who want the Fire Pass router
+can set `AUXILIARY_VISION_MODEL=accounts/fireworks/routers/kimi-k2p5-turbo`.
+
 ## OpenRouter, AI Gateway, Fireworks, and custom OpenAI-compatible base URLs
 
 Hermes contains logic to avoid leaking the wrong API key to a custom endpoint when multiple provider keys exist (e.g. `OPENROUTER_API_KEY`, `AI_GATEWAY_API_KEY`, `FIREWORKS_API_KEY`, and `OPENAI_API_KEY`).

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -50,6 +50,7 @@ hermes setup       # Or configure everything at once
 | **MiniMax** | International MiniMax endpoint | Set `MINIMAX_API_KEY` |
 | **MiniMax China** | China-region MiniMax endpoint | Set `MINIMAX_CN_API_KEY` |
 | **Alibaba Cloud** | Qwen models via DashScope | Set `DASHSCOPE_API_KEY` |
+| **Fireworks AI** | Serverless open models via Fireworks' OpenAI-compatible API | Set `FIREWORKS_API_KEY` |
 | **Hugging Face** | 20+ open models via unified router (Qwen, DeepSeek, Kimi, etc.) | Set `HF_TOKEN` |
 | **Kilo Code** | KiloCode-hosted models | Set `KILOCODE_API_KEY` |
 | **OpenCode Zen** | Pay-as-you-go access to curated models | Set `OPENCODE_ZEN_API_KEY` |

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -67,7 +67,7 @@ Common options:
 | `-q`, `--query "..."` | One-shot, non-interactive prompt. |
 | `-m`, `--model <model>` | Override the model for this run. |
 | `-t`, `--toolsets <csv>` | Enable a comma-separated set of toolsets. |
-| `--provider <provider>` | Force a provider: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `huggingface`, `alibaba`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`, `kilocode`. |
+| `--provider <provider>` | Force a provider: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `huggingface`, `alibaba`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`, `kilocode`, `fireworks`. |
 | `-s`, `--skills <name>` | Preload one or more skills for the session (can be repeated or comma-separated). |
 | `-v`, `--verbose` | Verbose output. |
 | `-Q`, `--quiet` | Programmatic mode: suppress banner/spinner/tool previews. |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -16,6 +16,8 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | `OPENROUTER_BASE_URL` | Override the OpenRouter-compatible base URL |
 | `AI_GATEWAY_API_KEY` | Vercel AI Gateway API key ([ai-gateway.vercel.sh](https://ai-gateway.vercel.sh)) |
 | `AI_GATEWAY_BASE_URL` | Override AI Gateway base URL (default: `https://ai-gateway.vercel.sh/v1`) |
+| `FIREWORKS_API_KEY` | Fireworks AI API key ([app.fireworks.ai](https://app.fireworks.ai/settings/users/api-keys)) |
+| `FIREWORKS_BASE_URL` | Override Fireworks base URL (default: `https://api.fireworks.ai/inference/v1`) |
 | `OPENAI_API_KEY` | API key for custom OpenAI-compatible endpoints (used with `OPENAI_BASE_URL`) |
 | `OPENAI_BASE_URL` | Base URL for custom endpoint (VLLM, SGLang, etc.) |
 | `COPILOT_GITHUB_TOKEN` | GitHub token for Copilot API — first priority (OAuth `gho_*` or fine-grained PAT `github_pat_*`; classic PATs `ghp_*` are **not supported**) |
@@ -63,7 +65,7 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 
 | Variable | Description |
 |----------|-------------|
-| `HERMES_INFERENCE_PROVIDER` | Override provider selection: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `huggingface`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`, `kilocode`, `alibaba` (default: `auto`) |
+| `HERMES_INFERENCE_PROVIDER` | Override provider selection: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `huggingface`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`, `kilocode`, `alibaba`, `fireworks` (default: `auto`) |
 | `HERMES_PORTAL_BASE_URL` | Override Nous Portal URL (for development/testing) |
 | `NOUS_INFERENCE_BASE_URL` | Override Nous inference API URL |
 | `HERMES_NOUS_MIN_KEY_TTL_SECONDS` | Min agent key TTL before re-mint (default: 1800 = 30min) |

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -24,6 +24,7 @@ Hermes Agent works with any OpenAI-compatible API. Supported providers include:
 - **z.ai / ZhipuAI** — GLM models
 - **Kimi / Moonshot AI** — Kimi models
 - **MiniMax** — global and China endpoints
+- **Fireworks AI** — serverless open models through an OpenAI-compatible API
 - **Local models** — via [Ollama](https://ollama.com/), [vLLM](https://docs.vllm.ai/), [llama.cpp](https://github.com/ggerganov/llama.cpp), [SGLang](https://github.com/sgl-project/sglang), or any OpenAI-compatible server
 
 Set your provider with `hermes model` or by editing `~/.hermes/.env`. See the [Environment Variables](./environment-variables.md) reference for all provider keys.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -89,6 +89,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **MiniMax** | `MINIMAX_API_KEY` in `~/.hermes/.env` (provider: `minimax`) |
 | **MiniMax China** | `MINIMAX_CN_API_KEY` in `~/.hermes/.env` (provider: `minimax-cn`) |
 | **Alibaba Cloud** | `DASHSCOPE_API_KEY` in `~/.hermes/.env` (provider: `alibaba`, aliases: `dashscope`, `qwen`) |
+| **Fireworks AI** | `FIREWORKS_API_KEY` in `~/.hermes/.env` (provider: `fireworks`, aliases: `fireworks-ai`, `fw`) |
 | **Kilo Code** | `KILOCODE_API_KEY` in `~/.hermes/.env` (provider: `kilocode`) |
 | **OpenCode Zen** | `OPENCODE_ZEN_API_KEY` in `~/.hermes/.env` (provider: `opencode-zen`) |
 | **OpenCode Go** | `OPENCODE_GO_API_KEY` in `~/.hermes/.env` (provider: `opencode-go`) |
@@ -228,6 +229,25 @@ model:
 ```
 
 Base URLs can be overridden with `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, or `DASHSCOPE_BASE_URL` environment variables.
+
+### Fireworks AI
+
+[Fireworks' OpenAI compatibility layer](https://docs.fireworks.ai/tools-sdks/openai-compatibility) exposes a standard OpenAI-compatible endpoint at `https://api.fireworks.ai/inference/v1`. Hermes supports it as a first-class provider, so you can switch to Fireworks with a provider ID instead of treating it as a generic custom endpoint.
+
+```bash
+# Fireworks AI
+hermes chat --provider fireworks --model accounts/fireworks/models/kimi-k2p5
+# Requires: FIREWORKS_API_KEY in ~/.hermes/.env
+```
+
+Or set it permanently in `config.yaml`:
+```yaml
+model:
+  provider: "fireworks"
+  default: "accounts/fireworks/models/kimi-k2p5"
+```
+
+The base URL can be overridden with `FIREWORKS_BASE_URL`.
 
 ### Hugging Face Inference Providers
 
@@ -658,7 +678,7 @@ fallback_model:
 
 When activated, the fallback swaps the model and provider mid-session without losing your conversation. It fires **at most once** per session.
 
-Supported providers: `openrouter`, `nous`, `openai-codex`, `copilot`, `anthropic`, `huggingface`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`, `custom`.
+Supported providers: `openrouter`, `nous`, `openai-codex`, `copilot`, `anthropic`, `huggingface`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`, `fireworks`, `custom`.
 
 :::tip
 Fallback is configured exclusively through `config.yaml` — there are no environment variables for it. For full details on when it triggers, supported providers, and how it interacts with auxiliary tasks and delegation, see [Fallback Providers](/docs/user-guide/features/fallback-providers).
@@ -1006,7 +1026,7 @@ Every model slot in Hermes — auxiliary tasks, compression, fallback — uses t
 
 When `base_url` is set, Hermes ignores the provider and calls that endpoint directly (using `api_key` or `OPENAI_API_KEY` for auth). When only `provider` is set, Hermes uses that provider's built-in auth and base URL.
 
-Available providers: `auto`, `openrouter`, `nous`, `codex`, `copilot`, `anthropic`, `main`, `zai`, `kimi-coding`, `minimax`, and any provider registered in the [provider registry](/docs/reference/environment-variables).
+Available providers: `auto`, `openrouter`, `nous`, `codex`, `copilot`, `anthropic`, `main`, `zai`, `kimi-coding`, `minimax`, `fireworks`, and any provider registered in the [provider registry](/docs/reference/environment-variables).
 
 ### Full auxiliary config reference
 
@@ -1553,7 +1573,7 @@ delegation:
 
 **Direct endpoint override:** If you want the obvious custom-endpoint path, set `delegation.base_url`, `delegation.api_key`, and `delegation.model`. That sends subagents directly to that OpenAI-compatible endpoint and takes precedence over `delegation.provider`. If `delegation.api_key` is omitted, Hermes falls back to `OPENAI_API_KEY` only.
 
-The delegation provider uses the same credential resolution as CLI/gateway startup. All configured providers are supported: `openrouter`, `nous`, `copilot`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`. When a provider is set, the system automatically resolves the correct base URL, API key, and API mode — no manual credential wiring needed.
+The delegation provider uses the same credential resolution as CLI/gateway startup. All configured providers are supported: `openrouter`, `nous`, `copilot`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`, `fireworks`. When a provider is set, the system automatically resolves the correct base URL, API key, and API mode — no manual credential wiring needed.
 
 **Precedence:** `delegation.base_url` in config → `delegation.provider` in config → parent provider (inherited). `delegation.model` in config → parent model (inherited). Setting just `model` without `provider` changes only the model name while keeping the parent's credentials (useful for switching models within the same provider like OpenRouter).
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -249,6 +249,12 @@ model:
 
 The base URL can be overridden with `FIREWORKS_BASE_URL`.
 
+Hermes can also use Fireworks for auxiliary vision/image-analysis tasks. The
+default Fireworks vision backend is `accounts/fireworks/models/kimi-k2p5`.
+If you have Fire Pass enabled, point `AUXILIARY_VISION_MODEL` at
+`accounts/fireworks/routers/kimi-k2p5-turbo` to use the Fire Pass router for
+vision-capable coding flows with the same Fireworks provider credentials.
+
 ### Hugging Face Inference Providers
 
 [Hugging Face Inference Providers](https://huggingface.co/docs/inference-providers) routes to 20+ open models through a unified OpenAI-compatible endpoint (`router.huggingface.co/v1`). Requests are automatically routed to the fastest available backend (Groq, Together, SambaNova, etc.) with automatic failover.

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -43,6 +43,7 @@ Both `provider` and `model` are **required**. If either is missing, the fallback
 | Kimi / Moonshot | `kimi-coding` | `KIMI_API_KEY` |
 | MiniMax | `minimax` | `MINIMAX_API_KEY` |
 | MiniMax (China) | `minimax-cn` | `MINIMAX_CN_API_KEY` |
+| Fireworks AI | `fireworks` | `FIREWORKS_API_KEY` |
 | Kilo Code | `kilocode` | `KILOCODE_API_KEY` |
 | Alibaba / DashScope | `alibaba` | `DASHSCOPE_API_KEY` |
 | Hugging Face | `huggingface` | `HF_TOKEN` |
@@ -163,7 +164,7 @@ When a task's provider is set to `"auto"` (the default), Hermes tries providers 
 
 ```text
 OpenRouter → Nous Portal → Custom endpoint → Codex OAuth →
-API-key providers (z.ai, Kimi, MiniMax, Hugging Face, Anthropic) → give up
+API-key providers (z.ai, Kimi, MiniMax, Fireworks, Hugging Face, Anthropic) → give up
 ```
 
 **For vision tasks:**


### PR DESCRIPTION
## What changed

- added Fireworks AI as a first-class API-key provider across auth, runtime resolution, model catalogs, setup, doctor, status, and auxiliary client routing
- added Fireworks model metadata and models.dev mapping so provider detection and context-window fallbacks behave consistently
- documented Fireworks usage, environment variables, provider routing, and fallback-provider support in the README and Docusaurus docs
- extended provider, setup, runtime, and models.dev tests to cover Fireworks aliases and curated models

## Why

Hermes already supports several OpenAI-compatible providers. Fireworks uses the same integration shape, but it was missing from provider registration, setup flows, runtime/provider detection, and user-facing docs.

## Impact

- users can configure `FIREWORKS_API_KEY` or `FIREWORKS_BASE_URL` and run Hermes with `--provider fireworks`
- interactive setup now offers Fireworks alongside the existing provider choices
- provider selection, auxiliary-provider defaults, and fallback docs stay aligned with the existing terminology and UX

## Validation

- `python -m pytest tests/ -q --ignore=tests/integration --tb=short -n auto`
- `python -m pytest tests/test_api_key_providers.py tests/test_runtime_provider_resolution.py tests/hermes_cli/test_model_validation.py tests/test_setup_model_selection.py tests/agent/test_models_dev.py -q --ignore=tests/integration --tb=short -n auto`
- `cd website && npm ci`
- `cd website && source ../.venv/bin/activate && npm run lint:diagrams && npm run build`
