### PR TITLE
fix(cli): initialize ctx_len before compact banner path

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2162,6 +2162,12 @@ class HermesCLI:
     def show_banner(self):
         """Display the welcome banner in Claude Code style."""
         self.console.clear()
+
+        # Get context length for display before branching so it remains
+        # available to the low-context warning logic in compact mode too.
+        ctx_len = None
+        if hasattr(self, 'agent') and self.agent and hasattr(self.agent, 'context_compressor'):
+            ctx_len = self.agent.context_compressor.context_length
         
         # Auto-compact for narrow terminals — the full banner with caduceus
         # + tool list needs ~80 columns minimum to render without wrapping.
@@ -2177,11 +2183,6 @@ class HermesCLI:
             
             # Get terminal working directory (where commands will execute)
             cwd = os.getenv("TERMINAL_CWD", os.getcwd())
-            
-            # Get context length for display
-            ctx_len = None
-            if hasattr(self, 'agent') and self.agent and hasattr(self.agent, 'context_compressor'):
-                ctx_len = self.agent.context_compressor.context_length
             
             # Build and display the banner
             build_welcome_banner(

--- a/tests/test_cli_context_warning.py
+++ b/tests/test_cli_context_warning.py
@@ -145,3 +145,15 @@ class TestLowContextWarning:
         calls = [str(c) for c in cli_obj.console.print.call_args_list]
         warning_calls = [c for c in calls if "too low" in c]
         assert len(warning_calls) == 0
+
+    def test_compact_banner_does_not_crash_on_narrow_terminal(self, cli_obj):
+        """Compact mode should still have ctx_len defined for warning logic."""
+        cli_obj.agent.context_compressor.context_length = 4096
+
+        with patch("shutil.get_terminal_size", return_value=os.terminal_size((70, 40))), \
+             patch("cli._build_compact_banner", return_value="compact banner"):
+            cli_obj.show_banner()
+
+        calls = [str(c) for c in cli_obj.console.print.call_args_list]
+        warning_calls = [c for c in calls if "too low" in c]
+        assert len(warning_calls) == 1


### PR DESCRIPTION
## Bug Description

On terminals narrower than 80 columns, Hermes switches to the compact banner path in `HermesCLI.show_banner()`. After the recent low-context warning was added, that compact path could reach the trailing `if ctx_len and ctx_len <= 8192:` check without ever initializing `ctx_len`, causing:

```python
UnboundLocalError: cannot access local variable 'ctx_len' where it is not associated with a value
```

## Root Cause

`ctx_len` was initialized only inside the full-banner (`else`) branch, but it was referenced later outside the branch. Narrow terminals always take the compact branch, so `ctx_len` remained undefined there.

## Fix

- Initialize `ctx_len` before branching between compact and full banner rendering
- Keep the existing low-context warning behavior unchanged
- Add a regression test that forces a narrow terminal width and exercises the compact banner path

## How to Verify

1. Start Hermes in a terminal narrower than 80 columns
2. Confirm startup no longer crashes in `show_banner()` with `UnboundLocalError`
3. Run `python -m py_compile cli.py tests/test_cli_context_warning.py`

## Test Plan

- [x] Added regression test for this bug
- [ ] Existing tests still pass
- [x] Manual verification of the root cause and fix logic
- [x] `python -m py_compile cli.py tests/test_cli_context_warning.py`

Note: I could not run the targeted pytest file locally because this environment is missing `prompt_toolkit`, and the repo's default pytest `-n` addopts also requires `pytest-xdist`.

## Risk Assessment

Low — this is a small, localized initialization fix that only moves `ctx_len` setup earlier so both banner paths can safely use the same warning logic.