### PR TITLE
fix(redact): remove re.IGNORECASE from _ENV_ASSIGN_RE to prevent masking lowercase variables

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -50,11 +50,13 @@ _PREFIX_PATTERNS = [
     r"exa_[A-Za-z0-9]{10,}",            # Exa search API key
 ]
 
-# ENV assignment patterns: KEY=value where KEY contains a secret-like name
+# ENV assignment patterns: KEY=value where KEY contains a secret-like name.
+# No re.IGNORECASE — only match ALL-UPPERCASE env var names (e.g. API_KEY=...)
+# to avoid redacting lowercase Python variable assignments (e.g. before_tokens = ...).
+# Fixes: https://github.com/NousResearch/hermes-agent/issues/4367
 _SECRET_ENV_NAMES = r"(?:API_?KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|AUTH)"
 _ENV_ASSIGN_RE = re.compile(
-    rf"([A-Z_]*{_SECRET_ENV_NAMES}[A-Z_]*)\s*=\s*(['\"]?)(\S+)\2",
-    re.IGNORECASE,
+    rf"(?:^|(?<=\s))([A-Z_]*{_SECRET_ENV_NAMES}[A-Z_]*)\s*=\s*(['\"]?)(\S+)\2",
 )
 
 # JSON field patterns: "apiKey": "value", "token": "value", etc.

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -82,6 +82,40 @@ class TestEnvAssignments:
         result = redact_sensitive_text(text)
         assert result == text
 
+    def test_lowercase_python_variable_token_unchanged(self):
+        # Regression: #4367 — lowercase 'token' assignment must not be redacted
+        text = "before_tokens = response.usage.prompt_tokens"
+        result = redact_sensitive_text(text)
+        assert result == text
+
+    def test_lowercase_python_variable_api_key_unchanged(self):
+        # Regression: #4367 — lowercase 'api_key' must not be redacted
+        text = "api_key = config.get('api_key')"
+        result = redact_sensitive_text(text)
+        assert result == text
+
+    def test_typescript_await_token_unchanged(self):
+        # Regression: #4451 — 'await' keyword must not be redacted as a secret value
+        # re.IGNORECASE on _ENV_ASSIGN_RE caused 'token = await' to match,
+        # turning 'const token = await getToken()' into 'const token=*** getToken()'
+        text = "const token = await getToken();"
+        result = redact_sensitive_text(text)
+        assert result == text
+
+    def test_typescript_await_secret_unchanged(self):
+        # Regression: #4451 — similar pattern with 'secret' variable
+        text = "const secret = await fetchSecret();"
+        result = redact_sensitive_text(text)
+        assert result == text
+
+    def test_export_whitespace_preserved(self):
+        # Regression: whitespace before uppercase env var must be preserved
+        text = "export SECRET_TOKEN=mypassword"
+        result = redact_sensitive_text(text)
+        assert result.startswith("export ")
+        assert "SECRET_TOKEN=" in result
+        assert "mypassword" not in result
+
 
 class TestJsonFields:
     def test_json_api_key(self):


### PR DESCRIPTION
## Root Cause

`_ENV_ASSIGN_RE` was compiled with `re.IGNORECASE`, making the uppercase-only pattern `[A-Z_]*TOKEN[A-Z_]*` also match lowercase names. This caused two distinct bugs:

## Bugs Fixed

**#4367 — Python variable assignments incorrectly redacted**
```python
before_tokens = response.usage.prompt_tokens  # was redacted to: before_tokens=***
api_key = config.get('api_key')               # was redacted to: api_key=***
```

**#4451 — `await` keyword corrupted in TypeScript/TSX patch tool output**
```typescript
// Before (upstream bug):
const token = await getToken();  →  const token=*** getToken();
const secret = await fetchSecret();  →  const secret=*** fetchSecret();

// After (this fix):
const token = await getToken();  →  const token = await getToken();  ✓
```

The `await` keyword was being redacted because `token` (lowercase) matched the pattern with `re.IGNORECASE`, and `await` was the first non-whitespace word after `=`, so `_mask_token("await")` → `***` (5 chars < 18).

## Fix

Two changes to `_ENV_ASSIGN_RE`:

1. **Remove `re.IGNORECASE`** — only ALL-UPPERCASE env var names should match (e.g. `API_KEY`, `SECRET_TOKEN`). Lowercase Python/JS/TS variable names are never redacted.
2. **Add `(?:^|(?<=\s))` lookbehind** — prevents the pattern from consuming leading whitespace, so `export SECRET_TOKEN=value` stays `export SECRET_TOKEN=***` (not `exportSECRET_TOKEN=***`).

## Tests

Added 5 new regression tests in `TestEnvAssignments`:
- `test_lowercase_python_variable_token_unchanged` — #4367
- `test_lowercase_python_variable_api_key_unchanged` — #4367
- `test_typescript_await_token_unchanged` — #4451
- `test_typescript_await_secret_unchanged` — #4451
- `test_export_whitespace_preserved` — whitespace regression

All 43 tests pass.

Fixes #4367
Fixes #4451

🤖 Generated with [Claude Code](https://claude.com/claude-code)