### PR TITLE
feat(providers): add Mistral AI, Nebius AI, and Scaleway as first-class providers

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -220,6 +220,30 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("HF_TOKEN",),
         base_url_env_var="HF_BASE_URL",
     ),
+    "mistral": ProviderConfig(
+        id="mistral",
+        name="Mistral AI",
+        auth_type="api_key",
+        inference_base_url="https://api.mistral.ai/v1",
+        api_key_env_vars=("MISTRAL_API_KEY",),
+        base_url_env_var="MISTRAL_BASE_URL",
+    ),
+    "nebius": ProviderConfig(
+        id="nebius",
+        name="Nebius AI",
+        auth_type="api_key",
+        inference_base_url="https://api.tokenfactory.nebius.com/v1",
+        api_key_env_vars=("NEBIUS_API_KEY",),
+        base_url_env_var="NEBIUS_BASE_URL",
+    ),
+    "scaleway": ProviderConfig(
+        id="scaleway",
+        name="Scaleway Generative APIs",
+        auth_type="api_key",
+        inference_base_url="https://api.scaleway.ai/v1",
+        api_key_env_vars=("SCALEWAY_API_KEY", "SCW_SECRET_KEY"),
+        base_url_env_var="SCALEWAY_BASE_URL",
+    ),
 }
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -951,6 +951,9 @@ def select_provider_and_model():
         ("ai-gateway", "AI Gateway (Vercel — 200+ models, pay-per-use)"),
         ("alibaba", "Alibaba Cloud / DashScope Coding (Qwen + multi-provider)"),
         ("huggingface", "Hugging Face Inference Providers (20+ open models)"),
+        ("mistral", "Mistral AI (direct API)"),
+        ("nebius", "Nebius AI Studio (Llama, Qwen, DeepSeek)"),
+        ("scaleway", "Scaleway Generative APIs (EU cloud, OpenAI-compatible)"),
     ]
 
     # Add user-defined custom providers from config.yaml
@@ -1023,7 +1026,7 @@ def select_provider_and_model():
         _model_flow_anthropic(config, current_model)
     elif selected_provider == "kimi-coding":
         _model_flow_kimi(config, current_model)
-    elif selected_provider in ("zai", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface"):
+    elif selected_provider in ("zai", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface", "mistral", "nebius", "scaleway"):
         _model_flow_api_key_provider(config, selected_provider, current_model)
 
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -242,6 +242,34 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "XiaomiMiMo/MiMo-V2-Flash",
         "moonshotai/Kimi-K2-Thinking",
     ],
+    "mistral": [
+        "mistral-large-latest",
+        "mistral-medium-latest",
+        "mistral-small-latest",
+        "codestral-latest",
+        "devstral-small-latest",
+        "mistral-saba-latest",
+        "ministral-8b-latest",
+        "ministral-3b-latest",
+    ],
+    "nebius": [
+        "deepseek-ai/DeepSeek-R1-0528",
+        "nvidia/Llama-3_1-Nemotron-Ultra-253B-v1",
+        "openai/gpt-oss-120b",
+        "moonshotai/Kimi-K2-Instruct",
+        "moonshotai/Kimi-K2-Thinking",
+        "zai-org/GLM-4.5",
+        "meta-llama/Llama-3.3-70B-Instruct",
+    ],
+    "scaleway": [
+        "llama-3.3-70b-instruct",
+        "llama-3.1-8b-instruct",
+        "mistral-nemo-instruct-2407",
+        "qwen2.5-coder-32b-instruct",
+        "deepseek-r1",
+        "deepseek-r1-distill-llama-70b",
+        "phi-4",
+    ],
 }
 
 _PROVIDER_LABELS = {
@@ -262,6 +290,9 @@ _PROVIDER_LABELS = {
     "kilocode": "Kilo Code",
     "alibaba": "Alibaba Cloud (DashScope)",
     "huggingface": "Hugging Face",
+    "mistral": "Mistral AI",
+    "nebius": "Nebius AI",
+    "scaleway": "Scaleway Generative APIs",
     "custom": "Custom endpoint",
 }
 
@@ -300,6 +331,12 @@ _PROVIDER_ALIASES = {
     "hf": "huggingface",
     "hugging-face": "huggingface",
     "huggingface-hub": "huggingface",
+    "mistral-ai": "mistral",
+    "mistralai": "mistral",
+    "nebius-ai": "nebius",
+    "nebius-studio": "nebius",
+    "scw": "scaleway",
+    "scaleway-ai": "scaleway",
 }
 
 
@@ -335,7 +372,7 @@ def list_available_providers() -> list[dict[str, str]]:
         "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
         "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "anthropic", "alibaba",
         "opencode-zen", "opencode-go",
-        "ai-gateway", "deepseek", "custom",
+        "ai-gateway", "deepseek", "mistral", "nebius", "scaleway", "custom",
     ]
     # Build reverse alias map
     aliases_for: dict[str, list[str]] = {}


### PR DESCRIPTION
## Summary

- **Mistral AI** — `api.mistral.ai/v1`, `MISTRAL_API_KEY`, 8 curated models (mistral-large/medium/small-latest, codestral, devstral, mistral-saba, ministral-8b/3b)
- **Nebius AI** — `api.tokenfactory.nebius.com/v1`, `NEBIUS_API_KEY`, 7 chat models (DeepSeek-R1-0528, Nemotron-Ultra-253B, gpt-oss-120b, Kimi-K2-Instruct/Thinking, GLM-4.5, Llama-3.3-70B)
- **Scaleway Generative APIs** — `api.scaleway.ai/v1`, `SCALEWAY_API_KEY` / `SCW_SECRET_KEY`, 7 models (Llama-3.3-70B, Llama-3.1-8B, Mistral-Nemo, Qwen2.5-Coder-32B, DeepSeek-R1, Phi-4)

Each provider is wired up consistently across all four integration points:
1. `PROVIDER_REGISTRY` in `auth.py` — base URL, env vars, auth type
2. `_PROVIDER_MODELS` / `_PROVIDER_LABELS` / `_PROVIDER_ALIASES` / `_PROVIDER_ORDER` in `models.py`
3. `hermes model` picker menu in `main.py`
4. `_model_flow_api_key_provider` routing in `main.py`

All three use the generic `api_key` auth flow — no new code paths needed.

## Test plan

- [x] 91/91 existing model/provider/setup tests pass (`test_models`, `test_model_validation`, `test_status_model_provider`, `test_setup_model_provider`)
- [x] `ruff` — no new issues
- [x] `bandit` — no new High/Medium issues
- [ ] `hermes model` shows Mistral AI, Nebius AI, Scaleway in the picker
- [ ] Selecting each provider prompts for API key and shows model list
- [ ] Config saved correctly to `~/.hermes/config.yaml`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)