### PR TITLE
fix: intercept long sleep commands that block agent and prevent user interaction

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1023,6 +1023,23 @@ def terminal_tool(
                 }, ensure_ascii=False)
 
         # Prepare command for execution
+        # Intercept long `sleep` commands that block the agent and prevent
+        # user interaction.  Guide the model toward background + poll instead.
+        _sleep_match = re.match(r"^\s*sleep\s+(\d+)", command)
+        if _sleep_match and int(_sleep_match.group(1)) > 30 and not background:
+            _sleep_secs = int(_sleep_match.group(1))
+            return json.dumps({
+                "output": "",
+                "exit_code": -1,
+                "error": (
+                    f"Rejected: 'sleep {_sleep_secs}' would block the agent for "
+                    f"{_sleep_secs}s, preventing user interaction. "
+                    "Instead: run your long process with background=true, then "
+                    "use process(action='poll', session_id=...) to check progress. "
+                    "For short waits, use sleep values <= 30."
+                ),
+            }, ensure_ascii=False)
+
         if background:
             # Spawn a tracked background process via the process registry.
             # For local backends: uses subprocess.Popen with output buffering.


### PR DESCRIPTION
## Problem

The agent generates `sleep N && tail` polling loops to monitor long-running processes. A `sleep 360` blocks the entire agent for 6 minutes — during which user messages cannot interrupt (the interrupt flag is checked between tool calls, not during subprocess execution), no text response is possible, and the iteration budget doesn't decrement.

Real example from a user session:
```
💻 terminal: "sleep 360 && tail -15 /root/.../log"   ← 6 min block
user: "what are you doing now"
💻 terminal: "sleep 300 && tail -10 /root/.../log"   ← 5 min block  
user: "please pause streaming and provide a text output summary"
💻 terminal: "sleep 420 && tail -10 /root/.../log"   ← STILL no text response
```

## Fix

Intercept foreground `sleep N` commands where N > 30 seconds before they reach `env.execute()`. Return an error that guides the model toward the correct pattern:

```
Rejected: 'sleep 360' would block the agent for 360s, preventing user interaction.
Instead: run your long process with background=true, then use
process(action='poll', session_id=...) to check progress.
```

**Allowed:** `sleep 5`, `sleep 30`, background sleeps, `echo sleep 300`  
**Blocked:** `sleep 360`, `sleep 300 && tail`, `sleep 420 && tail`

## Changes

17 lines added to `tools/terminal_tool.py`.

Closes #4162