### PR TITLE
fix: _is_openai_client_closed handles is_closed as method (openai SDK >=2.21.0)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3453,10 +3453,16 @@ class AIAgent:
 
         if isinstance(client, Mock):
             return False
-        if bool(getattr(client, "is_closed", False)):
+        is_closed = getattr(client, "is_closed", None)
+        if callable(is_closed):
+            if is_closed():
+                return True
+        elif bool(is_closed):
             return True
         http_client = getattr(client, "_client", None)
-        return bool(getattr(http_client, "is_closed", False))
+        if http_client is not None:
+            return bool(getattr(http_client, "is_closed", False))
+        return False
 
     def _create_openai_client(self, client_kwargs: dict, *, reason: str, shared: bool) -> Any:
         if self.provider == "copilot-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://copilot"):


### PR DESCRIPTION
## Bug: `_is_openai_client_closed` false positive — openai SDK `is_closed` is a method, not a property

Fixes #4377

### Problem
In openai SDK v2.21.0+, `OpenAI.is_closed` is a **bound method**, not a bool property. The old code:

```python
if bool(getattr(client, "is_closed", False)):
```

`bool(<bound method>)` is **always `True`**, even when the client is open. This causes every API call to:
1. Falsely detect the shared client as closed
2. Create a new shared client (TCP + TLS handshake)
3. Close the old healthy client
4. Create a per-request client (another TCP + TLS handshake)
5. Close the per-request client after the stream

This adds ~100-200ms of connection overhead per API call.

### Fix
Check if `is_closed` is callable and call it if so:

```python
is_closed = getattr(client, "is_closed", None)
if callable(is_closed):
    if is_closed():
        return True
elif bool(is_closed):
    return True
http_client = getattr(client, "_client", None)
if http_client is not None:
    return bool(getattr(http_client, "is_closed", False))
return False
```

Also guard against `http_client` being `None`.