### PR TITLE
security: bind SMS and Webhook adapters to 127.0.0.1 by default

### DIFF
--- a/gateway/platforms/sms.py
+++ b/gateway/platforms/sms.py
@@ -104,7 +104,8 @@ class SmsAdapter(BasePlatformAdapter):
 
         self._runner = web.AppRunner(app)
         await self._runner.setup()
-        site = web.TCPSite(self._runner, "0.0.0.0", self._webhook_port)
+        _host = os.getenv("SMS_WEBHOOK_HOST", "127.0.0.1")
+        site = web.TCPSite(self._runner, _host, self._webhook_port)
         await site.start()
         self._http_session = aiohttp.ClientSession(
             timeout=aiohttp.ClientTimeout(total=30),

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -51,7 +51,7 @@ from gateway.platforms.base import (
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_HOST = "0.0.0.0"
+DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8644
 _INSECURE_NO_AUTH = "INSECURE_NO_AUTH"
 _DYNAMIC_ROUTES_FILENAME = "webhook_subscriptions.json"


### PR DESCRIPTION
Both adapters bound to 0.0.0.0, exposing HTTP servers to the local network. The API server adapter already correctly defaults to 127.0.0.1. SMS host now configurable via SMS_WEBHOOK_HOST env var. 3 lines changed. Closes #4260