### PR TITLE
fix(banner): show honcho tools as available when configured

### DIFF
--- a/tests/tools/test_honcho_tools.py
+++ b/tests/tools/test_honcho_tools.py
@@ -1,9 +1,84 @@
 """Regression tests for per-call Honcho tool session routing."""
 
 import json
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+from dataclasses import dataclass
 
 from tools import honcho_tools
+
+
+class TestCheckHonchoAvailable:
+    """Tests for _check_honcho_available (banner + runtime gating)."""
+
+    def setup_method(self):
+        self.orig_manager = honcho_tools._session_manager
+        self.orig_key = honcho_tools._session_key
+
+    def teardown_method(self):
+        honcho_tools._session_manager = self.orig_manager
+        honcho_tools._session_key = self.orig_key
+
+    def test_returns_true_when_session_active(self):
+        """Fast path: session context already injected (mid-conversation)."""
+        honcho_tools._session_manager = MagicMock()
+        honcho_tools._session_key = "test-key"
+        assert honcho_tools._check_honcho_available() is True
+
+    def test_returns_true_when_configured_but_no_session(self):
+        """Slow path: honcho configured but agent not started yet (banner time)."""
+        honcho_tools._session_manager = None
+        honcho_tools._session_key = None
+
+        @dataclass
+        class FakeConfig:
+            enabled: bool = True
+            api_key: str = "test-key"
+            base_url: str = None
+
+        with patch("tools.honcho_tools.HonchoClientConfig", create=True):
+            with patch(
+                "honcho_integration.client.HonchoClientConfig"
+            ) as mock_cls:
+                mock_cls.from_global_config.return_value = FakeConfig()
+                assert honcho_tools._check_honcho_available() is True
+
+    def test_returns_false_when_not_configured(self):
+        """No session, no config: tool genuinely unavailable."""
+        honcho_tools._session_manager = None
+        honcho_tools._session_key = None
+
+        @dataclass
+        class FakeConfig:
+            enabled: bool = False
+            api_key: str = None
+            base_url: str = None
+
+        with patch(
+            "honcho_integration.client.HonchoClientConfig"
+        ) as mock_cls:
+            mock_cls.from_global_config.return_value = FakeConfig()
+            assert honcho_tools._check_honcho_available() is False
+
+    def test_returns_false_when_import_fails(self):
+        """Graceful fallback when honcho_integration not installed."""
+        import sys
+
+        honcho_tools._session_manager = None
+        honcho_tools._session_key = None
+
+        # Hide honcho_integration from the import system to simulate
+        # an environment where the package is not installed.
+        hidden = {
+            k: sys.modules.pop(k)
+            for k in list(sys.modules)
+            if k.startswith("honcho_integration")
+        }
+        try:
+            with patch.dict(sys.modules, {"honcho_integration": None,
+                                          "honcho_integration.client": None}):
+                assert honcho_tools._check_honcho_available() is False
+        finally:
+            sys.modules.update(hidden)
 
 
 class TestHonchoToolSessionContext:

--- a/tools/honcho_tools.py
+++ b/tools/honcho_tools.py
@@ -45,8 +45,23 @@ def clear_session_context() -> None:
 # ── Availability check ──
 
 def _check_honcho_available() -> bool:
-    """Tool is only available when Honcho is active."""
-    return _session_manager is not None and _session_key is not None
+    """Tool is available when Honcho is active OR configured.
+
+    At banner time the session context hasn't been injected yet, but if
+    a valid config exists the tools *will* activate once the agent starts.
+    Returning True for "configured" prevents the banner from marking
+    honcho tools as red/disabled when they're actually going to work.
+    """
+    # Fast path: session already active (mid-conversation)
+    if _session_manager is not None and _session_key is not None:
+        return True
+    # Slow path: check if Honcho is configured (banner time)
+    try:
+        from honcho_integration.client import HonchoClientConfig
+        cfg = HonchoClientConfig.from_global_config()
+        return cfg.enabled and bool(cfg.api_key or cfg.base_url)
+    except Exception:
+        return False
 
 
 def _resolve_session_context(**kwargs):


### PR DESCRIPTION
## Summary

Fixes honcho tools showing as red/disabled in the startup banner even when properly configured.

### Problem

The honcho `check_fn` only checked runtime session state (`_session_manager is not None`), which isn't injected until `AIAgent.__init__()`. The banner renders before agent construction, so honcho tools always appeared unavailable at startup.

### Fix

Updated `_check_honcho_available()` in `tools/honcho_tools.py` to check configuration as a fallback:

1. **Fast path** (unchanged): if session context is active, return True immediately
2. **Slow path** (new): if no session, load `HonchoClientConfig.from_global_config()` and check `enabled + api_key/base_url`
3. **Graceful fallback**: if `honcho_integration` isn't installed, return False

This correctly reflects "will honcho work once the session starts?" rather than "is honcho running right now?"

### Tests

4 new tests in `test_honcho_tools.py`:
- Session active → True
- Configured but no session (banner time) → True
- Not configured → False
- Import failure (package not installed) → False

Closes #1843 (took the intent, implemented differently — the original PR had a dict key bug and the delegate_tool change was stale).
