### PR TITLE
fix(gateway): use target user's HERMES_HOME in system service unit

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -484,6 +484,11 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
 
     if system:
         username, group_name, home_dir = _system_service_identity(run_as_user)
+        # When installing via sudo, get_hermes_home() resolves to /root/.hermes
+        # because Path.home() returns root's home.  For system services we need
+        # the *target* user's HERMES_HOME instead.
+        if not os.getenv("HERMES_HOME"):
+            hermes_home = str(Path(home_dir) / ".hermes")
         path_entries.extend(_build_user_local_paths(Path(home_dir), path_entries))
         path_entries.extend(common_bin_paths)
         sane_path = ":".join(path_entries)

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -101,6 +101,21 @@ class TestGeneratedSystemdUnits:
         assert "TimeoutStopSec=60" in unit
         assert "WantedBy=multi-user.target" in unit
 
+    def test_system_unit_uses_target_user_hermes_home_not_root(self, monkeypatch):
+        """When installed via sudo, HERMES_HOME must point to the target user's
+        home directory, not /root/.hermes (the installing user)."""
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_system_service_identity",
+            lambda run_as_user=None: ("alice", "alice", "/home/alice"),
+        )
+
+        unit = gateway_cli.generate_systemd_unit(system=True)
+
+        assert 'HERMES_HOME=/home/alice/.hermes' in unit
+        assert '/root/.hermes' not in unit
+
 
 class TestGatewayStopCleanup:
     def test_stop_sweeps_manual_gateway_processes_after_service_stop(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- When `sudo hermes gateway install --system` generates the systemd unit file, `get_hermes_home()` resolves to `/root/.hermes` (root's home) instead of the target user's `~/.hermes`. This causes the gateway service to read config/env from the wrong directory, leading to missing or stale credentials and hard-to-diagnose failures (e.g. doubled Telegram bot tokens).
- Derives `HERMES_HOME` from the target user's home directory (already resolved by `_system_service_identity()`) when `HERMES_HOME` is not explicitly set in the environment.
- Adds a regression test verifying the system unit contains the target user's path.

## Test plan

- [x] `pytest tests/hermes_cli/test_gateway_service.py` — all 29 tests pass
- [x] New test `test_system_unit_uses_target_user_hermes_home_not_root` asserts `HERMES_HOME=/home/alice/.hermes` appears in generated unit and `/root/.hermes` does not

<details>
<summary>🤖 AI-assisted debugging session notes</summary>

### How this bug was found

The gateway on a Linux server (running as systemd system service for user `forged`) was failing to start with a confusing error: the Telegram bot token appeared **doubled** — the same token concatenated with itself.

Both `~/.hermes/config.yaml` and `~/.hermes/.env` contained the correct single token, so the doubling wasn't a user config error.

### Root cause trace

1. The systemd unit file had `Environment="HERMES_HOME=/root/.hermes"` despite the service running as user `forged` with `HOME=/home/forged`.
2. This happened because `generate_systemd_unit()` in `hermes_cli/gateway.py` calls `get_hermes_home()` at line 481, which falls back to `Path.home() / ".hermes"`. When installed via `sudo`, `Path.home()` returns `/root`.
3. Meanwhile, `_system_service_identity()` already correctly resolves the target user's home via `SUDO_USER` and `pwd.getpwnam()` — but this value was only used for the `HOME=` and `User=` fields, not for `HERMES_HOME=`.
4. With the wrong `HERMES_HOME`, the gateway read config from `/root/.hermes` (which had stale data from a prior root-level setup attempt), while the real `.env` with the correct token lived at `/home/forged/.hermes/.env`. The token from the stale root config was combined with the env var token, producing the doubled value that Telegram rejected.

### The fix

For system services, when `HERMES_HOME` is not explicitly set in the environment, derive it from the target user's home directory (`home_dir` from `_system_service_identity()`) instead of using `get_hermes_home()` which reflects the installing user (root).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)