### PR TITLE
fix(credentials): validate mounted credential file paths

### DIFF
--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -98,6 +98,62 @@ class TestRegisterCredentialFiles:
         mounts = get_credential_file_mounts()
         assert "real.json" in mounts[0]["container_path"]
 
+    def test_rejects_traversal_paths(self, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        outside = tmp_path / "outside.txt"
+        outside.write_text("secret")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            missing = register_credential_files(["../outside.txt"])
+
+        assert missing == ["../outside.txt"]
+        assert get_credential_file_mounts() == []
+
+    def test_rejects_absolute_paths(self, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        outside = tmp_path / "outside.txt"
+        outside.write_text("secret")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            missing = register_credential_files([str(outside)])
+
+        assert missing == [str(outside)]
+        assert get_credential_file_mounts() == []
+
+    def test_rejects_symlink_escape_paths(self, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        outside = tmp_path / "outside.txt"
+        outside.write_text("secret")
+        (hermes_home / "token.json").symlink_to(outside)
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            missing = register_credential_files(["token.json"])
+
+        assert missing == ["token.json"]
+        assert get_credential_file_mounts() == []
+
+
+class TestConfigCredentialFiles:
+    def test_ignores_unsafe_config_paths(self, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        outside = tmp_path / "outside.txt"
+        outside.write_text("secret")
+        config_path.write_text(
+            "terminal:\n  credential_files:\n    - ../outside.txt\n",
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+            reset_config_cache()
+            mounts = get_credential_file_mounts()
+
+        assert mounts == []
+
 
 class TestSkillsDirectoryMount:
     def test_returns_mount_when_skills_dir_exists(self, tmp_path):

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -30,7 +30,8 @@ from __future__ import annotations
 
 import logging
 import os
-from pathlib import Path
+import re
+from pathlib import Path, PurePosixPath
 from typing import Dict, List
 
 logger = logging.getLogger(__name__)
@@ -47,6 +48,46 @@ def _resolve_hermes_home() -> Path:
     return Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
 
 
+def _normalize_relative_credential_path(relative_path: str) -> str:
+    """Validate a credential file path as a safe path under HERMES_HOME."""
+    if not isinstance(relative_path, str):
+        raise ValueError("Credential file path must be a string.")
+
+    raw = relative_path.strip()
+    if not raw:
+        raise ValueError("Credential file path must not be empty.")
+
+    normalized = raw.replace("\\", "/")
+    path = PurePosixPath(normalized)
+    parts = [part for part in path.parts if part not in ("", ".")]
+
+    if normalized.startswith("/") or path.is_absolute():
+        raise ValueError(f"Credential file path must be relative to HERMES_HOME: {relative_path}")
+    if not parts or any(part == ".." for part in parts):
+        raise ValueError(f"Credential file path must stay within HERMES_HOME: {relative_path}")
+    if re.fullmatch(r"[A-Za-z]:", parts[0]):
+        raise ValueError(f"Credential file path must be relative to HERMES_HOME: {relative_path}")
+
+    return "/".join(parts)
+
+
+def _resolve_host_credential_path(relative_path: str) -> Path:
+    """Resolve a validated credential path and ensure it stays under HERMES_HOME."""
+    hermes_home = _resolve_hermes_home()
+    safe_rel_path = _normalize_relative_credential_path(relative_path)
+    host_path = (hermes_home / safe_rel_path).resolve()
+    hermes_root = hermes_home.resolve()
+
+    try:
+        host_path.relative_to(hermes_root)
+    except ValueError as exc:
+        raise ValueError(
+            f"Credential file path resolves outside HERMES_HOME: {relative_path}"
+        ) from exc
+
+    return host_path
+
+
 def register_credential_file(
     relative_path: str,
     container_base: str = "/root/.hermes",
@@ -56,13 +97,17 @@ def register_credential_file(
     *relative_path* is relative to ``HERMES_HOME`` (e.g. ``google_token.json``).
     Returns True if the file exists on the host and was registered.
     """
-    hermes_home = _resolve_hermes_home()
-    host_path = hermes_home / relative_path
+    try:
+        safe_rel_path = _normalize_relative_credential_path(relative_path)
+        host_path = _resolve_host_credential_path(relative_path)
+    except ValueError as exc:
+        logger.warning("credential_files: rejecting unsafe path %r (%s)", relative_path, exc)
+        return False
     if not host_path.is_file():
         logger.debug("credential_files: skipping %s (not found)", host_path)
         return False
 
-    container_path = f"{container_base.rstrip('/')}/{relative_path}"
+    container_path = f"{container_base.rstrip('/')}/{safe_rel_path}"
     _registered_files[container_path] = str(host_path)
     logger.debug("credential_files: registered %s -> %s", host_path, container_path)
     return True
@@ -112,9 +157,18 @@ def _load_config_files() -> List[Dict[str, str]]:
             if isinstance(cred_files, list):
                 for item in cred_files:
                     if isinstance(item, str) and item.strip():
-                        host_path = hermes_home / item.strip()
+                        try:
+                            safe_rel_path = _normalize_relative_credential_path(item)
+                            host_path = _resolve_host_credential_path(item)
+                        except ValueError as exc:
+                            logger.warning(
+                                "credential_files: ignoring unsafe config path %r (%s)",
+                                item,
+                                exc,
+                            )
+                            continue
                         if host_path.is_file():
-                            container_path = f"/root/.hermes/{item.strip()}"
+                            container_path = f"/root/.hermes/{safe_rel_path}"
                             result.append({
                                 "host_path": str(host_path),
                                 "container_path": container_path,


### PR DESCRIPTION
## What does this PR do?
Fixes a credential-file mount safety issue for remote execution backends.

Previously, `required_credential_files` entries from skill frontmatter were passed through as relative paths under `HERMES_HOME` without validating traversal segments, absolute paths, or symlink escapes. That meant a skill could register entries like `../outside.txt` or an absolute path and have arbitrary host files added to the sandbox mount list.

This change validates credential file paths as safe relative paths under `HERMES_HOME`, rejects paths that resolve outside that root, and applies the same guard to `terminal.credential_files` config entries.

## Type of Change
- [x] Bug fix
- [x] Security fix
- [x] Tests

## Changes Made
- Validate credential file paths as relative paths under `HERMES_HOME`
- Reject traversal segments, absolute paths, and drive-style paths
- Reject symlinked credential files that resolve outside `HERMES_HOME`
- Apply the same validation to config-based `terminal.credential_files`
- Added regression tests for traversal, absolute-path, symlink-escape, and unsafe config entries

## How to Test
1. Run `source .venv/bin/activate`
2. Run `python -m pytest tests/tools/test_credential_files.py tests/tools/test_skills_tool.py -q`
3. Confirm `register_credential_file('../outside.txt')` returns `False`
4. Confirm `register_credential_file('/abs/path')` returns `False`
5. Confirm a symlink inside `HERMES_HOME` pointing outside is rejected and not mounted

## Validation
- `python -m pytest tests/tools/test_credential_files.py -q` → `16 passed`
- `python -m pytest tests/tools/test_skills_tool.py -q` → `77 passed`
- Manual repro before the fix: traversal and absolute paths appeared in `get_credential_file_mounts()`
- Manual repro after the fix: both unsafe paths are rejected and the mount list stays empty
