### PR TITLE
fix(gateway): use setsid instead of systemd-run --user for /update

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2642,24 +2642,24 @@ class GatewayRunner:
         }
         pending_path.write_text(json.dumps(pending))
 
-        # Spawn `hermes update` in a separate cgroup so it survives gateway
-        # restart.  systemd-run --user --scope creates a transient scope unit.
+        # Spawn `hermes update` detached so it survives gateway restart.
+        # Use setsid for portable session detach (works under system services
+        # where systemd-run --user fails due to missing D-Bus session).
         update_cmd = f"{hermes_bin} update > {output_path} 2>&1"
         try:
-            systemd_run = shutil.which("systemd-run")
-            if systemd_run:
+            setsid = shutil.which("setsid")
+            if setsid:
+                # Preferred: setsid creates a new session, fully detached
                 subprocess.Popen(
-                    [systemd_run, "--user", "--scope",
-                     "--unit=hermes-update", "--",
-                     "bash", "-c", update_cmd],
+                    [setsid, "bash", "-c", update_cmd],
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
                     start_new_session=True,
                 )
             else:
-                # Fallback: best-effort detach with start_new_session
+                # Fallback: start_new_session=True is sufficient on most systems
                 subprocess.Popen(
-                    ["bash", "-c", f"nohup {update_cmd} &"],
+                    ["bash", "-c", update_cmd],
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
                     start_new_session=True,


### PR DESCRIPTION
## What does this PR do?

`/update` via Telegram silently failed when the gateway ran under a system-level systemd service. `systemd-run --user --scope` requires a user D-Bus session which is unavailable in system service context — the pending file was written but `hermes update` never executed.

Replace with `setsid` which creates a new detached session portably, without requiring D-Bus. Falls back to `start_new_session=True` on systems without `setsid`.

## Related Issue

Fixes #4017

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: Replaced `systemd-run --user --scope` with `setsid` in `_handle_update_command()`

## How to Test

1. Create a system-level systemd service running hermes gateway
2. Send `/update` via Telegram
3. Verify update executes and `.update_exit_code` is written
4. Verify works on user services too (fallback path)

## Checklist

- [x] I've read the Contributing Guide
- [x] Commit follows Conventional Commits
- [x] No duplicate PRs
- [x] Tested on Ubuntu 24.04 / WSL2