### PR TITLE
feat: add remote Hermes subagent setup flow + delegation tests

### DIFF
--- a/config_remote_agents_example.yaml
+++ b/config_remote_agents_example.yaml
@@ -1,0 +1,50 @@
+# Remote Agents Configuration Example
+# Add this to your ~/.hermes/config.yaml
+
+remote_agents:
+  # Coding agent - specialized for code generation and debugging
+  coding:
+    endpoint: "http://coding-agent:8080/v1"
+    api_key: "${CODING_AGENT_KEY}"
+    model: "qwen3.5"
+    timeout: 300
+    description: "Specialized coding agent for code generation and debugging"
+
+  # Research agent - for web research and analysis
+  research:
+    endpoint: "http://research-agent:8080/v1"
+    api_key: "${RESEARCH_AGENT_KEY}"
+    model: "gpt-5"
+    timeout: 600
+    description: "Research and analysis agent with web access"
+
+  # Fast/cheap agent - for simple tasks using a cheaper model
+  fast:
+    endpoint: "http://fast-agent:8080/v1"
+    api_key: "${FAST_AGENT_KEY}"
+    model: "gemma-2b"
+    timeout: 60
+    description: "Fast, cheap agent for simple tasks"
+
+# Usage examples:
+# 
+# 1. Delegate to coding agent:
+#    delegate_task(
+#      goal="Build a REST API for user management",
+#      context="Use FastAPI with PostgreSQL",
+#      agent="coding",
+#      toolsets=["terminal", "file"]
+#    )
+#
+# 2. Delegate to research agent:
+#    delegate_task(
+#      goal="Research the latest LLM architectures",
+#      agent="research",
+#      toolsets=["web"]
+#    )
+#
+# 3. Simple task to fast agent:
+#    delegate_task(
+#      goal="Explain what a transformer is",
+#      agent="fast"
+#    )

--- a/config_remote_agents_example.yaml
+++ b/config_remote_agents_example.yaml
@@ -6,7 +6,7 @@ remote_agents:
   coding:
     endpoint: "http://coding-agent:8080/v1"
     api_key: "${CODING_AGENT_KEY}"
-    model: "qwen3.5"
+    model: "hermes-agent"
     timeout: 300
     description: "Specialized coding agent for code generation and debugging"
 
@@ -14,7 +14,7 @@ remote_agents:
   research:
     endpoint: "http://research-agent:8080/v1"
     api_key: "${RESEARCH_AGENT_KEY}"
-    model: "gpt-5"
+    model: "hermes-agent"
     timeout: 600
     description: "Research and analysis agent with web access"
 
@@ -22,7 +22,7 @@ remote_agents:
   fast:
     endpoint: "http://fast-agent:8080/v1"
     api_key: "${FAST_AGENT_KEY}"
-    model: "gemma-2b"
+    model: "hermes-agent"
     timeout: 60
     description: "Fast, cheap agent for simple tasks"
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3373,12 +3373,12 @@ For more help on a command:
         "setup",
         help="Interactive setup wizard",
         description="Configure Hermes Agent with an interactive wizard. "
-                    "Run a specific section: hermes setup model|terminal|gateway|tools|agent"
+                    "Run a specific section: hermes setup model|terminal|gateway|tools|agent|remote"
     )
     setup_parser.add_argument(
         "section",
         nargs="?",
-        choices=["model", "terminal", "gateway", "tools", "agent"],
+        choices=["model", "terminal", "gateway", "tools", "agent", "remote"],
         default=None,
         help="Run a specific setup section instead of the full wizard"
     )

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -725,6 +725,7 @@ def _print_setup_summary(config: dict, hermes_home):
     print(f"   {color('hermes setup terminal', Colors.GREEN)} Change terminal backend")
     print(f"   {color('hermes setup gateway', Colors.GREEN)}  Configure messaging")
     print(f"   {color('hermes setup tools', Colors.GREEN)}    Configure tool providers")
+    print(f"   {color('hermes setup remote', Colors.GREEN)}   Manage remote delegation agents")
     print()
     print(f"   {color('hermes config', Colors.GREEN)}         View current settings")
     print(
@@ -2994,6 +2995,147 @@ def setup_tools(config: dict, first_install: bool = False):
     tools_command(first_install=first_install, config=config)
 
 
+def setup_remote_agents(config: dict):
+    """Manage remote Hermes instances used by delegate_task(agent=...)."""
+    print_header("Remote Agents")
+    print_info("Select a configured remote agent to edit it, add a new one, or remove one.")
+    print_info("Each agent uses an OpenAI-compatible base endpoint (e.g. http://host:8080/v1).")
+
+    def _normalize_agent_config(agent: Any) -> Dict[str, Any]:
+        if isinstance(agent, dict):
+            return dict(agent)
+        if isinstance(agent, str):
+            return {"endpoint": agent}
+        return {}
+
+    def _prompt_agent_fields(name: str, existing_cfg: Dict[str, Any]) -> Dict[str, Any] | None:
+        endpoint = prompt(
+            "Endpoint base URL",
+            str(existing_cfg.get("endpoint") or "http://localhost:8080/v1"),
+        ).strip().rstrip("/")
+        if not endpoint:
+            print_warning("Endpoint is required.")
+            return None
+
+        existing_api_key = str(existing_cfg.get("api_key") or "").strip()
+        if existing_api_key:
+            keep_existing = prompt_yes_no("Keep existing API key?", default=True)
+            if keep_existing:
+                api_key = existing_api_key
+            else:
+                api_key = prompt(
+                    "API key (literal or ${ENV_VAR}; leave blank for none)",
+                    password=True,
+                ).strip()
+        else:
+            api_key = prompt(
+                "API key (literal or ${ENV_VAR}; leave blank for none)",
+                password=True,
+            ).strip()
+
+        model = prompt(
+            "Model",
+            str(existing_cfg.get("model") or "hermes-agent"),
+        ).strip()
+
+        timeout_default = str(existing_cfg.get("timeout") or 300)
+        timeout_raw = prompt("Timeout in seconds", timeout_default).strip()
+        try:
+            timeout = int(timeout_raw)
+            if timeout <= 0:
+                raise ValueError
+        except ValueError:
+            print_warning("Invalid timeout; using 300 seconds.")
+            timeout = 300
+
+        description = prompt(
+            "Description",
+            str(existing_cfg.get("description") or f"Remote agent: {name}"),
+        ).strip()
+
+        return {
+            "endpoint": endpoint,
+            "api_key": api_key,
+            "model": model or "hermes-agent",
+            "timeout": timeout,
+            "description": description or f"Remote agent: {name}",
+        }
+
+    while True:
+        remote_agents = config.get("remote_agents")
+        if not isinstance(remote_agents, dict):
+            remote_agents = {}
+            config["remote_agents"] = remote_agents
+
+        agent_names = sorted(remote_agents.keys())
+        menu_choices = []
+        for name in agent_names:
+            agent = _normalize_agent_config(remote_agents.get(name))
+            endpoint = str(agent.get("endpoint") or "(no endpoint)")
+            model = str(agent.get("model") or "hermes-agent")
+            menu_choices.append(f"{name} — {endpoint} [{model}]")
+
+        menu_choices.append("Add new remote agent")
+        menu_choices.append("Back")
+
+        default_idx = len(agent_names) if not agent_names else 0
+        selection = prompt_choice("Remote agents:", menu_choices, default_idx)
+
+        add_idx = len(agent_names)
+        back_idx = len(agent_names) + 1
+
+        if selection == back_idx:
+            return
+
+        if selection == add_idx:
+            print()
+            name = prompt("Agent name (used in delegate_task(agent=...))").strip()
+            if not name:
+                print_warning("Agent name cannot be empty.")
+                continue
+
+            existing_cfg = _normalize_agent_config(remote_agents.get(name))
+            if name in remote_agents and not prompt_yes_no(
+                f"Agent '{name}' already exists. Edit it?", default=True
+            ):
+                continue
+
+            updated = _prompt_agent_fields(name, existing_cfg)
+            if updated is None:
+                continue
+            remote_agents[name] = updated
+            print_success(f"Saved remote agent '{name}'.")
+            continue
+
+        # Existing agent selected -> edit/remove submenu
+        name = agent_names[selection]
+        existing_cfg = _normalize_agent_config(remote_agents.get(name))
+        action = prompt_choice(
+            f"Agent '{name}':",
+            ["Edit agent", "Remove agent", "Back"],
+            0,
+        )
+
+        if action == 0:
+            updated = _prompt_agent_fields(name, existing_cfg)
+            if updated is None:
+                continue
+            remote_agents[name] = updated
+            print_success(f"Saved remote agent '{name}'.")
+            continue
+
+        if action == 1:
+            if prompt_yes_no(f"Remove remote agent '{name}'?", default=False):
+                remote_agents.pop(name, None)
+                if not remote_agents:
+                    config["remote_agents"] = {}
+                print_success(f"Removed remote agent '{name}'.")
+            continue
+
+        # Back from agent submenu
+        continue
+
+
 # =============================================================================
 # Post-Migration Section Skip Logic
 # =============================================================================
@@ -3202,6 +3344,7 @@ SETUP_SECTIONS = [
     ("gateway", "Messaging Platforms (Gateway)", setup_gateway),
     ("tools", "Tools", setup_tools),
     ("agent", "Agent Settings", setup_agent_settings),
+    ("remote", "Remote Agents", setup_remote_agents),
 ]
 
 
@@ -3215,6 +3358,7 @@ def run_setup_wizard(args):
       hermes setup gateway   — just messaging platforms
       hermes setup tools     — just tool configuration
       hermes setup agent     — just agent settings
+      hermes setup remote    — manage remote delegated agents
     """
     from hermes_cli.config import is_managed, managed_error
     if is_managed():
@@ -3328,6 +3472,7 @@ def run_setup_wizard(args):
             "Messaging Platforms (Gateway)",
             "Tools",
             "Agent Settings",
+            "Remote Agents",
             "---",
             "Exit",
         ]
@@ -3343,18 +3488,18 @@ def run_setup_wizard(args):
         elif choice == 1:
             # Full setup — fall through to run all sections
             pass
-        elif choice in (2, 8):
+        elif choice in (2, 9):
             # Separator — treat as exit
             print_info("Exiting. Run 'hermes setup' again when ready.")
             return
-        elif choice == 9:
+        elif choice == 10:
             print_info("Exiting. Run 'hermes setup' again when ready.")
             return
-        elif 3 <= choice <= 7:
+        elif 3 <= choice <= 8:
             # Individual section — map by key, not by position.
             # SETUP_SECTIONS includes TTS but the returning-user menu skips it,
             # so positional indexing (choice - 3) would dispatch the wrong section.
-            _RETURNING_USER_SECTION_KEYS = ["model", "terminal", "gateway", "tools", "agent"]
+            _RETURNING_USER_SECTION_KEYS = ["model", "terminal", "gateway", "tools", "agent", "remote"]
             section_key = _RETURNING_USER_SECTION_KEYS[choice - 3]
             section = next((s for s in SETUP_SECTIONS if s[0] == section_key), None)
             if section:

--- a/run_agent.py
+++ b/run_agent.py
@@ -5277,6 +5277,7 @@ class AIAgent:
                 toolsets=function_args.get("toolsets"),
                 tasks=function_args.get("tasks"),
                 max_iterations=function_args.get("max_iterations"),
+                agent=function_args.get("agent"),
                 parent_agent=self,
             )
         else:
@@ -5627,6 +5628,7 @@ class AIAgent:
                         toolsets=function_args.get("toolsets"),
                         tasks=tasks_arg,
                         max_iterations=function_args.get("max_iterations"),
+                        agent=function_args.get("agent"),
                         parent_agent=self,
                     )
                     _delegate_result = function_result

--- a/test_remote_agent.py
+++ b/test_remote_agent.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+Test script for remote agent functionality.
+
+Run this to verify the remote agent module is working correctly.
+"""
+
+import sys
+sys.path.insert(0, '/home/hermes/hermes-agent')
+
+def test_remote_agent_module():
+    """Test that the remote agent module loads correctly."""
+    print("Testing remote agent module...")
+    
+    try:
+        from tools.remote_agent import (
+            get_remote_agents,
+            call_remote_agent,
+            load_remote_agents_config,
+            refresh_remote_agents_config,
+        )
+        print("✓ Module imported successfully")
+    except ImportError as e:
+        print(f"✗ Failed to import module: {e}")
+        return False
+    
+    # Test config loading
+    print("\nTesting config loading...")
+    config = load_remote_agents_config()
+    print(f"  Config loaded: {config}")
+    
+    # Test get_remote_agents
+    print("\nTesting get_remote_agents()...")
+    agents = get_remote_agents()
+    print(f"  Remote agents: {list(agents.keys())}")
+    
+    print("\n✓ All tests passed!")
+    return True
+
+def test_delegate_tool_integration():
+    """Test that delegate_tool can import remote agent functions."""
+    print("\nTesting delegate_tool integration...")
+    
+    try:
+        from tools.delegate_tool import REMOTE_AGENTS_AVAILABLE
+        if REMOTE_AGENTS_AVAILABLE:
+            print("✓ Remote agents available in delegate_tool")
+        else:
+            print("✗ Remote agents NOT available in delegate_tool")
+            return False
+    except Exception as e:
+        print(f"✗ Failed to check integration: {e}")
+        return False
+    
+    print("✓ Delegate tool integration test passed!")
+    return True
+
+if __name__ == "__main__":
+    success = True
+    success &= test_remote_agent_module()
+    success &= test_delegate_tool_integration()
+    
+    if success:
+        print("\n" + "="*50)
+        print("ALL TESTS PASSED!")
+        print("="*50)
+        sys.exit(0)
+    else:
+        print("\n" + "="*50)
+        print("SOME TESTS FAILED")
+        print("="*50)
+        sys.exit(1)

--- a/tests/hermes_cli/test_setup_remote_agents.py
+++ b/tests/hermes_cli/test_setup_remote_agents.py
@@ -1,0 +1,122 @@
+"""Tests for remote-agent management inside `hermes setup`."""
+
+from argparse import Namespace
+import sys
+
+
+def _make_setup_args(**overrides):
+    return Namespace(
+        non_interactive=overrides.get("non_interactive", False),
+        section=overrides.get("section", None),
+        reset=overrides.get("reset", False),
+    )
+
+
+def test_cli_setup_remote_section_is_parsed(monkeypatch):
+    """`hermes setup remote` should parse and route to cmd_setup with section='remote'."""
+    from hermes_cli.main import main
+
+    captured = {}
+
+    def fake_cmd_setup(args):
+        captured["section"] = args.section
+        captured["non_interactive"] = args.non_interactive
+
+    monkeypatch.setattr("hermes_cli.main.cmd_setup", fake_cmd_setup)
+    monkeypatch.setattr(sys, "argv", ["hermes", "setup", "remote", "--non-interactive"])
+
+    main()
+
+    assert captured["section"] == "remote"
+    assert captured["non_interactive"] is True
+
+
+def test_run_setup_wizard_remote_section_dispatches(monkeypatch):
+    """Section-specific setup should dispatch the remote-agents section function."""
+    from hermes_cli import setup as setup_mod
+
+    called = {"remote": False, "saved": False}
+
+    def fake_remote(config):
+        called["remote"] = True
+        config.setdefault("remote_agents", {})["demo"] = {"endpoint": "http://demo/v1"}
+
+    monkeypatch.setattr(setup_mod, "ensure_hermes_home", lambda: None)
+    monkeypatch.setattr(setup_mod, "load_config", lambda: {})
+    monkeypatch.setattr(setup_mod, "get_hermes_home", lambda: "/tmp/.hermes")
+    monkeypatch.setattr(setup_mod, "is_interactive_stdin", lambda: True)
+    monkeypatch.setattr(setup_mod, "save_config", lambda cfg: called.__setitem__("saved", True))
+    monkeypatch.setattr(
+        setup_mod,
+        "SETUP_SECTIONS",
+        [("remote", "Remote Agents", fake_remote)],
+    )
+
+    args = _make_setup_args(section="remote")
+    setup_mod.run_setup_wizard(args)
+
+    assert called["remote"] is True
+    assert called["saved"] is True
+
+
+def test_setup_remote_agents_select_existing_then_remove(monkeypatch):
+    """Selecting an existing remote agent should allow removing it."""
+    from hermes_cli import setup as setup_mod
+
+    config = {
+        "remote_agents": {
+            "bsha": {
+                "endpoint": "http://bsha:8080/v1",
+                "api_key": "${BSHA_API_KEY}",
+                "model": "hermes-agent",
+                "timeout": 300,
+                "description": "BSHA remote Hermes",
+            }
+        }
+    }
+
+    # Main menu: select existing agent (0)
+    # Agent submenu: remove (1)
+    # Main menu again with no agents: back (1)
+    choice_values = iter([0, 1, 1])
+
+    monkeypatch.setattr(setup_mod, "prompt_choice", lambda *args, **kwargs: next(choice_values))
+    monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda *args, **kwargs: True)
+
+    setup_mod.setup_remote_agents(config)
+
+    assert config.get("remote_agents", {}) == {}
+
+
+def test_setup_remote_agents_add_hides_api_key_input(monkeypatch):
+    """API key prompt should use password input (hidden characters)."""
+    from hermes_cli import setup as setup_mod
+
+    config = {}
+    captured_password_flags = []
+
+    # No agents yet => menu is [Add new remote agent, Back]
+    # Choose add (0), then back (2) once an agent exists
+    choice_values = iter([0, 2])
+
+    prompt_values = iter([
+        "bsha",
+        "http://bsha:8080/v1",
+        "${BSHA_API_KEY}",
+        "hermes-agent",
+        "300",
+        "BSHA remote Hermes",
+    ])
+
+    def fake_prompt(question, default=None, password=False):
+        captured_password_flags.append((question, password))
+        return next(prompt_values)
+
+    monkeypatch.setattr(setup_mod, "prompt_choice", lambda *args, **kwargs: next(choice_values))
+    monkeypatch.setattr(setup_mod, "prompt", fake_prompt)
+
+    setup_mod.setup_remote_agents(config)
+
+    api_key_prompt = next((flag for q, flag in captured_password_flags if "API key" in q), None)
+    assert api_key_prompt is True
+    assert "bsha" in config.get("remote_agents", {})

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -27,6 +27,7 @@ from tools.delegate_tool import (
     _build_child_system_prompt,
     _strip_blocked_tools,
     _resolve_delegation_credentials,
+    _delegate_to_remote,
 )
 
 
@@ -248,6 +249,109 @@ class TestDelegateTask(unittest.TestCase):
             self.assertEqual(kwargs["api_key"], parent.api_key)
             self.assertEqual(kwargs["provider"], parent.provider)
             self.assertEqual(kwargs["api_mode"], parent.api_mode)
+
+
+class TestRemoteDelegation(unittest.TestCase):
+    def test_delegate_task_remote_routes_to_remote_helper(self):
+        """delegate_task(agent=...) should route through _delegate_to_remote."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("tools.delegate_tool._delegate_to_remote") as mock_remote:
+            mock_remote.return_value = json.dumps({"success": True, "type": "remote"})
+
+            result = json.loads(
+                delegate_task(
+                    goal="Inspect codebase",
+                    context="Use strict review",
+                    toolsets=["terminal", "file"],
+                    agent=" BSHA ",
+                    parent_agent=parent,
+                )
+            )
+
+            self.assertEqual(result["success"], True)
+            mock_remote.assert_called_once_with(
+                agent_name="BSHA",
+                goal="Inspect codebase",
+                context="Use strict review",
+                toolsets=["terminal", "file"],
+            )
+
+    def test_delegate_task_remote_requires_goal(self):
+        """Remote mode should reject missing goal before calling helper."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("tools.delegate_tool._delegate_to_remote") as mock_remote:
+            result = json.loads(delegate_task(agent="BSHA", parent_agent=parent))
+
+        self.assertIn("error", result)
+        self.assertIn("requires a 'goal'", result["error"])
+        mock_remote.assert_not_called()
+
+    def test_delegate_task_remote_ignores_depth_limit(self):
+        """Remote delegation check runs before local depth-limit guard."""
+        parent = _make_mock_parent(depth=MAX_DEPTH)
+
+        with patch("tools.delegate_tool._delegate_to_remote") as mock_remote:
+            mock_remote.return_value = json.dumps({"success": True, "type": "remote"})
+            result = json.loads(delegate_task(goal="hi", agent="bsha", parent_agent=parent))
+
+        self.assertTrue(result.get("success"))
+        mock_remote.assert_called_once()
+
+    @patch("tools.delegate_tool.REMOTE_AGENTS_AVAILABLE", True)
+    @patch("tools.delegate_tool.get_remote_agents")
+    @patch("tools.delegate_tool.call_remote_agent")
+    def test_delegate_to_remote_success_includes_resolved_endpoint(
+        self, mock_call_remote, mock_get_remote
+    ):
+        mock_get_remote.return_value = {
+            "bsha": {
+                "endpoint": "http://bsha:8080/v1",
+                "model": "hermes-agent",
+                "api_key": "${BSHA_API_KEY}",
+            }
+        }
+        mock_call_remote.return_value = {"content": "done"}
+
+        result = json.loads(
+            _delegate_to_remote(
+                agent_name="bsha",
+                goal="Run task",
+                context="ctx",
+                toolsets=["terminal"],
+            )
+        )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["type"], "remote")
+        self.assertEqual(result["agent"], "bsha")
+        self.assertEqual(result["resolved_endpoint"], "http://bsha:8080/v1")
+        self.assertEqual(result["result"], "done")
+
+    @patch("tools.delegate_tool.REMOTE_AGENTS_AVAILABLE", True)
+    @patch("tools.delegate_tool.get_remote_agents")
+    def test_delegate_to_remote_unknown_agent_reports_available(self, mock_get_remote):
+        mock_get_remote.return_value = {
+            "alpha": {"endpoint": "http://alpha/v1"},
+            "beta": {"endpoint": "http://beta/v1"},
+        }
+
+        result = json.loads(
+            _delegate_to_remote(
+                agent_name="missing",
+                goal="Run task",
+                context=None,
+                toolsets=None,
+            )
+        )
+
+        self.assertIn("error", result)
+        self.assertIn("Unknown remote agent", result["error"])
+        self.assertIn("alpha", result["error"])
+        self.assertIn("beta", result["error"])
+        self.assertEqual(result["type"], "remote")
+        self.assertEqual(result["resolved_endpoint"], None)
 
 
 class TestToolNamePreservation(unittest.TestCase):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -24,6 +24,14 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, List, Optional
 
+# Import remote agent module
+try:
+    from tools.remote_agent import get_remote_agents, call_remote_agent, refresh_remote_agents_config
+    REMOTE_AGENTS_AVAILABLE = True
+except ImportError:
+    REMOTE_AGENTS_AVAILABLE = False
+    logger.debug("Remote agents module not available")
+
 
 # Tools that children must never have access to
 DELEGATE_BLOCKED_TOOLS = frozenset([
@@ -397,25 +405,103 @@ def _run_single_child(
             except (ValueError, UnboundLocalError) as e:
                 logger.debug("Could not remove child from active_children: %s", e)
 
+def _delegate_to_remote(
+    agent_name: str,
+    goal: str,
+    context: Optional[str],
+    toolsets: Optional[List[str]],
+) -> str:
+    """
+    Delegate task to a remote Hermes agent.
+    
+    Args:
+        agent_name: Name of the remote agent from config
+        goal: The task/goal to accomplish
+        context: Additional context for the task
+        toolsets: Toolsets to enable (optional)
+        
+    Returns:
+        JSON string with the result or error
+    """
+    if not REMOTE_AGENTS_AVAILABLE:
+        return json.dumps({
+            "error": "Remote agents not available. Check that tools/remote_agent.py is installed."
+        })
+    
+    remote_agents = get_remote_agents()
+    
+    if agent_name not in remote_agents:
+        available = ", ".join(remote_agents.keys()) or "none"
+        return json.dumps({
+            "error": f"Unknown remote agent: '{agent_name}'. Available agents: {available}"
+        })
+    
+    agent_config = remote_agents.get(agent_name)
+    endpoint = agent_config.get("endpoint")
+    if not endpoint:
+        return json.dumps({
+            "error": f"Remote agent '{agent_name}' has no endpoint configured"
+        })
+    
+    logger.info(f"Delegating to remote agent '{agent_name}' at {endpoint}")
+    
+    # Call the remote agent
+    result = call_remote_agent(
+        agent_name=agent_name,
+        goal=goal,
+        context=context,
+        toolsets=toolsets,
+        stream=False,
+    )
+    
+    if "error" in result:
+        return json.dumps({
+            "error": f"Remote agent '{agent_name}' failed: {result['error']}"
+        })
+    
+    return json.dumps({
+        "success": True,
+        "agent": agent_name,
+        "type": "remote",
+        "result": result.get("content", ""),
+    })
+
+
 def delegate_task(
     goal: Optional[str] = None,
     context: Optional[str] = None,
     toolsets: Optional[List[str]] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
+    agent: Optional[str] = None,  # Remote agent name
     parent_agent=None,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks.
 
-    Supports two modes:
-      - Single: provide goal (+ optional context, toolsets)
-      - Batch:  provide tasks array [{goal, context, toolsets}, ...]
+    Supports three modes:
+      - Single local: provide goal (+ optional context, toolsets)
+      - Batch local:  provide tasks array [{goal, context, toolsets}, ...]
+      - Remote:       provide agent parameter to delegate to remote Hermes
 
     Returns JSON with results array, one entry per task.
     """
     if parent_agent is None:
         return json.dumps({"error": "delegate_task requires a parent agent context."})
+
+    # Check for remote agent delegation first
+    if agent and isinstance(agent, str) and agent.strip():
+        # Remote agent mode
+        if goal is None:
+            return json.dumps({
+                "error": "Remote agent mode requires a 'goal' parameter."
+            })
+        return _delegate_to_remote(
+            agent_name=agent.strip(),
+            goal=goal,
+            context=context,
+            toolsets=toolsets,
+        )
 
     # Depth limit
     depth = getattr(parent_agent, '_delegate_depth', 0)
@@ -687,18 +773,24 @@ DELEGATE_TASK_SCHEMA = {
         "Each subagent gets its own conversation, terminal session, and toolset. "
         "Only the final summary is returned -- intermediate tool results "
         "never enter your context window.\n\n"
-        "TWO MODES (one of 'goal' or 'tasks' is required):\n"
-        "1. Single task: provide 'goal' (+ optional context, toolsets)\n"
-        "2. Batch (parallel): provide 'tasks' array with up to 3 items. "
-        "All run concurrently and results are returned together.\n\n"
+        "THREE MODES:\n"
+        "1. Single local task: provide 'goal' (+ optional context, toolsets)\n"
+        "2. Batch local (parallel): provide 'tasks' array with up to 3 items. "
+        "All run concurrently and results are returned together.\n"
+        "3. Remote agent: provide 'agent' parameter to delegate to a remote "
+        "Hermes instance configured in ~/.hermes/config.yaml under remote_agents.\n"
+        "\n"
         "WHEN TO USE delegate_task:\n"
         "- Reasoning-heavy subtasks (debugging, code review, research synthesis)\n"
         "- Tasks that would flood your context with intermediate data\n"
-        "- Parallel independent workstreams (research A and B simultaneously)\n\n"
+        "- Parallel independent workstreams (research A and B simultaneously)\n"
+        "- Specialized remote agents for specific domains (coding, research, etc.)\n"
+        "\n"
         "WHEN NOT TO USE (use these instead):\n"
         "- Mechanical multi-step work with no reasoning needed -> use execute_code\n"
         "- Single tool call -> just call the tool directly\n"
-        "- Tasks needing user interaction -> subagents cannot use clarify\n\n"
+        "- Tasks needing user interaction -> subagents cannot use clarify\n"
+        "\n"
         "IMPORTANT:\n"
         "- Subagents have NO memory of your conversation. Pass all relevant "
         "info (file paths, error messages, constraints) via the 'context' field.\n"
@@ -735,6 +827,16 @@ DELEGATE_TASK_SCHEMA = {
                     "Common patterns: ['terminal', 'file'] for code work, "
                     "['web'] for research, ['terminal', 'file', 'web'] for "
                     "full-stack tasks."
+                ),
+            },
+            "agent": {
+                "type": "string",
+                "description": (
+                    "Optional: Name of a remote agent to delegate to. If specified, "
+                    "the task is sent to the remote Hermes instance configured in "
+                    "~/.hermes/config.yaml under remote_agents. The remote agent runs "
+                    "independently and returns a summary. Use this for specialized "
+                    "agents or to scale across multiple Hermes instances."
                 ),
             },
             "tasks": {
@@ -785,6 +887,7 @@ registry.register(
         toolsets=args.get("toolsets"),
         tasks=args.get("tasks"),
         max_iterations=args.get("max_iterations"),
+        agent=args.get("agent"),
         parent_agent=kw.get("parent_agent")),
     check_fn=check_delegate_requirements,
     emoji="🔀",

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -425,22 +425,32 @@ def _delegate_to_remote(
     """
     if not REMOTE_AGENTS_AVAILABLE:
         return json.dumps({
-            "error": "Remote agents not available. Check that tools/remote_agent.py is installed."
+            "error": "Remote agents not available. Check that tools/remote_agent.py is installed.",
+            "type": "remote",
+            "agent": agent_name,
+            "resolved_endpoint": None,
         })
     
+    logger.info(f"get remote agents {agent_name}")
     remote_agents = get_remote_agents()
     
     if agent_name not in remote_agents:
         available = ", ".join(remote_agents.keys()) or "none"
         return json.dumps({
-            "error": f"Unknown remote agent: '{agent_name}'. Available agents: {available}"
+            "error": f"Unknown remote agent: '{agent_name}'. Available agents: {available}",
+            "type": "remote",
+            "agent": agent_name,
+            "resolved_endpoint": None,
         })
     
     agent_config = remote_agents.get(agent_name)
     endpoint = agent_config.get("endpoint")
     if not endpoint:
         return json.dumps({
-            "error": f"Remote agent '{agent_name}' has no endpoint configured"
+            "error": f"Remote agent '{agent_name}' has no endpoint configured",
+            "type": "remote",
+            "agent": agent_name,
+            "resolved_endpoint": None,
         })
     
     logger.info(f"Delegating to remote agent '{agent_name}' at {endpoint}")
@@ -456,13 +466,17 @@ def _delegate_to_remote(
     
     if "error" in result:
         return json.dumps({
-            "error": f"Remote agent '{agent_name}' failed: {result['error']}"
+            "error": f"Remote agent '{agent_name}' failed: {result['error']}",
+            "type": "remote",
+            "agent": agent_name,
+            "resolved_endpoint": endpoint,
         })
     
     return json.dumps({
         "success": True,
         "agent": agent_name,
         "type": "remote",
+        "resolved_endpoint": endpoint,
         "result": result.get("content", ""),
     })
 
@@ -488,6 +502,7 @@ def delegate_task(
     """
     if parent_agent is None:
         return json.dumps({"error": "delegate_task requires a parent agent context."})
+    logger.info(f"delegate task remote agents {agent}")
 
     # Check for remote agent delegation first
     if agent and isinstance(agent, str) and agent.strip():
@@ -496,6 +511,7 @@ def delegate_task(
             return json.dumps({
                 "error": "Remote agent mode requires a 'goal' parameter."
             })
+        logger.info(f"delegate task goto remote agents {agent}")
         return _delegate_to_remote(
             agent_name=agent.strip(),
             goal=goal,

--- a/tools/remote_agent.py
+++ b/tools/remote_agent.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""
+Remote Agent Module
+
+Handles communication with remote Hermes instances via OpenAI-compatible
+API endpoints. Supports synchronous calls and streaming.
+"""
+
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+# Try to import httpx, fall back to requests
+try:
+    import httpx
+    HAS_HTTPX = True
+except ImportError:
+    HAS_HTTPX = False
+    try:
+        import requests
+        HAS_REQUESTS = True
+    except ImportError:
+        HAS_REQUESTS = False
+
+# Default timeout for remote agent calls
+DEFAULT_TIMEOUT = 300
+
+
+def _resolve_env_var(value: str) -> str:
+    """Resolve ${VAR_NAME} syntax to environment variable value."""
+    if not value:
+        return ""
+    if value.startswith("${") and value.endswith("}"):
+        var_name = value[2:-1]
+        return os.environ.get(var_name, "")
+    return value
+
+
+def load_remote_agents_config() -> Dict[str, Any]:
+    """
+    Load remote agents configuration from ~/.hermes/config.yaml.
+    
+    Returns a dict mapping agent names to their configurations.
+    """
+    try:
+        from hermes_cli.config import load_config
+        config = load_config()
+        remote_agents = config.get("remote_agents", {})
+        
+        # Resolve environment variables in config
+        resolved = {}
+        for name, agent_config in remote_agents.items():
+            if agent_config and isinstance(agent_config, dict):
+                resolved[name] = {
+                    "endpoint": agent_config.get("endpoint", ""),
+                    "api_key": _resolve_env_var(agent_config.get("api_key", "")),
+                    "model": agent_config.get("model", "qwen3.5"),
+                    "timeout": agent_config.get("timeout", DEFAULT_TIMEOUT),
+                    "description": agent_config.get("description", f"Remote agent: {name}"),
+                }
+            else:
+                resolved[name] = {
+                    "endpoint": agent_config if isinstance(agent_config, str) else "",
+                    "api_key": "",
+                    "model": "qwen3.5",
+                    "timeout": DEFAULT_TIMEOUT,
+                    "description": f"Remote agent: {name}",
+                }
+        return resolved
+    except ImportError:
+        logger.debug("hermes_cli.config not available, no remote agents configured")
+        return {}
+    except Exception as e:
+        logger.warning("Failed to load remote agents config: %s", e)
+        return {}
+
+
+# Cache for loaded config
+_remote_agents_config = None
+
+
+def get_remote_agents() -> Dict[str, Any]:
+    """Get cached remote agents configuration."""
+    global _remote_agents_config
+    if _remote_agents_config is None:
+        _remote_agents_config = load_remote_agents_config()
+    return _remote_agents_config
+
+
+def refresh_remote_agents_config():
+    """Force reload of remote agents configuration."""
+    global _remote_agents_config
+    _remote_agents_config = None
+
+
+def _build_remote_agent_prompt(
+    goal: str,
+    context: Optional[str],
+    toolsets: Optional[list]
+) -> str:
+    """Build system prompt for remote agent."""
+    parts = [
+        "You are a remote Hermes agent working on a delegated task.",
+        "",
+        f"YOUR TASK:\n{goal}",
+    ]
+    
+    if context and context.strip():
+        parts.append(f"\nCONTEXT:\n{context}")
+    
+    if toolsets:
+        parts.append(f"\nAVAILABLE TOOLS: {', '.join(toolsets)}")
+    
+    parts.append(
+        "\nComplete this task using your tools. When finished, provide a "
+        "clear, concise summary of:\n"
+        "- What you did\n"
+        "- What you found or accomplished\n"
+        "- Any files you created or modified\n"
+        "- Any issues encountered"
+    )
+    
+    return "\n".join(parts)
+
+
+def _blocking_request(
+    agent_name: str,
+    endpoint: str,
+    agent_config: Dict[str, Any],
+    messages: list
+) -> Dict[str, Any]:
+    """Make a blocking HTTP request to the remote agent."""
+    url = endpoint.rstrip("/") + "/chat/completions"
+    headers = {
+        "Content-Type": "application/json",
+    }
+    
+    api_key=agent_...ey")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    
+    payload = {
+        "model": agent_config.get("model", "qwen3.5"),
+        "messages": messages,
+        "stream": False,
+    }
+    
+    timeout = agent_config.get("timeout", DEFAULT_TIMEOUT)
+    
+    try:
+        if HAS_HTTPX:
+            with httpx.Client(timeout=timeout) as client:
+                response = client.post(url, headers=headers, json=payload)
+                response.raise_for_status()
+                data = response.json()
+                
+                content = data.get("choices", [{}])[0].get("message", {}).get("content", "")
+                return {"content": content, "agent": agent_name}
+        elif HAS_REQUESTS:
+            response = requests.post(url, headers=headers, json=payload, timeout=timeout)
+            response.raise_for_status()
+            data = response.json()
+            
+            content = data.get("choices", [{}])[0].get("message", {}).get("content", "")
+            return {"content": content, "agent": agent_name}
+        else:
+            return {"error": "No HTTP client available. Install 'httpx' or 'requests'."}
+            
+    except Exception as e:
+        logger.error("HTTP error calling %s: %s", agent_name, e)
+        return {"error": f"HTTP error: {str(e)}"}
+
+
+def _stream_request(
+    agent_name: str,
+    endpoint: str,
+    agent_config: Dict[str, Any],
+    messages: list
+) -> Dict[str, Any]:
+    """Make a streaming HTTP request to the remote agent."""
+    import httpx
+    
+    url = endpoint.rstrip("/") + "/chat/completions"
+    headers = {
+        "Content-Type": "application/json",
+    }
+    
+    api_key = agent_config.get("api_key")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    
+    payload = {
+        "model": agent_config.get("model", "qwen3.5"),
+        "messages": messages,
+        "stream": True,
+    }
+    
+    full_content = ""
+    
+    try:
+        with httpx.Client(timeout=agent_config.get("timeout", DEFAULT_TIMEOUT)) as client:
+            with client.stream("POST", url, headers=headers, json=payload) as response:
+                response.raise_for_status()
+                for line in response.iter_lines():
+                    if line.startswith("data: "):
+                        data = line[6:]
+                        if data == "[DONE]":
+                            break
+                        try:
+                            json_data = json.loads(data)
+                            delta = json_data.get("choices", [{}])[0].get("delta", {})
+                            content = delta.get("content", "")
+                            if content:
+                                full_content += content
+                        except json.JSONDecodeError:
+                            continue
+        
+        return {"content": full_content, "agent": agent_name}
+        
+    except httpx.HTTPError as e:
+        logger.error("HTTP error calling %s: %s", agent_name, e)
+        return {"error": f"HTTP error: {str(e)}"}
+
+
+def call_remote_agent(
+    agent_name: str,
+    goal: str,
+    context: Optional[str] = None,
+    toolsets: Optional[list] = None,
+    stream: bool = False,
+) -> Dict[str, Any]:
+    """
+    Make a single request to a remote agent.
+    
+    Args:
+        agent_name: Name of the remote agent from config
+        goal: The task/goal to accomplish
+        context: Additional context for the task
+        toolsets: Toolsets to enable (optional)
+        stream: Whether to stream the response
+        
+    Returns:
+        Dict with 'content' key containing the response, or error dict
+    """
+    config = get_remote_agents()
+    agent_config = config.get(agent_name)
+    
+    if not agent_config:
+        return {
+            "error": f"Unknown remote agent: {agent_name}. "
+                     f"Available agents: {', '.join(config.keys()) or 'none'}"
+        }
+    
+    endpoint = agent_config.get("endpoint")
+    if not endpoint:
+        return {"error": f"Remote agent {agent_name} has no endpoint configured"}
+    
+    # Build the request
+    system_prompt = _build_remote_agent_prompt(goal, context, toolsets)
+    
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": goal}
+    ]
+    
+    # Make the request
+    try:
+        if stream:
+            return _stream_request(agent_name, endpoint, agent_config, messages)
+        else:
+            return _blocking_request(agent_name, endpoint, agent_config, messages)
+    except Exception as e:
+        logger.exception("Remote agent call failed: %s", e)
+        return {"error": f"Remote agent {agent_name} failed: {str(e)}"}

--- a/tools/remote_agent.py
+++ b/tools/remote_agent.py
@@ -11,6 +11,8 @@ import logging
 import os
 from typing import Any, Dict, List, Optional
 
+logger = logging.getLogger(__name__)
+
 # Try to import httpx, fall back to requests
 try:
     import httpx
@@ -135,13 +137,13 @@ def _blocking_request(
     headers = {
         "Content-Type": "application/json",
     }
-    
-    api_key=agent_...ey")
+
+    api_key = agent_config.get("api_key")
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
     
     payload = {
-        "model": agent_config.get("model", "qwen3.5"),
+        "model": agent_config.get("model", "hermes-agent"),
         "messages": messages,
         "stream": False,
     }

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -49,6 +49,68 @@ curl http://localhost:8642/v1/chat/completions \
 
 Or connect Open WebUI, LobeChat, or any other frontend — see the [Open WebUI integration guide](/docs/user-guide/messaging/open-webui) for step-by-step instructions.
 
+## Adding Remote Hermes Servers
+
+If you want one Hermes instance to be reachable from other machines (or from cloud frontends), run it on a host with the API server enabled and expose it over your network/VPN/reverse proxy.
+
+### 1. Configure the remote host
+
+On the remote Hermes host, set:
+
+```bash
+API_SERVER_ENABLED=true
+API_SERVER_HOST=0.0.0.0
+API_SERVER_PORT=8642
+API_SERVER_KEY=replace-with-a-strong-key
+```
+
+Then start/restart the gateway:
+
+```bash
+hermes gateway
+```
+
+Use a firewall/security group to allow only trusted source IPs.
+
+### 2. Add the remote endpoint in your integration
+
+In any OpenAI-compatible client, set:
+
+- Base URL: `http://REMOTE_HOST:8642/v1` (or your HTTPS reverse-proxy URL)
+- API key: the same `API_SERVER_KEY` configured on the remote host
+- Model: `hermes-agent`
+
+You can keep multiple remote Hermes endpoints in your frontend and switch between them as needed (dev/staging/prod, personal/work, etc.).
+
+### 3. Test reachability locally with curl
+
+From your local machine, check health first:
+
+```bash
+curl -sS http://REMOTE_HOST:8642/health
+```
+
+Expected response:
+
+```json
+{"status":"ok"}
+```
+
+Then test an authenticated chat request:
+
+```bash
+curl -sS http://REMOTE_HOST:8642/v1/chat/completions \
+  -H "Authorization: Bearer replace-with-a-strong-key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "hermes-agent",
+    "messages": [{"role": "user", "content": "Reply with: remote reachability ok"}],
+    "stream": false
+  }'
+```
+
+If this returns a normal completion payload, the remote Hermes server is reachable and correctly authenticated.
+
 ## Endpoints
 
 ### POST /v1/chat/completions


### PR DESCRIPTION
## Summary
- add a new `hermes setup remote` section to manage remote Hermes agents
- add interactive CRUD flow in setup wizard:
  - select existing agent to edit/remove
  - add new remote agent
  - back entry at the bottom
- hide remote agent API key input using password-style prompt
- include remote section in returning-user setup menu and setup command choices
- add tests for setup remote flow and remote delegation behavior
- remove WebUI-specific wording in API server config description

## Validation
- `pytest tests/hermes_cli/test_setup_remote_agents.py -q`
- `pytest tests/hermes_cli/test_setup_noninteractive.py tests/hermes_cli/test_setup_openclaw_migration.py -q`
- `pytest tests/tools/test_delegate.py -q`

## Notes
- branch is pushed to fork: `Bepitic/feat/rol-hermes-sub-agents`
- PR targets `NousResearch/hermes-agent:main`