### PR TITLE
✨(approvals): make dangerous command approval timeout configurable

### DIFF
--- a/hermes_cli/callbacks.py
+++ b/hermes_cli/callbacks.py
@@ -241,7 +241,8 @@ def approval_callback(cli, command: str, description: str) -> str:
         lock = cli._approval_lock
 
     with lock:
-        timeout = 60
+        from cli import CLI_CONFIG
+        timeout = CLI_CONFIG.get("approvals", {}).get("timeout", 60)
         response_queue = queue.Queue()
         choices = ["once", "session", "always", "deny"]
         if len(command) > 70:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -221,7 +221,7 @@ def save_permanent_allowlist(patterns: set):
 # =========================================================================
 
 def prompt_dangerous_approval(command: str, description: str,
-                              timeout_seconds: int = 60,
+                              timeout_seconds: int | None = None,
                               allow_permanent: bool = True,
                               approval_callback=None) -> str:
     """Prompt the user to approve a dangerous command (CLI only).
@@ -236,6 +236,9 @@ def prompt_dangerous_approval(command: str, description: str,
 
     Returns: 'once', 'session', 'always', or 'deny'
     """
+    if timeout_seconds is None:
+        timeout_seconds = _get_approval_timeout()
+
     if approval_callback is not None:
         try:
             return approval_callback(command, description,
@@ -316,15 +319,28 @@ def _normalize_approval_mode(mode) -> str:
     return "manual"
 
 
-def _get_approval_mode() -> str:
-    """Read the approval mode from config. Returns 'manual', 'smart', or 'off'."""
+def _get_approval_config() -> dict:
+    """Read the approvals config block. Returns a dict with 'mode', 'timeout', etc."""
     try:
         from hermes_cli.config import load_config
         config = load_config()
-        mode = config.get("approvals", {}).get("mode", "manual")
-        return _normalize_approval_mode(mode)
+        return config.get("approvals", {}) or {}
     except Exception:
-        return "manual"
+        return {}
+
+
+def _get_approval_mode() -> str:
+    """Read the approval mode from config. Returns 'manual', 'smart', or 'off'."""
+    mode = _get_approval_config().get("mode", "manual")
+    return _normalize_approval_mode(mode)
+
+
+def _get_approval_timeout() -> int:
+    """Read the approval timeout from config. Defaults to 60 seconds."""
+    try:
+        return int(_get_approval_config().get("timeout", 60))
+    except (ValueError, TypeError):
+        return 60
 
 
 def _smart_approve(command: str, description: str) -> str:


### PR DESCRIPTION
## Summary

- Read `approvals.timeout` from `config.yaml` instead of hardcoding 60 seconds
- Applies to both the fallback CLI prompt (`tools/approval.py`) and the TUI prompt_toolkit callback (`hermes_cli/callbacks.py`)
- Default remains 60s when unset — no behavior change for existing users

## Motivation

When running complex agent workflows with delegation subtasks, the 60s timeout is often too short — the prompt expires and the command is denied before the user can respond. The `clarify` callback already reads its timeout from config, so this follows the same pattern.

```yaml
approvals:
  mode: smart
  timeout: 120
```

## Test plan

- [x] All 95 existing approval tests pass (`test_approval.py` + `test_cli_approval_ui.py`)
- [ ] Manual: set `approvals.timeout: 10` and verify the countdown matches
- [ ] Manual: remove `approvals.timeout` and verify 60s default

Closes #3765