### PR TITLE
feat: linked activity notices and Telegram approval buttons

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -16,10 +16,11 @@ from typing import Dict, List, Optional, Any
 logger = logging.getLogger(__name__)
 
 try:
-    from telegram import Update, Bot, Message
+    from telegram import Update, Bot, Message, InlineKeyboardButton, InlineKeyboardMarkup
     from telegram.ext import (
         Application,
         CommandHandler,
+        CallbackQueryHandler,
         MessageHandler as TelegramMessageHandler,
         ContextTypes,
         filters,
@@ -34,8 +35,11 @@ except ImportError:
     Message = Any
     Application = Any
     CommandHandler = Any
+    CallbackQueryHandler = Any
     TelegramMessageHandler = Any
     HTTPXRequest = Any
+    InlineKeyboardButton = Any
+    InlineKeyboardMarkup = Any
     filters = None
     ParseMode = None
     ChatType = None
@@ -76,6 +80,14 @@ def check_telegram_requirements() -> bool:
 # Matches every character that MarkdownV2 requires to be backslash-escaped
 # when it appears outside a code span or fenced code block.
 _MDV2_ESCAPE_RE = re.compile(r'([_*\[\]()~`>#\+\-=|{}.!\\])')
+
+_TELEGRAM_APPROVAL_CALLBACK_PREFIX = "approval:"
+_TELEGRAM_APPROVAL_CALLBACK_TO_COMMAND = {
+    "once": "/approve",
+    "session": "/approve session",
+    "always": "/approve always",
+    "deny": "/deny",
+}
 
 
 def _escape_mdv2(text: str) -> str:
@@ -527,6 +539,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 filters.PHOTO | filters.VIDEO | filters.AUDIO | filters.VOICE | filters.Document.ALL | filters.Sticker.ALL,
                 self._handle_media_message
             ))
+            self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
             
             # Start polling — retry initialize() for transient TLS resets
             try:
@@ -781,6 +794,59 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.error("[%s] Failed to send Telegram message: %s", self.name, e, exc_info=True)
             return SendResult(success=False, error=str(e))
+
+    async def send_approval_prompt(
+        self,
+        chat_id: str,
+        content: str,
+        *,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        allow_permanent: bool = True,
+    ) -> SendResult:
+        """Send an approval request with inline buttons in Telegram."""
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+
+        buttons = [
+            [InlineKeyboardButton("Approve once", callback_data=f"{_TELEGRAM_APPROVAL_CALLBACK_PREFIX}once")],
+            [InlineKeyboardButton("Approve session", callback_data=f"{_TELEGRAM_APPROVAL_CALLBACK_PREFIX}session")],
+        ]
+        if allow_permanent:
+            buttons.append([
+                InlineKeyboardButton("Approve always", callback_data=f"{_TELEGRAM_APPROVAL_CALLBACK_PREFIX}always")
+            ])
+        buttons.append([
+            InlineKeyboardButton("Deny", callback_data=f"{_TELEGRAM_APPROVAL_CALLBACK_PREFIX}deny")
+        ])
+        markup = InlineKeyboardMarkup(buttons)
+        formatted = self.format_message(content)
+        thread_id = metadata.get("thread_id") if metadata else None
+        reply_to_id = int(reply_to) if reply_to else None
+        effective_thread_id = int(thread_id) if thread_id else None
+        try:
+            msg = await self._bot.send_message(
+                chat_id=int(chat_id),
+                text=formatted,
+                parse_mode=ParseMode.MARKDOWN_V2,
+                reply_to_message_id=reply_to_id,
+                message_thread_id=effective_thread_id,
+                reply_markup=markup,
+            )
+        except Exception as md_error:
+            if "parse" in str(md_error).lower() or "markdown" in str(md_error).lower():
+                msg = await self._bot.send_message(
+                    chat_id=int(chat_id),
+                    text=_strip_mdv2(formatted),
+                    parse_mode=None,
+                    reply_to_message_id=reply_to_id,
+                    message_thread_id=effective_thread_id,
+                    reply_markup=markup,
+                )
+            else:
+                logger.error("[%s] Failed to send Telegram approval prompt: %s", self.name, md_error, exc_info=True)
+                return SendResult(success=False, error=str(md_error))
+        return SendResult(success=True, message_id=str(msg.message_id), raw_response={"message_id": msg.message_id})
 
     async def edit_message(
         self,
@@ -1333,6 +1399,53 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         
         event = self._build_message_event(update.message, MessageType.COMMAND)
+        await self.handle_message(event)
+
+    async def _handle_callback_query(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle inline-button callback queries for approval actions."""
+        query = getattr(update, "callback_query", None)
+        if not query:
+            return
+        data = getattr(query, "data", None) or ""
+        if not isinstance(data, str) or not data.startswith(_TELEGRAM_APPROVAL_CALLBACK_PREFIX):
+            try:
+                await query.answer()
+            except Exception:
+                pass
+            return
+
+        action = data[len(_TELEGRAM_APPROVAL_CALLBACK_PREFIX):].strip().lower()
+        command_text = _TELEGRAM_APPROVAL_CALLBACK_TO_COMMAND.get(action)
+        if not command_text:
+            try:
+                await query.answer("Unknown action", show_alert=False)
+            except Exception:
+                pass
+            return
+
+        msg = getattr(query, "message", None)
+        if msg is None:
+            try:
+                await query.answer("Message unavailable", show_alert=False)
+            except Exception:
+                pass
+            return
+
+        event = self._build_message_event(msg, MessageType.COMMAND)
+        event.text = command_text
+        event.message_type = MessageType.COMMAND
+        if getattr(query, "from_user", None):
+            event.source.user_id = str(query.from_user.id)
+            event.source.user_name = query.from_user.username or query.from_user.full_name or event.source.user_name
+        try:
+            await query.answer()
+        except Exception:
+            pass
+        try:
+            if msg.reply_markup:
+                await query.edit_message_reply_markup(reply_markup=None)
+        except Exception:
+            pass
         await self.handle_message(event)
     
     async def _handle_location_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2581,13 +2581,42 @@ class GatewayRunner:
                     cmd_preview = pending.get("command", "")
                     if len(cmd_preview) > 200:
                         cmd_preview = cmd_preview[:200] + "..."
+                    allow_permanent = bool(pending.get("allow_permanent", True))
                     approval_hint = (
                         f"\n\n⚠️ **Dangerous command requires approval:**\n"
                         f"```\n{cmd_preview}\n```\n"
-                        f"Reply `/approve` to execute, `/approve session` to approve this pattern "
-                        f"for the session, or `/deny` to cancel."
+                        + (
+                            "Use the buttons below to approve once, approve for this session, "
+                            + ("approve always, " if allow_permanent else "")
+                            + "or deny."
+                            if source.platform.value == "telegram"
+                            else f"Reply `/approve` to execute, `/approve session` to approve this pattern "
+                              + ("permanently with `/approve always`, " if allow_permanent else "")
+                              + "or `/deny` to cancel."
+                        )
                     )
-                    response = (response or "") + approval_hint
+                    if source.platform.value == "telegram":
+                        adapter = self.adapters.get(source.platform)
+                        send_buttons = getattr(adapter, "send_approval_prompt", None)
+                        if callable(send_buttons):
+                            thread_meta = {"thread_id": source.thread_id} if source.thread_id else None
+                            button_message = (response or "") + approval_hint
+                            try:
+                                await send_buttons(
+                                    chat_id=source.chat_id,
+                                    content=button_message,
+                                    reply_to=event.message_id,
+                                    metadata=thread_meta,
+                                    allow_permanent=allow_permanent,
+                                )
+                                response = ""
+                            except Exception as button_err:
+                                logger.debug("Telegram approval prompt buttons failed: %s", button_err)
+                                response = (response or "") + approval_hint
+                        else:
+                            response = (response or "") + approval_hint
+                    else:
+                        response = (response or "") + approval_hint
             except Exception as e:
                 logger.debug("Failed to check pending approvals: %s", e)
             

--- a/run_agent.py
+++ b/run_agent.py
@@ -109,6 +109,10 @@ HONCHO_TOOL_NAMES = {
     "honcho_conclude",
 }
 
+_SKIPPY_ACTIVITY_QUERY = 'skippy OR openclaw OR "inter-session"'
+_SKIPPY_ACTIVITY_MAX_MATCHES = 3
+_SKIPPY_ACTIVITY_SNIPPET_RE = re.compile(r">>>|<<<")
+
 
 class _SafeWriter:
     """Transparent stdio wrapper that catches OSError/ValueError from broken pipes.
@@ -2668,6 +2672,111 @@ class AIAgent:
             prompt_parts.append(PLATFORM_HINTS[platform_key])
 
         return "\n\n".join(prompt_parts)
+
+    def _find_previous_user_session(self) -> Optional[Dict[str, Any]]:
+        """Return the most recent prior session for the current platform/source."""
+        if not self._session_db:
+            return None
+
+        current_row = None
+        try:
+            current_row = self._session_db.get_session(self.session_id)
+        except Exception:
+            current_row = None
+
+        current_source = (
+            (current_row or {}).get("source")
+            or self.platform
+            or os.environ.get("HERMES_SESSION_SOURCE", "cli")
+        )
+
+        try:
+            sessions = self._session_db.list_sessions_rich(source=current_source, limit=10)
+        except Exception:
+            return None
+
+        for session in sessions:
+            if session.get("id") != self.session_id:
+                return session
+        return None
+
+    @staticmethod
+    def _clean_activity_snippet(snippet: str) -> str:
+        """Normalize FTS snippet markup for prompt injection."""
+        if not snippet:
+            return ""
+        cleaned = _SKIPPY_ACTIVITY_SNIPPET_RE.sub("", snippet)
+        cleaned = re.sub(r"\s+", " ", cleaned).strip()
+        if len(cleaned) > 120:
+            cleaned = cleaned[:117].rstrip() + "..."
+        return cleaned
+
+    def _build_skippy_activity_notice(self, is_first_turn: bool) -> str:
+        """Build an ephemeral notice about new Skippy/OpenClaw activity since the last chat."""
+        if not is_first_turn or not self._session_db:
+            return ""
+
+        previous_session = self._find_previous_user_session()
+        if not previous_session:
+            return ""
+
+        cutoff = previous_session.get("last_active") or previous_session.get("started_at")
+        if not cutoff:
+            return ""
+
+        try:
+            matches = self._session_db.search_messages(
+                query=_SKIPPY_ACTIVITY_QUERY,
+                exclude_sources=["tool"],
+                role_filter=["user", "assistant"],
+                limit=20,
+            )
+        except Exception:
+            return ""
+
+        recent = []
+        seen_sessions = set()
+        for match in matches:
+            if match.get("session_id") == self.session_id:
+                continue
+            if (match.get("timestamp") or 0) <= cutoff:
+                continue
+            session_id = match.get("session_id")
+            if not session_id or session_id in seen_sessions:
+                continue
+            seen_sessions.add(session_id)
+            recent.append(match)
+            if len(recent) >= _SKIPPY_ACTIVITY_MAX_MATCHES:
+                break
+
+        if not recent:
+            return ""
+
+        bullets = []
+        for match in recent:
+            snippet = self._clean_activity_snippet(match.get("snippet") or "")
+            started = match.get("session_started")
+            if started:
+                try:
+                    started_label = datetime.fromtimestamp(float(started)).strftime("%b %d %H:%M")
+                except Exception:
+                    started_label = None
+            else:
+                started_label = None
+            if started_label and snippet:
+                bullets.append(f"- {started_label}: {snippet}")
+            elif snippet:
+                bullets.append(f"- {snippet}")
+
+        if not bullets:
+            return ""
+
+        return (
+            "# New linked activity since the last chat\n"
+            f"I found {len(recent)} newer session(s) mentioning Skippy/OpenClaw after the previous conversation with this user. "
+            "Use this as a continuity nudge; pull full details with session_search if it matters.\n"
+            + "\n".join(bullets)
+        )
 
     # =========================================================================
     # Pre/post-call guardrails (inspired by PR #1321 — @alireza78a)
@@ -6145,6 +6254,12 @@ class AIAgent:
         # that will be appended to the ephemeral system prompt for every
         # API call in this turn (not persisted to session DB or cache).
         _plugin_turn_context = ""
+        _turn_context_parts = []
+        _skippy_activity_notice = self._build_skippy_activity_notice(
+            is_first_turn=(not bool(conversation_history))
+        )
+        if _skippy_activity_notice:
+            _turn_context_parts.append(_skippy_activity_notice)
         try:
             from hermes_cli.plugins import invoke_hook as _invoke_hook
             _pre_results = _invoke_hook(
@@ -6156,16 +6271,15 @@ class AIAgent:
                 model=self.model,
                 platform=getattr(self, "platform", None) or "",
             )
-            _ctx_parts = []
             for r in _pre_results:
                 if isinstance(r, dict) and r.get("context"):
-                    _ctx_parts.append(str(r["context"]))
+                    _turn_context_parts.append(str(r["context"]))
                 elif isinstance(r, str) and r.strip():
-                    _ctx_parts.append(r)
-            if _ctx_parts:
-                _plugin_turn_context = "\n\n".join(_ctx_parts)
+                    _turn_context_parts.append(r)
         except Exception as exc:
             logger.warning("pre_llm_call hook failed: %s", exc)
+        if _turn_context_parts:
+            _plugin_turn_context = "\n\n".join(_turn_context_parts)
 
         # Main conversation loop
         api_call_count = 0

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -1,0 +1,78 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.platforms.telegram import TelegramAdapter
+from gateway.session import SessionSource
+
+
+def _make_event(text: str = "") -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.COMMAND,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="123",
+            user_id="orig-user",
+            user_name="orig-name",
+        ),
+        message_id="55",
+    )
+
+
+@pytest.mark.asyncio
+async def test_callback_query_maps_session_approval_to_command():
+    adapter = object.__new__(TelegramAdapter)
+    event = _make_event()
+    adapter._build_message_event = MagicMock(return_value=event)
+    adapter.handle_message = AsyncMock()
+
+    query = SimpleNamespace(
+        data="approval:session",
+        from_user=SimpleNamespace(id=999, username="tyler", full_name="Tyler Martin"),
+        message=SimpleNamespace(reply_markup=object()),
+        answer=AsyncMock(),
+        edit_message_reply_markup=AsyncMock(),
+    )
+    update = SimpleNamespace(callback_query=query)
+
+    await TelegramAdapter._handle_callback_query(adapter, update, None)
+
+    assert event.text == "/approve session"
+    assert event.source.user_id == "999"
+    assert event.source.user_name == "tyler"
+    adapter.handle_message.assert_awaited_once_with(event)
+    query.answer.assert_awaited()
+    query.edit_message_reply_markup.assert_awaited_once_with(reply_markup=None)
+
+
+@pytest.mark.asyncio
+async def test_send_approval_prompt_uses_inline_keyboard():
+    adapter = object.__new__(TelegramAdapter)
+    adapter._bot = SimpleNamespace(
+        send_message=AsyncMock(return_value=SimpleNamespace(message_id=42))
+    )
+    adapter.format_message = MagicMock(side_effect=lambda content: content)
+    adapter.platform = Platform.TELEGRAM
+
+    result = await TelegramAdapter.send_approval_prompt(
+        adapter,
+        chat_id="123",
+        content="Dangerous command requires approval.",
+        reply_to="55",
+        metadata={"thread_id": "77"},
+        allow_permanent=False,
+    )
+
+    assert result.success is True
+    adapter._bot.send_message.assert_awaited_once()
+    kwargs = adapter._bot.send_message.await_args.kwargs
+    assert kwargs["chat_id"] == 123
+    assert kwargs["reply_to_message_id"] == 55
+    assert kwargs["message_thread_id"] == 77
+    markup = kwargs["reply_markup"]
+    labels = [button.text for row in markup.inline_keyboard for button in row]
+    assert labels == ["Approve once", "Approve session", "Deny"]

--- a/tests/test_skippy_activity_notice.py
+++ b/tests/test_skippy_activity_notice.py
@@ -1,0 +1,69 @@
+import time
+
+from hermes_state import SessionDB
+from run_agent import AIAgent
+
+
+def _make_agent(db: SessionDB, session_id: str, platform: str = "telegram") -> AIAgent:
+    agent = object.__new__(AIAgent)
+    agent._session_db = db
+    agent.session_id = session_id
+    agent.platform = platform
+    return agent
+
+
+def test_build_skippy_activity_notice_empty_without_prior_session(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("current", source="telegram", model="test")
+
+    agent = _make_agent(db, "current")
+
+    assert agent._build_skippy_activity_notice(is_first_turn=True) == ""
+    assert agent._build_skippy_activity_notice(is_first_turn=False) == ""
+
+
+
+def test_build_skippy_activity_notice_reports_newer_skippy_activity(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+
+    db.create_session("old-chat", source="telegram", model="test")
+    db.append_message("old-chat", "user", "Last time we talked about email triage.")
+
+    time.sleep(0.02)
+
+    db.create_session("skippy-session", source="cli", model="test")
+    db.append_message("skippy-session", "assistant", "Skippy and OpenClaw discussed thread routing.")
+
+    time.sleep(0.02)
+
+    db.create_session("current", source="telegram", model="test")
+    db.append_message("current", "user", "Hello again")
+
+    agent = _make_agent(db, "current")
+    notice = agent._build_skippy_activity_notice(is_first_turn=True)
+
+    assert "New linked activity since the last chat" in notice
+    assert "Skippy/OpenClaw" in notice
+    assert "thread routing" in notice
+    assert "old-chat" not in notice
+
+
+
+def test_build_skippy_activity_notice_ignores_older_matches(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+
+    db.create_session("ancient-skippy", source="cli", model="test")
+    db.append_message("ancient-skippy", "assistant", "Skippy mentioned OpenClaw months ago.")
+
+    time.sleep(0.02)
+
+    db.create_session("old-chat", source="telegram", model="test")
+    db.append_message("old-chat", "user", "Our previous conversation.")
+
+    time.sleep(0.02)
+
+    db.create_session("current", source="telegram", model="test")
+
+    agent = _make_agent(db, "current")
+
+    assert agent._build_skippy_activity_notice(is_first_turn=True) == ""

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -592,6 +592,7 @@ def check_all_command_guards(command: str, env_type: str,
             "pattern_key": primary_key,        # backward compat
             "pattern_keys": all_keys,           # all keys for replay
             "description": combined_desc,
+            "allow_permanent": not has_tirith,
         })
         return {
             "approved": False,


### PR DESCRIPTION
## Summary
- add first-turn linked activity notices as ephemeral context
- add Telegram approval buttons for approve once/session/always/deny
- keep slash-command approvals as fallback

## Tests
- python -m pytest tests/gateway/test_telegram_approval_buttons.py tests/test_skippy_activity_notice.py -q
- python -m py_compile gateway/platforms/telegram.py gateway/run.py tools/approval.py run_agent.py tests/gateway/test_telegram_approval_buttons.py tests/test_skippy_activity_notice.py

Closes #3915