### PR TITLE
Add /fast command for Codex priority mode

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1189,6 +1189,7 @@ class HermesCLI:
         self._providers_order = pr.get("order")
         self._provider_require_params = pr.get("require_parameters", False)
         self._provider_data_collection = pr.get("data_collection")
+        self.codex_service_tier = None
         
         # Fallback provider chain — tried in order when primary fails after retries.
         # Supports new list format (fallback_providers) and legacy single-dict (fallback_model).
@@ -2096,6 +2097,7 @@ class HermesCLI:
                 base_url=runtime.get("base_url"),
                 provider=runtime.get("provider"),
                 api_mode=runtime.get("api_mode"),
+                service_tier=self.codex_service_tier,
                 acp_command=runtime.get("command"),
                 acp_args=runtime.get("args"),
                 max_iterations=self.max_turns,
@@ -2997,11 +2999,13 @@ class HermesCLI:
         self.conversation_history = []
         self._pending_title = None
         self._resumed = False
+        self.codex_service_tier = None
 
         if self.agent:
             self.agent.session_id = self.session_id
             self.agent.session_start = self.session_start
             self.agent.reset_session_state()
+            self.agent.service_tier = None
             if hasattr(self.agent, "_last_flushed_db_idx"):
                 self.agent._last_flushed_db_idx = 0
             if hasattr(self.agent, "_todo_store"):
@@ -3069,6 +3073,7 @@ class HermesCLI:
         self.session_id = target_id
         self._resumed = True
         self._pending_title = None
+        self.codex_service_tier = None
 
         # Load conversation history
         restored = self._session_db.get_messages_as_conversation(target_id)
@@ -3084,6 +3089,7 @@ class HermesCLI:
         if self.agent:
             self.agent.session_id = target_id
             self.agent.reset_session_state()
+            self.agent.service_tier = None
             if hasattr(self.agent, "_last_flushed_db_idx"):
                 self.agent._last_flushed_db_idx = len(self.conversation_history)
             if hasattr(self.agent, "_todo_store"):
@@ -3862,6 +3868,8 @@ class HermesCLI:
             self._toggle_verbose()
         elif canonical == "yolo":
             self._toggle_yolo()
+        elif canonical == "fast":
+            self._handle_fast_command(cmd_original)
         elif canonical == "reasoning":
             self._handle_reasoning_command(cmd_original)
         elif canonical == "compress":
@@ -4091,6 +4099,7 @@ class HermesCLI:
                     base_url=turn_route["runtime"].get("base_url"),
                     provider=turn_route["runtime"].get("provider"),
                     api_mode=turn_route["runtime"].get("api_mode"),
+                    service_tier=self.codex_service_tier,
                     acp_command=turn_route["runtime"].get("command"),
                     acp_args=turn_route["runtime"].get("args"),
                     max_iterations=self.max_turns,
@@ -4587,6 +4596,37 @@ class HermesCLI:
         else:
             os.environ["HERMES_YOLO_MODE"] = "1"
             self.console.print("  ⚡ YOLO mode [bold green]ON[/] — all commands auto-approved. Use with caution.")
+
+    def _handle_fast_command(self, cmd: str):
+        """Handle /fast — session-local Codex fast mode."""
+        from hermes_cli.fast_mode import FAST_MODE_USAGE, fast_mode_note, parse_fast_command_arg
+
+        parts = cmd.strip().split(maxsplit=1)
+        action = parse_fast_command_arg(parts[1] if len(parts) > 1 else "")
+        if action is None:
+            _cprint(f"  {_DIM}Usage: {FAST_MODE_USAGE}{_RST}")
+            return
+
+        current_enabled = self.codex_service_tier == "fast"
+        if action == "status":
+            enabled = current_enabled
+        elif action == "toggle":
+            enabled = not current_enabled
+        else:
+            enabled = action == "on"
+
+        if action != "status":
+            self.codex_service_tier = "fast" if enabled else None
+            if self.agent:
+                self.agent.service_tier = self.codex_service_tier
+
+        provider = getattr(self.agent, "provider", None) if self.agent else getattr(self, "provider", None)
+        model = getattr(self.agent, "model", None) if self.agent else getattr(self, "model", None)
+        state = "ON ✓" if enabled else "off"
+        _cprint(f"  {_GOLD}Fast mode: {state}{_RST}")
+        _cprint(f"  {_DIM}{fast_mode_note(provider=provider, model=model, enabled=enabled)}{_RST}")
+        if action != "status":
+            _cprint(f"  {_DIM}Takes effect on the next message.{_RST}")
 
     def _handle_reasoning_command(self, cmd: str):
         """Handle /reasoning — manage effort level and display toggle.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1885,6 +1885,9 @@ class GatewayRunner:
         if canonical == "reasoning":
             return await self._handle_reasoning_command(event)
 
+        if canonical == "fast":
+            return await self._handle_fast_command(event)
+
         if canonical == "verbose":
             return await self._handle_verbose_command(event)
 
@@ -4127,6 +4130,7 @@ class GatewayRunner:
                 agent = AIAgent(
                     model=turn_route["model"],
                     **turn_route["runtime"],
+                    service_tier=None,
                     max_iterations=8,
                     quiet_mode=True,
                     verbose_logging=False,
@@ -4202,6 +4206,36 @@ class GatewayRunner:
                 )
             except Exception:
                 pass
+
+    async def _handle_fast_command(self, event: MessageEvent) -> str:
+        """Handle /fast — session-local Codex fast mode."""
+        from hermes_cli.fast_mode import FAST_MODE_USAGE, fast_mode_note, parse_fast_command_arg
+
+        action = parse_fast_command_arg(event.get_command_args())
+        if action is None:
+            return f"⚡ Usage: `{FAST_MODE_USAGE}`"
+
+        session_entry = self.session_store.get_or_create_session(event.source)
+        current_enabled = getattr(session_entry, "service_tier_override", None) == "fast"
+
+        if action == "status":
+            enabled = current_enabled
+        elif action == "toggle":
+            enabled = not current_enabled
+        else:
+            enabled = action == "on"
+
+        if action != "status":
+            self.session_store.set_service_tier_override(
+                session_entry.session_key,
+                "fast" if enabled else None,
+            )
+
+        state = "on ✓" if enabled else "off"
+        lines = [f"⚡ **Fast mode:** {state}", f"_{fast_mode_note(enabled=enabled)}_"]
+        if action != "status":
+            lines.append("_(takes effect on next message)_")
+        return "\n".join(lines)
 
     async def _handle_reasoning_command(self, event: MessageEvent) -> str:
         """Handle /reasoning command — manage reasoning effort and display toggle.
@@ -5580,6 +5614,8 @@ class GatewayRunner:
 
             pr = self._provider_routing
             honcho_manager, honcho_config = self._get_or_create_gateway_honcho(session_key)
+            session_entry = self.session_store.get_session(session_key) if getattr(self, "session_store", None) else None
+            service_tier = getattr(session_entry, "service_tier_override", None)
             reasoning_config = self._load_reasoning_config()
             self._reasoning_config = reasoning_config
             # Set up streaming consumer if enabled
@@ -5637,6 +5673,7 @@ class GatewayRunner:
                 agent = AIAgent(
                     model=turn_route["model"],
                     **turn_route["runtime"],
+                    service_tier=service_tier,
                     max_iterations=max_iterations,
                     quiet_mode=True,
                     verbose_logging=False,
@@ -5670,6 +5707,7 @@ class GatewayRunner:
             agent.stream_delta_callback = _stream_delta_cb
             agent.status_callback = _status_callback_sync
             agent.reasoning_config = reasoning_config
+            agent.service_tier = service_tier
 
             # Background review delivery — send "💾 Memory updated" etc. to user
             def _bg_review_send(message: str) -> None:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -357,6 +357,9 @@ class SessionEntry:
     
     # Last API-reported prompt tokens (for accurate compression pre-check)
     last_prompt_tokens: int = 0
+
+    # Session-local runtime overrides (slash commands like /fast).
+    service_tier_override: Optional[str] = None
     
     # Set when a session was created because the previous one expired;
     # consumed once by the message handler to inject a notice into context
@@ -381,6 +384,7 @@ class SessionEntry:
             "last_prompt_tokens": self.last_prompt_tokens,
             "estimated_cost_usd": self.estimated_cost_usd,
             "cost_status": self.cost_status,
+            "service_tier_override": self.service_tier_override,
         }
         if self.origin:
             result["origin"] = self.origin.to_dict()
@@ -416,6 +420,7 @@ class SessionEntry:
             last_prompt_tokens=data.get("last_prompt_tokens", 0),
             estimated_cost_usd=data.get("estimated_cost_usd", 0.0),
             cost_status=data.get("cost_status", "unknown"),
+            service_tier_override=data.get("service_tier_override"),
         )
 
 
@@ -710,6 +715,7 @@ class SessionStore:
                 display_name=source.chat_name,
                 platform=source.platform,
                 chat_type=source.chat_type,
+                service_tier_override=None,
                 was_auto_reset=was_auto_reset,
                 auto_reset_reason=auto_reset_reason,
                 reset_had_activity=reset_had_activity,
@@ -802,6 +808,26 @@ class SessionStore:
             except Exception as e:
                 logger.debug("Session DB operation failed: %s", e)
 
+    def get_session(self, session_key: str) -> Optional[SessionEntry]:
+        """Return a session entry by key without creating a new session."""
+        with self._lock:
+            self._ensure_loaded_locked()
+            return self._entries.get(session_key)
+
+    def set_service_tier_override(self, session_key: str, service_tier: Optional[str]) -> bool:
+        """Persist a session-local service-tier override."""
+        from hermes_cli.fast_mode import normalize_service_tier
+
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return False
+            entry.service_tier_override = normalize_service_tier(service_tier)
+            entry.updated_at = _now()
+            self._save()
+            return True
+
     def reset_session(self, session_key: str) -> Optional[SessionEntry]:
         """Force reset a session, creating a new session ID."""
         db_end_session_id = None
@@ -829,6 +855,7 @@ class SessionStore:
                 display_name=old_entry.display_name,
                 platform=old_entry.platform,
                 chat_type=old_entry.chat_type,
+                service_tier_override=None,
             )
 
             self._entries[session_key] = new_entry
@@ -888,6 +915,7 @@ class SessionStore:
                 display_name=old_entry.display_name,
                 platform=old_entry.platform,
                 chat_type=old_entry.chat_type,
+                service_tier_override=None,
             )
 
             self._entries[session_key] = new_entry

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -19,6 +19,7 @@ from typing import Any
 from prompt_toolkit.auto_suggest import AutoSuggest, Suggestion
 from prompt_toolkit.completion import Completer, Completion
 
+from hermes_cli.fast_mode import FAST_MODE_SUBCOMMANDS
 
 # ---------------------------------------------------------------------------
 # CommandDef dataclass
@@ -84,6 +85,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True),
     CommandDef("provider", "Show available providers and current provider",
                "Configuration"),
+    CommandDef("fast", "Toggle Codex fast mode", "Configuration",
+               args_hint="[on|off|status]", subcommands=FAST_MODE_SUBCOMMANDS),
     CommandDef("prompt", "View/set custom system prompt", "Configuration",
                cli_only=True, args_hint="[text]", subcommands=("clear",)),
     CommandDef("personality", "Set a predefined personality", "Configuration",

--- a/hermes_cli/fast_mode.py
+++ b/hermes_cli/fast_mode.py
@@ -1,0 +1,67 @@
+"""Shared helpers for Hermes /fast mode."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+FAST_MODE_USAGE = "/fast [on|off|status]"
+FAST_MODE_SUBCOMMANDS = ("on", "off", "status")
+
+
+def parse_fast_command_arg(raw: str | None) -> str | None:
+    """Parse a /fast argument into toggle/on/off/status.
+
+    Returns:
+        "toggle", "on", "off", "status", or None for invalid input.
+    """
+    if raw is None:
+        return "toggle"
+    value = raw.strip().lower()
+    if not value:
+        return "toggle"
+    if value in {"on", "off", "status"}:
+        return value
+    return None
+
+
+def normalize_service_tier(value: str | None) -> Optional[str]:
+    """Normalize service-tier state to Hermes' internal values."""
+    if value is None:
+        return None
+    normalized = str(value).strip().lower()
+    if not normalized or normalized in {"off", "none", "default", "standard"}:
+        return None
+    if normalized in {"fast", "priority"}:
+        return "fast"
+    if normalized == "flex":
+        return "flex"
+    return None
+
+
+def responses_api_service_tier(value: str | None) -> Optional[str]:
+    """Map Hermes service-tier state to OpenAI/Codex Responses payload values."""
+    normalized = normalize_service_tier(value)
+    if normalized == "fast":
+        return "priority"
+    if normalized == "flex":
+        return "flex"
+    return None
+
+
+def fast_mode_note(
+    provider: str | None = None,
+    model: str | None = None,
+    enabled: bool = True,
+) -> str:
+    """Return a short applicability note for user-facing status output."""
+    if not enabled:
+        return "Fast mode is off — Hermes will not send service_tier=priority until you turn it on."
+
+    provider_norm = (provider or "").strip().lower()
+    model_norm = (model or "").strip().lower().split("/")[-1]
+    if provider_norm == "openai-codex" and model_norm == "gpt-5.4":
+        return "Hermes will send service_tier=priority on the next Codex turn."
+    if provider_norm == "openai-codex":
+        return "Hermes sends service_tier=priority on Codex turns; non-gpt-5.4 models may ignore it."
+    return "Hermes sends service_tier=priority on OpenAI Codex gpt-5.4 turns; other providers/models ignore it."

--- a/run_agent.py
+++ b/run_agent.py
@@ -74,6 +74,7 @@ from tools.browser_tool import cleanup_browser
 
 
 from hermes_constants import OPENROUTER_BASE_URL
+from hermes_cli.fast_mode import normalize_service_tier, responses_api_service_tier
 
 # Agent internals extracted to agent/ package for modularity
 from agent.prompt_builder import (
@@ -494,6 +495,7 @@ class AIAgent:
         tool_gen_callback: callable = None,
         status_callback: callable = None,
         max_tokens: int = None,
+        service_tier: str = None,
         reasoning_config: Dict[str, Any] = None,
         prefill_messages: List[Dict[str, Any]] = None,
         platform: str = None,
@@ -566,6 +568,7 @@ class AIAgent:
         self.quiet_mode = quiet_mode
         self.ephemeral_system_prompt = ephemeral_system_prompt
         self.platform = platform  # "cli", "telegram", "discord", "whatsapp", etc.
+        self.service_tier = normalize_service_tier(service_tier)
         # Pluggable print function — CLI replaces this with _cprint so that
         # raw ANSI status lines are routed through prompt_toolkit's renderer
         # instead of going directly to stdout where patch_stdout's StdoutProxy
@@ -3230,6 +3233,7 @@ class AIAgent:
             "model", "instructions", "input", "tools", "store",
             "reasoning", "include", "max_output_tokens", "temperature",
             "tool_choice", "parallel_tool_calls", "prompt_cache_key",
+            "service_tier",
         }
         normalized: Dict[str, Any] = {
             "model": model,
@@ -3260,6 +3264,12 @@ class AIAgent:
             val = api_kwargs.get(passthrough_key)
             if val is not None:
                 normalized[passthrough_key] = val
+
+        service_tier = api_kwargs.get("service_tier")
+        if service_tier is not None:
+            if not isinstance(service_tier, str) or service_tier not in {"priority", "flex"}:
+                raise ValueError("Codex Responses 'service_tier' must be 'priority' or 'flex' when set.")
+            normalized["service_tier"] = service_tier
 
         if allow_stream:
             stream = api_kwargs.get("stream")
@@ -4667,6 +4677,15 @@ class AIAgent:
 
             if not is_github_responses:
                 kwargs["prompt_cache_key"] = self.session_id
+
+            api_service_tier = responses_api_service_tier(self.service_tier)
+            if api_service_tier and not is_github_responses:
+                base_url_lower = (self.base_url or "").lower()
+                if (
+                    self._is_direct_openai_url(self.base_url)
+                    or "chatgpt.com/backend-api/codex" in base_url_lower
+                ):
+                    kwargs["service_tier"] = api_service_tier
 
             if reasoning_enabled:
                 if is_github_responses:

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -1,0 +1,155 @@
+import asyncio
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource, SessionStore
+
+
+def _make_event(text="/fast", platform=Platform.TELEGRAM, user_id="12345", chat_id="67890"):
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner(tmp_path):
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._show_reasoning = False
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner._agent_cache = {}
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.hooks.loaded_hooks = []
+    runner._session_db = None
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+    runner.session_store = SessionStore(tmp_path / "sessions", GatewayConfig())
+    return runner
+
+
+class _CapturingAgent:
+    last_init = None
+
+    def __init__(self, *args, **kwargs):
+        type(self).last_init = dict(kwargs)
+        self.tools = []
+        self.service_tier = kwargs.get("service_tier")
+        self.model = kwargs.get("model")
+        self.provider = kwargs.get("provider")
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.session_total_tokens = 0
+        self.session_api_calls = 1
+        self.session_input_tokens = 0
+        self.session_output_tokens = 0
+        self.session_cache_read_tokens = 0
+        self.session_cache_write_tokens = 0
+        self.session_estimated_cost_usd = 0.0
+        self.session_cost_status = "unknown"
+        self.session_cost_source = "none"
+
+    def run_conversation(self, user_message: str, conversation_history=None, task_id=None):
+        return {
+            "final_response": "ok",
+            "messages": [],
+            "api_calls": 1,
+            "tools": [],
+        }
+
+
+class TestGatewayFastCommand:
+    @pytest.mark.asyncio
+    async def test_help_output_lists_fast(self, tmp_path):
+        runner = _make_runner(tmp_path)
+
+        result = await runner._handle_help_command(_make_event("/help"))
+
+        assert "/fast [on|off|status]" in result
+
+    @pytest.mark.asyncio
+    async def test_handle_fast_command_sets_session_override(self, tmp_path):
+        runner = _make_runner(tmp_path)
+        event = _make_event("/fast on")
+
+        result = await runner._handle_fast_command(event)
+        entry = runner.session_store.get_or_create_session(event.source)
+
+        assert "takes effect on next message" in result
+        assert entry.service_tier_override == "fast"
+
+    def test_force_new_session_clears_fast_override(self, tmp_path):
+        runner = _make_runner(tmp_path)
+        source = _make_event("/fast on").source
+
+        entry = runner.session_store.get_or_create_session(source)
+        runner.session_store.set_service_tier_override(entry.session_key, "fast")
+
+        fresh_entry = runner.session_store.get_or_create_session(source, force_new=True)
+
+        assert fresh_entry.session_id != entry.session_id
+        assert fresh_entry.service_tier_override is None
+
+    def test_switch_session_clears_fast_override(self, tmp_path):
+        runner = _make_runner(tmp_path)
+        source = _make_event("/fast on").source
+
+        entry = runner.session_store.get_or_create_session(source)
+        runner.session_store.set_service_tier_override(entry.session_key, "fast")
+
+        switched_entry = runner.session_store.switch_session(entry.session_key, "older_session_abc")
+
+        assert switched_entry is not None
+        assert switched_entry.session_id == "older_session_abc"
+        assert switched_entry.service_tier_override is None
+
+    def test_run_agent_passes_service_tier_from_session(self, tmp_path, monkeypatch):
+        runner = _make_runner(tmp_path)
+        event = _make_event("/fast on", platform=Platform.LOCAL, chat_id="cli")
+        entry = runner.session_store.get_or_create_session(event.source)
+        runner.session_store.set_service_tier_override(entry.session_key, "fast")
+
+        monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+        monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+        monkeypatch.setattr(
+            gateway_run,
+            "_resolve_runtime_agent_kwargs",
+            lambda: {
+                "provider": "openai-codex",
+                "api_mode": "codex_responses",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "api_key": "test-key",
+            },
+        )
+        fake_run_agent = types.ModuleType("run_agent")
+        fake_run_agent.AIAgent = _CapturingAgent
+        monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+        _CapturingAgent.last_init = None
+        result = asyncio.run(
+            runner._run_agent(
+                message="ping",
+                context_prompt="",
+                history=[],
+                source=event.source,
+                session_id=entry.session_id,
+                session_key=entry.session_key,
+            )
+        )
+
+        assert result["final_response"] == "ok"
+        assert _CapturingAgent.last_init is not None
+        assert _CapturingAgent.last_init["service_tier"] == "fast"

--- a/tests/hermes_cli/test_fast_mode.py
+++ b/tests/hermes_cli/test_fast_mode.py
@@ -1,0 +1,36 @@
+from hermes_cli.fast_mode import (
+    FAST_MODE_USAGE,
+    fast_mode_note,
+    normalize_service_tier,
+    parse_fast_command_arg,
+    responses_api_service_tier,
+)
+
+
+class TestFastModeHelpers:
+    def test_parse_fast_command_args(self):
+        assert parse_fast_command_arg("") == "toggle"
+        assert parse_fast_command_arg(None) == "toggle"
+        assert parse_fast_command_arg("on") == "on"
+        assert parse_fast_command_arg("off") == "off"
+        assert parse_fast_command_arg("status") == "status"
+        assert parse_fast_command_arg("weird") is None
+
+    def test_normalize_service_tier(self):
+        assert normalize_service_tier(None) is None
+        assert normalize_service_tier("priority") == "fast"
+        assert normalize_service_tier("fast") == "fast"
+        assert normalize_service_tier("flex") == "flex"
+        assert normalize_service_tier("off") is None
+
+    def test_responses_api_mapping(self):
+        assert responses_api_service_tier("fast") == "priority"
+        assert responses_api_service_tier("priority") == "priority"
+        assert responses_api_service_tier("flex") == "flex"
+        assert responses_api_service_tier(None) is None
+
+    def test_fast_mode_note(self):
+        assert "service_tier=priority" in fast_mode_note()
+        assert "next Codex turn" in fast_mode_note("openai-codex", "gpt-5.4")
+        assert "will not send" in fast_mode_note(enabled=False)
+        assert FAST_MODE_USAGE.startswith("/fast")

--- a/tests/test_cli_fast_command.py
+++ b/tests/test_cli_fast_command.py
@@ -1,0 +1,57 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from cli import HermesCLI
+
+
+def _make_cli():
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.codex_service_tier = None
+    cli.agent = None
+    cli.model = "gpt-5.4"
+    cli.provider = "openai-codex"
+    return cli
+
+
+class TestCliFastCommand:
+    def test_process_command_routes_fast(self):
+        cli = _make_cli()
+        cli._handle_fast_command = MagicMock()
+
+        result = cli.process_command("/fast on")
+
+        assert result is True
+        cli._handle_fast_command.assert_called_once_with("/fast on")
+
+    def test_handle_fast_on_updates_live_agent(self):
+        cli = _make_cli()
+        cli.agent = SimpleNamespace(service_tier=None, provider="openai-codex", model="gpt-5.4")
+
+        with patch("cli._cprint") as mock_cprint:
+            cli._handle_fast_command("/fast on")
+
+        assert cli.codex_service_tier == "fast"
+        assert cli.agent.service_tier == "fast"
+        printed = "\n".join(call.args[0] for call in mock_cprint.call_args_list)
+        assert "Fast mode" in printed
+        assert "service_tier=priority" in printed
+
+    def test_handle_fast_status_does_not_mutate(self):
+        cli = _make_cli()
+        cli.codex_service_tier = "fast"
+
+        with patch("cli._cprint") as mock_cprint:
+            cli._handle_fast_command("/fast status")
+
+        assert cli.codex_service_tier == "fast"
+        printed = "\n".join(call.args[0] for call in mock_cprint.call_args_list)
+        assert "ON" in printed
+
+    def test_handle_fast_invalid_arg_shows_usage(self):
+        cli = _make_cli()
+
+        with patch("cli._cprint") as mock_cprint:
+            cli._handle_fast_command("/fast turbo")
+
+        assert cli.codex_service_tier is None
+        assert any("Usage: /fast" in call.args[0] for call in mock_cprint.call_args_list)

--- a/tests/test_cli_new_session.py
+++ b/tests/test_cli_new_session.py
@@ -28,6 +28,7 @@ class _FakeAgent:
         self.session_id = session_id
         self.session_start = session_start
         self.model = "anthropic/claude-opus-4.6"
+        self.service_tier = None
         self._last_flushed_db_idx = 7
         self._todo_store = TodoStore()
         self._todo_store.write(
@@ -137,6 +138,8 @@ def test_new_command_creates_real_fresh_session_and_resets_agent_state(tmp_path)
     cli = _prepare_cli_with_active_session(tmp_path)
     old_session_id = cli.session_id
     old_session_start = cli.session_start
+    cli.codex_service_tier = "fast"
+    cli.agent.service_tier = "fast"
 
     cli.process_command("/new")
 
@@ -154,10 +157,26 @@ def test_new_command_creates_real_fresh_session_and_resets_agent_state(tmp_path)
     assert cli.agent.session_id == cli.session_id
     assert cli.agent._last_flushed_db_idx == 0
     assert cli.agent._todo_store.read() == []
+    assert cli.codex_service_tier is None
+    assert cli.agent.service_tier is None
     assert cli.session_start > old_session_start
     assert cli.agent.session_start == cli.session_start
     cli.agent.flush_memories.assert_called_once_with([{"role": "user", "content": "hello"}])
     cli.agent._invalidate_system_prompt.assert_called_once()
+
+
+def test_resume_command_clears_fast_mode(tmp_path):
+    cli = _prepare_cli_with_active_session(tmp_path)
+    resumed_session_id = "previous_session_123"
+    cli._session_db.create_session(session_id=resumed_session_id, source="cli", model=cli.model)
+    cli.codex_service_tier = "fast"
+    cli.agent.service_tier = "fast"
+
+    cli._handle_resume_command(f"/resume {resumed_session_id}")
+
+    assert cli.session_id == resumed_session_id
+    assert cli.codex_service_tier is None
+    assert cli.agent.service_tier is None
 
 
 def test_reset_command_is_alias_for_new_session(tmp_path):

--- a/tests/test_provider_parity.py
+++ b/tests/test_provider_parity.py
@@ -286,6 +286,42 @@ class TestBuildApiKwargsCodex:
         assert "name" in tools[0]
         assert "function" not in tools[0]
 
+    def test_fast_service_tier_maps_to_priority(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "openai-codex", api_mode="codex_responses",
+                            base_url="https://chatgpt.com/backend-api/codex")
+        agent.service_tier = "fast"
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+        assert kwargs["service_tier"] == "priority"
+
+    def test_non_openai_responses_route_omits_service_tier(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "custom", api_mode="codex_responses",
+                            base_url="https://example.invalid/v1")
+        agent.service_tier = "fast"
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+        assert "service_tier" not in kwargs
+
+    def test_openai_codex_provider_on_openrouter_omits_service_tier(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "openai-codex", api_mode="codex_responses",
+                            base_url="https://openrouter.ai/api/v1")
+        agent.service_tier = "fast"
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+        assert "service_tier" not in kwargs
+
+    def test_preflight_accepts_priority_service_tier(self, monkeypatch):
+        agent = _make_agent(monkeypatch, "openai-codex", api_mode="codex_responses",
+                            base_url="https://chatgpt.com/backend-api/codex")
+        normalized = agent._preflight_codex_api_kwargs(
+            {
+                "model": "gpt-5.4",
+                "instructions": "be helpful",
+                "input": [{"role": "user", "content": "hi"}],
+                "tools": [],
+                "store": False,
+                "service_tier": "priority",
+            }
+        )
+        assert normalized["service_tier"] == "priority"
+
 
 # ── Message conversion tests ────────────────────────────────────────────────
 


### PR DESCRIPTION
Summary:
- add a session-local `/fast` command in CLI and gateway
- map fast mode to Codex Responses `service_tier=priority` for supported OpenAI/Codex routes
- clear fast-mode overrides on new/reset/resume/session switches
- add focused regression coverage for helper parsing, CLI command handling, gateway session propagation, and Codex request kwargs

Details:
- introduces `hermes_cli.fast_mode` for shared parsing + messaging helpers
- threads `service_tier` through `AIAgent` and Codex preflight/kwargs building
- persists gateway-side fast-mode state in `SessionStore.service_tier_override`
- keeps non-supported providers/routes unchanged by omitting `service_tier`

Validation:
- `python -m pytest tests/hermes_cli/test_fast_mode.py tests/test_cli_fast_command.py tests/gateway/test_fast_command.py tests/test_cli_new_session.py tests/test_provider_parity.py::TestBuildApiKwargsCodex -q -n 0`
- `python -m py_compile cli.py gateway/run.py gateway/session.py hermes_cli/commands.py hermes_cli/fast_mode.py run_agent.py tests/test_cli_new_session.py tests/test_provider_parity.py tests/test_cli_fast_command.py tests/hermes_cli/test_fast_mode.py tests/gateway/test_fast_command.py`

Notes:
- I attempted a broader local suite run as well, but it was interrupted and current upstream `origin/main` has unrelated environment-sensitive test behavior around auxiliary provider resolution on this machine. The focused `/fast` coverage above is green on this branch.
