### PR TITLE
feat: add Fireworks context length detection support

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -176,6 +176,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "api.deepseek.com": "deepseek",
     "api.githubcopilot.com": "copilot",
     "models.github.ai": "copilot",
+    "api.fireworks.ai": "fireworks",
 }
 
 

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -43,6 +43,7 @@ PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "opencode-zen": "opencode",
     "opencode-go": "opencode-go",
     "kilocode": "kilo",
+    "fireworks": "fireworks-ai",
 }
 
 


### PR DESCRIPTION
Salvage of PR #3989 by @sroecker with a fix: the models.dev provider key is `fireworks-ai`, not `fireworks`. The original mapping would silently fail the lookup and still fall back to 128K.

**Changes:**
- `model_metadata.py`: add `api.fireworks.ai` → `fireworks` URL mapping
- `models_dev.py`: add `fireworks` → `fireworks-ai` provider mapping (corrected key)

Fireworks has 14 models on models.dev with correct context lengths (e.g. kimi-k2p5-turbo: 256K, deepseek-v3p1: 164K, glm-5: 203K).