### PR TITLE
fix(alibaba): use standard DashScope international endpoint

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -160,7 +160,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         id="alibaba",
         name="Alibaba Cloud (DashScope)",
         auth_type="api_key",
-        inference_base_url="https://coding-intl.dashscope.aliyuncs.com/v1",
+        inference_base_url="https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
         api_key_env_vars=("DASHSCOPE_API_KEY",),
         base_url_env_var="DASHSCOPE_BASE_URL",
     ),

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -545,7 +545,7 @@ def test_alibaba_default_coding_intl_endpoint_uses_chat_completions(monkeypatch)
 
     assert resolved["provider"] == "alibaba"
     assert resolved["api_mode"] == "chat_completions"
-    assert resolved["base_url"] == "https://coding-intl.dashscope.aliyuncs.com/v1"
+    assert resolved["base_url"] == "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
 
 
 def test_alibaba_anthropic_endpoint_override_uses_anthropic_messages(monkeypatch):


### PR DESCRIPTION
Salvage of #3935 by @kagura-agent — cherry-picked onto current main with test fix.

Changes the default Alibaba DashScope endpoint from the Coding Plan-only URL (`coding-intl.dashscope.aliyuncs.com/v1`) to the standard international endpoint (`dashscope-intl.aliyuncs.com/compatible-mode/v1`). The old default only worked with Coding Plan keys (`sk-sp-*`); standard DashScope API keys got `invalid_api_key`. Users with Coding Plan keys can override via `DASHSCOPE_BASE_URL`.

Follow-up: updated runtime provider test to match the new default.

Closes #3935