### PR TITLE
feat(slack): add button-based approval flow for dangerous commands

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -402,6 +402,7 @@ _RETRYABLE_ERROR_PATTERNS = (
 
 # Type for message handlers
 MessageHandler = Callable[[MessageEvent], Awaitable[Optional[str]]]
+ApprovalActionHandler = Callable[[str, str], Awaitable[Optional[str]]]
 
 
 class BasePlatformAdapter(ABC):
@@ -419,6 +420,7 @@ class BasePlatformAdapter(ABC):
         self.config = config
         self.platform = platform
         self._message_handler: Optional[MessageHandler] = None
+        self._approval_action_handler: Optional[ApprovalActionHandler] = None
         self._running = False
         self._fatal_error_code: Optional[str] = None
         self._fatal_error_message: Optional[str] = None
@@ -518,6 +520,17 @@ class BasePlatformAdapter(ABC):
         an optional response string.
         """
         self._message_handler = handler
+
+    def set_approval_action_handler(self, handler: ApprovalActionHandler) -> None:
+        """
+        Set the handler for platform-native approval actions.
+
+        The handler receives ``(approval_id, action)`` where ``approval_id`` is
+        the opaque platform-provided approval token and ``action`` is one of
+        the platform's canonical approval actions such as ``approve``,
+        ``approve session``, or ``deny``.
+        """
+        self._approval_action_handler = handler
     
     @abstractmethod
     async def connect(self) -> bool:

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -176,6 +176,21 @@ class SlackAdapter(BasePlatformAdapter):
                 await ack()
                 await self._handle_slash_command(command)
 
+            @self._app.action("hermes_approve_once")
+            async def handle_approve_once(ack, body, action):
+                await ack()
+                await self._handle_approval_action(body, "approve")
+
+            @self._app.action("hermes_approve_session")
+            async def handle_approve_session(ack, body, action):
+                await ack()
+                await self._handle_approval_action(body, "approve session")
+
+            @self._app.action("hermes_deny")
+            async def handle_deny(ack, body, action):
+                await ack()
+                await self._handle_approval_action(body, "deny")
+
             # Start Socket Mode handler in background
             self._handler = AsyncSocketModeHandler(self._app, app_token)
             self._socket_mode_task = asyncio.create_task(self._handler.start_async())
@@ -932,6 +947,125 @@ class SlackAdapter(BasePlatformAdapter):
         )
 
         await self.handle_message(event)
+
+    async def _handle_approval_action(self, body: dict, command_text: str) -> None:
+        """Handle Slack Block Kit approval buttons inside a thread or DM.
+
+        Slack slash commands do not work inside threads, so approvals use
+        buttons that resolve the pending approval directly by approval ID.
+        """
+        if not self._approval_action_handler:
+            return
+
+        channel = body.get("channel") or {}
+        user = body.get("user") or {}
+        message = body.get("message") or {}
+        container = body.get("container") or {}
+        actions = body.get("actions") or []
+
+        channel_id = channel.get("id", "")
+        user_id = user.get("id", "")
+        approval_id = actions[0].get("value", "") if actions else ""
+
+        actual_thread_ts = (
+            container.get("thread_ts")
+            or message.get("thread_ts")
+            or message.get("ts")
+        )
+
+        try:
+            response = await self._approval_action_handler(approval_id, command_text)
+        except Exception as e:  # pragma: no cover - defensive logging
+            logger.error("[Slack] Approval action failed: %s", e, exc_info=True)
+            response = f"❌ Approval action failed: {e}"
+
+        try:
+            action_label = {
+                "approve": "Approved once",
+                "approve session": "Approved for session",
+                "deny": "Denied",
+            }.get(command_text, command_text)
+            await self._app.client.chat_update(
+                channel=channel_id,
+                ts=container.get("message_ts") or message.get("ts"),
+                text=f"✅ {action_label} by <@{user_id}>",
+                blocks=[],
+            )
+        except Exception:
+            pass
+
+        if response:
+            metadata = {"thread_id": actual_thread_ts} if actual_thread_ts else None
+            await self.send(channel_id, response, metadata=metadata)
+
+    async def send_exec_approval(
+        self,
+        chat_id: str,
+        command: str,
+        approval_id: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a Slack Block Kit approval prompt for a dangerous command."""
+        if not self._app:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            max_text = 2700
+            cmd_display = command if len(command) <= max_text else command[: max_text - 3] + "..."
+            thread_ts = self._resolve_thread_ts(reply_to, metadata)
+
+            blocks = [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": (
+                            "*Dangerous command requires approval*\n"
+                            f"```{cmd_display}```"
+                        ),
+                    },
+                },
+                {
+                    "type": "actions",
+                    "elements": [
+                        {
+                            "type": "button",
+                            "text": {"type": "plain_text", "text": "Approve Once"},
+                            "style": "primary",
+                            "action_id": "hermes_approve_once",
+                            "value": approval_id,
+                        },
+                        {
+                            "type": "button",
+                            "text": {"type": "plain_text", "text": "Approve Session"},
+                            "action_id": "hermes_approve_session",
+                            "value": approval_id,
+                        },
+                        {
+                            "type": "button",
+                            "text": {"type": "plain_text", "text": "Deny"},
+                            "style": "danger",
+                            "action_id": "hermes_deny",
+                            "value": approval_id,
+                        },
+                    ],
+                },
+            ]
+
+            kwargs = {
+                "channel": chat_id,
+                "text": "Dangerous command requires approval",
+                "blocks": blocks,
+            }
+            if thread_ts:
+                kwargs["thread_ts"] = thread_ts
+
+            result = await self._app.client.chat_postMessage(**kwargs)
+            return SendResult(success=True, message_id=result.get("ts"), raw_response=result)
+        except Exception as e:  # pragma: no cover - defensive logging
+            logger.error("[Slack] Failed to send approval prompt: %s", e, exc_info=True)
+            return SendResult(success=False, error=str(e))
 
     async def _download_slack_file(self, url: str, ext: str, audio: bool = False, team_id: str = "") -> str:
         """Download a Slack file using the bot token for auth, with retry."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1115,6 +1115,7 @@ class GatewayRunner:
             
             # Set up message + fatal error handlers
             adapter.set_message_handler(self._handle_message)
+            adapter.set_approval_action_handler(self._handle_platform_approval_action)
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             
             # Try to connect
@@ -1362,6 +1363,7 @@ class GatewayRunner:
                         continue
 
                     adapter.set_message_handler(self._handle_message)
+                    adapter.set_approval_action_handler(self._handle_platform_approval_action)
                     adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
 
                     success = await adapter.connect()
@@ -5093,6 +5095,49 @@ class GatewayRunner:
     # ------------------------------------------------------------------
 
     _APPROVAL_TIMEOUT_SECONDS = 300  # 5 minutes
+
+    async def _handle_platform_approval_action(
+        self,
+        approval_id: str,
+        action: str,
+    ) -> str:
+        """Resolve a pending dangerous-command approval by approval ID.
+
+        Messaging platforms with native UI controls, such as Slack buttons,
+        should call this directly instead of synthesizing a new slash-command
+        message. The approval ID is the stored session key for the pending
+        command. Signals the blocked agent thread via the blocking gateway
+        approval mechanism in tools/approval.py.
+        """
+        session_key = (approval_id or "").strip()
+        if not session_key:
+            return "Invalid approval request."
+
+        canonical = action.strip().lower()
+        if canonical not in {"approve", "approve session", "deny"}:
+            return f"Unsupported approval action: {action}"
+
+        from tools.approval import resolve_gateway_approval, has_blocking_approval
+
+        if not has_blocking_approval(session_key):
+            return "No pending command to approve."
+
+        choice = "deny" if canonical == "deny" else ("session" if canonical == "approve session" else "once")
+        scope_msg = " (pattern approved for this session)" if choice == "session" else ""
+
+        count = resolve_gateway_approval(session_key, choice)
+        if not count:
+            return "No pending command to approve."
+
+        if choice == "deny":
+            logger.info("User denied dangerous command via platform approval UI")
+            return "❌ Command denied."
+
+        logger.info(
+            "User approved dangerous command via platform approval UI%s",
+            scope_msg,
+        )
+        return f"✅ Command approved{scope_msg}. The agent is resuming..."
 
     async def _handle_approve_command(self, event: MessageEvent) -> Optional[str]:
         """Handle /approve command — unblock waiting agent thread(s).

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -338,6 +338,75 @@ class TestDenyCommand:
         assert "No pending command" in result
 
 
+class TestPlatformApprovalActions:
+
+    @pytest.mark.asyncio
+    async def test_platform_approve_once_executes_pending_command(self):
+        runner = _make_runner()
+        source = _make_source()
+        session_key = runner._session_key_for_source(source)
+        runner._pending_approvals[session_key] = _make_pending_approval()
+
+        with (
+            patch("tools.terminal_tool.terminal_tool", return_value="done") as mock_term,
+            patch("tools.approval.approve_session") as mock_session,
+        ):
+            result = await runner._handle_platform_approval_action(session_key, "approve")
+
+        assert "✅ Command approved and executed" in result
+        mock_session.assert_called_once_with(session_key, "sudo")
+        mock_term.assert_called_once_with(command="sudo rm -rf /tmp/test", force=True)
+        assert session_key not in runner._pending_approvals
+
+    @pytest.mark.asyncio
+    async def test_platform_approve_session_marks_session_scope(self):
+        runner = _make_runner()
+        source = _make_source()
+        session_key = runner._session_key_for_source(source)
+        runner._pending_approvals[session_key] = _make_pending_approval()
+
+        with (
+            patch("tools.terminal_tool.terminal_tool", return_value="done"),
+            patch("tools.approval.approve_session") as mock_session,
+        ):
+            result = await runner._handle_platform_approval_action(session_key, "approve session")
+
+        assert "pattern approved for this session" in result
+        mock_session.assert_called_once_with(session_key, "sudo")
+
+    @pytest.mark.asyncio
+    async def test_platform_deny_clears_pending(self):
+        runner = _make_runner()
+        source = _make_source()
+        session_key = runner._session_key_for_source(source)
+        runner._pending_approvals[session_key] = _make_pending_approval()
+
+        result = await runner._handle_platform_approval_action(session_key, "deny")
+
+        assert "❌ Command denied" in result
+        assert session_key not in runner._pending_approvals
+
+    @pytest.mark.asyncio
+    async def test_platform_approval_invalid_action(self):
+        runner = _make_runner()
+        result = await runner._handle_platform_approval_action("approval-1", "maybe")
+        assert "Unsupported approval action" in result
+
+    @pytest.mark.asyncio
+    async def test_platform_approval_expired(self):
+        runner = _make_runner()
+        source = _make_source()
+        session_key = runner._session_key_for_source(source)
+        approval = _make_pending_approval()
+        approval["timestamp"] = time.time() - 600
+        runner._pending_approvals[session_key] = approval
+
+        result = await runner._handle_platform_approval_action(session_key, "approve")
+
+        assert "expired" in result
+        assert session_key not in runner._pending_approvals
+
+
 # ------------------------------------------------------------------
 # Bare "yes" must NOT trigger approval
 # ------------------------------------------------------------------

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -705,3 +705,86 @@ class TestFallbackNoCallback:
 
         assert result["approved"] is False
         assert result.get("status") == "approval_required"
+
+
+# ------------------------------------------------------------------
+# Regression: "Approve Once" must not grant session-wide approval
+# Fix: NousResearch/hermes-agent#4698
+# ------------------------------------------------------------------
+
+
+class TestApproveOnceScope:
+
+    def setup_method(self):
+        _clear_approval_state()
+
+    def test_approve_once_does_not_grant_session_wide_approval(self):
+        """Approving with 'once' must not add the pattern to the session allowlist.
+
+        Regression test for the bug where choice in ("once", "session") caused
+        approve_session() to be called for both choices, making a one-time
+        approval silently cover all subsequent identical commands in the session.
+        """
+        from tools.approval import (
+            register_gateway_notify,
+            unregister_gateway_notify,
+            resolve_gateway_approval,
+            check_all_command_guards,
+            reset_current_session_key,
+            set_current_session_key,
+        )
+
+        session_key = "once-scope-test"
+        notified = []
+        register_gateway_notify(session_key, lambda d: notified.append(d))
+
+        results = [None, None]
+
+        def run_command(index, command):
+            token = set_current_session_key(session_key)
+            os.environ["HERMES_EXEC_ASK"] = "1"
+            os.environ["HERMES_SESSION_KEY"] = session_key
+            try:
+                results[index] = check_all_command_guards(command, "local")
+            finally:
+                os.environ.pop("HERMES_EXEC_ASK", None)
+                os.environ.pop("HERMES_SESSION_KEY", None)
+                reset_current_session_key(token)
+
+        # First command — run and approve with "once"
+        t1 = threading.Thread(target=run_command, args=(0, "rm -rf /first"))
+        t1.start()
+
+        for _ in range(50):
+            if notified:
+                break
+            time.sleep(0.05)
+
+        assert len(notified) == 1, "First command should have triggered a notification"
+        resolve_gateway_approval(session_key, "once")
+        t1.join(timeout=5)
+
+        assert results[0] is not None
+        assert results[0]["approved"] is True
+
+        # Second command with the same dangerous pattern — must prompt again
+        t2 = threading.Thread(target=run_command, args=(1, "rm -rf /second"))
+        t2.start()
+
+        for _ in range(50):
+            if len(notified) >= 2:
+                break
+            time.sleep(0.05)
+
+        assert len(notified) == 2, (
+            "Second command should have prompted again — 'once' must not grant "
+            "session-wide approval"
+        )
+
+        resolve_gateway_approval(session_key, "once")
+        t2.join(timeout=5)
+
+        assert results[1] is not None
+        assert results[1]["approved"] is True
+
+        unregister_gateway_notify(session_key)

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -345,46 +345,45 @@ class TestPlatformApprovalActions:
         runner = _make_runner()
         source = _make_source()
         session_key = runner._session_key_for_source(source)
-        runner._pending_approvals[session_key] = _make_pending_approval()
 
         with (
-            patch("tools.terminal_tool.terminal_tool", return_value="done") as mock_term,
-            patch("tools.approval.approve_session") as mock_session,
+            patch("tools.approval.has_blocking_approval", return_value=True),
+            patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve,
         ):
             result = await runner._handle_platform_approval_action(session_key, "approve")
 
-        assert "✅ Command approved and executed" in result
-        mock_session.assert_called_once_with(session_key, "sudo")
-        mock_term.assert_called_once_with(command="sudo rm -rf /tmp/test", force=True)
-        assert session_key not in runner._pending_approvals
+        assert "✅ Command approved" in result
+        mock_resolve.assert_called_once_with(session_key, "once")
 
     @pytest.mark.asyncio
     async def test_platform_approve_session_marks_session_scope(self):
         runner = _make_runner()
         source = _make_source()
         session_key = runner._session_key_for_source(source)
-        runner._pending_approvals[session_key] = _make_pending_approval()
 
         with (
-            patch("tools.terminal_tool.terminal_tool", return_value="done"),
-            patch("tools.approval.approve_session") as mock_session,
+            patch("tools.approval.has_blocking_approval", return_value=True),
+            patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve,
         ):
             result = await runner._handle_platform_approval_action(session_key, "approve session")
 
         assert "pattern approved for this session" in result
-        mock_session.assert_called_once_with(session_key, "sudo")
+        mock_resolve.assert_called_once_with(session_key, "session")
 
     @pytest.mark.asyncio
     async def test_platform_deny_clears_pending(self):
         runner = _make_runner()
         source = _make_source()
         session_key = runner._session_key_for_source(source)
-        runner._pending_approvals[session_key] = _make_pending_approval()
 
-        result = await runner._handle_platform_approval_action(session_key, "deny")
+        with (
+            patch("tools.approval.has_blocking_approval", return_value=True),
+            patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve,
+        ):
+            result = await runner._handle_platform_approval_action(session_key, "deny")
 
         assert "❌ Command denied" in result
-        assert session_key not in runner._pending_approvals
+        mock_resolve.assert_called_once_with(session_key, "deny")
 
     @pytest.mark.asyncio
     async def test_platform_approval_invalid_action(self):
@@ -393,18 +392,16 @@ class TestPlatformApprovalActions:
         assert "Unsupported approval action" in result
 
     @pytest.mark.asyncio
-    async def test_platform_approval_expired(self):
+    async def test_platform_approval_no_pending(self):
+        """Returns a clear message when no blocked approval exists for the session."""
         runner = _make_runner()
         source = _make_source()
         session_key = runner._session_key_for_source(source)
-        approval = _make_pending_approval()
-        approval["timestamp"] = time.time() - 600
-        runner._pending_approvals[session_key] = approval
 
-        result = await runner._handle_platform_approval_action(session_key, "approve")
+        with patch("tools.approval.has_blocking_approval", return_value=False):
+            result = await runner._handle_platform_approval_action(session_key, "approve")
 
-        assert "expired" in result
-        assert session_key not in runner._pending_approvals
+        assert "No pending command" in result
 
 
 # ------------------------------------------------------------------

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -103,6 +103,7 @@ class TestAppMentionHandler:
         # Track which events get registered
         registered_events = []
         registered_commands = []
+        registered_actions = []
 
         mock_app = MagicMock()
 
@@ -118,8 +119,15 @@ class TestAppMentionHandler:
                 return fn
             return decorator
 
+        def mock_action(action_id):
+            def decorator(fn):
+                registered_actions.append(action_id)
+                return fn
+            return decorator
+
         mock_app.event = mock_event
         mock_app.command = mock_command
+        mock_app.action = mock_action
         mock_app.client = AsyncMock()
         mock_app.client.auth_test = AsyncMock(return_value={
             "user_id": "U_BOT",
@@ -146,6 +154,58 @@ class TestAppMentionHandler:
         assert "message" in registered_events
         assert "app_mention" in registered_events
         assert "/hermes" in registered_commands
+        assert "hermes_approve_once" in registered_actions
+        assert "hermes_approve_session" in registered_actions
+        assert "hermes_deny" in registered_actions
+
+
+class TestSlackApprovalButtons:
+    @pytest.mark.asyncio
+    async def test_send_exec_approval_posts_buttons(self, adapter):
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "123.456"})
+
+        result = await adapter.send_exec_approval(
+            chat_id="C123",
+            command="rm -rf /tmp/test",
+            approval_id="approval-1",
+            metadata={"thread_id": "123.000"},
+        )
+
+        assert result.success
+        call_kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert call_kwargs["channel"] == "C123"
+        assert call_kwargs["thread_ts"] == "123.000"
+        assert call_kwargs["blocks"][1]["elements"][0]["action_id"] == "hermes_approve_once"
+        assert call_kwargs["blocks"][1]["elements"][1]["action_id"] == "hermes_approve_session"
+        assert call_kwargs["blocks"][1]["elements"][2]["action_id"] == "hermes_deny"
+
+    @pytest.mark.asyncio
+    async def test_handle_approval_action_invokes_platform_handler_and_updates_thread(self, adapter):
+        adapter._approval_action_handler = AsyncMock(return_value="approved output")
+        adapter.send = AsyncMock(return_value=SendResult(success=True))
+        adapter._app.client.chat_update = AsyncMock()
+
+        body = {
+            "channel": {"id": "C123"},
+            "user": {"id": "U123"},
+            "container": {"message_ts": "200.000", "thread_ts": "100.000"},
+            "message": {"ts": "200.000", "thread_ts": "100.000"},
+            "actions": [{"value": "approval-1"}],
+        }
+
+        await adapter._handle_approval_action(body, "approve session")
+
+        adapter._approval_action_handler.assert_awaited_once_with("approval-1", "approve session")
+        adapter._app.client.chat_update.assert_awaited_once()
+        update_kwargs = adapter._app.client.chat_update.call_args.kwargs
+        assert update_kwargs["channel"] == "C123"
+        assert update_kwargs["ts"] == "200.000"
+        assert "Approved for session" in update_kwargs["text"]
+        adapter.send.assert_awaited_once_with(
+            "C123",
+            "approved output",
+            metadata={"thread_id": "100.000"},
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -813,7 +813,7 @@ def check_all_command_guards(command: str, env_type: str,
 
             # User approved — persist based on scope (same logic as CLI)
             for key, _, is_tirith in warnings:
-                if choice in ("once", "session") or (choice == "always" and is_tirith):
+                if choice == "session" or (choice == "always" and is_tirith):
                     approve_session(session_key, key)
                 elif choice == "always":
                     approve_session(session_key, key)


### PR DESCRIPTION
## What does this PR do?

Adds Slack-native approval buttons for dangerous command prompts.

Hermes currently replies in Slack threads, but Slack custom slash commands are not supported in threads. That makes the existing text-based approval flow awkward for Slack, especially when a dangerous command needs explicit approval. This PR adds Block Kit approval buttons for Slack so approvals can happen directly inside the threaded conversation without relying on slash commands.

**Rebase note:** This branch has been rebased onto current main and adapted to the blocking gateway approval mechanism introduced after the original commit. The old `_pending_approvals` dict + `terminal_tool(force=True)` approach has been replaced with `has_blocking_approval` / `resolve_gateway_approval` from `tools/approval.py`.

This PR also includes the fix from #4698 (`approve-once` must not grant session-wide approval) along with its regression test, so both features land together and are covered end-to-end.

## Related Issue

No existing issue — this is a new feature.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a platform-level approval action handler to the gateway base adapter so messaging platforms can submit structured approve/deny actions.
- Added Slack Block Kit approval buttons for dangerous command prompts in `gateway/platforms/slack.py`.
- Wired Slack button actions into the blocking gateway approval mechanism in `gateway/run.py` (`has_blocking_approval` / `resolve_gateway_approval`).
- Suppressed the extra Slack-only approval hint text when button delivery succeeds.
- Fixed `approve_session()` being called for `choice == "once"` (refs #4698) — one-time approvals no longer silently become session-wide.
- Added gateway tests covering Slack button rendering, Slack button action handling, platform approval action execution, and the approve-once scope regression.

## How to Test

1. Configure Hermes with Slack Socket Mode and a working Slack app.
2. Trigger a dangerous command from Slack that requires approval.
3. Click `Approve Once`, `Approve Session`, or `Deny` in the Slack thread and verify the pending command behaves correctly.
4. Verify `Approve Once` prompts again on the next identical dangerous command (regression for #4698).
5. Run `pytest tests/gateway/test_slack.py tests/gateway/test_approve_deny_commands.py -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (Dockerized Hermes + Slack Socket Mode)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Targeted gateway coverage added and passing:
  - `pytest tests/gateway/test_slack.py tests/gateway/test_approve_deny_commands.py -q`
  - All 28 tests in `test_approve_deny_commands.py` pass