### PR TITLE
feat(skills): support Agent Skills .well-known URI v0.2.0

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -586,17 +586,44 @@ class TestWellKnownSkillSource:
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
     @patch("tools.skills_hub.httpx.get")
-    def test_search_accepts_domain_root_and_resolves_index(self, mock_get, _mock_read_cache, _mock_write_cache):
+    def test_search_domain_root_prefers_v2_path(self, mock_get, _mock_read_cache, _mock_write_cache):
+        """Domain root: v0.2.0 path tried first; if it succeeds, v0.1.0 is never fetched."""
         mock_get.return_value = MagicMock(
             status_code=200,
-            json=lambda: {"skills": [{"name": "git-workflow", "description": "Git rules", "files": ["SKILL.md"]}]},
+            json=lambda: {
+                "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+                "skills": [{"name": "agent", "type": "skill-md", "description": "Agent skill",
+                             "url": "/.well-known/agent-skills/agent/SKILL.md"}],
+            },
         )
 
         results = self._source().search("https://example.com", limit=10)
 
         assert len(results) == 1
-        called_url = mock_get.call_args.args[0]
-        assert called_url == "https://example.com/.well-known/skills/index.json"
+        first_called_url = mock_get.call_args_list[0].args[0]
+        assert first_called_url == "https://example.com/.well-known/agent-skills/index.json"
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub.httpx.get")
+    def test_search_domain_root_falls_back_to_v1_when_v2_missing(self, mock_get, _mock_read_cache, _mock_write_cache):
+        """Domain root: falls back to v0.1.0 path when v0.2.0 endpoint returns 404."""
+        def fake_get(url, *args, **kwargs):
+            if "agent-skills" in url:
+                return MagicMock(status_code=404)
+            return MagicMock(
+                status_code=200,
+                json=lambda: {"skills": [{"name": "git-workflow", "description": "Git rules", "files": ["SKILL.md"]}]},
+            )
+        mock_get.side_effect = fake_get
+
+        results = self._source().search("https://example.com", limit=10)
+
+        assert len(results) == 1
+        assert results[0].name == "git-workflow"
+        urls_called = [c.args[0] for c in mock_get.call_args_list]
+        assert "https://example.com/.well-known/agent-skills/index.json" in urls_called
+        assert "https://example.com/.well-known/skills/index.json" in urls_called
 
     @patch("tools.skills_hub._write_index_cache")
     @patch("tools.skills_hub._read_index_cache", return_value=None)
@@ -647,6 +674,92 @@ class TestWellKnownSkillSource:
         assert bundle.source == "well-known"
         assert bundle.files["SKILL.md"] == "# Code Review\n"
         assert bundle.files["references/checklist.md"] == "- [ ] security\n"
+
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub.httpx.get")
+    def test_search_v2_index_normalises_url_field(self, mock_get, _mock_read_cache, _mock_write_cache):
+        """v0.2.0 entries with a ``url`` field are normalised to files+identifier."""
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {
+                "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+                "skills": [
+                    {
+                        "name": "agent",
+                        "type": "skill-md",
+                        "description": "Agent skill",
+                        "url": "/.well-known/agent-skills/agent/SKILL.md",
+                        "digest": "sha256:abc123",
+                    }
+                ],
+            },
+        )
+
+        results = self._source().search(
+            "https://example.com/.well-known/agent-skills/index.json", limit=10
+        )
+
+        assert len(results) == 1
+        assert results[0].name == "agent"
+        assert results[0].identifier == "well-known:https://example.com/.well-known/agent-skills/agent"
+        assert results[0].source == "well-known"
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub.httpx.get")
+    def test_fetch_v2_skill_downloads_from_derived_url(self, mock_get, _mock_read_cache, _mock_write_cache):
+        """v0.2.0 fetch resolves the skill file URL from the normalised entry."""
+        def fake_get(url, *args, **kwargs):
+            if url.endswith("/index.json"):
+                return MagicMock(status_code=200, json=lambda: {
+                    "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+                    "skills": [{
+                        "name": "agent",
+                        "type": "skill-md",
+                        "description": "Agent skill",
+                        "url": "/.well-known/agent-skills/agent/SKILL.md",
+                    }],
+                })
+            if url.endswith("/agent/SKILL.md"):
+                return MagicMock(status_code=200, text="---\nname: agent\ndescription: Agent skill\n---\n\n# Agent\n")
+            raise AssertionError(f"Unexpected URL: {url}")
+
+        mock_get.side_effect = fake_get
+
+        bundle = self._source().fetch(
+            "well-known:https://example.com/.well-known/agent-skills/agent"
+        )
+
+        assert bundle is not None
+        assert bundle.source == "well-known"
+        assert "SKILL.md" in bundle.files
+        assert bundle.files["SKILL.md"].startswith("---")
+
+    @patch("tools.skills_hub._write_index_cache")
+    @patch("tools.skills_hub._read_index_cache", return_value=None)
+    @patch("tools.skills_hub.httpx.get")
+    def test_v2_unknown_type_entries_skipped(self, mock_get, _mock_read_cache, _mock_write_cache):
+        """v0.2.0 entries with an unknown ``type`` are skipped gracefully."""
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {
+                "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+                "skills": [
+                    {"name": "future-type", "type": "unknown-future", "url": "/x/y.md"},
+                    {"name": "agent", "type": "skill-md", "description": "Agent skill",
+                     "url": "/.well-known/agent-skills/agent/SKILL.md"},
+                ],
+            },
+        )
+
+        results = self._source().search(
+            "https://example.com/.well-known/agent-skills/index.json", limit=10
+        )
+
+        assert len(results) == 1
+        assert results[0].name == "agent"
 
 
 class TestCheckForSkillUpdates:

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -624,9 +624,20 @@ class GitHubSource(SkillSource):
 # ---------------------------------------------------------------------------
 
 class WellKnownSkillSource(SkillSource):
-    """Read skills from a domain exposing /.well-known/skills/index.json."""
+    """Read skills from a domain exposing the Agent Skills .well-known URI.
 
-    BASE_PATH = "/.well-known/skills"
+    Supports both spec versions:
+      v0.2.0 — /.well-known/agent-skills/index.json  (tried first)
+      v0.1.0 — /.well-known/skills/index.json        (fallback)
+
+    v0.2.0 index entries use an explicit ``url`` field pointing directly to
+    the skill file (e.g. ``/.well-known/agent-skills/agent/SKILL.md``) instead
+    of a ``files`` array. This adapter normalises both formats so all
+    downstream methods (search / inspect / fetch) work identically.
+    """
+
+    AGENT_SKILLS_PATH = "/.well-known/agent-skills"  # v0.2.0
+    BASE_PATH = "/.well-known/skills"                 # v0.1.0
 
     def source_id(self) -> str:
         return "well-known"
@@ -635,11 +646,7 @@ class WellKnownSkillSource(SkillSource):
         return "community"
 
     def search(self, query: str, limit: int = 10) -> List[SkillMeta]:
-        index_url = self._query_to_index_url(query)
-        if not index_url:
-            return []
-
-        parsed = self._parse_index(index_url)
+        parsed = self._resolve_index(query)
         if not parsed:
             return []
 
@@ -735,16 +742,48 @@ class WellKnownSkillSource(SkillSource):
             },
         )
 
-    def _query_to_index_url(self, query: str) -> Optional[str]:
+    # ------------------------------------------------------------------
+    # Index resolution (v0.2.0 first, v0.1.0 fallback)
+    # ------------------------------------------------------------------
+
+    def _resolve_index(self, query: str) -> Optional[dict]:
+        """Try each candidate index URL in order and return the first that parses."""
+        for url in self._candidate_index_urls(query):
+            result = self._parse_index(url)
+            if result is not None:
+                return result
+        return None
+
+    def _candidate_index_urls(self, query: str) -> List[str]:
+        """Return ordered list of index.json URLs to try for a query string.
+
+        - Explicit index.json URL → use as-is (single candidate).
+        - URL containing a known path prefix → resolve to that index.
+        - Domain root → try v0.2.0 path first, then v0.1.0 fallback.
+        """
         query = query.strip()
         if not query.startswith(("http://", "https://")):
-            return None
+            return []
         if query.endswith("/index.json"):
-            return query
-        if f"{self.BASE_PATH}/" in query:
-            base_url = query.split(f"{self.BASE_PATH}/", 1)[0] + self.BASE_PATH
-            return f"{base_url}/index.json"
-        return query.rstrip("/") + f"{self.BASE_PATH}/index.json"
+            return [query]
+        for path in (self.AGENT_SKILLS_PATH, self.BASE_PATH):
+            if f"{path}/" in query:
+                base_url = query.split(f"{path}/", 1)[0] + path
+                return [f"{base_url}/index.json"]
+        base = query.rstrip("/")
+        return [
+            f"{base}{self.AGENT_SKILLS_PATH}/index.json",
+            f"{base}{self.BASE_PATH}/index.json",
+        ]
+
+    # ------------------------------------------------------------------
+    # Identifier parsing
+    # ------------------------------------------------------------------
+
+    def _query_to_index_url(self, query: str) -> Optional[str]:
+        """Return primary candidate index URL (kept for internal use)."""
+        urls = self._candidate_index_urls(query)
+        return urls[0] if urls else None
 
     def _parse_identifier(self, identifier: str) -> Optional[dict]:
         raw = identifier[len("well-known:"):] if identifier.startswith("well-known:") else identifier
@@ -773,18 +812,25 @@ class WellKnownSkillSource(SkillSource):
         else:
             skill_url = clean_url.rstrip("/")
 
-        if f"{self.BASE_PATH}/" not in skill_url:
-            return None
+        # Accept both v0.2.0 and v0.1.0 path prefixes
+        for path in (self.AGENT_SKILLS_PATH, self.BASE_PATH):
+            if f"{path}/" in skill_url:
+                base_url, skill_name = skill_url.rsplit("/", 1)
+                return {
+                    "index_url": f"{base_url}/index.json",
+                    "base_url": base_url,
+                    "skill_name": skill_name,
+                    "skill_url": skill_url,
+                }
 
-        base_url, skill_name = skill_url.rsplit("/", 1)
-        return {
-            "index_url": f"{base_url}/index.json",
-            "base_url": base_url,
-            "skill_name": skill_name,
-            "skill_url": skill_url,
-        }
+        return None
+
+    # ------------------------------------------------------------------
+    # Index fetch + normalisation
+    # ------------------------------------------------------------------
 
     def _parse_index(self, index_url: str) -> Optional[dict]:
+        """Fetch and normalise an index.json, handling both v0.1.0 and v0.2.0."""
         cache_key = f"well_known_index_{hashlib.md5(index_url.encode()).hexdigest()}"
         cached = _read_index_cache(cache_key)
         if isinstance(cached, dict) and isinstance(cached.get("skills"), list):
@@ -802,13 +848,50 @@ class WellKnownSkillSource(SkillSource):
         if not isinstance(skills, list):
             return None
 
+        base_url = index_url[:-len("/index.json")]
+        normalised = self._normalise_entries(skills, base_url, index_url)
+
         parsed = {
             "index_url": index_url,
-            "base_url": index_url[:-len("/index.json")],
-            "skills": skills,
+            "base_url": base_url,
+            "skills": normalised,
         }
         _write_index_cache(cache_key, parsed)
         return parsed
+
+    def _normalise_entries(
+        self, entries: list, base_url: str, index_url: str
+    ) -> list:
+        """Normalise v0.2.0 entries to the v0.1.0 shape used by the rest of the adapter.
+
+        v0.2.0 entries have a ``url`` field (domain-relative path to the skill
+        file) instead of a ``files`` array. This method converts them so all
+        downstream code only needs to handle one format:
+          - ``files``: list of relative filenames within the skill directory
+          - The entry's ``name`` continues to identify the skill directory under base_url
+        """
+        result = []
+        parsed_base = urlparse(index_url)
+        domain = f"{parsed_base.scheme}://{parsed_base.netloc}"
+
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            if "url" in entry and "files" not in entry:
+                # v0.2.0: derive files and skill_url from the explicit url field
+                skill_type = entry.get("type", "skill-md")
+                if skill_type != "skill-md":
+                    # Unknown type — skip rather than guess
+                    continue
+                rel_url = entry["url"]  # e.g. "/.well-known/agent-skills/agent/SKILL.md"
+                parts = rel_url.rstrip("/").rsplit("/", 1)
+                if len(parts) != 2:
+                    continue
+                filename = parts[1]  # "SKILL.md"
+                entry = dict(entry)
+                entry["files"] = [filename]
+            result.append(entry)
+        return result
 
     def _index_entry(self, index_url: str, skill_name: str) -> Optional[dict]:
         parsed = self._parse_index(index_url)


### PR DESCRIPTION
 What does this PR do?                                                                                                                                                                                     
                                                                                                                                                                                                            
  Agent Skills spec v0.2.0 changed two things: the endpoint path (/.well-known/skills/ → /.well-known/agent-skills/) and the index entry format (files[] array → explicit url field pointing directly to the skill file). This broke hermes skills install well-known:... for all domains that had migrated to v0.2.0, including agentskills.io.                                                                      
  
  WellKnownSkillSource now:                                                                                                                                                                                 
  - Tries /.well-known/agent-skills/index.json (v0.2.0) first when given a domain root
  - Falls back to /.well-known/skills/index.json (v0.1.0) if the v0.2.0 endpoint returns 404                                                                                                                
  - Normalises v0.2.0 url-field entries into the internal files[] shape so all downstream fetch/inspect/search paths work without branching
  - Skips entries with unknown type values gracefully instead of erroring                                                                                                                                   
                                                                                                                                                                                                            
  Related Issue                                                                                                                                                                                             
                                                                                                                                                                                                             #3781                                                                                                                                                                                               
                                                            
  Type of Change

  - ✨ New feature (non-breaking change that adds functionality)
  - ✅ Tests (adding or improving test coverage)
                                                                                                                                                                                                            
  Changes Made
                                                                                                                                                                                                            
  - tools/skills_hub.py: added AGENT_SKILLS_PATH constant and _resolve_index / _candidate_index_urls / _normalise_entries methods to WellKnownSkillSource; updated _parse_identifier to recognise both path  prefixes
  - tests/tools/test_skills_hub.py: 4 new tests covering domain root fallback, v0.2.0 normalisation, v0.2.0 fetch, and unknown type skipping; updated existing domain root test to reflect v0.2.0-first behaviour                                                                                                                                                                                                 
  
  How to Test                                                                                                                                                                                               
                                                            
  1. hermes skills install well-known:https://agentskills.io — should succeed (v0.2.0 endpoint)                                                                                                             
  2. hermes skills install well-known:https://<v1-domain> — should still succeed (v0.1.0 fallback)
  3. pytest tests/tools/test_skills_hub.py::TestWellKnownSkillSource -q — 8 passed                                                                                                                          
                                                                                                                                                                                                            
  Checklist                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                
  - My commit messages follow Conventional Commits
  - My PR contains only changes related to this feature
  - I've run pytest tests/tools/test_skills_hub.py::TestWellKnownSkillSource -q and all tests pass                                                                                                          
  - I've added tests for my changes                                                                                                                                                                         
  - Backward compatible — v0.1.0 endpoints continue working unchanged                                                                                                                                       
                                                                                                                                                                                                            
  Documentation & Housekeeping                              
                                                                                                                                                                                                            
  - Documentation update — N/A (
  - Cross-platform impact considered — N/A
             