### PR TITLE
fix(setup): use npm ci instead of npm install in hermes update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3038,7 +3038,7 @@ def cmd_update(args):
             import shutil
             if shutil.which("npm"):
                 print("→ Updating Node.js dependencies...")
-                subprocess.run(["npm", "install", "--silent"], cwd=PROJECT_ROOT, check=False)
+                subprocess.run(["npm", "ci", "--silent"], cwd=PROJECT_ROOT, check=False)
         
         print()
         print("✓ Code updated!")


### PR DESCRIPTION
## What does this PR do?

Replaces `npm install --silent` with `npm ci --silent` in the `hermes update` command. `npm install` re-resolves the dependency graph and rewrites `package-lock.json`, leaving a dirty working tree after every update. `npm ci` installs exactly from the committed lockfile without mutating it.

## Related Issue

Fixes #4048

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py` line 3041: `npm install --silent` → `npm ci --silent`

One line changed. The WhatsApp bridge `npm install` (line 742) is intentionally left as-is — that is an initial install into an empty `node_modules/`, where `npm install` is correct.

## How to Test

```bash
cd ~/.hermes/hermes-agent
git status            # clean
hermes update
git status            # package-lock.json should remain unmodified
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (one-line behavioral change in update command)
- [ ] I've added tests for my changes — N/A
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — N/A
- [ ] I've updated `cli-config.yaml.example` — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — `npm ci` is available on all platforms with npm 5.7+
- [ ] I've updated tool descriptions/schemas — N/A