### PR TITLE
fix(cli): pin entire TUI to bottom of terminal on startup

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6343,6 +6343,17 @@ class HermesCLI:
 
     def run(self):
         """Run the interactive CLI loop with persistent input at bottom."""
+        # Push the entire TUI to the bottom of the terminal so the banner,
+        # responses, and prompt all appear pinned to the bottom — empty
+        # space stays above, not below.  This prints enough blank lines to
+        # scroll the cursor to the last row before any content is rendered.
+        try:
+            _term_lines = shutil.get_terminal_size().lines
+            if _term_lines > 2:
+                print("\n" * (_term_lines - 1), end="", flush=True)
+        except Exception:
+            pass
+
         self.show_banner()
 
         # One-line Honcho session indicator (TTY-only, not captured by agent).
@@ -7568,18 +7579,6 @@ class HermesCLI:
                     finally:
                         self._agent_running = False
                         self._spinner_text = ""
-
-                        # Push the input prompt toward the bottom of the
-                        # terminal so it doesn't sit mid-screen after short
-                        # responses.  patch_stdout renders these newlines
-                        # above the input area, creating visual separation
-                        # and anchoring the prompt near the bottom.
-                        try:
-                            _pad = shutil.get_terminal_size().lines // 2
-                            if _pad > 2:
-                                _cprint("\n" * _pad)
-                        except Exception:
-                            pass
 
                         app.invalidate()  # Refresh status line
 


### PR DESCRIPTION
## Summary

Replaces the per-response padding from PR #4359 with a one-time initial scroll at session start.

**Problem:** PR #4359 printed `terminal_height // 2` blank newlines after every response to push the prompt to the bottom. This created a massive void between short responses and the prompt — the response sat at the top of the terminal, the prompt at the bottom, with empty space between. ([screenshot](https://github.com/NousResearch/hermes-agent/issues/4359))

**Fix:** Print `terminal_height - 1` newlines once at the start of `run()`, before the banner. This scrolls the cursor to the bottom row so the entire TUI (banner, content, prompt) appears pinned to the bottom with empty space above, not below. `patch_stdout` naturally keeps the prompt at the bottom from there — no per-response padding needed.

## Changes

- **Added** initial terminal scroll in `run()` before `show_banner()` (11 lines)
- **Removed** per-response padding in the agent loop `finally` block (12 lines)

## Test plan

- `python -m pytest tests/test_cli_init.py -n0 -q` — 24/24 passed
- Live PTY test in tmux: banner pinned to bottom, prompt at bottom, no void after responses
- py_compile clean