### PR TITLE
fix(gateway): remove expired sessions from disk after proactive memory flush

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1291,6 +1291,15 @@ class GatewayRunner:
                         await self._async_flush_memories(entry.session_id, key)
                         self._shutdown_gateway_honcho(key)
                         self.session_store._pre_flushed_sessions.add(entry.session_id)
+                        # Remove flushed expired session from the store so it
+                        # won't be re-discovered on the next gateway restart.
+                        with self.session_store._lock:
+                            self.session_store._entries.pop(key, None)
+                            self.session_store._save()
+                        logger.info(
+                            "Pre-reset memory flush completed for session %s",
+                            entry.session_id,
+                        )
                     except Exception as e:
                         logger.debug("Proactive memory flush failed for %s: %s", entry.session_id, e)
             except Exception as e:

--- a/tests/gateway/test_async_memory_flush.py
+++ b/tests/gateway/test_async_memory_flush.py
@@ -178,3 +178,63 @@ class TestPreFlushedSessionsTracking:
         assert "sid_a" not in idle_store._pre_flushed_sessions
         # discard on non-existent should not raise
         idle_store._pre_flushed_sessions.discard("sid_nonexistent")
+
+
+class TestFlushedSessionRemovedFromDisk:
+    """After a successful proactive flush, the session entry must be removed
+    from the on-disk store so that a gateway restart does not re-flush it."""
+
+    def test_flushed_entry_removed_from_entries(self, idle_store):
+        """Flushed expired sessions should be popped from _entries."""
+        key = "agent:main:discord:thread:123"
+        entry = SessionEntry(
+            session_key=key,
+            session_id="sid_flush_1",
+            created_at=datetime.now() - timedelta(hours=5),
+            updated_at=datetime.now() - timedelta(hours=5),
+            platform=Platform.DISCORD,
+            chat_type="thread",
+        )
+        idle_store._entries[key] = entry
+
+        # Simulate the post-flush cleanup from _session_expiry_watcher
+        idle_store._pre_flushed_sessions.add(entry.session_id)
+        with idle_store._lock:
+            idle_store._entries.pop(key, None)
+            idle_store._save()
+
+        assert key not in idle_store._entries
+        # A fresh load should also not contain the entry
+        idle_store._loaded = False
+        idle_store._ensure_loaded()
+        assert key not in idle_store._entries
+
+    def test_flushed_entry_survives_restart_without_cleanup(self, idle_store):
+        """Without the disk cleanup, a flushed session persists across restarts.
+
+        This test demonstrates the original bug: _pre_flushed_sessions is
+        in-memory only, so after re-load the entry reappears as flushable.
+        """
+        key = "agent:main:discord:thread:456"
+        entry = SessionEntry(
+            session_key=key,
+            session_id="sid_flush_2",
+            created_at=datetime.now() - timedelta(hours=5),
+            updated_at=datetime.now() - timedelta(hours=5),
+            platform=Platform.DISCORD,
+            chat_type="thread",
+        )
+        idle_store._entries[key] = entry
+        idle_store._save()
+
+        # Mark as flushed in-memory only (the old buggy behavior)
+        idle_store._pre_flushed_sessions.add(entry.session_id)
+
+        # Simulate a gateway restart — reset in-memory state, reload from disk
+        idle_store._pre_flushed_sessions = set()
+        idle_store._loaded = False
+        idle_store._ensure_loaded()
+
+        # The entry is back and would be re-flushed
+        assert key in idle_store._entries
+        assert entry.session_id not in idle_store._pre_flushed_sessions


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where the gateway becomes unresponsive after a restart due to the proactive memory flush loop re-flushing already-flushed expired sessions.

The `_session_expiry_watcher` (introduced in d80c30cc) flushes memories for expired sessions to Honcho, then tracks them in the in-memory `_pre_flushed_sessions` set to prevent double-flushing within a single process lifetime. However, this set is never persisted to disk. On gateway restart, the set resets to empty while the expired session entries remain in `sessions.json`. The watcher rediscovers and re-flushes the same sessions every restart cycle, blocking the event loop and making all platforms (Discord, Telegram, etc.) unresponsive for 10-15+ minutes per cycle.

## Related Issue

No existing issue — discovered in production when a gateway restart triggered a cascade of ~30 expired session flushes that repeated on every subsequent restart.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: After a successful proactive memory flush, remove the expired session entry from the session store on disk (`_entries.pop()` + `_save()`). This ensures flushed sessions are never re-discovered on restart.
- `tests/gateway/test_async_memory_flush.py`: Two regression tests — one verifying entries are removed from disk after flush, one demonstrating the original bug (in-memory guard lost on restart).

## How to Test

1. Start the gateway with Honcho enabled and several expired sessions in `sessions.json`
2. Observe the watcher flush them once
3. Restart the gateway
4. Confirm the flushed sessions are NOT re-discovered or re-flushed

```bash
source .venv/bin/activate
python -m pytest -q tests/gateway/test_async_memory_flush.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
