### PR TITLE
feat: add X-Client-Source header to Tavily API requests

### DIFF
--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -183,7 +183,12 @@ def _tavily_request(endpoint: str, payload: dict) -> dict:
     payload["api_key"] = api_key
     url = f"{_TAVILY_BASE_URL}/{endpoint.lstrip('/')}"
     logger.info("Tavily %s request to %s", endpoint, url)
-    response = httpx.post(url, json=payload, timeout=60)
+    response = httpx.post(
+        url,
+        json=payload,
+        timeout=60,
+        headers={"X-Client-Source": "hermes-agent"},
+    )
     response.raise_for_status()
     return response.json()
 


### PR DESCRIPTION
## Summary
- Adds `X-Client-Source: hermes-agent` header to all outbound Tavily API requests
- Enables Tavily to attribute usage to hermes-agent, matching the convention used by their own Python SDK (`tavily-python`) and MCP server (`MCP`)
- Consistent with the existing `x-exa-integration: hermes-agent` header already set for the Exa provider

## Changes
- `tools/web_tools.py`: Pass `headers={"X-Client-Source": "hermes-agent"}` to the `httpx.post()` call in `_tavily_request()`