### PR TITLE
fix(gateway): synchronize gateway and adapter pending message queues …

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6037,19 +6037,34 @@ class GatewayRunner:
             # Use session_key (not source.chat_id) to match adapter's storage keys.
             pending = None
             if result and adapter and session_key:
+                # Fetch accumulated string messages from the gateway queue
+                gateway_pending_text = self._pending_messages.pop(session_key, None)
+                
                 if result.get("interrupted"):
                     # Interrupted — consume the interrupt message
                     pending_event = adapter.get_pending_message(session_key)
-                    if pending_event:
+                    
+                    if pending_event and pending_event.text:
                         pending = pending_event.text
+                        # Merge both queues if both have pending content
+                        if gateway_pending_text:
+                            pending = f"{gateway_pending_text}\n{pending}"
+                    elif gateway_pending_text:
+                        pending = gateway_pending_text
                     elif result.get("interrupt_message"):
                         pending = result.get("interrupt_message")
                 else:
-                    # Normal completion — check for /queue'd messages that were
-                    # stored without triggering an interrupt.
+                    # Normal completion — check for /queue'd messages
                     pending_event = adapter.get_pending_message(session_key)
-                    if pending_event:
+                    
+                    if pending_event and pending_event.text:
                         pending = pending_event.text
+                        if gateway_pending_text:
+                            pending = f"{gateway_pending_text}\n{pending}"
+                    elif gateway_pending_text:
+                        pending = gateway_pending_text
+                    
+                    if pending:
                         logger.debug("Processing queued message after agent completion: '%s...'", pending[:40])
             
             if pending:


### PR DESCRIPTION
…(#4469)

## What does this PR do?

## Description
This PR fixes the issue where rapid consecutive messages are lost during an active agent run. It bridges the state mismatch between `GatewayRunner._pending_messages` (which accumulates plain text) and `adapter._pending_messages` (which handles `MessageEvent` objects).

**Fixes #4469**

## Root Cause
When a user sends messages while the agent is running, `GatewayRunner.interrupt()` correctly accumulates the text in `self._pending_messages`. However, when the agent resumes, it exclusively polled `adapter.get_pending_message(session_key)`. This caused all messages queued at the gateway level to be orphaned and ignored.

## Changes
- Modified the pending message retrieval block in `run.py` (`_run_agent`).
- The system now correctly pops the accumulated string from `self._pending_messages` first.
- It then checks `adapter.get_pending_message()` for any platform-specific events (like photo bursts or queued commands).
- If both queues contain data, the text is cleanly concatenated (`\n`) and passed to the agent without causing `TypeError` or recursive loops.
- Both interrupted and normal completion flows are synchronized.

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

