### PR TITLE
fix(security): guard profile import against zip-slip path traversal

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -735,6 +735,21 @@ def import_profile(archive_path: str, name: Optional[str] = None) -> Path:
     profiles_root = _get_profiles_root()
     profiles_root.mkdir(parents=True, exist_ok=True)
 
+    # Guard against zip-slip: validate all member paths before extracting.
+    # A malicious archive could contain entries like '../../.ssh/authorized_keys'
+    # that would escape the profiles root directory.
+    import tarfile as _tarfile
+    with _tarfile.open(str(archive), 'r:gz') as _tf:
+        profiles_root_resolved = profiles_root.resolve()
+        for member in _tf.getmembers():
+            member_path = (profiles_root / member.name).resolve()
+            try:
+                member_path.relative_to(profiles_root_resolved)
+            except ValueError:
+                raise ValueError(
+                    f"Archive contains unsafe path: {member.name}. "
+                    f"Refusing to extract.")
+
     shutil.unpack_archive(str(archive), str(profiles_root))
 
     # If the archive extracted under a different name, rename


### PR DESCRIPTION
## What does this PR do?

`hermes profile import` uses `shutil.unpack_archive()` to extract
a user-supplied `.tar.gz` archive without validating member paths.

A malicious archive can contain entries with `..` path traversal:

`shutil.unpack_archive()` extracts these without any path checking,
allowing files to be written outside the profiles root directory —
potentially overwriting SSH keys, cron jobs, or other sensitive files.

Note: v0.5.0 fixed zip-slip in `hermes update` (#3250), but
`hermes profile import` was not covered by that fix.

## Fix

Added a pre-extraction validation loop that resolves every member path
and checks it stays within `profiles_root` via `relative_to()`.
If any member escapes, extraction is refused with a clear error.

This is the same pattern used in the self-update zip-slip fix (#3250).

## Type of Change

- [x] 🔒 Security fix (zip-slip / path traversal)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Consistent with existing zip-slip fix in hermes update (#3250)
- [x] No behavior change for legitimate profile archives