### PR TITLE
fix: skip empty/whitespace text in Telegram send to prevent 400 errors

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -742,6 +742,10 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot:
             return SendResult(success=False, error="Not connected")
         
+        # Skip whitespace-only text to prevent Telegram 400 empty-text errors.
+        if not content or not content.strip():
+            return SendResult(success=True, message_id=None)
+        
         try:
             # Format and split message if needed
             formatted = self.format_message(content)


### PR DESCRIPTION
Telegram API returns HTTP 400 when sent whitespace-only or empty text. The send() method at telegram.py:734 has no guard — blank content from hooks, tool-only responses, or compression artifacts passes through and crashes. Adds a 3-line check at the top. Equivalent to OpenClaw #56620.