### PR TITLE
Add paginated /commands flow for Telegram gateway

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -622,10 +622,19 @@ class TelegramAdapter(BasePlatformAdapter):
             # gateway command there automatically adds it to the Telegram menu.
             try:
                 from telegram import BotCommand
-                from hermes_cli.commands import telegram_bot_commands
+                from hermes_cli.commands import telegram_menu_commands
+
+                menu_commands, hidden_count = telegram_menu_commands(max_commands=100)
                 await self._bot.set_my_commands([
-                    BotCommand(name, desc) for name, desc in telegram_bot_commands()
+                    BotCommand(name, desc) for name, desc in menu_commands
                 ])
+                if hidden_count:
+                    logger.info(
+                        "[%s] Telegram menu capped at %d commands; %d additional commands remain callable but hidden. Use /commands for the full list.",
+                        self.name,
+                        len(menu_commands),
+                        hidden_count,
+                    )
             except Exception as e:
                 logger.warning(
                     "[%s] Could not register Telegram command menu: %s",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1817,6 +1817,9 @@ class GatewayRunner:
         
         if canonical == "help":
             return await self._handle_help_command(event)
+
+        if canonical == "commands":
+            return await self._handle_commands_command(event)
         
         if canonical == "status":
             return await self._handle_status_command(event)
@@ -3059,6 +3062,7 @@ class GatewayRunner:
         from hermes_cli.commands import gateway_help_lines
         lines = [
             "📖 **Hermes Commands**\n",
+            "Use `/commands` for a paginated list when the full command set is too long.\n",
             *gateway_help_lines(),
         ]
         try:
@@ -3070,6 +3074,54 @@ class GatewayRunner:
                     lines.append(f"`{cmd}` — {skill_cmds[cmd]['description']}")
         except Exception:
             pass
+        return "\n".join(lines)
+
+    async def _handle_commands_command(self, event: MessageEvent) -> str:
+        """Handle /commands command - show the full command list in pages."""
+        from gateway.config import Platform
+        from hermes_cli.commands import gateway_help_lines
+
+        raw_args = event.get_command_args().strip()
+        if raw_args:
+            try:
+                requested_page = int(raw_args)
+            except ValueError:
+                return "Usage: `/commands [page]`"
+        else:
+            requested_page = 1
+
+        entries = list(gateway_help_lines())
+        try:
+            from agent.skill_commands import get_skill_commands
+
+            skill_cmds = get_skill_commands()
+            for name in sorted(skill_cmds):
+                desc = skill_cmds[name].get("description", "").strip() or "Skill command"
+                entries.append(f"`{name}` -- {desc}")
+        except Exception:
+            pass
+
+        if not entries:
+            return "No gateway commands are available."
+
+        page_size = 10 if event.source.platform == Platform.TELEGRAM else 15
+        total_pages = max(1, (len(entries) + page_size - 1) // page_size)
+        page = max(1, min(requested_page, total_pages))
+        start = (page - 1) * page_size
+        page_entries = entries[start:start + page_size]
+
+        lines = [
+            f"📚 **Commands** ({len(entries)} total, page {page}/{total_pages})",
+            "",
+            *page_entries,
+        ]
+        if total_pages > 1:
+            lines.extend([
+                "",
+                f"Use `/commands {max(1, page - 1)}` or `/commands {min(total_pages, page + 1)}` to move between pages.",
+            ])
+        if page != requested_page:
+            lines.append(f"Requested page {requested_page} was out of range, showing page {page}.")
         return "\n".join(lines)
     
     async def _handle_provider_command(self, event: MessageEvent) -> str:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -118,6 +118,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                "Tools & Skills", cli_only=True),
 
     # Info
+    CommandDef("commands", "Browse all available commands in pages", "Info",
+               gateway_only=True, args_hint="[page]"),
     CommandDef("help", "Show available commands", "Info"),
     CommandDef("usage", "Show token usage for the current session", "Info"),
     CommandDef("insights", "Show usage insights and analytics", "Info",
@@ -359,6 +361,17 @@ def telegram_bot_commands() -> list[tuple[str, str]]:
         tg_name = cmd.name.replace("-", "_")
         result.append((tg_name, cmd.description))
     return result
+
+
+def telegram_menu_commands(max_commands: int = 100) -> tuple[list[tuple[str, str]], int]:
+    """Return Telegram menu commands capped to the Bot API limit.
+
+    Commands beyond ``max_commands`` remain callable in the gateway; they are
+    just omitted from Telegram's native slash-command picker.
+    """
+    all_commands = telegram_bot_commands()
+    hidden_count = max(0, len(all_commands) - max_commands)
+    return all_commands[:max_commands], hidden_count
 
 
 def slack_subcommand_map() -> dict[str, str]:

--- a/tests/gateway/test_commands_command.py
+++ b/tests/gateway/test_commands_command.py
@@ -1,0 +1,74 @@
+"""Tests for gateway /commands pagination and discovery text."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_event(text="/commands", platform=Platform.TELEGRAM, user_id="12345", chat_id="67890"):
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._show_reasoning = False
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.hooks.loaded_hooks = []
+    runner._session_db = None
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+    return runner
+
+
+class TestCommandsCommand:
+    @pytest.mark.asyncio
+    async def test_help_mentions_commands_pagination(self):
+        runner = _make_runner()
+
+        result = await runner._handle_help_command(_make_event("/help"))
+
+        assert "Use `/commands` for a paginated list" in result
+
+    @pytest.mark.asyncio
+    async def test_commands_first_page_is_paginated(self):
+        runner = _make_runner()
+
+        result = await runner._handle_commands_command(_make_event("/commands"))
+
+        assert "page 1/" in result
+        assert "Use `/commands 1` or `/commands 2`" in result
+        assert "`/new` -- Start a new session" in result
+
+    @pytest.mark.asyncio
+    async def test_commands_invalid_page_returns_usage(self):
+        runner = _make_runner()
+
+        result = await runner._handle_commands_command(_make_event("/commands nope"))
+
+        assert result == "Usage: `/commands [page]`"
+
+    @pytest.mark.asyncio
+    async def test_commands_out_of_range_clamps_page(self):
+        runner = _make_runner()
+
+        result = await runner._handle_commands_command(_make_event("/commands 999"))
+
+        assert "Requested page 999 was out of range" in result

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -13,10 +13,13 @@ from hermes_cli.commands import (
     SlashCommandAutoSuggest,
     SlashCommandCompleter,
     gateway_help_lines,
+    rebuild_lookups,
     resolve_command,
     slack_subcommand_map,
     telegram_bot_commands,
+    telegram_menu_commands,
 )
+import hermes_cli.commands as commands_mod
 
 
 def _completions(completer: SlashCommandCompleter, text: str):
@@ -158,6 +161,9 @@ class TestGatewayKnownCommands:
         assert "bg" in GATEWAY_KNOWN_COMMANDS
         assert "background" in GATEWAY_KNOWN_COMMANDS
 
+    def test_commands_is_known_gateway_command(self):
+        assert "commands" in GATEWAY_KNOWN_COMMANDS
+
     def test_is_frozenset(self):
         assert isinstance(GATEWAY_KNOWN_COMMANDS, frozenset)
 
@@ -201,6 +207,30 @@ class TestTelegramBotCommands:
             if cmd.cli_only and not cmd.gateway_config_gate:
                 tg_name = cmd.name.replace("-", "_")
                 assert tg_name not in names
+
+    def test_commands_is_present_in_telegram_menu(self):
+        names = {name for name, _ in telegram_bot_commands()}
+        assert "commands" in names
+
+    def test_menu_helper_caps_overflow(self):
+        original_registry = list(commands_mod.COMMAND_REGISTRY)
+        try:
+            extra = [
+                CommandDef(f"extra{i}", f"Extra command {i}", "Info", gateway_only=True)
+                for i in range(120)
+            ]
+            commands_mod.COMMAND_REGISTRY[:] = [*original_registry, *extra]
+            rebuild_lookups()
+
+            menu_commands, hidden_count = telegram_menu_commands(max_commands=100)
+
+            assert len(menu_commands) == 100
+            assert hidden_count > 0
+            assert menu_commands[0][0] == "new"
+            assert "commands" in {name for name, _ in menu_commands}
+        finally:
+            commands_mod.COMMAND_REGISTRY[:] = original_registry
+            rebuild_lookups()
 
 
 class TestSlackSubcommandMap:


### PR DESCRIPTION
## Summary
- add a gateway-only `/commands [page]` command to browse the full command list in pages
- cap Telegram `setMyCommands` registration at 100 entries while keeping overflow commands callable
- point `/help` users to `/commands` and add regression tests for menu capping and pagination

## Why
Telegram's Bot API hard-limits native bot commands to 100 entries. When Hermes grows beyond that via gateway/plugin commands, native menu registration can fail even though the commands themselves are still valid. This change follows the same split used by others: cap the native Telegram menu, and move full command discovery to a dedicated `/commands` surface.

## Validation
- `source .venv/bin/activate && python -m pytest tests/hermes_cli/test_commands.py tests/gateway/test_commands_command.py tests/gateway/test_reasoning_command.py -q`
- `source .venv/bin/activate && python -m pytest tests/gateway/test_background_command.py tests/gateway/test_voice_command.py tests/gateway/test_title_command.py tests/gateway/test_update_command.py -q`
- `source .venv/bin/activate && python -m pytest tests/hermes_cli/test_commands.py -q`

## Notes
- `source .venv/bin/activate && python -m pytest tests/gateway/ -q` was also run, but three unrelated WhatsApp connect tests failed in this local environment because a real local gateway lock was already present (`Another local Hermes gateway is already using this WhatsApp session`).
