### PR TITLE
fix(skills): handle non-dict metadata in extract_skill_conditions

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -230,7 +230,8 @@ def get_all_skills_dirs() -> List[Path]:
 
 def extract_skill_conditions(frontmatter: Dict[str, Any]) -> Dict[str, List]:
     """Extract conditional activation fields from parsed frontmatter."""
-    hermes = (frontmatter.get("metadata") or {}).get("hermes") or {}
+    metadata = frontmatter.get("metadata")
+    hermes = (metadata.get("hermes") or {}) if isinstance(metadata, dict) else {}
     return {
         "fallback_for_toolsets": hermes.get("fallback_for_toolsets", []),
         "requires_toolsets": hermes.get("requires_toolsets", []),


### PR DESCRIPTION
## Summary
Fixes #4244 — `extract_skill_conditions()` crashes with `AttributeError: 'str' object has no attribute 'get'` when skill frontmatter `metadata` is parsed as a string instead of a dict.

## Root Cause
`skill_utils.py:233` assumed `metadata` is always `dict` or `None`. The `or {}` guard only catches falsy values — a non-empty string is truthy, so `.get()` is called on `str`.

## Fix
Added `isinstance(metadata, dict)` check, matching the existing defensive pattern already used in `skills_tool.py:1078`.

## Test plan
- [x] 214/214 existing skill tests pass
- [x] Verified 6 edge cases: dict, string, None, empty dict, int, list