### PR TITLE
fix(setup): save API key to model config for custom endpoints

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1274,6 +1274,8 @@ def _model_flow_custom(config):
             cfg["model"] = model
         model["provider"] = "custom"
         model["base_url"] = effective_url
+        if effective_key:
+            model["api_key"] = effective_key
         model.pop("api_mode", None)  # let runtime auto-detect from URL
         save_config(cfg)
         deactivate_provider()


### PR DESCRIPTION
## Summary

After the config refactor (#4165), setting up a new custom cloud endpoint (Together.ai, RunPod, Groq direct, etc.) silently loses the API key. Hermes sends requests with no authentication and the user gets 401/403 errors.

Existing users are unaffected because their old .env files still have OPENAI_API_KEY. Only fresh setups after the refactor hit this.

## Root Cause

`_model_flow_custom()` saves `model.provider = "custom"` and `model.base_url` to config.yaml (line 1275-1276) but not the API key. The key is only saved to the `custom_providers` list via `_save_custom_provider()`.

At runtime, `_get_named_custom_provider()` in `runtime_provider.py:133` rejects plain `"custom"` — it only handles `custom:<name>` patterns. So the `custom_providers` list is never consulted and the stored key is unreachable.

The resolution chain falls through to checking `os.getenv("OPENAI_API_KEY")` which is empty (the refactor removed the .env save), then `_ensure_runtime_credentials()` silently replaces the empty key with `"no-key-required"`.

```
_model_flow_custom saves: model.provider="custom", model.base_url="https://api.together.ai/v1"
                          custom_providers[0].api_key="sk-xxx" (unreachable)
                          model.api_key → NOT SAVED

runtime resolves: _get_named_custom_provider("custom") → None (rejects plain "custom")
                  os.getenv("OPENAI_API_KEY") → empty
                  → "no-key-required" → 401
```

## Fix

Save `model.api_key` to config alongside `model.provider` and `model.base_url`:

```python
if effective_key:
    model["api_key"] = effective_key
```

One line, consistent with how `model.provider` and `model.base_url` are already saved.

Note: #4180 fixes a different issue in the same flow (wizard overwriting config on final save). This fix addresses the runtime key resolution gap.