### PR TITLE
fix(daytona): quote sync paths before shell mkdir

### DIFF
--- a/tests/tools/test_daytona_environment.py
+++ b/tests/tools/test_daytona_environment.py
@@ -1,6 +1,8 @@
 """Unit tests for the Daytona cloud sandbox environment backend."""
 
+import shlex
 import threading
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch, PropertyMock
 
@@ -319,6 +321,23 @@ class TestExecute:
         result = env.execute("echo retry")
         assert result["output"] == "ok"
         assert result["returncode"] == 0
+
+
+class TestSyncSafety:
+    def test_upload_if_changed_quotes_parent_path(self, make_env, tmp_path):
+        env = make_env()
+        env._sandbox.process.exec.reset_mock()
+
+        host_file = tmp_path / "token.txt"
+        host_file.write_text("secret", encoding="utf-8")
+        remote_path = "/root/.hermes/skills/evil; touch /tmp/daytona-owned/file.txt"
+
+        uploaded = env._upload_if_changed(str(host_file), remote_path)
+
+        assert uploaded is True
+        expected_parent = str(Path(remote_path).parent)
+        mkdir_cmd = env._sandbox.process.exec.call_args_list[0][0][0]
+        assert mkdir_cmd == f"mkdir -p {shlex.quote(expected_parent)}"
 
 
 # ---------------------------------------------------------------------------

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -12,6 +12,7 @@ import shlex
 import threading
 import uuid
 import warnings
+from pathlib import Path
 from typing import Optional
 
 from tools.environments.base import BaseEnvironment
@@ -144,7 +145,7 @@ class DaytonaEnvironment(BaseEnvironment):
             return False
         try:
             parent = str(Path(remote_path).parent)
-            self._sandbox.process.exec(f"mkdir -p {parent}")
+            self._sandbox.process.exec(f"mkdir -p {shlex.quote(parent)}")
             self._sandbox.fs.upload_file(host_path, remote_path)
             self._synced_files[remote_path] = file_key
             return True


### PR DESCRIPTION
## What does this PR do?
Fixes broken and unsafe file sync handling in the Daytona environment backend.

`_upload_if_changed()` uses a shell `mkdir -p ...` call before uploading credential and skill files into the sandbox. In current `main`, that code path had two issues:

- it referenced `Path` without importing it, so sync could fail with `NameError`
- it interpolated the remote parent path into the shell command without quoting, so metacharacters in the path could break the command or be interpreted by the shell

This change imports `Path` in the module and quotes the parent directory before invoking `mkdir -p`.

## Type of Change
- [x] Bug fix
- [x] Security fix
- [x] Tests

## Changes Made
- Import `Path` for the `_upload_if_changed()` code path
- Quote the remote parent path before shelling out to `mkdir -p`
- Added a regression test covering a path with shell metacharacters

## How to Test
1. Run `source .venv/bin/activate`
2. Run `python -m pytest tests/tools/test_daytona_environment.py -q`
3. Exercise `_upload_if_changed()` with a remote path containing shell metacharacters
4. Confirm the sync succeeds and the generated `mkdir -p` command uses a single quoted parent path

## Notes
- Manual repro before the fix: `_upload_if_changed()` could raise `NameError: name 'Path' is not defined`
- Manual repro after the fix: the upload succeeds and the mkdir command is `mkdir -p '/root/.hermes/skills/evil; touch /tmp/daytona-owned'`
- Full suite on current `main` still has unrelated failures in Slack app mention registration, `/tools disable` reset behavior, delegate credential resolution, and transcription provider tests
