### PR TITLE
fix: report subagent status as completed when summary exists

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -289,7 +289,10 @@ def _run_single_child(
 
         if interrupted:
             status = "interrupted"
-        elif completed and summary:
+        elif summary:
+            # A summary means the subagent produced usable output.
+            # exit_reason ("completed" vs "max_iterations") already
+            # tells the parent *how* the task ended.
             status = "completed"
         else:
             status = "failed"


### PR DESCRIPTION
## Summary

When a subagent hit `max_iterations`, its status was always reported as `"failed"` even when it produced a usable summary. This is because `run_agent.py` sets `completed = final_response is not None and api_call_count < self.max_iterations` — so hitting the iteration limit always means `completed=False`, regardless of output.

### Fix

Gate status on whether a summary was produced, not on the `completed` flag:

```python
if interrupted:
    status = "interrupted"
elif summary:
    status = "completed"
else:
    status = "failed"
```

The `exit_reason` field already distinguishes `"completed"` vs `"max_iterations"` for anything that needs to know how the task ended. The `status` field now answers "did the subagent produce usable output?"

### Tests

54 existing delegation tests pass. No test changes needed — existing tests already assert `status: "completed"` for tasks with summaries.

Closes #1899 (took the intent, simplified the approach — original PR used fragile error-substring scanning of tool messages).
