### PR TITLE
fix(gif-search): migrate from deprecated Tenor API to Giphy API

### DIFF
--- a/skills/media/gif-search/SKILL.md
+++ b/skills/media/gif-search/SKILL.md
@@ -1,58 +1,59 @@
 ---
 name: gif-search
-description: Search and download GIFs from Tenor using curl. No dependencies beyond curl and jq. Useful for finding reaction GIFs, creating visual content, and sending GIFs in chat.
-version: 1.1.0
+description: Search and download GIFs from Giphy using curl. No dependencies beyond curl and jq. Useful for finding reaction GIFs, creating visual content, and sending GIFs in chat.
+version: 2.0.0
 author: Hermes Agent
 license: MIT
-prerequisites:
-  env_vars: [TENOR_API_KEY]
-  commands: [curl, jq]
+required_environment_variables:
+  - name: GIPHY_API_KEY
+    prompt: Giphy API key
+    help: Get a free API key from https://developers.giphy.com
 metadata:
   hermes:
-    tags: [GIF, Media, Search, Tenor, API]
+    tags: [GIF, Media, Search, Giphy, API]
 ---
 
-# GIF Search (Tenor API)
+# GIF Search (Giphy API)
 
-Search and download GIFs directly via the Tenor API using curl. No extra tools needed.
+Search and download GIFs directly via the Giphy API using curl. No extra tools needed.
 
 ## Setup
 
-Set your Tenor API key in your environment (add to `~/.hermes/.env`):
+Set your Giphy API key in your environment (add to `~/.hermes/.env`):
 
 ```bash
-TENOR_API_KEY=your_key_here
+GIPHY_API_KEY=your_key_here
 ```
 
-Get a free API key at https://developers.google.com/tenor/guides/quickstart — the Google Cloud Console Tenor API key is free and has generous rate limits.
+Get a free API key at https://developers.giphy.com — the Giphy API has a free tier with generous rate limits (42 requests per hour).
 
 ## Prerequisites
 
 - `curl` and `jq` (both standard on macOS/Linux)
-- `TENOR_API_KEY` environment variable
+- `GIPHY_API_KEY` environment variable
 
 ## Search for GIFs
 
 ```bash
 # Search and get GIF URLs
-curl -s "https://tenor.googleapis.com/v2/search?q=thumbs+up&limit=5&key=${TENOR_API_KEY}" | jq -r '.results[].media_formats.gif.url'
+curl -s "https://api.giphy.com/v1/gifs/search?q=thumbs+up&limit=5&api_key=${GIPHY_API_KEY}" | jq -r '.data[].images.original.url'
 
 # Get smaller/preview versions
-curl -s "https://tenor.googleapis.com/v2/search?q=nice+work&limit=3&key=${TENOR_API_KEY}" | jq -r '.results[].media_formats.tinygif.url'
+curl -s "https://api.giphy.com/v1/gifs/search?q=nice+work&limit=3&api_key=${GIPHY_API_KEY}" | jq -r '.data[].images.fixed_height.url'
 ```
 
 ## Download a GIF
 
 ```bash
 # Search and download the top result
-URL=$(curl -s "https://tenor.googleapis.com/v2/search?q=celebration&limit=1&key=${TENOR_API_KEY}" | jq -r '.results[0].media_formats.gif.url')
+URL=$(curl -s "https://api.giphy.com/v1/gifs/search?q=celebration&limit=1&api_key=${GIPHY_API_KEY}" | jq -r '.data[0].images.original.url')
 curl -sL "$URL" -o celebration.gif
 ```
 
 ## Get Full Metadata
 
 ```bash
-curl -s "https://tenor.googleapis.com/v2/search?q=cat&limit=3&key=${TENOR_API_KEY}" | jq '.results[] | {title: .title, url: .media_formats.gif.url, preview: .media_formats.tinygif.url, dimensions: .media_formats.gif.dims}'
+curl -s "https://api.giphy.com/v1/gifs/search?q=cat&limit=3&api_key=${GIPHY_API_KEY}" | jq '.data[] | {title: .title, url: .images.original.url, preview: .images.fixed_height.url, dimensions: .images.original}'
 ```
 
 ## API Parameters
@@ -60,27 +61,28 @@ curl -s "https://tenor.googleapis.com/v2/search?q=cat&limit=3&key=${TENOR_API_KE
 | Parameter | Description |
 |-----------|-------------|
 | `q` | Search query (URL-encode spaces as `+`) |
-| `limit` | Max results (1-50, default 20) |
-| `key` | API key (from `$TENOR_API_KEY` env var) |
-| `media_filter` | Filter formats: `gif`, `tinygif`, `mp4`, `tinymp4`, `webm` |
-| `contentfilter` | Safety: `off`, `low`, `medium`, `high` |
-| `locale` | Language: `en_US`, `es`, `fr`, etc. |
+| `limit` | Max results (1-50, default 25) |
+| `api_key` | API key (from `$GIPHY_API_KEY` env var) |
+| `rating` | Content rating: `g`, `pg`, `pg-13`, `r` |
+| `lang` | Language: `en`, `es`, `fr`, etc. |
+| `offset` | Pagination offset |
 
-## Available Media Formats
+## Available Image Formats
 
-Each result has multiple formats under `.media_formats`:
+Each result has multiple formats under `.images`:
 
 | Format | Use case |
 |--------|----------|
-| `gif` | Full quality GIF |
-| `tinygif` | Small preview GIF |
-| `mp4` | Video version (smaller file size) |
-| `tinymp4` | Small preview video |
-| `webm` | WebM video |
-| `nanogif` | Tiny thumbnail |
+| `original` | Full quality GIF |
+| `fixed_height` | Small preview GIF (fixed height) |
+| `fixed_width` | Small preview GIF (fixed width) |
+| `downsized` | Optimized smaller GIF |
+| `preview_gif` | Very small preview GIF |
+| `preview_webp` | WebP preview |
 
 ## Notes
 
 - URL-encode the query: spaces as `+`, special chars as `%XX`
-- For sending in chat, `tinygif` URLs are lighter weight
+- For sending in chat, `fixed_height` URLs are lighter weight
 - GIF URLs can be used directly in markdown: `![alt](url)`
+- Rate limit: 42 requests per hour on the free tier

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -169,7 +169,7 @@ Generate some audio.
         assert msg is None
 
     def test_uses_shared_skill_loader_for_secure_setup(self, tmp_path, monkeypatch):
-        monkeypatch.delenv("TENOR_API_KEY", raising=False)
+        monkeypatch.delenv("GIPHY_API_KEY", raising=False)
         calls = []
 
         def fake_secret_callback(var_name, prompt, metadata=None):
@@ -195,8 +195,8 @@ Generate some audio.
                 "test-skill",
                 frontmatter_extra=(
                     "required_environment_variables:\n"
-                    "  - name: TENOR_API_KEY\n"
-                    "    prompt: Tenor API key\n"
+                    "  - name: GIPHY_API_KEY\n"
+                    "    prompt: Giphy API key\n"
                 ),
             )
             scan_skill_commands()
@@ -205,12 +205,12 @@ Generate some audio.
         assert msg is not None
         assert "test-skill" in msg
         assert len(calls) == 1
-        assert calls[0][0] == "TENOR_API_KEY"
+        assert calls[0][0] == "GIPHY_API_KEY"
 
     def test_gateway_still_loads_skill_but_returns_setup_guidance(
         self, tmp_path, monkeypatch
     ):
-        monkeypatch.delenv("TENOR_API_KEY", raising=False)
+        monkeypatch.delenv("GIPHY_API_KEY", raising=False)
 
         def fail_if_called(var_name, prompt, metadata=None):
             raise AssertionError(
@@ -233,8 +233,8 @@ Generate some audio.
                     "test-skill",
                     frontmatter_extra=(
                         "required_environment_variables:\n"
-                        "  - name: TENOR_API_KEY\n"
-                        "    prompt: Tenor API key\n"
+                        "  - name: GIPHY_API_KEY\n"
+                        "    prompt: Giphy API key\n"
                     ),
                 )
                 scan_skill_commands()

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -135,16 +135,16 @@ class TestSaveEnvValueSecure:
 
     def test_save_env_value_updates_process_environment(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}, clear=False):
-            os.environ.pop("TENOR_API_KEY", None)
-            save_env_value("TENOR_API_KEY", "sk-test-secret")
-            assert os.environ["TENOR_API_KEY"] == "sk-test-secret"
+            os.environ.pop("GIPHY_API_KEY", None)
+            save_env_value("GIPHY_API_KEY", "sk-test-secret")
+            assert os.environ["GIPHY_API_KEY"] == "sk-test-secret"
 
     def test_save_env_value_hardens_file_permissions_on_posix(self, tmp_path):
         if os.name == "nt":
             return
 
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
-            save_env_value("TENOR_API_KEY", "sk-test-secret")
+            save_env_value("GIPHY_API_KEY", "sk-test-secret")
             env_mode = (tmp_path / ".env").stat().st_mode & 0o777
             assert env_mode == 0o600
 

--- a/tests/test_cli_secret_capture.py
+++ b/tests/test_cli_secret_capture.py
@@ -43,13 +43,13 @@ def test_secret_capture_callback_can_be_completed_from_cli_state_machine():
     with patch("hermes_cli.callbacks.save_env_value_secure") as save_secret:
         save_secret.return_value = {
             "success": True,
-            "stored_as": "TENOR_API_KEY",
+            "stored_as": "GIPHY_API_KEY",
             "validated": False,
         }
 
         thread = threading.Thread(
             target=lambda: results.append(
-                cli._secret_capture_callback("TENOR_API_KEY", "Tenor API key")
+                cli._secret_capture_callback("GIPHY_API_KEY", "Giphy API key")
             )
         )
         thread.start()
@@ -63,7 +63,7 @@ def test_secret_capture_callback_can_be_completed_from_cli_state_machine():
         thread.join(timeout=2)
 
     assert results[0]["success"] is True
-    assert results[0]["stored_as"] == "TENOR_API_KEY"
+    assert results[0]["stored_as"] == "GIPHY_API_KEY"
     assert results[0]["skipped"] is False
 
 
@@ -71,8 +71,8 @@ def test_cancel_secret_capture_marks_setup_skipped():
     cli = _make_cli_stub()
     cli._secret_state = {
         "response_queue": queue.Queue(),
-        "var_name": "TENOR_API_KEY",
-        "prompt": "Tenor API key",
+        "var_name": "GIPHY_API_KEY",
+        "prompt": "Giphy API key",
         "metadata": {},
     }
     cli._secret_deadline = 123
@@ -91,13 +91,13 @@ def test_secret_capture_uses_getpass_without_tui():
     ) as save_secret:
         save_secret.return_value = {
             "success": True,
-            "stored_as": "TENOR_API_KEY",
+            "stored_as": "GIPHY_API_KEY",
             "validated": False,
         }
-        result = prompt_for_secret(cli, "TENOR_API_KEY", "Tenor API key")
+        result = prompt_for_secret(cli, "GIPHY_API_KEY", "Giphy API key")
 
     assert result["success"] is True
-    assert result["stored_as"] == "TENOR_API_KEY"
+    assert result["stored_as"] == "GIPHY_API_KEY"
     assert result["skipped"] is False
 
 
@@ -114,7 +114,7 @@ def test_secret_capture_timeout_clears_hidden_input_buffer():
         "hermes_cli.callbacks._time.monotonic",
         side_effect=[0, 121],
     ):
-        result = prompt_for_secret(cli, "TENOR_API_KEY", "Tenor API key")
+        result = prompt_for_secret(cli, "GIPHY_API_KEY", "Giphy API key")
 
     assert result["success"] is True
     assert result["skipped"] is True

--- a/tests/tools/test_env_passthrough.py
+++ b/tests/tools/test_env_passthrough.py
@@ -25,9 +25,9 @@ def _clean_passthrough():
 
 class TestSkillScopedPassthrough:
     def test_register_and_check(self):
-        assert not is_env_passthrough("TENOR_API_KEY")
-        register_env_passthrough(["TENOR_API_KEY"])
-        assert is_env_passthrough("TENOR_API_KEY")
+        assert not is_env_passthrough("GIPHY_API_KEY")
+        register_env_passthrough(["GIPHY_API_KEY"])
+        assert is_env_passthrough("GIPHY_API_KEY")
 
     def test_register_multiple(self):
         register_env_passthrough(["FOO_TOKEN", "BAR_SECRET"])
@@ -36,10 +36,10 @@ class TestSkillScopedPassthrough:
         assert not is_env_passthrough("OTHER_KEY")
 
     def test_clear(self):
-        register_env_passthrough(["TENOR_API_KEY"])
-        assert is_env_passthrough("TENOR_API_KEY")
+        register_env_passthrough(["GIPHY_API_KEY"])
+        assert is_env_passthrough("GIPHY_API_KEY")
         clear_env_passthrough()
-        assert not is_env_passthrough("TENOR_API_KEY")
+        assert not is_env_passthrough("GIPHY_API_KEY")
 
     def test_get_all(self):
         register_env_passthrough(["A_KEY", "B_TOKEN"])

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -305,7 +305,7 @@ class TestSecretCaptureResultContract:
     def test_secret_request_result_does_not_include_secret_value(self):
         result = {
             "success": True,
-            "stored_as": "TENOR_API_KEY",
+            "stored_as": "GIPHY_API_KEY",
             "validated": False,
         }
         assert "secret" not in json.dumps(result).lower()

--- a/tests/tools/test_skill_env_passthrough.py
+++ b/tests/tools/test_skill_env_passthrough.py
@@ -44,15 +44,15 @@ class TestSkillViewRegistersPassthrough:
             "test-skill",
             frontmatter_extra=(
                 "required_environment_variables:\n"
-                "  - name: TENOR_API_KEY\n"
-                "    prompt: Enter your Tenor API key\n"
+                "  - name: GIPHY_API_KEY\n"
+                "    prompt: Enter your Giphy API key\n"
             ),
         )
         monkeypatch.setattr(
             "tools.skills_tool.SKILLS_DIR", tmp_path
         )
         # Set the env var so it's "available"
-        monkeypatch.setenv("TENOR_API_KEY", "test-value-123")
+        monkeypatch.setenv("GIPHY_API_KEY", "test-value-123")
 
         # Patch the secret capture callback to not prompt
         with patch("tools.skills_tool._secret_capture_callback", None):
@@ -61,7 +61,7 @@ class TestSkillViewRegistersPassthrough:
             result = json.loads(skill_view(name="test-skill"))
 
         assert result["success"] is True
-        assert is_env_passthrough("TENOR_API_KEY")
+        assert is_env_passthrough("GIPHY_API_KEY")
 
     def test_remote_backend_persisted_env_vars_registered(self, tmp_path, monkeypatch):
         """Remote-backed skills still register locally available env vars."""
@@ -71,16 +71,16 @@ class TestSkillViewRegistersPassthrough:
             "test-skill",
             frontmatter_extra=(
                 "required_environment_variables:\n"
-                "  - name: TENOR_API_KEY\n"
-                "    prompt: Enter your Tenor API key\n"
+                "  - name: GIPHY_API_KEY\n"
+                "    prompt: Enter your Giphy API key\n"
             ),
         )
         monkeypatch.setattr("tools.skills_tool.SKILLS_DIR", tmp_path)
 
         from hermes_cli.config import save_env_value
 
-        save_env_value("TENOR_API_KEY", "persisted-value-123")
-        monkeypatch.delenv("TENOR_API_KEY", raising=False)
+        save_env_value("GIPHY_API_KEY", "persisted-value-123")
+        monkeypatch.delenv("GIPHY_API_KEY", raising=False)
 
         with patch("tools.skills_tool._secret_capture_callback", None):
             from tools.skills_tool import skill_view
@@ -90,7 +90,7 @@ class TestSkillViewRegistersPassthrough:
         assert result["success"] is True
         assert result["setup_needed"] is False
         assert result["missing_required_environment_variables"] == []
-        assert is_env_passthrough("TENOR_API_KEY")
+        assert is_env_passthrough("GIPHY_API_KEY")
 
     def test_missing_env_vars_not_registered(self, tmp_path, monkeypatch):
         """When a skill declares required_environment_variables but the var is NOT set,

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -119,9 +119,9 @@ class TestRequiredEnvironmentVariablesNormalization:
         frontmatter = {
             "required_environment_variables": [
                 {
-                    "name": "TENOR_API_KEY",
-                    "prompt": "Tenor API key",
-                    "help": "Get a key from https://developers.google.com/tenor",
+                    "name": "GIPHY_API_KEY",
+                    "prompt": "Giphy API key",
+                    "help": "Get a free key from https://developers.giphy.com",
                     "required_for": "full functionality",
                 }
             ]
@@ -131,22 +131,22 @@ class TestRequiredEnvironmentVariablesNormalization:
 
         assert result == [
             {
-                "name": "TENOR_API_KEY",
-                "prompt": "Tenor API key",
-                "help": "Get a key from https://developers.google.com/tenor",
+                "name": "GIPHY_API_KEY",
+                "prompt": "Giphy API key",
+                "help": "Get a free key from https://developers.giphy.com",
                 "required_for": "full functionality",
             }
         ]
 
     def test_normalizes_legacy_prerequisites_env_vars(self):
-        frontmatter = {"prerequisites": {"env_vars": ["TENOR_API_KEY"]}}
+        frontmatter = {"prerequisites": {"env_vars": ["GIPHY_API_KEY"]}}
 
         result = _get_required_environment_variables(frontmatter)
 
         assert result == [
             {
-                "name": "TENOR_API_KEY",
-                "prompt": "Enter value for TENOR_API_KEY",
+                "name": "GIPHY_API_KEY",
+                "prompt": "Enter value for GIPHY_API_KEY",
             }
         ]
 
@@ -406,7 +406,7 @@ class TestSkillView:
 
 class TestSkillViewSecureSetupOnLoad:
     def test_requests_missing_required_env_and_continues(self, tmp_path, monkeypatch):
-        monkeypatch.delenv("TENOR_API_KEY", raising=False)
+        monkeypatch.delenv("GIPHY_API_KEY", raising=False)
         calls = []
 
         def fake_secret_callback(var_name, prompt, metadata=None):
@@ -438,9 +438,9 @@ class TestSkillViewSecureSetupOnLoad:
                 "gif-search",
                 frontmatter_extra=(
                     "required_environment_variables:\n"
-                    "  - name: TENOR_API_KEY\n"
-                    "    prompt: Tenor API key\n"
-                    "    help: Get a key from https://developers.google.com/tenor\n"
+                    "  - name: GIPHY_API_KEY\n"
+                    "    prompt: Giphy API key\n"
+                    "    help: Get a free key from https://developers.giphy.com\n"
                     "    required_for: full functionality\n"
                 ),
             )
@@ -451,20 +451,20 @@ class TestSkillViewSecureSetupOnLoad:
         assert result["name"] == "gif-search"
         assert calls == [
             {
-                "var_name": "TENOR_API_KEY",
-                "prompt": "Tenor API key",
+                "var_name": "GIPHY_API_KEY",
+                "prompt": "Giphy API key",
                 "metadata": {
                     "skill_name": "gif-search",
-                    "help": "Get a key from https://developers.google.com/tenor",
+                    "help": "Get a free key from https://developers.giphy.com",
                     "required_for": "full functionality",
                 },
             }
         ]
-        assert result["required_environment_variables"][0]["name"] == "TENOR_API_KEY"
+        assert result["required_environment_variables"][0]["name"] == "GIPHY_API_KEY"
         assert result["setup_skipped"] is False
 
     def test_allows_skipping_secure_setup_and_still_loads(self, tmp_path, monkeypatch):
-        monkeypatch.delenv("TENOR_API_KEY", raising=False)
+        monkeypatch.delenv("GIPHY_API_KEY", raising=False)
 
         def fake_secret_callback(var_name, prompt, metadata=None):
             return {
@@ -487,8 +487,8 @@ class TestSkillViewSecureSetupOnLoad:
                 "gif-search",
                 frontmatter_extra=(
                     "required_environment_variables:\n"
-                    "  - name: TENOR_API_KEY\n"
-                    "    prompt: Tenor API key\n"
+                    "  - name: GIPHY_API_KEY\n"
+                    "    prompt: Giphy API key\n"
                 ),
             )
             raw = skill_view("gif-search")
@@ -503,7 +503,7 @@ class TestSkillViewSecureSetupOnLoad:
         tmp_path,
         monkeypatch,
     ):
-        monkeypatch.delenv("TENOR_API_KEY", raising=False)
+        monkeypatch.delenv("GIPHY_API_KEY", raising=False)
         called = {"value": False}
 
         def fake_secret_callback(var_name, prompt, metadata=None):
@@ -531,8 +531,8 @@ class TestSkillViewSecureSetupOnLoad:
                     "gif-search",
                     frontmatter_extra=(
                         "required_environment_variables:\n"
-                        "  - name: TENOR_API_KEY\n"
-                        "    prompt: Tenor API key\n"
+                        "  - name: GIPHY_API_KEY\n"
+                        "    prompt: Giphy API key\n"
                     ),
                 )
                 raw = skill_view("gif-search")
@@ -908,7 +908,7 @@ class TestSkillViewPrerequisites:
         self, tmp_path, monkeypatch, backend
     ):
         monkeypatch.setenv("TERMINAL_ENV", backend)
-        monkeypatch.delenv("TENOR_API_KEY", raising=False)
+        monkeypatch.delenv("GIPHY_API_KEY", raising=False)
         calls = []
 
         def fake_secret_callback(var_name, prompt, metadata=None):
@@ -934,8 +934,8 @@ class TestSkillViewPrerequisites:
                 "gif-search",
                 frontmatter_extra=(
                     "required_environment_variables:\n"
-                    "  - name: TENOR_API_KEY\n"
-                    "    prompt: Tenor API key\n"
+                    "  - name: GIPHY_API_KEY\n"
+                    "    prompt: Giphy API key\n"
                 ),
             )
             raw = skill_view("gif-search")
@@ -1006,7 +1006,7 @@ Do the legacy thing.
         self, tmp_path, monkeypatch
     ):
         monkeypatch.setenv("TERMINAL_ENV", "local")
-        monkeypatch.delenv("TENOR_API_KEY", raising=False)
+        monkeypatch.delenv("GIPHY_API_KEY", raising=False)
 
         def fake_secret_callback(var_name, prompt, metadata=None):
             from hermes_cli.config import save_env_value
@@ -1032,13 +1032,13 @@ Do the legacy thing.
                 "gif-search",
                 frontmatter_extra=(
                     "required_environment_variables:\n"
-                    "  - name: TENOR_API_KEY\n"
-                    "    prompt: Tenor API key\n"
+                    "  - name: GIPHY_API_KEY\n"
+                    "    prompt: Giphy API key\n"
                 ),
             )
             from hermes_cli.config import save_env_value
 
-            save_env_value("TENOR_API_KEY", "")
+            save_env_value("GIPHY_API_KEY", "")
             raw = skill_view("gif-search")
 
         result = json.loads(raw)


### PR DESCRIPTION
Closes #4181

## Summary
Migrated the gif-search skill from Tenor API to Giphy API due to Tenor deprecation.

## Changes
- Updated SKILL.md with new Giphy endpoints and response paths
- Bumped version to 2.0.0 (breaking change)
- Updated rate limits to 42 req/hour for Giphy free tier
- Migrated all tests from TENOR_API_KEY to GIPHY_API_KEY

## Testing
All 8 test files have been updated and the migration is complete and consistent.