### PR TITLE
fix(cli): ensure on_session_end hook fires on all exit paths

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7445,6 +7445,22 @@ class HermesCLI:
         # Register atexit cleanup so resources are freed even on unexpected exit
         atexit.register(_run_cleanup)
         
+        # Register signal handlers for graceful shutdown on SSH disconnect / SIGTERM
+        def _signal_handler(signum, frame):
+            """Handle SIGHUP/SIGTERM by triggering graceful cleanup."""
+            logger.debug("Received signal %s, triggering graceful shutdown", signum)
+            # The finally block in run_interactive will handle cleanup and on_session_end hook
+            raise KeyboardInterrupt()
+        
+        try:
+            import signal as _signal
+            _signal.signal(_signal.SIGTERM, _signal_handler)
+            # SIGHUP is not available on Windows
+            if hasattr(_signal, 'SIGHUP'):
+                _signal.signal(_signal.SIGHUP, _signal_handler)
+        except Exception:
+            pass  # Signal handlers may fail in restricted environments
+        
         # Install a custom asyncio exception handler that suppresses the
         # "Event loop is closed" RuntimeError from httpx transport cleanup.
         # This is defense-in-depth — the primary fix is neuter_async_httpx_del
@@ -7468,7 +7484,7 @@ class HermesCLI:
                 except Exception:
                     pass
                 app.run()
-        except (EOFError, KeyboardInterrupt):
+        except (EOFError, KeyboardInterrupt, BrokenPipeError):
             pass
         finally:
             self._should_exit = True
@@ -7507,6 +7523,20 @@ class HermesCLI:
                     self._session_db.end_session(self.agent.session_id, "cli_close")
                 except (Exception, KeyboardInterrupt) as e:
                     logger.debug("Could not close session in DB: %s", e)
+            # Plugin hook: on_session_end - fire on Ctrl+C exit too
+            if self.agent:
+                try:
+                    from hermes_cli.plugins import invoke_hook as _invoke_hook
+                    _invoke_hook(
+                        "on_session_end",
+                        session_id=self.agent.session_id,
+                        completed=False,
+                        interrupted=True,
+                        model=getattr(self.agent, 'model', None),
+                        platform=getattr(self.agent, 'platform', None) or "cli",
+                    )
+                except Exception:
+                    pass
             _run_cleanup()
             self._print_exit_summary()
 


### PR DESCRIPTION
## Problem

The `on_session_end` plugin hook was not firing on abrupt CLI exits, causing sessions to remain unindexed in FTS5. This affected three scenarios:

1. **Ctrl+C (KeyboardInterrupt)**: Hook not called, session orphaned in JSON without SQLite index
2. **SSH disconnect (BrokenPipeError)**: Not captured, process died without cleanup  
3. **SIGTERM/SIGHUP (kill/terminal hangup)**: No signal handlers, instant death

## Solution

All exit paths now converge to the same `finally` block that invokes `on_session_end`.

### Changes

- **finally block**: Added `invoke_hook("on_session_end", ...)` with `interrupted=True`
- **except tuple**: Added `BrokenPipeError` alongside `KeyboardInterrupt`
- **Signal handlers**: SIGHUP/SIGTERM now raise `KeyboardInterrupt()` to trigger cleanup

### Flow

All exit paths (Ctrl+C, SSH drop, SIGTERM, SIGHUP, normal exit) now execute the same cleanup sequence including the `on_session_end` hook.

## Testing

- `pytest tests/hermes_cli/ -q`: 755 passed
- `pytest tests/test_plugins.py -q`: 19 passed
- Manual: Verified hook fires on Ctrl+C with test plugin

## Impact

Plugins can now reliably cleanup and sync session state on any exit type, fixing the "orphaned JSON sessions" issue.
