### PR TITLE
fix(skill_utils): add type check for metadata field in extract_skill_conditions

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -230,7 +230,13 @@ def get_all_skills_dirs() -> List[Path]:
 
 def extract_skill_conditions(frontmatter: Dict[str, Any]) -> Dict[str, List]:
     """Extract conditional activation fields from parsed frontmatter."""
-    hermes = (frontmatter.get("metadata") or {}).get("hermes") or {}
+    metadata = frontmatter.get("metadata")
+    # Handle cases where metadata is not a dict (e.g., a string from malformed YAML)
+    if not isinstance(metadata, dict):
+        metadata = {}
+    hermes = metadata.get("hermes") or {}
+    if not isinstance(hermes, dict):
+        hermes = {}
     return {
         "fallback_for_toolsets": hermes.get("fallback_for_toolsets", []),
         "requires_toolsets": hermes.get("requires_toolsets", []),


### PR DESCRIPTION
## Summary

Cherry-picked from #4433 by @Leegenux onto current main.

Adds `isinstance(metadata, dict)` guards in `extract_skill_conditions()` to prevent `AttributeError` when malformed YAML frontmatter produces a string `metadata` field instead of a dict. Also guards `hermes` field the same way.

This makes `skill_utils.py` consistent with `skills_tool.py` (line 1078) which already has this check.

## Test plan
- Full suite: 7479 passed (8 pre-existing failures unrelated to this change)
- E2E: verified string metadata, empty string, integer metadata, string hermes field, missing metadata, and normal dict metadata all handled correctly

Closes #4433