### PR TITLE
fix(auth): use bearer auth for MiniMax Anthropic endpoints

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -162,6 +162,21 @@ def _is_oauth_token(key: str) -> bool:
     return True
 
 
+def _requires_bearer_auth(base_url: str | None) -> bool:
+    """Return True for Anthropic-compatible providers that require Bearer auth.
+
+    Some third-party /anthropic endpoints implement Anthropic's Messages API but
+    require Authorization: Bearer instead of Anthropic's native x-api-key header.
+    MiniMax's global and China Anthropic-compatible endpoints follow this pattern.
+    """
+    if not base_url:
+        return False
+    normalized = base_url.rstrip("/").lower()
+    return normalized.startswith("https://api.minimax.io/anthropic") or normalized.startswith(
+        "https://api.minimaxi.com/anthropic"
+    )
+
+
 def build_anthropic_client(api_key: str, base_url: str = None):
     """Create an Anthropic client, auto-detecting setup-tokens vs API keys.
 
@@ -180,7 +195,17 @@ def build_anthropic_client(api_key: str, base_url: str = None):
     if base_url:
         kwargs["base_url"] = base_url
 
-    if _is_oauth_token(api_key):
+    if _requires_bearer_auth(base_url):
+        # Some Anthropic-compatible providers (e.g. MiniMax) expect the API key in
+        # Authorization: Bearer even for regular API keys. Route those endpoints
+        # through auth_token so the SDK sends Bearer auth instead of x-api-key.
+        # Check this before OAuth token shape detection because MiniMax secrets do
+        # not use Anthropic's sk-ant-api prefix and would otherwise be misread as
+        # Anthropic OAuth/setup tokens.
+        kwargs["auth_token"] = api_key
+        if _COMMON_BETAS:
+            kwargs["default_headers"] = {"anthropic-beta": ",".join(_COMMON_BETAS)}
+    elif _is_oauth_token(api_key):
         # OAuth access token / setup-token → Bearer auth + Claude Code identity.
         # Anthropic routes OAuth requests based on user-agent and headers;
         # without Claude Code's fingerprint, requests get intermittent 500s.

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -77,9 +77,22 @@ class TestBuildAnthropicClient:
 
     def test_custom_base_url(self):
         with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
-            build_anthropic_client("sk-ant-api03-x", base_url="https://custom.api.com")
+            build_anthropic_client("***", base_url="https://custom.api.com")
             kwargs = mock_sdk.Anthropic.call_args[1]
             assert kwargs["base_url"] == "https://custom.api.com"
+
+    def test_minimax_anthropic_endpoint_uses_bearer_auth_for_regular_api_keys(self):
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client(
+                "minimax-secret-123",
+                base_url="https://api.minimax.io/anthropic",
+            )
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["auth_token"] == "minimax-secret-123"
+            assert "api_key" not in kwargs
+            assert kwargs["default_headers"] == {
+                "anthropic-beta": "interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14"
+            }
 
 
 class TestReadClaudeCodeCredentials:
@@ -88,16 +101,16 @@ class TestReadClaudeCodeCredentials:
         cred_file.parent.mkdir(parents=True)
         cred_file.write_text(json.dumps({
             "claudeAiOauth": {
-                "accessToken": "sk-ant-oat01-token",
-                "refreshToken": "sk-ant-oat01-refresh",
+                "accessToken": "sk-ant...oken",
+                "refreshToken": "sk-ant...resh",
                 "expiresAt": int(time.time() * 1000) + 3600_000,
             }
         }))
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
         creds = read_claude_code_credentials()
         assert creds is not None
-        assert creds["accessToken"] == "sk-ant-oat01-token"
-        assert creds["refreshToken"] == "sk-ant-oat01-refresh"
+        assert creds["accessToken"] == "sk-ant...oken"
+        assert creds["refreshToken"] == "sk-ant...resh"
         assert creds["source"] == "claude_code_credentials_file"
 
     def test_ignores_primary_api_key_for_native_anthropic_resolution(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem

MiniMax's Anthropic-compatible `/anthropic` endpoints were failing with HTTP 401 authentication errors in Hermes gateway sessions even when `MINIMAX_API_KEY` was configured correctly.

The user-visible failure matched MiniMax's auth error exactly:
- `login fail: Please carry the API secret key in the 'Authorization' field of the request header`

This broke Telegram and Discord replies for MiniMax-backed sessions.

## Root Cause

Hermes routes MiniMax through `anthropic_messages` mode, but `build_anthropic_client()` inferred auth mode only from Anthropic token shape:
- native Anthropic API keys -> `x-api-key`
- everything else -> Anthropic OAuth/setup-token bearer flow

MiniMax is Anthropic-compatible at the message API layer, but not at the auth layer. Its `/anthropic` endpoints expect regular API keys via `Authorization: Bearer ...`, not Anthropic's native `x-api-key` header.

Because MiniMax secrets do not use Anthropic's `sk-ant-api` prefix, Hermes could also misclassify them as Anthropic OAuth/setup tokens and attach Claude Code OAuth headers that do not belong on MiniMax requests.

## Fix

- add `_requires_bearer_auth()` to detect Anthropic-compatible providers that require bearer auth
- force MiniMax global and China `/anthropic` endpoints through `auth_token` instead of `api_key`
- keep native Anthropic auth behavior unchanged
- check provider-specific bearer handling before Anthropic OAuth token-shape detection
- add a regression test covering MiniMax's Anthropic endpoint auth path

## Testing

- `uv run --with pytest --with pytest-xdist python -m pytest tests/test_anthropic_adapter.py tests/test_run_agent.py -q -k 'anthropic or minimax'`
  - 118 passed

## Research Notes

Checked the adjacent ecosystem before patching:
- MiniMax's docs show `Authorization: Bearer <key>` for ChatCompletion v2 requests
- `bkerf/claude-code-multi` configures MiniMax with `auth_token`
- `MiniMax-AI/Mini-Agent` explicitly sets `Authorization: Bearer {api_key}` even when using Anthropic's SDK
- OpenClaw has matching bug reports for MiniMax Anthropic-mode 401s caused by incorrect auth-header behavior
