### PR TITLE
fix(nix): accept macosx_14_0 wheels on aarch64-darwin

### DIFF
--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -1,8 +1,7 @@
 # nix/checks.nix — Build-time verification tests
 #
-# Checks are Linux-only: the full Python venv (via uv2nix) includes
-# transitive deps like onnxruntime that lack compatible wheels on
-# aarch64-darwin. The package and devShell still work on macOS.
+# Checks are Linux-only because the test derivations need to execute
+# binaries (hermes, hermes-agent), which requires a matching host platform.
 { inputs, ... }: {
   perSystem = { pkgs, system, lib, ... }:
     let

--- a/nix/python.nix
+++ b/nix/python.nix
@@ -1,6 +1,7 @@
 # nix/python.nix — uv2nix virtual environment builder
 {
   python311,
+  stdenv,
   lib,
   callPackage,
   uv2nix,
@@ -14,12 +15,26 @@ let
     sourcePreference = "wheel";
   };
 
+  # nixos-24.11 reports darwinSdkVersion "11.0" on aarch64-darwin, but
+  # packages like onnxruntime only ship macosx_14_0 wheels.  Raise the
+  # version so pyproject-nix's wheel-tag check accepts them — safe because
+  # we install pre-built wheels, not compile against the SDK.
+  darwinSdkOverride = final: prev:
+    lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+      stdenv = prev.stdenv // {
+        targetPlatform = prev.stdenv.targetPlatform // {
+          darwinSdkVersion = "14.0";
+        };
+      };
+    };
+
   pythonSet =
     (callPackage pyproject-nix.build.packages {
       python = python311;
     }).overrideScope
       (lib.composeManyExtensions [
         pyproject-build-systems.overlays.default
+        darwinSdkOverride
         overlay
       ]);
 in


### PR DESCRIPTION
## Summary

`nix build` / `nix run` fails on Apple Silicon with:

```
error: No compatible wheel, nor sdist found for package 'onnxruntime' 1.24.4
```

nixos-24.11 sets `darwinSdkVersion = "11.0"` on aarch64-darwin, but onnxruntime only publishes `macosx_14_0_arm64` wheels. pyproject-nix's wheel-tag compatibility check requires `darwinSdkVersion >= 14.0`, so it rejects every available wheel.

### Fix

Override `darwinSdkVersion` to `"14.0"` inside the pyproject-nix package scope. This only affects wheel selection at Nix evaluation time. Actual builds still use the original stdenv, and since we install pre-built wheels no SDK headers are involved.

This also means the `voice` extra (onnxruntime, ctranslate2, faster-whisper) now resolves on macOS, whereas before it was silently broken.