### PR TITLE
fix(skill_utils): add type check for metadata field

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -230,7 +230,13 @@ def get_all_skills_dirs() -> List[Path]:
 
 def extract_skill_conditions(frontmatter: Dict[str, Any]) -> Dict[str, List]:
     """Extract conditional activation fields from parsed frontmatter."""
-    hermes = (frontmatter.get("metadata") or {}).get("hermes") or {}
+    metadata = frontmatter.get("metadata")
+    # Handle cases where metadata is not a dict (e.g., a string from malformed YAML)
+    if not isinstance(metadata, dict):
+        metadata = {}
+    hermes = metadata.get("hermes") or {}
+    if not isinstance(hermes, dict):
+        hermes = {}
     return {
         "fallback_for_toolsets": hermes.get("fallback_for_toolsets", []),
         "requires_toolsets": hermes.get("requires_toolsets", []),


### PR DESCRIPTION
## Summary

When PyYAML is unavailable or YAML frontmatter is malformed, the fallback parser in `parse_frontmatter()` may return `metadata` as a string instead of a dict. This causes `AttributeError: 'str' object has no attribute 'get'` when `extract_skill_conditions()` calls `.get("hermes")` on the string.

## Changes

Added explicit type checks in `extract_skill_conditions()` to handle cases where:
1. `metadata` field is not a dict (e.g., empty string or malformed YAML)
2. `metadata.hermes` field is not a dict

## Test Plan

Verified that skills with malformed YAML frontmatter (metadata as string) no longer crash the agent during system prompt building.

## Reproduction

Error seen in logs:
```
AttributeError: 'str' object has no attribute 'get'
  File "agent/skill_utils.py", line 233, in extract_skill_conditions
    hermes = (frontmatter.get("metadata") or {}).get("hermes") or {}
```

This occurred when some skill files had YAML frontmatter like:
```yaml
metadata: '{"clawdbot": {...}}'  # Inline JSON string, not dict
```