### PR TITLE
fix: stricter criteria for skill creation in flush prompt

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -654,9 +654,11 @@ class GatewayRunner:
                 "Review the conversation above and:\n"
                 "1. Save any important facts, preferences, or decisions to memory "
                 "(user profile or your notes) that would be useful in future sessions.\n"
-                "2. If you discovered a reusable workflow or solved a non-trivial "
-                "problem, consider saving it as a skill.\n"
-                "3. If nothing is worth saving, that's fine — just skip.\n\n"
+                "2. Only save a skill if ALL of these are true:\n"
+                "   a) Will be reused within days, not months\n"
+                "   b) Has 5+ distinct steps that are easy to misconfigure\n"
+                "   c) Involves unique knowledge (API quirks, workarounds) not in official docs\n"
+                "   d) NOT a one-off installation or command that will never repeat\n\n"
             )
 
             if _current_memory:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -654,7 +654,7 @@ class GatewayRunner:
                 "Review the conversation above and:\n"
                 "1. Save any important facts, preferences, or decisions to memory "
                 "(user profile or your notes) that would be useful in future sessions.\n"
-                "2. Only save a skill if ALL of these are true:\n"
+                "2. Only save a skill if ANY 3 of these are true:\n"
                 "   a) Will be reused within days, not months\n"
                 "   b) Has 5+ distinct steps that are easy to misconfigure\n"
                 "   c) Involves unique knowledge (API quirks, workarounds) not in official docs\n"

--- a/tests/gateway/test_flush_memory_stale_guard.py
+++ b/tests/gateway/test_flush_memory_stale_guard.py
@@ -219,5 +219,5 @@ class TestFlushPromptStructure:
         flush_prompt = tmp_agent.run_conversation.call_args.kwargs.get("user_message", "")
         assert "automatically reset" in flush_prompt
         assert "Save any important facts" in flush_prompt
-        assert "consider saving it as a skill" in flush_prompt
+        assert "Only save a skill if ANY 3 of these are true" in flush_prompt
         assert "Do NOT respond to the user" in flush_prompt


### PR DESCRIPTION
## Summary

Prevents the flush agent from creating low-value skills like one-off installation workflows.

## Changes

Modified `_flush_memories_for_session()` in `gateway/run.py` — skill creation now requires **ANY 3** of:

1. Will be reused within days, not months
2. Has 5+ distinct steps that are easy to misconfigure
3. Involves unique knowledge (API quirks, workarounds) not in official docs
4. NOT a one-off installation or command that will never repeat

## Rationale

The flush agent (pre-reset memory extraction) was too eager to create skills. A single memos installation was saved despite being a one-off task. These stricter criteria filter out environment-specific one-offs while preserving genuinely reusable workflows.