### PR TITLE
feat: add Gemini 3.1 preview models to OpenRouter and Nous catalogs

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -64,6 +64,8 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "openai/gpt-5.3-codex",
         "google/gemini-3-pro-preview",
         "google/gemini-3-flash-preview",
+        "google/gemini-3.1-pro-preview",
+        "google/gemini-3.1-flash-lite-preview",
         "qwen/qwen3.5-plus-02-15",
         "qwen/qwen3.5-35b-a3b",
         "stepfun/step-3.5-flash",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -35,6 +35,8 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("openai/gpt-5.3-codex",            ""),
     ("google/gemini-3-pro-preview",     ""),
     ("google/gemini-3-flash-preview",   ""),
+    ("google/gemini-3.1-pro-preview",     ""),
+    ("google/gemini-3.1-flash-lite-preview",   ""),
     ("qwen/qwen3.5-plus-02-15",         ""),
     ("qwen/qwen3.5-35b-a3b",            ""),
     ("stepfun/step-3.5-flash",          ""),


### PR DESCRIPTION
## Summary

Adds Gemini 3.1 preview models to the model catalog:
- `google/gemini-3.1-pro-preview` (frontier reasoning)
- `google/gemini-3.1-flash-lite-preview` (high-efficiency)

Both model IDs confirmed live on OpenRouter.

## Changes

- Added to `OPENROUTER_MODELS` list (cherry-picked from PR #3756 by @TypQxQ)
- Also added to `_PROVIDER_MODELS["nous"]` list (was missing from original PR)

Closes #3753. Salvaged from #3756 with completeness fix.
EOF; __hermes_rc=$?; printf '__HERMES_FENCE_a9f7b3__'; exit $__hermes_rc
