### PR TITLE
fix(registry): ensure tool schema always has name field (#3729)

### DIFF
--- a/tools/registry.py
+++ b/tools/registry.py
@@ -115,7 +115,13 @@ class ToolRegistry:
                     if not quiet:
                         logger.debug("Tool %s unavailable (check failed)", name)
                     continue
-            result.append({"type": "function", "function": entry.schema})
+            # Ensure schema has a "name" field: use entry.name as the canonical
+            # name so callers (model_tools.py etc.) can always access
+            # schema["name"] without a KeyError.  #3729
+            schema = dict(entry.schema) if isinstance(entry.schema, dict) else dict(entry.schema)
+            if "name" not in schema:
+                schema["name"] = entry.name
+            result.append({"type": "function", "function": schema})
         return result
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Fix Issue #3729: KeyError: name in get_tool_definitions

**Problem:** hermes crashes with `KeyError: name` on startup when any registered tool has a schema dict that does not include a name key.

**Root Cause:** ToolRegistry.register() does not ensure that the schema dict contains a name key. Most built-in tools include it, but if a plugin or external tool omits it, get_definitions() returns a schema without name, and model_tools.py:308 crashes.

**Fix:** In get_definitions(), copy the schema and fill in the name field from entry.name if missing. This ensures the canonical name is always available without requiring every plugin to explicitly include it.