### PR TITLE
fix(docs): escape angle-bracket URLs in feishu.md breaking MDX build

### DIFF
--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -32,8 +32,8 @@ Set it to `false` only if you explicitly want one shared conversation per chat.
 ## Step 1: Create a Feishu / Lark App
 
 1. Open the Feishu or Lark developer console:
-   - Feishu: <https://open.feishu.cn/>
-   - Lark: <https://open.larksuite.com/>
+   - Feishu: [https://open.feishu.cn/](https://open.feishu.cn/)
+   - Lark: [https://open.larksuite.com/](https://open.larksuite.com/)
 2. Create a new app.
 3. In **Credentials & Basic Info**, copy the **App ID** and **App Secret**.
 4. Enable the **Bot** capability for the app.


### PR DESCRIPTION
The Docusaurus site deploy has been failing because `feishu.md` (from WeCom PR #3847) has `<https://open.feishu.cn/>` which MDX parses as a JSX tag. The `/` in the URL triggers `Unexpected character` compile errors, blocking ALL docs deployments.

Fix: use `[text](url)` markdown link syntax instead of angle-bracket autolinks.

This unblocks the deploy so the migration guide and all other recent docs changes go live.