### PR TITLE
fix(auth): stop silently falling back to OpenRouter when no provider is configured

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -26,6 +26,7 @@ except ImportError:
         msvcrt = None
 from pathlib import Path
 from hermes_constants import get_hermes_home
+from hermes_cli.config import load_config
 from typing import Optional
 
 from hermes_time import now as _hermes_now
@@ -164,18 +165,29 @@ def _deliver_result(job: dict, content: str) -> None:
         logger.warning("Job '%s': platform '%s' not configured/enabled", job["id"], platform_name)
         return
 
-    # Wrap the content so the user knows this is a cron delivery and that
-    # the interactive agent has no visibility into it.
-    task_name = job.get("name", job["id"])
-    wrapped = (
-        f"Cronjob Response: {task_name}\n"
-        f"-------------\n\n"
-        f"{content}\n\n"
-        f"Note: The agent cannot see this message, and therefore cannot respond to it."
-    )
+    # Optionally wrap the content with a header/footer so the user knows this
+    # is a cron delivery.  Wrapping is on by default; set cron.wrap_response: false
+    # in config.yaml for clean output.
+    wrap_response = True
+    try:
+        user_cfg = load_config()
+        wrap_response = user_cfg.get("cron", {}).get("wrap_response", True)
+    except Exception:
+        pass
+
+    if wrap_response:
+        task_name = job.get("name", job["id"])
+        delivery_content = (
+            f"Cronjob Response: {task_name}\n"
+            f"-------------\n\n"
+            f"{content}\n\n"
+            f"Note: The agent cannot see this message, and therefore cannot respond to it."
+        )
+    else:
+        delivery_content = content
 
     # Run the async send in a fresh event loop (safe from any thread)
-    coro = _send_to_platform(platform, pconfig, chat_id, wrapped, thread_id=thread_id)
+    coro = _send_to_platform(platform, pconfig, chat_id, delivery_content, thread_id=thread_id)
     try:
         result = asyncio.run(coro)
     except RuntimeError:
@@ -186,7 +198,7 @@ def _deliver_result(job: dict, content: str) -> None:
         coro.close()
         import concurrent.futures
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-            future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, wrapped, thread_id=thread_id))
+            future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, delivery_content, thread_id=thread_id))
             result = future.result(timeout=30)
     except Exception as e:
         logger.error("Job '%s': delivery to %s:%s failed: %s", job["id"], platform_name, chat_id, e)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -429,6 +429,12 @@ DEFAULT_CONFIG = {
         },
     },
 
+    "cron": {
+        # Wrap delivered cron responses with a header (task name) and footer
+        # ("The agent cannot see this message").  Set to false for clean output.
+        "wrap_response": True,
+    },
+
     # Config schema version - bump this when adding new required fields
     "_config_version": 10,
 }

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -167,6 +167,32 @@ class TestDeliverResultWrapping:
         sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
         assert "Cronjob Response: abc-123" in sent_content
 
+    def test_delivery_skips_wrapping_when_config_disabled(self):
+        """When cron.wrap_response is false, deliver raw content without header/footer."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}):
+            job = {
+                "id": "test-job",
+                "name": "daily-report",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+            }
+            _deliver_result(job, "Clean output only.")
+
+        send_mock.assert_called_once()
+        sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
+        assert sent_content == "Clean output only."
+        assert "Cronjob Response" not in sent_content
+        assert "The agent cannot see" not in sent_content
+
     def test_no_mirror_to_session_call(self):
         """Cron deliveries should NOT mirror into the gateway session."""
         from gateway.config import Platform


### PR DESCRIPTION
## Summary

Stops Hermes from silently falling back to OpenRouter + Claude Opus when no provider is configured. Users now get a clear error with setup instructions instead of being routed to a provider they never intended.

Motivated by [a user in Discord](https://discord.com) who set `provider: lmstudio`, got "Unknown provider 'lmstudio'", reinstalled, and then had their local Qwen 3.5 9B model confidently claiming to be Claude Opus via OpenRouter — because every fallback path defaulted there.

## Changes

**auth.py:**
- `resolve_provider()` final fallback now raises `AuthError("No inference provider configured. Run 'hermes model'...")` instead of silently returning `"openrouter"`
- Added local server aliases: `lmstudio`, `lm-studio`, `lm_studio`, `ollama`, `vllm`, `llamacpp`, `llama.cpp`, `llama-cpp` → all map to `"custom"`

**gateway/run.py + cron/scheduler.py:**
- Removed hardcoded `"anthropic/claude-opus-4.6"` model fallback — these now use `""` and read from config.yaml like everything else

**cli-config.yaml.example:**
- Complete provider documentation listing all supported providers, required keys, and local server setup instructions with examples

## What this prevents

- User configures a local server but misspells the provider → clear error instead of silent OpenRouter routing
- Fresh install with no API keys → clear "run hermes model" guidance instead of trying OpenRouter with no key
- Local Qwen/Llama model claiming to be Claude because the default model name was `anthropic/claude-opus-4.6`

## Tests
- 258 auth/provider/fallback tests pass
- Updated `test_auto_does_not_select_copilot_from_github_token` to expect AuthError instead of "openrouter" fallback
