### PR TITLE
fix: credential pool rotates on 401 after failed refresh

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3861,6 +3861,13 @@ class AIAgent:
                 logger.info(f"Credential 401 — refreshed pool entry {getattr(refreshed, 'id', '?')}")
                 self._swap_credential(refreshed)
                 return True, has_retried_429
+            # Refresh failed — rotate to next credential instead of giving up.
+            # The failed entry is already marked exhausted by try_refresh_current().
+            next_entry = pool.mark_exhausted_and_rotate(status_code=401)
+            if next_entry is not None:
+                logger.info(f"Credential 401 (refresh failed) — rotated to pool entry {getattr(next_entry, 'id', '?')}")
+                self._swap_credential(next_entry)
+                return True, False
 
         return False, has_retried_429
 

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1827,6 +1827,71 @@ class TestCredentialPoolRecovery:
         agent._swap_credential.assert_called_once_with(next_entry)
 
 
+    def test_recover_with_pool_refreshes_on_401(self, agent):
+        """401 with successful refresh should swap to refreshed credential."""
+        refreshed_entry = SimpleNamespace(label="refreshed-primary", id="abc")
+
+        class _Pool:
+            def try_refresh_current(self):
+                return refreshed_entry
+
+        agent._credential_pool = _Pool()
+        agent._swap_credential = MagicMock()
+
+        recovered, retry_same = agent._recover_with_credential_pool(
+            status_code=401,
+            has_retried_429=False,
+        )
+
+        assert recovered is True
+        agent._swap_credential.assert_called_once_with(refreshed_entry)
+
+    def test_recover_with_pool_rotates_on_401_when_refresh_fails(self, agent):
+        """401 with failed refresh should rotate to next credential."""
+        next_entry = SimpleNamespace(label="secondary", id="def")
+
+        class _Pool:
+            def try_refresh_current(self):
+                return None  # refresh failed
+
+            def mark_exhausted_and_rotate(self, *, status_code):
+                assert status_code == 401
+                return next_entry
+
+        agent._credential_pool = _Pool()
+        agent._swap_credential = MagicMock()
+
+        recovered, retry_same = agent._recover_with_credential_pool(
+            status_code=401,
+            has_retried_429=False,
+        )
+
+        assert recovered is True
+        assert retry_same is False
+        agent._swap_credential.assert_called_once_with(next_entry)
+
+    def test_recover_with_pool_401_refresh_fails_no_more_credentials(self, agent):
+        """401 with failed refresh and no other credentials returns not recovered."""
+
+        class _Pool:
+            def try_refresh_current(self):
+                return None
+
+            def mark_exhausted_and_rotate(self, *, status_code):
+                return None  # no more credentials
+
+        agent._credential_pool = _Pool()
+        agent._swap_credential = MagicMock()
+
+        recovered, retry_same = agent._recover_with_credential_pool(
+            status_code=401,
+            has_retried_429=False,
+        )
+
+        assert recovered is False
+        agent._swap_credential.assert_not_called()
+
+
 class TestMaxTokensParam:
     """Verify _max_tokens_param returns the correct key for each provider."""
 


### PR DESCRIPTION
## Summary

Fixes credential pool not auto-switching to the next credential when a 401 occurs and the current credential's OAuth refresh fails.

**Bug:** `_recover_with_credential_pool` only tried to refresh the current token on 401. If the refresh failed (revoked account, dead refresh token, etc.), it returned "not recovered" without rotating to the next pool entry. Users who added a second valid credential via `hermes auth add` would never see it used.

**Fix:** After a failed refresh attempt on 401, call `mark_exhausted_and_rotate(status_code=401)` to try the next available credential — same pattern already used by 429 and 402 handlers.

**Flow after fix:**
```
401 → try refresh current (~200ms)
       ├─ refresh works → use it, done
       └─ refresh fails → rotate to next credential
                          ├─ next credential available → use it
                          └─ no credentials left → fall through to legacy handler
```

Reported by Schinsly via Discord.

## Changes
- `run_agent.py`: Added rotation fallback to 401 branch in `_recover_with_credential_pool` (+7 lines)
- `tests/test_run_agent.py`: Added 3 tests covering 401 refresh success, refresh-fail-then-rotate, and no-remaining-credentials

## Test plan
- `pytest tests/test_run_agent.py::TestCredentialPoolRecovery` — all 5 pass
- `pytest tests/test_run_agent.py` — all 220 pass
- `pytest tests/test_credential_pool.py` — all 23 pass