### PR TITLE
fix(security): remove terminal from sandbox allowed tools in execute_code

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -13,6 +13,7 @@ Run with:  python -m pytest tests/test_code_execution.py -v
 """
 
 import pytest
+
 pytestmark = pytest.mark.skip(reason="Hangs in non-interactive environments")
 
 
@@ -35,19 +36,33 @@ from tools.code_execution_tool import (
 )
 
 
-def _mock_handle_function_call(function_name, function_args, task_id=None, user_task=None):
+def _mock_handle_function_call(
+    function_name, function_args, task_id=None, user_task=None
+):
     """Mock dispatcher that returns canned responses for each tool."""
     if function_name == "terminal":
         cmd = function_args.get("command", "")
         return json.dumps({"output": f"mock output for: {cmd}", "exit_code": 0})
     if function_name == "web_search":
-        return json.dumps({"results": [{"url": "https://example.com", "title": "Example", "description": "A test result"}]})
+        return json.dumps(
+            {
+                "results": [
+                    {
+                        "url": "https://example.com",
+                        "title": "Example",
+                        "description": "A test result",
+                    }
+                ]
+            }
+        )
     if function_name == "read_file":
         return json.dumps({"content": "line 1\nline 2\nline 3\n", "total_lines": 3})
     if function_name == "write_file":
         return json.dumps({"status": "ok", "path": function_args.get("path", "")})
     if function_name == "search_files":
-        return json.dumps({"matches": [{"file": "test.py", "line": 1, "text": "match"}]})
+        return json.dumps(
+            {"matches": [{"file": "test.py", "line": 1, "text": "match"}]}
+        )
     if function_name == "patch":
         return json.dumps({"status": "ok", "replacements": 1})
     if function_name == "web_extract":
@@ -73,8 +88,7 @@ class TestHermesToolsGeneration(unittest.TestCase):
             self.assertIn(f"def {tool}(", src)
 
     def test_generates_subset(self):
-        src = generate_hermes_tools_module(["terminal", "web_search"])
-        self.assertIn("def terminal(", src)
+        src = generate_hermes_tools_module(["web_search"])
         self.assertIn("def web_search(", src)
         self.assertNotIn("def read_file(", src)
 
@@ -84,12 +98,12 @@ class TestHermesToolsGeneration(unittest.TestCase):
         self.assertIn("def _call(", src)  # infrastructure still present
 
     def test_non_allowed_tools_ignored(self):
-        src = generate_hermes_tools_module(["vision_analyze", "terminal"])
-        self.assertIn("def terminal(", src)
+        src = generate_hermes_tools_module(["vision_analyze", "web_search"])
+        self.assertIn("def web_search(", src)
         self.assertNotIn("def vision_analyze(", src)
 
     def test_rpc_infrastructure_present(self):
-        src = generate_hermes_tools_module(["terminal"])
+        src = generate_hermes_tools_module(["web_search"])
         self.assertIn("HERMES_RPC_SOCKET", src)
         self.assertIn("AF_UNIX", src)
         self.assertIn("def _connect(", src)
@@ -97,7 +111,7 @@ class TestHermesToolsGeneration(unittest.TestCase):
 
     def test_convenience_helpers_present(self):
         """Verify json_parse, shell_quote, and retry helpers are generated."""
-        src = generate_hermes_tools_module(["terminal"])
+        src = generate_hermes_tools_module(["web_search"])
         self.assertIn("def json_parse(", src)
         self.assertIn("def shell_quote(", src)
         self.assertIn("def retry(", src)
@@ -114,7 +128,9 @@ class TestExecuteCode(unittest.TestCase):
             # Use real execution but mock the tool dispatcher
             pass
         # Actually run with full integration, mocking at the model_tools level
-        with patch("model_tools.handle_function_call", side_effect=_mock_handle_function_call):
+        with patch(
+            "model_tools.handle_function_call", side_effect=_mock_handle_function_call
+        ):
             result = execute_code(
                 code=code,
                 task_id="test-task",
@@ -131,29 +147,29 @@ class TestExecuteCode(unittest.TestCase):
 
     def test_repo_root_modules_are_importable(self):
         """Sandboxed scripts can import modules that live at the repo root."""
-        result = self._run('import hermes_constants; print(hermes_constants.__file__)')
+        result = self._run("import hermes_constants; print(hermes_constants.__file__)")
         self.assertEqual(result["status"], "success")
         self.assertIn("hermes_constants.py", result["output"])
 
     def test_single_tool_call(self):
-        """Script calls terminal and prints the result."""
+        """Script calls web_search and prints the result."""
         code = """
-from hermes_tools import terminal
-result = terminal("echo hello")
-print(result.get("output", ""))
+from hermes_tools import web_search
+result = web_search("test query")
+print(result.get("results", []))
 """
         result = self._run(code)
         self.assertEqual(result["status"], "success")
-        self.assertIn("mock output for: echo hello", result["output"])
+        self.assertIn("mock output for:", result["output"])
         self.assertEqual(result["tool_calls_made"], 1)
 
     def test_multi_tool_chain(self):
         """Script calls multiple tools sequentially."""
         code = """
-from hermes_tools import terminal, read_file
-r1 = terminal("ls")
+from hermes_tools import web_search, read_file
+r1 = web_search("test query")
 r2 = read_file("test.py")
-print(f"terminal: {r1['output'][:20]}")
+print(f"results: {len(r1.get('results', []))}")
 print(f"file lines: {r2['total_lines']}")
 """
         result = self._run(code)
@@ -209,19 +225,28 @@ raise RuntimeError("deliberate crash")
         result = self._run(code)
         self.assertEqual(result["status"], "error")
         self.assertIn("before error", result["output"])
-        self.assertIn("RuntimeError", result.get("error", "") + result.get("output", ""))
+        self.assertIn(
+            "RuntimeError", result.get("error", "") + result.get("output", "")
+        )
 
     def test_timeout_enforcement(self):
         """Script that sleeps too long is killed."""
         code = "import time; time.sleep(999)"
-        with patch("model_tools.handle_function_call", side_effect=_mock_handle_function_call):
+        with patch(
+            "model_tools.handle_function_call", side_effect=_mock_handle_function_call
+        ):
             # Override config to use a very short timeout
-            with patch("tools.code_execution_tool._load_config", return_value={"timeout": 2, "max_tool_calls": 50}):
-                result = json.loads(execute_code(
-                    code=code,
-                    task_id="test-task",
-                    enabled_tools=list(SANDBOX_ALLOWED_TOOLS),
-                ))
+            with patch(
+                "tools.code_execution_tool._load_config",
+                return_value={"timeout": 2, "max_tool_calls": 50},
+            ):
+                result = json.loads(
+                    execute_code(
+                        code=code,
+                        task_id="test-task",
+                        enabled_tools=list(SANDBOX_ALLOWED_TOOLS),
+                    )
+                )
         self.assertEqual(result["status"], "timeout")
         self.assertIn("timed out", result.get("error", ""))
 
@@ -324,8 +349,6 @@ class TestStubSchemaDrift(unittest.TestCase):
 
     # Parameters that are internal (injected by the handler, not user-facing)
     _INTERNAL_PARAMS = {"task_id", "user_task"}
-    # Parameters intentionally blocked in the sandbox
-    _BLOCKED_TERMINAL_PARAMS = {"background", "check_interval", "pty"}
 
     def test_stubs_cover_all_schema_params(self):
         """Every user-facing parameter in the real schema must appear in the
@@ -347,19 +370,18 @@ class TestStubSchemaDrift(unittest.TestCase):
 
             schema_props = entry.schema.get("parameters", {}).get("properties", {})
             schema_params = set(schema_props.keys()) - self._INTERNAL_PARAMS
-            if tool_name == "terminal":
-                schema_params -= self._BLOCKED_TERMINAL_PARAMS
 
             # Extract parameter names from the stub signature string
             # Match word before colon: "pattern: str, target: str = ..."
-            stub_params = set(re.findall(r'(\w+)\s*:', sig))
+            stub_params = set(re.findall(r"(\w+)\s*:", sig))
 
             missing = schema_params - stub_params
             self.assertEqual(
-                missing, set(),
+                missing,
+                set(),
                 f"Stub for '{tool_name}' is missing parameters that exist in "
                 f"the real schema: {missing}. Update _TOOL_STUBS in "
-                f"code_execution_tool.py to include them."
+                f"code_execution_tool.py to include them.",
             )
 
     def test_stubs_pass_all_params_to_rpc(self):
@@ -369,26 +391,34 @@ class TestStubSchemaDrift(unittest.TestCase):
         from tools.code_execution_tool import _TOOL_STUBS
 
         for tool_name, (func_name, sig, doc, args_expr) in _TOOL_STUBS.items():
-            stub_params = set(re.findall(r'(\w+)\s*:', sig))
+            stub_params = set(re.findall(r"(\w+)\s*:", sig))
             # Check that each param name appears in the args dict expression
             for param in stub_params:
                 self.assertIn(
                     f'"{param}"',
                     args_expr,
                     f"Stub for '{tool_name}' has parameter '{param}' in its "
-                    f"signature but doesn't pass it in the args dict: {args_expr}"
+                    f"signature but doesn't pass it in the args dict: {args_expr}",
                 )
 
     def test_search_files_target_uses_current_values(self):
         """search_files stub should use 'content'/'files', not old 'grep'/'find'."""
         from tools.code_execution_tool import _TOOL_STUBS
+
         _, sig, doc, _ = _TOOL_STUBS["search_files"]
-        self.assertIn('"content"', sig,
-                      "search_files stub should default target to 'content', not 'grep'")
-        self.assertNotIn('"grep"', sig,
-                         "search_files stub still uses obsolete 'grep' target value")
-        self.assertNotIn('"find"', doc,
-                         "search_files stub docstring still uses obsolete 'find' target value")
+        self.assertIn(
+            '"content"',
+            sig,
+            "search_files stub should default target to 'content', not 'grep'",
+        )
+        self.assertNotIn(
+            '"grep"', sig, "search_files stub still uses obsolete 'grep' target value"
+        )
+        self.assertNotIn(
+            '"find"',
+            doc,
+            "search_files stub docstring still uses obsolete 'find' target value",
+        )
 
     def test_generated_module_accepts_all_params(self):
         """The generated hermes_tools.py module should accept all current params
@@ -412,6 +442,7 @@ class TestStubSchemaDrift(unittest.TestCase):
 # build_execute_code_schema
 # ---------------------------------------------------------------------------
 
+
 class TestBuildExecuteCodeSchema(unittest.TestCase):
     """Tests for build_execute_code_schema — the dynamic schema generator."""
 
@@ -429,31 +460,28 @@ class TestBuildExecuteCodeSchema(unittest.TestCase):
         self.assertEqual(schema["parameters"]["required"], ["code"])
 
     def test_subset_only_lists_enabled_tools(self):
-        enabled = {"terminal", "read_file"}
+        enabled = {"web_search", "read_file"}
         schema = build_execute_code_schema(enabled)
         desc = schema["description"]
-        self.assertIn("terminal(", desc)
+        self.assertIn("web_search(", desc)
         self.assertIn("read_file(", desc)
-        self.assertNotIn("web_search(", desc)
         self.assertNotIn("web_extract(", desc)
         self.assertNotIn("write_file(", desc)
 
     def test_single_tool(self):
-        schema = build_execute_code_schema({"terminal"})
+        schema = build_execute_code_schema({"web_search"})
         desc = schema["description"]
-        self.assertIn("terminal(", desc)
-        self.assertNotIn("web_search(", desc)
+        self.assertIn("web_search(", desc)
+        self.assertNotIn("web_extract(", desc)
 
-    def test_import_examples_prefer_web_search_and_terminal(self):
-        enabled = {"web_search", "terminal", "read_file"}
+    def test_import_examples_prefer_web_search(self):
+        enabled = {"web_search", "read_file"}
         schema = build_execute_code_schema(enabled)
         code_desc = schema["parameters"]["properties"]["code"]["description"]
         self.assertIn("web_search", code_desc)
-        self.assertIn("terminal", code_desc)
 
     def test_import_examples_fallback_when_no_preferred(self):
-        """When neither web_search nor terminal are enabled, falls back to
-        sorted first two tools."""
+        """When web_search is not enabled, falls back to sorted first two tools."""
         enabled = {"read_file", "write_file", "patch"}
         schema = build_execute_code_schema(enabled)
         code_desc = schema["parameters"]["properties"]["code"]["description"]
@@ -466,8 +494,11 @@ class TestBuildExecuteCodeSchema(unittest.TestCase):
         in the code property description."""
         schema = build_execute_code_schema(set())
         code_desc = schema["parameters"]["properties"]["code"]["description"]
-        self.assertNotIn("import , ...", code_desc,
-                         "Empty enabled set produces broken import syntax in description")
+        self.assertNotIn(
+            "import , ...",
+            code_desc,
+            "Empty enabled set produces broken import syntax in description",
+        )
 
     def test_real_scenario_all_sandbox_tools_disabled(self):
         """Reproduce the exact code path from model_tools.py:231-234.
@@ -480,7 +511,7 @@ class TestBuildExecuteCodeSchema(unittest.TestCase):
             dynamic_schema = build_execute_code_schema(sandbox_enabled)
 
         SANDBOX_ALLOWED_TOOLS = {web_search, web_extract, read_file, write_file,
-                                  search_files, patch, terminal}
+                                  search_files, patch}
         tools_to_include  = {"execute_code"}
         intersection      = empty set
         """
@@ -488,13 +519,17 @@ class TestBuildExecuteCodeSchema(unittest.TestCase):
         tools_to_include = {"execute_code"}
         sandbox_enabled = SANDBOX_ALLOWED_TOOLS & tools_to_include
 
-        self.assertEqual(sandbox_enabled, set(),
-                         "Intersection should be empty when only execute_code is enabled")
+        self.assertEqual(
+            sandbox_enabled,
+            set(),
+            "Intersection should be empty when only execute_code is enabled",
+        )
 
         schema = build_execute_code_schema(sandbox_enabled)
         code_desc = schema["parameters"]["properties"]["code"]["description"]
-        self.assertNotIn("import , ...", code_desc,
-                         "Bug: broken import syntax sent to the model")
+        self.assertNotIn(
+            "import , ...", code_desc, "Bug: broken import syntax sent to the model"
+        )
 
     def test_real_scenario_only_vision_enabled(self):
         """Another real path: user runs `hermes tools code_execution,vision`.
@@ -535,6 +570,7 @@ class TestBuildExecuteCodeSchema(unittest.TestCase):
 # Environment variable filtering (security critical)
 # ---------------------------------------------------------------------------
 
+
 @unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")
 class TestEnvVarFiltering(unittest.TestCase):
     """Verify that execute_code filters environment variables correctly.
@@ -545,19 +581,21 @@ class TestEnvVarFiltering(unittest.TestCase):
 
     def _get_child_env(self, extra_env=None):
         """Run a script that dumps its environment and return the env dict."""
-        code = (
-            "import os, json\n"
-            "print(json.dumps(dict(os.environ)))\n"
-        )
+        code = "import os, json\nprint(json.dumps(dict(os.environ)))\n"
         env_backup = os.environ.copy()
         try:
             if extra_env:
                 os.environ.update(extra_env)
-            with patch("model_tools.handle_function_call", return_value='{}'), \
-                 patch("tools.code_execution_tool._load_config",
-                       return_value={"timeout": 10, "max_tool_calls": 50}):
-                raw = execute_code(code, task_id="test-env",
-                                   enabled_tools=list(SANDBOX_ALLOWED_TOOLS))
+            with (
+                patch("model_tools.handle_function_call", return_value="{}"),
+                patch(
+                    "tools.code_execution_tool._load_config",
+                    return_value={"timeout": 10, "max_tool_calls": 50},
+                ),
+            ):
+                raw = execute_code(
+                    code, task_id="test-env", enabled_tools=list(SANDBOX_ALLOWED_TOOLS)
+                )
         finally:
             os.environ.clear()
             os.environ.update(env_backup)
@@ -567,31 +605,37 @@ class TestEnvVarFiltering(unittest.TestCase):
         return json.loads(result["output"].strip())
 
     def test_api_keys_excluded(self):
-        child_env = self._get_child_env({
-            "OPENAI_API_KEY": "sk-secret123",
-            "ANTHROPIC_API_KEY": "sk-ant-secret",
-            "FIRECRAWL_API_KEY": "fc-secret",
-        })
+        child_env = self._get_child_env(
+            {
+                "OPENAI_API_KEY": "sk-secret123",
+                "ANTHROPIC_API_KEY": "sk-ant-secret",
+                "FIRECRAWL_API_KEY": "fc-secret",
+            }
+        )
         self.assertNotIn("OPENAI_API_KEY", child_env)
         self.assertNotIn("ANTHROPIC_API_KEY", child_env)
         self.assertNotIn("FIRECRAWL_API_KEY", child_env)
 
     def test_tokens_excluded(self):
-        child_env = self._get_child_env({
-            "GITHUB_TOKEN": "ghp_secret",
-            "MODAL_TOKEN_ID": "tok-123",
-            "MODAL_TOKEN_SECRET": "tok-sec",
-        })
+        child_env = self._get_child_env(
+            {
+                "GITHUB_TOKEN": "ghp_secret",
+                "MODAL_TOKEN_ID": "tok-123",
+                "MODAL_TOKEN_SECRET": "tok-sec",
+            }
+        )
         self.assertNotIn("GITHUB_TOKEN", child_env)
         self.assertNotIn("MODAL_TOKEN_ID", child_env)
         self.assertNotIn("MODAL_TOKEN_SECRET", child_env)
 
     def test_password_vars_excluded(self):
-        child_env = self._get_child_env({
-            "DB_PASSWORD": "hunter2",
-            "MY_PASSWD": "secret",
-            "AUTH_CREDENTIAL": "cred",
-        })
+        child_env = self._get_child_env(
+            {
+                "DB_PASSWORD": "hunter2",
+                "MY_PASSWD": "secret",
+                "AUTH_CREDENTIAL": "cred",
+            }
+        )
         self.assertNotIn("DB_PASSWORD", child_env)
         self.assertNotIn("MY_PASSWD", child_env)
         self.assertNotIn("AUTH_CREDENTIAL", child_env)
@@ -638,8 +682,8 @@ class TestEnvVarFiltering(unittest.TestCase):
 # execute_code edge cases
 # ---------------------------------------------------------------------------
 
-class TestExecuteCodeEdgeCases(unittest.TestCase):
 
+class TestExecuteCodeEdgeCases(unittest.TestCase):
     def test_windows_returns_error(self):
         """On Windows (or when SANDBOX_AVAILABLE is False), returns error JSON."""
         with patch("tools.code_execution_tool.SANDBOX_AVAILABLE", False):
@@ -656,61 +700,65 @@ class TestExecuteCodeEdgeCases(unittest.TestCase):
     def test_none_enabled_tools_uses_all(self):
         """When enabled_tools is None, all sandbox tools should be available."""
         code = (
-            "from hermes_tools import terminal, web_search, read_file\n"
-            "print('all imports ok')\n"
+            "from hermes_tools import web_search, read_file\nprint('all imports ok')\n"
         )
-        with patch("model_tools.handle_function_call",
-                    return_value=json.dumps({"ok": True})):
-            result = json.loads(execute_code(code, task_id="test-none",
-                                             enabled_tools=None))
+        with patch(
+            "model_tools.handle_function_call", return_value=json.dumps({"ok": True})
+        ):
+            result = json.loads(
+                execute_code(code, task_id="test-none", enabled_tools=None)
+            )
         self.assertEqual(result["status"], "success")
         self.assertIn("all imports ok", result["output"])
 
     @unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")
     def test_empty_enabled_tools_uses_all(self):
         """When enabled_tools is [] (empty), all sandbox tools should be available."""
-        code = (
-            "from hermes_tools import terminal, web_search\n"
-            "print('imports ok')\n"
-        )
-        with patch("model_tools.handle_function_call",
-                    return_value=json.dumps({"ok": True})):
-            result = json.loads(execute_code(code, task_id="test-empty",
-                                             enabled_tools=[]))
+        code = "from hermes_tools import web_search\nprint('imports ok')\n"
+        with patch(
+            "model_tools.handle_function_call", return_value=json.dumps({"ok": True})
+        ):
+            result = json.loads(
+                execute_code(code, task_id="test-empty", enabled_tools=[])
+            )
         self.assertEqual(result["status"], "success")
         self.assertIn("imports ok", result["output"])
 
     @unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")
     def test_nonoverlapping_tools_fallback(self):
         """When enabled_tools has no overlap with SANDBOX_ALLOWED_TOOLS,
-        should fall back to all allowed tools."""
-        code = (
-            "from hermes_tools import terminal\n"
-            "print('fallback ok')\n"
-        )
-        with patch("model_tools.handle_function_call",
-                    return_value=json.dumps({"ok": True})):
-            result = json.loads(execute_code(
-                code, task_id="test-nonoverlap",
-                enabled_tools=["vision_analyze", "browser_snapshot"],
-            ))
+        falls back to empty set (no tools available)."""
+        code = "from hermes_tools import web_search\nprint('web_search available')\n"
+        with patch(
+            "model_tools.handle_function_call", return_value=json.dumps({"ok": True})
+        ):
+            result = json.loads(
+                execute_code(
+                    code,
+                    task_id="test-nonoverlap",
+                    enabled_tools=["vision_analyze", "browser_snapshot"],
+                )
+            )
         self.assertEqual(result["status"], "success")
-        self.assertIn("fallback ok", result["output"])
+        self.assertIn("web_search available", result["output"])
 
 
 # ---------------------------------------------------------------------------
 # _load_config
 # ---------------------------------------------------------------------------
 
+
 class TestLoadConfig(unittest.TestCase):
     def test_returns_empty_dict_when_cli_config_unavailable(self):
         from tools.code_execution_tool import _load_config
+
         with patch.dict("sys.modules", {"cli": None}):
             result = _load_config()
             self.assertIsInstance(result, dict)
 
     def test_returns_code_execution_section(self):
         from tools.code_execution_tool import _load_config
+
         mock_cli = MagicMock()
         mock_cli.CLI_CONFIG = {"code_execution": {"timeout": 120, "max_tool_calls": 10}}
         with patch.dict("sys.modules", {"cli": mock_cli}):
@@ -722,6 +770,7 @@ class TestLoadConfig(unittest.TestCase):
 # Interrupt event
 # ---------------------------------------------------------------------------
 
+
 @unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")
 class TestInterruptHandling(unittest.TestCase):
     def test_interrupt_event_stops_execution(self):
@@ -730,26 +779,38 @@ class TestInterruptHandling(unittest.TestCase):
 
         def set_interrupt_after_delay():
             import time as _t
+
             _t.sleep(1)
             from tools.terminal_tool import _interrupt_event
+
             _interrupt_event.set()
 
         t = threading.Thread(target=set_interrupt_after_delay, daemon=True)
         t.start()
 
         try:
-            with patch("model_tools.handle_function_call",
-                        return_value=json.dumps({"ok": True})), \
-                 patch("tools.code_execution_tool._load_config",
-                       return_value={"timeout": 30, "max_tool_calls": 50}):
-                result = json.loads(execute_code(
-                    code, task_id="test-interrupt",
-                    enabled_tools=list(SANDBOX_ALLOWED_TOOLS),
-                ))
+            with (
+                patch(
+                    "model_tools.handle_function_call",
+                    return_value=json.dumps({"ok": True}),
+                ),
+                patch(
+                    "tools.code_execution_tool._load_config",
+                    return_value={"timeout": 30, "max_tool_calls": 50},
+                ),
+            ):
+                result = json.loads(
+                    execute_code(
+                        code,
+                        task_id="test-interrupt",
+                        enabled_tools=list(SANDBOX_ALLOWED_TOOLS),
+                    )
+                )
             self.assertEqual(result["status"], "interrupted")
             self.assertIn("interrupted", result["output"])
         finally:
             from tools.terminal_tool import _interrupt_event
+
             _interrupt_event.clear()
             t.join(timeout=3)
 
@@ -758,7 +819,9 @@ class TestHeadTailTruncation(unittest.TestCase):
     """Tests for head+tail truncation of large stdout in execute_code."""
 
     def _run(self, code):
-        with patch("model_tools.handle_function_call", side_effect=_mock_handle_function_call):
+        with patch(
+            "model_tools.handle_function_call", side_effect=_mock_handle_function_call
+        ):
             result = execute_code(
                 code=code,
                 task_id="test-task",
@@ -775,13 +838,13 @@ class TestHeadTailTruncation(unittest.TestCase):
 
     def test_large_output_preserves_head_and_tail(self):
         """Output exceeding MAX_STDOUT_BYTES keeps both head and tail."""
-        code = '''
+        code = """
 # Print HEAD marker, then filler, then TAIL marker
 print("HEAD_MARKER_START")
 for i in range(15000):
     print(f"filler_line_{i:06d}_padding_to_fill_buffer")
 print("TAIL_MARKER_END")
-'''
+"""
         result = self._run(code)
         self.assertEqual(result["status"], "success")
         output = result["output"]
@@ -794,10 +857,10 @@ print("TAIL_MARKER_END")
 
     def test_truncation_notice_format(self):
         """Truncation notice includes character counts."""
-        code = '''
+        code = """
 for i in range(15000):
     print(f"padding_line_{i:06d}_xxxxxxxxxxxxxxxxxxxxxxxxxx")
-'''
+"""
         result = self._run(code)
         output = result["output"]
         if "TRUNCATED" in output:

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -38,23 +38,24 @@ logger = logging.getLogger(__name__)
 
 SANDBOX_AVAILABLE = sys.platform != "win32"
 
-# The 7 tools allowed inside the sandbox. The intersection of this list
+# The 6 tools allowed inside the sandbox. The intersection of this list
 # and the session's enabled tools determines which stubs are generated.
-SANDBOX_ALLOWED_TOOLS = frozenset([
-    "web_search",
-    "web_extract",
-    "read_file",
-    "write_file",
-    "search_files",
-    "patch",
-    "terminal",
-])
+SANDBOX_ALLOWED_TOOLS = frozenset(
+    [
+        "web_search",
+        "web_extract",
+        "read_file",
+        "write_file",
+        "search_files",
+        "patch",
+    ]
+)
 
 # Resource limit defaults (overridable via config.yaml → code_execution.*)
-DEFAULT_TIMEOUT = 300        # 5 minutes
+DEFAULT_TIMEOUT = 300  # 5 minutes
 DEFAULT_MAX_TOOL_CALLS = 50
-MAX_STDOUT_BYTES = 50_000    # 50 KB
-MAX_STDERR_BYTES = 10_000    # 10 KB
+MAX_STDOUT_BYTES = 50_000  # 50 KB
+MAX_STDERR_BYTES = 10_000  # 10 KB
 
 
 def check_sandbox_requirements() -> bool:
@@ -104,12 +105,6 @@ _TOOL_STUBS = {
         'path: str = None, old_string: str = None, new_string: str = None, replace_all: bool = False, mode: str = "replace", patch: str = None',
         '"""Targeted find-and-replace (mode="replace") or V4A multi-file patches (mode="patch"). Returns dict with status."""',
         '{"path": path, "old_string": old_string, "new_string": new_string, "replace_all": replace_all, "mode": mode, "patch": patch}',
-    ),
-    "terminal": (
-        "terminal",
-        "command: str, timeout: int = None, workdir: str = None",
-        '"""Run a shell command (foreground only). Returns dict with "output" and "exit_code"."""',
-        '{"command": command, "timeout": timeout, "workdir": workdir}',
     ),
 }
 
@@ -215,15 +210,12 @@ def _call(tool_name, args):
 # RPC server (runs in a thread inside the parent process)
 # ---------------------------------------------------------------------------
 
-# Terminal parameters that must not be used from ephemeral sandbox scripts
-_TERMINAL_BLOCKED_PARAMS = {"background", "check_interval", "pty"}
-
 
 def _rpc_server_loop(
     server_sock: socket.socket,
     task_id: str,
     tool_call_log: list,
-    tool_call_counter: list,   # mutable [int] so the thread can increment
+    tool_call_counter: list,  # mutable [int] so the thread can increment
     max_tool_calls: int,
     allowed_tools: frozenset,
 ):
@@ -270,30 +262,29 @@ def _rpc_server_loop(
                 # Enforce the allow-list
                 if tool_name not in allowed_tools:
                     available = ", ".join(sorted(allowed_tools))
-                    resp = json.dumps({
-                        "error": (
-                            f"Tool '{tool_name}' is not available in execute_code. "
-                            f"Available: {available}"
-                        )
-                    })
+                    resp = json.dumps(
+                        {
+                            "error": (
+                                f"Tool '{tool_name}' is not available in execute_code. "
+                                f"Available: {available}"
+                            )
+                        }
+                    )
                     conn.sendall((resp + "\n").encode())
                     continue
 
                 # Enforce tool call limit
                 if tool_call_counter[0] >= max_tool_calls:
-                    resp = json.dumps({
-                        "error": (
-                            f"Tool call limit reached ({max_tool_calls}). "
-                            "No more tool calls allowed in this execution."
-                        )
-                    })
+                    resp = json.dumps(
+                        {
+                            "error": (
+                                f"Tool call limit reached ({max_tool_calls}). "
+                                "No more tool calls allowed in this execution."
+                            )
+                        }
+                    )
                     conn.sendall((resp + "\n").encode())
                     continue
-
-                # Strip forbidden terminal parameters
-                if tool_name == "terminal" and isinstance(tool_args, dict):
-                    for param in _TERMINAL_BLOCKED_PARAMS:
-                        tool_args.pop(param, None)
 
                 # Dispatch through the standard tool handler.
                 # Suppress stdout/stderr from internal tool handlers so
@@ -319,11 +310,13 @@ def _rpc_server_loop(
 
                 # Log for observability
                 args_preview = str(tool_args)[:80]
-                tool_call_log.append({
-                    "tool": tool_name,
-                    "args_preview": args_preview,
-                    "duration": round(call_duration, 2),
-                })
+                tool_call_log.append(
+                    {
+                        "tool": tool_name,
+                        "args_preview": args_preview,
+                        "duration": round(call_duration, 2),
+                    }
+                )
 
                 conn.sendall((result + "\n").encode())
 
@@ -342,6 +335,7 @@ def _rpc_server_loop(
 # ---------------------------------------------------------------------------
 # Main entry point
 # ---------------------------------------------------------------------------
+
 
 def execute_code(
     code: str,
@@ -362,9 +356,11 @@ def execute_code(
         JSON string with execution results.
     """
     if not SANDBOX_AVAILABLE:
-        return json.dumps({
-            "error": "execute_code is not available on Windows. Use normal tool calls instead."
-        })
+        return json.dumps(
+            {
+                "error": "execute_code is not available on Windows. Use normal tool calls instead."
+            }
+        )
 
     if not code or not code.strip():
         return json.dumps({"error": "No code provided."})
@@ -382,7 +378,7 @@ def execute_code(
     sandbox_tools = frozenset(SANDBOX_ALLOWED_TOOLS & session_tools)
 
     if not sandbox_tools:
-        sandbox_tools = SANDBOX_ALLOWED_TOOLS
+        sandbox_tools = frozenset()
 
     # --- Set up temp directory with hermes_tools.py and script.py ---
     tmpdir = tempfile.mkdtemp(prefix="hermes_sandbox_")
@@ -417,8 +413,12 @@ def execute_code(
         rpc_thread = threading.Thread(
             target=_rpc_server_loop,
             args=(
-                server_sock, task_id, tool_call_log,
-                tool_call_counter, max_tool_calls, sandbox_tools,
+                server_sock,
+                task_id,
+                tool_call_log,
+                tool_call_counter,
+                max_tool_calls,
+                sandbox_tools,
             ),
             daemon=True,
         )
@@ -431,11 +431,32 @@ def execute_code(
         # Exception: env vars declared by loaded skills (via env_passthrough
         # registry) or explicitly allowed by the user in config.yaml
         # (terminal.env_passthrough) are passed through.
-        _SAFE_ENV_PREFIXES = ("PATH", "HOME", "USER", "LANG", "LC_", "TERM",
-                              "TMPDIR", "TMP", "TEMP", "SHELL", "LOGNAME",
-                              "XDG_", "PYTHONPATH", "VIRTUAL_ENV", "CONDA")
-        _SECRET_SUBSTRINGS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL",
-                              "PASSWD", "AUTH")
+        _SAFE_ENV_PREFIXES = (
+            "PATH",
+            "HOME",
+            "USER",
+            "LANG",
+            "LC_",
+            "TERM",
+            "TMPDIR",
+            "TMP",
+            "TEMP",
+            "SHELL",
+            "LOGNAME",
+            "XDG_",
+            "PYTHONPATH",
+            "VIRTUAL_ENV",
+            "CONDA",
+        )
+        _SECRET_SUBSTRINGS = (
+            "KEY",
+            "TOKEN",
+            "SECRET",
+            "PASSWORD",
+            "CREDENTIAL",
+            "PASSWD",
+            "AUTH",
+        )
         try:
             from tools.env_passthrough import is_env_passthrough as _is_passthrough
         except Exception:
@@ -458,7 +479,9 @@ def execute_code(
         # repo-root modules are available to child scripts.
         _hermes_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         _existing_pp = child_env.get("PYTHONPATH", "")
-        child_env["PYTHONPATH"] = _hermes_root + (os.pathsep + _existing_pp if _existing_pp else "")
+        child_env["PYTHONPATH"] = _hermes_root + (
+            os.pathsep + _existing_pp if _existing_pp else ""
+        )
         # Inject user's configured timezone so datetime.now() in sandboxed
         # code reflects the correct wall-clock time.
         _tz_name = os.getenv("HERMES_TIMEZONE", "").strip()
@@ -483,7 +506,7 @@ def execute_code(
         # For stdout we use a head+tail strategy: keep the first HEAD_BYTES
         # and a rolling window of the last TAIL_BYTES so the final print()
         # output is never lost.  Stderr keeps head-only (errors appear early).
-        _STDOUT_HEAD_BYTES = int(MAX_STDOUT_BYTES * 0.4)   # 40% head
+        _STDOUT_HEAD_BYTES = int(MAX_STDOUT_BYTES * 0.4)  # 40% head
         _STDOUT_TAIL_BYTES = MAX_STDOUT_BYTES - _STDOUT_HEAD_BYTES  # 60% tail
 
         def _drain(pipe, chunks, max_bytes):
@@ -503,10 +526,13 @@ def execute_code(
 
         stdout_total_bytes = [0]  # mutable ref for total bytes seen
 
-        def _drain_head_tail(pipe, head_chunks, tail_chunks, head_bytes, tail_bytes, total_ref):
+        def _drain_head_tail(
+            pipe, head_chunks, tail_chunks, head_bytes, tail_bytes, total_ref
+        ):
             """Drain stdout keeping both head and tail data."""
             head_collected = 0
             from collections import deque
+
             tail_buf = deque()
             tail_collected = 0
             try:
@@ -540,12 +566,20 @@ def execute_code(
 
         stdout_reader = threading.Thread(
             target=_drain_head_tail,
-            args=(proc.stdout, stdout_head_chunks, stdout_tail_chunks,
-                  _STDOUT_HEAD_BYTES, _STDOUT_TAIL_BYTES, stdout_total_bytes),
-            daemon=True
+            args=(
+                proc.stdout,
+                stdout_head_chunks,
+                stdout_tail_chunks,
+                _STDOUT_HEAD_BYTES,
+                _STDOUT_TAIL_BYTES,
+                stdout_total_bytes,
+            ),
+            daemon=True,
         )
         stderr_reader = threading.Thread(
-            target=_drain, args=(proc.stderr, stderr_chunks, MAX_STDERR_BYTES), daemon=True
+            target=_drain,
+            args=(proc.stderr, stderr_chunks, MAX_STDERR_BYTES),
+            daemon=True,
         )
         stdout_reader.start()
         stderr_reader.start()
@@ -593,6 +627,7 @@ def execute_code(
         # Strip ANSI escape sequences so the model never sees terminal
         # formatting — prevents it from copying escapes into file writes.
         from tools.ansi_strip import strip_ansi
+
         stdout_text = strip_ansi(stdout_text)
         stderr_text = strip_ansi(stderr_text)
 
@@ -607,7 +642,9 @@ def execute_code(
         if status == "timeout":
             result["error"] = f"Script timed out after {timeout}s and was killed."
         elif status == "interrupted":
-            result["output"] = stdout_text + "\n[execution interrupted — user sent a new message]"
+            result["output"] = (
+                stdout_text + "\n[execution interrupted — user sent a new message]"
+            )
         elif exit_code != 0:
             result["status"] = "error"
             result["error"] = stderr_text or f"Script exited with code {exit_code}"
@@ -627,12 +664,15 @@ def execute_code(
             exc,
             exc_info=True,
         )
-        return json.dumps({
-            "status": "error",
-            "error": str(exc),
-            "tool_calls_made": tool_call_counter[0],
-            "duration_seconds": duration,
-        }, ensure_ascii=False)
+        return json.dumps(
+            {
+                "status": "error",
+                "error": str(exc),
+                "tool_calls_made": tool_call_counter[0],
+                "duration_seconds": duration,
+            },
+            ensure_ascii=False,
+        )
 
     finally:
         # Cleanup temp dir and socket
@@ -642,6 +682,7 @@ def execute_code(
             except OSError as e:
                 logger.debug("Server socket close error: %s", e)
         import shutil
+
         shutil.rmtree(tmpdir, ignore_errors=True)
         try:
             os.unlink(sock_path)
@@ -674,7 +715,9 @@ def _kill_process_group(proc, escalate: bool = False):
                 else:
                     os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
             except (ProcessLookupError, PermissionError) as e:
-                logger.debug("Could not kill process group with SIGKILL: %s", e, exc_info=True)
+                logger.debug(
+                    "Could not kill process group with SIGKILL: %s", e, exc_info=True
+                )
                 try:
                     proc.kill()
                 except Exception as e2:
@@ -685,6 +728,7 @@ def _load_config() -> dict:
     """Load code_execution config from CLI_CONFIG if available."""
     try:
         from cli import CLI_CONFIG
+
         return CLI_CONFIG.get("code_execution", {})
     except Exception:
         return {}
@@ -697,27 +741,36 @@ def _load_config() -> dict:
 # Per-tool documentation lines for the execute_code description.
 # Ordered to match the canonical display order.
 _TOOL_DOC_LINES = [
-    ("web_search",
-     "  web_search(query: str, limit: int = 5) -> dict\n"
-     "    Returns {\"data\": {\"web\": [{\"url\", \"title\", \"description\"}, ...]}}"),
-    ("web_extract",
-     "  web_extract(urls: list[str]) -> dict\n"
-     "    Returns {\"results\": [{\"url\", \"title\", \"content\", \"error\"}, ...]} where content is markdown"),
-    ("read_file",
-     "  read_file(path: str, offset: int = 1, limit: int = 500) -> dict\n"
-     "    Lines are 1-indexed. Returns {\"content\": \"...\", \"total_lines\": N}"),
-    ("write_file",
-     "  write_file(path: str, content: str) -> dict\n"
-     "    Always overwrites the entire file."),
-    ("search_files",
-     "  search_files(pattern: str, target=\"content\", path=\".\", file_glob=None, limit=50) -> dict\n"
-     "    target: \"content\" (search inside files) or \"files\" (find files by name). Returns {\"matches\": [...]}"),
-    ("patch",
-     "  patch(path: str, old_string: str, new_string: str, replace_all: bool = False) -> dict\n"
-     "    Replaces old_string with new_string in the file."),
-    ("terminal",
-     "  terminal(command: str, timeout=None, workdir=None) -> dict\n"
-     "    Foreground only (no background/pty). Returns {\"output\": \"...\", \"exit_code\": N}"),
+    (
+        "web_search",
+        "  web_search(query: str, limit: int = 5) -> dict\n"
+        '    Returns {"data": {"web": [{"url", "title", "description"}, ...]}}',
+    ),
+    (
+        "web_extract",
+        "  web_extract(urls: list[str]) -> dict\n"
+        '    Returns {"results": [{"url", "title", "content", "error"}, ...]} where content is markdown',
+    ),
+    (
+        "read_file",
+        "  read_file(path: str, offset: int = 1, limit: int = 500) -> dict\n"
+        '    Lines are 1-indexed. Returns {"content": "...", "total_lines": N}',
+    ),
+    (
+        "write_file",
+        "  write_file(path: str, content: str) -> dict\n"
+        "    Always overwrites the entire file.",
+    ),
+    (
+        "search_files",
+        '  search_files(pattern: str, target="content", path=".", file_glob=None, limit=50) -> dict\n'
+        '    target: "content" (search inside files) or "files" (find files by name). Returns {"matches": [...]}',
+    ),
+    (
+        "patch",
+        "  patch(path: str, old_string: str, new_string: str, replace_all: bool = False) -> dict\n"
+        "    Replaces old_string with new_string in the file.",
+    ),
 ]
 
 
@@ -737,7 +790,7 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None) -> dict:
     )
 
     # Build example import list from enabled tools
-    import_examples = [n for n in ("web_search", "terminal") if n in enabled_sandbox_tools]
+    import_examples = [n for n in ("web_search",) if n in enabled_sandbox_tools]
     if not import_examples:
         import_examples = sorted(enabled_sandbox_tools)[:2]
     if import_examples:
@@ -756,12 +809,11 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None) -> dict:
         "or the task requires interactive user input.\n\n"
         f"Available via `from hermes_tools import ...`:\n\n"
         f"{tool_lines}\n\n"
-        "Limits: 5-minute timeout, 50KB stdout cap, max 50 tool calls per script. "
-        "terminal() is foreground-only (no background or pty).\n\n"
+        "Limits: 5-minute timeout, 50KB stdout cap, max 50 tool calls per script.\n\n"
         "Print your final result to stdout. Use Python stdlib (json, re, math, csv, "
         "datetime, collections, etc.) for processing between tool calls.\n\n"
         "Also available (no import needed — built into hermes_tools):\n"
-        "  json_parse(text: str) — json.loads with strict=False; use for terminal() output with control chars\n"
+        "  json_parse(text: str) — json.loads with strict=False; use for parsing tool output with control chars\n"
         "  shell_quote(s: str) — shlex.quote(); use when interpolating dynamic strings into shell commands\n"
         "  retry(fn, max_attempts=3, delay=2) — retry with exponential backoff for transient failures"
     )
@@ -800,7 +852,8 @@ registry.register(
     handler=lambda args, **kw: execute_code(
         code=args.get("code", ""),
         task_id=kw.get("task_id"),
-        enabled_tools=kw.get("enabled_tools")),
+        enabled_tools=kw.get("enabled_tools"),
+    ),
     check_fn=check_sandbox_requirements,
     emoji="🐍",
 )

--- a/website/docs/user-guide/features/code-execution.md
+++ b/website/docs/user-guide/features/code-execution.md
@@ -27,7 +27,7 @@ for r in results["data"]["web"]:
 print(summary)
 ```
 
-**Available tools in sandbox:** `web_search`, `web_extract`, `read_file`, `write_file`, `search_files`, `patch`, `terminal` (foreground only).
+**Available tools in sandbox:** `web_search`, `web_extract`, `read_file`, `write_file`, `search_files`, `patch`.
 
 ## When the Agent Uses This
 


### PR DESCRIPTION
## Summary

The code execution sandbox (`execute_code`) in `tools/code_execution_tool.py` included `terminal` in `SANDBOX_ALLOWED_TOOLS`, allowing LLM-generated Python code running inside the sandbox to execute arbitrary shell commands via the RPC stub — bypassing the `check_dangerous_command()` approval system that protects direct `terminal` tool calls.

This is not a real sandbox (no container/namespace isolation). `rm -rf /` would execute as the user on the host, with no approval prompt.

Fixes #4146

## What changed

### `tools/code_execution_tool.py`
- Remove `"terminal"` from `SANDBOX_ALLOWED_TOOLS` frozenset (7 → 6 tools)
- Remove `_TOOL_STUBS["terminal"]` entry (dead code — never generated post-fix)
- Remove `_TERMINAL_BLOCKED_PARAMS` variable and its stripping block (unreachable post-fix)
- Remove terminal from `_TOOL_DOC_LINES` and schema description
- Remove stale `"terminal() is foreground-only..."` from description
- Remove `"terminal"` from `import_examples` tuple
- Change fallback to `frozenset()` (was `SANDBOX_ALLOWED_TOOLS`) to prevent terminal re-introduction when `enabled_tools` is None/empty

### `tests/tools/test_code_execution.py`
- Rewrite ~11 tests that used `terminal` as a sandbox tool to use `web_search` instead

### `website/docs/user-guide/features/code-execution.md`
- Remove `terminal` from sandbox tools list

## How to test

1. `hermes chat -q "Write a Python script that runs in the sandbox and calls terminal('echo hello')"`
   - Should receive a clear error — `terminal` is not available in sandbox
2. `hermes chat -q "Use execute_code to search the web"`
   - Should work normally with `web_search`
3. `hermes chat -q "Use terminal to run echo hello"`
   - Should work normally via direct tool call with approval prompt

## Platforms tested

Linux (primary), macOS (UDS compatible). This fix only affects Unix-like systems (Windows already had sandbox disabled).

## Security note

This is a **critical security fix** — shell injection from sandbox code. The `terminal` tool remains available as a direct LLM tool call, protected by `check_dangerous_command()` with the 78-pattern dangerous command detection and user approval flow.