### PR TITLE
fix(cli): initialize ctx_len before compact banner path

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2168,18 +2168,18 @@ class HermesCLI:
         term_width = shutil.get_terminal_size().columns
         use_compact = self.compact or term_width < 80
         
+        ctx_len = None
         if use_compact:
             self.console.print(_build_compact_banner())
             self._show_status()
         else:
             # Get tools for display
             tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
-            
+
             # Get terminal working directory (where commands will execute)
             cwd = os.getenv("TERMINAL_CWD", os.getcwd())
-            
+
             # Get context length for display
-            ctx_len = None
             if hasattr(self, 'agent') and self.agent and hasattr(self.agent, 'context_compressor'):
                 ctx_len = self.agent.context_compressor.context_length
             


### PR DESCRIPTION
## Summary
- `ctx_len` was only assigned inside the `else` (non-compact) branch of `show_banner()` but referenced unconditionally after the `if/else`, causing `UnboundLocalError` when the terminal is narrow or `--compact` is set.
- Moved `ctx_len = None` before the branch so it's always initialized.

## Test plan
- [ ] Run `hermes` in a terminal narrower than 80 columns (triggers compact banner)
- [ ] Run `hermes --compact`
- [ ] Confirm no `UnboundLocalError` crash on startup