### PR TITLE
fix(security): reject private and loopback IPs in Telegram DoH fallback

### DIFF
--- a/gateway/platforms/telegram_network.py
+++ b/gateway/platforms/telegram_network.py
@@ -135,6 +135,9 @@ def _normalize_fallback_ips(values: Iterable[str]) -> list[str]:
         if addr.version != 4:
             logger.warning("Ignoring non-IPv4 Telegram fallback IP: %s", raw)
             continue
+        if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_unspecified:
+            logger.warning("Ignoring private/internal Telegram fallback IP: %s", raw)
+            continue
         normalized.append(str(addr))
     return normalized
 


### PR DESCRIPTION
Telegram DoH fallback accepted any valid IPv4, including private/loopback. A compromised DoH response could inject `169.254.169.254` (AWS metadata) or `127.0.0.1` for SSRF.

Adds a 3-line guard using Python's `ipaddress` checks (`is_private`, `is_loopback`, `is_link_local`, `is_unspecified`), consistent with existing SSRF protection in `url_safety.py`.

Full security audit of `telegram_network.py` found no other vulnerabilities. 210 telegram tests pass.

Cherry-picked from PR #4001 by @maymuneth with authorship preserved.