### PR TITLE
ux: show 'Initializing agent...' on first message

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5597,6 +5597,8 @@ class HermesCLI:
             self.agent = None
 
         # Initialize agent if needed
+        if self.agent is None:
+            _cprint(f"{_DIM}Initializing agent...{_RST}")
         if not self._init_agent(
             model_override=turn_route["model"],
             runtime_override=turn_route["runtime"],


### PR DESCRIPTION
Salvage of PR #4080 by @SHL0MS.

Shows a dim "Initializing agent..." message before the heavy first-time agent init (client creation, tool loading, memory, compression). Only fires when `self.agent is None` — first message or after model switch. Subsequent messages skip it.

E2E verified in live PTY session — message appears on first interaction, absent on second.

Closes #4080