### PR TITLE
fix(terminal): respect config.yaml docker_image and terminal settings…

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -453,9 +453,16 @@ def _get_env_config() -> Dict[str, Any]:
     """Get terminal environment configuration from environment variables."""
     # Default image with Python and Node.js for maximum compatibility
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
-    env_type = os.getenv("TERMINAL_ENV", "local")
+    # Load config.yaml terminal block to use as fallback before hardcoded defaults
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config().get("terminal", {})
+    except Exception:
+        cfg = {}
+
+    env_type = os.getenv("TERMINAL_ENV", cfg.get("backend", "local"))
     
-    mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in ("true", "1", "yes")
+    mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", str(cfg.get("docker_mount_cwd_to_workspace", "false"))).lower() in ("true", "1", "yes")
 
     # Default cwd: local uses the host's current directory, everything
     # else starts in the user's home (~ resolves to whatever account
@@ -471,7 +478,7 @@ def _get_env_config() -> Dict[str, Any]:
     # If Docker cwd passthrough is explicitly enabled, remap the host path to
     # /workspace and track the original host path separately. Otherwise keep the
     # normal sandbox behavior and discard host paths.
-    cwd = os.getenv("TERMINAL_CWD", default_cwd)
+    cwd = os.getenv("TERMINAL_CWD", cfg.get("cwd", default_cwd))
     host_cwd = None
     host_prefixes = ("/Users/", "/home/", "C:\\", "C:/")
     if env_type == "docker" and mount_docker_cwd:
@@ -495,16 +502,16 @@ def _get_env_config() -> Dict[str, Any]:
 
     return {
         "env_type": env_type,
-        "docker_image": os.getenv("TERMINAL_DOCKER_IMAGE", default_image),
-        "docker_forward_env": _parse_env_var("TERMINAL_DOCKER_FORWARD_ENV", "[]", json.loads, "valid JSON"),
-        "singularity_image": os.getenv("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
-        "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", default_image),
-        "daytona_image": os.getenv("TERMINAL_DAYTONA_IMAGE", default_image),
+        "docker_image": os.getenv("TERMINAL_DOCKER_IMAGE", cfg.get("docker_image", default_image)),
+        "docker_forward_env": _parse_env_var("TERMINAL_DOCKER_FORWARD_ENV", json.dumps(cfg.get("docker_forward_env", [])), json.loads, "valid JSON"),
+        "singularity_image": os.getenv("TERMINAL_SINGULARITY_IMAGE", cfg.get("singularity_image", f"docker://{default_image}")),
+        "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", cfg.get("modal_image", default_image)),
+        "daytona_image": os.getenv("TERMINAL_DAYTONA_IMAGE", cfg.get("daytona_image", default_image)),
         "cwd": cwd,
         "host_cwd": host_cwd,
         "docker_mount_cwd_to_workspace": mount_docker_cwd,
-        "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180"),
-        "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300"),
+        "timeout": _parse_env_var("TERMINAL_TIMEOUT", str(cfg.get("timeout", "180"))),
+        "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", str(cfg.get("lifetime_seconds", "300"))),
         # SSH-specific config
         "ssh_host": os.getenv("TERMINAL_SSH_HOST", ""),
         "ssh_user": os.getenv("TERMINAL_SSH_USER", ""),
@@ -515,15 +522,15 @@ def _get_env_config() -> Dict[str, Any]:
         # Per-backend env vars override if explicitly set.
         "ssh_persistent": os.getenv(
             "TERMINAL_SSH_PERSISTENT",
-            os.getenv("TERMINAL_PERSISTENT_SHELL", "true"),
+            os.getenv("TERMINAL_PERSISTENT_SHELL", str(cfg.get("persistent_shell", "true"))),
         ).lower() in ("true", "1", "yes"),
         "local_persistent": os.getenv("TERMINAL_LOCAL_PERSISTENT", "false").lower() in ("true", "1", "yes"),
         # Container resource config (applies to docker, singularity, modal, daytona -- ignored for local/ssh)
-        "container_cpu": _parse_env_var("TERMINAL_CONTAINER_CPU", "1", float, "number"),
-        "container_memory": _parse_env_var("TERMINAL_CONTAINER_MEMORY", "5120"),     # MB (default 5GB)
-        "container_disk": _parse_env_var("TERMINAL_CONTAINER_DISK", "51200"),        # MB (default 50GB)
-        "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in ("true", "1", "yes"),
-        "docker_volumes": _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON"),
+        "container_cpu": _parse_env_var("TERMINAL_CONTAINER_CPU", str(cfg.get("container_cpu", "1")), float, "number"),
+        "container_memory": _parse_env_var("TERMINAL_CONTAINER_MEMORY", str(cfg.get("container_memory", "5120"))),     # MB (default 5GB)
+        "container_disk": _parse_env_var("TERMINAL_CONTAINER_DISK", str(cfg.get("container_disk", "51200"))),        # MB (default 50GB)
+        "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", str(cfg.get("container_persistent", "true"))).lower() in ("true", "1", "yes"),
+        "docker_volumes": _parse_env_var("TERMINAL_DOCKER_VOLUMES", json.dumps(cfg.get("docker_volumes", [])), json.loads, "valid JSON"),
     }
 
 


### PR DESCRIPTION
… (#4344)

## What does this PR do?

Fixes #4344

**The Issue:**
The `_get_env_config()` function in `tools/terminal_tool.py` was exclusively reading from environment variables (`os.getenv`) and falling back to a hardcoded default image (`nikolaik/python-nodejs...`). It completely ignored the `terminal` block configurations specified in `config.yaml`, causing assigned images like `rust:trixie` to be bypassed entirely.

**The Fix:**
Updated `_get_env_config()` to safely load the `terminal` block from `config.yaml` as the primary fallback before using the hardcoded default values. This ensures that user-defined settings for `docker_image`, `cwd`, and other container configurations are correctly respected across all terminal backends without breaking existing environment variable overrides.

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

