### PR TITLE
fix: restore _config_version to 11 (reverted by stale-branch merge in #4419)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -517,7 +517,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 10,
+    "_config_version": 11,
 }
 
 # =============================================================================

--- a/tests/tools/test_browser_camofox_state.py
+++ b/tests/tools/test_browser_camofox_state.py
@@ -63,4 +63,4 @@ class TestCamofoxConfigDefaults:
         from hermes_cli.config import DEFAULT_CONFIG
 
         # managed_persistence is auto-merged by _deep_merge, no version bump needed
-        assert DEFAULT_CONFIG["_config_version"] == 10
+        assert DEFAULT_CONFIG["_config_version"] == 11


### PR DESCRIPTION
PR #4419 was based on pre-credential-pools main where `_config_version` was 10. The squash merge downgraded it from 11 (set by #2647) back to 10. This restores the correct value and fixes the test assertion.