### PR TITLE
docs: update adding-providers guide for unified setup flow

### DIFF
--- a/website/docs/developer-guide/adding-providers.md
+++ b/website/docs/developer-guide/adding-providers.md
@@ -28,7 +28,7 @@ A built-in provider has to line up across a few layers:
    - `api_key`
    - `source`
 3. `run_agent.py` uses `api_mode` to decide how requests are built and sent.
-4. `hermes_cli/models.py`, `hermes_cli/main.py`, and `hermes_cli/setup.py` make the provider show up in the CLI.
+4. `hermes_cli/models.py` and `hermes_cli/main.py` make the provider show up in the CLI. (`hermes_cli/setup.py` delegates to `main.py` automatically — no changes needed there.)
 5. `agent/auxiliary_client.py` and `agent/model_metadata.py` keep side tasks and token budgeting working.
 
 The important abstraction is `api_mode`.
@@ -78,11 +78,14 @@ This path includes everything from Path A plus:
 2. `hermes_cli/models.py`
 3. `hermes_cli/runtime_provider.py`
 4. `hermes_cli/main.py`
-5. `hermes_cli/setup.py`
-6. `agent/auxiliary_client.py`
-7. `agent/model_metadata.py`
-8. tests
-9. user-facing docs under `website/docs/`
+5. `agent/auxiliary_client.py`
+6. `agent/model_metadata.py`
+7. tests
+8. user-facing docs under `website/docs/`
+
+:::tip
+`hermes_cli/setup.py` does **not** need changes. The setup wizard delegates provider/model selection to `select_provider_and_model()` in `main.py` — any provider added there is automatically available in `hermes setup`.
+:::
 
 ### Additional for native / non-OpenAI providers
 
@@ -185,29 +188,22 @@ If the provider is OpenAI-compatible, `api_mode` should usually stay `chat_compl
 
 Be careful with API-key precedence. Hermes already contains logic to avoid leaking an OpenRouter key to unrelated endpoints. A new provider should be equally explicit about which key goes to which base URL.
 
-## Step 5: Wire the CLI in `hermes_cli/main.py` and `hermes_cli/setup.py`
+## Step 5: Wire the CLI in `hermes_cli/main.py`
 
-A provider is not discoverable until it shows up in the interactive flows.
+A provider is not discoverable until it shows up in the interactive `hermes model` flow.
 
-Update:
+Update these in `hermes_cli/main.py`:
 
-### `hermes_cli/main.py`
-
-- `provider_labels`
-- provider dispatch inside the `model` command
+- `provider_labels` dict
+- `providers` list in `select_provider_and_model()`
+- provider dispatch (`if selected_provider == ...`)
 - `--provider` argument choices
 - login/logout choices if the provider supports those flows
 - a `_model_flow_<provider>()` function, or reuse `_model_flow_api_key_provider()` if it fits
 
-### `hermes_cli/setup.py`
-
-- `provider_choices`
-- auth branch for the provider
-- model-selection branch
-- any provider-specific explanatory text
-- any place where a provider should be excluded from OpenRouter-only prompts or routing settings
-
-If you only update one of these files, `hermes model` and `hermes setup` will drift.
+:::tip
+`hermes_cli/setup.py` does not need changes — it calls `select_provider_and_model()` from `main.py`, so your new provider appears in both `hermes model` and `hermes setup` automatically.
+:::
 
 ## Step 6: Keep auxiliary calls working
 
@@ -353,8 +349,7 @@ Use this if the provider is standard chat completions.
 - [ ] aliases added in `hermes_cli/auth.py` and `hermes_cli/models.py`
 - [ ] model catalog added in `hermes_cli/models.py`
 - [ ] runtime branch added in `hermes_cli/runtime_provider.py`
-- [ ] CLI wiring added in `hermes_cli/main.py`
-- [ ] setup wiring added in `hermes_cli/setup.py`
+- [ ] CLI wiring added in `hermes_cli/main.py` (setup.py inherits automatically)
 - [ ] aux model added in `agent/auxiliary_client.py`
 - [ ] context lengths added in `agent/model_metadata.py`
 - [ ] runtime / CLI tests updated
@@ -412,7 +407,7 @@ If you are hunting for all the places a provider touches, search these symbols:
 - `_PROVIDER_MODELS`
 - `resolve_runtime_provider`
 - `_model_flow_`
-- `provider_choices`
+- `select_provider_and_model`
 - `api_mode`
 - `_API_KEY_PROVIDER_AUX_MODELS`
 - `self.client.`


### PR DESCRIPTION
Follow-up to #4200. Removes setup.py from the provider addition checklist and file list since setup_model_provider() now delegates to select_provider_and_model() from main.py. New providers only need to be wired in main.py — setup.py inherits automatically.