### PR TITLE
fix: improve context compression quality — higher limits, tool tracking, degradation warning

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -199,7 +199,7 @@ class ContextCompressor:
     def _serialize_for_summary(self, turns: List[Dict[str, Any]]) -> str:
         """Serialize conversation turns into labeled text for the summarizer.
 
-        Includes tool call arguments and result content (up to 3000 chars
+        Includes tool call arguments and result content (up to 6000 chars
         per message) so the summarizer can preserve specific details like
         file paths, commands, and outputs.
         """
@@ -211,15 +211,15 @@ class ContextCompressor:
             # Tool results: keep more content than before (3000 chars)
             if role == "tool":
                 tool_id = msg.get("tool_call_id", "")
-                if len(content) > 3000:
-                    content = content[:2000] + "\n...[truncated]...\n" + content[-800:]
+                if len(content) > 6000:
+                    content = content[:4000] + "\n...[truncated]...\n" + content[-1500:]
                 parts.append(f"[TOOL RESULT {tool_id}]: {content}")
                 continue
 
             # Assistant messages: include tool call names AND arguments
             if role == "assistant":
-                if len(content) > 3000:
-                    content = content[:2000] + "\n...[truncated]...\n" + content[-800:]
+                if len(content) > 6000:
+                    content = content[:4000] + "\n...[truncated]...\n" + content[-1500:]
                 tool_calls = msg.get("tool_calls", [])
                 if tool_calls:
                     tc_parts = []
@@ -229,8 +229,8 @@ class ContextCompressor:
                             name = fn.get("name", "?")
                             args = fn.get("arguments", "")
                             # Truncate long arguments but keep enough for context
-                            if len(args) > 500:
-                                args = args[:400] + "..."
+                            if len(args) > 1500:
+                                args = args[:1200] + "..."
                             tc_parts.append(f"  {name}({args})")
                         else:
                             fn = getattr(tc, "function", None)
@@ -241,8 +241,8 @@ class ContextCompressor:
                 continue
 
             # User and other roles
-            if len(content) > 3000:
-                content = content[:2000] + "\n...[truncated]...\n" + content[-800:]
+            if len(content) > 6000:
+                content = content[:4000] + "\n...[truncated]...\n" + content[-1500:]
             parts.append(f"[{role.upper()}]: {content}")
 
         return "\n\n".join(parts)
@@ -299,6 +299,9 @@ Update the summary using this exact structure. PRESERVE all existing information
 ## Critical Context
 [Any specific values, error messages, configuration details, or data that would be lost without explicit preservation]
 
+## Tools & Patterns
+[Which tools were used, how they were used effectively, and any tool-specific discoveries. Accumulate across compactions.]
+
 Target ~{summary_budget} tokens. Be specific — include file paths, command outputs, error messages, and concrete values rather than vague descriptions.
 
 Write only the summary body. Do not include any preamble or prefix."""
@@ -336,6 +339,9 @@ Use this exact structure:
 
 ## Critical Context
 [Any specific values, error messages, configuration details, or data that would be lost without explicit preservation]
+
+## Tools & Patterns
+[Which tools were used, how they were used effectively, and any tool-specific discoveries (e.g., preferred flags, working invocations, successful command patterns)]
 
 Target ~{summary_budget} tokens. Be specific — include file paths, command outputs, error messages, and concrete values rather than vague descriptions. The goal is to prevent the next assistant from repeating work or losing important details.
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -5204,6 +5204,15 @@ class AIAgent:
             except Exception as e:
                 logger.warning("Session DB compression split failed — new session will NOT be indexed: %s", e)
 
+        # Warn on repeated compressions (quality degrades with each pass)
+        _cc = self.context_compressor.compression_count
+        if _cc >= 2:
+            self._vprint(
+                f"{self.log_prefix}⚠️  Session compressed {_cc} times — "
+                f"accuracy may degrade. Consider /new to start fresh.",
+                force=True,
+            )
+
         # Reset context pressure warning and token estimate — usage drops
         # after compaction.  Without this, the stale last_prompt_tokens from
         # the previous API call causes the pressure calculation to stay at


### PR DESCRIPTION
## Summary

Three targeted improvements to the compression system that address the most impactful remaining quality issues documented in #499.

### 1. Increase serializer truncation limits

The summarizer LLM was working from heavily truncated input:

| Content type | Before | After |
|-------------|--------|-------|
| Tool results | 3,000 chars (2000+800) | 6,000 chars (4000+1500) |
| Assistant content | 3,000 chars | 6,000 chars |
| Tool call arguments | 500 chars | 1,500 chars |
| User messages | 3,000 chars | 6,000 chars |

A 200-line code edit or a full test output was being cut to 3000 chars before the summarizer ever ran. The summary was working from incomplete data. The budget here is the *summary model's* context window, not the main model's — there's room.

### 2. Add "Tools & Patterns" section to compression prompts

Both the first-pass and iterative compression prompts now include:

```
## Tools & Patterns
[Which tools were used, how they were used effectively, and any
tool-specific discoveries (e.g., preferred flags, working invocations,
successful command patterns)]
```

After compression, the agent retains tool *definitions* (from `self.tools`) but loses conversational context of HOW those tools were used effectively. This section preserves working invocations, preferred flags, and tool-specific discoveries.

### 3. Degradation warning on repeated compressions

After the 2nd compression, the user sees:

```
⚠️  Session compressed 3 times — accuracy may degrade. Consider /new to start fresh.
```

`compression_count` was already tracked (`context_compressor.py:145`) but never surfaced. Multiple compressions silently compound quality loss — "summaries of summaries" lose information with each pass.

## Changes

24 lines changed, 9 added across `agent/context_compressor.py` and `run_agent.py`.

Ref #499