### PR TITLE
fix(cli): use atomic write in save_config_value to prevent config loss on interrupt

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -991,9 +991,10 @@ def save_config_value(key_path: str, value: any) -> bool:
             current = current[key]
         current[keys[-1]] = value
         
-        # Save back
-        with open(config_path, 'w') as f:
-            yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+        # Save back atomically — write to temp file + fsync + os.replace
+        # so an interrupt never leaves config.yaml truncated or empty.
+        from utils import atomic_yaml_write
+        atomic_yaml_write(config_path, config)
         
         # Enforce owner-only permissions on config files (contain API keys)
         try:

--- a/tests/test_save_config_atomic.py
+++ b/tests/test_save_config_atomic.py
@@ -1,0 +1,100 @@
+"""Tests for atomic write in save_config_value.
+
+save_config_value() previously used a bare open(path, 'w') + yaml.dump()
+to write config.yaml. The 'w' mode truncates the file to zero bytes
+immediately on open, before any data is written. If the process is
+interrupted between truncation and completion of yaml.dump(), config.yaml
+is left empty or partially written — losing all user configuration.
+
+The fix replaces the bare write with atomic_yaml_write() which uses
+temp file + fsync + os.replace, matching the gateway config write path.
+"""
+
+import os
+import tempfile
+import yaml
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+class TestSaveConfigValueAtomic:
+    """cli.py — save_config_value() must use atomic write."""
+
+    def test_existing_config_preserved_on_new_key(self, tmp_path):
+        """atomic_yaml_write preserves existing keys when adding new ones."""
+        config_path = tmp_path / "config.yaml"
+        original = {"api_key": "sk-secret", "model": "gpt-4"}
+        config_path.write_text(yaml.dump(original))
+
+        # Simulate the save_config_value flow: load, modify, atomic write
+        config = yaml.safe_load(config_path.read_text()) or {}
+        config["display"] = {"skin": "dark"}
+
+        from utils import atomic_yaml_write
+        atomic_yaml_write(config_path, config)
+
+        result = yaml.safe_load(config_path.read_text())
+        assert result["api_key"] == "sk-secret"
+        assert result["model"] == "gpt-4"
+        assert result["display"]["skin"] == "dark"
+
+    def test_atomic_write_survives_if_file_exists(self, tmp_path):
+        """atomic_yaml_write should not lose data even if called on existing file."""
+        config_path = tmp_path / "config.yaml"
+        original_data = {"provider": "openrouter", "model": "claude-3"}
+        config_path.write_text(yaml.dump(original_data))
+
+        from utils import atomic_yaml_write
+        new_data = {**original_data, "display": {"show_reasoning": True}}
+        atomic_yaml_write(config_path, new_data)
+
+        result = yaml.safe_load(config_path.read_text())
+        assert result["provider"] == "openrouter"
+        assert result["display"]["show_reasoning"] is True
+
+    def test_atomic_write_creates_new_file(self, tmp_path):
+        """atomic_yaml_write should create the file if it doesn't exist."""
+        config_path = tmp_path / "subdir" / "config.yaml"
+
+        from utils import atomic_yaml_write
+        atomic_yaml_write(config_path, {"new": "config"})
+
+        assert config_path.exists()
+        result = yaml.safe_load(config_path.read_text())
+        assert result["new"] == "config"
+
+
+class TestSourceLineVerification:
+    """Verify cli.py save_config_value uses atomic_yaml_write."""
+
+    @staticmethod
+    def _read_source() -> str:
+        import os
+        base = os.path.dirname(os.path.dirname(__file__))
+        with open(os.path.join(base, "cli.py")) as f:
+            return f.read()
+
+    def test_no_bare_open_w_in_save_config_value(self):
+        """save_config_value should not use open(path, 'w') for writing."""
+        src = self._read_source()
+        func_start = src.index("def save_config_value(")
+        func_end = src.index("\ndef ", func_start + 1)
+        func_body = src[func_start:func_end]
+
+        assert "open(config_path, 'w')" not in func_body, (
+            "cli.py save_config_value still uses bare open(path, 'w') — "
+            "use atomic_yaml_write() instead"
+        )
+
+    def test_atomic_yaml_write_in_save_config_value(self):
+        """save_config_value should use atomic_yaml_write."""
+        src = self._read_source()
+        func_start = src.index("def save_config_value(")
+        func_end = src.index("\ndef ", func_start + 1)
+        func_body = src[func_start:func_end]
+
+        assert "atomic_yaml_write" in func_body, (
+            "cli.py save_config_value does not use atomic_yaml_write"
+        )


### PR DESCRIPTION
`save_config_value()` uses bare `open(config_path, 'w')` + `yaml.dump()` to write config.yaml. The `'w'` mode truncates the file to zero bytes immediately on open, before any data is written. If the process is interrupted between truncation and completion of `yaml.dump()`, config.yaml is left empty — all user configuration (API keys, model settings, preferences) is gone.

The gateway config write path already uses `atomic_yaml_write()` (temp file + fsync + `os.replace`) but the CLI path was missed. Every `/set`, `/reasoning`, `/thinking`, `/personality`, and `/skin` command goes through `save_config_value()`.

## Changes Made

Replaced the bare `open(path, 'w')` + `yaml.dump()` in `save_config_value()` with the existing `atomic_yaml_write()` utility from `utils.py`.

## How to Test

```bash
python3 -m pytest tests/test_save_config_atomic.py -v
```

5 tests: atomic write preserves existing keys, creates new files, handles existing files, source verification (no bare `open('w')`, `atomic_yaml_write` present).

## Checklist

- [x] Tests added (5 tests)
- [x] Full test suite run — no regressions
- [x] Tested on Linux (Ubuntu 22.04)