### PR TITLE
fix: _is_openai_client_closed false positive with openai SDK method-style is_closed

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3490,7 +3490,12 @@ class AIAgent:
 
         if isinstance(client, Mock):
             return False
-        if bool(getattr(client, "is_closed", False)):
+        # openai SDK exposes is_closed as a method; call it so we check
+        # the return value instead of the always-truthy bound method.
+        is_closed = getattr(client, "is_closed", False)
+        if callable(is_closed):
+            is_closed = is_closed()
+        if bool(is_closed):
             return True
         http_client = getattr(client, "_client", None)
         return bool(getattr(http_client, "is_closed", False))

--- a/tests/test_openai_client_lifecycle.py
+++ b/tests/test_openai_client_lifecycle.py
@@ -187,3 +187,16 @@ def test_streaming_call_recreates_closed_shared_client_before_request(monkeypatc
     assert stale_shared.close_calls >= 1
     assert request_client.close_calls >= 1
     assert len(factory.calls) == 2
+
+
+def test_method_style_is_closed_not_false_positive():
+    """openai SDK is_closed is a method — bool(<bound method>) is always True."""
+
+    class MethodClient:
+        def __init__(self, closed):
+            self._client = SimpleNamespace(is_closed=closed)
+        def is_closed(self):
+            return self._client.is_closed
+
+    assert not run_agent.AIAgent._is_openai_client_closed(MethodClient(closed=False))
+    assert run_agent.AIAgent._is_openai_client_closed(MethodClient(closed=True))


### PR DESCRIPTION
## Summary

- Fix `_is_openai_client_closed` to call `is_closed()` when it's callable instead of checking truthiness of the bound method object
- Add regression test with a method-style `is_closed` client

## Why

The openai SDK (`>=2.21.0`) exposes `is_closed` as a method, not a property:

```python
# openai/_base_client.py
class SyncAPIClient:
    def is_closed(self) -> bool:
        return self._client.is_closed
```

The current check `bool(getattr(client, "is_closed", False))` returns `True` for the bound method object itself (all callables are truthy), so every API call falsely detects the shared client as closed and recreates it — adding an unnecessary TCP+TLS round trip per call to replace a healthy client.

Existing tests don't catch this because `FakeRequestClient` doesn't define `is_closed`, so `getattr` returns the `False` default and falls through to the `_client.is_closed` check which works correctly.

Fixes #4377