### PR TITLE
fix: Profile model configuration ignored 

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -132,7 +132,7 @@ def load_cli_config() -> Dict[str, Any]:
     Returns default values if no config file exists.
     """
     # Check user config first ({HERMES_HOME}/config.yaml)
-    user_config_path = _hermes_home / 'config.yaml'
+    user_config_path = get_hermes_home() / 'config.yaml'
     project_config_path = Path(__file__).parent / 'cli-config.yaml'
 
     # Use user config if it exists, otherwise project config


### PR DESCRIPTION
## Summary

Fixes #4486 — Profile-specific model configurations were being ignored because `CLI_CONFIG` was loaded from the default `~/.hermes/config.yaml` before the profile override set `HERMES_HOME` to the profile directory.

When running `hermes -p <profile> chat`, the CLI now correctly loads the model from the profile's `config.yaml` instead of falling back to the hardcoded default (`anthropic/claude-opus-4.6`).

---

## The Problem

### Timing Issue

1. `cli.py` is imported, which evaluates `CLI_CONFIG = load_cli_config()` at module level (line 446)
2. `load_cli_config()` uses the cached `_hermes_home` value (set at line 76 during import to `~/.hermes`)
3. Later, `_apply_profile_override()` in `main.py` sets `HERMES_HOME` to `~/.hermes/profiles/<profile>`
4. But `CLI_CONFIG` is already cached with the wrong config
5. Profile's model configuration is silently ignored

### Before Fix

```bash
$ hermes profile show orchestrator
Profile: orchestrator
Model:   fireworks-ai/accounts/fireworks/routers/kimi-k2p5-turbo ✅

$ hermes -p orchestrator chat
⚕ claude-opus-4.6 · 0:05          ❌ Wrong model!
```

### After Fix

```bash
$ hermes -p orchestrator chat
⚕ kimi-k2p5-turbo · 0:05           ✅ Correct model!
```

---

## The Fix

Changed **one line** in `cli.py` (line 135) from:

```python
user_config_path = _hermes_home / 'config.yaml'
```

to:

```python
user_config_path = get_hermes_home() / 'config.yaml'
```

This ensures `load_cli_config()` reads the current `HERMES_HOME` environment variable each time it's called, rather than using the cached value from module import time.

---

## Affected Code

| File | Line | Change |
|------|------|--------|
| `cli.py` | 135 | `_hermes_home` → `get_hermes_home()` |

---

## Root Cause Details

The cached `_hermes_home` is set at module import time (line 76):

```python
_hermes_home = get_hermes_home()  # Evaluated before profile override
```

While `get_hermes_home()` reads `HERMES_HOME` fresh each call:

```python
def get_hermes_home() -> Path:
    return Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
```

The profile override in `main.py` happens after this cache is set:

```python
_apply_profile_override()  # Sets HERMES_HOME to profile directory
# ...later...
from cli import main as cli_main  # cli.py already imported with wrong config
```

---

## Backwards Compatibility

- No breaking changes
- Existing behavior preserved when not using profiles
- Users should add `default: <model>` to profile configs for complete override (see note below)

---

## Note on Config Precedence

Hermes checks `model.default` before `model.model`. The hardcoded defaults in `cli.py` include:

```python
"default": "anthropic/claude-opus-4.6"
```

When profile configs merge with defaults, if the profile doesn't specify `default`, the hardcoded opus remains. Users should add:

```yaml
model:
  default: fireworks-ai/accounts/fireworks/routers/kimi-k2p5-turbo
  provider: fireworks
  model: fireworks-ai/accounts/fireworks/routers/kimi-k2p5-turbo
```

---

## Test Plan

1. Create profile with non-default model:
   ```bash
   hermes profile create test-profile
   ```

2. Set model in profile config:
   ```yaml
   model:
     default: <some-model>
     provider: <provider>
   ```

3. Run with profile:
   ```bash
   hermes -p test-profile chat
   ```

4. Verify status bar shows correct model, not `claude-opus-4.6`

---

## Related

- Fixes #4486