### PR TITLE
fix(cli): use display width for chat input; fix(cron): init MCP servers

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6897,17 +6897,25 @@ class HermesCLI:
         def _input_height():
             try:
                 doc = input_area.buffer.document
-                prompt_width = max(2, len(self._get_tui_prompt_text()))
+                # Use display width (get_cwidth) for accurate terminal column count,
+                # since Unicode characters like Chinese render at 2 columns wide.
+                try:
+                    from prompt_toolkit.utils import get_cwidth
+                except Exception:
+                    get_cwidth = None
+                prompt_text = self._get_tui_prompt_text()
+                prompt_width = get_cwidth(prompt_text) if get_cwidth else max(2, len(prompt_text))
                 available_width = shutil.get_terminal_size().columns - prompt_width
                 if available_width < 10:
                     available_width = 40
                 visual_lines = 0
                 for line in doc.lines:
                     # Each logical line takes at least 1 visual row; long lines wrap
-                    if len(line) == 0:
+                    line_width = get_cwidth(line) if get_cwidth else len(line)
+                    if line_width == 0:
                         visual_lines += 1
                     else:
-                        visual_lines += max(1, -(-len(line) // available_width))  # ceil division
+                        visual_lines += max(1, -(-line_width // available_width))  # ceil division
                 return min(max(visual_lines, 1), 8)
             except Exception:
                 return 1

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -358,6 +358,18 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         except Exception as e:
             logger.warning("Job '%s': failed to load config.yaml, using defaults: %s", job_id, e)
 
+        # Initialize MCP servers so cron jobs can use MCP tools.
+        # This mirrors the initialization done in cli.py for interactive sessions.
+        # The MCP event loop is shared across all cron job runs in the same process.
+        try:
+            from tools.mcp_tool import discover_mcp_tools, _ensure_mcp_loop
+            _ensure_mcp_loop()
+            mcp_tool_names = discover_mcp_tools()
+            if mcp_tool_names:
+                logger.info("Job '%s': discovered %d MCP tools", job_id, len(mcp_tool_names))
+        except Exception as e:
+            logger.warning("Job '%s': failed to initialize MCP servers: %s", job_id, e)
+
         # Reasoning config from env or config.yaml
         from hermes_constants import parse_reasoning_effort
         effort = os.getenv("HERMES_REASONING_EFFORT", "")


### PR DESCRIPTION
## Summary

- **cli**: Fix chat input box height calculation to use display width (`get_cwidth`) instead of `len()` for proper CJK character support
- **cron**: Initialize MCP servers before running cron jobs so they can use MCP tools

## Root Cause (cli)

The `_input_height()` function in `cli.py:6910` used `len(line)` to calculate visual line count. This works for ASCII (1 char = 1 column) but fails for CJK characters (1 char = 2 columns).

## Root Cause (cron)

Cron jobs could not use MCP tools because `discover_mcp_tools()` was only called in the main CLI process, not in the scheduler's `run_job()` context.

## Test plan

- [ ] Type 236 English characters - cursor should stay in input box
- [ ] Type 236 Chinese characters - input box should grow tall enough before wrapping
- [ ] Create a cron job with an MCP tool (e.g., filesystem MCP server) and verify it works

Fixes #4212
Fixes #4219