### PR TITLE
fix(update): avoid launchd restart race on macOS

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3125,8 +3125,8 @@ def cmd_update(args):
             from gateway.status import get_running_pid, remove_pid_file
             from hermes_cli.gateway import (
                 get_service_name, get_launchd_plist_path, is_macos, is_linux,
-                refresh_launchd_plist_if_needed,
-                _ensure_user_systemd_env, get_systemd_linger_status,
+                launchd_restart, _ensure_user_systemd_env,
+                get_systemd_linger_status,
             )
             import signal as _signal
 
@@ -3201,26 +3201,16 @@ def cmd_update(args):
                             else:
                                 print("  Try manually: hermes gateway restart")
                 elif has_launchd_service:
-                    # Refresh the plist first (picks up --replace and other
-                    # changes from the update we just pulled).
-                    refresh_launchd_plist_if_needed()
-                    # Explicit stop+start — don't rely on KeepAlive respawn
-                    # after a manual SIGTERM, which would race with the
-                    # PID file cleanup.
+                    # Use the shared launchd restart helper so we wait for the
+                    # old gateway process to fully exit before starting the new
+                    # one. This avoids stop/start races during self-update.
                     print("→ Restarting gateway service...")
-                    _launchd_label = get_launchd_label()
-                    stop = subprocess.run(
-                        ["launchctl", "stop", _launchd_label],
-                        capture_output=True, text=True, timeout=10,
-                    )
-                    start = subprocess.run(
-                        ["launchctl", "start", _launchd_label],
-                        capture_output=True, text=True, timeout=10,
-                    )
-                    if start.returncode == 0:
+                    try:
+                        launchd_restart()
                         print("✓ Gateway restarted via launchd.")
-                    else:
-                        print(f"⚠ Gateway restart failed: {start.stderr.strip()}")
+                    except subprocess.CalledProcessError as e:
+                        stderr = (getattr(e, "stderr", "") or "").strip()
+                        print(f"⚠ Gateway restart failed: {stderr}")
                         print("  Try manually: hermes gateway restart")
                 elif existing_pid:
                     try:

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -296,21 +296,14 @@ class TestCmdUpdateLaunchdRestart:
 
         # Mock get_running_pid to return a PID
         with patch("gateway.status.get_running_pid", return_value=12345), \
-             patch("gateway.status.remove_pid_file"):
+             patch("gateway.status.remove_pid_file"), \
+             patch.object(gateway_cli, "launchd_restart") as mock_launchd_restart:
             cmd_update(mock_args)
 
         captured = capsys.readouterr().out
         assert "Gateway restarted via launchd" in captured
         assert "Restart it with: hermes gateway run" not in captured
-        # Verify launchctl stop + start were called (not manual SIGTERM)
-        launchctl_calls = [
-            c for c in mock_run.call_args_list
-            if len(c.args[0]) > 0 and c.args[0][0] == "launchctl"
-        ]
-        stop_calls = [c for c in launchctl_calls if "stop" in c.args[0]]
-        start_calls = [c for c in launchctl_calls if "start" in c.args[0]]
-        assert len(stop_calls) >= 1
-        assert len(start_calls) >= 1
+        mock_launchd_restart.assert_called_once_with()
 
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")


### PR DESCRIPTION
## What changed

This keeps the update fix as small as possible.

When `hermes update` runs on macOS and detects a launchd-managed gateway, it currently issues `launchctl stop` and `launchctl start` back to back inside `cmd_update()`. In practice that can race with gateway shutdown, leaving a dead window where the gateway stops but does not come back until the user manually restarts it.

This change switches the update path to reuse the existing shared `launchd_restart()` helper instead of inlining a separate stop/start flow.

## Why

`cmd_update()` had its own launchd restart logic that skipped the existing wait-for-exit path:

- old code: `launchctl stop` -> immediate `launchctl start`
- safe shared path: `launchd_stop()` -> `_wait_for_gateway_exit()` -> `launchd_start()`

The codebase already had the safer restart sequence, but the self-update flow was not using it.

## How to test

Manual repro before the fix on macOS:

1. Run the gateway under launchd.
2. Trigger `hermes update`.
3. Observe that the update completes and the gateway shuts down.
4. Observe that the gateway may not come back automatically.

Verification after the fix:

```bash
pytest -q tests/hermes_cli/test_update_gateway_restart.py
```

Expected result:

- `17 passed`

## Platforms tested

- macOS

## Scope / risk

- no behavior changes for Linux/systemd or manual gateway runs
- no changes to the launchd helper itself
- no new restart logic introduced
- just routes the macOS self-update path through the existing safe helper

Risk is low because this reuses the already-shared launchd restart path instead of maintaining a second, slightly different restart implementation in `cmd_update()`.
