### PR TITLE
security: redact secrets from execute_code output and all tool results

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5877,6 +5877,14 @@ class AIAgent:
                     f"exceeding the {MAX_TOOL_RESULT_CHARS:,} char limit]"
                 )
 
+            # Redact secrets from tool output before it enters LLM context.
+            # Defense-in-depth: individual tools (terminal, file_tools) also
+            # redact, but this catches any tool that doesn't (e.g. execute_code,
+            # browser, MCP tools). Prevents secret exfiltration via prompt injection.
+            if isinstance(function_result, str):
+                from agent.redact import redact_sensitive_text
+                function_result = redact_sensitive_text(function_result)
+
             tool_msg = {
                 "role": "tool",
                 "content": function_result,

--- a/run_agent.py
+++ b/run_agent.py
@@ -5622,6 +5622,11 @@ class AIAgent:
                     f"exceeding the {MAX_TOOL_RESULT_CHARS:,} char limit]"
                 )
 
+            # Redact secrets before entering LLM context (concurrent path)
+            if isinstance(function_result, str):
+                from agent.redact import redact_sensitive_text
+                function_result = redact_sensitive_text(function_result)
+
             # Append tool result message in order
             tool_msg = {
                 "role": "tool",

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -252,3 +252,39 @@ class TestElevenLabsTavilyExaKeys:
         assert "XYZ789abcdef" not in result
         assert "HOME=/home/user" in result
         assert "SHELL=/bin/bash" in result
+
+
+class TestCodeExecutionRedaction:
+    """Verify execute_code output is redacted before reaching LLM context."""
+
+    def test_env_var_in_stdout_is_redacted(self):
+        """Secrets printed via os.environ should be masked."""
+        text = "ANTHROPIC_API_KEY=sk-ant-api03-abc123def456ghi789jkl012mno345"
+        result = redact_sensitive_text(text)
+        assert "sk-ant-api03-abc123def456ghi789jkl012mno345" not in result
+        assert "ANTHROPIC_API_KEY=" in result
+        assert "***" in result or "..." in result
+
+    def test_openrouter_key_in_stdout_is_redacted(self):
+        """OpenRouter keys in script output should be masked."""
+        text = "sk-or-v1-abc123def456ghi789jkl012mno345pqr678stu901"
+        result = redact_sensitive_text(text)
+        assert "abc123def456" not in result
+
+    def test_multiple_keys_in_environ_dump(self):
+        """Full os.environ dump should redact all known key formats."""
+        text = (
+            "OPENAI_API_KEY=sk-proj-abc123def456ghi789jkl\n"
+            "GROQ_API_KEY=gsk_abc123def456ghi789jkl012\n"
+            "DISCORD_BOT_TOKEN=MTIzNDU2Nzg5MDEyMzQ1Njc4.abc.def\n"
+            "DATABASE_URL=postgres://user:secretpass123@host/db\n"
+        )
+        result = redact_sensitive_text(text)
+        assert "sk-proj-abc123" not in result
+        assert "secretpass123" not in result
+
+    def test_non_secret_output_unchanged(self):
+        """Regular script output should pass through unmodified."""
+        text = "Hello world\nResult: 42\nProcessed 100 items"
+        result = redact_sensitive_text(text)
+        assert result == text

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -288,3 +288,41 @@ class TestCodeExecutionRedaction:
         text = "Hello world\nResult: 42\nProcessed 100 items"
         result = redact_sensitive_text(text)
         assert result == text
+
+
+class TestMemoryAndSkillSecretBlocking:
+    """Verify secrets are blocked from being written to memory and skills."""
+
+    def test_memory_blocks_api_key(self):
+        from tools.memory_tool import _scan_memory_content
+        result = _scan_memory_content("Found key: sk-ant-api03-abc123def456ghi789jkl012mno345")
+        assert result is not None
+        assert "API key" in result or "Blocked" in result
+
+    def test_memory_blocks_env_assignment(self):
+        from tools.memory_tool import _scan_memory_content
+        result = _scan_memory_content("OPENAI_API_KEY=sk-proj-abc123def456ghi789")
+        assert result is not None
+        assert "Blocked" in result
+
+    def test_memory_allows_normal_content(self):
+        from tools.memory_tool import _scan_memory_content
+        result = _scan_memory_content("User prefers dark mode and uses TypeScript.")
+        assert result is None
+
+    def test_skill_blocks_api_key(self):
+        from tools.skill_manager_tool import _scan_skill_for_secrets
+        result = _scan_skill_for_secrets("Use this key: sk-ant-api03-abc123def456ghi789jkl012mno345")
+        assert result is not None
+        assert "Blocked" in result
+
+    def test_skill_blocks_env_assignment(self):
+        from tools.skill_manager_tool import _scan_skill_for_secrets
+        result = _scan_skill_for_secrets("ANTHROPIC_TOKEN=sk-ant-oat01-abc123def456ghi789")
+        assert result is not None
+        assert "Blocked" in result
+
+    def test_skill_allows_normal_content(self):
+        from tools.skill_manager_tool import _scan_skill_for_secrets
+        result = _scan_skill_for_secrets("# My Skill\n\nThis skill helps with coding tasks.")
+        assert result is None

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -596,6 +596,13 @@ def execute_code(
         stdout_text = strip_ansi(stdout_text)
         stderr_text = strip_ansi(stderr_text)
 
+        # Redact secrets from script output — same as terminal_tool.
+        # Without this, execute_code can exfiltrate .env secrets via
+        # `import os; print(os.environ)` bypassing terminal redaction.
+        from agent.redact import redact_sensitive_text
+        stdout_text = redact_sensitive_text(stdout_text)
+        stderr_text = redact_sensitive_text(stderr_text)
+
         # Build response
         result: Dict[str, Any] = {
             "status": status,

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -84,6 +84,15 @@ def _scan_memory_content(content: str) -> Optional[str]:
         if re.search(pattern, content, re.IGNORECASE):
             return f"Blocked: content matches threat pattern '{pid}'. Memory entries are injected into the system prompt and must not contain injection or exfiltration payloads."
 
+    # Block raw secrets — memory is persisted to disk and injected into
+    # every future system prompt. A prompt injection that saves a secret
+    # to memory would exfiltrate it across sessions.
+    from agent.redact import _PREFIX_RE, _ENV_ASSIGN_RE
+    if _PREFIX_RE.search(content):
+        return "Blocked: content contains what appears to be an API key or token. Secrets must not be stored in memory."
+    if _ENV_ASSIGN_RE.search(content):
+        return "Blocked: content contains a secret assignment (KEY=value pattern). Secrets must not be stored in memory."
+
     return None
 
 

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -525,6 +525,18 @@ def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
 # Main entry point
 # =============================================================================
 
+def _scan_skill_for_secrets(text: str) -> Optional[str]:
+    """Block raw secrets from being written into skill files."""
+    if not text:
+        return None
+    from agent.redact import _PREFIX_RE, _ENV_ASSIGN_RE
+    if _PREFIX_RE.search(text):
+        return "Blocked: content contains what appears to be an API key or token. Secrets must not be stored in skills."
+    if _ENV_ASSIGN_RE.search(text):
+        return "Blocked: content contains a secret assignment (KEY=value pattern). Secrets must not be stored in skills."
+    return None
+
+
 def skill_manage(
     action: str,
     name: str,
@@ -541,6 +553,13 @@ def skill_manage(
 
     Returns JSON string with results.
     """
+    # Block secrets from being persisted in skill files
+    for text in (content, file_content, new_string):
+        if text:
+            secret_err = _scan_skill_for_secrets(text)
+            if secret_err:
+                return json.dumps({"success": False, "error": secret_err}, ensure_ascii=False)
+
     if action == "create":
         if not content:
             return json.dumps({"success": False, "error": "content is required for 'create'. Provide the full SKILL.md text (frontmatter + body)."}, ensure_ascii=False)


### PR DESCRIPTION
## Summary

Multiple secret exfiltration vectors where API keys and tokens from `.env` could leak into LLM context or persistent storage, bypassing existing redaction.

## Vulnerabilities Fixed

### 1. execute_code (PTC) — raw stdout returned without redaction
`execute_code` runs Python scripts and returns stdout to LLM context. No redaction was applied:
```python
import os; print(os.environ["ANTHROPIC_API_KEY"])
```
This bypasses `terminal_tool`'s redaction entirely.

**Fix:** Apply `redact_sensitive_text` to stdout and stderr in `code_execution_tool.py`.

### 2. All tool results — no defense-in-depth redaction
Only `terminal_tool` and `file_tools` had redaction. Browser, MCP, vision, delegate, and all other tools returned raw output to LLM context.

**Fix:** Add `redact_sensitive_text` to both sequential and concurrent tool result paths in `run_agent.py` — catches any tool that doesn't redact internally.

### 3. Memory persistence — secrets writable to memory files
Memory entries are injected into the system prompt on every session. A prompt injection that saves `ANTHROPIC_API_KEY=sk-ant-...` to memory would exfiltrate it across all future sessions.

**Fix:** Add API key and KEY=value pattern scanning to `_scan_memory_content` in `memory_tool.py`.

### 4. Skill persistence — secrets writable to skill files
Skill files are loaded into context when referenced. Same exfiltration vector as memory.

**Fix:** Add `_scan_skill_for_secrets` to `skill_manage` — blocks create, edit, patch, and write_file actions containing secrets.

## What was vulnerable

| Vector | Had protection? | Fix |
|--------|----------------|-----|
| terminal_tool output | Yes (existing) | — |
| file_tools read | Yes (existing) | — |
| execute_code stdout | **No** | redact_sensitive_text on stdout/stderr |
| All tool results → LLM | **No** | defense-in-depth in run_agent.py |
| Memory persistence | **No** | secret pattern scanning |
| Skill persistence | **No** | secret pattern scanning |



## Test plan

- [x] 48 redaction tests passing (38 existing + 10 new)
- [x] execute_code: env var, OpenRouter key, multi-key dump, non-secret passthrough
- [x] memory: blocks API key, blocks env assignment, allows normal content
- [x] skill: blocks API key, blocks env assignment, allows normal content