### PR TITLE
fix: ensure tool schema always includes name field

### DIFF
--- a/tools/registry.py
+++ b/tools/registry.py
@@ -115,7 +115,9 @@ class ToolRegistry:
                     if not quiet:
                         logger.debug("Tool %s unavailable (check failed)", name)
                     continue
-            result.append({"type": "function", "function": entry.schema})
+            # Ensure schema always has a "name" field — use entry.name as fallback
+            schema_with_name = {**entry.schema, "name": entry.name}
+            result.append({"type": "function", "function": schema_with_name})
         return result
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
Ensures `get_definitions()` always includes the `name` field in tool schemas, using the registered `entry.name` as authoritative source. Prevents KeyError crash when plugins or external tools register schemas without a name key.

Cherry-picked from PR #3740 by @ekkoitac. Closes #3729.

Supersedes #3730, #3744, #3762 (all fix the same issue — this is the smallest/cleanest approach).