### PR TITLE
fix(cron): stop truncating job IDs in list view

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -56,7 +56,7 @@ def cron_list(show_all: bool = False):
     print()
 
     for job in jobs:
-        job_id = job.get("id", "?")[:8]
+        job_id = job.get("id", "?")
         name = job.get("name", "(unnamed)")
         schedule = job.get("schedule_display", job.get("schedule", {}).get("value", "?"))
         state = job.get("state", "scheduled" if job.get("enabled", True) else "paused")


### PR DESCRIPTION
## Problem

The `hermes cron list` command truncated job IDs to 8 characters:

```python
job_id = job.get("id", "?")[:8]  # <-- truncation
```

This made it impossible to use the displayed IDs with other commands like `hermes cron run <job_id>` since those commands require the **full** job ID.

## Fix

Remove the truncation — display the complete job ID.

## Impact

Users can now copy job IDs directly from `hermes cron list` output and use them with `hermes cron run`, `hermes cron pause`, etc.
