### PR TITLE
fix(setup): align max_turns default to 90 across docs and prompts

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -18063,7 +18063,7 @@ def main(
         reasoning: Reasoning effort for this run (none|minimal|low|medium|high|xhigh|max|ultra). Overrides agent.reasoning_effort.
         api_key: API key for authentication
         base_url: Base URL for the API
-        max_turns: Maximum tool-calling iterations (default: 60)
+        max_turns: Maximum tool-calling iterations (default: 90)
         verbose: Enable verbose logging
         compact: Use compact display mode
         list_tools: List available tools and exit


### PR DESCRIPTION
## What does this PR do?

Setup wizard showed inconsistent values for max iterations default:
- `cli.py` docstring said `default: 60`
- `setup.py` info text said `Recommended: 30-60`
- But actual default and `config.py` description both say `90`

This caused confusion during first-time setup (#4018).

Aligned all references to `90` to match the actual default value.

## Related Issue

Fixes #4018

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py`: Updated docstring `default: 60` → `default: 90`
- `hermes_cli/setup.py`: Updated info text to match config.py description

## How to Test

1. Run `hermes setup`
2. Navigate to Agent Settings → Max iterations
3. Verify prompt shows `[90]` and description matches

## Checklist

- [x] I've read the Contributing Guide
- [x] Commit follows Conventional Commits
- [x] No duplicate PRs
- [x] Tested on Ubuntu 24.04 / WSL2