### PR TITLE
fix(cron): release scheduler lock before running jobs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -356,40 +356,48 @@ def tick(verbose: bool = True) -> int:
         if verbose:
             logger.info("%s - %s job(s) due", _hermes_now().strftime('%H:%M:%S'), len(due_jobs))
 
-        executed = 0
-        for job in due_jobs:
-            try:
-                success, output, final_response, error = run_job(job)
-
-                output_file = save_job_output(job["id"], output)
-                if verbose:
-                    logger.info("Output saved to: %s", output_file)
-
-                # Deliver the final response to the origin/target chat
-                deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
-                if deliver_content:
-                    try:
-                        _deliver_result(job, deliver_content)
-                    except Exception as de:
-                        logger.error("Delivery failed for job %s: %s", job["id"], de)
-
-                mark_job_run(job["id"], success, error)
-                executed += 1
-
-            except Exception as e:
-                logger.error("Error processing job %s: %s", job['id'], e)
-                mark_job_run(job["id"], False, str(e))
-
-        return executed
     finally:
-        if fcntl:
-            fcntl.flock(lock_fd, fcntl.LOCK_UN)
-        elif msvcrt:
-            try:
-                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
-            except (OSError, IOError):
-                pass
-        lock_fd.close()
+        # Release lock after selecting due jobs — run_job() executes outside
+        # the lock so slow jobs cannot block unrelated scheduler ticks.
+        if lock_fd is not None:
+            if fcntl:
+                try:
+                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                except (OSError, IOError):
+                    pass
+            elif msvcrt:
+                try:
+                    msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
+                except (OSError, IOError):
+                    pass
+            lock_fd.close()
+            lock_fd = None
+
+    executed = 0
+    for job in due_jobs:
+        try:
+            success, output, final_response, error = run_job(job)
+
+            output_file = save_job_output(job["id"], output)
+            if verbose:
+                logger.info("Output saved to: %s", output_file)
+
+            # Deliver the final response to the origin/target chat
+            deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
+            if deliver_content:
+                try:
+                    _deliver_result(job, deliver_content)
+                except Exception as de:
+                    logger.error("Delivery failed for job %s: %s", job["id"], de)
+
+            mark_job_run(job["id"], success, error)
+            executed += 1
+
+        except Exception as e:
+            logger.error("Error processing job %s: %s", job['id'], e)
+            mark_job_run(job["id"], False, str(e))
+
+    return executed
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this PR do?

Long-running cron jobs were blocking the entire scheduler tick loop because `run_job()` executed while the tick lock was still held. One slow job could delay all unrelated due jobs and block the next 60-second gateway tick — effectively causing scheduler starvation.

This PR scopes the file lock to due-job **selection only**, then releases it before executing jobs. Each job now runs outside the global tick lock.

## Related Issue

Fixes #3752

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py`: Moved `run_job()` loop outside the tick lock scope. Lock is released immediately after `get_due_jobs()` completes.

## How to Test

1. Create two cron jobs — one slow (long LLM task), one fast
2. Schedule both for the same tick
3. Verify fast job is not blocked by slow job
4. Verify next 60-second tick starts on time

## Checklist

- [x] I've read the Contributing Guide
- [x] Commit follows Conventional Commits
- [x] No duplicate PRs
- [x] Tested on Ubuntu 24.04 / WSL2

