### PR TITLE
feat: add /yolo slash command to toggle dangerous command approvals

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3836,6 +3836,8 @@ class HermesCLI:
             self.console.print(f"  Status bar {state}")
         elif canonical == "verbose":
             self._toggle_verbose()
+        elif canonical == "yolo":
+            self._toggle_yolo()
         elif canonical == "reasoning":
             self._handle_reasoning_command(cmd_original)
         elif canonical == "compress":
@@ -4433,6 +4435,17 @@ class HermesCLI:
             "verbose": f"{_Colors.BOLD}{_Colors.GREEN}Tool progress: VERBOSE{_Colors.RESET} — full args, results, think blocks, and debug logs.",
         }
         _cprint(labels.get(self.tool_progress_mode, ""))
+
+    def _toggle_yolo(self):
+        """Toggle YOLO mode — skip all dangerous command approval prompts."""
+        import os
+        current = bool(os.environ.get("HERMES_YOLO_MODE"))
+        if current:
+            os.environ.pop("HERMES_YOLO_MODE", None)
+            self.console.print("  ⚠ YOLO mode [bold red]OFF[/] — dangerous commands will require approval.")
+        else:
+            os.environ["HERMES_YOLO_MODE"] = "1"
+            self.console.print("  ⚡ YOLO mode [bold green]ON[/] — all commands auto-approved. Use with caution.")
 
     def _handle_reasoning_command(self, cmd: str):
         """Handle /reasoning — manage effort level and display toggle.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1830,6 +1830,9 @@ class GatewayRunner:
         if canonical == "verbose":
             return await self._handle_verbose_command(event)
 
+        if canonical == "yolo":
+            return await self._handle_yolo_command(event)
+
         if canonical == "provider":
             return await self._handle_provider_command(event)
         
@@ -3998,6 +4001,16 @@ class GatewayRunner:
             return f"🧠 ✓ Reasoning effort set to `{effort}` (saved to config)\n_(takes effect on next message)_"
         else:
             return f"🧠 ✓ Reasoning effort set to `{effort}` (this session only)"
+
+    async def _handle_yolo_command(self, event: MessageEvent) -> str:
+        """Handle /yolo — toggle dangerous command approval bypass."""
+        current = bool(os.environ.get("HERMES_YOLO_MODE"))
+        if current:
+            os.environ.pop("HERMES_YOLO_MODE", None)
+            return "⚠️ YOLO mode **OFF** — dangerous commands will require approval."
+        else:
+            os.environ["HERMES_YOLO_MODE"] = "1"
+            return "⚡ YOLO mode **ON** — all commands auto-approved. Use with caution."
 
     async def _handle_verbose_command(self, event: MessageEvent) -> str:
         """Handle /verbose command — cycle tool progress display mode.

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -90,6 +90,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("verbose", "Cycle tool progress display: off -> new -> all -> verbose",
                "Configuration", cli_only=True,
                gateway_config_gate="display.tool_progress_command"),
+    CommandDef("yolo", "Toggle YOLO mode (skip all dangerous command approvals)",
+               "Configuration"),
     CommandDef("reasoning", "Manage reasoning effort and display", "Configuration",
                args_hint="[level|show|hide]",
                subcommands=("none", "low", "minimal", "medium", "high", "xhigh", "show", "hide", "on", "off")),


### PR DESCRIPTION
## Summary

Adds `/yolo` as a slash command for both CLI and gateway platforms. Toggles `HERMES_YOLO_MODE` at runtime — when on, all dangerous command approvals are skipped.

## Usage

```
/yolo    →  ⚡ YOLO mode ON — all commands auto-approved. Use with caution.
/yolo    →  ⚠ YOLO mode OFF — dangerous commands will require approval.
```

## Implementation

- **commands.py** — `CommandDef("yolo", ...)` in the registry (Configuration category, available on all platforms)
- **cli.py** — `_toggle_yolo()` sets/clears `HERMES_YOLO_MODE` env var
- **gateway/run.py** — `_handle_yolo_command()` same toggle, returns status message

Hooks into the existing approval system — `check_all_command_guards()` in `tools/approval.py` already checks `HERMES_YOLO_MODE` at line 539 and bypasses all prompts when set.

Session-scoped (env var, resets on process end). The existing `--yolo` CLI flag sets the same var at launch time — this just adds mid-session toggle.

## Tests

443 tests pass (commands, gateway, yolo mode, slash command resolution).