### PR TITLE
fix(cron): stop truncating job IDs in list view

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -56,7 +56,7 @@ def cron_list(show_all: bool = False):
     print()
 
     for job in jobs:
-        job_id = job.get("id", "?")[:8]
+        job_id = job.get("id", "?")
         name = job.get("name", "(unnamed)")
         schedule = job.get("schedule_display", job.get("schedule", {}).get("value", "?"))
         state = job.get("state", "scheduled" if job.get("enabled", True) else "paused")


### PR DESCRIPTION
Salvage of #3939 by @vitobotta.

Removes `[:8]` truncation from `hermes cron list` output. Job IDs are 12 hex chars — truncating to 8 makes them unusable with `hermes cron run/pause/remove` which require the full ID.

Closes #3939.