### PR TITLE
fix: remove dead /model command remnants from gateway and Discord

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1518,11 +1518,6 @@ class DiscordAdapter(BasePlatformAdapter):
         async def slash_reset(interaction: discord.Interaction):
             await self._run_simple_slash(interaction, "/reset", "Session reset~")
 
-        @tree.command(name="model", description="Show or change the model")
-        @discord.app_commands.describe(name="Model name (e.g. anthropic/claude-sonnet-4). Leave empty to see current.")
-        async def slash_model(interaction: discord.Interaction, name: str = ""):
-            await self._run_simple_slash(interaction, f"/model {name}".strip())
-
         @tree.command(name="reasoning", description="Show or change reasoning effort")
         @discord.app_commands.describe(effort="Reasoning effort: xhigh, high, medium, low, minimal, or none.")
         async def slash_reasoning(interaction: discord.Interaction, effort: str = ""):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -458,7 +458,7 @@ class GatewayRunner:
 
         # Track active fallback model/provider when primary is rate-limited.
         # Set after an agent run where fallback was activated; cleared when
-        # the primary model succeeds again or the user switches via /model.
+        # the primary model succeeds again or the user changes via hermes model.
         self._effective_model: Optional[str] = None
         self._effective_provider: Optional[str] = None
 
@@ -5186,7 +5186,7 @@ class GatewayRunner:
         return hashlib.sha256(blob.encode()).hexdigest()[:16]
 
     def _evict_cached_agent(self, session_key: str) -> None:
-        """Remove a cached agent for a session (called on /new, /model, etc)."""
+        """Remove a cached agent for a session (called on /new, etc)."""
         _lock = getattr(self, "_agent_cache_lock", None)
         if _lock:
             with _lock:
@@ -5839,7 +5839,7 @@ class GatewayRunner:
             response = await loop.run_in_executor(None, run_sync)
 
             # Track fallback model state: if the agent switched to a
-            # fallback model during this run, persist it so /model shows
+            # fallback model during this run, persist it so /status shows
             # the actually-active model instead of the config default.
             _agent = agent_holder[0]
             if _agent is not None and hasattr(_agent, 'model'):

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1,7 +1,7 @@
-"""Shared model-switching logic for CLI and gateway /model commands.
+"""Shared model-switching logic for `hermes model` and ACP adapter.
 
-Both the CLI (cli.py) and gateway (gateway/run.py) /model handlers
-share the same core pipeline:
+Both the `hermes model` CLI subcommand and the ACP adapter's /model
+handler share the same core pipeline:
 
   parse_model_input → is_custom detection → auto-detect provider
   → credential resolution → validate model → return result
@@ -181,7 +181,7 @@ def switch_model(
 
 
 def switch_to_custom_provider() -> CustomAutoResult:
-    """Handle bare '/model custom' — resolve endpoint and auto-detect model.
+    """Handle bare 'custom' model input — resolve endpoint and auto-detect model.
 
     Returns a result object; the caller handles persistence and output.
     """
@@ -220,7 +220,7 @@ def switch_to_custom_provider() -> CustomAutoResult:
             error_message=(
                 f"Custom endpoint at {cust_base} is reachable but no single "
                 f"model was auto-detected. Specify the model explicitly: "
-                f"/model custom:<model-name>"
+                f"hermes model (then pick a custom provider)"
             ),
         )
 


### PR DESCRIPTION
## Summary
- PR #3080 removed the `/model` command handler from gateway and CLI but left remnants in the code
- **Discord**: removed `/model` slash command registration — it was registering a command that silently fails in the gateway dispatch
- **gateway/run.py**: updated 3 stale comments referencing `/model` as if it's a functional command
- **model_switch.py**: updated docstring and error message — the module is still used by `hermes model` and ACP adapter, but the old docstring claimed it served "CLI and gateway /model commands"

The ACP adapter's `/model` handler (`acp_adapter/server.py`) is untouched — that one works correctly.

## Test plan
- [x] `model_switch.py` still imported by `hermes_cli/main.py` and `acp_adapter/server.py`
- [ ] Discord bot starts without errors after removing the slash command
- [ ] Gateway dispatch no longer has any `/model` code path