### PR TITLE
fix(gateway): use correct signal-cli-rest-api health check endpoint

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -198,7 +198,7 @@ class SignalAdapter(BasePlatformAdapter):
 
         # Health check — verify signal-cli daemon is reachable
         try:
-            resp = await self.client.get(f"{self.http_url}/api/v1/check", timeout=10.0)
+            resp = await self.client.get(f"{self.http_url}/v1/about", timeout=10.0)
             if resp.status_code != 200:
                 logger.error("Signal: health check failed (status %d)", resp.status_code)
                 return False
@@ -330,7 +330,7 @@ class SignalAdapter(BasePlatformAdapter):
                 logger.warning("Signal: SSE idle for %.0fs, checking daemon health", elapsed)
                 try:
                     resp = await self.client.get(
-                        f"{self.http_url}/api/v1/check", timeout=10.0
+                        f"{self.http_url}/v1/about", timeout=10.0
                     )
                     if resp.status_code == 200:
                         # Daemon is alive but SSE is idle — update activity to

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2529,7 +2529,7 @@ def _setup_signal():
     print_info("  Testing connection...")
     try:
         import httpx
-        resp = httpx.get(f"{url.rstrip('/')}/api/v1/check", timeout=10.0)
+        resp = httpx.get(f"{url.rstrip('/')}/v1/about", timeout=10.0)
         if resp.status_code == 200:
             print_success("  signal-cli daemon is reachable!")
         else:

--- a/website/docs/user-guide/messaging/signal.md
+++ b/website/docs/user-guide/messaging/signal.md
@@ -72,7 +72,7 @@ Keep this running in the background. You can use `systemd`, `tmux`, `screen`, or
 Verify it's running:
 
 ```bash
-curl http://127.0.0.1:8080/api/v1/check
+curl http://127.0.0.1:8080/v1/about
 # Should return: {"versions":{"signal-cli":...}}
 ```
 


### PR DESCRIPTION
## What does this PR do?

Fixes the Signal adapter health check endpoint. `signal-cli-rest-api` does not expose `/api/v1/check` — it returns 404. The correct endpoint is `/v1/about`, which returns version and registration info.

This affects both the startup health check and the SSE idle timeout handler, causing spurious "health check failed" log warnings on every connection cycle.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/signal.py` (line 230): Changed health check URL from `/api/v1/check` to `/v1/about`
- `gateway/platforms/signal.py` (line 368): Changed SSE idle timeout health check URL from `/api/v1/check` to `/v1/about`

## How to Test

1. Run signal-cli-rest-api in Docker
2. Start the Hermes gateway with Signal adapter enabled
3. Observe logs — health check should succeed (previously logged 404 errors every 2 seconds)

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes — existing integration tests don't cover live signal-cli-rest-api
- [x] I've tested on my platform: Ubuntu 24.04 (Proxmox VM) with signal-cli-rest-api v0.93 in Docker

### Documentation & Housekeeping

- [x] N/A for all documentation items
