### PR TITLE
fix(security): block agent-created skills when scan verdict requires confirmation

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -2,7 +2,7 @@
 
 import json
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from tools.skill_manager_tool import (
     _validate_name,
@@ -411,3 +411,71 @@ class TestSkillManageDispatcher:
             raw = skill_manage(action="create", name="test-skill", content=VALID_SKILL_CONTENT)
         result = json.loads(raw)
         assert result["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# Security scan — "ask" policy enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityScanAskPolicy:
+    """_security_scan_skill must block when should_allow_install returns None (ask)."""
+
+    def test_ask_verdict_is_blocked(self, tmp_path):
+        """allowed=None (ask) must return an error string, not silently allow."""
+        mock_result = MagicMock()
+        mock_result.findings = [MagicMock()]
+
+        with (
+            patch("tools.skill_manager_tool._GUARD_AVAILABLE", True),
+            patch("tools.skill_manager_tool.scan_skill", return_value=mock_result),
+            patch(
+                "tools.skill_manager_tool.should_allow_install",
+                return_value=(None, "Requires confirmation (agent-created + dangerous verdict)"),
+            ),
+            patch("tools.skill_manager_tool.format_scan_report", return_value="[scan report]"),
+        ):
+            from tools.skill_manager_tool import _security_scan_skill
+            err = _security_scan_skill(tmp_path)
+
+        assert err is not None, "ask verdict must not silently pass through"
+        assert "confirmation" in err.lower()
+        assert "[scan report]" in err
+
+    def test_blocked_verdict_still_blocked(self, tmp_path):
+        """allowed=False (block) must still return an error string."""
+        mock_result = MagicMock()
+        mock_result.findings = [MagicMock()]
+
+        with (
+            patch("tools.skill_manager_tool._GUARD_AVAILABLE", True),
+            patch("tools.skill_manager_tool.scan_skill", return_value=mock_result),
+            patch(
+                "tools.skill_manager_tool.should_allow_install",
+                return_value=(False, "Blocked (community source + dangerous verdict)"),
+            ),
+            patch("tools.skill_manager_tool.format_scan_report", return_value="[scan report]"),
+        ):
+            from tools.skill_manager_tool import _security_scan_skill
+            err = _security_scan_skill(tmp_path)
+
+        assert err is not None
+        assert "blocked" in err.lower()
+
+    def test_safe_verdict_passes(self, tmp_path):
+        """allowed=True (safe) must return None (no error)."""
+        mock_result = MagicMock()
+        mock_result.findings = []
+
+        with (
+            patch("tools.skill_manager_tool._GUARD_AVAILABLE", True),
+            patch("tools.skill_manager_tool.scan_skill", return_value=mock_result),
+            patch(
+                "tools.skill_manager_tool.should_allow_install",
+                return_value=(True, "Allowed (agent-created source, safe verdict)"),
+            ),
+        ):
+            from tools.skill_manager_tool import _security_scan_skill
+            err = _security_scan_skill(tmp_path)
+
+        assert err is None

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -64,11 +64,15 @@ def _security_scan_skill(skill_dir: Path) -> Optional[str]:
             report = format_scan_report(result)
             return f"Security scan blocked this skill ({reason}):\n{report}"
         if allowed is None:
-            # "ask" — allow but include the warning so the user sees the findings
+            # "ask" — policy requires user confirmation; block and surface the report
+            # so the user can review findings before deciding to install with --force.
             report = format_scan_report(result)
-            logger.warning("Agent-created skill has security findings: %s", reason)
-            # Don't block — return None to allow, but log the warning
-            return None
+            return (
+                f"Security scan requires confirmation before installing this skill "
+                f"({reason}):\n{report}\n"
+                "To install anyway, delete the skill directory and recreate it after "
+                "reviewing the findings above."
+            )
     except Exception as e:
         logger.warning("Security scan failed for %s: %s", skill_dir, e, exc_info=True)
     return None


### PR DESCRIPTION
## What does this PR do?

The `should_allow_install()` policy table in `skills_guard.py` declares `ask` (returns `None`) for agent-created skills with a `dangerous` verdict, meaning the user must confirm before installation proceeds:

```python
INSTALL_POLICY = {
    #                  safe      caution    dangerous
    "agent-created": ("allow",  "allow",   "ask"),   # dangerous → ask
}
```

The previous implementation in `_security_scan_skill()` silently logged a warning and returned `None` (allowed) when `should_allow_install` returned `None`, making the `ask` gate a complete no-op:

```python
if allowed is None:
    # "ask" — allow but include the warning so the user sees the findings
    logger.warning("Agent-created skill has security findings: %s", reason)
    # Don't block — return None to allow, but log the warning
    return None  # ← silently allowed through
```

## Security Impact

A prompt-injected agent (e.g. reading a malicious web page via `web_extract` or `browser_navigate`) could exploit this to write a persistent skill containing critical-severity patterns — secret exfiltration via `curl`, reading `~/.hermes/auth.json`, etc. — and have it installed without any user confirmation. The skill would then execute in subsequent agent sessions.

## Fix

When `allowed is None`, `_security_scan_skill` now returns the scan report as an error string, identical to the `allowed is False` path. The skill create/edit path already surfaces any non-None return as a failure to the caller, so no other changes are needed.

```python
if allowed is None:
    report = format_scan_report(result)
    return (
        f"Security scan requires confirmation before installing this skill "
        f"({reason}):\n{report}\n"
        "To install anyway, delete the skill directory and recreate it after "
        "reviewing the findings above."
    )
```

## Tests

Three new tests in `TestSecurityScanAskPolicy`:
- `test_ask_verdict_is_blocked` — `allowed=None` must return an error string, not `None`
- `test_blocked_verdict_still_blocked` — `allowed=False` path unaffected
- `test_safe_verdict_passes` — `allowed=True` still returns `None` (no error)

## Related

- #4168 — broader subprocess isolation and exfiltration detection audit
- #4268 — prompt injection via sticker descriptions (same attack surface category)

## Type of Change

- [x] 🔒 Security fix

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] Tests added for the fixed behavior
- [x] No behavior change for safe or caution verdicts