### PR TITLE
fix(terminal): intercept long sleep commands to prevent agent blocking

### DIFF
--- a/tests/tools/test_terminal_sleep_interception.py
+++ b/tests/tools/test_terminal_sleep_interception.py
@@ -1,0 +1,87 @@
+"""Tests for sleep command interception in terminal_tool."""
+
+import pytest
+from tools.terminal_tool import _check_long_sleep_command, _MAX_FOREGROUND_SLEEP_SECONDS
+
+
+class TestSleepCommandInterception:
+    """Test the _check_long_sleep_command helper function."""
+
+    def test_short_sleep_allowed(self):
+        """Sleep commands under the threshold should be allowed."""
+        result = _check_long_sleep_command("sleep 30", background=False)
+        assert not result["blocked"]
+
+    def test_long_sleep_blocked(self):
+        """Sleep commands over the threshold should be blocked in foreground."""
+        result = _check_long_sleep_command("sleep 120", background=False)
+        assert result["blocked"]
+        assert "background=true" in result["message"]
+        assert "process(action=\"poll\")" in result["message"]
+
+    def test_long_sleep_allowed_in_background(self):
+        """Long sleep commands should be allowed when background=True."""
+        result = _check_long_sleep_command("sleep 3600", background=True)
+        assert not result["blocked"]
+
+    def test_sleep_with_minutes_unit(self):
+        """Sleep with 'm' unit (minutes) should be parsed correctly."""
+        # 2m = 120s, over threshold
+        result = _check_long_sleep_command("sleep 2m", background=False)
+        assert result["blocked"]
+        
+        # 30s (no unit) under threshold
+        result = _check_long_sleep_command("sleep 30", background=False)
+        assert not result["blocked"]
+
+    def test_sleep_with_hours_unit(self):
+        """Sleep with 'h' unit (hours) should be parsed correctly."""
+        result = _check_long_sleep_command("sleep 1h", background=False)
+        assert result["blocked"]
+
+    def test_sleep_in_pipeline(self):
+        """Sleep command in a pipeline should still be detected."""
+        result = _check_long_sleep_command("sleep 300 && tail -15 /var/log/app.log", background=False)
+        assert result["blocked"]
+
+    def test_sleep_after_semicolon(self):
+        """Sleep command after semicolon should be detected."""
+        result = _check_long_sleep_command("echo start; sleep 600; echo done", background=False)
+        assert result["blocked"]
+
+    def test_no_sleep_command(self):
+        """Commands without sleep should pass through."""
+        result = _check_long_sleep_command("ls -la /tmp", background=False)
+        assert not result["blocked"]
+        
+        result = _check_long_sleep_command("tail -f /var/log/syslog", background=False)
+        assert not result["blocked"]
+
+    def test_sleep_exact_threshold(self):
+        """Sleep exactly at threshold should be allowed."""
+        result = _check_long_sleep_command(f"sleep {_MAX_FOREGROUND_SLEEP_SECONDS}", background=False)
+        assert not result["blocked"]
+        
+        # One second over should be blocked
+        result = _check_long_sleep_command(f"sleep {_MAX_FOREGROUND_SLEEP_SECONDS + 1}", background=False)
+        assert result["blocked"]
+
+    def test_sleep_case_insensitive(self):
+        """Sleep detection should be case-insensitive."""
+        result = _check_long_sleep_command("SLEEP 300", background=False)
+        assert result["blocked"]
+        
+        result = _check_long_sleep_command("Sleep 300", background=False)
+        assert result["blocked"]
+
+    def test_sleepy_not_matched(self):
+        """Commands containing 'sleep' as part of another word should not match."""
+        # 'sleepy' is not the same as 'sleep'
+        result = _check_long_sleep_command("echo sleepy300", background=False)
+        assert not result["blocked"]
+
+    def test_error_message_includes_duration(self):
+        """Error message should include the detected duration."""
+        result = _check_long_sleep_command("sleep 360", background=False)
+        assert result["blocked"]
+        assert "360s" in result["message"]

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -33,6 +33,7 @@ Usage:
 import importlib.util
 import json
 import logging
+import re
 import os
 import platform
 import time
@@ -177,6 +178,67 @@ def _handle_sudo_failure(output: str, env_type: str) -> str:
             return output + f"\n\n💡 Tip: To enable sudo over messaging, add SUDO_PASSWORD to {_dhh()}/.env on the agent machine."
     
     return output
+
+
+# Maximum sleep duration (seconds) allowed in foreground commands.
+# Longer sleeps should use background=true + process(action="poll").
+_MAX_FOREGROUND_SLEEP_SECONDS = 60
+
+
+def _check_long_sleep_command(command: str, background: bool) -> dict:
+    """
+    Detect blocking sleep commands that would make the agent unresponsive.
+    
+    Returns {"blocked": True, "message": "..."} if a long sleep is detected
+    in a foreground command, otherwise {"blocked": False}.
+    
+    Why this matters:
+    - `sleep 360 && tail -15 log` blocks the agent for 6 minutes
+    - During this time, user messages cannot interrupt
+    - The agent appears frozen/unresponsive
+    
+    The correct pattern is: background=true + process(action="poll")
+    """
+    if background:
+        # Background processes don't block the main agent loop
+        return {"blocked": False}
+    
+    # Match patterns like: sleep 300, sleep 5m, sleep 2h
+    # Handles: `sleep 60`, `sleep 60 && ...`, `sleep 5m; ...`
+    sleep_pattern = re.compile(
+        r'\bsleep\s+(\d+)([smh]?)\b',
+        re.IGNORECASE
+    )
+    
+    match = sleep_pattern.search(command)
+    if not match:
+        return {"blocked": False}
+    
+    value = int(match.group(1))
+    unit = match.group(2).lower() if match.group(2) else 's'
+    
+    # Convert to seconds
+    if unit == 'm':
+        seconds = value * 60
+    elif unit == 'h':
+        seconds = value * 3600
+    else:
+        seconds = value
+    
+    if seconds > _MAX_FOREGROUND_SLEEP_SECONDS:
+        return {
+            "blocked": True,
+            "message": (
+                f"Command contains `sleep {match.group(0)}` ({seconds}s) which would "
+                f"block the agent and prevent user interaction.\n\n"
+                f"For long waits, use background=true and process(action=\"poll\") instead:\n"
+                f"1. Start: terminal(command=\"your_command\", background=true)\n"
+                f"2. Check: process(action=\"poll\", session_id=\"...\")\n\n"
+                f"This allows the user to interact with you while the process runs."
+            ),
+        }
+    
+    return {"blocked": False}
 
 
 def _prompt_for_sudo_password(timeout_seconds: int = 45) -> str:
@@ -1082,6 +1144,16 @@ def terminal_tool(
                     "error": approval.get("message", fallback_msg),
                     "status": "blocked"
                 }, ensure_ascii=False)
+
+        # Check for long sleep commands that would block agent responsiveness
+        sleep_check = _check_long_sleep_command(command, background)
+        if sleep_check.get("blocked"):
+            return json.dumps({
+                "output": "",
+                "exit_code": -1,
+                "error": sleep_check["message"],
+                "status": "blocked"
+            }, ensure_ascii=False)
 
         # Prepare command for execution
         if background:


### PR DESCRIPTION
## Summary

Addresses issue #4162 (P0 fix).

## Problem

The agent generates `sleep N && tail -15 logfile` polling loops that block the entire agent for minutes. During this time:
- User messages cannot interrupt (the interrupt flag is checked between tool calls, not during subprocess execution)
- No text response is possible
- The agent appears frozen/unresponsive

Example observed behavior:
```
💻 terminal: "sleep 360 && tail -15 /root/.../log"   ← 6 min block
user: "what are you doing now"
💻 terminal: "tail -20 /root/.../log"
💻 terminal: "sleep 300 && tail -10 /root/.../log"   ← 5 min block
```

## Solution

Add a guard that rejects foreground sleep commands exceeding 60 seconds, with guidance to use `background=true` + `process(action="poll")` instead.

### Changes:
- Add `_check_long_sleep_command()` helper with regex-based detection
- Support sleep with units (s/m/h): `sleep 5m`, `sleep 1h`
- Case-insensitive matching, pipeline-aware
- Block only foreground; background sleeps are allowed
- Helpful error message with correct usage pattern

### Example error message:
```
Command contains `sleep 360` (360s) which would block the agent and prevent user interaction.

For long waits, use background=true and process(action="poll") instead:
1. Start: terminal(command="your_command", background=true)
2. Check: process(action="poll", session_id="...")

This allows the user to interact with you while the process runs.
```

## Tests

12 new tests covering:
- Short/long sleep threshold
- Sleep with units (m/h)
- Sleep in pipelines and semicolon chains
- Background mode bypass
- Case sensitivity
- Word boundary (sleepy vs sleep)
- Exact threshold edge case
- Error message content

All tests pass ✅

Closes #4162 (P0 fix)