### PR TITLE
fix: harden codex responses preflight and stream error handling

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3237,9 +3237,10 @@ class AIAgent:
             "model": model,
             "instructions": instructions,
             "input": normalized_input,
-            "tools": normalized_tools,
             "store": False,
         }
+        if normalized_tools is not None:
+            normalized["tools"] = normalized_tools
 
         # Pass through reasoning config
         reasoning = api_kwargs.get("reasoning")
@@ -3582,6 +3583,8 @@ class AIAgent:
 
     def _run_codex_stream(self, api_kwargs: dict, client: Any = None, on_first_delta: callable = None):
         """Execute one streaming Responses API request and return the final response."""
+        import httpx as _httpx
+
         active_client = client or self._ensure_primary_openai_client(reason="codex_stream_direct")
         max_stream_retries = 1
         has_tool_calls = False
@@ -3615,6 +3618,22 @@ class AIAgent:
                             if reasoning_text:
                                 self._fire_reasoning_delta(reasoning_text)
                     return stream.get_final_response()
+            except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
+                if attempt < max_stream_retries:
+                    logger.debug(
+                        "Codex Responses stream transport failed (attempt %s/%s); retrying. %s error=%s",
+                        attempt + 1,
+                        max_stream_retries + 1,
+                        self._client_log_context(),
+                        exc,
+                    )
+                    continue
+                logger.debug(
+                    "Codex Responses stream transport failed; falling back to create(stream=True). %s error=%s",
+                    self._client_log_context(),
+                    exc,
+                )
+                return self._run_codex_create_stream_fallback(api_kwargs, client=active_client)
             except RuntimeError as exc:
                 err_text = str(exc)
                 missing_completed = "response.completed" in err_text

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -782,3 +782,35 @@ class TestCodexStreamCallbacks:
 
         response = agent._run_codex_stream({}, client=mock_client)
         assert "Hello from Codex!" in deltas
+
+    def test_codex_remote_protocol_error_falls_back_to_create_stream(self):
+        from run_agent import AIAgent
+        import httpx
+
+        fallback_response = SimpleNamespace(
+            output=[SimpleNamespace(
+                type="message",
+                content=[SimpleNamespace(type="output_text", text="fallback from create stream")],
+            )],
+            status="completed",
+        )
+
+        mock_client = MagicMock()
+        mock_client.responses.stream.side_effect = httpx.RemoteProtocolError(
+            "peer closed connection without sending complete message body"
+        )
+
+        agent = AIAgent(
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "codex_responses"
+        agent._interrupt_requested = False
+
+        with patch.object(agent, "_run_codex_create_stream_fallback", return_value=fallback_response) as mock_fallback:
+            response = agent._run_codex_stream({}, client=mock_client)
+
+        assert response is fallback_response
+        mock_fallback.assert_called_once_with({}, client=mock_client)


### PR DESCRIPTION
## Summary

Salvage of #4283 by @curtitoo (cherry-picked onto current main).

Fixes two real gaps in the Codex Responses API path:

1. **`tools=None` in preflight** — `_preflight_codex_api_kwargs()` unconditionally included `"tools": normalized_tools` in the request dict. When no tools were configured, this sent `"tools": null` to the API. Fix: only include the key when `normalized_tools is not None`.

2. **Transport error handling in `_run_codex_stream()`** — The method only caught `RuntimeError` (for missing `response.completed`). httpx transport errors (`RemoteProtocolError`, `ReadTimeout`, `ConnectError`) escaped entirely, unlike the chat completions streaming path which has comprehensive httpx error handling. Fix: catch transport errors, retry once, then fall back to `_run_codex_create_stream_fallback()`.

## Verification

- `pytest tests/test_streaming.py` — 20/20 pass (including 2 new codex tests)
- `pytest tests/test_run_agent.py tests/test_codex_execution_paths.py tests/test_provider_parity.py` — 294/294 pass
- **Live E2E with Codex API** — tested both fixes against `gpt-5.3-codex` via `chatgpt.com/backend-api/codex`:
  - No tools: `completed=True, response=Four` (previously would have sent `tools=null`)
  - With tools: `completed=True, response=Four` (regression check)

Closes #4283.
