### PR TITLE
fix(setup): auto-install matrix-nio during hermes setup

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6500,6 +6500,24 @@ class HermesCLI:
             self._should_exit = True
             event.app.exit()
 
+        @kb.add('c-z')
+        def handle_ctrl_z(event):
+            """Handle Ctrl+Z - suspend process to background (Unix only)."""
+            import sys
+            if sys.platform == 'win32':
+                _cprint(f"\n{_DIM}Suspend (Ctrl+Z) is not supported on Windows.{_RST}")
+                event.app.invalidate()
+                return
+            import os, signal as _sig
+            from prompt_toolkit.application import run_in_terminal
+            from hermes_cli.skin_engine import get_active_skin
+            agent_name = get_active_skin().get_branding("agent_name", "Hermes Agent")
+            msg = f"\n{agent_name} has been suspended. Run `fg` to bring {agent_name} back."
+            def _suspend():
+                os.write(1, msg.encode())
+                os.kill(0, _sig.SIGTSTP)
+            run_in_terminal(_suspend)
+
         # Voice push-to-talk key: configurable via config.yaml (voice.record_key)
         # Default: Ctrl+B (avoids conflict with Ctrl+R readline reverse-search)
         # Config uses "ctrl+b" format; prompt_toolkit expects "c-b" format.


### PR DESCRIPTION
## Summary

Salvaged from PR #1978 by @Gutslabs and PR #1979 by @cutepawss — applied onto current main with authorship preserved.

Setup previously only printed a manual install hint for `matrix-nio`, causing the gateway to crash with "matrix-nio not installed" after configuring Matrix. Now auto-installs the package during setup.

**Changes:**

- **`hermes_cli/setup.py`** — Replaces the manual hint with auto-install logic using the same uv-first/pip-fallback pattern as Daytona and Modal backends. Installs `matrix-nio[e2e]` when E2EE is enabled, plain `matrix-nio` otherwise. (from #1978)
- **`pyproject.toml`** — Adds `hermes-agent[matrix]` to the `[all]` extra so `pip install hermes-agent[all]` includes it. (from #1978 and #1979)
- **`tests/test_project_metadata.py`** — Regression test ensuring `hermes-agent[matrix]` stays in the `[all]` group. (from #1979)

Closes #1978, closes #1979
