### PR TITLE
feat(gateway): add message:received and message:processed hook events

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -7,13 +7,32 @@ Hooks are discovered from ~/.hermes/hooks/ directories, each containing:
   - handler.py (Python handler with async def handle(event_type, context))
 
 Events:
+  Gateway lifecycle:
   - gateway:startup     -- Gateway process starts
+
+  Session lifecycle:
   - session:start       -- New session created (first message of a new session)
   - session:end         -- Session ends (user ran /new or /reset)
   - session:reset       -- Session reset completed (new session entry created)
+
+  Agent lifecycle:
   - agent:start         -- Agent begins processing a message
   - agent:step          -- Each turn in the tool-calling loop
   - agent:end           -- Agent finishes processing
+
+  Message lifecycle:
+  - message:received    -- Inbound message before processing. Handler receives
+                           context dict with event, platform, chat_type, metadata,
+                           and should_process (default True). Set
+                           context["should_process"] = False to drop the message.
+                           NOTE: Fires after platform-specific gating (mention
+                           checks, bot filters). Use adapter config (e.g.
+                           DISCORD_FREE_RESPONSE_CHANNELS) for pre-gating control.
+  - message:processed  -- Agent response sent (or error). Handler receives
+                           context dict with event, platform, response text,
+                           success (bool), error (str | None), and metadata.
+
+  Commands:
   - command:*           -- Any slash command executed (wildcard match)
 
 Errors in hooks are caught and logged but never block the main pipeline.

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -431,6 +431,8 @@ class BasePlatformAdapter(ABC):
         self._background_tasks: set[asyncio.Task] = set()
         # Chats where auto-TTS on voice input is disabled (set by /voice off)
         self._auto_tts_disabled_chats: set = set()
+        # Gateway hook registry for message lifecycle events (set by GatewayRunner)
+        self._hooks: Optional["HookRegistry"] = None
 
     @property
     def has_fatal_error(self) -> bool:
@@ -514,6 +516,33 @@ class BasePlatformAdapter(ABC):
         an optional response string.
         """
         self._message_handler = handler
+
+    def set_hooks(self, hooks: "HookRegistry") -> None:
+        """
+        Attach the gateway hook registry for message lifecycle events.
+
+        The hooks are used to fire message:received (before processing) and
+        message:processed (after response) events. External handlers in
+        ~/.hermes/hooks/ can use these to implement gating, analytics, or
+        post-response actions.
+        """
+        self._hooks = hooks
+
+    def _build_hook_metadata(self, event: MessageEvent) -> dict:
+        """
+        Build platform metadata dict for hook context.
+
+        Subclasses may override to add platform-specific fields. The default
+        implementation extracts the most common fields available to all adapters.
+        """
+        source = event.source
+        return {
+            "chat_id": source.chat_id if source else None,
+            "user_id": source.user_id if source else None,
+            "chat_type": source.chat_type if source else None,
+            "thread_id": source.thread_id if source else None,
+            "message_id": event.message_id,
+        }
     
     @abstractmethod
     async def connect(self) -> bool:
@@ -1013,7 +1042,44 @@ class BasePlatformAdapter(ABC):
         """
         if not self._message_handler:
             return
-        
+
+        # --- message:received hook ---
+        # Fires before session registration. Hooks can set should_process=False to drop.
+        if self._hooks is not None and self._hooks._handlers.get("message:received"):
+            hook_ctx = {
+                "event": event,
+                "platform": self.platform.value,
+                "chat_type": event.source.chat_type if event.source else None,
+                "should_process": True,
+                "metadata": self._build_hook_metadata(event),
+            }
+            try:
+                await asyncio.wait_for(
+                    self._hooks.emit("message:received", hook_ctx),
+                    timeout=float(os.getenv("HERMES_HOOK_TIMEOUT", "5")),
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "message:received hook timed out for %s in %s — processing message (fail-open)",
+                    event.source.user_name if event.source else "unknown",
+                    event.source.chat_id if event.source else "unknown",
+                )
+            except Exception:
+                logger.warning(
+                    "message:received hook error for %s in %s — processing message (fail-open)",
+                    event.source.user_name if event.source else "unknown",
+                    event.source.chat_id if event.source else "unknown",
+                    exc_info=True,
+                )
+            if hook_ctx.get("should_process") is False:
+                logger.debug(
+                    "message:received hook dropped message from %s in %s",
+                    event.source.user_name if event.source else "unknown",
+                    event.source.chat_id if event.source else "unknown",
+                )
+                return
+        # --- end hook ---
+
         session_key = build_session_key(
             event.source,
             group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
@@ -1092,6 +1158,11 @@ class BasePlatformAdapter(ABC):
             if getattr(result, "success", False):
                 delivery_succeeded = True
 
+        # Track hook state for message:processed
+        _hook_response: Optional[str] = None
+        _hook_success: bool = False
+        _hook_error: Optional[str] = None
+
         # Create interrupt event for this session
         interrupt_event = asyncio.Event()
         self._active_sessions[session_key] = interrupt_event
@@ -1105,6 +1176,8 @@ class BasePlatformAdapter(ABC):
 
             # Call the handler (this can take a while with tool calls)
             response = await self._message_handler(event)
+            _hook_response = response
+            _hook_success = True
             
             # Send response if any
             if not response:
@@ -1297,6 +1370,7 @@ class BasePlatformAdapter(ABC):
             raise
         except Exception as e:
             await self._run_processing_hook("on_processing_complete", event, False)
+            _hook_error = str(e)
             logger.error("[%s] Error handling message: %s", self.name, e, exc_info=True)
             # Send the error to the user so they aren't left with radio silence
             try:
@@ -1315,6 +1389,29 @@ class BasePlatformAdapter(ABC):
             except Exception:
                 pass  # Last resort — don't let error reporting crash the handler
         finally:
+            # --- message:processed hook ---
+            if self._hooks is not None and self._hooks._handlers.get("message:processed"):
+                processed_ctx = {
+                    "event": event,
+                    "platform": self.platform.value,
+                    "response": _hook_response,
+                    "success": _hook_success,
+                    "error": _hook_error,
+                    "metadata": self._build_hook_metadata(event),
+                }
+                try:
+                    await asyncio.wait_for(
+                        self._hooks.emit("message:processed", processed_ctx),
+                        timeout=float(os.getenv("HERMES_HOOK_TIMEOUT", "5")),
+                    )
+                except Exception:
+                    logger.debug(
+                        "message:processed hook error for %s (non-critical)",
+                        event.source.chat_id if event.source else "unknown",
+                        exc_info=True,
+                    )
+            # --- end hook ---
+
             # Stop typing indicator
             typing_task.cancel()
             try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1126,6 +1126,8 @@ class GatewayRunner:
             # Set up message + fatal error handlers
             adapter.set_message_handler(self._handle_message)
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
+            if hasattr(self, "hooks"):
+                adapter.set_hooks(self.hooks)
             
             # Try to connect
             logger.info("Connecting to %s...", platform.value)
@@ -1358,6 +1360,8 @@ class GatewayRunner:
 
                     adapter.set_message_handler(self._handle_message)
                     adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
+                    if hasattr(self, "hooks"):
+                        adapter.set_hooks(self.hooks)
 
                     success = await adapter.connect()
                     if success:

--- a/tests/gateway/test_message_lifecycle_hooks.py
+++ b/tests/gateway/test_message_lifecycle_hooks.py
@@ -1,0 +1,894 @@
+"""Tests for message:received and message:processed gateway hook events."""
+
+import asyncio
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+
+from gateway.hooks import HookRegistry
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SessionSource,
+)
+from gateway.config import Platform, PlatformConfig
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test fixtures and helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class StubAdapter(BasePlatformAdapter):
+    """Minimal concrete adapter for testing message lifecycle hooks."""
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        pass
+
+    async def send(
+        self, chat_id: str, content: str = "", *, reply_to: str = None, **kwargs
+    ) -> MagicMock:
+        return MagicMock(success=True)
+
+    async def send_typing(self, chat_id: str, **kwargs) -> None:
+        pass
+
+    async def stop_typing(self, chat_id: str, **kwargs) -> None:
+        pass
+
+    async def get_chat_info(self, chat_id: str) -> dict:
+        return {"id": chat_id, "type": "dm"}
+
+
+def _make_source(
+    chat_id: str = "ch123",
+    user_id: str = "u1",
+    user_name: str = "tester",
+    chat_type: str = "dm",
+    thread_id: str = None,
+):
+    return SessionSource(
+        platform=Platform.DISCORD,
+        chat_id=chat_id,
+        chat_type=chat_type,
+        user_id=user_id,
+        user_name=user_name,
+        thread_id=thread_id,
+    )
+
+
+def _make_event(
+    text: str = "hello",
+    chat_id: str = "ch123",
+    user_id: str = "u1",
+    user_name: str = "tester",
+    chat_type: str = "dm",
+    message_id: str = "msg1",
+    thread_id: str = None,
+):
+    return MessageEvent(
+        text=text,
+        source=_make_source(
+            chat_id=chat_id,
+            user_id=user_id,
+            user_name=user_name,
+            chat_type=chat_type,
+            thread_id=thread_id,
+        ),
+        message_id=message_id,
+    )
+
+
+def _make_adapter(hooks: HookRegistry = None) -> StubAdapter:
+    """Create a StubAdapter with optional hooks wired."""
+    config = PlatformConfig(enabled=True)
+    adapter = StubAdapter(config, Platform.DISCORD)
+    adapter.set_message_handler(AsyncMock(return_value="bot response"))
+    if hooks is not None:
+        adapter.set_hooks(hooks)
+    return adapter
+
+
+def _create_hook_dir(
+    tmp_path: Path, hook_name: str, events: list, handler_code: str
+) -> Path:
+    """Create a hook directory with HOOK.yaml and handler.py."""
+    hook_dir = tmp_path / hook_name
+    hook_dir.mkdir()
+    (hook_dir / "HOOK.yaml").write_text(
+        f"name: {hook_name}\ndescription: Test hook\n"
+        f"events: {events}\n"
+    )
+    (hook_dir / "handler.py").write_text(handler_code)
+    return hook_dir
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# message:received — core behavior
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestMessageReceivedBasic:
+    """Basic message:received hook behavior."""
+
+    def test_no_hooks_message_processed_normally(self, tmp_path):
+        """When no hooks are registered, messages process normally."""
+        adapter = _make_adapter(hooks=None)
+        event = _make_event()
+
+        async def run():
+            await adapter.handle_message(event)
+            # Give background task time to run
+            await asyncio.sleep(0.05)
+
+        asyncio.get_event_loop().run_until_complete(run())
+        adapter._message_handler.assert_called_once_with(event)
+
+    def test_empty_hooks_message_processed_normally(self, tmp_path):
+        """When HookRegistry has no handlers, messages process normally."""
+        hooks = HookRegistry()
+        adapter = _make_adapter(hooks=hooks)
+        event = _make_event()
+
+        async def run():
+            await adapter.handle_message(event)
+            await asyncio.sleep(0.05)
+
+        asyncio.get_event_loop().run_until_complete(run())
+        adapter._message_handler.assert_called_once_with(event)
+
+    def test_hook_fires_before_message_handler(self, tmp_path):
+        """message:received hook fires before _message_handler is called."""
+        call_order = []
+
+        async def hook_handler(event_type, context):
+            call_order.append("hook")
+
+        hooks = HookRegistry()
+        hook_dir = _create_hook_dir(
+            tmp_path,
+            "order-hook",
+            '["message:received"]',
+            f"async def handle(event_type, context):\n"
+            f"    import asyncio\n"
+            f"    await asyncio.sleep(0.01)\n"
+            f"    call_order.append('hook')\n",
+        )
+        # Manually register since we're using tmp_path
+        hooks._handlers.setdefault("message:received", []).append(hook_handler)
+        hooks._loaded_hooks.append(
+            {"name": "order-hook", "events": ["message:received"], "path": str(hook_dir)}
+        )
+
+        handler_mock = AsyncMock(return_value="response")
+        adapter = _make_adapter(hooks=hooks)
+        adapter.set_message_handler(handler_mock)
+        event = _make_event()
+
+        async def run():
+            await adapter.handle_message(event)
+            await asyncio.sleep(0.1)
+
+        asyncio.get_event_loop().run_until_complete(run())
+        assert call_order == ["hook"]
+        handler_mock.assert_called_once()
+
+    def test_hook_can_drop_message(self, tmp_path):
+        """Hook setting should_process=False drops the message."""
+        hooks = HookRegistry()
+        hooks._handlers.setdefault("message:received", []).append(
+            lambda event_type, context: context.__setitem__("should_process", False)
+        )
+        hooks._loaded_hooks.append(
+            {"name": "drop-hook", "events": ["message:received"], "path": "/tmp"}
+        )
+
+        adapter = _make_adapter(hooks=hooks)
+        event = _make_event()
+
+        async def run():
+            await adapter.handle_message(event)
+            await asyncio.sleep(0.05)
+
+        asyncio.get_event_loop().run_until_complete(run())
+        # Handler should NOT have been called
+        adapter._message_handler.assert_not_called()
+
+    def test_hook_default_allows_message(self, tmp_path):
+        """Hook that does nothing (default) allows the message through."""
+        hooks = HookRegistry()
+        hooks._handlers.setdefault("message:received", []).append(
+            lambda event_type, context: None  # does nothing
+        )
+        hooks._loaded_hooks.append(
+            {"name": "noop-hook", "events": ["message:received"], "path": "/tmp"}
+        )
+
+        adapter = _make_adapter(hooks=hooks)
+        event = _make_event()
+
+        async def run():
+            await adapter.handle_message(event)
+            await asyncio.sleep(0.05)
+
+        asyncio.get_event_loop().run_until_complete(run())
+        adapter._message_handler.assert_called_once()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# message:received — context fields
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestMessageReceivedContext:
+    """message:received hook context contains all required fields."""
+
+    def test_hook_context_has_required_fields(self, tmp_path):
+        """Context includes event, platform, chat_type, should_process, metadata."""
+        captured = {}
+
+        async def capture_hook(event_type, context):
+            captured.update(context)
+
+        hooks = HookRegistry()
+        hooks._handlers.setdefault("message:received", []).append(capture_hook)
+        hooks._loaded_hooks.append(
+            {"name": "capture", "events": ["message:received"], "path": "/tmp"}
+        )
+
+        adapter = _make_adapter(hooks=hooks)
+        event = _make_event(text="test message", chat_id="ch999")
+
+        async def run():
+            await adapter.handle_message(event)
+            await asyncio.sleep(0.05)
+
+        asyncio.get_event_loop().run_until_complete(run())
+
+        assert "event" in captured
+        assert "platform" in captured
+        assert "chat_type" in captured
+        assert "should_process" in captured
+        assert "metadata" in captured
+
+    def test_hook_context_platform_is_string(self, tmp_path):
+        """Platform is a string (e.g. 'discord'), not the Platform enum."""
+        captured = {}
+
+        async def capture_hook(event_type, context):
+            captured["platform"] = context["platform"]
+
+        hooks = HookRegistry()
+        hooks._handlers.setdefault("message:received", []).append(capture_hook)
+        hooks._loaded_hooks.append(
+            {"name": "capture", "events": ["message:received"], "path": "/tmp"}
+        )
+
+        adapter = _make_adapter(hooks=hooks)
+        event = _make_event()
+
+        async def run():
+            await adapter.handle_message(event)
+            await asyncio.sleep(0.05)
+
+        asyncio.get_event_loop().run_until_complete(run())
+        assert captured["platform"] == "discord"
+        assert isinstance(captured["platform"], str)
+
+    def test_hook_context_metadata_fields(self, tmp_path):
+        """metadata contains chat_id, user_id, chat_type, thread_id, message_id."""
+        captured = {}
+
+        async def capture_hook(event_type, context):
+            captured["metadata"] = context["metadata"]
+
+        hooks = HookRegistry()
+        hooks._handlers.setdefault("message:received", []).append(capture_hook)
+        hooks._loaded_hooks.append(
+            {"name": "capture", "events": ["message:received"], "path": "/tmp"}
+        )
+
+        adapter = _make_adapter(hooks=hooks)
+        event = _make_event(
+            chat_id="ch_test",
+            user_id="u_test",
+            chat_type="group",
+            thread_id="th_test",
+            message_id="msg_test",
+        )
+
+        async def run():
+            await adapter.handle_message(event)
+            await asyncio.sleep(0.05)
+
+        asyncio.get_event_loop().run_until_complete(run())
+
+        md = captured["metadata"]
+        assert md["chat_id"] == "ch_test"
+        assert md["user_id"] == "u_test"
+        assert md["chat_type"] == "group"
+        assert md["thread_id"] == "th_test"
+        assert md["message_id"] == "msg_test"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# message:received — multiple hooks
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestMessageReceivedMultipleHooks:
+    """Multiple hooks all run; any False drops the message."""
+
+    def test_multiple_hooks_all_run(self, tmp_path):
+        """Both hooks run even when first allows and second allows."""
+        call_log = []
+
+        async def hook_a(event_type, context):
+            call_log.append("a")
+
+        async def hook_b(event_type, context):
+            call_log.append("b")
+
+        hooks = HookRegistry()
+        hooks._handlers.setdefault("message:received", []).extend([hook_a, hook_b])
+        hooks._loaded_hooks.extend([
+            {"name": "hook-a", "events": ["message:received"], "path": "/tmp"},
+            {"name": "hook-b", "events": ["message:received"], "path": "/tmp"},
+        ])
+
+        adapter = _make_adapter(hooks=hooks)
+        event = _make_event()
+
+        async def run():
+            await adapter.handle_message(event)
+            await asyncio.sleep(0.05)
+
+        asyncio.get_event_loop().run_until_complete(run())
+        assert "a" in call_log
+        assert "b" in call_log
+        adapter._message_handler.assert_called_once()
+
+    def test_any_hook_false_drops_message(self, tmp_path):
+        """If any hook sets should_process=False, message is dropped."""
+        call_log = []
+
+        async def hook_allow(event_type, context):
+            call_log.append("allow")
+
+        async def hook_drop(event_type, context):
+            call_log.append("drop")
+            context["should_process"] = False
+
+        async def hook_never_runs(event_type, context):
+            call_log.append("never")
+
+        hooks = HookRegistry()
+        hooks._handlers.setdefault("message:received", []).extend([
+            hook_allow, hook_drop, hook_never_runs
+        ])
+        hooks._loaded_hooks.extend([
+            {"name": "allow", "events": ["message:received"], "path": "/tmp"},
+            {"name": "drop", "events": ["message:received"], "path": "/tmp"},
+            {"name": "never", "events": ["message:received"], "path": "/tmp"},
+        ])
+
+        adapter = _make_adapter(hooks=hooks)
+        event = _make_event()
+
+        async def run():
+            await adapter.handle_message(event)
+            await asyncio.sleep(0.05)
+
+        asyncio.get_event_loop().run_until_complete(run())
+        # All hooks run (no short-circuit)
+        assert "allow" in call_log
+        assert "drop" in call_log
+        assert "never" in call_log
+        # But message was dropped
+        adapter._message_handler.assert_not_called()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# message:received — should_process identity check
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestShouldProcessIdentityCheck:
+    """Only should_process is False (identity) drops; falsy values do not."""
+
+    @pytest.mark.parametrize(
+        "value,should_process",
+        [
+            (None, True),       # None is falsy but not False
+            (0, True),         # 0 is falsy but not False
+            ("", True),        # empty string is falsy but not False
+            (False, False),    # only False drops
+            (True, True),      # True is identity-True
+        ],
+    )
+    def test_should_process_identity(self, tmp_path, value, should_process):
+        """Only is False (not just falsy) causes a drop."""
+        hooks = HookRegistry()
+        hooks._handlers.setdefault("message:received", []).append(
+            lambda event_type, context: context.__setitem__("should_process", value)
+        )
+        hooks._loaded_hooks.append(
+            {"name": "test", "events": ["message:received"], "path": "/tmp"}
+        )
+
+        adapter = _make_adapter(hooks=hooks)
+        event = _make_event()
+
+        async def run():
+            await adapter.handle_message(event)
+            await asyncio.sleep(0.05)
+
+        asyncio.get_event_loop().run_until_complete(run())
+
+        if should_process is False:
+            adapter._message_handler.assert_not_called()
+        else:
+            adapter._message_handler.assert_called_once()
+
+    def test_deleted_should_process_key_allows(self, tmp_path):
+        """Deleting should_process key (not present) allows the message."""
+        hooks = HookRegistry()
+        hooks._handlers.setdefault("message:received", []).append(
+            lambda event_type, context: context.pop("should_process", None)
+        )
+        hooks._loaded_hooks.append(
+            {"name": "test", "events": ["message:received"], "path": "/tmp"}
+        )
+
+        adapter = _make_adapter(hooks=hooks)
+        event = _make_event()
+
+        async def run():
+            await adapter.handle_message(event)
+            await asyncio.sleep(0.05)
+
+        asyncio.get_event_loop().run_until_complete(run())
+        adapter._message_handler.assert_called_once()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# message:received — error and timeout handling
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestMessageReceivedFailOpen:
+    """Hook errors and timeouts fail-open (message is processed)."""
+
+    def test_hook_fail_open_on_exception(self, tmp_path):
+        """Hook raising an exception: message is still processed."""
+        async def bad_hook(event_type, context):
+            raise RuntimeError("hook error")
+
+        hooks = HookRegistry()
+        hooks._handlers.setdefault("message:received", []).append(bad_hook)
+        hooks._loaded_hooks.append(
+            {"name": "bad", "events": ["message:received"], "path": "/tmp"}
+        )
+
+        adapter = _make_adapter(hooks=hooks)
+        event = _make_event()
+
+        async def run():
+            await adapter.handle_message(event)
+            await asyncio.sleep(0.05)
+
+        asyncio.get_event_loop().run_until_complete(run())
+        adapter._message_handler.assert_called_once()
+
+    def test_hook_fail_open_on_timeout(self, tmp_path):
+        """Hook exceeding timeout: message is still processed after timeout."""
+        import time
+
+        async def slow_hook(event_type, context):
+            await asyncio.sleep(10)  # much longer than 1s timeout
+
+        hooks = HookRegistry()
+        hooks._handlers.setdefault("message:received", []).append(slow_hook)
+        hooks._loaded_hooks.append(
+            {"name": "slow", "events": ["message:received"], "path": "/tmp"}
+        )
+
+        adapter = _make_adapter(hooks=hooks)
+        event = _make_event()
+
+        start = time.monotonic()
+
+        async def run():
+            await adapter.handle_message(event)
+            await asyncio.sleep(0.05)
+
+        asyncio.get_event_loop().run_until_complete(run())
+        elapsed = time.monotonic() - start
+
+        # Should have timed out well under 10s (should be ~5-6s total)
+        assert elapsed < 8, f"Timeout took too long: {elapsed:.1f}s"
+        adapter._message_handler.assert_called_once()
+
+    def test_hook_timeout_configurable_via_env(self, tmp_path):
+        """HERMES_HOOK_TIMEOUT env var controls the timeout."""
+        import time
+
+        async def slow_hook(event_type, context):
+            await asyncio.sleep(3)
+
+        hooks = HookRegistry()
+        hooks._handlers.setdefault("message:received", []).append(slow_hook)
+        hooks._loaded_hooks.append(
+            {"name": "slow", "events": ["message:received"], "path": "/tmp"}
+        )
+
+        adapter = _make_adapter(hooks=hooks)
+        event = _make_event()
+
+        with patch.dict(os.environ, {"HERMES_HOOK_TIMEOUT": "0.5"}):
+            start = time.monotonic()
+
+            async def run():
+                await adapter.handle_message(event)
+                await asyncio.sleep(0.05)
+
+            asyncio.get_event_loop().run_until_complete(run())
+            elapsed = time.monotonic() - start
+
+        # Should have timed out at 0.5s
+        assert elapsed < 2, f"Timeout did not respect HERMES_HOOK_TIMEOUT: {elapsed:.1f}s"
+        adapter._message_handler.assert_called_once()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# message:processed — core behavior
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestMessageProcessedBasic:
+    """message:processed hook fires after agent response."""
+
+    def test_processed_fires_after_successful_response(self, tmp_path):
+        """Hook fires with success=True and response text after normal completion."""
+        captured = {}
+
+        async def processed_hook(event_type, context):
+            captured.update(context)
+
+        hooks = HookRegistry()
+        hooks._handlers.setdefault("message:processed", []).append(processed_hook)
+        hooks._loaded_hooks.append(
+            {"name": "processed", "events": ["message:processed"], "path": "/tmp"}
+        )
+
+        adapter = _make_adapter(hooks=hooks)
+        adapter.set_message_handler(AsyncMock(return_value="hello world"))
+        event = _make_event()
+
+        async def run():
+            await adapter.handle_message(event)
+            await asyncio.sleep(0.1)
+
+        asyncio.get_event_loop().run_until_complete(run())
+
+        assert captured.get("success") is True
+        assert captured.get("response") == "hello world"
+        assert captured.get("error") is None
+
+    def test_processed_fires_after_error(self, tmp_path):
+        """Hook fires with success=False and error string when handler raises."""
+        captured = {}
+
+        async def processed_hook(event_type, context):
+            captured.update(context)
+
+        hooks = HookRegistry()
+        hooks._handlers.setdefault("message:processed", []).append(processed_hook)
+        hooks._loaded_hooks.append(
+            {"name": "processed", "events": ["message:processed"], "path": "/tmp"}
+        )
+
+        adapter = _make_adapter(hooks=hooks)
+        adapter.set_message_handler(AsyncMock(side_effect=RuntimeError("test error")))
+
+        # Mock send so the error handler doesn't fail
+        async def mock_send(*args, **kwargs):
+            pass
+
+        event = _make_event()
+        adapter.send = mock_send
+
+        async def run():
+            await adapter.handle_message(event)
+            await asyncio.sleep(0.1)
+
+        asyncio.get_event_loop().run_until_complete(run())
+
+        assert captured.get("success") is False
+        assert "test error" in captured.get("error", "")
+
+    def test_processed_not_fired_when_message_dropped(self, tmp_path):
+        """message:processed does NOT fire when message:received dropped the message."""
+        call_log = []
+
+        async def received_drop(event_type, context):
+            call_log.append("received")
+            context["should_process"] = False
+
+        async def processed_hook(event_type, context):
+            call_log.append("processed")
+
+        hooks = HookRegistry()
+        hooks._handlers.setdefault("message:received", []).append(received_drop)
+        hooks._handlers.setdefault("message:processed", []).append(processed_hook)
+        hooks._loaded_hooks.extend([
+            {"name": "drop", "events": ["message:received"], "path": "/tmp"},
+            {"name": "processed", "events": ["message:processed"], "path": "/tmp"},
+        ])
+
+        adapter = _make_adapter(hooks=hooks)
+        event = _make_event()
+
+        async def run():
+            await adapter.handle_message(event)
+            await asyncio.sleep(0.05)
+
+        asyncio.get_event_loop().run_until_complete(run())
+
+        assert "received" in call_log
+        assert "processed" not in call_log
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# message:processed — context fields
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestMessageProcessedContext:
+    """message:processed context contains response, success, error, event, metadata."""
+
+    def test_processed_context_has_response_and_event(self, tmp_path):
+        """Context includes response text and the original MessageEvent."""
+        captured = {}
+
+        async def hook(event_type, context):
+            captured["response"] = context["response"]
+            captured["event"] = context["event"]
+
+        hooks = HookRegistry()
+        hooks._handlers.setdefault("message:processed", []).append(hook)
+        hooks._loaded_hooks.append(
+            {"name": "test", "events": ["message:processed"], "path": "/tmp"}
+        )
+
+        adapter = _make_adapter(hooks=hooks)
+        adapter.set_message_handler(AsyncMock(return_value="final answer"))
+        event = _make_event(text="original question")
+
+        async def run():
+            await adapter.handle_message(event)
+            await asyncio.sleep(0.1)
+
+        asyncio.get_event_loop().run_until_complete(run())
+
+        assert captured["response"] == "final answer"
+        assert captured["event"].text == "original question"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# message:processed — error handling
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestMessageProcessedErrorHandling:
+    """message:processed hook errors are non-critical."""
+
+    def test_processed_error_does_not_break_cleanup(self, tmp_path):
+        """Hook error in message:processed does not prevent session cleanup."""
+
+        async def bad_hook(event_type, context):
+            raise RuntimeError("processed hook error")
+
+        hooks = HookRegistry()
+        hooks._handlers.setdefault("message:processed", []).append(bad_hook)
+        hooks._loaded_hooks.append(
+            {"name": "bad", "events": ["message:processed"], "path": "/tmp"}
+        )
+
+        adapter = _make_adapter(hooks=hooks)
+        event = _make_event()
+
+        # Should not raise — error should be caught
+        async def run():
+            await adapter.handle_message(event)
+            await asyncio.sleep(0.1)
+
+        # If this raises, the test fails
+        asyncio.get_event_loop().run_until_complete(run())
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Integration / edge cases
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestIntegrationEdgeCases:
+    """Edge cases involving the broader gateway system."""
+
+    def test_hooks_none_attribute_passthrough(self, tmp_path):
+        """adapter._hooks = None (never set): messages process normally."""
+        config = PlatformConfig(enabled=True)
+        adapter = StubAdapter(config, Platform.DISCORD)
+        # _hooks is None by default (never set)
+        adapter.set_message_handler(AsyncMock(return_value="response"))
+        event = _make_event()
+
+        async def run():
+            await adapter.handle_message(event)
+            await asyncio.sleep(0.05)
+
+        asyncio.get_event_loop().run_until_complete(run())
+        adapter._message_handler.assert_called_once()
+
+    def test_set_hooks_after_connect(self, tmp_path):
+        """Setting hooks after initial connect: hooks fire on subsequent messages."""
+        captured = []
+
+        async def hook(event_type, context):
+            captured.append("fired")
+
+        hooks = HookRegistry()
+        hooks._handlers.setdefault("message:received", []).append(hook)
+        hooks._loaded_hooks.append(
+            {"name": "test", "events": ["message:received"], "path": "/tmp"}
+        )
+
+        config = PlatformConfig(enabled=True)
+        adapter = StubAdapter(config, Platform.DISCORD)
+        adapter.set_message_handler(AsyncMock(return_value="response"))
+
+        event1 = _make_event(text="first", message_id="m1")
+        event2 = _make_event(text="second", message_id="m2")
+
+        async def run():
+            # Message before set_hooks
+            await adapter.handle_message(event1)
+            await asyncio.sleep(0.05)
+            # Set hooks
+            adapter.set_hooks(hooks)
+            # Message after set_hooks
+            await adapter.handle_message(event2)
+            await asyncio.sleep(0.05)
+
+        asyncio.get_event_loop().run_until_complete(run())
+
+        # Only event2 should have triggered the hook
+        assert captured == ["fired"]
+
+    def test_hook_with_photo_batching(self, tmp_path):
+        """Photo messages still batch correctly when a hook is registered."""
+        captured = []
+
+        async def hook(event_type, context):
+            captured.append(context["event"].message_id)
+
+        hooks = HookRegistry()
+        hooks._handlers.setdefault("message:received", []).append(hook)
+        hooks._loaded_hooks.append(
+            {"name": "test", "events": ["message:received"], "path": "/tmp"}
+        )
+
+        adapter = _make_adapter(hooks=hooks)
+
+        photo_event1 = _make_event(
+            text="", message_id="photo1", chat_type="dm"
+        )
+        photo_event1.message_type = MessageType.PHOTO
+        photo_event1.media_urls = ["http://example.com/photo1.jpg"]
+        photo_event1.media_types = ["image/jpeg"]
+
+        photo_event2 = _make_event(
+            text="", message_id="photo2", chat_type="dm"
+        )
+        photo_event2.message_type = MessageType.PHOTO
+        photo_event2.media_urls = ["http://example.com/photo2.jpg"]
+        photo_event2.media_types = ["image/jpeg"]
+
+        async def run():
+            await adapter.handle_message(photo_event1)
+            await adapter.handle_message(photo_event2)
+            await asyncio.sleep(0.1)
+
+        asyncio.get_event_loop().run_until_complete(run())
+
+        # Both photos triggered the hook independently
+        assert "photo1" in captured
+        assert "photo2" in captured
+
+    def test_both_hooks_fire_for_same_message(self, tmp_path):
+        """Both message:received and message:processed fire for the same message."""
+        received_log = []
+        processed_log = []
+
+        async def received_hook(event_type, context):
+            received_log.append(context["event"].message_id)
+
+        async def processed_hook(event_type, context):
+            processed_log.append(context["event"].message_id)
+
+        hooks = HookRegistry()
+        hooks._handlers.setdefault("message:received", []).append(received_hook)
+        hooks._handlers.setdefault("message:processed", []).append(processed_hook)
+        hooks._loaded_hooks.extend([
+            {"name": "recv", "events": ["message:received"], "path": "/tmp"},
+            {"name": "proc", "events": ["message:processed"], "path": "/tmp"},
+        ])
+
+        adapter = _make_adapter(hooks=hooks)
+        adapter.set_message_handler(AsyncMock(return_value="response"))
+        event = _make_event(message_id="both_hooks_test")
+
+        async def run():
+            await adapter.handle_message(event)
+            await asyncio.sleep(0.1)
+
+        asyncio.get_event_loop().run_until_complete(run())
+
+        assert received_log == ["both_hooks_test"]
+        assert processed_log == ["both_hooks_test"]
+
+    def test_async_hook_supported(self, tmp_path):
+        """Async hook handlers work correctly."""
+        captured = []
+
+        async def async_hook(event_type, context):
+            await asyncio.sleep(0.01)
+            captured.append("async_ok")
+
+        hooks = HookRegistry()
+        hooks._handlers.setdefault("message:received", []).append(async_hook)
+        hooks._loaded_hooks.append(
+            {"name": "async", "events": ["message:received"], "path": "/tmp"}
+        )
+
+        adapter = _make_adapter(hooks=hooks)
+        event = _make_event()
+
+        async def run():
+            await adapter.handle_message(event)
+            await asyncio.sleep(0.1)
+
+        asyncio.get_event_loop().run_until_complete(run())
+
+        assert captured == ["async_ok"]
+        adapter._message_handler.assert_called_once()
+
+    def test_sync_hook_supported(self, tmp_path):
+        """Sync hook handlers work correctly (legacy support)."""
+        captured = []
+
+        def sync_hook(event_type, context):
+            captured.append("sync_ok")
+
+        hooks = HookRegistry()
+        hooks._handlers.setdefault("message:received", []).append(sync_hook)
+        hooks._loaded_hooks.append(
+            {"name": "sync", "events": ["message:received"], "path": "/tmp"}
+        )
+
+        adapter = _make_adapter(hooks=hooks)
+        event = _make_event()
+
+        async def run():
+            await adapter.handle_message(event)
+            await asyncio.sleep(0.05)
+
+        asyncio.get_event_loop().run_until_complete(run())
+
+        assert captured == ["sync_ok"]
+        adapter._message_handler.assert_called_once()


### PR DESCRIPTION
## What does this PR do?

Adds two gateway hook events — `message:received` and `message:processed` — that fire in `BasePlatformAdapter` for **all 12+ platform adapters** without modifying any adapter code.

### The Problem

Multiple open PRs (#3539, #2764, #3434) independently patch platform adapter source files to answer the same question: *"Should the bot respond to this message?"* Each creates merge conflicts and maintenance burden. There is no extension point between "adapter receives message" and "agent processes message."

### The Solution

Two new hook events in `BasePlatformAdapter.handle_message()`:

**`message:received`** — fires before session registration. Hooks can inspect the message and set `context["should_process"] = False` to silently drop it. Use cases: ambient-mode classifiers, rate limiting, content filtering, analytics.

**`message:processed`** — fires after the agent response is sent (or after an error). Includes response text and success/error state. Use cases: thread participation tracking, response analytics, feedback collection, audit logging.

Because both hooks are in `BasePlatformAdapter` (the universal funnel), they cover Discord, Telegram, Slack, WhatsApp, Signal, Matrix, Email, Mattermost, SMS, HomeAssistant, DingTalk, and Webhook automatically — including any future adapters.

### Example hook

```yaml
# ~/.hermes/hooks/my-classifier/HOOK.yaml
name: my-classifier
description: ML-based response gating
events: ["message:received"]
```

```python
# ~/.hermes/hooks/my-classifier/handler.py
import aiohttp

CLASSIFIER_URL = "http://localhost:8000/classify"
AMBIENT_CHANNELS = {"123456789", "987654321"}

async def handle(event_type, context):
    if context["metadata"]["chat_id"] not in AMBIENT_CHANNELS:
        return  # allow by default

    async with aiohttp.ClientSession() as session:
        resp = await session.post(CLASSIFIER_URL, json={
            "text": context["event"].text,
            "channel": context["metadata"]["chat_id"],
        })
        result = await resp.json()

    if not result.get("should_respond"):
        context["should_process"] = False
```

### Design Decisions

| Decision | Choice | Rationale |
|---|---|---|
| Hook location | `handle_message()` in BasePlatformAdapter | Covers all 12 adapters with zero adapter changes |
| Drop mechanism | `context["should_process"] = False` | Mutable dict, consistent with existing hook pattern |
| Failure mode | Fail-open (allow on error/timeout) | Hooks should never break message delivery |
| Timeout | 5s default, configurable via `HERMES_HOOK_TIMEOUT` | Prevents stuck hooks from blocking pipeline |
| Identity check | `is False` not truthiness | Prevents accidental drops from None/0/"" |
| All hooks run | No short-circuit on first drop | Allows observability hooks to see every message |
| Zero overhead | Skip hook logic when no handlers registered | Attribute + dict check only when unused |

## Related Issue

Relates to #3539 (Telegram wake-word gating), #2764 (Slack auto-respond threads), #3434 (Discord channel routing) — all solve variants of the same problem by patching adapter source.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/base.py` — Add `_hooks` attribute, `set_hooks()` method, `_build_hook_metadata()` method, `message:received` hook call in `handle_message()`, `message:processed` hook call in `_process_message_background()`
- `gateway/hooks.py` — Documentation update only (new event descriptions in docstring)
- `gateway/run.py` — Call `adapter.set_hooks(self.hooks)` at both adapter initialization sites (lines ~1023, ~1255)
- `tests/gateway/test_message_lifecycle_hooks.py` — **New file**: ~350 lines covering normal flow, drop, timeout, error, multiple hooks, edge cases

**No adapter files modified.** All 12 adapters inherit hook support automatically via `BasePlatformAdapter`. Uses existing `self.platform.value` for platform name string.

## How to Test

```bash
# Run new tests
pytest tests/gateway/test_message_lifecycle_hooks.py -v

# Run existing hook tests (verify no regression)
pytest tests/gateway/test_hooks.py -v

# Run existing base adapter tests (verify no regression)
pytest tests/gateway/test_platform_base.py -v

# Full suite
pytest tests/ -q
```

Manual test:
1. Create `~/.hermes/hooks/test-gate/HOOK.yaml` with `events: ["message:received"]`
2. Create `handler.py` that prints context and optionally sets `should_process = False`
3. Start gateway, send message, verify hook fires in logs
4. Set `should_process = False`, verify message silently dropped
5. Clean up: `rm -rf ~/.hermes/hooks/test-gate/`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x (Apple Silicon, Darwin)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — hooks.py docstring updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (HERMES_HOOK_TIMEOUT is env-only, optional)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (hooks architecture unchanged, new events only)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — No platform-specific code; uses only asyncio and dict operations
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

<!-- Will add gateway log output showing hook firing after implementation -->
