### PR TITLE
fix(gateway): harden gateway /btw history handling

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1833,6 +1833,10 @@ class GatewayRunner:
                     del self._running_agents[_quick_key]
                 return await self._handle_reset_command(event)
 
+            # /btw <question> — run a side question without interrupting
+            if _cmd_def_inner and _cmd_def_inner.name == "btw":
+                return await self._handle_btw_command(event)
+
             # /queue <prompt> — queue without interrupting
             if event.get_command() in ("queue", "q"):
                 queued_text = event.get_command_args().strip()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -268,6 +268,55 @@ def _expand_whatsapp_auth_aliases(identifier: str) -> set:
 
     return resolved
 
+
+def _build_agent_history(history: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Convert transcript/session messages into agent-safe conversation history."""
+    agent_history = []
+    for msg in history:
+        role = msg.get("role")
+        if not role:
+            continue
+
+        # Transcript metadata is for Hermes, not for the provider chat API.
+        if role in ("session_meta",):
+            continue
+
+        # The agent rebuilds its own system prompt for each run.
+        if role == "system":
+            continue
+
+        # Preserve rich assistant/tool messages so valid assistant->tool
+        # sequences survive reloads and retries.
+        has_tool_calls = "tool_calls" in msg
+        has_tool_call_id = "tool_call_id" in msg
+        is_tool_message = role == "tool"
+
+        if has_tool_calls or has_tool_call_id or is_tool_message:
+            clean_msg = {k: v for k, v in msg.items() if k != "timestamp"}
+            agent_history.append(clean_msg)
+            continue
+
+        content = msg.get("content")
+        if not content:
+            continue
+
+        if msg.get("mirror"):
+            mirror_src = msg.get("mirror_source", "another session")
+            content = f"[Delivered from {mirror_src}] {content}"
+
+        entry = {"role": role, "content": content}
+
+        # Preserve reasoning state on assistant messages across reloads.
+        if role == "assistant":
+            for _rkey in ("reasoning", "reasoning_details", "codex_reasoning_items"):
+                _rval = msg.get(_rkey)
+                if _rval:
+                    entry[_rkey] = _rval
+
+        agent_history.append(entry)
+
+    return agent_history
+
 logger = logging.getLogger(__name__)
 
 # Sentinel placed into _running_agents immediately when a session starts
@@ -4116,6 +4165,7 @@ class GatewayRunner:
             else:
                 session_entry = self.session_store.get_or_create_session(source)
                 history_snapshot = self.session_store.load_transcript(session_entry.session_id)
+            history_snapshot = _build_agent_history(history_snapshot)
 
             btw_prompt = (
                 "[Ephemeral /btw side question. Answer using the conversation "
@@ -5702,50 +5752,7 @@ class GatewayRunner:
             #      that may include tool_calls, tool_call_id, reasoning, etc.
             #      - These must be passed through intact so the API sees valid
             #        assistant→tool sequences (dropping tool_calls causes 500 errors)
-            agent_history = []
-            for msg in history:
-                role = msg.get("role")
-                if not role:
-                    continue
-                
-                # Skip metadata entries (tool definitions, session info)
-                # -- these are for transcript logging, not for the LLM
-                if role in ("session_meta",):
-                    continue
-                
-                # Skip system messages -- the agent rebuilds its own system prompt
-                if role == "system":
-                    continue
-                
-                # Rich agent messages (tool_calls, tool results) must be passed
-                # through intact so the API sees valid assistant→tool sequences
-                has_tool_calls = "tool_calls" in msg
-                has_tool_call_id = "tool_call_id" in msg
-                is_tool_message = role == "tool"
-                
-                if has_tool_calls or has_tool_call_id or is_tool_message:
-                    clean_msg = {k: v for k, v in msg.items() if k != "timestamp"}
-                    agent_history.append(clean_msg)
-                else:
-                    # Simple text message - just need role and content
-                    content = msg.get("content")
-                    if content:
-                        # Tag cross-platform mirror messages so the agent knows their origin
-                        if msg.get("mirror"):
-                            mirror_src = msg.get("mirror_source", "another session")
-                            content = f"[Delivered from {mirror_src}] {content}"
-                        entry = {"role": role, "content": content}
-                        # Preserve reasoning fields on assistant messages so
-                        # multi-turn reasoning context survives session reload.
-                        # The agent's _build_api_kwargs converts these to the
-                        # provider-specific format (reasoning_content, etc.).
-                        if role == "assistant":
-                            for _rkey in ("reasoning", "reasoning_details",
-                                          "codex_reasoning_items"):
-                                _rval = msg.get(_rkey)
-                                if _rval:
-                                    entry[_rkey] = _rval
-                        agent_history.append(entry)
+            agent_history = _build_agent_history(history)
             
             # Collect MEDIA paths already in history so we can exclude them
             # from the current turn's extraction. This is compression-safe:

--- a/tests/gateway/test_btw_command.py
+++ b/tests/gateway/test_btw_command.py
@@ -1,0 +1,86 @@
+"""Tests for /btw gateway slash command."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_event(text="/btw", platform=Platform.TELEGRAM, user_id="12345", chat_id="67890"):
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._session_db = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner._background_tasks = set()
+    runner._active_btw_tasks = {}
+
+    mock_store = MagicMock()
+    mock_store.get_or_create_session.return_value = MagicMock(session_id="sess_123")
+    runner.session_store = mock_store
+
+    from gateway.hooks import HookRegistry
+    runner.hooks = HookRegistry()
+
+    return runner
+
+
+class TestRunBtwTask:
+    @pytest.mark.asyncio
+    async def test_idle_transcript_filters_session_meta_before_agent_call(self):
+        runner = _make_runner()
+        runner.session_store.load_transcript.return_value = [
+            {"role": "session_meta", "tools": [], "timestamp": "t0"},
+            {"role": "user", "content": "main context", "timestamp": "t1"},
+            {"role": "assistant", "content": "current answer", "timestamp": "t2"},
+        ]
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send = AsyncMock()
+        mock_adapter.extract_media = MagicMock(return_value=([], "Looks good"))
+        mock_adapter.extract_images = MagicMock(return_value=([], "Looks good"))
+        runner.adapters[Platform.TELEGRAM] = mock_adapter
+
+        source = _make_event(text="/btw what owns titles?").source
+        fake_loop = MagicMock()
+        fake_loop.run_in_executor = AsyncMock(side_effect=lambda pool, fn: fn())
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def run_conversation(self, *, user_message, conversation_history, task_id, sync_honcho):
+                captured["roles"] = [msg.get("role") for msg in conversation_history]
+                return {"final_response": "Looks good", "messages": []}
+
+        with patch("gateway.run._resolve_runtime_agent_kwargs", return_value={"api_key": "test-key"}), \
+             patch("gateway.run._load_gateway_config", return_value={}), \
+             patch("gateway.run._resolve_gateway_model", return_value="anthropic/claude-opus-4.6"), \
+             patch("gateway.run.asyncio.get_event_loop", return_value=fake_loop), \
+             patch("gateway.run.AIAgent", FakeAgent, create=True), \
+             patch("run_agent.AIAgent", FakeAgent):
+            await runner._run_btw_task("what owns titles?", source, "telegram:12345:67890", "btw_test")
+
+        assert captured["roles"] == ["user", "assistant"]
+        sent = mock_adapter.send.call_args.kwargs["content"]
+        assert "💬 /btw" in sent
+        assert "Looks good" in sent

--- a/tests/gateway/test_btw_command.py
+++ b/tests/gateway/test_btw_command.py
@@ -84,3 +84,25 @@ class TestRunBtwTask:
         sent = mock_adapter.send.call_args.kwargs["content"]
         assert "💬 /btw" in sent
         assert "Looks good" in sent
+
+
+class TestHandleMessageBtwDuringActiveRun:
+    @pytest.mark.asyncio
+    async def test_btw_does_not_interrupt_running_agent(self):
+        runner = _make_runner()
+        event = _make_event(text="/btw what owns titles?")
+        session_key = "telegram:12345:67890"
+
+        running_agent = MagicMock()
+        runner._running_agents[session_key] = running_agent
+        runner._pending_messages = {}
+        runner._is_user_authorized = MagicMock(return_value=True)
+        runner._session_key_for_source = MagicMock(return_value=session_key)
+        runner._handle_btw_command = AsyncMock(return_value='💬 /btw: "what owns titles?"\nReply will appear here shortly.')
+
+        result = await runner._handle_message(event)
+
+        assert result == '💬 /btw: "what owns titles?"\nReply will appear here shortly.'
+        runner._handle_btw_command.assert_awaited_once_with(event)
+        running_agent.interrupt.assert_not_called()
+        assert runner._pending_messages == {}


### PR DESCRIPTION
## What does this PR do?

  Fixes two gateway-specific /btw bugs in messaging channels.

  First, /btw could fail on an idle existing session because it loaded raw saved transcript history containing internal session_meta entries and passed them directly to the model. That produced provider errors like invalid role:
  session_meta.

  Second, /btw could interrupt an active main run because the gateway’s busy-session path treated it like a normal incoming message and triggered the default interrupt flow before command dispatch.

  This PR fixes both issues by reusing the gateway’s agent-safe history filtering for /btw and by exempting /btw from the busy-session interrupt path so it can run as a side question without disrupting the main task.

  ## Related Issue

  No tracked issue.

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [ ] 📝 Documentation update
  - [x] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️ Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  ## Changes Made

  - Added a shared agent-history sanitizer in gateway/run.py for filtering transcript-only entries like session_meta and system before passing history to the model
  - Updated gateway /btw to sanitize stored transcript history before creating the ephemeral side-agent conversation
  - Updated the busy-session gateway path so /btw no longer interrupts an active main run
  - Added a regression test covering idle stored-transcript /btw with session_meta
  - Added a regression test covering active-run /btw to verify it does not call interrupt()

  ## How to Test

  1. Run the targeted test suites:
     python -m pytest tests/gateway/test_btw_command.py
     python -m pytest tests/gateway/test_transcript_offset.py
     python -m pytest tests/hermes_cli/test_commands.py
  2. In a messaging channel with an existing idle session, send /btw <question>.
     Verify it returns a normal /btw reply instead of failing with an invalid-role error.
  3. In a messaging channel while a main task is actively running, send /btw <question>.
     Verify the /btw reply appears without interrupting the main run.

  ## Checklist

  ### Code

  - [x] I've read the Contributing Guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit messages follow Conventional Commits (https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
  - [x] I searched for existing PRs (https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - [x] My PR contains only changes related to this fix/feature (no unrelated commits)
  - [ ] I've run pytest tests/ -q and all tests pass
  - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - [x] I've tested on my platform: Ubuntu/Linux using /home/x/Downloads/venv

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
  - [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
  - [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
  - [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

  ## Screenshots / Logs

  Targeted test results:

  - tests/gateway/test_btw_command.py: passed
  - tests/gateway/test_transcript_offset.py: passed
  - tests/hermes_cli/test_commands.py: passed
