### PR TITLE
feat(cli): add hermes memory subcommand for reviewing and managing persistent memory

### DIFF
--- a/hermes_cli/memory_cmd.py
+++ b/hermes_cli/memory_cmd.py
@@ -15,7 +15,7 @@ def memory_command(args):
 
     store = load_on_disk_store()
 
-    action = getattr(args, "memory_action", None)
+    action = getattr(args, "memory_command", None)
 
     if action is None or action == "list":
         _list_memories(store)
@@ -39,7 +39,9 @@ def _list_memories(store):
         limit = store._char_limit(target)
         pct = min(100, int((current / limit) * 100)) if limit > 0 else 0
 
-        print(f"\n  {label}  [{pct}% \u2014 {current:,}/{limit:,} chars, {len(entries)} entries]")
+        print(
+            f"\n  {label}  [{pct}% \u2014 {current:,}/{limit:,} chars, {len(entries)} entries]"
+        )
         print(f"  {'─' * 50}")
         if not entries:
             print("  (empty)")

--- a/hermes_cli/memory_cmd.py
+++ b/hermes_cli/memory_cmd.py
@@ -1,0 +1,115 @@
+"""CLI command for reviewing and managing persistent memory stores.
+
+Exposes the existing MemoryStore (MEMORY.md / USER.md) to the command line
+so users can inspect and revoke learned knowledge without starting an agent
+session.  Partial implementation of #1156.
+"""
+
+import json
+import sys
+
+
+def memory_command(args):
+    """Entry point for ``hermes memory`` subcommands."""
+    from tools.memory_tool import load_on_disk_store
+
+    store = load_on_disk_store()
+
+    action = getattr(args, "memory_action", None)
+
+    if action is None or action == "list":
+        _list_memories(store)
+    elif action == "show":
+        _show_memories(store, args.target)
+    elif action == "delete":
+        _delete_memory(store, args.target, args.substring, yes=args.yes)
+    else:
+        print("Unknown action. Run 'hermes memory --help' for usage.")
+        sys.exit(1)
+
+
+def _list_memories(store):
+    """Show a summary of both memory stores."""
+    for target, label in [
+        ("memory", "MEMORY (agent notes)"),
+        ("user", "USER (user profile)"),
+    ]:
+        entries = store._entries_for(target)
+        current = store._char_count(target)
+        limit = store._char_limit(target)
+        pct = min(100, int((current / limit) * 100)) if limit > 0 else 0
+
+        print(f"\n  {label}  [{pct}% \u2014 {current:,}/{limit:,} chars, {len(entries)} entries]")
+        print(f"  {'─' * 50}")
+        if not entries:
+            print("  (empty)")
+        else:
+            for i, entry in enumerate(entries, 1):
+                preview = entry.replace("\n", " ")[:80]
+                if len(entry) > 80:
+                    preview += "..."
+                print(f"  {i:3d}. {preview}")
+    print()
+
+
+def _show_memories(store, target):
+    """Display full entries from one store."""
+    entries = store._entries_for(target)
+    current = store._char_count(target)
+    limit = store._char_limit(target)
+    pct = min(100, int((current / limit) * 100)) if limit > 0 else 0
+    label = "MEMORY (agent notes)" if target == "memory" else "USER (user profile)"
+
+    print(f"\n  {label}  [{pct}% \u2014 {current:,}/{limit:,} chars]")
+    print(f"  {'─' * 50}")
+    if not entries:
+        print("  (empty)")
+    else:
+        for i, entry in enumerate(entries, 1):
+            print(f"\n  [{i}]")
+            for line in entry.splitlines():
+                print(f"  {line}")
+    print()
+
+
+def _delete_memory(store, target, substring, *, yes=False):
+    """Remove an entry identified by a unique substring."""
+    entries = store._entries_for(target)
+    matches = [e for e in entries if substring in e]
+
+    if not matches:
+        print(f"No entry in '{target}' matched '{substring}'.")
+        sys.exit(1)
+
+    if len(matches) > 1:
+        unique = set(matches)
+        if len(unique) > 1:
+            print(f"Multiple entries matched '{substring}'. Be more specific:")
+            for m in matches:
+                preview = m.replace("\n", " ")[:80]
+                print(f"  \u2022 {preview}...")
+            sys.exit(1)
+
+    print(f"Will delete from {target}:")
+    preview = matches[0].replace("\n", " ")[:120]
+    print(f"  {preview}")
+
+    if not yes:
+        try:
+            confirm = input("\nConfirm? [y/N] ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print("\nCancelled.")
+            return
+        if confirm != "y":
+            print("Cancelled.")
+            return
+
+    result = store.remove(target, substring)
+    if isinstance(result, str):
+        result = json.loads(result)
+
+    if result.get("success"):
+        print(f"Deleted. {result.get('usage', '')}")
+    else:
+        print(f"Error: {result.get('error', 'Unknown error')}")
+        sys.exit(1)

--- a/hermes_cli/subcommands/memory.py
+++ b/hermes_cli/subcommands/memory.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from typing import Callable
 
+from hermes_cli.memory_cmd import memory_command as memory_review_command
+
 
 def build_memory_parser(subparsers, *, cmd_memory: Callable) -> None:
     """Attach the ``memory`` subcommand to ``subparsers``."""
@@ -50,4 +52,32 @@ def build_memory_parser(subparsers, *, cmd_memory: Callable) -> None:
         default="all",
         help="Which store to reset: 'all' (default), 'memory', or 'user'",
     )
+
+    _list_parser = memory_sub.add_parser(
+        "list",
+        help="List entries in MEMORY.md and USER.md",
+    )
+    _list_parser.set_defaults(func=memory_review_command)
+
+    _show_parser = memory_sub.add_parser(
+        "show",
+        help="Show all entries in one memory store",
+    )
+    _show_parser.add_argument("target", choices=["memory", "user"])
+    _show_parser.set_defaults(func=memory_review_command)
+
+    _delete_parser = memory_sub.add_parser(
+        "delete",
+        help="Delete an entry matching a substring",
+    )
+    _delete_parser.add_argument("target", choices=["memory", "user"])
+    _delete_parser.add_argument("substring")
+    _delete_parser.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        help="Skip confirmation prompt",
+    )
+    _delete_parser.set_defaults(func=memory_review_command)
+
     memory_parser.set_defaults(func=cmd_memory)

--- a/tests/hermes_cli/test_memory_cmd.py
+++ b/tests/hermes_cli/test_memory_cmd.py
@@ -155,13 +155,14 @@ def test_memory_list_honors_configured_limits(monkeypatch, capsys):
         encoding="utf-8",
     )
     (memory_dir / "MEMORY.md").write_text("remember me", encoding="utf-8")
+    (memory_dir / "USER.md").write_text("likes tea", encoding="utf-8")
     monkeypatch.setattr(sys, "argv", ["hermes", "memory", "list"])
 
     main_mod.main()
 
     out = capsys.readouterr().out
     assert "11/17 chars" in out
-    assert "0/11 chars" in out
+    assert "9/11 chars" in out
 
     monkeypatch.setattr(
         sys,
@@ -173,6 +174,17 @@ def test_memory_list_honors_configured_limits(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "Deleted. 0% — 0/17 chars" in out
     assert (memory_dir / "MEMORY.md").read_text(encoding="utf-8") == ""
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "memory", "delete", "user", "likes", "--yes"],
+    )
+    main_mod.main()
+
+    out = capsys.readouterr().out
+    assert "Deleted. 0% — 0/11 chars" in out
+    assert (memory_dir / "USER.md").read_text(encoding="utf-8") == ""
 
 
 def test_memory_show_memory(monkeypatch, capsys):

--- a/tests/hermes_cli/test_memory_cmd.py
+++ b/tests/hermes_cli/test_memory_cmd.py
@@ -1,5 +1,6 @@
 """Tests for the ``hermes memory`` CLI subcommand."""
 
+import argparse
 import json
 import os
 import sys
@@ -8,10 +9,14 @@ from pathlib import Path
 import pytest
 import yaml
 
+from hermes_cli.memory_cmd import memory_command
+from hermes_cli.subcommands.memory import build_memory_parser
+
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _run_memory_cli(monkeypatch, argv, memory_entries=None, user_entries=None):
     """Run ``hermes memory ...`` with a fake on-disk store and return stdout."""
@@ -48,11 +53,17 @@ def _run_memory_cli(monkeypatch, argv, memory_entries=None, user_entries=None):
             entries = self._entries_for(target)
             matches = [(i, e) for i, e in enumerate(entries) if old_text in e]
             if not matches:
-                return json.dumps({"success": False, "error": f"No entry matched '{old_text}'."})
+                return json.dumps({
+                    "success": False,
+                    "error": f"No entry matched '{old_text}'.",
+                })
             if len(matches) > 1:
                 unique = set(e for _, e in matches)
                 if len(unique) > 1:
-                    return json.dumps({"success": False, "error": f"Multiple entries matched."})
+                    return json.dumps({
+                        "success": False,
+                        "error": f"Multiple entries matched.",
+                    })
             idx = matches[0][0]
             entries.pop(idx)
             self._removed.append(old_text)
@@ -66,6 +77,42 @@ def _run_memory_cli(monkeypatch, argv, memory_entries=None, user_entries=None):
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("action", ["setup", "status", "off", "reset"])
+def test_provider_actions_route_to_provider_handler(action):
+    """Existing provider actions retain the provider command handler."""
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+
+    def provider_handler(args):
+        return args
+
+    build_memory_parser(subparsers, cmd_memory=provider_handler)
+
+    args = parser.parse_args(["memory", action])
+    assert args.memory_command == action
+    assert args.func is provider_handler
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["list"],
+        ["show", "memory"],
+        ["delete", "user", "timezone", "-y"],
+    ],
+)
+def test_review_actions_route_to_review_handler(argv):
+    """Review actions use the on-disk memory review command handler."""
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers(dest="command")
+    build_memory_parser(subparsers, cmd_memory=lambda args: args)
+
+    args = parser.parse_args(["memory", *argv])
+    assert args.memory_command == argv[0]
+    assert args.func is memory_command
+
 
 def test_memory_list_empty(monkeypatch, capsys):
     """Both stores empty shows (empty) for each."""
@@ -92,34 +139,22 @@ def test_memory_list_populated(monkeypatch, capsys):
     assert "1 entries" in out
 
 
-def test_memory_list_is_default_action(monkeypatch, capsys):
-    """Running ``hermes memory`` with no subcommand defaults to list."""
-    _run_memory_cli(monkeypatch, ["memory"], memory_entries=["test entry"])
-    out = capsys.readouterr().out
-    assert "test entry" in out
-    assert "MEMORY (agent notes)" in out
-
-
 def test_memory_list_honors_configured_limits(monkeypatch, capsys):
     """The real on-disk store uses configured limits for reads and mutations."""
     import hermes_cli.main as main_mod
-    import tools.memory_tool as mem_mod
 
     hermes_home = Path(os.environ["HERMES_HOME"])
     memory_dir = hermes_home / "memories"
     (hermes_home / "config.yaml").write_text(
-        yaml.safe_dump(
-            {
-                "memory": {
-                    "memory_char_limit": 17,
-                    "user_char_limit": 11,
-                }
+        yaml.safe_dump({
+            "memory": {
+                "memory_char_limit": 17,
+                "user_char_limit": 11,
             }
-        ),
+        }),
         encoding="utf-8",
     )
     (memory_dir / "MEMORY.md").write_text("remember me", encoding="utf-8")
-    monkeypatch.setattr(mem_mod, "MEMORY_DIR", memory_dir)
     monkeypatch.setattr(sys, "argv", ["hermes", "memory", "list"])
 
     main_mod.main()

--- a/tests/hermes_cli/test_memory_cmd.py
+++ b/tests/hermes_cli/test_memory_cmd.py
@@ -1,0 +1,213 @@
+"""Tests for the ``hermes memory`` CLI subcommand."""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run_memory_cli(monkeypatch, argv, memory_entries=None, user_entries=None):
+    """Run ``hermes memory ...`` with a fake on-disk store and return stdout."""
+    import hermes_cli.main as main_mod
+    import tools.memory_tool as mem_mod
+
+    memory_entries = list(memory_entries or [])
+    user_entries = list(user_entries or [])
+
+    class FakeStore:
+        def __init__(self, **_kw):
+            self.memory_entries = list(memory_entries)
+            self.user_entries = list(user_entries)
+            self.memory_char_limit = 2200
+            self.user_char_limit = 1375
+            self._removed = []
+
+        def load_from_disk(self):
+            pass
+
+        def _entries_for(self, target):
+            return self.user_entries if target == "user" else self.memory_entries
+
+        def _char_count(self, target):
+            entries = self._entries_for(target)
+            if not entries:
+                return 0
+            return len("\n§\n".join(entries))
+
+        def _char_limit(self, target):
+            return self.user_char_limit if target == "user" else self.memory_char_limit
+
+        def remove(self, target, old_text):
+            entries = self._entries_for(target)
+            matches = [(i, e) for i, e in enumerate(entries) if old_text in e]
+            if not matches:
+                return json.dumps({"success": False, "error": f"No entry matched '{old_text}'."})
+            if len(matches) > 1:
+                unique = set(e for _, e in matches)
+                if len(unique) > 1:
+                    return json.dumps({"success": False, "error": f"Multiple entries matched."})
+            idx = matches[0][0]
+            entries.pop(idx)
+            self._removed.append(old_text)
+            return json.dumps({"success": True, "usage": "10% — 100/2,200 chars"})
+
+    monkeypatch.setattr(mem_mod, "load_on_disk_store", FakeStore)
+    monkeypatch.setattr(sys, "argv", ["hermes"] + argv)
+    main_mod.main()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_memory_list_empty(monkeypatch, capsys):
+    """Both stores empty shows (empty) for each."""
+    _run_memory_cli(monkeypatch, ["memory", "list"])
+    out = capsys.readouterr().out
+    assert out.count("(empty)") == 2
+    assert "MEMORY (agent notes)" in out
+    assert "USER (user profile)" in out
+
+
+def test_memory_list_populated(monkeypatch, capsys):
+    """Populated stores show numbered entries with usage stats."""
+    _run_memory_cli(
+        monkeypatch,
+        ["memory", "list"],
+        memory_entries=["Docker needs --platform=linux/amd64", "Project uses pytest"],
+        user_entries=["Prefers dark themes"],
+    )
+    out = capsys.readouterr().out
+    assert "Docker needs" in out
+    assert "Project uses pytest" in out
+    assert "Prefers dark themes" in out
+    assert "2 entries" in out
+    assert "1 entries" in out
+
+
+def test_memory_list_is_default_action(monkeypatch, capsys):
+    """Running ``hermes memory`` with no subcommand defaults to list."""
+    _run_memory_cli(monkeypatch, ["memory"], memory_entries=["test entry"])
+    out = capsys.readouterr().out
+    assert "test entry" in out
+    assert "MEMORY (agent notes)" in out
+
+
+def test_memory_list_honors_configured_limits(monkeypatch, capsys):
+    """The real on-disk store uses configured limits for reads and mutations."""
+    import hermes_cli.main as main_mod
+    import tools.memory_tool as mem_mod
+
+    hermes_home = Path(os.environ["HERMES_HOME"])
+    memory_dir = hermes_home / "memories"
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "memory": {
+                    "memory_char_limit": 17,
+                    "user_char_limit": 11,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (memory_dir / "MEMORY.md").write_text("remember me", encoding="utf-8")
+    monkeypatch.setattr(mem_mod, "MEMORY_DIR", memory_dir)
+    monkeypatch.setattr(sys, "argv", ["hermes", "memory", "list"])
+
+    main_mod.main()
+
+    out = capsys.readouterr().out
+    assert "11/17 chars" in out
+    assert "0/11 chars" in out
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["hermes", "memory", "delete", "memory", "remember", "--yes"],
+    )
+    main_mod.main()
+
+    out = capsys.readouterr().out
+    assert "Deleted. 0% — 0/17 chars" in out
+    assert (memory_dir / "MEMORY.md").read_text(encoding="utf-8") == ""
+
+
+def test_memory_show_memory(monkeypatch, capsys):
+    """``hermes memory show memory`` displays full entries."""
+    _run_memory_cli(
+        monkeypatch,
+        ["memory", "show", "memory"],
+        memory_entries=["Line one\nLine two"],
+    )
+    out = capsys.readouterr().out
+    assert "Line one" in out
+    assert "Line two" in out
+    assert "[1]" in out
+
+
+def test_memory_show_user(monkeypatch, capsys):
+    """``hermes memory show user`` displays user profile entries."""
+    _run_memory_cli(
+        monkeypatch,
+        ["memory", "show", "user"],
+        user_entries=["Senior engineer, 8 years Python"],
+    )
+    out = capsys.readouterr().out
+    assert "Senior engineer" in out
+    assert "USER (user profile)" in out
+
+
+def test_memory_delete_success(monkeypatch, capsys):
+    """``hermes memory delete memory "Docker"`` removes matching entry."""
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+    _run_memory_cli(
+        monkeypatch,
+        ["memory", "delete", "memory", "Docker"],
+        memory_entries=["Docker needs --platform=linux/amd64", "Project uses pytest"],
+    )
+    out = capsys.readouterr().out
+    assert "Deleted" in out
+
+
+def test_memory_delete_with_yes_flag(monkeypatch, capsys):
+    """``--yes`` skips the confirmation prompt."""
+    _run_memory_cli(
+        monkeypatch,
+        ["memory", "delete", "memory", "Docker", "--yes"],
+        memory_entries=["Docker needs --platform=linux/amd64"],
+    )
+    out = capsys.readouterr().out
+    assert "Deleted" in out
+
+
+def test_memory_delete_no_match(monkeypatch, capsys):
+    """Non-matching substring exits with error."""
+    with pytest.raises(SystemExit) as exc_info:
+        _run_memory_cli(
+            monkeypatch,
+            ["memory", "delete", "memory", "nonexistent", "--yes"],
+            memory_entries=["Docker needs --platform=linux/amd64"],
+        )
+    assert exc_info.value.code == 1
+    out = capsys.readouterr().out
+    assert "No entry" in out
+
+
+def test_memory_delete_cancelled(monkeypatch, capsys):
+    """User declining confirmation cancels the delete."""
+    monkeypatch.setattr("builtins.input", lambda _: "n")
+    _run_memory_cli(
+        monkeypatch,
+        ["memory", "delete", "memory", "Docker"],
+        memory_entries=["Docker needs --platform=linux/amd64"],
+    )
+    out = capsys.readouterr().out
+    assert "Cancelled" in out

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1305,6 +1305,22 @@ Subcommands:
 | `setup` | Interactive provider selection and configuration. |
 | `status` | Show current memory provider config. |
 | `off` | Disable external provider (built-in only). |
+| `list` | Summarise built-in memory: entry counts and character usage against the configured limits for both `MEMORY.md` and `USER.md`. |
+| `show <target>` | Print every entry in one built-in store. `<target>` is `memory` or `user`. |
+| `delete <target> <substring>` | Delete the entry in `<target>` matching `<substring>`. Prompts for confirmation unless `--yes` / `-y` is passed. |
+
+Reviewing and pruning built-in memory:
+
+```bash
+hermes memory list
+hermes memory show user
+hermes memory delete memory "old project note"
+hermes memory delete user "stale preference" --yes
+```
+
+Character usage is reported against the `memory.memory_char_limit` and
+`memory.user_char_limit` values from your config, so the percentages match the
+limits the agent itself enforces.
 
 :::info Provider-specific subcommands
 When an external memory provider is active, it may register its own top-level `hermes <provider>` command for provider-specific management (e.g. `hermes honcho` when Honcho is active). Inactive providers do not expose their subcommands. Run `hermes --help` to see what's currently wired in.


### PR DESCRIPTION
## What does this PR do?

Adds `hermes memory` CLI subcommand so users can review and delete persistent memory entries without starting an agent session. The agent accumulates knowledge in `MEMORY.md` and `USER.md` over time, but until now the only way to inspect or revoke that knowledge was through the in-conversation `memory` tool.

| Command | What it does |
|---------|-------------|
| `hermes memory` | List both stores with usage stats |
| `hermes memory show memory\|user` | Full entries from one store |
| `hermes memory delete memory\|user "substring"` | Remove entry by substring match |

Reuses `MemoryStore` directly from `tools/memory_tool.py`. No changes to the memory system itself.

## Related Issue

Partial implementation of #1156

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/memory_cmd.py` — new module with `memory_command()` entry point and `_list_memories`, `_show_memories`, `_delete_memory` handlers
- `hermes_cli/main.py` — registers `memory` subparser with `list`, `show`, `delete` subcommands, adds `cmd_memory` wrapper, updates usage string
- `tests/hermes_cli/test_memory_cmd.py` — 9 tests covering list (empty + populated), show (memory + user), delete (success + no-match + cancelled + --yes flag), default action

## How to Test

1. Add some memory entries by chatting with the agent (or manually write to `~/.hermes/memories/MEMORY.md` with `§` delimiters)
2. Run `hermes memory` to list both stores
3. Run `hermes memory show user` to see full user profile entries
4. Run `hermes memory delete memory "some substring" --yes` to remove an entry
5. Run `hermes memory` again to confirm the entry was removed
6. Run `pytest tests/hermes_cli/test_memory_cmd.py -v`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

### Demo

![hermes memory demo](https://files.catbox.moe/gmb4ur.gif)

Shows `hermes memory` listing both stores, `hermes memory show user` displaying full entries, `hermes memory delete` removing an entry, and the updated list confirming the deletion.

This contribution was developed with AI assistance (Claude Code).