### PR TITLE
fix(tests): resolve 10 CI failures across hooks, tiktoken, plugins

### DIFF
--- a/tests/gateway/test_hooks.py
+++ b/tests/gateway/test_hooks.py
@@ -29,13 +29,18 @@ class TestHookRegistryInit:
         assert reg._handlers == {}
 
 
+def _patch_no_builtins(reg):
+    """Suppress built-in hook registration so tests only exercise user-hook discovery."""
+    return patch.object(reg, "_register_builtin_hooks")
+
+
 class TestDiscoverAndLoad:
     def test_loads_valid_hook(self, tmp_path):
         _create_hook(tmp_path, "my-hook", '["agent:start"]',
                       "def handle(event_type, context):\n    pass\n")
 
         reg = HookRegistry()
-        with patch("gateway.hooks.HOOKS_DIR", tmp_path):
+        with patch("gateway.hooks.HOOKS_DIR", tmp_path), _patch_no_builtins(reg):
             reg.discover_and_load()
 
         assert len(reg.loaded_hooks) == 1
@@ -48,7 +53,7 @@ class TestDiscoverAndLoad:
         (hook_dir / "handler.py").write_text("def handle(e, c): pass\n")
 
         reg = HookRegistry()
-        with patch("gateway.hooks.HOOKS_DIR", tmp_path):
+        with patch("gateway.hooks.HOOKS_DIR", tmp_path), _patch_no_builtins(reg):
             reg.discover_and_load()
 
         assert len(reg.loaded_hooks) == 0
@@ -59,7 +64,7 @@ class TestDiscoverAndLoad:
         (hook_dir / "HOOK.yaml").write_text("name: bad\nevents: ['agent:start']\n")
 
         reg = HookRegistry()
-        with patch("gateway.hooks.HOOKS_DIR", tmp_path):
+        with patch("gateway.hooks.HOOKS_DIR", tmp_path), _patch_no_builtins(reg):
             reg.discover_and_load()
 
         assert len(reg.loaded_hooks) == 0
@@ -71,7 +76,7 @@ class TestDiscoverAndLoad:
         (hook_dir / "handler.py").write_text("def handle(e, c): pass\n")
 
         reg = HookRegistry()
-        with patch("gateway.hooks.HOOKS_DIR", tmp_path):
+        with patch("gateway.hooks.HOOKS_DIR", tmp_path), _patch_no_builtins(reg):
             reg.discover_and_load()
 
         assert len(reg.loaded_hooks) == 0
@@ -83,14 +88,14 @@ class TestDiscoverAndLoad:
         (hook_dir / "handler.py").write_text("def something_else(): pass\n")
 
         reg = HookRegistry()
-        with patch("gateway.hooks.HOOKS_DIR", tmp_path):
+        with patch("gateway.hooks.HOOKS_DIR", tmp_path), _patch_no_builtins(reg):
             reg.discover_and_load()
 
         assert len(reg.loaded_hooks) == 0
 
     def test_nonexistent_hooks_dir(self, tmp_path):
         reg = HookRegistry()
-        with patch("gateway.hooks.HOOKS_DIR", tmp_path / "nonexistent"):
+        with patch("gateway.hooks.HOOKS_DIR", tmp_path / "nonexistent"), _patch_no_builtins(reg):
             reg.discover_and_load()
 
         assert len(reg.loaded_hooks) == 0
@@ -102,7 +107,7 @@ class TestDiscoverAndLoad:
                       "def handle(e, c): pass\n")
 
         reg = HookRegistry()
-        with patch("gateway.hooks.HOOKS_DIR", tmp_path):
+        with patch("gateway.hooks.HOOKS_DIR", tmp_path), _patch_no_builtins(reg):
             reg.discover_and_load()
 
         assert len(reg.loaded_hooks) == 2

--- a/tests/hermes_cli/test_tool_token_estimation.py
+++ b/tests/hermes_cli/test_tool_token_estimation.py
@@ -4,10 +4,20 @@ from unittest.mock import patch
 
 import pytest
 
+# tiktoken is not in core/[all] deps — skip estimation tests when unavailable
+_has_tiktoken = True
+try:
+    import tiktoken  # noqa: F401
+except ImportError:
+    _has_tiktoken = False
+
+_needs_tiktoken = pytest.mark.skipif(not _has_tiktoken, reason="tiktoken not installed")
+
 
 # ─── Token Estimation Tests ──────────────────────────────────────────────────
 
 
+@_needs_tiktoken
 def test_estimate_tool_tokens_returns_positive_counts():
     """_estimate_tool_tokens should return a non-empty dict with positive values."""
     from hermes_cli.tools_config import _estimate_tool_tokens, _tool_token_cache
@@ -26,6 +36,7 @@ def test_estimate_tool_tokens_returns_positive_counts():
         assert count > 0, f"Tool {name} has non-positive token count: {count}"
 
 
+@_needs_tiktoken
 def test_estimate_tool_tokens_is_cached():
     """Second call should return the same cached dict object."""
     import hermes_cli.tools_config as tc
@@ -60,6 +71,7 @@ def test_estimate_tool_tokens_returns_empty_when_tiktoken_unavailable(monkeypatc
     tc._tool_token_cache = None
 
 
+@_needs_tiktoken
 def test_estimate_tool_tokens_covers_known_tools():
     """Should include schemas for well-known tools like terminal, web_search."""
     import hermes_cli.tools_config as tc

--- a/tests/test_plugins_cmd.py
+++ b/tests/test_plugins_cmd.py
@@ -150,11 +150,11 @@ class TestPluginsCommandDispatch:
         plugins_command(args)
         mock_list.assert_called_once()
 
-    @patch("hermes_cli.plugins_cmd.cmd_list")
-    def test_none_falls_through_to_list(self, mock_list):
+    @patch("hermes_cli.plugins_cmd.cmd_toggle")
+    def test_none_falls_through_to_toggle(self, mock_toggle):
         args = self._make_args(None)
         plugins_command(args)
-        mock_list.assert_called_once()
+        mock_toggle.assert_called_once()
 
     @patch("hermes_cli.plugins_cmd.cmd_install")
     def test_install_dispatches(self, mock_install):


### PR DESCRIPTION
## Summary

Fixes all 10 CI test failures on main (7078 passed, 10 failed → 7088 passed, 0 failed).

### test_hooks.py — 7 failures
Built-in `boot-md` hook is always loaded by `_register_builtin_hooks()`, which runs before user-hook discovery. Tests expected 0/1/2 loaded hooks but got +1 from boot-md.

**Fix:** Mock out `_register_builtin_hooks` in `TestDiscoverAndLoad` tests so they isolate user-hook discovery logic. The `TestEmit` tests are unaffected (boot-md only registers for `gateway:startup`, not `agent:start`).

### test_tool_token_estimation.py — 2 failures
`tiktoken` is not in core or `[all]` dependencies. The `_estimate_tool_tokens()` function gracefully returns `{}` when tiktoken is missing, but tests asserted non-empty results.

**Fix:** Added `@skipif(not _has_tiktoken)` markers on the 3 tests that need actual tiktoken. The graceful-degradation test (`test_returns_empty_when_tiktoken_unavailable`) still runs unconditionally.

### test_plugins_cmd.py — 1 failure
Bare `hermes plugins` now dispatches to `cmd_toggle()` (interactive curses UI) instead of `cmd_list()`.

**Fix:** Updated test to mock and assert `cmd_toggle` instead of `cmd_list`.

### Verification
- 68/68 targeted tests pass
- 4509 passed, 0 failed across gateway + hermes_cli + tools suites
