### PR TITLE
fix(tests): resolve 6 CI failures from stale env var reads and name collision

### DIFF
--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -686,10 +686,15 @@ class TestVisionClientFallback:
 
         Many local models (Qwen-VL, LLaVA, etc.) support vision.
         When no OpenRouter/Nous/Codex is available, try the custom endpoint.
+
+        Since the March 2026 config refactor, OPENAI_BASE_URL env var is no
+        longer consulted — base_url comes from config.yaml via
+        resolve_runtime_provider.  Mock _resolve_custom_runtime directly.
         """
-        monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:1234/v1")
         monkeypatch.setenv("OPENAI_API_KEY", "local-key")
         with patch("agent.auxiliary_client._read_nous_auth", return_value=None), \
+             patch("agent.auxiliary_client._resolve_custom_runtime",
+                   return_value=("http://localhost:1234/v1", "local-key")), \
              patch("agent.auxiliary_client.OpenAI") as mock_openai:
             client, model = get_vision_auxiliary_client()
         assert client is not None  # Custom endpoint picked up as fallback

--- a/tests/test_codex_execution_paths.py
+++ b/tests/test_codex_execution_paths.py
@@ -138,8 +138,10 @@ def test_gateway_run_agent_codex_path_handles_internal_401_refresh(monkeypatch):
             "api_key": "codex-token",
         },
     )
+    # Since the March 2026 config refactor, HERMES_MODEL env var is no longer
+    # consulted — model comes from config.yaml via _resolve_gateway_model().
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.3-codex")
     monkeypatch.setenv("HERMES_TOOL_PROGRESS", "false")
-    monkeypatch.setenv("HERMES_MODEL", "gpt-5.3-codex")
 
     _Codex401ThenSuccessAgent.refresh_attempts = 0
     _Codex401ThenSuccessAgent.last_init = {}

--- a/tests/test_provider_parity.py
+++ b/tests/test_provider_parity.py
@@ -559,11 +559,18 @@ class TestAuxiliaryClientProviderPriority:
         assert model == "google/gemini-3-flash-preview"
 
     def test_custom_endpoint_when_no_nous(self, monkeypatch):
+        """Custom endpoint is used when no OpenRouter/Nous keys are available.
+
+        Since the March 2026 config refactor, OPENAI_BASE_URL env var is no
+        longer consulted — base_url comes from config.yaml via
+        resolve_runtime_provider.  Mock _resolve_custom_runtime directly.
+        """
         monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
-        monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:1234/v1")
         monkeypatch.setenv("OPENAI_API_KEY", "local-key")
         from agent.auxiliary_client import get_text_auxiliary_client
         with patch("agent.auxiliary_client._read_nous_auth", return_value=None), \
+             patch("agent.auxiliary_client._resolve_custom_runtime",
+                   return_value=("http://localhost:1234/v1", "local-key")), \
              patch("agent.auxiliary_client.OpenAI") as mock:
             client, model = get_text_auxiliary_client()
         assert mock.call_args.kwargs["base_url"] == "http://localhost:1234/v1"

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -140,10 +140,19 @@ def test_custom_endpoint_prefers_openai_key(monkeypatch):
 
     Regression test for #560: when base_url is a non-OpenRouter endpoint,
     OPENROUTER_API_KEY was being sent as the auth header instead of OPENAI_API_KEY.
+
+    Since the March 2026 config refactor, OPENAI_BASE_URL env var is no longer
+    consulted — base_url comes exclusively from config.yaml (model.base_url).
     """
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
-    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
-    monkeypatch.setenv("OPENAI_BASE_URL", "https://api.z.ai/api/coding/paas/v4")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "custom",
+            "base_url": "https://api.z.ai/api/coding/paas/v4",
+        },
+    )
     monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
     monkeypatch.setenv("OPENAI_API_KEY", "zai-key")
     monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-key")
@@ -225,10 +234,18 @@ def test_custom_endpoint_auto_provider_prefers_openai_key(monkeypatch):
     """Auto provider with non-OpenRouter base_url should prefer OPENAI_API_KEY.
 
     Same as #560 but via 'hermes model' flow which sets provider to 'auto'.
+
+    Since the March 2026 config refactor, OPENAI_BASE_URL env var is no longer
+    consulted — base_url comes exclusively from config.yaml (model.base_url).
     """
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
-    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
-    monkeypatch.setenv("OPENAI_BASE_URL", "https://my-vllm-server.example.com/v1")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "base_url": "https://my-vllm-server.example.com/v1",
+        },
+    )
     monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
     monkeypatch.setenv("OPENAI_API_KEY", "sk-vllm-key")
     monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-...leak")

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -238,7 +238,7 @@ _PROVIDER_REGISTRY: Dict[str, type] = {
 _cached_cloud_provider: Optional[CloudBrowserProvider] = None
 _cloud_provider_resolved = False
 _allow_private_urls_resolved = False
-_allow_private_urls: Optional[bool] = None
+_cached_allow_private_urls: Optional[bool] = None
 
 
 def _get_cloud_provider() -> Optional[CloudBrowserProvider]:
@@ -273,12 +273,12 @@ def _allow_private_urls() -> bool:
     Reads ``config["browser"]["allow_private_urls"]`` once and caches the result
     for the process lifetime.  Defaults to ``False`` (SSRF protection active).
     """
-    global _allow_private_urls, _allow_private_urls_resolved
+    global _cached_allow_private_urls, _allow_private_urls_resolved
     if _allow_private_urls_resolved:
-        return _allow_private_urls
+        return _cached_allow_private_urls
 
     _allow_private_urls_resolved = True
-    _allow_private_urls = False  # safe default
+    _cached_allow_private_urls = False  # safe default
     try:
         hermes_home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
         config_path = hermes_home / "config.yaml"
@@ -286,10 +286,10 @@ def _allow_private_urls() -> bool:
             import yaml
             with open(config_path) as f:
                 cfg = yaml.safe_load(f) or {}
-            _allow_private_urls = bool(cfg.get("browser", {}).get("allow_private_urls"))
+            _cached_allow_private_urls = bool(cfg.get("browser", {}).get("allow_private_urls"))
     except Exception as e:
         logger.debug("Could not read allow_private_urls from config: %s", e)
-    return _allow_private_urls
+    return _cached_allow_private_urls
 
 
 def _socket_safe_tmpdir() -> str:


### PR DESCRIPTION
## Summary

Fixes 6 pre-existing CI failures that passed locally (real config/keys) but failed in CI (blanked keys, no config.yaml).

### Bug fix (production code)

**`_allow_private_urls` name collision in `browser_tool.py`** — The function used `global _allow_private_urls` and then assigned `_allow_private_urls = False`, replacing itself in the module namespace with a boolean. After the first call, subsequent calls hit `TypeError: 'bool' object is not callable`. Renamed the cache variable to `_cached_allow_private_urls`. This is a real bug that could affect any user with `browser.allow_private_urls` config.

### Test fixes (5 stale tests)

All 5 tests relied on env vars that were removed in the March 2026 config refactor:

| Test | Stale env var | Fix |
|------|--------------|-----|
| `test_custom_endpoint_prefers_openai_key` | `OPENAI_BASE_URL` | Mock `_get_model_config` with config dict |
| `test_custom_endpoint_auto_provider_prefers_openai_key` | `OPENAI_BASE_URL` | Mock `_get_model_config` with config dict |
| `test_custom_endpoint_when_no_nous` | `OPENAI_BASE_URL` | Mock `_resolve_custom_runtime` directly |
| `test_vision_auto_falls_back_to_custom_endpoint` | `OPENAI_BASE_URL` | Mock `_resolve_custom_runtime` directly |
| `test_gateway_run_agent_codex_path_handles_internal_401_refresh` | `HERMES_MODEL` | Mock `_resolve_gateway_model` |

### Testing

- All 6 previously-failing tests now pass
- hermes_cli + provider tests: 895 passed
- tools + agent tests: 2378 passed
- gateway tests: 1794 passed
