### PR TITLE
fix(security): allow RFC 2544 benchmark range for TUN/Fake-IP proxy users

### DIFF
--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -1,5 +1,6 @@
 """Tests for SSRF protection in url_safety module."""
 
+import os
 import socket
 from unittest.mock import patch
 
@@ -174,3 +175,65 @@ class TestIsBlockedIp:
     def test_allowed_ips(self, ip_str):
         ip = ipaddress.ip_address(ip_str)
         assert _is_blocked_ip(ip) is False, f"{ip_str} should be allowed"
+
+
+class TestRFC2544Allowlist:
+    """Tests for RFC 2544 benchmark range (198.18.0.0/15) allowlist."""
+
+    def test_rfc2544_blocked_by_default(self):
+        """198.18.x.x is blocked when HERMES_ALLOW_RFC2544 is not set."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_ALLOW_RFC2544", None)
+            ip = ipaddress.ip_address("198.18.0.1")
+            assert _is_blocked_ip(ip) is True
+
+    def test_rfc2544_allowed_with_env_var(self):
+        """198.18.x.x is allowed when HERMES_ALLOW_RFC2544=true."""
+        with patch.dict(os.environ, {"HERMES_ALLOW_RFC2544": "true"}):
+            ip = ipaddress.ip_address("198.18.0.1")
+            assert _is_blocked_ip(ip) is False
+
+    def test_rfc2544_range_start_allowed(self):
+        """198.18.0.0 (range start) allowed with env var."""
+        with patch.dict(os.environ, {"HERMES_ALLOW_RFC2544": "true"}):
+            ip = ipaddress.ip_address("198.18.0.0")
+            assert _is_blocked_ip(ip) is False
+
+    def test_rfc2544_range_end_allowed(self):
+        """198.19.255.255 (range end) allowed with env var."""
+        with patch.dict(os.environ, {"HERMES_ALLOW_RFC2544": "true"}):
+            ip = ipaddress.ip_address("198.19.255.255")
+            assert _is_blocked_ip(ip) is False
+
+    def test_rfc2544_upper_half_allowed(self):
+        """198.19.x.x (upper half of /15) allowed with env var."""
+        with patch.dict(os.environ, {"HERMES_ALLOW_RFC2544": "true"}):
+            ip = ipaddress.ip_address("198.19.128.1")
+            assert _is_blocked_ip(ip) is False
+
+    def test_other_private_still_blocked_with_env_var(self):
+        """Other private IPs remain blocked even when RFC 2544 is allowed."""
+        with patch.dict(os.environ, {"HERMES_ALLOW_RFC2544": "true"}):
+            for ip_str in ["10.0.0.1", "192.168.1.1", "172.16.0.1", "127.0.0.1"]:
+                ip = ipaddress.ip_address(ip_str)
+                assert _is_blocked_ip(ip) is True, f"{ip_str} should still be blocked"
+
+    def test_rfc2544_env_var_case_insensitive(self):
+        """HERMES_ALLOW_RFC2544=True (capitalized) also works."""
+        with patch.dict(os.environ, {"HERMES_ALLOW_RFC2544": "True"}):
+            ip = ipaddress.ip_address("198.18.0.1")
+            assert _is_blocked_ip(ip) is False
+
+    def test_rfc2544_env_var_false_still_blocks(self):
+        """HERMES_ALLOW_RFC2544=false does not allow the range."""
+        with patch.dict(os.environ, {"HERMES_ALLOW_RFC2544": "false"}):
+            ip = ipaddress.ip_address("198.18.0.1")
+            assert _is_blocked_ip(ip) is True
+
+    def test_rfc2544_is_safe_url_integration(self):
+        """End-to-end: URL resolving to RFC 2544 IP allowed with env var."""
+        with patch.dict(os.environ, {"HERMES_ALLOW_RFC2544": "true"}):
+            with patch("socket.getaddrinfo", return_value=[
+                (2, 1, 6, "", ("198.18.1.1", 0)),
+            ]):
+                assert is_safe_url("http://proxy-host.example/") is True

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -17,6 +17,7 @@ Limitations (documented, not fixable at pre-flight level):
 
 import ipaddress
 import logging
+import os
 import socket
 from urllib.parse import urlparse
 
@@ -34,9 +35,23 @@ _BLOCKED_HOSTNAMES = frozenset({
 # VPNs, and some cloud internal networks.
 _CGNAT_NETWORK = ipaddress.ip_network("100.64.0.0/10")
 
+# RFC 2544 Benchmarking range (198.18.0.0/15). Python's ipaddress.is_private
+# returns True for this range, but TUN/Fake-IP proxy software (Clash, Mihomo,
+# Sing-box, Surge) routes traffic through it. Set HERMES_ALLOW_RFC2544=true to
+# allow requests to this range.
+_RFC2544_BENCHMARK = ipaddress.ip_network("198.18.0.0/15")
+
 
 def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     """Return True if the IP should be blocked for SSRF protection."""
+    # Allow RFC 2544 benchmark range when opted in via env var.
+    # Checked before is_private since Python marks this range as private.
+    if (
+        os.environ.get("HERMES_ALLOW_RFC2544", "").lower() == "true"
+        and isinstance(ip, ipaddress.IPv4Address)
+        and ip in _RFC2544_BENCHMARK
+    ):
+        return False
     if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
         return True
     if ip.is_multicast or ip.is_unspecified:


### PR DESCRIPTION
Fixes #3777

## Problem

Python's `ipaddress.is_private` returns `True` for `198.18.0.0/15` (RFC 2544 Benchmarking range). TUN/Fake-IP proxy software (Clash, Mihomo, Sing-box, Surge) uses this range for virtual DNS IPs, causing all URL-accessing tools (`browser_navigate`, `web_extract`, `web_search`, etc.) to fail with "Blocked: URL targets a private or internal address".

## Solution

Add opt-in env var `HERMES_ALLOW_RFC2544=true` that exempts `198.18.0.0/15` from SSRF blocking.

- **Default behavior preserved**: range is blocked unless explicitly opted in
- **Checked before `is_private`**: since Python marks this range as private, the check must come first
- **IPv4 only**: the RFC 2544 range is IPv4-specific
- **Similar approach**: OpenClaw solved this with `ssrfPolicy.allowRfc2544BenchmarkRange` config (PR #51407)

## Changes

- `tools/url_safety.py`: Add `_RFC2544_BENCHMARK` constant + env var check in `_is_blocked_ip()`
- `tests/tools/test_url_safety.py`: Add `TestRFC2544Allowlist` class with 10 tests covering default-blocked, opt-in allowed, range boundaries, and isolation from other private ranges

## Tests

```
57 passed in 3.89s
```

All existing + 10 new tests pass.