### PR TITLE
fix(webhook): enforce chunked body limits

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -114,7 +114,7 @@ class WebhookAdapter(BasePlatformAdapter):
                     f"For testing without auth, set secret to '{_INSECURE_NO_AUTH}'."
                 )
 
-        app = web.Application()
+        app = web.Application(client_max_size=self._max_body_bytes)
         app.router.add_get("/health", self._handle_health)
         app.router.add_post("/webhooks/{route_name}", self._handle_webhook)
 
@@ -270,9 +270,17 @@ class WebhookAdapter(BasePlatformAdapter):
         # Read body
         try:
             raw_body = await request.read()
+        except web.HTTPRequestEntityTooLarge:
+            return web.json_response(
+                {"error": "Payload too large"}, status=413
+            )
         except Exception as e:
             logger.error("[webhook] Failed to read body: %s", e)
             return web.json_response({"error": "Bad request"}, status=400)
+        if len(raw_body) > self._max_body_bytes:
+            return web.json_response(
+                {"error": "Payload too large"}, status=413
+            )
 
         # Validate HMAC signature (skip for INSECURE_NO_AUTH testing mode)
         secret = route_config.get("secret", self._global_secret)

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -67,7 +67,7 @@ def _make_adapter(routes=None, **kwargs):
 
 def _create_app(adapter: WebhookAdapter) -> web.Application:
     """Build the aiohttp Application from the adapter (without starting a full server)."""
-    app = web.Application()
+    app = web.Application(client_max_size=adapter._max_body_bytes)
     app.router.add_get("/health", adapter._handle_health)
     app.router.add_post("/webhooks/{route_name}", adapter._handle_webhook)
     return app
@@ -515,6 +515,29 @@ class TestBodySize:
                 headers={"Content-Length": "999999"},
             )
             assert resp.status == 413
+
+    @pytest.mark.asyncio
+    async def test_chunked_oversized_payload_rejected(self):
+        """Chunked request bodies over the limit still return 413."""
+        routes = {"big": {"secret": _INSECURE_NO_AUTH, "prompt": "test"}}
+        adapter = _make_adapter(routes=routes, max_body_bytes=100)
+        adapter.handle_message = AsyncMock()
+
+        async def _chunked_body():
+            payload = json.dumps({"data": "x" * 500}).encode("utf-8")
+            for i in range(0, len(payload), 64):
+                yield payload[i : i + 64]
+                await asyncio.sleep(0)
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/big",
+                data=_chunked_body(),
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 413
+            adapter.handle_message.assert_not_awaited()
 
 
 # ===================================================================


### PR DESCRIPTION
## What does this PR do?
Fixes webhook payload size enforcement for chunked requests.

Previously, the webhook adapter only rejected oversized payloads when `Content-Length` was present and over the configured `max_body_bytes`. Chunked requests omit `Content-Length`, so an oversized webhook body could still be fully read and accepted.

This change enforces the same limit for chunked bodies by configuring aiohttp's `client_max_size`, mapping `HTTPRequestEntityTooLarge` to a clean `413` response, and keeping a post-read size check as a defensive fallback.

## Type of Change
- [x] Bug fix
- [x] Security fix
- [x] Tests

## Changes Made
- Set `client_max_size` on the webhook aiohttp app from `max_body_bytes`
- Return `413 Payload too large` when `request.read()` exceeds the limit
- Keep an explicit post-read size check as a fallback
- Added a regression test for oversized chunked request bodies

## How to Test
1. Run `source .venv/bin/activate`
2. Run `python -m pytest tests/gateway/test_webhook_adapter.py -q`
3. Send a chunked webhook request larger than `max_body_bytes`
4. Confirm the adapter returns `413` instead of accepting the webhook

## Notes
- Manual repro before the fix: an oversized chunked request returned `202 Accepted`
- Manual repro after the fix: the same request returns `413 Payload too large`
- Full suite on current `main` still has unrelated failures in Slack, delegate credential resolution, transcription, website policy, and CLI tools reset tests
