### PR TITLE
feat: show turn duration after each agent response

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5728,6 +5728,8 @@ class HermesCLI:
                     "2-3 sentences max. No code blocks or markdown.] "
                 )
 
+            _turn_start = time.time()
+
             def run_agent():
                 nonlocal result
                 agent_message = _voice_prefix + message if _voice_prefix else message
@@ -5829,6 +5831,17 @@ class HermesCLI:
             import time as _time
             sys.stdout.flush()
             _time.sleep(0.15)
+
+            # Show turn duration
+            _turn_elapsed = time.time() - _turn_start
+            if _turn_elapsed >= 1.0:
+                if _turn_elapsed >= 60:
+                    _mins = int(_turn_elapsed // 60)
+                    _secs = int(_turn_elapsed % 60)
+                    _dur_str = f"{_mins}m {_secs}s"
+                else:
+                    _dur_str = f"{_turn_elapsed:.1f}s"
+                _cprint(f"{_DIM}  [{_dur_str}]{_RST}")
 
             # Update history with full conversation
             self.conversation_history = result.get("messages", self.conversation_history) if result else self.conversation_history


### PR DESCRIPTION
## Summary

Display elapsed time after each agent response, giving users visibility into response latency.

```
● What does this function do?

  [response from agent...]

  [3.2s]
```

For longer turns: `[1m 45s]`

## Implementation

- Timer starts before the agent thread launch
- Duration displayed after the response flush, before history update  
- Only shown when turn takes >= 1 second (sub-second turns are silent to avoid clutter)
- Uses existing `_DIM`/`_RST` styling for an unobtrusive look

## Changes

13 lines added to `cli.py`.