### PR TITLE
fix: openclaw migration overwrites model config dict with string

### DIFF
--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -1297,7 +1297,11 @@ class Migrator:
 
         if self.execute:
             backup_path = self.maybe_backup(destination)
-            hermes_config["model"] = model_str
+            existing_model = hermes_config.get("model")
+            if isinstance(existing_model, dict):
+                existing_model["default"] = model_str
+            else:
+                hermes_config["model"] = {"default": model_str}
             dump_yaml_file(destination, hermes_config)
             self.record("model-config", source_path, destination, "migrated", backup=str(backup_path) if backup_path else "", model=model_str)
         else:


### PR DESCRIPTION
## Summary

`migrate_model_config()` writes `config["model"] = model_str` which replaces the entire model dict with a bare string. This causes `'str' object has no attribute 'get'` on every prompt after migration.

## Root cause

```python
# Before (bug): overwrites dict with string
hermes_config["model"] = model_str

# config.yaml becomes:
# model: "anthropic/claude-sonnet-4"   <-- string, loses provider/base_url

# Any code doing model_cfg.get("default") crashes
```

## Fix

Preserve existing model dict, only update the `default` key:

```python
existing_model = hermes_config.get("model")
if isinstance(existing_model, dict):
    existing_model["default"] = model_str
else:
    hermes_config["model"] = {"default": model_str}
```

## Edge cases tested

- model is dict (normal) — updates default, preserves provider/base_url
- model is string (already broken) — converts to dict
- model key missing (fresh install) — creates dict
- model is None — creates dict

## Affected users

Multiple reports in Discord — all from users who migrated from OpenClaw. Reinstalling without migration was the only workaround.