### PR TITLE
fix(cli): remove input() from /tools disable that freezes the terminal

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2789,22 +2789,12 @@ class HermesCLI:
             print(f"  MCP tool:          /tools {subcommand} github:create_issue")
             return
 
-        # Confirm session reset before applying
-        verb = "Disable" if subcommand == "disable" else "Enable"
+        # Apply the change directly — the user typing the command is implicit
+        # consent.  Do NOT use input() here; it hangs inside prompt_toolkit's
+        # TUI event loop (known pitfall).
+        verb = "Disabling" if subcommand == "disable" else "Enabling"
         label = ", ".join(names)
-        _cprint(f"{_GOLD}{verb} {label}?{_RST}")
-        _cprint(f"{_DIM}This will save to config and reset your session so the "
-                f"change takes effect cleanly.{_RST}")
-        try:
-            answer = input("  Continue? [y/N] ").strip().lower()
-        except (EOFError, KeyboardInterrupt):
-            print()
-            _cprint(f"{_DIM}Cancelled.{_RST}")
-            return
-
-        if answer not in ("y", "yes"):
-            _cprint(f"{_DIM}Cancelled.{_RST}")
-            return
+        _cprint(f"{_GOLD}{verb} {label}...{_RST}")
 
         tools_disable_enable_command(
             Namespace(tools_action=subcommand, names=names, platform="cli"))


### PR DESCRIPTION
## Summary

`/tools disable <name>` and `/tools enable <name>` froze the terminal with no way to respond. The Y/N confirmation prompt used `input()`, which hangs inside prompt_toolkit's TUI event loop (known pitfall documented in AGENTS.md).

## Fix

Removed the `input()` confirmation. Typing the slash command is implicit consent — same pattern used by `/skills install`, `/skills uninstall`, and all other mutating slash commands.

## Before
```
/tools disable web
Disable web?
This will save to config and reset your session...
  Continue? [y/N] █  ← frozen, keys don't register
```

## After
```
/tools disable web
Disabling web...
✓ Disabled: web
Session reset. New tool configuration is active.
```

## Verified
Live-tested in tmux PTY — both `/tools disable` and `/tools enable` execute instantly with no freeze.