### PR TITLE
fix(signal): restore voice note transcription and captioned replies

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -968,11 +968,18 @@ class BasePlatformAdapter(ABC):
                 # Play TTS audio before text (voice-first experience)
                 if _tts_path and Path(_tts_path).exists():
                     try:
-                        await self.play_tts(
+                        tts_result = await self.play_tts(
                             chat_id=event.source.chat_id,
                             audio_path=_tts_path,
+                            caption=text_content if self.platform.value.lower() == "signal" else None,
                             metadata=_thread_metadata,
                         )
+                        if (
+                            self.platform.value.lower() == "signal"
+                            and getattr(tts_result, "success", False)
+                            and event.message_type == MessageType.VOICE
+                        ):
+                            text_content = ""
                     finally:
                         try:
                             os.remove(_tts_path)

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -22,7 +22,7 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Any
-from urllib.parse import unquote
+from urllib.parse import quote, unquote
 
 import httpx
 
@@ -50,6 +50,7 @@ SSE_RETRY_DELAY_INITIAL = 2.0
 SSE_RETRY_DELAY_MAX = 60.0
 HEALTH_CHECK_INTERVAL = 30.0  # seconds between health checks
 HEALTH_CHECK_STALE_THRESHOLD = 120.0  # seconds without SSE activity before concern
+SIGNAL_ATTACHMENTS_DIR = Path("~/.local/share/signal-cli/attachments").expanduser()
 
 # E.164 phone number pattern for redaction
 _PHONE_RE = re.compile(r"\+[1-9]\d{6,14}")
@@ -85,7 +86,10 @@ def _guess_extension(data: bytes) -> str:
         return ".webp"
     if data[:4] == b"%PDF":
         return ".pdf"
-    if len(data) >= 8 and data[4:8] == b"ftyp":
+    if len(data) >= 12 and data[4:8] == b"ftyp":
+        brand = data[8:12]
+        if brand in (b"M4A ", b"M4B ", b"M4P "):
+            return ".m4a"
         return ".mp4"
     if data[:4] == b"OggS":
         return ".ogg"
@@ -116,6 +120,39 @@ _EXT_TO_MIME = {
 def _ext_to_mime(ext: str) -> str:
     """Map file extension to MIME type."""
     return _EXT_TO_MIME.get(ext.lower(), "application/octet-stream")
+
+
+def _resolve_signal_attachment_path(attachment: dict) -> Optional[str]:
+    """Resolve a signal-cli attachment to a local file path when possible."""
+    if not attachment or not isinstance(attachment, dict):
+        return None
+
+    candidate_fields = (
+        "path",
+        "file",
+        "filePath",
+        "localPath",
+        "storedFilename",
+        "storedFileName",
+        "storedFile",
+        "filename",
+        "fileName",
+    )
+
+    for field in candidate_fields:
+        value = attachment.get(field)
+        if not value or not isinstance(value, str):
+            continue
+
+        candidate = Path(value).expanduser()
+        if candidate.exists() and candidate.is_file():
+            return str(candidate)
+
+        fallback = SIGNAL_ATTACHMENTS_DIR / Path(value).name
+        if fallback.exists() and fallback.is_file():
+            return str(fallback)
+
+    return None
 
 
 def _render_mentions(text: str, mentions: list) -> str:
@@ -253,7 +290,7 @@ class SignalAdapter(BasePlatformAdapter):
 
     async def _sse_listener(self) -> None:
         """Listen for SSE events from signal-cli daemon."""
-        url = f"{self.http_url}/api/v1/events?account={self.account}"
+        url = f"{self.http_url}/api/v1/events?account={quote(self.account, safe='')}"
         backoff = SSE_RETRY_DELAY_INITIAL
 
         while self._running:
@@ -448,13 +485,18 @@ class SignalAdapter(BasePlatformAdapter):
             for att in attachments_data:
                 att_id = att.get("id")
                 att_size = att.get("size", 0)
-                if not att_id:
+                if not att_id and not _resolve_signal_attachment_path(att):
                     continue
                 if att_size > SIGNAL_MAX_ATTACHMENT_SIZE:
                     logger.warning("Signal: attachment too large (%d bytes), skipping", att_size)
                     continue
                 try:
-                    cached_path, ext = await self._fetch_attachment(att_id)
+                    cached_path, ext = await self._fetch_attachment(
+                        att_id,
+                        sender=sender,
+                        group_id=group_id,
+                        attachment=att,
+                    )
                     if cached_path:
                         # Use contentType from Signal if available, else map from extension
                         content_type = att.get("contentType") or _ext_to_mime(ext)
@@ -511,12 +553,32 @@ class SignalAdapter(BasePlatformAdapter):
     # Attachment Handling
     # ------------------------------------------------------------------
 
-    async def _fetch_attachment(self, attachment_id: str) -> tuple:
+    async def _fetch_attachment(
+        self,
+        attachment_id: Optional[str],
+        sender: Optional[str] = None,
+        group_id: Optional[str] = None,
+        attachment: Optional[dict] = None,
+    ) -> tuple:
         """Fetch an attachment via JSON-RPC and cache it. Returns (path, ext)."""
-        result = await self._rpc("getAttachment", {
+        local_path = _resolve_signal_attachment_path(attachment or {})
+        if local_path and Path(local_path).exists():
+            ext = Path(local_path).suffix.lower() or ".bin"
+            return local_path, ext
+
+        if not attachment_id:
+            return None, ""
+
+        params = {
             "account": self.account,
-            "attachmentId": attachment_id,
-        })
+            "id": attachment_id,
+        }
+        if group_id:
+            params["groupId"] = group_id
+        elif sender:
+            params["recipient"] = sender
+
+        result = await self._rpc("getAttachment", params)
 
         if not result:
             return None, ""
@@ -677,6 +739,37 @@ class SignalAdapter(BasePlatformAdapter):
             self._track_sent_timestamp(result)
             return SendResult(success=True)
         return SendResult(success=False, error="RPC send with attachment failed")
+
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send an audio attachment, optionally with a caption."""
+        await self._stop_typing_indicator(chat_id)
+
+        if not Path(audio_path).exists():
+            return SendResult(success=False, error="Audio file not found")
+
+        params: Dict[str, Any] = {
+            "account": self.account,
+            "message": caption or "",
+            "attachments": [audio_path],
+        }
+
+        if chat_id.startswith("group:"):
+            params["groupId"] = chat_id[6:]
+        else:
+            params["recipient"] = [chat_id]
+
+        result = await self._rpc("send", params)
+        if result is not None:
+            self._track_sent_timestamp(result)
+            return SendResult(success=True)
+        return SendResult(success=False, error="RPC send voice failed")
 
     async def send_document(
         self,

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1,13 +1,17 @@
 """Tests for gateway/platforms/base.py — MessageEvent, media extraction, message truncation."""
 
+import asyncio
 import os
-from unittest.mock import patch
+import sys
+import types
+from unittest.mock import AsyncMock, patch
 
 from gateway.platforms.base import (
     BasePlatformAdapter,
     GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE,
     MessageEvent,
     MessageType,
+    SendResult,
 )
 
 
@@ -410,3 +414,89 @@ class TestGetHumanDelay:
         with patch.dict(os.environ, env):
             delay = BasePlatformAdapter._get_human_delay()
             assert 0.1 <= delay <= 0.2
+
+
+class TestSignalVoiceReplyBehavior:
+    def _adapter(self, platform):
+        class StubAdapter(BasePlatformAdapter):
+            async def connect(self):
+                return True
+
+            async def disconnect(self):
+                pass
+
+            async def send(self, *a, **kw):
+                return SendResult(success=True)
+
+            async def get_chat_info(self, *a):
+                return {}
+
+        from gateway.config import PlatformConfig
+
+        config = PlatformConfig(enabled=True, token="***")
+        return StubAdapter(config=config, platform=platform)
+
+    def _event(self):
+        from gateway.config import Platform
+        from gateway.session import SessionSource
+
+        return MessageEvent(
+            text="hello",
+            message_type=MessageType.VOICE,
+            source=SessionSource(platform=Platform.SIGNAL, chat_id="chat-1", user_id="user-1"),
+        )
+
+    def test_signal_voice_reply_sends_caption_only_once(self, tmp_path):
+        from gateway.config import Platform
+
+        adapter = self._adapter(Platform.SIGNAL)
+        event = self._event()
+        tts_file = tmp_path / "reply.mp3"
+        tts_file.write_bytes(b"audio")
+
+        adapter._message_handler = AsyncMock(return_value="hello from hermes")
+        adapter.play_tts = AsyncMock(return_value=SendResult(success=True))
+        adapter.send = AsyncMock(return_value=SendResult(success=True))
+        adapter._keep_typing = AsyncMock()
+        adapter._run_processing_hook = AsyncMock()
+
+        fake_tts = types.ModuleType("tools.tts_tool")
+        fake_tts.check_tts_requirements = lambda: True
+        fake_tts.text_to_speech_tool = lambda text: '{"file_path": "%s"}' % str(tts_file)
+
+        with patch.dict(sys.modules, {"tools.tts_tool": fake_tts}):
+            asyncio.run(adapter._process_message_background(event, "session-1"))
+
+        assert adapter.play_tts.await_count == 1
+        assert adapter.play_tts.await_args.kwargs["caption"] == "hello from hermes"
+        adapter.send.assert_not_awaited()
+
+    def test_non_signal_voice_reply_still_sends_text_after_tts(self, tmp_path):
+        from gateway.config import Platform
+        from gateway.session import SessionSource
+
+        adapter = self._adapter(Platform.TELEGRAM)
+        event = MessageEvent(
+            text="hello",
+            message_type=MessageType.VOICE,
+            source=SessionSource(platform=Platform.TELEGRAM, chat_id="chat-1", user_id="user-1"),
+        )
+        tts_file = tmp_path / "reply.mp3"
+        tts_file.write_bytes(b"audio")
+
+        adapter._message_handler = AsyncMock(return_value="hello from hermes")
+        adapter.play_tts = AsyncMock(return_value=SendResult(success=True))
+        adapter.send = AsyncMock(return_value=SendResult(success=True))
+        adapter._keep_typing = AsyncMock()
+        adapter._run_processing_hook = AsyncMock()
+
+        fake_tts = types.ModuleType("tools.tts_tool")
+        fake_tts.check_tts_requirements = lambda: True
+        fake_tts.text_to_speech_tool = lambda text: '{"file_path": "%s"}' % str(tts_file)
+
+        with patch.dict(sys.modules, {"tools.tts_tool": fake_tts}):
+            asyncio.run(adapter._process_message_background(event, "session-1"))
+
+        assert adapter.play_tts.await_count == 1
+        assert adapter.play_tts.await_args.kwargs["caption"] is None
+        adapter.send.assert_awaited_once()

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -1,9 +1,40 @@
 """Tests for Signal messenger platform adapter."""
+import base64
 import json
 import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
+from urllib.parse import quote
 
 from gateway.config import Platform, PlatformConfig
+
+
+# ---------------------------------------------------------------------------
+# Shared Helpers
+# ---------------------------------------------------------------------------
+
+def _make_signal_adapter(monkeypatch, account="+155****4567", **extra):
+    """Create a SignalAdapter with sensible test defaults."""
+    monkeypatch.setenv("SIGNAL_GROUP_ALLOWED_USERS", extra.pop("group_allowed", ""))
+    from gateway.platforms.signal import SignalAdapter
+    config = PlatformConfig()
+    config.enabled = True
+    config.extra = {
+        "http_url": "http://localhost:8080",
+        "account": account,
+        **extra,
+    }
+    return SignalAdapter(config)
+
+
+def _stub_rpc(return_value):
+    """Return an async mock for SignalAdapter._rpc that captures call params."""
+    captured = []
+
+    async def mock_rpc(method, params, rpc_id=None):
+        captured.append({"method": method, "params": dict(params)})
+        return return_value
+
+    return mock_rpc, captured
 
 
 # ---------------------------------------------------------------------------
@@ -145,6 +176,10 @@ class TestSignalHelpers:
         from gateway.platforms.signal import _guess_extension
         assert _guess_extension(b"\x00\x00\x00\x18ftypisom" + b"\x00" * 100) == ".mp4"
 
+    def test_guess_extension_m4a(self):
+        from gateway.platforms.signal import _guess_extension
+        assert _guess_extension(b"\x00\x00\x00\x18ftypM4A " + b"\x00" * 100) == ".m4a"
+
     def test_guess_extension_unknown(self):
         from gateway.platforms.signal import _guess_extension
         assert _guess_extension(b"\x00\x01\x02\x03" * 10) == ".bin"
@@ -190,8 +225,141 @@ class TestSignalHelpers:
 
 
 # ---------------------------------------------------------------------------
-# Session Source
+# SSE URL Encoding (Bug Fix: phone numbers with + must be URL-encoded)
 # ---------------------------------------------------------------------------
+
+class TestSignalSSEUrlEncoding:
+    """Verify that phone numbers with + are URL-encoded in the SSE endpoint."""
+
+    def test_sse_url_encodes_plus_in_account(self):
+        """The + in E.164 phone numbers must be percent-encoded in the SSE query string."""
+        encoded = quote("+31612345678", safe="")
+        assert encoded == "%2B31612345678"
+
+    def test_sse_url_encoding_preserves_digits(self):
+        """Digits and country codes should pass through URL encoding unchanged."""
+        assert quote("+15551234567", safe="") == "%2B15551234567"
+
+
+# ---------------------------------------------------------------------------
+# Attachment Fetch (Bug Fix: parameter must be "id" not "attachmentId")
+# ---------------------------------------------------------------------------
+
+class TestSignalAttachmentFetch:
+    """Verify that _fetch_attachment uses the correct RPC parameter name."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_attachment_uses_id_parameter(self, monkeypatch):
+        """RPC getAttachment must use 'id', not 'attachmentId' (signal-cli requirement)."""
+        adapter = _make_signal_adapter(monkeypatch)
+
+        png_data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        b64_data = base64.b64encode(png_data).decode()
+
+        adapter._rpc, captured = _stub_rpc({"data": b64_data})
+
+        with patch("gateway.platforms.signal.cache_image_from_bytes", return_value="/tmp/test.png"):
+            await adapter._fetch_attachment("attachment-123")
+
+        call = captured[0]
+        assert call["method"] == "getAttachment"
+        assert call["params"]["id"] == "attachment-123"
+        assert "attachmentId" not in call["params"], "Must NOT use 'attachmentId' — causes NullPointerException in signal-cli"
+        assert call["params"]["account"] == "+155****4567"
+
+    @pytest.mark.asyncio
+    async def test_fetch_attachment_returns_none_on_empty(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._rpc, _ = _stub_rpc(None)
+        path, ext = await adapter._fetch_attachment("missing-id")
+        assert path is None
+        assert ext == ""
+
+    @pytest.mark.asyncio
+    async def test_fetch_attachment_uses_recipient_for_dm(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+
+        png_data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        b64_data = base64.b64encode(png_data).decode()
+        adapter._rpc, captured = _stub_rpc({"data": b64_data})
+
+        with patch("gateway.platforms.signal.cache_image_from_bytes", return_value="/tmp/test.png"):
+            await adapter._fetch_attachment("attachment-123", sender="+155****1111")
+
+        call = captured[0]
+        assert call["params"]["recipient"] == "+155****1111"
+        assert "groupId" not in call["params"]
+
+    @pytest.mark.asyncio
+    async def test_fetch_attachment_uses_group_id_for_groups(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+
+        png_data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        b64_data = base64.b64encode(png_data).decode()
+        adapter._rpc, captured = _stub_rpc({"data": b64_data})
+
+        with patch("gateway.platforms.signal.cache_image_from_bytes", return_value="/tmp/test.png"):
+            await adapter._fetch_attachment("attachment-123", sender="+155****1111", group_id="group-abc")
+
+        call = captured[0]
+        assert call["params"]["groupId"] == "group-abc"
+        assert "recipient" not in call["params"]
+
+    @pytest.mark.asyncio
+    async def test_fetch_attachment_uses_local_path_when_available(self, monkeypatch, tmp_path):
+        adapter = _make_signal_adapter(monkeypatch)
+        local_file = tmp_path / "voice-note.m4a"
+        local_file.write_bytes(b"audio")
+
+        rpc = AsyncMock(return_value=None)
+        adapter._rpc = rpc
+
+        path, ext = await adapter._fetch_attachment(
+            "attachment-123",
+            attachment={"path": str(local_file)},
+        )
+
+        assert path == str(local_file)
+        assert ext == ".m4a"
+        rpc.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_fetch_attachment_uses_local_path_without_id(self, monkeypatch, tmp_path):
+        adapter = _make_signal_adapter(monkeypatch)
+        local_file = tmp_path / "voice-note.m4a"
+        local_file.write_bytes(b"audio")
+
+        rpc = AsyncMock(return_value=None)
+        adapter._rpc = rpc
+
+        path, ext = await adapter._fetch_attachment(
+            None,
+            attachment={"path": str(local_file)},
+        )
+
+        assert path == str(local_file)
+        assert ext == ".m4a"
+        rpc.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_fetch_attachment_handles_dict_response(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+
+        pdf_data = b"%PDF-1.4" + b"\x00" * 100
+        b64_data = base64.b64encode(pdf_data).decode()
+
+        adapter._rpc, _ = _stub_rpc({"data": b64_data})
+
+        with patch("gateway.platforms.signal.cache_document_from_bytes", return_value="/tmp/test.pdf"):
+            path, ext = await adapter._fetch_attachment("doc-456")
+
+        assert path == "/tmp/test.pdf"
+        assert ext == ".pdf"
+
+
+# ---------------------------------------------------------------------------
+# Session Source
+
 
 class TestSignalSessionSource:
     def test_session_source_alt_fields(self):
@@ -290,9 +458,26 @@ class TestSignalAuthorization:
 # ---------------------------------------------------------------------------
 
 class TestSignalSendMessage:
+    @pytest.mark.asyncio
+    async def test_send_voice_attaches_caption(self, monkeypatch, tmp_path):
+        adapter = _make_signal_adapter(monkeypatch)
+        audio_file = tmp_path / "reply.m4a"
+        audio_file.write_bytes(b"audio")
+
+        adapter._rpc, captured = _stub_rpc({"timestamp": 123})
+        result = await adapter.send_voice("+15550001111", str(audio_file), caption="hello there")
+
+        assert result.success is True
+        call = captured[0]
+        assert call["method"] == "send"
+        assert call["params"]["message"] == "hello there"
+        assert call["params"]["attachments"] == [str(audio_file)]
+        assert call["params"]["recipient"] == ["+15550001111"]
+
     def test_signal_in_platform_map(self):
         """Signal should be in the send_message tool's platform map."""
+        pytest.importorskip("firecrawl")
         from tools.send_message_tool import send_message_tool
-        # Just verify the import works and Signal is a valid platform
-        from gateway.config import Platform
-        assert Platform.SIGNAL.value == "signal"
+        platform_map = send_message_tool.__globals__.get("PLATFORM_PATTERNS", {})
+        assert "signal" in platform_map
+


### PR DESCRIPTION
## Bug Description

Hermes could connect to Signal and handle text messages, but Signal voice notes were not handled reliably end-to-end. In practice, Hermes could fail to recover incoming voice-note attachments from signal-cli, which prevented transcription, and Signal voice replies were split into separate audio and text messages.

## Root Cause

Signal voice-note handling was missing several Signal-specific pieces:
- `getAttachment` calls did not include the DM/group routing context signal-cli expects
- incoming attachments were not recovered directly from local signal-cli attachment files when available
- M4A voice-note containers were detected as generic MP4 files
- Signal had no platform-specific `send_voice()` implementation
- base auto-TTS logic sent Signal voice replies as separate audio and text messages instead of a single captioned audio attachment

## Fix

This PR restores Signal voice-note support end-to-end by:
- resolving local signal-cli attachment paths when present
- passing `recipient` or `groupId` to `getAttachment` requests
- detecting `ftypM4A` containers as `.m4a`
- adding a Signal `send_voice()` implementation
- attaching the text reply as the caption on Signal TTS audio replies and suppressing the extra follow-up text message
- adding regression coverage for attachment recovery, RPC parameter shape, M4A detection, and Signal-specific voice-reply behavior

## How to Verify

1. Configure Hermes to use the Signal adapter with a local `signal-cli` daemon.
2. Send Hermes a Signal voice note and confirm Hermes receives and transcribes it.
3. Confirm Hermes replies with a single audio attachment carrying the text as its caption instead of separate audio and text messages.
4. Run:
   `python -m pytest -q -o addopts= tests/gateway/test_signal.py tests/gateway/test_platform_base.py`

## Test Plan

- [x] Added regression test for this bug
- [x] Existing targeted tests still pass
- [x] Manual verification completed locally against the Signal gateway setup

## Risk Assessment

Medium — this only touches Signal-specific attachment and voice-reply paths plus a small Signal-only branch in shared auto-TTS behavior. The change is covered by targeted regression tests and does not affect other messaging adapters unless they opt into the same captioned-TTS behavior.