### PR TITLE
fix: back up config.yaml before hermes setup modifies it

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -3258,6 +3258,21 @@ def run_setup_wizard(args):
     config = load_config()
     hermes_home = get_hermes_home()
 
+    # Back up existing config before setup modifies it (#3522)
+    config_path = get_config_path()
+    if config_path.exists():
+        from datetime import datetime as _dt
+        _backup_path = config_path.with_suffix(
+            f".yaml.bak.{_dt.now().strftime('%Y%m%d_%H%M%S')}"
+        )
+        try:
+            import shutil
+            shutil.copy2(config_path, _backup_path)
+        except Exception:
+            _backup_path = None
+    else:
+        _backup_path = None
+
     # Detect non-interactive environments (headless SSH, Docker, CI/CD)
     non_interactive = getattr(args, 'non_interactive', False)
     if not non_interactive and not is_interactive_stdin():
@@ -3456,6 +3471,10 @@ def run_setup_wizard(args):
 
     # Save and show summary
     save_config(config)
+    if _backup_path and _backup_path.exists():
+        print_info(f"Previous config backed up to: {_backup_path}")
+        print_info("If setup changed a value you customized, restore it with:")
+        print_info(f"  cp {_backup_path} {config_path}")
     _print_setup_summary(config, hermes_home)
 
 


### PR DESCRIPTION
## Summary

Create a timestamped backup of `config.yaml` before the setup wizard modifies it, so users can recover customized values that get overwritten.

## Problem

`hermes setup` can silently reset user-customized config values to defaults. For example, a user who set `compression.threshold: 0.80` to prevent compaction loops with a 32K-context local model gets reverted to `0.50` after running setup, re-triggering the exact problem they'd fixed. (See #3522 for the full report.)

## What this PR does

1. Before any setup section runs, copies `config.yaml` to `config.yaml.bak.YYYYMMDD_HHMMSS`
2. After setup completes, shows the backup path and a restore command:
   ```
   ℹ Previous config backed up to: ~/.hermes/config.yaml.bak.20260330_180000
   ℹ If setup changed a value you customized, restore it with:
   ℹ   cp ~/.hermes/config.yaml.bak.20260330_180000 ~/.hermes/config.yaml
   ```

## Scope

This is the minimal safe fix — a backup + restore path. The deeper fix (making setup merge new defaults under existing user values instead of overwriting) is a larger change tracked in #3522.

## Changes

19 lines added to `hermes_cli/setup.py`.

Addresses #3522