### PR TITLE
feat: upgrade MiniMax default model to M2.7 across all catalogs

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -110,6 +110,8 @@ DEFAULT_CONTEXT_LENGTHS = {
     "gemini-3.1-pro": 1048576,
     "gemini-3-pro": 1048576,
     "gemini-3-flash": 1048576,
+    "minimax-m2.7": 204800,
+    "minimax-m2.7-highspeed": 204800,
     "minimax-m2.5": 204800,
     "minimax-m2.5-free": 204800,
     "minimax-m2.1": 204800,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1466,11 +1466,15 @@ _PROVIDER_MODELS = {
         "kimi-k2-0905-preview",
     ],
     "minimax": [
+        "MiniMax-M2.7",
+        "MiniMax-M2.7-highspeed",
         "MiniMax-M2.5",
         "MiniMax-M2.5-highspeed",
         "MiniMax-M2.1",
     ],
     "minimax-cn": [
+        "MiniMax-M2.7",
+        "MiniMax-M2.7-highspeed",
         "MiniMax-M2.5",
         "MiniMax-M2.5-highspeed",
         "MiniMax-M2.1",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -39,7 +39,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("qwen/qwen3.5-plus-02-15",         ""),
     ("qwen/qwen3.5-35b-a3b",            ""),
     ("stepfun/step-3.5-flash",          ""),
-    ("minimax/minimax-m2.5",            ""),
+    ("minimax/minimax-m2.7",            ""),
     ("z-ai/glm-5",                      ""),
     ("z-ai/glm-5-turbo",                ""),
     ("moonshotai/kimi-k2.5",            ""),
@@ -150,6 +150,8 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gemini-3.1-pro",
         "gemini-3-pro",
         "gemini-3-flash",
+        "minimax-m2.7",
+        "minimax-m2.7-highspeed",
         "minimax-m2.5",
         "minimax-m2.5-free",
         "minimax-m2.1",
@@ -165,7 +167,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "opencode-go": [
         "glm-5",
         "kimi-k2.5",
-        "minimax-m2.5",
+        "minimax-m2.7",
     ],
     "ai-gateway": [
         "anthropic/claude-opus-4.6",

--- a/tests/test_minimax_m27_upgrade.py
+++ b/tests/test_minimax_m27_upgrade.py
@@ -1,0 +1,183 @@
+"""Tests for MiniMax M2.7 model upgrade.
+
+Validates that MiniMax-M2.7 and MiniMax-M2.7-highspeed are correctly
+registered across all model catalogs: provider model lists, context
+window metadata, and OpenRouter model references.
+"""
+
+import ast
+import re
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers – parse Python source ASTs to extract model lists without importing
+# ---------------------------------------------------------------------------
+
+def _extract_dict_literal(source: str, variable_name: str) -> dict:
+    """Extract a top-level dict assignment from Python source."""
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == variable_name:
+                    return ast.literal_eval(node.value)
+    raise ValueError(f"{variable_name!r} not found")
+
+
+def _read(path: str) -> str:
+    with open(path) as f:
+        return f.read()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests
+# ---------------------------------------------------------------------------
+
+class TestMiniMaxM27ContextWindows:
+    """model_metadata.py should list M2.7 context windows."""
+
+    @pytest.fixture(autouse=True)
+    def load_metadata(self):
+        src = _read("agent/model_metadata.py")
+        # Parse DEFAULT_CONTEXT_LENGTHS – it's the second dict (bare model IDs)
+        tree = ast.parse(src)
+        dicts = {}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                for t in node.targets:
+                    if isinstance(t, ast.Name) and "CONTEXT" in t.id:
+                        dicts[t.id] = ast.literal_eval(node.value)
+        self.default_ctx = dicts.get("DEFAULT_CONTEXT_LENGTHS", {})
+
+    def test_m27_in_context_lengths(self):
+        assert "minimax-m2.7" in self.default_ctx
+        assert self.default_ctx["minimax-m2.7"] == 204800
+
+    def test_m27_highspeed_in_context_lengths(self):
+        assert "minimax-m2.7-highspeed" in self.default_ctx
+        assert self.default_ctx["minimax-m2.7-highspeed"] == 204800
+
+    def test_m25_still_present(self):
+        assert "minimax-m2.5" in self.default_ctx
+
+
+class TestMiniMaxM27ProviderModels:
+    """main.py _PROVIDER_MODELS should list M2.7 for both minimax providers."""
+
+    @pytest.fixture(autouse=True)
+    def load_provider_models(self):
+        src = _read("hermes_cli/main.py")
+        # Extract _PROVIDER_MODELS dict using regex since it's deeply nested
+        # Find the assignment and parse just that portion
+        match = re.search(r'_PROVIDER_MODELS\s*=\s*\{', src)
+        assert match, "_PROVIDER_MODELS not found in main.py"
+        start = match.start()
+        # Find matching closing brace
+        depth = 0
+        for i, c in enumerate(src[start:], start):
+            if c == '{':
+                depth += 1
+            elif c == '}':
+                depth -= 1
+                if depth == 0:
+                    end = i + 1
+                    break
+        self.provider_models = ast.literal_eval(src[start + len("_PROVIDER_MODELS = "):end])
+
+    def test_minimax_has_m27(self):
+        models = self.provider_models["minimax"]
+        assert "MiniMax-M2.7" in models
+        assert "MiniMax-M2.7-highspeed" in models
+
+    def test_minimax_cn_has_m27(self):
+        models = self.provider_models["minimax-cn"]
+        assert "MiniMax-M2.7" in models
+        assert "MiniMax-M2.7-highspeed" in models
+
+    def test_m27_listed_before_m25(self):
+        """M2.7 should appear before M2.5 (newest first)."""
+        models = self.provider_models["minimax"]
+        idx_m27 = models.index("MiniMax-M2.7")
+        idx_m25 = models.index("MiniMax-M2.5")
+        assert idx_m27 < idx_m25
+
+    def test_minimax_still_has_m25(self):
+        models = self.provider_models["minimax"]
+        assert "MiniMax-M2.5" in models
+        assert "MiniMax-M2.5-highspeed" in models
+
+    def test_minimax_cn_still_has_m25(self):
+        models = self.provider_models["minimax-cn"]
+        assert "MiniMax-M2.5" in models
+
+
+class TestMiniMaxM27OpenRouter:
+    """models.py should reference M2.7 on OpenRouter."""
+
+    def test_openrouter_uses_m27(self):
+        src = _read("hermes_cli/models.py")
+        assert 'minimax/minimax-m2.7' in src
+        # Should NOT have the old m2.5 OpenRouter reference
+        # (the tuple entry, not the bare ID list)
+        assert '("minimax/minimax-m2.5"' not in src
+
+
+class TestMiniMaxM27BareIDs:
+    """models.py opencode-zen / opencode-go bare ID lists should include M2.7."""
+
+    def test_opencode_zen_has_m27(self):
+        src = _read("hermes_cli/models.py")
+        # Find opencode-zen list
+        match = re.search(r'"opencode-zen":\s*\[([^\]]+)\]', src, re.DOTALL)
+        assert match, "opencode-zen not found in models.py"
+        block = match.group(1)
+        assert '"minimax-m2.7"' in block
+
+    def test_opencode_go_has_m27(self):
+        src = _read("hermes_cli/models.py")
+        match = re.search(r'"opencode-go":\s*\[([^\]]+)\]', src, re.DOTALL)
+        assert match, "opencode-go not found in models.py"
+        block = match.group(1)
+        assert '"minimax-m2.7"' in block
+
+
+class TestMiniMaxM27AuxiliaryDefaults:
+    """auxiliary_client.py should default to M2.7-highspeed."""
+
+    def test_auxiliary_defaults_m27(self):
+        src = _read("agent/auxiliary_client.py")
+        assert 'MiniMax-M2.7-highspeed' in src
+
+
+# ---------------------------------------------------------------------------
+# Integration-style tests (still file-based, no network)
+# ---------------------------------------------------------------------------
+
+class TestMiniMaxM27CrossFileConsistency:
+    """Cross-file consistency: all M2.7 references should agree."""
+
+    def test_model_metadata_has_both_canonical_and_bare(self):
+        src = _read("agent/model_metadata.py")
+        assert '"MiniMax-M2.7"' in src
+        assert '"MiniMax-M2.7-highspeed"' in src
+        assert '"minimax-m2.7"' in src
+        assert '"minimax-m2.7-highspeed"' in src
+
+    def test_context_window_is_204k(self):
+        """All MiniMax M2.7 context windows should be 204800."""
+        src = _read("agent/model_metadata.py")
+        for line in src.splitlines():
+            if "m2.7" in line.lower() and ":" in line:
+                assert "204800" in line, f"Wrong context window: {line.strip()}"
+
+    def test_provider_models_match_between_files(self):
+        """minimax provider lists in main.py and models.py should both have M2.7."""
+        main_src = _read("hermes_cli/main.py")
+        models_src = _read("hermes_cli/models.py")
+
+        for src, filename in [(main_src, "main.py"), (models_src, "models.py")]:
+            match = re.search(r'"minimax":\s*\[([^\]]+)\]', src, re.DOTALL)
+            assert match, f"minimax provider not found in {filename}"
+            block = match.group(1)
+            assert "M2.7" in block, f"M2.7 missing from minimax in {filename}"

--- a/tests/test_setup_model_selection.py
+++ b/tests/test_setup_model_selection.py
@@ -32,8 +32,8 @@ class TestSetupProviderModelSelection:
     @pytest.mark.parametrize("provider_id,expected_defaults", [
         ("zai", ["glm-5", "glm-4.7", "glm-4.5", "glm-4.5-flash"]),
         ("kimi-coding", ["kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"]),
-        ("minimax", ["MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"]),
-        ("minimax-cn", ["MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"]),
+        ("minimax", ["MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"]),
+        ("minimax-cn", ["MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"]),
     ])
     @patch("hermes_cli.models.fetch_api_models", return_value=[])
     @patch("hermes_cli.config.get_env_value", return_value="fake-key")


### PR DESCRIPTION
## Summary

Upgrade MiniMax default model references from M2.5 to M2.7 across all remaining model catalogs.

MiniMax-M2.7 is already registered in `model_metadata.py` (canonical names), `models.py` (provider model lists), and `auxiliary_client.py` (auxiliary defaults), but a few catalogs still reference M2.5 only:

- **`hermes_cli/main.py`** — `_PROVIDER_MODELS` for `minimax` and `minimax-cn` providers now include M2.7 and M2.7-highspeed at the top of the list
- **`agent/model_metadata.py`** — bare model IDs (`minimax-m2.7`, `minimax-m2.7-highspeed`) added to `DEFAULT_CONTEXT_LENGTHS` (204K)
- **`hermes_cli/models.py`** — OpenRouter model reference upgraded from `minimax/minimax-m2.5` to `minimax/minimax-m2.7`; `opencode-zen` and `opencode-go` bare ID lists updated to M2.7

## Changes

| File | Change |
|------|--------|
| `hermes_cli/main.py` | Add M2.7 + M2.7-highspeed to `_PROVIDER_MODELS["minimax"]` and `_PROVIDER_MODELS["minimax-cn"]` |
| `agent/model_metadata.py` | Add `minimax-m2.7` and `minimax-m2.7-highspeed` bare IDs to `DEFAULT_CONTEXT_LENGTHS` |
| `hermes_cli/models.py` | Upgrade OpenRouter ref from m2.5 → m2.7; upgrade `opencode-zen` and `opencode-go` bare IDs |
| `tests/test_setup_model_selection.py` | Update parametrized expectations to include M2.7 models |
| `tests/test_minimax_m27_upgrade.py` | **New** — 15 unit + integration tests validating M2.7 registration across all catalogs |

## Test plan

- [x] 15 new tests pass (`pytest tests/test_minimax_m27_upgrade.py` — all green)
- [x] Existing test expectations updated in `test_setup_model_selection.py`
- [ ] Verify `hermes chat --provider minimax` shows M2.7 models in selection
- [ ] Verify `hermes chat --provider minimax-cn` shows M2.7 models in selection