### PR TITLE
fix(cli): wire /model slash command into the interactive chat loop

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3233,7 +3233,106 @@ class HermesCLI:
             print("  Run: hermes setup")
             print()
 
-        print("  To change model or provider, use: hermes model")
+        print("  To change model or provider, use: /model provider:model or hermes model")
+
+    def _handle_model_command(self, cmd: str):
+        """Handle /model for in-session inspection and switching."""
+        from hermes_cli.auth import (
+            _save_model_choice,
+            _update_config_for_provider,
+            deactivate_provider,
+        )
+        from hermes_cli.model_switch import switch_model, switch_to_custom_provider
+        from hermes_cli.models import provider_label
+
+        parts = cmd.strip().split(maxsplit=1)
+        raw_arg = parts[1].strip() if len(parts) > 1 else ""
+        current_provider = (
+            self.requested_provider
+            if isinstance(self.requested_provider, str)
+            and self.requested_provider.startswith("custom:")
+            else (self.provider or self.requested_provider or "openrouter")
+        )
+
+        if not raw_arg:
+            print(f"Current model: {self.model}")
+            print(f"Provider: {provider_label(current_provider)}")
+            if self.base_url and (
+                "localhost" in self.base_url
+                or "127.0.0.1" in self.base_url
+                or "0.0.0.0" in self.base_url
+            ):
+                print(f"Endpoint: {self.base_url}")
+            print("Usage: /model list")
+            print("       /model provider:model")
+            print("Run `hermes model` for the full interactive picker.")
+            return
+
+        lowered = raw_arg.lower()
+        if lowered == "list":
+            self._show_model_and_providers()
+            return
+
+        if lowered == "custom":
+            auto = switch_to_custom_provider()
+            if not auto.success:
+                _cprint(f"\033[1;31m{auto.error_message}{_RST}")
+                return
+
+            result_model = auto.model
+            result_provider = (
+                self.requested_provider
+                if isinstance(self.requested_provider, str)
+                and self.requested_provider.startswith("custom:")
+                else "custom"
+            )
+            result_base_url = auto.base_url
+            result_api_key = auto.api_key
+            result_provider_label = provider_label(result_provider)
+            warning_message = ""
+        else:
+            result = switch_model(
+                raw_arg,
+                current_provider=current_provider,
+                current_base_url=self.base_url or "",
+                current_api_key=self.api_key or "",
+            )
+            if not result.success:
+                _cprint(f"\033[1;31m{result.error_message}{_RST}")
+                return
+
+            result_model = result.new_model
+            result_provider = result.target_provider
+            result_base_url = result.base_url
+            result_api_key = result.api_key
+            result_provider_label = result.provider_label or provider_label(result.target_provider)
+            warning_message = result.warning_message or ""
+
+        _update_config_for_provider(result_provider, result_base_url)
+        _save_model_choice(result_model)
+        if result_provider not in {"nous", "openai-codex"}:
+            deactivate_provider()
+
+        self.model = result_model
+        self.requested_provider = result_provider
+        self.provider = result_provider
+        self.base_url = result_base_url or self.base_url
+        self.api_key = result_api_key or self.api_key
+        self._model_is_default = False
+        self.agent = None
+        self._active_agent_route_signature = None
+
+        if not self._ensure_runtime_credentials():
+            _cprint(
+                f"{_DIM}Model selection was saved, but runtime credentials need attention. "
+                f"Use /provider or hermes model to review the active provider.{_RST}"
+            )
+            return
+
+        print(f"Switched model to: {self.model}")
+        print(f"Provider: {result_provider_label}")
+        if warning_message:
+            print(f"Warning: {warning_message}")
 
     def _handle_prompt_command(self, cmd: str):
         """Handle the /prompt command to view or set system prompt."""
@@ -3806,6 +3905,8 @@ class HermesCLI:
             self._handle_resume_command(cmd_original)
         elif canonical == "provider":
             self._show_model_and_providers()
+        elif canonical == "model":
+            self._handle_model_command(cmd_original)
         elif canonical == "prompt":
             # Use original case so prompt text isn't lowercased
             self._handle_prompt_command(cmd_original)

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -81,6 +81,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True),
     CommandDef("provider", "Show available providers and current provider",
                "Configuration"),
+    CommandDef("model", "Show or switch the active model", "Configuration",
+               cli_only=True, args_hint="[provider:model|list]"),
     CommandDef("prompt", "View/set custom system prompt", "Configuration",
                cli_only=True, args_hint="[text]", subcommands=("clear",)),
     CommandDef("personality", "Set a predefined personality", "Configuration",

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -75,6 +75,7 @@ class TestResolveCommand:
     def test_canonical_name_resolves(self):
         assert resolve_command("help").name == "help"
         assert resolve_command("background").name == "background"
+        assert resolve_command("model").name == "model"
 
     def test_alias_resolves_to_canonical(self):
         assert resolve_command("bg").name == "background"
@@ -310,6 +311,10 @@ class TestSlashCommandCompleter:
         assert "reset" in texts
         assert "retry" in texts
         assert "reload-mcp" in texts
+
+    def test_model_command_autocompletes(self):
+        completions = _completions(SlashCommandCompleter(), "/mo")
+        assert [item.text for item in completions] == ["model"]
 
     def test_builtin_completion_display_meta_shows_description(self):
         completions = _completions(SlashCommandCompleter(), "/help")

--- a/tests/test_cli_model_command.py
+++ b/tests/test_cli_model_command.py
@@ -1,0 +1,93 @@
+"""Regression tests for the interactive CLI /model slash command."""
+
+from unittest.mock import MagicMock, patch
+
+from cli import HermesCLI
+
+
+def _make_cli():
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.config = {}
+    cli_obj.console = MagicMock()
+    cli_obj.agent = object()
+    cli_obj.conversation_history = []
+    cli_obj.session_id = "session-test"
+    cli_obj._pending_input = MagicMock()
+    cli_obj.model = "anthropic/claude-opus-4.6"
+    cli_obj.provider = "openrouter"
+    cli_obj.requested_provider = "auto"
+    cli_obj.api_key = "test-key"
+    cli_obj.base_url = "https://openrouter.ai/api/v1"
+    cli_obj.api_mode = "chat_completions"
+    cli_obj._active_agent_route_signature = ("anthropic/claude-opus-4.6", "openrouter")
+    cli_obj._model_is_default = True
+    return cli_obj
+
+
+def test_process_command_dispatches_model_handler():
+    cli_obj = _make_cli()
+
+    with patch.object(cli_obj, "_handle_model_command") as handler:
+        cli_obj.process_command("/model openai/gpt-5.4")
+
+    handler.assert_called_once_with("/model openai/gpt-5.4")
+
+
+def test_handle_model_command_shows_status_and_usage(capsys):
+    cli_obj = _make_cli()
+
+    cli_obj._handle_model_command("/model")
+
+    output = capsys.readouterr().out
+    assert "Current model: anthropic/claude-opus-4.6" in output
+    assert "Provider: OpenRouter" in output
+    assert "Usage: /model list" in output
+    assert "Run `hermes model` for the full interactive picker." in output
+
+
+def test_handle_model_command_list_shows_provider_listing():
+    cli_obj = _make_cli()
+
+    with patch.object(cli_obj, "_show_model_and_providers") as show_listing:
+        cli_obj._handle_model_command("/model list")
+
+    show_listing.assert_called_once()
+
+
+def test_handle_model_command_switches_model_and_persists():
+    cli_obj = _make_cli()
+
+    class _Result:
+        success = True
+        new_model = "gpt-5.4"
+        target_provider = "openai-codex"
+        provider_label = "OpenAI Codex"
+        base_url = "https://chatgpt.com/backend-api/codex"
+        api_key = "codex-key"
+        warning_message = ""
+
+    with patch("hermes_cli.model_switch.switch_model", return_value=_Result()) as switch_mock, \
+         patch("hermes_cli.auth._update_config_for_provider") as update_provider, \
+         patch("hermes_cli.auth._save_model_choice") as save_model, \
+         patch("hermes_cli.auth.deactivate_provider") as deactivate_provider, \
+         patch.object(cli_obj, "_ensure_runtime_credentials", return_value=True) as ensure_runtime:
+        cli_obj._handle_model_command("/model openai-codex:gpt-5.4")
+
+    switch_mock.assert_called_once_with(
+        "openai-codex:gpt-5.4",
+        current_provider="openrouter",
+        current_base_url="https://openrouter.ai/api/v1",
+        current_api_key="test-key",
+    )
+    update_provider.assert_called_once_with("openai-codex", "https://chatgpt.com/backend-api/codex")
+    save_model.assert_called_once_with("gpt-5.4")
+    deactivate_provider.assert_not_called()
+    ensure_runtime.assert_called_once()
+    assert cli_obj.model == "gpt-5.4"
+    assert cli_obj.requested_provider == "openai-codex"
+    assert cli_obj.provider == "openai-codex"
+    assert cli_obj.api_key == "codex-key"
+    assert cli_obj.base_url == "https://chatgpt.com/backend-api/codex"
+    assert cli_obj.agent is None
+    assert cli_obj._active_agent_route_signature is None
+    assert cli_obj._model_is_default is False


### PR DESCRIPTION
## What does this PR do?

This fixes the interactive CLI `/model` slash command path, which was documented but not actually wired into the TUI chat loop.

Before this change:
- `/model` did not appear in slash-command autocomplete
- typing `/model` inside an active `hermes` session had no effect
- the shared model-switching logic existed, but the interactive CLI never called it

This change registers `/model` in the central command registry, adds CLI dispatch for it, and implements an in-session handler that can:
- show the current model/provider
- list available providers/models via `/model list`
- switch the active session model with `/model provider:model`

This is the right fix because it uses the existing shared model-switch pipeline rather than introducing a separate CLI-only implementation.

## Related Issue

Fixes #3821

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `/model` to the central slash-command registry in `hermes_cli/commands.py`
- Added interactive CLI dispatch for `/model` in `cli.py`
- Implemented `HermesCLI._handle_model_command()` in `cli.py`
- Reused `hermes_cli.model_switch` for runtime model switching instead of duplicating logic
- Added regression tests for `/model` dispatch and behavior in `tests/test_cli_model_command.py`
- Added registry/autocomplete coverage for `/model` in `tests/hermes_cli/test_commands.py`

## How to Test

1. Start an interactive CLI session with `hermes`
2. Type `/mo` and press Tab
3. Verify `/model` appears in autocomplete
4. Run `/model` and verify it prints the current model/provider and usage
5. Run `/model list` and verify it shows the provider/model listing
6. Run `/model openai-codex:gpt-5.4` or another valid provider:model pair and verify the active session updates
7. Run:
   `./.venv/bin/python -m pytest tests/test_cli_model_command.py tests/hermes_cli/test_commands.py tests/test_cli_prefix_matching.py -q`

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Apple Silicon, repo-local `.venv`)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Validation used:

```bash
.venv/bin/python -m pytest tests/test_cli_model_command.py tests/hermes_cli/test_commands.py tests/test_cli_prefix_matching.py -q
