### PR TITLE
feat: add MiniMax M2.7 to hermes model picker and opencode-go

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1591,11 +1591,15 @@ _PROVIDER_MODELS = {
         "kimi-k2-0905-preview",
     ],
     "minimax": [
+        "MiniMax-M2.7",
+        "MiniMax-M2.7-highspeed",
         "MiniMax-M2.5",
         "MiniMax-M2.5-highspeed",
         "MiniMax-M2.1",
     ],
     "minimax-cn": [
+        "MiniMax-M2.7",
+        "MiniMax-M2.7-highspeed",
         "MiniMax-M2.5",
         "MiniMax-M2.5-highspeed",
         "MiniMax-M2.1",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -191,7 +191,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "opencode-go": [
         "glm-5",
         "kimi-k2.5",
-        "minimax-m2.5",
+        "minimax-m2.7",
     ],
     "ai-gateway": [
         "anthropic/claude-opus-4.6",

--- a/tests/test_setup_model_selection.py
+++ b/tests/test_setup_model_selection.py
@@ -32,8 +32,8 @@ class TestSetupProviderModelSelection:
     @pytest.mark.parametrize("provider_id,expected_defaults", [
         ("zai", ["glm-5", "glm-4.7", "glm-4.5", "glm-4.5-flash"]),
         ("kimi-coding", ["kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"]),
-        ("minimax", ["MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"]),
-        ("minimax-cn", ["MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"]),
+        ("minimax", ["MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"]),
+        ("minimax-cn", ["MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"]),
     ])
     @patch("hermes_cli.models.fetch_api_models", return_value=[])
     @patch("hermes_cli.config.get_env_value", return_value="fake-key")


### PR DESCRIPTION
## Summary

Add MiniMax-M2.7 and M2.7-highspeed to the remaining catalog gaps:

- **`hermes_cli/main.py`** — `_PROVIDER_MODELS` for `minimax` and `minimax-cn` now include M2.7 and M2.7-highspeed at the top of the list
- **`hermes_cli/models.py`** — `opencode-go` bare ID upgraded from `minimax-m2.5` to `minimax-m2.7`
- **`tests/test_setup_model_selection.py`** — updated parametrized expectations

Salvaged from PR #4197 by @octo-patch. Most of that PR's changes were already on main (`models.py` OpenRouter ref, `_PROVIDER_MODELS`, bare ID lists, `auxiliary_client.py` defaults). These were the two remaining gaps.

## Test plan

- [x] `pytest tests/test_setup_model_selection.py` — 6 passed
