### PR TITLE
fix: custom provider falls through to OpenRouter — three missing resolution paths

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -719,6 +719,18 @@ def resolve_provider(
     if explicit_api_key or explicit_base_url:
         return "openrouter"
 
+    # Check config.yaml model.provider — explicit user choice takes priority
+    # over stale API keys lingering in the environment (#4172).
+    try:
+        from hermes_cli.config import load_config as _load_cfg
+        _cfg = _load_cfg()
+        _cfg_provider = str((_cfg.get("model") or {}).get("provider") or "").strip().lower()
+        if _cfg_provider and _cfg_provider not in ("auto", ""):
+            # Normalize through the same alias map used above (line 686+)
+            return _PROVIDER_ALIASES.get(_cfg_provider, _cfg_provider)
+    except Exception:
+        pass
+
     # Check auth store for an active OAuth provider
     try:
         auth_store = _load_auth_store()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1295,6 +1295,12 @@ def _model_flow_custom(config):
         save_config(cfg)
         deactivate_provider()
 
+        # Clear stale OpenRouter key that would override the custom
+        # endpoint in auto-detection (#4172).  Don't clear OPENAI_API_KEY —
+        # the custom endpoint itself may use it.
+        if get_env_value("OPENROUTER_API_KEY"):
+            save_env_value("OPENROUTER_API_KEY", "")
+
         print(f"Default model set to: {model_name} (via {effective_url})")
     else:
         if base_url or api_key:

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -419,6 +419,29 @@ def resolve_runtime_provider(
             "requested_provider": requested_provider,
         }
 
+    # Custom endpoint (local Ollama, vLLM, llama.cpp, etc.)
+    # The user set model.provider: "custom" in config.yaml — resolve from
+    # model.base_url and OPENAI_BASE_URL, not from OpenRouter (#4172).
+    if provider == "custom":
+        model_cfg = _get_model_config()
+        cfg_base_url = (model_cfg.get("base_url") or "").strip().rstrip("/")
+        env_base_url = (explicit_base_url or "").strip() or os.getenv("OPENAI_BASE_URL", "").strip()
+        base_url = cfg_base_url or env_base_url
+        if base_url:
+            api_key = (
+                (explicit_api_key or "").strip()
+                or os.getenv("OPENAI_API_KEY", "").strip()
+                or "no-key-required"
+            )
+            return {
+                "provider": "custom",
+                "api_mode": _detect_api_mode_for_url(base_url) or "chat_completions",
+                "base_url": base_url.rstrip("/"),
+                "api_key": api_key,
+                "source": "config:model.provider=custom",
+                "requested_provider": requested_provider,
+            }
+
     runtime = _resolve_openrouter_runtime(
         requested_provider=requested_provider,
         explicit_api_key=explicit_api_key,


### PR DESCRIPTION
## Problem

Users who configure a custom endpoint (local Ollama, vLLM, llama.cpp) via `hermes setup` find their traffic silently routed through OpenRouter. `/provider` shows `ollama/qwen3.5 via OpenRouter` despite the user explicitly selecting their local endpoint and having no OpenRouter configuration.

Reported by multiple users.

## Three root causes

### 1. `resolve_runtime_provider()` has no handler for `provider == "custom"` (runtime_provider.py)

This is the primary bug. The runtime resolver handles `nous`, `openai-codex`, `copilot-acp`, `anthropic`, and API-key providers — but when `resolve_provider()` returns `"custom"`, there is no matching branch. It falls through to `_resolve_openrouter_runtime()` at line 422, which returns an OpenRouter runtime with the user's localhost base_url. Result: correct endpoint, wrong provider label, wrong billing.

Additionally, `_get_named_custom_provider()` at line 133 explicitly returns `None` when `requested_provider == "custom"` — it's treated as a generic label, not a resolvable provider.

**Fix:** Added a `provider == "custom"` handler that reads `model.base_url` from config.yaml and `OPENAI_BASE_URL` from env. (+23 lines)

### 2. `resolve_provider()` ignores `model.provider` in config.yaml (auth.py)

The auto-detection chain goes: OAuth store → env var scan → provider registry. It never checks `model.provider` from config.yaml. A stale `OPENROUTER_API_KEY` in `~/.hermes/.env` from a previous setup wins over the user's explicit `model.provider: "custom"`.

**Fix:** Added config.yaml check as priority #2, before env var scanning. (+15 lines)

### 3. `_model_flow_custom()` doesn't clear stale provider keys (main.py)

When switching to a custom endpoint, `deactivate_provider()` clears the OAuth store but leaves `OPENROUTER_API_KEY` in `.env`. This key then wins the auto-detect on next startup.

**Fix:** Clear `OPENROUTER_API_KEY` from `.env` when switching to custom. (+4 lines)

## Changes

44 insertions across `hermes_cli/runtime_provider.py`, `hermes_cli/auth.py`, `hermes_cli/main.py`.

Closes #4172