### PR TITLE
fix(agent): use standard MiniMax-M2.7 for auxiliary model instead of highspeed

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -56,8 +56,8 @@ logger = logging.getLogger(__name__)
 _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "zai": "glm-4.5-flash",
     "kimi-coding": "kimi-k2-turbo-preview",
-    "minimax": "MiniMax-M2.7-highspeed",
-    "minimax-cn": "MiniMax-M2.7-highspeed",
+    "minimax": "MiniMax-M2.7",
+    "minimax-cn": "MiniMax-M2.7",
     "anthropic": "claude-haiku-4-5-20251001",
     "ai-gateway": "google/gemini-3-flash",
     "opencode-zen": "gemini-3-flash",


### PR DESCRIPTION
## What does this PR do?

Changes the default MiniMax auxiliary model from `MiniMax-M2.7-highspeed` to `MiniMax-M2.7`. The highspeed variant is the same model running on faster hardware at exactly 2x the price — users with MiniMax as their provider are silently paying double for every auxiliary call (summarization, compression, vision).

| Variant | Input | Output | Throughput |
|---------|-------|--------|------------|
| **MiniMax-M2.7** (standard) | $0.30/M | $1.20/M | ~33 tok/s |
| **MiniMax-M2.7-highspeed** | $0.60/M | $2.40/M | ~51 tok/s |

For auxiliary side tasks where latency is not critical, the standard tier is the correct default.

Source: [OpenRouter pricing](https://openrouter.ai/minimax/minimax-m2.7), [MiniMax pricing docs](https://platform.minimax.io/docs/guides/pricing-paygo)

## Related Issue

Fixes #4082

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/auxiliary_client.py` lines 59-60: `MiniMax-M2.7-highspeed` → `MiniMax-M2.7` for both `minimax` and `minimax-cn` entries in `_API_KEY_PROVIDER_AUX_MODELS`

## How to Test

1. Configure MiniMax as your provider
2. Send a message that triggers an auxiliary call (e.g. context compression, web extract summarization)
3. Verify the auxiliary request targets `MiniMax-M2.7` (not `MiniMax-M2.7-highspeed`) in logs
4. Confirm API billing reflects standard tier pricing

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (config value change, no logic affected)
- [ ] I've added tests for my changes — N/A
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — N/A
- [ ] I've updated `cli-config.yaml.example` — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — model name string, platform-agnostic
- [ ] I've updated tool descriptions/schemas — N/A