### PR TITLE
fix: banner alignment in installer script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -94,7 +94,7 @@ print_banner() {
     echo ""
     echo -e "${MAGENTA}${BOLD}"
     echo "┌─────────────────────────────────────────────────────────┐"
-    echo "│             ⚕ Hermes Agent Installer                   │"
+    echo "│             ⚕ Hermes Agent Installer                    │"
     echo "├─────────────────────────────────────────────────────────┤"
     echo "│  An open source AI agent by Nous Research.              │"
     echo "└─────────────────────────────────────────────────────────┘"


### PR DESCRIPTION
Installer banner title line was 58 chars, all other lines 59. Adds one missing space.

Cherry-picked from PR #3763 by @theawakener0 with authorship preserved.