### PR TITLE
Tools: default missing schema names to the registered tool name

### DIFF
--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -356,6 +356,38 @@ class TestPluginToolVisibility:
         tool_names3 = [t["function"]["name"] for t in tools3]
         assert "vis_tool" in tool_names3
 
+    def test_plugin_tool_without_schema_name_uses_registered_name(self, tmp_path, monkeypatch):
+        """Plugin tools should stay loadable even if schema["name"] is omitted."""
+        import hermes_cli.plugins as plugins_mod
+
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        plugin_dir = plugins_dir / "missing_name_plugin"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.yaml").write_text(yaml.dump({"name": "missing_name_plugin"}))
+        (plugin_dir / "__init__.py").write_text(
+            'def register(ctx):\n'
+            '    ctx.register_tool(\n'
+            '        name="missing_name_tool",\n'
+            '        toolset="plugin_missing_name_plugin",\n'
+            '        schema={"description": "Visible", "parameters": {"type": "object", "properties": {}}},\n'
+            '        handler=lambda args, **kw: "ok",\n'
+            '    )\n'
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", mgr)
+
+        from model_tools import get_tool_definitions
+
+        tools = get_tool_definitions(
+            enabled_toolsets=["plugin_missing_name_plugin"],
+            quiet_mode=True,
+        )
+
+        assert [t["function"]["name"] for t in tools] == ["missing_name_tool"]
+
 
 # ── TestPluginManagerList ──────────────────────────────────────────────────
 

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -66,6 +66,8 @@ class ToolRegistry:
         emoji: str = "",
     ):
         """Register a tool.  Called at module-import time by each tool file."""
+        normalized_schema = dict(schema)
+        normalized_schema.setdefault("name", name)
         existing = self._tools.get(name)
         if existing and existing.toolset != toolset:
             logger.warning(
@@ -76,12 +78,12 @@ class ToolRegistry:
         self._tools[name] = ToolEntry(
             name=name,
             toolset=toolset,
-            schema=schema,
+            schema=normalized_schema,
             handler=handler,
             check_fn=check_fn,
             requires_env=requires_env or [],
             is_async=is_async,
-            description=description or schema.get("description", ""),
+            description=description or normalized_schema.get("description", ""),
             emoji=emoji,
         )
         if check_fn and toolset not in self._toolset_checks:


### PR DESCRIPTION
## Summary
- fill in `schema.name` from the registered tool name when plugin tools omit it
- keep plugin/tool registry behavior backward compatible for existing schemas
- add a regression test covering plugin tools without `schema["name"]`

Fixes #3729