### PR TITLE
fix: prevent WhatsApp echo loop in self-chat mode

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -687,6 +687,12 @@ class WhatsAppAdapter(BasePlatformAdapter):
     async def _build_message_event(self, data: Dict[str, Any]) -> Optional[MessageEvent]:
         """Build a MessageEvent from bridge message data, downloading images to cache."""
         try:
+            # Skip messages sent by the bot itself to prevent echo loops.
+            # In self-chat mode (the default), the bridge reports outbound
+            # replies back as new inbound messages.
+            if data.get("fromMe"):
+                return None
+
             # Determine message type
             msg_type = MessageType.TEXT
             if data.get("hasMedia"):


### PR DESCRIPTION
In self-chat mode (the default), the WhatsApp bridge reports the bot's own outbound replies back as new inbound messages. The adapter has no fromMe filter, causing an infinite echo loop where the agent processes its own responses and replies again indefinitely. Adds a fromMe check at the top of _build_message_event(). 6 lines. Equivalent to OpenClaw #54570.