### PR TITLE
Fix missing Kimi headers during fallback activation

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -521,13 +521,8 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
         base_url = str(creds.get("base_url", "")).strip().rstrip("/") or pconfig.inference_base_url
         model = _API_KEY_PROVIDER_AUX_MODELS.get(provider_id, "default")
         logger.debug("Auxiliary text client: %s (%s)", pconfig.name, model)
-        extra = {}
-        if "api.kimi.com" in base_url.lower():
-            extra["default_headers"] = {"User-Agent": "KimiCLI/1.0"}
-        elif "api.githubcopilot.com" in base_url.lower():
-            from hermes_cli.models import copilot_default_headers
-
-            extra["default_headers"] = copilot_default_headers()
+        default_headers = _default_headers_for_base_url(base_url)
+        extra = {"default_headers": default_headers} if default_headers else {}
         return OpenAI(api_key=api_key, base_url=base_url, **extra), model
 
     return None, None
@@ -755,6 +750,20 @@ def _resolve_auto() -> Tuple[Optional[OpenAI], Optional[str]]:
 # below — never look up auth env vars ad-hoc.
 
 
+def _default_headers_for_base_url(base_url: str) -> dict[str, str]:
+    """Return provider-specific default headers for an OpenAI-compatible base URL."""
+    normalized = str(base_url or "").lower()
+    if "openrouter" in normalized:
+        return dict(_OR_HEADERS)
+    if "api.githubcopilot.com" in normalized:
+        from hermes_cli.models import copilot_default_headers
+
+        return copilot_default_headers()
+    if "api.kimi.com" in normalized:
+        return {"User-Agent": "KimiCLI/1.3"}
+    return {}
+
+
 def _to_async_client(sync_client, model: str):
     """Convert a sync client to its async counterpart, preserving Codex routing."""
     from openai import AsyncOpenAI
@@ -768,15 +777,9 @@ def _to_async_client(sync_client, model: str):
         "api_key": sync_client.api_key,
         "base_url": str(sync_client.base_url),
     }
-    base_lower = str(sync_client.base_url).lower()
-    if "openrouter" in base_lower:
-        async_kwargs["default_headers"] = dict(_OR_HEADERS)
-    elif "api.githubcopilot.com" in base_lower:
-        from hermes_cli.models import copilot_default_headers
-
-        async_kwargs["default_headers"] = copilot_default_headers()
-    elif "api.kimi.com" in base_lower:
-        async_kwargs["default_headers"] = {"User-Agent": "KimiCLI/1.0"}
+    default_headers = _default_headers_for_base_url(sync_client.base_url)
+    if default_headers:
+        async_kwargs["default_headers"] = default_headers
     return AsyncOpenAI(**async_kwargs), model
 
 
@@ -951,17 +954,12 @@ def resolve_provider_client(
         default_model = _API_KEY_PROVIDER_AUX_MODELS.get(provider, "")
         final_model = model or default_model
 
-        # Provider-specific headers
-        headers = {}
-        if "api.kimi.com" in base_url.lower():
-            headers["User-Agent"] = "KimiCLI/1.0"
-        elif "api.githubcopilot.com" in base_url.lower():
-            from hermes_cli.models import copilot_default_headers
-
-            headers.update(copilot_default_headers())
-
-        client = OpenAI(api_key=api_key, base_url=base_url,
-                        **({"default_headers": headers} if headers else {}))
+        default_headers = _default_headers_for_base_url(base_url)
+        client = OpenAI(
+            api_key=api_key,
+            base_url=base_url,
+            **({"default_headers": default_headers} if default_headers else {}),
+        )
         logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
         return (_to_async_client(client, final_model) if async_mode
                 else (client, final_model))

--- a/run_agent.py
+++ b/run_agent.py
@@ -718,21 +718,11 @@ class AIAgent:
                 if self.provider == "copilot-acp":
                     client_kwargs["command"] = self.acp_command
                     client_kwargs["args"] = self.acp_args
-                effective_base = base_url
-                if "openrouter" in effective_base.lower():
-                    client_kwargs["default_headers"] = {
-                        "HTTP-Referer": "https://hermes-agent.nousresearch.com",
-                        "X-OpenRouter-Title": "Hermes Agent",
-                        "X-OpenRouter-Categories": "productivity,cli-agent",
-                    }
-                elif "api.githubcopilot.com" in effective_base.lower():
-                    from hermes_cli.models import copilot_default_headers
+                from agent.auxiliary_client import _default_headers_for_base_url
 
-                    client_kwargs["default_headers"] = copilot_default_headers()
-                elif "api.kimi.com" in effective_base.lower():
-                    client_kwargs["default_headers"] = {
-                        "User-Agent": "KimiCLI/1.3",
-                    }
+                default_headers = _default_headers_for_base_url(base_url)
+                if default_headers:
+                    client_kwargs["default_headers"] = default_headers
             else:
                 # No explicit creds — use the centralized provider router
                 from agent.auxiliary_client import resolve_provider_client
@@ -3820,7 +3810,10 @@ class AIAgent:
         # raw_codex=True because the main agent needs direct responses.stream()
         # access for Codex providers.
         try:
-            from agent.auxiliary_client import resolve_provider_client
+            from agent.auxiliary_client import (
+                _default_headers_for_base_url,
+                resolve_provider_client,
+            )
             fb_client, _ = resolve_provider_client(
                 fb_provider, model=fb_model, raw_codex=True)
             if fb_client is None:
@@ -3863,6 +3856,9 @@ class AIAgent:
                     "api_key": fb_client.api_key,
                     "base_url": fb_base_url,
                 }
+                default_headers = getattr(fb_client, "_default_headers", None) or _default_headers_for_base_url(fb_base_url)
+                if default_headers:
+                    self._client_kwargs["default_headers"] = dict(default_headers)
 
             # Re-evaluate prompt caching for the new provider/model
             is_native_anthropic = fb_api_mode == "anthropic_messages"

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -408,12 +408,15 @@ class TestExplicitProviderRouting:
             assert client is not None
 
     def test_explicit_kimi(self, monkeypatch):
-        """provider='kimi-coding' should use KIMI_API_KEY."""
+        """provider='kimi-coding' should use KIMI_API_KEY and Kimi CLI headers."""
         monkeypatch.setenv("KIMI_API_KEY", "kimi-test-key")
         with patch("agent.auxiliary_client.OpenAI") as mock_openai:
             mock_openai.return_value = MagicMock()
             client, model = resolve_provider_client("kimi-coding")
             assert client is not None
+
+        call_kwargs = mock_openai.call_args.kwargs
+        assert call_kwargs["default_headers"]["User-Agent"] == "KimiCLI/1.3"
 
     def test_explicit_minimax(self, monkeypatch):
         """provider='minimax' should use MINIMAX_API_KEY."""

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -2305,7 +2305,7 @@ class TestFallbackAnthropicProvider:
 
         mock_client = MagicMock()
         mock_client.base_url = "https://openrouter.ai/api/v1"
-        mock_client.api_key = "sk-or-test"
+        mock_client.api_key="***"
 
         with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
             result = agent._try_activate_fallback()
@@ -2313,6 +2313,22 @@ class TestFallbackAnthropicProvider:
         assert result is True
         assert agent.api_mode == "chat_completions"
         assert agent.client is mock_client
+
+    def test_fallback_to_kimi_preserves_default_headers(self, agent):
+        agent._fallback_activated = False
+        agent._fallback_model = {"provider": "kimi-coding", "model": "kimi-k2.5"}
+
+        mock_client = MagicMock()
+        mock_client.base_url = "https://api.kimi.com/coding/v1"
+        mock_client.api_key="***"
+        mock_client._default_headers = None
+
+        with patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)):
+            result = agent._try_activate_fallback()
+
+        assert result is True
+        assert agent.client is mock_client
+        assert agent._client_kwargs["default_headers"] == {"User-Agent": "KimiCLI/1.3"}
 
 
 def test_aiagent_uses_copilot_acp_client():


### PR DESCRIPTION
## Summary
- preserve provider-specific default headers when activating fallback clients
- centralize OpenAI-compatible default header selection for Kimi, Copilot, and OpenRouter
- add regression tests for Kimi provider routing and fallback activation

## Testing
- `uv run --extra dev python -m pytest tests/agent/test_auxiliary_client.py -k 'explicit_kimi' tests/test_run_agent.py -k 'fallback_to_kimi_preserves_default_headers or fallback_to_openrouter_uses_openai_client or fallback_to_anthropic'`
- `uv run python -m py_compile agent/auxiliary_client.py run_agent.py`

## Context
This fixes `fallback_model` flows where `kimi-coding` requests lost the required `User-Agent: KimiCLI/1.3` header and failed with 403 responses from the Kimi Coding API.
