### PR TITLE
fix: add gpt-5.4-mini to Codex fallback catalog

### DIFF
--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -12,6 +12,8 @@ import os
 logger = logging.getLogger(__name__)
 
 DEFAULT_CODEX_MODELS: List[str] = [
+    "gpt-5.4-mini",
+    "gpt-5.4",
     "gpt-5.3-codex",
     "gpt-5.2-codex",
     "gpt-5.1-codex-max",
@@ -19,8 +21,9 @@ DEFAULT_CODEX_MODELS: List[str] = [
 ]
 
 _FORWARD_COMPAT_TEMPLATE_MODELS: List[tuple[str, tuple[str, ...]]] = [
-    ("gpt-5.3-codex", ("gpt-5.2-codex",)),
+    ("gpt-5.4-mini", ("gpt-5.3-codex", "gpt-5.2-codex")),
     ("gpt-5.4", ("gpt-5.3-codex", "gpt-5.2-codex")),
+    ("gpt-5.3-codex", ("gpt-5.2-codex",)),
     ("gpt-5.3-codex-spark", ("gpt-5.3-codex", "gpt-5.2-codex")),
 ]
 

--- a/tests/test_codex_models.py
+++ b/tests/test_codex_models.py
@@ -33,6 +33,7 @@ def test_get_codex_model_ids_prioritizes_default_and_cache(tmp_path, monkeypatch
     assert "gpt-5.3-codex" in models
     # Non-codex-suffixed models are included when the cache says they're available
     assert "gpt-5.4" in models
+    assert "gpt-5.4-mini" in models
     assert "gpt-5-hidden-codex" not in models
 
 
@@ -64,7 +65,7 @@ def test_get_codex_model_ids_adds_forward_compat_models_from_templates(monkeypat
 
     models = get_codex_model_ids(access_token="codex-access-token")
 
-    assert models == ["gpt-5.2-codex", "gpt-5.3-codex", "gpt-5.4", "gpt-5.3-codex-spark"]
+    assert models == ["gpt-5.2-codex", "gpt-5.4-mini", "gpt-5.4", "gpt-5.3-codex", "gpt-5.3-codex-spark"]
 
 
 def test_model_command_uses_runtime_access_token_for_codex_list(monkeypatch):


### PR DESCRIPTION
Adds `gpt-5.4-mini` and `gpt-5.4` to the Codex default model list and forward-compat templates so they appear in model selection for Codex users without needing live API discovery.

Cherry-picked from PR #3713 by @hdbscan with authorship preserved. All 13 Codex model tests pass.