### PR TITLE
fix(agent): reset fallback provider state in reset_session_state

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1263,6 +1263,11 @@ class AIAgent:
         # Turn counter (added after reset_session_state was first written — #2635)
         self._user_turn_count = 0
 
+        # Fallback provider state — must reset so each new session starts on
+        # the primary model, not stuck on a fallback from a previous session.
+        self._fallback_index = 0
+        self._fallback_activated = False
+
         # Context compressor internal counters (if present)
         if hasattr(self, "context_compressor") and self.context_compressor:
             self.context_compressor.last_prompt_tokens = 0

--- a/tests/test_fallback_reset.py
+++ b/tests/test_fallback_reset.py
@@ -1,0 +1,105 @@
+"""Tests for fallback state reset in reset_session_state.
+
+When the primary model fails and Hermes falls back to an alternative
+provider, _fallback_index and _fallback_activated are set. But
+reset_session_state() — called between gateway conversations to reuse
+the cached agent — never reset these fields. This means every subsequent
+conversation stays on the fallback model permanently, and once the
+fallback chain is exhausted, fallback protection is disabled forever.
+"""
+
+import pytest
+
+
+class TestFallbackResetOnSessionReset:
+    """run_agent.py — reset_session_state() must reset fallback fields."""
+
+    @staticmethod
+    def _make_agent():
+        """Build a minimal AIAgent bypassing __init__."""
+        from run_agent import AIAgent
+        agent = AIAgent.__new__(AIAgent)
+        # Set minimal attributes needed by reset_session_state
+        agent.session_total_tokens = 100
+        agent.session_input_tokens = 50
+        agent.session_output_tokens = 50
+        agent.session_prompt_tokens = 50
+        agent.session_completion_tokens = 50
+        agent.session_cache_read_tokens = 0
+        agent.session_cache_write_tokens = 0
+        agent.session_reasoning_tokens = 0
+        agent.session_api_calls = 5
+        agent.session_estimated_cost_usd = 0.01
+        agent.session_cost_status = "estimated"
+        agent.session_cost_source = "pricing"
+        agent._user_turn_count = 3
+        agent._fallback_index = 2
+        agent._fallback_activated = True
+        agent._fallback_chain = [
+            {"model": "gpt-4o", "provider": "openai"},
+            {"model": "claude-3", "provider": "anthropic"},
+        ]
+        return agent
+
+    def test_fallback_index_reset_to_zero(self):
+        """_fallback_index must be 0 after reset so fallback starts fresh."""
+        agent = self._make_agent()
+        assert agent._fallback_index == 2  # pre-condition
+
+        agent.reset_session_state()
+
+        assert agent._fallback_index == 0
+
+    def test_fallback_activated_reset_to_false(self):
+        """_fallback_activated must be False after reset."""
+        agent = self._make_agent()
+        assert agent._fallback_activated is True  # pre-condition
+
+        agent.reset_session_state()
+
+        assert agent._fallback_activated is False
+
+    def test_fallback_chain_preserved(self):
+        """The fallback chain itself should not be cleared — only the pointer."""
+        agent = self._make_agent()
+
+        agent.reset_session_state()
+
+        assert len(agent._fallback_chain) == 2
+        assert agent._fallback_chain[0]["model"] == "gpt-4o"
+
+    def test_token_counters_also_reset(self):
+        """Verify token counters are still reset (no regression)."""
+        agent = self._make_agent()
+
+        agent.reset_session_state()
+
+        assert agent.session_total_tokens == 0
+        assert agent.session_api_calls == 0
+        assert agent.session_estimated_cost_usd == 0.0
+
+
+class TestSourceLineVerification:
+    """Verify the source has fallback reset in reset_session_state."""
+
+    @staticmethod
+    def _read_reset_method() -> str:
+        import os
+        base = os.path.dirname(os.path.dirname(__file__))
+        with open(os.path.join(base, "run_agent.py")) as f:
+            src = f.read()
+        start = src.index("def reset_session_state(self)")
+        end = src.index("\n    def ", start + 1)
+        return src[start:end]
+
+    def test_fallback_index_reset_present(self):
+        body = self._read_reset_method()
+        assert "self._fallback_index = 0" in body, (
+            "reset_session_state() missing self._fallback_index = 0"
+        )
+
+    def test_fallback_activated_reset_present(self):
+        body = self._read_reset_method()
+        assert "self._fallback_activated = False" in body, (
+            "reset_session_state() missing self._fallback_activated = False"
+        )


### PR DESCRIPTION
`reset_session_state()` resets all token counters, turn count, and compressor state between gateway conversations — but never resets `_fallback_index` or `_fallback_activated`. Once the primary model fails and fallback activates, every subsequent conversation in the same gateway session stays on the fallback model permanently. Users unknowingly talk to a weaker model for all future messages, with no way to return to the primary short of restarting the gateway. Once the fallback chain is fully exhausted, fallback protection is also permanently disabled for that session.

## Changes Made

Added `self._fallback_index = 0` and `self._fallback_activated = False` to `reset_session_state()` in `run_agent.py`, alongside the existing token/turn/compressor resets.

## How to Test

```bash
python3 -m pytest tests/test_fallback_reset.py -v
```

6 tests: fallback index reset to 0, fallback activated reset to False, fallback chain preserved (not cleared), token counters still reset (no regression), source line verification for both fields.

## Checklist

- [x] Tests added (6 tests)
- [x] Full test suite run — no regressions
- [x] Tested on Linux (Ubuntu 22.04)