### PR TITLE
fix(cron): tighten [SILENT] instruction to prevent report-with-silent-prefix

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -236,11 +236,12 @@ def _build_job_prompt(job: dict) -> str:
     # Always prepend [SILENT] guidance so the cron agent can suppress
     # delivery when it has nothing new or noteworthy to report.
     silent_hint = (
-        "[SYSTEM: If you have nothing new or noteworthy to report, respond "
-        "with exactly \"[SILENT]\" (optionally followed by a brief internal "
-        "note). This suppresses delivery to the user while still saving "
-        "output locally. Only use [SILENT] when there are genuinely no "
-        "changes worth reporting.]\n\n"
+        "[SYSTEM: If you have a meaningful status report or findings, "
+        "send them — that is the whole point of this job. Only respond "
+        "with exactly \"[SILENT]\" (nothing else) when there is genuinely "
+        "nothing new to report. [SILENT] suppresses delivery to the user. "
+        "Never combine [SILENT] with content — either report your "
+        "findings normally, or say [SILENT] and nothing more.]\n\n"
     )
     prompt = silent_hint + prompt
     if skills is None:


### PR DESCRIPTION
The cron PR scout wrote a full analysis report and prefixed it with [SILENT], defeating the purpose. The old instruction said 'optionally followed by a brief internal note' which the model interpreted as license to write a full report.

New instruction is explicit:

> respond with ONLY the word "\[SILENT\]" — nothing else. Do NOT combine \[SILENT\] with a report: if you have findings worth sharing, write a normal response WITHOUT the \[SILENT\] prefix. \[SILENT\] means 'nothing to say', not 'here is my report but please hide it'.