### PR TITLE
fix(cli): skip tool-call-only entries in resume recap, expose limits as config options

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2207,10 +2207,13 @@ class HermesCLI:
         if self.resume_display == "minimal":
             return
 
-        MAX_DISPLAY_EXCHANGES = 10   # max user+assistant pairs to show
-        MAX_USER_LEN = 300           # truncate user messages
-        MAX_ASST_LEN = 200           # truncate assistant text
-        MAX_ASST_LINES = 3           # max lines of assistant text
+        # Read limits from config (with hardcoded defaults)
+        _disp = CLI_CONFIG.get("display", {})
+        MAX_DISPLAY_EXCHANGES = int(_disp.get("resume_exchanges", 10))
+        MAX_USER_LEN = int(_disp.get("resume_max_user_chars", 300))
+        MAX_ASST_LEN = int(_disp.get("resume_max_assistant_chars", 200))
+        MAX_ASST_LINES = int(_disp.get("resume_max_assistant_lines", 3))
+        SKIP_TOOL_ONLY = _disp.get("resume_skip_tool_only", True)
 
         def _strip_reasoning(text: str) -> str:
             """Remove <REASONING_SCRATCHPAD>...</REASONING_SCRATCHPAD> blocks
@@ -2281,6 +2284,10 @@ class HermesCLI:
                     parts.append(f"[{tc_count} tool {noun}: {names_str}]")
                 if not parts:
                     # Skip pure-reasoning messages that have no visible output
+                    continue
+                # Skip tool-call-only entries when SKIP_TOOL_ONLY is enabled
+                has_text = bool(text)
+                if SKIP_TOOL_ONLY and not has_text and tool_calls:
                     continue
                 entries.append(("assistant", " ".join(parts)))
 


### PR DESCRIPTION
Fixes #4337

## Fix 1: Skip tool-call-only entries
When resume_skip_tool_only: true (default), assistant messages that only contain tool calls with no text are excluded from the recap display. This prevents [1 tool call: terminal] entries from consuming all display slots.

## Fix 2: Configurable limits
All hardcoded constants are now readable from config.yaml:

display:
  resume_exchanges: 10          # max meaningful exchanges
  resume_max_user_chars: 300    # user message truncation
  resume_max_assistant_chars: 200  # assistant text truncation
  resume_max_assistant_lines: 3   # max lines of assistant text
  resume_skip_tool_only: true    # skip tool-call-only entries
