### PR TITLE
fix: hot fail over between anthropic and codex

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -109,6 +109,103 @@ HONCHO_TOOL_NAMES = {
     "honcho_conclude",
 }
 
+_HOT_FAILOVER_COOLDOWNS: dict[str, float] = {}
+_HOT_FAILOVER_LOCK = threading.Lock()
+_HOT_FAILOVER_SUPPORTED_PROVIDERS = ("anthropic", "openai-codex")
+_HOT_FAILOVER_DEFAULT_COOLDOWN_SECONDS = 5 * 60
+
+
+def _provider_is_logged_in(provider: str) -> bool:
+    provider_name = (provider or "").strip().lower()
+    if not provider_name:
+        return False
+    try:
+        from hermes_cli.auth import get_auth_status
+
+        status = get_auth_status(provider_name) or {}
+    except Exception:
+        logger.debug("Failed to resolve auth status for provider %s", provider_name, exc_info=True)
+        return False
+    return bool(status.get("logged_in") or status.get("configured"))
+
+
+
+def _default_model_for_provider(provider: str) -> str | None:
+    provider_name = (provider or "").strip().lower()
+    if not provider_name:
+        return None
+    try:
+        from hermes_cli.models import get_provider_models
+
+        models = get_provider_models(provider_name)
+    except Exception:
+        logger.debug("Failed to resolve default model for provider %s", provider_name, exc_info=True)
+        return None
+    if not models:
+        return None
+    first = models[0]
+    if isinstance(first, (list, tuple)) and first:
+        return str(first[0]).strip() or None
+    if isinstance(first, str):
+        return first.strip() or None
+    return None
+
+
+
+def _mark_provider_cooldown(provider: str, *, retry_after_seconds: int | float | None = None) -> float:
+    provider_name = (provider or "").strip().lower()
+    if not provider_name:
+        return 0.0
+    try:
+        retry_after = max(0.0, float(retry_after_seconds or 0.0))
+    except (TypeError, ValueError):
+        retry_after = 0.0
+    cooldown_seconds = retry_after or float(_HOT_FAILOVER_DEFAULT_COOLDOWN_SECONDS)
+    until = time.time() + cooldown_seconds
+    with _HOT_FAILOVER_LOCK:
+        _HOT_FAILOVER_COOLDOWNS[provider_name] = until
+    return until
+
+
+
+def _provider_cooldown_remaining(provider: str) -> float:
+    provider_name = (provider or "").strip().lower()
+    if not provider_name:
+        return 0.0
+    now = time.time()
+    with _HOT_FAILOVER_LOCK:
+        until = _HOT_FAILOVER_COOLDOWNS.get(provider_name, 0.0)
+        if until <= now:
+            _HOT_FAILOVER_COOLDOWNS.pop(provider_name, None)
+            return 0.0
+    return max(0.0, until - now)
+
+
+
+def _codexbar_rate_limit_hint() -> dict[str, Any] | None:
+    try:
+        from cron.usage_governor import get_codex_usage_snapshot
+
+        snapshot = get_codex_usage_snapshot() or {}
+    except Exception:
+        logger.debug("Failed to read CodexBar usage snapshot", exc_info=True)
+        return None
+    if not snapshot or snapshot.get("stale"):
+        return None
+    limited = (not snapshot.get("allowed", True)) or bool(snapshot.get("limit_reached", False))
+    if not limited:
+        return None
+    retry_after = max(
+        int(snapshot.get("primary_reset_after_seconds") or 0),
+        int(snapshot.get("secondary_reset_after_seconds") or 0),
+        60,
+    )
+    return {
+        "provider": "openai-codex",
+        "retry_after_seconds": retry_after,
+        "source": snapshot.get("source") or "codexbar",
+    }
+
 
 class _SafeWriter:
     """Transparent stdio wrapper that catches OSError/ValueError from broken pipes.
@@ -910,17 +1007,13 @@ class AIAgent:
         
         # Provider fallback chain — ordered list of backup providers tried
         # when the primary is exhausted (rate-limit, overload, connection
-        # failure).  Supports both legacy single-dict ``fallback_model`` and
-        # new list ``fallback_providers`` format.
-        if isinstance(fallback_model, list):
-            self._fallback_chain = [
-                f for f in fallback_model
-                if isinstance(f, dict) and f.get("provider") and f.get("model")
-            ]
-        elif isinstance(fallback_model, dict) and fallback_model.get("provider") and fallback_model.get("model"):
-            self._fallback_chain = [fallback_model]
-        else:
-            self._fallback_chain = []
+        # failure). Supports both legacy single-dict ``fallback_model`` and
+        # new list ``fallback_providers`` format, then augments the chain with
+        # symmetric hot-failover entries (Anthropic <-> Codex) when both
+        # providers are available.
+        self._primary_provider = self.provider
+        self._primary_model = self.model
+        self._fallback_chain = self._build_fallback_chain(fallback_model)
         self._fallback_index = 0
         self._fallback_activated = False
         # Legacy attribute kept for backward compat (tests, external callers)
@@ -4491,6 +4584,77 @@ class AIAgent:
             raise result["error"]
         return result["response"]
 
+    def _build_fallback_chain(self, fallback_model: Dict[str, Any] | list[Dict[str, Any]] | None) -> list[dict[str, str]]:
+        chain: list[dict[str, str]] = []
+        raw_entries = fallback_model if isinstance(fallback_model, list) else [fallback_model]
+        for entry in raw_entries:
+            if not isinstance(entry, dict):
+                continue
+            provider = str(entry.get("provider") or "").strip().lower()
+            model = str(entry.get("model") or "").strip()
+            if not provider or not model:
+                continue
+            chain.append({"provider": provider, "model": model})
+
+        seen_pairs = {
+            (str(self.provider or "").strip().lower(), str(self.model or "").strip())
+        }
+        normalized: list[dict[str, str]] = []
+        for entry in chain:
+            key = (entry["provider"], entry["model"])
+            if key in seen_pairs:
+                continue
+            seen_pairs.add(key)
+            normalized.append(entry)
+
+        current_provider = str(self.provider or "").strip().lower()
+        if current_provider in _HOT_FAILOVER_SUPPORTED_PROVIDERS:
+            alternate_provider = (
+                "openai-codex" if current_provider == "anthropic" else "anthropic"
+            )
+            if _provider_is_logged_in(alternate_provider):
+                alternate_model = _default_model_for_provider(alternate_provider)
+                if alternate_model:
+                    key = (alternate_provider, alternate_model)
+                    if key not in seen_pairs:
+                        normalized.append({
+                            "provider": alternate_provider,
+                            "model": alternate_model,
+                        })
+                        seen_pairs.add(key)
+
+        return normalized
+
+    def _provider_rate_limit_hint(self, provider: str) -> dict[str, Any] | None:
+        provider_name = (provider or "").strip().lower()
+        if not provider_name:
+            return None
+        cooldown_remaining = _provider_cooldown_remaining(provider_name)
+        if cooldown_remaining > 0:
+            return {
+                "provider": provider_name,
+                "retry_after_seconds": int(max(1, round(cooldown_remaining))),
+                "source": "cooldown",
+            }
+        if provider_name == "openai-codex":
+            return _codexbar_rate_limit_hint()
+        return None
+
+    def _maybe_activate_hot_failover_before_request(self) -> bool:
+        hint = self._provider_rate_limit_hint(self.provider)
+        if not hint:
+            return False
+        provider_name = str(hint.get("provider") or self.provider or "").strip().lower()
+        retry_after = int(hint.get("retry_after_seconds") or 0)
+        source = str(hint.get("source") or "rate-limit").strip()
+        _mark_provider_cooldown(provider_name, retry_after_seconds=retry_after)
+        if self._fallback_index >= len(self._fallback_chain):
+            return False
+        self._emit_status(
+            f"⚠️ {provider_name} unavailable ({source}) — switching provider immediately..."
+        )
+        return self._try_activate_fallback()
+
     # ── Provider fallback ──────────────────────────────────────────────────
 
     def _try_activate_fallback(self) -> bool:
@@ -4514,6 +4678,20 @@ class AIAgent:
         fb_model = (fb.get("model") or "").strip()
         if not fb_provider or not fb_model:
             return self._try_activate_fallback()  # skip invalid, try next
+        if fb_provider == (self.provider or "").strip().lower() and fb_model == (self.model or "").strip():
+            return self._try_activate_fallback()
+
+        rate_limit_hint = self._provider_rate_limit_hint(fb_provider)
+        if rate_limit_hint:
+            retry_after = int(rate_limit_hint.get("retry_after_seconds") or 0)
+            _mark_provider_cooldown(fb_provider, retry_after_seconds=retry_after)
+            logger.info(
+                "Skipping fallback %s (%s) because provider is temporarily unavailable via %s",
+                fb_model,
+                fb_provider,
+                rate_limit_hint.get("source") or "cooldown",
+            )
+            return self._try_activate_fallback()
 
         # Use centralized router for client construction.
         # raw_codex=True because the main agent needs direct responses.stream()
@@ -6646,6 +6824,9 @@ class AIAgent:
 
             while retry_count < max_retries:
                 try:
+                    if self._maybe_activate_hot_failover_before_request():
+                        retry_count = 0
+                        continue
                     api_kwargs = self._build_api_kwargs(api_messages)
                     if self.api_mode == "codex_responses":
                         api_kwargs = self._preflight_codex_api_kwargs(api_kwargs, allow_stream=False)
@@ -6755,8 +6936,10 @@ class AIAgent:
                         retry_count += 1
                         
                         # Eager fallback: empty/malformed responses are a common
-                        # rate-limit symptom.  Switch to fallback immediately
-                        # rather than retrying with extended backoff.
+                        # rate-limit symptom. Mark the current provider as cooling
+                        # down and switch immediately instead of retrying with
+                        # extended backoff.
+                        _mark_provider_cooldown(self.provider)
                         if self._fallback_index < len(self._fallback_chain):
                             self._emit_status("⚠️ Empty/malformed response — switching to fallback...")
                         if self._try_activate_fallback():
@@ -7229,6 +7412,12 @@ class AIAgent:
                         or "usage limit" in error_msg
                         or "quota" in error_msg
                     )
+                    if is_rate_limited:
+                        _retry_after_header = None
+                        _headers = getattr(getattr(api_error, "response", None), "headers", None)
+                        if _headers and hasattr(_headers, "get"):
+                            _retry_after_header = _headers.get("retry-after") or _headers.get("Retry-After")
+                        _mark_provider_cooldown(self.provider, retry_after_seconds=_retry_after_header)
                     if is_rate_limited and self._fallback_index < len(self._fallback_chain):
                         # Don't eagerly fallback if credential pool rotation may
                         # still recover.  The pool's retry-then-rotate cycle needs

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -7,18 +7,50 @@ advancement through multiple providers.
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+import run_agent
 from run_agent import AIAgent
 
 
-def _make_agent(fallback_model=None):
+@pytest.fixture(autouse=True)
+def _clear_hot_failover_state():
+    run_agent._HOT_FAILOVER_COOLDOWNS.clear()
+    yield
+    run_agent._HOT_FAILOVER_COOLDOWNS.clear()
+
+
+def _make_agent(
+    fallback_model=None,
+    *,
+    provider=None,
+    model="claude-opus-4-6",
+    provider_logged_in=False,
+    default_model=None,
+):
     """Create a minimal AIAgent with optional fallback config."""
+    provider_patch = (
+        patch("run_agent._provider_is_logged_in", side_effect=provider_logged_in)
+        if callable(provider_logged_in)
+        else patch("run_agent._provider_is_logged_in", return_value=provider_logged_in)
+    )
+    explicit_base_url = None
+    if provider == "openai-codex":
+        explicit_base_url = "https://chatgpt.com/backend-api/codex"
+    elif provider == "anthropic":
+        explicit_base_url = "https://api.anthropic.com"
+
     with (
         patch("run_agent.get_tool_definitions", return_value=[]),
         patch("run_agent.check_toolset_requirements", return_value={}),
         patch("run_agent.OpenAI"),
+        provider_patch,
+        patch("run_agent._default_model_for_provider", return_value=default_model),
     ):
         agent = AIAgent(
-            api_key="test-key",
+            api_key="***",
+            base_url=explicit_base_url,
+            provider=provider,
+            model=model,
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,
@@ -44,6 +76,28 @@ class TestFallbackChainInit:
         assert agent._fallback_chain == []
         assert agent._fallback_index == 0
         assert agent._fallback_model is None
+
+    def test_auto_appends_codex_for_anthropic_primary(self):
+        agent = _make_agent(
+            fallback_model=None,
+            provider="anthropic",
+            model="claude-opus-4-6",
+            provider_logged_in=lambda provider: provider == "openai-codex",
+            default_model="gpt-5.4",
+        )
+
+        assert agent._fallback_chain == [{"provider": "openai-codex", "model": "gpt-5.4"}]
+
+    def test_auto_appends_anthropic_for_codex_primary(self):
+        agent = _make_agent(
+            fallback_model=None,
+            provider="openai-codex",
+            model="gpt-5.4",
+            provider_logged_in=lambda provider: provider == "anthropic",
+            default_model="claude-opus-4-6",
+        )
+
+        assert agent._fallback_chain == [{"provider": "anthropic", "model": "claude-opus-4-6"}]
 
     def test_single_dict_backwards_compat(self):
         fb = {"provider": "openai", "model": "gpt-4o"}
@@ -154,3 +208,30 @@ class TestFallbackChainAdvancement:
             ]
             assert agent._try_activate_fallback() is True
             assert agent.model == "gpt-4o"
+
+    def test_skips_rate_limited_provider_to_next(self):
+        fbs = [
+            {"provider": "openai-codex", "model": "gpt-5.4"},
+            {"provider": "zai", "model": "glm-4.7"},
+        ]
+        agent = _make_agent(fallback_model=fbs, provider="anthropic", model="claude-opus-4-6")
+        with (
+            patch.object(agent, "_provider_rate_limit_hint", side_effect=[{"source": "cooldown", "retry_after_seconds": 90}, None]),
+            patch("agent.auxiliary_client.resolve_provider_client", return_value=(_mock_client(), "glm-4.7")),
+        ):
+            assert agent._try_activate_fallback() is True
+            assert agent.model == "glm-4.7"
+            assert agent._fallback_index == 2
+
+    def test_preflight_hot_failover_switches_before_request(self):
+        agent = _make_agent(
+            fallback_model={"provider": "anthropic", "model": "claude-opus-4-6"},
+            provider="openai-codex",
+            model="gpt-5.4",
+        )
+        with (
+            patch.object(agent, "_provider_rate_limit_hint", return_value={"provider": "openai-codex", "retry_after_seconds": 120, "source": "codexbar"}),
+            patch.object(agent, "_try_activate_fallback", return_value=True) as mock_activate,
+        ):
+            assert agent._maybe_activate_hot_failover_before_request() is True
+            mock_activate.assert_called_once()


### PR DESCRIPTION
## Summary
- add hot failover cooldowns so Anthropic/Codex switch immediately after rate limits
- auto-append the opposite provider to the fallback chain when both accounts are available
- consult CodexBar usage before requests so Codex can fail over pre-emptively

## Test Plan
- python -m pytest tests/test_provider_fallback.py -q
- python -m pytest tests/test_run_agent.py -k "fallback or rate_limit or recover_with_pool" -q
- python -m pytest tests/ -q *(repo has pre-existing unrelated failures/errors: ACP import, transcription deps, cron/file guard tests, auth-provider tests)*