### PR TITLE
fix(ci): build and push multi-arch Docker image (linux/amd64 + linux/arm64)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,68 @@
+name: Docker Build and Publish
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Build amd64 only so we can `load` the image for smoke testing.
+      # A second multi-arch build follows on push to main.
+      - name: Build image (amd64, smoke test)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          load: true
+          platforms: linux/amd64
+          tags: nousresearch/hermes-agent:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Test image starts
+        run: |
+          docker run --rm \
+            -v /tmp/hermes-test:/opt/data \
+            --entrypoint /opt/hermes/docker/entrypoint.sh \
+            nousresearch/hermes-agent:test --help
+
+      - name: Log in to Docker Hub
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push multi-arch image (amd64 + arm64)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            nousresearch/hermes-agent:latest
+            nousresearch/hermes-agent:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Closes #3913

## Problem

The `docker-publish.yml` workflow never specified `platforms`, so buildx defaulted to `linux/amd64` only. Users on Apple Silicon (M1/M2/M3) had to rely on Rosetta 2 emulation with no documentation.

## Changes

**`.github/workflows/docker-publish.yml`**

1. **Add `setup-qemu-action@v3`** — enables cross-compilation of `arm64` binaries on the `ubuntu-latest` (amd64) runner via QEMU user-space emulation.

2. **Smoke-test build stays `linux/amd64` only** — `docker/build-push-action` with `load: true` cannot export a multi-arch manifest to the local Docker daemon. The existing test step (`docker run --help`) therefore keeps `platforms: linux/amd64` so it keeps working unchanged.

3. **Push step gains `platforms: linux/amd64,linux/arm64`** — only runs on merge to `main` (same gate as before). Produces a proper multi-arch manifest on Docker Hub; `docker pull` will automatically pick the right layer for the host architecture.

4. **`timeout-minutes: 30 → 60`** — arm64 cross-compilation under QEMU is ~3-4× slower than native; 30 min is tight on a cold cache run.

## Why not a native arm64 runner?

GitHub-hosted arm64 runners are available but not free for open-source projects at this time. QEMU is the standard approach used by most OSS projects (e.g. Home Assistant, Grafana). A comment in the workflow makes the split explicit so it's easy to swap later.

## Testing

The smoke-test step is unchanged and will still run on every PR. The multi-arch push only triggers on `main`, same as before.
