### PR TITLE
fix(gateway): block launchctl self-termination commands

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -564,6 +564,30 @@ class TestGatewayProtection:
         dangerous, key, desc = detect_dangerous_command(cmd)
         assert dangerous is True
 
+    def test_launchctl_stop_gateway_detected(self):
+        cmd = "launchctl stop ai.hermes.gateway"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
+    def test_launchctl_stop_start_gateway_detected(self):
+        cmd = "launchctl stop ai.hermes.gateway && sleep 2 && launchctl start ai.hermes.gateway"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
+    def test_launchctl_kickstart_gateway_detected(self):
+        cmd = "launchctl kickstart -k gui/502/ai.hermes.gateway"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
+    def test_launchctl_unload_gateway_plist_detected(self):
+        cmd = "launchctl unload ~/Library/LaunchAgents/ai.hermes.gateway.plist"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-termination" in desc
+
     def test_pkill_unrelated_not_flagged(self):
         """pkill targeting unrelated processes should not be flagged."""
         cmd = "pkill -f nginx"
@@ -639,5 +663,4 @@ class TestNormalizationBypass:
         cmd = "\uff4c\uff53 -\uff4c\uff41 /tmp"
         dangerous, key, desc = detect_dangerous_command(cmd)
         assert dangerous is False
-
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -71,6 +71,8 @@ DANGEROUS_PATTERNS = [
     (r'\bnohup\b.*gateway\s+run\b', "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')"),
     # Self-termination protection: prevent agent from killing its own process
     (r'\b(pkill|killall)\b.*\b(hermes|gateway|cli\.py)\b', "kill hermes/gateway process (self-termination)"),
+    (r'\blaunchctl\s+(stop|start|kickstart|unload|load|bootout|bootstrap)\b.*\bai\.hermes\.gateway\b', "manage hermes launchd service directly (self-termination)"),
+    (r'\blaunchctl\s+(unload|load)\b.*\bai\.hermes\.gateway(?:-[^/\s]+)?\.plist\b', "manage hermes launchd service directly (self-termination)"),
     # File copy/move/edit into sensitive system paths
     (r'\b(cp|mv|install)\b.*\s/etc/', "copy/move file into /etc/"),
     (r'\bsed\s+-[^\s]*i.*\s/etc/', "in-place edit of system config"),


### PR DESCRIPTION
## Summary
- extend dangerous command detection to catch direct launchctl management of ai.hermes.gateway
- block stop/start, kickstart, load/unload, bootstrap, and bootout patterns that can self-terminate the running gateway
- add regression coverage for launchctl-based self-termination commands

## Problem
Hermes already guarded against pkill and killall targeting its own gateway process, but it did not treat launchctl management of ai.hermes.gateway as self-termination. On macOS, running launchctl stop ai.hermes.gateway from inside the gateway kills the active process immediately, aborting the in-flight task. A later restart creates a fresh process and does not resume the interrupted work.

## Testing
- /Users/butler/.hermes/hermes-agent/venv/bin/pytest tests/tools/test_approval.py
