### PR TITLE
feat(cli): render markdown tables and formatting in non-streaming responses

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15,6 +15,7 @@ Usage:
 
 import logging
 import os
+import re as _re
 import shutil
 import sys
 import json
@@ -470,6 +471,7 @@ except Exception:
 
 from rich import box as rich_box
 from rich.console import Console
+from rich.markdown import Markdown as _RichMarkdown
 from rich.markup import escape as _escape
 from rich.panel import Panel
 from rich.text import Text as _RichText
@@ -807,6 +809,28 @@ def _rich_text_from_ansi(text: str) -> _RichText:
     ``[not markup]`` while still interpreting real ANSI color codes.
     """
     return _RichText.from_ansi(text or "")
+
+
+_MD_PATTERNS = (
+    _re.compile(r"^\|.*\|.*\|", _re.MULTILINE),          # markdown table row
+    _re.compile(r"^#{1,6}\s+\S", _re.MULTILINE),         # heading
+    _re.compile(r"^```", _re.MULTILINE),                  # fenced code block
+    _re.compile(r"^\s*[-*]\s+\S", _re.MULTILINE),         # unordered list
+    _re.compile(r"^\s*\d+\.\s+\S", _re.MULTILINE),       # ordered list
+)
+
+
+def _looks_like_markdown(text: str) -> bool:
+    """Return True if *text* contains at least two markdown indicators."""
+    hits = sum(1 for p in _MD_PATTERNS if p.search(text))
+    return hits >= 2
+
+
+def _render_response_content(text: str):
+    """Return a Rich renderable: Markdown if the text looks like it, else ANSI."""
+    if _looks_like_markdown(text):
+        return _RichMarkdown(text)
+    return _rich_text_from_ansi(text)
 
 
 def _cprint(text: str):
@@ -4160,7 +4184,7 @@ class HermesCLI:
 
                     _chat_console = ChatConsole()
                     _chat_console.print(Panel(
-                        _rich_text_from_ansi(response),
+                        _render_response_content(response),
                         title=f"[{_resp_color} bold]{label} (background #{task_num})[/]",
                         title_align="left",
                         border_style=_resp_color,
@@ -4284,7 +4308,7 @@ class HermesCLI:
                         _resp_color = "#4F6D4A"
 
                     ChatConsole().print(Panel(
-                        _rich_text_from_ansi(response),
+                        _render_response_content(response),
                         title=f"[{_resp_color} bold]⚕ /btw[/]",
                         title_align="left",
                         border_style=_resp_color,
@@ -6043,7 +6067,7 @@ class HermesCLI:
                 else:
                     _chat_console = ChatConsole()
                     _chat_console.print(Panel(
-                        _rich_text_from_ansi(response),
+                        _render_response_content(response),
                         title=f"[{_resp_color} bold]{label}[/]",
                         title_align="left",
                         border_style=_resp_color,


### PR DESCRIPTION
## Summary

Fixes #3621 - CLI now renders markdown (tables, headings, code blocks, lists) properly in non-streaming mode instead of displaying raw syntax like `| header | header |`.

## Changes

- Added `_looks_like_markdown()` heuristic that detects markdown content by checking for 2+ indicators (tables, headings, fenced code blocks, ordered/unordered lists)
- Added `_render_response_content()` that returns `rich.Markdown` when markdown is detected, falls back to existing `_rich_text_from_ansi()` for plain text
- Updated all 3 non-streaming Panel render sites:
  - Main response panel (~L6067)
  - Background task response panel (~L4184)
  - `/btw` side-question response panel (~L4308)

## What's NOT changed

- Streaming behavior is untouched, token-by-token rendering remains as-is
- No new dependencies - `rich.Markdown` is already available via the existing `rich>=14.3.3` requirement

## Why a heuristic?

Blindly passing every response through `rich.Markdown` would break plain text and ANSI colored tool output. The 2-indicator threshold avoids false positives (e.g. a line starting with `#` in a shell command won't trigger markdown rendering on its own).

## Test plan

- [x] Syntax check passes
- [x] 10/10 custom heuristic unit tests pass (detection + return type)
- [x] 86/86 existing CLI tests pass (4 pre-existing async failures unrelated to this change)
- [ ] Manual verification: send a query that returns a markdown table with `stream: false` and confirm it renders as a formatted table

## Future work

Streaming markdown rendering (#3621 streaming case) is intentionally deferred to a separate PR. It involves UX tradeoffs (buffering vs re-rendering vs incremental parsing) that deserve their own discussion.
