### PR TITLE
feat: add inline diff previews for write actions

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2162,6 +2162,12 @@ class HermesCLI:
     def show_banner(self):
         """Display the welcome banner in Claude Code style."""
         self.console.clear()
+
+        # Get context length for display before branching so it remains
+        # available to the low-context warning logic in compact mode too.
+        ctx_len = None
+        if hasattr(self, 'agent') and self.agent and hasattr(self.agent, 'context_compressor'):
+            ctx_len = self.agent.context_compressor.context_length
         
         # Auto-compact for narrow terminals — the full banner with caduceus
         # + tool list needs ~80 columns minimum to render without wrapping.
@@ -2177,11 +2183,6 @@ class HermesCLI:
             
             # Get terminal working directory (where commands will execute)
             cwd = os.getenv("TERMINAL_CWD", os.getcwd())
-            
-            # Get context length for display
-            ctx_len = None
-            if hasattr(self, 'agent') and self.agent and hasattr(self.agent, 'context_compressor'):
-                ctx_len = self.agent.context_compressor.context_length
             
             # Build and display the banner
             build_welcome_banner(

--- a/tests/test_cli_context_warning.py
+++ b/tests/test_cli_context_warning.py
@@ -32,6 +32,8 @@ def cli_obj(_isolate):
         obj.session_id = None
         obj.api_key = "test"
         obj.base_url = ""
+        obj.provider = "test"
+        obj._provider_source = None
         # Mock agent with context compressor
         obj.agent = SimpleNamespace(
             context_compressor=SimpleNamespace(context_length=None)

--- a/tests/test_cli_context_warning.py
+++ b/tests/test_cli_context_warning.py
@@ -145,3 +145,15 @@ class TestLowContextWarning:
         calls = [str(c) for c in cli_obj.console.print.call_args_list]
         warning_calls = [c for c in calls if "too low" in c]
         assert len(warning_calls) == 0
+
+    def test_compact_banner_does_not_crash_on_narrow_terminal(self, cli_obj):
+        """Compact mode should still have ctx_len defined for warning logic."""
+        cli_obj.agent.context_compressor.context_length = 4096
+
+        with patch("shutil.get_terminal_size", return_value=os.terminal_size((70, 40))), \
+             patch("cli._build_compact_banner", return_value="compact banner"):
+            cli_obj.show_banner()
+
+        calls = [str(c) for c in cli_obj.console.print.call_args_list]
+        warning_calls = [c for c in calls if "too low" in c]
+        assert len(warning_calls) == 1


### PR DESCRIPTION
## Summary

Adds inline diff previews to the CLI transcript for write actions (`write_file`, `patch`, `skill_manage`). When a file-modifying tool completes successfully, a colored unified diff is rendered inline showing exactly what changed.

### How it works
1. `tool_start_callback` captures a filesystem snapshot of target files before the tool runs
2. `tool_complete_callback` computes a unified diff between before/after states
3. The diff is rendered with ANSI coloring (red bg for removed, green bg for added) and capped at 80 lines / 6 files to avoid flooding the transcript

### Config
Gated by `display.inline_diffs` (default: `true`). Disable with:
```
hermes config set display.inline_diffs false
```

### Additional fix
Normalizes `_extract_parallel_scope_path` to convert relative paths to absolute, fixing a bug where parallel tool execution could miss file conflicts when the same file is referenced with relative vs absolute paths.

### Changes
- `agent/display.py` — Snapshot capture, diff computation, inline ANSI rendering (+296 lines)
- `cli.py` — `_on_tool_start` / `_on_tool_complete` callbacks, `_inline_diffs_enabled` config gate
- `run_agent.py` — `tool_start_callback` / `tool_complete_callback` params, hook invocations in both sequential and concurrent execution paths, path normalization fix
- `hermes_cli/config.py` — `display.inline_diffs` default
- Tests — 10 new display tests, 5 new run_agent tests (callbacks + path normalization)

Salvaged from PR #3774 by @kshitijk4poor — rebuilt on current main, added config gate, removed unused `subprocess` import. Contributor authorship preserved.
