### PR TITLE
feat: Venice E2EE support for TEE-encrypted inference

### DIFF
--- a/agent/venice_e2ee_adapter.py
+++ b/agent/venice_e2ee_adapter.py
@@ -1,0 +1,181 @@
+"""Venice E2EE adapter for Hermes Agent.
+
+Provides synchronous encryption/decryption using the venice-e2ee library.
+Activated automatically when the model ID starts with "e2ee-".
+
+Requires: pip install venice-e2ee
+"""
+
+import asyncio
+import copy
+import logging
+import os
+import time
+
+logger = logging.getLogger(__name__)
+
+try:
+    import httpx
+    from venice_e2ee.crypto import (
+        decrypt_chunk,
+        derive_aes_key,
+        encrypt_message,
+        generate_keypair,
+        to_hex,
+    )
+    from venice_e2ee.attestation import verify_attestation
+    from venice_e2ee.types import E2EESession
+
+    _HAS_VENICE_E2EE = True
+except ImportError:
+    _HAS_VENICE_E2EE = False
+
+
+def _require_venice_e2ee():
+    if not _HAS_VENICE_E2EE:
+        raise RuntimeError(
+            "venice-e2ee package is required for E2EE models. "
+            "Install with: pip install venice-e2ee"
+        )
+
+
+# ── Session creation (sync) ──────────────────────────────────────────
+
+
+def create_session_sync(
+    api_key: str,
+    base_url: str,
+    model_id: str,
+    verify: bool = True,
+) -> "E2EESession":
+    """Create an E2EE session synchronously.
+
+    Fetches TEE attestation via sync httpx, verifies the TDX quote,
+    and derives an AES-256-GCM key via ECDH + HKDF.
+    """
+    _require_venice_e2ee()
+
+    private_key, public_key, pub_key_hex = generate_keypair()
+    nonce = os.urandom(32)
+
+    base = base_url.rstrip("/")
+    attestation_url = f"{base}/tee/attestation"
+
+    with httpx.Client(timeout=30.0) as client:
+        resp = client.get(
+            attestation_url,
+            params={"model": model_id, "nonce": nonce.hex()},
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+        resp.raise_for_status()
+        attestation_resp = resp.json()
+
+    model_pub_key_hex = (
+        attestation_resp.get("signing_key")
+        or attestation_resp.get("signing_public_key")
+    )
+    if not model_pub_key_hex:
+        raise ValueError("No signing key in attestation response")
+
+    attestation_result = None
+    if verify:
+        # verify_attestation is async; safe to use asyncio.run() here since
+        # Hermes Agent calls this from a worker thread, not an event loop.
+        attestation_result = asyncio.run(
+            verify_attestation(attestation_resp, nonce)
+        )
+        if attestation_result.errors:
+            raise ValueError(
+                "TEE attestation verification failed:\n  - "
+                + "\n  - ".join(attestation_result.errors)
+            )
+
+    aes_key = derive_aes_key(private_key, model_pub_key_hex)
+
+    session = E2EESession(
+        private_key=private_key,
+        public_key=public_key,
+        pub_key_hex=pub_key_hex,
+        model_pub_key_hex=model_pub_key_hex,
+        aes_key=aes_key,
+        model_id=model_id,
+        created=time.time(),
+        attestation=attestation_result,
+    )
+
+    logger.info(
+        "Venice E2EE session created for %s (nonce=%s, bound=%s)",
+        model_id,
+        getattr(attestation_result, "nonce_verified", "?"),
+        getattr(attestation_result, "signing_key_bound", "?"),
+    )
+    return session
+
+
+# ── Session caching ───────────────────────────────────────────────────
+
+
+def get_or_create_session(
+    api_key: str,
+    base_url: str,
+    model_id: str,
+    existing: "E2EESession | None",
+    ttl: float = 1800.0,
+) -> "E2EESession":
+    """Return the cached session if still valid, or create a new one."""
+    if (
+        existing is not None
+        and existing.model_id == model_id
+        and time.time() - existing.created < ttl
+    ):
+        return existing
+    return create_session_sync(api_key, base_url, model_id)
+
+
+# ── Encryption ────────────────────────────────────────────────────────
+
+
+def encrypt_api_kwargs(session: "E2EESession", api_kwargs: dict) -> dict:
+    """Encrypt messages and inject E2EE headers/body into api_kwargs.
+
+    Returns a modified copy — does not mutate the original.
+    """
+    _require_venice_e2ee()
+    kwargs = copy.deepcopy(api_kwargs)
+
+    # Venice E2EE models don't support function calling
+    kwargs.pop("tools", None)
+    kwargs.pop("tool_choice", None)
+
+    # Encrypt message contents
+    messages = kwargs.get("messages", [])
+    for msg in messages:
+        content = msg.get("content")
+        if isinstance(content, str) and content:
+            msg["content"] = encrypt_message(
+                session.aes_key, session.public_key, content
+            )
+
+    # E2EE headers
+    kwargs["extra_headers"] = {
+        **kwargs.get("extra_headers", {}),
+        "X-Venice-TEE-Client-Pub-Key": session.pub_key_hex,
+        "X-Venice-TEE-Model-Pub-Key": session.model_pub_key_hex,
+        "X-Venice-TEE-Signing-Algo": "ecdsa",
+    }
+
+    # Venice parameters in request body
+    extra_body = kwargs.get("extra_body", {})
+    extra_body["venice_parameters"] = {"enable_e2ee": True}
+    kwargs["extra_body"] = extra_body
+
+    return kwargs
+
+
+# ── Decryption ────────────────────────────────────────────────────────
+
+
+def decrypt_delta(session: "E2EESession", text: str) -> str:
+    """Decrypt a streaming chunk. Passes through non-encrypted content."""
+    _require_venice_e2ee()
+    return decrypt_chunk(session.private_key, text)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+venice-e2ee = ["venice-e2ee[attestation] @ git+https://github.com/elkimek/venice-e2ee-python.git"]
 modal = ["modal>=1.0.0,<2"]
 daytona = ["daytona>=0.148.0,<1"]
 dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "mcp>=1.2.0,<2"]

--- a/run_agent.py
+++ b/run_agent.py
@@ -845,6 +845,7 @@ class AIAgent:
         # access for Codex Responses API streaming.
         self._anthropic_client = None
         self._is_anthropic_oauth = False
+        self._venice_e2ee_session = None  # Venice E2EE session (lazy init)
 
         if self.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
@@ -4755,6 +4756,16 @@ class AIAgent:
                     continue
 
                 delta = chunk.choices[0].delta
+
+                # Venice E2EE: decrypt content and reasoning in-place
+                if self._venice_e2ee_session is not None and delta:
+                    from agent.venice_e2ee_adapter import decrypt_delta
+                    if delta.content:
+                        delta.content = decrypt_delta(self._venice_e2ee_session, delta.content)
+                    _e2ee_r = getattr(delta, "reasoning_content", None)
+                    if _e2ee_r:
+                        delta.reasoning_content = decrypt_delta(self._venice_e2ee_session, _e2ee_r)
+
                 if hasattr(chunk, "model") and chunk.model:
                     model_name = chunk.model
 
@@ -5965,6 +5976,16 @@ class AIAgent:
         # Applied last so overrides win over any defaults set above.
         if self.request_overrides:
             api_kwargs.update(self.request_overrides)
+
+        # Venice E2EE: encrypt messages for e2ee-* models
+        if self.model and self.model.startswith("e2ee-"):
+            from agent.venice_e2ee_adapter import encrypt_api_kwargs, get_or_create_session
+            _e2ee_api_key = self._client_kwargs.get("api_key", "")
+            _e2ee_base_url = str(self._client_kwargs.get("base_url", ""))
+            self._venice_e2ee_session = get_or_create_session(
+                _e2ee_api_key, _e2ee_base_url, self.model, self._venice_e2ee_session
+            )
+            api_kwargs = encrypt_api_kwargs(self._venice_e2ee_session, api_kwargs)
 
         return api_kwargs
 


### PR DESCRIPTION
## Summary

- Adds end-to-end encryption for Venice AI models running inside Intel TDX Trusted Execution Environments
- When a model ID starts with `e2ee-`, messages are automatically encrypted client-side and streaming responses are decrypted per-chunk — Venice never sees plaintext
- Protocol: ECDH (secp256k1) key exchange → HKDF-SHA256 → AES-256-GCM

## Changes

- **New `agent/venice_e2ee_adapter.py`**: sync adapter wrapping [`venice-e2ee`](https://github.com/elkimek/venice-e2ee-python) library — session creation with TDX attestation verification, message encryption, per-chunk streaming decryption
- **`run_agent.py`**: 3 surgical hooks (1 line session init, 10 lines encryption in `_build_api_kwargs`, 8 lines decryption in `_call_chat_completions`)
- **`pyproject.toml`**: `venice-e2ee` as optional dependency (`pip install hermes-agent[venice-e2ee]`)

## Usage

```bash
pip install "hermes-agent[venice-e2ee]"

# With Venice as a built-in provider (#6424)
hermes --provider venice --model e2ee-qwen3-5-122b-a10b "Hello from encrypted side"

# Or with manual custom endpoint
hermes --model e2ee-qwen3-5-122b-a10b \
       --base-url https://api.venice.ai/api/v1 \
       --api-key $VENICE_API_KEY --provider custom \
       "Hello from encrypted side"
```

## Test plan

- [x] Adapter smoke test: session creation, message encryption, chunk decryption against live Venice API
- [x] Full Hermes CLI test: encrypted prompt → streaming decrypted response ("Venice E2EE works with Hermes Agent")
- [x] Cross-language compatibility: Python ↔ TypeScript bidirectional encrypt/decrypt with pinned test vectors
- [x] Existing test suite: 6887 passed, 0 new failures

## Platforms tested

- Linux (Ubuntu 24.04, Python 3.12)

## Notes

- `venice-e2ee` is GPL-3.0 licensed, added as an **optional** dependency only — base Hermes install is unaffected
- Venice E2EE models don't support function calling, so `tools` are stripped from the request automatically
- Complements #6424 (Venice as first-class provider) — with both merged, `--provider venice` is all you need

🤖 Generated with [Claude Code](https://claude.com/claude-code)