### PR TITLE
fix(ssh): quote sync paths before remote shell calls

### DIFF
--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -2,7 +2,9 @@
 
 import json
 import os
+import shlex
 import subprocess
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -65,6 +67,63 @@ class TestBuildSSHCommand:
     def test_user_host_suffix(self):
         env = SSHEnvironment(host="h", user="u")
         assert env._build_ssh_command()[-1] == "u@h"
+
+    def test_sync_quotes_remote_paths(self, monkeypatch, tmp_path):
+        calls = []
+
+        def fake_run(cmd, *args, **kwargs):
+            calls.append(cmd)
+            stdout = "/root\n" if cmd and cmd[-1] == "echo $HOME" else ""
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+        credential_file = tmp_path / "token.txt"
+        credential_file.write_text("secret", encoding="utf-8")
+        skills_dir = tmp_path / "skills dir"
+        skills_dir.mkdir()
+
+        monkeypatch.setattr(ssh_env.shutil, "which", lambda _name: "/usr/bin/ssh")
+        monkeypatch.setattr("tools.environments.ssh.subprocess.run", fake_run)
+        monkeypatch.setattr(
+            "tools.credential_files.get_credential_file_mounts",
+            lambda: [
+                {
+                    "host_path": str(credential_file),
+                    "container_path": "/root/.hermes/skills/evil;touch /tmp/pwn/token.txt",
+                }
+            ],
+        )
+        monkeypatch.setattr(
+            "tools.credential_files.get_skills_directory_mount",
+            lambda **kw: {
+                "host_path": str(skills_dir),
+                "container_path": "/root/.hermes/skills/dir;touch /tmp/pwn",
+            },
+        )
+        monkeypatch.setattr("tools.environments.ssh.time.sleep", lambda _: None)
+
+        ssh_env.SSHEnvironment(host="example.com", user="alice")
+
+        mkdir_credential = calls[2]
+        rsync_credential = calls[3]
+        mkdir_skills = calls[4]
+        rsync_skills = calls[5]
+
+        assert mkdir_credential[-1] == (
+            "mkdir -p "
+            + shlex.quote("/root/.hermes/skills/evil;touch /tmp/pwn")
+        )
+        assert rsync_credential[-1] == (
+            "alice@example.com:"
+            + shlex.quote("/root/.hermes/skills/evil;touch /tmp/pwn/token.txt")
+        )
+        assert mkdir_skills[-1] == (
+            "mkdir -p "
+            + shlex.quote("/root/.hermes/skills/dir;touch /tmp/pwn")
+        )
+        assert rsync_skills[-1] == (
+            "alice@example.com:"
+            + shlex.quote("/root/.hermes/skills/dir;touch /tmp/pwn/")
+        )
 
 
 class TestTerminalToolConfig:

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -1,6 +1,7 @@
 """SSH remote execution environment with ControlMaster connection persistence."""
 
 import logging
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -126,9 +127,12 @@ class SSHEnvironment(PersistentShellMixin, BaseEnvironment):
                 remote_path = mount_entry["container_path"].replace("/root/.hermes", container_base, 1)
                 parent_dir = str(Path(remote_path).parent)
                 mkdir_cmd = self._build_ssh_command()
-                mkdir_cmd.append(f"mkdir -p {parent_dir}")
+                mkdir_cmd.append(f"mkdir -p {shlex.quote(parent_dir)}")
                 subprocess.run(mkdir_cmd, capture_output=True, text=True, timeout=10)
-                cmd = rsync_base + [mount_entry["host_path"], f"{dest_prefix}:{remote_path}"]
+                cmd = rsync_base + [
+                    mount_entry["host_path"],
+                    f"{dest_prefix}:{shlex.quote(remote_path)}",
+                ]
                 result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
                 if result.returncode == 0:
                     logger.info("SSH: synced credential %s -> %s", mount_entry["host_path"], remote_path)
@@ -140,11 +144,11 @@ class SSHEnvironment(PersistentShellMixin, BaseEnvironment):
             if skills_mount:
                 remote_path = skills_mount["container_path"]
                 mkdir_cmd = self._build_ssh_command()
-                mkdir_cmd.append(f"mkdir -p {remote_path}")
+                mkdir_cmd.append(f"mkdir -p {shlex.quote(remote_path)}")
                 subprocess.run(mkdir_cmd, capture_output=True, text=True, timeout=10)
                 cmd = rsync_base + [
                     skills_mount["host_path"].rstrip("/") + "/",
-                    f"{dest_prefix}:{remote_path}/",
+                    f"{dest_prefix}:{shlex.quote(remote_path.rstrip('/') + '/')}",
                 ]
                 result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
                 if result.returncode == 0:


### PR DESCRIPTION
## What does this PR do?
Fixes unsafe path handling in the SSH environment backend's credential and skills sync flow.

During `_sync_skills_and_credentials()`, the SSH backend builds remote `mkdir -p ...` commands and `rsync user@host:{remote_path}` destinations from sandbox paths derived from credential mounts and skill paths. In current `main`, those remote paths were interpolated without shell quoting.

That meant shell metacharacters in a synced remote path could be interpreted by the remote shell instead of being treated as a literal path.

This change quotes the remote paths before invoking remote shell commands or passing remote rsync destinations.

## Type of Change
- [x] Bug fix
- [x] Security fix
- [x] Tests

## Changes Made
- Quote credential sync parent directories before `ssh ... mkdir -p`
- Quote remote credential rsync destinations
- Quote skills directory sync paths for both `mkdir -p` and rsync
- Added a regression test that asserts quoted SSH and rsync arguments for metacharacter-containing paths

## How to Test
1. Run `source .venv/bin/activate`
2. Run `python -m pytest tests/tools/test_ssh_environment.py -q`
3. Exercise `_sync_skills_and_credentials()` with a remote path containing shell metacharacters
4. Confirm the generated SSH and rsync commands use quoted remote paths

## Notes
- Manual repro after the fix shows commands like:
  - `mkdir -p '/root/.hermes/skills/evil;touch /tmp/pwn'`
  - `alice@example.com:'/root/.hermes/skills/evil;touch /tmp/pwn/token.txt'`
- Full suite on current `main` still has unrelated failures in Slack app mention registration, `/tools disable` reset behavior, delegate credential resolution, and transcription provider tests
