### PR TITLE
fix: show quick commands in /help output

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2712,6 +2712,13 @@ class HermesCLI:
                     f"    [bold {_accent_hex()}]{cmd:<22}[/] [dim]-[/] {_escape(info['description'])}"
                 )
 
+        quick_commands = self.config.get("quick_commands", {})
+        if quick_commands:
+            _cprint(f"\n  {_BOLD}── Quick Commands ──{_RST}")
+            for name, qcmd in sorted(quick_commands.items()):
+                desc = qcmd.get("description", qcmd.get("type", "custom command"))
+                ChatConsole().print(f"    [bold {_accent_hex()}]/{name:<14}[/] [dim]-[/] {_escape(desc)}")
+
         _cprint(f"\n  {_DIM}Tip: Just type your message to chat with Hermes!{_RST}")
         _cprint(f"  {_DIM}Multi-line: Alt+Enter for a new line{_RST}")
         _cprint(f"  {_DIM}Paste image: Alt+V (or /paste){_RST}\n")


### PR DESCRIPTION
## Problem

User-defined `quick_commands` from config.yaml are functional (`cli.py:3932-3934`) but invisible in `/help`. The `show_help()` method iterates `COMMANDS_BY_CATEGORY` and `_skill_commands` but never reads `self.config.get("quick_commands")`.

## Fix

Add a "Quick Commands" section to `/help` after skill commands:

```
  ── Quick Commands ──
    /deploy        - Deploy to staging
    /test          - Run test suite
```

Reads from the same `self.config.get("quick_commands", {})` path the dispatcher uses.

## Changes

7 lines added to `cli.py`.

Closes #4090