### PR TITLE
fix(docs): mobile sidebar shows only close button due to backdrop-filter

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -63,8 +63,16 @@
 
 /* Navbar styling */
 .navbar {
-  backdrop-filter: blur(12px);
   border-bottom: 1px solid rgba(255, 215, 0, 0.08);
+}
+
+/* Frosted-glass blur — desktop only.
+   On mobile, backdrop-filter creates a stacking context that hides
+   the navbar-sidebar menu content (Docusaurus #6996). */
+@media (min-width: 997px) {
+  .navbar {
+    backdrop-filter: blur(12px);
+  }
 }
 
 .navbar__title {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -63,16 +63,16 @@
 
 /* Navbar styling */
 .navbar {
+  backdrop-filter: blur(12px);
   border-bottom: 1px solid rgba(255, 215, 0, 0.08);
 }
 
-/* Frosted-glass blur — desktop only.
-   On mobile, backdrop-filter creates a stacking context that hides
-   the navbar-sidebar menu content (Docusaurus #6996). */
-@media (min-width: 997px) {
-  .navbar {
-    backdrop-filter: blur(12px);
-  }
+/* backdrop-filter creates a stacking context that hides
+   .navbar-sidebar menu content (Docusaurus #6996). Remove it
+   while the mobile sidebar is open — both classes live on the
+   same <nav> element. */
+.navbar.navbar-sidebar--show {
+  backdrop-filter: none;
 }
 
 .navbar__title {


### PR DESCRIPTION
## Summary

- The mobile docs sidebar opens but renders **only the top bar with the X close button** — no menu content is visible
- Root cause: `backdrop-filter: blur(12px)` on `.navbar` creates a new CSS stacking context that hides `.navbar-sidebar__items` on mobile
- Fix: scope `backdrop-filter` to desktop only (`min-width: 997px`) where the sidebar is not rendered inside the navbar

This is a well-documented Docusaurus issue:
- [facebook/docusaurus#6996](https://github.com/facebook/docusaurus/issues/6996)
- [facebook/docusaurus#6853](https://github.com/facebook/docusaurus/discussions/6853)

## Test plan

- [x] Open docs site on mobile (or Chrome DevTools < 996px width)
- [x] Tap hamburger menu → sidebar should now show all navigation categories
- [x] Verify desktop still has the frosted-glass blur effect on the navbar