### PR TITLE
fix(cron): suppress delivery only when response is exactly [SILENT]

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -572,7 +572,7 @@ def tick(verbose: bool = True) -> int:
                 # output is already saved above).  Failed jobs always deliver.
                 deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
                 should_deliver = bool(deliver_content)
-                if should_deliver and success and deliver_content.strip().upper().startswith(SILENT_MARKER):
+                if should_deliver and success and deliver_content.strip().upper() == SILENT_MARKER:
                     logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
                     should_deliver = False
 


### PR DESCRIPTION
would be silently suppressed and never delivered to the user.

## Fix

Changed `.startswith(SILENT_MARKER)` to `== SILENT_MARKER` so delivery
is only suppressed when the entire response (after stripping whitespace)
is exactly `[SILENT]` — matching the documented intent.
```python
# Before (buggy)
deliver_content.strip().upper().startswith(SILENT_MARKER)

# After (fixed)
deliver_content.strip().upper() == SILENT_MARKER
```

## Impact

- Cron reports that accidentally or intentionally start with `[SILENT]`
  followed by content are now correctly delivered.
- Pure `[SILENT]` responses (the intended use) are unaffected.

## Type of Change

- [x] 🐛 Bug fix

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Fix matches documented system prompt intent
- [x] No behavior change for pure `[SILENT]` responses