### PR TITLE
fix(gateway): register webhook platform and toolset to fix KeyError on agent runs 

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -138,6 +138,7 @@ PLATFORMS = {
     "matrix":   {"label": "💬 Matrix",     "default_toolset": "hermes-matrix"},
     "dingtalk": {"label": "💬 DingTalk",   "default_toolset": "hermes-dingtalk"},
     "api_server": {"label": "🌐 API Server", "default_toolset": "hermes-api-server"},
+    "webhook":    {"label": "🪝 Webhook",    "default_toolset": "hermes-webhook"},
     "mattermost": {"label": "💬 Mattermost", "default_toolset": "hermes-mattermost"},
 }
 

--- a/tests/gateway/test_webhook_toolset.py
+++ b/tests/gateway/test_webhook_toolset.py
@@ -1,0 +1,38 @@
+"""Tests for hermes-webhook toolset and webhook platform registration."""
+from hermes_cli.tools_config import PLATFORMS
+from toolsets import get_toolset, resolve_toolset, validate_toolset
+
+
+class TestHermesWebhookToolset:
+    def test_toolset_exists(self):
+        assert get_toolset("hermes-webhook") is not None
+
+    def test_toolset_validates(self):
+        assert validate_toolset("hermes-webhook")
+
+    def test_toolset_includes_core_tools(self):
+        tools = resolve_toolset("hermes-webhook")
+        for tool in ["web_search", "web_extract", "terminal", "process",
+                     "read_file", "write_file", "patch", "search_files",
+                     "execute_code", "delegate_task", "todo", "memory",
+                     "session_search"]:
+            assert tool in tools, f"Missing expected tool: {tool}"
+
+    def test_toolset_includes_browser_tools(self):
+        tools = resolve_toolset("hermes-webhook")
+        for tool in ["browser_navigate", "browser_snapshot", "browser_click",
+                     "browser_type", "browser_scroll", "browser_back",
+                     "browser_press", "browser_close"]:
+            assert tool in tools, f"Missing browser tool: {tool}"
+
+
+class TestWebhookPlatformConfig:
+    def test_platforms_dict_includes_webhook(self):
+        assert "webhook" in PLATFORMS
+
+    def test_webhook_default_toolset(self):
+        assert PLATFORMS["webhook"]["default_toolset"] == "hermes-webhook"
+
+    def test_webhook_has_label(self):
+        assert "label" in PLATFORMS["webhook"]
+        assert PLATFORMS["webhook"]["label"]

--- a/toolsets.py
+++ b/toolsets.py
@@ -285,6 +285,12 @@ TOOLSETS = {
         "includes": []
     },
     
+    "hermes-webhook": {
+        "description": "Webhook toolset - full access for event-driven agent runs",
+        "tools": _HERMES_CORE_TOOLS,
+        "includes": []
+    },
+
     "hermes-cli": {
         "description": "Full interactive CLI toolset - all default tools plus cronjob management",
         "tools": _HERMES_CORE_TOOLS,


### PR DESCRIPTION
 What does this PR do?

  Webhook-triggered agent runs crashed with KeyError: 'webhook' because the webhook platform had no entry in PLATFORMS (tools_config.py) and no corresponding toolset in TOOLSETS (toolsets.py). When a webhook request was accepted and routed to the gateway, _get_platform_tools() tried to look up PLATFORMS["webhook"] and raised KeyError.

  This PR adds the two missing registrations, following the exact same pattern used by every other first-class platform (api_server, telegram, discord, etc.).

  Related Issue

  Fixes #3773

  Type of Change

  - 🐛 Bug fix (non-breaking change that fixes an issue)
  - ✅ Tests (adding or improving test coverage)

  Changes Made

  - hermes_cli/tools_config.py: added "webhook" entry to PLATFORMS
  - toolsets.py: added "hermes-webhook" toolset using _HERMES_CORE_TOOLS
  - tests/gateway/test_webhook_toolset.py: added toolset and platform registration tests (mirrors test_api_server_toolset.py)

  How to Test

  1. Enable webhook platform in config and start the gateway
  2. Configure a static route with secret: INSECURE_NO_AUTH for local testing
  3. Send a POST to /webhooks/<route> — agent run should complete without KeyError: 'webhook'
  4. Run pytest tests/gateway/test_webhook_toolset.py -q — all 7 tests pass

  Checklist


  - My commit messages follow Conventional Commits
  - My PR contains only changes related to this fix
  - I've run pytest tests/gateway/test_webhook_toolset.py -q and all tests pass
  - I've added tests for my changes

  Documentation & Housekeeping

  - I've updated relevant documentation — N/A 
  - I've updated cli-config.yaml.example if I added/changed config keys — N/A
  - I've considered cross-platform impact — N/A 


