### PR TITLE
fix(profiles): validate custom alias names

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3298,7 +3298,7 @@ def cmd_profile(args):
         list_profiles, create_profile, delete_profile, seed_profile_skills,
         get_active_profile, set_active_profile, get_active_profile_name,
         check_alias_collision, create_wrapper_script, remove_wrapper_script,
-        _is_wrapper_dir_in_path, _get_wrapper_dir,
+        validate_alias_name, _is_wrapper_dir_in_path, _get_wrapper_dir,
     )
     from hermes_constants import display_hermes_home
 
@@ -3469,6 +3469,11 @@ def cmd_profile(args):
             sys.exit(1)
 
         alias_name = custom_name or name
+        try:
+            validate_alias_name(alias_name)
+        except ValueError as e:
+            print(f"Error: {e}")
+            sys.exit(1)
 
         if remove:
             if remove_wrapper_script(alias_name):

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -116,6 +116,15 @@ def validate_profile_name(name: str) -> None:
         )
 
 
+def validate_alias_name(name: str) -> None:
+    """Raise ``ValueError`` if *name* is not a safe wrapper alias."""
+    if not _PROFILE_ID_RE.match(name):
+        raise ValueError(
+            f"Invalid alias name {name!r}. Alias names must match "
+            f"[a-z0-9][a-z0-9_-]{{0,63}}"
+        )
+
+
 def get_profile_dir(name: str) -> Path:
     """Resolve a profile name to its HERMES_HOME directory."""
     if name == "default":
@@ -139,6 +148,11 @@ def check_alias_collision(name: str) -> Optional[str]:
 
     Checks: reserved names, hermes subcommands, existing binaries in PATH.
     """
+    try:
+        validate_alias_name(name)
+    except ValueError as e:
+        return str(e)
+
     if name in _RESERVED_NAMES:
         return f"'{name}' is a reserved name"
     if name in _HERMES_SUBCOMMANDS:
@@ -178,6 +192,7 @@ def create_wrapper_script(name: str) -> Optional[Path]:
 
     Returns the path to the created wrapper, or None if creation failed.
     """
+    validate_alias_name(name)
     wrapper_dir = _get_wrapper_dir()
     try:
         wrapper_dir.mkdir(parents=True, exist_ok=True)
@@ -197,6 +212,7 @@ def create_wrapper_script(name: str) -> Optional[Path]:
 
 def remove_wrapper_script(name: str) -> bool:
     """Remove the wrapper script for a profile. Returns True if removed."""
+    validate_alias_name(name)
     wrapper_path = _get_wrapper_dir() / name
     if wrapper_path.exists():
         try:

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -17,6 +17,7 @@ from hermes_cli.profiles import (
     validate_profile_name,
     get_profile_dir,
     create_profile,
+    create_wrapper_script,
     delete_profile,
     list_profiles,
     set_active_profile,
@@ -24,6 +25,7 @@ from hermes_cli.profiles import (
     get_active_profile_name,
     resolve_profile_env,
     check_alias_collision,
+    remove_wrapper_script,
     rename_profile,
     export_profile,
     import_profile,
@@ -355,6 +357,36 @@ class TestAliasCollision:
         result = check_alias_collision("default")
         assert result is not None
         assert "reserved" in result.lower()
+
+    def test_invalid_alias_name_returns_message(self, profile_env):
+        result = check_alias_collision("../escape")
+        assert result is not None
+        assert "invalid alias name" in result.lower()
+
+
+class TestWrapperScripts:
+    def test_create_wrapper_rejects_traversal_name(self, profile_env):
+        with pytest.raises(ValueError, match="Invalid alias name"):
+            create_wrapper_script("../escape")
+
+        assert not (profile_env / ".local" / "escape").exists()
+
+    def test_create_wrapper_rejects_absolute_path(self, profile_env, tmp_path):
+        target = tmp_path / "abs-wrapper"
+        with pytest.raises(ValueError, match="Invalid alias name"):
+            create_wrapper_script(str(target))
+
+        assert not target.exists()
+
+    def test_remove_wrapper_rejects_traversal_name(self, profile_env):
+        escape_path = profile_env / ".local" / "escape"
+        escape_path.parent.mkdir(parents=True, exist_ok=True)
+        escape_path.write_text('#!/bin/sh\nexec hermes -p coder "$@"\n')
+
+        with pytest.raises(ValueError, match="Invalid alias name"):
+            remove_wrapper_script("../escape")
+
+        assert escape_path.exists()
 
 
 # ===================================================================


### PR DESCRIPTION
## What does this PR do?
Fixes unsafe custom alias handling in the profiles feature.

Previously, `hermes profile alias <profile> --name <custom>` accepted arbitrary alias strings and passed them straight into wrapper-path creation under `~/.local/bin`. Because the alias name was not validated as a single safe command name, values like `../escape` or absolute paths could escape the wrapper directory and write files elsewhere on disk.

This change validates custom alias names before collision checks, wrapper creation, or wrapper removal.

## Type of Change
- [x] Bug fix
- [x] Security fix
- [x] Tests

## Changes Made
- Added explicit validation for custom alias names
- Reject alias names that are not single safe command identifiers
- Enforced the validation in collision checks, wrapper creation, wrapper removal, and the CLI alias command path
- Added regression tests for traversal and absolute-path alias values

## How to Test
1. Run `source .venv/bin/activate`
2. Run `python -m pytest tests/hermes_cli/test_profiles.py -q`
3. Try `hermes profile alias coder --name ../escape`
4. Confirm it fails with an invalid alias error and does not create files outside `~/.local/bin`

## Notes
- Manual repro before the fix: `create_wrapper_script('../escape')` created `~/.local/escape`
- Manual repro after the fix: traversal and absolute-path aliases raise `ValueError` and create no files
- Full suite on current `main` still has unrelated failures in Slack app mention registration, `/tools disable` reset behavior, delegate credential resolution, and transcription provider tests
