### PR TITLE
fix: update fetch_transcript.py for youtube-transcript-api v1.x

### DIFF
--- a/skills/media/youtube-content/scripts/fetch_transcript.py
+++ b/skills/media/youtube-content/scripts/fetch_transcript.py
@@ -48,7 +48,11 @@ def format_timestamp(seconds: float) -> str:
 
 
 def fetch_transcript(video_id: str, languages: list = None):
-    """Fetch transcript segments from YouTube."""
+    """Fetch transcript segments from YouTube.
+
+    Returns a list of dicts with 'text', 'start', and 'duration' keys.
+    Compatible with youtube-transcript-api v1.x.
+    """
     try:
         from youtube_transcript_api import YouTubeTranscriptApi
     except ImportError:
@@ -56,9 +60,17 @@ def fetch_transcript(video_id: str, languages: list = None):
               file=sys.stderr)
         sys.exit(1)
 
+    api = YouTubeTranscriptApi()
     if languages:
-        return YouTubeTranscriptApi.get_transcript(video_id, languages=languages)
-    return YouTubeTranscriptApi.get_transcript(video_id)
+        result = api.fetch(video_id, languages=languages)
+    else:
+        result = api.fetch(video_id)
+
+    # v1.x returns FetchedTranscriptSnippet objects; normalize to dicts
+    return [
+        {"text": seg.text, "start": seg.start, "duration": seg.duration}
+        for seg in result
+    ]
 
 
 def main():


### PR DESCRIPTION
## Summary
- The `youtube-transcript-api` library removed the static `get_transcript()` method in v1.0
- Migrates `fetch_transcript.py` to the new instance-based `fetch()` API
- Normalizes `FetchedTranscriptSnippet` objects back to dicts so the rest of the script works unchanged

## Test plan
- [x] Verified `--text-only --timestamps` mode returns timestamped transcript
- [x] Verified JSON output mode returns correct segment count and duration
- [x] Tested against real YouTube video (767 segments, 26:20 duration)