### PR TITLE
feat(gateway): add LiveKit WebRTC voice platform support

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -587,6 +587,13 @@ PLATFORM_HINTS = {
         "![alt](/path) for local files; local paths are not served that way. "
         "Use MEDIA:/absolute/path instead."
     ),
+    "livekit": (
+        "You are communicating via a LiveKit voice channel (WebRTC). "
+        "The user speaks to you and hears your replies as audio. "
+        "Keep responses concise and conversational — they will be read aloud via TTS. "
+        "Avoid markdown formatting, long lists, code blocks, or URLs. "
+        "Do not include MEDIA: tags. Focus on clear, spoken-word responses."
+    ),
 }
 
 # ---------------------------------------------------------------------------

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1817,14 +1817,27 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         if Platform.LIVEKIT not in config.platforms:
             config.platforms[Platform.LIVEKIT] = PlatformConfig()
         config.platforms[Platform.LIVEKIT].enabled = True
+        livekit_room = os.getenv("LIVEKIT_ROOM", "hermes")
         config.platforms[Platform.LIVEKIT].extra.update({
             "url": livekit_url,
             "api_key": livekit_api_key,
             "api_secret": livekit_api_secret,
-            "room": os.getenv("LIVEKIT_ROOM", "hermes"),
+            "room": livekit_room,
             "agent_name": os.getenv("LIVEKIT_AGENT_NAME", "Hermes"),
             "agent_avatar": os.getenv("LIVEKIT_AGENT_AVATAR", ""),
         })
+        # LiveKit's adapter only ever joins one room, so the room IS the home
+        # channel by definition. Default LIVEKIT_HOME_CHANNEL to LIVEKIT_ROOM
+        # unless explicitly overridden — keeps cron/cross-platform delivery
+        # and the first-message onboarding gate sensible without requiring
+        # the user to duplicate the value in their env.
+        livekit_home = os.getenv("LIVEKIT_HOME_CHANNEL") or livekit_room
+        os.environ.setdefault("LIVEKIT_HOME_CHANNEL", livekit_home)
+        config.platforms[Platform.LIVEKIT].home_channel = HomeChannel(
+            platform=Platform.LIVEKIT,
+            chat_id=livekit_home,
+            name=os.getenv("LIVEKIT_HOME_CHANNEL_NAME", "Home"),
+        )
 
     # Session settings
     idle_minutes = os.getenv("SESSION_IDLE_MINUTES")

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -127,6 +127,8 @@ class Platform(Enum):
     BLUEBUBBLES = "bluebubbles"
     QQBOT = "qqbot"
     YUANBAO = "yuanbao"
+    LIVEKIT = "livekit"
+
     @classmethod
     def _missing_(cls, value):
         """Accept unknown platform names only for known plugin adapters.
@@ -436,6 +438,7 @@ _PLATFORM_CONNECTED_CHECKERS: dict[Platform, Callable[[PlatformConfig], bool]] =
         (cfg.extra.get("client_id") or os.getenv("DINGTALK_CLIENT_ID"))
         and (cfg.extra.get("client_secret") or os.getenv("DINGTALK_CLIENT_SECRET"))
     ),
+    Platform.LIVEKIT: lambda cfg: bool(cfg.extra.get("url")),
 }
 
 
@@ -1805,6 +1808,23 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         yuanbao_group_allow_from = os.getenv("YUANBAO_GROUP_ALLOW_FROM")
         if yuanbao_group_allow_from:
             extra["group_allow_from"] = yuanbao_group_allow_from
+
+    # LiveKit
+    livekit_url = os.getenv("LIVEKIT_URL")
+    livekit_api_key = os.getenv("LIVEKIT_API_KEY")
+    livekit_api_secret = os.getenv("LIVEKIT_API_SECRET")
+    if livekit_url and livekit_api_key and livekit_api_secret:
+        if Platform.LIVEKIT not in config.platforms:
+            config.platforms[Platform.LIVEKIT] = PlatformConfig()
+        config.platforms[Platform.LIVEKIT].enabled = True
+        config.platforms[Platform.LIVEKIT].extra.update({
+            "url": livekit_url,
+            "api_key": livekit_api_key,
+            "api_secret": livekit_api_secret,
+            "room": os.getenv("LIVEKIT_ROOM", "hermes"),
+            "agent_name": os.getenv("LIVEKIT_AGENT_NAME", "Hermes"),
+            "agent_avatar": os.getenv("LIVEKIT_AGENT_AVATAR", ""),
+        })
 
     # Session settings
     idle_minutes = os.getenv("SESSION_IDLE_MINUTES")

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2011,6 +2011,13 @@ class BasePlatformAdapter(ABC):
             text = f"{caption}\n{text}"
         return await self.send(chat_id=chat_id, content=text, reply_to=reply_to, metadata=metadata)
 
+    def prepare_tts_text(self, text: str) -> str:
+        """Prepare text for TTS. Override to filter tool output, code, etc.
+
+        Default strips markdown formatting and truncates to 4000 chars.
+        """
+        return re.sub(r'[*_`#\[\]()]', '', text)[:4000].strip()
+
     async def play_tts(
         self,
         chat_id: str,
@@ -3125,7 +3132,7 @@ class BasePlatformAdapter(ABC):
                         from tools.tts_tool import text_to_speech_tool, check_tts_requirements
                         if check_tts_requirements():
                             import json as _json
-                            speech_text = re.sub(r'[*_`#\[\]()]', '', text_content)[:4000].strip()
+                            speech_text = self.prepare_tts_text(text_content)
                             if not speech_text:
                                 raise ValueError("Empty text after markdown cleanup")
                             tts_result_str = await asyncio.to_thread(

--- a/gateway/platforms/livekit.py
+++ b/gateway/platforms/livekit.py
@@ -1,0 +1,687 @@
+"""
+LiveKit voice platform adapter using WebRTC.
+
+Connects to a LiveKit room, receives participant audio, transcribes via
+hermes's STT pipeline, feeds into the agent loop, and publishes TTS
+responses back as audio.
+
+Requires:
+    pip install 'hermes-agent[livekit]'
+    LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET env vars
+
+Configuration in config.yaml:
+    platforms:
+      livekit:
+        enabled: true
+        extra:
+          url: "wss://your-project.livekit.cloud"
+          api_key: "your-api-key"
+          api_secret: "your-api-secret"
+          room: "hermes"          # optional, default "hermes"
+"""
+
+import asyncio
+import io
+import logging
+import math
+import os
+import struct
+import subprocess
+import tempfile
+import time
+import uuid
+import wave
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+try:
+    from livekit import rtc
+    LIVEKIT_AVAILABLE = True
+except ImportError:
+    LIVEKIT_AVAILABLE = False
+    rtc = None  # type: ignore[assignment]
+
+try:
+    from livekit.api import AccessToken, VideoGrants
+    LIVEKIT_API_AVAILABLE = True
+except ImportError:
+    LIVEKIT_API_AVAILABLE = False
+    AccessToken = None  # type: ignore[assignment,misc]
+    VideoGrants = None  # type: ignore[assignment,misc]
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
+
+logger = logging.getLogger(__name__)
+
+# Voice detection
+SILENCE_THRESHOLD_SECONDS = 1.5   # seconds of silence → end of utterance
+MIN_SPEECH_DURATION = 0.5         # minimum seconds to process (skip noise)
+RMS_SILENCE_FLOOR = 50            # PCM RMS below this is silence
+POLL_INTERVAL = 0.2               # silence check interval in seconds
+
+# LiveKit audio defaults
+SAMPLE_RATE = 48000
+NUM_CHANNELS = 1
+
+# Reconnection
+RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
+
+
+def check_livekit_requirements() -> bool:
+    """Check if LiveKit dependencies are available and configured."""
+    if not LIVEKIT_AVAILABLE or not LIVEKIT_API_AVAILABLE:
+        return False
+    if not os.getenv("LIVEKIT_URL") or not os.getenv("LIVEKIT_API_KEY") or not os.getenv("LIVEKIT_API_SECRET"):
+        return False
+    return True
+
+
+def _compute_rms(pcm_data: bytes) -> float:
+    """Compute RMS energy of 16-bit PCM samples."""
+    if len(pcm_data) < 2:
+        return 0.0
+    n_samples = len(pcm_data) // 2
+    samples = struct.unpack(f"<{n_samples}h", pcm_data[:n_samples * 2])
+    if not samples:
+        return 0.0
+    return math.sqrt(sum(s * s for s in samples) / n_samples)
+
+
+def _pcm_to_wav(pcm_data: bytes, sample_rate: int, channels: int) -> bytes:
+    """Wrap raw 16-bit PCM in a WAV container."""
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(channels)
+        wf.setsampwidth(2)  # 16-bit
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm_data)
+    return buf.getvalue()
+
+
+class LiveKitAdapter(BasePlatformAdapter):
+    """LiveKit voice adapter using WebRTC.
+
+    Joins a LiveKit room, captures participant audio, transcribes to text,
+    and sends TTS replies back to the room.
+    """
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform.LIVEKIT)
+
+        extra = config.extra or {}
+        self._url: str = extra.get("url") or os.getenv("LIVEKIT_URL", "")
+        self._api_key: str = extra.get("api_key") or os.getenv("LIVEKIT_API_KEY", "")
+        self._api_secret: str = extra.get("api_secret") or os.getenv("LIVEKIT_API_SECRET", "")
+        self._room_name: str = extra.get("room") or os.getenv("LIVEKIT_ROOM", "hermes")
+        self._agent_name: str = extra.get("agent_name") or os.getenv("LIVEKIT_AGENT_NAME", "Hermes")
+        self._agent_avatar: str = extra.get("agent_avatar") or os.getenv("LIVEKIT_AGENT_AVATAR", "") or self._find_default_avatar()
+
+        self._room: Optional["rtc.Room"] = None
+        self._audio_source: Optional["rtc.AudioSource"] = None
+        self._local_track: Optional["rtc.LocalAudioTrack"] = None
+        self._silence_task: Optional[asyncio.Task] = None
+        self._connect_task: Optional[asyncio.Task] = None
+
+        # Per-participant audio buffers: identity -> (pcm bytearray, last_audio_time)
+        self._audio_buffers: Dict[str, bytearray] = {}
+        self._last_audio_time: Dict[str, float] = {}
+        self._audio_streams: Dict[str, asyncio.Task] = {}
+
+        # Pause audio capture during TTS playback
+        self._paused = False
+
+    @staticmethod
+    def _find_default_avatar() -> str:
+        """Look for a default avatar image in ~/.hermes/."""
+        from pathlib import Path
+        hermes_home = Path.home() / ".hermes"
+        for name in ("agent.png", "agent.jpg"):
+            path = hermes_home / name
+            if path.is_file():
+                return str(path)
+        return ""
+
+    def _resolve_avatar_url(self) -> str:
+        """Convert avatar to a URL suitable for LiveKit metadata.
+
+        If it's already a URL, use as-is. If it's a local file, encode
+        as a data URI so it works without a web server.
+        """
+        avatar = self._agent_avatar
+        if not avatar:
+            return ""
+        if avatar.startswith(("http://", "https://", "data:")):
+            return avatar
+        # Local file — base64 encode as data URI
+        try:
+            import base64
+            from pathlib import Path
+            path = Path(avatar).expanduser()
+            if not path.is_file():
+                return ""
+            suffix = path.suffix.lower()
+            mime = {".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg"}.get(suffix, "image/png")
+            data = base64.b64encode(path.read_bytes()).decode("ascii")
+            return f"data:{mime};base64,{data}"
+        except Exception:
+            return ""
+
+    # -- Connection lifecycle -----------------------------------------------
+
+    async def connect(self) -> bool:
+        """Connect to LiveKit room."""
+        if not LIVEKIT_AVAILABLE:
+            logger.warning("[%s] livekit SDK not installed. Run: pip install 'hermes-agent[livekit]'", self.name)
+            return False
+        if not LIVEKIT_API_AVAILABLE:
+            logger.warning("[%s] livekit-api not installed. Run: pip install 'hermes-agent[livekit]'", self.name)
+            return False
+        if not self._url or not self._api_key or not self._api_secret:
+            logger.warning("[%s] LIVEKIT_URL, LIVEKIT_API_KEY, and LIVEKIT_API_SECRET required", self.name)
+            return False
+
+        try:
+            self._room = rtc.Room()
+
+            # Register event handlers
+            self._room.on("track_subscribed", self._on_track_subscribed)
+            self._room.on("track_unsubscribed", self._on_track_unsubscribed)
+            self._room.on("participant_disconnected", self._on_participant_disconnected)
+            self._room.on("disconnected", self._on_disconnected)
+
+            # Create access token
+            import json as _json
+            token = (
+                AccessToken(api_key=self._api_key, api_secret=self._api_secret)
+                .with_identity(f"hermes-{self._agent_name.lower()}")
+                .with_name(self._agent_name)
+                .with_grants(VideoGrants(
+                    room_join=True,
+                    room=self._room_name,
+                    can_publish=True,
+                    can_subscribe=True,
+                    can_update_own_metadata=True,
+                ))
+            )
+            jwt_token = token.to_jwt()
+
+            # Connect to room
+            await self._room.connect(self._url, jwt_token)
+
+            # Set metadata (including avatar) after connecting — avoids JWT size limits
+            metadata = {}
+            avatar_url = self._resolve_avatar_url()
+            if avatar_url:
+                metadata["avatar"] = avatar_url
+            if metadata:
+                await self._room.local_participant.set_metadata(_json.dumps(metadata))
+
+            # Publish a local audio track for TTS playback
+            self._audio_source = rtc.AudioSource(SAMPLE_RATE, NUM_CHANNELS)
+            self._local_track = rtc.LocalAudioTrack.create_audio_track(
+                "hermes-voice", self._audio_source
+            )
+            options = rtc.TrackPublishOptions(source=rtc.TrackSource.SOURCE_MICROPHONE)
+            await self._room.local_participant.publish_track(self._local_track, options)
+
+            # Start silence detection loop
+            self._silence_task = asyncio.create_task(self._check_silence_loop())
+
+            self._mark_connected()
+            logger.info("[%s] Connected to room '%s' at %s", self.name, self._room_name, self._url)
+
+            # If no explicit agent name was configured, ask the LLM and reconnect
+            if not os.getenv("LIVEKIT_AGENT_NAME") and not (self.config.extra or {}).get("agent_name"):
+                asyncio.create_task(self._resolve_agent_name())
+
+            return True
+        except Exception as e:
+            logger.error("[%s] Failed to connect: %s", self.name, e)
+            return False
+
+    async def disconnect(self) -> None:
+        """Disconnect from LiveKit room."""
+        self._running = False
+        self._mark_disconnected()
+
+        if self._silence_task:
+            self._silence_task.cancel()
+            try:
+                await self._silence_task
+            except asyncio.CancelledError:
+                pass
+            self._silence_task = None
+
+        # Cancel all audio stream tasks
+        for task in self._audio_streams.values():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        self._audio_streams.clear()
+
+        if self._room:
+            await self._room.disconnect()
+            self._room = None
+
+        self._audio_source = None
+        self._local_track = None
+        self._audio_buffers.clear()
+        self._last_audio_time.clear()
+        logger.info("[%s] Disconnected", self.name)
+
+    # -- LiveKit event handlers ---------------------------------------------
+
+    def _on_track_subscribed(
+        self,
+        track: "rtc.Track",
+        publication: "rtc.RemoteTrackPublication",
+        participant: "rtc.RemoteParticipant",
+    ):
+        """Start capturing audio when a participant's audio track is subscribed."""
+        if track.kind != rtc.TrackKind.KIND_AUDIO:
+            return
+
+        identity = participant.identity
+        logger.info("[%s] Audio track subscribed: %s", self.name, identity)
+
+        # Initialize buffer for this participant
+        self._audio_buffers[identity] = bytearray()
+        self._last_audio_time[identity] = time.monotonic()
+
+        # Start receiving audio frames
+        stream = rtc.AudioStream(track)
+        task = asyncio.create_task(self._audio_receive_loop(stream, identity))
+        self._audio_streams[identity] = task
+
+    def _on_track_unsubscribed(
+        self,
+        track: "rtc.Track",
+        publication: "rtc.RemoteTrackPublication",
+        participant: "rtc.RemoteParticipant",
+    ):
+        """Clean up when a participant's audio track is unsubscribed."""
+        identity = participant.identity
+        logger.debug("[%s] Audio track unsubscribed: %s", self.name, identity)
+        self._cleanup_participant(identity)
+
+    def _on_participant_disconnected(self, participant: "rtc.RemoteParticipant"):
+        """Clean up when a participant leaves the room."""
+        identity = participant.identity
+        logger.info("[%s] Participant disconnected: %s", self.name, identity)
+        self._cleanup_participant(identity)
+
+    def _on_disconnected(self, reason: str = ""):
+        """Handle unexpected room disconnection — schedule reconnection."""
+        if not self._running:
+            return
+        logger.warning("[%s] Disconnected from room: %s. Will reconnect.", self.name, reason)
+        self._connect_task = asyncio.create_task(self._reconnect_loop())
+
+    async def _reconnect_loop(self):
+        """Reconnect to LiveKit with exponential backoff."""
+        backoff_idx = 0
+        while self._running:
+            delay = RECONNECT_BACKOFF[min(backoff_idx, len(RECONNECT_BACKOFF) - 1)]
+            logger.info("[%s] Reconnecting in %ds...", self.name, delay)
+            await asyncio.sleep(delay)
+            if not self._running:
+                return
+            try:
+                if await self.connect():
+                    logger.info("[%s] Reconnected successfully", self.name)
+                    return
+            except Exception as e:
+                logger.warning("[%s] Reconnect attempt failed: %s", self.name, e)
+            backoff_idx += 1
+
+    async def _resolve_agent_name(self):
+        """Ask the LLM for the agent's name, then update the display name in-place."""
+        try:
+            from openai import AsyncOpenAI
+            from hermes_cli.config import load_config
+
+            config = load_config()
+            model_config = config.get("model", {})
+            provider = model_config.get("provider", "")
+            model = model_config.get("default", "")
+
+            # Use the runtime provider resolution to get the right client
+            from hermes_cli.runtime_provider import resolve_requested_provider
+            resolved = resolve_requested_provider(provider, model)
+            if not resolved or not resolved.get("api_key"):
+                return
+
+            client = AsyncOpenAI(
+                api_key=resolved["api_key"],
+                base_url=resolved.get("base_url"),
+            )
+            resp = await client.chat.completions.create(
+                model=resolved.get("model", model),
+                messages=[{"role": "user", "content": "What is your name? Reply with ONLY your first name — no quotes, no punctuation, no explanation. It will be used as your on-screen display label in a video call."}],
+                max_tokens=20,
+            )
+            name = resp.choices[0].message.content.strip().strip('"').strip("'").split()[0] if resp.choices else ""
+            if not name or name.lower() == "hermes" or len(name) > 30:
+                return
+
+            logger.info("[%s] LLM says agent name is '%s', updating display name", self.name, name)
+            self._agent_name = name
+            await self._room.local_participant.set_name(name)
+        except Exception as e:
+            logger.debug("[%s] Could not resolve agent name from LLM: %s", self.name, e)
+
+    def _cleanup_participant(self, identity: str):
+        """Remove buffers and cancel audio stream for a participant."""
+        task = self._audio_streams.pop(identity, None)
+        if task:
+            task.cancel()
+        self._audio_buffers.pop(identity, None)
+        self._last_audio_time.pop(identity, None)
+
+    # -- Audio capture and processing ---------------------------------------
+
+    async def _audio_receive_loop(
+        self,
+        stream: "rtc.AudioStream",
+        identity: str,
+    ):
+        """Receive audio frames from a participant and buffer them.
+
+        This loop must drain the SDK's internal queue as fast as possible
+        to avoid 'native audio stream queue overflow' warnings.  All
+        heavy processing (RMS, silence detection) happens in
+        _check_silence_loop instead.
+        """
+        try:
+            async for event in stream:
+                if self._paused:
+                    continue
+                if identity not in self._audio_buffers:
+                    break
+
+                self._audio_buffers[identity].extend(event.frame.data.tobytes())
+        except asyncio.CancelledError:
+            return
+        except Exception as e:
+            logger.warning("[%s] Audio receive error for %s: %s", self.name, identity, e)
+
+    async def _check_silence_loop(self):
+        """Periodically check for completed utterances (silence after speech).
+
+        Each tick, we look at the tail of every participant's buffer to
+        decide whether they are currently speaking or silent.  When
+        silence exceeds the threshold, we extract the utterance and
+        send it for transcription.
+        """
+        # bytes per poll interval (how much audio one tick represents)
+        bytes_per_tick = int(SAMPLE_RATE * NUM_CHANNELS * 2 * POLL_INTERVAL)
+
+        try:
+            while self._running:
+                await asyncio.sleep(POLL_INTERVAL)
+
+                for identity in list(self._audio_buffers.keys()):
+                    buf = self._audio_buffers.get(identity)
+                    if buf is None:
+                        continue
+
+                    buf_len = len(buf)
+                    if buf_len == 0:
+                        continue
+
+                    # Check RMS of the most recent chunk to detect speech/silence
+                    tail = bytes(buf[-bytes_per_tick:]) if buf_len >= bytes_per_tick else bytes(buf)
+                    rms = _compute_rms(tail)
+
+                    if rms > RMS_SILENCE_FLOOR:
+                        # Active speech — update timestamp
+                        self._last_audio_time[identity] = time.monotonic()
+                        continue
+
+                    # Silent — check if silence has lasted long enough
+                    last_time = self._last_audio_time.get(identity)
+                    if last_time is None:
+                        # Never spoke — discard accumulated noise
+                        self._audio_buffers[identity] = bytearray()
+                        continue
+
+                    elapsed_silence = time.monotonic() - last_time
+                    if elapsed_silence < SILENCE_THRESHOLD_SECONDS:
+                        continue
+
+                    # Trim trailing silence from the buffer (keep only up to
+                    # SILENCE_THRESHOLD worth of trailing audio)
+                    silence_bytes = int(SILENCE_THRESHOLD_SECONDS * SAMPLE_RATE * NUM_CHANNELS * 2)
+                    speech_end = max(0, buf_len - silence_bytes)
+
+                    duration = speech_end / (SAMPLE_RATE * NUM_CHANNELS * 2)
+                    if duration < MIN_SPEECH_DURATION:
+                        # Too short — discard as noise
+                        self._audio_buffers[identity] = bytearray()
+                        self._last_audio_time.pop(identity, None)
+                        continue
+
+                    # Extract the utterance (speech portion only) and reset
+                    pcm_data = bytes(buf[:speech_end])
+                    self._audio_buffers[identity] = bytearray()
+                    self._last_audio_time.pop(identity, None)
+
+                    logger.info("[%s] Utterance from %s: %.1fs audio", self.name, identity, duration)
+                    asyncio.create_task(self._process_voice_input(identity, pcm_data))
+        except asyncio.CancelledError:
+            return
+
+    async def _process_voice_input(self, identity: str, pcm_data: bytes):
+        """Transcribe audio and feed into the agent loop."""
+        try:
+            # Write PCM to WAV temp file
+            wav_data = _pcm_to_wav(pcm_data, SAMPLE_RATE, NUM_CHANNELS)
+            tmp_dir = os.path.join(tempfile.gettempdir(), "hermes_livekit")
+            os.makedirs(tmp_dir, exist_ok=True)
+            wav_path = os.path.join(tmp_dir, f"utterance_{uuid.uuid4().hex[:8]}.wav")
+            with open(wav_path, "wb") as f:
+                f.write(wav_data)
+
+            # Transcribe using hermes STT pipeline
+            from tools.transcription_tools import transcribe_audio, get_stt_model_from_config
+            stt_model = get_stt_model_from_config()
+            result = await asyncio.to_thread(transcribe_audio, wav_path, model=stt_model)
+
+            # Clean up temp file
+            try:
+                os.unlink(wav_path)
+            except OSError:
+                pass
+
+            logger.info("[%s] STT result from %s: %s", self.name, identity, result)
+            transcript = (result.get("transcript") or result.get("text") or "").strip() if isinstance(result, dict) else ""
+            if not transcript:
+                logger.info("[%s] Empty transcript from %s, skipping", self.name, identity)
+                return
+
+            logger.info("[%s] Transcript from %s: %s", self.name, identity, transcript[:80])
+
+            # Build message event
+            source = self.build_source(
+                chat_id=self._room_name,
+                chat_name=self._room_name,
+                chat_type="group",
+                user_id=identity,
+                user_name=identity,
+            )
+
+            event = MessageEvent(
+                text=transcript,
+                message_type=MessageType.VOICE,
+                source=source,
+                message_id=uuid.uuid4().hex[:12],
+                media_urls=[],
+                timestamp=datetime.now(tz=timezone.utc),
+            )
+
+            await self.handle_message(event)
+        except Exception as e:
+            logger.error("[%s] Error processing voice from %s: %s", self.name, identity, e)
+
+    # -- Outbound messaging -------------------------------------------------
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send text via data channel (best-effort for connected web clients)."""
+        if not self._room:
+            return SendResult(success=False, error="Not connected to room")
+
+        try:
+            data = content.encode("utf-8")
+            await self._room.local_participant.publish_data(
+                data, reliable=True, topic="hermes-chat"
+            )
+            return SendResult(success=True, message_id=uuid.uuid4().hex[:12])
+        except Exception as e:
+            logger.debug("[%s] Data channel send failed (non-critical): %s", self.name, e)
+            # Not a failure — voice is the primary channel
+            return SendResult(success=True, message_id=uuid.uuid4().hex[:12])
+
+    async def play_tts(
+        self,
+        chat_id: str,
+        audio_path: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Play TTS audio into the LiveKit room via the published audio track."""
+        if not self._audio_source or not self._room:
+            return SendResult(success=False, error="Not connected to room")
+
+        try:
+            # Pause capture to avoid echo
+            self._paused = True
+
+            # Decode audio file to raw PCM using ffmpeg
+            pcm_data = await asyncio.to_thread(
+                self._decode_audio_to_pcm, audio_path
+            )
+            if not pcm_data:
+                self._paused = False
+                return SendResult(success=False, error="Failed to decode audio")
+
+            # Publish PCM frames to the audio source
+            # LiveKit expects frames of a specific size
+            samples_per_frame = SAMPLE_RATE // 50  # 20ms frames
+            bytes_per_frame = samples_per_frame * NUM_CHANNELS * 2  # 16-bit
+
+            offset = 0
+            while offset < len(pcm_data):
+                chunk = pcm_data[offset:offset + bytes_per_frame]
+                if len(chunk) < bytes_per_frame:
+                    # Pad the last frame with silence
+                    chunk = chunk + b"\x00" * (bytes_per_frame - len(chunk))
+
+                frame = rtc.AudioFrame(
+                    data=chunk,
+                    sample_rate=SAMPLE_RATE,
+                    num_channels=NUM_CHANNELS,
+                    samples_per_channel=samples_per_frame,
+                )
+                await self._audio_source.capture_frame(frame)
+                offset += bytes_per_frame
+
+            # Brief pause after playback before resuming capture
+            await asyncio.sleep(0.3)
+            self._paused = False
+
+            return SendResult(success=True, message_id=uuid.uuid4().hex[:12])
+        except Exception as e:
+            self._paused = False
+            logger.error("[%s] TTS playback error: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
+    @staticmethod
+    def _decode_audio_to_pcm(audio_path: str) -> Optional[bytes]:
+        """Decode an audio file to raw 16-bit PCM using ffmpeg."""
+        try:
+            result = subprocess.run(
+                [
+                    "ffmpeg", "-i", audio_path,
+                    "-f", "s16le",        # raw 16-bit little-endian PCM
+                    "-acodec", "pcm_s16le",
+                    "-ar", str(SAMPLE_RATE),
+                    "-ac", str(NUM_CHANNELS),
+                    "-loglevel", "error",
+                    "pipe:1",
+                ],
+                capture_output=True,
+                timeout=30,
+            )
+            if result.returncode != 0:
+                logger.warning("ffmpeg decode failed: %s", result.stderr.decode()[:200])
+                return None
+            return result.stdout
+        except FileNotFoundError:
+            logger.warning("ffmpeg not found — required for LiveKit TTS playback")
+            return None
+        except Exception as e:
+            logger.warning("Audio decode error: %s", e)
+            return None
+
+    def prepare_tts_text(self, text: str) -> str:
+        """Strip tool output, code blocks, URLs, and file paths for voice.
+
+        The full response is already sent via data channel — TTS should
+        only speak the conversational parts.
+        """
+        import re as _re
+
+        # Remove fenced code blocks (```...```)
+        text = _re.sub(r'```[\s\S]*?```', '', text)
+
+        # Remove inline code (`...`)
+        text = _re.sub(r'`[^`]+`', '', text)
+
+        # Remove URLs
+        text = _re.sub(r'https?://\S+', '', text)
+
+        # Remove file paths (/foo/bar, ~/foo, C:\foo)
+        text = _re.sub(r'(?:~|/|[A-Z]:\\)[\w./\\-]+', '', text)
+
+        # Remove MEDIA: tags
+        text = _re.sub(r'MEDIA:\S+', '', text)
+
+        # Remove markdown formatting
+        text = _re.sub(r'[*_`#\[\]()]', '', text)
+
+        # Collapse whitespace
+        text = _re.sub(r'\n{3,}', '\n\n', text)
+        text = _re.sub(r'  +', ' ', text)
+
+        return text[:4000].strip()
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        """No typing indicator for voice — no-op."""
+        pass
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        """Return info about the LiveKit room."""
+        participants = []
+        if self._room:
+            for p in self._room.remote_participants.values():
+                participants.append(p.identity)
+        return {
+            "name": self._room_name,
+            "type": "group",
+            "chat_id": chat_id,
+            "participants": participants,
+        }

--- a/gateway/platforms/livekit.py
+++ b/gateway/platforms/livekit.py
@@ -159,6 +159,17 @@ class LiveKitAdapter(BasePlatformAdapter):
 
         self._presence_poll_interval: float = self._resolve_presence_poll_interval()
 
+    def _should_auto_tts_for_chat(self, chat_id: str) -> bool:
+        """LiveKit is voice-first — always auto-TTS unless the chat opted out.
+
+        On text platforms the default is gated by ``voice.auto_tts`` (off by
+        default). On LiveKit the channel itself is audio, so a typed-only
+        reply gives the user nothing. Per-chat ``/voice off`` still wins.
+        """
+        if chat_id in self._auto_tts_disabled_chats:
+            return False
+        return True
+
     def _resolve_presence_poll_interval(self) -> float:
         """Pick the presence-poll interval: env override > cloud/local default.
 
@@ -565,7 +576,36 @@ class LiveKitAdapter(BasePlatformAdapter):
             logger.debug("[%s] Could not resolve agent name from LLM: %s", self.name, e)
 
     def _cleanup_participant(self, identity: str):
-        """Remove buffers and cancel audio stream for a participant."""
+        """Remove buffers and cancel audio stream for a participant.
+
+        If the participant was mid-utterance when the track went away
+        (e.g. their mic dropped or — for file-based publishers — the
+        clip ended), flush whatever speech has been buffered before
+        discarding it, so the user's last words still reach STT.
+        """
+        # Flush a pending utterance, if any, before tearing buffers down.
+        buf = self._audio_buffers.get(identity)
+        if buf is not None and identity in self._speaking_participants and len(buf) > 0:
+            silence_bytes = int(SILENCE_THRESHOLD_SECONDS * SAMPLE_RATE * NUM_CHANNELS * 2)
+            speech_end = max(0, len(buf) - silence_bytes)
+            duration = speech_end / (SAMPLE_RATE * NUM_CHANNELS * 2)
+            if duration >= MIN_SPEECH_DURATION:
+                pcm_data = bytes(buf[:speech_end])
+                logger.info(
+                    "[%s] Utterance from %s: %.1fs audio (flushed on track end)",
+                    self.name, identity, duration,
+                )
+                try:
+                    asyncio.create_task(
+                        self._publish_agent_event(
+                            "agent:listening-stop", {"identity": identity}
+                        )
+                    )
+                    asyncio.create_task(self._process_voice_input(identity, pcm_data))
+                except RuntimeError:
+                    # No running event loop (e.g. during disconnect path) — skip flush.
+                    pass
+
         task = self._audio_streams.pop(identity, None)
         if task:
             task.cancel()

--- a/gateway/platforms/livekit.py
+++ b/gateway/platforms/livekit.py
@@ -708,10 +708,11 @@ class LiveKitAdapter(BasePlatformAdapter):
             with open(wav_path, "wb") as f:
                 f.write(wav_data)
 
-            # Transcribe using hermes STT pipeline
-            from tools.transcription_tools import transcribe_audio, get_stt_model_from_config
-            stt_model = get_stt_model_from_config()
-            result = await asyncio.to_thread(transcribe_audio, wav_path, model=stt_model)
+            # Transcribe using hermes STT pipeline. transcribe_audio resolves
+            # the model from stt config internally when called with no model
+            # arg — same pattern other gateway adapters use.
+            from tools.transcription_tools import transcribe_audio
+            result = await asyncio.to_thread(transcribe_audio, wav_path)
 
             # Clean up temp file
             try:

--- a/gateway/platforms/livekit.py
+++ b/gateway/platforms/livekit.py
@@ -42,12 +42,15 @@ except ImportError:
     rtc = None  # type: ignore[assignment]
 
 try:
-    from livekit.api import AccessToken, VideoGrants
+    from livekit.api import AccessToken, VideoGrants, LiveKitAPI
+    from livekit.protocol.room import ListParticipantsRequest
     LIVEKIT_API_AVAILABLE = True
 except ImportError:
     LIVEKIT_API_AVAILABLE = False
     AccessToken = None  # type: ignore[assignment,misc]
     VideoGrants = None  # type: ignore[assignment,misc]
+    LiveKitAPI = None  # type: ignore[assignment,misc]
+    ListParticipantsRequest = None  # type: ignore[assignment,misc]
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
@@ -63,7 +66,8 @@ logger = logging.getLogger(__name__)
 SILENCE_THRESHOLD_SECONDS = 1.5   # seconds of silence → end of utterance
 MIN_SPEECH_DURATION = 0.5         # minimum seconds to process (skip noise)
 RMS_SILENCE_FLOOR = 50            # PCM RMS below this is silence
-POLL_INTERVAL = 0.2               # silence check interval in seconds
+POLL_INTERVAL = 0.2               # silence check interval when active
+IDLE_POLL_INTERVAL = 2.0          # silence check interval when no remote participants
 
 # LiveKit audio defaults
 SAMPLE_RATE = 48000
@@ -71,6 +75,10 @@ NUM_CHANNELS = 1
 
 # Reconnection
 RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
+MAX_RECONNECT_ATTEMPTS = 10       # give up after this many consecutive failures
+
+# Presence polling (when no humans in room, we stay out and poll)
+PRESENCE_POLL_INTERVAL = 30.0     # seconds between room-presence checks
 
 
 def check_livekit_requirements() -> bool:
@@ -127,6 +135,8 @@ class LiveKitAdapter(BasePlatformAdapter):
         self._local_track: Optional["rtc.LocalAudioTrack"] = None
         self._silence_task: Optional[asyncio.Task] = None
         self._connect_task: Optional[asyncio.Task] = None
+        self._presence_task: Optional[asyncio.Task] = None
+        self._graceful_leave: bool = False  # set while intentionally leaving
 
         # Per-participant audio buffers: identity -> (pcm bytearray, last_audio_time)
         self._audio_buffers: Dict[str, bytearray] = {}
@@ -178,7 +188,13 @@ class LiveKitAdapter(BasePlatformAdapter):
     # -- Connection lifecycle -----------------------------------------------
 
     async def connect(self) -> bool:
-        """Connect to LiveKit room."""
+        """Start the LiveKit adapter.
+
+        Presence-aware: if the room already has at least one remote
+        participant, join immediately. Otherwise stay out and run a
+        presence watcher that joins as soon as someone arrives. Either
+        way the adapter is "connected" from the gateway's point of view.
+        """
         if not LIVEKIT_AVAILABLE:
             logger.warning("[%s] livekit SDK not installed. Run: pip install 'hermes-agent[livekit]'", self.name)
             return False
@@ -189,6 +205,67 @@ class LiveKitAdapter(BasePlatformAdapter):
             logger.warning("[%s] LIVEKIT_URL, LIVEKIT_API_KEY, and LIVEKIT_API_SECRET required", self.name)
             return False
 
+        self._running = True
+
+        # Check if anyone is in the room already. If not, don't consume a
+        # participant slot — just watch.
+        count = await self._count_remote_participants()
+        if count > 0:
+            logger.info("[%s] %d participant(s) already in '%s', joining", self.name, count, self._room_name)
+            return await self._join_room()
+
+        logger.info("[%s] Room '%s' empty, watching for participants (poll %ds)", self.name, self._room_name, int(PRESENCE_POLL_INTERVAL))
+        self._mark_connected()
+        self._presence_task = asyncio.create_task(self._presence_watch_loop())
+        return True
+
+    async def _count_remote_participants(self) -> int:
+        """Count non-local participants currently in the room via the Server API.
+
+        Returns 0 on any error (room missing, network blip, etc.) — callers
+        treat that as "nobody here, keep polling".
+        """
+        try:
+            # Server API expects http(s):// scheme; convert from ws(s)://.
+            http_url = self._url
+            if http_url.startswith("wss://"):
+                http_url = "https://" + http_url[6:]
+            elif http_url.startswith("ws://"):
+                http_url = "http://" + http_url[5:]
+            http_url = http_url.rstrip("/")
+
+            client = LiveKitAPI(url=http_url, api_key=self._api_key, api_secret=self._api_secret)
+            try:
+                resp = await client.room.list_participants(
+                    ListParticipantsRequest(room=self._room_name)
+                )
+                return len(resp.participants)
+            finally:
+                await client.aclose()
+        except Exception as e:
+            logger.debug("[%s] presence check failed: %s", self.name, e)
+            return 0
+
+    async def _presence_watch_loop(self) -> None:
+        """Poll the room; join as soon as a remote participant appears."""
+        try:
+            while self._running:
+                await asyncio.sleep(PRESENCE_POLL_INTERVAL)
+                if not self._running:
+                    return
+                if self._room is not None:
+                    # Something else joined us (manual reconnect?); stop polling.
+                    return
+                count = await self._count_remote_participants()
+                if count > 0:
+                    logger.info("[%s] Participant detected in '%s', joining", self.name, self._room_name)
+                    if await self._join_room():
+                        return  # joined — done polling
+        except asyncio.CancelledError:
+            return
+
+    async def _join_room(self) -> bool:
+        """Actually establish the LiveKit room connection and start audio I/O."""
         try:
             self._room = rtc.Room()
 
@@ -253,6 +330,14 @@ class LiveKitAdapter(BasePlatformAdapter):
         self._running = False
         self._mark_disconnected()
 
+        if self._presence_task:
+            self._presence_task.cancel()
+            try:
+                await self._presence_task
+            except asyncio.CancelledError:
+                pass
+            self._presence_task = None
+
         if self._silence_task:
             self._silence_task.cancel()
             try:
@@ -271,7 +356,11 @@ class LiveKitAdapter(BasePlatformAdapter):
         self._audio_streams.clear()
 
         if self._room:
-            await self._room.disconnect()
+            self._graceful_leave = True
+            try:
+                await self._room.disconnect()
+            finally:
+                self._graceful_leave = False
             self._room = None
 
         self._audio_source = None
@@ -317,34 +406,96 @@ class LiveKitAdapter(BasePlatformAdapter):
         self._cleanup_participant(identity)
 
     def _on_participant_disconnected(self, participant: "rtc.RemoteParticipant"):
-        """Clean up when a participant leaves the room."""
+        """Clean up when a participant leaves the room.
+
+        If we're now alone in the room, drop the connection and go back
+        to presence polling — no need to consume a participant slot while
+        nobody's here to talk to.
+        """
         identity = participant.identity
         logger.info("[%s] Participant disconnected: %s", self.name, identity)
         self._cleanup_participant(identity)
 
+        if self._room and not self._room.remote_participants:
+            logger.info("[%s] Last participant left '%s', leaving room", self.name, self._room_name)
+            asyncio.create_task(self._leave_and_watch())
+
+    async def _leave_and_watch(self) -> None:
+        """Tear down the room connection and resume presence polling."""
+        # Stop silence detection and audio streams, but keep self._running
+        # so the presence loop can resume us later.
+        if self._silence_task:
+            self._silence_task.cancel()
+            try:
+                await self._silence_task
+            except asyncio.CancelledError:
+                pass
+            self._silence_task = None
+
+        for task in self._audio_streams.values():
+            task.cancel()
+        self._audio_streams.clear()
+        self._audio_buffers.clear()
+        self._last_audio_time.clear()
+        self._speaking_participants.clear()
+
+        if self._room:
+            self._graceful_leave = True
+            try:
+                await self._room.disconnect()
+            except Exception as e:
+                logger.debug("[%s] leave error: %s", self.name, e)
+            finally:
+                self._graceful_leave = False
+            self._room = None
+        self._audio_source = None
+        self._local_track = None
+
+        if self._running and (self._presence_task is None or self._presence_task.done()):
+            self._presence_task = asyncio.create_task(self._presence_watch_loop())
+
     def _on_disconnected(self, reason: str = ""):
-        """Handle unexpected room disconnection — schedule reconnection."""
-        if not self._running:
+        """Handle unexpected room disconnection — schedule reconnection.
+
+        Graceful leaves (empty room, full teardown) set ``_graceful_leave``
+        so we don't fight with ``_leave_and_watch`` / ``disconnect``.
+        """
+        if not self._running or self._graceful_leave:
             return
         logger.warning("[%s] Disconnected from room: %s. Will reconnect.", self.name, reason)
         self._connect_task = asyncio.create_task(self._reconnect_loop())
 
     async def _reconnect_loop(self):
-        """Reconnect to LiveKit with exponential backoff."""
+        """Reconnect to LiveKit with exponential backoff.
+
+        Caps at MAX_RECONNECT_ATTEMPTS consecutive failures — beyond that the
+        adapter stays disconnected rather than spamming a misconfigured URL
+        forever. The user can restart the gateway to retry.
+        """
         backoff_idx = 0
+        attempts = 0
         while self._running:
+            if attempts >= MAX_RECONNECT_ATTEMPTS:
+                logger.error(
+                    "[%s] Giving up after %d reconnect attempts. Restart the gateway to try again.",
+                    self.name, attempts,
+                )
+                self._running = False
+                self._mark_disconnected()
+                return
             delay = RECONNECT_BACKOFF[min(backoff_idx, len(RECONNECT_BACKOFF) - 1)]
-            logger.info("[%s] Reconnecting in %ds...", self.name, delay)
+            logger.info("[%s] Reconnecting in %ds (attempt %d/%d)...", self.name, delay, attempts + 1, MAX_RECONNECT_ATTEMPTS)
             await asyncio.sleep(delay)
             if not self._running:
                 return
             try:
-                if await self.connect():
+                if await self._join_room():
                     logger.info("[%s] Reconnected successfully", self.name)
                     return
             except Exception as e:
                 logger.warning("[%s] Reconnect attempt failed: %s", self.name, e)
             backoff_idx += 1
+            attempts += 1
 
     async def _resolve_agent_name(self):
         """Ask the LLM for the agent's name, then update the display name in-place."""
@@ -425,12 +576,21 @@ class LiveKitAdapter(BasePlatformAdapter):
         decide whether they are currently speaking or silent.  When
         silence exceeds the threshold, we extract the utterance and
         send it for transcription.
+
+        Drops to a slower poll when no participants are buffered — saves
+        CPU without delaying utterance detection (a joining participant
+        will trigger ``_on_track_subscribed`` immediately, not on the
+        next loop tick).
         """
         # bytes per poll interval (how much audio one tick represents)
         bytes_per_tick = int(SAMPLE_RATE * NUM_CHANNELS * 2 * POLL_INTERVAL)
 
         try:
             while self._running:
+                # No one to listen to — sleep longer.
+                if not self._audio_buffers:
+                    await asyncio.sleep(IDLE_POLL_INTERVAL)
+                    continue
                 await asyncio.sleep(POLL_INTERVAL)
 
                 for identity in list(self._audio_buffers.keys()):

--- a/gateway/platforms/livekit.py
+++ b/gateway/platforms/livekit.py
@@ -146,6 +146,17 @@ class LiveKitAdapter(BasePlatformAdapter):
         self._presence_task: Optional[asyncio.Task] = None
         self._graceful_leave: bool = False  # set while intentionally leaving
 
+        # Per-participant audio buffers: identity -> (pcm bytearray, last_audio_time)
+        self._audio_buffers: Dict[str, bytearray] = {}
+        self._last_audio_time: Dict[str, float] = {}
+        self._audio_streams: Dict[str, asyncio.Task] = {}
+
+        # Pause audio capture during TTS playback
+        self._paused = False
+
+        # Per-participant speech state (for listening-start/stop events)
+        self._speaking_participants: set[str] = set()
+
         self._presence_poll_interval: float = self._resolve_presence_poll_interval()
 
     def _resolve_presence_poll_interval(self) -> float:
@@ -168,17 +179,6 @@ class LiveKitAdapter(BasePlatformAdapter):
         interval = PRESENCE_POLL_INTERVAL_CLOUD if is_cloud else PRESENCE_POLL_INTERVAL_LOCAL
         logger.info("[%s] presence poll interval=%.1fs (%s default)", self.name, interval, "cloud" if is_cloud else "local")
         return interval
-
-        # Per-participant audio buffers: identity -> (pcm bytearray, last_audio_time)
-        self._audio_buffers: Dict[str, bytearray] = {}
-        self._last_audio_time: Dict[str, float] = {}
-        self._audio_streams: Dict[str, asyncio.Task] = {}
-
-        # Pause audio capture during TTS playback
-        self._paused = False
-
-        # Per-participant speech state (for listening-start/stop events)
-        self._speaking_participants: set[str] = set()
 
     @staticmethod
     def _find_default_avatar() -> str:

--- a/gateway/platforms/livekit.py
+++ b/gateway/platforms/livekit.py
@@ -77,8 +77,16 @@ NUM_CHANNELS = 1
 RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
 MAX_RECONNECT_ATTEMPTS = 10       # give up after this many consecutive failures
 
-# Presence polling (when no humans in room, we stay out and poll)
-PRESENCE_POLL_INTERVAL = 30.0     # seconds between room-presence checks
+# Presence polling (when no humans in room, we stay out and poll).
+# Defaults differ by deployment:
+#   - LiveKit Cloud has real API rate limits and we pay per-minute, so
+#     30s keeps headroom while still waking fast enough for normal UX.
+#   - Self-hosted LiveKit has no limits and no cost pressure, so we poll
+#     aggressively enough that the first speaker doesn't wait noticeably.
+# Override with LIVEKIT_PRESENCE_POLL_INTERVAL (seconds) in the env if
+# neither default fits.
+PRESENCE_POLL_INTERVAL_CLOUD = 30.0
+PRESENCE_POLL_INTERVAL_LOCAL = 5.0
 
 
 def check_livekit_requirements() -> bool:
@@ -137,6 +145,29 @@ class LiveKitAdapter(BasePlatformAdapter):
         self._connect_task: Optional[asyncio.Task] = None
         self._presence_task: Optional[asyncio.Task] = None
         self._graceful_leave: bool = False  # set while intentionally leaving
+
+        self._presence_poll_interval: float = self._resolve_presence_poll_interval()
+
+    def _resolve_presence_poll_interval(self) -> float:
+        """Pick the presence-poll interval: env override > cloud/local default.
+
+        LiveKit Cloud hosts on ``*.livekit.cloud``; anything else is treated
+        as a self-hosted deployment and gets the faster default.
+        """
+        override = os.getenv("LIVEKIT_PRESENCE_POLL_INTERVAL", "").strip()
+        if override:
+            try:
+                parsed = float(override)
+                if parsed > 0:
+                    logger.info("[%s] presence poll interval=%.1fs (LIVEKIT_PRESENCE_POLL_INTERVAL)", self.name, parsed)
+                    return parsed
+            except ValueError:
+                logger.warning("[%s] LIVEKIT_PRESENCE_POLL_INTERVAL=%r is not a number; using default", self.name, override)
+
+        is_cloud = ".livekit.cloud" in self._url.lower()
+        interval = PRESENCE_POLL_INTERVAL_CLOUD if is_cloud else PRESENCE_POLL_INTERVAL_LOCAL
+        logger.info("[%s] presence poll interval=%.1fs (%s default)", self.name, interval, "cloud" if is_cloud else "local")
+        return interval
 
         # Per-participant audio buffers: identity -> (pcm bytearray, last_audio_time)
         self._audio_buffers: Dict[str, bytearray] = {}
@@ -214,7 +245,7 @@ class LiveKitAdapter(BasePlatformAdapter):
             logger.info("[%s] %d participant(s) already in '%s', joining", self.name, count, self._room_name)
             return await self._join_room()
 
-        logger.info("[%s] Room '%s' empty, watching for participants (poll %ds)", self.name, self._room_name, int(PRESENCE_POLL_INTERVAL))
+        logger.info("[%s] Room '%s' empty, watching for participants (poll %.1fs)", self.name, self._room_name, self._presence_poll_interval)
         self._mark_connected()
         self._presence_task = asyncio.create_task(self._presence_watch_loop())
         return True
@@ -250,7 +281,7 @@ class LiveKitAdapter(BasePlatformAdapter):
         """Poll the room; join as soon as a remote participant appears."""
         try:
             while self._running:
-                await asyncio.sleep(PRESENCE_POLL_INTERVAL)
+                await asyncio.sleep(self._presence_poll_interval)
                 if not self._running:
                     return
                 if self._room is not None:

--- a/gateway/platforms/livekit.py
+++ b/gateway/platforms/livekit.py
@@ -136,6 +136,9 @@ class LiveKitAdapter(BasePlatformAdapter):
         # Pause audio capture during TTS playback
         self._paused = False
 
+        # Per-participant speech state (for listening-start/stop events)
+        self._speaking_participants: set[str] = set()
+
     @staticmethod
     def _find_default_avatar() -> str:
         """Look for a default avatar image in ~/.hermes/."""
@@ -275,6 +278,7 @@ class LiveKitAdapter(BasePlatformAdapter):
         self._local_track = None
         self._audio_buffers.clear()
         self._last_audio_time.clear()
+        self._speaking_participants.clear()
         logger.info("[%s] Disconnected", self.name)
 
     # -- LiveKit event handlers ---------------------------------------------
@@ -385,6 +389,7 @@ class LiveKitAdapter(BasePlatformAdapter):
             task.cancel()
         self._audio_buffers.pop(identity, None)
         self._last_audio_time.pop(identity, None)
+        self._speaking_participants.discard(identity)
 
     # -- Audio capture and processing ---------------------------------------
 
@@ -444,6 +449,14 @@ class LiveKitAdapter(BasePlatformAdapter):
                     if rms > RMS_SILENCE_FLOOR:
                         # Active speech — update timestamp
                         self._last_audio_time[identity] = time.monotonic()
+                        # Emit listening-start on first loud chunk of an utterance
+                        if identity not in self._speaking_participants:
+                            self._speaking_participants.add(identity)
+                            asyncio.create_task(
+                                self._publish_agent_event(
+                                    "agent:listening-start", {"identity": identity}
+                                )
+                            )
                         continue
 
                     # Silent — check if silence has lasted long enough
@@ -467,12 +480,26 @@ class LiveKitAdapter(BasePlatformAdapter):
                         # Too short — discard as noise
                         self._audio_buffers[identity] = bytearray()
                         self._last_audio_time.pop(identity, None)
+                        # False alarm — revert the listening-start we sent
+                        if identity in self._speaking_participants:
+                            self._speaking_participants.discard(identity)
+                            asyncio.create_task(
+                                self._publish_agent_event(
+                                    "agent:listening-stop", {"identity": identity}
+                                )
+                            )
                         continue
 
                     # Extract the utterance (speech portion only) and reset
                     pcm_data = bytes(buf[:speech_end])
                     self._audio_buffers[identity] = bytearray()
                     self._last_audio_time.pop(identity, None)
+                    self._speaking_participants.discard(identity)
+                    asyncio.create_task(
+                        self._publish_agent_event(
+                            "agent:listening-stop", {"identity": identity}
+                        )
+                    )
 
                     logger.info("[%s] Utterance from %s: %.1fs audio", self.name, identity, duration)
                     asyncio.create_task(self._process_voice_input(identity, pcm_data))
@@ -509,6 +536,12 @@ class LiveKitAdapter(BasePlatformAdapter):
 
             logger.info("[%s] Transcript from %s: %s", self.name, identity, transcript[:80])
 
+            # Publish the final user transcript so clients can update their UI.
+            await self._publish_agent_event(
+                "agent:user-transcript",
+                {"transcript": transcript, "final": True, "identity": identity},
+            )
+
             # Build message event
             source = self.build_source(
                 chat_id=self._room_name,
@@ -527,11 +560,36 @@ class LiveKitAdapter(BasePlatformAdapter):
                 timestamp=datetime.now(tz=timezone.utc),
             )
 
+            # Agent is about to invoke the LLM.
+            await self._publish_agent_event("agent:thinking-start")
             await self.handle_message(event)
         except Exception as e:
             logger.error("[%s] Error processing voice from %s: %s", self.name, identity, e)
 
     # -- Outbound messaging -------------------------------------------------
+
+    async def _publish_agent_event(
+        self, event_type: str, payload: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """Publish an agent:* lifecycle event as JSON on the default data topic.
+
+        Consumed by voice-agent.desktop (and any compatible client) to drive
+        UI state — listening/thinking/speaking indicators and live transcript
+        display. Topic is deliberately unset: the desktop client routes
+        messages with no topic (or any topic other than "hermes-chat") to its
+        JSON/event handler.
+        """
+        if not self._room:
+            return
+        try:
+            import json as _json
+            msg = {"type": event_type, "payload": payload or {}}
+            await self._room.local_participant.publish_data(
+                _json.dumps(msg).encode("utf-8"), reliable=True
+            )
+        except Exception as e:
+            # Never let UI telemetry break the voice flow.
+            logger.debug("[%s] agent event publish failed (%s): %s", self.name, event_type, e)
 
     async def send(
         self,
@@ -548,6 +606,11 @@ class LiveKitAdapter(BasePlatformAdapter):
             data = content.encode("utf-8")
             await self._room.local_participant.publish_data(
                 data, reliable=True, topic="hermes-chat"
+            )
+            # Mirror the content as an agent-transcript event so clients that
+            # render a conversation log can add an assistant message.
+            await self._publish_agent_event(
+                "agent:agent-transcript", {"transcript": content, "final": True}
             )
             return SendResult(success=True, message_id=uuid.uuid4().hex[:12])
         except Exception as e:
@@ -583,6 +646,8 @@ class LiveKitAdapter(BasePlatformAdapter):
             samples_per_frame = SAMPLE_RATE // 50  # 20ms frames
             bytes_per_frame = samples_per_frame * NUM_CHANNELS * 2  # 16-bit
 
+            await self._publish_agent_event("agent:speaking-start")
+
             offset = 0
             while offset < len(pcm_data):
                 chunk = pcm_data[offset:offset + bytes_per_frame]
@@ -602,10 +667,12 @@ class LiveKitAdapter(BasePlatformAdapter):
             # Brief pause after playback before resuming capture
             await asyncio.sleep(0.3)
             self._paused = False
+            await self._publish_agent_event("agent:speaking-stop")
 
             return SendResult(success=True, message_id=uuid.uuid4().hex[:12])
         except Exception as e:
             self._paused = False
+            await self._publish_agent_event("agent:speaking-stop")
             logger.error("[%s] TTS playback error: %s", self.name, e)
             return SendResult(success=False, error=str(e))
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5377,6 +5377,13 @@ class GatewayRunner:
                 return None
             return YuanbaoAdapter(config)
 
+        elif platform == Platform.LIVEKIT:
+            from gateway.platforms.livekit import LiveKitAdapter, check_livekit_requirements
+            if not check_livekit_requirements():
+                logger.warning("LiveKit: livekit SDK not installed or LIVEKIT_URL/API_KEY/API_SECRET not set")
+                return None
+            return LiveKitAdapter(config)
+
         return None
     def _is_user_authorized(self, source: SessionSource) -> bool:
         """
@@ -5419,6 +5426,7 @@ class GatewayRunner:
             Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOWED_USERS",
             Platform.QQBOT: "QQ_ALLOWED_USERS",
             Platform.YUANBAO: "YUANBAO_ALLOWED_USERS",
+            Platform.LIVEKIT: "LIVEKIT_ALLOWED_USERS",
         }
         platform_group_user_env_map = {
             Platform.TELEGRAM: "TELEGRAM_GROUP_ALLOWED_USERS",
@@ -5445,6 +5453,7 @@ class GatewayRunner:
             Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOW_ALL_USERS",
             Platform.QQBOT: "QQ_ALLOW_ALL_USERS",
             Platform.YUANBAO: "YUANBAO_ALLOW_ALL_USERS",
+            Platform.LIVEKIT: "LIVEKIT_ALLOW_ALL_USERS",
         }
         # Bots admitted by {PLATFORM}_ALLOW_BOTS bypass the human allowlist (#4466).
         platform_allow_bots_map = {

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4904,11 +4904,11 @@ def show_config():
     print()
     print(color("◆ Messaging Platforms", Colors.CYAN, Colors.BOLD))
     
-    telegram_token = get_env_value('TELEGRAM_BOT_TOKEN')
-    discord_token = get_env_value('DISCORD_BOT_TOKEN')
-    
-    print(f"  Telegram:     {'configured' if telegram_token else color('not configured', Colors.DIM)}")
-    print(f"  Discord:      {'configured' if discord_token else color('not configured', Colors.DIM)}")
+    from hermes_cli.status import MESSAGING_PLATFORMS
+    for name, (token_var, _home_var) in MESSAGING_PLATFORMS.items():
+        configured = bool(get_env_value(token_var))
+        status = "configured" if configured else color("not configured", Colors.DIM)
+        print(f"  {name + ':':14s}{status}")
     
     # Skill config
     try:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3353,6 +3353,7 @@ _PLATFORMS = [
         "label": "Matrix",
         "emoji": "🔐",
         "token_var": "MATRIX_ACCESS_TOKEN",
+        "extras": "matrix",
         "setup_instructions": [
             "1. Works with any Matrix homeserver (self-hosted Synapse/Conduit/Dendrite or matrix.org)",
             "2. Create a bot user on your homeserver, or use your own account",
@@ -3476,6 +3477,7 @@ _PLATFORMS = [
         "label": "DingTalk",
         "emoji": "💬",
         "token_var": "DINGTALK_CLIENT_ID",
+        "extras": "dingtalk",
         "setup_instructions": [
             "1. Go to https://open-dev.dingtalk.com → Create Application",
             "2. Under 'Credentials', copy the AppKey (Client ID) and AppSecret (Client Secret)",
@@ -3494,6 +3496,7 @@ _PLATFORMS = [
         "label": "Feishu / Lark",
         "emoji": "🪽",
         "token_var": "FEISHU_APP_ID",
+        "extras": "feishu",
         "setup_instructions": [
             "1. Go to https://open.feishu.cn/ (or https://open.larksuite.com/ for Lark)",
             "2. Create an app and copy the App ID and App Secret",
@@ -3646,6 +3649,37 @@ _PLATFORMS = [
              "help": "The App ID from your Yuanbao IM Bot credentials."},
             {"name": "YUANBAO_APP_SECRET", "prompt": "App Secret", "password": True,
              "help": "The App Secret (used for HMAC signing) from your Yuanbao IM Bot."},
+        ],
+    },
+    {
+        "key": "livekit",
+        "label": "LiveKit",
+        "emoji": "🎙️",
+        "token_var": "LIVEKIT_URL",
+        "extras": "livekit",
+        "setup_instructions": [
+            "1. Self-host LiveKit (https://docs.livekit.io/home/self-hosting/local/)",
+            "   or sign up for LiveKit Cloud (https://cloud.livekit.io)",
+            "2. Copy the WebSocket URL (e.g., wss://your-project.livekit.cloud)",
+            "3. Generate an API key and secret from your project settings",
+            "4. Connect to the room using any LiveKit client (web, mobile, or CLI)",
+        ],
+        "vars": [
+            {"name": "LIVEKIT_URL", "prompt": "LiveKit server URL", "password": False,
+             "help": "WebSocket URL for your LiveKit server (e.g. wss://your-project.livekit.cloud)."},
+            {"name": "LIVEKIT_API_KEY", "prompt": "API Key", "password": False,
+             "help": "API key from your LiveKit project settings."},
+            {"name": "LIVEKIT_API_SECRET", "prompt": "API Secret", "password": True,
+             "help": "API secret from your LiveKit project settings."},
+            {"name": "LIVEKIT_AGENT_NAME", "prompt": "Agent display name (default: Hermes)", "password": False,
+             "help": "The name shown for the agent in LiveKit rooms. Default is 'Hermes'. If not set, the agent will ask the LLM for its name."},
+            {"name": "LIVEKIT_AGENT_AVATAR", "prompt": "Agent avatar URL (optional)", "password": False,
+             "help": "URL to an image shown as the agent's avatar in LiveKit clients."},
+            {"name": "LIVEKIT_ROOM", "prompt": "Room name (default: hermes)", "password": False,
+             "help": "The LiveKit room the agent will join. Default is 'hermes'."},
+            {"name": "LIVEKIT_ALLOWED_USERS", "prompt": "Allowed participant identities (comma-separated, or empty)", "password": False,
+             "is_allowlist": True,
+             "help": "Restrict which LiveKit participants can interact with the agent."},
         ],
     },
 ]
@@ -3845,7 +3879,10 @@ def _setup_standard_platform(platform: dict):
         print_info(f"  {var['help']}")
         existing = get_env_value(var["name"])
         if existing and var["name"] != token_var:
-            print_info(f"  Current: {existing}")
+            if var.get("password"):
+                print_info(f"  Current: {'*' * min(len(existing), 12)}")
+            else:
+                print_info(f"  Current: {existing}")
 
         # Allowlist fields get special handling for the deny-by-default security model
         if var.get("is_allowlist"):
@@ -3908,6 +3945,35 @@ def _setup_standard_platform(platform: dict):
         if first_id and prompt_yes_no(f"  Use your user ID ({first_id}) as the home channel?", True):
             save_env_value(home_var, first_id)
             print_success(f"  Home channel set to {first_id}")
+
+    # Auto-install optional dependencies if the platform declares an extras group
+    extras_group = platform.get("extras")
+    if extras_group:
+        try:
+            # Check if deps are already available by trying the platform's import
+            _check_fn_name = f"check_{platform['key']}_requirements"
+            _mod = __import__(f"gateway.platforms.{platform['key']}", fromlist=[_check_fn_name])
+            _check_fn = getattr(_mod, _check_fn_name, None)
+            deps_ok = _check_fn() if _check_fn else True
+        except (ImportError, Exception):
+            deps_ok = False
+
+        if not deps_ok:
+            print()
+            print_info(f"  {label} requires additional Python packages.")
+            if prompt_yes_no(f"  Install them now? (pip install 'hermes-agent[{extras_group}]')", True):
+                import subprocess, sys, shutil
+                pip_cmd = "uv" if shutil.which("uv") else "pip"
+                install_args = [sys.executable, "-m", pip_cmd, "install", f"hermes-agent[{extras_group}]"]
+                if pip_cmd == "uv":
+                    install_args = ["uv", "pip", "install", f"hermes-agent[{extras_group}]"]
+                try:
+                    subprocess.run(install_args, check=True)
+                    print_success(f"  Installed {label} dependencies.")
+                except subprocess.CalledProcessError:
+                    print_warning(f"  Install failed — run manually: pip install 'hermes-agent[{extras_group}]'")
+            else:
+                print_info(f"  Skipped — install later: pip install 'hermes-agent[{extras_group}]'")
 
     print()
     print_success(f"{emoji} {label} configured!")

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3680,6 +3680,8 @@ _PLATFORMS = [
             {"name": "LIVEKIT_ALLOWED_USERS", "prompt": "Allowed participant identities (comma-separated, or empty)", "password": False,
              "is_allowlist": True,
              "help": "Restrict which LiveKit participants can interact with the agent."},
+            {"name": "LIVEKIT_PRESENCE_POLL_INTERVAL", "prompt": "Presence poll interval seconds (empty = auto)", "password": False,
+             "help": "Seconds between room-presence checks when no humans are in the room. Leave empty to auto-select: 30s for *.livekit.cloud, 5s for self-hosted."},
         ],
     },
 ]

--- a/hermes_cli/platforms.py
+++ b/hermes_cli/platforms.py
@@ -37,6 +37,7 @@ PLATFORMS: OrderedDict[str, PlatformInfo] = OrderedDict([
     ("weixin",         PlatformInfo(label="💬 Weixin",          default_toolset="hermes-weixin")),
     ("qqbot",          PlatformInfo(label="💬 QQBot",           default_toolset="hermes-qqbot")),
     ("yuanbao",        PlatformInfo(label="🤖 Yuanbao",         default_toolset="hermes-yuanbao")),
+    ("livekit",        PlatformInfo(label="🎙️ LiveKit",         default_toolset="hermes-livekit")),
     ("webhook",        PlatformInfo(label="🔗 Webhook",         default_toolset="hermes-webhook")),
     ("api_server",     PlatformInfo(label="🌐 API Server",      default_toolset="hermes-api-server")),
     ("cron",           PlatformInfo(label="⏰ Cron",            default_toolset="hermes-cron")),

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -22,6 +22,25 @@ from hermes_cli.vercel_auth import describe_vercel_auth
 from hermes_constants import OPENROUTER_MODELS_URL
 from tools.tool_backend_helpers import managed_nous_tools_enabled
 
+# Shared platform registry — used by both `hermes status` and `hermes config`
+MESSAGING_PLATFORMS = {
+    "Telegram": ("TELEGRAM_BOT_TOKEN", "TELEGRAM_HOME_CHANNEL"),
+    "Discord": ("DISCORD_BOT_TOKEN", "DISCORD_HOME_CHANNEL"),
+    "WhatsApp": ("WHATSAPP_ENABLED", None),
+    "Signal": ("SIGNAL_HTTP_URL", "SIGNAL_HOME_CHANNEL"),
+    "Slack": ("SLACK_BOT_TOKEN", None),
+    "Email": ("EMAIL_ADDRESS", "EMAIL_HOME_ADDRESS"),
+    "SMS": ("TWILIO_ACCOUNT_SID", "SMS_HOME_CHANNEL"),
+    "Mattermost": ("MATTERMOST_URL", None),
+    "Matrix": ("MATRIX_HOMESERVER_URL", None),
+    "DingTalk": ("DINGTALK_CLIENT_ID", None),
+    "Feishu": ("FEISHU_APP_ID", "FEISHU_HOME_CHANNEL"),
+    "WeCom": ("WECOM_BOT_ID", "WECOM_HOME_CHANNEL"),
+    "Weixin": ("WEIXIN_ACCOUNT_ID", "WEIXIN_HOME_CHANNEL"),
+    "BlueBubbles": ("BLUEBUBBLES_SERVER_URL", "BLUEBUBBLES_HOME_CHANNEL"),
+    "LiveKit": ("LIVEKIT_URL", None),
+}
+
 def check_mark(ok: bool) -> str:
     if ok:
         return color("✓", Colors.GREEN)
@@ -404,6 +423,7 @@ def show_status(args):
         "BlueBubbles": ("BLUEBUBBLES_SERVER_URL", "BLUEBUBBLES_HOME_CHANNEL"),
         "QQBot": ("QQ_APP_ID", "QQ_HOME_CHANNEL"),
         "Yuanbao": ("YUANBAO_APP_ID", "YUANBAO_HOME_CHANNEL"),
+        "LiveKit": ("LIVEKIT_URL", None),
     }
 
     for name, (token_var, home_var) in platforms.items():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,7 @@ youtube = [
 ]
 # `hermes dashboard` (localhost SPA + API).  Not in core to keep the default install lean.
 web = ["fastapi==0.133.1", "uvicorn[standard]==0.41.0"]
+livekit = ["livekit>=1.0.17,<2", "livekit-api>=1.0.7,<2"]
 rl = [
   "atroposlib @ git+https://github.com/NousResearch/atropos.git@c20c85256e5a45ad31edf8b7276e9c5ee1995a30",
   "tinker @ git+https://github.com/thinking-machines-lab/tinker.git@30517b667f18a3dfb7ef33fb56cf686d5820ba2b",
@@ -207,6 +208,7 @@ all = [
   "hermes-agent[google]",
   "hermes-agent[web]",
   "hermes-agent[youtube]",
+  "hermes-agent[livekit]",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,7 @@ youtube = [
 ]
 # `hermes dashboard` (localhost SPA + API).  Not in core to keep the default install lean.
 web = ["fastapi==0.133.1", "uvicorn[standard]==0.41.0"]
-livekit = ["livekit>=1.0.17,<2", "livekit-api>=1.0.7,<2"]
+livekit = ["livekit==1.1.7", "livekit-api==1.1.0"]
 rl = [
   "atroposlib @ git+https://github.com/NousResearch/atropos.git@c20c85256e5a45ad31edf8b7276e9c5ee1995a30",
   "tinker @ git+https://github.com/thinking-machines-lab/tinker.git@30517b667f18a3dfb7ef33fb56cf686d5820ba2b",

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -730,6 +730,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             result = await _send_qqbot(pconfig, chat_id, chunk)
         elif platform == Platform.YUANBAO:
             result = await _send_yuanbao(chat_id, chunk)
+        elif platform == Platform.LIVEKIT:
+            result = {"error": "LiveKit is a real-time voice channel — use voice replies instead of send_message."}
         else:
             # Plugin platform: route through the gateway's live adapter if
             # available, otherwise the plugin's standalone_sender_fn.

--- a/toolsets.py
+++ b/toolsets.py
@@ -527,10 +527,16 @@ TOOLSETS = {
         "includes": []
     },
 
+    "hermes-livekit": {
+        "description": "LiveKit voice toolset - interact with Hermes via WebRTC voice",
+        "tools": _HERMES_CORE_TOOLS,
+        "includes": []
+    },
+
     "hermes-gateway": {
         "description": "Gateway toolset - union of all messaging platform tools",
         "tools": [],
-        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-wecom-callback", "hermes-weixin", "hermes-qqbot", "hermes-webhook", "hermes-yuanbao"]
+        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-wecom-callback", "hermes-weixin", "hermes-qqbot", "hermes-webhook", "hermes-yuanbao", "hermes-livekit"]
     }
 }
 


### PR DESCRIPTION
> ⚠️ **Superseded — closed.** This work now ships as the standalone **[hermes-livekit](https://github.com/kortexa-ai/hermes-livekit)** plugin (pip-installable, no core patches required, and already ahead with a v0.3.0 remote-tools protocol). See the closing comment below for the rationale.

**Note:** This PR was authored and tested by Avery — a Hermes agent, with guidance from @francip.

---

## What Changed

Added LiveKit as a new gateway platform adapter, enabling real-time voice conversations with Hermes agents via WebRTC. Users can talk to their agent through any LiveKit-compatible client (browser, mobile, CLI).

**New file:** `gateway/platforms/livekit.py` (~600 lines)

**Modified files:** `pyproject.toml`, `gateway/config.py`, `gateway/run.py`, `gateway/platforms/base.py`, `gateway/channel_directory.py`, `toolsets.py`, `agent/prompt_builder.py`, `cron/scheduler.py`, `tools/send_message_tool.py`, `tools/cronjob_tools.py`, `hermes_cli/gateway.py`, `hermes_cli/status.py`, `hermes_cli/config.py`, `hermes_cli/tools_config.py`, `hermes_cli/skills_config.py`

### Changes

- **LiveKit adapter** (`gateway/platforms/livekit.py`): Full platform adapter with WebRTC audio capture, silence detection, STT transcription via hermes's existing pipeline (faster-whisper/Groq/OpenAI), TTS playback back to the room, data channel for text responses, reconnection with exponential backoff, and agent name resolution via LLM fallback
- **Optional dependency**: `livekit` extras group in `pyproject.toml` — only installed if the user enables LiveKit
- **Auto-install in setup wizard**: When configuring LiveKit (or Matrix, DingTalk, Feishu) via `hermes gateway setup`, the wizard now offers to install the required Python packages automatically. This is a generic mechanism — any platform with an `"extras"` key in its `_PLATFORMS` entry gets the prompt
- **TTS filtering hook**: Added `prepare_tts_text()` method to `BasePlatformAdapter` so subclasses can filter text before TTS generation. LiveKit adapter strips code blocks, URLs, file paths, and MEDIA tags — full text goes to data channel, only conversational content is spoken
- **Shared platform registry**: Extracted `MESSAGING_PLATFORMS` dict from `hermes_cli/status.py` so both `hermes status` and `hermes config` use the same list
- **Secret masking in setup**: The setup wizard now shows `************` instead of raw values for password fields when displaying current configuration
- All 16 integration points from `gateway/platforms/ADDING_A_PLATFORM.md` covered: Platform enum, env var loading, adapter factory, authorization maps, platform hints, toolsets, cron delivery, send_message routing, channel directory, status display, setup wizard, tools_config, skills_config, cronjob schema

### Why

Voice is a natural interface for AI agents. LiveKit provides an open-source WebRTC SFU that can be self-hosted on a $5 VPS or used via LiveKit Cloud, making it accessible to all Hermes users. The adapter reuses hermes's existing STT/TTS infrastructure (no new audio dependencies beyond the LiveKit SDK), keeping the implementation minimal and consistent with the Discord voice pipeline.

### Configuration

Three environment variables:

```bash
LIVEKIT_URL=wss://your-project.livekit.cloud   # or ws://your-server:7880
LIVEKIT_API_KEY=your-api-key
LIVEKIT_API_SECRET=your-api-secret
```

Optional:
```bash
LIVEKIT_ROOM=hermes              # Room name (default: "hermes")
LIVEKIT_AGENT_NAME=Avery         # Display name (default: asks the LLM, falls back to "Hermes")
LIVEKIT_AGENT_AVATAR=https://... # Avatar URL for LiveKit clients
LIVEKIT_ALLOW_ALL_USERS=true     # Authorization
```

### Setup wizard

`hermes gateway setup` → select LiveKit → enter credentials → auto-install dependencies:

<img width="647" height="891" alt="Screenshot 2026-03-29 at 21 34 30" src="https://github.com/user-attachments/assets/37c94042-973e-4ecb-8732-a7b657adb175" />

### Working voice conversation

Tested with LiveKit Meet (browser client) connecting to a self-hosted LiveKit server

### LiveKit Cloud

Also tested with LiveKit Cloud — same adapter, just a different URL:

<img width="1008" height="183" alt="Screenshot 2026-03-29 at 23 22 05" src="https://github.com/user-attachments/assets/62a82304-878a-483f-a18b-06dd2b309e54" />
<img width="1281" height="842" alt="Screenshot 2026-03-29 at 23 20 52" src="https://github.com/user-attachments/assets/69b4b87c-9f72-489a-9cb0-4ad660b6b7bd" />

### How to Test

**Install and configure:**
```bash
# Install LiveKit dependencies
pip install 'hermes-agent[livekit]'

# Configure (or use hermes gateway setup)
echo 'LIVEKIT_URL=wss://your-server' >> ~/.hermes/.env
echo 'LIVEKIT_API_KEY=your-key' >> ~/.hermes/.env
echo 'LIVEKIT_API_SECRET=your-secret' >> ~/.hermes/.env

# Start gateway
hermes gateway start
```

**Test voice:**
1. Connect to the room using any LiveKit client:
   - Browser: LiveKit Meet (`lk room join --open meet`)
   - CLI: `lk room join --publish-microphone --url <url> --api-key <key> --api-secret <secret> <room>`)
2. Speak — the agent should transcribe, process, and respond via voice
3. Text responses also appear on the data channel

**Test setup wizard:**
```bash
hermes gateway setup
# Select LiveKit, enter credentials, confirm auto-install
```

**Verify status:**
```bash
hermes status    # Shows LiveKit as configured
hermes config    # Shows LiveKit in platform list
```

### Validation

**Automated:**
```bash
source venv/bin/activate
python -m pytest tests/hermes_cli/test_tools_config.py::TestPlatformToolsetConsistency -v
```

Result: `3 passed` (platform consistency tests cover LiveKit in toolsets, tools_config, and skills_config)

**Full test suite:** 7062 passed, 17 failed (all 17 failures are pre-existing, unrelated to this PR)

### Known Limitations (v1)

- **macOS native LiveKit server**: The Python SDK's bundled WebRTC binary has a known bug on macOS 26 Tahoe (`failed to initialize pc`). Connecting to a remote Linux LiveKit server from macOS works fine. This is an upstream issue in `livekit/python-sdks`.
- **Voice only**: Text chat via data channel is best-effort (send only). Full bidirectional text is v2.
- **Single room**: The adapter joins one room. Multi-room support is v2.
- **No avatar display**: LiveKit Meet doesn't render participant avatars. The metadata is set for future custom clients.
- **Background noise sensitivity**: The silence detection uses simple RMS energy thresholds. WebRTC VAD (Silero/livekit-agents) would improve accuracy — v2.

### Platforms Tested

- ✅ macOS (snappy) → self-hosted LiveKit on Linux (smarty) via LAN
- ✅ macOS (snappy) → LiveKit Cloud
- ✅ Browser client (LiveKit Meet) with microphone
- ✅ CLI client (`lk room join`)
