### PR TITLE
fix(tools): read api_key and base_url from stt.openai config for local endpoints

### DIFF
--- a/tests/tools/test_transcription.py
+++ b/tests/tools/test_transcription.py
@@ -31,14 +31,16 @@ class TestGetProvider:
         monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "sk-test")
         monkeypatch.delenv("GROQ_API_KEY", raising=False)
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
-             patch("tools.transcription_tools._HAS_OPENAI", True):
+             patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("tools.transcription_tools._has_local_command", return_value=False):
             from tools.transcription_tools import _get_provider
             assert _get_provider({"provider": "local"}) == "none"
 
     def test_local_nothing_available(self, monkeypatch):
         monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
-             patch("tools.transcription_tools._HAS_OPENAI", False):
+             patch("tools.transcription_tools._HAS_OPENAI", False), \
+             patch("tools.transcription_tools._has_local_command", return_value=False):
             from tools.transcription_tools import _get_provider
             assert _get_provider({"provider": "local"}) == "none"
 
@@ -49,12 +51,23 @@ class TestGetProvider:
             assert _get_provider({"provider": "openai"}) == "openai"
 
     def test_explicit_openai_no_key_returns_none(self, monkeypatch):
-        """Explicit openai without key returns none — no cross-provider fallback."""
+        """Explicit openai without env key AND without config key returns none."""
         monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
              patch("tools.transcription_tools._HAS_OPENAI", True):
             from tools.transcription_tools import _get_provider
+            # No env key, no config key — provider must return none
             assert _get_provider({"provider": "openai"}) == "none"
+
+    def test_openai_with_config_api_key(self, monkeypatch):
+        """Config api_key in stt.openai should be accepted when no env key is set."""
+        monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        cfg = {"provider": "openai", "openai": {"api_key": "local-token", "base_url": "http://127.0.0.1:8001/v1"}}
+        with patch("tools.transcription_tools._HAS_OPENAI", True):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider(cfg) == "openai"
 
     def test_default_provider_is_local(self):
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True):
@@ -64,6 +77,38 @@ class TestGetProvider:
     def test_disabled_config_returns_none(self):
         from tools.transcription_tools import _get_provider
         assert _get_provider({"enabled": False, "provider": "openai"}) == "none"
+
+
+# ---------------------------------------------------------------------------
+# API key resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolveOpenAIApiKey:
+    """_resolve_openai_api_key() falls back to config when env vars are absent."""
+
+    def test_env_key_takes_priority(self, monkeypatch):
+        monkeypatch.setenv("VOICE_TOOLS_OPENAI_KEY", "sk-from-env")
+        from tools.transcription_tools import _resolve_openai_api_key
+        assert _resolve_openai_api_key({"openai": {"api_key": "config-key"}}) == "sk-from-env"
+
+    def test_openai_api_key_fallback(self, monkeypatch):
+        monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-fallback")
+        from tools.transcription_tools import _resolve_openai_api_key
+        assert _resolve_openai_api_key({}) == "sk-openai-fallback"
+
+    def test_config_key_fallback(self, monkeypatch):
+        monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        from tools.transcription_tools import _resolve_openai_api_key
+        assert _resolve_openai_api_key({"openai": {"api_key": "config-key"}}) == "config-key"
+
+    def test_no_key_returns_empty(self, monkeypatch):
+        monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        from tools.transcription_tools import _resolve_openai_api_key
+        assert _resolve_openai_api_key({}) == ""
 
 
 # ---------------------------------------------------------------------------
@@ -176,6 +221,48 @@ class TestTranscribeOpenAI:
 
         assert result["success"] is True
         assert result["transcript"] == "Hello from OpenAI"
+
+    def test_config_api_key_and_base_url(self, monkeypatch, tmp_path):
+        """Config stt.openai.api_key and base_url used when no env key is set."""
+        monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        audio_file = tmp_path / "test.ogg"
+        audio_file.write_bytes(b"fake audio")
+
+        mock_client = MagicMock()
+        mock_client.audio.transcriptions.create.return_value = "Hello from local"
+
+        local_cfg = {
+            "provider": "openai",
+            "openai": {
+                "api_key": "local-token",
+                "base_url": "http://127.0.0.1:8001/v1",
+                "model": "whisper-large-v3-turbo",
+            }
+        }
+
+        with patch("tools.transcription_tools._HAS_OPENAI", True), \
+             patch("tools.transcription_tools._load_stt_config", return_value=local_cfg), \
+             patch("openai.OpenAI", return_value=mock_client) as mock_openai_cls:
+            from tools.transcription_tools import _transcribe_openai
+            result = _transcribe_openai(str(audio_file), "whisper-large-v3-turbo")
+
+        assert result["success"] is True
+        assert result["transcript"] == "Hello from local"
+        # Verify it used the config base_url, not the default openai.com one
+        call_kwargs = mock_openai_cls.call_args
+        assert call_kwargs.kwargs.get("base_url") == "http://127.0.0.1:8001/v1"
+        assert call_kwargs.kwargs.get("api_key") == "local-token"
+
+    def test_no_key_anywhere(self, monkeypatch):
+        """No env key and no config key returns error."""
+        monkeypatch.delenv("VOICE_TOOLS_OPENAI_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "openai"}):
+            from tools.transcription_tools import _transcribe_openai
+            result = _transcribe_openai("/tmp/test.ogg", "whisper-1")
+        assert result["success"] is False
+        assert "VOICE_TOOLS_OPENAI_KEY" in result["error"]
 
 
 # ---------------------------------------------------------------------------

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -116,9 +116,15 @@ def is_stt_enabled(stt_config: Optional[dict] = None) -> bool:
     return bool(enabled)
 
 
-def _resolve_openai_api_key() -> str:
-    """Prefer the voice-tools key, but fall back to the normal OpenAI key."""
-    return os.getenv("VOICE_TOOLS_OPENAI_KEY", "") or os.getenv("OPENAI_API_KEY", "")
+def _resolve_openai_api_key(stt_config: Optional[dict] = None) -> str:
+    """Prefer the voice-tools key, fall back to OPENAI_API_KEY, then config api_key."""
+    key = os.getenv("VOICE_TOOLS_OPENAI_KEY", "") or os.getenv("OPENAI_API_KEY", "")
+    if key:
+        return key
+    # Fall back to api_key embedded in stt.openai config (for local/custom endpoints)
+    if stt_config is None:
+        stt_config = _load_stt_config()
+    return stt_config.get("openai", {}).get("api_key", "")
 
 
 def _find_binary(binary_name: str) -> Optional[str]:
@@ -210,7 +216,7 @@ def _get_provider(stt_config: dict) -> str:
             return "none"
 
         if provider == "openai":
-            if _HAS_OPENAI and _resolve_openai_api_key():
+            if _HAS_OPENAI and _resolve_openai_api_key(stt_config):
                 return "openai"
             logger.warning(
                 "STT provider 'openai' configured but no API key available"
@@ -436,26 +442,33 @@ def _transcribe_groq(file_path: str, model_name: str) -> Dict[str, Any]:
 
 
 def _transcribe_openai(file_path: str, model_name: str) -> Dict[str, Any]:
-    """Transcribe using OpenAI Whisper API (paid)."""
-    api_key = _resolve_openai_api_key()
+    """Transcribe using OpenAI Whisper API (paid) or a local OpenAI-compatible endpoint."""
+    stt_config = _load_stt_config()
+    openai_cfg = stt_config.get("openai", {})
+    api_key = _resolve_openai_api_key(stt_config)
     if not api_key:
         return {
             "success": False,
             "transcript": "",
-            "error": "Neither VOICE_TOOLS_OPENAI_KEY nor OPENAI_API_KEY is set",
+            "error": "Neither VOICE_TOOLS_OPENAI_KEY nor OPENAI_API_KEY is set, "
+                     "and no api_key found in stt.openai config",
         }
 
     if not _HAS_OPENAI:
         return {"success": False, "transcript": "", "error": "openai package not installed"}
 
-    # Auto-correct model if caller passed a Groq-only model
-    if model_name in GROQ_MODELS:
+    # Use base_url from config if provided (local/custom endpoints), else fall back to env/default
+    base_url = openai_cfg.get("base_url") or os.getenv("STT_OPENAI_BASE_URL", OPENAI_BASE_URL)
+
+    # Auto-correct model: only skip GROQ_MODELS when using real OpenAI endpoint
+    is_local = base_url and "openai.com" not in base_url
+    if not is_local and model_name in GROQ_MODELS:
         logger.info("Model %s not available on OpenAI, using %s", model_name, DEFAULT_STT_MODEL)
         model_name = DEFAULT_STT_MODEL
 
     try:
         from openai import OpenAI, APIError, APIConnectionError, APITimeoutError
-        client = OpenAI(api_key=api_key, base_url=OPENAI_BASE_URL, timeout=30, max_retries=0)
+        client = OpenAI(api_key=api_key, base_url=base_url, timeout=30, max_retries=0)
 
         with open(file_path, "rb") as audio_file:
             transcription = client.audio.transcriptions.create(


### PR DESCRIPTION
Fixes #4102

## Root Cause

Two bugs in `tools/transcription_tools.py`:

1. `_resolve_openai_api_key()` only checked env vars (`VOICE_TOOLS_OPENAI_KEY`,
   `OPENAI_API_KEY`). It never fell back to `stt.openai.api_key` in config, so
   `_get_provider()` returned `"none"` → "STT provider: MISSING" for anyone using
   a local endpoint with the key set only in config.

2. `_transcribe_openai()` used the module-level `OPENAI_BASE_URL` constant
   (`https://api.openai.com/v1`), completely ignoring `stt.openai.base_url` from
   config. Requests would go to openai.com instead of the configured local endpoint.

## Fix

- `_resolve_openai_api_key(stt_config=None)`: falls back to
  `stt_config.get("openai", {}).get("api_key", "")` when no env key is set
- `_get_provider`: passes `stt_config` to `_resolve_openai_api_key` so the openai
  branch validates against the config key
- `_transcribe_openai`: reads `base_url` and `api_key` from `stt.openai` config;
  skips GROQ_MODELS auto-correction when `base_url` doesn't contain `openai.com`
  so local model names like `whisper-large-v3-turbo` pass through unchanged

Also fixes two pre-existing test failures where `test_explicit_local_no_cloud_fallback`
and `test_local_nothing_available` would fail on machines with a `whisper` binary
in PATH (`_has_local_command()` returning `True`). Added `_has_local_command` mock
to make those tests hermetic.

## How to Verify

1. Configure `~/.hermes/config.yaml`:
   ```yaml
   stt:
     enabled: true
     provider: openai
     openai:
       model: whisper-large-v3-turbo
       base_url: http://127.0.0.1:8001/v1
       api_key: "any-string"
   ```
2. Before fix: voice mode reports "STT provider: MISSING"
3. After fix: voice mode reports "STT provider: OK (OpenAI)" and routes to the local endpoint

## Test Plan

- [x] New `TestResolveOpenAIApiKey` class (4 tests) for the key resolution fallback logic
- [x] `test_openai_with_config_api_key` — config key accepted when no env key is set
- [x] `test_config_api_key_and_base_url` — verifies correct `base_url` and `api_key`
      are passed to the `OpenAI()` client constructor
- [x] `test_no_key_anywhere` — no env key + no config key → error
- [x] All 27 tests in `tests/tools/test_transcription.py` pass
- [x] Full run of `tests/tools/`, `tests/agent/`, `tests/hermes_cli/`: 3098 passed, 0 new failures
      (28 pre-existing failures in unrelated browser/mcp/vision/web tests)

## Platforms Tested

- macOS 26.3.1 (arm64), Python 3.11.14, Hermes v0.6.0
