### PR TITLE
feat: add Fireworks context length detection support

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -176,6 +176,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "api.deepseek.com": "deepseek",
     "api.githubcopilot.com": "copilot",
     "models.github.ai": "copilot",
+    "api.fireworks.ai": "fireworks",
 }
 
 

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -43,6 +43,7 @@ PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "opencode-zen": "opencode",
     "opencode-go": "opencode-go",
     "kilocode": "kilo",
+    "fireworks": "fireworks",
 }
 
 


### PR DESCRIPTION
## Summary

Adds automatic context length detection for Fireworks-hosted models.

## Changes

- Add "api.fireworks.ai" URL mapping to "_URL_TO_PROVIDER" for automatic provider detection from base URL
- Add "fireworks" to "PROVIDER_TO_MODELS_DEV" mapping for models.dev registry lookup

## Problem Solved

Previously, models served via Fireworks (e.g., "accounts/fireworks/routers/kimi-k2p5-turbo") would default to 128K context because:
1. Fireworks URL wasn't in the provider mapping
2. Fireworks wasn't mapped for models.dev registry lookup

## Result

Fireworks models now get their correct context length from the models.dev registry instead of falling back to the 128K default.

## Test Plan

- [ ] Verify context length detection works for Fireworks-hosted models
- [ ] Confirm no regressions for other providers