### PR TITLE
Status: handle Linux runtimes without systemctl

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -5,6 +5,7 @@ Shows the status of all Hermes Agent components.
 """
 
 import os
+import shutil
 import sys
 import subprocess
 from pathlib import Path
@@ -277,19 +278,24 @@ def show_status(args):
     print(color("◆ Gateway Service", Colors.CYAN, Colors.BOLD))
     
     if sys.platform.startswith('linux'):
-        try:
-            from hermes_cli.gateway import get_service_name
-            _gw_svc = get_service_name()
-        except Exception:
-            _gw_svc = "hermes-gateway"
-        result = subprocess.run(
-            ["systemctl", "--user", "is-active", _gw_svc],
-            capture_output=True,
-            text=True
-        )
-        is_active = result.stdout.strip() == "active"
-        print(f"  Status:       {check_mark(is_active)} {'running' if is_active else 'stopped'}")
-        print("  Manager:      systemd (user)")
+        systemctl_path = shutil.which("systemctl")
+        if systemctl_path:
+            try:
+                from hermes_cli.gateway import get_service_name
+                _gw_svc = get_service_name()
+            except Exception:
+                _gw_svc = "hermes-gateway"
+            result = subprocess.run(
+                [systemctl_path, "--user", "is-active", _gw_svc],
+                capture_output=True,
+                text=True
+            )
+            is_active = result.stdout.strip() == "active"
+            print(f"  Status:       {check_mark(is_active)} {'running' if is_active else 'stopped'}")
+            print("  Manager:      systemd (user)")
+        else:
+            print(f"  Status:       {color('N/A', Colors.DIM)}")
+            print("  Manager:      systemd unavailable in this runtime")
         
     elif sys.platform == 'darwin':
         from hermes_cli.gateway import get_launchd_label

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -12,3 +12,15 @@ def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
     output = capsys.readouterr().out
     assert "Tavily" in output
     assert "tvly...cdef" in output
+
+
+def test_show_status_handles_linux_without_systemctl(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("hermes_cli.status.sys.platform", "linux")
+    monkeypatch.setattr("hermes_cli.status.shutil.which", lambda _name: None)
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "Gateway Service" in output
+    assert "systemd unavailable in this runtime" in output


### PR DESCRIPTION
## Summary
- guard `hermes status` against Linux runtimes that do not ship `systemctl`
- keep gateway status output informative instead of crashing
- add a regression test for the no-systemctl path

Fixes #3724