### PR TITLE
fix(telegram): truncate command names to 32 characters

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -355,15 +355,17 @@ def telegram_bot_commands() -> list[tuple[str, str]]:
     """Return (command_name, description) pairs for Telegram setMyCommands.
 
     Telegram command names cannot contain hyphens, so they are replaced with
-    underscores.  Aliases are skipped -- Telegram shows one menu entry per
+    underscores. Aliases are skipped -- Telegram shows one menu entry per
     canonical command.
+
+    Command names are truncated to 32 characters to comply with Telegram Bot API limits.
     """
     overrides = _resolve_config_gates()
     result: list[tuple[str, str]] = []
     for cmd in COMMAND_REGISTRY:
         if not _is_gateway_available(cmd, overrides):
             continue
-        tg_name = cmd.name.replace("-", "_")
+        tg_name = cmd.name.replace("-", "_")[:32]  # Telegram limit: 32 chars
         result.append((tg_name, cmd.description))
     return result
 
@@ -431,7 +433,7 @@ def telegram_menu_commands(max_commands: int = 100) -> tuple[list[tuple[str, str
         pm = get_plugin_manager()
         plugin_cmds = getattr(pm, "_plugin_commands", {})
         for cmd_name in sorted(plugin_cmds):
-            tg_name = cmd_name.replace("-", "_")
+            tg_name = cmd_name.replace("-", "_")[:32]  # Telegram limit: 32 chars
             desc = "Plugin command"
             if len(desc) > 40:
                 desc = desc[:37] + "..."
@@ -459,7 +461,7 @@ def telegram_menu_commands(max_commands: int = 100) -> tuple[list[tuple[str, str
                 continue
             if skill_path.startswith(_hub_dir):
                 continue
-            name = cmd_key.lstrip("/").replace("-", "_")
+            name = cmd_key.lstrip("/").replace("-", "_")[:32]  # Telegram limit: 32 chars
             desc = info.get("description", "")
             # Keep descriptions short — setMyCommands has an undocumented
             # total payload limit.  40 chars fits 100 commands safely.


### PR DESCRIPTION
## Problem

Telegram Bot API limits command names to 32 characters. Long skill names like `distributed_llm_pretraining_torchtitan` (38 chars) caused `setMyCommands` to fail with:

> Command length must not exceed 32

This prevented new commands (`/btw`, `/profile`, `/yolo`) from appearing in the Telegram menu after gateway restart.

Closes #4272

## Solution

Truncate command names to 32 characters in three places:
- `telegram_bot_commands()` for core commands  
- `telegram_menu_commands()` for plugin commands
- `telegram_menu_commands()` for skill commands

## Changes

- `hermes_cli/commands.py`: Added `[:32]` slicing to all command name transformations

## Testing

After this fix, gateway restart shows:
```
setMyCommands "HTTP/1.1 200 OK"
Telegram menu: 100 commands registered
```