### PR TITLE
feat: enable mouse support with config toggle

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7303,7 +7303,7 @@ class HermesCLI:
             key_bindings=kb,
             style=style,
             full_screen=False,
-            mouse_support=False,
+            mouse_support=self.config.get("tui", {}).get("mouse_support", False),
             **({'cursor': _STEADY_CURSOR} if _STEADY_CURSOR is not None else {}),
         )
         self._app = app  # Store reference for clarify_callback


### PR DESCRIPTION
Make mouse support configurable via `tui.mouse_support` in config.yaml. Default remains `False` (preserving existing behavior) since enabling mouse capture interferes with terminal multiplexer scrollback (tmux/screen) and terminal-native text selection. Users who want cursor positioning and in-app scrolling can opt in:

```yaml
tui:
  mouse_support: true
```

1 line changed in cli.py.