### PR TITLE
feat: respect NO_COLOR env var and TERM=dumb

### DIFF
--- a/hermes_cli/colors.py
+++ b/hermes_cli/colors.py
@@ -1,6 +1,22 @@
 """Shared ANSI color utilities for Hermes CLI modules."""
 
+import os
 import sys
+
+
+def should_use_color() -> bool:
+    """Return True when colored output is appropriate.
+
+    Respects the NO_COLOR environment variable (https://no-color.org/)
+    and TERM=dumb, in addition to the existing TTY check.
+    """
+    if os.environ.get("NO_COLOR") is not None:
+        return False
+    if os.environ.get("TERM") == "dumb":
+        return False
+    if not sys.stdout.isatty():
+        return False
+    return True
 
 
 class Colors:
@@ -16,7 +32,7 @@ class Colors:
 
 
 def color(text: str, *codes) -> str:
-    """Apply color codes to text (only when output is a TTY)."""
-    if not sys.stdout.isatty():
+    """Apply color codes to text (only when color output is appropriate)."""
+    if not should_use_color():
         return text
     return "".join(codes) + text + Colors.RESET


### PR DESCRIPTION
## Summary

- Add `should_use_color()` function to `hermes_cli/colors.py` that checks `NO_COLOR` ([no-color.org](https://no-color.org/)) and `TERM=dumb` before emitting ANSI escapes
- The existing `color()` helper now delegates to `should_use_color()` instead of a bare `isatty()` check
- All hermes_cli subcommands that import from `colors.py` (status, setup, config, doctor, gateway, cron, uninstall) automatically benefit

## Scope

This PR is the foundation. `cli.py` and `banner.py` still have inline ANSI constants (`_GOLD`, `_BOLD`, etc.) that bypass this module — tracked in #4071.

## Changes

18 lines added, 2 modified in `hermes_cli/colors.py`.

Closes #4066