### PR TITLE
docs: update Anthropic console URLs to platform.claude.com

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3973,7 +3973,7 @@ def _model_flow_anthropic(config, current_model=""):
 
         elif choice == "2":
             print()
-            print("  Get an API key at: https://console.anthropic.com/settings/keys")
+            print("  Get an API key at: https://platform.claude.com/settings/keys")
             print()
             try:
                 import getpass

--- a/run_agent.py
+++ b/run_agent.py
@@ -10151,7 +10151,7 @@ class AIAgent:
                         _dhh = _dhh_fn()
                         print(f"{self.log_prefix}     • Check ANTHROPIC_TOKEN in {_dhh}/.env for Hermes-managed OAuth/setup tokens")
                         print(f"{self.log_prefix}     • Check ANTHROPIC_API_KEY in {_dhh}/.env for API keys or legacy token values")
-                        print(f"{self.log_prefix}     • For API keys: verify at https://console.anthropic.com/settings/keys")
+                        print(f"{self.log_prefix}     • For API keys: verify at https://platform.claude.com/settings/keys")
                         print(f"{self.log_prefix}     • For Claude Code: run 'claude /login' to refresh, then retry")
                         print(f"{self.log_prefix}     • Legacy cleanup: hermes config set ANTHROPIC_TOKEN \"\"")
                         print(f"{self.log_prefix}     • Clear stale keys: hermes config set ANTHROPIC_API_KEY \"\"")


### PR DESCRIPTION
Anthropic migrated their developer console from `console.anthropic.com` to `platform.claude.com`. Three user-facing display URLs were still pointing to the old domain:

- `hermes_cli/setup.py` — API key setup prompt
- `hermes_cli/main.py` — model flow prompt  
- `run_agent.py` — 401 troubleshooting output

The OAuth token refresh endpoint was already migrated in PR #3246 (with fallback).

Spotted by @LucidPaths in PR #3237.