### PR TITLE
fix(telegram): enforce require_mention in group chats

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -351,6 +351,11 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     """Apply environment variable overrides to config."""
     
     # Telegram
+    # Telegram require_mention config
+    telegram_cfg = raw.get("telegram", {}) if isinstance(raw, dict) else {}
+    if "require_mention" in telegram_cfg and not os.getenv("TELEGRAM_REQUIRE_MENTION"):
+        os.environ["TELEGRAM_REQUIRE_MENTION"] = str(telegram_cfg["require_mention"]).lower()
+
     telegram_token = os.getenv("TELEGRAM_BOT_TOKEN")
     if telegram_token:
         if Platform.TELEGRAM not in config.platforms:

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -670,6 +670,25 @@ class TelegramAdapter(BasePlatformAdapter):
         if not update.message or not update.message.text:
             return
         
+        # require_mention: in groups, only respond to @mentions or replies to bot
+        msg = update.message
+        if msg.chat.type in ("group", "supergroup"):
+            require_mention = os.getenv("TELEGRAM_REQUIRE_MENTION", "true").lower() not in ("false", "0", "no")
+            if require_mention:
+                bot = context.bot
+                bot_username = bot.username if bot else None
+                is_mentioned = bool(
+                    bot_username and f"@{bot_username}".lower() in (msg.text or "").lower()
+                )
+                is_reply_to_bot = (
+                    msg.reply_to_message is not None
+                    and msg.reply_to_message.from_user is not None
+                    and bot is not None
+                    and msg.reply_to_message.from_user.id == bot.id
+                )
+                if not (is_mentioned or is_reply_to_bot):
+                    return
+
         event = self._build_message_event(update.message, MessageType.TEXT)
         await self.handle_message(event)
     


### PR DESCRIPTION
## What does this PR do?

Telegram gateway was responding to every group message even when `require_mention: true` was set in config.yaml. Gateway-level filtering was missing — only Discord had this implemented.

This PR adds group message filtering in `_handle_text_message()` to only process messages that:
- @mention the bot by username
- are replies to the bot's own messages
- are commands (`/`)

Also wires `telegram.require_mention` config key to `TELEGRAM_REQUIRE_MENTION` env var, matching the existing Discord pattern.

## Related Issue

Fixes #3979

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/telegram.py`: Added require_mention filter in `_handle_text_message()`
- `gateway/config.py`: Wired `telegram.require_mention` config key to env var

## How to Test

1. Add bot to a Telegram group
2. Set `require_mention: true` in config.yaml
3. Send a message without @mentioning the bot → bot should NOT respond
4. Send a message with @botusername → bot should respond
5. Reply to bot's message → bot should respond

## Checklist

- [x] I've read the Contributing Guide
- [x] Commit follows Conventional Commits
- [x] No duplicate PRs
- [x] Tested on Ubuntu 24.04 / WSL2

