### PR TITLE
fix(security): extend secret redaction to ElevenLabs, Tavily and Exa API keys

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -37,6 +37,9 @@ _PREFIX_PATTERNS = [
     r"dop_v1_[A-Za-z0-9]{10,}",         # DigitalOcean PAT
     r"doo_v1_[A-Za-z0-9]{10,}",         # DigitalOcean OAuth
     r"am_[A-Za-z0-9_-]{10,}",           # AgentMail API key
+    r"sk_[A-Za-z0-9_]{10,}",            # ElevenLabs TTS key (sk_ underscore, not sk- dash)
+    r"tvly-[A-Za-z0-9]{10,}",           # Tavily search API key
+    r"exa_[A-Za-z0-9]{10,}",            # Exa search API key
 ]
 
 # ENV assignment patterns: KEY=value where KEY contains a secret-like name

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -201,3 +201,52 @@ class TestSecretCapturePayloadRedaction:
         text = '{"raw_secret": "ghp_abc123def456ghi789jkl"}'
         result = redact_sensitive_text(text)
         assert "abc123def456" not in result
+
+
+class TestElevenLabsTavilyExaKeys:
+    """Regression tests for ElevenLabs (sk_), Tavily (tvly-), and Exa (exa_) keys."""
+
+    def test_elevenlabs_key_redacted(self):
+        text = "ELEVENLABS_API_KEY=sk_abc123def456ghi789jklmnopqrstu"
+        result = redact_sensitive_text(text)
+        assert "abc123def456ghi" not in result
+
+    def test_elevenlabs_key_in_log_line(self):
+        text = "Connecting to ElevenLabs with key sk_abc123def456ghi789jklmnopqrstu"
+        result = redact_sensitive_text(text)
+        assert "abc123def456ghi" not in result
+
+    def test_tavily_key_redacted(self):
+        text = "TAVILY_API_KEY=tvly-ABCdef123456789GHIJKL0000"
+        result = redact_sensitive_text(text)
+        assert "ABCdef123456789" not in result
+
+    def test_tavily_key_in_log_line(self):
+        text = "Initialising Tavily client with tvly-ABCdef123456789GHIJKL0000"
+        result = redact_sensitive_text(text)
+        assert "ABCdef123456789" not in result
+
+    def test_exa_key_redacted(self):
+        text = "EXA_API_KEY=exa_XYZ789abcdef000000000000000"
+        result = redact_sensitive_text(text)
+        assert "XYZ789abcdef" not in result
+
+    def test_exa_key_in_log_line(self):
+        text = "Using Exa client with key exa_XYZ789abcdef000000000000000"
+        result = redact_sensitive_text(text)
+        assert "XYZ789abcdef" not in result
+
+    def test_all_three_in_env_dump(self):
+        env_dump = (
+            "HOME=/home/user\n"
+            "ELEVENLABS_API_KEY=sk_abc123def456ghi789jklmnopqrstu\n"
+            "TAVILY_API_KEY=tvly-ABCdef123456789GHIJKL0000\n"
+            "EXA_API_KEY=exa_XYZ789abcdef000000000000000\n"
+            "SHELL=/bin/bash\n"
+        )
+        result = redact_sensitive_text(env_dump)
+        assert "abc123def456ghi" not in result
+        assert "ABCdef123456789" not in result
+        assert "XYZ789abcdef" not in result
+        assert "HOME=/home/user" in result
+        assert "SHELL=/bin/bash" in result


### PR DESCRIPTION
ElevenLabs (`sk_`), Tavily (`tvly-`), and Exa (`exa_`) API keys were not covered by `_PREFIX_PATTERNS` in `agent/redact.py`, leaking in plain text via `printenv` or log output.

**E2E verified** — all three key types now fully redacted in env dumps, log lines, and inline text. Non-secret lines preserved. Existing Stripe patterns unaffected.

Tests rewritten with correct assertions — the original PR's tests used vacuously true checks (`assert 'abc123def456' not in result` where that string was never in the input).

Salvaged from PR #3790 by @memosr with authorship preserved.