### PR TITLE
fix(security): use hmac.compare_digest for API server token comparison

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -18,6 +18,7 @@ Requires:
 """
 
 import asyncio
+import hmac
 import json
 import logging
 import os
@@ -363,7 +364,7 @@ class APIServerAdapter(BasePlatformAdapter):
         auth_header = request.headers.get("Authorization", "")
         if auth_header.startswith("Bearer "):
             token = auth_header[7:].strip()
-            if token == self._api_key:
+            if hmac.compare_digest(token, self._api_key):
                 return None  # Auth OK
 
         return web.json_response(

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -196,6 +196,20 @@ class TestAuth:
         assert result is not None
         assert result.status == 401
 
+    def test_auth_uses_compare_digest(self):
+        """Token comparison must go through hmac.compare_digest (timing-safe)."""
+        import gateway.platforms.api_server as api_server_mod
+        config = PlatformConfig(enabled=True, extra={"key": "sk-secret"})
+        adapter = APIServerAdapter(config)
+        mock_request = MagicMock()
+        mock_request.headers = {"Authorization": "Bearer sk-secret"}
+        with MagicMock() as _m:
+            import unittest.mock as _um
+            with _um.patch("gateway.platforms.api_server.hmac.compare_digest",
+                           wraps=api_server_mod.hmac.compare_digest) as spy:
+                adapter._check_auth(mock_request)
+                spy.assert_called_once_with("sk-secret", "sk-secret")
+
 
 # ---------------------------------------------------------------------------
 # Helpers for HTTP tests


### PR DESCRIPTION
## What does this PR do?

Replaces the direct `==` comparison in `_check_auth` with `hmac.compare_digest`.

**Before:**
```python
if token == self._api_key:
    return None  # Auth OK
```

**After:**
```python
if hmac.compare_digest(token, self._api_key):
    return None  # Auth OK
```

## Why

Python's `==` on strings short-circuits at the first mismatched byte, leaking the length of the common prefix through response latency. An adversary who can send many requests and measure timing differences can enumerate the API key character by character.

`hmac.compare_digest` is designed for exactly this use case: it always compares all bytes and returns in constant time regardless of where the strings diverge. It is the standard remedy for this class of vulnerability (CWE-208).

## Impact without fix

An attacker on the local network (or with network access to the API server port) could enumerate the `API_SERVER_KEY` character by character. Since the API server exposes full agent tool access including terminal commands, a valid key grants arbitrary command execution.

## Notes

- `hmac` is stdlib, no new dependency
- Behavior is identical; only the internal comparison mechanism changes
- The `not self._api_key` early-return path (no key configured) is unaffected

## Related

- #4185 — body size limit for chunked requests in same file (no conflict, different method)

## Type of Change

- [x] Security fix

## Checklist

- [x] Commit messages follow Conventional Commits
- [x] Test added verifying `hmac.compare_digest` is called
- [x] All existing auth tests pass