### PR TITLE
Add configurable Ctrl-D behavior

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -722,6 +722,15 @@ display:
   # Ctrl+C always interrupts regardless of this setting.
   busy_input_mode: interrupt
 
+  # Keyboard shortcut behavior in the interactive CLI.
+  # Ctrl+D defaults to exit for backward compatibility with existing users.
+  #   exit:   Always exit the CLI (default)
+  #   delete: Delete one character at the cursor, exit on empty input
+  #   auto:   macOS -> delete, other platforms -> exit
+  # Set this explicitly if you want macOS-style forward delete behavior.
+  key_bindings:
+    ctrl_d_action: exit
+
   # Background process notifications (gateway/messaging only).
   # Controls how chatty the process watcher is when you use
   # terminal(background=true, check_interval=...) from Telegram/Discord/etc.

--- a/cli.py
+++ b/cli.py
@@ -206,6 +206,9 @@ def load_cli_config() -> Dict[str, Any]:
             "show_reasoning": False,
             "streaming": True,
             "busy_input_mode": "interrupt",
+            "key_bindings": {
+                "ctrl_d_action": "exit",
+            },
 
             "skin": "default",
         },
@@ -1067,6 +1070,7 @@ class HermesCLI:
         # busy_input_mode: "interrupt" (Enter interrupts current run) or "queue" (Enter queues for next turn)
         _bim = CLI_CONFIG["display"].get("busy_input_mode", "interrupt")
         self.busy_input_mode = "queue" if str(_bim).strip().lower() == "queue" else "interrupt"
+        self.ctrl_d_action = self._resolve_ctrl_d_action_setting()
 
         self.verbose = verbose if verbose is not None else (self.tool_progress_mode == "verbose")
         
@@ -1278,6 +1282,37 @@ class HermesCLI:
         # Background task tracking: {task_id: threading.Thread}
         self._background_tasks: Dict[str, threading.Thread] = {}
         self._background_task_counter = 0
+
+    def _resolve_ctrl_d_action_setting(self) -> str:
+        """Resolve the configured Ctrl+D mode to exit, delete, or auto."""
+        display = self.config.get("display", {}) if isinstance(self.config, dict) else {}
+        key_bindings = display.get("key_bindings", {}) if isinstance(display, dict) else {}
+        raw_value = key_bindings.get("ctrl_d_action", "exit") if isinstance(key_bindings, dict) else "exit"
+        value = str(raw_value).strip().lower()
+        return value if value in {"exit", "delete", "auto"} else "exit"
+
+    def _effective_ctrl_d_action(self) -> str:
+        """Resolve auto to the platform-specific runtime action."""
+        if self.ctrl_d_action == "auto":
+            return "delete" if sys.platform == "darwin" else "exit"
+        return self.ctrl_d_action
+
+    def _handle_ctrl_d_action(self, buffer, exit_app) -> str:
+        """Apply the Ctrl+D action and return the action that was taken."""
+        action = self._effective_ctrl_d_action()
+        if action == "delete":
+            if not buffer.text:
+                self._should_exit = True
+                exit_app()
+                return "exit"
+            if buffer.cursor_position < len(buffer.text):
+                buffer.delete(count=1)
+                return "delete"
+            return "noop"
+
+        self._should_exit = True
+        exit_app()
+        return "exit"
 
     def _invalidate(self, min_interval: float = 0.25) -> None:
         """Throttled UI repaint — prevents terminal blinking on slow/SSH connections."""
@@ -6710,9 +6745,8 @@ class HermesCLI:
         
         @kb.add('c-d')
         def handle_ctrl_d(event):
-            """Handle Ctrl+D - exit."""
-            self._should_exit = True
-            event.app.exit()
+            """Handle Ctrl+D according to the configured action."""
+            self._handle_ctrl_d_action(event.app.current_buffer, event.app.exit)
 
         @kb.add('c-z')
         def handle_ctrl_z(event):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -344,6 +344,9 @@ DEFAULT_CONFIG = {
         "personality": "kawaii",
         "resume_display": "full",
         "busy_input_mode": "interrupt",
+        "key_bindings": {
+            "ctrl_d_action": "exit",
+        },
         "bell_on_complete": False,
         "show_reasoning": False,
         "streaming": False,

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -67,6 +67,7 @@ class TestLoadConfigDefaults:
             assert "max_turns" not in config
             assert "terminal" in config
             assert config["terminal"]["backend"] == "local"
+            assert config["display"]["key_bindings"]["ctrl_d_action"] == "exit"
 
     def test_legacy_root_level_max_turns_migrates_to_agent_config(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -43,6 +43,9 @@ def _make_cli(env_overrides=None, config_overrides=None, **kwargs):
         "prompt_toolkit.completion": MagicMock(),
         "prompt_toolkit.formatted_text": MagicMock(),
         "prompt_toolkit.auto_suggest": MagicMock(),
+        "fire": MagicMock(),
+        "firecrawl": MagicMock(),
+        "fal_client": MagicMock(),
     }
     with patch.dict(sys.modules, prompt_toolkit_stubs), \
          patch.dict("os.environ", clean_env, clear=False):
@@ -147,6 +150,76 @@ class TestBusyInputMode:
             cli._interrupt_queue.put(text)
         assert cli._interrupt_queue.get_nowait() == "redirect"
         assert cli._pending_input.empty()
+
+
+class TestCtrlDAction:
+    def test_default_ctrl_d_action_is_exit(self):
+        # Verify that the default keeps Ctrl+D on the legacy exit behavior.
+        cli = _make_cli()
+        assert cli.ctrl_d_action == "exit"
+        assert cli._effective_ctrl_d_action() == "exit"
+
+    def test_auto_ctrl_d_action_uses_delete_on_macos(self):
+        # Verify that explicit auto mode opts macOS into forward delete behavior.
+        cli = _make_cli(config_overrides={"display": {"key_bindings": {"ctrl_d_action": "auto"}}})
+        with patch("sys.platform", "darwin"):
+            assert cli._effective_ctrl_d_action() == "delete"
+
+    def test_auto_ctrl_d_action_uses_exit_off_macos(self):
+        # Verify that auto mode stays on exit outside macOS.
+        cli = _make_cli(config_overrides={"display": {"key_bindings": {"ctrl_d_action": "auto"}}})
+        with patch("sys.platform", "linux"):
+            assert cli._effective_ctrl_d_action() == "exit"
+
+    def test_invalid_ctrl_d_action_falls_back_to_exit(self):
+        # Verify that invalid values fail closed to exit.
+        cli = _make_cli(config_overrides={"display": {"key_bindings": {"ctrl_d_action": "bogus"}}})
+        assert cli.ctrl_d_action == "exit"
+
+    def test_delete_ctrl_d_action_removes_character_under_cursor(self):
+        # Verify that delete mode removes exactly one character under the cursor.
+        cli = _make_cli(config_overrides={"display": {"key_bindings": {"ctrl_d_action": "delete"}}})
+        buffer = MagicMock()
+        buffer.text = "hello"
+        buffer.cursor_position = 1
+        exit_app = MagicMock()
+
+        result = cli._handle_ctrl_d_action(buffer, exit_app)
+
+        assert result == "delete"
+        buffer.delete.assert_called_once_with(count=1)
+        exit_app.assert_not_called()
+        assert cli._should_exit is False
+
+    def test_delete_ctrl_d_action_is_noop_at_end_of_line(self):
+        # Verify that delete mode is a no-op at end of line.
+        cli = _make_cli(config_overrides={"display": {"key_bindings": {"ctrl_d_action": "delete"}}})
+        buffer = MagicMock()
+        buffer.text = "hello"
+        buffer.cursor_position = len(buffer.text)
+        exit_app = MagicMock()
+
+        result = cli._handle_ctrl_d_action(buffer, exit_app)
+
+        assert result == "noop"
+        buffer.delete.assert_not_called()
+        exit_app.assert_not_called()
+        assert cli._should_exit is False
+
+    def test_delete_ctrl_d_action_exits_on_empty_buffer(self):
+        # Verify that delete mode still exits on an empty buffer, matching EOF behavior.
+        cli = _make_cli(config_overrides={"display": {"key_bindings": {"ctrl_d_action": "delete"}}})
+        buffer = MagicMock()
+        buffer.text = ""
+        buffer.cursor_position = 0
+        exit_app = MagicMock()
+
+        result = cli._handle_ctrl_d_action(buffer, exit_app)
+
+        assert result == "exit"
+        buffer.delete.assert_not_called()
+        exit_app.assert_called_once_with()
+        assert cli._should_exit is True
 
 
 class TestSingleQueryState:


### PR DESCRIPTION
## Summary
- add `display.key_bindings.ctrl_d_action` to configure interactive CLI Ctrl+D behavior
- keep the default as `exit` for backward compatibility with existing users
- support opt-in `auto` mode for macOS-style forward delete behavior

## Notes
I would personally default macOS to `auto`, but I kept the default at `exit` out of respect for existing users and to avoid surprising behavior changes in current setups.

## Testing
- `python3 -m pytest -o addopts= tests/test_cli_init.py -k 'CtrlDAction or BusyInputMode' -q`
- `python3 -m pytest -o addopts= tests/hermes_cli/test_config.py -q`
