### PR TITLE
fix(security): validate WeCom media URLs against SSRF before download

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -621,6 +621,14 @@ class WeComAdapter(BasePlatformAdapter):
             return None
 
         try:
+            from tools.url_safety import is_safe_url
+            if not is_safe_url(url):
+                logger.warning("[%s] Blocked unsafe WeCom media URL: %s", self.name, url)
+                return None
+        except ImportError:
+            pass
+
+        try:
             raw, headers = await self._download_remote_bytes(url, max_bytes=ABSOLUTE_MAX_BYTES)
         except Exception as exc:
             logger.debug("[%s] Failed to download %s from %s: %s", self.name, kind, url, exc)


### PR DESCRIPTION
## What does this PR do?

The WeCom adapter's `_cache_media()` method downloads inbound media
files from URLs provided in WeCom webhook payloads without validating
them against the SSRF protection already used everywhere else in Hermes.

A malicious WeCom message with a crafted media URL could cause Hermes
to make requests to internal network services:
```json
{
  "msgtype": "image",
  "image": {
    "url": "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
  }
}
```

This would trigger an outbound request to the AWS instance metadata
service (or any other internal host), leaking cloud credentials or
probing internal services.

## Fix

Added an `is_safe_url()` check before `_download_remote_bytes()` —
consistent with the SSRF protection already applied in:
- `tools/web_tools.py`
- `tools/vision_tools.py`
- `gateway/platforms/base.py` (`cache_image_from_url`)

## Type of Change

- [x] 🔒 Security fix (SSRF)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Consistent with existing SSRF protection pattern in Hermes
- [x] No behavior change for legitimate WeCom media URLs
- [x] ImportError handled gracefully (url_safety unavailable edge case)