### PR TITLE
fix(setup): default max agent turns to 90 (#4018)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -435,8 +435,8 @@ skills:
 agent:
   # Maximum tool-calling iterations per conversation
   # Higher = more room for complex tasks, but costs more tokens
-  # Recommended: 20-30 for focused tasks, 50-100 for open exploration
-  max_turns: 60
+  # Recommended: Default is 90, which works for most tasks. Use 150+ for open exploration.
+  max_turns: 90
   
   # Enable verbose logging
   verbose: false

--- a/cli.py
+++ b/cli.py
@@ -7525,7 +7525,7 @@ def main(
         provider: Inference provider ("auto", "openrouter", "nous", "openai-codex", "zai", "kimi-coding", "minimax", "minimax-cn")
         api_key: API key for authentication
         base_url: Base URL for the API
-        max_turns: Maximum tool-calling iterations (default: 60)
+        max_turns: Maximum tool-calling iterations (default: 90)
         verbose: Enable verbose logging
         compact: Use compact display mode
         list_tools: List available tools and exit

--- a/environments/benchmarks/tblite/default.yaml
+++ b/environments/benchmarks/tblite/default.yaml
@@ -16,7 +16,7 @@
 
 env:
   enabled_toolsets: ["terminal", "file"]
-  max_agent_turns: 60
+  max_agent_turns: 90
   max_token_length: 32000
   agent_temperature: 0.8
   terminal_backend: "modal"

--- a/environments/benchmarks/tblite/local.yaml
+++ b/environments/benchmarks/tblite/local.yaml
@@ -14,7 +14,7 @@
 
 env:
   enabled_toolsets: ["terminal", "file"]
-  max_agent_turns: 60
+  max_agent_turns: 90
   max_token_length: 32000
   agent_temperature: 0.8
   terminal_backend: "docker"

--- a/environments/benchmarks/tblite/local_vllm.yaml
+++ b/environments/benchmarks/tblite/local_vllm.yaml
@@ -15,7 +15,7 @@
 
 env:
   enabled_toolsets: ["terminal", "file"]
-  max_agent_turns: 60
+  max_agent_turns: 90
   max_token_length: 16000
   agent_temperature: 0.6
   terminal_backend: "docker"

--- a/environments/benchmarks/terminalbench_2/default.yaml
+++ b/environments/benchmarks/terminalbench_2/default.yaml
@@ -15,7 +15,7 @@
 
 env:
   enabled_toolsets: ["terminal", "file"]
-  max_agent_turns: 60
+  max_agent_turns: 90
   max_token_length: 32000
   agent_temperature: 0.8
   terminal_backend: "modal"

--- a/website/docs/developer-guide/environments.md
+++ b/website/docs/developer-guide/environments.md
@@ -442,7 +442,7 @@ Environments can be configured via YAML files passed with `--config`:
 ```yaml
 env:
   enabled_toolsets: ["terminal", "file"]
-  max_agent_turns: 60
+  max_agent_turns: 90
   max_token_length: 32000
   agent_temperature: 0.8
   terminal_backend: "modal"


### PR DESCRIPTION
## What does this PR do?

As described in #4018, there is an inconsistency between 60/90 for max agent turns. I've fixed it to be 90 consistently everywhere it was still at 60.



## Related Issue

Fixes #4018 

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- cli-config.yaml.example: max_turns 60 -> 90
- cli.py: docstring default 60 -> 90
- environments/benchmarks/tblite/default.yaml: max_agent_turns 60 -> 90
- environments/benchmarks/tblite/local.yaml: max_agent_turns 60 -> 90
- environments/benchmarks/tblite/local_vllm.yaml: max_agent_turns 60 -> 90
- environments/benchmarks/terminalbench_2/default.yaml: max_agent_turns 60 -> 90
- website/docs/developer-guide/environments.md: Updated documentation examples for max_agent_turns default to 90

## How to Test

1. Install hermes via `setup-hermes.sh`.
2. Prompt shows 90 in both locations.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (existing PR is incorrect)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've tested on my platform: macOS 15.7.3

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) 
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys 

## Screenshots / Logs

<img width="552" height="86" alt="Screenshot 2026-03-30 at 16 24 17" src="https://github.com/user-attachments/assets/7852fe4c-84ff-4903-a9a9-f14c41ddd3a8" />
