### PR TITLE
fix(cli): surface recent sessions inside /history and /resume

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2949,10 +2949,57 @@ class HermesCLI:
         print(f"  Config File: {config_path} {config_status}")
         print()
     
+    def _list_recent_sessions(self, limit: int = 10) -> list[dict[str, Any]]:
+        """Return recent CLI sessions for in-chat browsing/resume affordances."""
+        if not self._session_db:
+            return []
+        try:
+            sessions = self._session_db.list_sessions_rich(
+                source="cli",
+                exclude_sources=["tool"],
+                limit=limit,
+            )
+        except Exception:
+            return []
+        return [s for s in sessions if s.get("id") != self.session_id]
+
+    def _show_recent_sessions(self, *, reason: str = "history", limit: int = 10) -> bool:
+        """Render recent sessions inline from the active chat TUI.
+
+        Returns True when something was shown, False if no session list was available.
+        """
+        sessions = self._list_recent_sessions(limit=limit)
+        if not sessions:
+            return False
+
+        from hermes_cli.main import _relative_time
+
+        print()
+        print("+" + "-" * 86 + "+")
+        print("|" + " " * 25 + "Recent Sessions" + " " * 46 + "|")
+        print("+" + "-" * 86 + "+")
+        print(f"  {'Title':<30} {'Preview':<30} {'Last Active':<12} ID")
+        print(f"  {'─' * 30} {'─' * 30} {'─' * 12} {'─' * 18}")
+        for session in sessions:
+            title = (session.get("title") or "—")[:30]
+            preview = (session.get("preview") or "")[:30]
+            last_active = _relative_time(session.get("last_active"))
+            print(f"  {title:<30} {preview:<30} {last_active:<12} {session['id']}")
+
+        print()
+        if reason == "history":
+            print("(._.) No messages in the current chat yet.")
+            print("      Above are recent sessions you can resume with /resume <session id or title>.")
+        else:
+            print("  Use /resume <session id or title> to switch to one of these sessions.")
+        print()
+        return True
+
     def show_history(self):
         """Display conversation history."""
         if not self.conversation_history:
-            print("(._.) No conversation history yet.")
+            if not self._show_recent_sessions(reason="history"):
+                print("(._.) No conversation history yet.")
             return
 
         preview_limit = 400
@@ -3077,6 +3124,8 @@ class HermesCLI:
 
         if not target:
             _cprint("  Usage: /resume <session_id_or_title>")
+            if self._show_recent_sessions(reason="resume"):
+                return
             _cprint("  Tip:   Use /history or `hermes sessions list` to find sessions.")
             return
 

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -191,6 +191,60 @@ class TestHistoryDisplay:
         assert "A" * 250 in output
         assert "A" * 250 + "..." not in output
 
+    def test_history_shows_recent_sessions_when_current_chat_is_empty(self, capsys):
+        cli = _make_cli()
+        cli.session_id = "current"
+        cli._session_db = MagicMock()
+        cli._session_db.list_sessions_rich.return_value = [
+            {
+                "id": "current",
+                "title": "Current",
+                "preview": "Current preview",
+                "last_active": 0,
+            },
+            {
+                "id": "20260401_201329_d85961",
+                "title": "Checking Running Hermes Agent",
+                "preview": "check running gateways for hermes agent",
+                "last_active": 0,
+            },
+        ]
+
+        cli.show_history()
+        output = capsys.readouterr().out
+
+        assert "Recent Sessions" in output
+        assert "Checking Running Hermes Agent" in output
+        assert "20260401_201329_d85961" in output
+        assert "No messages in the current chat yet." in output
+        assert "Current preview" not in output
+
+    def test_resume_without_target_lists_recent_sessions(self, capsys):
+        cli = _make_cli()
+        cli.session_id = "current"
+        cli._session_db = MagicMock()
+        cli._session_db.list_sessions_rich.return_value = [
+            {
+                "id": "current",
+                "title": "Current",
+                "preview": "Current preview",
+                "last_active": 0,
+            },
+            {
+                "id": "20260401_201329_d85961",
+                "title": "Checking Running Hermes Agent",
+                "preview": "check running gateways for hermes agent",
+                "last_active": 0,
+            },
+        ]
+
+        cli._handle_resume_command("/resume")
+        output = capsys.readouterr().out
+
+        assert "Recent Sessions" in output
+        assert "Checking Running Hermes Agent" in output
+        assert "Use /resume <session id or title> to switch" in output
+
 
 class TestRootLevelProviderOverride:
     """Root-level provider/base_url in config.yaml must NOT override model.provider."""


### PR DESCRIPTION
## Summary

The interactive CLI made session recovery too discoverability-hostile at the exact point users need it most: right after opening chat. If the current chat had no in-memory messages, `/history` only said `No conversation history yet`, and `/resume` required already knowing a session id or title.

This PR keeps Hermes' session-boundary resume model intact, but brings the in-chat UX closer to what other agent CLIs do when users need to recover prior work:

- OpenCode exposes an in-TUI `/sessions` surface (aliases `/resume`, `/continue`) for listing and switching sessions.
- Codex keeps transcript/history browsing available from inside the TUI rather than forcing users out to external shell commands.
- Aider supports restoring prior chat history directly at launch instead of requiring a separate session-discovery step.

Hermes should preserve its frozen-session semantics, but it should not require users to leave the chat TUI just to discover resumable sessions.

## What Changed

- added `HermesCLI._list_recent_sessions()` to fetch recent CLI sessions from the session DB while excluding the current session
- added `HermesCLI._show_recent_sessions()` to render a compact inline session table inside the active chat TUI
- changed `/history` so an empty current chat now shows recent resumable sessions instead of a dead-end `No conversation history yet`
- changed `/resume` with no argument so it lists recent sessions inline and shows resume guidance, instead of only telling users to run `hermes sessions list`
- kept the actual resume mechanics unchanged when a target session id/title is provided

## Why This Shape

Hermes should not copy CLIs that mutate a live session's underlying model/runtime state in-place, because Hermes relies on frozen per-session prompt identity and cache-friendly resume boundaries.

But discoverability is orthogonal to that constraint. Showing resumable sessions from inside the TUI improves the UX without:

- mutating the current live session's toolset/model assumptions
- rebuilding prompts mid-conversation
- breaking session cache expectations

So this follows the competitor UX pattern at the discovery layer, while keeping Hermes-safe session switching semantics underneath.

## Testing

- `source /Users/kshitij/Projects/hermes-agent/.venv/bin/activate && python -m pytest tests/test_cli_init.py tests/test_resume_display.py -q`
  - 53 passed
- live dry run via isolated `HERMES_HOME` + `SessionDB`
  - verified `cli.show_history()` prints an inline recent-session table when the active chat has no messages

## Notes

Related to the broader `/resume` parity/discoverability thread in #2591, but this PR focuses specifically on the in-chat session-listing UX gap that still remained after CLI resume support landed.
