### PR TITLE
fix: /usage command undercounts context by excluding tool messages

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4581,14 +4581,25 @@ class GatewayRunner:
         history = self.session_store.load_transcript(session_entry.session_id)
         if history:
             from agent.model_metadata import estimate_messages_tokens_rough
-            msgs = [m for m in history if m.get("role") in ("user", "assistant") and m.get("content")]
-            approx = estimate_messages_tokens_rough(msgs)
-            return (
-                f"📊 **Session Info**\n"
-                f"Messages: {len(msgs)}\n"
-                f"Estimated context: ~{approx:,} tokens\n"
-                f"_(Detailed usage available during active conversations)_"
-            )
+            # Use the full history (all roles) for accurate context estimation.
+            # The previous implementation filtered to only user+assistant messages
+            # with text content, which excluded tool results, tool-calling assistant
+            # turns, and system messages -- often the bulk of context in tool-heavy
+            # conversations.
+            approx = estimate_messages_tokens_rough(history)
+            lines = [
+                "📊 **Session Info**",
+                f"Messages: {len(history)}",
+                f"Estimated context: ~{approx:,} tokens",
+            ]
+            # If we have actual API-reported tokens from the last turn, show those
+            # as a more reliable reference alongside the rough estimate.
+            if session_entry.last_prompt_tokens and session_entry.last_prompt_tokens > 0:
+                lines.append(
+                    f"Last measured prompt: ~{session_entry.last_prompt_tokens:,} tokens"
+                )
+            lines.append("_(Detailed usage available during active conversations)_")
+            return "\n".join(lines)
         return "No usage data available for this session."
 
     async def _handle_insights_command(self, event: MessageEvent) -> str:


### PR DESCRIPTION
## Problem

The `/usage` command fallback path (shown between turns when no agent is actively running) severely undercounts context tokens. It filters the transcript to only `user` and `assistant` messages that have text `content`:

```python
msgs = [m for m in history if m.get("role") in ("user", "assistant") and m.get("content")]
```

This excludes:
- All `tool` role messages (tool results) — often the bulk of context in tool-heavy conversations
- Assistant messages that only contain `tool_calls` (no text content)
- System messages

In practice, tool results alone can be **2-5x** the size of user+assistant text, so a reported 34k tokens could correspond to 70k-150k+ actual context. This makes `/usage` misleadingly low while the model is already decohering from context overflow, and the user has no way to tell.

## Fix

- Estimate tokens from the **full history** (all roles), not the filtered subset
- Show **last measured prompt tokens** from the API when available (`session_entry.last_prompt_tokens`) as a more reliable reference
- Show total message count (including tool messages) instead of only user+assistant count

## Before

```
📊 Session Info
Messages: 95
Estimated context: ~34,755 tokens
_(Detailed usage available during active conversations)_
```

## After

```
📊 Session Info
Messages: 312
Estimated context: ~142,500 tokens
Last measured prompt: ~128,430 tokens
_(Detailed usage available during active conversations)_
```

## Testing

- All 31 existing usage-related tests pass
- `py_compile` passes on modified file