### PR TITLE
fix: strip orphaned think/reasoning tags from user-facing responses

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1389,6 +1389,7 @@ class AIAgent:
         content = re.sub(r'<thinking>.*?</thinking>', '', content, flags=re.DOTALL | re.IGNORECASE)
         content = re.sub(r'<reasoning>.*?</reasoning>', '', content, flags=re.DOTALL)
         content = re.sub(r'<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>', '', content, flags=re.DOTALL)
+        content = re.sub(r'</?(?:think|thinking|reasoning|REASONING_SCRATCHPAD)>\s*', '', content, flags=re.IGNORECASE)
         return content
 
     def _looks_like_codex_intermediate_ack(

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -230,6 +230,27 @@ class TestStripThinkBlocks:
         assert "line1" not in result
         assert "visible" in result
 
+    def test_orphaned_closing_think_tag(self, agent):
+        result = agent._strip_think_blocks("some reasoning</think>actual answer")
+        assert "</think>" not in result
+        assert "actual answer" in result
+
+    def test_orphaned_closing_thinking_tag(self, agent):
+        result = agent._strip_think_blocks("reasoning</thinking>answer")
+        assert "</thinking>" not in result
+        assert "answer" in result
+
+    def test_orphaned_opening_think_tag(self, agent):
+        result = agent._strip_think_blocks("<think>orphaned reasoning without close")
+        assert "<think>" not in result
+
+    def test_mixed_orphaned_and_paired_tags(self, agent):
+        text = "stray</think><think>paired reasoning</think> visible"
+        result = agent._strip_think_blocks(text)
+        assert "</think>" not in result
+        assert "<think>" not in result
+        assert "visible" in result
+
 
 class TestExtractReasoning:
     def test_reasoning_field(self, agent):


### PR DESCRIPTION
## Problem

Some models (e.g. Kimi K2.5 on Alibaba's OpenAI-compatible endpoint) emit reasoning as plain text followed by a closing `</think>` tag without a matching opening `<think>`. `_strip_think_blocks()` uses paired-tag regexes (`<think>.*?</think>`) that require both tags — orphaned `</think>` passes through unmatched and appears in user-facing responses.

Closes #4285

## Changes

**`run_agent.py`** — Add one catch-all regex to `_strip_think_blocks()`:
```python
content = re.sub(r'</?(?:think|thinking|reasoning|REASONING_SCRATCHPAD)>\s*', '', content, flags=re.IGNORECASE)
```

**`tests/test_run_agent.py`** — 4 new tests:
- `some reasoning</think>actual answer` → `</think>` stripped
- `reasoning</thinking>answer` → `</thinking>` stripped
- `<think>orphaned without close` → `<think>` stripped
- `stray</think><think>paired</think> visible` → all tags stripped, visible kept

## Test plan

- [x] `python -m pytest tests/test_run_agent.py::TestStripThinkBlocks -q` — 8 passed, 0 failed