### PR TITLE
fix(memory): add win file locking support via msvcrt

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -1,6 +1,9 @@
 """Tests for tools/memory_tool.py — MemoryStore, security scanning, and tool dispatcher."""
 
 import json
+import sys
+import threading
+import time
 import pytest
 from pathlib import Path
 
@@ -8,6 +11,8 @@ from tools.memory_tool import (
     MemoryStore,
     memory_tool,
     _scan_memory_content,
+    fcntl,
+    msvcrt,
     ENTRY_DELIMITER,
     MEMORY_SCHEMA,
 )
@@ -255,3 +260,121 @@ class TestMemoryToolDispatcher:
     def test_remove_requires_old_text(self, store):
         result = json.loads(memory_tool(action="remove", store=store))
         assert result["success"] is False
+
+
+# =========================================================================
+# Cross-platform file locking
+# =========================================================================
+
+class TestFileLockBasic:
+    def test_lock_acquired_and_released(self, tmp_path):
+        target = tmp_path / "test.md"
+        target.write_text("hello", encoding="utf-8")
+
+        with MemoryStore._file_lock(target):
+            pass
+
+        assert target.read_text(encoding="utf-8") == "hello"
+
+    def test_lock_file_created(self, tmp_path):
+        target = tmp_path / "test.md"
+        target.write_text("hello", encoding="utf-8")
+
+        with MemoryStore._file_lock(target):
+            lock_path = target.with_suffix(target.suffix + ".lock")
+            assert lock_path.exists()
+
+    def test_repeated_lock_cycles(self, tmp_path):
+        target = tmp_path / "test.md"
+        target.write_text("data", encoding="utf-8")
+
+        for _ in range(5):
+            with MemoryStore._file_lock(target):
+                pass
+
+        assert target.read_text(encoding="utf-8") == "data"
+
+
+class TestFileLockPlatformModules:
+    def test_exactly_one_backend_available(self):
+        assert fcntl is not None or msvcrt is not None, (
+            "Neither fcntl nor msvcrt is available — file locking broken"
+        )
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only")
+    def test_windows_uses_msvcrt(self):
+        assert msvcrt is not None, "msvcrt should be available on Windows"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Unix-only")
+    def test_unix_uses_fcntl(self):
+        assert fcntl is not None, "fcntl should be available on Unix"
+
+
+@pytest.mark.skipif(msvcrt is None, reason="msvcrt not available on this platform")
+class TestFileLockMsvcrtEdgeCases:
+    """Windows msvcrt.locking quirks — skipped entirely on non-Windows."""
+
+    def test_lock_file_has_content_on_windows(self, tmp_path):
+        """msvcrt.locking requires the file to have at least 1 byte."""
+        target = tmp_path / "test.md"
+        target.write_text("data", encoding="utf-8")
+        lock_path = target.with_suffix(target.suffix + ".lock")
+
+        with MemoryStore._file_lock(target):
+            assert lock_path.stat().st_size > 0, (
+                "Lock file must have content for msvcrt.locking"
+            )
+
+    def test_lock_file_created_with_content_even_when_empty(self, tmp_path):
+        """Lock file is seeded with content even if it doesn't exist yet."""
+        target = tmp_path / "test.md"
+        target.write_text("data", encoding="utf-8")
+        lock_path = target.with_suffix(target.suffix + ".lock")
+
+        if lock_path.exists():
+            lock_path.unlink()
+
+        with MemoryStore._file_lock(target):
+            assert lock_path.exists()
+            assert lock_path.stat().st_size > 0
+
+
+class TestFileLockExclusion:
+    def test_lock_excludes_concurrent_access(self, tmp_path):
+        target = tmp_path / "test.md"
+        target.write_text("data", encoding="utf-8")
+
+        acquired = []
+        blocked = threading.Event()
+        release = threading.Event()
+
+        def try_lock():
+            with MemoryStore._file_lock(target):
+                acquired.append(True)
+                blocked.set()
+                release.wait(timeout=5)
+
+        t = threading.Thread(target=try_lock, daemon=True)
+        t.start()
+
+        assert blocked.wait(timeout=3), "Background thread did not acquire lock in time"
+
+        start = time.monotonic()
+        got_it = False
+
+        def delayed_release():
+            time.sleep(0.3)
+            release.set()
+
+        threading.Thread(target=delayed_release, daemon=True).start()
+
+        with MemoryStore._file_lock(target):
+            got_it = True
+            elapsed = time.monotonic() - start
+
+        assert got_it
+        assert elapsed >= 0.2, (
+            f"Lock acquired too quickly ({elapsed:.3f}s) — likely not exclusive"
+        )
+
+        t.join(timeout=5)

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -23,7 +23,6 @@ Design:
 - Frozen snapshot pattern: system prompt is stable, tool responses show live state
 """
 
-import fcntl
 import json
 import logging
 import os
@@ -33,6 +32,16 @@ from contextlib import contextmanager
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Dict, Any, List, Optional
+
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
+
+try:
+    import msvcrt
+except ImportError:
+    msvcrt = None
 
 logger = logging.getLogger(__name__)
 
@@ -133,12 +142,27 @@ class MemoryStore:
         """
         lock_path = path.with_suffix(path.suffix + ".lock")
         lock_path.parent.mkdir(parents=True, exist_ok=True)
-        fd = open(lock_path, "w")
+
+        if msvcrt and (not lock_path.exists() or lock_path.stat().st_size == 0):
+            lock_path.write_text(" ", encoding="utf-8")
+
+        fd = open(lock_path, "r+" if msvcrt else "w")
         try:
-            fcntl.flock(fd, fcntl.LOCK_EX)
+            if fcntl:
+                fcntl.flock(fd, fcntl.LOCK_EX)
+            else:
+                fd.seek(0)
+                msvcrt.locking(fd.fileno(), msvcrt.LK_LOCK, 1)
             yield
         finally:
-            fcntl.flock(fd, fcntl.LOCK_UN)
+            if fcntl:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            else:
+                try:
+                    fd.seek(0)
+                    msvcrt.locking(fd.fileno(), msvcrt.LK_UNLCK, 1)
+                except (OSError, IOError):
+                    pass
             fd.close()
 
     @staticmethod


### PR DESCRIPTION
## What does this PR do?

fixes: https://github.com/NousResearch/hermes-agent/issues/3992

adds win support for file locking in `tools/memory_tool.py`. The memory tool uses `fcntl.flock` for file locking during read-modify-write operations on `MEMORY.md` and `USER.md`, but `fcntl` is unix-only and doesn't exist on windows, so we get an `ImportError` at import time and preventing the memory tool from loading entirely.

On unix-like - no behavior change, `fcntl` path is unchanged

## Related Issue

N/A — discovered during install on native windows.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/memory_tool.py`
  - Replaced bare `import fcntl` with `try/except ImportError` guards for both `fcntl` and `msvcrt`
  - Updated `_file_lock()` to use `msvcrt.locking` on Windows with the required 1-byte file content, `r+` mode, and `seek(0)` before lock/unlock calls
  - Added `except (OSError, IOError)` guard around unlock on Windows (matching `auth.py`)

## How to Test

- Trigger hermes to save the memory on win (you can just ask to save it)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, feat(scope):, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] N/A — I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [x] N/A — I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [x] N/A — I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] N/A — I've updated tool descriptions/schemas if I changed tool behavior — or N/A

