### PR TITLE
fix(gateway): resume agent loop after /approve executes command

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4600,7 +4600,28 @@ class GatewayRunner:
         logger.info("User approved dangerous command via /approve: %s...%s", cmd[:60], scope_msg)
         from tools.terminal_tool import terminal_tool
         result = terminal_tool(command=cmd, force=True)
-        return f"✅ Command approved and executed{scope_msg}.\n\n```\n{result[:3500]}\n```"
+
+        # Send the execution result to the user immediately
+        exec_msg = f"✅ Command approved and executed{scope_msg}.\n\n```\n{result[:3500]}\n```"
+        adapter = self.adapters.get(source.platform)
+        if adapter:
+            _meta = {"thread_id": source.thread_id} if source.thread_id else None
+            await adapter.send(source.chat_id, exec_msg, metadata=_meta)
+
+        # Resume the agent with the command result so it can continue its
+        # chain of thought instead of stopping after the approval.
+        from gateway.platforms.base import MessageEvent as _ME, MessageType as _MT
+        resume_event = _ME(
+            text=(
+                f"[System: The user approved the command. Here is the output]\n"
+                f"```\n{result[:3500]}\n```\n"
+                f"Continue with the task."
+            ),
+            message_type=_MT.TEXT,
+            source=source,
+            message_id=event.message_id,
+        )
+        return await self._handle_message(resume_event)
 
     async def _handle_deny_command(self, event: MessageEvent) -> str:
         """Handle /deny command — reject a pending dangerous command."""

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -85,12 +85,25 @@ class TestApproveCommand:
         runner._pending_approvals[session_key] = _make_pending_approval()
 
         event = _make_event("/approve")
-        with patch("tools.terminal_tool.terminal_tool", return_value="done") as mock_term:
+        with (
+            patch("tools.terminal_tool.terminal_tool", return_value="done") as mock_term,
+            patch.object(runner, "_handle_message", new_callable=AsyncMock, return_value="agent continued") as mock_hm,
+        ):
             result = await runner._handle_approve_command(event)
 
-        assert "✅ Command approved and executed" in result
+        # Command was executed with force=True
         mock_term.assert_called_once_with(command="sudo rm -rf /tmp/test", force=True)
         assert session_key not in runner._pending_approvals
+        # Execution result was sent to user immediately
+        adapter = runner.adapters[Platform.TELEGRAM]
+        adapter.send.assert_called_once()
+        sent_text = adapter.send.call_args[0][1]
+        assert "✅ Command approved and executed" in sent_text
+        # Agent was resumed via _handle_message with a synthetic event
+        mock_hm.assert_called_once()
+        resume_event = mock_hm.call_args[0][0]
+        assert "approved the command" in resume_event.text
+        assert "done" in resume_event.text
 
     @pytest.mark.asyncio
     async def test_approve_session_remembers_pattern(self):
@@ -104,10 +117,13 @@ class TestApproveCommand:
         with (
             patch("tools.terminal_tool.terminal_tool", return_value="done"),
             patch("tools.approval.approve_session") as mock_session,
+            patch.object(runner, "_handle_message", new_callable=AsyncMock, return_value=""),
         ):
             result = await runner._handle_approve_command(event)
 
-        assert "pattern approved for this session" in result
+        adapter = runner.adapters[Platform.TELEGRAM]
+        sent_text = adapter.send.call_args[0][1]
+        assert "pattern approved for this session" in sent_text
         mock_session.assert_called_once_with(session_key, "sudo")
 
     @pytest.mark.asyncio
@@ -122,11 +138,43 @@ class TestApproveCommand:
         with (
             patch("tools.terminal_tool.terminal_tool", return_value="done"),
             patch("tools.approval.approve_permanent") as mock_perm,
+            patch.object(runner, "_handle_message", new_callable=AsyncMock, return_value=""),
         ):
             result = await runner._handle_approve_command(event)
 
-        assert "pattern approved permanently" in result
+        adapter = runner.adapters[Platform.TELEGRAM]
+        sent_text = adapter.send.call_args[0][1]
+        assert "pattern approved permanently" in sent_text
         mock_perm.assert_called_once_with("sudo")
+
+    @pytest.mark.asyncio
+    async def test_approve_resumes_agent_with_command_output(self):
+        """After /approve, the agent loop is re-entered with command output.
+
+        Regression test: previously /approve executed the command but returned
+        a static string without resuming the agent, causing it to stop mid-task.
+        """
+        runner = _make_runner()
+        source = _make_source()
+        session_key = runner._session_key_for_source(source)
+        runner._pending_approvals[session_key] = _make_pending_approval(
+            command="python3 -c 'print(42)'"
+        )
+
+        event = _make_event("/approve")
+        with (
+            patch("tools.terminal_tool.terminal_tool", return_value="42\n") as mock_term,
+            patch.object(runner, "_handle_message", new_callable=AsyncMock, return_value="agent response") as mock_hm,
+        ):
+            result = await runner._handle_approve_command(event)
+
+        # The return value should be the agent's continuation, not a static string
+        assert result == "agent response"
+        # _handle_message was called with a synthetic event containing the output
+        mock_hm.assert_called_once()
+        resume_event = mock_hm.call_args[0][0]
+        assert "42" in resume_event.text
+        assert resume_event.source == source
 
     @pytest.mark.asyncio
     async def test_approve_no_pending(self):


### PR DESCRIPTION
## Summary

- **Bug**: When a dangerous command requires user approval via `/approve`, the gateway executes the command and returns the output to the chat — but never re-enters the agent loop. The agent stops mid-task with no way to receive the result and continue.
- **Fix**: After executing the approved command, the handler now (1) sends the result to the user immediately via `adapter.send()`, then (2) creates a synthetic `MessageEvent` with the output and dispatches it through `_handle_message()`, resuming the agent seamlessly.
- **Tests**: Updated existing approval tests to verify the new flow; added a dedicated regression test (`test_approve_resumes_agent_with_command_output`).

## Reproduction

1. Ask the agent to do something that triggers a dangerous command (e.g., `duckduckgo_search` via `python3 -c`)
2. Agent returns `approval_required` and prompts `/approve`
3. User sends `/approve`
4. **Before fix**: Command executes, output shown, agent stops — never continues the task
5. **After fix**: Command executes, output shown, agent continues with the result

## Test plan

- [x] All 10 tests in `tests/gateway/test_approve_deny_commands.py` pass
- [x] New test `test_approve_resumes_agent_with_command_output` validates agent continuation
- [ ] Manual verification: trigger a dangerous command via Discord, `/approve` it, confirm agent continues

🤖 Generated with [Claude Code](https://claude.com/claude-code)