### PR TITLE
feat(gateway): implement message splitting via custom separator durin…

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -194,6 +194,7 @@ class StreamingConfig:
     edit_interval: float = 0.3    # Seconds between message edits
     buffer_threshold: int = 40    # Chars before forcing an edit
     cursor: str = " ▉"           # Cursor shown during streaming
+    separator: str = "///"       # Custom separator to split message into new bubbles
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -202,6 +203,7 @@ class StreamingConfig:
             "edit_interval": self.edit_interval,
             "buffer_threshold": self.buffer_threshold,
             "cursor": self.cursor,
+            "separator": self.separator,
         }
 
     @classmethod
@@ -214,6 +216,7 @@ class StreamingConfig:
             edit_interval=float(data.get("edit_interval", 0.3)),
             buffer_threshold=int(data.get("buffer_threshold", 40)),
             cursor=data.get("cursor", " ▉"),
+            separator=data.get("separator", "///"),
         )
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5660,6 +5660,7 @@ class GatewayRunner:
                             edit_interval=_scfg.edit_interval,
                             buffer_threshold=_scfg.buffer_threshold,
                             cursor=_scfg.cursor,
+                            separator=_scfg.separator,
                         )
                         _stream_consumer = GatewayStreamConsumer(
                             adapter=_adapter,

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -34,6 +34,7 @@ class StreamConsumerConfig:
     edit_interval: float = 0.3
     buffer_threshold: int = 40
     cursor: str = " ▉"
+    separator: str = "///"  # Custom separator to split message into new bubbles
 
 
 class GatewayStreamConsumer:
@@ -108,14 +109,28 @@ class GatewayStreamConsumer:
                 # Decide whether to flush an edit
                 now = time.monotonic()
                 elapsed = now - self._last_edit_time
+                has_separator = self.cfg.separator and self.cfg.separator in self._accumulated
                 should_edit = (
                     got_done
+                    or has_separator
                     or (elapsed >= self.cfg.edit_interval
                         and len(self._accumulated) > 0)
                     or len(self._accumulated) >= self.cfg.buffer_threshold
                 )
 
                 if should_edit and self._accumulated:
+                    # Split by custom separator (e.g. "///")
+                    if self.cfg.separator:
+                        while self.cfg.separator in self._accumulated:
+                            split_at = self._accumulated.find(self.cfg.separator)
+                            chunk = self._accumulated[:split_at].rstrip()
+                            # Finalize this chunk (no cursor)
+                            await self._send_or_edit(chunk)
+                            # Strip separator and leading whitespace from remainder
+                            self._accumulated = self._accumulated[split_at + len(self.cfg.separator):].lstrip()
+                            self._message_id = None
+                            self._last_sent_text = ""
+
                     # Split overflow: if accumulated text exceeds the platform
                     # limit, finalize the current message and start a new one.
                     while (


### PR DESCRIPTION
 What does this PR do?

  This PR introduces a custom separator (defaulting to ///) that allows the messaging gateway to split a single streaming response into
  multiple message bubbles. 

  Problem: When streaming long responses, the gateway edits a single message bubble, resulting in a continuous "wall of text" that is
  difficult to read on mobile devices.
  Solution: By detecting a specific separator in the token stream, the GatewayStreamConsumer can now finalize the current message chunk and
  immediately start a new one. This allows developers and users to control message chunking dynamically via the model's output.

  Related Issue

  Fixes #4445

  Type of Change

   - [x] ✨ New feature (non-breaking change that adds functionality)

  Changes Made

   - gateway/stream_consumer.py: Added separator to StreamConsumerConfig and implemented splitting logic in the run() loop to handle
     immediate flushes and message ID resets when the separator is encountered.
   - gateway/config.py: Exposed separator in StreamingConfig to allow user customization via config.yaml.
   - gateway/run.py: Wired the configuration through to the stream consumer initialization.

  How to Test

   1. Enable streaming in your config.yaml:
   1    streaming:
   2      enabled: true
   3      separator: "///"
   2. Start the gateway: hermes gateway run
   3. Send a prompt that explicitly uses the separator, for example: "Give me two short facts about space, separated by ///"
   4. Verify that the response is delivered as two distinct message bubbles instead of one edited bubble.