### PR TITLE
fix(cli): allow empty strings and falsy values in config set

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2040,7 +2040,7 @@ def config_command(args):
     elif subcmd == "set":
         key = getattr(args, 'key', None)
         value = getattr(args, 'value', None)
-        if not key or not value:
+        if not key or value is None:
             print("Usage: hermes config set <key> <value>")
             print()
             print("Examples:")

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -1,12 +1,13 @@
 """Tests for set_config_value — verifying secrets route to .env and config to config.yaml."""
 
+import argparse
 import os
 from pathlib import Path
 from unittest.mock import patch, call
 
 import pytest
 
-from hermes_cli.config import set_config_value
+from hermes_cli.config import set_config_value, config_command
 
 
 @pytest.fixture(autouse=True)
@@ -125,3 +126,42 @@ class TestConfigYamlRouting:
             "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE=true" in env_content
             or "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE=True" in env_content
         )
+
+
+# ---------------------------------------------------------------------------
+# Empty / falsy values — regression tests for #4277
+# ---------------------------------------------------------------------------
+
+class TestFalsyValues:
+    """config set should accept empty strings and falsy values like '0'."""
+
+    def test_empty_string_routes_to_env(self, _isolated_hermes_home):
+        """Blanking an API key should write an empty value to .env."""
+        set_config_value("OPENROUTER_API_KEY", "")
+        env_content = _read_env(_isolated_hermes_home)
+        assert "OPENROUTER_API_KEY=" in env_content
+
+    def test_empty_string_routes_to_config(self, _isolated_hermes_home):
+        """Blanking a config key should write an empty string to config.yaml."""
+        set_config_value("model", "")
+        config = _read_config(_isolated_hermes_home)
+        assert "model: ''" in config or "model: \"\"" in config
+
+    def test_zero_routes_to_config(self, _isolated_hermes_home):
+        """Setting a config key to '0' should write 0 to config.yaml."""
+        set_config_value("verbose", "0")
+        config = _read_config(_isolated_hermes_home)
+        assert "verbose: 0" in config
+
+    def test_config_command_rejects_missing_value(self):
+        """config set with no value arg (None) should still exit."""
+        args = argparse.Namespace(config_command="set", key="model", value=None)
+        with pytest.raises(SystemExit):
+            config_command(args)
+
+    def test_config_command_accepts_empty_string(self, _isolated_hermes_home):
+        """config set KEY '' should not exit — it should set the value."""
+        args = argparse.Namespace(config_command="set", key="model", value="")
+        config_command(args)
+        config = _read_config(_isolated_hermes_home)
+        assert "model" in config


### PR DESCRIPTION
## Summary

`hermes config set KEY ""` prints usage and exits instead of setting the value. The guard at `hermes_cli/config.py:2043` uses `not value`, which is truthy for `""`, `"0"`, and `False`. Users cannot blank stale config values via the CLI — they have to manually edit config.yaml.

Reported by a user who needed to clear `OPENROUTER_API_KEY` after migrating to a local Ollama endpoint.

Closes #4277

### Changes

- `hermes_cli/config.py`: Changed `not value` → `value is None` in the `config_command` set guard. Argparse gives `None` when the positional is omitted (`nargs="?"`), so this correctly rejects missing arguments while accepting empty strings and zero
- `tests/hermes_cli/test_set_config_value.py`: 5 new regression tests — empty string to .env, empty string to config.yaml, zero to config.yaml, missing value rejection, and `config_command` entry point acceptance

### Testing

- 31/31 tests pass in `test_set_config_value.py` (26 existing + 5 new)
- Manually verified: `config set model ""` writes `model: ''`, `config set OPENROUTER_API_KEY ""` writes `OPENROUTER_API_KEY=`, `config set verbose 0` writes `verbose: 0`, and omitting the value arg still prints usage and exits
- Tested on Linux (Arch, Python 3.11)