### PR TITLE
feat: add --max-turns CLI flag to hermes chat

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -615,6 +615,7 @@ def cmd_chat(args):
         "worktree": getattr(args, "worktree", False),
         "checkpoints": getattr(args, "checkpoints", False),
         "pass_session_id": getattr(args, "pass_session_id", False),
+        "max_turns": getattr(args, "max_turns", None),
     }
     # Filter out None values
     kwargs = {k: v for k, v in kwargs.items() if v is not None}
@@ -3707,6 +3708,13 @@ For more help on a command:
         action="store_true",
         default=False,
         help="Enable filesystem checkpoints before destructive file operations (use /rollback to restore)"
+    )
+    chat_parser.add_argument(
+        "--max-turns",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Maximum tool-calling iterations per conversation turn (default: 90, or agent.max_turns in config)"
     )
     chat_parser.add_argument(
         "--yolo",


### PR DESCRIPTION
## Summary

Adds `--max-turns N` flag to `hermes chat` so programmatic callers (Paperclip adapter, batch scripts, etc.) can control the agent's tool-calling iteration limit per invocation.

## What changed

- **`hermes_cli/main.py`**: Added `--max-turns` argument to `chat_parser` (argparse)
- **`hermes_cli/main.py`**: Wire `max_turns` through `cmd_chat()` kwargs → `cli.py main()`

The `cli.py main()` already accepted `max_turns` as a parameter and `HermesCLI.__init__` already had the full priority chain (CLI arg > config `agent.max_turns` > env `HERMES_MAX_ITERATIONS` > default 90). This just exposes it as an argparse flag.

## Context

The `hermes-paperclip-adapter` needs to pass `--max-turns` to control iteration limits when spawning `hermes chat -q`. Without this flag, the only way to set it was via config.yaml or env var — neither of which work well for per-agent overrides in Paperclip.

## Test plan

```bash
hermes chat --help  # verify --max-turns N appears
hermes chat --max-turns 10 -q "What tools do you have?"  # verify it caps iterations
```

Existing tests pass — no behavior change for callers that don't use the flag.
