### PR TITLE
fix(profiles): export the default profile directory correctly

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -698,7 +698,8 @@ def export_profile(name: str, output_path: str) -> Path:
     output = Path(output_path)
     # shutil.make_archive wants the base name without extension
     base = str(output).removesuffix(".tar.gz").removesuffix(".tgz")
-    result = shutil.make_archive(base, "gztar", str(profile_dir.parent), name)
+    archive_root = profile_dir.name
+    result = shutil.make_archive(base, "gztar", str(profile_dir.parent), archive_root)
     return Path(result)
 
 

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -418,6 +418,19 @@ class TestExportImport:
         assert Path(result).exists()
         assert tarfile.is_tarfile(str(result))
 
+    def test_export_default_profile_uses_default_directory(self, profile_env, tmp_path):
+        default_home = get_profile_dir("default")
+        (default_home / "marker.txt").write_text("hello")
+
+        output = tmp_path / "export" / "default.tar.gz"
+        output.parent.mkdir(parents=True, exist_ok=True)
+        result = export_profile("default", str(output))
+
+        assert Path(result).exists()
+        with tarfile.open(result, "r:gz") as tf:
+            names = tf.getnames()
+        assert ".hermes/marker.txt" in names
+
     def test_import_restores_from_archive(self, profile_env, tmp_path):
         # Create and export a profile
         create_profile("coder", no_alias=True)


### PR DESCRIPTION
## What does this PR do?
Fixes `hermes profile export default` crashing instead of producing an archive.

The export helper was passing the logical profile name (`default`) to `shutil.make_archive()`, but the built-in default profile actually lives on disk as `~/.hermes`. That made the export path resolve to a non-existent directory and raised `FileNotFoundError`.

This change exports the real profile directory name and adds a regression test covering the built-in default profile.

## Type of Change
- [x] Bug fix
- [x] Tests

## Changes Made
- Export the resolved profile directory name instead of the logical profile name
- Added a regression test that exports the default profile and verifies the archive contents

## How to Test
1. Run `source .venv/bin/activate`
2. Run `python -m pytest tests/hermes_cli/test_profiles.py -q`
3. Create a marker file under the default profile and run `hermes profile export default -o /tmp/default.tar.gz`
4. Confirm the archive is created and contains `.hermes/...` content

## Verification
- Manual repro before fix: `export_profile("default", ...)` raised `FileNotFoundError`
- Manual repro after fix: archive is created successfully and contains `.hermes/marker.txt`
- `python -m pytest tests/hermes_cli/test_profiles.py -q` → `72 passed`
- `python -m pytest tests/ -q` still shows 7 unrelated existing failures on current `main` (Slack, CLI tools reset flow, delegate credential resolution, transcription, website policy)
