### PR TITLE
fix(cli): remove post-response blank padding in TUI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1890,6 +1890,13 @@ class HermesCLI:
         self._reasoning_buf = ""
         self._reasoning_preview_buf = ""
 
+    def _finish_agent_turn(self) -> None:
+        """Reset foreground turn state without emitting spacer output."""
+        self._agent_running = False
+        self._spinner_text = ""
+        if self._app:
+            self._app.invalidate()
+
     def _slow_command_status(self, command: str) -> str:
         """Return a user-facing status message for slower slash commands."""
         cmd_lower = command.lower().strip()
@@ -7566,22 +7573,7 @@ class HermesCLI:
                     try:
                         self.chat(user_input, images=submit_images or None)
                     finally:
-                        self._agent_running = False
-                        self._spinner_text = ""
-
-                        # Push the input prompt toward the bottom of the
-                        # terminal so it doesn't sit mid-screen after short
-                        # responses.  patch_stdout renders these newlines
-                        # above the input area, creating visual separation
-                        # and anchoring the prompt near the bottom.
-                        try:
-                            _pad = shutil.get_terminal_size().lines // 2
-                            if _pad > 2:
-                                _cprint("\n" * _pad)
-                        except Exception:
-                            pass
-
-                        app.invalidate()  # Refresh status line
+                        self._finish_agent_turn()
 
                         # Continuous voice: auto-restart recording after agent responds.
                         # Dispatch to a daemon thread so play_beep (sd.wait) and

--- a/tests/test_cli_prompt_spacing.py
+++ b/tests/test_cli_prompt_spacing.py
@@ -1,0 +1,39 @@
+"""Regression tests for CLI prompt spacing after foreground responses."""
+
+from unittest.mock import MagicMock, patch
+
+from cli import HermesCLI
+
+
+def _make_cli():
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj._agent_running = True
+    cli_obj._spinner_text = "thinking"
+    cli_obj._app = None
+    return cli_obj
+
+
+def test_finish_agent_turn_refreshes_status_without_printing_blank_padding():
+    """Foreground turn cleanup should not emit spacer newlines."""
+    cli_obj = _make_cli()
+    cli_obj._app = MagicMock()
+
+    with patch("cli._cprint") as mock_cprint:
+        cli_obj._finish_agent_turn()
+
+    assert cli_obj._agent_running is False
+    assert cli_obj._spinner_text == ""
+    cli_obj._app.invalidate.assert_called_once_with()
+    mock_cprint.assert_not_called()
+
+
+def test_finish_agent_turn_skips_invalidate_when_no_tui_app():
+    """Non-TUI callers can reuse the cleanup helper safely."""
+    cli_obj = _make_cli()
+
+    with patch("cli._cprint") as mock_cprint:
+        cli_obj._finish_agent_turn()
+
+    assert cli_obj._agent_running is False
+    assert cli_obj._spinner_text == ""
+    mock_cprint.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

Removes the extra post-response newline padding in the CLI TUI.

The CLI was inserting a large block of blank lines after each response to push the prompt lower in the terminal. In practice, this created a giant empty gap after short replies and made the interface feel broken during normal chat use.

This change removes that spacer output so the prompt appears directly after the response again.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Removed the post-response newline padding block in `cli.py`
- Added a small foreground turn cleanup helper to keep the behavior testable
- Added a regression test in `tests/test_cli_prompt_spacing.py` to verify CLI turn cleanup does not emit blank spacer output

## How to Test

1. Run `hermes`
2. Send a short message in the CLI
3. Verify the prompt appears directly after the response, without a large blank gap
4. Repeat with a few short turns to confirm the terminal no longer accumulates large blank spacer blocks

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before:
- Short CLI responses left a large blank block before the next prompt

After:
- The prompt appears immediately after the response with no artificial vertical padding

## Test Notes

Targeted tests for this change pass:

- `pytest tests/test_cli_prompt_spacing.py -q`
- `pytest tests/test_cli_background_tui_refresh.py -q`

I also ran the full suite with `pytest tests/ -v`, but it is not fully green on the current branch/worktree. The failures I saw were outside this CLI spacing change, including existing failures in:

- `tests/gateway/test_api_server.py`
- `tests/test_api_key_providers.py`
- `tests/test_cli_init.py`
- `tests/agent/test_auxiliary_client.py`
- `tests/hermes_cli/test_models.py`
- `tests/tools/test_delegate.py`
- `tests/tools/test_tirith_security.py`
- `tests/tools/test_file_read_guards.py`
