### PR TITLE
fix(alibaba): use standard DashScope international endpoint

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -160,7 +160,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         id="alibaba",
         name="Alibaba Cloud (DashScope)",
         auth_type="api_key",
-        inference_base_url="https://coding-intl.dashscope.aliyuncs.com/v1",
+        inference_base_url="https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
         api_key_env_vars=("DASHSCOPE_API_KEY",),
         base_url_env_var="DASHSCOPE_BASE_URL",
     ),


### PR DESCRIPTION
Fixes #3912

## Problem

The Alibaba Cloud (DashScope) provider has a hardcoded default endpoint (`coding-intl.dashscope.aliyuncs.com`) that only accepts Alibaba Coding Plan API keys. Standard DashScope API keys fail with `invalid_api_key`.

## Root Cause

`hermes_cli/auth.py` line 163 hardcodes:
```
https://coding-intl.dashscope.aliyuncs.com/v1
```

This is the **Coding Plan-only** endpoint, not the general-purpose one.

## Fix

Changed the default endpoint to the international compatible-mode endpoint:
```
https://dashscope-intl.aliyuncs.com/compatible-mode/v1
```

This works with standard DashScope API keys. Users with Coding Plan keys or China-region keys can still override via `DASHSCOPE_BASE_URL` env var or `config.yaml` `base_url`.

## Testing

3972 tests pass (3 pre-existing failures unrelated to this change).