### PR TITLE
fix(gateway): parse thread_id from delivery target format

### DIFF
--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -70,12 +70,15 @@ class DeliveryTarget:
         if target == "local":
             return cls(platform=Platform.LOCAL)
         
-        # Check for platform:chat_id format
+        # Check for platform:chat_id or platform:chat_id:thread_id format
         if ":" in target:
-            platform_str, chat_id = target.split(":", 1)
+            parts = target.split(":", 2)
+            platform_str = parts[0]
+            chat_id = parts[1] if len(parts) > 1 else None
+            thread_id = parts[2] if len(parts) > 2 else None
             try:
                 platform = Platform(platform_str)
-                return cls(platform=platform, chat_id=chat_id, is_explicit=True)
+                return cls(platform=platform, chat_id=chat_id, thread_id=thread_id, is_explicit=True)
             except ValueError:
                 # Unknown platform, treat as local
                 return cls(platform=Platform.LOCAL)
@@ -94,6 +97,8 @@ class DeliveryTarget:
             return "origin"
         if self.platform == Platform.LOCAL:
             return "local"
+        if self.chat_id and self.thread_id:
+            return f"{self.platform.value}:{self.chat_id}:{self.thread_id}"
         if self.chat_id:
             return f"{self.platform.value}:{self.chat_id}"
         return self.platform.value


### PR DESCRIPTION
## Summary

Salvages PR #3965 by @MacroAnarchy — fixes `DeliveryTarget.parse()` to correctly extract `thread_id` from the `platform:chat_id:thread_id` delivery target format.

### The bug

`DeliveryTarget.parse()` used `split(":", 1)` which only splits on the first colon. The documented triple-colon format (e.g. `telegram:-1001234567890:17585`) produced `chat_id = "-1001234567890:17585"` with `thread_id = None`.

### The fix

- `split(":", 2)` to correctly extract all three parts
- `to_string()` includes `thread_id` for proper round-tripping

### Scope

This is fully isolated — only affects `DeliveryTarget.parse()` / `to_string()` in `gateway/delivery.py`. The cron scheduler has its own parsing (`cron/scheduler.py` lines 83-89) that already handles thread_id correctly. No existing behavior changes.

### Testing

- `tests/gateway/test_delivery.py` — 16/16 pass

Closes #3965.
