### PR TITLE
feat(skills): smart ranking, usage tracking, and lifecycle management

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -9,6 +9,7 @@ import logging
 import os
 import re
 import threading
+import time
 from collections import OrderedDict
 from pathlib import Path
 
@@ -273,6 +274,136 @@ _SKILLS_PROMPT_CACHE_LOCK = threading.Lock()
 _SKILLS_SNAPSHOT_VERSION = 1
 
 
+_KEYWORD_STOPWORDS = frozenset({
+    "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
+    "have", "has", "had", "do", "does", "did", "will", "would", "could",
+    "should", "may", "might", "can", "shall", "to", "of", "in", "for",
+    "on", "with", "at", "by", "from", "as", "into", "through", "during",
+    "before", "after", "above", "below", "between", "and", "but", "or",
+    "not", "no", "nor", "so", "yet", "both", "either", "neither", "each",
+    "every", "all", "any", "few", "more", "most", "other", "some", "such",
+    "than", "too", "very", "just", "about", "this", "that", "these", "those",
+    "i", "me", "my", "we", "our", "you", "your", "he", "she", "it", "they",
+    "them", "what", "which", "who", "when", "where", "how", "why",
+})
+_KEYWORD_STRIP_RE = re.compile(r"[^\w\s-]")
+
+# Suffix stemmer: "debugging" → "debug", "deployment" → "deploy".
+# Only strips if remainder >= 3 chars.
+_STEM_SUFFIXES = (
+    "ation", "ment", "ting", "ing", "ness", "ous", "ive",
+    "ize", "ise", "ful", "less", "able", "ible", "ally",
+    "ily", "ion", "ers", "ler", "est", "ity",
+    "ly", "ed", "er", "es", "al",
+    "s",
+)
+
+# Bridges gaps that stemming can't: "tweet" → "twitter", "bug" → "debug".
+# Only entries where the user's word shares no stem with the skill metadata.
+# Plurals/verb forms are handled by _stem(), don't duplicate them here.
+_SYNONYMS: dict[str, list[str]] = {
+    "tweet": ["twitter", "x"],
+    "toot": ["mastodon"],
+    "post": ["social", "twitter", "blog"],
+    "bug": ["debug", "troubleshoot"],
+    "crash": ["debug", "error", "troubleshoot"],
+    "code": ["programming", "software"],
+    "server": ["linux", "deploy", "infrastructure"],
+    "container": ["docker", "kubernetes", "k8s"],
+    "cluster": ["kubernetes", "k8s"],
+    "cloud": ["aws", "terraform", "deploy"],
+    "ci": ["pipeline", "actions", "cd"],
+    "cd": ["pipeline", "deploy", "ci"],
+    "ai": ["ml", "llm", "model"],
+    "train": ["ml", "pytorch", "finetuning"],
+    "finetune": ["lora", "qlora", "llm"],
+    "vectordb": ["vector", "rag", "pinecone", "chroma", "qdrant"],
+    "website": ["web", "html", "frontend"],
+    "backend": ["api", "server", "fastapi"],
+    "auth": ["authentication", "oauth", "jwt"],
+    "doc": ["documentation", "writing"],
+    "paper": ["research", "arxiv", "academic"],
+    "find": ["search", "locate", "nearby"],
+    "nearby": ["location", "restaurant", "place"],
+    "monitor": ["monitoring", "prometheus", "grafana"],
+    "diagram": ["diagramming", "architecture", "chart"],
+    "test": ["testing", "pytest", "tdd"],
+}
+
+# Merge weights for usage-based scores vs keyword relevance.
+# Relevance is weighted higher so query-relevant skills beat
+# daily-driver habits when the user asks about something specific.
+_USAGE_WEIGHT = 1.0
+_RELEVANCE_WEIGHT = 3.0
+_BASE_SCORE = 0.01
+_HEADER_FOOTER_TOKENS = 80
+
+
+def _stem(word: str) -> str:
+    """Strip common English suffixes, keeping stems >= 3 chars."""
+    for suffix in _STEM_SUFFIXES:
+        if word.endswith(suffix) and len(word) - len(suffix) >= 3:
+            return word[:-len(suffix)]
+    return word
+
+
+def _expand_keywords(words: set[str]) -> set[str]:
+    """Expand keywords with stems and synonyms."""
+    expanded = set(words)
+    for word in words:
+        stem = _stem(word)
+        expanded.add(stem)
+        for lookup in (word, stem):
+            if lookup in _SYNONYMS:
+                expanded.update(_SYNONYMS[lookup])
+    return expanded
+
+
+def _estimate_tokens(text: str) -> int:
+    """Rough token estimate: ~3.5 chars per token for English text."""
+    return max(1, len(text) // 4)
+
+
+def compute_keyword_relevance(
+    user_message: str,
+    skill_entries: "list[dict]",
+) -> dict[str, float]:
+    """Score skills by Jaccard similarity to user message keywords.
+
+    Both sides are expanded with stems and synonyms before matching.
+    Returns {skill_name: 0.0–10.0}.
+    """
+    if not user_message or not skill_entries:
+        return {}
+
+    user_words = set(_KEYWORD_STRIP_RE.sub("", user_message.lower()).split())
+    user_keywords = user_words - _KEYWORD_STOPWORDS
+    if not user_keywords:
+        return {}
+    user_expanded = _expand_keywords(user_keywords)
+
+    scores: dict[str, float] = {}
+    for entry in skill_entries:
+        name = entry.get("skill_name", "")
+        skill_words: set[str] = set()
+        for field in [name, entry.get("description", ""), entry.get("category", "")]:
+            skill_words.update(
+                _KEYWORD_STRIP_RE.sub("", str(field).lower()).replace("-", " ").split()
+            )
+        for tag in entry.get("tags", []):
+            skill_words.update(str(tag).lower().replace("-", " ").split())
+        skill_words -= _KEYWORD_STOPWORDS
+        if not skill_words:
+            continue
+
+        skill_expanded = _expand_keywords(skill_words)
+        matched = user_expanded & skill_expanded
+        if matched:
+            scores[name] = len(matched) / len(user_expanded | skill_expanded) * 10.0
+
+    return scores
+
+
 def _skills_prompt_snapshot_path() -> Path:
     return get_hermes_home() / ".skills_prompt_snapshot.json"
 
@@ -358,6 +489,17 @@ def _build_snapshot_entry(
     if isinstance(platforms, str):
         platforms = [platforms]
 
+    # Extract tags for keyword relevance matching
+    hermes_meta = {}
+    metadata = frontmatter.get("metadata")
+    if isinstance(metadata, dict):
+        hermes_meta = metadata.get("hermes", {}) or {}
+    raw_tags = hermes_meta.get("tags") or frontmatter.get("tags", [])
+    if isinstance(raw_tags, str):
+        raw_tags = [t.strip() for t in raw_tags.split(",") if t.strip()]
+    elif not isinstance(raw_tags, list):
+        raw_tags = []
+
     return {
         "skill_name": skill_name,
         "category": category,
@@ -365,6 +507,7 @@ def _build_snapshot_entry(
         "description": description,
         "platforms": [str(p).strip() for p in platforms if str(p).strip()],
         "conditions": extract_skill_conditions(frontmatter),
+        "tags": [str(t) for t in raw_tags],
     }
 
 
@@ -436,6 +579,12 @@ def _skill_should_show(
 def build_skills_system_prompt(
     available_tools: "set[str] | None" = None,
     available_toolsets: "set[str] | None" = None,
+    *,
+    token_budget: int = 0,
+    max_prompt_skills: int = 0,
+    pinned_skills: "list[str] | None" = None,
+    skill_scores: "dict[str, float] | None" = None,
+    user_message: str = None,
 ) -> str:
     """Build a compact skill index for the system prompt.
 
@@ -450,20 +599,33 @@ def build_skills_system_prompt(
     scanned alongside the local ``~/.hermes/skills/`` directory.  External dirs
     are read-only — they appear in the index but new skills are always created
     in the local dir.  Local skills take precedence when names collide.
+
+    Args:
+        token_budget: Max tokens for the skills section (0 = unlimited).
+        max_prompt_skills: Hard cap on skill count (0 = unlimited).
+        pinned_skills: Skill names always included regardless of budget.
+        skill_scores: Optional dict of skill_name → score for ranking.
+        user_message: First user message for keyword relevance boosting.
     """
     hermes_home = get_hermes_home()
     skills_dir = hermes_home / "skills"
     external_dirs = get_all_skills_dirs()[1:]  # skip local (index 0)
+    pinned = set(pinned_skills or [])
 
     if not skills_dir.exists() and not external_dirs:
         return ""
 
-    # ── Layer 1: in-process LRU cache ─────────────────────────────────
+    _score_bucket = int(time.time()) // 3600
     cache_key = (
         str(skills_dir.resolve()),
         tuple(str(d) for d in external_dirs),
         tuple(sorted(str(t) for t in (available_tools or set()))),
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
+        token_budget,
+        max_prompt_skills,
+        tuple(sorted(pinned)),
+        _score_bucket,
+        bool(skill_scores),
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
@@ -476,12 +638,18 @@ def build_skills_system_prompt(
     # ── Layer 2: disk snapshot ────────────────────────────────────────
     snapshot = _load_skills_snapshot(skills_dir)
 
-    skills_by_category: dict[str, list[tuple[str, str]]] = {}
+    # Collect all eligible skills as flat list: (skill_name, description, category)
+    all_skills: list[tuple[str, str, str]] = []
     category_descriptions: dict[str, str] = {}
+
+    # relevance_entries: list of dicts with skill metadata for keyword matching.
+    # Populated from whichever path (snapshot or cold scan) we take.
+    relevance_entries: list[dict] = []
 
     if snapshot is not None:
         # Fast path: use pre-parsed metadata from disk
-        for entry in snapshot.get("skills", []):
+        relevance_entries = snapshot.get("skills", [])
+        for entry in relevance_entries:
             if not isinstance(entry, dict):
                 continue
             skill_name = entry.get("skill_name") or ""
@@ -498,9 +666,7 @@ def build_skills_system_prompt(
                 available_toolsets,
             ):
                 continue
-            skills_by_category.setdefault(category, []).append(
-                (skill_name, entry.get("description", ""))
-            )
+            all_skills.append((skill_name, entry.get("description", ""), category))
         category_descriptions = {
             str(k): str(v)
             for k, v in (snapshot.get("category_descriptions") or {}).items()
@@ -523,9 +689,9 @@ def build_skills_system_prompt(
                 available_toolsets,
             ):
                 continue
-            skills_by_category.setdefault(entry["category"], []).append(
-                (skill_name, entry["description"])
-            )
+            all_skills.append((skill_name, entry["description"], entry["category"]))
+
+        relevance_entries = skill_entries
 
         # Read category-level DESCRIPTION.md files
         for desc_file in iter_skill_index_files(skills_dir, "DESCRIPTION.md"):
@@ -548,14 +714,9 @@ def build_skills_system_prompt(
             category_descriptions,
         )
 
-    # ── External skill directories ─────────────────────────────────────
-    # Scan external dirs directly (no snapshot caching — they're read-only
-    # and typically small).  Local skills already in skills_by_category take
-    # precedence: we track seen names and skip duplicates from external dirs.
-    seen_skill_names: set[str] = set()
-    for cat_skills in skills_by_category.values():
-        for name, _desc in cat_skills:
-            seen_skill_names.add(name)
+    # External skill directories — scan directly (no snapshot caching).
+    # Local skills take precedence: skip duplicates from external dirs.
+    seen_skill_names = {s[0] for s in all_skills}
 
     for ext_dir in external_dirs:
         if not ext_dir.exists():
@@ -578,13 +739,11 @@ def build_skills_system_prompt(
                 ):
                     continue
                 seen_skill_names.add(skill_name)
-                skills_by_category.setdefault(entry["category"], []).append(
-                    (skill_name, entry["description"])
-                )
+                all_skills.append((skill_name, entry["description"], entry["category"]))
+                relevance_entries.append(entry)
             except Exception as e:
                 logger.debug("Error reading external skill %s: %s", skill_file, e)
 
-        # External category descriptions
         for desc_file in iter_skill_index_files(ext_dir, "DESCRIPTION.md"):
             try:
                 content = desc_file.read_text(encoding="utf-8")
@@ -598,26 +757,84 @@ def build_skills_system_prompt(
             except Exception as e:
                 logger.debug("Could not read external skill description %s: %s", desc_file, e)
 
-    if not skills_by_category:
+    if not all_skills:
         result = ""
     else:
+        # Normalize both signals to 0–1 before combining.
+        raw_usage = dict(skill_scores or {})
+        max_usage = max(raw_usage.values()) if raw_usage else 1.0
+
+        relevance: dict[str, float] = {}
+        if user_message and relevance_entries:
+            relevance = compute_keyword_relevance(user_message, relevance_entries)
+
+        merged_scores: dict[str, float] = {}
+        for name, _, _ in all_skills:
+            norm_usage = (raw_usage.get(name, 0.0) / max_usage) if max_usage else 0.0
+            norm_relevance = relevance.get(name, 0.0) / 10.0
+            merged_scores[name] = (
+                _USAGE_WEIGHT * norm_usage
+                + _RELEVANCE_WEIGHT * norm_relevance
+                + _BASE_SCORE
+            )
+
+        all_skills.sort(key=lambda s: (s[0] not in pinned, -merged_scores.get(s[0], _BASE_SCORE), s[0]))
+        total_skill_count = len(all_skills)
+
+        if max_prompt_skills > 0 and len(all_skills) > max_prompt_skills:
+            pinned_list = [s for s in all_skills if s[0] in pinned]
+            non_pinned = [s for s in all_skills if s[0] not in pinned]
+            all_skills = pinned_list + non_pinned[:max(0, max_prompt_skills - len(pinned_list))]
+
+        if token_budget > 0:
+            budget_remaining = token_budget - _HEADER_FOOTER_TOKENS
+            included: list[tuple[str, str, str]] = []
+            seen_categories: set[str] = set()
+
+            for name, desc, cat in all_skills:
+                cat_cost = 0
+                if cat not in seen_categories:
+                    cat_cost = _estimate_tokens(f"  {cat}: {category_descriptions.get(cat, '')}")
+                line_tokens = _estimate_tokens(f"    - {name}: {desc}" if desc else f"    - {name}") + cat_cost
+                if name in pinned or budget_remaining >= line_tokens:
+                    included.append((name, desc, cat))
+                    budget_remaining -= line_tokens
+                    seen_categories.add(cat)
+
+            all_skills = included
+
+        # Flat ranked list when scores drive ordering; grouped by category otherwise.
+        has_scores = bool(skill_scores) or bool(relevance)
         index_lines = []
-        for category in sorted(skills_by_category.keys()):
-            cat_desc = category_descriptions.get(category, "")
-            if cat_desc:
-                index_lines.append(f"  {category}: {cat_desc}")
-            else:
-                index_lines.append(f"  {category}:")
-            # Deduplicate and sort skills within each category
-            seen = set()
-            for name, desc in sorted(skills_by_category[category], key=lambda x: x[0]):
+        seen: set[str] = set()
+
+        if has_scores:
+            for name, desc, category in all_skills:
                 if name in seen:
                     continue
                 seen.add(name)
-                if desc:
-                    index_lines.append(f"    - {name}: {desc}")
-                else:
-                    index_lines.append(f"    - {name}")
+                index_lines.append(f"    - {name} [{category}]: {desc}" if desc else f"    - {name} [{category}]")
+        else:
+            skills_by_category: dict[str, list[tuple[str, str]]] = {}
+            for name, desc, category in all_skills:
+                skills_by_category.setdefault(category, []).append((name, desc))
+
+            for category in sorted(skills_by_category.keys()):
+                cat_desc = category_descriptions.get(category, "")
+                index_lines.append(f"  {category}: {cat_desc}" if cat_desc else f"  {category}:")
+                for name, desc in skills_by_category[category]:
+                    if name in seen:
+                        continue
+                    seen.add(name)
+                    index_lines.append(f"    - {name}: {desc}" if desc else f"    - {name}")
+
+        omitted = total_skill_count - len(all_skills)
+        footer = "If none match, proceed normally without loading a skill."
+        if omitted > 0:
+            footer = (
+                f"[{omitted} additional skill(s) available — "
+                f"use skills_list() to discover them]\n\n" + footer
+            )
 
         result = (
             "## Skills (mandatory)\n"
@@ -632,10 +849,9 @@ def build_skills_system_prompt(
             + "\n".join(index_lines) + "\n"
             "</available_skills>\n"
             "\n"
-            "If none match, proceed normally without loading a skill."
+            + footer
         )
 
-    # ── Store in LRU cache ────────────────────────────────────────────
     with _SKILLS_PROMPT_CACHE_LOCK:
         _SKILLS_PROMPT_CACHE[cache_key] = result
         _SKILLS_PROMPT_CACHE.move_to_end(cache_key)

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -9,6 +9,7 @@ import logging
 import os
 import re
 import threading
+import time
 from collections import OrderedDict
 from pathlib import Path
 
@@ -272,6 +273,136 @@ _SKILLS_PROMPT_CACHE_LOCK = threading.Lock()
 _SKILLS_SNAPSHOT_VERSION = 1
 
 
+_KEYWORD_STOPWORDS = frozenset({
+    "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
+    "have", "has", "had", "do", "does", "did", "will", "would", "could",
+    "should", "may", "might", "can", "shall", "to", "of", "in", "for",
+    "on", "with", "at", "by", "from", "as", "into", "through", "during",
+    "before", "after", "above", "below", "between", "and", "but", "or",
+    "not", "no", "nor", "so", "yet", "both", "either", "neither", "each",
+    "every", "all", "any", "few", "more", "most", "other", "some", "such",
+    "than", "too", "very", "just", "about", "this", "that", "these", "those",
+    "i", "me", "my", "we", "our", "you", "your", "he", "she", "it", "they",
+    "them", "what", "which", "who", "when", "where", "how", "why",
+})
+_KEYWORD_STRIP_RE = re.compile(r"[^\w\s-]")
+
+# Suffix stemmer: "debugging" → "debug", "deployment" → "deploy".
+# Only strips if remainder >= 3 chars.
+_STEM_SUFFIXES = (
+    "ation", "ment", "ting", "ing", "ness", "ous", "ive",
+    "ize", "ise", "ful", "less", "able", "ible", "ally",
+    "ily", "ion", "ers", "ler", "est", "ity",
+    "ly", "ed", "er", "es", "al",
+    "s",
+)
+
+# Bridges gaps that stemming can't: "tweet" → "twitter", "bug" → "debug".
+# Only entries where the user's word shares no stem with the skill metadata.
+# Plurals/verb forms are handled by _stem(), don't duplicate them here.
+_SYNONYMS: dict[str, list[str]] = {
+    "tweet": ["twitter", "x"],
+    "toot": ["mastodon"],
+    "post": ["social", "twitter", "blog"],
+    "bug": ["debug", "troubleshoot"],
+    "crash": ["debug", "error", "troubleshoot"],
+    "code": ["programming", "software"],
+    "server": ["linux", "deploy", "infrastructure"],
+    "container": ["docker", "kubernetes", "k8s"],
+    "cluster": ["kubernetes", "k8s"],
+    "cloud": ["aws", "terraform", "deploy"],
+    "ci": ["pipeline", "actions", "cd"],
+    "cd": ["pipeline", "deploy", "ci"],
+    "ai": ["ml", "llm", "model"],
+    "train": ["ml", "pytorch", "finetuning"],
+    "finetune": ["lora", "qlora", "llm"],
+    "vectordb": ["vector", "rag", "pinecone", "chroma", "qdrant"],
+    "website": ["web", "html", "frontend"],
+    "backend": ["api", "server", "fastapi"],
+    "auth": ["authentication", "oauth", "jwt"],
+    "doc": ["documentation", "writing"],
+    "paper": ["research", "arxiv", "academic"],
+    "find": ["search", "locate", "nearby"],
+    "nearby": ["location", "restaurant", "place"],
+    "monitor": ["monitoring", "prometheus", "grafana"],
+    "diagram": ["diagramming", "architecture", "chart"],
+    "test": ["testing", "pytest", "tdd"],
+}
+
+# Merge weights for usage-based scores vs keyword relevance.
+# Relevance is weighted higher so query-relevant skills beat
+# daily-driver habits when the user asks about something specific.
+_USAGE_WEIGHT = 1.0
+_RELEVANCE_WEIGHT = 3.0
+_BASE_SCORE = 0.01
+_HEADER_FOOTER_TOKENS = 80
+
+
+def _stem(word: str) -> str:
+    """Strip common English suffixes, keeping stems >= 3 chars."""
+    for suffix in _STEM_SUFFIXES:
+        if word.endswith(suffix) and len(word) - len(suffix) >= 3:
+            return word[:-len(suffix)]
+    return word
+
+
+def _expand_keywords(words: set[str]) -> set[str]:
+    """Expand keywords with stems and synonyms."""
+    expanded = set(words)
+    for word in words:
+        stem = _stem(word)
+        expanded.add(stem)
+        for lookup in (word, stem):
+            if lookup in _SYNONYMS:
+                expanded.update(_SYNONYMS[lookup])
+    return expanded
+
+
+def _estimate_tokens(text: str) -> int:
+    """Rough token estimate: ~3.5 chars per token for English text."""
+    return max(1, len(text) // 4)
+
+
+def compute_keyword_relevance(
+    user_message: str,
+    skill_entries: "list[dict]",
+) -> dict[str, float]:
+    """Score skills by Jaccard similarity to user message keywords.
+
+    Both sides are expanded with stems and synonyms before matching.
+    Returns {skill_name: 0.0–10.0}.
+    """
+    if not user_message or not skill_entries:
+        return {}
+
+    user_words = set(_KEYWORD_STRIP_RE.sub("", user_message.lower()).split())
+    user_keywords = user_words - _KEYWORD_STOPWORDS
+    if not user_keywords:
+        return {}
+    user_expanded = _expand_keywords(user_keywords)
+
+    scores: dict[str, float] = {}
+    for entry in skill_entries:
+        name = entry.get("skill_name", "")
+        skill_words: set[str] = set()
+        for field in [name, entry.get("description", ""), entry.get("category", "")]:
+            skill_words.update(
+                _KEYWORD_STRIP_RE.sub("", str(field).lower()).replace("-", " ").split()
+            )
+        for tag in entry.get("tags", []):
+            skill_words.update(str(tag).lower().replace("-", " ").split())
+        skill_words -= _KEYWORD_STOPWORDS
+        if not skill_words:
+            continue
+
+        skill_expanded = _expand_keywords(skill_words)
+        matched = user_expanded & skill_expanded
+        if matched:
+            scores[name] = len(matched) / len(user_expanded | skill_expanded) * 10.0
+
+    return scores
+
+
 def _skills_prompt_snapshot_path() -> Path:
     return get_hermes_home() / ".skills_prompt_snapshot.json"
 
@@ -357,6 +488,17 @@ def _build_snapshot_entry(
     if isinstance(platforms, str):
         platforms = [platforms]
 
+    # Extract tags for keyword relevance matching
+    hermes_meta = {}
+    metadata = frontmatter.get("metadata")
+    if isinstance(metadata, dict):
+        hermes_meta = metadata.get("hermes", {}) or {}
+    raw_tags = hermes_meta.get("tags") or frontmatter.get("tags", [])
+    if isinstance(raw_tags, str):
+        raw_tags = [t.strip() for t in raw_tags.split(",") if t.strip()]
+    elif not isinstance(raw_tags, list):
+        raw_tags = []
+
     return {
         "skill_name": skill_name,
         "category": category,
@@ -364,6 +506,7 @@ def _build_snapshot_entry(
         "description": description,
         "platforms": [str(p).strip() for p in platforms if str(p).strip()],
         "conditions": extract_skill_conditions(frontmatter),
+        "tags": [str(t) for t in raw_tags],
     }
 
 
@@ -435,6 +578,12 @@ def _skill_should_show(
 def build_skills_system_prompt(
     available_tools: "set[str] | None" = None,
     available_toolsets: "set[str] | None" = None,
+    *,
+    token_budget: int = 0,
+    max_prompt_skills: int = 0,
+    pinned_skills: "list[str] | None" = None,
+    skill_scores: "dict[str, float] | None" = None,
+    user_message: str = None,
 ) -> str:
     """Build a compact skill index for the system prompt.
 
@@ -444,18 +593,31 @@ def build_skills_system_prompt(
          mtime/size manifest — survives process restarts
 
     Falls back to a full filesystem scan when both layers miss.
+
+    Args:
+        token_budget: Max tokens for the skills section (0 = unlimited).
+        max_prompt_skills: Hard cap on skill count (0 = unlimited).
+        pinned_skills: Skill names always included regardless of budget.
+        skill_scores: Optional dict of skill_name → score for ranking.
+        user_message: First user message for keyword relevance boosting.
     """
     hermes_home = get_hermes_home()
     skills_dir = hermes_home / "skills"
+    pinned = set(pinned_skills or [])
 
     if not skills_dir.exists():
         return ""
 
-    # ── Layer 1: in-process LRU cache ─────────────────────────────────
+    _score_bucket = int(time.time()) // 3600
     cache_key = (
         str(skills_dir.resolve()),
         tuple(sorted(str(t) for t in (available_tools or set()))),
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
+        token_budget,
+        max_prompt_skills,
+        tuple(sorted(pinned)),
+        _score_bucket,
+        bool(skill_scores),
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
@@ -468,12 +630,18 @@ def build_skills_system_prompt(
     # ── Layer 2: disk snapshot ────────────────────────────────────────
     snapshot = _load_skills_snapshot(skills_dir)
 
-    skills_by_category: dict[str, list[tuple[str, str]]] = {}
+    # Collect all eligible skills as flat list: (skill_name, description, category)
+    all_skills: list[tuple[str, str, str]] = []
     category_descriptions: dict[str, str] = {}
+
+    # relevance_entries: list of dicts with skill metadata for keyword matching.
+    # Populated from whichever path (snapshot or cold scan) we take.
+    relevance_entries: list[dict] = []
 
     if snapshot is not None:
         # Fast path: use pre-parsed metadata from disk
-        for entry in snapshot.get("skills", []):
+        relevance_entries = snapshot.get("skills", [])
+        for entry in relevance_entries:
             if not isinstance(entry, dict):
                 continue
             skill_name = entry.get("skill_name") or ""
@@ -490,9 +658,7 @@ def build_skills_system_prompt(
                 available_toolsets,
             ):
                 continue
-            skills_by_category.setdefault(category, []).append(
-                (skill_name, entry.get("description", ""))
-            )
+            all_skills.append((skill_name, entry.get("description", ""), category))
         category_descriptions = {
             str(k): str(v)
             for k, v in (snapshot.get("category_descriptions") or {}).items()
@@ -515,9 +681,9 @@ def build_skills_system_prompt(
                 available_toolsets,
             ):
                 continue
-            skills_by_category.setdefault(entry["category"], []).append(
-                (skill_name, entry["description"])
-            )
+            all_skills.append((skill_name, entry["description"], entry["category"]))
+
+        relevance_entries = skill_entries
 
         # Read category-level DESCRIPTION.md files
         for desc_file in iter_skill_index_files(skills_dir, "DESCRIPTION.md"):
@@ -540,26 +706,84 @@ def build_skills_system_prompt(
             category_descriptions,
         )
 
-    if not skills_by_category:
+    if not all_skills:
         result = ""
     else:
+        # Normalize both signals to 0–1 before combining.
+        raw_usage = dict(skill_scores or {})
+        max_usage = max(raw_usage.values()) if raw_usage else 1.0
+
+        relevance: dict[str, float] = {}
+        if user_message and relevance_entries:
+            relevance = compute_keyword_relevance(user_message, relevance_entries)
+
+        merged_scores: dict[str, float] = {}
+        for name, _, _ in all_skills:
+            norm_usage = (raw_usage.get(name, 0.0) / max_usage) if max_usage else 0.0
+            norm_relevance = relevance.get(name, 0.0) / 10.0
+            merged_scores[name] = (
+                _USAGE_WEIGHT * norm_usage
+                + _RELEVANCE_WEIGHT * norm_relevance
+                + _BASE_SCORE
+            )
+
+        all_skills.sort(key=lambda s: (s[0] not in pinned, -merged_scores.get(s[0], _BASE_SCORE), s[0]))
+        total_skill_count = len(all_skills)
+
+        if max_prompt_skills > 0 and len(all_skills) > max_prompt_skills:
+            pinned_list = [s for s in all_skills if s[0] in pinned]
+            non_pinned = [s for s in all_skills if s[0] not in pinned]
+            all_skills = pinned_list + non_pinned[:max(0, max_prompt_skills - len(pinned_list))]
+
+        if token_budget > 0:
+            budget_remaining = token_budget - _HEADER_FOOTER_TOKENS
+            included: list[tuple[str, str, str]] = []
+            seen_categories: set[str] = set()
+
+            for name, desc, cat in all_skills:
+                cat_cost = 0
+                if cat not in seen_categories:
+                    cat_cost = _estimate_tokens(f"  {cat}: {category_descriptions.get(cat, '')}")
+                line_tokens = _estimate_tokens(f"    - {name}: {desc}" if desc else f"    - {name}") + cat_cost
+                if name in pinned or budget_remaining >= line_tokens:
+                    included.append((name, desc, cat))
+                    budget_remaining -= line_tokens
+                    seen_categories.add(cat)
+
+            all_skills = included
+
+        # Flat ranked list when scores drive ordering; grouped by category otherwise.
+        has_scores = bool(skill_scores) or bool(relevance)
         index_lines = []
-        for category in sorted(skills_by_category.keys()):
-            cat_desc = category_descriptions.get(category, "")
-            if cat_desc:
-                index_lines.append(f"  {category}: {cat_desc}")
-            else:
-                index_lines.append(f"  {category}:")
-            # Deduplicate and sort skills within each category
-            seen = set()
-            for name, desc in sorted(skills_by_category[category], key=lambda x: x[0]):
+        seen: set[str] = set()
+
+        if has_scores:
+            for name, desc, category in all_skills:
                 if name in seen:
                     continue
                 seen.add(name)
-                if desc:
-                    index_lines.append(f"    - {name}: {desc}")
-                else:
-                    index_lines.append(f"    - {name}")
+                index_lines.append(f"    - {name} [{category}]: {desc}" if desc else f"    - {name} [{category}]")
+        else:
+            skills_by_category: dict[str, list[tuple[str, str]]] = {}
+            for name, desc, category in all_skills:
+                skills_by_category.setdefault(category, []).append((name, desc))
+
+            for category in sorted(skills_by_category.keys()):
+                cat_desc = category_descriptions.get(category, "")
+                index_lines.append(f"  {category}: {cat_desc}" if cat_desc else f"  {category}:")
+                for name, desc in skills_by_category[category]:
+                    if name in seen:
+                        continue
+                    seen.add(name)
+                    index_lines.append(f"    - {name}: {desc}" if desc else f"    - {name}")
+
+        omitted = total_skill_count - len(all_skills)
+        footer = "If none match, proceed normally without loading a skill."
+        if omitted > 0:
+            footer = (
+                f"[{omitted} additional skill(s) available — "
+                f"use skills_list() to discover them]\n\n" + footer
+            )
 
         result = (
             "## Skills (mandatory)\n"
@@ -574,10 +798,9 @@ def build_skills_system_prompt(
             + "\n".join(index_lines) + "\n"
             "</available_skills>\n"
             "\n"
-            "If none match, proceed normally without loading a skill."
+            + footer
         )
 
-    # ── Store in LRU cache ────────────────────────────────────────────
     with _SKILLS_PROMPT_CACHE_LOCK:
         _SKILLS_PROMPT_CACHE[cache_key] = result
         _SKILLS_PROMPT_CACHE.move_to_end(cache_key)

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -227,6 +227,13 @@ def build_skill_invocation_message(
         return f"[Failed to load skill: {skill_info['name']}]"
 
     loaded_skill, skill_dir, skill_name = loaded
+    # Fire-and-forget usage tracking for slash command invocations
+    try:
+        from hermes_state import SessionDB
+        db = SessionDB()
+        db.record_skill_usage(skill_name, "slash_command", context_snippet=user_instruction[:200] if user_instruction else None)
+    except Exception:
+        pass
     activation_note = (
         f'[SYSTEM: The user has invoked the "{skill_name}" skill, indicating they want '
         "you to follow its instructions. The full skill content is loaded below.]"

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -242,6 +242,13 @@ def build_skill_invocation_message(
         return f"[Failed to load skill: {skill_info['name']}]"
 
     loaded_skill, skill_dir, skill_name = loaded
+    # Fire-and-forget usage tracking for slash command invocations
+    try:
+        from hermes_state import SessionDB
+        db = SessionDB()
+        db.record_skill_usage(skill_name, "slash_command", context_snippet=user_instruction[:200] if user_instruction else None)
+    except Exception:
+        pass
     activation_note = (
         f'[SYSTEM: The user has invoked the "{skill_name}" skill, indicating they want '
         "you to follow its instructions. The full skill content is loaded below.]"

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -24,7 +24,7 @@ PLATFORM_MAP = {
     "windows": "win32",
 }
 
-EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub"))
+EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub", ".archive"))
 
 # ── Lazy YAML loader ─────────────────────────────────────────────────────
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -340,6 +340,16 @@ DEFAULT_CONFIG = {
         "max_ms": 2500,
     },
     
+    # Skills overflow management — cap how many tokens the skills index consumes
+    # in the system prompt and control which skills are always included.
+    # All defaults preserve existing behavior (unlimited, no archival).
+    "skills": {
+        "token_budget": 0,          # max tokens for skills index (0 = unlimited, recommended: 4000)
+        "max_prompt_skills": 0,     # hard cap on skill count (0 = unlimited)
+        "pinned_skills": [],        # always included regardless of budget
+        "auto_archive_days": 0,     # 0 = disabled; N = archive after N days of inactivity
+    },
+
     # Persistent memory -- bounded curated memory injected into system prompt
     "memory": {
         "memory_enabled": True,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -412,6 +412,16 @@ DEFAULT_CONFIG = {
         "max_ms": 2500,
     },
     
+    # Skills overflow management — cap how many tokens the skills index consumes
+    # in the system prompt and control which skills are always included.
+    # All defaults preserve existing behavior (unlimited, no archival).
+    "skills": {
+        "token_budget": 0,          # max tokens for skills index (0 = unlimited, recommended: 4000)
+        "max_prompt_skills": 0,     # hard cap on skill count (0 = unlimited)
+        "pinned_skills": [],        # always included regardless of budget
+        "auto_archive_days": 0,     # 0 = disabled; N = archive after N days of inactivity
+    },
+
     # Persistent memory -- bounded curated memory injected into system prompt
     "memory": {
         "memory_enabled": True,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4284,12 +4284,29 @@ For more help on a command:
     # config sub-action: interactive enable/disable
     skills_subparsers.add_parser("config", help="Interactive skill configuration — enable/disable individual skills")
 
+    skills_stats = skills_subparsers.add_parser("stats", help="Show skill usage statistics (ranked by usage)")
+    skills_stats.add_argument("--days", type=int, default=None, help="Only show usage from last N days")
+
+    skills_archive_cmd = skills_subparsers.add_parser("archive", help="Archive a skill (move to .archive/)")
+    skills_archive_cmd.add_argument("name", help="Skill name to archive")
+
+    skills_restore_cmd = skills_subparsers.add_parser("restore", help="Restore an archived skill")
+    skills_restore_cmd.add_argument("name", help="Skill name to restore")
+
+    skills_prune_cmd = skills_subparsers.add_parser("prune", help="Bulk archive unused skills")
+    skills_prune_cmd.add_argument("--days", type=int, default=90, help="Archive skills unused for N days (default: 90)")
+    skills_prune_cmd.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompt")
+
     def cmd_skills(args):
+        action = getattr(args, 'skills_action', None)
         # Route 'config' action to skills_config module
-        if getattr(args, 'skills_action', None) == 'config':
+        if action == 'config':
             _require_tty("skills config")
             from hermes_cli.skills_config import skills_command as skills_config_command
             skills_config_command(args)
+        elif action in ('stats', 'archive', 'restore', 'prune'):
+            from hermes_cli.skills_config import skills_overflow_command
+            skills_overflow_command(args)
         else:
             from hermes_cli.skills_hub import skills_command
             skills_command(args)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3729,11 +3729,28 @@ For more help on a command:
     # config sub-action: interactive enable/disable
     skills_subparsers.add_parser("config", help="Interactive skill configuration — enable/disable individual skills")
 
+    skills_stats = skills_subparsers.add_parser("stats", help="Show skill usage statistics (ranked by usage)")
+    skills_stats.add_argument("--days", type=int, default=None, help="Only show usage from last N days")
+
+    skills_archive_cmd = skills_subparsers.add_parser("archive", help="Archive a skill (move to .archive/)")
+    skills_archive_cmd.add_argument("name", help="Skill name to archive")
+
+    skills_restore_cmd = skills_subparsers.add_parser("restore", help="Restore an archived skill")
+    skills_restore_cmd.add_argument("name", help="Skill name to restore")
+
+    skills_prune_cmd = skills_subparsers.add_parser("prune", help="Bulk archive unused skills")
+    skills_prune_cmd.add_argument("--days", type=int, default=90, help="Archive skills unused for N days (default: 90)")
+    skills_prune_cmd.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompt")
+
     def cmd_skills(args):
+        action = getattr(args, 'skills_action', None)
         # Route 'config' action to skills_config module
-        if getattr(args, 'skills_action', None) == 'config':
+        if action == 'config':
             from hermes_cli.skills_config import skills_command as skills_config_command
             skills_config_command(args)
+        elif action in ('stats', 'archive', 'restore', 'prune'):
+            from hermes_cli.skills_config import skills_overflow_command
+            skills_overflow_command(args)
         else:
             from hermes_cli.skills_hub import skills_command
             skills_command(args)

--- a/hermes_cli/skills_config.py
+++ b/hermes_cli/skills_config.py
@@ -185,3 +185,130 @@ def skills_command(args=None):
     save_disabled_skills(config, new_disabled, platform)
     enabled_count = len(skills) - len(new_disabled)
     print(color(f"✓ Saved: {enabled_count} enabled, {len(new_disabled)} disabled ({platform_label}).", Colors.GREEN))
+
+
+# ─── Skills Overflow Commands ────────────────────────────────────────────────
+
+def skills_overflow_command(args):
+    """Handle stats/archive/restore/prune subcommands."""
+    action = args.skills_action
+
+    if action == "stats":
+        _cmd_stats(getattr(args, "days", None))
+    elif action == "archive":
+        _cmd_archive(args.name)
+    elif action == "restore":
+        _cmd_restore(args.name)
+    elif action == "prune":
+        _cmd_prune(getattr(args, "days", 90), getattr(args, "yes", False))
+
+
+def _cmd_stats(since_days):
+    """Show skill usage statistics ranked by usage."""
+    import datetime
+
+    try:
+        from hermes_state import SessionDB
+        db = SessionDB()
+        stats = db.get_skill_usage_stats(since_days=since_days)
+    except Exception as e:
+        print(color(f"Error loading stats: {e}", Colors.RED))
+        return
+
+    if not stats:
+        period = f"last {since_days} days" if since_days else "all time"
+        print(color(f"No skill usage data found ({period}).", Colors.DIM))
+        print("Usage data is recorded when skills are viewed, invoked, or managed.")
+        return
+
+    period_label = f"last {since_days} days" if since_days else "all time"
+    print(color(f"\nSkill Usage Stats ({period_label})", Colors.BOLD))
+    print(f"{'Skill':<30} {'Uses':>6} {'Last Used':<20} {'Events'}")
+    print("─" * 80)
+
+    for s in stats:
+        name = s["skill_name"][:29]
+        total = s["total_uses"]
+        last_ts = s["last_used"]
+        last_str = datetime.datetime.fromtimestamp(last_ts).strftime("%Y-%m-%d %H:%M") if last_ts else "never"
+        events = ", ".join(f"{k}:{v}" for k, v in sorted(s["event_counts"].items()))
+        print(f"  {name:<28} {total:>6} {last_str:<20} {events}")
+
+    print(f"\n  Total: {len(stats)} skills with recorded usage")
+
+
+def _cmd_archive(name):
+    """Archive a single skill."""
+    from tools.skill_manager_tool import _archive_skill
+    result = _archive_skill(name)
+    if result.get("success"):
+        print(color(f"✓ {result['message']}", Colors.GREEN))
+        try:
+            from agent.prompt_builder import clear_skills_system_prompt_cache
+            clear_skills_system_prompt_cache(clear_snapshot=True)
+        except Exception:
+            pass
+    else:
+        print(color(f"✗ {result['error']}", Colors.RED))
+
+
+def _cmd_restore(name):
+    """Restore a single skill from archive."""
+    from tools.skill_manager_tool import _restore_skill
+    result = _restore_skill(name)
+    if result.get("success"):
+        print(color(f"✓ {result['message']}", Colors.GREEN))
+        try:
+            from agent.prompt_builder import clear_skills_system_prompt_cache
+            clear_skills_system_prompt_cache(clear_snapshot=True)
+        except Exception:
+            pass
+    else:
+        print(color(f"✗ {result['error']}", Colors.RED))
+        if result.get("archived_skills"):
+            print(f"  Available archived skills: {', '.join(result['archived_skills'])}")
+
+
+def _cmd_prune(days, skip_confirm):
+    """Bulk archive skills unused for more than N days."""
+    from tools.skill_manager_tool import find_archivable_skills, _archive_skill
+
+    config = load_config()
+    pinned = set(config.get("skills", {}).get("pinned_skills", []))
+
+    candidates = find_archivable_skills(days, pinned=pinned)
+
+    if not candidates:
+        print(color(f"No skills unused for >{days} days found.", Colors.DIM))
+        return
+
+    print(color(f"\nSkills unused for >{days} days ({len(candidates)}):", Colors.BOLD))
+    for name in sorted(candidates):
+        print(f"  - {name}")
+
+    if not skip_confirm:
+        try:
+            answer = input(f"\nArchive these {len(candidates)} skills? [y/N] ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print("\nAborted.")
+            return
+        if answer not in ("y", "yes"):
+            print("Aborted.")
+            return
+
+    archived = 0
+    for name in candidates:
+        result = _archive_skill(name)
+        if result.get("success"):
+            print(color(f"  ✓ Archived {name}", Colors.GREEN))
+            archived += 1
+        else:
+            print(color(f"  ✗ {name}: {result.get('error', 'unknown error')}", Colors.RED))
+
+    if archived:
+        try:
+            from agent.prompt_builder import clear_skills_system_prompt_cache
+            clear_skills_system_prompt_cache(clear_snapshot=True)
+        except Exception:
+            pass
+    print(f"\nArchived {archived}/{len(candidates)} skills.")

--- a/hermes_cli/skills_config.py
+++ b/hermes_cli/skills_config.py
@@ -183,3 +183,130 @@ def skills_command(args=None):
     save_disabled_skills(config, new_disabled, platform)
     enabled_count = len(skills) - len(new_disabled)
     print(color(f"✓ Saved: {enabled_count} enabled, {len(new_disabled)} disabled ({platform_label}).", Colors.GREEN))
+
+
+# ─── Skills Overflow Commands ────────────────────────────────────────────────
+
+def skills_overflow_command(args):
+    """Handle stats/archive/restore/prune subcommands."""
+    action = args.skills_action
+
+    if action == "stats":
+        _cmd_stats(getattr(args, "days", None))
+    elif action == "archive":
+        _cmd_archive(args.name)
+    elif action == "restore":
+        _cmd_restore(args.name)
+    elif action == "prune":
+        _cmd_prune(getattr(args, "days", 90), getattr(args, "yes", False))
+
+
+def _cmd_stats(since_days):
+    """Show skill usage statistics ranked by usage."""
+    import datetime
+
+    try:
+        from hermes_state import SessionDB
+        db = SessionDB()
+        stats = db.get_skill_usage_stats(since_days=since_days)
+    except Exception as e:
+        print(color(f"Error loading stats: {e}", Colors.RED))
+        return
+
+    if not stats:
+        period = f"last {since_days} days" if since_days else "all time"
+        print(color(f"No skill usage data found ({period}).", Colors.DIM))
+        print("Usage data is recorded when skills are viewed, invoked, or managed.")
+        return
+
+    period_label = f"last {since_days} days" if since_days else "all time"
+    print(color(f"\nSkill Usage Stats ({period_label})", Colors.BOLD))
+    print(f"{'Skill':<30} {'Uses':>6} {'Last Used':<20} {'Events'}")
+    print("─" * 80)
+
+    for s in stats:
+        name = s["skill_name"][:29]
+        total = s["total_uses"]
+        last_ts = s["last_used"]
+        last_str = datetime.datetime.fromtimestamp(last_ts).strftime("%Y-%m-%d %H:%M") if last_ts else "never"
+        events = ", ".join(f"{k}:{v}" for k, v in sorted(s["event_counts"].items()))
+        print(f"  {name:<28} {total:>6} {last_str:<20} {events}")
+
+    print(f"\n  Total: {len(stats)} skills with recorded usage")
+
+
+def _cmd_archive(name):
+    """Archive a single skill."""
+    from tools.skill_manager_tool import _archive_skill
+    result = _archive_skill(name)
+    if result.get("success"):
+        print(color(f"✓ {result['message']}", Colors.GREEN))
+        try:
+            from agent.prompt_builder import clear_skills_system_prompt_cache
+            clear_skills_system_prompt_cache(clear_snapshot=True)
+        except Exception:
+            pass
+    else:
+        print(color(f"✗ {result['error']}", Colors.RED))
+
+
+def _cmd_restore(name):
+    """Restore a single skill from archive."""
+    from tools.skill_manager_tool import _restore_skill
+    result = _restore_skill(name)
+    if result.get("success"):
+        print(color(f"✓ {result['message']}", Colors.GREEN))
+        try:
+            from agent.prompt_builder import clear_skills_system_prompt_cache
+            clear_skills_system_prompt_cache(clear_snapshot=True)
+        except Exception:
+            pass
+    else:
+        print(color(f"✗ {result['error']}", Colors.RED))
+        if result.get("archived_skills"):
+            print(f"  Available archived skills: {', '.join(result['archived_skills'])}")
+
+
+def _cmd_prune(days, skip_confirm):
+    """Bulk archive skills unused for more than N days."""
+    from tools.skill_manager_tool import find_archivable_skills, _archive_skill
+
+    config = load_config()
+    pinned = set(config.get("skills", {}).get("pinned_skills", []))
+
+    candidates = find_archivable_skills(days, pinned=pinned)
+
+    if not candidates:
+        print(color(f"No skills unused for >{days} days found.", Colors.DIM))
+        return
+
+    print(color(f"\nSkills unused for >{days} days ({len(candidates)}):", Colors.BOLD))
+    for name in sorted(candidates):
+        print(f"  - {name}")
+
+    if not skip_confirm:
+        try:
+            answer = input(f"\nArchive these {len(candidates)} skills? [y/N] ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print("\nAborted.")
+            return
+        if answer not in ("y", "yes"):
+            print("Aborted.")
+            return
+
+    archived = 0
+    for name in candidates:
+        result = _archive_skill(name)
+        if result.get("success"):
+            print(color(f"  ✓ Archived {name}", Colors.GREEN))
+            archived += 1
+        else:
+            print(color(f"  ✗ {name}: {result.get('error', 'unknown error')}", Colors.RED))
+
+    if archived:
+        try:
+            from agent.prompt_builder import clear_skills_system_prompt_cache
+            clear_skills_system_prompt_cache(clear_snapshot=True)
+        except Exception:
+            pass
+    print(f"\nArchived {archived}/{len(candidates)} skills.")

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -32,7 +32,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -89,6 +89,17 @@ CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
+
+CREATE TABLE IF NOT EXISTS skill_usage (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    skill_name TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    session_id TEXT,
+    timestamp REAL NOT NULL,
+    context_snippet TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_skill_usage_name ON skill_usage(skill_name);
+CREATE INDEX IF NOT EXISTS idx_skill_usage_ts ON skill_usage(timestamp DESC);
 """
 
 FTS_SQL = """
@@ -330,6 +341,22 @@ class SessionDB:
                     except sqlite3.OperationalError:
                         pass  # Column already exists
                 cursor.execute("UPDATE schema_version SET version = 6")
+            if current_version < 7:
+                # v7: add skill_usage table for tracking skill views, invocations,
+                # and management actions — foundation for smart ranking and auto-archival.
+                cursor.executescript("""
+                    CREATE TABLE IF NOT EXISTS skill_usage (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        skill_name TEXT NOT NULL,
+                        event_type TEXT NOT NULL,
+                        session_id TEXT,
+                        timestamp REAL NOT NULL,
+                        context_snippet TEXT
+                    );
+                    CREATE INDEX IF NOT EXISTS idx_skill_usage_name ON skill_usage(skill_name);
+                    CREATE INDEX IF NOT EXISTS idx_skill_usage_ts ON skill_usage(timestamp DESC);
+                """)
+                cursor.execute("UPDATE schema_version SET version = 7")
 
         # Unique title index — always ensure it exists (safe to run after migrations
         # since the title column is guaranteed to exist at this point)
@@ -1272,3 +1299,105 @@ class SessionDB:
             return len(session_ids)
 
         return self._execute_write(_do)
+
+    # =========================================================================
+    # Skill usage tracking
+    # =========================================================================
+
+    # Purge skill_usage rows older than this many days on every Nth write.
+    _SKILL_USAGE_RETENTION_DAYS = 90
+    _SKILL_USAGE_PURGE_EVERY = 100
+
+    def record_skill_usage(
+        self,
+        skill_name: str,
+        event_type: str,
+        session_id: Optional[str] = None,
+        context_snippet: Optional[str] = None,
+    ) -> None:
+        """Record a skill usage event. Purges rows older than 90 days every 100 writes."""
+        snippet = (context_snippet or "")[:200] if context_snippet else None
+        def _do(conn):
+            conn.execute(
+                "INSERT INTO skill_usage (skill_name, event_type, session_id, timestamp, context_snippet) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (skill_name, event_type, session_id, time.time(), snippet),
+            )
+            if self._write_count % self._SKILL_USAGE_PURGE_EVERY == 0:
+                cutoff = time.time() - (self._SKILL_USAGE_RETENTION_DAYS * 86400)
+                conn.execute("DELETE FROM skill_usage WHERE timestamp < ?", (cutoff,))
+        try:
+            self._execute_write(_do)
+        except Exception as e:
+            logger.debug("Failed to record skill usage: %s", e)
+
+    def get_skill_usage_stats(self, since_days: Optional[int] = None) -> List[Dict[str, Any]]:
+        """Return usage stats per skill, optionally filtered by recency.
+
+        Returns list of dicts: [{skill_name, total_uses, last_used, event_counts}]
+        """
+        cutoff = time.time() - (since_days * 86400) if since_days else 0
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT skill_name, event_type, COUNT(*) as cnt, MAX(timestamp) as last_ts "
+                "FROM skill_usage WHERE timestamp > ? GROUP BY skill_name, event_type "
+                "ORDER BY last_ts DESC",
+                (cutoff,),
+            )
+            rows = cursor.fetchall()
+        skills: Dict[str, Dict[str, Any]] = {}
+        for row in rows:
+            name = row["skill_name"]
+            if name not in skills:
+                skills[name] = {"skill_name": name, "total_uses": 0, "last_used": 0.0, "event_counts": {}}
+            skills[name]["total_uses"] += row["cnt"]
+            skills[name]["event_counts"][row["event_type"]] = row["cnt"]
+            skills[name]["last_used"] = max(skills[name]["last_used"], row["last_ts"])
+        return sorted(skills.values(), key=lambda s: s["last_used"], reverse=True)
+
+    def get_skill_last_used(self, skill_name: str) -> Optional[float]:
+        """Return the timestamp of the most recent usage of a skill, or None."""
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT MAX(timestamp) as last_ts FROM skill_usage WHERE skill_name = ?",
+                (skill_name,),
+            )
+            row = cursor.fetchone()
+        return row["last_ts"] if row and row["last_ts"] else None
+
+    def get_skill_rankings(self, limit: int = 50, since_days: Optional[int] = None) -> Dict[str, float]:
+        """Compute usage-based skill scores for ranking in the system prompt.
+
+        Score formula (computed entirely in SQL):
+            score = (uses_30d * 2) + (uses_7d * 5) + recency_bonus
+        where recency_bonus = 10 if last used within 3d, 5 if within 7d, else 0.
+
+        Returns dict of {skill_name: score}.
+        """
+        now = time.time()
+        cutoff_30d = now - (30 * 86400)
+        cutoff_7d = now - (7 * 86400)
+        cutoff_3d = now - (3 * 86400)
+
+        with self._lock:
+            cursor = self._conn.execute(
+                """
+                SELECT
+                    skill_name,
+                    COUNT(*) * 2 +
+                    SUM(CASE WHEN timestamp > ? THEN 5 ELSE 0 END) +
+                    CASE
+                        WHEN MAX(timestamp) > ? THEN 10
+                        WHEN MAX(timestamp) > ? THEN 5
+                        ELSE 0
+                    END AS score
+                FROM skill_usage
+                WHERE timestamp > ?
+                GROUP BY skill_name
+                ORDER BY score DESC
+                LIMIT ?
+                """,
+                (cutoff_7d, cutoff_3d, cutoff_7d, cutoff_30d, limit or 50),
+            )
+            rows = cursor.fetchall()
+        return {row["skill_name"]: row["score"] for row in rows}

--- a/run_agent.py
+++ b/run_agent.py
@@ -1132,13 +1132,25 @@ class AIAgent:
                 self._user_profile_enabled = False
                 logger.debug("peer %s memory_mode=honcho: local USER.md writes disabled", _hcfg.peer_name or "user")
 
-        # Skills config: nudge interval for skill creation reminders
+        # Skills config: nudge interval, token budget, pinned skills
         self._skill_nudge_interval = 10
+        self._skills_token_budget = 0
+        self._skills_max_prompt = 0
+        self._skills_pinned: list[str] = []
+        self._skills_auto_archive_days = 0
         try:
             skills_config = _agent_cfg.get("skills", {})
             self._skill_nudge_interval = int(skills_config.get("creation_nudge_interval", 10))
+            self._skills_token_budget = int(skills_config.get("token_budget", 0))
+            self._skills_max_prompt = int(skills_config.get("max_prompt_skills", 0))
+            self._skills_pinned = list(skills_config.get("pinned_skills", []))
+            self._skills_auto_archive_days = int(skills_config.get("auto_archive_days", 0))
         except Exception:
             pass
+
+        # Auto-archive stale skills at session startup (background thread)
+        if self._skills_auto_archive_days > 0:
+            self._run_skill_auto_archive()
 
         # Tool-use enforcement config: "auto" (default — matches hardcoded
         # model list), true (always), false (never), or list of substrings.
@@ -2534,10 +2546,42 @@ class AIAgent:
             if not self.quiet_mode:
                 print(f"  Honcho write failed: {e}")
 
-    def _build_system_prompt(self, system_message: str = None) -> str:
+    def _run_skill_auto_archive(self) -> None:
+        """Auto-archive skills unused for more than auto_archive_days.
+
+        Runs in a background thread to avoid blocking session startup.
+        """
+        def _do_archive():
+            try:
+                from tools.skill_manager_tool import find_archivable_skills, _archive_skill
+                candidates = find_archivable_skills(
+                    self._skills_auto_archive_days,
+                    pinned=set(self._skills_pinned),
+                )
+                if not candidates:
+                    return
+                archived = 0
+                for name in candidates:
+                    try:
+                        if _archive_skill(name).get("success"):
+                            archived += 1
+                            logger.info("Auto-archived skill '%s'", name)
+                    except Exception as e:
+                        logger.debug("Failed to auto-archive '%s': %s", name, e)
+                if archived:
+                    from agent.prompt_builder import clear_skills_system_prompt_cache
+                    clear_skills_system_prompt_cache(clear_snapshot=True)
+                    logger.info("Auto-archived %d stale skill(s)", archived)
+            except Exception as e:
+                logger.debug("Skill auto-archive failed: %s", e)
+
+        import threading
+        threading.Thread(target=_do_archive, daemon=True).start()
+
+    def _build_system_prompt(self, system_message: str = None, user_message: str = None) -> str:
         """
         Assemble the full system prompt from all layers.
-        
+
         Called once per session (cached on self._cached_system_prompt) and only
         rebuilt after context compression events. This ensures the system prompt
         is stable across all turns in a session, maximizing prefix cache hits.
@@ -2690,9 +2734,24 @@ class AIAgent:
                 )
                 if toolset
             }
+            # Compute usage-based skill scores for smart ranking
+            _skill_scores: dict[str, float] = {}
+            try:
+                if self._session_db:
+                    _skill_scores = self._session_db.get_skill_rankings(limit=100)
+                else:
+                    from hermes_state import SessionDB
+                    _skill_scores = SessionDB().get_skill_rankings(limit=100)
+            except Exception:
+                pass
             skills_prompt = build_skills_system_prompt(
                 available_tools=self.valid_tool_names,
                 available_toolsets=avail_toolsets,
+                token_budget=self._skills_token_budget,
+                max_prompt_skills=self._skills_max_prompt,
+                pinned_skills=self._skills_pinned,
+                skill_scores=_skill_scores or None,
+                user_message=user_message,
             )
         else:
             skills_prompt = ""
@@ -6305,7 +6364,7 @@ class AIAgent:
                 self._cached_system_prompt = stored_prompt
             else:
                 # First turn of a new session — build from scratch.
-                self._cached_system_prompt = self._build_system_prompt(system_message)
+                self._cached_system_prompt = self._build_system_prompt(system_message, user_message=user_message)
                 # Bake Honcho context into the prompt so it's stable for
                 # the entire session (not re-fetched per turn).
                 if self._honcho_context:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1114,13 +1114,25 @@ class AIAgent:
                 self._user_profile_enabled = False
                 logger.debug("peer %s memory_mode=honcho: local USER.md writes disabled", _hcfg.peer_name or "user")
 
-        # Skills config: nudge interval for skill creation reminders
+        # Skills config: nudge interval, token budget, pinned skills
         self._skill_nudge_interval = 10
+        self._skills_token_budget = 0
+        self._skills_max_prompt = 0
+        self._skills_pinned: list[str] = []
+        self._skills_auto_archive_days = 0
         try:
             skills_config = _agent_cfg.get("skills", {})
             self._skill_nudge_interval = int(skills_config.get("creation_nudge_interval", 10))
+            self._skills_token_budget = int(skills_config.get("token_budget", 0))
+            self._skills_max_prompt = int(skills_config.get("max_prompt_skills", 0))
+            self._skills_pinned = list(skills_config.get("pinned_skills", []))
+            self._skills_auto_archive_days = int(skills_config.get("auto_archive_days", 0))
         except Exception:
             pass
+
+        # Auto-archive stale skills at session startup (background thread)
+        if self._skills_auto_archive_days > 0:
+            self._run_skill_auto_archive()
 
         # Tool-use enforcement config: "auto" (default — matches hardcoded
         # model list), true (always), false (never), or list of substrings.
@@ -2512,10 +2524,42 @@ class AIAgent:
             if not self.quiet_mode:
                 print(f"  Honcho write failed: {e}")
 
-    def _build_system_prompt(self, system_message: str = None) -> str:
+    def _run_skill_auto_archive(self) -> None:
+        """Auto-archive skills unused for more than auto_archive_days.
+
+        Runs in a background thread to avoid blocking session startup.
+        """
+        def _do_archive():
+            try:
+                from tools.skill_manager_tool import find_archivable_skills, _archive_skill
+                candidates = find_archivable_skills(
+                    self._skills_auto_archive_days,
+                    pinned=set(self._skills_pinned),
+                )
+                if not candidates:
+                    return
+                archived = 0
+                for name in candidates:
+                    try:
+                        if _archive_skill(name).get("success"):
+                            archived += 1
+                            logger.info("Auto-archived skill '%s'", name)
+                    except Exception as e:
+                        logger.debug("Failed to auto-archive '%s': %s", name, e)
+                if archived:
+                    from agent.prompt_builder import clear_skills_system_prompt_cache
+                    clear_skills_system_prompt_cache(clear_snapshot=True)
+                    logger.info("Auto-archived %d stale skill(s)", archived)
+            except Exception as e:
+                logger.debug("Skill auto-archive failed: %s", e)
+
+        import threading
+        threading.Thread(target=_do_archive, daemon=True).start()
+
+    def _build_system_prompt(self, system_message: str = None, user_message: str = None) -> str:
         """
         Assemble the full system prompt from all layers.
-        
+
         Called once per session (cached on self._cached_system_prompt) and only
         rebuilt after context compression events. This ensures the system prompt
         is stable across all turns in a session, maximizing prefix cache hits.
@@ -2668,9 +2712,24 @@ class AIAgent:
                 )
                 if toolset
             }
+            # Compute usage-based skill scores for smart ranking
+            _skill_scores: dict[str, float] = {}
+            try:
+                if self._session_db:
+                    _skill_scores = self._session_db.get_skill_rankings(limit=100)
+                else:
+                    from hermes_state import SessionDB
+                    _skill_scores = SessionDB().get_skill_rankings(limit=100)
+            except Exception:
+                pass
             skills_prompt = build_skills_system_prompt(
                 available_tools=self.valid_tool_names,
                 available_toolsets=avail_toolsets,
+                token_budget=self._skills_token_budget,
+                max_prompt_skills=self._skills_max_prompt,
+                pinned_skills=self._skills_pinned,
+                skill_scores=_skill_scores or None,
+                user_message=user_message,
             )
         else:
             skills_prompt = ""
@@ -6135,7 +6194,7 @@ class AIAgent:
                 self._cached_system_prompt = stored_prompt
             else:
                 # First turn of a new session — build from scratch.
-                self._cached_system_prompt = self._build_system_prompt(system_message)
+                self._cached_system_prompt = self._build_system_prompt(system_message, user_message=user_message)
                 # Bake Honcho context into the prompt so it's stable for
                 # the entire session (not re-fetched per turn).
                 if self._honcho_context:

--- a/tests/test_skills_overflow.py
+++ b/tests/test_skills_overflow.py
@@ -1,0 +1,573 @@
+"""Tests for the skills overflow fix — token budget, usage tracking, ranking,
+archival, deduplication, and keyword relevance.
+
+Covers changes across: hermes_state.py, agent/prompt_builder.py,
+tools/skill_manager_tool.py, tools/skills_tool.py.
+"""
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+# =========================================================================
+# Fixtures
+# =========================================================================
+
+
+@pytest.fixture()
+def db(tmp_path):
+    """Create a SessionDB with a temp database file."""
+    db_path = tmp_path / "test_state.db"
+    session_db = SessionDB(db_path=db_path)
+    yield session_db
+    session_db.close()
+
+
+@pytest.fixture()
+def skills_dir(tmp_path):
+    """Create a minimal skills directory with a few skills."""
+    sdir = tmp_path / "skills"
+    for name, desc, category in [
+        ("python-debug", "Debug Python scripts", "coding"),
+        ("git-workflow", "Git branching workflow", "devops"),
+        ("k8s-deploy", "Deploy to Kubernetes clusters", "devops"),
+        ("write-essay", "Write long-form essays", "writing"),
+        ("web-scrape", "Scrape web pages with BeautifulSoup", "coding"),
+    ]:
+        skill_path = sdir / category / name
+        skill_path.mkdir(parents=True, exist_ok=True)
+        (skill_path / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: {desc}\n---\n\nDo the thing.\n"
+        )
+    return sdir
+
+
+def _make_skill(skills_dir, name, desc="A test skill", category="general",
+                extra_frontmatter=""):
+    """Helper to create a skill in the given skills_dir."""
+    skill_path = skills_dir / category / name
+    skill_path.mkdir(parents=True, exist_ok=True)
+    (skill_path / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {desc}\n{extra_frontmatter}---\n\nStep 1.\n"
+    )
+    return skill_path
+
+
+# =========================================================================
+# SessionDB: skill_usage tracking
+# =========================================================================
+
+
+class TestRecordSkillUsage:
+    def test_record_and_retrieve(self, db):
+        db.record_skill_usage("python-debug", "view", session_id="s1")
+        stats = db.get_skill_usage_stats()
+        assert len(stats) == 1
+        assert stats[0]["skill_name"] == "python-debug"
+        assert stats[0]["total_uses"] == 1
+        assert stats[0]["event_counts"]["view"] == 1
+
+    def test_multiple_events(self, db):
+        db.record_skill_usage("git-workflow", "view")
+        db.record_skill_usage("git-workflow", "invoke")
+        db.record_skill_usage("git-workflow", "view")
+        stats = db.get_skill_usage_stats()
+        assert len(stats) == 1
+        assert stats[0]["total_uses"] == 3
+        assert stats[0]["event_counts"]["view"] == 2
+        assert stats[0]["event_counts"]["invoke"] == 1
+
+    def test_context_snippet_truncated(self, db):
+        long_snippet = "x" * 500
+        db.record_skill_usage("test-skill", "view", context_snippet=long_snippet)
+        stats = db.get_skill_usage_stats()
+        # Snippet is stored but truncated to 200; verify the record exists
+        assert stats[0]["total_uses"] == 1
+
+    def test_none_context_snippet(self, db):
+        db.record_skill_usage("test-skill", "view", context_snippet=None)
+        stats = db.get_skill_usage_stats()
+        assert len(stats) == 1
+
+    def test_fire_and_forget_never_raises(self, db):
+        """record_skill_usage should never raise, even on bad input."""
+        # This should not raise
+        db.record_skill_usage("", "", session_id=None)
+
+
+class TestGetSkillLastUsed:
+    def test_returns_none_for_unknown_skill(self, db):
+        assert db.get_skill_last_used("nonexistent") is None
+
+    def test_returns_timestamp(self, db):
+        before = time.time()
+        db.record_skill_usage("test-skill", "view")
+        after = time.time()
+        last = db.get_skill_last_used("test-skill")
+        assert last is not None
+        assert before <= last <= after
+
+    def test_returns_most_recent(self, db):
+        db.record_skill_usage("test-skill", "view")
+        time.sleep(0.01)
+        db.record_skill_usage("test-skill", "invoke")
+        last = db.get_skill_last_used("test-skill")
+        # Should be the invoke timestamp (most recent)
+        stats = db.get_skill_usage_stats()
+        assert last == stats[0]["last_used"]
+
+
+class TestGetSkillUsageStats:
+    def test_empty_db_returns_empty(self, db):
+        assert db.get_skill_usage_stats() == []
+
+    def test_since_days_filter(self, db):
+        db.record_skill_usage("recent-skill", "view")
+        stats_all = db.get_skill_usage_stats(since_days=None)
+        assert len(stats_all) == 1
+        # since_days=0 means cutoff=now, so nothing matches
+        stats_future = db.get_skill_usage_stats(since_days=0)
+        # cutoff = time.time() - 0 = time.time(), so events at time.time() may not pass
+        # This is edge-case-y; just check it doesn't crash
+        assert isinstance(stats_future, list)
+
+    def test_multiple_skills_sorted_by_recency(self, db):
+        db.record_skill_usage("old-skill", "view")
+        time.sleep(0.01)
+        db.record_skill_usage("new-skill", "view")
+        stats = db.get_skill_usage_stats()
+        assert stats[0]["skill_name"] == "new-skill"
+        assert stats[1]["skill_name"] == "old-skill"
+
+
+class TestGetSkillRankings:
+    def test_empty_db(self, db):
+        assert db.get_skill_rankings() == {}
+
+    def test_basic_scoring(self, db):
+        # Record 3 events for skill-a
+        for _ in range(3):
+            db.record_skill_usage("skill-a", "view")
+        # Record 1 event for skill-b
+        db.record_skill_usage("skill-b", "view")
+        rankings = db.get_skill_rankings()
+        assert "skill-a" in rankings
+        assert "skill-b" in rankings
+        assert rankings["skill-a"] > rankings["skill-b"]
+
+    def test_respects_limit(self, db):
+        for i in range(20):
+            db.record_skill_usage(f"skill-{i}", "view")
+        rankings = db.get_skill_rankings(limit=5)
+        assert len(rankings) <= 5
+
+    def test_returns_dict_of_floats(self, db):
+        db.record_skill_usage("test-skill", "view")
+        rankings = db.get_skill_rankings()
+        for name, score in rankings.items():
+            assert isinstance(name, str)
+            assert isinstance(score, (int, float))
+
+
+class TestSchemaV7Migration:
+    def test_skill_usage_table_exists(self, db):
+        """Verify the skill_usage table was created by the v7 migration."""
+        cursor = db._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='skill_usage'"
+        )
+        assert cursor.fetchone() is not None
+
+    def test_skill_usage_indexes_exist(self, db):
+        cursor = db._conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_skill_usage%'"
+        )
+        indexes = [row["name"] for row in cursor.fetchall()]
+        assert "idx_skill_usage_name" in indexes
+        assert "idx_skill_usage_ts" in indexes
+
+
+# =========================================================================
+# prompt_builder: token budget, keyword relevance, scoring
+# =========================================================================
+
+
+class TestEstimateTokens:
+    def test_basic(self):
+        from agent.prompt_builder import _estimate_tokens
+        assert _estimate_tokens("") == 1  # min 1
+        assert _estimate_tokens("hello world") >= 1
+        # ~11 chars / 4 ≈ 2-3 tokens
+        assert 1 <= _estimate_tokens("hello world") <= 5
+
+    def test_long_text(self):
+        from agent.prompt_builder import _estimate_tokens
+        text = "a" * 400
+        assert _estimate_tokens(text) == 100  # 400 // 4
+
+
+class TestComputeKeywordRelevance:
+    def test_empty_inputs(self):
+        from agent.prompt_builder import compute_keyword_relevance
+        assert compute_keyword_relevance("", []) == {}
+        assert compute_keyword_relevance("hello", []) == {}
+        assert compute_keyword_relevance("", [{"skill_name": "x"}]) == {}
+
+    def test_stopwords_only_message(self):
+        from agent.prompt_builder import compute_keyword_relevance
+        # Only stopwords → no keywords → empty result
+        assert compute_keyword_relevance("the is a an", [{"skill_name": "x"}]) == {}
+
+    def test_matching_skill(self):
+        from agent.prompt_builder import compute_keyword_relevance
+        entries = [
+            {"skill_name": "python-debug", "description": "Debug Python scripts",
+             "category": "coding", "tags": ["python", "debugging"]},
+        ]
+        scores = compute_keyword_relevance("help me debug python", entries)
+        assert "python-debug" in scores
+        assert scores["python-debug"] > 0
+
+    def test_no_match(self):
+        from agent.prompt_builder import compute_keyword_relevance
+        entries = [
+            {"skill_name": "k8s-deploy", "description": "Deploy to Kubernetes",
+             "category": "devops", "tags": ["kubernetes"]},
+        ]
+        scores = compute_keyword_relevance("write an essay about cats", entries)
+        assert scores.get("k8s-deploy", 0) == 0
+
+    def test_jaccard_not_recall(self):
+        """Score should use |intersection|/|union|, not |intersection|/|skill_words|."""
+        from agent.prompt_builder import compute_keyword_relevance
+        # Skill with just 1 keyword "git"
+        entries = [
+            {"skill_name": "git", "description": "", "category": "", "tags": []},
+        ]
+        # User message with many keywords — only "git" matches
+        scores = compute_keyword_relevance(
+            "please help me deploy kubernetes docker git helm", entries
+        )
+        # With Jaccard: 1 / (5 + 1 - 1) = 1/5 = 0.2 → scaled = 2.0
+        # With old recall: 1/1 = 1.0 → scaled = 10.0
+        # Score should be well below 10.0
+        assert scores.get("git", 0) < 5.0
+
+    def test_score_range(self):
+        from agent.prompt_builder import compute_keyword_relevance
+        entries = [
+            {"skill_name": "python-debug", "description": "Debug Python",
+             "category": "coding", "tags": []},
+        ]
+        scores = compute_keyword_relevance("debug python", entries)
+        for score in scores.values():
+            assert 0.0 <= score <= 10.0
+
+
+class TestBuildSkillsSystemPromptBudget:
+    """Test the token budget, pinning, and scoring features."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        from agent.prompt_builder import clear_skills_system_prompt_cache
+        clear_skills_system_prompt_cache(clear_snapshot=True)
+        yield
+        clear_skills_system_prompt_cache(clear_snapshot=True)
+
+    def test_no_budget_includes_all(self, monkeypatch, skills_dir):
+        """token_budget=0 (default) should include all skills."""
+        monkeypatch.setenv("HERMES_HOME", str(skills_dir.parent))
+        from agent.prompt_builder import build_skills_system_prompt
+        result = build_skills_system_prompt(token_budget=0)
+        assert "python-debug" in result
+        assert "git-workflow" in result
+        assert "k8s-deploy" in result
+        assert "write-essay" in result
+        assert "web-scrape" in result
+        # No "additional skill(s)" footer
+        assert "additional skill" not in result
+
+    def test_budget_truncates(self, monkeypatch, skills_dir):
+        """A tight budget should exclude some skills and show footer."""
+        monkeypatch.setenv("HERMES_HOME", str(skills_dir.parent))
+        from agent.prompt_builder import build_skills_system_prompt
+        # Very tight budget (just enough for chrome + maybe 1 skill)
+        result = build_skills_system_prompt(token_budget=100)
+        assert "additional skill(s) available" in result
+
+    def test_pinned_always_included(self, monkeypatch, skills_dir):
+        """Pinned skills must survive budget cuts."""
+        monkeypatch.setenv("HERMES_HOME", str(skills_dir.parent))
+        from agent.prompt_builder import build_skills_system_prompt
+        result = build_skills_system_prompt(
+            token_budget=150,
+            pinned_skills=["write-essay"],
+        )
+        assert "write-essay" in result
+
+    def test_max_prompt_skills_cap(self, monkeypatch, skills_dir):
+        """max_prompt_skills should hard-cap the count."""
+        monkeypatch.setenv("HERMES_HOME", str(skills_dir.parent))
+        from agent.prompt_builder import build_skills_system_prompt
+        result = build_skills_system_prompt(max_prompt_skills=2)
+        # Should have at most 2 skills + omitted footer
+        assert "additional skill(s) available" in result
+
+    def test_skill_scores_affect_order(self, monkeypatch, skills_dir):
+        """Higher-scored skills should appear before lower-scored ones."""
+        monkeypatch.setenv("HERMES_HOME", str(skills_dir.parent))
+        from agent.prompt_builder import build_skills_system_prompt
+        result = build_skills_system_prompt(
+            max_prompt_skills=2,
+            skill_scores={"write-essay": 100.0, "k8s-deploy": 50.0},
+        )
+        assert "write-essay" in result
+        # With only 2 slots and high scores on these two, they should be in
+        assert "k8s-deploy" in result
+
+    def test_backward_compatible_call(self, monkeypatch, skills_dir):
+        """Old call signature (no kwargs) should still work."""
+        monkeypatch.setenv("HERMES_HOME", str(skills_dir.parent))
+        from agent.prompt_builder import build_skills_system_prompt
+        # This is how the function was called before our changes
+        result = build_skills_system_prompt(
+            available_tools=None, available_toolsets=None
+        )
+        assert "python-debug" in result
+
+
+# =========================================================================
+# skill_manager_tool: archive, restore, dedup, bundled detection
+# =========================================================================
+
+
+class TestArchiveSkill:
+    def test_archive_and_restore(self, tmp_path):
+        from tools.skill_manager_tool import _archive_skill, _restore_skill, ARCHIVE_DIR
+        with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path):
+            with patch("tools.skill_manager_tool.ARCHIVE_DIR", tmp_path / ".archive"):
+                skill_dir = tmp_path / "my-skill"
+                skill_dir.mkdir()
+                (skill_dir / "SKILL.md").write_text(
+                    "---\nname: my-skill\ndescription: test\n---\n"
+                )
+
+                result = _archive_skill("my-skill")
+                assert result["success"] is True
+                assert not skill_dir.exists()
+                assert (tmp_path / ".archive" / "my-skill" / "SKILL.md").exists()
+
+                # Restore
+                result = _restore_skill("my-skill")
+                assert result["success"] is True
+                assert (tmp_path / "my-skill" / "SKILL.md").exists()
+
+    def test_archive_nonexistent(self, tmp_path):
+        from tools.skill_manager_tool import _archive_skill
+        with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path):
+            result = _archive_skill("nonexistent")
+            assert result["success"] is False
+
+    def test_restore_nonexistent(self, tmp_path):
+        from tools.skill_manager_tool import _restore_skill
+        with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path):
+            with patch("tools.skill_manager_tool.ARCHIVE_DIR", tmp_path / ".archive"):
+                result = _restore_skill("nonexistent")
+                assert result["success"] is False
+
+    def test_archive_bundled_blocked(self, tmp_path):
+        from tools.skill_manager_tool import _archive_skill
+        with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path):
+            with patch("tools.skill_manager_tool._is_bundled_skill", return_value=True):
+                skill_dir = tmp_path / "bundled-skill"
+                skill_dir.mkdir()
+                (skill_dir / "SKILL.md").write_text(
+                    "---\nname: bundled-skill\ndescription: test\n---\n"
+                )
+                result = _archive_skill("bundled-skill")
+                assert result["success"] is False
+                assert "bundled" in result["error"].lower()
+
+
+class TestFindSimilarSkills:
+    def test_name_stem_overlap(self, tmp_path):
+        from tools.skill_manager_tool import _find_similar_skills
+        # Must patch SKILLS_DIR in both skill_manager_tool AND skills_tool
+        # because _find_similar_skills calls _find_all_skills from skills_tool
+        with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path), \
+             patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            existing = tmp_path / "python-debug"
+            existing.mkdir(parents=True)
+            (existing / "SKILL.md").write_text(
+                "---\nname: python-debug\ndescription: Debug Python\n---\n"
+            )
+            content = "---\nname: python-lint\ndescription: Lint Python code\n---\n"
+            similar = _find_similar_skills("python-lint", content)
+            assert "python-debug" in similar
+
+    def test_no_self_match(self, tmp_path):
+        from tools.skill_manager_tool import _find_similar_skills
+        with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path), \
+             patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            existing = tmp_path / "my-skill"
+            existing.mkdir(parents=True)
+            (existing / "SKILL.md").write_text(
+                "---\nname: my-skill\ndescription: test\n---\n"
+            )
+            content = "---\nname: my-skill\ndescription: test\n---\n"
+            similar = _find_similar_skills("my-skill", content)
+            assert "my-skill" not in similar
+
+
+class TestFindArchivableSkills:
+    def test_skips_pinned(self, tmp_path, db):
+        from tools.skill_manager_tool import find_archivable_skills
+        with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path):
+            with patch("tools.skill_manager_tool._is_bundled_skill", return_value=False):
+                skill = tmp_path / "pinned-skill"
+                skill.mkdir()
+                (skill / "SKILL.md").write_text("---\nname: pinned-skill\n---\n")
+
+                candidates = find_archivable_skills(
+                    cutoff_days=0, pinned={"pinned-skill"}
+                )
+                assert "pinned-skill" not in candidates
+
+    def test_skips_bundled(self, tmp_path, db):
+        from tools.skill_manager_tool import find_archivable_skills
+        with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path):
+            with patch("tools.skill_manager_tool._is_bundled_skill", return_value=True):
+                skill = tmp_path / "bundled-skill"
+                skill.mkdir()
+                (skill / "SKILL.md").write_text("---\nname: bundled-skill\n---\n")
+
+                candidates = find_archivable_skills(cutoff_days=0)
+                assert "bundled-skill" not in candidates
+
+
+class TestIsBundledSkill:
+    def test_frontmatter_bundled_true(self, tmp_path):
+        from tools.skill_manager_tool import _is_bundled_skill
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: my-skill\nbundled: true\n---\n"
+        )
+        # Reset cache
+        import tools.skill_manager_tool as m
+        m._BUNDLED_SKILL_NAMES = frozenset()
+        assert _is_bundled_skill(skill_dir) is True
+
+    def test_not_bundled(self, tmp_path):
+        from tools.skill_manager_tool import _is_bundled_skill
+        skill_dir = tmp_path / "user-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: user-skill\ndescription: custom\n---\n"
+        )
+        import tools.skill_manager_tool as m
+        m._BUNDLED_SKILL_NAMES = frozenset()
+        assert _is_bundled_skill(skill_dir) is False
+
+
+# =========================================================================
+# skills_tool: archived listing, usage tracking
+# =========================================================================
+
+
+class TestSkillsListArchived:
+    def test_include_archived_false_default(self, tmp_path):
+        """include_archived=False should not show archived skills."""
+        from tools.skills_tool import skills_list, SKILLS_DIR
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            # Active skill
+            active = tmp_path / "active-skill"
+            active.mkdir()
+            (active / "SKILL.md").write_text(
+                "---\nname: active-skill\ndescription: Active\n---\n"
+            )
+            # Archived skill
+            archive = tmp_path / ".archive" / "old-skill"
+            archive.mkdir(parents=True)
+            (archive / "SKILL.md").write_text(
+                "---\nname: old-skill\ndescription: Old\n---\n"
+            )
+            result = json.loads(skills_list(include_archived=False))
+            names = [s["name"] for s in result.get("skills", [])]
+            assert "active-skill" in names
+            assert "old-skill" not in names
+
+    def test_include_archived_true(self, tmp_path):
+        """include_archived=True should show both active and archived."""
+        from tools.skills_tool import skills_list
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            active = tmp_path / "active-skill"
+            active.mkdir()
+            (active / "SKILL.md").write_text(
+                "---\nname: active-skill\ndescription: Active\n---\n"
+            )
+            archive = tmp_path / ".archive" / "old-skill"
+            archive.mkdir(parents=True)
+            (archive / "SKILL.md").write_text(
+                "---\nname: old-skill\ndescription: Old\n---\n"
+            )
+            result = json.loads(skills_list(include_archived=True))
+            names = [s["name"] for s in result.get("skills", [])]
+            assert "active-skill" in names
+            assert "old-skill" in names
+
+
+class TestSkillViewArchiveFallback:
+    def test_archived_skill_gives_hint(self, tmp_path):
+        """Viewing an archived skill should return a restore hint."""
+        from tools.skills_tool import skill_view
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            archive = tmp_path / ".archive" / "old-skill"
+            archive.mkdir(parents=True)
+            (archive / "SKILL.md").write_text(
+                "---\nname: old-skill\ndescription: Old\n---\n"
+            )
+            result = json.loads(skill_view("old-skill"))
+            assert result.get("archived") is True
+            assert "restore" in result.get("hint", "").lower()
+
+
+class TestTrackSkillUsage:
+    def test_does_not_raise(self, db):
+        """Usage recording should never raise."""
+        # fire-and-forget: even weird inputs shouldn't blow up
+        db.record_skill_usage("test", "view")
+        db.record_skill_usage("", "")
+
+
+# =========================================================================
+# Integration: excluded skill dirs
+# =========================================================================
+
+
+class TestExcludedSkillDirs:
+    def test_archive_in_excluded(self):
+        from agent.skill_utils import EXCLUDED_SKILL_DIRS
+        assert ".archive" in EXCLUDED_SKILL_DIRS
+
+    def test_archive_not_iterated(self, tmp_path):
+        """Archived skills should not appear in iter_skill_index_files."""
+        from agent.skill_utils import iter_skill_index_files
+        # Active skill
+        active = tmp_path / "active-skill"
+        active.mkdir()
+        (active / "SKILL.md").write_text("---\nname: active\n---\n")
+        # Archived skill
+        archived = tmp_path / ".archive" / "old-skill"
+        archived.mkdir(parents=True)
+        (archived / "SKILL.md").write_text("---\nname: old\n---\n")
+
+        found = list(iter_skill_index_files(tmp_path, "SKILL.md"))
+        found_names = [f.parent.name for f in found]
+        assert "active-skill" in found_names
+        assert "old-skill" not in found_names

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -38,6 +38,7 @@ import os
 import re
 import shutil
 import tempfile
+import time
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Dict, Any, Optional
@@ -88,6 +89,9 @@ VALID_NAME_RE = re.compile(r'^[a-z0-9][a-z0-9._-]*$')
 
 # Subdirectories allowed for write_file/remove_file
 ALLOWED_SUBDIRS = {"references", "templates", "scripts", "assets"}
+
+# Archive directory for auto-archived/manually archived skills
+ARCHIVE_DIR = SKILLS_DIR / ".archive"
 
 
 def check_skill_manage_requirements() -> bool:
@@ -161,15 +165,69 @@ def _resolve_skill_dir(name: str, category: str = None) -> Path:
 
 def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     """
-    Find a skill by name in ~/.hermes/skills/.
+    Find a skill by name in ~/.hermes/skills/ (excludes .archive).
     Returns {"path": Path} or None.
     """
     if not SKILLS_DIR.exists():
         return None
     for skill_md in SKILLS_DIR.rglob("SKILL.md"):
+        if ".archive" in skill_md.parts:
+            continue
         if skill_md.parent.name == name:
             return {"path": skill_md.parent}
     return None
+
+
+_DEDUP_STOPWORDS = frozenset({"", "a", "an", "the", "and", "or", "for", "to", "of", "in", "with", "is", "are"})
+
+
+def _find_similar_skills(name: str, content: str) -> list[str]:
+    """Find skills with similar names or descriptions. Returns up to 5 matches."""
+    # Get existing skills via the skills tool's listing (the public interface)
+    existing_skills: list[tuple[str, str]] = []  # (name, description)
+    try:
+        from tools.skills_tool import _find_all_skills
+        for s in _find_all_skills():
+            existing_skills.append((s.get("name", ""), s.get("description", "")))
+    except Exception:
+        pass
+    if not existing_skills:
+        return []
+
+    name_stem = set(re.sub(r"[-_.]", " ", name.lower()).split())
+
+    # Extract description from new skill's content frontmatter
+    new_desc_words: set[str] = set()
+    try:
+        if content.startswith("---"):
+            end_match = re.search(r"\n---\s*\n", content[3:])
+            if end_match:
+                fm_text = content[3:end_match.start() + 3]
+                parsed = yaml.safe_load(fm_text)
+                if isinstance(parsed, dict):
+                    new_desc_words = set(str(parsed.get("description", "")).lower().split()) - _DEDUP_STOPWORDS
+    except Exception:
+        pass
+
+    similar = []
+    for existing_name, existing_desc in existing_skills:
+        if existing_name == name:
+            continue
+        # Name stem overlap
+        existing_stem = set(re.sub(r"[-_.]", " ", existing_name.lower()).split())
+        if name_stem and existing_stem and name_stem & existing_stem:
+            similar.append(existing_name)
+            continue
+        # Description Jaccard similarity > 0.6
+        if new_desc_words and existing_desc:
+            ex_words = set(existing_desc.lower().split()) - _DEDUP_STOPWORDS
+            if ex_words:
+                intersection = new_desc_words & ex_words
+                union = new_desc_words | ex_words
+                if union and len(intersection) / len(union) > 0.6:
+                    similar.append(existing_name)
+
+    return similar[:5]
 
 
 def _validate_file_path(file_path: str) -> Optional[str]:
@@ -254,6 +312,9 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
             "error": f"A skill named '{name}' already exists at {existing['path']}."
         }
 
+    # Deduplication check — warn about similar existing skills
+    similar_skills = _find_similar_skills(name, content)
+
     # Create the skill directory
     skill_dir = _resolve_skill_dir(name, category)
     skill_dir.mkdir(parents=True, exist_ok=True)
@@ -280,6 +341,13 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
         "To add reference files, templates, or scripts, use "
         "skill_manage(action='write_file', name='{}', file_path='references/example.md', file_content='...')".format(name)
     )
+    if similar_skills:
+        result["similar_skills"] = similar_skills
+        result["dedup_warning"] = (
+            f"Found {len(similar_skills)} similar existing skill(s): "
+            + ", ".join(similar_skills)
+            + ". Consider reviewing them to avoid duplication."
+        )
     return result
 
 
@@ -492,6 +560,132 @@ def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
     }
 
 
+_BUNDLED_SKILL_NAMES: frozenset | None = None
+
+
+def _get_bundled_skill_names() -> frozenset:
+    """Return cached set of skill names bundled with the repo."""
+    global _BUNDLED_SKILL_NAMES
+    if _BUNDLED_SKILL_NAMES is not None:
+        return _BUNDLED_SKILL_NAMES
+    names: set[str] = set()
+    try:
+        repo_skills = Path(__file__).resolve().parent.parent / "skills"
+        if repo_skills.exists():
+            for candidate in repo_skills.rglob("SKILL.md"):
+                names.add(candidate.parent.name)
+    except Exception:
+        pass
+    _BUNDLED_SKILL_NAMES = frozenset(names)
+    return _BUNDLED_SKILL_NAMES
+
+
+def _is_bundled_skill(skill_dir: Path) -> bool:
+    """Check if a skill is bundled (shipped with the repo or has bundled: true)."""
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.exists():
+        return False
+    if skill_dir.name in _get_bundled_skill_names():
+        return True
+    try:
+        raw = skill_md.read_text(encoding="utf-8")[:1000]
+        if raw.startswith("---"):
+            end = re.search(r"\n---\s*\n", raw[3:])
+            if end:
+                fm_text = raw[3:end.start() + 3]
+                parsed = yaml.safe_load(fm_text)
+                if isinstance(parsed, dict) and parsed.get("bundled"):
+                    return True
+    except Exception:
+        pass
+    return False
+
+
+def _archive_skill(name: str) -> Dict[str, Any]:
+    """Move a skill to the archive directory."""
+    existing = _find_skill(name)
+    if not existing:
+        return {"success": False, "error": f"Skill '{name}' not found."}
+    skill_dir = existing["path"]
+
+    if _is_bundled_skill(skill_dir):
+        return {"success": False, "error": f"Cannot archive bundled skill '{name}'."}
+
+    ARCHIVE_DIR.mkdir(parents=True, exist_ok=True)
+    dest = ARCHIVE_DIR / skill_dir.name
+    if dest.exists():
+        return {"success": False, "error": f"Archived skill '{name}' already exists. Restore or delete it first."}
+
+    shutil.move(str(skill_dir), str(dest))
+
+    # Clean up empty parent category directories
+    parent = skill_dir.parent
+    if parent != SKILLS_DIR and parent.exists() and not any(parent.iterdir()):
+        try:
+            parent.rmdir()
+        except OSError:
+            pass
+
+    return {
+        "success": True,
+        "message": f"Skill '{name}' archived to .archive/. Use action='restore' to bring it back.",
+    }
+
+
+def _restore_skill(name: str) -> Dict[str, Any]:
+    """Restore a skill from the archive directory."""
+    if not ARCHIVE_DIR.exists():
+        return {"success": False, "error": f"No archive directory found."}
+
+    archived_dir = ARCHIVE_DIR / name
+    if not archived_dir.exists():
+        # List available archived skills
+        available = [d.name for d in ARCHIVE_DIR.iterdir() if d.is_dir() and (d / "SKILL.md").exists()]
+        return {
+            "success": False,
+            "error": f"Skill '{name}' not found in archive.",
+            "archived_skills": available if available else None,
+        }
+
+    # Check for name collision with active skills
+    if _find_skill(name):
+        return {"success": False, "error": f"Active skill '{name}' already exists. Delete it first."}
+
+    dest = SKILLS_DIR / name
+    shutil.move(str(archived_dir), str(dest))
+
+    return {
+        "success": True,
+        "message": f"Skill '{name}' restored from archive.",
+    }
+
+
+def find_archivable_skills(cutoff_days: int, pinned: "set[str] | None" = None) -> list[str]:
+    """Return user-created skill names unused for more than cutoff_days."""
+    if not SKILLS_DIR.exists():
+        return []
+    pinned = pinned or set()
+    try:
+        from hermes_state import SessionDB
+        db = SessionDB()
+    except Exception:
+        return []
+
+    candidates = []
+    for skill_md in SKILLS_DIR.rglob("SKILL.md"):
+        if ".archive" in skill_md.parts:
+            continue
+        skill_name = skill_md.parent.name
+        if skill_name in pinned or _is_bundled_skill(skill_md.parent):
+            continue
+        last_used = db.get_skill_last_used(skill_name)
+        if last_used is not None:
+            if (time.time() - last_used) / 86400 <= cutoff_days:
+                continue
+        candidates.append(skill_name)
+    return candidates
+
+
 # =============================================================================
 # Main entry point
 # =============================================================================
@@ -544,13 +738,26 @@ def skill_manage(
             return json.dumps({"success": False, "error": "file_path is required for 'remove_file'."}, ensure_ascii=False)
         result = _remove_file(name, file_path)
 
+    elif action == "archive":
+        result = _archive_skill(name)
+
+    elif action == "restore":
+        result = _restore_skill(name)
+
     else:
-        result = {"success": False, "error": f"Unknown action '{action}'. Use: create, edit, patch, delete, write_file, remove_file"}
+        result = {"success": False, "error": f"Unknown action '{action}'. Use: create, edit, patch, delete, write_file, remove_file, archive, restore"}
 
     if result.get("success"):
         try:
             from agent.prompt_builder import clear_skills_system_prompt_cache
             clear_skills_system_prompt_cache(clear_snapshot=True)
+        except Exception:
+            pass
+        # Fire-and-forget usage tracking
+        try:
+            from hermes_state import SessionDB
+            db = SessionDB()
+            db.record_skill_usage(name, action)
         except Exception:
             pass
 
@@ -570,7 +777,7 @@ SKILL_MANAGE_SCHEMA = {
         "Actions: create (full SKILL.md + optional category), "
         "patch (old_string/new_string — preferred for fixes), "
         "edit (full SKILL.md rewrite — major overhauls only), "
-        "delete, write_file, remove_file.\n\n"
+        "delete, write_file, remove_file, archive, restore.\n\n"
         "Create when: complex task succeeded (5+ calls), errors overcome, "
         "user-corrected approach worked, non-trivial workflow discovered, "
         "or user asks you to remember a procedure.\n"
@@ -587,7 +794,7 @@ SKILL_MANAGE_SCHEMA = {
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["create", "patch", "edit", "delete", "write_file", "remove_file"],
+                "enum": ["create", "patch", "edit", "delete", "write_file", "remove_file", "archive", "restore"],
                 "description": "The action to perform."
             },
             "name": {

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -38,6 +38,7 @@ import os
 import re
 import shutil
 import tempfile
+import time
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Dict, Any, Optional
@@ -88,6 +89,9 @@ VALID_NAME_RE = re.compile(r'^[a-z0-9][a-z0-9._-]*$')
 
 # Subdirectories allowed for write_file/remove_file
 ALLOWED_SUBDIRS = {"references", "templates", "scripts", "assets"}
+
+# Archive directory for auto-archived/manually archived skills
+ARCHIVE_DIR = SKILLS_DIR / ".archive"
 
 
 def check_skill_manage_requirements() -> bool:
@@ -186,15 +190,69 @@ def _resolve_skill_dir(name: str, category: str = None) -> Path:
 
 def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     """
-    Find a skill by name in ~/.hermes/skills/.
+    Find a skill by name in ~/.hermes/skills/ (excludes .archive).
     Returns {"path": Path} or None.
     """
     if not SKILLS_DIR.exists():
         return None
     for skill_md in SKILLS_DIR.rglob("SKILL.md"):
+        if ".archive" in skill_md.parts:
+            continue
         if skill_md.parent.name == name:
             return {"path": skill_md.parent}
     return None
+
+
+_DEDUP_STOPWORDS = frozenset({"", "a", "an", "the", "and", "or", "for", "to", "of", "in", "with", "is", "are"})
+
+
+def _find_similar_skills(name: str, content: str) -> list[str]:
+    """Find skills with similar names or descriptions. Returns up to 5 matches."""
+    # Get existing skills via the skills tool's listing (the public interface)
+    existing_skills: list[tuple[str, str]] = []  # (name, description)
+    try:
+        from tools.skills_tool import _find_all_skills
+        for s in _find_all_skills():
+            existing_skills.append((s.get("name", ""), s.get("description", "")))
+    except Exception:
+        pass
+    if not existing_skills:
+        return []
+
+    name_stem = set(re.sub(r"[-_.]", " ", name.lower()).split())
+
+    # Extract description from new skill's content frontmatter
+    new_desc_words: set[str] = set()
+    try:
+        if content.startswith("---"):
+            end_match = re.search(r"\n---\s*\n", content[3:])
+            if end_match:
+                fm_text = content[3:end_match.start() + 3]
+                parsed = yaml.safe_load(fm_text)
+                if isinstance(parsed, dict):
+                    new_desc_words = set(str(parsed.get("description", "")).lower().split()) - _DEDUP_STOPWORDS
+    except Exception:
+        pass
+
+    similar = []
+    for existing_name, existing_desc in existing_skills:
+        if existing_name == name:
+            continue
+        # Name stem overlap
+        existing_stem = set(re.sub(r"[-_.]", " ", existing_name.lower()).split())
+        if name_stem and existing_stem and name_stem & existing_stem:
+            similar.append(existing_name)
+            continue
+        # Description Jaccard similarity > 0.6
+        if new_desc_words and existing_desc:
+            ex_words = set(existing_desc.lower().split()) - _DEDUP_STOPWORDS
+            if ex_words:
+                intersection = new_desc_words & ex_words
+                union = new_desc_words | ex_words
+                if union and len(intersection) / len(union) > 0.6:
+                    similar.append(existing_name)
+
+    return similar[:5]
 
 
 def _validate_file_path(file_path: str) -> Optional[str]:
@@ -283,6 +341,9 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
             "error": f"A skill named '{name}' already exists at {existing['path']}."
         }
 
+    # Deduplication check — warn about similar existing skills
+    similar_skills = _find_similar_skills(name, content)
+
     # Create the skill directory
     skill_dir = _resolve_skill_dir(name, category)
     skill_dir.mkdir(parents=True, exist_ok=True)
@@ -309,6 +370,13 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
         "To add reference files, templates, or scripts, use "
         "skill_manage(action='write_file', name='{}', file_path='references/example.md', file_content='...')".format(name)
     )
+    if similar_skills:
+        result["similar_skills"] = similar_skills
+        result["dedup_warning"] = (
+            f"Found {len(similar_skills)} similar existing skill(s): "
+            + ", ".join(similar_skills)
+            + ". Consider reviewing them to avoid duplication."
+        )
     return result
 
 
@@ -521,6 +589,132 @@ def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
     }
 
 
+_BUNDLED_SKILL_NAMES: frozenset | None = None
+
+
+def _get_bundled_skill_names() -> frozenset:
+    """Return cached set of skill names bundled with the repo."""
+    global _BUNDLED_SKILL_NAMES
+    if _BUNDLED_SKILL_NAMES is not None:
+        return _BUNDLED_SKILL_NAMES
+    names: set[str] = set()
+    try:
+        repo_skills = Path(__file__).resolve().parent.parent / "skills"
+        if repo_skills.exists():
+            for candidate in repo_skills.rglob("SKILL.md"):
+                names.add(candidate.parent.name)
+    except Exception:
+        pass
+    _BUNDLED_SKILL_NAMES = frozenset(names)
+    return _BUNDLED_SKILL_NAMES
+
+
+def _is_bundled_skill(skill_dir: Path) -> bool:
+    """Check if a skill is bundled (shipped with the repo or has bundled: true)."""
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.exists():
+        return False
+    if skill_dir.name in _get_bundled_skill_names():
+        return True
+    try:
+        raw = skill_md.read_text(encoding="utf-8")[:1000]
+        if raw.startswith("---"):
+            end = re.search(r"\n---\s*\n", raw[3:])
+            if end:
+                fm_text = raw[3:end.start() + 3]
+                parsed = yaml.safe_load(fm_text)
+                if isinstance(parsed, dict) and parsed.get("bundled"):
+                    return True
+    except Exception:
+        pass
+    return False
+
+
+def _archive_skill(name: str) -> Dict[str, Any]:
+    """Move a skill to the archive directory."""
+    existing = _find_skill(name)
+    if not existing:
+        return {"success": False, "error": f"Skill '{name}' not found."}
+    skill_dir = existing["path"]
+
+    if _is_bundled_skill(skill_dir):
+        return {"success": False, "error": f"Cannot archive bundled skill '{name}'."}
+
+    ARCHIVE_DIR.mkdir(parents=True, exist_ok=True)
+    dest = ARCHIVE_DIR / skill_dir.name
+    if dest.exists():
+        return {"success": False, "error": f"Archived skill '{name}' already exists. Restore or delete it first."}
+
+    shutil.move(str(skill_dir), str(dest))
+
+    # Clean up empty parent category directories
+    parent = skill_dir.parent
+    if parent != SKILLS_DIR and parent.exists() and not any(parent.iterdir()):
+        try:
+            parent.rmdir()
+        except OSError:
+            pass
+
+    return {
+        "success": True,
+        "message": f"Skill '{name}' archived to .archive/. Use action='restore' to bring it back.",
+    }
+
+
+def _restore_skill(name: str) -> Dict[str, Any]:
+    """Restore a skill from the archive directory."""
+    if not ARCHIVE_DIR.exists():
+        return {"success": False, "error": f"No archive directory found."}
+
+    archived_dir = ARCHIVE_DIR / name
+    if not archived_dir.exists():
+        # List available archived skills
+        available = [d.name for d in ARCHIVE_DIR.iterdir() if d.is_dir() and (d / "SKILL.md").exists()]
+        return {
+            "success": False,
+            "error": f"Skill '{name}' not found in archive.",
+            "archived_skills": available if available else None,
+        }
+
+    # Check for name collision with active skills
+    if _find_skill(name):
+        return {"success": False, "error": f"Active skill '{name}' already exists. Delete it first."}
+
+    dest = SKILLS_DIR / name
+    shutil.move(str(archived_dir), str(dest))
+
+    return {
+        "success": True,
+        "message": f"Skill '{name}' restored from archive.",
+    }
+
+
+def find_archivable_skills(cutoff_days: int, pinned: "set[str] | None" = None) -> list[str]:
+    """Return user-created skill names unused for more than cutoff_days."""
+    if not SKILLS_DIR.exists():
+        return []
+    pinned = pinned or set()
+    try:
+        from hermes_state import SessionDB
+        db = SessionDB()
+    except Exception:
+        return []
+
+    candidates = []
+    for skill_md in SKILLS_DIR.rglob("SKILL.md"):
+        if ".archive" in skill_md.parts:
+            continue
+        skill_name = skill_md.parent.name
+        if skill_name in pinned or _is_bundled_skill(skill_md.parent):
+            continue
+        last_used = db.get_skill_last_used(skill_name)
+        if last_used is not None:
+            if (time.time() - last_used) / 86400 <= cutoff_days:
+                continue
+        candidates.append(skill_name)
+    return candidates
+
+
 # =============================================================================
 # Main entry point
 # =============================================================================
@@ -573,13 +767,26 @@ def skill_manage(
             return json.dumps({"success": False, "error": "file_path is required for 'remove_file'."}, ensure_ascii=False)
         result = _remove_file(name, file_path)
 
+    elif action == "archive":
+        result = _archive_skill(name)
+
+    elif action == "restore":
+        result = _restore_skill(name)
+
     else:
-        result = {"success": False, "error": f"Unknown action '{action}'. Use: create, edit, patch, delete, write_file, remove_file"}
+        result = {"success": False, "error": f"Unknown action '{action}'. Use: create, edit, patch, delete, write_file, remove_file, archive, restore"}
 
     if result.get("success"):
         try:
             from agent.prompt_builder import clear_skills_system_prompt_cache
             clear_skills_system_prompt_cache(clear_snapshot=True)
+        except Exception:
+            pass
+        # Fire-and-forget usage tracking
+        try:
+            from hermes_state import SessionDB
+            db = SessionDB()
+            db.record_skill_usage(name, action)
         except Exception:
             pass
 
@@ -599,7 +806,7 @@ SKILL_MANAGE_SCHEMA = {
         "Actions: create (full SKILL.md + optional category), "
         "patch (old_string/new_string — preferred for fixes), "
         "edit (full SKILL.md rewrite — major overhauls only), "
-        "delete, write_file, remove_file.\n\n"
+        "delete, write_file, remove_file, archive, restore.\n\n"
         "Create when: complex task succeeded (5+ calls), errors overcome, "
         "user-corrected approach worked, non-trivial workflow discovered, "
         "or user asks you to remember a procedure.\n"
@@ -616,7 +823,7 @@ SKILL_MANAGE_SCHEMA = {
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["create", "patch", "edit", "delete", "write_file", "remove_file"],
+                "enum": ["create", "patch", "edit", "delete", "write_file", "remove_file", "archive", "restore"],
                 "description": "The action to perform."
             },
             "name": {

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -84,6 +84,7 @@ from tools.registry import registry
 logger = logging.getLogger(__name__)
 
 
+
 # All skills live in ~/.hermes/skills/ (seeded from bundled skills/ on install).
 # This is the single source of truth -- agent edits, hub installs, and bundled
 # skills all coexist here without polluting the git repo.
@@ -101,7 +102,7 @@ _PLATFORM_MAP = {
     "linux": "linux",
     "windows": "win32",
 }
-_EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub"))
+_EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub", ".archive"))
 _REMOTE_ENV_BACKENDS = frozenset({"docker", "singularity", "modal", "ssh", "daytona"})
 _secret_capture_callback = None
 
@@ -684,7 +685,7 @@ def skills_categories(verbose: bool = False, task_id: str = None) -> str:
         return json.dumps({"success": False, "error": str(e)}, ensure_ascii=False)
 
 
-def skills_list(category: str = None, task_id: str = None) -> str:
+def skills_list(category: str = None, task_id: str = None, include_archived: bool = False) -> str:
     """
     List all available skills (progressive disclosure tier 1 - minimal metadata).
 
@@ -694,6 +695,7 @@ def skills_list(category: str = None, task_id: str = None) -> str:
     Args:
         category: Optional category filter (e.g., "mlops")
         task_id: Optional task identifier used to probe the active backend
+        include_archived: If True, also list archived skills (marked with status="archived")
 
     Returns:
         JSON string with minimal skill info: name, description, category
@@ -713,6 +715,23 @@ def skills_list(category: str = None, task_id: str = None) -> str:
 
         # Find all skills
         all_skills = _find_all_skills()
+
+        # Optionally include archived skills
+        if include_archived:
+            archive_dir = SKILLS_DIR / ".archive"
+            if archive_dir.exists():
+                for skill_md in archive_dir.rglob("SKILL.md"):
+                    try:
+                        raw = skill_md.read_text(encoding="utf-8")[:2000]
+                        fm, _ = _parse_frontmatter(raw)
+                        all_skills.append({
+                            "name": fm.get("name", skill_md.parent.name),
+                            "description": fm.get("description", ""),
+                            "category": "archived",
+                            "status": "archived",
+                        })
+                    except Exception:
+                        pass
 
         if not all_skills:
             return json.dumps(
@@ -797,10 +816,12 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
                 skill_md = direct_path.with_suffix(".md")
                 break
 
-        # Search by directory name across all dirs
+        # Search by directory name across all dirs (skip archived)
         if not skill_md:
             for search_dir in all_dirs:
                 for found_skill_md in search_dir.rglob("SKILL.md"):
+                    if any(part in _EXCLUDED_SKILL_DIRS for part in found_skill_md.parts):
+                        continue
                     if found_skill_md.parent.name == name:
                         skill_dir = found_skill_md.parent
                         skill_md = found_skill_md
@@ -813,12 +834,26 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
             for search_dir in all_dirs:
                 for found_md in search_dir.rglob(f"{name}.md"):
                     if found_md.name != "SKILL.md":
+                        if any(part in _EXCLUDED_SKILL_DIRS for part in found_md.parts):
+                            continue
                         skill_md = found_md
                         break
                 if skill_md:
                     break
 
         if not skill_md or not skill_md.exists():
+            # Fallback: check the archive directory
+            archive_dir = SKILLS_DIR / ".archive" / name
+            if archive_dir.is_dir() and (archive_dir / "SKILL.md").exists():
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": f"Skill '{name}' is archived.",
+                        "hint": "Use skill_manage(action='restore', name='" + name + "') to restore it.",
+                        "archived": True,
+                    },
+                    ensure_ascii=False,
+                )
             available = [s["name"] for s in _find_all_skills()[:20]]
             return json.dumps(
                 {
@@ -1220,6 +1255,11 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
         if isinstance(metadata, dict):
             result["metadata"] = metadata
 
+        try:
+            from hermes_state import SessionDB
+            SessionDB().record_skill_usage(skill_name, "view")
+        except Exception:
+            pass
         return json.dumps(result, ensure_ascii=False)
 
     except Exception as e:
@@ -1297,7 +1337,11 @@ SKILLS_LIST_SCHEMA = {
             "category": {
                 "type": "string",
                 "description": "Optional category filter to narrow results",
-            }
+            },
+            "include_archived": {
+                "type": "boolean",
+                "description": "Include archived skills in the list (default: false)",
+            },
         },
         "required": [],
     },
@@ -1327,7 +1371,8 @@ registry.register(
     toolset="skills",
     schema=SKILLS_LIST_SCHEMA,
     handler=lambda args, **kw: skills_list(
-        category=args.get("category"), task_id=kw.get("task_id")
+        category=args.get("category"), task_id=kw.get("task_id"),
+        include_archived=args.get("include_archived", False),
     ),
     check_fn=check_skills_requirements,
     emoji="📚",

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -84,6 +84,7 @@ from tools.registry import registry
 logger = logging.getLogger(__name__)
 
 
+
 # All skills live in ~/.hermes/skills/ (seeded from bundled skills/ on install).
 # This is the single source of truth -- agent edits, hub installs, and bundled
 # skills all coexist here without polluting the git repo.
@@ -101,7 +102,7 @@ _PLATFORM_MAP = {
     "linux": "linux",
     "windows": "win32",
 }
-_EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub"))
+_EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub", ".archive"))
 _REMOTE_ENV_BACKENDS = frozenset({"docker", "singularity", "modal", "ssh", "daytona"})
 _secret_capture_callback = None
 
@@ -675,7 +676,7 @@ def skills_categories(verbose: bool = False, task_id: str = None) -> str:
         return json.dumps({"success": False, "error": str(e)}, ensure_ascii=False)
 
 
-def skills_list(category: str = None, task_id: str = None) -> str:
+def skills_list(category: str = None, task_id: str = None, include_archived: bool = False) -> str:
     """
     List all available skills (progressive disclosure tier 1 - minimal metadata).
 
@@ -685,6 +686,7 @@ def skills_list(category: str = None, task_id: str = None) -> str:
     Args:
         category: Optional category filter (e.g., "mlops")
         task_id: Optional task identifier used to probe the active backend
+        include_archived: If True, also list archived skills (marked with status="archived")
 
     Returns:
         JSON string with minimal skill info: name, description, category
@@ -704,6 +706,23 @@ def skills_list(category: str = None, task_id: str = None) -> str:
 
         # Find all skills
         all_skills = _find_all_skills()
+
+        # Optionally include archived skills
+        if include_archived:
+            archive_dir = SKILLS_DIR / ".archive"
+            if archive_dir.exists():
+                for skill_md in archive_dir.rglob("SKILL.md"):
+                    try:
+                        raw = skill_md.read_text(encoding="utf-8")[:2000]
+                        fm, _ = _parse_frontmatter(raw)
+                        all_skills.append({
+                            "name": fm.get("name", skill_md.parent.name),
+                            "description": fm.get("description", ""),
+                            "category": "archived",
+                            "status": "archived",
+                        })
+                    except Exception:
+                        pass
 
         if not all_skills:
             return json.dumps(
@@ -776,9 +795,11 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
         elif direct_path.with_suffix(".md").exists():
             skill_md = direct_path.with_suffix(".md")
 
-        # Search by directory name
+        # Search by directory name (skip archived skills)
         if not skill_md:
             for found_skill_md in SKILLS_DIR.rglob("SKILL.md"):
+                if any(part in _EXCLUDED_SKILL_DIRS for part in found_skill_md.parts):
+                    continue
                 if found_skill_md.parent.name == name:
                     skill_dir = found_skill_md.parent
                     skill_md = found_skill_md
@@ -788,10 +809,24 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
         if not skill_md:
             for found_md in SKILLS_DIR.rglob(f"{name}.md"):
                 if found_md.name != "SKILL.md":
+                    if any(part in _EXCLUDED_SKILL_DIRS for part in found_md.parts):
+                        continue
                     skill_md = found_md
                     break
 
         if not skill_md or not skill_md.exists():
+            # Fallback: check the archive directory
+            archive_dir = SKILLS_DIR / ".archive" / name
+            if archive_dir.is_dir() and (archive_dir / "SKILL.md").exists():
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": f"Skill '{name}' is archived.",
+                        "hint": "Use skill_manage(action='restore', name='" + name + "') to restore it.",
+                        "archived": True,
+                    },
+                    ensure_ascii=False,
+                )
             available = [s["name"] for s in _find_all_skills()[:20]]
             return json.dumps(
                 {
@@ -1156,6 +1191,11 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
         if isinstance(metadata, dict):
             result["metadata"] = metadata
 
+        try:
+            from hermes_state import SessionDB
+            SessionDB().record_skill_usage(skill_name, "view")
+        except Exception:
+            pass
         return json.dumps(result, ensure_ascii=False)
 
     except Exception as e:
@@ -1233,7 +1273,11 @@ SKILLS_LIST_SCHEMA = {
             "category": {
                 "type": "string",
                 "description": "Optional category filter to narrow results",
-            }
+            },
+            "include_archived": {
+                "type": "boolean",
+                "description": "Include archived skills in the list (default: false)",
+            },
         },
         "required": [],
     },
@@ -1263,7 +1307,8 @@ registry.register(
     toolset="skills",
     schema=SKILLS_LIST_SCHEMA,
     handler=lambda args, **kw: skills_list(
-        category=args.get("category"), task_id=kw.get("task_id")
+        category=args.get("category"), task_id=kw.get("task_id"),
+        include_archived=args.get("include_archived", False),
     ),
     check_fn=check_skills_requirements,
     emoji="📚",


### PR DESCRIPTION
## What does this PR do?

Skills in the system prompt are now ranked by usage frequency + keyword relevance to the user's message, replacing the alphabetical dump that buried the right skills.

Also adds usage tracking, opt-in token budgets, auto-archival of stale skills, and CLI commands to manage skill health.

## Problem

Every skill is injected into the system prompt alphabetically with no limits. With 98 skills, `ml-paper-writing` sits at position 86 and `systematic-debugging` at 95. The LLM scans through dozens of irrelevant skills before finding the one that matches — or gives up and improvises.

The system prompt is immune to context compression, so this gets worse over time as skills accumulate.

## How it works

1. **Usage tracking** — `skill_usage` table (schema v7) records every view, invoke, and slash command. Scored with recency-weighted frequency in a single SQL query.
2. **Keyword relevance** — Jaccard similarity between user message and skill metadata (name, description, tags), expanded with suffix stemming and a domain synonym map (`tweet` -> `twitter`, `bug` -> `debug`).
3. **Normalized merge** — both signals normalized to 0-1 before combining. Relevance weighted 3x so query-relevant skills beat daily-driver habits.
4. **Flat output** — when scores are active, skills listed in score order instead of grouped by category.

## Related Issue

#4356 #4379 #4319 #4391 #4404 

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/prompt_builder.py` — keyword relevance scoring, suffix stemmer, synonym map, token budget, normalized merge, flat ranked output
- `hermes_state.py` — schema v7 migration with `skill_usage` table, ranking/stats/last-used queries, self-cleaning purge
- `tools/skill_manager_tool.py` — archive/restore, bundled skill detection, dedup check on create, `find_archivable_skills()`
- `tools/skills_tool.py` — usage tracking on skill_view, `.archive` exclusion, `include_archived` param, archive fallback with restore hint
- `agent/skill_commands.py` — usage tracking on slash command invocations
- `agent/skill_utils.py` — `.archive` added to `EXCLUDED_SKILL_DIRS`
- `hermes_cli/config.py` — `skills` config block (token_budget, max_prompt_skills, pinned_skills, auto_archive_days)
- `hermes_cli/main.py` — argparse for stats/archive/restore/prune subcommands
- `hermes_cli/skills_config.py` — CLI implementations for stats, archive, restore, prune
- `run_agent.py` — loads skills config, computes usage scores, passes user_message to prompt builder, background auto-archive
- `tests/test_skills_overflow.py` — 47 tests covering all new features

All config defaults preserve existing behavior (0 = unlimited/disabled). No breaking changes.

## How to Test

1. `pytest tests/test_skills_overflow.py -v` — 47 tests, all pass
2. `pytest tests/ -k skill -q` — full skill test suite, 0 new regressions
3. Start hermes with default config — all skills appear as before
4. Set `skills.token_budget: 4000` — skills section capped, footer shows omitted count
5. `hermes skills stats` — shows usage data after interacting with skills
6. `hermes skills archive <name>` then `hermes skills restore <name>`
7. `hermes skills prune --days 90` — lists unused skills, prompts for confirmation

## Benchmark (98 real skills)

| Query | Before | After |
|-------|--------|-------|
| "write a research paper for NeurIPS" | ml-paper-writing 86, arxiv 82 | **2, 3** |
| "set up a vector database for RAG" | qdrant 73, pinecone 72, chroma 70 | **5, 7, 8** |
| "post a tweet about my project" | xitter 90 | **2** |
| "debug my python code that crashes" | systematic-debugging 95 | **9** |
| "find a restaurant nearby" | find-nearby 27 | **1** |

**Right skill in top 20: 29% -> 93%**

End-to-end with gemma-3-4b: LLM picked the correct skill **6/6** vs 4/6 on alphabetical ordering.

