### PR TITLE
fix(gateway): restart launchd-managed gateway with kickstart

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -807,6 +807,11 @@ def get_launchd_label() -> str:
     return f"ai.hermes.gateway-{suffix}" if suffix else "ai.hermes.gateway"
 
 
+def get_launchd_service_target() -> str:
+    """Return the launchd job target in ``domain/label`` form for kickstart."""
+    return f"gui/{os.getuid()}/{get_launchd_label()}"
+
+
 def generate_launchd_plist() -> str:
     python_path = get_python_path()
     working_dir = str(PROJECT_ROOT)
@@ -1021,14 +1026,17 @@ def _wait_for_gateway_exit(timeout: float = 10.0, force_after: float = 5.0):
 
 
 def launchd_restart():
+    refresh_launchd_plist_if_needed()
+    target = get_launchd_service_target()
     try:
-        launchd_stop()
+        subprocess.run(["launchctl", "kickstart", "-k", target], check=True)
     except subprocess.CalledProcessError as e:
         if e.returncode != 3:
             raise
-        print("↻ launchd job was unloaded; skipping stop")
-    _wait_for_gateway_exit()
-    launchd_start()
+        print("↻ launchd job was unloaded; reloading service definition")
+        launchd_start()
+        return
+    print("✓ Service restarted")
 
 def launchd_status(deep: bool = False):
     plist_path = get_launchd_plist_path()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3204,7 +3204,7 @@ def cmd_update(args):
             from gateway.status import get_running_pid, remove_pid_file
             from hermes_cli.gateway import (
                 get_service_name, get_launchd_plist_path, is_macos, is_linux,
-                refresh_launchd_plist_if_needed,
+                refresh_launchd_plist_if_needed, get_launchd_service_target,
                 _ensure_user_systemd_env, get_systemd_linger_status,
             )
             import signal as _signal
@@ -3310,19 +3310,13 @@ def cmd_update(args):
                         print(f"    sudo systemctl restart {_gw_service_name}")
                 elif has_launchd_service:
                     # Refresh the plist first (picks up --replace and other
-                    # changes from the update we just pulled).
+                    # changes from the update we just pulled). Use kickstart
+                    # instead of stop+start so updates invoked from inside the
+                    # gateway do not terminate the active process mid-command.
                     refresh_launchd_plist_if_needed()
-                    # Explicit stop+start — don't rely on KeepAlive respawn
-                    # after a manual SIGTERM, which would race with the
-                    # PID file cleanup.
                     print("→ Restarting gateway service...")
-                    _launchd_label = get_launchd_label()
-                    stop = subprocess.run(
-                        ["launchctl", "stop", _launchd_label],
-                        capture_output=True, text=True, timeout=10,
-                    )
                     start = subprocess.run(
-                        ["launchctl", "start", _launchd_label],
+                        ["launchctl", "kickstart", "-k", get_launchd_service_target()],
                         capture_output=True, text=True, timeout=10,
                     )
                     if start.returncode == 0:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -192,6 +192,24 @@ class TestLaunchdServiceRecovery:
         assert "stale" in output.lower()
         assert "not loaded" in output.lower()
 
+    def test_launchd_restart_uses_kickstart_target(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr(gateway_cli, "get_launchd_service_target", lambda: "gui/502/ai.hermes.gateway")
+
+        gateway_cli.launchd_restart()
+
+        assert calls[-1] == ["launchctl", "kickstart", "-k", "gui/502/ai.hermes.gateway"]
+
 
 class TestGatewayServiceDetection:
     def test_is_service_running_checks_system_scope_when_user_scope_is_inactive(self, monkeypatch):

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -313,15 +313,15 @@ class TestCmdUpdateLaunchdRestart:
         captured = capsys.readouterr().out
         assert "Gateway restarted via launchd" in captured
         assert "Restart it with: hermes gateway run" not in captured
-        # Verify launchctl stop + start were called (not manual SIGTERM)
+        # Verify launchctl kickstart was used rather than stop+start.
         launchctl_calls = [
             c for c in mock_run.call_args_list
             if len(c.args[0]) > 0 and c.args[0][0] == "launchctl"
         ]
-        stop_calls = [c for c in launchctl_calls if "stop" in c.args[0]]
-        start_calls = [c for c in launchctl_calls if "start" in c.args[0]]
-        assert len(stop_calls) >= 1
-        assert len(start_calls) >= 1
+        kickstart_calls = [c for c in launchctl_calls if "kickstart" in c.args[0]]
+        assert len(kickstart_calls) >= 1
+        assert not any("stop" in c.args[0] for c in launchctl_calls)
+        assert not any("start" in c.args[0] for c in launchctl_calls if "kickstart" not in c.args[0])
 
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")


### PR DESCRIPTION
## Summary
- replace the macOS launchd stop/start restart path with launchctl kickstart -k
- use the same kickstart flow from hermes update so self-triggered updates do not kill the gateway mid-command
- add launchd restart coverage for both the CLI helper and update flow

## Problem
On macOS, Hermes was trying to restart a launchd-managed gateway with launchctl stop followed by launchctl start. When that code path ran from inside the gateway itself, stop terminated the active process before it could finish the restart, which left the task half-complete and the service down.

## Testing
- /Users/butler/.hermes/hermes-agent/venv/bin/pytest tests/hermes_cli/test_update_gateway_restart.py tests/hermes_cli/test_gateway_service.py
