### PR TITLE
docs: remove stale /model slash command references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ hermes-agent/
 │   ├── tools_config.py   # `hermes tools` — enable/disable tools per platform
 │   ├── skills_hub.py     # `/skills` slash command (search, browse, install)
 │   ├── models.py         # Model catalog, provider model lists
-│   ├── model_switch.py   # Shared /model switch pipeline (CLI + gateway)
+│   ├── model_switch.py   # Model switch pipeline (CLI + ACP adapter)
 │   └── auth.py           # Provider credential resolution
 ├── tools/                # Tool implementations (one file per tool)
 │   ├── registry.py       # Central tool registry (schemas, handlers, dispatch)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Hermes has two entry points: start the terminal UI with `hermes`, or run the gat
 |---------|-----|---------------------|
 | Start chatting | `hermes` | Run `hermes gateway setup` + `hermes gateway start`, then send the bot a message |
 | Start fresh conversation | `/new` or `/reset` | `/new` or `/reset` |
-| Change model | `/model [provider:model]` | `/model [provider:model]` |
+| Change model | `hermes model` | `hermes model` |
 | Set a personality | `/personality [name]` | `/personality [name]` |
 | Retry or undo the last turn | `/retry`, `/undo` | `/retry`, `/undo` |
 | Compress context / check usage | `/compress`, `/usage`, `/insights [--days N]` | `/compress`, `/usage`, `/insights [days]` |

--- a/website/docs/developer-guide/adding-providers.md
+++ b/website/docs/developer-guide/adding-providers.md
@@ -110,7 +110,7 @@ That same id should appear in:
 - auxiliary-model defaults
 - tests
 
-If the id differs between those files, the provider will feel half-wired: auth may work while `/model`, setup, or runtime resolution silently misses it.
+If the id differs between those files, the provider will feel half-wired: auth may work while `hermes model`, setup, or runtime resolution silently misses it.
 
 ## Step 2: Add auth metadata in `hermes_cli/auth.py`
 
@@ -162,7 +162,7 @@ anthropic:claude-sonnet-4-6
 kimi:model-name
 ```
 
-If aliases are missing here, the provider may authenticate correctly but still fail in `/model` parsing.
+If aliases are missing here, the provider may authenticate correctly but still fail in `hermes model` parsing.
 
 ## Step 4: Resolve runtime data in `hermes_cli/runtime_provider.py`
 
@@ -377,7 +377,7 @@ Use this when the provider needs a new protocol path.
 
 ### 1. Adding the provider to auth but not to model parsing
 
-That makes credentials resolve correctly while `/model` and `provider:model` inputs fail.
+That makes credentials resolve correctly while `hermes model` and `provider:model` inputs fail.
 
 ### 2. Forgetting that `config["model"]` can be a string or a dict
 

--- a/website/docs/developer-guide/provider-runtime.md
+++ b/website/docs/developer-guide/provider-runtime.md
@@ -18,7 +18,7 @@ Primary implementation:
 
 - `hermes_cli/runtime_provider.py` — credential resolution, `_resolve_custom_runtime()`
 - `hermes_cli/auth.py` — provider registry, `resolve_provider()`
-- `hermes_cli/model_switch.py` — shared `/model` switch pipeline (CLI + gateway)
+- `hermes_cli/model_switch.py` — model switch pipeline (CLI + ACP adapter)
 - `agent/auxiliary_client.py` — auxiliary model routing
 
 If you are trying to add a new first-class inference provider, read [Adding Providers](./adding-providers.md) alongside this page.

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -96,7 +96,7 @@ Type `/` to see an autocomplete dropdown of all commands:
 |---------|-------------|
 | `/help` | Show all available commands |
 | `/tools` | List available tools |
-| `/model` | Switch models interactively |
+| `hermes model` | Switch models interactively (run outside a session) |
 | `/personality pirate` | Try a fun personality |
 | `/save` | Save the conversation |
 

--- a/website/docs/guides/tips.md
+++ b/website/docs/guides/tips.md
@@ -56,7 +56,7 @@ Press **Ctrl+V** to paste an image from your clipboard directly into the chat. T
 
 ### Slash Command Autocomplete
 
-Type `/` and press **Tab** to see all available commands. This includes built-in commands (`/compress`, `/model`, `/title`) and every installed skill. You don't need to memorize anything — Tab completion has you covered.
+Type `/` and press **Tab** to see all available commands. This includes built-in commands (`/compress`, `/provider`, `/title`) and every installed skill. You don't need to memorize anything — Tab completion has you covered.
 
 :::tip
 Use `/verbose` to cycle through tool output display modes: **off → new → all → verbose**. The "all" mode is great for watching what the agent does; "off" is cleanest for simple Q&A.
@@ -145,7 +145,7 @@ Instead of running terminal commands one at a time, ask the agent to write a scr
 
 ### Choose the Right Model
 
-Use `/model` to switch models mid-session. Use a frontier model (Claude Sonnet/Opus, GPT-4o) for complex reasoning and architecture decisions. Switch to a faster model for simple tasks like formatting, renaming, or boilerplate generation.
+Use `hermes model` to switch models between sessions. Use a frontier model (Claude Sonnet/Opus, GPT-4o) for complex reasoning and architecture decisions. Switch to a faster model for simple tasks like formatting, renaming, or boilerplate generation.
 
 :::tip
 Run `/usage` periodically to see your token consumption. Run `/insights` for a broader view of usage patterns over the last 30 days.

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -109,22 +109,6 @@ Use this when you want to:
 - configure a custom/self-hosted endpoint
 - save the new default into config
 
-### `/model` slash command (mid-session)
-
-Switch models without leaving a session:
-
-```
-/model                              # Show current model and available options
-/model claude-sonnet-4              # Switch model (auto-detects provider)
-/model zai:glm-5                    # Switch provider and model
-/model custom:qwen-2.5              # Use model on your custom endpoint
-/model custom                       # Auto-detect model from custom endpoint
-/model custom:local:qwen-2.5        # Use a named custom provider
-/model openrouter:anthropic/claude-sonnet-4  # Switch back to cloud
-```
-
-Provider and base URL changes are persisted to `config.yaml` automatically. When switching away from a custom endpoint, the stale base URL is cleared to prevent it leaking into other providers.
-
 ## `hermes gateway`
 
 ```bash

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -62,7 +62,7 @@ model:
   base_url: http://localhost:11434/v1
 ```
 
-Hermes persists the endpoint, provider, and base URL in `config.yaml` so it survives restarts. If your local server has exactly one model loaded, `/model custom` auto-detects it. You can also set `provider: custom` in config.yaml — it's a first-class provider, not an alias for anything else.
+Hermes persists the endpoint, provider, and base URL in `config.yaml` so it survives restarts. If your local server has exactly one model loaded, `hermes model` auto-detects it. You can also set `provider: custom` in config.yaml — it's a first-class provider, not an alias for anything else.
 
 This works with Ollama, vLLM, llama.cpp server, SGLang, LocalAI, and others. See the [Configuration guide](../user-guide/configuration.md) for details.
 

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -42,7 +42,6 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 | Command | Description |
 |---------|-------------|
 | `/config` | Show current configuration |
-| `/model [model-name]` | Show or change the current model. Supports: `/model claude-sonnet-4`, `/model provider:model` (switch providers), `/model custom:model` (custom endpoint), `/model custom:name:model` (named custom provider), `/model custom` (auto-detect from endpoint) |
 | `/provider` | Show available providers and current provider |
 | `/prompt` | View/set custom system prompt |
 | `/personality` | Set a predefined personality |
@@ -102,7 +101,6 @@ The messaging gateway supports the following built-in commands inside Telegram, 
 | `/reset` | Reset conversation history. |
 | `/status` | Show session info. |
 | `/stop` | Kill all running background processes and interrupt the running agent. |
-| `/model [provider:model]` | Show or change the model. Supports provider switches (`/model zai:glm-5`), custom endpoints (`/model custom:model`), named custom providers (`/model custom:local:qwen`), and auto-detect (`/model custom`). |
 | `/provider` | Show provider availability and auth status. |
 | `/personality [name]` | Set a personality overlay for the session. |
 | `/retry` | Retry the last message. |

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -106,7 +106,7 @@ Common examples:
 | Command | Description |
 |---------|-------------|
 | `/help` | Show command help |
-| `/model` | Show or change the current model |
+| `/provider` | Show current provider and available providers |
 | `/tools` | List currently available tools |
 | `/skills browse` | Browse the skills hub and official optional skills |
 | `/background <prompt>` | Run a prompt in a separate background session |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -291,28 +291,17 @@ LLM_MODEL=your-model-name
 
 All three approaches end up in the same runtime path. `hermes model` persists provider, model, and base URL to `config.yaml` so later sessions keep using that endpoint even if env vars are not set.
 
-### Switching Models with `/model`
+### Switching Models
 
-Once a custom endpoint is configured, you can switch models mid-session:
+To switch models or providers, use the `hermes model` subcommand outside of a session:
 
-```
-/model custom:qwen-2.5          # Switch to a model on your custom endpoint
-/model custom                    # Auto-detect the model from the endpoint
-/model openrouter:claude-sonnet-4 # Switch back to a cloud provider
-```
-
-If you have **named custom providers** configured (see below), use the triple syntax:
-
-```
-/model custom:local:qwen-2.5    # Use the "local" custom provider with model qwen-2.5
-/model custom:work:llama3       # Use the "work" custom provider with llama3
+```bash
+hermes model                    # Interactive model picker
+hermes model zai:glm-5          # Switch provider and model
+hermes model custom:qwen-2.5    # Use model on your custom endpoint
 ```
 
 When switching providers, Hermes persists the base URL and provider to config so the change survives restarts. When switching away from a custom endpoint to a built-in provider, the stale base URL is automatically cleared.
-
-:::tip
-`/model custom` (bare, no model name) queries your endpoint's `/models` API and auto-selects the model if exactly one is loaded. Useful for local servers running a single model.
-:::
 
 Everything below follows this same pattern — just change the URL, key, and model name.
 
@@ -562,12 +551,12 @@ custom_providers:
     api_mode: anthropic_messages  # for Anthropic-compatible proxies
 ```
 
-Switch between them mid-session with the triple syntax:
+Switch between them using `hermes model` with the provider prefix:
 
-```
-/model custom:local:qwen-2.5       # Use the "local" endpoint with qwen-2.5
-/model custom:work:llama3-70b      # Use the "work" endpoint with llama3-70b
-/model custom:anthropic-proxy:claude-sonnet-4  # Use the proxy
+```bash
+hermes model custom:local:qwen-2.5       # Use the "local" endpoint with qwen-2.5
+hermes model custom:work:llama3-70b      # Use the "work" endpoint with llama3-70b
+hermes model custom:anthropic-proxy:claude-sonnet-4  # Use the proxy
 ```
 
 You can also select named custom providers from the interactive `hermes model` menu.


### PR DESCRIPTION
## Summary
- The `/model` slash command was removed from CLI and gateway in #3080, but docs still referenced it
- Updated 11 files across user guides, reference docs, developer guides, README, and AGENTS.md to reference `hermes model` instead
- Release notes (RELEASE_*.md) left unchanged as historical records

## Test plan
- [x] Searched codebase for remaining `/model` references — only release notes remain
- [ ] Verify docs site builds without errors