### PR TITLE
fix(security): add missing GitHub OAuth token patterns and snapshot redact flag

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -13,11 +13,19 @@ import re
 
 logger = logging.getLogger(__name__)
 
+# Snapshot at import time so runtime env mutations (e.g. LLM-generated
+# `export HERMES_REDACT_SECRETS=false`) cannot disable redaction mid-session.
+_REDACT_ENABLED = os.getenv("HERMES_REDACT_SECRETS", "").lower() not in ("0", "false", "no", "off")
+
 # Known API key prefixes -- match the prefix + contiguous token chars
 _PREFIX_PATTERNS = [
     r"sk-[A-Za-z0-9_-]{10,}",           # OpenAI / OpenRouter / Anthropic (sk-ant-*)
     r"ghp_[A-Za-z0-9]{10,}",            # GitHub PAT (classic)
     r"github_pat_[A-Za-z0-9_]{10,}",    # GitHub PAT (fine-grained)
+    r"gho_[A-Za-z0-9]{10,}",            # GitHub OAuth access token
+    r"ghu_[A-Za-z0-9]{10,}",            # GitHub user-to-server token
+    r"ghs_[A-Za-z0-9]{10,}",            # GitHub server-to-server token
+    r"ghr_[A-Za-z0-9]{10,}",            # GitHub refresh token
     r"xox[baprs]-[A-Za-z0-9-]{10,}",    # Slack tokens
     r"AIza[A-Za-z0-9_-]{30,}",          # Google API keys
     r"pplx-[A-Za-z0-9]{10,}",           # Perplexity
@@ -109,7 +117,7 @@ def redact_sensitive_text(text: str) -> str:
         text = str(text)
     if not text:
         return text
-    if os.getenv("HERMES_REDACT_SECRETS", "").lower() in ("0", "false", "no", "off"):
+    if not _REDACT_ENABLED:
         return text
 
     # Known prefixes (sk-, ghp_, etc.)


### PR DESCRIPTION
## What does this PR do?

Two gaps in `agent/redact.py` left GitHub App and Copilot auth tokens unredacted.

**1. Missing GitHub token prefixes**

GitHub issues four token types; only two were in `_PREFIX_PATTERNS`:

| Prefix | Type | Before |
|--------|------|--------|
| `ghp_` | PAT (classic) | present |
| `github_pat_` | PAT (fine-grained) | present |
| `gho_` | OAuth access token | **missing** |
| `ghu_` | User-to-server token | **missing** |
| `ghs_` | Server-to-server token | **missing** |
| `ghr_` | Refresh token | **missing** |

All four missing types are produced by GitHub App and Copilot auth flows (`hermes_cli/copilot_auth.py`) and can appear in logs and tool output.

**2. Runtime env override could disable redaction**

`HERMES_REDACT_SECRETS` was re-read via `os.getenv()` on every `redact_sensitive_text()` call. An LLM-generated shell command (`export HERMES_REDACT_SECRETS=false`) could disable all secret masking for the rest of the session. The flag is now snapshotted at module import time as `_REDACT_ENABLED`.

> Note: ElevenLabs, Tavily and Exa patterns are already covered by #3920 which merged into main. This PR only adds the GitHub OAuth token patterns and the snapshot fix.

## Related Issue

Fixes #3971

## Type of Change

- [x] 🔒 Security fix
- [x] ✅ Tests

## Changes Made

- `agent/redact.py`: add `gho_`, `ghu_`, `ghs_`, `ghr_` prefix patterns
- `agent/redact.py`: replace per-call `os.getenv()` check with module-level `_REDACT_ENABLED` constant

## How to Test

1. `source .venv/bin/activate`
2. `pytest tests/agent/test_redact.py -q` — 38 tests, all pass
3. Spot check:
```python
from agent.redact import redact_sensitive_text
assert "abc123" not in redact_sensitive_text("gho_abc123defghijklmnop")
assert "abc123" not in redact_sensitive_text("ghu_abc123defghijklmnop")
assert "abc123" not in redact_sensitive_text("ghs_abc123defghijklmnop")
assert "abc123" not in redact_sensitive_text("ghr_abc123defghijklmnop")
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs — #3920 (ElevenLabs/Tavily/Exa) already merged, this adds the remaining gap
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/agent/test_redact.py -q` — 38 passed
- [ ] I've added tests for new patterns (covered by existing test infrastructure)
- [x] I've tested on my platform: macOS 

### Documentation & Housekeeping

- [x] N/A — no config keys or docs changed