### PR TITLE
fix(ci): add repo conditionals to prevent fork workflow failures

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -19,6 +19,8 @@ concurrency:
 
 jobs:
   build-and-deploy:
+    # Only run on the upstream repository, not on forks
+    if: github.repository == 'NousResearch/hermes-agent'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,6 +12,8 @@ concurrency:
 
 jobs:
   build-and-push:
+    # Only run on the upstream repository, not on forks
+    if: github.repository == 'NousResearch/hermes-agent'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
Salvage of the CI-conditional portion of #4021 by @StreamOfRon.

Adds `if: github.repository == 'NousResearch/hermes-agent'` to `deploy-site.yml` and `docker-publish.yml` so they skip on forks where upstream-specific resources (Docker Hub org, custom domain) are unavailable.

The original PR also bundled an unrelated SearXNG tool addition and a fork-specific sync-and-rebase workflow — those were not included.

Closes #4021.
