### PR TITLE
fix(cli): align venv wiring and add AI launcher

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ echo 'OPENROUTER_API_KEY=sk-or-v1-your-key' >> ~/.hermes/.env
 ```bash
 # Symlink for global access
 mkdir -p ~/.local/bin
-ln -sf "$(pwd)/venv/bin/hermes" ~/.local/bin/hermes
+ln -sf "$(pwd)/.venv/bin/hermes" ~/.local/bin/hermes
 
 # Verify
 hermes doctor

--- a/ai-launcher.yaml.example
+++ b/ai-launcher.yaml.example
@@ -1,0 +1,40 @@
+defaults:
+  tool: codex
+  profile: safe
+  workspace: ~/projects/hermes-agent
+  mode: interactive
+
+profiles:
+  safe:
+    description: Repo-scoped edits with approvals enabled
+    tool_args:
+      codex: ["--sandbox", "workspace-write", "--ask-for-approval", "on-request"]
+      claude: []
+
+  lab:
+    description: Trusted isolated lab host
+    tool_args:
+      codex: ["--sandbox", "danger-full-access", "--ask-for-approval", "never"]
+      claude: ["--dangerously-skip-permissions"]
+
+  review:
+    description: Read-only/manual review session
+    tool_args:
+      codex: ["--sandbox", "read-only", "--ask-for-approval", "on-request"]
+      claude: []
+
+tools:
+  codex:
+    command: ["codex"]
+    one_shot_prefix: ["exec"]
+
+  claude:
+    command: ["claude"]
+    one_shot_prefix: []
+
+  aider:
+    command: ["aider"]
+    one_shot_prefix: ["--message"]
+
+env:
+  OPENAI_API_KEY: ""

--- a/cli.py
+++ b/cli.py
@@ -1546,7 +1546,7 @@ class HermesCLI:
 
         # 2. Replace untouched default with a Codex model
         if self._model_is_default:
-            fallback_model = "gpt-5.3-codex"
+            fallback_model = "gpt-5.4"
             try:
                 from hermes_cli.codex_models import get_codex_model_ids
 

--- a/hermes_cli/ai_launcher.py
+++ b/hermes_cli/ai_launcher.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+DEFAULT_CONFIG_PATHS = (
+    Path.cwd() / "ai-launcher.yaml",
+    Path.home() / ".hermes" / "ai-launcher.yaml",
+)
+
+DEFAULT_CONFIG: dict[str, Any] = {
+    "defaults": {
+        "tool": "codex",
+        "profile": "safe",
+        "workspace": ".",
+        "mode": "interactive",
+    },
+    "profiles": {
+        "safe": {
+            "description": "Repo-scoped edits with approvals enabled",
+            "tool_args": {
+                "codex": ["--sandbox", "workspace-write", "--ask-for-approval", "on-request"],
+                "claude": [],
+            },
+        },
+        "lab": {
+            "description": "Trusted isolated host with broad access",
+            "tool_args": {
+                "codex": ["--sandbox", "danger-full-access", "--ask-for-approval", "never"],
+                "claude": [],
+            },
+        },
+        "review": {
+            "description": "Read-only or manual-review oriented session",
+            "tool_args": {
+                "codex": ["--sandbox", "read-only", "--ask-for-approval", "on-request"],
+                "claude": [],
+            },
+        },
+    },
+    "tools": {
+        "codex": {
+            "command": ["codex"],
+            "one_shot_prefix": ["exec"],
+            "supports_model_flag": False,
+        },
+        "claude": {
+            "command": ["claude"],
+            "one_shot_prefix": [],
+            "supports_model_flag": False,
+        },
+    },
+}
+
+
+@dataclass(frozen=True)
+class LaunchPlan:
+    command: list[str]
+    env: dict[str, str]
+    workspace: Path
+    mode: str
+    tool: str
+    profile: str
+
+
+def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    merged = dict(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            merged[key] = _deep_merge(base[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def load_launcher_config(config_path: str | None = None) -> tuple[dict[str, Any], Path | None]:
+    config = DEFAULT_CONFIG
+    search_paths = [Path(config_path).expanduser()] if config_path else list(DEFAULT_CONFIG_PATHS)
+    used_path: Path | None = None
+    for path in search_paths:
+        if not path.exists():
+            continue
+        with path.open("r", encoding="utf-8") as handle:
+            loaded = yaml.safe_load(handle) or {}
+        if not isinstance(loaded, dict):
+            raise ValueError(f"Launcher config must be a mapping: {path}")
+        config = _deep_merge(config, loaded)
+        used_path = path
+        break
+    return config, used_path
+
+
+def _choose(prompt: str, options: list[str], default: str) -> str:
+    options_display = ", ".join(options)
+    response = input(f"{prompt} [{options_display}] ({default}): ").strip()
+    if not response:
+        return default
+    if response not in options:
+        raise ValueError(f"Invalid selection '{response}'. Expected one of: {options_display}")
+    return response
+
+
+def _resolve_workspace(value: str | None, defaults: dict[str, Any]) -> Path:
+    raw = value or defaults.get("workspace", ".")
+    return Path(raw).expanduser().resolve()
+
+
+def build_launch_plan(
+    config: dict[str, Any],
+    *,
+    tool: str | None = None,
+    profile: str | None = None,
+    workspace: str | None = None,
+    mode: str | None = None,
+    model: str | None = None,
+    task: str | None = None,
+    extra_args: list[str] | None = None,
+    extra_env: dict[str, str] | None = None,
+) -> LaunchPlan:
+    defaults = config.get("defaults", {})
+    tools = config.get("tools", {})
+    profiles = config.get("profiles", {})
+
+    selected_tool = tool or defaults.get("tool")
+    if selected_tool not in tools:
+        raise ValueError(f"Unknown tool '{selected_tool}'. Available: {sorted(tools)}")
+
+    selected_profile = profile or defaults.get("profile")
+    if selected_profile not in profiles:
+        raise ValueError(f"Unknown profile '{selected_profile}'. Available: {sorted(profiles)}")
+
+    selected_mode = mode or defaults.get("mode", "interactive")
+    if selected_mode not in {"interactive", "one-shot"}:
+        raise ValueError("mode must be 'interactive' or 'one-shot'")
+
+    tool_cfg = tools[selected_tool]
+    profile_cfg = profiles[selected_profile]
+    resolved_workspace = _resolve_workspace(workspace, defaults)
+    command = list(tool_cfg.get("command", []))
+    if not command:
+        raise ValueError(f"Tool '{selected_tool}' is missing a command")
+
+    command.extend(profile_cfg.get("tool_args", {}).get(selected_tool, []))
+    command.extend(tool_cfg.get("extra_args", []))
+    command.extend(profile_cfg.get("extra_args", {}).get(selected_tool, []))
+
+    if model:
+        model_flag = tool_cfg.get("model_flag")
+        if model_flag:
+            command.extend([model_flag, model])
+        elif tool_cfg.get("supports_model_flag"):
+            raise ValueError(f"Tool '{selected_tool}' does not define model_flag")
+
+    if selected_mode == "one-shot":
+        command.extend(tool_cfg.get("one_shot_prefix", []))
+        if task:
+            command.append(task)
+    elif task:
+        raise ValueError("task is only valid with mode='one-shot'")
+
+    if extra_args:
+        command.extend(extra_args)
+
+    env = dict(os.environ)
+    env.update(config.get("env", {}))
+    env.update(tool_cfg.get("env", {}))
+    env.update(profile_cfg.get("env", {}).get(selected_tool, {}))
+    if extra_env:
+        env.update(extra_env)
+
+    return LaunchPlan(
+        command=command,
+        env=env,
+        workspace=resolved_workspace,
+        mode=selected_mode,
+        tool=selected_tool,
+        profile=selected_profile,
+    )
+
+
+def _parse_env_overrides(values: list[str]) -> dict[str, str]:
+    env: dict[str, str] = {}
+    for value in values:
+        if "=" not in value:
+            raise ValueError(f"Invalid env override '{value}'. Expected KEY=VALUE.")
+        key, raw = value.split("=", 1)
+        env[key] = raw
+    return env
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="hermes-ai-launch",
+        description="Small profile-based launcher for Codex, Claude, and similar agent CLIs.",
+    )
+    parser.add_argument("tool", nargs="?")
+    parser.add_argument("profile", nargs="?")
+    parser.add_argument("workspace", nargs="?")
+    parser.add_argument("--config", help="Path to ai-launcher.yaml")
+    parser.add_argument("--mode", choices=["interactive", "one-shot"])
+    parser.add_argument("--task", help="Prompt/task for one-shot runs")
+    parser.add_argument("--model", help="Optional model override if the tool config supports it")
+    parser.add_argument("--dry-run", action="store_true", help="Print the resolved command without executing it")
+    parser.add_argument("--env", action="append", default=[], help="Extra KEY=VALUE env override")
+
+    # parse_known_args allows launcher flags to appear after positional args.
+    # Unknown args are passed through to the target tool (codex/claude/etc.).
+    args, extra_args = parser.parse_known_args(argv)
+    setattr(args, "extra_args", extra_args)
+    return args
+
+
+def _prompt_for_missing(config: dict[str, Any], args: argparse.Namespace) -> None:
+    defaults = config.get("defaults", {})
+    if args.tool:
+        return
+
+    args.tool = _choose("Tool", sorted(config.get("tools", {})), defaults.get("tool", "codex"))
+    args.profile = args.profile or _choose(
+        "Profile",
+        sorted(config.get("profiles", {})),
+        defaults.get("profile", "safe"),
+    )
+    workspace_default = defaults.get("workspace", ".")
+    workspace_input = input(f"Workspace ({workspace_default}): ").strip()
+    args.workspace = args.workspace or workspace_input or workspace_default
+    args.mode = args.mode or _choose("Mode", ["interactive", "one-shot"], defaults.get("mode", "interactive"))
+    if args.mode == "one-shot" and not args.task:
+        args.task = input("Task: ").strip()
+
+
+def format_plan(plan: LaunchPlan) -> str:
+    rendered = " ".join(shlex.quote(part) for part in plan.command)
+    return f"cd {shlex.quote(str(plan.workspace))} && {rendered}"
+
+
+def execute_plan(plan: LaunchPlan, dry_run: bool = False) -> int:
+    print(f"Tool: {plan.tool}")
+    print(f"Profile: {plan.profile}")
+    print(f"Mode: {plan.mode}")
+    print(f"Workspace: {plan.workspace}")
+    print(f"Command: {format_plan(plan)}")
+    if dry_run:
+        return 0
+
+    completed = subprocess.run(plan.command, cwd=plan.workspace, env=plan.env, check=False)
+    return completed.returncode
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    config, used_path = load_launcher_config(args.config)
+    if used_path:
+        print(f"Using config: {used_path}")
+    elif args.config:
+        raise SystemExit(f"Config not found: {args.config}")
+
+    if not args.tool and sys.stdin.isatty():
+        _prompt_for_missing(config, args)
+
+    env_overrides = _parse_env_overrides(args.env)
+    extra_args = list(args.extra_args or [])
+    if extra_args and extra_args[0] == "--":
+        extra_args = extra_args[1:]
+
+    plan = build_launch_plan(
+        config,
+        tool=args.tool,
+        profile=args.profile,
+        workspace=args.workspace,
+        mode=args.mode,
+        model=args.model,
+        task=args.task,
+        extra_args=extra_args,
+        extra_env=env_overrides,
+    )
+    return execute_plan(plan, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ all = [
 hermes = "hermes_cli.main:main"
 hermes-agent = "run_agent:main"
 hermes-acp = "acp_adapter.entry:main"
+hermes-ai-launch = "hermes_cli.ai_launcher:main"
 
 [tool.setuptools]
 py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_constants", "hermes_state", "hermes_time", "rl_cli", "utils"]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -730,7 +730,7 @@ setup_path() {
     log_info "Setting up hermes command..."
 
     if [ "$USE_VENV" = true ]; then
-        HERMES_BIN="$INSTALL_DIR/venv/bin/hermes"
+        HERMES_BIN="$INSTALL_DIR/.venv/bin/hermes"
     else
         HERMES_BIN="$(which hermes 2>/dev/null || echo "")"
         if [ -z "$HERMES_BIN" ]; then
@@ -861,7 +861,7 @@ SOUL_EOF
 
     # Seed bundled skills into ~/.hermes/skills/ (manifest-based, one-time per skill)
     log_info "Syncing bundled skills to ~/.hermes/skills/ ..."
-    if "$INSTALL_DIR/venv/bin/python" "$INSTALL_DIR/tools/skills_sync.py" 2>/dev/null; then
+    if "$INSTALL_DIR/.venv/bin/python" "$INSTALL_DIR/tools/skills_sync.py" 2>/dev/null; then
         log_success "Skills synced to ~/.hermes/skills/"
     else
         # Fallback: simple directory copy if Python sync fails
@@ -950,7 +950,7 @@ run_setup_wizard() {
     # Run hermes setup using the venv Python directly (no activation needed).
     # Redirect stdin from /dev/tty so interactive prompts work when piped from curl.
     if [ "$USE_VENV" = true ]; then
-        "$INSTALL_DIR/venv/bin/python" -m hermes_cli.main setup < /dev/tty
+        "$INSTALL_DIR/.venv/bin/python" -m hermes_cli.main setup < /dev/tty
     else
         python -m hermes_cli.main setup < /dev/tty
     fi

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -99,16 +99,22 @@ fi
 
 echo -e "${CYAN}→${NC} Setting up virtual environment..."
 
-if [ -d "venv" ]; then
-    echo -e "${CYAN}→${NC} Removing old venv..."
-    rm -rf venv
+VENV_DIR=".venv"
+
+if [ -d "venv" ] && [ ! -e "$VENV_DIR" ]; then
+    echo -e "${CYAN}→${NC} Migrating legacy venv path to $VENV_DIR..."
+    mv venv "$VENV_DIR"
 fi
 
-$UV_CMD venv venv --python "$PYTHON_VERSION"
-echo -e "${GREEN}✓${NC} venv created (Python $PYTHON_VERSION)"
+if [ -d "$VENV_DIR" ]; then
+    echo -e "${CYAN}→${NC} Reusing existing $VENV_DIR"
+else
+    $UV_CMD venv "$VENV_DIR" --python "$PYTHON_VERSION"
+    echo -e "${GREEN}✓${NC} $VENV_DIR created (Python $PYTHON_VERSION)"
+fi
 
 # Tell uv to install into this venv (no activation needed for uv)
-export VIRTUAL_ENV="$SCRIPT_DIR/venv"
+export VIRTUAL_ENV="$SCRIPT_DIR/$VENV_DIR"
 
 # ============================================================================
 # Dependencies
@@ -120,7 +126,7 @@ echo -e "${CYAN}→${NC} Installing dependencies..."
 # fall back to pip install for compatibility or when lockfile is stale.
 if [ -f "uv.lock" ]; then
     echo -e "${CYAN}→${NC} Using uv.lock for hash-verified installation..."
-    UV_PROJECT_ENVIRONMENT="$SCRIPT_DIR/venv" $UV_CMD sync --all-extras --locked 2>/dev/null && \
+    UV_PROJECT_ENVIRONMENT="$SCRIPT_DIR/$VENV_DIR" $UV_CMD sync --all-extras --locked 2>/dev/null && \
         echo -e "${GREEN}✓${NC} Dependencies installed (lockfile verified)" || {
         echo -e "${YELLOW}⚠${NC} Lockfile install failed (may be outdated), falling back to pip install..."
         $UV_CMD pip install -e ".[all]" || $UV_CMD pip install -e "."
@@ -212,7 +218,7 @@ fi
 
 echo -e "${CYAN}→${NC} Setting up hermes command..."
 
-HERMES_BIN="$SCRIPT_DIR/venv/bin/hermes"
+HERMES_BIN="$SCRIPT_DIR/$VENV_DIR/bin/hermes"
 mkdir -p "$HOME/.local/bin"
 ln -sf "$HERMES_BIN" "$HOME/.local/bin/hermes"
 echo -e "${GREEN}✓${NC} Symlinked hermes → ~/.local/bin/hermes"
@@ -262,7 +268,7 @@ mkdir -p "$HERMES_SKILLS_DIR"
 
 echo ""
 echo "Syncing bundled skills to ~/.hermes/skills/ ..."
-if "$SCRIPT_DIR/venv/bin/python" "$SCRIPT_DIR/tools/skills_sync.py" 2>/dev/null; then
+if "$SCRIPT_DIR/$VENV_DIR/bin/python" "$SCRIPT_DIR/tools/skills_sync.py" 2>/dev/null; then
     echo -e "${GREEN}✓${NC} Skills synced"
 else
     # Fallback: copy if sync script fails (missing deps, etc.)
@@ -303,5 +309,5 @@ echo
 if [[ $REPLY =~ ^[Yy]$ ]] || [[ -z $REPLY ]]; then
     echo ""
     # Run directly with venv Python (no activation needed)
-    "$SCRIPT_DIR/venv/bin/python" -m hermes_cli.main setup
+    "$SCRIPT_DIR/$VENV_DIR/bin/python" -m hermes_cli.main setup
 fi

--- a/tests/hermes_cli/test_ai_launcher.py
+++ b/tests/hermes_cli/test_ai_launcher.py
@@ -1,0 +1,118 @@
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.ai_launcher import build_launch_plan, format_plan, load_launcher_config, parse_args
+
+
+def test_load_launcher_config_merges_override(tmp_path: Path) -> None:
+    config_path = tmp_path / "ai-launcher.yaml"
+    config_path.write_text(
+        """
+defaults:
+  tool: claude
+profiles:
+  lab:
+    tool_args:
+      claude: ["--dangerously-skip-permissions"]
+tools:
+  claude:
+    command: ["claude"]
+""",
+        encoding="utf-8",
+    )
+
+    config, used_path = load_launcher_config(str(config_path))
+
+    assert used_path == config_path
+    assert config["defaults"]["tool"] == "claude"
+    assert config["profiles"]["safe"]["tool_args"]["codex"] == [
+        "--sandbox",
+        "workspace-write",
+        "--ask-for-approval",
+        "on-request",
+    ]
+    assert config["profiles"]["lab"]["tool_args"]["claude"] == ["--dangerously-skip-permissions"]
+
+
+def test_build_launch_plan_for_codex_one_shot(tmp_path: Path) -> None:
+    config, _ = load_launcher_config()
+
+    plan = build_launch_plan(
+        config,
+        tool="codex",
+        profile="lab",
+        workspace=str(tmp_path),
+        mode="one-shot",
+        task="inspect the repo",
+        extra_args=["--json"],
+        extra_env={"FOO": "bar"},
+    )
+
+    assert plan.command == [
+        "codex",
+        "--sandbox",
+        "danger-full-access",
+        "--ask-for-approval",
+        "never",
+        "exec",
+        "inspect the repo",
+        "--json",
+    ]
+    assert plan.workspace == tmp_path.resolve()
+    assert plan.env["FOO"] == "bar"
+
+
+def test_build_launch_plan_rejects_interactive_task() -> None:
+    config, _ = load_launcher_config()
+
+    with pytest.raises(ValueError, match="task is only valid"):
+        build_launch_plan(
+            config,
+            tool="codex",
+            profile="safe",
+            mode="interactive",
+            task="should fail",
+        )
+
+
+def test_format_plan_quotes_workspace(tmp_path: Path) -> None:
+    config, _ = load_launcher_config()
+    workspace = tmp_path / "space dir"
+    workspace.mkdir()
+
+    plan = build_launch_plan(
+        config,
+        tool="codex",
+        profile="safe",
+        workspace=str(workspace),
+        mode="interactive",
+    )
+
+    rendered = format_plan(plan)
+    assert str(workspace) in rendered
+    assert "codex" in rendered
+
+
+def test_parse_args_accepts_launcher_flags_after_positionals(tmp_path: Path) -> None:
+    args = parse_args(
+        [
+            "codex",
+            "safe",
+            str(tmp_path),
+            "--mode",
+            "one-shot",
+            "--task",
+            "inspect the repo",
+            "--dry-run",
+            "--json",
+        ]
+    )
+
+    assert args.tool == "codex"
+    assert args.profile == "safe"
+    assert args.workspace == str(tmp_path)
+    assert args.mode == "one-shot"
+    assert args.task == "inspect the repo"
+    assert args.dry_run is True
+    assert args.extra_args == ["--json"]

--- a/tests/test_codex_models.py
+++ b/tests/test_codex_models.py
@@ -219,7 +219,7 @@ class TestNormalizeModelForProvider:
         assert cli.model == "gpt-5.3-codex"
 
     def test_default_fallback_when_api_fails(self):
-        """Default model falls back to gpt-5.3-codex when API unreachable."""
+        """Default model falls back to gpt-5.4 when API unreachable."""
         import cli as _cli_mod
         _clean_config = {
             "model": {
@@ -245,4 +245,4 @@ class TestNormalizeModelForProvider:
         ):
             changed = cli._normalize_model_for_provider("openai-codex")
         assert changed is True
-        assert cli.model == "gpt-5.3-codex"
+        assert cli.model == "gpt-5.4"

--- a/website/docs/developer-guide/contributing.md
+++ b/website/docs/developer-guide/contributing.md
@@ -71,7 +71,7 @@ echo 'OPENROUTER_API_KEY=sk-or-v1-your-key' >> ~/.hermes/.env
 ```bash
 # Symlink for global access
 mkdir -p ~/.local/bin
-ln -sf "$(pwd)/venv/bin/hermes" ~/.local/bin/hermes
+ln -sf "$(pwd)/.venv/bin/hermes" ~/.local/bin/hermes
 
 # Verify
 hermes doctor

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -188,7 +188,7 @@ hermes config set OPENROUTER_API_KEY sk-or-v1-your-key-here
 
 ```bash
 mkdir -p ~/.local/bin
-ln -sf "$(pwd)/venv/bin/hermes" ~/.local/bin/hermes
+ln -sf "$(pwd)/.venv/bin/hermes" ~/.local/bin/hermes
 ```
 
 If `~/.local/bin` isn't on your PATH, add it to your shell config:
@@ -250,7 +250,7 @@ echo 'OPENROUTER_API_KEY=sk-or-v1-your-key' >> ~/.hermes/.env
 
 # Make hermes available globally
 mkdir -p ~/.local/bin
-ln -sf "$(pwd)/venv/bin/hermes" ~/.local/bin/hermes
+ln -sf "$(pwd)/.venv/bin/hermes" ~/.local/bin/hermes
 
 # Verify
 hermes doctor


### PR DESCRIPTION
## Summary
- switch install/setup/docs references from `venv` to `.venv` so local/worktree wiring matches current Hermes behavior
- add `hermes-ai-launch` with profile-based launcher config plus tests and example YAML
- prefer `gpt-5.4` as the default Codex fallback when live model discovery is unavailable

## Test Plan
- `uv run --python 3.11 --extra dev pytest tests/hermes_cli/test_ai_launcher.py tests/test_codex_models.py tests/hermes_cli/test_models.py tests/hermes_cli/test_status_model_provider.py -q`

## Notes
- opened from a clean branch based on current `upstream/main` to avoid the noisy history from the previously merged local branch
