### PR TITLE
fix(cli): only pad short responses to avoid pushing content off-screen

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7610,10 +7610,23 @@ class HermesCLI:
                     app.invalidate()  # Refresh status line
 
                     try:
-                        self.chat(user_input, images=submit_images or None)
+                        _chat_response = self.chat(user_input, images=submit_images or None)
                     finally:
                         self._agent_running = False
                         self._spinner_text = ""
+
+                        # Only pad short responses — long ones already fill the terminal.
+                        # Fixes: https://github.com/NousResearch/hermes-agent/issues/4421
+                        try:
+                            _terminal_lines = shutil.get_terminal_size().lines
+                            _pad = _terminal_lines // 2
+                            if _pad > 2:
+                                _resp_lines = _chat_response.count("\n") + 1 if isinstance(_chat_response, str) else 1
+                                if _resp_lines < _pad:
+                                    _actual_pad = max(1, _pad - _resp_lines)
+                                    _cprint("\n" * _actual_pad)
+                        except Exception:
+                            pass
 
                         app.invalidate()  # Refresh status line
 


### PR DESCRIPTION
## Summary

- Unconditional half-terminal-height padding after every response (added in #4359, removed in #4412) caused long responses to be scrolled out of view
- Re-introduces post-response padding but gates it on response length: padding only fires when the response is shorter than half the terminal height
- Computes the exact gap (`_pad - _resp_lines`) so no unnecessary blank lines are added

## How it works

```python
_terminal_lines = shutil.get_terminal_size().lines
_pad = _terminal_lines // 2
if _pad > 2:
    _resp_lines = _chat_response.count("\n") + 1 if isinstance(_chat_response, str) else 1
    if _resp_lines < _pad:
        _actual_pad = max(1, _pad - _resp_lines)
        _cprint("\n" * _actual_pad)
```

- **Short response** → prompt is anchored near the bottom ✓
- **Long response** → no padding, content stays on screen ✓

Fixes #4421

## Test plan

- [x] Short response (e.g. "What is 2+2?") — blank padding appears after response, prompt sits near bottom
- [x] Long response (e.g. "Explain TCP/IP in detail") — no padding, response not pushed off-screen
- [x] `python3 -m py_compile cli.py` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)