### PR TITLE
fix(anthropic): write scopes field to Claude Code credentials on token refresh

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -338,7 +338,14 @@ def _refresh_oauth_token(creds: Dict[str, Any]) -> Optional[str]:
 
                 if new_access:
                     new_expires_ms = int(time.time() * 1000) + (expires_in * 1000)
-                    _write_claude_code_credentials(new_access, new_refresh, new_expires_ms)
+                    # Parse scopes from refresh response — Claude Code >=2.1.81
+                    # requires a "scopes" field in the credential store and checks
+                    # for "user:inference" before accepting the token as valid.
+                    scope_str = result.get("scope", "")
+                    scopes = scope_str.split() if scope_str else None
+                    _write_claude_code_credentials(
+                        new_access, new_refresh, new_expires_ms, scopes=scopes,
+                    )
                     logger.debug("Refreshed Claude Code OAuth token via %s", endpoint)
                     return new_access
         except Exception as e:
@@ -347,8 +354,20 @@ def _refresh_oauth_token(creds: Dict[str, Any]) -> Optional[str]:
     return None
 
 
-def _write_claude_code_credentials(access_token: str, refresh_token: str, expires_at_ms: int) -> None:
-    """Write refreshed credentials back to ~/.claude/.credentials.json."""
+def _write_claude_code_credentials(
+    access_token: str,
+    refresh_token: str,
+    expires_at_ms: int,
+    *,
+    scopes: Optional[list] = None,
+) -> None:
+    """Write refreshed credentials back to ~/.claude/.credentials.json.
+
+    The optional *scopes* list (e.g. ``["user:inference", "user:profile", ...]``)
+    is persisted so that Claude Code's own auth check recognises the credential
+    as valid.  Claude Code >=2.1.81 gates on the presence of ``"user:inference"``
+    in the stored scopes before it will use the token.
+    """
     cred_path = Path.home() / ".claude" / ".credentials.json"
     try:
         # Read existing file to preserve other fields
@@ -356,11 +375,19 @@ def _write_claude_code_credentials(access_token: str, refresh_token: str, expire
         if cred_path.exists():
             existing = json.loads(cred_path.read_text(encoding="utf-8"))
 
-        existing["claudeAiOauth"] = {
+        oauth_data: Dict[str, Any] = {
             "accessToken": access_token,
             "refreshToken": refresh_token,
             "expiresAt": expires_at_ms,
         }
+        if scopes is not None:
+            oauth_data["scopes"] = scopes
+        elif "claudeAiOauth" in existing and "scopes" in existing["claudeAiOauth"]:
+            # Preserve previously-stored scopes when the refresh response
+            # does not include a scope field.
+            oauth_data["scopes"] = existing["claudeAiOauth"]["scopes"]
+
+        existing["claudeAiOauth"] = oauth_data
 
         cred_path.parent.mkdir(parents=True, exist_ok=True)
         cred_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")


### PR DESCRIPTION
## What does this PR do?

Fixes a compatibility issue where Claude Code reports `loggedIn: false` and refuses to start when Hermes has refreshed the OAuth token.

**Root cause:** Claude Code >=2.1.81 added a check that gates on a `scopes` array containing `"user:inference"` in `~/.claude/.credentials.json` before accepting stored OAuth tokens. When Hermes refreshes the token via `_refresh_oauth_token()`, it writes only `accessToken`, `refreshToken`, and `expiresAt` — omitting the `scopes` field. Claude Code's internal auth validator (`checkAndRefreshOAuthTokenIfNeeded`) returns `false` immediately when scopes are missing, causing the CLI to report "Not logged in" even though the token is valid and works with the API.

**How I found it:** Reverse-engineered the minified Claude Code v2.1.87 binary. The function `TS(H)` checks `H?.includes(oh)` where `oh` = `"user:inference"`. This is called from `bW8` (checkAndRefreshOAuthTokenIfNeeded) with `K.scopes` from the credential store. When scopes is `undefined`, `TS()` returns `false` and the auth check bails.

## Related Issue

N/A (new discovery — no existing issue)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/anthropic_adapter.py`: Parse `scope` field from OAuth refresh response and pass to credential writer
- `agent/anthropic_adapter.py`: Add `scopes` keyword argument to `_write_claude_code_credentials()`
- `agent/anthropic_adapter.py`: Persist scopes array in `claudeAiOauth` credential store; preserve existing scopes when refresh response omits the field

## How to Test

1. Configure Hermes to use the Anthropic provider via Claude Code credentials
2. Let Hermes refresh an expired token (or trigger manually)
3. Run `claude auth status` — should report `loggedIn: true` (previously reported `false`)
4. Run `echo "hello" | claude --print` — should work (previously failed with "Not logged in")

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass (98 passed in test_anthropic_adapter.py, 2 passed in test_anthropic_oauth_flow.py)
- [ ] I've added tests for my changes — test would require mocking the OAuth token endpoint refresh response with a scope field
- [x] I've tested on my platform: Ubuntu 24.04 (Proxmox VM)

### Documentation & Housekeeping

- [x] N/A for all documentation items — no config keys or architecture changes

## Screenshots / Logs

Before fix:
```
$ claude auth status
{"loggedIn": false, "authMethod": "none", "apiProvider": "firstParty"}
```

After fix (adding scopes to credentials file):
```
$ claude auth status
{"loggedIn": true, "authMethod": "claude.ai", "apiProvider": "firstParty", "email": "...", "orgId": "..."}
```
