### PR TITLE
fix(mcp): prevent OAuth server from blocking Hermes startup

### DIFF
--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -186,8 +186,10 @@ async def _wait_for_callback() -> tuple[str, str | None]:
     code = result["auth_code"] or ""
     state = result["state"]
     if not code:
-        print("  Browser callback timed out. Paste the authorization code manually:")
-        code = input("  Code: ").strip()
+        raise TimeoutError(
+            "OAuth callback timed out — no authorization code received. "
+            "Re-authenticate with: hermes mcp auth <server-name>"
+        )
     return code, state
 
 
@@ -242,6 +244,23 @@ def build_oauth_auth(server_name: str, server_url: str):
         callback_handler=_wait_for_callback,
         timeout=120.0,
     )
+
+
+async def has_valid_token(server_name: str) -> bool:
+    """Return True if a non-expired OAuth token exists in storage for this server.
+
+    Used at startup to skip interactive browser flows when no token is cached.
+    A token with no expiry information is assumed valid (server will reject it
+    if it has actually expired, which will surface as a connection error).
+    """
+    storage = HermesTokenStorage(server_name)
+    tokens = await storage.get_tokens()
+    if tokens is None:
+        return False
+    if hasattr(tokens, "expires_at") and tokens.expires_at:
+        import time
+        return float(tokens.expires_at) > time.time() + 30  # 30s safety buffer
+    return True
 
 
 def remove_oauth_tokens(server_name: str) -> None:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -752,14 +752,23 @@ class MCPServerTask:
         headers = dict(config.get("headers") or {})
         connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
 
-        # OAuth 2.1 PKCE: build httpx.Auth handler using the MCP SDK
+        # OAuth 2.1 PKCE: build httpx.Auth handler using the MCP SDK.
+        # Only proceed if a valid cached token exists — initiating an interactive
+        # browser flow during startup would block Hermes for up to 120 seconds
+        # and deadlock the MCP event loop if the user is not present.
         _oauth_auth = None
         if self._auth_type == "oauth":
             try:
-                from tools.mcp_oauth import build_oauth_auth
+                from tools.mcp_oauth import build_oauth_auth, has_valid_token
+                if not await has_valid_token(self.name):
+                    raise RuntimeError(
+                        f"MCP server '{self.name}' requires OAuth but no valid token is "
+                        f"cached. Authenticate first with: hermes mcp auth {self.name}"
+                    )
                 _oauth_auth = build_oauth_auth(self.name, url)
             except Exception as exc:
                 logger.warning("MCP OAuth setup failed for '%s': %s", self.name, exc)
+                raise
 
         sampling_kwargs = self._sampling.session_kwargs() if self._sampling else {}
         _http_kwargs: dict = {


### PR DESCRIPTION
Fixes #4462

  A failing MCP OAuth server (e.g. Atlassian) could block Hermes startup
  for up to 120 seconds and permanently deadlock the MCP event loop.

  Root causes:
  - `_wait_for_callback` fell through to `input("  Code: ")` on browser
    timeout — a blocking syscall inside asyncio; event loop deadlocks forever
  - `_run_http` called `build_oauth_auth()` unconditionally, launching a
    browser flow at startup even with no cached token

  Changes:
  - `mcp_oauth.py`: replace `input()` with `TimeoutError`; add `has_valid_token()`
  - `mcp_tool.py`: guard OAuth with `has_valid_token()` — fail fast with
    "run hermes mcp auth <server>" message; re-raise so other servers load normally

  Before: Atlassian server → Hermes hangs/deadlocks
  After:  Atlassian server → instant warning, rest of Hermes starts normally