### PR TITLE
feat: add .aac audio format support to transcription tool

### DIFF
--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -12,7 +12,7 @@ Provides speech-to-text transcription with three providers:
 Used by the messaging gateway to automatically transcribe voice messages
 sent by users on Telegram, Discord, WhatsApp, Slack, and Signal.
 
-Supported input formats: mp3, mp4, mpeg, mpga, m4a, wav, webm, ogg
+Supported input formats: mp3, mp4, mpeg, mpga, m4a, wav, webm, ogg, aac
 
 Usage::
 
@@ -60,7 +60,7 @@ COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
 GROQ_BASE_URL = os.getenv("GROQ_BASE_URL", "https://api.groq.com/openai/v1")
 OPENAI_BASE_URL = os.getenv("STT_OPENAI_BASE_URL", "https://api.openai.com/v1")
 
-SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg"}
+SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".aac"}
 LOCAL_NATIVE_AUDIO_FORMATS = {".wav", ".aiff", ".aif"}
 MAX_FILE_SIZE = 25 * 1024 * 1024  # 25 MB
 


### PR DESCRIPTION
Salvage of #1964 by @AdrianScott onto current main. Fixes #1963.

## Summary

Adds `.aac` to `SUPPORTED_FORMATS` in the transcription tool. This unblocks Signal users sending .aac voice notes (the only platform that preserves the .aac extension).

No breakage risk — Telegram/Discord/WhatsApp never produce .aac files. Local transcription (default provider) handles .aac natively via ffmpeg. API providers may reject raw .aac but fail gracefully.

20/20 transcription tests pass.

---
Original PR: #1964 by @AdrianScott — cherry-picked with authorship preserved.