### PR TITLE
fix(security): add .config/gh to read protection for @file references

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -17,7 +17,7 @@ REFERENCE_PATTERN = re.compile(
     r"(?<![\w/])@(?:(?P<simple>diff|staged)\b|(?P<kind>file|folder|git|url):(?P<value>\S+))"
 )
 TRAILING_PUNCTUATION = ",.;!?"
-_SENSITIVE_HOME_DIRS = (".ssh", ".aws", ".gnupg", ".kube", ".docker", ".azure")
+_SENSITIVE_HOME_DIRS = (".ssh", ".aws", ".gnupg", ".kube", ".docker", ".azure", ".config/gh")
 _SENSITIVE_HERMES_DIRS = (Path("skills") / ".hub",)
 _SENSITIVE_HOME_FILES = (
     Path(".ssh") / "authorized_keys",


### PR DESCRIPTION
Follow-up to PR #4305 (merged). The `.config/gh` directory was added to write-deny but missed from `_SENSITIVE_HOME_DIRS` in `context_references.py`, leaving GitHub CLI OAuth tokens (`hosts.yml`) exposed via `@file:~/.config/gh/hosts.yml` context injection.

One-line fix: adds `.config/gh` to the sensitive home dirs tuple.