### PR TITLE
fix(plugins): reject manifest names that target plugins root

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -40,6 +40,8 @@ def _sanitize_plugin_name(name: str, plugins_dir: Path) -> Path:
     """
     if not name:
         raise ValueError("Plugin name must not be empty.")
+    if name == ".":
+        raise ValueError("Invalid plugin name '.': must not resolve to the plugins directory itself.")
 
     # Reject obvious traversal characters
     for bad in ("/", "\\", ".."):
@@ -55,6 +57,10 @@ def _sanitize_plugin_name(name: str, plugins_dir: Path) -> Path:
     ):
         raise ValueError(
             f"Invalid plugin name '{name}': resolves outside the plugins directory."
+        )
+    if target == plugins_resolved:
+        raise ValueError(
+            f"Invalid plugin name '{name}': must not resolve to the plugins directory itself."
         )
 
     return target

--- a/tests/test_plugins_cmd.py
+++ b/tests/test_plugins_cmd.py
@@ -43,6 +43,10 @@ class TestSanitizePluginName:
         with pytest.raises(ValueError, match="must not contain"):
             _sanitize_plugin_name("..", tmp_path)
 
+    def test_rejects_single_dot(self, tmp_path):
+        with pytest.raises(ValueError, match="plugins directory itself"):
+            _sanitize_plugin_name(".", tmp_path)
+
     def test_rejects_forward_slash(self, tmp_path):
         with pytest.raises(ValueError, match="must not contain"):
             _sanitize_plugin_name("foo/bar", tmp_path)
@@ -227,6 +231,36 @@ class TestCmdInstall:
         with pytest.raises(SystemExit) as exc_info:
             cmd_install("invalid")
         assert exc_info.value.code == 1
+
+    @patch("hermes_cli.plugins_cmd.shutil.rmtree")
+    @patch("hermes_cli.plugins_cmd.subprocess.run")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    @patch("hermes_cli.plugins_cmd._resolve_git_url")
+    @patch("hermes_cli.plugins_cmd._read_manifest")
+    def test_install_rejects_manifest_name_resolving_to_plugins_root(
+        self,
+        mock_read_manifest,
+        mock_resolve,
+        mock_plugins_dir,
+        mock_run,
+        mock_rmtree,
+        tmp_path,
+    ):
+        from hermes_cli.plugins_cmd import cmd_install
+
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        mock_plugins_dir.return_value = plugins_dir
+        mock_resolve.return_value = "https://github.com/example/plugin.git"
+        mock_read_manifest.return_value = {"name": "."}
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_install("example/plugin", force=True)
+
+        assert exc_info.value.code == 1
+        removed_paths = [str(call.args[0]) for call in mock_rmtree.call_args_list if call.args]
+        assert str(plugins_dir) not in removed_paths
 
 
 # ── cmd_update tests ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?
Fixes a plugin installer path-safety issue where a plugin manifest could declare `name: "."` and resolve to the plugins root itself.

Previously, `_sanitize_plugin_name()` allowed names that resolved exactly to `~/.hermes/plugins/`. In the install flow, that meant `cmd_install(..., force=True)` could treat the plugins root as the target path and remove the entire plugins directory before reinstalling.

This change rejects plugin names that resolve to the plugins root itself and adds regression coverage for both the sanitizer and the install flow.

## Type of Change
- [x] Bug fix
- [x] Security fix
- [x] Tests

## Changes Made
- Reject `.` as a plugin name
- Reject any plugin name that resolves to the plugins directory itself
- Add a regression test for `cmd_install(..., force=True)` with a manifest name of `.`
- Preserve existing valid plugin names and install behavior

## How to Test
1. Run `source .venv/bin/activate`
2. Run `python -m pytest tests/test_plugins.py tests/test_plugins_cmd.py -q`
3. Confirm `_sanitize_plugin_name(".", plugins_dir)` raises `ValueError`
4. Confirm `cmd_install(..., force=True)` rejects a manifest with `name: "."` without removing the plugins root

## Validation
- `python -m pytest tests/test_plugins.py tests/test_plugins_cmd.py -q` → `63 passed`
- Manual repro before the fix: `_sanitize_plugin_name(".", plugins_dir)` resolved to the plugins root path
- Manual repro after the fix: `_sanitize_plugin_name(".", plugins_dir)` raises `ValueError`
