### PR TITLE
feat(prompt): add Gemini-specific operational guidance

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -187,7 +187,29 @@ TOOL_USE_ENFORCEMENT_GUIDANCE = (
 
 # Model name substrings that trigger tool-use enforcement guidance.
 # Add new patterns here when a model family needs explicit steering.
-TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex")
+TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex", "gemini")
+
+# Gemini-specific operational guidance, adapted from OpenCode's gemini.txt.
+# Injected alongside TOOL_USE_ENFORCEMENT_GUIDANCE when the model is Gemini.
+GEMINI_OPERATIONAL_GUIDANCE = (
+    "# Gemini operational directives\n"
+    "Follow these operational rules strictly:\n"
+    "- **Absolute paths:** Always construct and use absolute file paths for all "
+    "file system operations. Combine the project root with relative paths.\n"
+    "- **Verify first:** Use read_file/search_files to check file contents and "
+    "project structure before making changes. Never guess at file contents.\n"
+    "- **Dependency checks:** Never assume a library is available. Check "
+    "package.json, requirements.txt, Cargo.toml, etc. before importing.\n"
+    "- **Conciseness:** Keep explanatory text brief — a few sentences, not "
+    "paragraphs. Focus on actions and results over narration.\n"
+    "- **Parallel tool calls:** When you need to perform multiple independent "
+    "operations (e.g. reading several files), make all the tool calls in a "
+    "single response rather than sequentially.\n"
+    "- **Non-interactive commands:** Use flags like -y, --yes, --non-interactive "
+    "to prevent CLI tools from hanging on prompts.\n"
+    "- **Keep going:** Work autonomously until the task is fully resolved. "
+    "Don't stop with a plan — execute it.\n"
+)
 
 PLATFORM_HINTS = {
     "whatsapp": (

--- a/run_agent.py
+++ b/run_agent.py
@@ -79,6 +79,7 @@ from hermes_constants import OPENROUTER_BASE_URL
 from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY, PLATFORM_HINTS,
     MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, SKILLS_GUIDANCE,
+    GEMINI_OPERATIONAL_GUIDANCE,
 )
 from agent.model_metadata import (
     fetch_model_metadata,
@@ -2602,6 +2603,10 @@ class AIAgent:
                 _inject = any(p in model_lower for p in TOOL_USE_ENFORCEMENT_MODELS)
             if _inject:
                 prompt_parts.append(TOOL_USE_ENFORCEMENT_GUIDANCE)
+                # Gemini-specific operational guidance (conciseness, absolute
+                # paths, parallel tool calls, etc.)
+                if "gemini" in (self.model or "").lower():
+                    prompt_parts.append(GEMINI_OPERATIONAL_GUIDANCE)
 
         # Honcho CLI awareness: tell Hermes about its own management commands
         # so it can refer the user to them rather than reinventing answers.


### PR DESCRIPTION
## Summary

Adds Gemini-specific system prompt guidance adapted from [OpenCode's gemini.txt](https://raw.githubusercontent.com/anomalyco/opencode/refs/heads/dev/packages/opencode/src/session/prompt/gemini.txt). Gemini models now get structured operational directives alongside the existing tool-use enforcement.

## What gets injected (Gemini models only)

- **Absolute paths** — always construct full paths for file operations
- **Verify first** — read_file/search_files before editing, never guess
- **Dependency checks** — check package manifests before importing
- **Conciseness** — brief explanations, focus on actions
- **Parallel tool calls** — independent operations in a single response
- **Non-interactive** — `-y`, `--yes` flags to prevent CLI hangs
- **Keep going** — work autonomously until the task is fully resolved

## Scoping

| Model | Tool-use enforcement | Gemini directives |
|---|---|---|
| Gemini | ✅ | ✅ |
| GPT/Codex | ✅ | ✗ |
| Claude | ✗ | ✗ |
| Auxiliary (any) | ✗ | ✗ |

Auxiliary model calls (vision, compression, session search, etc.) don't go through `_build_system_prompt()` and are completely unaffected.

## Changes
- `agent/prompt_builder.py` — added `GEMINI_OPERATIONAL_GUIDANCE` constant, added `"gemini"` to `TOOL_USE_ENFORCEMENT_MODELS`
- `run_agent.py` — inject Gemini guidance when model name contains "gemini"