### PR TITLE
feat: add /profile slash command to show active profile

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2837,6 +2837,28 @@ class HermesCLI:
         print("  Example: python cli.py --toolsets web,terminal")
         print()
     
+    def _handle_profile_command(self):
+        """Display active profile name and home directory."""
+        from hermes_constants import get_hermes_home, display_hermes_home
+
+        home = get_hermes_home()
+        display = display_hermes_home()
+
+        profiles_parent = Path.home() / ".hermes" / "profiles"
+        try:
+            rel = home.relative_to(profiles_parent)
+            profile_name = str(rel).split("/")[0]
+        except ValueError:
+            profile_name = None
+
+        print()
+        if profile_name:
+            print(f"  Profile: {profile_name}")
+        else:
+            print("  Profile: default")
+        print(f"  Home:    {display}")
+        print()
+
     def show_config(self):
         """Display current configuration with kawaii ASCII art."""
         # Get terminal config from environment (which was set from cli-config.yaml)
@@ -3679,6 +3701,8 @@ class HermesCLI:
             return False
         elif canonical == "help":
             self.show_help()
+        elif canonical == "profile":
+            self._handle_profile_command()
         elif canonical == "tools":
             self._handle_tools_command(cmd_original)
         elif canonical == "toolsets":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1865,6 +1865,9 @@ class GatewayRunner:
         if canonical == "commands":
             return await self._handle_commands_command(event)
         
+        if canonical == "profile":
+            return await self._handle_profile_command(event)
+
         if canonical == "status":
             return await self._handle_status_command(event)
         
@@ -3055,6 +3058,36 @@ class GatewayRunner:
             return f"{header}\n\n{session_info}"
         return header
     
+    async def _handle_profile_command(self, event: MessageEvent) -> str:
+        """Handle /profile — show active profile name and home directory."""
+        from hermes_constants import get_hermes_home, display_hermes_home
+        from pathlib import Path
+
+        home = get_hermes_home()
+        display = display_hermes_home()
+
+        # Detect profile name from HERMES_HOME path
+        # Profile paths look like: ~/.hermes/profiles/<name>
+        profiles_parent = Path.home() / ".hermes" / "profiles"
+        try:
+            rel = home.relative_to(profiles_parent)
+            profile_name = str(rel).split("/")[0]
+        except ValueError:
+            profile_name = None
+
+        if profile_name:
+            lines = [
+                f"👤 **Profile:** `{profile_name}`",
+                f"📂 **Home:** `{display}`",
+            ]
+        else:
+            lines = [
+                "👤 **Profile:** default",
+                f"📂 **Home:** `{display}`",
+            ]
+
+        return "\n".join(lines)
+
     async def _handle_status_command(self, event: MessageEvent) -> str:
         """Handle /status command."""
         source = event.source

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -71,6 +71,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                aliases=("q",), args_hint="<prompt>"),
     CommandDef("status", "Show session info", "Session",
                gateway_only=True),
+    CommandDef("profile", "Show active profile name and home directory", "Info"),
     CommandDef("sethome", "Set this chat as the home channel", "Session",
                gateway_only=True, aliases=("set-home",)),
     CommandDef("resume", "Resume a previously-named session", "Session",


### PR DESCRIPTION
## Summary

Adds `/profile` slash command so users can check which profile they're talking to — works in CLI, Telegram, Discord, Slack, and all other platforms.

### Usage

```
/profile
```

**Output (with profile):**
```
👤 Profile: coder
📂 Home: ~/.hermes/profiles/coder
```

**Output (default, no profile):**
```
👤 Profile: default
📂 Home: ~/.hermes
```

### Changes

- `hermes_cli/commands.py` — added `CommandDef("profile", ...)` in Info category
- `gateway/run.py` — `_handle_profile_command()` handler
- `cli.py` — `_handle_profile_command()` handler

Detection: checks if `HERMES_HOME` is under `~/.hermes/profiles/` to extract the profile name. Falls back to "default" for the base install.

### Verification
- Shows in Telegram bot command menu ✓
- In `GATEWAY_KNOWN_COMMANDS` ✓
- `resolve_command("profile")` resolves correctly ✓
- 79 command + hooks tests pass ✓
