### PR TITLE
feat(api_server): multimodal content support (images + audio)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8642
 MAX_STORED_RESPONSES = 100
-MAX_REQUEST_BYTES = 1_000_000  # 1 MB default limit for POST bodies
+MAX_REQUEST_BYTES = int(os.getenv("API_SERVER_MAX_BODY_MB", "50")) * 1_000_000
 
 
 def check_api_server_requirements() -> bool:
@@ -416,6 +416,127 @@ class APIServerAdapter(BasePlatformAdapter):
         return agent
 
     # ------------------------------------------------------------------
+    # Multimodal content processing
+    # ------------------------------------------------------------------
+
+    async def _process_multimodal_content(self, user_message_content) -> str:
+        """Process multimodal content parts into enriched plain text.
+
+        Replicates the Telegram gateway pattern: images are described via
+        vision_analyze_tool, audio is transcribed via transcribe_audio,
+        and the results are prepended to the text content.
+        """
+        if isinstance(user_message_content, str):
+            return user_message_content
+
+        if not isinstance(user_message_content, list):
+            return str(user_message_content)
+
+        text_parts = []
+        image_descriptions = []
+        audio_transcripts = []
+
+        for part in user_message_content:
+            if not isinstance(part, dict):
+                if isinstance(part, str):
+                    text_parts.append(part)
+                continue
+
+            ptype = part.get("type", "")
+
+            if ptype in ("text", "input_text"):
+                text_parts.append(part.get("text", ""))
+            elif ptype == "image_url":
+                try:
+                    desc = await self._describe_image(part)
+                    if desc:
+                        image_descriptions.append(desc)
+                except Exception as e:
+                    logger.warning("Image processing failed: %s", e)
+                    image_descriptions.append("[The user sent an image but it could not be processed]")
+            elif ptype == "input_audio":
+                try:
+                    transcript = await self._transcribe_audio(part)
+                    if transcript:
+                        audio_transcripts.append(transcript)
+                except Exception as e:
+                    logger.warning("Audio processing failed: %s", e)
+                    audio_transcripts.append("[The user sent a voice message but it could not be processed]")
+
+        enriched = []
+        enriched.extend(image_descriptions)
+        enriched.extend(audio_transcripts)
+        enriched.extend(text_parts)
+        return "\n\n".join(p for p in enriched if p)
+
+    async def _describe_image(self, part: dict) -> Optional[str]:
+        """Describe an image_url content part using the vision tool."""
+        from tools.vision_tools import vision_analyze_tool
+
+        image_url = part.get("image_url", {})
+        url = image_url.get("url", "") if isinstance(image_url, dict) else str(image_url)
+        if not url:
+            return None
+
+        # Base64 data URI → temp file
+        if url.startswith("data:"):
+            import base64 as _b64
+            import tempfile
+            header, b64data = url.split(",", 1)
+            ext = header.split("/")[-1].split(";")[0]
+            raw = _b64.b64decode(b64data)
+            tmp = tempfile.NamedTemporaryFile(suffix=f".{ext}", delete=False)
+            tmp.write(raw)
+            tmp.close()
+            url = tmp.name
+
+        analysis_prompt = (
+            "Describe everything visible in this image in thorough detail. "
+            "Include any text, code, data, objects, people, layout, colors, "
+            "and any other notable visual information."
+        )
+        result_json = await vision_analyze_tool(image_url=url, user_prompt=analysis_prompt)
+        result = json.loads(result_json)
+        if result.get("success"):
+            description = result.get("analysis", "")
+            return (
+                f"[The user sent an image~ Here's what I can see:\n{description}]\n"
+                f"[If you need a closer look, use vision_analyze with image_url: {url} ~]"
+            )
+        return (
+            f"[The user sent an image but vision analysis failed. "
+            f"You can try vision_analyze with image_url: {url} ]"
+        )
+
+    async def _transcribe_audio(self, part: dict) -> Optional[str]:
+        """Transcribe an input_audio content part using the STT pipeline."""
+        from tools.transcription_tools import transcribe_audio
+        import base64 as _b64
+        import tempfile
+
+        audio_data = part.get("input_audio", {})
+        b64data = audio_data.get("data", "")
+        fmt = audio_data.get("format", "wav")
+        if not b64data:
+            return None
+
+        raw = _b64.b64decode(b64data)
+        tmp = tempfile.NamedTemporaryFile(suffix=f".{fmt}", delete=False)
+        tmp.write(raw)
+        tmp.close()
+
+        try:
+            loop = asyncio.get_event_loop()
+            result = await loop.run_in_executor(None, lambda: transcribe_audio(tmp.name))
+        finally:
+            os.unlink(tmp.name)
+
+        if result.get("success"):
+            transcript = result.get("transcript", "")
+            return f'[The user sent a voice message~ Here\'s what they said: "{transcript}"]'
+        return f"[The user sent a voice message but transcription failed: {result.get('error', 'unknown')}]"
+
+    # ------------------------------------------------------------------
     # HTTP Handlers
     # ------------------------------------------------------------------
 
@@ -480,6 +601,11 @@ class APIServerAdapter(BasePlatformAdapter):
                     system_prompt = system_prompt + "\n" + content
             elif role in ("user", "assistant"):
                 conversation_messages.append({"role": role, "content": content})
+
+        # Process multimodal content in the last user message
+        if conversation_messages and conversation_messages[-1].get("role") == "user":
+            last = conversation_messages[-1]
+            last["content"] = await self._process_multimodal_content(last.get("content", ""))
 
         # Extract the last user message as the primary input
         user_message = ""


### PR DESCRIPTION
## Summary

The API server's `/v1/chat/completions` endpoint now handles OpenAI multimodal content arrays (images and audio) instead of silently dropping non-text parts.

- **Body limit**: `MAX_REQUEST_BYTES` raised from 1 MB to 50 MB (configurable via `API_SERVER_MAX_BODY_MB` env var) -- base64-encoded images exceed the old limit, causing 413 rejections
- **Images**: `image_url` content parts are described via `vision_analyze_tool` and enriched as text -- same pattern as the Telegram gateway's `_enrich_message_with_vision()`
- **Audio**: `input_audio` content parts are transcribed via `transcribe_audio()` (Whisper/Groq/OpenAI STT) -- same pattern as the Telegram gateway's `_enrich_message_with_transcription()`
- **Text**: `text`/`input_text` parts pass through as-is; plain string content is unchanged (no regression)

This enables any OpenAI-compatible frontend (Open WebUI, oye, LibreChat, etc.) to send images and voice messages through the API server.

## Test plan

- [ ] Text-only messages work as before (regression)
- [ ] Content array with `text` parts only -- extracted correctly
- [ ] `image_url` with base64 data URI -- vision describes it, agent responds
- [ ] `input_audio` with base64 webm/wav -- STT transcribes, agent responds to transcript
- [ ] Large image (5 MB) doesn't hit body limit
- [ ] Vision/STT failure doesn't crash the request (graceful fallback message)
