### PR TITLE
fix(agent/redact): preserve lowercase Python variable assignments from redaction

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -51,10 +51,10 @@ _PREFIX_PATTERNS = [
 ]
 
 # ENV assignment patterns: KEY=value where KEY contains a secret-like name
+# Must be ALL uppercase (environment variables, not Python variables like before_tokens)
 _SECRET_ENV_NAMES = r"(?:API_?KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|AUTH)"
 _ENV_ASSIGN_RE = re.compile(
-    rf"([A-Z_]{{0,50}}{_SECRET_ENV_NAMES}[A-Z_]{{0,50}})\s*=\s*(['\"]?)(\S+)\2",
-    re.IGNORECASE,
+    rf"(?:^|\s)([A-Z_]{{1,64}}{_SECRET_ENV_NAMES}[A-Z_]{{0,64}})\s*=\s*(['\"]?)(\S+)\2",
 )
 
 # JSON field patterns: "apiKey": "value", "token": "value", etc.

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -82,6 +82,21 @@ class TestEnvAssignments:
         result = redact_sensitive_text(text)
         assert result == text
 
+    def test_lowercase_python_vars_not_redacted(self):
+        """Regression test: lowercase Python variable assignments should NOT be redacted.
+        
+        This was causing issues with code like:
+        before_tokens = self._estimate_current_context_tokens()
+        """
+        test_cases = [
+            "before_tokens = self._estimate_current_context_tokens()",
+            "my_token = some_value",
+            "api_key = secret",
+        ]
+        for text in test_cases:
+            result = redact_sensitive_text(text)
+            assert result == text, f"Expected '{text}' to remain unchanged, got '{result}'"
+
 
 class TestJsonFields:
     def test_json_api_key(self):


### PR DESCRIPTION
# Fix: Preserve lowercase Python variable assignments from redaction

## Problem

The redaction regex in `agent/redact.py` incorrectly redacted values of lowercase Python variable assignments, treating them as environment variables containing secrets.

**Before:**
```
before_tokens = self._estimate_current_context_tokens()
```

Was incorrectly transformed to:
```
before_tokens = ***
```

## Root Cause

The `_ENV_ASSIGN_RE` regex used the `re.IGNORECASE` flag, which caused it to match lowercase Python variable names (like `before_tokens`, `api_key`, `my_token`) in addition to uppercase environment variables (like `API_KEY`, `OPENAI_API_KEY`).

## Solution

1. **Removed `re.IGNORECASE` flag** — now only ALL-uppercase environment variables match
2. **Added `(?:(?:^|\s))` anchor** — ensures match starts at beginning of string or after whitespace
3. **Added regression test** — `test_lowercase_python_vars_not_redacted` with 3 test cases

## Changes

### `agent/redact.py`
- Added comment documenting the ALL-uppercase requirement (line 54)
- Changed regex pattern to anchor at start/whitespace
- Removed `re.IGNORECASE` flag

### `tests/agent/test_redact.py`
- Added `test_lowercase_python_vars_not_redacted` method
- Tests 3 cases: `before_tokens`, `my_token`, `api_key`

## Testing

All 39 tests pass:
```bash
python3 -m pytest tests/agent/test_redact.py -v
# 39 passed, 5 warnings in 0.35s
```

## Verification

**Before fix:**
```
"before_tokens = self._estimate_current_context_tokens()" → "before_tokens = ***"
```

**After fix:**
```
"before_tokens = self._estimate_current_context_tokens()" → "before_tokens = self._estimate_current_context_tokens()"
```

---

Closes: #4367 
