### PR TITLE
fix: cap Telegram menu at 50 commands — API rejects above ~60

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -623,7 +623,9 @@ class TelegramAdapter(BasePlatformAdapter):
             try:
                 from telegram import BotCommand
                 from hermes_cli.commands import telegram_menu_commands
-                menu_commands, hidden_count = telegram_menu_commands(max_commands=100)
+                # Telegram docs say 100, but setMyCommands returns
+                # BOT_COMMANDS_TOO_MUCH above ~60 due to metadata overhead.
+                menu_commands, hidden_count = telegram_menu_commands(max_commands=50)
                 await self._bot.set_my_commands([
                     BotCommand(name, desc) for name, desc in menu_commands
                 ])

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -381,16 +381,20 @@ def telegram_menu_commands(max_commands: int = 100) -> tuple[list[tuple[str, str
     # directly, but don't clutter the Telegram menu.
     try:
         from agent.skill_commands import get_skill_commands
-        from pathlib import Path
-        # The repo's built-in skills live under <repo>/skills/
-        _repo_skills_dir = str(Path(__file__).resolve().parent.parent / "skills")
+        from tools.skills_tool import SKILLS_DIR
+        # Built-in skills are synced to SKILLS_DIR (~/.hermes/skills/).
+        # Hub-installed skills go into SKILLS_DIR/.hub/.  Exclude .hub/ skills
+        # from the menu — they're user-installed, not repo built-in.
+        _skills_dir = str(SKILLS_DIR.resolve())
+        _hub_dir = str((SKILLS_DIR / ".hub").resolve())
         skill_cmds = get_skill_commands()
         for cmd_key in sorted(skill_cmds):
             info = skill_cmds[cmd_key]
-            # Only include skills whose SKILL.md is in the repo's skills/ dir
             skill_path = info.get("skill_md_path", "")
-            if not skill_path.startswith(_repo_skills_dir):
+            if not skill_path.startswith(_skills_dir):
                 continue
+            if skill_path.startswith(_hub_dir):
+                continue  # hub-installed, not built-in
             name = cmd_key.lstrip("/").replace("-", "_")
             desc = info.get("description", "")
             # Telegram descriptions max 256 chars


### PR DESCRIPTION
Telegram setMyCommands returns BOT_COMMANDS_TOO_MUCH when registering close to 100 commands despite docs claiming 100 limit. Metadata overhead causes rejection above ~60. Cap at 50 for reliability — remaining commands accessible via /commands.