### PR TITLE
fix(security): add missing GitHub OAuth token patterns + snapshot redact flag

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -13,11 +13,19 @@ import re
 
 logger = logging.getLogger(__name__)
 
+# Snapshot at import time so runtime env mutations (e.g. LLM-generated
+# `export HERMES_REDACT_SECRETS=false`) cannot disable redaction mid-session.
+_REDACT_ENABLED = os.getenv("HERMES_REDACT_SECRETS", "").lower() not in ("0", "false", "no", "off")
+
 # Known API key prefixes -- match the prefix + contiguous token chars
 _PREFIX_PATTERNS = [
     r"sk-[A-Za-z0-9_-]{10,}",           # OpenAI / OpenRouter / Anthropic (sk-ant-*)
     r"ghp_[A-Za-z0-9]{10,}",            # GitHub PAT (classic)
     r"github_pat_[A-Za-z0-9_]{10,}",    # GitHub PAT (fine-grained)
+    r"gho_[A-Za-z0-9]{10,}",            # GitHub OAuth access token
+    r"ghu_[A-Za-z0-9]{10,}",            # GitHub user-to-server token
+    r"ghs_[A-Za-z0-9]{10,}",            # GitHub server-to-server token
+    r"ghr_[A-Za-z0-9]{10,}",            # GitHub refresh token
     r"xox[baprs]-[A-Za-z0-9-]{10,}",    # Slack tokens
     r"AIza[A-Za-z0-9_-]{30,}",          # Google API keys
     r"pplx-[A-Za-z0-9]{10,}",           # Perplexity
@@ -109,7 +117,7 @@ def redact_sensitive_text(text: str) -> str:
         text = str(text)
     if not text:
         return text
-    if os.getenv("HERMES_REDACT_SECRETS", "").lower() in ("0", "false", "no", "off"):
+    if not _REDACT_ENABLED:
         return text
 
     # Known prefixes (sk-, ghp_, etc.)

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -12,6 +12,8 @@ from agent.redact import redact_sensitive_text, RedactingFormatter
 def _ensure_redaction_enabled(monkeypatch):
     """Ensure HERMES_REDACT_SECRETS is not disabled by prior test imports."""
     monkeypatch.delenv("HERMES_REDACT_SECRETS", raising=False)
+    # Also patch the module-level snapshot so it reflects the cleared env var
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
 
 
 class TestKnownPrefixes:


### PR DESCRIPTION
## Summary

Salvages the substantive changes from PR #3978 by @dlkakbs — adds missing GitHub OAuth token prefixes to `agent/redact.py` and snapshots the redaction toggle at module import time.

### Changes

**From #3978 (cherry-picked, contributor authorship preserved):**
- Add `gho_`, `ghu_`, `ghs_`, `ghr_` prefix patterns to `_PREFIX_PATTERNS` (GitHub OAuth, user-to-server, server-to-server, refresh tokens)
- Replace per-call `os.getenv("HERMES_REDACT_SECRETS")` with module-level `_REDACT_ENABLED` constant snapshotted at import time — prevents runtime env mutation from disabling redaction mid-session

**Follow-up fix:**
- Patch test fixture `_ensure_redaction_enabled` to also `monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)` — the module-level snapshot captures the host env at import time, so `monkeypatch.delenv()` alone wasn't sufficient when `HERMES_REDACT_SECRETS=false` is set

### Testing

- `tests/agent/test_redact.py` — 38/38 pass

Closes #3978.
