### PR TITLE
Support custom_providers in auxiliary_client resolution

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1051,6 +1051,33 @@ def resolve_provider_client(
                        "but no endpoint credentials found")
         return None, None
 
+    # ── Check custom_providers (config.yaml) first ─────────────────────
+    # Custom providers (e.g., "google", "ollama", "custom-endpoint") are defined
+    # in config.yaml's custom_providers list and stored in the credential pool.
+    try:
+        from agent.credential_pool import _iter_custom_providers
+        
+        for custom_name, custom_entry in _iter_custom_providers():
+            if custom_name == provider:
+                # Found a matching custom provider
+                custom_base = custom_entry.get("base_url", "").strip().rstrip("/")
+                custom_key = custom_entry.get("api_key", "").strip() or "no-key-required"
+                
+                if not custom_base:
+                    logger.warning(
+                        "resolve_provider_client: custom provider %r has no base_url",
+                        provider
+                    )
+                    return None, None
+                
+                final_model = model or _read_main_model() or "gpt-4o-mini"
+                client = OpenAI(api_key=custom_key, base_url=custom_base)
+                logger.debug("resolve_provider_client: custom_provider %r (%s)", provider, final_model)
+                return (_to_async_client(client, final_model) if async_mode
+                        else (client, final_model))
+    except Exception as exc:
+        logger.debug("resolve_provider_client: error checking custom_providers: %s", exc)
+    
     # ── API-key providers from PROVIDER_REGISTRY ─────────────────────
     try:
         from hermes_cli.auth import PROVIDER_REGISTRY, resolve_api_key_provider_credentials


### PR DESCRIPTION
## Problem
Auxiliary client operations (memory flush, compression, session search, vision analysis) fail with 'unknown provider' warnings when using custom_providers defined in config.yaml. This causes session expiry crashes on memory flush when custom providers like Google AI or local Ollama are configured.

## Root Cause
`resolve_provider_client()` only checks the hardcoded PROVIDER_REGISTRY, not the custom_providers list from config.yaml. Custom providers are available via the credential pool but weren't being consulted for auxiliary tasks.

## Solution
Added a check in `resolve_provider_client()` to iterate through custom_providers (via credential pool) BEFORE checking PROVIDER_REGISTRY. This allows auxiliary clients to find custom endpoints without registry entries.

## Changes
- Modified `agent/auxiliary_client.py`: Added custom_providers resolution logic in `resolve_provider_client()`
- No breaking changes, maintains backward compatibility
- Fixes auxiliary client crashes when using custom providers

## Testing
- Verified with Google AI custom provider as auxiliary compression backend
- Memory flush and session expiry no longer crash
- Falls through to PROVIDER_REGISTRY if no custom_provider match found