### PR TITLE
fix(security): catch sensitive path writes in approval checks

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -339,6 +339,16 @@ class TestTeePattern:
         assert dangerous is True
         assert key is not None
 
+    def test_tee_custom_hermes_home_env(self):
+        dangerous, key, desc = detect_dangerous_command("echo x | tee $HERMES_HOME/.env")
+        assert dangerous is True
+        assert key is not None
+
+    def test_tee_quoted_custom_hermes_home_env(self):
+        dangerous, key, desc = detect_dangerous_command('echo x | tee "$HERMES_HOME/.env"')
+        assert dangerous is True
+        assert key is not None
+
     def test_tee_tmp_safe(self):
         dangerous, key, desc = detect_dangerous_command("echo hello | tee /tmp/output.txt")
         assert dangerous is False
@@ -370,6 +380,30 @@ class TestFindExecFullPathRm:
 
     def test_find_print_safe(self):
         dangerous, key, desc = detect_dangerous_command("find . -name '*.py' -print")
+        assert dangerous is False
+        assert key is None
+
+
+class TestSensitiveRedirectPattern:
+    """Detect shell redirection writes to sensitive user-managed paths."""
+
+    def test_redirect_to_custom_hermes_home_env(self):
+        dangerous, key, desc = detect_dangerous_command("echo x > $HERMES_HOME/.env")
+        assert dangerous is True
+        assert key is not None
+
+    def test_append_to_home_ssh_authorized_keys(self):
+        dangerous, key, desc = detect_dangerous_command("cat key >> $HOME/.ssh/authorized_keys")
+        assert dangerous is True
+        assert key is not None
+
+    def test_append_to_tilde_ssh_authorized_keys(self):
+        dangerous, key, desc = detect_dangerous_command("cat key >> ~/.ssh/authorized_keys")
+        assert dangerous is True
+        assert key is not None
+
+    def test_redirect_to_safe_tmp_file(self):
+        dangerous, key, desc = detect_dangerous_command("echo hello > /tmp/output.txt")
         assert dangerous is False
         assert key is None
 
@@ -605,4 +639,5 @@ class TestNormalizationBypass:
         cmd = "\uff4c\uff53 -\uff4c\uff41 /tmp"
         dangerous, key, desc = detect_dangerous_command(cmd)
         assert dangerous is False
+
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -18,6 +18,21 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+# Sensitive write targets that should trigger approval even when referenced
+# via shell expansions like $HOME or $HERMES_HOME.
+_SSH_SENSITIVE_PATH = r'(?:~|\$home|\$\{home\})/\.ssh(?:/|$)'
+_HERMES_ENV_PATH = (
+    r'(?:~\/\.hermes/|'
+    r'(?:\$home|\$\{home\})/\.hermes/|'
+    r'(?:\$hermes_home|\$\{hermes_home\})/)'
+    r'\.env\b'
+)
+_SENSITIVE_WRITE_TARGET = (
+    r'(?:/etc/|/dev/sd|'
+    rf'{_SSH_SENSITIVE_PATH}|'
+    rf'{_HERMES_ENV_PATH})'
+)
+
 # =========================================================================
 # Dangerous command patterns
 # =========================================================================
@@ -46,7 +61,8 @@ DANGEROUS_PATTERNS = [
     (r'\b(python[23]?|perl|ruby|node)\s+-[ec]\s+', "script execution via -e/-c flag"),
     (r'\b(curl|wget)\b.*\|\s*(ba)?sh\b', "pipe remote content to shell"),
     (r'\b(bash|sh|zsh|ksh)\s+<\s*<?\s*\(\s*(curl|wget)\b', "execute remote script via process substitution"),
-    (r'\btee\b.*(/etc/|/dev/sd|\.ssh/|\.hermes/\.env)', "overwrite system file via tee"),
+    (rf'\btee\b.*["\']?{_SENSITIVE_WRITE_TARGET}', "overwrite system file via tee"),
+    (rf'>>?\s*["\']?{_SENSITIVE_WRITE_TARGET}', "overwrite system file via redirection"),
     (r'\bxargs\s+.*\brm\b', "xargs with rm"),
     (r'\bfind\b.*-exec\s+(/\S*/)?rm\b', "find -exec rm"),
     (r'\bfind\b.*-delete\b', "find -delete"),


### PR DESCRIPTION
Salvage of #1934 by @Gutslabs onto current main.

## Summary

Extends dangerous command detection to catch writes to sensitive paths via shell variable expansions (`$HOME`, `$HERMES_HOME`, `${HOME}`) and redirect operators (`>`, `>>`).

### Previously missed (now caught)
- `echo x | tee $HERMES_HOME/.env`
- `echo x | tee "$HERMES_HOME/.env"`
- `echo x > $HERMES_HOME/.env`
- `cat key >> $HOME/.ssh/authorized_keys`
- `cat key >> ~/.ssh/authorized_keys`

### Changes
- Consolidated `_SENSITIVE_WRITE_TARGET` regex covering `/etc/`, `/dev/sd`, SSH paths (`~/.ssh/`, `$HOME/.ssh/`), and HERMES `.env` (`~/.hermes/.env`, `$HOME/.hermes/.env`, `$HERMES_HOME/.env`)
- Updated `tee` pattern to use consolidated target
- New redirect pattern catches `>` / `>>` writes to sensitive paths
- 7 new regression tests + safe-write negative case

## Testing
- 103/103 approval + yolo mode tests pass
- E2E verified: all 5 gaps confirmed missed before fix, all caught after

---
Original PR: #1934 by @Gutslabs — cherry-picked with authorship preserved.
