### PR TITLE
feat(cli): add /copy command for clipboard markdown export

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2840,6 +2840,91 @@ class HermesCLI:
         killed = process_registry.kill_all()
         print(f"  ✅ Stopped {killed} process(es).")
 
+    @staticmethod
+    def _strip_reasoning_blocks(text: str) -> str:
+        """Remove internal reasoning scratchpad blocks from display/copy text."""
+        import re
+        cleaned = re.sub(
+            r"<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>\s*",
+            "",
+            text,
+            flags=re.DOTALL,
+        )
+        cleaned = re.sub(
+            r"<REASONING_SCRATCHPAD>.*$",
+            "",
+            cleaned,
+            flags=re.DOTALL,
+        )
+        return cleaned.strip()
+
+    def _last_visible_message(self) -> Optional[Dict[str, Any]]:
+        for message in reversed(self.conversation_history):
+            role = message.get("role")
+            if role in {"user", "assistant"}:
+                return message
+        return None
+
+    def _message_markdown_body(self, message: Dict[str, Any]) -> str:
+        content = message.get("content")
+        role = message.get("role", "assistant")
+        text = ""
+        if isinstance(content, list):
+            parts = []
+            for part in content:
+                if not isinstance(part, dict):
+                    continue
+                if part.get("type") == "text":
+                    parts.append(str(part.get("text", "")))
+                elif part.get("type") == "image_url":
+                    image_url = part.get("image_url") or {}
+                    url = image_url.get("url") if isinstance(image_url, dict) else ""
+                    parts.append(f"![attached image]({url})" if url and not str(url).startswith("data:") else "[attached image]")
+            text = "\n\n".join(part.strip() for part in parts if str(part).strip())
+        elif content is not None:
+            text = str(content)
+        if role == "assistant":
+            text = self._strip_reasoning_blocks(text)
+        text = text.strip()
+        if text:
+            return text
+        tool_calls = message.get("tool_calls") or []
+        if tool_calls:
+            names = []
+            for tc in tool_calls:
+                fn = tc.get("function", {}) if isinstance(tc, dict) else {}
+                name = fn.get("name", "unknown") if isinstance(fn, dict) else "unknown"
+                if name not in names:
+                    names.append(name)
+            noun = "call" if len(tool_calls) == 1 else "calls"
+            return f"(requested {len(tool_calls)} tool {noun}: {', '.join(names)})"
+        return ""
+
+    def _format_message_as_markdown(self, message: Dict[str, Any]) -> str:
+        role = message.get("role", "assistant")
+        heading = "Hermes" if role == "assistant" else "You"
+        body = self._message_markdown_body(message)
+        return f"## {heading}\n\n{body}".strip()
+
+    def _handle_copy_command(self):
+        """Handle /copy — copy the last visible chat message as Markdown."""
+        from hermes_cli.clipboard import copy_text_to_clipboard
+
+        message = self._last_visible_message()
+        if message is None:
+            print("(._.) No visible message to copy yet.")
+            return
+
+        markdown = self._format_message_as_markdown(message)
+        if not markdown.strip():
+            print("(._.) The last visible message is empty.")
+            return
+
+        if copy_text_to_clipboard(markdown):
+            print("(^_^)b Copied the last visible message as Markdown.")
+        else:
+            print("(x_x) Couldn't copy to the system clipboard.")
+
     def _handle_paste_command(self):
         """Handle /paste — explicitly check clipboard for an image.
 
@@ -4482,6 +4567,8 @@ class HermesCLI:
             self._show_usage()
         elif canonical == "insights":
             self._show_insights(cmd_original)
+        elif canonical == "copy":
+            self._handle_copy_command()
         elif canonical == "paste":
             self._handle_paste_command()
         elif canonical == "reload-mcp":

--- a/hermes_cli/clipboard.py
+++ b/hermes_cli/clipboard.py
@@ -54,6 +54,14 @@ def has_clipboard_image() -> bool:
     return _xclip_has_image()
 
 
+def copy_text_to_clipboard(text: str) -> bool:
+    """Copy plain text to the system clipboard."""
+    payload = str(text or "")
+    if sys.platform == "darwin":
+        return _macos_copy_text(payload)
+    return _linux_copy_text(payload)
+
+
 # ── macOS ────────────────────────────────────────────────────────────────
 
 def _macos_save(dest: Path) -> bool:
@@ -70,6 +78,22 @@ def _macos_has_image() -> bool:
         )
         return "«class PNGf»" in info.stdout or "«class TIFF»" in info.stdout
     except Exception:
+        return False
+
+
+def _macos_copy_text(text: str) -> bool:
+    """Copy text to the macOS clipboard via pbcopy."""
+    try:
+        result = subprocess.run(
+            ["pbcopy"],
+            input=text,
+            text=True,
+            capture_output=True,
+            timeout=3,
+        )
+        return result.returncode == 0
+    except Exception as e:
+        logger.debug("pbcopy failed: %s", e)
         return False
 
 
@@ -244,6 +268,17 @@ def _linux_save(dest: Path) -> bool:
     return _xclip_save(dest)
 
 
+def _linux_copy_text(text: str) -> bool:
+    """Try text clipboard backends in priority order: WSL → Wayland → X11."""
+    if _is_wsl():
+        if _wsl_copy_text(text):
+            return True
+    if os.environ.get("WAYLAND_DISPLAY"):
+        if _wayland_copy_text(text):
+            return True
+    return _xclip_copy_text(text)
+
+
 # ── WSL2 (powershell.exe) ────────────────────────────────────────────────
 # Reuses _PS_CHECK_IMAGE / _PS_EXTRACT_IMAGE defined above.
 
@@ -260,6 +295,24 @@ def _wsl_has_image() -> bool:
         logger.debug("powershell.exe not found — WSL clipboard unavailable")
     except Exception as e:
         logger.debug("WSL clipboard check failed: %s", e)
+    return False
+
+
+def _wsl_copy_text(text: str) -> bool:
+    """Copy text to the Windows clipboard from WSL."""
+    try:
+        result = subprocess.run(
+            ["clip.exe"],
+            input=text,
+            text=True,
+            capture_output=True,
+            timeout=5,
+        )
+        return result.returncode == 0
+    except FileNotFoundError:
+        logger.debug("clip.exe not found — WSL clipboard unavailable")
+    except Exception as e:
+        logger.debug("WSL clipboard text copy failed: %s", e)
     return False
 
 
@@ -304,8 +357,26 @@ def _wayland_has_image() -> bool:
         )
     except FileNotFoundError:
         logger.debug("wl-paste not installed — Wayland clipboard unavailable")
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug("Wayland clipboard check failed: %s", e)
+    return False
+
+
+def _wayland_copy_text(text: str) -> bool:
+    """Copy text to the clipboard in Wayland sessions."""
+    try:
+        result = subprocess.run(
+            ["wl-copy"],
+            input=text,
+            text=True,
+            capture_output=True,
+            timeout=3,
+        )
+        return result.returncode == 0
+    except FileNotFoundError:
+        logger.debug("wl-copy not installed — Wayland clipboard unavailable")
+    except Exception as e:
+        logger.debug("wl-copy failed: %s", e)
     return False
 
 
@@ -407,11 +478,31 @@ def _xclip_has_image() -> bool:
             ["xclip", "-selection", "clipboard", "-t", "TARGETS", "-o"],
             capture_output=True, text=True, timeout=3,
         )
-        return r.returncode == 0 and "image/png" in r.stdout
+        if r.returncode != 0:
+            return False
+        return any(line.startswith("image/") for line in r.stdout.splitlines())
     except FileNotFoundError:
-        pass
-    except Exception:
-        pass
+        logger.debug("xclip not installed — X11 clipboard unavailable")
+    except Exception as e:
+        logger.debug("xclip clipboard check failed: %s", e)
+    return False
+
+
+def _xclip_copy_text(text: str) -> bool:
+    """Copy text to the clipboard in X11 sessions."""
+    try:
+        result = subprocess.run(
+            ["xclip", "-selection", "clipboard"],
+            input=text,
+            text=True,
+            capture_output=True,
+            timeout=3,
+        )
+        return result.returncode == 0
+    except FileNotFoundError:
+        logger.debug("xclip not installed — X11 clipboard unavailable")
+    except Exception as e:
+        logger.debug("xclip failed: %s", e)
     return False
 
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -136,6 +136,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True, aliases=("gateway",)),
     CommandDef("paste", "Check clipboard for an image and attach it", "Info",
                cli_only=True),
+    CommandDef("copy", "Copy the last visible message to the clipboard as Markdown", "Info",
+               cli_only=True),
     CommandDef("update", "Update Hermes Agent to the latest version", "Info",
                gateway_only=True),
 

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -331,6 +331,32 @@ class TestRootLevelProviderOverride:
         assert "provider" not in result  # root key still cleaned up
 
 
+class TestCopyCommand:
+    def test_copy_command_copies_last_visible_message_as_markdown(self):
+        cli = _make_cli()
+        cli.conversation_history = [
+            {"role": "user", "content": "Can you summarize this?"},
+            {"role": "assistant", "content": "Sure.\n\n- Item 1\n- Item 2"},
+        ]
+
+        with patch("hermes_cli.clipboard.copy_text_to_clipboard", return_value=True) as mock_copy:
+            cli._handle_copy_command()
+
+        mock_copy.assert_called_once_with("## Hermes\n\nSure.\n\n- Item 1\n- Item 2")
+
+    def test_copy_command_reports_when_there_is_no_visible_message(self, capsys):
+        cli = _make_cli()
+        cli.conversation_history = [
+            {"role": "system", "content": "hidden"},
+            {"role": "tool", "content": "hidden"},
+        ]
+
+        cli._handle_copy_command()
+        output = capsys.readouterr().out
+
+        assert "No visible message" in output
+
+
 class TestProviderResolution:
     def test_api_key_is_string_or_none(self):
         cli = _make_cli()

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -127,6 +127,10 @@ class TestDerivedDicts:
         assert "/reload_mcp" in COMMANDS
         assert "/gateway" in COMMANDS
 
+    def test_copy_command_present_with_expected_description(self):
+        assert "/copy" in COMMANDS
+        assert COMMANDS["/copy"] == "Copy the last visible message to the clipboard as Markdown"
+
     def test_commands_by_category_covers_all_categories(self):
         registry_categories = {cmd.category for cmd in COMMAND_REGISTRY if not cmd.gateway_only}
         assert set(COMMANDS_BY_CATEGORY.keys()) == registry_categories


### PR DESCRIPTION
## Summary
- add a `/copy` CLI command that copies the last visible chat message as Markdown
- add cross-platform text clipboard helpers for macOS, WSL, Wayland, and X11
- strip assistant reasoning scratchpad blocks before copying
- add command-registry and lightweight CLI behavior tests

## Why
This makes it easy to export the last visible Hermes reply or user message to the system clipboard in a clean Markdown format without manual selection or copying hidden scratchpad content.

## How to test
- run `pytest tests/hermes_cli/test_commands.py tests/cli/test_cli_init.py -q` (note: `test_cli_init.py` lives under `tests/cli/` after the recent test reorg)
- start `hermes chat`, send a message, then run `/copy` in the CLI
- verify the clipboard receives Markdown like `## Hermes` or `## You` plus the message body
- verify assistant scratchpad content is not copied

## Platforms tested
- macOS (implementation and tests)
- WSL/Wayland/X11 code paths added with platform-specific clipboard backends and existing subprocess patterns