### PR TITLE
fix(gateway): add system dirs to PATH for UV Python compatibility

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -9,6 +9,14 @@ import os
 import shutil
 import signal
 import subprocess
+
+# Ensure /bin and /usr/bin are on PATH so launchctl/systemctl are discoverable
+# when running under UV's bundled Python which ships a minimal PATH.
+_sys_dirs = {"/bin", "/usr/bin", "/usr/sbin", "/sbin"}
+_path_dirs = set(os.environ.get("PATH", "").split(os.pathsep))
+_missing = _sys_dirs - _path_dirs
+if _missing:
+    os.environ["PATH"] = os.environ.get("PATH", "") + os.pathsep + os.pathsep.join(sorted(_missing))
 import sys
 from pathlib import Path
 


### PR DESCRIPTION
## Summary

- UV's bundled Python ships a minimal `PATH` that excludes `/bin` and `/usr/bin`, causing `launchctl` and `systemctl` subprocess calls in `gateway.py` to fail with `FileNotFoundError`
- Adds system directories (`/bin`, `/usr/bin`, `/usr/sbin`, `/sbin`) to `PATH` at module import time when missing

## Reproduction

```
❯ hermes gateway start
FileNotFoundError: [Errno 2] No such file or directory: 'launchctl'
```

Occurs on macOS with hermes installed via UV (`~/.local/share/uv/python/cpython-3.11.15-macos-aarch64-none`).

Fixes #3849