### PR TITLE
Harden Slack connect auth_test handling for sync/async clients

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -9,6 +9,7 @@ Uses slack-bolt (Python) with Socket Mode for:
 """
 
 import asyncio
+import inspect
 import logging
 import os
 import re
@@ -96,7 +97,17 @@ class SlackAdapter(BasePlatformAdapter):
             self._app = AsyncApp(token=bot_token)
 
             # Get our own bot user ID for mention detection
-            auth_response = await self._app.client.auth_test()
+            auth_response = {}
+            auth_test_fn = getattr(self._app.client, "auth_test", None)
+            if callable(auth_test_fn):
+                maybe_result = auth_test_fn()
+                resolved = await maybe_result if inspect.isawaitable(maybe_result) else maybe_result
+                if isinstance(resolved, dict):
+                    auth_response = resolved
+                else:
+                    data = getattr(resolved, "data", None)
+                    if isinstance(data, dict):
+                        auth_response = data
             self._bot_user_id = auth_response.get("user_id")
             bot_name = auth_response.get("user", "unknown")
 

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -136,6 +136,47 @@ class TestAppMentionHandler:
         assert "app_mention" in registered_events
         assert "/hermes" in registered_commands
 
+    def test_connect_handles_sync_auth_test_mock(self):
+        """connect() should tolerate auth_test mocked as a sync method."""
+        config = PlatformConfig(enabled=True, token="xoxb-fake")
+        adapter = SlackAdapter(config)
+
+        registered_events = []
+        registered_commands = []
+
+        mock_app = MagicMock()
+
+        def mock_event(event_type):
+            def decorator(fn):
+                registered_events.append(event_type)
+                return fn
+            return decorator
+
+        def mock_command(cmd):
+            def decorator(fn):
+                registered_commands.append(cmd)
+                return fn
+            return decorator
+
+        mock_app.event = mock_event
+        mock_app.command = mock_command
+        mock_app.client = MagicMock()
+        mock_app.client.auth_test = MagicMock(return_value={
+            "user_id": "U_BOT_SYNC",
+            "user": "testbot-sync",
+        })
+
+        with patch.object(_slack_mod, "AsyncApp", return_value=mock_app), \
+             patch.object(_slack_mod, "AsyncSocketModeHandler", return_value=MagicMock()), \
+             patch.dict(os.environ, {"SLACK_APP_TOKEN": "xapp-fake"}), \
+             patch("asyncio.create_task"):
+            assert asyncio.run(adapter.connect()) is True
+
+        assert adapter._bot_user_id == "U_BOT_SYNC"
+        assert "message" in registered_events
+        assert "app_mention" in registered_events
+        assert "/hermes" in registered_commands
+
 
 # ---------------------------------------------------------------------------
 # TestSendDocument


### PR DESCRIPTION
Updated SlackAdapter.connect() to safely handle auth_test() results when they are awaitable or sync values.
Added a regression test for sync auth_test mocks.

Prevents Slack init/test failures in CI where auth_test is mocked as non-awaitable