### PR TITLE
fix: prefer curated model list when live probe returns fewer models

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2125,7 +2125,7 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
         api_key_for_probe = existing_key or (get_env_value(key_env) if key_env else "")
         live_models = fetch_api_models(api_key_for_probe, effective_base)
 
-    if live_models:
+    if live_models and len(live_models) >= len(curated):
         model_list = live_models
         print(f"  Found {len(model_list)} model(s) from {pconfig.name} API")
     else:


### PR DESCRIPTION
## Summary

MiniMax M2.7 wasn't showing up in the `hermes model` picker for MiniMax provider users.

### Root cause

The model picker probes the live `/models` endpoint when the curated list has fewer than 8 models. MiniMax has 5 curated models, so it probes. When the user's base URL is an Anthropic-compatible endpoint (`https://api.minimax.io/anthropic`), the `/models` response only returns 3 models (M2.5, M2.5-highspeed, M2.1) — M2.7 isn't listed there yet. Since the live probe returned a non-empty list, it was used instead of the curated list.

### Fix

One-line change: when the live probe returns fewer models than the curated list, prefer curated. This ensures new models in our curated list always appear regardless of endpoint quirks.

```python
# Before
if live_models:
# After  
if live_models and len(live_models) >= len(curated):
```

754/754 hermes_cli tests pass.
