### PR TITLE
fix(cli): show quick commands in /help output

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2708,6 +2708,15 @@ class HermesCLI:
                     f"    [bold {_accent_hex()}]{cmd:<22}[/] [dim]-[/] {_escape(info['description'])}"
                 )
 
+        quick_commands = self.config.get("quick_commands", {})
+        if quick_commands:
+            _cprint(f"\n  ⚡ {_BOLD}Quick Commands{_RST} ({len(quick_commands)} configured):")
+            for name, qcmd in sorted(quick_commands.items()):
+                desc = qcmd.get("description", qcmd.get("type", ""))
+                ChatConsole().print(
+                    f"    [bold {_accent_hex()}]{('/' + name):<22}[/] [dim]-[/] {_escape(desc)}"
+                )
+
         _cprint(f"\n  {_DIM}Tip: Just type your message to chat with Hermes!{_RST}")
         _cprint(f"  {_DIM}Multi-line: Alt+Enter for a new line{_RST}")
         _cprint(f"  {_DIM}Paste image: Alt+V (or /paste){_RST}\n")


### PR DESCRIPTION
## What/Why

User-defined `quick_commands` from `config.yaml` work correctly when invoked, but they're invisible in `/help` output. Users have no way to discover which quick commands are available without reading the config file directly.

## Related Issue

Fixes #4090

## Type of Change

- [x] Bug fix

## Changes Made

Added a "Quick Commands" section to `show_help()` in `cli.py` (line 2711). After displaying skill commands and before the tips section, the method now reads `self.config.get("quick_commands", {})` and lists each command with its description. Falls back to the `type` field if no `description` key is present.

The formatting matches the existing skill commands section: same indentation, same `ChatConsole().print` with accent color and dim separator.

## How to Test

1. Add quick commands to `config.yaml`:
   ```yaml
   quick_commands:
     status:
       type: exec
       command: "echo 'all good'"
       description: "Check system status"
   ```
2. Run `/help` 
3. Verify the "Quick Commands" section appears between "Skill Commands" and the tips

## Checklist

- [x] Code follows PEP 8 style
- [x] Changes are minimal and focused
- [x] Platform tested: macOS

This contribution was developed with AI assistance (Claude Code).