### PR TITLE
feat: add customizable Tavily API URL via TAVILY_API_URL env var

### DIFF
--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -163,7 +163,19 @@ def _get_async_parallel_client():
 
 # ─── Tavily Client ───────────────────────────────────────────────────────────
 
-_TAVILY_BASE_URL = "https://api.tavily.com"
+def _get_tavily_base_url() -> str:
+    """Get the Tavily API base URL.
+
+    Uses TAVILY_API_URL environment variable if set (for proxy/custom endpoint).
+    Falls back to the default Tavily API URL.
+    """
+    custom_url = os.getenv("TAVILY_API_URL")
+    if custom_url:
+        logger.info("Using custom Tavily API URL: %s", custom_url)
+        return custom_url.rstrip("/")
+    return "https://api.tavily.com"
+
+_TAVILY_BASE_URL = _get_tavily_base_url()
 
 
 def _tavily_request(endpoint: str, payload: dict) -> dict:


### PR DESCRIPTION
## Summary

This PR adds support for customizing the Tavily API base URL via the TAVILY_API_URL environment variable, similar to how FIRECRAWL_API_URL already works for the Firecrawl backend.

## Motivation

In restricted or enterprise environments, external API endpoints are often only accessible through internal proxies for security, compliance, or network policy reasons. This change enables users to:

- Route Tavily API requests through an internal proxy server
- Use custom API endpoints or self-hosted alternatives  
- Implement API key rotation or request logging at a proxy layer
- Comply with corporate network policies that restrict direct external access

## Changes

- Modified the Tavily base URL to be dynamically resolved via a helper function
- The function checks for TAVILY_API_URL environment variable first
- Falls back to the default https://api.tavily.com if not set
- Logs when a custom URL is being used for visibility

## Usage

Set the environment variable to your custom endpoint:

    export TAVILY_API_URL=http://localhost:8080
    export TAVILY_API_URL=https://internal-proxy.company.com/tavily

The proxy must forward requests to the actual Tavily API endpoint.

## Backward Compatibility

This change is fully backward compatible:
- No changes required for existing users
- Default behavior unchanged (uses official Tavily API)
- No breaking changes to the API or configuration

## Testing

The change has been tested with a local proxy implementation that forwards requests to Tavily and works correctly with the custom URL configuration.
