### PR TITLE
fix(agent): support full context length resolution for direct Gemini API endpoints

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -171,6 +171,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "dashscope.aliyuncs.com": "alibaba",
     "dashscope-intl.aliyuncs.com": "alibaba",
     "openrouter.ai": "openrouter",
+    "generativelanguage.googleapis.com": "google",
     "inference-api.nousresearch.com": "nous",
     "api.deepseek.com": "deepseek",
     "api.githubcopilot.com": "copilot",

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -12,7 +12,7 @@ Provides speech-to-text transcription with three providers:
 Used by the messaging gateway to automatically transcribe voice messages
 sent by users on Telegram, Discord, WhatsApp, Slack, and Signal.
 
-Supported input formats: mp3, mp4, mpeg, mpga, m4a, wav, webm, ogg
+Supported input formats: mp3, mp4, mpeg, mpga, m4a, wav, webm, ogg, aac
 
 Usage::
 
@@ -60,7 +60,7 @@ COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
 GROQ_BASE_URL = os.getenv("GROQ_BASE_URL", "https://api.groq.com/openai/v1")
 OPENAI_BASE_URL = os.getenv("STT_OPENAI_BASE_URL", "https://api.openai.com/v1")
 
-SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg"}
+SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".aac"}
 LOCAL_NATIVE_AUDIO_FORMATS = {".wav", ".aiff", ".aif"}
 MAX_FILE_SIZE = 25 * 1024 * 1024  # 25 MB
 


### PR DESCRIPTION
Salvage of #1990 by @bb873 onto current main.

## Summary

Adds `generativelanguage.googleapis.com` to `_URL_TO_PROVIDER` in `model_metadata.py` so direct Gemini API users get correct 1M+ token context length instead of the 128K unknown-proxy fallback.

**Before:** `get_model_context_length('gemini-2.5-pro', base_url=gemini_url)` → 128,000
**After:** `get_model_context_length('gemini-2.5-pro', base_url=gemini_url)` → 1,048,576

Note: the original PR targeted the old tuple-based `known_hosts` structure which was refactored to `_URL_TO_PROVIDER` dict on main. Applied the fix to the current structure with provider mapped to `"google"` for models.dev resolution.

---
Original PR: #1990 by @bb873 — cherry-picked with authorship preserved.