### PR TITLE
fix: add webhook platform support and skip home channel prompt

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -170,39 +170,11 @@ class WebhookAdapter(BasePlatformAdapter):
             logger.info("[webhook] Response for %s: %s", chat_id, content[:200])
             return SendResult(success=True)
 
-        # Filter out tool progress output for github_comment delivery
-        # The agent may post its own review via gh pr review, and we don't want
-        # to post tool progress as a separate comment.
         if deliver_type == "github_comment":
-            # Skip if content is just tool progress (starts with tool indicators)
-            content_stripped = content.strip()
-            
-            # Tool progress patterns to skip
-            tool_patterns = [
-                "💻 terminal:",
-                "💻 $",
-                "💻 terminal",
-                "📖 read",
-                "🔍 grep",
-                "🔎 search",
-                "📄 fetch",
-                "🐍 exec",
-                "[tool]",
-            ]
-            
-            # Check if content is primarily tool output
-            is_tool_output = any(
-                content_stripped.startswith(pattern) 
-                for pattern in tool_patterns
-            )
-            
-            # Also skip if content is too short (likely just progress)
-            is_too_short = len(content_stripped) < 100
-            
-            # Skip if it looks like a single tool call
-            if is_tool_output or is_too_short:
+            # Skip empty or trivially short content
+            if not content or len(content.strip()) < 50:
                 logger.info(
-                    "[webhook] Skipping github_comment delivery - content is tool progress or too short"
+                    "[webhook] Skipping github_comment delivery - content too short"
                 )
                 return SendResult(success=True)
             

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -170,7 +170,42 @@ class WebhookAdapter(BasePlatformAdapter):
             logger.info("[webhook] Response for %s: %s", chat_id, content[:200])
             return SendResult(success=True)
 
+        # Filter out tool progress output for github_comment delivery
+        # The agent may post its own review via gh pr review, and we don't want
+        # to post tool progress as a separate comment.
         if deliver_type == "github_comment":
+            # Skip if content is just tool progress (starts with tool indicators)
+            content_stripped = content.strip()
+            
+            # Tool progress patterns to skip
+            tool_patterns = [
+                "💻 terminal:",
+                "💻 $",
+                "💻 terminal",
+                "📖 read",
+                "🔍 grep",
+                "🔎 search",
+                "📄 fetch",
+                "🐍 exec",
+                "[tool]",
+            ]
+            
+            # Check if content is primarily tool output
+            is_tool_output = any(
+                content_stripped.startswith(pattern) 
+                for pattern in tool_patterns
+            )
+            
+            # Also skip if content is too short (likely just progress)
+            is_too_short = len(content_stripped) < 100
+            
+            # Skip if it looks like a single tool call
+            if is_tool_output or is_too_short:
+                logger.info(
+                    "[webhook] Skipping github_comment delivery - content is tool progress or too short"
+                )
+                return SendResult(success=True)
+            
             return await self._deliver_github_comment(content, delivery)
 
         # Cross-platform delivery (telegram, discord, etc.)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5347,7 +5347,10 @@ class GatewayRunner:
             or os.getenv("HERMES_TOOL_PROGRESS_MODE")
             or "all"
         )
-        tool_progress_enabled = progress_mode != "off"
+        # Disable tool progress for webhooks - they don't support message editing,
+        # so each progress line would be sent as a separate message.
+        from gateway.config import Platform
+        tool_progress_enabled = progress_mode != "off" and source.platform != Platform.WEBHOOK
         
         # Queue for progress messages (thread-safe)
         progress_queue = queue.Queue() if tool_progress_enabled else None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2439,7 +2439,8 @@ class GatewayRunner:
             )
         
         # One-time prompt if no home channel is set for this platform
-        if not history and source.platform and source.platform != Platform.LOCAL:
+        # Skip for webhooks - they deliver directly to configured targets (github_comment, etc.)
+        if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK:
             platform_name = source.platform.value
             env_key = f"{platform_name.upper()}_HOME_CHANNEL"
             if not os.getenv(env_key):

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -145,6 +145,7 @@ PLATFORMS = {
     "wecom": {"label": "💬 WeCom", "default_toolset": "hermes-wecom"},
     "api_server": {"label": "🌐 API Server", "default_toolset": "hermes-api-server"},
     "mattermost": {"label": "💬 Mattermost", "default_toolset": "hermes-mattermost"},
+    "webhook": {"label": "🔗 Webhook", "default_toolset": "hermes-cli"},
 }
 
 


### PR DESCRIPTION
## Summary

Four fixes for webhook platform support:

1. **Add missing webhook platform entry** to `PLATFORMS` dict in `tools_config.py`
   - Without this, spawning an agent from a webhook trigger crashed with `KeyError: 'webhook'`

2. **Skip "No home channel" prompt for webhooks** in `gateway/run.py`
   - Webhooks don't need a home channel - they deliver directly to configured targets

3. **Disable tool progress for webhooks** in `gateway/run.py`
   - Webhooks don't support message editing, so each tool progress line would be sent as a separate message
   - This fix disables tool progress entirely for webhook platforms at the source

4. **Simplified content check** in `gateway/platforms/webhook.py`
   - Just skip empty or trivially short content (< 50 chars)
   - No more brittle string-matching for tool progress patterns

## Testing

Tested with a GitHub PR webhook that triggers code review comments.

Before fixes:
- Webhook crashed with KeyError
- "No home channel" message posted to GitHub comments
- Tool progress ("💻 terminal: ...") posted as separate comments

After all fixes:
- Webhook triggers agent successfully
- No spurious messages
- Only the final response is posted as a GitHub comment