### PR TITLE
fix: show correct shell reload instruction for macOS/zsh users

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -699,14 +699,19 @@ install_deps() {
 
     # Install the main package in editable mode with all extras.
     # Try [all] first, fall back to base install if extras have issues.
-    if ! $UV_CMD pip install -e ".[all]" 2>/dev/null; then
+    ALL_INSTALL_LOG=$(mktemp)
+    if ! $UV_CMD pip install -e ".[all]" 2>"$ALL_INSTALL_LOG"; then
         log_warn "Full install (.[all]) failed, trying base install..."
+        log_info "Reason: $(tail -5 "$ALL_INSTALL_LOG" | head -3)"
+        rm -f "$ALL_INSTALL_LOG"
         if ! $UV_CMD pip install -e "."; then
             log_error "Package installation failed."
             log_info "Check that build tools are installed: sudo apt install build-essential python3-dev"
             log_info "Then re-run: cd $INSTALL_DIR && uv pip install -e '.[all]'"
             exit 1
         fi
+    else
+        rm -f "$ALL_INSTALL_LOG"
     fi
 
     log_success "Main package installed"
@@ -1070,7 +1075,14 @@ print_success() {
     echo ""
     echo -e "${YELLOW}⚡ Reload your shell to use 'hermes' command:${NC}"
     echo ""
-    echo "   source ~/.bashrc   # or ~/.zshrc"
+    LOGIN_SHELL="$(basename "${SHELL:-/bin/bash}")"
+    if [ "$LOGIN_SHELL" = "zsh" ]; then
+        echo "   source ~/.zshrc"
+    elif [ "$LOGIN_SHELL" = "bash" ]; then
+        echo "   source ~/.bashrc"
+    else
+        echo "   source ~/.bashrc   # or ~/.zshrc"
+    fi
     echo ""
 
     # Show Node.js warning if auto-install failed


### PR DESCRIPTION
## Summary

A new macOS user installing Hermes via `curl | bash` gets stuck because the installer always shows:

```
source ~/.bashrc   # or ~/.zshrc
```

On macOS (where zsh is the default shell), `~/.bashrc` doesn't exist, so the user gets:
```
source: no such file or directory: /Users/akinsane/.bashrc
```

The installer's `setup_path()` function already detects zsh correctly and writes the PATH export to `~/.zshrc`, but the final `print_success()` instructions were hardcoded to suggest `~/.bashrc`.

## Changes

1. **Shell-aware reload instructions** — `print_success()` now detects `$SHELL` and shows:
   - `source ~/.zshrc` for zsh users (macOS default)
   - `source ~/.bashrc` for bash users
   - Both options for unknown shells

2. **Visible `.[all]` install failure reason** — Previously `2>/dev/null` silenced all error output when the full extras install failed. Now captures stderr to a temp file and shows the last few lines, so users can diagnose the failure.

## Reported by
User akinsane on macOS (Mac Mini, ARM)