### PR TITLE
CLI: handle closed stdout ValueError in safe print paths

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1271,7 +1271,7 @@ class AIAgent:
         try:
             fn = self._print_fn or print
             fn(*args, **kwargs)
-        except OSError:
+        except (OSError, ValueError):
             pass
 
     def _vprint(self, *args, force: bool = False, **kwargs):
@@ -7875,7 +7875,7 @@ class AIAgent:
                 error_msg = f"Error during OpenAI-compatible API call #{api_call_count}: {str(e)}"
                 try:
                     print(f"❌ {error_msg}")
-                except OSError:
+                except (OSError, ValueError):
                     logger.error(error_msg)
                 
                 if self.verbose_logging:

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -137,6 +137,15 @@ def test_aiagent_reuses_existing_errors_log_handler():
             root_logger.addHandler(handler)
 
 
+def test_safe_print_ignores_closed_stdout_value_error(agent):
+    broken_print = MagicMock(side_effect=ValueError("I/O operation on closed file"))
+    agent._print_fn = broken_print
+
+    agent._safe_print("hello")
+
+    broken_print.assert_called_once_with("hello")
+
+
 # ---------------------------------------------------------------------------
 # Helper to build mock assistant messages (API response objects)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- treat closed-stdout `ValueError` the same way as `OSError` in `_safe_print`
- harden the OpenAI-compatible API error printer against the same failure mode
- add a regression test for the `_safe_print` path

Fixes #3534