### PR TITLE
fix: use structured reasoning field directly for thinking models

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -869,10 +869,7 @@ def generate_launchd_plist() -> str:
     <true/>
     
     <key>KeepAlive</key>
-    <dict>
-        <key>SuccessfulExit</key>
-        <false/>
-    </dict>
+    <true/>
     
     <key>StandardOutPath</key>
     <string>{log_dir}/gateway.log</string>

--- a/run_agent.py
+++ b/run_agent.py
@@ -7917,13 +7917,36 @@ class AIAgent:
                             self._response_was_previewed = True
                             break
 
-                        # No fallback available — this is a genuine empty response.
+                        # No fallback available — check if the model used a
+                        # structured reasoning field (reasoning_content) for its
+                        # answer.  Thinking models (Kimi K2.5, DeepSeek-R1, etc.)
+                        # consistently put their full response there and leave
+                        # content empty.  Retrying won't change that behavior —
+                        # use the reasoning immediately instead of wasting API calls.
+                        reasoning_text = self._extract_reasoning(assistant_message)
+                        if reasoning_text and (
+                            getattr(assistant_message, 'reasoning_content', None)
+                            or getattr(assistant_message, 'reasoning', None)
+                        ):
+                            self._vprint(f"{self.log_prefix}ℹ️  Thinking model returned response in reasoning field — using directly.")
+                            final_response = reasoning_text
+                            empty_msg = {
+                                "role": "assistant",
+                                "content": final_response,
+                                "reasoning": reasoning_text,
+                                "finish_reason": finish_reason,
+                            }
+                            messages.append(empty_msg)
+                            if hasattr(self, '_empty_content_retries'):
+                                self._empty_content_retries = 0
+                            break
+
+                        # Genuine empty response (no structured reasoning field).
                         # Retry in case the model just had a bad generation.
                         if not hasattr(self, '_empty_content_retries'):
                             self._empty_content_retries = 0
                         self._empty_content_retries += 1
-                        
-                        reasoning_text = self._extract_reasoning(assistant_message)
+
                         self._vprint(f"{self.log_prefix}⚠️  Response only contains think block with no content after it")
                         if reasoning_text:
                             reasoning_preview = reasoning_text[:500] + "..." if len(reasoning_text) > 500 else reasoning_text
@@ -7931,7 +7954,7 @@ class AIAgent:
                         else:
                             content_preview = final_response[:80] + "..." if len(final_response) > 80 else final_response
                             self._vprint(f"{self.log_prefix}   Content: '{content_preview}'")
-                        
+
                         if self._empty_content_retries < 3:
                             self._vprint(f"{self.log_prefix}🔄 Retrying API call ({self._empty_content_retries}/3)...")
                             continue


### PR DESCRIPTION
## Summary

- **Thinking models (Kimi K2.5, DeepSeek-R1, etc.) put their full response in the `reasoning_content` API field with an empty `content` field.** The existing empty-content retry loop wastes 3 API calls per response before falling back to the reasoning text — retrying doesn't change deterministic model behavior.
- Adds an early exit in the empty-content handler: when the structured `reasoning_content` or `reasoning` field is populated (distinct from inline `<think>` tags in content), use it immediately as the response.
- Changes macOS LaunchAgent `KeepAlive` from conditional (`SuccessfulExit: false`) to unconditional (`true`), so the gateway restarts after clean exits — not just crashes.

## Context

Discovered during a 48-hour soak test running Kimi K2.5 via OpenRouter as a cron-driven orchestrator. Analytical prompts (read a file + summarize findings) triggered the issue on nearly every execution:

- **28** think-block-only warnings
- **22** wasted retry API calls (each a full round-trip to OpenRouter)
- **6** max-retry exhaustions before the existing fallback kicked in

The existing `#3444` fix (thinking-budget exhaustion detection) and `#3010` (GLM reasoning-only handling) address related thinking-model edge cases but don't cover this specific pattern: a populated `reasoning_content` **API field** with empty `content`.

### Before
```
⚠️  Response only contains think block with no content after it
   Reasoning:  Model: kimi-k2.5 via OpenRouter. Vault check: all 31 checks passed...
🔄 Retrying API call (1/3)...
⚠️  Response only contains think block with no content after it
🔄 Retrying API call (2/3)...
⚠️  Response only contains think block with no content after it
❌ Max retries (3) for empty content exceeded.
Using reasoning as response content (model wrapped entire response in think tags).
```

### After
```
ℹ️  Thinking model returned response in reasoning field — using directly.
```

## Test plan

- [x] Tested with Kimi K2.5 via OpenRouter (cron job: read vault-check log + summarize)
- [x] Heartbeat prompts (simple, non-analytical) unaffected — still produce content directly
- [x] Existing retry path preserved for genuinely empty responses (no structured reasoning)
- [x] `python -c "import py_compile; py_compile.compile('run_agent.py', doraise=True)"` passes
- [ ] Verify with DeepSeek-R1 (same `reasoning_content` field pattern expected)
- [ ] Verify non-thinking models (GPT-4o, Claude, Llama) are unaffected (no `reasoning_content` field → skip early exit, reach existing retry path as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)