### PR TITLE
fix(profiles): import flat archives safely

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -26,8 +26,9 @@ import shutil
 import stat
 import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import List, Optional
 
 _PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
@@ -702,6 +703,25 @@ def export_profile(name: str, output_path: str) -> Path:
     return Path(result)
 
 
+def _inspect_profile_archive(archive: Path) -> set[str]:
+    """Validate archive members and return discovered top-level names."""
+    import tarfile
+
+    top_names: set[str] = set()
+    with tarfile.open(archive, "r:gz") as tf:
+        for member in tf.getmembers():
+            member_path = PurePosixPath(member.name)
+            parts = member_path.parts
+            if not parts:
+                continue
+            if member_path.is_absolute() or any(part in ("", ".", "..") for part in parts):
+                raise ValueError(f"Unsafe archive member path: {member.name}")
+            if member.issym() or member.islnk():
+                raise ValueError(f"Archive contains unsupported link entry: {member.name}")
+            top_names.add(parts[0])
+    return top_names
+
+
 def import_profile(archive_path: str, name: Optional[str] = None) -> Path:
     """Import a profile from a tar.gz archive.
 
@@ -714,13 +734,9 @@ def import_profile(archive_path: str, name: Optional[str] = None) -> Path:
     if not archive.exists():
         raise FileNotFoundError(f"Archive not found: {archive}")
 
-    # Peek at the archive to find the top-level directory name
-    with tarfile.open(archive, "r:gz") as tf:
-        top_dirs = {m.name.split("/")[0] for m in tf.getmembers() if "/" in m.name}
-        if not top_dirs:
-            top_dirs = {m.name for m in tf.getmembers() if m.isdir()}
+    top_dirs = _inspect_profile_archive(archive)
 
-    inferred_name = name or (top_dirs.pop() if len(top_dirs) == 1 else None)
+    inferred_name = name or (next(iter(top_dirs)) if len(top_dirs) == 1 else None)
     if not inferred_name:
         raise ValueError(
             "Cannot determine profile name from archive. "
@@ -735,12 +751,21 @@ def import_profile(archive_path: str, name: Optional[str] = None) -> Path:
     profiles_root = _get_profiles_root()
     profiles_root.mkdir(parents=True, exist_ok=True)
 
-    shutil.unpack_archive(str(archive), str(profiles_root))
+    with tempfile.TemporaryDirectory(dir=profiles_root, prefix=".profile-import-") as tmpdir:
+        extract_root = Path(tmpdir)
+        with tarfile.open(archive, "r:gz") as tf:
+            tf.extractall(extract_root, filter="data")
 
-    # If the archive extracted under a different name, rename
-    extracted = profiles_root / (top_dirs.pop() if top_dirs else inferred_name)
-    if extracted != profile_dir and extracted.exists():
-        extracted.rename(profile_dir)
+        extracted_items = list(extract_root.iterdir())
+        if not extracted_items:
+            raise ValueError(f"Archive is empty: {archive}")
+
+        if len(extracted_items) == 1 and extracted_items[0].is_dir():
+            extracted_items[0].rename(profile_dir)
+        else:
+            profile_dir.mkdir(parents=True, exist_ok=False)
+            for item in extracted_items:
+                item.rename(profile_dir / item.name)
 
     return profile_dir
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -5,6 +5,7 @@ management, export/import, renaming, alias collision checks, profile isolation,
 and shell completion generation.
 """
 
+import io
 import json
 import os
 import tarfile
@@ -452,6 +453,35 @@ class TestExportImport:
     def test_export_nonexistent_raises(self, profile_env, tmp_path):
         with pytest.raises(FileNotFoundError):
             export_profile("nonexistent", str(tmp_path / "out.tar.gz"))
+
+    def test_import_flat_archive_wraps_files_under_requested_name(self, profile_env, tmp_path):
+        archive_path = tmp_path / "export" / "flat.tar.gz"
+        archive_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with tarfile.open(archive_path, "w:gz") as tf:
+            for name, payload in [("config.yaml", b"model: x\n"), ("marker.txt", b"hello")]:
+                info = tarfile.TarInfo(name=name)
+                info.size = len(payload)
+                tf.addfile(info, io.BytesIO(payload))
+
+        imported = import_profile(str(archive_path), name="coder")
+        assert imported.is_dir()
+        assert (imported / "config.yaml").read_text() == "model: x\n"
+        assert (imported / "marker.txt").read_text() == "hello"
+        assert not ((_get_profiles_root()) / "config.yaml").exists()
+
+    def test_import_rejects_unsafe_member_paths(self, profile_env, tmp_path):
+        archive_path = tmp_path / "export" / "unsafe.tar.gz"
+        archive_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with tarfile.open(archive_path, "w:gz") as tf:
+            info = tarfile.TarInfo(name="../escape.txt")
+            payload = b"nope"
+            info.size = len(payload)
+            tf.addfile(info, io.BytesIO(payload))
+
+        with pytest.raises(ValueError, match="Unsafe archive member path"):
+            import_profile(str(archive_path), name="coder")
 
 
 # ===================================================================


### PR DESCRIPTION
## What does this PR do?
Fixes `hermes profile import` when the archive does not contain a single top-level profile directory.

Previously, flat archives were extracted directly into `~/.hermes/profiles/`, which left stray files in the profiles root while `import_profile()` still returned `~/.hermes/profiles/<name>` as if the import had succeeded there.

This change validates archive member paths, extracts into a temporary staging directory, and then moves the extracted content into the requested profile directory.

## Type of Change
- [x] Bug fix
- [x] Safety fix
- [x] Tests

## Changes Made
- Validate archive members before import and reject unsafe path/link entries
- Extract profile archives into a temporary staging directory first
- Wrap flat archive contents under the requested profile directory instead of spilling them into `~/.hermes/profiles/`
- Added regression tests for flat archives and unsafe member paths

## How to Test
1. Run `source .venv/bin/activate`
2. Run `pytest -q tests/hermes_cli/test_profiles.py`
3. Import a flat archive with `hermes profile import <archive> --name coder`
4. Confirm the imported files end up under `~/.hermes/profiles/coder/` instead of directly in `~/.hermes/profiles/`

## Validation
- `pytest -q tests/hermes_cli/test_profiles.py` -> `73 passed`
- Direct repro for a flat archive now creates `profiles/coder/` and no longer leaves files in `profiles/`
