### PR TITLE
ux: show 'Initializing agent...' on first message

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5560,6 +5560,8 @@ class HermesCLI:
             self.agent = None
 
         # Initialize agent if needed
+        if self.agent is None:
+            _cprint(f"{_DIM}Initializing agent...{_RST}")
         if not self._init_agent(
             model_override=turn_route["model"],
             runtime_override=turn_route["runtime"],


### PR DESCRIPTION
## Summary

- Display a brief status message before the heavy agent initialization (OpenAI client, tool loading, memory, compression setup)
- Only prints when `self.agent is None` (first message or after model switch)
- Users no longer stare at a blank screen for several seconds on first interaction

## Changes

2 lines added to `cli.py`.

Closes #4060