### PR TITLE
fix: omit tools param when empty instead of sending None

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4721,9 +4721,10 @@ class AIAgent:
         api_kwargs = {
             "model": self.model,
             "messages": sanitized_messages,
-            "tools": self.tools if self.tools else None,
             "timeout": float(os.getenv("HERMES_API_TIMEOUT", 1800.0)),
         }
+        if self.tools:
+            api_kwargs["tools"] = self.tools
 
         if self.max_tokens is not None:
             api_kwargs.update(self._max_tokens_param(self.max_tokens))


### PR DESCRIPTION
When `self.tools` is empty, the chat completions kwargs were sending `tools=None`, which the OpenAI SDK serializes as `"tools": null` in JSON. Some providers (Fireworks AI) reject this.

PR #3736 proposed changing to `tools=[]`, but that trades one breakage for another — Anthropic and other strict providers reject empty arrays.

The correct fix: don't include the `tools` key at all. The SDK treats a missing parameter as `NOT_GIVEN` and omits it from the request entirely. Works with all providers.

Inspired by #3736 (@kelsia14 identified the issue).