### PR TITLE
fix(agent): user-friendly 429 rate limit messages with Retry-After support

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7229,7 +7229,10 @@ class AIAgent:
                             retry_count = 0
                             continue
                         _final_summary = self._summarize_api_error(api_error)
-                        self._vprint(f"{self.log_prefix}❌ Max retries ({max_retries}) exceeded. Giving up.", force=True)
+                        if is_rate_limited:
+                            self._vprint(f"{self.log_prefix}❌ Rate limit persisted after {max_retries} retries. Please try again later.", force=True)
+                        else:
+                            self._vprint(f"{self.log_prefix}❌ Max retries ({max_retries}) exceeded. Giving up.", force=True)
                         self._vprint(f"{self.log_prefix}   💀 Final error: {_final_summary}", force=True)
 
                         # Detect SSE stream-drop pattern (e.g. "Network
@@ -7289,8 +7292,22 @@ class AIAgent:
                             "error": _final_summary,
                         }
 
-                    wait_time = min(2 ** retry_count, 60)  # Exponential backoff: 2s, 4s, 8s, 16s, 32s, 60s, 60s
-                    self._emit_status(f"⏳ Retrying in {wait_time}s (attempt {retry_count}/{max_retries})...")
+                    # For rate limits, respect the Retry-After header if present
+                    _retry_after = None
+                    if is_rate_limited:
+                        _resp_headers = getattr(getattr(api_error, "response", None), "headers", None)
+                        if _resp_headers and hasattr(_resp_headers, "get"):
+                            _ra_raw = _resp_headers.get("retry-after") or _resp_headers.get("Retry-After")
+                            if _ra_raw:
+                                try:
+                                    _retry_after = min(int(_ra_raw), 120)  # Cap at 2 minutes
+                                except (TypeError, ValueError):
+                                    pass
+                    wait_time = _retry_after if _retry_after else min(2 ** retry_count, 60)
+                    if is_rate_limited:
+                        self._emit_status(f"⏱️ Rate limit reached. Waiting {wait_time}s before retry (attempt {retry_count + 1}/{max_retries})...")
+                    else:
+                        self._emit_status(f"⏳ Retrying in {wait_time}s (attempt {retry_count}/{max_retries})...")
                     logger.warning(
                         "Retrying API call in %ss (attempt %s/%s) %s error=%s",
                         wait_time,


### PR DESCRIPTION
Salvage of #1835 by @ygd58 onto current main. References #1826.

## Summary

When hitting rate limits (429), the agent now:

- **Retry-After header support**: Extracts `Retry-After` from the provider response and uses it as the wait time instead of blind exponential backoff (capped at 120s)
- **Rate-limit-specific retry message**: `⏱️ Rate limit reached. Waiting 7s before retry (attempt 2/3)...` instead of generic retry text
- **Rate-limit-specific exhaustion message**: `❌ Rate limit persisted after N retries. Please try again later.` instead of generic `Max retries exceeded`

Non-429 errors keep the existing exponential backoff and generic messaging. All messaging goes through `_emit_status` (safe for CLI + gateway).

## Dropped from original PR

- Countdown progress bar (`\r` carriage return through `_vprint` — risky with prompt_toolkit's `patch_stdout`)
- Unrelated `delegate_tool.py` change (stale pattern, doesn't match current code)

## Testing

- 215/215 run_agent tests pass
- Live tested: mock 429 with `Retry-After: 7` header → agent correctly waited 7s (not 2s exponential), showed rate-limit-specific message, retried successfully

---
Original PR: #1835 by @ygd58