### PR TITLE
fix(redact): prevent secret scanner from corrupting language keywords…

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -126,6 +126,10 @@ def redact_sensitive_text(text: str) -> str:
     # ENV assignments: OPENAI_API_KEY=sk-abc...
     def _redact_env(m):
         name, quote, value = m.group(1), m.group(2), m.group(3)
+        
+        if not quote and value.lower() in ("await", "new", "true", "false", "null", "undefined"):
+            return m.group(0)
+            
         return f"{name}={quote}{_mask_token(value)}{quote}"
     text = _ENV_ASSIGN_RE.sub(_redact_env, text)
 


### PR DESCRIPTION
… (#4451)

## What does this PR do?

-----
This PR addresses the critical issue where the patch tool intermittently corrupts TypeScript/TSX files by replacing the `await` keyword with `***`.

**Fixes #4451**

## Root Cause Analysis
The bug was not in the patch parser itself, but in the secret redaction engine (`agent/redact.py`). The `_ENV_ASSIGN_RE` regex was overly aggressive. When it encountered lines like `const token = await getToken();`, it matched the variable name `token`, assumed it was an environment assignment, and redacted the subsequent unquoted value (`await`) because it was under 18 characters. 

## Changes Made
- Added a guard clause in the `_redact_env` function inside `agent/redact.py`.
- The scanner now explicitly ignores common unquoted language primitives (`await`, `new`, `null`, `true`, `false`, `undefined`) immediately following an assignment operator.
- Legitimate secrets inside quotes (`token = "sk-..."`) remain fully protected.

**## ⚠️ Important Note Regarding v0.6.0**
The release notes for v0.6.0 mentioned recovering a file damaged by the patch tool's redaction (Issue #3801). However, that was only a surface-level recovery of a specific file. The underlying aggressive regex in the redaction engine was left untouched, which is why users are still experiencing this silent corruption in the latest builds. This PR provides the definitive root-cause fix for the engine itself.

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

