### PR TITLE
fix(cli): only pad short responses to anchor prompt near bottom

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7574,10 +7574,15 @@ class HermesCLI:
                         # responses.  patch_stdout renders these newlines
                         # above the input area, creating visual separation
                         # and anchoring the prompt near the bottom.
+                        # Only pad when the response was short enough to
+                        # leave the prompt stranded mid-screen (#4359).
                         try:
-                            _pad = shutil.get_terminal_size().lines // 2
-                            if _pad > 2:
-                                _cprint("\n" * _pad)
+                            _term_h = shutil.get_terminal_size().lines
+                            _resp_lines = response.count('\n') + 1 if response else 0
+                            if _resp_lines < _term_h // 3:
+                                _pad = (_term_h // 3) - _resp_lines
+                                if _pad > 2:
+                                    _cprint("\n" * _pad)
                         except Exception:
                             pass
 


### PR DESCRIPTION
## Problem

The unconditional padding from #4359 injected `terminal_height // 2` blank lines after **every** response, creating excessive whitespace between conversation exchanges — regardless of response length. Even a response with tool output and a full response box got ~20 blank lines appended.
<img width="941" height="1030" alt="screenshot-2026-03-31_21-42-47" src="https://github.com/user-attachments/assets/6009ac0b-6397-459b-9230-59e819943487" />

## Fix

- Only pad when the response is shorter than `terminal_height // 3` lines
- Padding amount is reduced by the actual response length
- Long responses that already fill the screen get zero padding

This preserves the original intent (short responses don't leave the prompt stranded mid-screen) while eliminating the excessive whitespace for normal/long responses.