### PR TITLE
feat: auto-detect models from server probe in custom endpoint setup

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1242,21 +1242,9 @@ def _model_flow_custom(config):
     try:
         base_url = input(f"API base URL [{current_url or 'e.g. https://api.example.com/v1'}]: ").strip()
         api_key = input(f"API key [{current_key[:8] + '...' if current_key else 'optional'}]: ").strip()
-        model_name = input("Model name (e.g. gpt-4, llama-3-70b): ").strip()
-        context_length_str = input("Context length in tokens [leave blank for auto-detect]: ").strip()
     except (KeyboardInterrupt, EOFError):
         print("\nCancelled.")
         return
-
-    context_length = None
-    if context_length_str:
-        try:
-            context_length = int(context_length_str.replace(",", "").replace("k", "000").replace("K", "000"))
-            if context_length <= 0:
-                context_length = None
-        except ValueError:
-            print(f"Invalid context length: {context_length_str} — will auto-detect.")
-            context_length = None
 
     if not base_url and not current_url:
         print("No URL provided. Cancelled.")
@@ -1293,6 +1281,44 @@ def _model_flow_custom(config):
         )
         if probe.get("suggested_base_url"):
             print(f"  If this server expects /v1, try base URL: {probe['suggested_base_url']}")
+
+    # Select model — use probe results when available, fall back to manual input
+    model_name = ""
+    detected_models = probe.get("models") or []
+    try:
+        if len(detected_models) == 1:
+            print(f"  Detected model: {detected_models[0]}")
+            confirm = input("  Use this model? [Y/n]: ").strip().lower()
+            if confirm in ("", "y", "yes"):
+                model_name = detected_models[0]
+            else:
+                model_name = input("Model name (e.g. gpt-4, llama-3-70b): ").strip()
+        elif len(detected_models) > 1:
+            print("  Available models:")
+            for i, m in enumerate(detected_models, 1):
+                print(f"    {i}. {m}")
+            pick = input(f"  Select model [1-{len(detected_models)}] or type name: ").strip()
+            if pick.isdigit() and 1 <= int(pick) <= len(detected_models):
+                model_name = detected_models[int(pick) - 1]
+            elif pick:
+                model_name = pick
+        else:
+            model_name = input("Model name (e.g. gpt-4, llama-3-70b): ").strip()
+
+        context_length_str = input("Context length in tokens [leave blank for auto-detect]: ").strip()
+    except (KeyboardInterrupt, EOFError):
+        print("\nCancelled.")
+        return
+
+    context_length = None
+    if context_length_str:
+        try:
+            context_length = int(context_length_str.replace(",", "").replace("k", "000").replace("K", "000"))
+            if context_length <= 0:
+                context_length = None
+        except ValueError:
+            print(f"Invalid context length: {context_length_str} — will auto-detect.")
+            context_length = None
 
     if model_name:
         _save_model_choice(model_name)

--- a/tests/test_cli_provider_resolution.py
+++ b/tests/test_cli_provider_resolution.py
@@ -460,13 +460,16 @@ def test_model_flow_custom_saves_verified_v1_base_url(monkeypatch, capsys):
     )
     monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
 
-    answers = iter(["http://localhost:8000", "local-key", "llm", ""])
+    # After the probe detects a single model ("llm"), the flow asks
+    # "Use this model? [Y/n]:" — confirm with Enter, then context length.
+    answers = iter(["http://localhost:8000", "local-key", "", ""])
     monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
 
     hermes_main._model_flow_custom({})
     output = capsys.readouterr().out
 
     assert "Saving the working base URL instead" in output
+    assert "Detected model: llm" in output
     # OPENAI_BASE_URL is no longer saved to .env — config.yaml is authoritative
     assert "OPENAI_BASE_URL" not in saved_env
     assert saved_env["MODEL"] == "llm"


### PR DESCRIPTION
## Summary

Re-implements the custom endpoint model flow change from PR #4194 (by @sudoingX) against current main. The original PR couldn't be cherry-picked due to three recent refactors (#4165, #4172, #4182) that significantly changed `_model_flow_custom`.

### What changed

`_model_flow_custom` now probes the server **before** asking for a model name and uses the results:

- **1 model detected** → prints the name and asks `Use this model? [Y/n]:` (Enter to confirm)
- **Multiple models** → numbered list picker, or type a name directly
- **No models / probe failed** → falls back to the existing manual input prompt

Context length prompt also moved after model selection — the user sees the verified endpoint status before being asked for details.

### What's preserved (unchanged)

All three recent fixes in `_model_flow_custom` are untouched:
- `config["model"] = dict(model)` caller dict sync (#4172)
- `model["api_key"] = effective_key` persistence (#4182)
- No `save_env_value("OPENAI_BASE_URL", ...)` calls (#4165)

### Affected paths

Both `hermes model` (via `select_provider_and_model`) and `hermes setup` (via `setup_model_provider`) call `_model_flow_custom`, so both get the improvement.

### Tests

Updated `test_model_flow_custom_saves_verified_v1_base_url` to match the new input sequence (confirm detected model instead of typing it). 956 tests pass; 2 pre-existing test pollution failures unrelated to this change (confirmed same on clean main).

Credit: @sudoingX for the original idea and approach in PR #4194.
