### PR TITLE
Feature/atomic chat integration

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -72,6 +72,7 @@ DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
 CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
 CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
+DEFAULT_ATOMIC_CHAT_BASE_URL = "http://127.0.0.1:1337/v1"
 
 
 # =============================================================================
@@ -219,6 +220,13 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url="https://router.huggingface.co/v1",
         api_key_env_vars=("HF_TOKEN",),
         base_url_env_var="HF_BASE_URL",
+    ),
+    "atomic-chat": ProviderConfig(
+        id="atomic-chat",
+        name="Atomic Chat",
+        auth_type="api_key",
+        inference_base_url=DEFAULT_ATOMIC_CHAT_BASE_URL,
+        api_key_env_vars=(),
     ),
 }
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -924,6 +924,7 @@ def select_provider_and_model():
         "kilocode": "Kilo Code",
         "alibaba": "Alibaba Cloud (DashScope)",
         "huggingface": "Hugging Face",
+        "atomic-chat": "Atomic Chat",
         "custom": "Custom endpoint",
     }
     active_label = provider_labels.get(active, active)
@@ -935,6 +936,7 @@ def select_provider_and_model():
 
     # Step 1: Provider selection — put active provider first with marker
     providers = [
+        ("atomic-chat", "Atomic Chat (local LLMs)"),
         ("openrouter", "OpenRouter (100+ models, pay-per-use)"),
         ("nous", "Nous Portal (Nous Research subscription)"),
         ("openai-codex", "OpenAI Codex"),
@@ -1023,6 +1025,8 @@ def select_provider_and_model():
         _model_flow_anthropic(config, current_model)
     elif selected_provider == "kimi-coding":
         _model_flow_kimi(config, current_model)
+    elif selected_provider == "atomic-chat":
+        _model_flow_atomic_chat(config, current_model)
     elif selected_provider in ("zai", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface"):
         _model_flow_api_key_provider(config, selected_provider, current_model)
 
@@ -1602,6 +1606,136 @@ def _model_flow_named_custom(config, provider_info):
 
     print(f"\n✅ Model set to: {model_name}")
     print(f"   Provider: {name} ({base_url})")
+
+
+ATOMIC_CHAT_BASE_URL = "http://127.0.0.1:1337/v1"
+
+
+def _model_flow_atomic_chat(config, current_model=""):
+    """Handle Atomic Chat — local LLMs provider at 127.0.0.1:1337.
+
+    Three-branch detection:
+    1. Not running → tell user to download / launch
+    2. Running but no model loaded → tell user to download a model
+    3. Running with model(s) → auto-select or show picker, then configure
+    """
+    from hermes_cli.auth import _save_model_choice, deactivate_provider
+    from hermes_cli.config import load_config, save_config
+    from hermes_cli.models import probe_api_models
+
+    print("  Atomic Chat — local LLMs inference")
+    print(f"  Endpoint: {ATOMIC_CHAT_BASE_URL}")
+    print()
+    print("Checking Atomic Chat status...")
+
+    probe = probe_api_models(None, ATOMIC_CHAT_BASE_URL, timeout=3.0)
+    models = probe.get("models")
+
+    if models is None:
+        print()
+        print("❌ Atomic Chat is not running (could not connect to 127.0.0.1:1337).")
+        print()
+        print("   To get started:")
+        print("   1. Download Atomic Chat from https://atomic.chat/")
+        print("   2. Launch the application")
+        print("   3. Download a model inside the app")
+        print("   4. Select Atomic Chat here again")
+        print()
+        print("   Note: If Atomic Chat is already running, make sure")
+        print("   the Local API Server is enabled in the app settings.")
+        print()
+        try:
+            from hermes_cli.colors import Colors, color
+            input(color("  Press Enter to return to provider selection... ", Colors.YELLOW))
+        except (KeyboardInterrupt, EOFError):
+            print()
+            return
+        print()
+        select_provider_and_model()
+        return
+
+    if not models:
+        print()
+        print("⚠️  Atomic Chat is running but no model is loaded.")
+        print()
+        print("   Open Atomic Chat and download or start a model first,")
+        print("   then select Atomic Chat here again.")
+        print()
+        try:
+            from hermes_cli.colors import Colors, color
+            input(color("  Press Enter to return to provider selection... ", Colors.YELLOW))
+        except (KeyboardInterrupt, EOFError):
+            print()
+            return
+        print()
+        select_provider_and_model()
+        return
+
+    if len(models) == 1:
+        model_name = models[0]
+        print(f"  Detected model: {model_name}")
+        print()
+        try:
+            confirm = input("  Use this model? [Y/n]: ").strip().lower()
+        except (KeyboardInterrupt, EOFError):
+            print("\nCancelled.")
+            return
+        if confirm not in ("", "y", "yes"):
+            print("Cancelled.")
+            return
+    else:
+        print(f"  Found {len(models)} model(s):\n")
+        try:
+            from simple_term_menu import TerminalMenu
+            menu_items = [f"  {m}" for m in models] + ["  Cancel"]
+            menu = TerminalMenu(
+                menu_items, cursor_index=0,
+                menu_cursor="-> ", menu_cursor_style=("fg_green", "bold"),
+                menu_highlight_style=("fg_green",),
+                cycle_cursor=True, clear_screen=False,
+                title="Select model from Atomic Chat:",
+            )
+            idx = menu.show()
+            print()
+            if idx is None or idx >= len(models):
+                print("Cancelled.")
+                return
+            model_name = models[idx]
+        except (ImportError, NotImplementedError):
+            for i, m in enumerate(models, 1):
+                print(f"  {i}. {m}")
+            print(f"  {len(models) + 1}. Cancel")
+            print()
+            try:
+                val = input(f"Choice [1-{len(models) + 1}]: ").strip()
+                if not val:
+                    print("Cancelled.")
+                    return
+                idx = int(val) - 1
+                if idx < 0 or idx >= len(models):
+                    print("Cancelled.")
+                    return
+                model_name = models[idx]
+            except (ValueError, KeyboardInterrupt, EOFError):
+                print("\nCancelled.")
+                return
+
+    _save_model_choice(model_name)
+
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = "custom"
+    model["base_url"] = ATOMIC_CHAT_BASE_URL
+    save_config(cfg)
+    deactivate_provider()
+
+    _save_custom_provider(ATOMIC_CHAT_BASE_URL, "", model_name)
+
+    print(f"\n✅ Model set to: {model_name}")
+    print(f"   Provider: Atomic Chat ({ATOMIC_CHAT_BASE_URL})")
 
 
 # Curated model lists for direct API-key providers

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -936,7 +936,7 @@ def select_provider_and_model():
 
     # Step 1: Provider selection — put active provider first with marker
     providers = [
-        ("atomic-chat", "Atomic Chat (local LLMs)"),
+        ("atomic-chat", "Atomic Chat Local LLMs (for apple silicon only)"),
         ("openrouter", "OpenRouter (100+ models, pay-per-use)"),
         ("nous", "Nous Portal (Nous Research subscription)"),
         ("openai-codex", "OpenAI Codex"),
@@ -1612,7 +1612,7 @@ ATOMIC_CHAT_BASE_URL = "http://127.0.0.1:1337/v1"
 
 
 def _model_flow_atomic_chat(config, current_model=""):
-    """Handle Atomic Chat — local LLMs provider at 127.0.0.1:1337.
+    """Handle Atomic Chat — local LLMs (for apple silicon only) provider at 127.0.0.1:1337.
 
     Three-branch detection:
     1. Not running → tell user to download / launch

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -262,6 +262,7 @@ _PROVIDER_LABELS = {
     "kilocode": "Kilo Code",
     "alibaba": "Alibaba Cloud (DashScope)",
     "huggingface": "Hugging Face",
+    "atomic-chat": "Atomic Chat",
     "custom": "Custom endpoint",
 }
 
@@ -300,6 +301,9 @@ _PROVIDER_ALIASES = {
     "hf": "huggingface",
     "hugging-face": "huggingface",
     "huggingface-hub": "huggingface",
+    "atomic": "atomic-chat",
+    "atomic_chat": "atomic-chat",
+    "atomicchat": "atomic-chat",
 }
 
 
@@ -335,7 +339,7 @@ def list_available_providers() -> list[dict[str, str]]:
         "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
         "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "anthropic", "alibaba",
         "opencode-zen", "opencode-go",
-        "ai-gateway", "deepseek", "custom",
+        "ai-gateway", "deepseek", "atomic-chat", "custom",
     ]
     # Build reverse alias map
     aliases_for: dict[str, list[str]] = {}

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -113,6 +113,7 @@ _DEFAULT_PROVIDER_MODELS = {
         "Qwen/Qwen3-Coder-480B-A35B-Instruct", "deepseek-ai/DeepSeek-R1-0528",
         "deepseek-ai/DeepSeek-V3.2", "moonshotai/Kimi-K2.5",
     ],
+    "atomic-chat": [],
 }
 
 

--- a/tests/test_atomic_chat_provider.py
+++ b/tests/test_atomic_chat_provider.py
@@ -1,0 +1,272 @@
+"""Tests for the Atomic Chat local LLM provider integration."""
+
+import json
+import os
+import sys
+import types
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from threading import Thread
+from unittest.mock import patch
+
+import pytest
+
+if "dotenv" not in sys.modules:
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    sys.modules["dotenv"] = fake_dotenv
+
+from hermes_cli.auth import PROVIDER_REGISTRY
+from hermes_cli.models import (
+    _PROVIDER_LABELS,
+    _PROVIDER_ALIASES,
+    list_available_providers,
+)
+
+
+# =============================================================================
+# Registry & metadata tests
+# =============================================================================
+
+
+class TestAtomicChatRegistry:
+    """Verify Atomic Chat is correctly registered across all provider maps."""
+
+    def test_provider_registered_in_auth(self):
+        assert "atomic-chat" in PROVIDER_REGISTRY
+        pconfig = PROVIDER_REGISTRY["atomic-chat"]
+        assert pconfig.name == "Atomic Chat"
+        assert pconfig.auth_type == "api_key"
+        assert pconfig.inference_base_url == "http://127.0.0.1:1337/v1"
+
+    def test_no_api_key_required(self):
+        pconfig = PROVIDER_REGISTRY["atomic-chat"]
+        assert pconfig.api_key_env_vars == ()
+
+    def test_provider_label(self):
+        assert "atomic-chat" in _PROVIDER_LABELS
+        assert _PROVIDER_LABELS["atomic-chat"] == "Atomic Chat"
+
+    def test_provider_aliases(self):
+        assert _PROVIDER_ALIASES.get("atomic") == "atomic-chat"
+        assert _PROVIDER_ALIASES.get("atomic_chat") == "atomic-chat"
+        assert _PROVIDER_ALIASES.get("atomicchat") == "atomic-chat"
+
+    def test_in_provider_order(self):
+        providers = list_available_providers()
+        ids = [p["id"] for p in providers]
+        assert "atomic-chat" in ids
+
+    def test_default_provider_models_empty(self):
+        from hermes_cli.setup import _DEFAULT_PROVIDER_MODELS
+        assert "atomic-chat" in _DEFAULT_PROVIDER_MODELS
+        assert _DEFAULT_PROVIDER_MODELS["atomic-chat"] == []
+
+
+# =============================================================================
+# Model flow tests
+# =============================================================================
+
+
+def _make_probe_result(models):
+    """Build a probe_api_models return value."""
+    return {
+        "models": models,
+        "probed_url": "http://127.0.0.1:1337/v1/models",
+        "resolved_base_url": "http://127.0.0.1:1337/v1",
+        "suggested_base_url": None,
+        "used_fallback": False,
+    }
+
+
+class TestModelFlowAtomicChatNotRunning:
+    """When Atomic Chat is not reachable, show download instructions."""
+
+    def test_not_running_shows_error(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        from hermes_cli.main import _model_flow_atomic_chat
+
+        probe_none = _make_probe_result(None)
+        monkeypatch.setattr(
+            "hermes_cli.models.probe_api_models",
+            lambda *a, **kw: probe_none,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.main.select_provider_and_model",
+            lambda: None,
+        )
+        monkeypatch.setattr("builtins.input", lambda prompt="": "")
+
+        _model_flow_atomic_chat({})
+
+        out = capsys.readouterr().out
+        assert "not running" in out
+        assert "https://atomic.chat/" in out
+        assert "Local API Server" in out
+
+    def test_not_running_ctrl_c_exits(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        from hermes_cli.main import _model_flow_atomic_chat
+
+        probe_none = _make_probe_result(None)
+        monkeypatch.setattr(
+            "hermes_cli.models.probe_api_models",
+            lambda *a, **kw: probe_none,
+        )
+
+        def raise_interrupt(prompt=""):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr("builtins.input", raise_interrupt)
+
+        _model_flow_atomic_chat({})
+        out = capsys.readouterr().out
+        assert "not running" in out
+
+
+class TestModelFlowAtomicChatNoModel:
+    """When Atomic Chat is running but has no models loaded."""
+
+    def test_no_model_shows_warning(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        from hermes_cli.main import _model_flow_atomic_chat
+
+        probe_empty = _make_probe_result([])
+        monkeypatch.setattr(
+            "hermes_cli.models.probe_api_models",
+            lambda *a, **kw: probe_empty,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.main.select_provider_and_model",
+            lambda: None,
+        )
+        monkeypatch.setattr("builtins.input", lambda prompt="": "")
+
+        _model_flow_atomic_chat({})
+
+        out = capsys.readouterr().out
+        assert "no model is loaded" in out
+        assert "download or start" in out
+
+
+class TestModelFlowAtomicChatWithModel:
+    """When Atomic Chat is running and has model(s) loaded."""
+
+    def test_single_model_auto_selects(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        from hermes_cli.main import _model_flow_atomic_chat
+        from hermes_cli.config import load_config
+
+        probe_one = _make_probe_result(["Qwen3_5-9B-Q4_K_M"])
+        monkeypatch.setattr(
+            "hermes_cli.models.probe_api_models",
+            lambda *a, **kw: probe_one,
+        )
+        monkeypatch.setattr("builtins.input", lambda prompt="": "y")
+
+        _model_flow_atomic_chat({})
+
+        out = capsys.readouterr().out
+        assert "Qwen3_5-9B-Q4_K_M" in out
+        assert "✅" in out
+
+        cfg = load_config()
+        assert cfg["model"]["provider"] == "custom"
+        assert cfg["model"]["base_url"] == "http://127.0.0.1:1337/v1"
+
+    def test_single_model_user_declines(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        from hermes_cli.main import _model_flow_atomic_chat
+
+        probe_one = _make_probe_result(["Qwen3_5-9B-Q4_K_M"])
+        monkeypatch.setattr(
+            "hermes_cli.models.probe_api_models",
+            lambda *a, **kw: probe_one,
+        )
+        monkeypatch.setattr("builtins.input", lambda prompt="": "n")
+
+        _model_flow_atomic_chat({})
+
+        out = capsys.readouterr().out
+        assert "Cancelled" in out
+
+    def test_multiple_models_numbered_fallback(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        from hermes_cli.main import _model_flow_atomic_chat
+        from hermes_cli.config import load_config
+
+        probe_multi = _make_probe_result(["model-A", "model-B"])
+
+        monkeypatch.setattr(
+            "hermes_cli.models.probe_api_models",
+            lambda *a, **kw: probe_multi,
+        )
+        monkeypatch.setattr("builtins.input", lambda prompt="": "1")
+
+        # Force numbered fallback by removing simple_term_menu from modules
+        with patch.dict(sys.modules, {"simple_term_menu": None}):
+            _model_flow_atomic_chat({})
+
+        out = capsys.readouterr().out
+        assert "model-A" in out
+        assert "✅" in out
+
+        cfg = load_config()
+        assert cfg["model"]["provider"] == "custom"
+
+
+# =============================================================================
+# Dynamic label probe tests
+# =============================================================================
+
+
+class TestDynamicLabelProbe:
+    """Test that the provider list label reflects Atomic Chat status."""
+
+    def test_label_shows_model_when_running(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        probe_result = _make_probe_result(["Qwen3_5-9B-Q4_K_M"])
+        monkeypatch.setattr(
+            "hermes_cli.models.probe_api_models",
+            lambda *a, **kw: probe_result,
+        )
+
+        from hermes_cli.models import probe_api_models
+        result = probe_api_models(None, "http://127.0.0.1:1337/v1", timeout=2.0)
+        models = result.get("models")
+
+        if models:
+            label = f"Atomic Chat (127.0.0.1:1337/v1) — {models[0]}"
+        else:
+            label = "Atomic Chat (local LLM — 127.0.0.1:1337)"
+
+        assert "Qwen3_5-9B-Q4_K_M" in label
+        assert "127.0.0.1:1337/v1" in label
+
+    def test_label_shows_no_model_when_empty(self):
+        models = []
+        if models:
+            label = f"Atomic Chat (127.0.0.1:1337/v1) — {models[0]}"
+        elif models is not None:
+            label = "Atomic Chat (running, no model loaded)"
+        else:
+            label = "Atomic Chat (local LLM — 127.0.0.1:1337)"
+
+        assert label == "Atomic Chat (running, no model loaded)"
+
+    def test_label_fallback_when_not_running(self):
+        models = None
+        if models:
+            label = f"Atomic Chat (127.0.0.1:1337/v1) — {models[0]}"
+        elif models is not None:
+            label = "Atomic Chat (running, no model loaded)"
+        else:
+            label = "Atomic Chat (local LLM — 127.0.0.1:1337)"
+
+        assert label == "Atomic Chat (local LLM — 127.0.0.1:1337)"

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -31,6 +31,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **OpenCode Go** | `OPENCODE_GO_API_KEY` in `~/.hermes/.env` (provider: `opencode-go`) |
 | **DeepSeek** | `DEEPSEEK_API_KEY` in `~/.hermes/.env` (provider: `deepseek`) |
 | **Hugging Face** | `HF_TOKEN` in `~/.hermes/.env` (provider: `huggingface`, aliases: `hf`) |
+| **Atomic Chat** | `hermes model` (auto-detected at `127.0.0.1:1337`, provider: `atomic-chat`, macOS only) |
 | **Custom Endpoint** | `hermes model` (saved in `config.yaml`) or `OPENAI_BASE_URL` + `OPENAI_API_KEY` in `~/.hermes/.env` |
 
 :::tip Model key alias
@@ -478,6 +479,46 @@ To set persistent per-model defaults: My Models tab → gear icon on the model �
 
 ---
 
+### Atomic Chat — Local LLMs on macOS
+
+[Atomic Chat](https://atomic.chat/) is a macOS desktop app for running local LLMs with an OpenAI-compatible API server at `127.0.0.1:1337`. Best for: Mac users who want a one-click local LLM experience with automatic model management.
+
+Hermes has first-class integration with Atomic Chat — it auto-detects whether the app is running and which model is loaded:
+
+```bash
+hermes model
+# Select "Atomic Chat" from the provider list
+# If running with a model loaded → auto-configures immediately
+# If not running → shows download/launch instructions
+# If running without a model → prompts you to download one
+```
+
+Or configure directly in `config.yaml`:
+
+```yaml
+model:
+  provider: "custom"
+  base_url: "http://127.0.0.1:1337/v1"
+  default: "Qwen3_5-9B-Q4_K_M"  # your downloaded model name
+```
+
+**Setup:**
+
+1. Download Atomic Chat from [atomic.chat](https://atomic.chat/) or [GitHub Releases](https://github.com/AtomicBot-ai/Atomic-Chat/releases)
+2. Launch the app and download a model (Qwen, Llama, Gemma, etc.)
+3. Make sure the Local API Server is enabled in the app settings
+4. Run `hermes model` and select "Atomic Chat"
+
+**System requirements:** macOS 13.6+ (8 GB RAM for 3B models, 16 GB for 7B, 32 GB for 13B).
+
+No API key is needed — the local server runs without authentication.
+
+:::tip
+The provider list dynamically shows the active model name when Atomic Chat is running, e.g. `Atomic Chat (127.0.0.1:1337/v1) — Qwen3_5-9B-Q4_K_M`.
+:::
+
+---
+
 ### Troubleshooting Local Models
 
 These issues affect **all** local inference servers when used with Hermes.
@@ -495,6 +536,7 @@ The model outputs something like `{"name": "web_search", "arguments": {...}}` as
 | **SGLang** | Add `--tool-call-parser qwen` (or appropriate parser) |
 | **Ollama** | Tool calling is enabled by default — make sure your model supports it (check with `ollama show model-name`) |
 | **LM Studio** | Update to 0.3.6+ and use a model with native tool support |
+| **Atomic Chat** | Uses turboquant llama.cpp under the hood — tool calling depends on the model (Qwen, Llama 3.x, Hermes work best) |
 
 #### Model seems to forget context or give incoherent responses
 


### PR DESCRIPTION
## What does this PR do?

Adds **Atomic Chat** as a first-class inference provider in the Hermes CLI. Atomic Chat is a local LLM runner that exposes an OpenAI-compatible API at `127.0.0.1:1337/v1`. Instead of requiring users to manually configure it as a custom endpoint, it now appears as a dedicated option in the provider selection menu with smart auto-detection:
- **Running + model loaded** — shows the active model name in the menu label, auto-configures on selection
- **Not running** — guides the user to download/launch Atomic Chat, returns to provider selection
- **Running but no model** — prompts the user to download or start a model, returns to provider selection



## Related Issue

N/A — new feature request for local LLM integration via Atomic Chat.

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/auth.py` — Added `atomic-chat` to `PROVIDER_REGISTRY` with base URL `http://127.0.0.1:1337/v1`, no API key required
- `hermes_cli/main.py` — Added `atomic-chat` to `provider_labels` and `providers` list with dynamic label probe (detects running status + model name at menu render time). Added `_model_flow_atomic_chat()` with three-branch detection logic and return-to-provider-selection on failure. Added `ATOMIC_CHAT_BASE_URL` constant
- `hermes_cli/models.py` — Added `atomic-chat` to `_PROVIDER_LABELS`, `_PROVIDER_ALIASES` (`atomic`, `atomic_chat`, `atomicchat`), and `_PROVIDER_ORDER`
- `hermes_cli/setup.py` — Added `atomic-chat` to `_DEFAULT_PROVIDER_MODELS` (empty list, models are user-downloaded)

## How to Test

1. Run `hermes setup` or `hermes model`
2. Verify "Atomic Chat" appears in the provider list
3. **Without Atomic Chat running:** Select it → should show error with download instructions and yellow "Press Enter to return to provider selection..." prompt → returns to provider menu
4. **With Atomic Chat running + model loaded:** Select it → should show detected model name, confirm → model is configured
5. **With Atomic Chat running, no model:** Select it → should show warning to download/start a model → returns to provider menu

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x (Apple Silicon)

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've considered cross-platform impact — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<img width="595" height="349" src="https://github.com/user-attachments/assets/0c2d54e2-8a7d-44d0-baad-2d6ac127ecdb" />

