### PR TITLE
feat: add Ctrl+L to clear screen and force full TUI redraw

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6593,6 +6593,12 @@ class HermesCLI:
             self._should_exit = True
             event.app.exit()
 
+        @kb.add('c-l')
+        def handle_ctrl_l(event):
+            """Handle Ctrl+L - clear screen and force full redraw."""
+            event.app.renderer.clear()
+            event.app.invalidate()
+
         @kb.add('c-z')
         def handle_ctrl_z(event):
             """Handle Ctrl+Z - suspend process to background (Unix only)."""


### PR DESCRIPTION
## Summary

Add `Ctrl+L` keybinding to clear the screen and force a full prompt_toolkit redraw. Standard terminal convention — recovers from rendering artifacts after resizes, tmux reattach, SSH reconnect, etc.

## Changes

6 lines added to `cli.py`. Uses `event.app.renderer.clear()` + `event.app.invalidate()`.