### PR TITLE
fix(cli): handle closed stdout ValueError in safe print paths

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1285,7 +1285,7 @@ class AIAgent:
         try:
             fn = self._print_fn or print
             fn(*args, **kwargs)
-        except OSError:
+        except (OSError, ValueError):
             pass
 
     def _vprint(self, *args, force: bool = False, **kwargs):
@@ -7909,7 +7909,7 @@ class AIAgent:
                 error_msg = f"Error during OpenAI-compatible API call #{api_call_count}: {str(e)}"
                 try:
                     print(f"❌ {error_msg}")
-                except OSError:
+                except (OSError, ValueError):
                     logger.error(error_msg)
                 
                 if self.verbose_logging:


### PR DESCRIPTION
When stdout is closed (piped to a dead process, broken terminal), Python raises `ValueError('I/O operation on closed file')`, not `OSError`. `_safe_print` and the API error printer only caught `OSError`, letting the `ValueError` propagate and crash the agent.

**Bug verified:** Created an AIAgent with a print function that raises `ValueError` — confirmed it crashes through `_safe_print` on current main, handled gracefully after the fix.

Fixes #3534. Salvaged from PR #3760 by @apexscaleai with authorship preserved.