### PR TITLE
Fix UnboundLocalError in show_banner() for compact mode

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2163,6 +2163,11 @@ class HermesCLI:
         """Display the welcome banner in Claude Code style."""
         self.console.clear()
         
+        # Get context length for display and warnings (initialize early to avoid UnboundLocalError)
+        ctx_len = None
+        if hasattr(self, 'agent') and self.agent and hasattr(self.agent, 'context_compressor'):
+            ctx_len = self.agent.context_compressor.context_length
+        
         # Auto-compact for narrow terminals — the full banner with caduceus
         # + tool list needs ~80 columns minimum to render without wrapping.
         term_width = shutil.get_terminal_size().columns
@@ -2177,11 +2182,6 @@ class HermesCLI:
             
             # Get terminal working directory (where commands will execute)
             cwd = os.getenv("TERMINAL_CWD", os.getcwd())
-            
-            # Get context length for display
-            ctx_len = None
-            if hasattr(self, 'agent') and self.agent and hasattr(self.agent, 'context_compressor'):
-                ctx_len = self.agent.context_compressor.context_length
             
             # Build and display the banner
             build_welcome_banner(


### PR DESCRIPTION
Fixes a bug where Hermes CLI crashes with UnboundLocalError when using compact banner mode.