### PR TITLE
fix: clear api_mode on provider switch instead of hardcoding chat_completions

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1269,7 +1269,7 @@ def _model_flow_custom(config):
             cfg["model"] = model
         model["provider"] = "custom"
         model["base_url"] = effective_url
-        model["api_mode"] = "chat_completions"
+        model.pop("api_mode", None)  # let runtime auto-detect from URL
         save_config(cfg)
         deactivate_provider()
 
@@ -2051,7 +2051,7 @@ def _model_flow_kimi(config, current_model=""):
             cfg["model"] = model
         model["provider"] = provider_id
         model["base_url"] = effective_base
-        model["api_mode"] = "chat_completions"
+        model.pop("api_mode", None)  # let runtime auto-detect from URL
         save_config(cfg)
         deactivate_provider()
 
@@ -2158,7 +2158,7 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
             cfg["model"] = model
         model["provider"] = provider_id
         model["base_url"] = effective_base
-        model["api_mode"] = "chat_completions"
+        model.pop("api_mode", None)  # let runtime auto-detect from URL
         save_config(cfg)
         deactivate_provider()
 


### PR DESCRIPTION
## Summary

Fixes a regression from PR #3726 (merged today) that broke MiniMax, MiniMax-CN, and Alibaba provider switching.

## Problem

PR #3726 fixed stale `codex_responses` persisting after switching from Codex by hardcoding `api_mode = "chat_completions"` in 5 model flows. But MiniMax uses `https://api.minimax.io/anthropic` which needs `anthropic_messages` — the hardcoded value overrides the URL-based auto-detection in `runtime_provider.py`, causing the OpenAI SDK to hit `POST .../anthropic/chat/completions` → 404.

Affected providers: MiniMax, MiniMax-CN, Alibaba (all use `/anthropic` endpoints).

## Fix

Replace `model["api_mode"] = "chat_completions"` with `model.pop("api_mode", None)` in 3 URL-dependent flows:
- `_model_flow_custom` — user could enter an `/anthropic` URL
- `_model_flow_kimi` — safe to auto-detect
- `_model_flow_api_key_provider` — MiniMax/Alibaba use `/anthropic`

The runtime resolver in `runtime_provider.py` already correctly auto-detects api_mode from the base_url suffix. Clearing the config value lets it work.

OpenRouter and Copilot ACP flows keep the explicit `chat_completions` since their api_mode is always known.

## E2E Verified

| Switch | api_mode | Status |
|--------|----------|--------|
| Codex → MiniMax (`/anthropic`) | `anthropic_messages` | ✅ |
| Codex → Z.AI (`/v4`) | `chat_completions` | ✅ |
| Codex → Custom `/anthropic` | `anthropic_messages` | ✅ |
| Codex → Alibaba `/anthropic` | `anthropic_messages` | ✅ |
| Codex → MiniMax-CN `/anthropic` | `anthropic_messages` | ✅ |
| Codex → Kimi (`/v1`) | `chat_completions` | ✅ |
| Codex → HuggingFace (`/v1`) | `chat_completions` | ✅ |
| OpenRouter (explicit) | `chat_completions` | ✅ |
| `resolve_runtime_provider(requested="minimax")` | `anthropic_messages` | ✅ |

754 hermes_cli tests pass.

Reported by stefan171.
