### PR TITLE
fix(profiles): read model.default key in profile list display

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -241,7 +241,7 @@ def _read_config_model(profile_dir: Path) -> tuple:
         if isinstance(model_cfg, str):
             return model_cfg, None
         if isinstance(model_cfg, dict):
-            return model_cfg.get("model"), model_cfg.get("provider")
+            return model_cfg.get("default") or model_cfg.get("model"), model_cfg.get("provider")
         return None, None
     except Exception:
         return None, None


### PR DESCRIPTION
Salvage of #3896 by @txhno.

`_read_config_model()` was reading `model.get("model")` but `_save_model_choice()` writes to `model["default"]`. Profile list always showed a blank model name.

Fix: try `model.default` first, fall back to `model.model` for compat.

E2E verified — `hermes profile list` now correctly shows the configured model.