### PR TITLE
fix(security): keep Hermes secrets out of env passthrough

### DIFF
--- a/tests/tools/test_env_passthrough.py
+++ b/tests/tools/test_env_passthrough.py
@@ -105,6 +105,16 @@ class TestConfigPassthrough:
         assert "CONFIG_KEY" in all_pt
         assert "SKILL_KEY" in all_pt
 
+    def test_ignores_protected_config_entry(self, tmp_path, monkeypatch):
+        config = {"terminal": {"env_passthrough": ["OPENAI_API_KEY", "SAFE_KEY"]}}
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(yaml.dump(config))
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        reset_config_cache()
+
+        assert not is_env_passthrough("OPENAI_API_KEY")
+        assert is_env_passthrough("SAFE_KEY")
+
 
 class TestExecuteCodeIntegration:
     """Verify that the passthrough is checked in execute_code's env filtering."""
@@ -172,7 +182,7 @@ class TestTerminalIntegration:
         assert blocked_var not in result
         assert "PATH" in result
 
-    def test_passthrough_allows_blocklisted_var(self):
+    def test_passthrough_does_not_allow_blocklisted_var(self):
         from tools.environments.local import _sanitize_subprocess_env, _HERMES_PROVIDER_ENV_BLOCKLIST
 
         blocked_var = next(iter(_HERMES_PROVIDER_ENV_BLOCKLIST))
@@ -180,8 +190,7 @@ class TestTerminalIntegration:
 
         env = {blocked_var: "secret_value", "PATH": "/usr/bin"}
         result = _sanitize_subprocess_env(env)
-        assert blocked_var in result
-        assert result[blocked_var] == "secret_value"
+        assert blocked_var not in result
 
     def test_make_run_env_passthrough(self, monkeypatch):
         from tools.environments.local import _make_run_env, _HERMES_PROVIDER_ENV_BLOCKLIST
@@ -193,7 +202,7 @@ class TestTerminalIntegration:
         result_before = _make_run_env({})
         assert blocked_var not in result_before
 
-        # With passthrough — allowed
+        # Attempted passthrough for Hermes-managed secrets stays blocked.
         register_env_passthrough([blocked_var])
         result_after = _make_run_env({})
-        assert blocked_var in result_after
+        assert blocked_var not in result_after

--- a/tests/tools/test_skill_env_passthrough.py
+++ b/tests/tools/test_skill_env_passthrough.py
@@ -132,3 +132,26 @@ class TestSkillViewRegistersPassthrough:
         assert result["success"] is True
         from tools.env_passthrough import get_all_passthrough
         assert len(get_all_passthrough()) == 0
+
+    def test_protected_hermes_secret_not_registered(self, tmp_path, monkeypatch):
+        """Skill metadata must not punch provider secrets through the sandbox."""
+        _create_skill(
+            tmp_path,
+            "protected-skill",
+            frontmatter_extra=(
+                "required_environment_variables:\n"
+                "  - name: OPENAI_API_KEY\n"
+                "    prompt: Enter your OpenAI API key\n"
+            ),
+        )
+        monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", tmp_path)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-secret")
+
+        with patch("tools.skills_tool._secret_capture_callback", None):
+            from tools.skills_tool import skill_view
+
+            result = json.loads(skill_view(name="protected-skill"))
+
+        assert result["success"] is True
+        assert result["setup_needed"] is False
+        assert not is_env_passthrough("OPENAI_API_KEY")

--- a/tools/env_passthrough.py
+++ b/tools/env_passthrough.py
@@ -24,6 +24,8 @@ import os
 from pathlib import Path
 from typing import Iterable
 
+from tools.sensitive_env import HERMES_SENSITIVE_ENV_BLOCKLIST
+
 logger = logging.getLogger(__name__)
 
 # Session-scoped set of env var names that should pass through to sandboxes.
@@ -31,6 +33,11 @@ _allowed_env_vars: set[str] = set()
 
 # Cache for the config-based allowlist (loaded once per process).
 _config_passthrough: frozenset[str] | None = None
+
+
+def _is_protected_passthrough_name(var_name: str) -> bool:
+    """Return True when a passthrough target is a Hermes-managed secret."""
+    return var_name in HERMES_SENSITIVE_ENV_BLOCKLIST
 
 
 def register_env_passthrough(var_names: Iterable[str]) -> None:
@@ -41,6 +48,12 @@ def register_env_passthrough(var_names: Iterable[str]) -> None:
     for name in var_names:
         name = name.strip()
         if name:
+            if _is_protected_passthrough_name(name):
+                logger.warning(
+                    "env passthrough: refusing to allow Hermes-managed secret %s",
+                    name,
+                )
+                continue
             _allowed_env_vars.add(name)
             logger.debug("env passthrough: registered %s", name)
 
@@ -64,7 +77,14 @@ def _load_config_passthrough() -> frozenset[str]:
             if isinstance(passthrough, list):
                 for item in passthrough:
                     if isinstance(item, str) and item.strip():
-                        result.add(item.strip())
+                        name = item.strip()
+                        if _is_protected_passthrough_name(name):
+                            logger.warning(
+                                "env passthrough: ignoring protected config entry %s",
+                                name,
+                            )
+                            continue
+                        result.add(name)
     except Exception as e:
         logger.debug("Could not read tools.env_passthrough from config: %s", e)
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -14,6 +14,7 @@ _IS_WINDOWS = platform.system() == "Windows"
 from tools.environments.base import BaseEnvironment
 from tools.environments.persistent_shell import PersistentShellMixin
 from tools.interrupt import is_interrupted
+from tools.sensitive_env import HERMES_SENSITIVE_ENV_BLOCKLIST
 
 # Unique marker to isolate real command output from shell init/exit noise.
 # printf (no trailing newline) keeps the boundaries clean for splitting.
@@ -27,108 +28,7 @@ _OUTPUT_FENCE = "__HERMES_FENCE_a9f7b3__"
 # Built dynamically from the provider registry so new providers are
 # automatically covered without manual blocklist maintenance.
 _HERMES_PROVIDER_ENV_FORCE_PREFIX = "_HERMES_FORCE_"
-
-
-def _build_provider_env_blocklist() -> frozenset:
-    """Derive the blocklist from provider, tool, and gateway config.
-
-    Automatically picks up api_key_env_vars and base_url_env_var from
-    every registered provider, plus tool/messaging env vars from the
-    optional config registry, so new Hermes-managed secrets are blocked
-    in subprocesses without having to maintain multiple static lists.
-    """
-    blocked: set[str] = set()
-
-    try:
-        from hermes_cli.auth import PROVIDER_REGISTRY
-        for pconfig in PROVIDER_REGISTRY.values():
-            blocked.update(pconfig.api_key_env_vars)
-            if pconfig.base_url_env_var:
-                blocked.add(pconfig.base_url_env_var)
-    except ImportError:
-        pass
-
-    try:
-        from hermes_cli.config import OPTIONAL_ENV_VARS
-        for name, metadata in OPTIONAL_ENV_VARS.items():
-            category = metadata.get("category")
-            if category in {"tool", "messaging"}:
-                blocked.add(name)
-            elif category == "setting" and metadata.get("password"):
-                blocked.add(name)
-    except ImportError:
-        pass
-
-    # Vars not covered above but still Hermes-internal / conflict-prone.
-    blocked.update({
-        "OPENAI_BASE_URL",
-        "OPENAI_API_KEY",
-        "OPENAI_API_BASE",         # legacy alias
-        "OPENAI_ORG_ID",
-        "OPENAI_ORGANIZATION",
-        "OPENROUTER_API_KEY",
-        "ANTHROPIC_BASE_URL",
-        "ANTHROPIC_TOKEN",         # OAuth token (not in registry as env var)
-        "CLAUDE_CODE_OAUTH_TOKEN",
-        "LLM_MODEL",
-        # Expanded isolation for other major providers (Issue #1002)
-        "GOOGLE_API_KEY",          # Gemini / Google AI Studio
-        "DEEPSEEK_API_KEY",        # DeepSeek
-        "MISTRAL_API_KEY",         # Mistral AI
-        "GROQ_API_KEY",            # Groq
-        "TOGETHER_API_KEY",        # Together AI
-        "PERPLEXITY_API_KEY",      # Perplexity
-        "COHERE_API_KEY",          # Cohere
-        "FIREWORKS_API_KEY",       # Fireworks AI
-        "XAI_API_KEY",             # xAI (Grok)
-        "HELICONE_API_KEY",        # LLM Observability proxy
-        "PARALLEL_API_KEY",
-        "FIRECRAWL_API_KEY",
-        "FIRECRAWL_API_URL",
-        # Gateway/runtime config not represented in OPTIONAL_ENV_VARS.
-        "TELEGRAM_HOME_CHANNEL",
-        "TELEGRAM_HOME_CHANNEL_NAME",
-        "DISCORD_HOME_CHANNEL",
-        "DISCORD_HOME_CHANNEL_NAME",
-        "DISCORD_REQUIRE_MENTION",
-        "DISCORD_FREE_RESPONSE_CHANNELS",
-        "DISCORD_AUTO_THREAD",
-        "SLACK_HOME_CHANNEL",
-        "SLACK_HOME_CHANNEL_NAME",
-        "SLACK_ALLOWED_USERS",
-        "WHATSAPP_ENABLED",
-        "WHATSAPP_MODE",
-        "WHATSAPP_ALLOWED_USERS",
-        "SIGNAL_HTTP_URL",
-        "SIGNAL_ACCOUNT",
-        "SIGNAL_ALLOWED_USERS",
-        "SIGNAL_GROUP_ALLOWED_USERS",
-        "SIGNAL_HOME_CHANNEL",
-        "SIGNAL_HOME_CHANNEL_NAME",
-        "SIGNAL_IGNORE_STORIES",
-        "HASS_TOKEN",
-        "HASS_URL",
-        "EMAIL_ADDRESS",
-        "EMAIL_PASSWORD",
-        "EMAIL_IMAP_HOST",
-        "EMAIL_SMTP_HOST",
-        "EMAIL_HOME_ADDRESS",
-        "EMAIL_HOME_ADDRESS_NAME",
-        "GATEWAY_ALLOWED_USERS",
-        # Skills Hub / GitHub app auth paths and aliases.
-        "GH_TOKEN",
-        "GITHUB_APP_ID",
-        "GITHUB_APP_PRIVATE_KEY_PATH",
-        "GITHUB_APP_INSTALLATION_ID",
-        # Remote sandbox backend credentials.
-        "MODAL_TOKEN_ID",
-        "MODAL_TOKEN_SECRET",
-        "DAYTONA_API_KEY",
-    })
-    return frozenset(blocked)
-
-
-_HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
+_HERMES_PROVIDER_ENV_BLOCKLIST = HERMES_SENSITIVE_ENV_BLOCKLIST
 
 
 def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = None) -> dict:

--- a/tools/sensitive_env.py
+++ b/tools/sensitive_env.py
@@ -1,0 +1,103 @@
+"""Shared registry of Hermes-managed sensitive environment variables.
+
+These vars are owned by Hermes itself (provider keys, gateway tokens,
+tool credentials, etc.) and must never be exposed to sandboxed child
+processes via skill-driven or config-driven passthrough.
+"""
+
+from __future__ import annotations
+
+
+def build_sensitive_env_blocklist() -> frozenset[str]:
+    """Return env vars that Hermes manages internally and should not forward."""
+    blocked: set[str] = set()
+
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY
+
+        for pconfig in PROVIDER_REGISTRY.values():
+            blocked.update(pconfig.api_key_env_vars)
+            if pconfig.base_url_env_var:
+                blocked.add(pconfig.base_url_env_var)
+    except ImportError:
+        pass
+
+    try:
+        from hermes_cli.config import OPTIONAL_ENV_VARS
+
+        for name, metadata in OPTIONAL_ENV_VARS.items():
+            category = metadata.get("category")
+            if category in {"tool", "messaging"}:
+                blocked.add(name)
+            elif category == "setting" and metadata.get("password"):
+                blocked.add(name)
+    except ImportError:
+        pass
+
+    blocked.update(
+        {
+            "OPENAI_BASE_URL",
+            "OPENAI_API_KEY",
+            "OPENAI_API_BASE",
+            "OPENAI_ORG_ID",
+            "OPENAI_ORGANIZATION",
+            "OPENROUTER_API_KEY",
+            "ANTHROPIC_BASE_URL",
+            "ANTHROPIC_TOKEN",
+            "CLAUDE_CODE_OAUTH_TOKEN",
+            "LLM_MODEL",
+            "GOOGLE_API_KEY",
+            "DEEPSEEK_API_KEY",
+            "MISTRAL_API_KEY",
+            "GROQ_API_KEY",
+            "TOGETHER_API_KEY",
+            "PERPLEXITY_API_KEY",
+            "COHERE_API_KEY",
+            "FIREWORKS_API_KEY",
+            "XAI_API_KEY",
+            "HELICONE_API_KEY",
+            "PARALLEL_API_KEY",
+            "FIRECRAWL_API_KEY",
+            "FIRECRAWL_API_URL",
+            "TELEGRAM_HOME_CHANNEL",
+            "TELEGRAM_HOME_CHANNEL_NAME",
+            "DISCORD_HOME_CHANNEL",
+            "DISCORD_HOME_CHANNEL_NAME",
+            "DISCORD_REQUIRE_MENTION",
+            "DISCORD_FREE_RESPONSE_CHANNELS",
+            "DISCORD_AUTO_THREAD",
+            "SLACK_HOME_CHANNEL",
+            "SLACK_HOME_CHANNEL_NAME",
+            "SLACK_ALLOWED_USERS",
+            "WHATSAPP_ENABLED",
+            "WHATSAPP_MODE",
+            "WHATSAPP_ALLOWED_USERS",
+            "SIGNAL_HTTP_URL",
+            "SIGNAL_ACCOUNT",
+            "SIGNAL_ALLOWED_USERS",
+            "SIGNAL_GROUP_ALLOWED_USERS",
+            "SIGNAL_HOME_CHANNEL",
+            "SIGNAL_HOME_CHANNEL_NAME",
+            "SIGNAL_IGNORE_STORIES",
+            "HASS_TOKEN",
+            "HASS_URL",
+            "EMAIL_ADDRESS",
+            "EMAIL_PASSWORD",
+            "EMAIL_IMAP_HOST",
+            "EMAIL_SMTP_HOST",
+            "EMAIL_HOME_ADDRESS",
+            "EMAIL_HOME_ADDRESS_NAME",
+            "GATEWAY_ALLOWED_USERS",
+            "GH_TOKEN",
+            "GITHUB_APP_ID",
+            "GITHUB_APP_PRIVATE_KEY_PATH",
+            "GITHUB_APP_INSTALLATION_ID",
+            "MODAL_TOKEN_ID",
+            "MODAL_TOKEN_SECRET",
+            "DAYTONA_API_KEY",
+        }
+    )
+    return frozenset(blocked)
+
+
+HERMES_SENSITIVE_ENV_BLOCKLIST = build_sensitive_env_blocklist()

--- a/website/docs/developer-guide/creating-skills.md
+++ b/website/docs/developer-guide/creating-skills.md
@@ -168,7 +168,7 @@ required_environment_variables:
 The user can skip setup and keep loading the skill. Hermes never exposes the raw secret value to the model. Gateway and messaging sessions show local setup guidance instead of collecting secrets in-band.
 
 :::tip Sandbox Passthrough
-When your skill is loaded, any declared `required_environment_variables` that are set are **automatically passed through** to `execute_code` and `terminal` sandboxes — including remote backends like Docker and Modal. Your skill's scripts can access `$TENOR_API_KEY` (or `os.environ["TENOR_API_KEY"]` in Python) without the user needing to configure anything extra. See [Environment Variable Passthrough](/docs/user-guide/security#environment-variable-passthrough) for details.
+When your skill is loaded, any declared `required_environment_variables` that are set are **automatically passed through** to `execute_code` and `terminal` sandboxes — including remote backends like Docker and Modal. Your skill's scripts can access `$TENOR_API_KEY` (or `os.environ["TENOR_API_KEY"]` in Python) without the user needing to configure anything extra. Hermes-managed infrastructure secrets are excluded from passthrough even if declared here. See [Environment Variable Passthrough](/docs/user-guide/security#environment-variable-passthrough) for details.
 :::
 
 Legacy `prerequisites.env_vars` remains supported as a backward-compatible alias.

--- a/website/docs/user-guide/features/code-execution.md
+++ b/website/docs/user-guide/features/code-execution.md
@@ -176,7 +176,7 @@ Environment variables containing `KEY`, `TOKEN`, `SECRET`, `PASSWORD`, `CREDENTI
 
 ### Skill Environment Variable Passthrough
 
-When a skill declares `required_environment_variables` in its frontmatter, those variables are **automatically passed through** to both `execute_code` and `terminal` sandboxes after the skill is loaded. This lets skills use their declared API keys without weakening the security posture for arbitrary code.
+When a skill declares `required_environment_variables` in its frontmatter, those variables are **automatically passed through** to both `execute_code` and `terminal` sandboxes after the skill is loaded. This lets skills use their declared API keys without weakening the security posture for arbitrary code. Hermes-managed provider, gateway, and tool secrets remain blocked even if a skill declares them.
 
 For non-skill use cases, you can explicitly allowlist variables in `config.yaml`:
 

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -140,7 +140,7 @@ required_environment_variables:
 
 When a missing value is encountered, Hermes asks for it securely only when the skill is actually loaded in the local CLI. You can skip setup and keep using the skill. Messaging surfaces never ask for secrets in chat — they tell you to use `hermes setup` or `~/.hermes/.env` locally instead.
 
-Once set, declared env vars are **automatically passed through** to `execute_code` and `terminal` sandboxes — the skill's scripts can use `$TENOR_API_KEY` directly. For non-skill env vars, use the `terminal.env_passthrough` config option. See [Environment Variable Passthrough](/docs/user-guide/security#environment-variable-passthrough) for details.
+Once set, declared env vars are **automatically passed through** to `execute_code` and `terminal` sandboxes — the skill's scripts can use `$TENOR_API_KEY` directly. Hermes-managed provider, gateway, and tool secrets remain blocked even if a skill declares them. For non-skill env vars, use the `terminal.env_passthrough` config option. See [Environment Variable Passthrough](/docs/user-guide/security#environment-variable-passthrough) for details.
 
 ## Skill Directory Structure
 

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -270,6 +270,8 @@ Two mechanisms allow specific variables through the sandbox filters:
 
 When a skill is loaded (via `skill_view` or the `/skill` command) and declares `required_environment_variables`, any of those vars that are actually set in the environment are automatically registered as passthrough. Missing vars (still in setup-needed state) are **not** registered.
 
+Hermes-managed infrastructure secrets are an exception: provider API keys, gateway tokens, and tool credentials stay blocked even if a skill or `terminal.env_passthrough` declares them.
+
 ```yaml
 # In a skill's SKILL.md frontmatter
 required_environment_variables:
@@ -340,7 +342,7 @@ Paths are relative to `~/.hermes/`. Files are mounted to `/root/.hermes/` inside
 - Credential files are mounted **read-only** into Docker containers
 - Skills Guard scans skill content for suspicious env access patterns before installation
 - Missing/unset vars are never registered (you can't leak what doesn't exist)
-- Hermes infrastructure secrets (provider API keys, gateway tokens) should never be added to `env_passthrough` — they have dedicated mechanisms
+- Hermes infrastructure secrets (provider API keys, gateway tokens, tool credentials) stay blocked even if a skill or config entry tries to pass them through
 
 ## MCP Credential Handling
 


### PR DESCRIPTION
## What does this PR do?
Fixes a sandbox secret-filter bypass in skill and config env passthrough.

Hermes strips provider API keys, gateway tokens, and tool credentials from `terminal` / `execute_code` child environments by default. However, a skill could declare one of those Hermes-managed secrets in `required_environment_variables`, or a user could list it in `terminal.env_passthrough`, and the passthrough registry would re-allow it.

That meant loading a third-party skill that declared something like `OPENAI_API_KEY` could silently punch Hermes-managed secrets back into sandboxed child processes.

This change keeps Hermes-managed secrets blocked even when a skill or config entry tries to pass them through, and updates the docs to match the enforced behavior.

## Type of Change
- [x] Bug fix
- [x] Security fix
- [x] Tests
- [x] Documentation

## Changes Made
- Added a shared Hermes-sensitive env blocklist module
- Reused that blocklist in the local terminal sanitizer
- Rejected Hermes-managed secrets from skill-scoped env passthrough
- Ignored Hermes-managed secrets in `terminal.env_passthrough`
- Added regression tests covering skill and config bypass attempts
- Updated passthrough docs to describe the enforced restriction

## How to Test
1. Run `source .venv/bin/activate`
2. Run `python -m pytest tests/tools/test_env_passthrough.py tests/tools/test_skill_env_passthrough.py tests/tools/test_local_env_blocklist.py tests/tools/test_skills_tool.py -q`
3. Load a skill that declares `required_environment_variables: [OPENAI_API_KEY, TENOR_API_KEY]`
4. Confirm `OPENAI_API_KEY` is not registered/passed through, while `TENOR_API_KEY` still is
5. Add `OPENAI_API_KEY` to `terminal.env_passthrough` and confirm it is ignored

## Validation
- `python -m pytest tests/tools/test_env_passthrough.py tests/tools/test_skill_env_passthrough.py tests/tools/test_local_env_blocklist.py tests/tools/test_skills_tool.py -q` → `117 passed`
- Manual repro before the fix: a skill declaring `OPENAI_API_KEY` caused `is_env_passthrough("OPENAI_API_KEY") == True` and `_sanitize_subprocess_env(...)` kept the secret
- Manual repro after the fix: `OPENAI_API_KEY` stays blocked while normal skill-specific keys like `TENOR_API_KEY` still pass through
