### PR TITLE
fix(security): reject private and loopback IPs in Telegram DoH fallback

### DIFF
--- a/gateway/platforms/telegram_network.py
+++ b/gateway/platforms/telegram_network.py
@@ -135,6 +135,9 @@ def _normalize_fallback_ips(values: Iterable[str]) -> list[str]:
         if addr.version != 4:
             logger.warning("Ignoring non-IPv4 Telegram fallback IP: %s", raw)
             continue
+        if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_unspecified:
+            logger.warning("Ignoring private/internal Telegram fallback IP: %s", raw)
+            continue
         normalized.append(str(addr))
     return normalized
 


### PR DESCRIPTION
## What does this PR do?

`_normalize_fallback_ips()` in `gateway/platforms/telegram_network.py`
only checked that fallback IPs were valid IPv4 addresses. It did not
reject private, loopback, link-local, or unspecified addresses.

A compromised or MITM'd DoH provider (Google/Cloudflare DNS-over-HTTPS)
could inject a private IP such as `169.254.169.254` (AWS metadata service)
or `127.0.0.1` into the fallback list. Hermes would then connect to that
address while preserving the `api.telegram.org` TLS SNI header — an SSRF
attack that could expose cloud instance metadata or internal services.

## Fix

Added a single guard in `_normalize_fallback_ips()`:
```python
if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_unspecified:
    logger.warning("Ignoring private/internal Telegram fallback IP: %s", raw)
    continue
```

This is consistent with the SSRF protection already applied in
`tools/url_safety.py` for web and browser tools.

## Type of Change

- [x] 🔒 Security fix

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] No behavior change for legitimate Telegram IPs
- [x] Consistent with existing SSRF protection in url_safety.py