### PR TITLE
feat(fallback): add silent_fallback option to suppress status messages

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -82,6 +82,26 @@ model:
 #     model: google/gemini-2.5-flash
 
 # =============================================================================
+# Fallback Model (optional)
+# =============================================================================
+# Automatic failover to a backup provider when the primary model fails.
+# Supports both single fallback (dict) and fallback chain (list of dicts).
+#
+# fallback_model:
+#   provider: openrouter
+#   model: anthropic/claude-sonnet-4
+#   silent_fallback: true    # Set to true to suppress fallback status messages
+#
+# Or for multiple fallback providers (tried in order):
+# fallback_model:
+#   - provider: openrouter
+#     model: anthropic/claude-sonnet-4
+#     silent_fallback: false
+#   - provider: nous
+#     model: nous-hermes-3
+#     silent_fallback: true
+
+# =============================================================================
 # Git Worktree Isolation
 # =============================================================================
 # When enabled, each CLI session creates an isolated git worktree so multiple

--- a/cli.py
+++ b/cli.py
@@ -1279,6 +1279,20 @@ class HermesCLI:
         self._background_tasks: Dict[str, threading.Thread] = {}
         self._background_task_counter = 0
 
+    def _extract_silent_fallback(self, fallback_model) -> bool:
+        """Extract silent_fallback from fallback_model config.
+
+        For a single dict, returns the silent_fallback value (default False).
+        For a list, returns True only if ALL providers have silent_fallback=True.
+        """
+        if not fallback_model:
+            return False
+        if isinstance(fallback_model, dict):
+            return bool(fallback_model.get("silent_fallback", False))
+        if isinstance(fallback_model, list):
+            return all(bool(f.get("silent_fallback", False)) for f in fallback_model if isinstance(f, dict))
+        return False
+
     def _invalidate(self, min_interval: float = 0.25) -> None:
         """Throttled UI repaint — prevents terminal blinking on slow/SSH connections."""
         import time as _time
@@ -2122,6 +2136,7 @@ class HermesCLI:
                 reasoning_callback=self._current_reasoning_callback(),
                 honcho_session_key=None,  # resolved by run_agent via config sessions map / title
                 fallback_model=self._fallback_model,
+                silent_fallback=self._extract_silent_fallback(self._fallback_model),
                 thinking_callback=self._on_thinking,
                 checkpoints_enabled=self.checkpoints_enabled,
                 checkpoint_max_snapshots=self.checkpoint_max_snapshots,

--- a/cli.py
+++ b/cli.py
@@ -1279,18 +1279,16 @@ class HermesCLI:
         self._background_tasks: Dict[str, threading.Thread] = {}
         self._background_task_counter = 0
 
-    def _extract_silent_fallback(self, fallback_model) -> bool:
-        """Extract silent_fallback from fallback_model config.
-
-        For a single dict, returns the silent_fallback value (default False).
-        For a list, returns True only if ALL providers have silent_fallback=True.
-        """
-        if not fallback_model:
-            return False
+    @staticmethod
+    def _extract_silent_fallback(fallback_model) -> bool:
+        """Extract silent_fallback flag from fallback_model config."""
         if isinstance(fallback_model, dict):
-            return bool(fallback_model.get("silent_fallback", False))
+            return fallback_model.get("silent_fallback", False)
         if isinstance(fallback_model, list):
-            return all(bool(f.get("silent_fallback", False)) for f in fallback_model if isinstance(f, dict))
+            return bool(fallback_model) and all(
+                isinstance(f, dict) and f.get("silent_fallback", False)
+                for f in fallback_model
+            )
         return False
 
     def _invalidate(self, min_interval: float = 0.25) -> None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -427,6 +427,7 @@ class GatewayRunner:
         self._show_reasoning = self._load_show_reasoning()
         self._provider_routing = self._load_provider_routing()
         self._fallback_model = self._load_fallback_model()
+        self._silent_fallback = self._extract_silent_fallback(self._fallback_model)
         self._smart_model_routing = self._load_smart_model_routing()
 
         # Wire process registry into session store for reset protection
@@ -1027,6 +1028,21 @@ class GatewayRunner:
         except Exception:
             pass
         return None
+
+    @staticmethod
+    def _extract_silent_fallback(fallback_model) -> bool:
+        """Extract silent_fallback from fallback_model config.
+
+        For a single dict, returns the silent_fallback value (default False).
+        For a list, returns True only if ALL providers have silent_fallback=True.
+        """
+        if not fallback_model:
+            return False
+        if isinstance(fallback_model, dict):
+            return bool(fallback_model.get("silent_fallback", False))
+        if isinstance(fallback_model, list):
+            return all(bool(f.get("silent_fallback", False)) for f in fallback_model if isinstance(f, dict))
+        return False
 
     @staticmethod
     def _load_smart_model_routing() -> dict:
@@ -3969,6 +3985,7 @@ class GatewayRunner:
                     platform=platform_key,
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
+                    silent_fallback=getattr(self, '_silent_fallback', False),
                 )
 
                 return agent.run_conversation(
@@ -4143,6 +4160,7 @@ class GatewayRunner:
                     platform=platform_key,
                     session_db=None,
                     fallback_model=self._fallback_model,
+                    silent_fallback=getattr(self, '_silent_fallback', False),
                     skip_memory=True,
                     skip_context_files=True,
                     persist_session=False,
@@ -5658,6 +5676,7 @@ class GatewayRunner:
                     honcho_config=honcho_config,
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
+                    silent_fallback=getattr(self, '_silent_fallback', False),
                 )
                 if _cache_lock and _cache is not None:
                     with _cache_lock:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1031,17 +1031,14 @@ class GatewayRunner:
 
     @staticmethod
     def _extract_silent_fallback(fallback_model) -> bool:
-        """Extract silent_fallback from fallback_model config.
-
-        For a single dict, returns the silent_fallback value (default False).
-        For a list, returns True only if ALL providers have silent_fallback=True.
-        """
-        if not fallback_model:
-            return False
+        """Extract silent_fallback flag from fallback_model config."""
         if isinstance(fallback_model, dict):
-            return bool(fallback_model.get("silent_fallback", False))
+            return fallback_model.get("silent_fallback", False)
         if isinstance(fallback_model, list):
-            return all(bool(f.get("silent_fallback", False)) for f in fallback_model if isinstance(f, dict))
+            return bool(fallback_model) and all(
+                isinstance(f, dict) and f.get("silent_fallback", False)
+                for f in fallback_model
+            )
         return False
 
     @staticmethod
@@ -3985,7 +3982,7 @@ class GatewayRunner:
                     platform=platform_key,
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
-                    silent_fallback=getattr(self, '_silent_fallback', False),
+                    silent_fallback=getattr(self, "_silent_fallback", False),
                 )
 
                 return agent.run_conversation(
@@ -4160,7 +4157,7 @@ class GatewayRunner:
                     platform=platform_key,
                     session_db=None,
                     fallback_model=self._fallback_model,
-                    silent_fallback=getattr(self, '_silent_fallback', False),
+                    silent_fallback=getattr(self, "_silent_fallback", False),
                     skip_memory=True,
                     skip_context_files=True,
                     persist_session=False,
@@ -5676,7 +5673,7 @@ class GatewayRunner:
                     honcho_config=honcho_config,
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
-                    silent_fallback=getattr(self, '_silent_fallback', False),
+                    silent_fallback=getattr(self, "_silent_fallback", False),
                 )
                 if _cache_lock and _cache is not None:
                     with _cache_lock:

--- a/run_agent.py
+++ b/run_agent.py
@@ -505,6 +505,7 @@ class AIAgent:
         honcho_config=None,
         iteration_budget: "IterationBudget" = None,
         fallback_model: Dict[str, Any] = None,
+        silent_fallback: bool = False,
         credential_pool=None,
         checkpoints_enabled: bool = False,
         checkpoint_max_snapshots: int = 50,
@@ -915,6 +916,7 @@ class AIAgent:
             self._fallback_chain = []
         self._fallback_index = 0
         self._fallback_activated = False
+        self._silent_fallback = silent_fallback
         # Legacy attribute kept for backward compat (tests, external callers)
         self._fallback_model = self._fallback_chain[0] if self._fallback_chain else None
         if self._fallback_chain and not self.quiet_mode:
@@ -4537,10 +4539,11 @@ class AIAgent:
                     fb_context_length * self.context_compressor.threshold_percent
                 )
 
-            self._emit_status(
-                f"🔄 Primary model failed — switching to fallback: "
-                f"{fb_model} via {fb_provider}"
-            )
+            if not getattr(self, "_silent_fallback", False):
+                self._emit_status(
+                    f"🔄 Primary model failed — switching to fallback: "
+                    f"{fb_model} via {fb_provider}"
+                )
             logging.info(
                 "Fallback activated: %s → %s (%s)",
                 old_model, fb_model, fb_provider,
@@ -6670,7 +6673,8 @@ class AIAgent:
                         # rate-limit symptom.  Switch to fallback immediately
                         # rather than retrying with extended backoff.
                         if self._fallback_index < len(self._fallback_chain):
-                            self._emit_status("⚠️ Empty/malformed response — switching to fallback...")
+                            if not getattr(self, "_silent_fallback", False):
+                                self._emit_status("⚠️ Empty/malformed response — switching to fallback...")
                         if self._try_activate_fallback():
                             retry_count = 0
                             continue
@@ -7142,7 +7146,8 @@ class AIAgent:
                         or "quota" in error_msg
                     )
                     if is_rate_limited and self._fallback_index < len(self._fallback_chain):
-                        self._emit_status("⚠️ Rate limited — switching to fallback provider...")
+                        if not getattr(self, "_silent_fallback", False):
+                            self._emit_status("⚠️ Rate limited — switching to fallback provider...")
                         if self._try_activate_fallback():
                             retry_count = 0
                             continue

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -27,9 +27,12 @@ Add a `fallback_model` section to `~/.hermes/config.yaml`:
 fallback_model:
   provider: openrouter
   model: anthropic/claude-sonnet-4
+  silent_fallback: false  # Set to true to suppress fallback status messages
 ```
 
 Both `provider` and `model` are **required**. If either is missing, the fallback is disabled.
+
+The `silent_fallback` option (default: `false`) controls whether fallback events are displayed in the chat. When `true`, the "⚠️ Rate limited — switching to fallback provider..." and similar messages are suppressed.
 
 ### Supported Providers
 
@@ -95,6 +98,7 @@ model:
 fallback_model:
   provider: openrouter
   model: anthropic/claude-sonnet-4
+  silent_fallback: true
 ```
 
 **Nous Portal as fallback for OpenRouter:**
@@ -106,6 +110,7 @@ model:
 fallback_model:
   provider: nous
   model: nous-hermes-3
+  silent_fallback: true
 ```
 
 **Local model as fallback for cloud:**
@@ -115,6 +120,7 @@ fallback_model:
   model: llama-3.1-70b
   base_url: http://localhost:8000/v1
   api_key_env: LOCAL_API_KEY
+  silent_fallback: true
 ```
 
 **Codex OAuth as fallback:**
@@ -122,6 +128,18 @@ fallback_model:
 fallback_model:
   provider: openai-codex
   model: gpt-5.3-codex
+  silent_fallback: true
+```
+
+**Multiple fallback providers (chain):**
+```yaml
+fallback_model:
+  - provider: openrouter
+    model: anthropic/claude-sonnet-4
+    silent_fallback: false
+  - provider: nous
+    model: nous-hermes-3
+    silent_fallback: true
 ```
 
 ### Where Fallback Works


### PR DESCRIPTION
## Summary
Add `silent_fallback` option to suppress fallback status messages in chat when a fallback model is activated due to rate limits or errors.

### Problem
When a fallback model is configured, Hermes displays status messages like "⚠️ Rate limited — switching to fallback provider..." every time a fallback occurs. Some users prefer a silent experience.

### Solution
New `silent_fallback: true` config option that suppresses all user-facing fallback status messages while maintaining logging for debugging purposes.

### Configuration
```yaml
fallback_model:
  provider: openrouter
  model: anthropic/claude-sonnet-4
  silent_fallback: true   # suppresses status messages
```

Or for multiple fallback providers:
```yaml
fallback_model:
  - provider: openrouter
    model: anthropic/claude-sonnet-4
    silent_fallback: false
  - provider: nous
    model: nous-hermes-3
    silent_fallback: true
```

### Testing
- All 39 existing fallback tests pass
- Manual verification confirms messages are suppressed when `silent_fallback: true`

### Files Changed
- `run_agent.py` - Core fallback message suppression logic
- `gateway/run.py` - Pass `silent_fallback` to AIAgent instances  
- `cli.py` - Extract and pass `silent_fallback` config
- `cli-config.yaml.example` - Updated documentation with examples
- `website/docs/user-guide/features/fallback-providers.md` - User guide updated

---
Open to alternative approaches if maintainers prefer differently.