### PR TITLE
feat(cli): add action recorder for capturing and replaying tool sequences

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2490,6 +2490,12 @@ def cmd_cron(args):
     cron_command(args)
 
 
+def cmd_record(args):
+    """Action recording management."""
+    from hermes_cli.record import record_command
+    record_command(args)
+
+
 def cmd_webhook(args):
     """Webhook subscription management."""
     from hermes_cli.webhook import webhook_command
@@ -3384,7 +3390,7 @@ def _coalesce_session_name_args(argv: list) -> list:
     """
     _SUBCOMMANDS = {
         "chat", "model", "gateway", "setup", "whatsapp", "login", "logout", "auth",
-        "status", "cron", "doctor", "config", "pairing", "skills", "tools",
+        "status", "cron", "record", "doctor", "config", "pairing", "skills", "tools",
         "mcp", "sessions", "insights", "version", "update", "uninstall",
         "profile",
     }
@@ -4104,6 +4110,47 @@ For more help on a command:
     cron_subparsers.add_parser("tick", help="Run due jobs once and exit")
 
     cron_parser.set_defaults(func=cmd_cron)
+
+    # =========================================================================
+    # record command
+    # =========================================================================
+    record_parser = subparsers.add_parser(
+        "record",
+        help="Action recording management",
+        description="Record, replay, and schedule action sequences",
+    )
+    record_subparsers = record_parser.add_subparsers(dest="record_command")
+
+    # record list
+    record_subparsers.add_parser("list", help="List saved recordings")
+
+    # record show
+    record_show = record_subparsers.add_parser("show", help="Show recording details")
+    record_show.add_argument("name", help="Recording name")
+
+    # record start
+    record_start = record_subparsers.add_parser("start", help="Start recording tool calls")
+    record_start.add_argument("name", help="Recording name")
+    record_start.add_argument("--description", default="", help="Optional description")
+
+    # record stop
+    record_subparsers.add_parser("stop", help="Stop the active recording")
+
+    # record run
+    record_run = record_subparsers.add_parser("run", help="Replay a recording")
+    record_run.add_argument("name", help="Recording name to replay")
+
+    # record schedule
+    record_schedule = record_subparsers.add_parser("schedule", help="Schedule a recording as a cron job")
+    record_schedule.add_argument("name", help="Recording name")
+    record_schedule.add_argument("schedule", help="Schedule string (e.g., 'every 1h', '0 9 * * *')")
+    record_schedule.add_argument("--job-name", dest="name_override", help="Optional cron job name")
+
+    # record delete
+    record_delete = record_subparsers.add_parser("delete", aliases=["rm"], help="Delete a recording")
+    record_delete.add_argument("name", help="Recording name to delete")
+
+    record_parser.set_defaults(func=cmd_record)
 
     # =========================================================================
     # webhook command

--- a/hermes_cli/record.py
+++ b/hermes_cli/record.py
@@ -1,0 +1,247 @@
+"""
+Record subcommand for hermes CLI.
+
+Handles standalone recording management commands: list, show, start, stop,
+run, schedule, and delete.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent.resolve()
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from hermes_cli.colors import Colors, color
+
+
+def record_list():
+    """List all saved recordings."""
+    from recording.store import list_recordings
+
+    recordings = list_recordings()
+    if not recordings:
+        print(color("No saved recordings.", Colors.DIM))
+        print(color("Start one with: hermes record start <name>", Colors.DIM))
+        return
+
+    print()
+    print(
+        color(
+            "┌─────────────────────────────────────────────────────────────────────────┐",
+            Colors.CYAN,
+        )
+    )
+    print(
+        color(
+            "│                          Recordings                                    │",
+            Colors.CYAN,
+        )
+    )
+    print(
+        color(
+            "└─────────────────────────────────────────────────────────────────────────┘",
+            Colors.CYAN,
+        )
+    )
+    print()
+
+    for rec in recordings:
+        name = rec.get("name", "?")
+        desc = rec.get("description", "")
+        steps = rec.get("step_count", 0)
+        created = rec.get("created_at", "?")
+
+        print(f"  {color(name, Colors.YELLOW)}")
+        if desc:
+            print(f"    Description: {desc}")
+        print(f"    Steps:       {steps}")
+        print(f"    Created:     {created}")
+        print()
+
+
+def record_show(name):
+    """Show full details of a recording including steps."""
+    from recording.store import get_recording
+
+    rec = get_recording(name)
+    if not rec:
+        print(color(f"Recording not found: {name}", Colors.RED))
+        return 1
+
+    print()
+    print(f"  {color('Name:', Colors.CYAN)} {rec.get('name', '?')}")
+    print(f"  {color('Description:', Colors.CYAN)} {rec.get('description', '')}")
+    print(f"  {color('Created:', Colors.CYAN)} {rec.get('created_at', '?')}")
+    print()
+
+    steps = rec.get("steps", [])
+    if not steps:
+        print(color("  No steps recorded.", Colors.DIM))
+        return 0
+
+    print(f"  {color('Steps:', Colors.CYAN)} ({len(steps)} total)")
+    print()
+    for i, step in enumerate(steps):
+        tool = step.get("tool", "?")
+        expected = step.get("expected_status", "?")
+        args = step.get("arguments", {})
+        args_preview = json.dumps(args, ensure_ascii=False)
+        if len(args_preview) > 120:
+            args_preview = args_preview[:120] + "..."
+
+        status_color = Colors.GREEN if expected == "success" else Colors.YELLOW
+        print(f"  {i + 1}. {color(tool, Colors.YELLOW)} [{color(expected, status_color)}]")
+        print(f"     {args_preview}")
+        print()
+
+    return 0
+
+
+def record_start(name, description=""):
+    """Start recording tool calls in the current session."""
+    from recording.capture import RecordingSession
+
+    try:
+        session = RecordingSession(name, description)
+        session.start()
+    except (ValueError, RuntimeError) as e:
+        print(color(f"Cannot start recording: {e}", Colors.RED))
+        return 1
+
+    print(color(f"Recording started: {name}", Colors.GREEN))
+    print(color("Tool calls in this session will be captured.", Colors.DIM))
+    print(color("Stop with: hermes record stop", Colors.DIM))
+    return 0
+
+
+def record_stop():
+    """Stop the active recording session."""
+    from recording.capture import get_active_session
+
+    session = get_active_session()
+    if session is None:
+        print(color("No active recording session.", Colors.YELLOW))
+        return 1
+
+    summary = session.stop()
+    print(color(f"Recording stopped: {summary['name']}", Colors.GREEN))
+    print(f"  Steps captured: {summary['step_count']}")
+    return 0
+
+
+def record_run(name):
+    """Replay a recording."""
+    from recording.store import get_recording
+    from recording.replay import replay_recording
+
+    rec = get_recording(name)
+    if not rec:
+        print(color(f"Recording not found: {name}", Colors.RED))
+        return 1
+
+    steps = rec.get("steps", [])
+    if not steps:
+        print(color(f"Recording '{name}' has no steps.", Colors.YELLOW))
+        return 0
+
+    print(f"Replaying '{name}' ({len(steps)} steps)...")
+    print()
+
+    def on_step(i, step, result):
+        tool = step.get("tool", "?")
+        status = "ok" if not result.startswith("Error") else "error"
+        print(f"  Step {i + 1}/{len(steps)}: {tool} [{status}]")
+
+    def on_deviation(i, step, result):
+        tool = step.get("tool", "?")
+        expected = step.get("expected_status", "?")
+        print(color(f"  Deviation at step {i + 1} ({tool}): expected {expected}", Colors.YELLOW))
+        return True  # Continue by default
+
+    summary = replay_recording(rec, on_step=on_step, on_deviation=on_deviation)
+
+    print()
+    if summary["success"]:
+        print(color(f"Replay completed: {summary['steps_completed']}/{summary['steps_total']} steps", Colors.GREEN))
+    else:
+        print(color(f"Replay failed: {summary['error']}", Colors.RED))
+    return 0 if summary["success"] else 1
+
+
+def record_schedule(name, schedule, name_override=None):
+    """Schedule a recording as a cron job."""
+    from recording.store import get_recording
+    from cron.jobs import create_job
+
+    rec = get_recording(name)
+    if not rec:
+        print(color(f"Recording not found: {name}", Colors.RED))
+        return 1
+
+    job_name = name_override or f"recording:{rec['name']}"
+    prompt = f"[REPLAY_RECORDING:{name}] Execute the recorded action sequence '{name}'."
+
+    try:
+        job = create_job(
+            prompt=prompt,
+            schedule=schedule,
+            name=job_name,
+        )
+    except Exception as e:
+        print(color(f"Failed to schedule: {e}", Colors.RED))
+        return 1
+
+    print(color(f"Scheduled recording '{name}' as cron job", Colors.GREEN))
+    print(f"  Job ID:    {job.get('id', '?')}")
+    print(f"  Name:      {job_name}")
+    print(f"  Schedule:  {schedule}")
+    print(f"  Next run:  {job.get('next_run_at', '?')}")
+    return 0
+
+
+def record_delete(name):
+    """Delete a recording."""
+    from recording.store import delete_recording
+
+    if delete_recording(name):
+        print(color(f"Deleted recording: {name}", Colors.GREEN))
+        return 0
+    else:
+        print(color(f"Recording not found: {name}", Colors.RED))
+        return 1
+
+
+def record_command(args):
+    """Handle record subcommands."""
+    subcmd = getattr(args, "record_command", None)
+
+    if subcmd is None or subcmd == "list":
+        record_list()
+        return 0
+
+    if subcmd == "show":
+        return record_show(args.name)
+
+    if subcmd == "start":
+        return record_start(args.name, getattr(args, "description", ""))
+
+    if subcmd == "stop":
+        return record_stop()
+
+    if subcmd == "run":
+        return record_run(args.name)
+
+    if subcmd == "schedule":
+        return record_schedule(
+            args.name,
+            args.schedule,
+            name_override=getattr(args, "name_override", None),
+        )
+
+    if subcmd in {"delete", "rm"}:
+        return record_delete(args.name)
+
+    print(f"Unknown record command: {subcmd}")
+    print("Usage: hermes record [list|show|start|stop|run|schedule|delete]")
+    sys.exit(1)

--- a/recording/__init__.py
+++ b/recording/__init__.py
@@ -1,0 +1,31 @@
+"""
+Action recording and replay for Hermes Agent.
+
+Records tool call sequences during agent sessions and replays them,
+allowing users to capture workflows and schedule them as cron jobs.
+
+Recordings are stored in ~/.hermes/recordings/{name}.yaml
+"""
+
+from recording.store import (
+    create_recording,
+    get_recording,
+    list_recordings,
+    delete_recording,
+    add_step,
+    RECORDINGS_DIR,
+)
+from recording.replay import replay_recording
+from recording.capture import RecordingSession, get_active_session
+
+__all__ = [
+    "create_recording",
+    "get_recording",
+    "list_recordings",
+    "delete_recording",
+    "add_step",
+    "replay_recording",
+    "RecordingSession",
+    "get_active_session",
+    "RECORDINGS_DIR",
+]

--- a/recording/capture.py
+++ b/recording/capture.py
@@ -1,0 +1,96 @@
+"""
+Session capture for action recording.
+
+Provides a global singleton that intercepts tool calls during an agent
+session and records them for later replay.
+"""
+
+import logging
+import threading
+from typing import Optional
+
+from recording.store import add_step, create_recording, get_recording
+
+logger = logging.getLogger(__name__)
+
+# Thread-safe global singleton
+_lock = threading.Lock()
+_active_session: Optional["RecordingSession"] = None
+
+
+def get_active_session() -> Optional["RecordingSession"]:
+    """Return the active recording session, or None if not recording.
+
+    This is called from the agent's tool execution loop. It must be
+    fast and safe to call on every tool invocation.
+    """
+    return _active_session
+
+
+class RecordingSession:
+    """Captures tool calls during an agent session for later replay.
+
+    Usage::
+
+        session = RecordingSession("my-recording")
+        session.start()
+        # ... agent runs, tool calls are captured via get_active_session() ...
+        session.stop()
+    """
+
+    def __init__(self, name: str, description: str = ""):
+        self.name = name
+        self.description = description
+        self._active = False
+        self._step_count = 0
+
+    def start(self) -> None:
+        """Begin recording. Creates the recording in the store and registers
+        this session as the global active session."""
+        global _active_session
+        with _lock:
+            if _active_session is not None:
+                raise RuntimeError(
+                    f"Another recording is already active: {_active_session.name}"
+                )
+            # Create the recording file (raises ValueError if exists)
+            existing = get_recording(self.name)
+            if existing is None:
+                create_recording(self.name, self.description)
+            self._active = True
+            _active_session = self
+        logger.info("Recording started: %s", self.name)
+
+    def stop(self) -> dict:
+        """Stop recording and deregister from global state.
+
+        Returns:
+            Summary dict with name, step_count.
+        """
+        global _active_session
+        with _lock:
+            self._active = False
+            if _active_session is self:
+                _active_session = None
+        logger.info("Recording stopped: %s (%d steps)", self.name, self._step_count)
+        return {"name": self.name, "step_count": self._step_count}
+
+    def capture_tool_call(
+        self, tool_name: str, arguments: dict, result: str, success: bool
+    ) -> None:
+        """Record a single tool call. Called by the agent loop hook.
+
+        Safe to call from any thread. If the session is not active, this
+        is a no-op.
+        """
+        if not self._active:
+            return
+        try:
+            add_step(self.name, tool_name, arguments, result, success)
+            self._step_count += 1
+        except Exception as e:
+            logger.warning("Failed to capture tool call %s: %s", tool_name, e)
+
+    @property
+    def is_active(self) -> bool:
+        return self._active

--- a/recording/replay.py
+++ b/recording/replay.py
@@ -1,0 +1,118 @@
+"""
+Replay engine for recorded action sequences.
+
+Executes each step in a recording sequentially via model_tools.handle_function_call().
+"""
+
+import json
+import logging
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def replay_recording(
+    recording: dict,
+    on_step: Optional[Callable[[int, dict, str], None]] = None,
+    on_deviation: Optional[Callable[[int, dict, str], bool]] = None,
+    task_id: str = "replay",
+) -> dict:
+    """Execute each step in a recording sequentially.
+
+    Args:
+        recording: Full recording dict from store.get_recording().
+        on_step: Optional callback(step_index, step, result) for progress.
+        on_deviation: Optional callback(step_index, step, result) when result
+            status differs from expected. Return True to continue, False to abort.
+            If None, deviations are logged but execution continues.
+        task_id: Task ID for tool dispatch.
+
+    Returns:
+        Dict with keys: success, steps_completed, steps_total, results, error.
+    """
+    from model_tools import handle_function_call
+
+    steps = recording.get("steps", [])
+    results = []
+    error = None
+
+    for i, step in enumerate(steps):
+        tool = step.get("tool", "")
+        arguments = step.get("arguments", {})
+        expected_status = step.get("expected_status", "success")
+
+        try:
+            result = handle_function_call(tool, arguments, task_id)
+        except Exception as e:
+            result = f"Error executing tool '{tool}': {e}"
+            logger.error("Replay step %d (%s) raised: %s", i, tool, e)
+
+        # Determine if this step's result matches expectations
+        is_error = _is_error_result(result)
+        actual_status = "error" if is_error else "success"
+        deviated = actual_status != expected_status
+
+        step_result = {
+            "step": i,
+            "tool": tool,
+            "status": actual_status,
+            "deviated": deviated,
+            "result_preview": result[:500] if len(result) > 500 else result,
+        }
+        results.append(step_result)
+
+        if on_step:
+            try:
+                on_step(i, step, result)
+            except Exception as cb_err:
+                logger.debug("on_step callback error: %s", cb_err)
+
+        if deviated:
+            logger.warning(
+                "Replay step %d (%s): expected %s, got %s",
+                i, tool, expected_status, actual_status,
+            )
+            if on_deviation:
+                try:
+                    should_continue = on_deviation(i, step, result)
+                except Exception as cb_err:
+                    logger.debug("on_deviation callback error: %s", cb_err)
+                    should_continue = True
+                if not should_continue:
+                    error = f"Aborted at step {i} ({tool}): {actual_status} (expected {expected_status})"
+                    return {
+                        "success": False,
+                        "steps_completed": i + 1,
+                        "steps_total": len(steps),
+                        "results": results,
+                        "error": error,
+                    }
+
+    return {
+        "success": True,
+        "steps_completed": len(steps),
+        "steps_total": len(steps),
+        "results": results,
+        "error": None,
+    }
+
+
+def _is_error_result(result: str) -> bool:
+    """Heuristic check if a tool result indicates an error."""
+    if not result:
+        return False
+    # Check for common error patterns in tool results
+    try:
+        parsed = json.loads(result)
+        if isinstance(parsed, dict):
+            if parsed.get("success") is False:
+                return True
+            if "error" in parsed and parsed["error"]:
+                return True
+    except (json.JSONDecodeError, TypeError):
+        pass
+    # Check for error prefix patterns
+    lower = result.lower()
+    if lower.startswith("error executing tool") or lower.startswith("error:"):
+        return True
+    return False

--- a/recording/store.py
+++ b/recording/store.py
@@ -1,0 +1,206 @@
+"""
+Recording storage and management.
+
+Recordings are stored as YAML files in ~/.hermes/recordings/{name}.yaml.
+Each recording contains metadata and an ordered list of tool call steps.
+"""
+
+import logging
+import os
+import re
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+HERMES_DIR = get_hermes_home()
+RECORDINGS_DIR = HERMES_DIR / "recordings"
+
+_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]*$")
+_MAX_NAME_LEN = 64
+
+
+def _secure_dir(path: Path):
+    """Set directory to owner-only access (0700). No-op on Windows."""
+    try:
+        os.chmod(path, 0o700)
+    except (OSError, NotImplementedError):
+        pass
+
+
+def _secure_file(path: Path):
+    """Set file to owner-only read/write (0600). No-op on Windows."""
+    try:
+        if path.exists():
+            os.chmod(path, 0o600)
+    except (OSError, NotImplementedError):
+        pass
+
+
+def ensure_dirs():
+    """Ensure recordings directory exists with secure permissions."""
+    RECORDINGS_DIR.mkdir(parents=True, exist_ok=True)
+    _secure_dir(RECORDINGS_DIR)
+
+
+def validate_name(name: str) -> str:
+    """Validate and return a recording name.
+
+    Raises ValueError if the name is invalid.
+    """
+    if not name or not isinstance(name, str):
+        raise ValueError("Recording name must be a non-empty string")
+    name = name.strip()
+    if len(name) > _MAX_NAME_LEN:
+        raise ValueError(f"Recording name must be {_MAX_NAME_LEN} characters or fewer")
+    if not _NAME_PATTERN.match(name):
+        raise ValueError(
+            "Recording name must start with alphanumeric and contain only "
+            "letters, digits, hyphens, and underscores"
+        )
+    return name
+
+
+def _recording_path(name: str) -> Path:
+    """Return the file path for a recording."""
+    return RECORDINGS_DIR / f"{name}.yaml"
+
+
+def _save(name: str, data: dict) -> None:
+    """Atomic write of a recording YAML file."""
+    ensure_dirs()
+    target = _recording_path(name)
+    # Atomic write: write to temp file in same dir, then rename
+    fd, tmp_path = tempfile.mkstemp(dir=str(RECORDINGS_DIR), suffix=".yaml.tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            yaml.dump(data, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+        os.replace(tmp_path, str(target))
+    except Exception:
+        # Clean up temp file on failure
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+    _secure_file(target)
+
+
+def create_recording(name: str, description: str = "") -> dict:
+    """Create a new empty recording.
+
+    Args:
+        name: Recording identifier (alphanumeric, hyphens, underscores).
+        description: Optional human-readable description.
+
+    Returns:
+        Recording metadata dict.
+
+    Raises:
+        ValueError: If name is invalid or recording already exists.
+    """
+    name = validate_name(name)
+    if _recording_path(name).exists():
+        raise ValueError(f"Recording '{name}' already exists")
+
+    data = {
+        "name": name,
+        "description": description,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "steps": [],
+    }
+    _save(name, data)
+    logger.info("Created recording: %s", name)
+    return data
+
+
+def get_recording(name: str) -> Optional[dict]:
+    """Load a recording by name.
+
+    Returns:
+        Full recording dict, or None if not found.
+    """
+    path = _recording_path(name)
+    if not path.exists():
+        return None
+    try:
+        with open(path, encoding="utf-8") as f:
+            return yaml.safe_load(f)
+    except Exception as e:
+        logger.error("Failed to load recording '%s': %s", name, e)
+        return None
+
+
+def list_recordings() -> List[dict]:
+    """List all recordings (metadata only, no step details).
+
+    Returns:
+        List of recording summary dicts with name, description, created_at,
+        and step_count.
+    """
+    ensure_dirs()
+    result = []
+    for path in sorted(RECORDINGS_DIR.glob("*.yaml")):
+        try:
+            with open(path, encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+            if data and isinstance(data, dict):
+                result.append({
+                    "name": data.get("name", path.stem),
+                    "description": data.get("description", ""),
+                    "created_at": data.get("created_at", ""),
+                    "step_count": len(data.get("steps", [])),
+                })
+        except Exception as e:
+            logger.warning("Skipping malformed recording %s: %s", path.name, e)
+    return result
+
+
+def delete_recording(name: str) -> bool:
+    """Delete a recording file.
+
+    Returns:
+        True if deleted, False if not found.
+    """
+    path = _recording_path(name)
+    if not path.exists():
+        return False
+    path.unlink()
+    logger.info("Deleted recording: %s", name)
+    return True
+
+
+def add_step(name: str, tool: str, arguments: dict, result: str, success: bool) -> dict:
+    """Append a tool call step to an existing recording.
+
+    Args:
+        name: Recording name.
+        tool: Tool/function name that was called.
+        arguments: Tool call arguments dict.
+        result: Tool call result string.
+        success: Whether the tool call succeeded.
+
+    Returns:
+        The step dict that was added.
+
+    Raises:
+        ValueError: If recording not found.
+    """
+    data = get_recording(name)
+    if data is None:
+        raise ValueError(f"Recording '{name}' not found")
+
+    step = {
+        "tool": tool,
+        "arguments": arguments,
+        "expected_status": "success" if success else "error",
+    }
+    data["steps"].append(step)
+    _save(name, data)
+    return step

--- a/run_agent.py
+++ b/run_agent.py
@@ -5630,6 +5630,15 @@ class AIAgent:
                     result_preview = function_result[:200] if len(function_result) > 200 else function_result
                     logger.warning("Tool %s returned error (%.2fs): %s", function_name, tool_duration, result_preview)
 
+                # Recording capture hook — record tool calls for action replay
+                try:
+                    from recording.capture import get_active_session as _get_rec_session
+                    _rec = _get_rec_session()
+                    if _rec is not None:
+                        _rec.capture_tool_call(function_name, function_args, function_result, not is_error)
+                except Exception:
+                    pass  # never block tool execution for recording
+
                 if self.verbose_logging:
                     logging.debug(f"Tool {function_name} completed in {tool_duration:.2f}s")
                     logging.debug(f"Tool result ({len(function_result)} chars): {function_result}")
@@ -5905,6 +5914,15 @@ class AIAgent:
             _is_error_result, _ = _detect_tool_failure(function_name, function_result)
             if _is_error_result:
                 logger.warning("Tool %s returned error (%.2fs): %s", function_name, tool_duration, result_preview)
+
+            # Recording capture hook — record tool calls for action replay
+            try:
+                from recording.capture import get_active_session as _get_rec_session
+                _rec = _get_rec_session()
+                if _rec is not None:
+                    _rec.capture_tool_call(function_name, function_args, function_result, not _is_error_result)
+            except Exception:
+                pass  # never block tool execution for recording
 
             if self.verbose_logging:
                 logging.debug(f"Tool {function_name} completed in {tool_duration:.2f}s")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ def _isolate_hermes_home(tmp_path, monkeypatch):
     (fake_home / "cron").mkdir()
     (fake_home / "memories").mkdir()
     (fake_home / "skills").mkdir()
+    (fake_home / "recordings").mkdir()
     monkeypatch.setenv("HERMES_HOME", str(fake_home))
     # Reset plugin singleton so tests don't leak plugins from ~/.hermes/plugins/
     try:

--- a/tests/hermes_cli/test_record.py
+++ b/tests/hermes_cli/test_record.py
@@ -1,0 +1,118 @@
+"""Tests for hermes_cli/record.py — CLI record subcommand."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from io import StringIO
+
+import recording.store as store_mod
+from recording.store import create_recording, add_step, get_recording
+
+
+@pytest.fixture(autouse=True)
+def _patch_recordings_dir(tmp_path, monkeypatch):
+    """Ensure RECORDINGS_DIR points to the test-local temp directory."""
+    rec_dir = tmp_path / "hermes_test" / "recordings"
+    rec_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(store_mod, "RECORDINGS_DIR", rec_dir)
+
+
+class TestRecordList:
+    def test_list_empty(self, capsys):
+        from hermes_cli.record import record_list
+        record_list()
+        out = capsys.readouterr().out
+        assert "No saved recordings" in out
+
+    def test_list_with_recordings(self, capsys):
+        create_recording("list-a", "Description A")
+        create_recording("list-b")
+
+        from hermes_cli.record import record_list
+        record_list()
+        out = capsys.readouterr().out
+        assert "list-a" in out
+        assert "Description A" in out
+        assert "list-b" in out
+
+
+class TestRecordShow:
+    def test_show_existing(self, capsys):
+        create_recording("show-test", "A recording")
+        add_step("show-test", "terminal", {"command": "ls"}, "files", True)
+
+        from hermes_cli.record import record_show
+        result = record_show("show-test")
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "show-test" in out
+        assert "terminal" in out
+
+    def test_show_nonexistent(self, capsys):
+        from hermes_cli.record import record_show
+        result = record_show("nope")
+        assert result == 1
+        out = capsys.readouterr().out
+        assert "not found" in out
+
+
+class TestRecordDelete:
+    def test_delete_existing(self, capsys):
+        create_recording("del-test")
+
+        from hermes_cli.record import record_delete
+        result = record_delete("del-test")
+        assert result == 0
+        assert get_recording("del-test") is None
+
+    def test_delete_nonexistent(self, capsys):
+        from hermes_cli.record import record_delete
+        result = record_delete("ghost")
+        assert result == 1
+
+
+class TestRecordSchedule:
+    @patch("cron.jobs.create_job")
+    def test_schedule_creates_job(self, mock_create_job, capsys):
+        create_recording("sched-test")
+        add_step("sched-test", "terminal", {"command": "echo"}, "out", True)
+
+        mock_create_job.return_value = {
+            "id": "job-123",
+            "name": "recording:sched-test",
+            "next_run_at": "2026-04-02T08:00:00",
+        }
+
+        from hermes_cli.record import record_schedule
+        result = record_schedule("sched-test", "0 8 * * *")
+        assert result == 0
+
+        mock_create_job.assert_called_once()
+        call_kwargs = mock_create_job.call_args
+        assert "REPLAY_RECORDING:sched-test" in call_kwargs.kwargs.get("prompt", "") or \
+               "REPLAY_RECORDING:sched-test" in str(call_kwargs)
+
+    def test_schedule_nonexistent(self, capsys):
+        from hermes_cli.record import record_schedule
+        result = record_schedule("no-such", "0 8 * * *")
+        assert result == 1
+
+
+class TestRecordRun:
+    @patch("model_tools.handle_function_call")
+    def test_run_basic(self, mock_handle, capsys):
+        import json
+        mock_handle.return_value = json.dumps({"success": True})
+
+        create_recording("run-test")
+        add_step("run-test", "terminal", {"command": "echo hi"}, "hi", True)
+
+        from hermes_cli.record import record_run
+        result = record_run("run-test")
+        assert result == 0
+        out = capsys.readouterr().out
+        assert "completed" in out.lower() or "Replay" in out
+
+    def test_run_nonexistent(self, capsys):
+        from hermes_cli.record import record_run
+        result = record_run("nope")
+        assert result == 1

--- a/tests/recording/test_capture.py
+++ b/tests/recording/test_capture.py
@@ -1,0 +1,99 @@
+"""Tests for recording/capture.py — session capture singleton."""
+
+import pytest
+from unittest.mock import patch
+
+import recording.store as store_mod
+from recording.capture import RecordingSession, get_active_session, _lock
+import recording.capture as capture_mod
+
+
+@pytest.fixture(autouse=True)
+def _reset_global_session():
+    """Reset the global singleton between tests."""
+    capture_mod._active_session = None
+    yield
+    capture_mod._active_session = None
+
+
+@pytest.fixture(autouse=True)
+def _patch_recordings_dir(tmp_path, monkeypatch):
+    """Ensure RECORDINGS_DIR points to the test-local temp directory."""
+    rec_dir = tmp_path / "hermes_test" / "recordings"
+    rec_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(store_mod, "RECORDINGS_DIR", rec_dir)
+
+
+class TestGetActiveSession:
+    def test_none_when_no_recording(self):
+        assert get_active_session() is None
+
+
+class TestRecordingSession:
+    def test_start_stop_lifecycle(self):
+        session = RecordingSession("lifecycle-test", "A test")
+        assert not session.is_active
+
+        session.start()
+        assert session.is_active
+        assert get_active_session() is session
+
+        summary = session.stop()
+        assert not session.is_active
+        assert get_active_session() is None
+        assert summary["name"] == "lifecycle-test"
+        assert summary["step_count"] == 0
+
+    def test_capture_calls(self):
+        session = RecordingSession("capture-test")
+        session.start()
+
+        session.capture_tool_call("terminal", {"command": "echo hi"}, "hi", True)
+        session.capture_tool_call("write_file", {"path": "/tmp/x"}, "ok", True)
+
+        summary = session.stop()
+        assert summary["step_count"] == 2
+
+        from recording.store import get_recording
+        rec = get_recording("capture-test")
+        assert len(rec["steps"]) == 2
+        assert rec["steps"][0]["tool"] == "terminal"
+        assert rec["steps"][1]["tool"] == "write_file"
+
+    def test_capture_when_inactive(self):
+        session = RecordingSession("inactive-test")
+        # Don't start the session
+        session.capture_tool_call("terminal", {"command": "echo"}, "out", True)
+        # Should be a no-op — step count stays 0
+        assert session._step_count == 0
+
+    def test_double_start_raises(self):
+        s1 = RecordingSession("first")
+        s1.start()
+
+        s2 = RecordingSession("second")
+        with pytest.raises(RuntimeError, match="already active"):
+            s2.start()
+
+        s1.stop()
+
+    def test_stop_without_start(self):
+        session = RecordingSession("never-started")
+        # stop() should work gracefully even if never started
+        summary = session.stop()
+        assert summary["step_count"] == 0
+
+    def test_start_existing_recording(self):
+        """Starting a session for an already-existing recording should resume it."""
+        from recording.store import create_recording, add_step
+        create_recording("existing")
+        add_step("existing", "terminal", {"command": "old"}, "old-out", True)
+
+        session = RecordingSession("existing")
+        session.start()
+        session.capture_tool_call("terminal", {"command": "new"}, "new-out", True)
+        session.stop()
+
+        from recording.store import get_recording
+        rec = get_recording("existing")
+        assert len(rec["steps"]) == 2

--- a/tests/recording/test_replay.py
+++ b/tests/recording/test_replay.py
@@ -1,0 +1,153 @@
+"""Tests for recording/replay.py — replay engine."""
+
+import json
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from recording.replay import replay_recording, _is_error_result
+
+
+class TestIsErrorResult:
+    def test_success_json(self):
+        assert _is_error_result(json.dumps({"success": True, "data": "ok"})) is False
+
+    def test_failure_json(self):
+        assert _is_error_result(json.dumps({"success": False, "error": "bad"})) is True
+
+    def test_error_key(self):
+        assert _is_error_result(json.dumps({"error": "something broke"})) is True
+
+    def test_error_prefix(self):
+        assert _is_error_result("Error executing tool 'terminal': boom") is True
+
+    def test_plain_text(self):
+        assert _is_error_result("hello world") is False
+
+    def test_empty(self):
+        assert _is_error_result("") is False
+
+
+class TestReplayRecording:
+    @patch("model_tools.handle_function_call")
+    def test_basic_replay(self, mock_handle):
+        mock_handle.return_value = json.dumps({"success": True})
+
+        recording = {
+            "name": "test",
+            "steps": [
+                {"tool": "terminal", "arguments": {"command": "echo hi"}, "expected_status": "success"},
+                {"tool": "terminal", "arguments": {"command": "echo bye"}, "expected_status": "success"},
+            ],
+        }
+
+        result = replay_recording(recording)
+        assert result["success"] is True
+        assert result["steps_completed"] == 2
+        assert result["steps_total"] == 2
+        assert result["error"] is None
+        assert mock_handle.call_count == 2
+
+    @patch("model_tools.handle_function_call")
+    def test_empty_recording(self, mock_handle):
+        recording = {"name": "empty", "steps": []}
+        result = replay_recording(recording)
+        assert result["success"] is True
+        assert result["steps_completed"] == 0
+        assert mock_handle.call_count == 0
+
+    @patch("model_tools.handle_function_call")
+    def test_deviation_continues_by_default(self, mock_handle):
+        # Step expects success but tool returns error
+        mock_handle.return_value = json.dumps({"success": False, "error": "oops"})
+
+        recording = {
+            "name": "deviate",
+            "steps": [
+                {"tool": "terminal", "arguments": {"command": "fail"}, "expected_status": "success"},
+                {"tool": "terminal", "arguments": {"command": "ok"}, "expected_status": "error"},
+            ],
+        }
+
+        result = replay_recording(recording)
+        # Without on_deviation callback, deviations are logged but execution continues
+        assert result["success"] is True
+        assert result["steps_completed"] == 2
+
+    @patch("model_tools.handle_function_call")
+    def test_deviation_callback_abort(self, mock_handle):
+        mock_handle.return_value = json.dumps({"success": False, "error": "fail"})
+
+        recording = {
+            "name": "abort",
+            "steps": [
+                {"tool": "terminal", "arguments": {"command": "fail"}, "expected_status": "success"},
+                {"tool": "terminal", "arguments": {"command": "never"}, "expected_status": "success"},
+            ],
+        }
+
+        def abort_on_deviation(i, step, result):
+            return False
+
+        result = replay_recording(recording, on_deviation=abort_on_deviation)
+        assert result["success"] is False
+        assert result["steps_completed"] == 1
+        assert "Aborted" in result["error"]
+        # Second step should not have been called
+        assert mock_handle.call_count == 1
+
+    @patch("model_tools.handle_function_call")
+    def test_deviation_callback_continue(self, mock_handle):
+        mock_handle.return_value = json.dumps({"success": False, "error": "fail"})
+
+        recording = {
+            "name": "continue",
+            "steps": [
+                {"tool": "terminal", "arguments": {"command": "fail"}, "expected_status": "success"},
+                {"tool": "terminal", "arguments": {"command": "also-fail"}, "expected_status": "success"},
+            ],
+        }
+
+        def continue_on_deviation(i, step, result):
+            return True
+
+        result = replay_recording(recording, on_deviation=continue_on_deviation)
+        assert result["success"] is True
+        assert result["steps_completed"] == 2
+
+    @patch("model_tools.handle_function_call")
+    def test_on_step_callback(self, mock_handle):
+        mock_handle.return_value = json.dumps({"success": True})
+
+        recording = {
+            "name": "callback",
+            "steps": [
+                {"tool": "terminal", "arguments": {"command": "a"}, "expected_status": "success"},
+                {"tool": "terminal", "arguments": {"command": "b"}, "expected_status": "success"},
+            ],
+        }
+
+        steps_seen = []
+
+        def on_step(i, step, result):
+            steps_seen.append(i)
+
+        replay_recording(recording, on_step=on_step)
+        assert steps_seen == [0, 1]
+
+    @patch("model_tools.handle_function_call")
+    def test_tool_exception_is_caught(self, mock_handle):
+        mock_handle.side_effect = RuntimeError("tool crashed")
+
+        recording = {
+            "name": "crash",
+            "steps": [
+                {"tool": "terminal", "arguments": {"command": "crash"}, "expected_status": "success"},
+            ],
+        }
+
+        result = replay_recording(recording)
+        # Exception is caught and treated as error
+        assert result["steps_completed"] == 1
+        assert result["results"][0]["status"] == "error"
+        assert result["results"][0]["deviated"] is True

--- a/tests/recording/test_store.py
+++ b/tests/recording/test_store.py
@@ -1,0 +1,156 @@
+"""Tests for recording/store.py — recording CRUD operations."""
+
+import pytest
+
+import recording.store as store_mod
+from recording.store import (
+    create_recording,
+    get_recording,
+    list_recordings,
+    delete_recording,
+    add_step,
+    validate_name,
+)
+
+
+@pytest.fixture(autouse=True)
+def _patch_recordings_dir(tmp_path, monkeypatch):
+    """Ensure RECORDINGS_DIR points to the test-local temp directory."""
+    rec_dir = tmp_path / "hermes_test" / "recordings"
+    rec_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(store_mod, "RECORDINGS_DIR", rec_dir)
+
+
+class TestValidateName:
+    def test_valid_names(self):
+        assert validate_name("daily-report") == "daily-report"
+        assert validate_name("test_recording") == "test_recording"
+        assert validate_name("a123") == "a123"
+        assert validate_name("Report1") == "Report1"
+
+    def test_empty_name(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            validate_name("")
+
+    def test_none_name(self):
+        with pytest.raises(ValueError, match="non-empty"):
+            validate_name(None)
+
+    def test_invalid_chars(self):
+        with pytest.raises(ValueError, match="alphanumeric"):
+            validate_name("has spaces")
+        with pytest.raises(ValueError, match="alphanumeric"):
+            validate_name("has/slash")
+        with pytest.raises(ValueError, match="alphanumeric"):
+            validate_name("has.dot")
+
+    def test_starts_with_hyphen(self):
+        with pytest.raises(ValueError, match="alphanumeric"):
+            validate_name("-starts-bad")
+
+    def test_too_long(self):
+        with pytest.raises(ValueError, match="64 characters"):
+            validate_name("a" * 65)
+
+    def test_max_length_ok(self):
+        name = "a" * 64
+        assert validate_name(name) == name
+
+
+class TestCreateRecording:
+    def test_basic_create(self):
+        rec = create_recording("test-rec", description="A test recording")
+        assert rec["name"] == "test-rec"
+        assert rec["description"] == "A test recording"
+        assert rec["steps"] == []
+        assert "created_at" in rec
+
+    def test_create_no_description(self):
+        rec = create_recording("minimal")
+        assert rec["description"] == ""
+
+    def test_create_duplicate(self):
+        create_recording("dup")
+        with pytest.raises(ValueError, match="already exists"):
+            create_recording("dup")
+
+    def test_create_invalid_name(self):
+        with pytest.raises(ValueError):
+            create_recording("bad name!")
+
+
+class TestGetRecording:
+    def test_get_existing(self):
+        create_recording("get-test", description="desc")
+        rec = get_recording("get-test")
+        assert rec is not None
+        assert rec["name"] == "get-test"
+        assert rec["description"] == "desc"
+
+    def test_get_nonexistent(self):
+        assert get_recording("does-not-exist") is None
+
+
+class TestListRecordings:
+    def test_list_empty(self):
+        result = list_recordings()
+        assert result == []
+
+    def test_list_multiple(self):
+        create_recording("rec-a")
+        create_recording("rec-b")
+        create_recording("rec-c")
+
+        result = list_recordings()
+        names = [r["name"] for r in result]
+        assert "rec-a" in names
+        assert "rec-b" in names
+        assert "rec-c" in names
+
+    def test_list_includes_step_count(self):
+        create_recording("counted")
+        add_step("counted", "terminal", {"command": "echo hi"}, "hi", True)
+        add_step("counted", "terminal", {"command": "echo bye"}, "bye", True)
+
+        result = list_recordings()
+        rec = next(r for r in result if r["name"] == "counted")
+        assert rec["step_count"] == 2
+
+
+class TestDeleteRecording:
+    def test_delete_existing(self):
+        create_recording("to-delete")
+        assert delete_recording("to-delete") is True
+        assert get_recording("to-delete") is None
+
+    def test_delete_nonexistent(self):
+        assert delete_recording("ghost") is False
+
+
+class TestAddStep:
+    def test_add_single_step(self):
+        create_recording("steps-test")
+        step = add_step("steps-test", "terminal", {"command": "ls"}, "file1\nfile2", True)
+        assert step["tool"] == "terminal"
+        assert step["arguments"]["command"] == "ls"
+        assert step["expected_status"] == "success"
+
+    def test_add_error_step(self):
+        create_recording("error-step")
+        step = add_step("error-step", "terminal", {"command": "bad"}, "Error: not found", False)
+        assert step["expected_status"] == "error"
+
+    def test_steps_accumulate(self):
+        create_recording("multi-step")
+        add_step("multi-step", "terminal", {"command": "a"}, "out_a", True)
+        add_step("multi-step", "terminal", {"command": "b"}, "out_b", True)
+        add_step("multi-step", "write_file", {"path": "/tmp/x"}, "ok", True)
+
+        rec = get_recording("multi-step")
+        assert len(rec["steps"]) == 3
+        assert rec["steps"][0]["arguments"]["command"] == "a"
+        assert rec["steps"][2]["tool"] == "write_file"
+
+    def test_add_step_nonexistent(self):
+        with pytest.raises(ValueError, match="not found"):
+            add_step("nope", "terminal", {}, "", True)


### PR DESCRIPTION
## Summary

- Adds `hermes record` CLI command with subcommands: `list`, `show`, `start`, `stop`, `run`, `schedule`, `delete`
- New `recording/` module with YAML-based storage (`~/.hermes/recordings/`), sequential replay engine, and global capture session
- Lightweight capture hooks in `run_agent.py` (both sequential and concurrent tool execution paths) — no-op when not recording
- `record schedule` integrates with the existing cron system to schedule recorded workflows

### CLI Usage

```bash
hermes record start "daily-report"       # Begin capturing tool calls
hermes record stop                       # Stop capturing
hermes record list                       # List saved recordings
hermes record show "daily-report"        # Show recording details/steps
hermes record run "daily-report"         # Replay a recording
hermes record schedule "daily-report" "0 8 * * 1-5"  # Schedule via cron
hermes record delete "daily-report"      # Delete a recording
```

### Architecture

- **`recording/store.py`** — CRUD for recordings stored as YAML in `~/.hermes/recordings/`. Follows patterns from `cron/jobs.py` (secure dirs, atomic writes, name validation).
- **`recording/replay.py`** — Executes steps sequentially via `model_tools.handle_function_call()`. Deviation callbacks allow abort-on-failure behavior.
- **`recording/capture.py`** — Thread-safe global singleton (`get_active_session()`) checked from the tool execution loop. Returns `None` when idle — zero overhead for normal operations.
- **`hermes_cli/record.py`** — CLI handler following `hermes_cli/cron.py` patterns.

## Test plan

- [x] 52 unit tests covering store CRUD, replay engine (mocked tool dispatch), capture lifecycle, and CLI subcommands
- [x] Core agent tests (`test_run_agent.py` — 231 tests) pass with no regressions
- [ ] Manual test: `hermes record list` shows empty state
- [ ] Manual test: full cycle — start → run session → stop → show → run replay

Closes #4439

🤖 Generated with [Claude Code](https://claude.com/claude-code)