### PR TITLE
feat(update): rebase local commits instead of discarding on update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2945,6 +2945,17 @@ def cmd_update(args):
 
         print(f"→ Found {commit_count} new commit(s)")
 
+        # Detect local commits before pulling so we can rebase instead of
+        # discarding them when fast-forward is not possible.
+        local_ahead = subprocess.run(
+            git_cmd + ["rev-list", "--count", f"origin/{branch}..HEAD"],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        local_commit_count = int(local_ahead.stdout.strip())
+
         print("→ Pulling updates...")
         update_succeeded = False
         try:
@@ -2955,22 +2966,52 @@ def cmd_update(args):
                 text=True,
             )
             if pull_result.returncode != 0:
-                # ff-only failed — local and remote have diverged (e.g. upstream
-                # force-pushed or rebase).  Since local changes are already
-                # stashed, reset to match the remote exactly.
-                print("  ⚠ Fast-forward not possible (history diverged), resetting to match remote...")
-                reset_result = subprocess.run(
-                    git_cmd + ["reset", "--hard", f"origin/{branch}"],
-                    cwd=PROJECT_ROOT,
-                    capture_output=True,
-                    text=True,
-                )
-                if reset_result.returncode != 0:
-                    print(f"✗ Failed to reset to origin/{branch}.")
-                    if reset_result.stderr.strip():
-                        print(f"  {reset_result.stderr.strip()}")
-                    print("  Try manually: git fetch origin && git reset --hard origin/main")
-                    sys.exit(1)
+                # ff-only failed. If there are local commits, try rebase to
+                # preserve them on top of the new upstream. Otherwise reset.
+                if local_commit_count > 0:
+                    print(f"  ⚠ Fast-forward not possible (have {local_commit_count} local commit(s)), rebasing...")
+                    rebase_result = subprocess.run(
+                        git_cmd + ["rebase", f"origin/{branch}"],
+                        cwd=PROJECT_ROOT,
+                        capture_output=True,
+                        text=True,
+                    )
+                    if rebase_result.returncode != 0:
+                        # Rebase hit conflicts — abort and report
+                        subprocess.run(
+                            git_cmd + ["rebase", "--abort"],
+                            cwd=PROJECT_ROOT,
+                            capture_output=True,
+                        )
+                        # Gather which commits were being rebased
+                        print("✗ Rebase failed due to merge conflicts.")
+                        print(f"  Your {local_commit_count} local commit(s) were NOT lost.")
+                        print(f"  Stashed changes are preserved (ref: {auto_stash_ref}).")
+                        print()
+                        print("  To resolve manually:")
+                        print(f"    git rebase origin/{branch}")
+                        print("    # fix conflicts, then: git rebase --continue")
+                        if auto_stash_ref:
+                            print(f"    git stash apply {auto_stash_ref}")
+                        sys.exit(1)
+                else:
+                    print("  ⚠ Fast-forward not possible (history diverged), resetting to match remote...")
+                    reset_result = subprocess.run(
+                        git_cmd + ["reset", "--hard", f"origin/{branch}"],
+                        cwd=PROJECT_ROOT,
+                        capture_output=True,
+                        text=True,
+                    )
+                    if reset_result.returncode != 0:
+                        print(f"✗ Failed to reset to origin/{branch}.")
+                        if reset_result.stderr.strip():
+                            print(f"  {reset_result.stderr.strip()}")
+                        print("  Try manually: git fetch origin && git reset --hard origin/main")
+                        sys.exit(1)
+            else:
+                # ff-only pull succeeded
+                if local_commit_count > 0:
+                    print(f"  ✓ Pulled {commit_count} upstream commit(s), preserved {local_commit_count} local commit(s)")
             update_succeeded = True
         finally:
             if auto_stash_ref is not None:


### PR DESCRIPTION
## Problem

When `hermes update` is run and the local branch has commits ahead of `origin/main` (e.g. cherry-picked patches, local plugin hooks, config customizations), the update flow does `git reset --hard origin/main` — silently destroying all local commits.

This is especially painful for users who:
- Maintain local patches on top of Hermes (plugins, hooks, provider fixes)
- Cherry-pick features from PRs before they merge
- Have any local customization committed to their main branch

## Fix

Detect local commits before pulling. When fast-forward fails:

1. **Local commits exist** → `git rebase origin/main` to replay local commits on top of the new upstream
   - If rebase hits conflicts → abort cleanly, report which commits are affected, and give manual resolution instructions
   - Never silently discard or auto-resolve
2. **No local commits** (pure divergence from upstream force-push) → `git reset --hard origin/main` (same as before)
3. **ff-only succeeds** → show notification if local commits were preserved alongside upstream updates

## Before / After

**Before**: `hermes update` with 1 local commit → commit silently destroyed, user confused

**After**: `hermes update` with 1 local commit → rebase preserves it, user sees:
```
→ Found 12 new commit(s)
→ Pulling updates...
  ⚠ Fast-forward not possible (have 1 local commit(s)), rebasing...
  → Updating Python dependencies...
```

Or if conflicts:
```
✗ Rebase failed due to merge conflicts.
  Your 1 local commit(s) were NOT lost.
  Stashed changes are preserved (ref: abc123).

  To resolve manually:
    git rebase origin/main
    # fix conflicts, then: git rebase --continue
    git stash apply abc123
```

## Testing

- Local commits + upstream update: rebase succeeds, commits preserved
- Local commits + conflicting upstream update: rebase aborts, clear instructions
- No local commits + diverged: reset --hard (unchanged behavior)
- No local commits + ff succeeds: normal update (unchanged)