### PR TITLE
fix: update session_log_file during context compression

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5183,6 +5183,8 @@ class AIAgent:
                 self._session_db.end_session(self.session_id, "compression")
                 old_session_id = self.session_id
                 self.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
+                # Update session_log_file to point to the new session's JSON file
+                self.session_log_file = self.logs_dir / f"session_{self.session_id}.json"
                 self._session_db.create_session(
                     session_id=self.session_id,
                     source=self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),


### PR DESCRIPTION
When context compression creates a child session with a new `session_id`, `session_log_file` was still pointing to the old session's JSON file. This caused `_save_session_log()` to write new data to the wrong file.

**Bug verified:** After compression changes `self.session_id`, `self.session_log_file` retained the old path — confirmed by instantiating AIAgent, simulating the session_id change, and checking the file path.

**Fix:** +2 lines following the existing pattern from `__init__` (line 883).

Salvaged from PR #3731 by @kelsia14 with authorship preserved.