### PR TITLE
fix(cli): initialize ctx_len before compact banner path

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2162,6 +2162,7 @@ class HermesCLI:
     def show_banner(self):
         """Display the welcome banner in Claude Code style."""
         self.console.clear()
+        ctx_len = None
         
         # Auto-compact for narrow terminals — the full banner with caduceus
         # + tool list needs ~80 columns minimum to render without wrapping.
@@ -2179,7 +2180,6 @@ class HermesCLI:
             cwd = os.getenv("TERMINAL_CWD", os.getcwd())
             
             # Get context length for display
-            ctx_len = None
             if hasattr(self, 'agent') and self.agent and hasattr(self.agent, 'context_compressor'):
                 ctx_len = self.agent.context_compressor.context_length
             

--- a/tests/test_cli_context_warning.py
+++ b/tests/test_cli_context_warning.py
@@ -42,6 +42,17 @@ def cli_obj(_isolate):
 class TestLowContextWarning:
     """Tests that the CLI warns about low context lengths."""
 
+    def test_compact_banner_does_not_crash_when_context_length_unknown(self, cli_obj):
+        """Compact banner path should not reference an uninitialized ctx_len."""
+        cli_obj.compact = True
+        cli_obj.agent.context_compressor.context_length = None
+        with patch("cli._build_compact_banner", return_value="compact"), \
+             patch.object(cli_obj, "_show_status"):
+            cli_obj.show_banner()
+
+        calls = [str(c) for c in cli_obj.console.print.call_args_list]
+        assert any("compact" in c for c in calls)
+
     def test_no_warning_for_normal_context(self, cli_obj):
         """No warning when context is 32k+."""
         cli_obj.agent.context_compressor.context_length = 32768


### PR DESCRIPTION
## What does this PR do?

Fixes a CLI startup crash in the compact banner path.

When Hermes starts in compact mode, `show_banner()` could reference `ctx_len` before it was initialized. This caused an `UnboundLocalError` during startup instead of showing the banner.

This change initializes `ctx_len` before the compact/non-compact branch so both paths are safe.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Initialized `ctx_len` before the compact banner branch in `cli.py`
- Added a regression test in `tests/test_cli_context_warning.py` covering compact mode with unknown context length

## How to Test

1. Start `hermes` in a narrow terminal or with compact mode enabled
2. Verify the CLI starts normally
3. Confirm the banner renders instead of crashing with `UnboundLocalError`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Test Notes

Targeted tests for this change pass:

- `pytest tests/test_cli_context_warning.py -q`
- `pytest tests/hermes_cli/test_banner.py -q`
