### PR TITLE
fix: remove dead /model command remnants from gateway and Discord

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1518,11 +1518,6 @@ class DiscordAdapter(BasePlatformAdapter):
         async def slash_reset(interaction: discord.Interaction):
             await self._run_simple_slash(interaction, "/reset", "Session reset~")
 
-        @tree.command(name="model", description="Show or change the model")
-        @discord.app_commands.describe(name="Model name (e.g. anthropic/claude-sonnet-4). Leave empty to see current.")
-        async def slash_model(interaction: discord.Interaction, name: str = ""):
-            await self._run_simple_slash(interaction, f"/model {name}".strip())
-
         @tree.command(name="reasoning", description="Show or change reasoning effort")
         @discord.app_commands.describe(effort="Reasoning effort: xhigh, high, medium, low, minimal, or none.")
         async def slash_reasoning(interaction: discord.Interaction, effort: str = ""):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -458,7 +458,7 @@ class GatewayRunner:
 
         # Track active fallback model/provider when primary is rate-limited.
         # Set after an agent run where fallback was activated; cleared when
-        # the primary model succeeds again or the user switches via /model.
+        # the primary model succeeds again or the user restarts the gateway.
         self._effective_model: Optional[str] = None
         self._effective_provider: Optional[str] = None
 
@@ -3244,7 +3244,7 @@ class GatewayRunner:
             lines.append(f"{auth} `{p['id']}` — {p['label']}{aliases}{marker}")
 
         lines.append("")
-        lines.append("Switch: `/model provider:model-name`")
+        lines.append("Switch model: `hermes model` (outside gateway)")
         lines.append("Setup: `hermes setup`")
         return "\n".join(lines)
     
@@ -5117,7 +5117,7 @@ class GatewayRunner:
         return hashlib.sha256(blob.encode()).hexdigest()[:16]
 
     def _evict_cached_agent(self, session_key: str) -> None:
-        """Remove a cached agent for a session (called on /new, /model, etc)."""
+        """Remove a cached agent for a session (called on /new, /reset, etc)."""
         _lock = getattr(self, "_agent_cache_lock", None)
         if _lock:
             with _lock:
@@ -5779,7 +5779,7 @@ class GatewayRunner:
             response = await loop.run_in_executor(None, run_sync)
 
             # Track fallback model state: if the agent switched to a
-            # fallback model during this run, persist it so /model shows
+            # fallback model during this run, persist it so /provider shows
             # the actually-active model instead of the config default.
             _agent = agent_holder[0]
             if _agent is not None and hasattr(_agent, 'model'):


### PR DESCRIPTION
## Summary

`/model` was removed in #3080 but several references survived in the gateway:

- `/provider` help text still showed `Switch: /model provider:model-name`
- Discord had a **registered `/model` slash command** that dispatched `/model <name>` as raw text to the agent (which interprets it as a regular message, not a command)
- 3 code comments still referenced `/model`

## Changes

- `gateway/run.py` — update help text to point to `hermes model` subcommand, fix 3 stale comments
- `gateway/platforms/discord.py` — remove dead `/model` slash command registration (5 lines)

4 insertions, 9 deletions.

Addresses #4039