### PR TITLE
fix: skip empty/whitespace text in Telegram send to prevent 400 errors

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -742,6 +742,10 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot:
             return SendResult(success=False, error="Not connected")
         
+        # Skip whitespace-only text to prevent Telegram 400 empty-text errors.
+        if not content or not content.strip():
+            return SendResult(success=True, message_id=None)
+        
         try:
             # Format and split message if needed
             formatted = self.format_message(content)


### PR DESCRIPTION
Salvage of #4274 by @SHL0MS. Cherry-picked onto current main.

Adds a 3-line guard at the top of `TelegramAdapter.send()` — returns `SendResult(success=True)` for empty/whitespace content instead of letting it hit the Telegram API (which rejects with 400).

Closes #4274.