### PR TITLE
fix: treat non-sk-ant- prefixed keys (e.g. Azure AI Foundry) as regular API keys

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -152,13 +152,17 @@ def _is_oauth_token(key: str) -> bool:
 
     Regular API keys start with 'sk-ant-api'. Everything else (setup-tokens
     starting with 'sk-ant-oat', managed keys, JWTs, etc.) needs Bearer auth.
+    Azure AI Foundry keys (non sk-ant- prefixed) should use x-api-key, not Bearer.
     """
     if not key:
         return False
     # Regular Console API keys use x-api-key header
     if key.startswith("sk-ant-api"):
         return False
-    # Everything else (setup-tokens, managed keys, JWTs) uses Bearer auth
+    # Azure AI Foundry keys don't start with sk-ant- at all — treat as regular API key
+    if not key.startswith("sk-ant-"):
+        return False
+    # Everything else (setup-tokens sk-ant-oat, managed keys, JWTs) uses Bearer auth
     return True
 
 


### PR DESCRIPTION
## Problem

`_is_oauth_token()` in `agent/anthropic_adapter.py` returns `True` for any key that doesn't start with `sk-ant-api`. This incorrectly classifies Azure AI Foundry keys (which start with arbitrary characters like `82ut...`) as OAuth/setup tokens, causing Hermes to send them with `Authorization: Bearer` instead of `x-api-key`.

Azure AI Foundry's WAF rejects the Bearer header with HTTP 401, making Hermes completely unusable with Azure Anthropic endpoints.

## Fix

Added an explicit early-return for keys that don't start with `sk-ant-` at all — these are third-party provider keys (Azure, AWS Bedrock, etc.) that should always use `x-api-key` auth:

```python
# Azure AI Foundry keys don't start with sk-ant- at all — treat as regular API key
if not key.startswith("sk-ant-"):
    return False
```

## Testing

Verified with Azure AI Foundry endpoint (`services.ai.azure.com/anthropic`) using Sonnet 4.6 — responses successful after fix, 401s before.

## Impact

Anyone using Hermes with Azure Anthropic endpoints (Azure AI Foundry, Azure Government) was getting silent 401 errors and fallback to OpenRouter. This is a one-liner fix.