### PR TITLE
fix: add Fireworks AI provider mapping for correct context length detection

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -176,6 +176,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "api.deepseek.com": "deepseek",
     "api.githubcopilot.com": "copilot",
     "models.github.ai": "copilot",
+    "fireworks.ai": "fireworks-ai",
 }
 
 

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -43,6 +43,8 @@ PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "opencode-zen": "opencode",
     "opencode-go": "opencode-go",
     "kilocode": "kilo",
+    "fireworks-ai": "fireworks-ai",
+    "custom": "custom",
 }
 
 


### PR DESCRIPTION
Adds Fireworks AI URL/provider mappings so models like `kimi-k2p5-turbo` correctly resolve their 256K context window instead of falling back to 128K default.

Changes:
- `agent/model_metadata.py`: Add `fireworks.ai` → `fireworks-ai` URL mapping  
- `agent/models_dev.py`: Add `fireworks-ai` and `custom` provider mappings

Fixes context detection for Fireworks AI OpenAI-compatible endpoints.