### PR TITLE
fix(cli): UnboundLocalError for ctx_len in compact banner path

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2162,12 +2162,13 @@ class HermesCLI:
     def show_banner(self):
         """Display the welcome banner in Claude Code style."""
         self.console.clear()
-        
+
         # Auto-compact for narrow terminals — the full banner with caduceus
         # + tool list needs ~80 columns minimum to render without wrapping.
         term_width = shutil.get_terminal_size().columns
         use_compact = self.compact or term_width < 80
-        
+
+        ctx_len = None
         if use_compact:
             self.console.print(_build_compact_banner())
             self._show_status()
@@ -2179,7 +2180,6 @@ class HermesCLI:
             cwd = os.getenv("TERMINAL_CWD", os.getcwd())
             
             # Get context length for display
-            ctx_len = None
             if hasattr(self, 'agent') and self.agent and hasattr(self.agent, 'context_compressor'):
                 ctx_len = self.agent.context_compressor.context_length
             


### PR DESCRIPTION
## Summary
- `ctx_len` was only initialized inside the full-banner `else` branch but referenced unconditionally on line 2201, causing `UnboundLocalError` when the terminal is narrower than 80 columns (compact banner path).
- Moves initialization before the `if`/`else` so both paths have access.

## Repro
1. Resize terminal to < 80 columns
2. Run `hermes`
3. Crash: `UnboundLocalError: cannot access local variable 'ctx_len'`

## Test plan
- [x] Run `hermes` in a terminal < 80 cols wide — no crash
- [ ] Run `hermes` in a terminal >= 80 cols wide — banner displays normally with context length warning if applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)