### PR TITLE
fix(provider): auto+base_url bypasses cloud API when custom endpoint configured

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -319,6 +319,35 @@ def resolve_runtime_provider(
         custom_runtime["requested_provider"] = requested_provider
         return custom_runtime
 
+    # If provider is "auto" (or unset) but config.yaml has an explicit base_url
+    # pointing at a custom/local endpoint (e.g. Ollama at localhost:11434),
+    # route through the OpenAI-compatible resolver instead of letting
+    # resolve_provider() pick up an ANTHROPIC_API_KEY or OPENAI_API_KEY from
+    # the environment and send the request to a cloud API. Fixes #3846.
+    if not explicit_base_url and not explicit_api_key:
+        model_cfg = _get_model_config()
+        cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+        cfg_base_url = str(model_cfg.get("base_url") or "").strip()
+        if cfg_base_url and cfg_provider in ("auto", ""):
+            # Check that base_url isn't one of the well-known cloud API roots
+            # (OpenRouter, Anthropic, OpenAI). If it's something else (Ollama,
+            # LM Studio, vLLM, …) we honour it directly. The full detection
+            # logic lives in _resolve_openrouter_runtime; we just skip the
+            # resolve_provider() call so env-var credentials don't shadow it.
+            _known_cloud_prefixes = (
+                "openrouter.ai",
+                "api.anthropic.com",
+                "api.openai.com",
+            )
+            if not any(prefix in cfg_base_url for prefix in _known_cloud_prefixes):
+                runtime = _resolve_openrouter_runtime(
+                    requested_provider=requested_provider,
+                    explicit_api_key=explicit_api_key,
+                    explicit_base_url=explicit_base_url,
+                )
+                runtime["requested_provider"] = requested_provider
+                return runtime
+
     provider = resolve_provider(
         requested_provider,
         explicit_api_key=explicit_api_key,

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -103,6 +103,82 @@ def test_resolve_runtime_provider_auto_uses_custom_config_base_url(monkeypatch):
     assert resolved["base_url"] == "https://custom.example/v1"
 
 
+def test_auto_provider_with_local_base_url_bypasses_anthropic_key(monkeypatch):
+    """provider:auto + base_url:localhost should NOT route to Anthropic even if
+    ANTHROPIC_API_KEY is set in the environment. Regression test for #3846.
+
+    Users running Ollama locally had requests silently sent to Anthropic's API
+    because resolve_provider("auto") picked up ANTHROPIC_API_KEY before the
+    config.yaml base_url was checked.
+    """
+    # ANTHROPIC_API_KEY is present in environment — should be ignored
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fake-key")
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "default": "ollama/minimax-m2.7:cloud",
+            "provider": "auto",
+            "base_url": "http://localhost:11434",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider()
+
+    # Must NOT go to Anthropic's API
+    assert "anthropic.com" not in resolved.get("base_url", ""), (
+        f"Expected custom endpoint, got Anthropic: {resolved}"
+    )
+    assert resolved["base_url"] == "http://localhost:11434"
+    # provider should be custom/openrouter (OpenAI-compat), not anthropic
+    assert resolved["provider"] != "anthropic", (
+        f"Should have routed to custom endpoint, not anthropic: {resolved}"
+    )
+
+
+def test_auto_provider_with_known_cloud_base_url_still_uses_anthropic(monkeypatch):
+    """provider:auto + base_url pointing to Anthropic should still use Anthropic.
+
+    The bypass only applies to non-cloud endpoints.
+    """
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-fake-key")
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "auto",
+            "base_url": "https://api.anthropic.com",
+        },
+    )
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "anthropic")
+    # Mock the anthropic token resolver
+    import hermes_cli.runtime_provider as rp_mod
+    monkeypatch.setattr(
+        rp_mod,
+        "resolve_runtime_provider",
+        lambda **kw: {
+            "provider": "anthropic",
+            "api_mode": "anthropic_messages",
+            "base_url": "https://api.anthropic.com",
+            "api_key": "sk-ant-fake-key",
+            "source": "env",
+            "requested_provider": "auto",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider()
+    assert resolved["provider"] == "anthropic"
+    assert "anthropic.com" in resolved["base_url"]
+
+
 def test_openrouter_key_takes_priority_over_openai_key(monkeypatch):
     """OPENROUTER_API_KEY should be used over OPENAI_API_KEY when both are set.
 


### PR DESCRIPTION
Fixes #3846

## Problem

When `config.yaml` has `provider: auto` and `base_url: http://localhost:11434` (Ollama), requests were silently sent to `https://api.anthropic.com` if `ANTHROPIC_API_KEY` was present in the environment — completely ignoring the configured local endpoint.

User's config:
```yaml
model:
  default: ollama/minimax-m2.7:cloud
  provider: auto
  base_url: http://localhost:11434
fallback_providers: []
```

Error they saw:
```
⚠️ Non-retryable error (HTTP 401) — trying fallback...
⚠️ Error code: 401 - {'error': {'message': 'No cookie auth credentials found', 'code': 401}}
```
And later:
```
📝 Error: HTTP 400: Your credit balance is too low to access the Anthropic API.
   Model: ollama/minimax-m2.7:cloud
   Endpoint: https://api.anthropic.com    ← wrong endpoint
```

## Root Cause

`resolve_provider("auto")` scans environment variables and returns `"anthropic"` when `ANTHROPIC_API_KEY` is set. The `anthropic` branch in `resolve_runtime_provider()` then checks `model.base_url` from config — but only when `cfg_provider == "anthropic"`. Since `cfg_provider` is `"auto"`, `base_url` is ignored and the request goes to `api.anthropic.com`.

## Fix

In `resolve_runtime_provider()`, before calling `resolve_provider()`, check if:
- no explicit provider/key/url override was passed
- `provider` is `"auto"` or unset in config
- a non-cloud `base_url` is explicitly configured

If so, short-circuit directly to `_resolve_openrouter_runtime()` which already handles custom/OpenAI-compatible endpoints (Ollama, LM Studio, vLLM, remote Ollama instances). Well-known cloud API roots (`openrouter.ai`, `api.anthropic.com`, `api.openai.com`) are excluded from the bypass so existing behavior is preserved.

## Tests

Two new tests in `tests/test_runtime_provider_resolution.py`:
- `test_auto_provider_with_local_base_url_bypasses_anthropic_key` — the regression test for #3846
- `test_auto_provider_with_known_cloud_base_url_still_uses_anthropic` — verifies Anthropic path unaffected when base_url targets Anthropic

```
38 passed (36 existing + 2 new)
```

## Workaround for users on current version

Until this is merged, set `provider: custom` explicitly in `~/.hermes/config.yaml`:
```yaml
model:
  default: ollama/minimax-m2.7:cloud
  provider: custom          # ← change from auto to custom
  base_url: http://localhost:11434
```
