### PR TITLE
fix(paths): respect HERMES_HOME for protected .env write-deny path

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -32,6 +32,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any
 from pathlib import Path
+from hermes_constants import get_hermes_home
 
 
 # ---------------------------------------------------------------------------
@@ -46,7 +47,7 @@ WRITE_DENIED_PATHS = {
         os.path.join(_HOME, ".ssh", "id_rsa"),
         os.path.join(_HOME, ".ssh", "id_ed25519"),
         os.path.join(_HOME, ".ssh", "config"),
-        os.path.join(_HOME, ".hermes", ".env"),
+        str(get_hermes_home() / ".env"),
         os.path.join(_HOME, ".bashrc"),
         os.path.join(_HOME, ".zshrc"),
         os.path.join(_HOME, ".profile"),


### PR DESCRIPTION
The write-deny list in `file_operations.py` hardcoded `~/.hermes/.env`, which misses the actual `.env` in custom HERMES_HOME or profile setups. Uses `get_hermes_home()` for profile-safe path resolution.

Salvaged from PR #3232 by @erhnysr with authorship preserved.

Note: PR #3205 (same author, `file_tools.py`) was already fixed on main via commit e97c0cb5.