### PR TITLE
fix: add Shift+Enter keybinding for multiline input

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6319,6 +6319,11 @@ class HermesCLI:
             """Alt+Enter inserts a newline for multi-line input."""
             event.current_buffer.insert_text('\n')
 
+        @kb.add('s-enter')
+        def handle_shift_enter(event):
+            """Shift+Enter inserts a newline for multi-line input."""
+            event.current_buffer.insert_text('\n')
+
         @kb.add('c-j')
         def handle_ctrl_enter(event):
             """Ctrl+Enter (c-j) inserts a newline. Most terminals send c-j for Ctrl+Enter."""


### PR DESCRIPTION
## Problem

The comment on the TextArea creation (line 6644) says:

```python
# Create the input area with multiline (shift+enter), autocomplete, and paste handling
```

But only Alt+Enter (`escape, enter`) and Ctrl+Enter (`c-j`) were actually bound. Shift+Enter did nothing — pressing it just submitted the input like regular Enter.

Other CLI agents (Claude Code, Amp, etc.) use Shift+Enter for newlines, so this is a natural expectation.

## Fix

Added `s-enter` keybinding to insert a newline, matching the existing Alt+Enter and Ctrl+Enter behavior:

```python
@kb.add('s-enter')
def handle_shift_enter(event):
    """Shift+Enter inserts a newline for multi-line input."""
    event.current_buffer.insert_text('\n')
```

5-line change, no side effects. Works in Ghostty — haven't tested other terminals but `prompt_toolkit` handles `s-enter` natively.