### PR TITLE
fix(banner): show lazy-initialized tools in yellow instead of red (salvage #1854)

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -258,7 +258,7 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
         get_toolset_for_tool: Callable to map tool name -> toolset name.
         context_length: Model's context window size in tokens.
     """
-    from model_tools import check_tool_availability
+    from model_tools import check_tool_availability, TOOLSET_REQUIREMENTS
     if get_toolset_for_tool is None:
         from model_tools import get_toolset_for_tool
 
@@ -267,8 +267,18 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
 
     _, unavailable_toolsets = check_tool_availability(quiet=True)
     disabled_tools = set()
+    # Tools whose toolset has a check_fn are lazy-initialized (e.g. honcho,
+    # homeassistant) — they show as unavailable at banner time because the
+    # check hasn't run yet, but they aren't misconfigured.
+    lazy_tools = set()
     for item in unavailable_toolsets:
-        disabled_tools.update(item.get("tools", []))
+        toolset_name = item.get("name", "")
+        ts_req = TOOLSET_REQUIREMENTS.get(toolset_name, {})
+        tools_in_ts = item.get("tools", [])
+        if ts_req.get("check_fn"):
+            lazy_tools.update(tools_in_ts)
+        else:
+            disabled_tools.update(tools_in_ts)
 
     layout_table = Table.grid(padding=(0, 2))
     layout_table.add_column("left", justify="center")
@@ -328,6 +338,8 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
         for name in sorted(tool_names):
             if name in disabled_tools:
                 colored_names.append(f"[red]{name}[/]")
+            elif name in lazy_tools:
+                colored_names.append(f"[yellow]{name}[/]")
             else:
                 colored_names.append(f"[{text}]{name}[/]")
 
@@ -347,6 +359,8 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
                     colored_names.append("[dim]...[/]")
                 elif name in disabled_tools:
                     colored_names.append(f"[red]{name}[/]")
+                elif name in lazy_tools:
+                    colored_names.append(f"[yellow]{name}[/]")
                 else:
                     colored_names.append(f"[{text}]{name}[/]")
             tools_str = ", ".join(colored_names)


### PR DESCRIPTION
## Summary

Salvage of #1854 by @Jah-yee. Only the banner fix was taken; unrelated bundled changes (context_compressor, STT config, auth default_model, SessionResetPolicy) were discarded.

## Problem

Tools from check_fn-gated toolsets (honcho, homeassistant) showed as red in the startup banner even when properly configured. The check_fn runs lazily after session context is set, but the banner renders before agent init — so these tools always appeared "broken."

## Fix

Single file change (`hermes_cli/banner.py`, +16/-2). Distinguishes three tool states:

| Color | Meaning |
|-------|---------|
| Red | Truly unavailable (missing env var / API key) |
| Yellow | Lazy-initialized (check_fn pending, activates on use) |
| Normal | Available and ready |

Uses `TOOLSET_REQUIREMENTS[toolset]["check_fn"]` to identify lazy-init toolsets.

## Live verified

PTY test confirmed honcho/homeassistant tools render with ANSI yellow (`\033[33m`), not red.

## Tests

6914 passed, 9 pre-existing failures, 0 regressions.