### PR TITLE
fix(gateway): read custom_providers context_length in hygiene compression

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2277,6 +2277,29 @@ class GatewayRunner:
                         _hyg_api_key = _hyg_runtime.get("api_key")
                     except Exception:
                         pass
+
+                # Check custom_providers per-model context_length
+                # (same fallback as run_agent.py lines 1171-1189).
+                # Must run after runtime resolution so _hyg_base_url is set.
+                if _hyg_config_context_length is None and _hyg_base_url:
+                    try:
+                        _hyg_custom_providers = _hyg_data.get("custom_providers")
+                        if isinstance(_hyg_custom_providers, list):
+                            for _cp in _hyg_custom_providers:
+                                if not isinstance(_cp, dict):
+                                    continue
+                                _cp_url = (_cp.get("base_url") or "").rstrip("/")
+                                if _cp_url and _cp_url == _hyg_base_url.rstrip("/"):
+                                    _cp_models = _cp.get("models", {})
+                                    if isinstance(_cp_models, dict):
+                                        _cp_model_cfg = _cp_models.get(_hyg_model, {})
+                                        if isinstance(_cp_model_cfg, dict):
+                                            _cp_ctx = _cp_model_cfg.get("context_length")
+                                            if _cp_ctx is not None:
+                                                _hyg_config_context_length = int(_cp_ctx)
+                                    break
+                    except (TypeError, ValueError):
+                        pass
             except Exception:
                 pass
 


### PR DESCRIPTION
Gateway hygiene pre-compression only checked `model.context_length` from config, missing per-model context_length defined in `custom_providers` entries. Custom provider users got the 128K default instead of their configured value, causing premature compression.

**Root cause:** The agent's own compressor reads `custom_providers` correctly (run_agent.py lines 1171-1189), but the gateway's hygiene pre-compression block was missing this fallback.

**Fix:** Adds the same `custom_providers` lookup to the hygiene block, positioned after runtime provider resolution so `base_url` is available for matching.

**Example:** A user with `custom_providers.models.Qwen3.5-35B-A3B.context_length: 200000` was getting hygiene compression at 85% of 128K = 109K instead of 85% of 200K = 170K.

Reported by LauraOP in Discord. 61 gateway compression/hygiene tests pass.