### PR TITLE
Harden gateway boolean coercion to preserve defaults

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -28,8 +28,19 @@ def _coerce_bool(value: Any, default: bool = True) -> bool:
     if isinstance(value, bool):
         return value
     if isinstance(value, str):
-        return value.strip().lower() in ("true", "1", "yes", "on")
-    return bool(value)
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "off"}:
+            return False
+        return default
+    if isinstance(value, int):
+        if value == 1:
+            return True
+        if value == 0:
+            return False
+        return default
+    return default
 
 
 def _normalize_unauthorized_dm_behavior(value: Any, default: str = "pair") -> str:

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -6,6 +6,7 @@ from gateway.config import (
     Platform,
     PlatformConfig,
     SessionResetPolicy,
+    _coerce_bool,
     load_gateway_config,
 )
 
@@ -90,6 +91,21 @@ class TestSessionResetPolicy:
         assert restored.mode == "both"
         assert restored.at_hour == 4
         assert restored.idle_minutes == 1440
+
+
+class TestCoerceBool:
+    def test_recognized_values(self):
+        assert _coerce_bool("true", False) is True
+        assert _coerce_bool("off", True) is False
+        assert _coerce_bool(1, False) is True
+        assert _coerce_bool(0, True) is False
+
+    def test_invalid_values_preserve_default(self):
+        assert _coerce_bool("maybe", True) is True
+        assert _coerce_bool("maybe", False) is False
+        assert _coerce_bool(2, True) is True
+        assert _coerce_bool(-1, False) is False
+        assert _coerce_bool(object(), True) is True
 
 
 class TestGatewayConfigRoundtrip:


### PR DESCRIPTION
Updated _coerce_bool in gateway/config.py to preserve caller defaults for invalid inputs.
Added focused tests in tests/gateway/test_config.py for recognized boolean-like values and invalid-input fallback behavior.