### PR TITLE
fix(api_server): enforce chunked request body limits

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -207,6 +207,40 @@ def _openai_error(message: str, err_type: str = "invalid_request_error", param: 
     }
 
 
+async def _read_json_request(
+    request: "web.Request",
+    *,
+    openai_style: bool = False,
+) -> tuple[Optional[Dict[str, Any]], Optional["web.Response"]]:
+    """Parse a JSON request body with consistent oversized-body handling."""
+    try:
+        body = await request.json()
+    except web.HTTPRequestEntityTooLarge:
+        if openai_style:
+            return None, web.json_response(
+                _openai_error("Request body too large.", code="body_too_large"),
+                status=413,
+            )
+        return None, web.json_response({"error": "Request body too large"}, status=413)
+    except (json.JSONDecodeError, Exception):
+        if openai_style:
+            return None, web.json_response(
+                _openai_error("Invalid JSON in request body"),
+                status=400,
+            )
+        return None, web.json_response({"error": "Invalid JSON in request body"}, status=400)
+
+    if not isinstance(body, dict):
+        if openai_style:
+            return None, web.json_response(
+                _openai_error("Invalid JSON in request body"),
+                status=400,
+            )
+        return None, web.json_response({"error": "Invalid JSON in request body"}, status=400)
+
+    return body, None
+
+
 if AIOHTTP_AVAILABLE:
     @web.middleware
     async def body_limit_middleware(request, handler):
@@ -219,7 +253,13 @@ if AIOHTTP_AVAILABLE:
                         return web.json_response(_openai_error("Request body too large.", code="body_too_large"), status=413)
                 except ValueError:
                     return web.json_response(_openai_error("Invalid Content-Length header.", code="invalid_content_length"), status=400)
-        return await handler(request)
+        try:
+            return await handler(request)
+        except web.HTTPRequestEntityTooLarge:
+            return web.json_response(
+                _openai_error("Request body too large.", code="body_too_large"),
+                status=413,
+            )
 else:
     body_limit_middleware = None  # type: ignore[assignment]
 
@@ -450,11 +490,9 @@ class APIServerAdapter(BasePlatformAdapter):
         if auth_err:
             return auth_err
 
-        # Parse request body
-        try:
-            body = await request.json()
-        except (json.JSONDecodeError, Exception):
-            return web.json_response(_openai_error("Invalid JSON in request body"), status=400)
+        body, error = await _read_json_request(request, openai_style=True)
+        if error:
+            return error
 
         messages = body.get("messages")
         if not messages or not isinstance(messages, list):
@@ -701,14 +739,9 @@ class APIServerAdapter(BasePlatformAdapter):
         if auth_err:
             return auth_err
 
-        # Parse request body
-        try:
-            body = await request.json()
-        except (json.JSONDecodeError, Exception):
-            return web.json_response(
-                {"error": {"message": "Invalid JSON in request body", "type": "invalid_request_error"}},
-                status=400,
-            )
+        body, error = await _read_json_request(request, openai_style=True)
+        if error:
+            return error
 
         raw_input = body.get("input")
         if raw_input is None:
@@ -964,7 +997,9 @@ class APIServerAdapter(BasePlatformAdapter):
         if cron_err:
             return cron_err
         try:
-            body = await request.json()
+            body, error = await _read_json_request(request)
+            if error:
+                return error
             name = (body.get("name") or "").strip()
             schedule = (body.get("schedule") or "").strip()
             prompt = body.get("prompt", "")
@@ -1034,7 +1069,9 @@ class APIServerAdapter(BasePlatformAdapter):
         if id_err:
             return id_err
         try:
-            body = await request.json()
+            body, error = await _read_json_request(request)
+            if error:
+                return error
             # Whitelist allowed fields to prevent arbitrary key injection
             sanitized = {k: v for k, v in body.items() if k in self._UPDATE_ALLOWED_FIELDS}
             if not sanitized:
@@ -1241,8 +1278,8 @@ class APIServerAdapter(BasePlatformAdapter):
             return False
 
         try:
-            mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
-            self._app = web.Application(middlewares=mws)
+            mws = [mw for mw in (cors_middleware, security_headers_middleware, body_limit_middleware) if mw is not None]
+            self._app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
             self._app["api_server_adapter"] = self
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/v1/health", self._handle_health)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -24,8 +24,10 @@ from aiohttp.test_utils import AioHTTPTestCase, TestClient, TestServer
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
+    MAX_REQUEST_BYTES,
     ResponseStore,
     _CORS_HEADERS,
+    body_limit_middleware,
     check_api_server_requirements,
     cors_middleware,
     security_headers_middleware,
@@ -215,8 +217,8 @@ def _make_adapter(api_key: str = "", cors_origins=None) -> APIServerAdapter:
 
 def _create_app(adapter: APIServerAdapter) -> web.Application:
     """Create the aiohttp app from the adapter (without starting the full server)."""
-    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
-    app = web.Application(middlewares=mws)
+    mws = [mw for mw in (cors_middleware, security_headers_middleware, body_limit_middleware) if mw is not None]
+    app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
     app["api_server_adapter"] = adapter
     app.router.add_get("/health", adapter._handle_health)
     app.router.add_get("/v1/health", adapter._handle_health)
@@ -318,6 +320,33 @@ class TestModelsEndpoint:
 
 
 class TestChatCompletionsEndpoint:
+    @pytest.mark.asyncio
+    async def test_chunked_oversize_body_returns_413(self, adapter):
+        """Chunked requests must not bypass the request-body size limit."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                over = "x" * (MAX_REQUEST_BYTES + 200)
+                payload = json.dumps(
+                    {"model": "hermes-agent", "messages": [{"role": "user", "content": over}]}
+                ).encode("utf-8")
+
+                async def _chunked():
+                    chunk_size = 65536
+                    for idx in range(0, len(payload), chunk_size):
+                        yield payload[idx : idx + chunk_size]
+
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    data=_chunked(),
+                    headers={"Content-Type": "application/json"},
+                )
+
+            assert resp.status == 413
+            data = await resp.json()
+            assert data["error"]["code"] == "body_too_large"
+            mock_run.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_invalid_json_returns_400(self, adapter):
         app = _create_app(adapter)


### PR DESCRIPTION
## What does this PR do?
Fixes a request-size limit bypass in the API server.

The API server tried to reject oversized POST bodies early by checking `Content-Length`, but chunked requests do not send that header. A client could send an oversized JSON body with `Transfer-Encoding: chunked` and bypass the 1 MB limit entirely.

This change enables aiohttp's real body-size limit, preserves the existing JSON 413 error envelope for oversized requests, and adds a regression test proving chunked requests no longer slip through.

## Type of Change
- [x] Bug fix
- [x] Security fix
- [x] Tests

## Changes Made
- Enabled `client_max_size=MAX_REQUEST_BYTES` on the API server app
- Normalized middleware order so security headers still wrap body-limit responses
- Added shared JSON-body parsing that preserves 413 for oversized bodies instead of degrading to 400 invalid JSON
- Added a regression test for chunked oversized `/v1/chat/completions` requests

## How to Test
1. Run `source .venv/bin/activate`
2. Run `python -m pytest tests/gateway/test_api_server.py -q`
3. Send a JSON request larger than 1 MB with `Transfer-Encoding: chunked` to `/v1/chat/completions`
4. Confirm the server returns `413` with `code: body_too_large`
5. Confirm normal-sized requests still succeed

## Validation
- `python -m pytest tests/gateway/test_api_server.py -q` → `89 passed`
- Manual repro before the fix: a chunked oversized request to `/v1/chat/completions` returned `200`
- Manual repro after the fix: the same request returns `413` with the OpenAI-style `body_too_large` error payload
