### PR TITLE
fix: strip orphaned think/reasoning tags from user-facing responses

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1389,6 +1389,7 @@ class AIAgent:
         content = re.sub(r'<thinking>.*?</thinking>', '', content, flags=re.DOTALL | re.IGNORECASE)
         content = re.sub(r'<reasoning>.*?</reasoning>', '', content, flags=re.DOTALL)
         content = re.sub(r'<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>', '', content, flags=re.DOTALL)
+        content = re.sub(r'</?(?:think|thinking|reasoning|REASONING_SCRATCHPAD)>\s*', '', content, flags=re.IGNORECASE)
         return content
 
     def _looks_like_codex_intermediate_ack(

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -230,6 +230,27 @@ class TestStripThinkBlocks:
         assert "line1" not in result
         assert "visible" in result
 
+    def test_orphaned_closing_think_tag(self, agent):
+        result = agent._strip_think_blocks("some reasoning</think>actual answer")
+        assert "</think>" not in result
+        assert "actual answer" in result
+
+    def test_orphaned_closing_thinking_tag(self, agent):
+        result = agent._strip_think_blocks("reasoning</thinking>answer")
+        assert "</thinking>" not in result
+        assert "answer" in result
+
+    def test_orphaned_opening_think_tag(self, agent):
+        result = agent._strip_think_blocks("<think>orphaned reasoning without close")
+        assert "<think>" not in result
+
+    def test_mixed_orphaned_and_paired_tags(self, agent):
+        text = "stray</think><think>paired reasoning</think> visible"
+        result = agent._strip_think_blocks(text)
+        assert "</think>" not in result
+        assert "<think>" not in result
+        assert "visible" in result
+
 
 class TestExtractReasoning:
     def test_reasoning_field(self, agent):


### PR DESCRIPTION
## Summary

Salvages PR #4286 by @arasovic — strips orphaned think/reasoning tags from user-facing responses.

### The bug

Models like Kimi K2.5 on Alibaba's endpoint emit reasoning as plain text followed by a bare `</think>` without a matching opening tag. The existing paired-tag regexes (`<think>.*?</think>`) require both tags, so orphaned tags pass through and appear in user responses.

### The fix

One catch-all regex added after the paired-tag removals in `_strip_think_blocks()`:
```python
content = re.sub(r'</?(?:think|thinking|reasoning|REASONING_SCRATCHPAD)>\s*', '', content, flags=re.IGNORECASE)
```

Runs after paired removal so it only catches orphans. 4 new tests covering orphaned close, orphaned open, and mixed scenarios.

### Testing

- `TestStripThinkBlocks` — 8/8 pass (4 existing + 4 new)

Closes #4286. Fixes #4285.
