### PR TITLE
fix(matrix): handle encrypted media in E2EE rooms

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -266,6 +266,11 @@ class MatrixAdapter(BasePlatformAdapter):
         client.add_event_callback(self._on_room_message_media, nio.RoomMessageAudio)
         client.add_event_callback(self._on_room_message_media, nio.RoomMessageVideo)
         client.add_event_callback(self._on_room_message_media, nio.RoomMessageFile)
+        # Encrypted media events (E2EE rooms where the file data is encrypted).
+        client.add_event_callback(self._on_room_message_media, nio.RoomEncryptedImage)
+        client.add_event_callback(self._on_room_message_media, nio.RoomEncryptedAudio)
+        client.add_event_callback(self._on_room_message_media, nio.RoomEncryptedVideo)
+        client.add_event_callback(self._on_room_message_media, nio.RoomEncryptedFile)
         client.add_event_callback(self._on_invite, nio.InviteMemberEvent)
 
         # If E2EE: handle encrypted events.
@@ -983,10 +988,10 @@ class MatrixAdapter(BasePlatformAdapter):
         msg_type = MessageType.DOCUMENT
         is_voice_message = False
         
-        if isinstance(event, nio.RoomMessageImage):
+        if isinstance(event, (nio.RoomMessageImage, nio.RoomEncryptedImage)):
             msg_type = MessageType.PHOTO
             media_type = event_mimetype or "image/png"
-        elif isinstance(event, nio.RoomMessageAudio):
+        elif isinstance(event, (nio.RoomMessageAudio, nio.RoomEncryptedAudio)):
             # Check for MSC3245 voice flag: org.matrix.msc3245.voice: {}
             source_content = getattr(event, "source", {}).get("content", {})
             if source_content.get("org.matrix.msc3245.voice") is not None:
@@ -995,7 +1000,7 @@ class MatrixAdapter(BasePlatformAdapter):
             else:
                 msg_type = MessageType.AUDIO
             media_type = event_mimetype or "audio/ogg"
-        elif isinstance(event, nio.RoomMessageVideo):
+        elif isinstance(event, (nio.RoomMessageVideo, nio.RoomEncryptedVideo)):
             msg_type = MessageType.VIDEO
             media_type = event_mimetype or "video/mp4"
         elif event_mimetype:
@@ -1013,8 +1018,18 @@ class MatrixAdapter(BasePlatformAdapter):
                 ext = ext_map.get(event_mimetype, ".jpg")
                 download_resp = await self._client.download(url)
                 if isinstance(download_resp, nio.DownloadResponse):
+                    image_data = download_resp.body
+                    # Decrypt attachment data for encrypted media events.
+                    if hasattr(event, "key") and hasattr(event, "hashes") and hasattr(event, "iv"):
+                        from nio.crypto import decrypt_attachment
+                        image_data = decrypt_attachment(
+                            image_data,
+                            event.key.get("k", ""),
+                            event.hashes.get("sha256", ""),
+                            event.iv,
+                        )
                     from gateway.platforms.base import cache_image_from_bytes
-                    cached_path = cache_image_from_bytes(download_resp.body, ext=ext)
+                    cached_path = cache_image_from_bytes(image_data, ext=ext)
                     logger.info("[Matrix] Cached user image at %s", cached_path)
             except Exception as e:
                 logger.warning("[Matrix] Failed to cache image: %s", e)


### PR DESCRIPTION
## Summary

- Encrypted media (images, audio, video, files) in E2EE Matrix rooms were silently dropped
- matrix-nio emits `RoomEncryptedImage/Audio/Video/File` for these — distinct from `MegolmEvent` (encrypted text) and `RoomMessageImage` (unencrypted media)
- No callbacks were registered for these event types, so the gateway never processed them

## Changes

- Register event callbacks for all four `RoomEncrypted*` media types
- Extend `isinstance` checks in `_on_room_message_media` to match both encrypted and unencrypted variants
- Decrypt attachment data after download using `nio.crypto.decrypt_attachment` before caching

## Test plan

- [x] Send an image in an E2EE Matrix room — bot receives and processes it
- [x] Vision analysis works on decrypted image (valid JPEG/PNG, not encrypted bytes)
- [x] Unencrypted rooms still work as before
- [x] Existing test suite: 6887 passed, 0 new failures
- [ ] Audio/video/file attachments in E2EE rooms (same code path, not yet tested)

## Platforms tested

- Linux (Ubuntu 24.04, Python 3.12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)