### PR TITLE
fix(cron): fall back to auto-detect provider when explicit provider fails

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -402,8 +402,17 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 runtime_kwargs["explicit_base_url"] = job.get("base_url")
             runtime = resolve_runtime_provider(**runtime_kwargs)
         except Exception as exc:
-            message = format_runtime_provider_error(exc)
-            raise RuntimeError(message) from exc
+            # If the explicitly configured provider fails (e.g. missing API key),
+            # fall back to auto-detection so the cron job can still run.
+            logger.warning(
+                "Job '%s': provider resolution failed (%s), falling back to auto-detect",
+                job_id, exc,
+            )
+            try:
+                runtime = resolve_runtime_provider(requested="auto")
+            except Exception as fallback_exc:
+                message = format_runtime_provider_error(fallback_exc)
+                raise RuntimeError(message) from fallback_exc
 
         from agent.smart_model_routing import resolve_turn_route
         turn_route = resolve_turn_route(


### PR DESCRIPTION
## Problem

When a cron job's configured provider (from `config.yaml` model.provider or `HERMES_INFERENCE_PROVIDER` env) has no valid credentials — e.g. the config references `anthropic` but `ANTHROPIC_API_KEY` is not set — the job fails immediately with an `AuthError`. The entire cron run is lost.

This is especially painful after initial setup where config.yaml may contain a default or stale provider that doesn't match the available credentials.

## Fix

When `resolve_runtime_provider()` raises for the explicitly configured provider, catch the exception and retry with `requested="auto"` to find any working provider before giving up.

The original error is logged as a warning, so operators can see that a fallback occurred and fix the config:
```
Job my-job: provider resolution failed (No Anthropic credentials found), falling back to auto-detect
```

If auto-detection also fails, the original hard error is preserved.

## Testing

- Cron job with `config.yaml` pointing to `anthropic` but no Anthropic key: previously failed, now falls back to auto-detecting a working provider
- Cron job with valid explicit provider: no change in behavior
- Cron job with no configured provider at all: already uses auto, no change