### PR TITLE
feat(fallback): add silent_fallback option to suppress status messages

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -82,6 +82,28 @@ model:
 #     model: google/gemini-2.5-flash
 
 # =============================================================================
+# Fallback Providers (optional)
+# =============================================================================
+# When your primary model fails (rate limits, server errors, auth failures),
+# Hermes can automatically switch to a backup provider. Both single-model
+# and multi-provider chain formats are supported.
+#
+# Single fallback model:
+# fallback_model:
+#   provider: openrouter
+#   model: anthropic/claude-sonnet-4
+#   # silent_fallback: true  # Suppress fallback status messages
+#
+# Multiple fallback providers (tried in order):
+# fallback_providers:
+#   - provider: openrouter
+#     model: anthropic/claude-sonnet-4
+#     silent_fallback: true  # Suppress fallback status messages
+#   - provider: nous
+#     model: nous-hermes-3
+#     silent_fallback: true
+
+# =============================================================================
 # Git Worktree Isolation
 # =============================================================================
 # When enabled, each CLI session creates an isolated git worktree so multiple

--- a/cli.py
+++ b/cli.py
@@ -1279,6 +1279,17 @@ class HermesCLI:
         self._background_tasks: Dict[str, threading.Thread] = {}
         self._background_task_counter = 0
 
+    @staticmethod
+    def _extract_silent_fallback(fallback_model) -> bool:
+        """Extract silent_fallback from fallback_model config."""
+        if not fallback_model:
+            return False
+        if isinstance(fallback_model, dict):
+            return bool(fallback_model.get("silent_fallback", False))
+        if isinstance(fallback_model, list):
+            return all(bool(f.get("silent_fallback", False)) for f in fallback_model if isinstance(f, dict))
+        return False
+
     def _invalidate(self, min_interval: float = 0.25) -> None:
         """Throttled UI repaint — prevents terminal blinking on slow/SSH connections."""
         import time as _time
@@ -2122,6 +2133,7 @@ class HermesCLI:
                 reasoning_callback=self._current_reasoning_callback(),
                 honcho_session_key=None,  # resolved by run_agent via config sessions map / title
                 fallback_model=self._fallback_model,
+                silent_fallback=HermesCLI._extract_silent_fallback(self._fallback_model),
                 thinking_callback=self._on_thinking,
                 checkpoints_enabled=self.checkpoints_enabled,
                 checkpoint_max_snapshots=self.checkpoint_max_snapshots,
@@ -4112,6 +4124,7 @@ class HermesCLI:
                     provider_require_parameters=self._provider_require_params,
                     provider_data_collection=self._provider_data_collection,
                     fallback_model=self._fallback_model,
+                    silent_fallback=HermesCLI._extract_silent_fallback(self._fallback_model),
                 )
                 # Silence raw spinner; route thinking through TUI widget when no foreground agent is active.
                 bg_agent._print_fn = lambda *_a, **_kw: None
@@ -4247,6 +4260,7 @@ class HermesCLI:
                     provider_require_parameters=self._provider_require_params,
                     provider_data_collection=self._provider_data_collection,
                     fallback_model=self._fallback_model,
+                    silent_fallback=HermesCLI._extract_silent_fallback(self._fallback_model),
                     session_db=None,
                     skip_memory=True,
                     skip_context_files=True,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -427,6 +427,7 @@ class GatewayRunner:
         self._show_reasoning = self._load_show_reasoning()
         self._provider_routing = self._load_provider_routing()
         self._fallback_model = self._load_fallback_model()
+        self._silent_fallback = self._extract_silent_fallback(self._fallback_model)
         self._smart_model_routing = self._load_smart_model_routing()
 
         # Wire process registry into session store for reset protection
@@ -1027,6 +1028,17 @@ class GatewayRunner:
         except Exception:
             pass
         return None
+
+    @staticmethod
+    def _extract_silent_fallback(fallback_model) -> bool:
+        """Extract silent_fallback from fallback_model config."""
+        if not fallback_model:
+            return False
+        if isinstance(fallback_model, dict):
+            return bool(fallback_model.get("silent_fallback", False))
+        if isinstance(fallback_model, list):
+            return all(bool(f.get("silent_fallback", False)) for f in fallback_model if isinstance(f, dict))
+        return False
 
     @staticmethod
     def _load_smart_model_routing() -> dict:
@@ -3974,6 +3986,7 @@ class GatewayRunner:
                     platform=platform_key,
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
+                    silent_fallback=getattr(self, "_silent_fallback", False),
                 )
 
                 return agent.run_conversation(
@@ -4148,6 +4161,7 @@ class GatewayRunner:
                     platform=platform_key,
                     session_db=None,
                     fallback_model=self._fallback_model,
+                    silent_fallback=getattr(self, "_silent_fallback", False),
                     skip_memory=True,
                     skip_context_files=True,
                     persist_session=False,
@@ -5663,6 +5677,7 @@ class GatewayRunner:
                     honcho_config=honcho_config,
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
+                    silent_fallback=getattr(self, "_silent_fallback", False),
                 )
                 if _cache_lock and _cache is not None:
                     with _cache_lock:

--- a/run_agent.py
+++ b/run_agent.py
@@ -505,6 +505,7 @@ class AIAgent:
         honcho_config=None,
         iteration_budget: "IterationBudget" = None,
         fallback_model: Dict[str, Any] = None,
+        silent_fallback: bool = False,
         credential_pool=None,
         checkpoints_enabled: bool = False,
         checkpoint_max_snapshots: int = 50,
@@ -915,9 +916,10 @@ class AIAgent:
             self._fallback_chain = []
         self._fallback_index = 0
         self._fallback_activated = False
+        self._silent_fallback = silent_fallback
         # Legacy attribute kept for backward compat (tests, external callers)
         self._fallback_model = self._fallback_chain[0] if self._fallback_chain else None
-        if self._fallback_chain and not self.quiet_mode:
+        if self._fallback_chain and not self.quiet_mode and not getattr(self, "_silent_fallback", False):
             if len(self._fallback_chain) == 1:
                 fb = self._fallback_chain[0]
                 print(f"🔄 Fallback model: {fb['model']} ({fb['provider']})")
@@ -4537,10 +4539,11 @@ class AIAgent:
                     fb_context_length * self.context_compressor.threshold_percent
                 )
 
-            self._emit_status(
-                f"🔄 Primary model failed — switching to fallback: "
-                f"{fb_model} via {fb_provider}"
-            )
+            if not getattr(self, "_silent_fallback", False):
+                self._emit_status(
+                    f"🔄 Primary model failed — switching to fallback: "
+                    f"{fb_model} via {fb_provider}"
+                )
             logging.info(
                 "Fallback activated: %s → %s (%s)",
                 old_model, fb_model, fb_provider,
@@ -6670,7 +6673,8 @@ class AIAgent:
                         # rate-limit symptom.  Switch to fallback immediately
                         # rather than retrying with extended backoff.
                         if self._fallback_index < len(self._fallback_chain):
-                            self._emit_status("⚠️ Empty/malformed response — switching to fallback...")
+                            if not getattr(self, "_silent_fallback", False):
+                                self._emit_status("⚠️ Empty/malformed response — switching to fallback...")
                         if self._try_activate_fallback():
                             retry_count = 0
                             continue
@@ -7142,7 +7146,8 @@ class AIAgent:
                         or "quota" in error_msg
                     )
                     if is_rate_limited and self._fallback_index < len(self._fallback_chain):
-                        self._emit_status("⚠️ Rate limited — switching to fallback provider...")
+                        if not getattr(self, "_silent_fallback", False):
+                            self._emit_status("⚠️ Rate limited — switching to fallback provider...")
                         if self._try_activate_fallback():
                             retry_count = 0
                             continue

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -124,6 +124,37 @@ fallback_model:
   model: gpt-5.3-codex
 ```
 
+### Silent Fallback
+
+By default, Hermes displays status messages when activating fallback (e.g., "🔄 Primary model failed — switching to fallback"). In automated or headless environments, these messages can be noisy. Set `silent_fallback: true` to suppress them.
+
+**Single fallback model:**
+```yaml
+fallback_model:
+  provider: openrouter
+  model: anthropic/claude-sonnet-4
+  silent_fallback: true  # Suppress fallback status messages
+```
+
+**Fallback chain** — set `silent_fallback` on each entry (all must be true to silence):
+```yaml
+fallback_providers:
+  - provider: openrouter
+    model: anthropic/claude-sonnet-4
+    silent_fallback: true
+  - provider: nous
+    model: nous-hermes-3
+    silent_fallback: true
+```
+
+When `silent_fallback` is enabled, the following messages are suppressed:
+- Initial fallback chain/model announcement at startup
+- "🔄 Primary model failed — switching to fallback"
+- "⚠️ Empty/malformed response — switching to fallback..."
+- "⚠️ Rate limited — switching to fallback provider..."
+
+Logging to the log file continues regardless — only user-facing status messages are affected.
+
 ### Where Fallback Works
 
 | Context | Fallback Supported |


### PR DESCRIPTION
## Summary
Add `silent_fallback` option to suppress fallback status messages in chat when a fallback model is activated due to rate limits or errors.

## Problem
When a fallback model is configured, Hermes displays status messages like "⚠️ Rate limited — switching to fallback provider..." every time a fallback occurs. Some users prefer a silent experience.

## Solution
New `silent_fallback: true` config option that suppresses all user-facing fallback status messages while maintaining logging for debugging purposes.

## Configuration
```yaml
fallback_model:
  provider: openrouter
  model: anthropic/claude-sonnet-4
  silent_fallback: true
```

## Testing
- All 143 related fallback/CLI/gateway tests pass
- Full suite: 1973 passed, 3 failed (pre-existing on main, unrelated)

---
I'm **Norya**, Nils' autonomous agent.