### PR TITLE
fix(agent): robust context compression summary fallback

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -341,32 +341,55 @@ Target ~{summary_budget} tokens. Be specific — include file paths, command out
 
 Write only the summary body. Do not include any preamble or prefix."""
 
-        try:
-            call_kwargs = {
-                "task": "compression",
-                "messages": [{"role": "user", "content": prompt}],
-                "temperature": 0.3,
-                "max_tokens": summary_budget * 2,
-                # timeout resolved from auxiliary.compression.timeout config by call_llm
-            }
-            if self.summary_model:
-                call_kwargs["model"] = self.summary_model
-            response = call_llm(**call_kwargs)
-            content = response.choices[0].message.content
+        def _coerce_summary_content(resp) -> str:
+            content = resp.choices[0].message.content
             # Handle cases where content is not a string (e.g., dict from llama.cpp)
             if not isinstance(content, str):
                 content = str(content) if content else ""
-            summary = content.strip()
-            # Store for iterative updates on next compaction
+            return (content or "").strip()
+
+        call_kwargs = {
+            "task": "compression",
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0.3,
+            "max_tokens": summary_budget * 2,
+            # timeout resolved from auxiliary.compression.timeout config by call_llm
+        }
+
+        try:
+            # Attempt 1: honor configured summary_model override when present.
+            attempt_kwargs = dict(call_kwargs)
+            if self.summary_model:
+                attempt_kwargs["model"] = self.summary_model
+
+            response = call_llm(**attempt_kwargs)
+            summary = _coerce_summary_content(response)
             self._previous_summary = summary
             return self._with_summary_prefix(summary)
+
         except RuntimeError:
-            logging.warning("Context compression: no provider available for "
-                            "summary. Middle turns will be dropped without summary.")
+            logging.warning(
+                "Context compression: no provider available for summary. "
+                "Middle turns will be dropped without summary."
+            )
             return None
+
         except Exception as e:
+            # Attempt 2 (robustness): if the summary model/provider was misconfigured
+            # (e.g. google/* model routed to a Codex endpoint), retry using the
+            # main provider/model to avoid silent compaction failure.
             logging.warning("Failed to generate context summary: %s", e)
-            return None
+            try:
+                retry_kwargs = dict(call_kwargs)
+                retry_kwargs["provider"] = "main"
+                retry_kwargs["model"] = self.model
+                response = call_llm(**retry_kwargs)
+                summary = _coerce_summary_content(response)
+                self._previous_summary = summary
+                return self._with_summary_prefix(summary)
+            except Exception as e2:
+                logging.warning("Context summary retry (provider=main) failed: %s", e2)
+                return None
 
     @staticmethod
     def _with_summary_prefix(summary: str) -> str:
@@ -610,6 +633,20 @@ Write only the summary body. Do not include any preamble or prefix."""
 
         # Phase 3: Generate structured summary
         summary = self._generate_summary(turns_to_summarize)
+
+        # If we couldn't generate a summary, do NOT fail silently. Insert a short
+        # warning marker so both the user and the next assistant understand why
+        # continuity may degrade (e.g., misconfigured summary model/provider).
+        if not summary:
+            warning = (
+                "[CONTEXT COMPACTION WARNING] Failed to generate a compaction summary. "
+                "Earlier turns may have been dropped without a summary, which can lead "
+                "to inconsistent answers or lost context. Fix by configuring a summary "
+                "model/provider supported by your main endpoint (e.g. set "
+                "compression.summary_provider/model appropriately, or set "
+                "auxiliary.compression.provider=main)."
+            )
+            summary = self._with_summary_prefix(warning)
 
         # Phase 4: Assemble compressed message list
         compressed = []

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -157,6 +157,55 @@ class TestGenerateSummaryNoneContent:
         assert len(result) < len(msgs)
 
 
+class TestSummaryRobustFallback:
+    def test_generate_summary_retries_with_main_provider(self):
+        """If the summary model/provider is misconfigured, we retry with provider=main."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "[CONTEXT SUMMARY]: recovered"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="gpt-5.2",
+                quiet_mode=True,
+                summary_model_override="google/gemini-3-flash-preview",
+            )
+
+        messages = [
+            {"role": "user", "content": "do something"},
+            {"role": "assistant", "content": "ok"},
+        ]
+
+        def side_effect(**kwargs):
+            # First attempt fails (simulating unsupported model on endpoint)
+            if kwargs.get("provider") != "main":
+                raise Exception("model is not supported")
+            return mock_response
+
+        with patch("agent.context_compressor.call_llm", side_effect=side_effect) as mocked:
+            summary = c._generate_summary(messages)
+
+        assert isinstance(summary, str)
+        assert summary.startswith(SUMMARY_PREFIX)
+        assert mocked.call_count == 2
+        assert mocked.call_args_list[1].kwargs.get("provider") == "main"
+        assert mocked.call_args_list[1].kwargs.get("model") == "gpt-5.2"
+
+    def test_compress_inserts_warning_summary_when_generate_summary_returns_none(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=2, protect_last_n=2)
+
+        msgs = [{"role": "user" if i % 2 == 0 else "assistant", "content": f"msg {i}"} for i in range(12)]
+        with patch.object(c, "_generate_summary", return_value=None):
+            result = c.compress(msgs)
+
+        contents = [m.get("content", "") for m in result]
+        assert any(
+            (isinstance(x, str) and x.startswith(SUMMARY_PREFIX) and "CONTEXT COMPACTION WARNING" in x)
+            for x in contents
+        )
+
+
 class TestNonStringContent:
     """Regression: content as dict (e.g., llama.cpp tool calls) must not crash."""
 


### PR DESCRIPTION
### What changed

This PR makes context compaction (conversation compression) more robust when summary generation fails due to misconfigured auxiliary model routing.

1. **Retry summary generation using the main provider/model**
   - If the configured summary model/provider fails (e.g. `google/*` model routed to a Codex endpoint), the compressor retries with:
     - `provider="main"`
     - `model=self.model` (the main conversation model)

2. **Never fail silently when compaction cannot produce a summary**
   - If summary generation still returns `None`, we insert an explicit **compaction warning summary marker** (with the standard compaction prefix), explaining that earlier turns may have been dropped without a summary and how to fix configuration.

### Why

We observed failures where context compression attempted to use an unsupported summarization model for the active endpoint (e.g. `google/gemini-3-flash-preview` on a Codex ChatGPT account). The summary call failed, a session split occurred due to “compression”, and continuity degraded (inconsistent answers / lost context).

This PR both:
- **recovers automatically** in common misconfiguration cases, and
- **warns explicitly** when compaction cannot summarize.

### User impact / behavior

- In the common failure mode (auxiliary summary model incompatible with the active endpoint), Hermes will now still generate a compaction summary using the main model instead of failing compaction silently.
- If summarization still fails, the transcript includes a clear warning marker that explains the continuity risks and points to config knobs (`compression.summary_*` and `auxiliary.compression.provider=main`).

### How to reproduce (example)

1. Configure context compression to use a model that the active endpoint cannot serve (e.g. `compression.summary_model: google/gemini-3-flash-preview` while using a Codex endpoint).
2. Generate enough turns/tool output to trigger context compaction.
3. Observe summary generation failure and degraded continuity.

### How this fixes it

- On summary failure, compaction performs a second attempt using `provider=main` + the main model, avoiding the incompatible auxiliary route.
- If the fallback also fails, compaction still injects a warning summary marker to make the failure explicit to both users and future assistants.

### Tests

- Added unit tests covering:
  - retry behavior when the first summary call fails and the second succeeds (`provider=main`)
  - warning marker insertion when summary generation returns `None`

Command run locally:
- `PYTHONPATH="$PWD" pytest -q tests/agent/test_context_compressor.py`

### Files changed

- `agent/context_compressor.py`
- `tests/agent/test_context_compressor.py`