### PR TITLE
fix(security): isolate tool subprocesses with PID namespaces

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -566,7 +566,7 @@ Hermes has terminal access. Security matters.
 | **Cron prompt injection** | Scanner in `tools/cronjob_tools.py` blocks instruction-override patterns |
 | **Write deny list** | Protected paths (`~/.ssh/authorized_keys`, `/etc/shadow`) resolved via `os.path.realpath()` to prevent symlink bypass |
 | **Skills guard** | Security scanner for hub-installed skills (`tools/skills_guard.py`) |
-| **Code execution sandbox** | `execute_code` and `terminal` child processes run with API keys stripped from environment and isolated in a PID namespace (Linux) to prevent `/proc/environ` recovery |
+| **Code execution sandbox** | `execute_code` and short-lived foreground local `terminal` commands run with API keys stripped from environment and isolated in a PID namespace (Linux) to prevent `/proc/environ` recovery |
 | **Container hardening** | Docker: all capabilities dropped, no privilege escalation, PID limits, size-limited tmpfs |
 
 ### When contributing security-sensitive code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -566,7 +566,7 @@ Hermes has terminal access. Security matters.
 | **Cron prompt injection** | Scanner in `tools/cronjob_tools.py` blocks instruction-override patterns |
 | **Write deny list** | Protected paths (`~/.ssh/authorized_keys`, `/etc/shadow`) resolved via `os.path.realpath()` to prevent symlink bypass |
 | **Skills guard** | Security scanner for hub-installed skills (`tools/skills_guard.py`) |
-| **Code execution sandbox** | `execute_code` child process runs with API keys stripped from environment |
+| **Code execution sandbox** | `execute_code` and `terminal` child processes run with API keys stripped from environment and isolated in a PID namespace (Linux) to prevent `/proc/environ` recovery |
 | **Container hardening** | Docker: all capabilities dropped, no privilege escalation, PID limits, size-limited tmpfs |
 
 ### When contributing security-sensitive code

--- a/tests/tools/_proc_environ_child.py
+++ b/tests/tools/_proc_environ_child.py
@@ -1,0 +1,20 @@
+"""Helper: child process for /proc/environ isolation test.
+
+Spawned inside a PID namespace by _proc_environ_parent.py with a
+clean environment. Attempts to read the parent's /proc/<ppid>/environ
+and print the value of HERMES_TEST_SECRET.
+"""
+import os
+
+ppid = os.getppid()
+try:
+    with open(f"/proc/{ppid}/environ", "rb") as f:
+        raw = f.read()
+    env = dict(
+        e.decode("utf-8", "replace").split("=", 1)
+        for e in raw.split(b"\x00")
+        if b"=" in e
+    )
+    print(env.get("HERMES_TEST_SECRET", "NOT_FOUND"))
+except Exception as e:
+    print(f"ERROR:{e}")

--- a/tests/tools/_proc_environ_parent.py
+++ b/tests/tools/_proc_environ_parent.py
@@ -1,0 +1,23 @@
+"""Helper: parent process for /proc/environ isolation test.
+
+Spawned by TestProcEnvironIsolation with HERMES_TEST_SECRET in its
+exec-time environment. Spawns a child via _pidns_wrap with a clean
+env, then prints whatever the child outputs.
+"""
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.environ["HERMES_AGENT_ROOT"])
+from tools.environments.local import _pidns_wrap
+
+child_script = sys.argv[1]
+child_env = {"PATH": os.environ.get("PATH", "/usr/bin"), "HOME": "/tmp"}
+
+result = subprocess.run(
+    _pidns_wrap([sys.executable, child_script]),
+    env=child_env,
+    capture_output=True,
+    text=True,
+)
+print(result.stdout.strip())

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -17,7 +17,12 @@ from tools.environments.local import (
     LocalEnvironment,
     _HERMES_PROVIDER_ENV_BLOCKLIST,
     _HERMES_PROVIDER_ENV_FORCE_PREFIX,
+    _have_unshare,
 )
+
+
+_is_linux = os.uname().sysname == "Linux" if hasattr(os, "uname") else False
+_has_unshare = _have_unshare()
 
 
 def _make_fake_popen(captured: dict):
@@ -307,53 +312,88 @@ class TestPidNamespaceWrap:
         cmd = ["bash", "-c", "echo hi"]
         assert local._pidns_wrap(cmd) is cmd
 
+    def test_have_unshare_requires_working_probe(self, monkeypatch):
+        from tools.environments import local
 
-import platform
-import shutil
+        monkeypatch.setattr(local, "_IS_LINUX", True)
+        monkeypatch.setattr(local.shutil, "which", lambda _: "/usr/bin/unshare")
 
-_is_linux = platform.system() == "Linux"
-_has_unshare = _is_linux and shutil.which("unshare") is not None
+        def fake_run(*args, **kwargs):
+            proc = MagicMock()
+            proc.returncode = 1
+            return proc
+
+        monkeypatch.setattr(local.subprocess, "run", fake_run)
+        assert local._have_unshare() is False
+
+    def test_have_unshare_accepts_successful_probe(self, monkeypatch):
+        from tools.environments import local
+
+        monkeypatch.setattr(local, "_IS_LINUX", True)
+        monkeypatch.setattr(local.shutil, "which", lambda _: "/usr/bin/unshare")
+
+        def fake_run(*args, **kwargs):
+            proc = MagicMock()
+            proc.returncode = 0
+            return proc
+
+        monkeypatch.setattr(local.subprocess, "run", fake_run)
+        assert local._have_unshare() is True
+
+    def test_persistent_shell_spawn_is_not_wrapped(self, monkeypatch):
+        """Persistent shells keep host-visible PIDs for child cleanup."""
+        from tools.environments import local
+
+        captured = {}
+
+        def fake_popen(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return MagicMock()
+
+        monkeypatch.setattr(local, "_UNSHARE_AVAILABLE", True)
+        monkeypatch.setattr(local, "_find_bash", lambda: "/bin/bash")
+        monkeypatch.setattr(local.subprocess, "Popen", fake_popen)
+
+        env = local.LocalEnvironment(cwd="/tmp", timeout=10)
+        env._spawn_shell_process()
+
+        assert captured["cmd"] == ["/bin/bash", "-l"]
 
 
 @pytest.mark.skipif(not _is_linux, reason="Linux-only: /proc does not exist on other platforms")
 @pytest.mark.skipif(not _has_unshare, reason="unshare not available")
 class TestProcEnvironIsolation:
-    """Regression test: PID namespace prevents /proc/environ secret recovery."""
+    """Regression test: PID namespace prevents /proc/environ secret recovery.
+
+    /proc/<pid>/environ is a kernel snapshot from exec time — os.environ
+    changes after startup do NOT appear there. The test uses a two-level
+    spawn: a parent process started WITH the secret in its env, which then
+    spawns a namespaced child that tries to read it back via /proc.
+
+    See: tests/tools/_proc_environ_parent.py
+    See: tests/tools/_proc_environ_child.py
+    """
 
     def test_pidns_child_cannot_read_parent_environ(self):
         """A child in a PID namespace cannot recover stripped env vars via /proc."""
-        import subprocess, sys, tempfile
-        from tools.environments.local import _pidns_wrap
+        import subprocess, sys
 
-        child_script = (
-            "import os\n"
-            "ppid = os.getppid()\n"
-            "try:\n"
-            "    with open(f'/proc/{ppid}/environ', 'rb') as f:\n"
-            "        raw = f.read()\n"
-            "    env = dict(\n"
-            "        e.decode('utf-8', 'replace').split('=', 1)\n"
-            "        for e in raw.split(b'\\x00') if b'=' in e\n"
-            "    )\n"
-            "    print(env.get('HERMES_TEST_SECRET', 'NOT_FOUND'))\n"
-            "except Exception as e:\n"
-            "    print(f'ERROR:{e}')\n"
-        )
+        tests_dir = os.path.dirname(os.path.abspath(__file__))
+        hermes_root = os.path.dirname(os.path.dirname(tests_dir))
+        parent_script = os.path.join(tests_dir, "_proc_environ_parent.py")
+        child_script = os.path.join(tests_dir, "_proc_environ_child.py")
 
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
-            f.write(child_script)
-            script = f.name
-
-        parent_env = os.environ.copy()
-        parent_env["HERMES_TEST_SECRET"] = "leaked-value-12345"
-
-        child_env = {"PATH": parent_env.get("PATH", "/usr/bin"), "HOME": "/tmp"}
+        parent_env = {
+            "PATH": os.environ.get("PATH", "/usr/bin"),
+            "HOME": "/tmp",
+            "HERMES_TEST_SECRET": "leaked-value-12345",
+            "HERMES_AGENT_ROOT": hermes_root,
+        }
         result = subprocess.run(
-            _pidns_wrap([sys.executable, script]),
-            env=child_env,
+            [sys.executable, parent_script, child_script],
+            env=parent_env,
             capture_output=True, text=True,
         )
-        os.unlink(script)
         output = result.stdout.strip()
         assert output != "leaked-value-12345", (
             "Child in PID namespace should NOT be able to recover the secret"

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -9,6 +9,7 @@ See: https://github.com/NousResearch/hermes-agent/issues/1264
 """
 
 import os
+import pytest
 import threading
 from unittest.mock import MagicMock, patch
 
@@ -288,6 +289,75 @@ class TestBlocklistCoverage:
             "DAYTONA_API_KEY",
         }
         assert extras.issubset(_HERMES_PROVIDER_ENV_BLOCKLIST)
+
+
+class TestPidNamespaceWrap:
+    """Verify _pidns_wrap wraps commands on Linux and is a no-op elsewhere."""
+
+    def test_wraps_on_linux_with_unshare(self, monkeypatch):
+        from tools.environments import local
+        monkeypatch.setattr(local, "_UNSHARE_AVAILABLE", True)
+        result = local._pidns_wrap(["bash", "-c", "echo hi"])
+        assert result[:5] == ["unshare", "--user", "--pid", "--fork", "--mount-proc"]
+        assert result[5:] == ["bash", "-c", "echo hi"]
+
+    def test_noop_without_unshare(self, monkeypatch):
+        from tools.environments import local
+        monkeypatch.setattr(local, "_UNSHARE_AVAILABLE", False)
+        cmd = ["bash", "-c", "echo hi"]
+        assert local._pidns_wrap(cmd) is cmd
+
+
+import platform
+import shutil
+
+_is_linux = platform.system() == "Linux"
+_has_unshare = _is_linux and shutil.which("unshare") is not None
+
+
+@pytest.mark.skipif(not _is_linux, reason="Linux-only: /proc does not exist on other platforms")
+@pytest.mark.skipif(not _has_unshare, reason="unshare not available")
+class TestProcEnvironIsolation:
+    """Regression test: PID namespace prevents /proc/environ secret recovery."""
+
+    def test_pidns_child_cannot_read_parent_environ(self):
+        """A child in a PID namespace cannot recover stripped env vars via /proc."""
+        import subprocess, sys, tempfile
+        from tools.environments.local import _pidns_wrap
+
+        child_script = (
+            "import os\n"
+            "ppid = os.getppid()\n"
+            "try:\n"
+            "    with open(f'/proc/{ppid}/environ', 'rb') as f:\n"
+            "        raw = f.read()\n"
+            "    env = dict(\n"
+            "        e.decode('utf-8', 'replace').split('=', 1)\n"
+            "        for e in raw.split(b'\\x00') if b'=' in e\n"
+            "    )\n"
+            "    print(env.get('HERMES_TEST_SECRET', 'NOT_FOUND'))\n"
+            "except Exception as e:\n"
+            "    print(f'ERROR:{e}')\n"
+        )
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+            f.write(child_script)
+            script = f.name
+
+        parent_env = os.environ.copy()
+        parent_env["HERMES_TEST_SECRET"] = "leaked-value-12345"
+
+        child_env = {"PATH": parent_env.get("PATH", "/usr/bin"), "HOME": "/tmp"}
+        result = subprocess.run(
+            _pidns_wrap([sys.executable, script]),
+            env=child_env,
+            capture_output=True, text=True,
+        )
+        os.unlink(script)
+        output = result.stdout.strip()
+        assert output != "leaked-value-12345", (
+            "Child in PID namespace should NOT be able to recover the secret"
+        )
 
 
 class TestSanePathIncludesHomebrew:

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 try:
     from tools.environments.local import _pidns_wrap as _pidns_wrap_exec
 except ImportError:
-    def _pidns_wrap_exec(cmd):
+    def _pidns_wrap_exec(cmd: list[str]) -> list[str]:
         return cmd
 
 SANDBOX_AVAILABLE = sys.platform != "win32"

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -40,7 +40,8 @@ logger = logging.getLogger(__name__)
 try:
     from tools.environments.local import _pidns_wrap as _pidns_wrap_exec
 except ImportError:
-    _pidns_wrap_exec = lambda cmd: cmd  # noqa: E731
+    def _pidns_wrap_exec(cmd):
+        return cmd
 
 SANDBOX_AVAILABLE = sys.platform != "win32"
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -36,6 +36,12 @@ from typing import Any, Dict, List, Optional
 # Availability gate: UDS requires a POSIX OS
 logger = logging.getLogger(__name__)
 
+
+try:
+    from tools.environments.local import _pidns_wrap as _pidns_wrap_exec
+except ImportError:
+    _pidns_wrap_exec = lambda cmd: cmd  # noqa: E731
+
 SANDBOX_AVAILABLE = sys.platform != "win32"
 
 # The 7 tools allowed inside the sandbox. The intersection of this list
@@ -466,7 +472,7 @@ def execute_code(
             child_env["TZ"] = _tz_name
 
         proc = subprocess.Popen(
-            [sys.executable, "script.py"],
+            _pidns_wrap_exec([sys.executable, "script.py"]),
             cwd=tmpdir,
             env=child_env,
             stdout=subprocess.PIPE,

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -133,10 +133,26 @@ _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
 
 
 def _have_unshare() -> bool:
-    """Check if unshare(1) is available (Linux only)."""
+    """Check if unshare(1) is usable for unprivileged PID namespaces."""
     if not _IS_LINUX:
         return False
-    return shutil.which("unshare") is not None
+
+    unshare_bin = shutil.which("unshare")
+    if unshare_bin is None:
+        return False
+
+    try:
+        probe = subprocess.run(
+            [unshare_bin, "--user", "--pid", "--fork", "--mount-proc", "/bin/sh", "-c", "exit 0"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+    return probe.returncode == 0
 
 
 _UNSHARE_AVAILABLE = _have_unshare()
@@ -149,6 +165,10 @@ def _pidns_wrap(cmd: list[str]) -> list[str]:
     parent and recover env vars that were stripped by the blocklist.
     Running the child in its own PID namespace (with a remounted /proc)
     hides the parent's PID entirely.
+
+    Intended for short-lived subprocesses only. Persistent local shells
+    currently stay in the host PID namespace because timeout/interrupt
+    cleanup tracks host PIDs for child reaping.
 
     Falls back to the unwrapped command on non-Linux or when unshare is
     unavailable (e.g. restricted containers).
@@ -368,7 +388,9 @@ class LocalEnvironment(PersistentShellMixin, BaseEnvironment):
         user_shell = _find_bash()
         run_env = _make_run_env(self.env)
         return subprocess.Popen(
-            _pidns_wrap([user_shell, "-l"]),
+            # Persistent local shells keep host-visible PIDs so interrupt/
+            # timeout cleanup can still target the right child process tree.
+            [user_shell, "-l"],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -10,6 +10,7 @@ import threading
 import time
 
 _IS_WINDOWS = platform.system() == "Windows"
+_IS_LINUX = platform.system() == "Linux"
 
 from tools.environments.base import BaseEnvironment
 from tools.environments.persistent_shell import PersistentShellMixin
@@ -129,6 +130,32 @@ def _build_provider_env_blocklist() -> frozenset:
 
 
 _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
+
+
+def _have_unshare() -> bool:
+    """Check if unshare(1) is available (Linux only)."""
+    if not _IS_LINUX:
+        return False
+    return shutil.which("unshare") is not None
+
+
+_UNSHARE_AVAILABLE = _have_unshare()
+
+
+def _pidns_wrap(cmd: list[str]) -> list[str]:
+    """Wrap a command in a PID namespace to prevent /proc/environ snooping.
+
+    On Linux, any same-UID process can read /proc/<pid>/environ of the
+    parent and recover env vars that were stripped by the blocklist.
+    Running the child in its own PID namespace (with a remounted /proc)
+    hides the parent's PID entirely.
+
+    Falls back to the unwrapped command on non-Linux or when unshare is
+    unavailable (e.g. restricted containers).
+    """
+    if not _UNSHARE_AVAILABLE:
+        return cmd
+    return ["unshare", "--user", "--pid", "--fork", "--mount-proc"] + cmd
 
 
 def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = None) -> dict:
@@ -341,7 +368,7 @@ class LocalEnvironment(PersistentShellMixin, BaseEnvironment):
         user_shell = _find_bash()
         run_env = _make_run_env(self.env)
         return subprocess.Popen(
-            [user_shell, "-l"],
+            _pidns_wrap([user_shell, "-l"]),
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
@@ -406,7 +433,7 @@ class LocalEnvironment(PersistentShellMixin, BaseEnvironment):
         run_env = _make_run_env(self.env)
 
         proc = subprocess.Popen(
-            [user_shell, "-lic", fenced_cmd],
+            _pidns_wrap([user_shell, "-lic", fenced_cmd]),
             text=True,
             cwd=work_dir,
             env=run_env,

--- a/website/docs/developer-guide/contributing.md
+++ b/website/docs/developer-guide/contributing.md
@@ -150,7 +150,7 @@ Hermes has terminal access. Security matters.
 | **Cron prompt injection** | Scanner blocks instruction-override patterns |
 | **Write deny list** | Protected paths resolved via `os.path.realpath()` to prevent symlink bypass |
 | **Skills guard** | Security scanner for hub-installed skills |
-| **Code execution sandbox** | Child process runs with API keys stripped and PID namespace isolation (Linux) to prevent `/proc/environ` recovery |
+| **Code execution sandbox** | `execute_code` and short-lived foreground local `terminal` commands run with API keys stripped and PID namespace isolation (Linux) to prevent `/proc/environ` recovery |
 | **Container hardening** | Docker: all capabilities dropped, no privilege escalation, PID limits |
 
 ### Contributing Security-Sensitive Code

--- a/website/docs/developer-guide/contributing.md
+++ b/website/docs/developer-guide/contributing.md
@@ -150,7 +150,7 @@ Hermes has terminal access. Security matters.
 | **Cron prompt injection** | Scanner blocks instruction-override patterns |
 | **Write deny list** | Protected paths resolved via `os.path.realpath()` to prevent symlink bypass |
 | **Skills guard** | Security scanner for hub-installed skills |
-| **Code execution sandbox** | Child process runs with API keys stripped |
+| **Code execution sandbox** | Child process runs with API keys stripped and PID namespace isolation (Linux) to prevent `/proc/environ` recovery |
 | **Container hardening** | Docker: all capabilities dropped, no privilege escalation, PID limits |
 
 ### Contributing Security-Sensitive Code

--- a/website/docs/user-guide/features/code-execution.md
+++ b/website/docs/user-guide/features/code-execution.md
@@ -170,6 +170,8 @@ The response always includes `status` (success/error/timeout/interrupted), `outp
 
 :::danger Security Model
 The child process runs with a **minimal environment**. API keys, tokens, and credentials are stripped by default. On Linux, the child is additionally isolated in a PID namespace so it cannot recover stripped secrets via `/proc/environ`. The script accesses tools exclusively via the RPC channel — it cannot read secrets from environment variables unless explicitly allowed.
+
+Note: secrets stored on the filesystem (e.g. `~/.hermes/.env`) remain readable by child processes. Also, PID namespace isolation is not yet applied to persistent/background/PTY local terminal modes. See [Environment Variable Passthrough](/docs/user-guide/security#environment-variable-passthrough) for details on limitations.
 :::
 
 Environment variables containing `KEY`, `TOKEN`, `SECRET`, `PASSWORD`, `CREDENTIAL`, `PASSWD`, or `AUTH` in their names are excluded. Only safe system variables (`PATH`, `HOME`, `LANG`, `SHELL`, `PYTHONPATH`, `VIRTUAL_ENV`, etc.) are passed through.

--- a/website/docs/user-guide/features/code-execution.md
+++ b/website/docs/user-guide/features/code-execution.md
@@ -169,7 +169,7 @@ The response always includes `status` (success/error/timeout/interrupted), `outp
 ## Security
 
 :::danger Security Model
-The child process runs with a **minimal environment**. API keys, tokens, and credentials are stripped by default. The script accesses tools exclusively via the RPC channel — it cannot read secrets from environment variables unless explicitly allowed.
+The child process runs with a **minimal environment**. API keys, tokens, and credentials are stripped by default. On Linux, the child is additionally isolated in a PID namespace so it cannot recover stripped secrets via `/proc/environ`. The script accesses tools exclusively via the RPC channel — it cannot read secrets from environment variables unless explicitly allowed.
 :::
 
 Environment variables containing `KEY`, `TOKEN`, `SECRET`, `PASSWORD`, `CREDENTIAL`, `PASSWD`, or `AUTH` in their names are excluded. Only safe system variables (`PATH`, `HOME`, `LANG`, `SHELL`, `PYTHONPATH`, `VIRTUAL_ENV`, etc.) are passed through.

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -326,7 +326,13 @@ If you add names to `terminal.docker_forward_env`, those variables are intention
 
 ## Environment Variable Passthrough {#environment-variable-passthrough}
 
-Both `execute_code` and `terminal` strip sensitive environment variables from child processes to prevent credential exfiltration by LLM-generated code. On Linux, child processes are additionally isolated in a PID namespace to prevent recovery of stripped secrets via `/proc/environ`. However, skills that declare `required_environment_variables` legitimately need access to those vars.
+Both `execute_code` and `terminal` strip sensitive environment variables from child processes to prevent credential exfiltration by LLM-generated code. On Linux, `execute_code` children and short-lived foreground local `terminal` commands are additionally isolated in a PID namespace to prevent recovery of stripped secrets via `/proc/environ`.
+
+:::warning Limitation
+Environment variable stripping and PID namespace isolation do not protect secrets stored on the filesystem. Child processes share the parent's filesystem and can read `~/.hermes/.env` and `~/.hermes/auth.json` directly. Also, persistent local shells (`TERMINAL_LOCAL_PERSISTENT=true`) and local `terminal(background=true)` / `terminal(pty=true)` sessions do not yet use PID namespace isolation. Running Hermes in a container with secrets provided exclusively through environment variables provides the strongest isolation.
+:::
+
+However, skills that declare `required_environment_variables` legitimately need access to those vars.
 
 ### How It Works
 

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -326,7 +326,7 @@ If you add names to `terminal.docker_forward_env`, those variables are intention
 
 ## Environment Variable Passthrough {#environment-variable-passthrough}
 
-Both `execute_code` and `terminal` strip sensitive environment variables from child processes to prevent credential exfiltration by LLM-generated code. However, skills that declare `required_environment_variables` legitimately need access to those vars.
+Both `execute_code` and `terminal` strip sensitive environment variables from child processes to prevent credential exfiltration by LLM-generated code. On Linux, child processes are additionally isolated in a PID namespace to prevent recovery of stripped secrets via `/proc/environ`. However, skills that declare `required_environment_variables` legitimately need access to those vars.
 
 ### How It Works
 


### PR DESCRIPTION
## What does this PR do?

The env blocklist in `_sanitize_subprocess_env()` and the `_SECRET_SUBSTRINGS` filter in `code_execution_tool` can be bypassed on Linux: any same-UID child process can read `/proc/<parent_pid>/environ` and recover every stripped variable.

This PR wraps **short-lived tool subprocesses** in a PID namespace via `unshare --user --pid --fork --mount-proc`. Inside the namespace, `/proc` is remounted so the parent's PID does not exist — the child cannot address or scan for the parent's environ.

Falls back to the current (unwrapped) behavior on non-Linux platforms and when `unshare` is unavailable (e.g. restricted containers).

## Related Issue

Partially addresses #4427

## Scope

PID namespace isolation is applied to:
- **`execute_code`** — sandboxed Python script spawn
- **Short-lived foreground local `terminal` commands** — one-shot `subprocess.Popen` path

**Not** applied to persistent local shells, `terminal(background=true)`, or `terminal(pty=true)`, because their timeout/interrupt cleanup depends on host-visible PIDs (`$$` plus `pkill -P`). Inside a PID namespace that PID becomes namespace-local, which makes child reaping unreliable.

### Known limitations

- **Filesystem secrets are not protected.** Child processes share the parent's filesystem and can read `~/.hermes/.env` and `~/.hermes/auth.json` directly. Running Hermes in a container with secrets provided exclusively through environment variables provides the strongest isolation.
- Persistent local shells remain in the host PID namespace (see above).

## Type of Change

- [x] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tools/environments/local.py`: Added `_have_unshare()` runtime probe and `_pidns_wrap()` helper that prefixes commands with `unshare --user --pid --fork --mount-proc` on Linux. Applied to the one-shot foreground command spawn path.
- `tools/code_execution_tool.py`: Imports `_pidns_wrap` from `local.py` and applies it to the sandboxed Python script spawn.
- `tests/tools/test_local_env_blocklist.py`: Added unit tests for `_pidns_wrap` (wrap/no-op behavior), `_have_unshare` probe, persistent-shell-not-wrapped assertion, and a regression integration test that spawns a real child in a PID namespace and verifies it cannot recover stripped env vars via `/proc`.
- `website/docs/user-guide/security.md`: Added limitation warning documenting filesystem secret exposure and persistent-shell gap.

## How to Test

1. Run unit tests: `pytest tests/tools/test_local_env_blocklist.py::TestPidNamespaceWrap -v`
2. Run integration test (Linux with `unshare` available): `pytest tests/tools/test_local_env_blocklist.py::TestProcEnvironIsolation -v`
3. Integration test is skipped on macOS/Windows and when `unshare` is unavailable

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` — some pre-existing test failures unrelated to this PR (same failures reproduced on `origin/main`)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Docker (official Hermes image, Debian 13, Python 3.13)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (security.md, code-execution.md, contributing.md)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A