### PR TITLE
fix(cli): use absolute path for launchctl to avoid UV Python PATH issues

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -14,6 +14,11 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 
+# Absolute path to launchctl. UV's bundled Python can ship with a minimal PATH
+# that doesn't include /bin, causing FileNotFoundError when running launchctl.
+# Use shutil.which() first, then fall back to the standard macOS location.
+_LAUNCHCTL = shutil.which("launchctl") or "/bin/launchctl"
+
 from hermes_cli.config import get_env_value, get_hermes_home, save_env_value, is_managed, managed_error
 # display_hermes_home is imported lazily at call sites to avoid ImportError
 # when hermes_constants is cached from a pre-update version during `hermes update`.
@@ -933,8 +938,8 @@ def refresh_launchd_plist_if_needed() -> bool:
 
     plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
     # Unload/reload so launchd picks up the new definition
-    subprocess.run(["launchctl", "unload", str(plist_path)], check=False)
-    subprocess.run(["launchctl", "load", str(plist_path)], check=False)
+    subprocess.run([_LAUNCHCTL, "unload", str(plist_path)], check=False)
+    subprocess.run([_LAUNCHCTL, "load", str(plist_path)], check=False)
     print("↻ Updated gateway launchd service definition to match the current Hermes install")
     return True
 
@@ -956,7 +961,7 @@ def launchd_install(force: bool = False):
     print(f"Installing launchd service to: {plist_path}")
     plist_path.write_text(generate_launchd_plist())
     
-    subprocess.run(["launchctl", "load", str(plist_path)], check=True)
+    subprocess.run([_LAUNCHCTL, "load", str(plist_path)], check=True)
     
     print()
     print("✓ Service installed and loaded!")
@@ -968,7 +973,7 @@ def launchd_install(force: bool = False):
 
 def launchd_uninstall():
     plist_path = get_launchd_plist_path()
-    subprocess.run(["launchctl", "unload", str(plist_path)], check=False)
+    subprocess.run([_LAUNCHCTL, "unload", str(plist_path)], check=False)
     
     if plist_path.exists():
         plist_path.unlink()
@@ -985,25 +990,25 @@ def launchd_start():
         print("↻ launchd plist missing; regenerating service definition")
         plist_path.parent.mkdir(parents=True, exist_ok=True)
         plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
-        subprocess.run(["launchctl", "load", str(plist_path)], check=True)
-        subprocess.run(["launchctl", "start", label], check=True)
+        subprocess.run([_LAUNCHCTL, "load", str(plist_path)], check=True)
+        subprocess.run([_LAUNCHCTL, "start", label], check=True)
         print("✓ Service started")
         return
 
     refresh_launchd_plist_if_needed()
     try:
-        subprocess.run(["launchctl", "start", label], check=True)
+        subprocess.run([_LAUNCHCTL, "start", label], check=True)
     except subprocess.CalledProcessError as e:
         if e.returncode != 3:
             raise
         print("↻ launchd job was unloaded; reloading service definition")
-        subprocess.run(["launchctl", "load", str(plist_path)], check=True)
-        subprocess.run(["launchctl", "start", label], check=True)
+        subprocess.run([_LAUNCHCTL, "load", str(plist_path)], check=True)
+        subprocess.run([_LAUNCHCTL, "start", label], check=True)
     print("✓ Service started")
 
 def launchd_stop():
     label = get_launchd_label()
-    subprocess.run(["launchctl", "stop", label], check=True)
+    subprocess.run([_LAUNCHCTL, "stop", label], check=True)
     print("✓ Service stopped")
 
 def _wait_for_gateway_exit(timeout: float = 10.0, force_after: float = 5.0):
@@ -1060,7 +1065,7 @@ def launchd_status(deep: bool = False):
     plist_path = get_launchd_plist_path()
     label = get_launchd_label()
     result = subprocess.run(
-        ["launchctl", "list", label],
+        [_LAUNCHCTL, "list", label],
         capture_output=True,
         text=True
     )
@@ -1620,7 +1625,7 @@ def _is_service_running() -> bool:
         return False
     elif is_macos() and get_launchd_plist_path().exists():
         result = subprocess.run(
-            ["launchctl", "list", get_launchd_label()],
+            [_LAUNCHCTL, "list", get_launchd_label()],
             capture_output=True, text=True
         )
         return result.returncode == 0

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -45,6 +45,7 @@ Usage:
 
 import argparse
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -66,6 +67,9 @@ def _require_tty(command_name: str) -> None:
         )
         sys.exit(1)
 
+# Absolute path to launchctl. UV's bundled Python can ship with a minimal PATH
+# that doesn't include /bin, causing FileNotFoundError when running launchctl.
+_LAUNCHCTL = shutil.which("launchctl") or "/bin/launchctl"
 
 # Add project root to path
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
@@ -3350,7 +3354,7 @@ def cmd_update(args):
                     plist_path = get_launchd_plist_path()
                     if plist_path.exists():
                         check = subprocess.run(
-                            ["launchctl", "list", get_launchd_label()],
+                            [_LAUNCHCTL, "list", get_launchd_label()],
                             capture_output=True, text=True, timeout=5,
                         )
                         has_launchd_service = check.returncode == 0
@@ -3423,11 +3427,11 @@ def cmd_update(args):
                     print("→ Restarting gateway service...")
                     _launchd_label = get_launchd_label()
                     stop = subprocess.run(
-                        ["launchctl", "stop", _launchd_label],
+                        [_LAUNCHCTL, "stop", _launchd_label],
                         capture_output=True, text=True, timeout=10,
                     )
                     start = subprocess.run(
-                        ["launchctl", "start", _launchd_label],
+                        [_LAUNCHCTL, "start", _launchd_label],
                         capture_output=True, text=True, timeout=10,
                     )
                     if start.returncode == 0:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -28,6 +28,10 @@ import subprocess
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath, PureWindowsPath
+
+# Absolute path to launchctl. UV's bundled Python can ship with a minimal PATH
+# that doesn't include /bin, causing FileNotFoundError when running launchctl.
+_LAUNCHCTL = shutil.which("launchctl") or "/bin/launchctl"
 from typing import List, Optional
 
 _PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
@@ -591,7 +595,7 @@ def _cleanup_gateway_service(name: str, profile_dir: Path) -> None:
             plist_path = get_launchd_plist_path()
             if plist_path.exists():
                 subprocess.run(
-                    ["launchctl", "unload", str(plist_path)],
+                    [_LAUNCHCTL, "unload", str(plist_path)],
                     capture_output=True, check=False, timeout=10,
                 )
                 plist_path.unlink(missing_ok=True)

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -5,11 +5,16 @@ Shows the status of all Hermes Agent components.
 """
 
 import os
+import shutil
 import sys
 import subprocess
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
+
+# Absolute path to launchctl. UV's bundled Python can ship with a minimal PATH
+# that doesn't include /bin, causing FileNotFoundError when running launchctl.
+_LAUNCHCTL = shutil.which("launchctl") or "/bin/launchctl"
 
 from hermes_cli.auth import AuthError, resolve_provider
 from hermes_cli.colors import Colors, color
@@ -329,7 +334,7 @@ def show_status(args):
         from hermes_cli.gateway import get_launchd_label
         try:
             result = subprocess.run(
-                ["launchctl", "list", get_launchd_label()],
+                [_LAUNCHCTL, "list", get_launchd_label()],
                 capture_output=True,
                 text=True,
                 timeout=5

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -146,8 +146,8 @@ class TestLaunchdServiceRecovery:
 
         assert "--replace" in plist_path.read_text(encoding="utf-8")
         assert calls[:2] == [
-            ["launchctl", "unload", str(plist_path)],
-            ["launchctl", "load", str(plist_path)],
+            [gateway_cli._LAUNCHCTL, "unload", str(plist_path)],
+            [gateway_cli._LAUNCHCTL, "load", str(plist_path)],
         ]
 
     def test_launchd_start_reloads_unloaded_job_and_retries(self, tmp_path, monkeypatch):
@@ -159,7 +159,7 @@ class TestLaunchdServiceRecovery:
 
         def fake_run(cmd, check=False, **kwargs):
             calls.append(cmd)
-            if cmd == ["launchctl", "start", label] and calls.count(cmd) == 1:
+            if cmd == [gateway_cli._LAUNCHCTL, "start", label] and calls.count(cmd) == 1:
                 raise gateway_cli.subprocess.CalledProcessError(3, cmd, stderr="Could not find service")
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
@@ -169,9 +169,9 @@ class TestLaunchdServiceRecovery:
         gateway_cli.launchd_start()
 
         assert calls == [
-            ["launchctl", "start", label],
-            ["launchctl", "load", str(plist_path)],
-            ["launchctl", "start", label],
+            [gateway_cli._LAUNCHCTL, "start", label],
+            [gateway_cli._LAUNCHCTL, "load", str(plist_path)],
+            [gateway_cli._LAUNCHCTL, "start", label],
         ]
 
     def test_launchd_status_reports_local_stale_plist_when_unloaded(self, tmp_path, monkeypatch, capsys):
@@ -266,7 +266,7 @@ class TestGatewaySystemServiceRouting:
             gateway_cli,
             "launchd_restart",
             lambda: (_ for _ in ()).throw(
-                gateway_cli.subprocess.CalledProcessError(5, ["launchctl", "start", "ai.hermes.gateway"])
+                gateway_cli.subprocess.CalledProcessError(5, [gateway_cli._LAUNCHCTL, "start", "ai.hermes.gateway"])
             ),
         )
 

--- a/tests/hermes_cli/test_launchctl_path.py
+++ b/tests/hermes_cli/test_launchctl_path.py
@@ -1,0 +1,40 @@
+"""Tests that launchctl constant is properly resolved.
+
+When UV's bundled Python has a minimal PATH that doesn't include /bin,
+subprocess calls to launchctl would fail with FileNotFoundError.
+This test verifies that the _LAUNCHCTL constant falls back to the
+absolute path /bin/launchctl.
+"""
+
+import os
+import shutil
+from unittest.mock import patch
+
+
+def test_launchctl_fallback_to_absolute_path():
+    """When shutil.which() returns None, should fall back to /bin/launchctl."""
+    with patch.object(shutil, "which", return_value=None):
+        # Re-import to recalculate the constant
+        import importlib
+        import hermes_cli.gateway as gateway_module
+        importlib.reload(gateway_module)
+        
+        assert gateway_module._LAUNCHCTL == "/bin/launchctl"
+
+
+def test_launchctl_uses_which_result_when_available():
+    """When shutil.which() finds launchctl, should use that path."""
+    with patch.object(shutil, "which", return_value="/usr/bin/launchctl"):
+        import importlib
+        import hermes_cli.gateway as gateway_module
+        importlib.reload(gateway_module)
+        
+        assert gateway_module._LAUNCHCTL == "/usr/bin/launchctl"
+
+
+def test_launchctl_constant_is_string():
+    """_LAUNCHCTL should always be a non-empty string."""
+    from hermes_cli import gateway
+    
+    assert isinstance(gateway._LAUNCHCTL, str)
+    assert len(gateway._LAUNCHCTL) > 0

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -316,7 +316,7 @@ class TestCmdUpdateLaunchdRestart:
         # Verify launchctl stop + start were called (not manual SIGTERM)
         launchctl_calls = [
             c for c in mock_run.call_args_list
-            if len(c.args[0]) > 0 and c.args[0][0] == "launchctl"
+            if len(c.args[0]) > 0 and "launchctl" in c.args[0][0]
         ]
         stop_calls = [c for c in launchctl_calls if "stop" in c.args[0]]
         start_calls = [c for c in launchctl_calls if "start" in c.args[0]]


### PR DESCRIPTION
## Problem

`hermes gateway start` fails on macOS when hermes is installed via UV:

```
FileNotFoundError: [Errno 2] No such file or directory: 'launchctl'
```

UV's bundled Python (`cpython-3.11.15-macos-aarch64-none`) ships with a minimal `PATH` that does not include `/bin` or `/usr/bin`. Since the code calls `subprocess.run(["launchctl", ...])` without an absolute path, it fails to find the binary.

## Solution

This PR:
- Adds a `_LAUNCHCTL` constant that uses `shutil.which()` with `/bin/launchctl` fallback
- Replaces all bare `launchctl` subprocess calls with the constant
- Applies the fix to all affected files: `gateway.py`, `main.py`, `status.py`, `profiles.py`
- Adds test coverage for the fallback behavior

## Testing

Added tests in `tests/hermes_cli/test_launchctl_path.py` that verify:
- Fallback to `/bin/launchctl` when `shutil.which()` returns None
- Uses `shutil.which()` result when available
- Constant is always a non-empty string

Fixes #3849