### PR TITLE
fix(security): extend secret redaction to ElevenLabs, Tavily and Exa API keys

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -37,6 +37,9 @@ _PREFIX_PATTERNS = [
     r"dop_v1_[A-Za-z0-9]{10,}",         # DigitalOcean PAT
     r"doo_v1_[A-Za-z0-9]{10,}",         # DigitalOcean OAuth
     r"am_[A-Za-z0-9_-]{10,}",           # AgentMail API key
+    r"sk_[A-Za-z0-9_]{10,}",            # ElevenLabs TTS key (sk_ with underscore, not caught by sk-)
+    r"tvly-[A-Za-z0-9]{10,}",           # Tavily search API key
+    r"exa_[A-Za-z0-9]{10,}",            # Exa search API key
 ]
 
 # ENV assignment patterns: KEY=value where KEY contains a secret-like name

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -201,3 +201,74 @@ class TestSecretCapturePayloadRedaction:
         text = '{"raw_secret": "ghp_abc123def456ghi789jkl"}'
         result = redact_sensitive_text(text)
         assert "abc123def456" not in result
+
+
+class TestMissingProviderKeys:
+    """Regression tests for provider keys previously not covered by redaction.
+
+    These keys were leaked in plain text to logs and tool output because
+    their prefixes were absent from _PREFIX_PATTERNS.
+    """
+
+    def test_elevenlabs_key_redacted(self):
+        """ElevenLabs TTS keys start with sk_ (underscore), not sk- (dash).
+        The existing sk- pattern did NOT catch these."""
+        text = "ELEVENLABS_API_KEY=sk_xxxxxxxx11labs0000000000000000"
+        result = redact_sensitive_text(text)
+        assert "abc123def456" not in result
+
+    def test_elevenlabs_key_in_log_line(self):
+        """ElevenLabs key appearing inline in a log message."""
+        text = "Connecting to ElevenLabs with key sk_xxxxxxxx11labs0000000000000000"
+        result = redact_sensitive_text(text)
+        assert "abc123def456" not in result
+        assert "sk_pro" in result  # prefix preserved for debuggability
+
+    def test_elevenlabs_key_not_confused_with_stripe(self):
+        """sk_live_ and sk_test_ (Stripe) are already covered — make sure
+        the new sk_ pattern doesn't double-match or break Stripe coverage."""
+        stripe_live = "sk_live_xxxxxxxxxxxxxxxxxxxxxxx"
+        stripe_test = "sk_test_xxxxxxxxxxxxxxxxxxxxxxx"
+        for key in [stripe_live, stripe_test]:
+            result = redact_sensitive_text(key)
+            assert "abc123def456" not in result
+
+    def test_tavily_key_redacted(self):
+        """Tavily search API keys use tvly- prefix."""
+        text = "TAVILY_API_KEY=tvly-FAKEKEY0000000000000000000"
+        result = redact_sensitive_text(text)
+        assert "abc123def456" not in result
+
+    def test_tavily_key_in_log_line(self):
+        """Tavily key appearing inline in a log message."""
+        text = "Initialising Tavily client with tvly-FAKEKEY0000000000000000000"
+        result = redact_sensitive_text(text)
+        assert "abc123def456" not in result
+        assert "tvly-a" in result  # prefix preserved
+
+    def test_exa_key_redacted(self):
+        """Exa search API keys use exa_ prefix."""
+        text = "EXA_API_KEY=exa_FAKEKEY00000000000000000000"
+        result = redact_sensitive_text(text)
+        assert "abc123def456" not in result
+
+    def test_exa_key_in_log_line(self):
+        """Exa key appearing inline in a log message."""
+        text = "Using Exa client with key exa_FAKEKEY00000000000000000000"
+        result = redact_sensitive_text(text)
+        assert "abc123def456" not in result
+        assert "exa_ab" in result  # prefix preserved
+
+    def test_all_three_in_env_dump(self):
+        """Simulate printenv output containing all three previously-missed keys."""
+        env_dump = (
+            "HOME=/home/user\n"
+            "ELEVENLABS_API_KEY=sk_xxxxxxxx11labs0000000000000000\n"
+            "TAVILY_API_KEY=tvly-FAKEKEY0000000000000000000\n"
+            "EXA_API_KEY=exa_FAKEKEY00000000000000000000\n"
+            "SHELL=/bin/bash\n"
+        )
+        result = redact_sensitive_text(env_dump)
+        assert "abc123def456" not in result
+        assert "HOME=/home/user" in result
+        assert "SHELL=/bin/bash" in result


### PR DESCRIPTION
## What does this PR do?

Three provider API keys used by Hermes were leaking in plain text to
logs and tool output because their prefixes were missing from
`_PREFIX_PATTERNS` in `agent/redact.py`.

**ElevenLabs TTS keys** start with `sk_` (underscore). The existing
pattern only covers `sk-` (dash). One character difference — completely
missed.

**Tavily search keys** use a `tvly-` prefix. No pattern existed.

**Exa search keys** use an `exa_` prefix. No pattern existed.

All three providers are actively used by Hermes (TTS, web search).
Running `printenv` or any command that dumps environment variables would
expose these keys in full.

## Related Issue

No existing issue — this is a proactive security fix.

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `agent/redact.py`:
  - Added `r"sk_[A-Za-z0-9_]{10,}"` — ElevenLabs TTS key
  - Added `r"tvly-[A-Za-z0-9]{10,}"` — Tavily search API key
  - Added `r"exa_[A-Za-z0-9]{10,}"` — Exa search API key

- `tests/agent/test_redact.py`:
  - Added `TestMissingProviderKeys` class with new test cases
  - Covers inline log lines and env dump format

## How to Test

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] No duplicate PR found
- [x] PR contains only this security fix
- [x] pytest passes
- [x] Tests added for the fix
- [x] Tested on: Ubuntu 24.04
- [x] Cross-platform: pure regex, no OS calls — N/A