### PR TITLE
fix: fit all 100 commands in Telegram menu with 40-char descriptions

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -623,9 +623,10 @@ class TelegramAdapter(BasePlatformAdapter):
             try:
                 from telegram import BotCommand
                 from hermes_cli.commands import telegram_menu_commands
-                # Telegram docs say 100, but setMyCommands returns
-                # BOT_COMMANDS_TOO_MUCH above ~60 due to metadata overhead.
-                menu_commands, hidden_count = telegram_menu_commands(max_commands=50)
+                # Telegram allows up to 100 commands but has an undocumented
+                # payload size limit.  Skill descriptions are truncated to 40
+                # chars in telegram_menu_commands() to fit 100 commands safely.
+                menu_commands, hidden_count = telegram_menu_commands(max_commands=100)
                 await self._bot.set_my_commands([
                     BotCommand(name, desc) for name, desc in menu_commands
                 ])

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -399,10 +399,10 @@ def telegram_menu_commands(max_commands: int = 100) -> tuple[list[tuple[str, str
                 continue  # hub-installed, not built-in
             name = cmd_key.lstrip("/").replace("-", "_")
             desc = info.get("description", "")
-            # Keep descriptions short for the Telegram menu — long descs
-            # contribute to setMyCommands payload limits.
-            if len(desc) > 100:
-                desc = desc[:97] + "..."
+            # Keep descriptions short — setMyCommands has an undocumented
+            # total payload limit.  40 chars fits 100 commands safely.
+            if len(desc) > 40:
+                desc = desc[:37] + "..."
             all_commands.append((name, desc))
     except Exception:
         pass

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -399,9 +399,10 @@ def telegram_menu_commands(max_commands: int = 100) -> tuple[list[tuple[str, str
                 continue  # hub-installed, not built-in
             name = cmd_key.lstrip("/").replace("-", "_")
             desc = info.get("description", "")
-            # Telegram descriptions max 256 chars
-            if len(desc) > 256:
-                desc = desc[:253] + "..."
+            # Keep descriptions short for the Telegram menu — long descs
+            # contribute to setMyCommands payload limits.
+            if len(desc) > 100:
+                desc = desc[:97] + "..."
             all_commands.append((name, desc))
     except Exception:
         pass


### PR DESCRIPTION
setMyCommands has an undocumented total payload size limit — not just a command count limit. 50 commands with 256-char descriptions failed, 100 with 40-char descriptions works (~5300 total chars). Truncate skill descriptions to 40 chars in the Telegram picker, set cap to 100. Full descriptions available via /commands.