### PR TITLE
fix(security): exclude auth.json and .env from profile exports

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -74,6 +74,7 @@ _DEFAULT_EXPORT_EXCLUDE_ROOT = frozenset({
     "hermes_state.db",
     "response_store.db", "response_store.db-shm", "response_store.db-wal",
     "gateway.pid", "gateway_state.json", "processes.json",
+    "auth.json",            # API keys, OAuth tokens, credential pools
     "auth.lock", "active_profile", ".update_check",
     "errors.log",
     ".hermes_history",
@@ -765,8 +766,17 @@ def export_profile(name: str, output_path: str) -> Path:
             result = shutil.make_archive(base, "gztar", tmpdir, "default")
             return Path(result)
 
-    result = shutil.make_archive(base, "gztar", str(profile_dir.parent), name)
-    return Path(result)
+    # Named profiles — stage a filtered copy to exclude credentials
+    with tempfile.TemporaryDirectory() as tmpdir:
+        staged = Path(tmpdir) / name
+        _CREDENTIAL_FILES = {"auth.json", ".env"}
+        shutil.copytree(
+            profile_dir,
+            staged,
+            ignore=lambda d, contents: _CREDENTIAL_FILES & set(contents),
+        )
+        result = shutil.make_archive(base, "gztar", tmpdir, name)
+        return Path(result)
 
 
 def _normalize_profile_archive_parts(member_name: str) -> List[str]:

--- a/tests/hermes_cli/test_profile_export_credentials.py
+++ b/tests/hermes_cli/test_profile_export_credentials.py
@@ -1,0 +1,48 @@
+"""Tests for credential exclusion during profile export.
+
+Profile exports should NEVER include auth.json or .env — these contain
+API keys, OAuth tokens, and credential pool data. Users share exported
+profiles; leaking credentials in the archive is a security issue.
+"""
+
+import tarfile
+from pathlib import Path
+
+from hermes_cli.profiles import export_profile, _DEFAULT_EXPORT_EXCLUDE_ROOT
+
+
+class TestCredentialExclusion:
+
+    def test_auth_json_in_default_exclude_set(self):
+        """auth.json must be in the default export exclusion set."""
+        assert "auth.json" in _DEFAULT_EXPORT_EXCLUDE_ROOT
+
+    def test_named_profile_export_excludes_auth(self, tmp_path, monkeypatch):
+        """Named profile export must not contain auth.json or .env."""
+        profiles_root = tmp_path / "profiles"
+        profile_dir = profiles_root / "testprofile"
+        profile_dir.mkdir(parents=True)
+
+        # Create a profile with credentials
+        (profile_dir / "config.yaml").write_text("model: gpt-4\n")
+        (profile_dir / "auth.json").write_text('{"tokens": {"access": "sk-secret"}}')
+        (profile_dir / ".env").write_text("OPENROUTER_API_KEY=sk-secret-key\n")
+        (profile_dir / "SOUL.md").write_text("I am helpful.\n")
+        (profile_dir / "memories").mkdir()
+        (profile_dir / "memories" / "MEMORY.md").write_text("# Memories\n")
+
+        monkeypatch.setattr("hermes_cli.profiles._get_profiles_root", lambda: profiles_root)
+        monkeypatch.setattr("hermes_cli.profiles.get_profile_dir", lambda n: profile_dir)
+        monkeypatch.setattr("hermes_cli.profiles.validate_profile_name", lambda n: None)
+
+        output = tmp_path / "export.tar.gz"
+        result = export_profile("testprofile", str(output))
+
+        # Check archive contents
+        with tarfile.open(result, "r:gz") as tf:
+            names = tf.getnames()
+
+        assert any("config.yaml" in n for n in names), "config.yaml should be in export"
+        assert any("SOUL.md" in n for n in names), "SOUL.md should be in export"
+        assert not any("auth.json" in n for n in names), "auth.json must NOT be in export"
+        assert not any(".env" in n for n in names), ".env must NOT be in export"


### PR DESCRIPTION
## Summary

`hermes profile export` includes `auth.json` in the archive — leaking every API key, OAuth token, and credential pool entry. Users sharing exported profiles unknowingly share all their credentials.

## Root Cause

**Named profiles** (line 769): `shutil.make_archive` archives the entire profile directory with zero exclusions.

**Default profile** (line 760): Uses `_default_export_ignore` which excludes databases and caches, but `auth.json` is NOT in `_DEFAULT_EXPORT_EXCLUDE_ROOT`. The set includes `auth.lock` but not `auth.json` — a clear oversight.

`auth.json` contains the full `credential_pool` (all API keys for all providers) and `providers` (OAuth access_token/refresh_token pairs).

## Fix

**Default profile**: Added `"auth.json"` to `_DEFAULT_EXPORT_EXCLUDE_ROOT`.

**Named profiles**: Replaced bare `make_archive` with a staged copy that filters out `auth.json` and `.env` before archiving — matching the approach already used for default profile exports.

## Tests

2 tests: `auth.json` is in the exclusion set, named profile export archive doesn't contain `auth.json` or `.env`.

```
2 passed
```