### PR TITLE
fix: add CAMOFOX_PORT=9377 to Docker commands for camofox-browser

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -364,10 +364,10 @@ def _run_post_setup(post_setup_key: str):
             _print_info("    Start the Camofox server:")
             _print_info("      npx @askjo/camoufox-browser")
             _print_info("    First run downloads the Camoufox engine (~300MB)")
-            _print_info("    Or use Docker: docker run -p 9377:9377 jo-inc/camofox-browser")
+            _print_info("    Or use Docker: docker run -p 9377:9377 -e CAMOFOX_PORT=9377 jo-inc/camofox-browser")
         elif not shutil.which("npm"):
             _print_warning("    Node.js not found. Install Camofox via Docker:")
-            _print_info("      docker run -p 9377:9377 jo-inc/camofox-browser")
+            _print_info("      docker run -p 9377:9377 -e CAMOFOX_PORT=9377 jo-inc/camofox-browser")
 
     elif post_setup_key == "rl_training":
         try:

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -15,7 +15,7 @@ Setup::
     npm install && npm start   # downloads Camoufox (~300MB) on first run
 
     # Option 2: Docker
-    docker run -p 9377:9377 jo-inc/camofox-browser
+    docker run -p 9377:9377 -e CAMOFOX_PORT=9377 jo-inc/camofox-browser
 
 Then set ``CAMOFOX_URL=http://localhost:9377`` in ``~/.hermes/.env``.
 """
@@ -184,7 +184,7 @@ def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
             "success": False,
             "error": f"Cannot connect to Camofox at {get_camofox_url()}. "
                      "Is the server running? Start with: npm start (in camofox-browser dir) "
-                     "or: docker run -p 9377:9377 jo-inc/camofox-browser",
+                     "or: docker run -p 9377:9377 -e CAMOFOX_PORT=9377 jo-inc/camofox-browser",
         })
     except Exception as e:
         return json.dumps({"success": False, "error": str(e)})


### PR DESCRIPTION
The camofox-browser Docker image defaults to port 3000 internally, not 9377. Our Docker commands used `-p 9377:9377` which silently fails — host port 9377 maps to container port 9377 where nothing listens.

**E2E verified on this machine:**
- `-p 9377:9377` alone → `curl /health` returns `000` (connection reset)
- `-p 9377:9377 -e CAMOFOX_PORT=9377` → `{"ok":true,"engine":"camoufox","browserConnected":true}`

Updated all 4 Docker command strings across `tools/browser_camofox.py` (module docstring + error message) and `hermes_cli/tools_config.py` (2 setup hints).

Reported by community member Blood Shot in Discord.