### PR TITLE
fix(cli): honor main tracking remote during update checks

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -12,6 +12,7 @@ import threading
 import time
 from pathlib import Path
 from hermes_constants import get_hermes_home
+from hermes_cli.update_git import resolve_update_remote
 from typing import Dict, List, Optional
 
 from rich.console import Console
@@ -131,11 +132,12 @@ _UPDATE_CHECK_CACHE_SECONDS = 6 * 3600
 
 
 def check_for_updates() -> Optional[int]:
-    """Check how many commits behind origin/main the local repo is.
+    """Check how many commits behind the update remote's ``main`` branch we are.
 
-    Does a ``git fetch`` at most once every 6 hours (cached to
-    ``~/.hermes/.update_check``).  Returns the number of commits behind,
-    or ``None`` if the check fails or isn't applicable.
+    The update remote is normally the tracking remote for ``main`` when present,
+    otherwise ``origin``. Does a ``git fetch`` at most once every 6 hours
+    (cached to ``~/.hermes/.update_check``). Returns the number of commits
+    behind, or ``None`` if the check fails or isn't applicable.
     """
     hermes_home = get_hermes_home()
     repo_dir = hermes_home / "hermes-agent"
@@ -147,12 +149,17 @@ def check_for_updates() -> Optional[int]:
     if not (repo_dir / ".git").exists():
         return None
 
+    update_remote = resolve_update_remote(repo_dir)
+
     # Read cache
     now = time.time()
     try:
         if cache_file.exists():
             cached = json.loads(cache_file.read_text())
-            if now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS:
+            if (
+                now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
+                and cached.get("remote") == update_remote
+            ):
                 return cached.get("behind")
     except Exception:
         pass
@@ -160,7 +167,7 @@ def check_for_updates() -> Optional[int]:
     # Fetch latest refs (fast — only downloads ref metadata, no files)
     try:
         subprocess.run(
-            ["git", "fetch", "origin", "--quiet"],
+            ["git", "fetch", update_remote, "--quiet"],
             capture_output=True, timeout=10,
             cwd=str(repo_dir),
         )
@@ -170,7 +177,7 @@ def check_for_updates() -> Optional[int]:
     # Count commits behind
     try:
         result = subprocess.run(
-            ["git", "rev-list", "--count", "HEAD..origin/main"],
+            ["git", "rev-list", "--count", f"HEAD..{update_remote}/main"],
             capture_output=True, text=True, timeout=5,
             cwd=str(repo_dir),
         )
@@ -183,7 +190,7 @@ def check_for_updates() -> Optional[int]:
 
     # Write cache
     try:
-        cache_file.write_text(json.dumps({"ts": now, "behind": behind}))
+        cache_file.write_text(json.dumps({"ts": now, "behind": behind, "remote": update_remote}))
     except Exception:
         pass
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2885,6 +2885,7 @@ def cmd_update(args):
     """Update Hermes Agent to the latest version."""
     import shutil
     from hermes_cli.config import is_managed, managed_error
+    from hermes_cli.update_git import resolve_update_remote
 
     if is_managed():
         managed_error("update Hermes Agent")
@@ -2925,9 +2926,11 @@ def cmd_update(args):
         if sys.platform == "win32":
             git_cmd = ["git", "-c", "windows.appendAtomically=false"]
 
-        print("→ Fetching updates...")
+        update_remote = resolve_update_remote(PROJECT_ROOT)
+
+        print(f"→ Fetching updates from {update_remote}...")
         fetch_result = subprocess.run(
-            git_cmd + ["fetch", "origin"],
+            git_cmd + ["fetch", update_remote],
             cwd=PROJECT_ROOT,
             capture_output=True,
             text=True,
@@ -2940,7 +2943,7 @@ def cmd_update(args):
             elif "Authentication failed" in stderr or "could not read Username" in stderr:
                 print("✗ Authentication failed — check your git credentials or SSH key.")
             else:
-                print(f"✗ Failed to fetch updates from origin.")
+                print(f"✗ Failed to fetch updates from {update_remote}.")
                 if stderr:
                     print(f"  {stderr.splitlines()[0]}")
             sys.exit(1)
@@ -2978,7 +2981,7 @@ def cmd_update(args):
 
         # Check if there are updates
         result = subprocess.run(
-            git_cmd + ["rev-list", f"HEAD..origin/{branch}", "--count"],
+            git_cmd + ["rev-list", f"HEAD..{update_remote}/{branch}", "--count"],
             cwd=PROJECT_ROOT,
             capture_output=True,
             text=True,
@@ -3008,7 +3011,7 @@ def cmd_update(args):
         update_succeeded = False
         try:
             pull_result = subprocess.run(
-                git_cmd + ["pull", "--ff-only", "origin", branch],
+                git_cmd + ["pull", "--ff-only", update_remote, branch],
                 cwd=PROJECT_ROOT,
                 capture_output=True,
                 text=True,
@@ -3017,18 +3020,18 @@ def cmd_update(args):
                 # ff-only failed — local and remote have diverged (e.g. upstream
                 # force-pushed or rebase).  Since local changes are already
                 # stashed, reset to match the remote exactly.
-                print("  ⚠ Fast-forward not possible (history diverged), resetting to match remote...")
+                print(f"  ⚠ Fast-forward not possible (history diverged), resetting to match {update_remote}/{branch}...")
                 reset_result = subprocess.run(
-                    git_cmd + ["reset", "--hard", f"origin/{branch}"],
+                    git_cmd + ["reset", "--hard", f"{update_remote}/{branch}"],
                     cwd=PROJECT_ROOT,
                     capture_output=True,
                     text=True,
                 )
                 if reset_result.returncode != 0:
-                    print(f"✗ Failed to reset to origin/{branch}.")
+                    print(f"✗ Failed to reset to {update_remote}/{branch}.")
                     if reset_result.stderr.strip():
                         print(f"  {reset_result.stderr.strip()}")
-                    print("  Try manually: git fetch origin && git reset --hard origin/main")
+                    print(f"  Try manually: git fetch {update_remote} && git reset --hard {update_remote}/main")
                     sys.exit(1)
             update_succeeded = True
         finally:

--- a/hermes_cli/update_git.py
+++ b/hermes_cli/update_git.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import List, Optional
+
+
+def _git_stdout(repo_dir: Path, args: List[str], *, timeout: Optional[int] = None) -> tuple[int, str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=str(repo_dir),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    return result.returncode, (result.stdout or "").strip()
+
+
+def resolve_update_remote(repo_dir: Path) -> str:
+    """Resolve which git remote Hermes should use for update checks.
+
+    Prefer the configured tracking remote for ``main`` when available. This
+    avoids false "Already up to date" results in contributor checkouts where
+    ``origin`` points to a personal fork and ``main`` tracks ``upstream/main``.
+
+    Fallback order:
+    1. ``branch.main.remote`` when it exists and the remote is configured
+    2. ``origin``
+    3. ``upstream``
+    4. first configured remote
+    5. literal ``origin`` as a final default
+    """
+
+    rc, configured_remote = _git_stdout(repo_dir, ["config", "--get", "branch.main.remote"], timeout=5)
+    rc_remotes, remotes_out = _git_stdout(repo_dir, ["remote"], timeout=5)
+    remotes = [line.strip() for line in remotes_out.splitlines() if line.strip()] if rc_remotes == 0 else []
+
+    if rc == 0 and configured_remote and configured_remote in remotes:
+        return configured_remote
+    if "origin" in remotes:
+        return "origin"
+    if "upstream" in remotes:
+        return "upstream"
+    if remotes:
+        return remotes[0]
+    return "origin"

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -4,6 +4,8 @@ import subprocess
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import hermes_cli.main as hermes_main
+
 import pytest
 
 from hermes_cli.main import cmd_update, PROJECT_ROOT
@@ -105,6 +107,33 @@ class TestCmdUpdateBranchFallback:
         commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
         pull_cmds = [c for c in commands if "pull" in c]
         assert len(pull_cmds) == 0
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_update_uses_main_tracking_remote_when_origin_is_a_fork(
+        self, mock_run, _mock_which, mock_args, monkeypatch
+    ):
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="2"
+        )
+        monkeypatch.setattr(hermes_main, "PROJECT_ROOT", PROJECT_ROOT)
+        monkeypatch.setattr(
+            "hermes_cli.update_git.resolve_update_remote",
+            lambda _repo_dir: "upstream",
+        )
+
+        cmd_update(mock_args)
+
+        commands = [" ".join(str(a) for a in c.args[0]) for c in mock_run.call_args_list]
+        fetch_cmds = [c for c in commands if "fetch upstream" in c]
+        rev_list_cmds = [c for c in commands if "rev-list" in c]
+        pull_cmds = [c for c in commands if "pull" in c]
+
+        assert len(fetch_cmds) == 1
+        assert len(rev_list_cmds) == 1
+        assert "upstream/main" in rev_list_cmds[0]
+        assert len(pull_cmds) == 1
+        assert "pull --ff-only upstream main" in pull_cmds[0]
 
     def test_update_non_interactive_skips_migration_prompt(self, mock_args, capsys):
         """When stdin/stdout aren't TTYs, config migration prompt is skipped."""

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -25,11 +25,12 @@ def test_check_for_updates_uses_cache(tmp_path):
     (repo_dir / ".git").mkdir()
 
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3}))
+    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3, "remote": "origin"}))
 
     with patch("hermes_cli.banner.os.getenv", return_value=str(tmp_path)):
-        with patch("hermes_cli.banner.subprocess.run") as mock_run:
-            result = check_for_updates()
+        with patch("hermes_cli.banner.resolve_update_remote", return_value="origin"):
+            with patch("hermes_cli.banner.subprocess.run") as mock_run:
+                result = check_for_updates()
 
     assert result == 3
     mock_run.assert_not_called()
@@ -45,13 +46,14 @@ def test_check_for_updates_expired_cache(tmp_path):
 
     # Write an expired cache (timestamp far in the past)
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": 0, "behind": 1}))
+    cache_file.write_text(json.dumps({"ts": 0, "behind": 1, "remote": "origin"}))
 
     mock_result = MagicMock(returncode=0, stdout="5\n")
 
     with patch("hermes_cli.banner.os.getenv", return_value=str(tmp_path)):
-        with patch("hermes_cli.banner.subprocess.run", return_value=mock_result) as mock_run:
-            result = check_for_updates()
+        with patch("hermes_cli.banner.resolve_update_remote", return_value="origin"):
+            with patch("hermes_cli.banner.subprocess.run", return_value=mock_result) as mock_run:
+                result = check_for_updates()
 
     assert result == 5
     assert mock_run.call_count == 2  # git fetch + git rev-list
@@ -90,11 +92,34 @@ def test_check_for_updates_fallback_to_project_root():
     import tempfile
     with tempfile.TemporaryDirectory() as td:
         with patch("hermes_cli.banner.os.getenv", return_value=td):
-            with patch("hermes_cli.banner.subprocess.run") as mock_run:
-                mock_run.return_value = MagicMock(returncode=0, stdout="0\n")
-                result = banner.check_for_updates()
+            with patch("hermes_cli.banner.resolve_update_remote", return_value="origin"):
+                with patch("hermes_cli.banner.subprocess.run") as mock_run:
+                    mock_run.return_value = MagicMock(returncode=0, stdout="0\n")
+                    result = banner.check_for_updates()
         # Should have fallen back to project root and run git commands
         assert mock_run.call_count >= 1
+
+
+def test_check_for_updates_invalidates_cache_when_remote_changes(tmp_path):
+    """A cache entry for a different remote should not short-circuit the git check."""
+    from hermes_cli.banner import check_for_updates
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3, "remote": "origin"}))
+
+    mock_result = MagicMock(returncode=0, stdout="7\n")
+
+    with patch("hermes_cli.banner.os.getenv", return_value=str(tmp_path)):
+        with patch("hermes_cli.banner.resolve_update_remote", return_value="upstream"):
+            with patch("hermes_cli.banner.subprocess.run", return_value=mock_result) as mock_run:
+                result = check_for_updates()
+
+    assert result == 7
+    assert mock_run.call_count == 2
 
 
 def test_prefetch_non_blocking():

--- a/tests/hermes_cli/test_update_git.py
+++ b/tests/hermes_cli/test_update_git.py
@@ -1,0 +1,37 @@
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from hermes_cli.update_git import resolve_update_remote
+
+
+def test_resolve_update_remote_prefers_main_tracking_remote(tmp_path):
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+
+    def side_effect(cmd, **kwargs):
+        joined = " ".join(str(c) for c in cmd)
+        if "config --get branch.main.remote" in joined:
+            return subprocess.CompletedProcess(cmd, 0, stdout="upstream\n", stderr="")
+        if cmd[-1] == "remote":
+            return subprocess.CompletedProcess(cmd, 0, stdout="origin\nupstream\n", stderr="")
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    with patch("hermes_cli.update_git.subprocess.run", side_effect=side_effect):
+        assert resolve_update_remote(repo_dir) == "upstream"
+
+
+def test_resolve_update_remote_falls_back_to_origin(tmp_path):
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+
+    def side_effect(cmd, **kwargs):
+        joined = " ".join(str(c) for c in cmd)
+        if "config --get branch.main.remote" in joined:
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="")
+        if cmd[-1] == "remote":
+            return subprocess.CompletedProcess(cmd, 0, stdout="origin\n", stderr="")
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    with patch("hermes_cli.update_git.subprocess.run", side_effect=side_effect):
+        assert resolve_update_remote(repo_dir) == "origin"


### PR DESCRIPTION
## Problem

`hermes update` and the CLI banner update check assume `origin/main` is always the canonical update source.

That is true for managed installs, but it is false in common contributor/dev checkouts where:
- `origin` points to a personal fork
- `main` tracks `upstream/main`

In that layout Hermes can fetch the fork, see `HEAD..origin/main == 0`, and incorrectly print `Already up to date!` even when the canonical upstream repo has newer commits.

## Root Cause

The update path and banner check hardcoded `origin/main` instead of resolving the configured tracking remote for `main`.

That made update status depend on remote naming conventions rather than the repository's actual branch tracking configuration.

## Fix

- added `hermes_cli/update_git.py` with `resolve_update_remote()`
- prefer `branch.main.remote` when it exists and the remote is configured
- fall back to `origin`, then `upstream`, then the first configured remote
- updated `hermes_cli.main.cmd_update()` to fetch/pull/reset against the resolved update remote
- updated `hermes_cli.banner.check_for_updates()` to use the same remote resolution
- made the banner cache remote-aware so stale cached results from a different remote do not mask updates

## Testing

- `python -m pytest tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_update_check.py tests/hermes_cli/test_update_git.py -q`
  - 15 passed

## Notes

This fixes the false-positive "Already up to date" behavior in fork-based Hermes development checkouts while preserving existing behavior for normal installs where `main` tracks `origin/main`. 