### PR TITLE
fix(security): exclude auth.json and .env from profile exports

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -75,6 +75,7 @@ _DEFAULT_EXPORT_EXCLUDE_ROOT = frozenset({
     "response_store.db", "response_store.db-shm", "response_store.db-wal",
     "gateway.pid", "gateway_state.json", "processes.json",
     "auth.json",            # API keys, OAuth tokens, credential pools
+    ".env",                 # API keys (dotenv)
     "auth.lock", "active_profile", ".update_check",
     "errors.log",
     ".hermes_history",

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -74,6 +74,7 @@ _DEFAULT_EXPORT_EXCLUDE_ROOT = frozenset({
     "hermes_state.db",
     "response_store.db", "response_store.db-shm", "response_store.db-wal",
     "gateway.pid", "gateway_state.json", "processes.json",
+    "auth.json",            # API keys, OAuth tokens, credential pools
     "auth.lock", "active_profile", ".update_check",
     "errors.log",
     ".hermes_history",
@@ -765,8 +766,17 @@ def export_profile(name: str, output_path: str) -> Path:
             result = shutil.make_archive(base, "gztar", tmpdir, "default")
             return Path(result)
 
-    result = shutil.make_archive(base, "gztar", str(profile_dir.parent), name)
-    return Path(result)
+    # Named profiles — stage a filtered copy to exclude credentials
+    with tempfile.TemporaryDirectory() as tmpdir:
+        staged = Path(tmpdir) / name
+        _CREDENTIAL_FILES = {"auth.json", ".env"}
+        shutil.copytree(
+            profile_dir,
+            staged,
+            ignore=lambda d, contents: _CREDENTIAL_FILES & set(contents),
+        )
+        result = shutil.make_archive(base, "gztar", tmpdir, name)
+        return Path(result)
 
 
 def _normalize_profile_archive_parts(member_name: str) -> List[str]:

--- a/tests/hermes_cli/test_profile_export_credentials.py
+++ b/tests/hermes_cli/test_profile_export_credentials.py
@@ -1,0 +1,48 @@
+"""Tests for credential exclusion during profile export.
+
+Profile exports should NEVER include auth.json or .env — these contain
+API keys, OAuth tokens, and credential pool data. Users share exported
+profiles; leaking credentials in the archive is a security issue.
+"""
+
+import tarfile
+from pathlib import Path
+
+from hermes_cli.profiles import export_profile, _DEFAULT_EXPORT_EXCLUDE_ROOT
+
+
+class TestCredentialExclusion:
+
+    def test_auth_json_in_default_exclude_set(self):
+        """auth.json must be in the default export exclusion set."""
+        assert "auth.json" in _DEFAULT_EXPORT_EXCLUDE_ROOT
+
+    def test_named_profile_export_excludes_auth(self, tmp_path, monkeypatch):
+        """Named profile export must not contain auth.json or .env."""
+        profiles_root = tmp_path / "profiles"
+        profile_dir = profiles_root / "testprofile"
+        profile_dir.mkdir(parents=True)
+
+        # Create a profile with credentials
+        (profile_dir / "config.yaml").write_text("model: gpt-4\n")
+        (profile_dir / "auth.json").write_text('{"tokens": {"access": "sk-secret"}}')
+        (profile_dir / ".env").write_text("OPENROUTER_API_KEY=sk-secret-key\n")
+        (profile_dir / "SOUL.md").write_text("I am helpful.\n")
+        (profile_dir / "memories").mkdir()
+        (profile_dir / "memories" / "MEMORY.md").write_text("# Memories\n")
+
+        monkeypatch.setattr("hermes_cli.profiles._get_profiles_root", lambda: profiles_root)
+        monkeypatch.setattr("hermes_cli.profiles.get_profile_dir", lambda n: profile_dir)
+        monkeypatch.setattr("hermes_cli.profiles.validate_profile_name", lambda n: None)
+
+        output = tmp_path / "export.tar.gz"
+        result = export_profile("testprofile", str(output))
+
+        # Check archive contents
+        with tarfile.open(result, "r:gz") as tf:
+            names = tf.getnames()
+
+        assert any("config.yaml" in n for n in names), "config.yaml should be in export"
+        assert any("SOUL.md" in n for n in names), "SOUL.md should be in export"
+        assert not any("auth.json" in n for n in names), "auth.json must NOT be in export"
+        assert not any(".env" in n for n in names), ".env must NOT be in export"

--- a/tests/hermes_cli/test_profile_export_credentials.py
+++ b/tests/hermes_cli/test_profile_export_credentials.py
@@ -17,6 +17,10 @@ class TestCredentialExclusion:
         """auth.json must be in the default export exclusion set."""
         assert "auth.json" in _DEFAULT_EXPORT_EXCLUDE_ROOT
 
+    def test_dotenv_in_default_exclude_set(self):
+        """.env must be in the default export exclusion set."""
+        assert ".env" in _DEFAULT_EXPORT_EXCLUDE_ROOT
+
     def test_named_profile_export_excludes_auth(self, tmp_path, monkeypatch):
         """Named profile export must not contain auth.json or .env."""
         profiles_root = tmp_path / "profiles"

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -505,7 +505,7 @@ class TestExportImport:
         assert tarfile.is_tarfile(str(result))
 
     def test_export_default_includes_profile_data(self, profile_env, tmp_path):
-        """Profile data files end up in the archive."""
+        """Profile data files end up in the archive (credentials excluded)."""
         default_dir = get_profile_dir("default")
         (default_dir / "config.yaml").write_text("model: test")
         (default_dir / ".env").write_text("KEY=val")
@@ -522,7 +522,7 @@ class TestExportImport:
             names = tf.getnames()
 
         assert "default/config.yaml" in names
-        assert "default/.env" in names
+        assert "default/.env" not in names  # credentials excluded
         assert "default/SOUL.md" in names
         assert "default/memories/MEMORY.md" in names
 


### PR DESCRIPTION
## Summary

Salvage of #4452 by @dieutx with a follow-up fix.

`hermes profile export` included `auth.json` and `.env` in archives — leaking API keys, OAuth tokens, and credential pool entries when users share exported profiles.

## Changes

**From #4452 (cherry-picked, @dieutx):**
- Added `auth.json` to `_DEFAULT_EXPORT_EXCLUDE_ROOT`
- Named profile exports now use a staged copytree that filters out `auth.json` and `.env`
- Tests for both exclusion set membership and named profile archive contents

**Follow-up fix:**
- Added `.env` to `_DEFAULT_EXPORT_EXCLUDE_ROOT` (the original PR missed this — default profile exports would still leak `.env`)
- Added test for `.env` in default exclusion set
- Updated existing test that incorrectly asserted `.env` presence in exports

## Test results

83 profile tests passed + E2E verification of both default and named profile export paths confirming credentials are excluded and legitimate files are preserved.