### PR TITLE
fix(honcho): honor host-scoped base URLs

### DIFF
--- a/honcho_integration/cli.py
+++ b/honcho_integration/cli.py
@@ -45,6 +45,21 @@ def _resolve_api_key(cfg: dict) -> str:
     return host_key or cfg.get("apiKey", "") or os.environ.get("HONCHO_API_KEY", "")
 
 
+def _validate_connection(hcfg) -> None:
+    """Force a real Honcho API path instead of only constructing the SDK client."""
+    from honcho_integration.client import get_honcho_client, reset_honcho_client
+    from honcho_integration.session import HonchoSessionManager
+
+    reset_honcho_client()
+    client = get_honcho_client(hcfg)
+    manager = HonchoSessionManager(
+        honcho=client,
+        config=hcfg,
+        context_tokens=hcfg.context_tokens,
+    )
+    manager.get_or_create(hcfg.resolve_session_name())
+
+
 def _prompt(label: str, default: str | None = None, secret: bool = False) -> str:
     suffix = f" [{default}]" if default else ""
     sys.stdout.write(f"  {label}{suffix}: ")
@@ -194,10 +209,9 @@ def cmd_setup(args) -> None:
     # Test connection
     print("  Testing connection... ", end="", flush=True)
     try:
-        from honcho_integration.client import HonchoClientConfig, get_honcho_client, reset_honcho_client
-        reset_honcho_client()
+        from honcho_integration.client import HonchoClientConfig
         hcfg = HonchoClientConfig.from_global_config()
-        get_honcho_client(hcfg)
+        _validate_connection(hcfg)
         print("OK")
     except Exception as e:
         print(f"FAILED\n  Error: {e}")
@@ -273,7 +287,7 @@ def cmd_status(args) -> None:
     if hcfg.enabled and (hcfg.api_key or hcfg.base_url):
         print("\n  Connection... ", end="", flush=True)
         try:
-            get_honcho_client(hcfg)
+            _validate_connection(hcfg)
             print("OK\n")
         except Exception as e:
             print(f"FAILED ({e})\n")

--- a/honcho_integration/client.py
+++ b/honcho_integration/client.py
@@ -198,7 +198,10 @@ class HonchoClientConfig:
         )
 
         base_url = (
-            raw.get("baseUrl")
+            host_block.get("base_url")
+            or host_block.get("baseUrl")
+            or raw.get("base_url")
+            or raw.get("baseUrl")
             or os.environ.get("HONCHO_BASE_URL", "").strip()
             or None
         )

--- a/tests/honcho_integration/test_cli.py
+++ b/tests/honcho_integration/test_cli.py
@@ -1,6 +1,12 @@
 """Tests for Honcho CLI helpers."""
 
-from honcho_integration.cli import _resolve_api_key
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from honcho_integration.client import HonchoClientConfig
+from honcho_integration.cli import _resolve_api_key, _validate_connection, cmd_status
 
 
 class TestResolveApiKey:
@@ -26,4 +32,44 @@ class TestResolveApiKey:
         monkeypatch.setenv("HONCHO_API_KEY", "env-key")
         assert _resolve_api_key({}) == "env-key"
         monkeypatch.delenv("HONCHO_API_KEY", raising=False)
+
+
+class TestValidateConnection:
+    def test_runs_real_session_validation_path(self):
+        cfg = HonchoClientConfig(api_key="***", enabled=True, peer_name="damien")
+        mock_client = MagicMock()
+        mock_manager = MagicMock()
+
+        with (
+            patch("honcho_integration.client.reset_honcho_client") as mock_reset,
+            patch("honcho_integration.client.get_honcho_client", return_value=mock_client) as mock_get_client,
+            patch("honcho_integration.session.HonchoSessionManager", return_value=mock_manager) as mock_manager_cls,
+        ):
+            _validate_connection(cfg)
+
+        mock_reset.assert_called_once_with()
+        mock_get_client.assert_called_once_with(cfg)
+        mock_manager_cls.assert_called_once_with(
+            honcho=mock_client,
+            config=cfg,
+            context_tokens=cfg.context_tokens,
+        )
+        mock_manager.get_or_create.assert_called_once_with(cfg.resolve_session_name())
+
+
+class TestCmdStatus:
+    def test_reports_failed_real_connection_validation(self, capsys):
+        cfg = HonchoClientConfig(api_key="***", enabled=True, peer_name="damien")
+
+        with (
+            patch.dict(sys.modules, {"honcho": MagicMock()}),
+            patch("honcho_integration.cli._read_config", return_value={"apiKey": "***"}),
+            patch("honcho_integration.cli._config_path", return_value=Path("/tmp/config.json")),
+            patch("honcho_integration.client.HonchoClientConfig.from_global_config", return_value=cfg),
+            patch("honcho_integration.cli._validate_connection", side_effect=RuntimeError("boom")),
+        ):
+            cmd_status(SimpleNamespace())
+
+        output = capsys.readouterr().out
+        assert "Connection... FAILED (boom)" in output
 

--- a/tests/honcho_integration/test_client.py
+++ b/tests/honcho_integration/test_client.py
@@ -223,8 +223,8 @@ class TestFromGlobalConfig:
             config = HonchoClientConfig.from_global_config(config_path=config_file)
         assert config.base_url == "http://config-host:9000"
 
-    def test_base_url_not_read_from_host_block(self, tmp_path):
-        """baseUrl is a root-level connection setting, not overridable per-host (consistent with apiKey)."""
+    def test_base_url_from_host_block_camel_case(self, tmp_path):
+        """Host-level baseUrl should be honored for self-hosted Honcho."""
         config_file = tmp_path / "config.json"
         config_file.write_text(json.dumps({
             "baseUrl": "http://root:9000",
@@ -232,7 +232,25 @@ class TestFromGlobalConfig:
         }))
 
         config = HonchoClientConfig.from_global_config(config_path=config_file)
-        assert config.base_url == "http://root:9000"
+        assert config.base_url == "http://host-block:9001"
+
+    def test_base_url_from_host_block_snake_case(self, tmp_path):
+        """Host-level base_url should also be honored for self-hosted Honcho."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "hosts": {"hermes": {"base_url": "http://host-block:9001"}},
+        }))
+
+        config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.base_url == "http://host-block:9001"
+
+    def test_base_url_from_root_snake_case(self, tmp_path):
+        """Root-level base_url should be accepted as an alias for baseUrl."""
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({"base_url": "http://root-snake:9000"}))
+
+        config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.base_url == "http://root-snake:9000"
 
 
 class TestResolveSessionName:


### PR DESCRIPTION
Support host-level and snake_case Honcho base URL configuration so local and
self-hosted Hermes setups can resolve hosts.hermes.base_url/baseUrl
correctly.

Also make honcho status/setup validate a real session path instead of only
constructing the SDK client, and add regression coverage for both behaviors.

Co-Authored-By: Hermes Agent <no-reply@example.com>
