### PR TITLE
fix(gateway): restore /model command for messaging

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1894,6 +1894,9 @@ class GatewayRunner:
 
         if canonical == "provider":
             return await self._handle_provider_command(event)
+
+        if canonical == "model":
+            return await self._handle_model_command(event)
         
         if canonical == "personality":
             return await self._handle_personality_command(event)
@@ -4203,6 +4206,181 @@ class GatewayRunner:
                 )
             except Exception:
                 pass
+
+    async def _handle_model_command(self, event: MessageEvent) -> str:
+        """Handle /model command - show or change the current model for gateway chats."""
+        import yaml
+        from hermes_cli.models import (
+            curated_models_for_provider,
+            normalize_provider,
+            _PROVIDER_LABELS,
+        )
+
+        args = event.get_command_args().strip()
+        config_path = _hermes_home / 'config.yaml'
+
+        current = _resolve_gateway_model() or "anthropic/claude-opus-4.6"
+        current_provider = "openrouter"
+        try:
+            if config_path.exists():
+                with open(config_path, encoding="utf-8") as f:
+                    cfg = yaml.safe_load(f) or {}
+                model_cfg = cfg.get("model", {})
+                if isinstance(model_cfg, dict):
+                    current_provider = model_cfg.get("provider", current_provider)
+        except Exception:
+            pass
+
+        current_provider = normalize_provider(current_provider)
+        if current_provider == "auto":
+            try:
+                from hermes_cli.auth import resolve_provider as _resolve_provider
+                current_provider = _resolve_provider(current_provider)
+            except Exception:
+                current_provider = "openrouter"
+
+        if current_provider == "openrouter" and os.getenv("OPENAI_BASE_URL", "").strip():
+            current_provider = "custom"
+
+        def _save_model_config(new_model: str, *, provider: str | None = None, base_url: str | None = None) -> bool:
+            try:
+                user_config = {}
+                if config_path.exists():
+                    with open(config_path, encoding="utf-8") as f:
+                        user_config = yaml.safe_load(f) or {}
+                if "model" not in user_config or not isinstance(user_config["model"], dict):
+                    user_config["model"] = {}
+                user_config["model"]["default"] = new_model
+                if provider is not None:
+                    user_config["model"]["provider"] = provider
+                if base_url is not None:
+                    if base_url and "openrouter.ai" not in base_url:
+                        user_config["model"]["base_url"] = base_url
+                    else:
+                        user_config["model"].pop("base_url", None)
+                atomic_yaml_write(config_path, user_config)
+                return True
+            except Exception as e:
+                logger.error("Failed to save model config: %s", e)
+                return False
+
+        if not args:
+            if self._effective_model:
+                eff_provider = self._effective_provider or 'unknown'
+                eff_label = _PROVIDER_LABELS.get(eff_provider, eff_provider)
+                cfg_label = _PROVIDER_LABELS.get(current_provider, current_provider)
+                lines = [
+                    f"🤖 **Active model:** `{self._effective_model}` (fallback)",
+                    f"**Provider:** {eff_label}",
+                    f"**Primary model** (`{current}` via {cfg_label}) is rate-limited.",
+                    "",
+                    "To change: `/model model-name`",
+                    "Switch provider: `/model provider:model-name`",
+                ]
+                return "\n".join(lines)
+
+            provider_label = _PROVIDER_LABELS.get(current_provider, current_provider)
+            lines = [
+                f"🤖 **Current model:** `{current}`",
+                f"**Provider:** {provider_label}",
+            ]
+            if current_provider == "custom":
+                from hermes_cli.models import _get_custom_base_url
+                custom_url = _get_custom_base_url() or os.getenv("OPENAI_BASE_URL", "")
+                if custom_url:
+                    lines.append(f"**Endpoint:** `{custom_url}`")
+            lines.append("")
+            curated = curated_models_for_provider(current_provider)
+            if curated:
+                lines.append(f"**Available models ({provider_label}):**")
+                for mid, desc in curated:
+                    marker = " ←" if mid == current else ""
+                    label = f"  _{desc}_" if desc else ""
+                    lines.append(f"• `{mid}`{label}{marker}")
+                lines.append("")
+            lines.append("To change: `/model model-name`")
+            lines.append("Switch provider: `/model provider-name` or `/model provider:model-name`")
+            return "\n".join(lines)
+
+        if args.strip().lower() == "custom":
+            from hermes_cli.model_switch import switch_to_custom_provider
+            cust_result = switch_to_custom_provider()
+            if not cust_result.success:
+                return f"⚠️ {cust_result.error_message}"
+
+            saved = _save_model_config(
+                cust_result.model,
+                provider="custom",
+                base_url=cust_result.base_url,
+            )
+            os.environ["HERMES_MODEL"] = cust_result.model
+            os.environ["HERMES_INFERENCE_PROVIDER"] = "custom"
+            self._effective_model = None
+            self._effective_provider = None
+            self._evict_cached_agent(self._session_key_for_source(event.source))
+            persist_note = "saved to config" if saved else "this session only"
+            return (
+                f"🤖 Model changed to `{cust_result.model}` ({persist_note})\n"
+                f"**Provider:** Custom\n"
+                f"**Endpoint:** `{cust_result.base_url}`\n"
+                f"_Model auto-detected from endpoint. Takes effect on next message._"
+            )
+
+        from hermes_cli.model_switch import switch_model
+        _resolved_base = ""
+        try:
+            from hermes_cli.runtime_provider import resolve_runtime_provider as _rtp
+            _resolved_base = _rtp(requested=current_provider).get("base_url", "")
+        except Exception:
+            pass
+
+        result = switch_model(
+            args,
+            current_provider,
+            current_base_url=_resolved_base,
+            current_api_key=os.getenv("OPENAI_API_KEY") or "",
+        )
+
+        if not result.success:
+            msg = result.error_message
+            tip = "\n\nUse `/model` to see available models, `/provider` to see providers" if "Did you mean" not in msg else ""
+            return f"⚠️ {msg}{tip}"
+
+        saved = False
+        if result.persist:
+            saved = _save_model_config(
+                result.new_model,
+                provider=result.target_provider if result.provider_changed else None,
+                base_url=result.base_url if result.provider_changed else None,
+            )
+
+        os.environ["HERMES_MODEL"] = result.new_model
+        if result.provider_changed:
+            os.environ["HERMES_INFERENCE_PROVIDER"] = result.target_provider
+
+        self._effective_model = None
+        self._effective_provider = None
+        self._evict_cached_agent(self._session_key_for_source(event.source))
+
+        provider_note = f"\n**Provider:** {result.provider_label}" if result.provider_changed else ""
+        warning = f"\n⚠️ {result.warning_message}" if result.warning_message else ""
+        persist_note = "saved to config" if saved else ("this session only — will revert on restart" if not result.persist else "this session only")
+
+        custom_hint = ""
+        if result.is_custom_target:
+            endpoint = result.base_url or _resolved_base or "custom endpoint"
+            custom_hint = f"\n**Endpoint:** `{endpoint}`"
+            if not result.provider_changed:
+                custom_hint += (
+                    "\n_To switch providers, use_ `/model provider:model`"
+                    "\n_e.g._ `/model openrouter:anthropic/claude-sonnet-4`"
+                )
+
+        return (
+            f"🤖 Model changed to `{result.new_model}` ({persist_note})"
+            f"{provider_note}{warning}{custom_hint}\n_(takes effect on next message)_"
+        )
+
 
     async def _handle_reasoning_command(self, event: MessageEvent) -> str:
         """Handle /reasoning command — manage reasoning effort and display toggle.

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -82,6 +82,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     # Configuration
     CommandDef("config", "Show current configuration", "Configuration",
                cli_only=True),
+    CommandDef("model", "Show or change the current model", "Configuration",
+               gateway_only=True, args_hint="[name]"),
     CommandDef("provider", "Show available providers and current provider",
                "Configuration"),
     CommandDef("prompt", "View/set custom system prompt", "Configuration",

--- a/tests/gateway/test_model_command.py
+++ b/tests/gateway/test_model_command.py
@@ -1,0 +1,183 @@
+"""Tests for the gateway /model command."""
+
+import os
+import sys
+import types
+
+
+def _install_fake_prompt_toolkit():
+    if 'prompt_toolkit' in sys.modules:
+        return
+    prompt_toolkit = types.ModuleType('prompt_toolkit')
+    auto_suggest = types.ModuleType('prompt_toolkit.auto_suggest')
+    completion = types.ModuleType('prompt_toolkit.completion')
+
+    class AutoSuggest:  # pragma: no cover - simple test shim
+        pass
+
+    class Suggestion:
+        def __init__(self, text=''):
+            self.text = text
+
+    class Completer:  # pragma: no cover - simple test shim
+        pass
+
+    class Completion:
+        def __init__(self, text='', start_position=0, display=None, display_meta=None):
+            self.text = text
+            self.start_position = start_position
+            self.display = display
+            self.display_meta = display_meta
+            self.display_text = display or text
+            self.display_meta_text = display_meta or ''
+
+    auto_suggest.AutoSuggest = AutoSuggest
+    auto_suggest.Suggestion = Suggestion
+    completion.Completer = Completer
+    completion.Completion = Completion
+    sys.modules['prompt_toolkit'] = prompt_toolkit
+    sys.modules['prompt_toolkit.auto_suggest'] = auto_suggest
+    sys.modules['prompt_toolkit.completion'] = completion
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import yaml
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+from hermes_cli.model_switch import ModelSwitchResult
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _make_runner():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="test")}
+    )
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._effective_model = None
+    runner._effective_provider = None
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner._send_voice_reply = AsyncMock()
+    runner._capture_gateway_honcho_if_configured = lambda *args, **kwargs: None
+    runner._emit_gateway_run_progress = AsyncMock()
+    runner._evict_cached_agent = MagicMock()
+    runner._session_key_for_source = lambda source: f"key:{source.chat_id}"
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_model_command_appears_in_gateway_help():
+    _install_fake_prompt_toolkit()
+    runner = _make_runner()
+
+    result = await runner._handle_help_command(_make_event('/help'))
+
+    assert '/model [name]' in result
+
+
+@pytest.mark.asyncio
+async def test_handle_model_command_shows_current_model(tmp_path, monkeypatch):
+    hermes_home = tmp_path / 'hermes'
+    hermes_home.mkdir()
+    (hermes_home / 'config.yaml').write_text(
+        """model:
+  default: openai/gpt-5.4
+  provider: openrouter
+""",
+        encoding='utf-8',
+    )
+    monkeypatch.setattr(gateway_run, '_hermes_home', hermes_home)
+
+    runner = _make_runner()
+    result = await runner._handle_model_command(_make_event('/model'))
+
+    assert 'Current model' in result
+    assert 'openai/gpt-5.4' in result
+    assert 'OpenRouter' in result
+
+
+@pytest.mark.asyncio
+async def test_handle_model_command_switches_and_persists(tmp_path, monkeypatch):
+    hermes_home = tmp_path / 'hermes'
+    hermes_home.mkdir()
+    config_path = hermes_home / 'config.yaml'
+    config_path.write_text(
+        """model:
+  default: anthropic/claude-sonnet-4
+  provider: openrouter
+""",
+        encoding='utf-8',
+    )
+    monkeypatch.setattr(gateway_run, '_hermes_home', hermes_home)
+    monkeypatch.delenv('HERMES_MODEL', raising=False)
+    monkeypatch.delenv('HERMES_INFERENCE_PROVIDER', raising=False)
+
+    runner = _make_runner()
+
+    monkeypatch.setattr(
+        'hermes_cli.model_switch.switch_model',
+        lambda *args, **kwargs: ModelSwitchResult(
+            success=True,
+            new_model='openai/gpt-5.5',
+            target_provider='openrouter',
+            provider_changed=False,
+            persist=True,
+            provider_label='OpenRouter',
+        ),
+    )
+    monkeypatch.setattr(
+        'hermes_cli.runtime_provider.resolve_runtime_provider',
+        lambda requested=None: {'base_url': 'https://openrouter.ai/api/v1', 'api_key': 'k'},
+    )
+
+    result = await runner._handle_model_command(_make_event('/model openai/gpt-5.5'))
+
+    saved = yaml.safe_load(config_path.read_text(encoding='utf-8'))
+    assert saved['model']['default'] == 'openai/gpt-5.5'
+    assert os.environ['HERMES_MODEL'] == 'openai/gpt-5.5'
+    runner._evict_cached_agent.assert_called_once_with('key:c1')
+    assert 'saved to config' in result
+    assert 'takes effect on next message' in result
+
+
+@pytest.mark.asyncio
+async def test_handle_message_dispatches_model_command():
+    _install_fake_prompt_toolkit()
+    runner = _make_runner()
+    runner._handle_model_command = AsyncMock(return_value='ok-model')
+
+    result = await runner._handle_message(_make_event('/model openai/gpt-5.5'))
+
+    assert result == 'ok-model'
+    runner._handle_model_command.assert_awaited_once()

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -185,6 +185,19 @@ class TestGatewayHelpLines:
         assert "/bg" in bg_line[0]
 
 
+class TestGatewayModelCommandRegistry:
+    def test_model_is_gateway_only(self):
+        cmd = resolve_command("model")
+        assert cmd is not None
+        assert cmd.gateway_only is True
+        assert cmd.cli_only is False
+
+    def test_model_in_gateway_known_commands_and_telegram_menu(self):
+        assert "model" in GATEWAY_KNOWN_COMMANDS
+        names = {name for name, _ in telegram_bot_commands()}
+        assert "model" in names
+
+
 class TestTelegramBotCommands:
     def test_returns_list_of_tuples(self):
         cmds = telegram_bot_commands()


### PR DESCRIPTION
## Summary
- restore the `/model` slash command for messaging/gateway users
- persist gateway model changes back to `config.yaml` and evict the cached session agent so the next message uses the new model
- add gateway regression coverage for showing, switching, and dispatching `/model`

## Testing
- `python -m compileall /home/devuser/code/work/hermes-agent/gateway/run.py /home/devuser/code/work/hermes-agent/hermes_cli/commands.py /home/devuser/code/work/hermes-agent/tests/gateway/test_model_command.py`
- `pytest -o addopts='' -q /home/devuser/code/work/hermes-agent/tests/gateway/test_model_command.py`
- `python3 - <<'PY2'`
  (stub prompt_toolkit and assert `model` is gateway-only, appears in Telegram commands, and is excluded from CLI COMMANDS)
  `PY2`

Closes #4039
