### PR TITLE
fix: rate-limit pairing rejection messages to prevent spam

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1695,6 +1695,11 @@ class GatewayRunner:
             # In DMs: offer pairing code. In groups: silently ignore.
             if source.chat_type == "dm" and self._get_unauthorized_dm_behavior(source.platform) == "pair":
                 platform_name = source.platform.value if source.platform else "unknown"
+                # Rate-limit ALL pairing responses (code or rejection) to
+                # prevent spamming the user with repeated messages when
+                # multiple DMs arrive in quick succession.
+                if self.pairing_store._is_rate_limited(platform_name, source.user_id):
+                    return None
                 code = self.pairing_store.generate_code(
                     platform_name, source.user_id, source.user_name or ""
                 )
@@ -1716,6 +1721,8 @@ class GatewayRunner:
                             "Too many pairing requests right now~ "
                             "Please try again later!"
                         )
+                    # Record rate limit so subsequent messages are silently ignored
+                    self.pairing_store._record_rate_limit(platform_name, source.user_id)
             return None
         
         # PRIORITY handling when an agent is already running for this session.

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -60,6 +60,7 @@ def _make_runner(platform: Platform, config: GatewayConfig):
     runner.adapters = {platform: adapter}
     runner.pairing_store = MagicMock()
     runner.pairing_store.is_approved.return_value = False
+    runner.pairing_store._is_rate_limited.return_value = False
     return runner, adapter
 
 


### PR DESCRIPTION
## Summary

When `generate_code()` returns None (user rate-limited or max pending codes reached), the "Too many pairing requests" message was sent on **every subsequent DM** with no cooldown. A user sending 30 messages would receive 30 identical rejection replies.

Reported by a user on Discord who thought their Hermes was hacked — it sent "Too many pairing requests" to 5 unauthorized WhatsApp contacts 30 times each after updating to 0.6.0.

## Root cause

In `_handle_message()`, the `generate_code()` call has rate limiting (only generates one code per user per cooldown window). But when it returns None, the rejection message has **no rate limiting** — it fires on every single incoming message.

## Fix

- Check `_is_rate_limited()` **before** any pairing response — if rate limited, silently ignore
- Record rate limit after sending a rejection, so subsequent messages are silently ignored

Before: 10 messages from unauthorized user → 1 code + 9 "Too many" replies (10 messages sent)
After: 10 messages from unauthorized user → 1 code + 9 silently ignored (1 message sent)

## Test plan

- [x] 34 pairing/unauthorized tests passing
- [x] Simulated old vs new behavior confirms spam eliminated