### PR TITLE
fix(cli): persist interactive sessions before exit

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5565,6 +5565,54 @@ class HermesCLI:
                 pass
 
 
+    def _ensure_current_session_indexed(self, *, model_override: str = None) -> None:
+        """Create the current CLI session row before the first agent turn.
+
+        The interactive UI exposes ``self.session_id`` before the model has fully
+        initialized. If the first turn is interrupted or agent init fails, we still
+        want ``hermes sessions list`` / ``--resume`` to recognize that session ID.
+        ``INSERT OR IGNORE`` keeps this safe to call repeatedly.
+        """
+        if self._resumed or not self._session_db:
+            return
+        try:
+            self._session_db.create_session(
+                session_id=self.session_id,
+                source=os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                model=model_override or self.model,
+                model_config={
+                    "max_iterations": self.max_turns,
+                    "reasoning_config": self.reasoning_config,
+                },
+            )
+        except Exception as e:
+            logger.debug("Could not pre-index CLI session %s: %s", self.session_id, e)
+
+    def _persist_session_on_exit(self) -> None:
+        """Flush any in-memory history to SQLite before closing the CLI session."""
+        if not self._session_db:
+            return
+
+        if self.agent and self.conversation_history:
+            flush_fn = getattr(self.agent, "_flush_messages_to_session_db", None)
+            if callable(flush_fn):
+                try:
+                    flush_fn(self.conversation_history)
+                except (Exception, KeyboardInterrupt) as e:
+                    logger.debug("Could not flush pending session history on exit: %s", e)
+
+        session_id = None
+        if self.agent and getattr(self.agent, "session_id", None):
+            session_id = self.agent.session_id
+        elif getattr(self, "session_id", None):
+            session_id = self.session_id
+
+        if session_id:
+            try:
+                self._session_db.end_session(session_id, "cli_close")
+            except (Exception, KeyboardInterrupt) as e:
+                logger.debug("Could not close session in DB: %s", e)
+
     def chat(self, message, images: list = None) -> Optional[str]:
         """
         Send a message to the agent and get a response.
@@ -5595,6 +5643,8 @@ class HermesCLI:
         turn_route = self._resolve_turn_agent_config(message)
         if turn_route["signature"] != self._active_agent_route_signature:
             self.agent = None
+
+        self._ensure_current_session_indexed(model_override=turn_route["model"])
 
         # Initialize agent if needed
         if self.agent is None:
@@ -7503,12 +7553,7 @@ class HermesCLI:
                     self.agent._honcho.shutdown()
                 except (Exception, KeyboardInterrupt):
                     pass
-            # Close session in SQLite
-            if hasattr(self, '_session_db') and self._session_db and self.agent:
-                try:
-                    self._session_db.end_session(self.agent.session_id, "cli_close")
-                except (Exception, KeyboardInterrupt) as e:
-                    logger.debug("Could not close session in DB: %s", e)
+            self._persist_session_on_exit()
             _run_cleanup()
             self._print_exit_summary()
 

--- a/tests/test_cli_session_persistence.py
+++ b/tests/test_cli_session_persistence.py
@@ -1,0 +1,123 @@
+"""Regression tests for CLI session indexing/persistence on early exit paths."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+from hermes_state import SessionDB
+
+
+def _make_cli(env_overrides=None, config_overrides=None, **kwargs):
+    """Create a HermesCLI instance with minimal prompt_toolkit mocking."""
+    clean_config = {
+        "model": {
+            "default": "anthropic/claude-opus-4.6",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "auto",
+        },
+        "display": {"compact": False, "tool_progress": "all"},
+        "agent": {},
+        "terminal": {"env_type": "local"},
+    }
+    if config_overrides:
+        clean_config.update(config_overrides)
+    clean_env = {"LLM_MODEL": "", "HERMES_MAX_ITERATIONS": ""}
+    if env_overrides:
+        clean_env.update(env_overrides)
+
+    prompt_toolkit_stubs = {
+        "prompt_toolkit": MagicMock(),
+        "prompt_toolkit.history": MagicMock(),
+        "prompt_toolkit.styles": MagicMock(),
+        "prompt_toolkit.patch_stdout": MagicMock(),
+        "prompt_toolkit.application": MagicMock(),
+        "prompt_toolkit.layout": MagicMock(),
+        "prompt_toolkit.layout.processors": MagicMock(),
+        "prompt_toolkit.filters": MagicMock(),
+        "prompt_toolkit.layout.dimension": MagicMock(),
+        "prompt_toolkit.layout.menus": MagicMock(),
+        "prompt_toolkit.widgets": MagicMock(),
+        "prompt_toolkit.key_binding": MagicMock(),
+        "prompt_toolkit.completion": MagicMock(),
+        "prompt_toolkit.formatted_text": MagicMock(),
+        "prompt_toolkit.auto_suggest": MagicMock(),
+    }
+
+    with patch.dict(sys.modules, prompt_toolkit_stubs), patch.dict(
+        os.environ, clean_env, clear=False
+    ):
+        import cli as cli_mod
+
+        cli_mod = importlib.reload(cli_mod)
+        with patch.object(cli_mod, "get_tool_definitions", return_value=[]), patch.dict(
+            cli_mod.__dict__, {"CLI_CONFIG": clean_config}
+        ):
+            return cli_mod.HermesCLI(**kwargs)
+
+
+def test_chat_indexes_new_session_before_agent_init(tmp_path):
+    cli = _make_cli()
+    cli._session_db = SessionDB(db_path=tmp_path / "state.db")
+    cli._ensure_runtime_credentials = MagicMock(return_value=True)
+    cli._resolve_turn_agent_config = MagicMock(
+        return_value={
+            "signature": ("test/model", "auto", None, None),
+            "model": "test/model",
+            "runtime": {"provider": "auto", "base_url": None, "api_key": None, "api_mode": None, "command": None, "args": []},
+            "label": "default",
+        }
+    )
+    cli._init_agent = MagicMock(return_value=False)
+
+    assert cli._session_db.get_session(cli.session_id) is None
+
+    assert cli.chat("hello") is None
+
+    session = cli._session_db.get_session(cli.session_id)
+    assert session is not None
+    assert session["source"] == "cli"
+    assert session["model"] == "test/model"
+
+
+def test_persist_session_on_exit_closes_preindexed_session_without_agent(tmp_path):
+    cli = _make_cli()
+    cli._session_db = SessionDB(db_path=tmp_path / "state.db")
+
+    cli._ensure_current_session_indexed(model_override="test/model")
+    cli._persist_session_on_exit()
+
+    session = cli._session_db.get_session(cli.session_id)
+    assert session is not None
+    assert session["model"] == "test/model"
+    assert session["end_reason"] == "cli_close"
+
+
+def test_persist_session_on_exit_flushes_pending_history_and_closes_session(tmp_path):
+    cli = _make_cli()
+    cli._session_db = SessionDB(db_path=tmp_path / "state.db")
+    cli.conversation_history = [{"role": "user", "content": "hello"}]
+
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}, clear=False):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            model="test/model",
+            quiet_mode=True,
+            session_db=cli._session_db,
+            session_id=cli.session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    cli.agent = agent
+    cli._persist_session_on_exit()
+
+    session = cli._session_db.get_session(cli.session_id)
+    assert session is not None
+    assert session["end_reason"] == "cli_close"
+
+    restored = cli._session_db.get_messages_as_conversation(cli.session_id)
+    assert restored == cli.conversation_history


### PR DESCRIPTION
## Summary
- Restore CLI session persistence for early interactive exit paths.
- Pre-index fresh CLI sessions before first agent initialization so exposed session IDs are resumable/listed even if init fails.
- Flush pending history and close session rows on exit, including the no-agent edge case.

## Why
- A prior fix for CLI session persistence was lost.
- Users could see a session ID in the CLI but fail to find/resume it later because the SQLite row was never created or never closed properly.
- This is a bug-fix/data-loss-prevention change and aligns with Hermes CONTRIBUTING priorities.

## Validation
- Targeted tests:
  - `pytest tests/test_cli_session_persistence.py tests/test_cli_new_session.py tests/test_hermes_state.py tests/test_860_dedup.py -q -n 0`
  - `148 passed`
- Full suite:
  - `python -m pytest tests/ -q`
  - `7263 passed, 164 skipped, 12 failed, 156 warnings`
  - Remaining failures appear unrelated to this PR:
    - `tests/test_api_key_providers.py::TestResolveApiKeyProviderCredentials::test_resolve_zai_with_key`
    - `tests/test_api_key_providers.py::TestKimiCodeCredentialAutoDetect::test_non_kimi_providers_unaffected`
    - `tests/test_anthropic_adapter.py::TestIsOAuthToken::test_managed_key`
    - `tests/test_anthropic_adapter.py::TestIsOAuthToken::test_jwt_token`
    - `tests/test_cli_provider_resolution.py::test_cmd_model_falls_back_to_auto_on_invalid_provider`
    - `tests/tools/test_browser_camofox.py::TestCamofoxGetImages::test_get_images`
    - `tests/tools/test_delegate.py::TestDelegationCredentialResolution::test_direct_endpoint_does_not_fall_back_to_openrouter_api_key_env`
    - `tests/tools/test_transcription.py::TestTranscribeOpenAI::test_no_key`
    - `tests/tools/test_transcription.py::TestGetProvider::test_explicit_local_no_cloud_fallback`
    - `tests/tools/test_transcription.py::TestGetProvider::test_local_nothing_available`
    - `tests/tools/test_transcription.py::TestGetProvider::test_explicit_openai_no_key_returns_none`
    - `tests/test_trajectory_compressor.py::TestGenerateSummary::test_generate_summary_async_handles_none_content`
- Manual Hermes exercise:
  - Ran `chat -Q -q 'Say only: ok'` in a temp `HERMES_HOME`
  - Confirmed session row exists in `state.db`
  - Confirmed `sessions list` shows the created session
  - Confirmed `chat --resume <session_id> -Q -q 'Say only: resumed'` resumes successfully
  - Additionally validated the pre-indexed/no-agent exit path closes with `end_reason='cli_close'`

## Platform notes
- Tested on: Linux
- Cross-platform risk: low-to-moderate
- This change touches terminal/CLI exit behavior, SQLite persistence, and file I/O; prompt_toolkit/TUI behavior on non-Linux terminals remains unverified

## Scope
- Focused PR containing:
  - CLI session pre-indexing before first agent init
  - CLI exit persistence/close handling
  - Regression tests for failed-init and no-agent exit paths
- Explicitly not included:
  - Unrelated session UX changes
  - Broader resume/UI cleanup
  - Fixes for current unrelated full-suite failures

## Related context
- Recovers previously lost local fix `c0937612fc61d4909e43308a8345ab9a5cae828e`
- Prepared in isolated worktree to avoid mixing with in-progress `/fast` changes
