### PR TITLE
feat(skills): add rich spreadsheet skill for xlsx/csv handling

### DIFF
--- a/skills/data-science/spreadsheet/SKILL.md
+++ b/skills/data-science/spreadsheet/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: spreadsheet
+description: "Use this skill any time a spreadsheet file is involved — .xlsx, .csv, .tsv, or .xls. This includes: reading, parsing, analyzing, creating, editing, or transforming tabular data; applying formulas; creating pivot tables; generating charts; diffing spreadsheets; or converting between formats. Trigger whenever the user mentions spreadsheet, Excel, CSV, workbook, or references a tabular data file."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [spreadsheet, excel, csv, data, pandas, openpyxl, pivot, chart]
+    related_skills: [jupyter-live-kernel]
+---
+
+# Spreadsheet Skill
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Read spreadsheet to JSON | `python scripts/read_sheet.py data.xlsx` |
+| Read specific sheet | `python scripts/read_sheet.py data.xlsx --sheet Sales` |
+| Read as markdown table | `python scripts/read_sheet.py data.xlsx --format markdown` |
+| Write JSON to spreadsheet | `python scripts/write_sheet.py output.xlsx --input data.json` |
+| Write JSON from stdin | `echo '[{"a":1}]' \| python scripts/write_sheet.py output.xlsx` |
+| Set a formula | `python scripts/apply_formula.py data.xlsx --cell B10 --formula '=SUM(B1:B9)'` |
+| Create pivot table | `python scripts/pivot.py data.xlsx --rows Category --values Revenue --aggfunc sum` |
+| Embed a chart | `python scripts/chart.py data.xlsx --type bar --x Month --y Revenue` |
+| Diff two files | `python scripts/diff.py old.xlsx new.xlsx` |
+
+**All scripts** are in this skill's `scripts/` directory. Run them via the terminal tool with `python scripts/<script>.py`.
+
+---
+
+## Prerequisites
+
+```bash
+# Install required packages (use uv if available, otherwise pip)
+uv pip install openpyxl pandas xlsxwriter 2>/dev/null || pip install openpyxl pandas xlsxwriter
+```
+
+These packages are only needed for xlsx operations. CSV reading/writing works with no extra dependencies.
+
+---
+
+## Reading Data
+
+```bash
+# Read entire workbook (first sheet by default) → JSON array of row objects
+python scripts/read_sheet.py report.xlsx
+
+# Read a specific sheet
+python scripts/read_sheet.py report.xlsx --sheet "Q3 Data"
+
+# Read a cell range
+python scripts/read_sheet.py report.xlsx --range A1:D20
+
+# Output as markdown table (great for displaying to user)
+python scripts/read_sheet.py report.xlsx --format markdown
+
+# Read CSV
+python scripts/read_sheet.py data.csv
+
+# Read TSV
+python scripts/read_sheet.py data.tsv
+```
+
+Output is JSON by default — an array of objects where keys are column headers.
+
+---
+
+## Writing Data
+
+```bash
+# Write from a JSON file
+python scripts/write_sheet.py output.xlsx --input data.json
+
+# Pipe JSON from stdin
+echo '[{"Name": "Alice", "Score": 95}, {"Name": "Bob", "Score": 87}]' | python scripts/write_sheet.py output.xlsx
+
+# Write to a named sheet
+python scripts/write_sheet.py output.xlsx --input data.json --sheet Results
+
+# Write CSV instead of xlsx
+python scripts/write_sheet.py output.csv --input data.json
+```
+
+The JSON input should be an array of objects with consistent keys.
+
+---
+
+## Formulas
+
+```bash
+# Set a single formula
+python scripts/apply_formula.py report.xlsx --cell B10 --formula '=SUM(B1:B9)'
+
+# Set formula on a specific sheet
+python scripts/apply_formula.py report.xlsx --cell C5 --formula '=AVERAGE(C1:C4)' --sheet Analysis
+
+# Batch-apply formulas from JSON
+python scripts/apply_formula.py report.xlsx --batch '[{"cell": "B10", "formula": "=SUM(B1:B9)"}, {"cell": "C10", "formula": "=AVERAGE(C1:C9)"}]'
+```
+
+Formulas are written as-is (Excel syntax). They are NOT evaluated by the script — Excel or another spreadsheet app will compute values on open.
+
+---
+
+## Pivot Tables
+
+```bash
+# Basic pivot: sum of Revenue grouped by Category
+python scripts/pivot.py sales.xlsx --rows Category --values Revenue --aggfunc sum
+
+# Multi-dimensional: Category rows, Month columns
+python scripts/pivot.py sales.xlsx --rows Category --cols Month --values Revenue --aggfunc sum
+
+# Save result to a new file
+python scripts/pivot.py sales.xlsx --rows Category --values Revenue --aggfunc mean --output pivot_result.xlsx
+
+# Available aggregations: sum, mean, count, min, max, median
+```
+
+Output is JSON by default. Use `--output` to write to a new spreadsheet.
+
+---
+
+## Charts
+
+```bash
+# Bar chart
+python scripts/chart.py data.xlsx --type bar --x Month --y Revenue --title "Monthly Revenue"
+
+# Line chart saved to a different file
+python scripts/chart.py data.xlsx --type line --x Date --y Price --output chart.xlsx
+
+# Pie chart
+python scripts/chart.py data.xlsx --type pie --x Category --y Amount
+
+# Scatter plot
+python scripts/chart.py data.xlsx --type scatter --x Weight --y Height
+
+# Supported types: bar, line, pie, scatter, area
+```
+
+Charts are embedded into the xlsx file on a new sheet named "Chart". Use `--output` to write to a separate file instead of modifying the input.
+
+---
+
+## Diffing
+
+```bash
+# Compare two files (cell-level diff)
+python scripts/diff.py old.xlsx new.xlsx
+
+# Compare specific sheets
+python scripts/diff.py old.xlsx new.xlsx --sheet "Q3 Data"
+
+# Output as markdown
+python scripts/diff.py old.xlsx new.xlsx --format markdown
+```
+
+Shows added, removed, and changed cells with old/new values.
+
+---
+
+## Common Patterns
+
+### Read → Transform → Write
+
+```bash
+# 1. Read data
+python scripts/read_sheet.py input.xlsx > /tmp/data.json
+
+# 2. Transform with Python/jq/etc.
+# (use terminal or write a quick script)
+
+# 3. Write back
+python scripts/write_sheet.py output.xlsx --input /tmp/data.json
+```
+
+### Analyze and Report
+
+```bash
+# Read the data
+python scripts/read_sheet.py sales.xlsx --format markdown
+
+# Create a pivot summary
+python scripts/pivot.py sales.xlsx --rows Region --values Revenue --aggfunc sum --output summary.xlsx
+
+# Add a chart
+python scripts/chart.py summary.xlsx --type bar --x Region --y Revenue --title "Revenue by Region"
+```
+
+### Best Practices
+
+- **Always read before modifying** — check the sheet structure and column names first
+- **CSV for simple data** — if the user doesn't need formatting, formulas, or charts, prefer CSV
+- **Large files** — for files with >100k rows, warn the user that operations may be slow and consider reading a subset with `--range`
+- **Preserve originals** — write to a new file rather than overwriting the input unless explicitly asked
+- **Column names** — the scripts use the first row as headers by default; if the file has no headers, the agent should note this
+
+---
+
+## Dependencies
+
+| Package | Purpose | Install |
+|---------|---------|---------|
+| `openpyxl` | Read/write xlsx with formatting | `pip install openpyxl` |
+| `pandas` | Pivot tables, aggregation, CSV | `pip install pandas` |
+| `xlsxwriter` | Chart embedding | `pip install xlsxwriter` |

--- a/skills/data-science/spreadsheet/scripts/apply_formula.py
+++ b/skills/data-science/spreadsheet/scripts/apply_formula.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Set formulas in xlsx cells.
+
+Usage:
+    python apply_formula.py data.xlsx --cell B10 --formula '=SUM(B1:B9)'
+    python apply_formula.py data.xlsx --cell C5 --formula '=AVERAGE(C1:C4)' --sheet Analysis
+    python apply_formula.py data.xlsx --batch '[{"cell":"B10","formula":"=SUM(B1:B9)"}]'
+"""
+
+import argparse
+import json
+import sys
+
+
+def apply_formula(path, cell, formula, sheet=None):
+    """Set a formula in a specific cell of an xlsx file.
+
+    Args:
+        path: Path to the xlsx file.
+        cell: Cell reference like 'B10'.
+        formula: Excel formula string like '=SUM(B1:B9)'.
+        sheet: Sheet name. Defaults to active sheet.
+    """
+    import openpyxl
+
+    wb = openpyxl.load_workbook(path)
+    ws = wb[sheet] if sheet else wb.active
+    ws[cell] = formula
+    wb.save(path)
+
+
+def apply_formulas_batch(path, formulas, sheet=None):
+    """Apply multiple formulas at once.
+
+    Args:
+        path: Path to the xlsx file.
+        formulas: List of dicts with 'cell' and 'formula' keys.
+        sheet: Sheet name. Defaults to active sheet.
+    """
+    import openpyxl
+
+    wb = openpyxl.load_workbook(path)
+    ws = wb[sheet] if sheet else wb.active
+    for entry in formulas:
+        ws[entry["cell"]] = entry["formula"]
+    wb.save(path)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Set formulas in xlsx cells")
+    parser.add_argument("path", help="Path to xlsx file")
+    parser.add_argument("--cell", help="Cell reference (e.g., B10)")
+    parser.add_argument("--formula", help="Excel formula (e.g., =SUM(B1:B9))")
+    parser.add_argument("--sheet", default=None, help="Sheet name")
+    parser.add_argument("--batch", default=None, help='JSON array of {"cell", "formula"} objects')
+    args = parser.parse_args()
+
+    if args.batch:
+        formulas = json.loads(args.batch)
+        apply_formulas_batch(args.path, formulas, sheet=args.sheet)
+        print(f"Applied {len(formulas)} formulas to {args.path}")
+    elif args.cell and args.formula:
+        apply_formula(args.path, args.cell, args.formula, sheet=args.sheet)
+        print(f"Set {args.cell} = {args.formula} in {args.path}")
+    else:
+        print("Error: provide --cell and --formula, or --batch", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/data-science/spreadsheet/scripts/chart.py
+++ b/skills/data-science/spreadsheet/scripts/chart.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Embed charts into xlsx workbooks.
+
+Usage:
+    python chart.py data.xlsx --type bar --x Month --y Revenue
+    python chart.py data.xlsx --type line --x Date --y Price --output chart.xlsx --title "Price Trend"
+"""
+
+import argparse
+import os
+import sys
+
+
+# Map of chart type names to openpyxl chart classes
+_CHART_TYPES = {
+    "bar": "BarChart",
+    "line": "LineChart",
+    "pie": "PieChart",
+    "scatter": "ScatterChart",
+    "area": "AreaChart",
+}
+
+
+def create_chart(path, chart_type, x_col, y_col, output=None, title=None, sheet=None):
+    """Embed a chart into an xlsx workbook.
+
+    Args:
+        path: Input xlsx file path.
+        chart_type: One of 'bar', 'line', 'pie', 'scatter', 'area'.
+        x_col: Column name for X axis / categories.
+        y_col: Column name for Y axis / values.
+        output: Optional output path. If None, modifies input file in place.
+        title: Optional chart title.
+        sheet: Sheet name to read data from.
+    """
+    import openpyxl
+    from openpyxl.chart import BarChart, LineChart, PieChart, ScatterChart, AreaChart, Reference
+
+    chart_classes = {
+        "bar": BarChart,
+        "line": LineChart,
+        "pie": PieChart,
+        "scatter": ScatterChart,
+        "area": AreaChart,
+    }
+
+    if chart_type not in chart_classes:
+        raise ValueError(f"Unsupported chart type: {chart_type}. Use: {', '.join(chart_classes)}")
+
+    wb = openpyxl.load_workbook(path)
+    ws = wb[sheet] if sheet else wb.active
+
+    # Find column indices by header name
+    headers = {cell.value: cell.column for cell in ws[1]}
+    if x_col not in headers:
+        raise ValueError(f"Column '{x_col}' not found. Available: {list(headers.keys())}")
+    if y_col not in headers:
+        raise ValueError(f"Column '{y_col}' not found. Available: {list(headers.keys())}")
+
+    x_col_idx = headers[x_col]
+    y_col_idx = headers[y_col]
+    max_row = ws.max_row
+
+    chart = chart_classes[chart_type]()
+    if title:
+        chart.title = title
+
+    data_ref = Reference(ws, min_col=y_col_idx, min_row=1, max_row=max_row)
+    cats_ref = Reference(ws, min_col=x_col_idx, min_row=2, max_row=max_row)
+
+    if chart_type == "scatter":
+        from openpyxl.chart import Series as ChartSeries
+
+        x_values = Reference(ws, min_col=x_col_idx, min_row=2, max_row=max_row)
+        y_values = Reference(ws, min_col=y_col_idx, min_row=2, max_row=max_row)
+        series = ChartSeries(y_values, x_values, title=y_col)
+        chart.series.append(series)
+    else:
+        chart.add_data(data_ref, titles_from_data=True)
+        chart.set_categories(cats_ref)
+
+    chart.width = 18
+    chart.height = 12
+
+    # Add chart to a new sheet
+    chart_sheet_name = "Chart"
+    if chart_sheet_name in wb.sheetnames:
+        del wb[chart_sheet_name]
+    chart_ws = wb.create_sheet(chart_sheet_name)
+    chart_ws.add_chart(chart, "A1")
+
+    target = output or path
+    wb.save(target)
+    return target
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Embed charts into xlsx workbooks")
+    parser.add_argument("path", help="Input xlsx file path")
+    parser.add_argument(
+        "--type",
+        required=True,
+        dest="chart_type",
+        choices=list(_CHART_TYPES.keys()),
+        help="Chart type",
+    )
+    parser.add_argument("--x", required=True, dest="x_col", help="X axis / categories column name")
+    parser.add_argument("--y", required=True, dest="y_col", help="Y axis / values column name")
+    parser.add_argument("--output", default=None, help="Output file (default: modify input in place)")
+    parser.add_argument("--title", default=None, help="Chart title")
+    parser.add_argument("--sheet", default=None, help="Data sheet name")
+    args = parser.parse_args()
+
+    target = create_chart(
+        args.path,
+        chart_type=args.chart_type,
+        x_col=args.x_col,
+        y_col=args.y_col,
+        output=args.output,
+        title=args.title,
+        sheet=args.sheet,
+    )
+    print(f"Chart created in {target}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/data-science/spreadsheet/scripts/diff.py
+++ b/skills/data-science/spreadsheet/scripts/diff.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Cell-level diff between two spreadsheet files.
+
+Usage:
+    python diff.py old.xlsx new.xlsx
+    python diff.py old.xlsx new.xlsx --sheet "Sales"
+    python diff.py old.csv new.csv --format markdown
+"""
+
+import argparse
+import csv
+import json
+import os
+import sys
+
+
+def _read_as_grid(path, sheet=None):
+    """Read a file into a 2D list of cell values (list of rows)."""
+    ext = os.path.splitext(path)[1].lower()
+    if ext in (".xlsx", ".xls"):
+        import openpyxl
+
+        wb = openpyxl.load_workbook(path, read_only=True, data_only=True)
+        try:
+            ws = wb[sheet] if sheet else wb.active
+            return [list(row) for row in ws.iter_rows(values_only=True)]
+        finally:
+            wb.close()
+    else:
+        delimiter = "\t" if ext == ".tsv" else ","
+        with open(path, newline="", encoding="utf-8-sig") as f:
+            reader = csv.reader(f, delimiter=delimiter)
+            return [row for row in reader]
+
+
+def _col_index_to_letter(index):
+    """Convert 0-based column index to Excel column letter(s)."""
+    result = ""
+    index += 1
+    while index > 0:
+        index, remainder = divmod(index - 1, 26)
+        result = chr(65 + remainder) + result
+    return result
+
+
+def diff_sheets(old_path, new_path, sheet=None):
+    """Compute cell-level differences between two spreadsheet files.
+
+    Args:
+        old_path: Path to the original file.
+        new_path: Path to the new file.
+        sheet: Sheet name (xlsx only).
+
+    Returns:
+        List of change dicts: {"cell": "A1", "type": "changed"|"added"|"removed",
+                                "old": value, "new": value}
+    """
+    old_grid = _read_as_grid(old_path, sheet=sheet)
+    new_grid = _read_as_grid(new_path, sheet=sheet)
+
+    max_rows = max(len(old_grid), len(new_grid))
+    max_cols = 0
+    for row in old_grid + new_grid:
+        if len(row) > max_cols:
+            max_cols = len(row)
+
+    changes = []
+    for r in range(max_rows):
+        old_row = old_grid[r] if r < len(old_grid) else []
+        new_row = new_grid[r] if r < len(new_grid) else []
+        row_max_cols = max(len(old_row), len(new_row))
+
+        for c in range(row_max_cols):
+            old_val = old_row[c] if c < len(old_row) else None
+            new_val = new_row[c] if c < len(new_row) else None
+
+            # Normalize for comparison
+            old_str = str(old_val) if old_val is not None else ""
+            new_str = str(new_val) if new_val is not None else ""
+
+            if old_str != new_str:
+                cell_ref = f"{_col_index_to_letter(c)}{r + 1}"
+                if old_val is None or old_str == "":
+                    change_type = "added"
+                elif new_val is None or new_str == "":
+                    change_type = "removed"
+                else:
+                    change_type = "changed"
+                changes.append({
+                    "cell": cell_ref,
+                    "type": change_type,
+                    "old": old_val,
+                    "new": new_val,
+                })
+
+    return changes
+
+
+def format_markdown(changes):
+    """Format diff results as a markdown table."""
+    if not changes:
+        return "No differences found."
+    lines = ["| Cell | Type | Old | New |", "| --- | --- | --- | --- |"]
+    for ch in changes:
+        old = str(ch["old"]) if ch["old"] is not None else ""
+        new = str(ch["new"]) if ch["new"] is not None else ""
+        lines.append(f"| {ch['cell']} | {ch['type']} | {old} | {new} |")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Cell-level diff between two spreadsheet files")
+    parser.add_argument("old", help="Path to original file")
+    parser.add_argument("new", help="Path to new file")
+    parser.add_argument("--sheet", default=None, help="Sheet name (xlsx only)")
+    parser.add_argument(
+        "--format",
+        choices=["json", "markdown"],
+        default="json",
+        help="Output format (default: json)",
+    )
+    args = parser.parse_args()
+
+    changes = diff_sheets(args.old, args.new, sheet=args.sheet)
+
+    if args.format == "markdown":
+        print(format_markdown(changes))
+    else:
+        print(json.dumps(changes, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/data-science/spreadsheet/scripts/pivot.py
+++ b/skills/data-science/spreadsheet/scripts/pivot.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Create pivot tables from spreadsheet data.
+
+Usage:
+    python pivot.py sales.xlsx --rows Category --values Revenue --aggfunc sum
+    python pivot.py sales.xlsx --rows Category --cols Month --values Revenue --aggfunc sum --output pivot.xlsx
+"""
+
+import argparse
+import json
+import os
+import sys
+
+
+def create_pivot(path, rows, cols=None, values=None, aggfunc="sum", sheet=None):
+    """Create a pivot table from spreadsheet data.
+
+    Args:
+        path: Path to input file (xlsx/csv).
+        rows: Column name(s) for pivot rows.
+        cols: Optional column name(s) for pivot columns.
+        values: Column name for values to aggregate.
+        aggfunc: Aggregation function (sum, mean, count, min, max, median).
+        sheet: Sheet name (xlsx only).
+
+    Returns:
+        List of row dicts representing the pivot table.
+    """
+    import pandas as pd
+
+    ext = os.path.splitext(path)[1].lower()
+    if ext in (".xlsx", ".xls"):
+        df = pd.read_excel(path, sheet_name=sheet or 0)
+    elif ext == ".tsv":
+        df = pd.read_csv(path, delimiter="\t")
+    else:
+        df = pd.read_csv(path)
+
+    if isinstance(rows, str):
+        rows = [rows]
+    if isinstance(cols, str):
+        cols = [cols]
+
+    pivot_args = {"index": rows, "aggfunc": aggfunc}
+    if cols:
+        pivot_args["columns"] = cols
+    if values:
+        pivot_args["values"] = values
+
+    pt = pd.pivot_table(df, **pivot_args)
+    pt = pt.reset_index()
+
+    # Flatten MultiIndex columns if present
+    if hasattr(pt.columns, "levels"):
+        pt.columns = ["_".join(str(c) for c in col).strip("_") for col in pt.columns.values]
+
+    return json.loads(pt.to_json(orient="records", default_handler=str))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create pivot tables from spreadsheet data")
+    parser.add_argument("path", help="Input file path")
+    parser.add_argument("--rows", required=True, nargs="+", help="Row grouping column(s)")
+    parser.add_argument("--cols", nargs="+", default=None, help="Column grouping column(s)")
+    parser.add_argument("--values", default=None, help="Values column to aggregate")
+    parser.add_argument(
+        "--aggfunc",
+        default="sum",
+        choices=["sum", "mean", "count", "min", "max", "median"],
+        help="Aggregation function (default: sum)",
+    )
+    parser.add_argument("--sheet", default=None, help="Sheet name (xlsx only)")
+    parser.add_argument("--output", default=None, help="Output file path (writes xlsx/csv)")
+    args = parser.parse_args()
+
+    result = create_pivot(
+        args.path,
+        rows=args.rows,
+        cols=args.cols,
+        values=args.values,
+        aggfunc=args.aggfunc,
+        sheet=args.sheet,
+    )
+
+    if args.output:
+        import pandas as pd
+
+        df = pd.DataFrame(result)
+        ext = os.path.splitext(args.output)[1].lower()
+        if ext in (".xlsx", ".xls"):
+            df.to_excel(args.output, index=False)
+        else:
+            df.to_csv(args.output, index=False)
+        print(f"Pivot table written to {args.output} ({len(result)} rows)")
+    else:
+        print(json.dumps(result, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/data-science/spreadsheet/scripts/read_sheet.py
+++ b/skills/data-science/spreadsheet/scripts/read_sheet.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Read xlsx/csv/tsv files and output structured data.
+
+Usage:
+    python read_sheet.py data.xlsx
+    python read_sheet.py data.xlsx --sheet "Sales" --format markdown
+    python read_sheet.py data.csv --range A1:D20
+"""
+
+import argparse
+import csv
+import json
+import os
+import sys
+
+
+def _col_letter_to_index(letter):
+    """Convert column letter(s) to 0-based index. A=0, B=1, ..., Z=25, AA=26."""
+    result = 0
+    for ch in letter.upper():
+        result = result * 26 + (ord(ch) - ord("A") + 1)
+    return result - 1
+
+
+def _parse_range(range_str):
+    """Parse a range like 'A1:D20' into (min_row, min_col, max_row, max_col) all 0-based."""
+    import re
+
+    m = re.match(r"([A-Za-z]+)(\d+):([A-Za-z]+)(\d+)", range_str)
+    if not m:
+        raise ValueError(f"Invalid range: {range_str}")
+    min_col = _col_letter_to_index(m.group(1))
+    min_row = int(m.group(2)) - 1
+    max_col = _col_letter_to_index(m.group(3))
+    max_row = int(m.group(4)) - 1
+    return min_row, min_col, max_row, max_col
+
+
+def read_xlsx(path, sheet=None, cell_range=None):
+    """Read an xlsx file and return a list of row dicts.
+
+    Args:
+        path: Path to the xlsx file.
+        sheet: Sheet name to read. Defaults to the active sheet.
+        cell_range: Optional range string like 'A1:D20'.
+
+    Returns:
+        List of dicts where keys are column headers.
+    """
+    import openpyxl
+
+    wb = openpyxl.load_workbook(path, read_only=True, data_only=True)
+    try:
+        ws = wb[sheet] if sheet else wb.active
+        rows = list(ws.iter_rows(values_only=True))
+    finally:
+        wb.close()
+
+    if not rows:
+        return []
+
+    if cell_range:
+        min_row, min_col, max_row, max_col = _parse_range(cell_range)
+        rows = [
+            tuple(row[min_col : max_col + 1] if len(row) > min_col else ())
+            for row in rows[min_row : max_row + 1]
+        ]
+
+    headers = [str(h) if h is not None else f"col_{i}" for i, h in enumerate(rows[0])]
+    result = []
+    for row in rows[1:]:
+        record = {}
+        for i, header in enumerate(headers):
+            val = row[i] if i < len(row) else None
+            record[header] = val
+        result.append(record)
+    return result
+
+
+def read_csv(path, delimiter=","):
+    """Read a CSV/TSV file and return a list of row dicts.
+
+    Args:
+        path: Path to the csv/tsv file.
+        delimiter: Field delimiter (default: comma).
+
+    Returns:
+        List of dicts where keys are column headers.
+    """
+    with open(path, newline="", encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f, delimiter=delimiter)
+        return [dict(row) for row in reader]
+
+
+def _detect_delimiter(path):
+    """Guess delimiter from file extension."""
+    ext = os.path.splitext(path)[1].lower()
+    if ext == ".tsv":
+        return "\t"
+    return ","
+
+
+def read_sheet(path, sheet=None, cell_range=None):
+    """Read any supported spreadsheet format.
+
+    Dispatches to read_xlsx or read_csv based on file extension.
+    """
+    ext = os.path.splitext(path)[1].lower()
+    if ext in (".xlsx", ".xls"):
+        return read_xlsx(path, sheet=sheet, cell_range=cell_range)
+    elif ext in (".csv", ".tsv"):
+        return read_csv(path, delimiter=_detect_delimiter(path))
+    else:
+        raise ValueError(f"Unsupported file format: {ext}")
+
+
+def format_markdown(rows):
+    """Format row dicts as a markdown table."""
+    if not rows:
+        return "(empty)"
+    headers = list(rows[0].keys())
+    lines = []
+    lines.append("| " + " | ".join(headers) + " |")
+    lines.append("| " + " | ".join("---" for _ in headers) + " |")
+    for row in rows:
+        vals = [str(row.get(h, "")) for h in headers]
+        lines.append("| " + " | ".join(vals) + " |")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Read spreadsheet files to structured output")
+    parser.add_argument("path", help="Path to xlsx, csv, or tsv file")
+    parser.add_argument("--sheet", default=None, help="Sheet name (xlsx only)")
+    parser.add_argument("--range", default=None, help="Cell range like A1:D20")
+    parser.add_argument(
+        "--format",
+        choices=["json", "markdown"],
+        default="json",
+        help="Output format (default: json)",
+    )
+    args = parser.parse_args()
+
+    rows = read_sheet(args.path, sheet=args.sheet, cell_range=args.range)
+
+    if args.format == "markdown":
+        print(format_markdown(rows))
+    else:
+        print(json.dumps(rows, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/data-science/spreadsheet/scripts/write_sheet.py
+++ b/skills/data-science/spreadsheet/scripts/write_sheet.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Write JSON data to xlsx or csv files.
+
+Usage:
+    python write_sheet.py output.xlsx --input data.json
+    echo '[{"a":1}]' | python write_sheet.py output.csv
+    python write_sheet.py output.xlsx --input data.json --sheet Results
+"""
+
+import argparse
+import csv
+import json
+import os
+import sys
+
+
+def write_xlsx(data, path, sheet_name="Sheet1"):
+    """Write a list of row dicts to an xlsx file.
+
+    Args:
+        data: List of dicts with consistent keys.
+        path: Output file path.
+        sheet_name: Name of the sheet to create.
+    """
+    import openpyxl
+
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = sheet_name
+
+    if not data:
+        wb.save(path)
+        return
+
+    headers = list(data[0].keys())
+    ws.append(headers)
+    for row in data:
+        ws.append([row.get(h) for h in headers])
+
+    wb.save(path)
+
+
+def write_csv(data, path, delimiter=","):
+    """Write a list of row dicts to a CSV file.
+
+    Args:
+        data: List of dicts with consistent keys.
+        path: Output file path.
+        delimiter: Field delimiter (default: comma).
+    """
+    if not data:
+        with open(path, "w", newline="", encoding="utf-8") as f:
+            pass
+        return
+
+    headers = list(data[0].keys())
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=headers, delimiter=delimiter)
+        writer.writeheader()
+        writer.writerows(data)
+
+
+def write_sheet(data, path, sheet_name="Sheet1"):
+    """Write data to the appropriate format based on file extension."""
+    ext = os.path.splitext(path)[1].lower()
+    if ext in (".xlsx", ".xls"):
+        write_xlsx(data, path, sheet_name=sheet_name)
+    elif ext == ".tsv":
+        write_csv(data, path, delimiter="\t")
+    else:
+        write_csv(data, path)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Write JSON data to spreadsheet files")
+    parser.add_argument("path", help="Output file path (.xlsx, .csv, .tsv)")
+    parser.add_argument("--input", dest="input_file", default=None, help="JSON input file (reads stdin if omitted)")
+    parser.add_argument("--sheet", default="Sheet1", help="Sheet name (xlsx only, default: Sheet1)")
+    args = parser.parse_args()
+
+    if args.input_file:
+        with open(args.input_file, encoding="utf-8") as f:
+            data = json.load(f)
+    else:
+        data = json.load(sys.stdin)
+
+    if not isinstance(data, list):
+        print("Error: input must be a JSON array of objects", file=sys.stderr)
+        sys.exit(1)
+
+    write_sheet(data, args.path, sheet_name=args.sheet)
+    print(f"Wrote {len(data)} rows to {args.path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/skills/test_spreadsheet_scripts.py
+++ b/tests/skills/test_spreadsheet_scripts.py
@@ -1,0 +1,460 @@
+"""Tests for the spreadsheet skill helper scripts."""
+
+import csv
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import scripts as modules via importlib (they live outside the package tree)
+# ---------------------------------------------------------------------------
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "skills" / "data-science" / "spreadsheet" / "scripts"
+
+
+def _import_script(name):
+    """Import a script from the spreadsheet skill's scripts/ directory."""
+    spec = importlib.util.spec_from_file_location(name, SCRIPTS_DIR / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Only import if openpyxl/pandas are available
+openpyxl = pytest.importorskip("openpyxl")
+pandas = pytest.importorskip("pandas")
+
+read_sheet_mod = _import_script("read_sheet")
+write_sheet_mod = _import_script("write_sheet")
+apply_formula_mod = _import_script("apply_formula")
+pivot_mod = _import_script("pivot")
+chart_mod = _import_script("chart")
+diff_mod = _import_script("diff")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_xlsx(path, rows, sheet_name="Sheet1"):
+    """Create a minimal xlsx file from a list of row lists (first row = headers)."""
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = sheet_name
+    for row in rows:
+        ws.append(row)
+    wb.save(str(path))
+
+
+def _create_csv(path, rows, delimiter=","):
+    """Create a minimal CSV from a list of row lists (first row = headers)."""
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f, delimiter=delimiter)
+        for row in rows:
+            writer.writerow(row)
+
+
+# ===========================================================================
+# read_sheet tests
+# ===========================================================================
+
+
+class TestReadSheet:
+    def test_read_xlsx_basic(self, tmp_path):
+        path = tmp_path / "test.xlsx"
+        _create_xlsx(path, [["Name", "Score"], ["Alice", 95], ["Bob", 87]])
+
+        result = read_sheet_mod.read_xlsx(str(path))
+        assert len(result) == 2
+        assert result[0]["Name"] == "Alice"
+        assert result[0]["Score"] == 95
+        assert result[1]["Name"] == "Bob"
+
+    def test_read_xlsx_specific_sheet(self, tmp_path):
+        path = tmp_path / "multi.xlsx"
+        wb = openpyxl.Workbook()
+        ws1 = wb.active
+        ws1.title = "Data"
+        ws1.append(["X", "Y"])
+        ws1.append([1, 2])
+        ws2 = wb.create_sheet("Other")
+        ws2.append(["A", "B"])
+        ws2.append([3, 4])
+        wb.save(str(path))
+
+        result = read_sheet_mod.read_xlsx(str(path), sheet="Other")
+        assert len(result) == 1
+        assert result[0]["A"] == 3
+
+    def test_read_xlsx_with_range(self, tmp_path):
+        path = tmp_path / "range.xlsx"
+        _create_xlsx(path, [
+            ["A", "B", "C"],
+            [1, 2, 3],
+            [4, 5, 6],
+            [7, 8, 9],
+        ])
+
+        result = read_sheet_mod.read_xlsx(str(path), cell_range="A1:B3")
+        assert len(result) == 2
+        assert "C" not in result[0]
+        assert result[0]["A"] == 1
+        assert result[1]["A"] == 4
+
+    def test_read_csv(self, tmp_path):
+        path = tmp_path / "test.csv"
+        _create_csv(path, [["Name", "Score"], ["Alice", "95"], ["Bob", "87"]])
+
+        result = read_sheet_mod.read_csv(str(path))
+        assert len(result) == 2
+        assert result[0]["Name"] == "Alice"
+
+    def test_read_tsv(self, tmp_path):
+        path = tmp_path / "test.tsv"
+        _create_csv(path, [["Name", "Score"], ["Alice", "95"]], delimiter="\t")
+
+        result = read_sheet_mod.read_csv(str(path), delimiter="\t")
+        assert len(result) == 1
+        assert result[0]["Name"] == "Alice"
+
+    def test_read_sheet_dispatch_xlsx(self, tmp_path):
+        path = tmp_path / "dispatch.xlsx"
+        _create_xlsx(path, [["Col"], ["val"]])
+        result = read_sheet_mod.read_sheet(str(path))
+        assert len(result) == 1
+
+    def test_read_sheet_dispatch_csv(self, tmp_path):
+        path = tmp_path / "dispatch.csv"
+        _create_csv(path, [["Col"], ["val"]])
+        result = read_sheet_mod.read_sheet(str(path))
+        assert len(result) == 1
+
+    def test_read_empty_xlsx(self, tmp_path):
+        path = tmp_path / "empty.xlsx"
+        wb = openpyxl.Workbook()
+        wb.save(str(path))
+        result = read_sheet_mod.read_xlsx(str(path))
+        # Empty sheet — only has the default empty row
+        assert isinstance(result, list)
+
+    def test_format_markdown(self):
+        rows = [{"Name": "Alice", "Score": 95}]
+        md = read_sheet_mod.format_markdown(rows)
+        assert "| Name | Score |" in md
+        assert "| Alice | 95 |" in md
+
+    def test_format_markdown_empty(self):
+        assert read_sheet_mod.format_markdown([]) == "(empty)"
+
+
+# ===========================================================================
+# write_sheet tests
+# ===========================================================================
+
+
+class TestWriteSheet:
+    def test_write_xlsx_roundtrip(self, tmp_path):
+        data = [{"Name": "Alice", "Score": 95}, {"Name": "Bob", "Score": 87}]
+        path = tmp_path / "out.xlsx"
+        write_sheet_mod.write_xlsx(data, str(path))
+
+        result = read_sheet_mod.read_xlsx(str(path))
+        assert len(result) == 2
+        assert result[0]["Name"] == "Alice"
+        assert result[1]["Score"] == 87
+
+    def test_write_csv_roundtrip(self, tmp_path):
+        data = [{"Name": "Alice", "Score": "95"}]
+        path = tmp_path / "out.csv"
+        write_sheet_mod.write_csv(data, str(path))
+
+        result = read_sheet_mod.read_csv(str(path))
+        assert len(result) == 1
+        assert result[0]["Name"] == "Alice"
+
+    def test_write_xlsx_named_sheet(self, tmp_path):
+        data = [{"X": 1}]
+        path = tmp_path / "named.xlsx"
+        write_sheet_mod.write_xlsx(data, str(path), sheet_name="Results")
+
+        wb = openpyxl.load_workbook(str(path))
+        assert "Results" in wb.sheetnames
+        wb.close()
+
+    def test_write_empty(self, tmp_path):
+        path = tmp_path / "empty.xlsx"
+        write_sheet_mod.write_xlsx([], str(path))
+        assert path.exists()
+
+    def test_write_sheet_dispatch(self, tmp_path):
+        data = [{"A": 1}]
+        xlsx_path = tmp_path / "dispatch.xlsx"
+        csv_path = tmp_path / "dispatch.csv"
+
+        write_sheet_mod.write_sheet(data, str(xlsx_path))
+        write_sheet_mod.write_sheet(data, str(csv_path))
+
+        assert xlsx_path.exists()
+        assert csv_path.exists()
+
+
+# ===========================================================================
+# apply_formula tests
+# ===========================================================================
+
+
+class TestApplyFormula:
+    def test_single_formula(self, tmp_path):
+        path = tmp_path / "formulas.xlsx"
+        _create_xlsx(path, [["Val"], [10], [20], [30]])
+
+        apply_formula_mod.apply_formula(str(path), "A5", "=SUM(A2:A4)")
+
+        wb = openpyxl.load_workbook(str(path))
+        ws = wb.active
+        assert ws["A5"].value == "=SUM(A2:A4)"
+        wb.close()
+
+    def test_formula_specific_sheet(self, tmp_path):
+        path = tmp_path / "multi.xlsx"
+        wb = openpyxl.Workbook()
+        ws1 = wb.active
+        ws1.title = "Data"
+        ws1.append(["V"])
+        ws1.append([5])
+        ws2 = wb.create_sheet("Calc")
+        ws2.append(["R"])
+        wb.save(str(path))
+
+        apply_formula_mod.apply_formula(str(path), "A2", "=Data!A2*2", sheet="Calc")
+
+        wb = openpyxl.load_workbook(str(path))
+        assert wb["Calc"]["A2"].value == "=Data!A2*2"
+        wb.close()
+
+    def test_batch_formulas(self, tmp_path):
+        path = tmp_path / "batch.xlsx"
+        _create_xlsx(path, [["A", "B"], [1, 2], [3, 4]])
+
+        formulas = [
+            {"cell": "A4", "formula": "=SUM(A2:A3)"},
+            {"cell": "B4", "formula": "=SUM(B2:B3)"},
+        ]
+        apply_formula_mod.apply_formulas_batch(str(path), formulas)
+
+        wb = openpyxl.load_workbook(str(path))
+        ws = wb.active
+        assert ws["A4"].value == "=SUM(A2:A3)"
+        assert ws["B4"].value == "=SUM(B2:B3)"
+        wb.close()
+
+
+# ===========================================================================
+# pivot tests
+# ===========================================================================
+
+
+class TestPivot:
+    def test_basic_pivot(self, tmp_path):
+        path = tmp_path / "sales.xlsx"
+        _create_xlsx(path, [
+            ["Category", "Revenue"],
+            ["A", 100],
+            ["B", 200],
+            ["A", 150],
+        ])
+
+        result = pivot_mod.create_pivot(str(path), rows="Category", values="Revenue", aggfunc="sum")
+        assert len(result) == 2
+        # Find category A
+        cat_a = next(r for r in result if r["Category"] == "A")
+        assert cat_a["Revenue"] == 250
+
+    def test_pivot_with_cols(self, tmp_path):
+        path = tmp_path / "pivot_cols.xlsx"
+        _create_xlsx(path, [
+            ["Cat", "Month", "Val"],
+            ["A", "Jan", 10],
+            ["A", "Feb", 20],
+            ["B", "Jan", 30],
+        ])
+
+        result = pivot_mod.create_pivot(
+            str(path), rows="Cat", cols="Month", values="Val", aggfunc="sum"
+        )
+        assert len(result) == 2
+
+    def test_pivot_count(self, tmp_path):
+        path = tmp_path / "count.xlsx"
+        _create_xlsx(path, [
+            ["Category", "Item"],
+            ["A", "x"],
+            ["A", "y"],
+            ["B", "z"],
+        ])
+
+        result = pivot_mod.create_pivot(
+            str(path), rows="Category", values="Item", aggfunc="count"
+        )
+        cat_a = next(r for r in result if r["Category"] == "A")
+        assert cat_a["Item"] == 2
+
+    def test_pivot_csv_input(self, tmp_path):
+        path = tmp_path / "data.csv"
+        _create_csv(path, [["Cat", "Val"], ["A", "10"], ["B", "20"]])
+
+        result = pivot_mod.create_pivot(str(path), rows="Cat", values="Val", aggfunc="sum")
+        assert len(result) == 2
+
+
+# ===========================================================================
+# chart tests
+# ===========================================================================
+
+
+class TestChart:
+    def test_bar_chart(self, tmp_path):
+        path = tmp_path / "chart_data.xlsx"
+        _create_xlsx(path, [
+            ["Month", "Revenue"],
+            ["Jan", 100],
+            ["Feb", 200],
+            ["Mar", 150],
+        ])
+
+        output = tmp_path / "chart_out.xlsx"
+        chart_mod.create_chart(str(path), "bar", "Month", "Revenue", output=str(output), title="Test")
+
+        wb = openpyxl.load_workbook(str(output))
+        assert "Chart" in wb.sheetnames
+        wb.close()
+
+    def test_line_chart(self, tmp_path):
+        path = tmp_path / "line.xlsx"
+        _create_xlsx(path, [["X", "Y"], [1, 10], [2, 20]])
+        chart_mod.create_chart(str(path), "line", "X", "Y")
+
+        wb = openpyxl.load_workbook(str(path))
+        assert "Chart" in wb.sheetnames
+        wb.close()
+
+    def test_scatter_chart(self, tmp_path):
+        path = tmp_path / "scatter.xlsx"
+        _create_xlsx(path, [["Weight", "Height"], [60, 170], [70, 175]])
+        chart_mod.create_chart(str(path), "scatter", "Weight", "Height")
+
+        wb = openpyxl.load_workbook(str(path))
+        assert "Chart" in wb.sheetnames
+        wb.close()
+
+    def test_chart_invalid_column(self, tmp_path):
+        path = tmp_path / "bad_col.xlsx"
+        _create_xlsx(path, [["A", "B"], [1, 2]])
+
+        with pytest.raises(ValueError, match="not found"):
+            chart_mod.create_chart(str(path), "bar", "Missing", "B")
+
+    def test_chart_invalid_type(self, tmp_path):
+        path = tmp_path / "bad_type.xlsx"
+        _create_xlsx(path, [["A", "B"], [1, 2]])
+
+        with pytest.raises(ValueError, match="Unsupported"):
+            chart_mod.create_chart(str(path), "radar", "A", "B")
+
+
+# ===========================================================================
+# diff tests
+# ===========================================================================
+
+
+class TestDiff:
+    def test_identical_files(self, tmp_path):
+        a = tmp_path / "a.xlsx"
+        b = tmp_path / "b.xlsx"
+        _create_xlsx(a, [["H"], [1]])
+        _create_xlsx(b, [["H"], [1]])
+
+        changes = diff_mod.diff_sheets(str(a), str(b))
+        assert changes == []
+
+    def test_changed_cell(self, tmp_path):
+        a = tmp_path / "a.xlsx"
+        b = tmp_path / "b.xlsx"
+        _create_xlsx(a, [["H"], [1]])
+        _create_xlsx(b, [["H"], [2]])
+
+        changes = diff_mod.diff_sheets(str(a), str(b))
+        assert len(changes) == 1
+        assert changes[0]["cell"] == "A2"
+        assert changes[0]["type"] == "changed"
+        assert changes[0]["old"] == 1
+        assert changes[0]["new"] == 2
+
+    def test_added_row(self, tmp_path):
+        a = tmp_path / "a.xlsx"
+        b = tmp_path / "b.xlsx"
+        _create_xlsx(a, [["H"], [1]])
+        _create_xlsx(b, [["H"], [1], [2]])
+
+        changes = diff_mod.diff_sheets(str(a), str(b))
+        assert any(ch["type"] == "added" for ch in changes)
+
+    def test_removed_cell(self, tmp_path):
+        a = tmp_path / "a.xlsx"
+        b = tmp_path / "b.xlsx"
+        _create_xlsx(a, [["H"], [1], [2]])
+        _create_xlsx(b, [["H"], [1]])
+
+        changes = diff_mod.diff_sheets(str(a), str(b))
+        assert any(ch["type"] == "removed" for ch in changes)
+
+    def test_diff_csv(self, tmp_path):
+        a = tmp_path / "a.csv"
+        b = tmp_path / "b.csv"
+        _create_csv(a, [["H"], ["old"]])
+        _create_csv(b, [["H"], ["new"]])
+
+        changes = diff_mod.diff_sheets(str(a), str(b))
+        assert len(changes) == 1
+        assert changes[0]["type"] == "changed"
+
+    def test_diff_markdown_format(self):
+        changes = [{"cell": "A1", "type": "changed", "old": 1, "new": 2}]
+        md = diff_mod.format_markdown(changes)
+        assert "| A1 |" in md
+        assert "changed" in md
+
+    def test_diff_markdown_no_changes(self):
+        assert "No differences" in diff_mod.format_markdown([])
+
+
+# ===========================================================================
+# Utility function tests
+# ===========================================================================
+
+
+class TestUtilities:
+    def test_col_letter_to_index(self):
+        assert read_sheet_mod._col_letter_to_index("A") == 0
+        assert read_sheet_mod._col_letter_to_index("B") == 1
+        assert read_sheet_mod._col_letter_to_index("Z") == 25
+        assert read_sheet_mod._col_letter_to_index("AA") == 26
+
+    def test_col_index_to_letter(self):
+        assert diff_mod._col_index_to_letter(0) == "A"
+        assert diff_mod._col_index_to_letter(1) == "B"
+        assert diff_mod._col_index_to_letter(25) == "Z"
+        assert diff_mod._col_index_to_letter(26) == "AA"
+
+    def test_parse_range(self):
+        result = read_sheet_mod._parse_range("A1:D20")
+        assert result == (0, 0, 19, 3)
+
+    def test_parse_range_invalid(self):
+        with pytest.raises(ValueError):
+            read_sheet_mod._parse_range("invalid")


### PR DESCRIPTION
## Summary

- Adds a new bundled `spreadsheet` skill in the `data-science` category with comprehensive instructions for xlsx/csv operations
- Includes 6 standalone helper scripts: `read_sheet`, `write_sheet`, `apply_formula`, `pivot`, `chart`, `diff`
- Scripts use `openpyxl`, `pandas`, and `xlsxwriter` as user-installed dependencies, with stdlib `csv` as a zero-dep fallback for plain CSVs
- All scripts are CLI tools with `argparse`, invoked via the terminal tool following the pattern established by the `powerpoint` skill

## Test plan

- [x] 38 unit tests covering all 6 scripts (read/write roundtrips, formulas, pivots, charts, diffing, edge cases)
- [ ] Verify skill appears in `skills_list()` after sync
- [ ] Verify `skill_view("spreadsheet")` returns content and linked scripts
- [ ] Manual test: read a real xlsx file, create a pivot table, embed a chart

Closes #4438

🤖 Generated with [Claude Code](https://claude.com/claude-code)