### PR TITLE
fix(skill_utils): guard against non-dict metadata in extract_skill_conditions

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -240,6 +240,11 @@ PLATFORM_HINTS = {
         "is preserved for threading. Do not include greetings or sign-offs unless "
         "contextually appropriate."
     ),
+    "ntfy": (
+        "You are communicating via ntfy push notifications. Use plain text only — "
+        "no markdown formatting. Keep responses concise; ntfy messages are push "
+        "notifications delivered to the user's device."
+    ),
     "cron": (
         "You are running as a scheduled cron job. There is no user present — you "
         "cannot ask questions, request clarification, or wait for follow-up. Execute "

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -230,7 +230,8 @@ def get_all_skills_dirs() -> List[Path]:
 
 def extract_skill_conditions(frontmatter: Dict[str, Any]) -> Dict[str, List]:
     """Extract conditional activation fields from parsed frontmatter."""
-    hermes = (frontmatter.get("metadata") or {}).get("hermes") or {}
+    _metadata = frontmatter.get("metadata")
+    hermes = (_metadata.get("hermes") if isinstance(_metadata, dict) else {}) or {}
     return {
         "fallback_for_toolsets": hermes.get("fallback_for_toolsets", []),
         "requires_toolsets": hermes.get("requires_toolsets", []),

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -166,6 +166,7 @@ def _deliver_result(job: dict, content: str) -> None:
         "wecom": Platform.WECOM,
         "email": Platform.EMAIL,
         "sms": Platform.SMS,
+        "ntfy": Platform.NTFY,
     }
     platform = platform_map.get(platform_name.lower())
     if not platform:

--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -61,8 +61,8 @@ def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
         except Exception as e:
             logger.warning("Channel directory: failed to build %s: %s", platform.value, e)
 
-    # Telegram, WhatsApp & Signal can't enumerate chats -- pull from session history
-    for plat_name in ("telegram", "whatsapp", "signal", "email", "sms"):
+    # Telegram, WhatsApp, Signal & ntfy can't enumerate chats -- pull from session history
+    for plat_name in ("telegram", "whatsapp", "signal", "email", "sms", "ntfy"):
         if plat_name not in platforms:
             platforms[plat_name] = _build_from_sessions(plat_name)
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -66,6 +66,7 @@ class Platform(Enum):
     WEBHOOK = "webhook"
     FEISHU = "feishu"
     WECOM = "wecom"
+    NTFY = "ntfy"
 
 
 @dataclass
@@ -288,6 +289,11 @@ class GatewayConfig:
                 connected.append(platform)
             # WeCom uses extra dict for bot credentials
             elif platform == Platform.WECOM and config.extra.get("bot_id"):
+                connected.append(platform)
+            # ntfy uses extra dict for server/topic or env vars
+            elif platform == Platform.NTFY and (
+                config.extra.get("topic") or os.getenv("NTFY_TOPIC", "")
+            ):
                 connected.append(platform)
         return connected
     
@@ -891,6 +897,30 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 chat_id=wecom_home,
                 name=os.getenv("WECOM_HOME_CHANNEL_NAME", "Home"),
             )
+
+    # ntfy
+    ntfy_topic = os.getenv("NTFY_TOPIC")
+    if ntfy_topic:
+        if Platform.NTFY not in config.platforms:
+            config.platforms[Platform.NTFY] = PlatformConfig()
+        config.platforms[Platform.NTFY].enabled = True
+        config.platforms[Platform.NTFY].extra["topic"] = ntfy_topic
+        ntfy_server = os.getenv("NTFY_SERVER_URL", "")
+        if ntfy_server:
+            config.platforms[Platform.NTFY].extra["server"] = ntfy_server
+        ntfy_token = os.getenv("NTFY_TOKEN", "")
+        if ntfy_token:
+            config.platforms[Platform.NTFY].extra["token"] = ntfy_token
+        ntfy_publish_topic = os.getenv("NTFY_PUBLISH_TOPIC", "")
+        if ntfy_publish_topic:
+            config.platforms[Platform.NTFY].extra["publish_topic"] = ntfy_publish_topic
+    ntfy_home = os.getenv("NTFY_HOME_CHANNEL")
+    if ntfy_home and Platform.NTFY in config.platforms:
+        config.platforms[Platform.NTFY].home_channel = HomeChannel(
+            platform=Platform.NTFY,
+            chat_id=ntfy_home,
+            name=os.getenv("NTFY_HOME_CHANNEL_NAME", "Home"),
+        )
 
     # Session settings
     idle_minutes = os.getenv("SESSION_IDLE_MINUTES")

--- a/gateway/platforms/ntfy.py
+++ b/gateway/platforms/ntfy.py
@@ -1,0 +1,326 @@
+"""
+ntfy platform adapter.
+
+Uses httpx streaming to receive messages published to a subscribed topic,
+and HTTP POST to publish replies. Works with ntfy.sh or any self-hosted
+ntfy server.
+
+Requires:
+    pip install httpx  (already a dependency)
+    NTFY_TOPIC env var (and optionally NTFY_SERVER_URL, NTFY_TOKEN,
+    NTFY_PUBLISH_TOPIC)
+
+Configuration in config.yaml:
+    platforms:
+      ntfy:
+        enabled: true
+        extra:
+          server: "https://ntfy.sh"       # or self-hosted URL
+          topic: "hermes-in"              # subscribe topic (incoming)
+          publish_topic: "hermes-out"     # optional — defaults to topic
+          token: "..."                    # optional Bearer / Basic auth token
+"""
+
+import asyncio
+import json
+import logging
+import os
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+try:
+    import httpx
+    HTTPX_AVAILABLE = True
+except ImportError:
+    HTTPX_AVAILABLE = False
+    httpx = None  # type: ignore[assignment]
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SERVER = "https://ntfy.sh"
+MAX_MESSAGE_LENGTH = 4096  # ntfy message body limit
+DEDUP_WINDOW_SECONDS = 300
+DEDUP_MAX_SIZE = 1000
+RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
+STREAM_TIMEOUT_SECONDS = 90  # ntfy keepalive default is 55s; give margin
+
+
+def check_ntfy_requirements() -> bool:
+    """Check if ntfy adapter dependencies are available and configured."""
+    if not HTTPX_AVAILABLE:
+        return False
+    extra = {}
+    try:
+        from gateway.config import load_gateway_config, Platform as _P
+        cfg = load_gateway_config()
+        pc = cfg.platforms.get(_P.NTFY)
+        if pc:
+            extra = pc.extra or {}
+    except Exception:
+        pass
+    topic = extra.get("topic") or os.getenv("NTFY_TOPIC", "")
+    return bool(topic)
+
+
+class NtfyAdapter(BasePlatformAdapter):
+    """ntfy adapter.
+
+    Subscribes to a topic via HTTP streaming (/json endpoint) and publishes
+    replies via HTTP POST. No external SDK — only httpx is required.
+    """
+
+    MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform.NTFY)
+
+        extra = config.extra or {}
+        self._server: str = (
+            extra.get("server")
+            or os.getenv("NTFY_SERVER_URL", DEFAULT_SERVER)
+        ).rstrip("/")
+        self._topic: str = extra.get("topic") or os.getenv("NTFY_TOPIC", "")
+        self._publish_topic: str = (
+            extra.get("publish_topic")
+            or os.getenv("NTFY_PUBLISH_TOPIC", "")
+            or self._topic
+        )
+        self._token: str = extra.get("token") or os.getenv("NTFY_TOKEN", "")
+
+        self._stream_task: Optional[asyncio.Task] = None
+        self._http_client: Optional["httpx.AsyncClient"] = None
+
+        # Message deduplication: msg_id -> timestamp
+        self._seen_messages: Dict[str, float] = {}
+
+    # -- Connection lifecycle -----------------------------------------------
+
+    async def connect(self) -> bool:
+        """Connect to ntfy by starting the streaming subscription task."""
+        if not HTTPX_AVAILABLE:
+            logger.warning("[%s] httpx not installed. Run: pip install httpx", self.name)
+            return False
+        if not self._topic:
+            logger.warning("[%s] NTFY_TOPIC not configured", self.name)
+            return False
+
+        try:
+            self._http_client = httpx.AsyncClient(timeout=None)
+            self._stream_task = asyncio.create_task(self._run_stream())
+            self._mark_connected()
+            logger.info("[%s] Connected — subscribing to %s/%s", self.name, self._server, self._topic)
+            return True
+        except Exception as e:
+            logger.error("[%s] Failed to connect: %s", self.name, e)
+            return False
+
+    async def _run_stream(self) -> None:
+        """Subscribe to the ntfy topic with automatic reconnection."""
+        backoff_idx = 0
+        url = f"{self._server}/{self._topic}/json"
+        headers = self._auth_headers()
+
+        while self._running:
+            try:
+                logger.debug("[%s] Opening stream to %s", self.name, url)
+                await self._consume_stream(url, headers)
+            except asyncio.CancelledError:
+                return
+            except Exception as e:
+                if not self._running:
+                    return
+                logger.warning("[%s] Stream error: %s", self.name, e)
+
+            if not self._running:
+                return
+
+            delay = RECONNECT_BACKOFF[min(backoff_idx, len(RECONNECT_BACKOFF) - 1)]
+            logger.info("[%s] Reconnecting in %ds...", self.name, delay)
+            await asyncio.sleep(delay)
+            backoff_idx += 1
+
+    async def _consume_stream(self, url: str, headers: Dict[str, str]) -> None:
+        """Open an HTTP streaming connection and dispatch events."""
+        # poll=true keeps the connection alive with keepalive events
+        params = {"poll": "false"}
+        async with self._http_client.stream(
+            "GET",
+            url,
+            headers=headers,
+            params=params,
+            timeout=httpx.Timeout(connect=15.0, read=STREAM_TIMEOUT_SECONDS, write=15.0, pool=15.0),
+        ) as response:
+            if response.status_code == 401:
+                logger.error("[%s] Authentication failed (401). Check NTFY_TOKEN.", self.name)
+                return
+            if response.status_code == 404:
+                logger.error("[%s] Topic not found (404): %s", self.name, self._topic)
+                return
+            response.raise_for_status()
+
+            async for line in response.aiter_lines():
+                if not self._running:
+                    return
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if event.get("event") == "message":
+                    await self._on_message(event)
+
+    async def disconnect(self) -> None:
+        """Disconnect from ntfy."""
+        self._running = False
+        self._mark_disconnected()
+
+        if self._stream_task:
+            self._stream_task.cancel()
+            try:
+                await self._stream_task
+            except asyncio.CancelledError:
+                pass
+            self._stream_task = None
+
+        if self._http_client:
+            await self._http_client.aclose()
+            self._http_client = None
+
+        self._seen_messages.clear()
+        logger.info("[%s] Disconnected", self.name)
+
+    # -- Inbound message processing -----------------------------------------
+
+    async def _on_message(self, event: Dict[str, Any]) -> None:
+        """Process an incoming ntfy message event."""
+        msg_id = event.get("id") or uuid.uuid4().hex
+        if self._is_duplicate(msg_id):
+            logger.debug("[%s] Duplicate message %s, skipping", self.name, msg_id)
+            return
+
+        text = (event.get("message") or "").strip()
+        if not text:
+            logger.debug("[%s] Empty message body, skipping", self.name)
+            return
+
+        topic = event.get("topic") or self._topic
+        sender = event.get("title") or ""
+
+        # ntfy has no native user ID — use the title field if present,
+        # otherwise fall back to the topic name as the "sender".
+        user_id = sender or topic
+        user_name = sender or topic
+
+        source = self.build_source(
+            chat_id=topic,
+            chat_name=topic,
+            chat_type="dm",
+            user_id=user_id,
+            user_name=user_name,
+        )
+
+        # Parse timestamp
+        unix_ts = event.get("time")
+        try:
+            timestamp = datetime.fromtimestamp(int(unix_ts), tz=timezone.utc) if unix_ts else datetime.now(tz=timezone.utc)
+        except (ValueError, OSError, TypeError):
+            timestamp = datetime.now(tz=timezone.utc)
+
+        message_event = MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id=msg_id,
+            raw_message=event,
+            timestamp=timestamp,
+        )
+
+        logger.debug("[%s] Message on topic %s: %s", self.name, topic, text[:80])
+        await self.handle_message(message_event)
+
+    # -- Deduplication ------------------------------------------------------
+
+    def _is_duplicate(self, msg_id: str) -> bool:
+        """Return True if this message ID was already seen within the dedup window."""
+        now = time.time()
+        if len(self._seen_messages) > DEDUP_MAX_SIZE:
+            cutoff = now - DEDUP_WINDOW_SECONDS
+            self._seen_messages = {k: v for k, v in self._seen_messages.items() if v > cutoff}
+
+        if msg_id in self._seen_messages:
+            return True
+        self._seen_messages[msg_id] = now
+        return False
+
+    # -- Outbound messaging -------------------------------------------------
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Publish a message to the configured publish topic."""
+        metadata = metadata or {}
+        publish_topic = metadata.get("publish_topic") or self._publish_topic or chat_id
+
+        if not self._http_client:
+            return SendResult(success=False, error="HTTP client not initialized")
+
+        url = f"{self._server}/{publish_topic}"
+        headers = {**self._auth_headers(), "Content-Type": "text/plain; charset=utf-8"}
+
+        body = content[:self.MAX_MESSAGE_LENGTH]
+
+        try:
+            resp = await self._http_client.post(url, content=body.encode("utf-8"), headers=headers, timeout=15.0)
+            if resp.status_code < 300:
+                try:
+                    data = resp.json()
+                    returned_id = data.get("id") or uuid.uuid4().hex[:12]
+                except Exception:
+                    returned_id = uuid.uuid4().hex[:12]
+                return SendResult(success=True, message_id=returned_id)
+            body_text = resp.text
+            logger.warning("[%s] Send failed HTTP %d: %s", self.name, resp.status_code, body_text[:200])
+            return SendResult(success=False, error=f"HTTP {resp.status_code}: {body_text[:200]}")
+        except httpx.TimeoutException:
+            return SendResult(success=False, error="Timeout publishing to ntfy")
+        except Exception as e:
+            logger.error("[%s] Send error: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        """ntfy does not support typing indicators."""
+        pass
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        """Return basic info about an ntfy topic."""
+        return {"name": chat_id, "type": "dm"}
+
+    # -- Helpers ------------------------------------------------------------
+
+    def _auth_headers(self) -> Dict[str, str]:
+        """Build Authorization header if a token is configured."""
+        if not self._token:
+            return {}
+        # ntfy supports both Bearer tokens and Base64-encoded Basic auth;
+        # prefer Bearer for API tokens, Basic for username:password pairs.
+        if ":" in self._token:
+            import base64
+            encoded = base64.b64encode(self._token.encode()).decode()
+            return {"Authorization": f"Basic {encoded}"}
+        return {"Authorization": f"Bearer {self._token}"}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1079,6 +1079,7 @@ class GatewayRunner:
                        "MATRIX_ALLOWED_USERS", "DINGTALK_ALLOWED_USERS",
                        "FEISHU_ALLOWED_USERS",
                        "WECOM_ALLOWED_USERS",
+                       "NTFY_ALLOWED_USERS",
                        "GATEWAY_ALLOWED_USERS")
         )
         _allow_all = os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes") or any(
@@ -1089,7 +1090,8 @@ class GatewayRunner:
                        "SMS_ALLOW_ALL_USERS", "MATTERMOST_ALLOW_ALL_USERS",
                        "MATRIX_ALLOW_ALL_USERS", "DINGTALK_ALLOW_ALL_USERS",
                        "FEISHU_ALLOW_ALL_USERS",
-                       "WECOM_ALLOW_ALL_USERS")
+                       "WECOM_ALLOW_ALL_USERS",
+                       "NTFY_ALLOW_ALL_USERS")
         )
         if not _any_allowlist and not _allow_all:
             logger.warning(
@@ -1576,6 +1578,13 @@ class GatewayRunner:
             adapter.gateway_runner = self  # For cross-platform delivery
             return adapter
 
+        elif platform == Platform.NTFY:
+            from gateway.platforms.ntfy import NtfyAdapter, check_ntfy_requirements
+            if not check_ntfy_requirements():
+                logger.warning("ntfy: NTFY_TOPIC not configured")
+                return None
+            return NtfyAdapter(config)
+
         return None
     
     def _is_user_authorized(self, source: SessionSource) -> bool:
@@ -1614,6 +1623,7 @@ class GatewayRunner:
             Platform.DINGTALK: "DINGTALK_ALLOWED_USERS",
             Platform.FEISHU: "FEISHU_ALLOWED_USERS",
             Platform.WECOM: "WECOM_ALLOWED_USERS",
+            Platform.NTFY: "NTFY_ALLOWED_USERS",
         }
         platform_allow_all_map = {
             Platform.TELEGRAM: "TELEGRAM_ALLOW_ALL_USERS",
@@ -1628,6 +1638,7 @@ class GatewayRunner:
             Platform.DINGTALK: "DINGTALK_ALLOW_ALL_USERS",
             Platform.FEISHU: "FEISHU_ALLOW_ALL_USERS",
             Platform.WECOM: "WECOM_ALLOW_ALL_USERS",
+            Platform.NTFY: "NTFY_ALLOW_ALL_USERS",
         }
 
         # Per-platform allow-all flag (e.g., DISCORD_ALLOW_ALL_USERS=true)

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -257,6 +257,7 @@ def show_status(args):
         "DingTalk": ("DINGTALK_CLIENT_ID", None),
         "Feishu": ("FEISHU_APP_ID", "FEISHU_HOME_CHANNEL"),
         "WeCom": ("WECOM_BOT_ID", "WECOM_HOME_CHANNEL"),
+        "ntfy": ("NTFY_TOPIC", "NTFY_HOME_CHANNEL"),
     }
     
     for name, (token_var, home_var) in platforms.items():

--- a/optional-skills/research/arxiv/SKILL.md
+++ b/optional-skills/research/arxiv/SKILL.md
@@ -1,0 +1,398 @@
+---
+name: arxiv
+description: Search and retrieve academic papers from arxiv.org — keyword search, author lookup, category browsing, paper details, and citation generation. No API key required. Use the Python `arxiv` library when available; fall back to the direct HTTP API (no package needed) otherwise.
+version: 1.0.0
+author: sprmn24
+license: MIT
+metadata:
+  hermes:
+    tags: [arxiv, research, academic, papers, science, citations]
+    related_skills: [duckduckgo-search]
+    fallback_for_toolsets: []
+---
+
+# arXiv Academic Paper Search
+
+Search and retrieve academic papers from [arxiv.org](https://arxiv.org). **No API key required.**
+
+Use this skill when you need to find peer-reviewed preprints, retrieve paper metadata and abstracts, browse recent submissions by subject category, or generate citations for academic work.
+
+## Detection Flow
+
+Check what is available before choosing an approach:
+
+```bash
+# Check Python arxiv package availability
+python -c "import arxiv; print('arxiv=installed')" 2>/dev/null || echo "arxiv=missing"
+
+# Check curl for direct HTTP API access
+command -v curl >/dev/null && echo "curl=installed" || echo "curl=missing"
+```
+
+Decision tree:
+1. If the `arxiv` Python package is installed in the active runtime, use Method 1 (Python library)
+2. If `arxiv` is not installed but `curl` is available, use Method 2 (direct HTTP API — no package needed)
+3. To install the `arxiv` package, run `pip install arxiv` first and verify the same runtime can import it
+
+Important runtime note:
+- Terminal and `execute_code` are separate runtimes
+- Installing `arxiv` in the shell does not guarantee `execute_code` can import it
+- The HTTP API approach works anywhere `curl` or `requests` is available without extra packages
+
+## Installation
+
+Install only when the Python library approach is specifically needed and the runtime does not already provide it.
+
+```bash
+# Install the arxiv Python package
+pip install arxiv
+
+# Verify
+python -c "import arxiv; print(arxiv.__version__)"
+```
+
+## Method 1: Python Library
+
+Use the `arxiv` package when it is confirmed available in the active runtime.
+
+### Search by Keyword
+
+```python
+import arxiv
+
+client = arxiv.Client()
+search = arxiv.Search(
+    query="transformer attention mechanism",
+    max_results=5,
+    sort_by=arxiv.SortCriterion.Relevance,
+)
+
+for paper in client.results(search):
+    print(paper.entry_id)
+    print(paper.title)
+    print(paper.authors)
+    print(paper.published.date())
+    print(paper.summary[:300])
+    print(paper.pdf_url)
+    print()
+```
+
+### Search by Author
+
+```python
+import arxiv
+
+client = arxiv.Client()
+search = arxiv.Search(
+    query='au:"Yoshua Bengio"',
+    max_results=5,
+    sort_by=arxiv.SortCriterion.SubmittedDate,
+)
+
+for paper in client.results(search):
+    print(paper.title)
+    print(paper.published.date())
+    print(paper.entry_id)
+    print()
+```
+
+### Search by Category
+
+```python
+import arxiv
+
+client = arxiv.Client()
+search = arxiv.Search(
+    query="cat:cs.LG",          # machine learning category
+    max_results=10,
+    sort_by=arxiv.SortCriterion.SubmittedDate,
+)
+
+for paper in client.results(search):
+    print(paper.title)
+    print(paper.categories)
+    print(paper.published.date())
+    print()
+```
+
+### Fetch a Specific Paper by ID
+
+```python
+import arxiv
+
+client = arxiv.Client()
+# Use the arxiv ID (with or without version suffix)
+paper = next(client.results(arxiv.Search(id_list=["2301.07041"])))
+
+print(paper.title)
+print([str(a) for a in paper.authors])
+print(paper.published.date())
+print(paper.summary)
+print(paper.pdf_url)
+print(paper.categories)
+```
+
+### Browse Recent Papers by Category
+
+```python
+import arxiv
+from datetime import datetime, timedelta, timezone
+
+client = arxiv.Client()
+search = arxiv.Search(
+    query="cat:cs.AI",
+    max_results=20,
+    sort_by=arxiv.SortCriterion.SubmittedDate,
+    sort_order=arxiv.SortOrder.Descending,
+)
+
+cutoff = datetime.now(timezone.utc) - timedelta(days=7)
+for paper in client.results(search):
+    if paper.published < cutoff:
+        break
+    print(paper.published.date(), "|", paper.title)
+    print(paper.entry_id)
+    print()
+```
+
+### Generate Citations
+
+```python
+import arxiv
+
+client = arxiv.Client()
+paper = next(client.results(arxiv.Search(id_list=["2301.07041"])))
+
+# APA citation
+authors = [str(a) for a in paper.authors]
+if len(authors) == 1:
+    author_str = authors[0]
+elif len(authors) == 2:
+    author_str = " & ".join(authors)
+else:
+    author_str = authors[0] + " et al."
+
+apa = (
+    f"{author_str} ({paper.published.year}). "
+    f"{paper.title}. "
+    f"arXiv preprint arXiv:{paper.entry_id.split('/')[-1]}."
+)
+print("APA:")
+print(apa)
+
+# BibTeX citation
+arxiv_id = paper.entry_id.split("/")[-1].replace(".", "_")
+first_author_last = str(paper.authors[0]).split()[-1].lower()
+bibtex = f"""@misc{{{first_author_last}{paper.published.year}_{arxiv_id},
+  title   = {{{{{paper.title}}}}},
+  author  = {{{" and ".join(str(a) for a in paper.authors)}}},
+  year    = {{{paper.published.year}}},
+  eprint  = {{{paper.entry_id.split('/')[-1]}}},
+  archivePrefix = {{arXiv}},
+  primaryClass  = {{{paper.primary_category}}}
+}}"""
+print("\nBibTeX:")
+print(bibtex)
+```
+
+### Sort and Filter Options
+
+```python
+import arxiv
+
+# Sort options
+arxiv.SortCriterion.Relevance        # default — best match
+arxiv.SortCriterion.SubmittedDate    # most recently submitted
+arxiv.SortCriterion.LastUpdatedDate  # most recently updated
+
+# Sort order
+arxiv.SortOrder.Descending           # newest first (default)
+arxiv.SortOrder.Ascending            # oldest first
+```
+
+### Query Syntax Reference
+
+| Prefix | Matches | Example |
+|--------|---------|---------|
+| `au:` | Author name | `au:"Yann LeCun"` |
+| `ti:` | Title words | `ti:diffusion` |
+| `abs:` | Abstract words | `abs:contrastive learning` |
+| `cat:` | Category | `cat:cs.CV` |
+| `id:` | arXiv ID | `id:2301.07041` |
+| *(none)* | All fields | `neural network` |
+
+Combine with `AND`, `OR`, `ANDNOT`:
+
+```
+ti:diffusion AND cat:cs.CV
+au:"Hinton" AND ti:capsule
+abs:"large language model" ANDNOT ti:survey
+```
+
+## Method 2: Direct HTTP API (No Package Required)
+
+The arXiv API is a plain HTTP endpoint that returns Atom XML. Use this approach when no Python package is available.
+
+### Search with curl
+
+```bash
+# Keyword search — returns Atom XML
+curl -sG "https://export.arxiv.org/api/query" \
+  --data-urlencode "search_query=all:attention mechanism transformer" \
+  --data-urlencode "start=0" \
+  --data-urlencode "max_results=5" \
+  --data-urlencode "sortBy=relevance" \
+  --data-urlencode "sortOrder=descending"
+```
+
+```bash
+# Author search
+curl -sG "https://export.arxiv.org/api/query" \
+  --data-urlencode 'search_query=au:"Geoffrey Hinton"' \
+  --data-urlencode "max_results=5" \
+  --data-urlencode "sortBy=submittedDate"
+```
+
+```bash
+# Category + recent papers
+curl -sG "https://export.arxiv.org/api/query" \
+  --data-urlencode "search_query=cat:cs.AI" \
+  --data-urlencode "max_results=10" \
+  --data-urlencode "sortBy=submittedDate" \
+  --data-urlencode "sortOrder=descending"
+```
+
+```bash
+# Fetch by specific arXiv ID
+curl -sG "https://export.arxiv.org/api/query" \
+  --data-urlencode "id_list=2301.07041"
+```
+
+### Parse the XML Response with Python
+
+```python
+import urllib.request
+import urllib.parse
+import xml.etree.ElementTree as ET
+
+NS = {
+    "atom":  "http://www.w3.org/2005/Atom",
+    "arxiv": "http://arxiv.org/schemas/atom",
+}
+
+def arxiv_search(query, max_results=5, sort_by="relevance"):
+    params = urllib.parse.urlencode({
+        "search_query": query,
+        "max_results":  max_results,
+        "sortBy":       sort_by,
+        "sortOrder":    "descending",
+    })
+    url = f"https://export.arxiv.org/api/query?{params}"
+    with urllib.request.urlopen(url) as resp:
+        root = ET.fromstring(resp.read())
+
+    papers = []
+    for entry in root.findall("atom:entry", NS):
+        arxiv_id = entry.find("atom:id", NS).text.split("/abs/")[-1]
+        papers.append({
+            "id":        arxiv_id,
+            "title":     entry.find("atom:title", NS).text.strip(),
+            "authors":   [a.find("atom:name", NS).text
+                          for a in entry.findall("atom:author", NS)],
+            "published": entry.find("atom:published", NS).text[:10],
+            "abstract":  entry.find("atom:summary", NS).text.strip(),
+            "pdf_url":   f"https://arxiv.org/pdf/{arxiv_id}",
+            "abs_url":   f"https://arxiv.org/abs/{arxiv_id}",
+        })
+    return papers
+
+# Example usage
+for p in arxiv_search("cat:cs.LG AND ti:diffusion", max_results=3):
+    print(p["id"], "|", p["title"])
+    print("Authors:", ", ".join(p["authors"][:3]))
+    print("Published:", p["published"])
+    print("PDF:", p["pdf_url"])
+    print()
+```
+
+### API Parameters
+
+| Parameter | Values | Description |
+|-----------|--------|-------------|
+| `search_query` | query string | Keywords, fields, categories |
+| `id_list` | comma-separated IDs | Fetch specific papers |
+| `start` | integer (default 0) | Pagination offset |
+| `max_results` | integer (max 2000) | Results to return |
+| `sortBy` | `relevance`, `submittedDate`, `lastUpdatedDate` | Sort criterion |
+| `sortOrder` | `ascending`, `descending` | Sort direction |
+
+## Common arXiv Categories
+
+| Category | Subject |
+|----------|---------|
+| `cs.AI` | Artificial Intelligence |
+| `cs.LG` | Machine Learning |
+| `cs.CV` | Computer Vision |
+| `cs.CL` | Computation and Language (NLP) |
+| `cs.RO` | Robotics |
+| `cs.CR` | Cryptography and Security |
+| `cs.DS` | Data Structures and Algorithms |
+| `cs.NE` | Neural and Evolutionary Computing |
+| `stat.ML` | Statistics — Machine Learning |
+| `math.ST` | Statistics Theory |
+| `math.OC` | Optimization and Control |
+| `physics.data-an` | Data Analysis, Statistics and Probability |
+| `q-bio.NC` | Neurons and Cognition |
+| `econ.EM` | Econometrics |
+
+Full category taxonomy: https://arxiv.org/category_taxonomy
+
+## Workflow: Search then Retrieve Full Text
+
+arXiv metadata includes the abstract but not the full paper text. To read the full paper:
+
+1. Search and find the arXiv ID
+2. Use the PDF URL (`https://arxiv.org/pdf/<id>`) with a PDF-reading tool, or
+3. Use the HTML version (`https://arxiv.org/html/<id>`) which is available for many recent papers
+
+```bash
+# Download PDF to a local file
+curl -sL "https://arxiv.org/pdf/2301.07041" -o paper.pdf
+
+# Fetch HTML version (when available)
+curl -sL "https://arxiv.org/html/2301.07041"
+```
+
+## Limitations
+
+- **Rate limiting**: The arXiv API asks for no more than 3 requests per second. Add a short delay (`time.sleep(1)`) between requests in loops.
+- **Max results per request**: The API returns at most 2000 results per query. Use pagination (`start` offset) for larger result sets.
+- **Abstract only**: The API returns metadata and abstracts. Full text requires fetching the PDF or HTML page separately.
+- **PDF availability**: Some very old papers may not have PDFs; check the `pdf_url` field before fetching.
+- **HTML availability**: HTML versions (`/html/`) are only available for papers that were submitted in a compatible LaTeX format — not all papers have this.
+- **Search ranking**: arXiv relevance ranking is simpler than commercial search engines; broad queries may return loosely related papers.
+- **No authentication**: The public API has no per-user quotas, but abusive usage may result in IP-level throttling.
+
+## Troubleshooting
+
+| Problem | Likely Cause | What To Do |
+|---------|--------------|------------|
+| `ModuleNotFoundError: No module named 'arxiv'` | Package not installed in this runtime | Install `arxiv` via pip, or switch to the HTTP API method |
+| Empty results from Python library | Query syntax error or no matches | Test the same query with curl; check field prefixes (`au:`, `ti:`, etc.) |
+| HTTP 503 from API | Temporary overload or rate limit hit | Wait a few seconds and retry; reduce request frequency |
+| XML parse error from HTTP API | Unexpected response (e.g., error page) | Print raw response first; verify URL and parameters |
+| PDF download returns HTML | Paper has no PDF, or ID is wrong | Confirm the ID at `https://arxiv.org/abs/<id>` first |
+| `StopIteration` from `next(client.results(...))` | No results for the given ID or query | Check the ID is correct; use `list()` and test for empty |
+
+## Pitfalls
+
+- **`id_list` vs `search_query`**: Use `id_list` for known IDs; `search_query` for keyword lookups. Mixing them in one call can cause unexpected results.
+- **Versioned IDs**: arXiv IDs can include a version suffix (e.g., `2301.07041v2`). Omitting the version returns the latest; include it to pin a specific version.
+- **Author name formatting**: Author search (`au:`) is fuzzy. For exact matches wrap in quotes: `au:"Bengio, Yoshua"` or `au:"Y. Bengio"`.
+- **Package vs HTTP API field names differ**: The Python library uses `.summary` for abstract; the raw XML uses `<summary>`. Keep the approach consistent within one workflow.
+- **`max_results` in Python library**: Pass as a keyword argument to `arxiv.Search(max_results=N)`, not positionally.
+- **Rate limit in loops**: When iterating over many results, `client.results()` fetches pages automatically — do not set an excessively large `max_results` if you only need a few papers.
+
+## Validated With
+
+Validated examples against `arxiv==2.x` semantics. Confirmed that `categories` is `List[str]` and `primary_category` is `str` — neither uses a `.term` attribute. Timezone handling uses `datetime.now(timezone.utc)` to match the UTC-aware `paper.published` field.

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -1,0 +1,58 @@
+"""Tests for agent/skill_utils.py — extract_skill_conditions metadata handling."""
+
+from agent.skill_utils import extract_skill_conditions
+
+
+def test_metadata_as_dict_with_hermes():
+    """Normal case: metadata is a dict containing hermes keys."""
+    frontmatter = {
+        "metadata": {
+            "hermes": {
+                "fallback_for_toolsets": ["toolset_a"],
+                "requires_toolsets": ["toolset_b"],
+                "fallback_for_tools": ["tool_x"],
+                "requires_tools": ["tool_y"],
+            }
+        }
+    }
+    result = extract_skill_conditions(frontmatter)
+    assert result["fallback_for_toolsets"] == ["toolset_a"]
+    assert result["requires_toolsets"] == ["toolset_b"]
+    assert result["fallback_for_tools"] == ["tool_x"]
+    assert result["requires_tools"] == ["tool_y"]
+
+
+def test_metadata_as_string_does_not_crash():
+    """Bug case: metadata is a non-dict truthy value (e.g. a YAML string)."""
+    frontmatter = {"metadata": "some text"}
+    result = extract_skill_conditions(frontmatter)
+    assert result == {
+        "fallback_for_toolsets": [],
+        "requires_toolsets": [],
+        "fallback_for_tools": [],
+        "requires_tools": [],
+    }
+
+
+def test_metadata_as_none():
+    """metadata key is present but set to null/None."""
+    frontmatter = {"metadata": None}
+    result = extract_skill_conditions(frontmatter)
+    assert result == {
+        "fallback_for_toolsets": [],
+        "requires_toolsets": [],
+        "fallback_for_tools": [],
+        "requires_tools": [],
+    }
+
+
+def test_metadata_missing_entirely():
+    """metadata key is absent from frontmatter."""
+    frontmatter = {"name": "my-skill", "description": "Does stuff."}
+    result = extract_skill_conditions(frontmatter)
+    assert result == {
+        "fallback_for_toolsets": [],
+        "requires_toolsets": [],
+        "fallback_for_tools": [],
+        "requires_tools": [],
+    }

--- a/tests/gateway/test_ntfy.py
+++ b/tests/gateway/test_ntfy.py
@@ -1,0 +1,881 @@
+"""Tests for ntfy platform adapter and integration points."""
+
+import asyncio
+import base64
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+
+
+def _run(coro):
+    """Run an async coroutine synchronously."""
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ---------------------------------------------------------------------------
+# Platform enum
+# ---------------------------------------------------------------------------
+
+
+class TestPlatformEnum:
+
+    def test_ntfy_value(self):
+        assert Platform.NTFY.value == "ntfy"
+
+    def test_ntfy_in_all_platforms(self):
+        values = [p.value for p in Platform]
+        assert "ntfy" in values
+
+
+# ---------------------------------------------------------------------------
+# Requirements check
+# ---------------------------------------------------------------------------
+
+
+class TestNtfyRequirements:
+
+    def test_returns_false_when_httpx_unavailable(self, monkeypatch):
+        monkeypatch.setenv("NTFY_TOPIC", "hermes-test")
+        monkeypatch.setattr("gateway.platforms.ntfy.HTTPX_AVAILABLE", False)
+        from gateway.platforms.ntfy import check_ntfy_requirements
+        assert check_ntfy_requirements() is False
+
+    def test_returns_false_when_topic_not_set(self, monkeypatch):
+        monkeypatch.setattr("gateway.platforms.ntfy.HTTPX_AVAILABLE", True)
+        monkeypatch.delenv("NTFY_TOPIC", raising=False)
+        from gateway.platforms.ntfy import check_ntfy_requirements
+        with patch("gateway.config.load_gateway_config") as mock_load:
+            mock_cfg = MagicMock()
+            mock_cfg.platforms = {}
+            mock_load.return_value = mock_cfg
+            assert check_ntfy_requirements() is False
+
+    def test_returns_true_when_topic_set_via_env(self, monkeypatch):
+        monkeypatch.setattr("gateway.platforms.ntfy.HTTPX_AVAILABLE", True)
+        monkeypatch.setenv("NTFY_TOPIC", "hermes-test")
+        from gateway.platforms.ntfy import check_ntfy_requirements
+        assert check_ntfy_requirements() is True
+
+    def test_returns_true_when_topic_set_via_extra(self, monkeypatch):
+        monkeypatch.setattr("gateway.platforms.ntfy.HTTPX_AVAILABLE", True)
+        monkeypatch.delenv("NTFY_TOPIC", raising=False)
+        from gateway.platforms.ntfy import check_ntfy_requirements
+        with patch("gateway.config.load_gateway_config") as mock_load:
+            mock_pc = MagicMock()
+            mock_pc.extra = {"topic": "hermes-cfg"}
+            mock_cfg = MagicMock()
+            mock_cfg.platforms = {Platform.NTFY: mock_pc}
+            mock_load.return_value = mock_cfg
+            assert check_ntfy_requirements() is True
+
+
+# ---------------------------------------------------------------------------
+# Config loading from env vars
+# ---------------------------------------------------------------------------
+
+
+class TestNtfyConfigLoading:
+
+    def test_ntfy_topic_enables_platform(self, monkeypatch):
+        from gateway.config import load_gateway_config
+
+        monkeypatch.setenv("NTFY_TOPIC", "hermes-in")
+        config = load_gateway_config()
+        assert Platform.NTFY in config.platforms
+        pc = config.platforms[Platform.NTFY]
+        assert pc.enabled is True
+        assert pc.extra["topic"] == "hermes-in"
+
+    def test_ntfy_server_url_stored_in_extra(self, monkeypatch):
+        from gateway.config import load_gateway_config
+
+        monkeypatch.setenv("NTFY_TOPIC", "hermes-in")
+        monkeypatch.setenv("NTFY_SERVER_URL", "https://ntfy.example.com")
+        config = load_gateway_config()
+        pc = config.platforms[Platform.NTFY]
+        assert pc.extra.get("server") == "https://ntfy.example.com"
+
+    def test_ntfy_token_stored_in_extra(self, monkeypatch):
+        from gateway.config import load_gateway_config
+
+        monkeypatch.setenv("NTFY_TOPIC", "hermes-in")
+        monkeypatch.setenv("NTFY_TOKEN", "tk_secret")
+        config = load_gateway_config()
+        pc = config.platforms[Platform.NTFY]
+        assert pc.extra.get("token") == "tk_secret"
+
+    def test_ntfy_publish_topic_stored_in_extra(self, monkeypatch):
+        from gateway.config import load_gateway_config
+
+        monkeypatch.setenv("NTFY_TOPIC", "hermes-in")
+        monkeypatch.setenv("NTFY_PUBLISH_TOPIC", "hermes-out")
+        config = load_gateway_config()
+        pc = config.platforms[Platform.NTFY]
+        assert pc.extra.get("publish_topic") == "hermes-out"
+
+    def test_ntfy_home_channel_set(self, monkeypatch):
+        from gateway.config import load_gateway_config
+
+        monkeypatch.setenv("NTFY_TOPIC", "hermes-in")
+        monkeypatch.setenv("NTFY_HOME_CHANNEL", "hermes-home")
+        config = load_gateway_config()
+        pc = config.platforms[Platform.NTFY]
+        assert pc.home_channel is not None
+        assert pc.home_channel.chat_id == "hermes-home"
+        assert pc.home_channel.platform == Platform.NTFY
+
+    def test_ntfy_home_channel_name_default(self, monkeypatch):
+        from gateway.config import load_gateway_config
+
+        monkeypatch.setenv("NTFY_TOPIC", "hermes-in")
+        monkeypatch.setenv("NTFY_HOME_CHANNEL", "hermes-home")
+        monkeypatch.delenv("NTFY_HOME_CHANNEL_NAME", raising=False)
+        config = load_gateway_config()
+        pc = config.platforms[Platform.NTFY]
+        assert pc.home_channel.name == "Home"
+
+    def test_ntfy_not_enabled_when_topic_absent(self, monkeypatch):
+        from gateway.config import load_gateway_config
+
+        monkeypatch.delenv("NTFY_TOPIC", raising=False)
+        config = load_gateway_config()
+        pc = config.platforms.get(Platform.NTFY)
+        if pc is not None:
+            assert not pc.enabled or pc.extra.get("topic", "") == ""
+
+    def test_ntfy_in_connected_platforms_when_topic_set(self, monkeypatch):
+        from gateway.config import load_gateway_config
+
+        monkeypatch.setenv("NTFY_TOPIC", "hermes-in")
+        config = load_gateway_config()
+        connected = config.get_connected_platforms()
+        assert Platform.NTFY in connected
+
+
+# ---------------------------------------------------------------------------
+# Adapter construction
+# ---------------------------------------------------------------------------
+
+
+class TestNtfyAdapterInit:
+
+    def test_default_server_url(self, monkeypatch):
+        from gateway.platforms.ntfy import NtfyAdapter, DEFAULT_SERVER
+
+        monkeypatch.delenv("NTFY_SERVER_URL", raising=False)
+        config = PlatformConfig(enabled=True, extra={"topic": "hermes-in"})
+        adapter = NtfyAdapter(config)
+        assert adapter._server == DEFAULT_SERVER.rstrip("/")
+
+    def test_topic_read_from_extra(self):
+        from gateway.platforms.ntfy import NtfyAdapter
+
+        config = PlatformConfig(enabled=True, extra={"topic": "my-topic"})
+        adapter = NtfyAdapter(config)
+        assert adapter._topic == "my-topic"
+
+    def test_topic_read_from_env(self, monkeypatch):
+        from gateway.platforms.ntfy import NtfyAdapter
+
+        monkeypatch.setenv("NTFY_TOPIC", "env-topic")
+        config = PlatformConfig(enabled=True, extra={})
+        adapter = NtfyAdapter(config)
+        assert adapter._topic == "env-topic"
+
+    def test_publish_topic_falls_back_to_topic(self, monkeypatch):
+        from gateway.platforms.ntfy import NtfyAdapter
+
+        monkeypatch.delenv("NTFY_PUBLISH_TOPIC", raising=False)
+        config = PlatformConfig(enabled=True, extra={"topic": "hermes-in"})
+        adapter = NtfyAdapter(config)
+        assert adapter._publish_topic == "hermes-in"
+
+    def test_publish_topic_uses_extra_value(self):
+        from gateway.platforms.ntfy import NtfyAdapter
+
+        config = PlatformConfig(
+            enabled=True,
+            extra={"topic": "hermes-in", "publish_topic": "hermes-out"},
+        )
+        adapter = NtfyAdapter(config)
+        assert adapter._publish_topic == "hermes-out"
+
+    def test_token_read_from_extra(self):
+        from gateway.platforms.ntfy import NtfyAdapter
+
+        config = PlatformConfig(enabled=True, extra={"topic": "t", "token": "tok-123"})
+        adapter = NtfyAdapter(config)
+        assert adapter._token == "tok-123"
+
+    def test_token_read_from_env(self, monkeypatch):
+        from gateway.platforms.ntfy import NtfyAdapter
+
+        monkeypatch.setenv("NTFY_TOKEN", "env-token")
+        config = PlatformConfig(enabled=True, extra={"topic": "t"})
+        adapter = NtfyAdapter(config)
+        assert adapter._token == "env-token"
+
+    def test_server_trailing_slash_stripped(self):
+        from gateway.platforms.ntfy import NtfyAdapter
+
+        config = PlatformConfig(
+            enabled=True,
+            extra={"topic": "t", "server": "https://ntfy.example.com/"},
+        )
+        adapter = NtfyAdapter(config)
+        assert not adapter._server.endswith("/")
+
+    def test_name_is_ntfy(self):
+        from gateway.platforms.ntfy import NtfyAdapter
+
+        config = PlatformConfig(enabled=True, extra={"topic": "t"})
+        adapter = NtfyAdapter(config)
+        assert adapter.name == "Ntfy"
+
+    def test_initial_state(self):
+        from gateway.platforms.ntfy import NtfyAdapter
+
+        config = PlatformConfig(enabled=True, extra={"topic": "t"})
+        adapter = NtfyAdapter(config)
+        assert adapter._stream_task is None
+        assert adapter._http_client is None
+        assert adapter._seen_messages == {}
+
+
+# ---------------------------------------------------------------------------
+# Auth headers
+# ---------------------------------------------------------------------------
+
+
+class TestAuthHeaders:
+
+    def _make_adapter(self, token=""):
+        from gateway.platforms.ntfy import NtfyAdapter
+
+        config = PlatformConfig(enabled=True, extra={"topic": "t", "token": token})
+        return NtfyAdapter(config)
+
+    def test_no_token_returns_empty_dict(self):
+        adapter = self._make_adapter(token="")
+        assert adapter._auth_headers() == {}
+
+    def test_bearer_token_for_plain_token(self):
+        adapter = self._make_adapter(token="myapitoken")
+        headers = adapter._auth_headers()
+        assert "Authorization" in headers
+        assert headers["Authorization"] == "Bearer myapitoken"
+
+    def test_basic_auth_for_user_colon_password(self):
+        adapter = self._make_adapter(token="user:pass")
+        headers = adapter._auth_headers()
+        assert "Authorization" in headers
+        assert headers["Authorization"].startswith("Basic ")
+        decoded = base64.b64decode(headers["Authorization"][6:]).decode()
+        assert decoded == "user:pass"
+
+    def test_bearer_token_used_when_no_colon(self):
+        adapter = self._make_adapter(token="noColonHere")
+        headers = adapter._auth_headers()
+        assert headers["Authorization"] == "Bearer noColonHere"
+
+    def test_auth_header_key_is_authorization(self):
+        adapter = self._make_adapter(token="tok")
+        headers = adapter._auth_headers()
+        assert list(headers.keys()) == ["Authorization"]
+
+
+# ---------------------------------------------------------------------------
+# Deduplication
+# ---------------------------------------------------------------------------
+
+
+class TestDeduplication:
+
+    def _make_adapter(self):
+        from gateway.platforms.ntfy import NtfyAdapter
+
+        return NtfyAdapter(PlatformConfig(enabled=True, extra={"topic": "t"}))
+
+    def test_first_message_not_duplicate(self):
+        adapter = self._make_adapter()
+        assert adapter._is_duplicate("msg-1") is False
+
+    def test_second_occurrence_is_duplicate(self):
+        adapter = self._make_adapter()
+        adapter._is_duplicate("msg-1")
+        assert adapter._is_duplicate("msg-1") is True
+
+    def test_different_ids_not_duplicate(self):
+        adapter = self._make_adapter()
+        adapter._is_duplicate("msg-1")
+        assert adapter._is_duplicate("msg-2") is False
+
+    def test_many_messages_recorded(self):
+        adapter = self._make_adapter()
+        for i in range(50):
+            adapter._is_duplicate(f"msg-{i}")
+        assert len(adapter._seen_messages) == 50
+
+    def test_cache_pruned_on_overflow(self):
+        from gateway.platforms.ntfy import NtfyAdapter, DEDUP_MAX_SIZE
+
+        adapter = NtfyAdapter(PlatformConfig(enabled=True, extra={"topic": "t"}))
+        for i in range(DEDUP_MAX_SIZE + 20):
+            adapter._is_duplicate(f"msg-{i}")
+        assert len(adapter._seen_messages) <= DEDUP_MAX_SIZE + 20
+
+    def test_expired_id_can_be_seen_again(self):
+        import time
+        from gateway.platforms.ntfy import NtfyAdapter, DEDUP_WINDOW_SECONDS, DEDUP_MAX_SIZE
+
+        adapter = NtfyAdapter(PlatformConfig(enabled=True, extra={"topic": "t"}))
+        adapter._seen_messages["old-msg"] = time.time() - DEDUP_WINDOW_SECONDS - 1
+        for i in range(DEDUP_MAX_SIZE + 1):
+            adapter._is_duplicate(f"fill-{i}")
+        assert adapter._is_duplicate("old-msg") is False
+
+
+# ---------------------------------------------------------------------------
+# connect() / disconnect()
+# ---------------------------------------------------------------------------
+
+
+class TestConnect:
+
+    def test_connect_fails_when_httpx_unavailable(self, monkeypatch):
+        monkeypatch.setattr("gateway.platforms.ntfy.HTTPX_AVAILABLE", False)
+        from gateway.platforms.ntfy import NtfyAdapter
+
+        adapter = NtfyAdapter(PlatformConfig(enabled=True, extra={"topic": "t"}))
+        result = _run(adapter.connect())
+        assert result is False
+
+    def test_connect_fails_when_no_topic(self, monkeypatch):
+        monkeypatch.setattr("gateway.platforms.ntfy.HTTPX_AVAILABLE", True)
+        monkeypatch.delenv("NTFY_TOPIC", raising=False)
+        from gateway.platforms.ntfy import NtfyAdapter
+
+        config = PlatformConfig(enabled=True, extra={})
+        adapter = NtfyAdapter(config)
+        result = _run(adapter.connect())
+        assert result is False
+
+    def test_connect_starts_stream_task(self, monkeypatch):
+        monkeypatch.setattr("gateway.platforms.ntfy.HTTPX_AVAILABLE", True)
+        from gateway.platforms.ntfy import NtfyAdapter
+
+        config = PlatformConfig(enabled=True, extra={"topic": "hermes-test"})
+        adapter = NtfyAdapter(config)
+
+        with patch.object(adapter, "_run_stream", new_callable=AsyncMock):
+            with patch("gateway.platforms.ntfy.httpx") as mock_httpx:
+                mock_httpx.AsyncClient.return_value = MagicMock()
+                result = _run(adapter.connect())
+
+        assert result is True
+        assert adapter._stream_task is not None
+        adapter._stream_task.cancel()
+        try:
+            _run(adapter._stream_task)
+        except (asyncio.CancelledError, Exception):
+            pass
+
+    def test_disconnect_clears_state(self):
+        from gateway.platforms.ntfy import NtfyAdapter
+
+        adapter = NtfyAdapter(PlatformConfig(enabled=True, extra={"topic": "t"}))
+        adapter._seen_messages["x"] = 1.0
+        adapter._http_client = AsyncMock()
+        adapter._stream_task = None
+        adapter._running = True
+
+        _run(adapter.disconnect())
+
+        assert adapter._seen_messages == {}
+        assert adapter._http_client is None
+        assert adapter._running is False
+
+    def test_disconnect_cancels_stream_task(self):
+        from gateway.platforms.ntfy import NtfyAdapter
+
+        adapter = NtfyAdapter(PlatformConfig(enabled=True, extra={"topic": "t"}))
+
+        async def _hang():
+            await asyncio.sleep(9999)
+
+        loop = asyncio.get_event_loop()
+        adapter._stream_task = loop.create_task(_hang())
+        adapter._http_client = AsyncMock()
+        adapter._running = True
+
+        _run(adapter.disconnect())
+        assert adapter._stream_task is None
+
+
+# ---------------------------------------------------------------------------
+# send()
+# ---------------------------------------------------------------------------
+
+
+class TestSend:
+
+    def _make_adapter(self, topic="hermes-in", publish_topic="", token=""):
+        from gateway.platforms.ntfy import NtfyAdapter
+
+        extra = {"topic": topic, "token": token}
+        if publish_topic:
+            extra["publish_topic"] = publish_topic
+        return NtfyAdapter(PlatformConfig(enabled=True, extra=extra))
+
+    def test_send_fails_without_http_client(self):
+        adapter = self._make_adapter()
+        result = _run(adapter.send("hermes-in", "hello"))
+        assert result.success is False
+        assert "not initialized" in result.error.lower()
+
+    def test_send_posts_to_publish_topic(self):
+        adapter = self._make_adapter(topic="hermes-in", publish_topic="hermes-out")
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"id": "abc123"}
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        adapter._http_client = mock_client
+
+        result = _run(adapter.send("hermes-in", "Hello ntfy!"))
+        assert result.success is True
+        assert result.message_id == "abc123"
+
+        call_args = mock_client.post.call_args
+        posted_url = call_args[0][0]
+        assert posted_url.endswith("/hermes-out")
+
+    def test_send_falls_back_to_subscribe_topic(self):
+        adapter = self._make_adapter(topic="hermes-in")
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {}
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        adapter._http_client = mock_client
+
+        result = _run(adapter.send("hermes-in", "Hello!"))
+        assert result.success is True
+        posted_url = mock_client.post.call_args[0][0]
+        assert posted_url.endswith("/hermes-in")
+
+    def test_send_uses_metadata_publish_topic(self):
+        adapter = self._make_adapter(topic="hermes-in")
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {}
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        adapter._http_client = mock_client
+
+        result = _run(adapter.send(
+            "hermes-in", "Hi!", metadata={"publish_topic": "override-out"}
+        ))
+        assert result.success is True
+        posted_url = mock_client.post.call_args[0][0]
+        assert posted_url.endswith("/override-out")
+
+    def test_send_handles_http_error_status(self):
+        adapter = self._make_adapter(topic="hermes-in")
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 403
+        mock_resp.text = "Forbidden"
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        adapter._http_client = mock_client
+
+        result = _run(adapter.send("hermes-in", "Hello!"))
+        assert result.success is False
+        assert "403" in result.error
+
+    def test_send_handles_timeout(self):
+        import gateway.platforms.ntfy as ntfy_mod
+
+        adapter = self._make_adapter(topic="hermes-in")
+
+        class _FakeTimeout(Exception):
+            pass
+
+        fake_httpx = MagicMock()
+        fake_httpx.TimeoutException = _FakeTimeout
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(side_effect=_FakeTimeout("timed out"))
+        adapter._http_client = mock_client
+
+        with patch.object(ntfy_mod, "httpx", fake_httpx):
+            result = _run(adapter.send("hermes-in", "Hello!"))
+
+        assert result.success is False
+        assert "timeout" in result.error.lower()
+
+    def test_send_truncates_to_max_length(self):
+        from gateway.platforms.ntfy import NtfyAdapter, MAX_MESSAGE_LENGTH
+
+        adapter = self._make_adapter(topic="t")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {}
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        adapter._http_client = mock_client
+
+        long_msg = "x" * (MAX_MESSAGE_LENGTH + 500)
+        _run(adapter.send("t", long_msg))
+
+        posted_body = mock_client.post.call_args[1]["content"]
+        assert len(posted_body.decode()) <= MAX_MESSAGE_LENGTH
+
+    def test_send_typing_is_noop(self):
+        from gateway.platforms.ntfy import NtfyAdapter
+
+        adapter = NtfyAdapter(PlatformConfig(enabled=True, extra={"topic": "t"}))
+        # Should not raise
+        _run(adapter.send_typing("t"))
+
+    def test_get_chat_info_returns_dict(self):
+        from gateway.platforms.ntfy import NtfyAdapter
+
+        adapter = NtfyAdapter(PlatformConfig(enabled=True, extra={"topic": "t"}))
+        info = _run(adapter.get_chat_info("hermes-in"))
+        assert info["name"] == "hermes-in"
+        assert info["type"] == "dm"
+
+    def test_send_includes_bearer_auth_header(self):
+        adapter = self._make_adapter(topic="hermes-in", token="mytoken")
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {}
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        adapter._http_client = mock_client
+
+        _run(adapter.send("hermes-in", "secure message"))
+
+        call_headers = mock_client.post.call_args[1]["headers"]
+        assert call_headers.get("Authorization") == "Bearer mytoken"
+
+
+# ---------------------------------------------------------------------------
+# Inbound message processing
+# ---------------------------------------------------------------------------
+
+
+class TestOnMessage:
+
+    def _make_adapter(self):
+        from gateway.platforms.ntfy import NtfyAdapter
+
+        adapter = NtfyAdapter(PlatformConfig(enabled=True, extra={"topic": "hermes-in"}))
+        return adapter
+
+    def test_message_dispatched_to_handler(self):
+        adapter = self._make_adapter()
+        calls = []
+
+        async def handler(event):
+            calls.append(event)
+
+        adapter.set_message_handler(handler)
+
+        event = {
+            "id": "evt-001",
+            "event": "message",
+            "topic": "hermes-in",
+            "message": "Hello from ntfy",
+            "time": 1700000000,
+        }
+        _run(adapter._on_message(event))
+        assert len(calls) == 1
+        assert calls[0].text == "Hello from ntfy"
+
+    def test_empty_message_skipped(self):
+        adapter = self._make_adapter()
+        calls = []
+
+        async def handler(event):
+            calls.append(event)
+
+        adapter.set_message_handler(handler)
+        _run(adapter._on_message({
+            "id": "x", "event": "message", "topic": "t", "message": "", "time": None
+        }))
+        assert calls == []
+
+    def test_duplicate_message_skipped(self):
+        adapter = self._make_adapter()
+        calls = []
+
+        async def handler(event):
+            calls.append(event)
+
+        adapter.set_message_handler(handler)
+
+        event = {"id": "dup-1", "event": "message", "topic": "hermes-in", "message": "hi", "time": None}
+        _run(adapter._on_message(event))
+        _run(adapter._on_message(event))
+        assert len(calls) == 1
+
+    def test_timestamp_parsed_from_event(self):
+        from datetime import timezone
+
+        adapter = self._make_adapter()
+        captured = []
+
+        async def handler(event):
+            captured.append(event)
+
+        adapter.set_message_handler(handler)
+
+        _run(adapter._on_message({
+            "id": "ts-1",
+            "event": "message",
+            "topic": "hermes-in",
+            "message": "ping",
+            "time": 1700000000,
+        }))
+        ts = captured[0].timestamp
+        assert ts.tzinfo == timezone.utc
+
+    def test_message_id_set_from_event(self):
+        adapter = self._make_adapter()
+        captured = []
+
+        async def handler(event):
+            captured.append(event)
+
+        adapter.set_message_handler(handler)
+        _run(adapter._on_message({
+            "id": "ntfy-id-42",
+            "event": "message",
+            "topic": "hermes-in",
+            "message": "test",
+            "time": None,
+        }))
+        assert captured[0].message_id == "ntfy-id-42"
+
+    def test_title_used_as_user_name(self):
+        adapter = self._make_adapter()
+        captured = []
+
+        async def handler(event):
+            captured.append(event)
+
+        adapter.set_message_handler(handler)
+        _run(adapter._on_message({
+            "id": "u-1",
+            "event": "message",
+            "topic": "hermes-in",
+            "message": "hello",
+            "title": "Alice",
+            "time": None,
+        }))
+        assert captured[0].source.user_name == "Alice"
+
+    def test_source_chat_id_is_topic(self):
+        adapter = self._make_adapter()
+        captured = []
+
+        async def handler(event):
+            captured.append(event)
+
+        adapter.set_message_handler(handler)
+        _run(adapter._on_message({
+            "id": "s-1",
+            "event": "message",
+            "topic": "hermes-in",
+            "message": "hello",
+            "time": None,
+        }))
+        assert captured[0].source.chat_id == "hermes-in"
+
+
+# ---------------------------------------------------------------------------
+# Integration: send_message_tool platform_map (source-level checks)
+# ---------------------------------------------------------------------------
+
+
+class TestSendMessageToolIntegration:
+
+    def test_ntfy_in_platform_enum(self):
+        assert hasattr(Platform, "NTFY")
+        assert Platform.NTFY.value == "ntfy"
+
+    def test_ntfy_in_platform_map_source(self):
+        src = open("tools/send_message_tool.py").read()
+        assert '"ntfy": Platform.NTFY' in src
+
+    def test_send_ntfy_function_in_source(self):
+        src = open("tools/send_message_tool.py").read()
+        assert "async def _send_ntfy" in src
+
+    def test_ntfy_branch_in_send_to_platform_source(self):
+        src = open("tools/send_message_tool.py").read()
+        assert "Platform.NTFY" in src
+        assert "_send_ntfy" in src
+
+    def test_send_ntfy_reads_server_from_extra(self):
+        src = open("tools/send_message_tool.py").read()
+        assert 'extra.get("server")' in src
+        assert "NTFY_SERVER_URL" in src
+
+    def test_send_ntfy_reads_topic_from_extra(self):
+        src = open("tools/send_message_tool.py").read()
+        assert 'extra.get("topic")' in src
+        assert "NTFY_TOPIC" in src
+
+    def test_send_ntfy_reads_token_from_extra(self):
+        src = open("tools/send_message_tool.py").read()
+        assert 'extra.get("token")' in src
+        assert "NTFY_TOKEN" in src
+
+
+# ---------------------------------------------------------------------------
+# Integration: cron scheduler platform_map
+# ---------------------------------------------------------------------------
+
+
+class TestCronSchedulerIntegration:
+
+    def test_ntfy_in_scheduler_platform_map_source(self):
+        src = open("cron/scheduler.py").read()
+        assert '"ntfy": Platform.NTFY' in src
+
+    def test_ntfy_in_cronjob_deliver_description(self):
+        src = open("tools/cronjob_tools.py").read()
+        assert "ntfy" in src.lower()
+
+
+# ---------------------------------------------------------------------------
+# Integration: gateway/run.py authorization maps
+# ---------------------------------------------------------------------------
+
+
+class TestRunAuthorizationMaps:
+
+    def test_ntfy_allowed_users_in_allowlist_check(self):
+        src = open("gateway/run.py").read()
+        assert "NTFY_ALLOWED_USERS" in src
+
+    def test_ntfy_allow_all_users_in_allowlist_check(self):
+        src = open("gateway/run.py").read()
+        assert "NTFY_ALLOW_ALL_USERS" in src
+
+    def test_ntfy_in_platform_env_map(self):
+        src = open("gateway/run.py").read()
+        assert 'Platform.NTFY: "NTFY_ALLOWED_USERS"' in src
+
+    def test_ntfy_in_allow_all_map(self):
+        src = open("gateway/run.py").read()
+        assert 'Platform.NTFY: "NTFY_ALLOW_ALL_USERS"' in src
+
+    def test_ntfy_create_adapter_branch(self):
+        src = open("gateway/run.py").read()
+        assert "Platform.NTFY" in src
+        assert "NtfyAdapter" in src
+
+    def test_ntfy_startup_allowlist_includes_ntfy_allowed_users(self):
+        src = open("gateway/run.py").read()
+        # Verify both env vars appear in the startup check tuples
+        assert '"NTFY_ALLOWED_USERS"' in src
+        assert '"NTFY_ALLOW_ALL_USERS"' in src
+
+
+# ---------------------------------------------------------------------------
+# Integration: toolsets
+# ---------------------------------------------------------------------------
+
+
+class TestToolsets:
+
+    def test_hermes_ntfy_toolset_exists(self):
+        from toolsets import get_toolset
+
+        ts = get_toolset("hermes-ntfy")
+        assert ts is not None
+        assert "tools" in ts
+
+    def test_hermes_ntfy_in_gateway_includes(self):
+        from toolsets import get_toolset
+
+        gw = get_toolset("hermes-gateway")
+        assert "hermes-ntfy" in gw["includes"]
+
+    def test_hermes_ntfy_resolves_tools(self):
+        from toolsets import resolve_toolset
+
+        tools = resolve_toolset("hermes-ntfy")
+        assert len(tools) > 0
+
+    def test_hermes_ntfy_description_mentions_ntfy(self):
+        from toolsets import get_toolset
+
+        ts = get_toolset("hermes-ntfy")
+        assert "ntfy" in ts["description"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Integration: prompt_builder platform hints
+# ---------------------------------------------------------------------------
+
+
+class TestPromptBuilderHints:
+
+    def test_ntfy_hint_exists(self):
+        from agent.prompt_builder import PLATFORM_HINTS
+
+        assert "ntfy" in PLATFORM_HINTS
+
+    def test_ntfy_hint_mentions_plain_text(self):
+        from agent.prompt_builder import PLATFORM_HINTS
+
+        hint = PLATFORM_HINTS["ntfy"].lower()
+        assert "plain text" in hint
+
+    def test_ntfy_hint_mentions_push_or_notifications(self):
+        from agent.prompt_builder import PLATFORM_HINTS
+
+        hint = PLATFORM_HINTS["ntfy"].lower()
+        assert "push" in hint or "notification" in hint
+
+
+# ---------------------------------------------------------------------------
+# Integration: channel_directory
+# ---------------------------------------------------------------------------
+
+
+class TestChannelDirectory:
+
+    def test_ntfy_in_session_based_platforms_source(self):
+        src = open("gateway/channel_directory.py").read()
+        assert '"ntfy"' in src
+
+    def test_build_channel_directory_includes_ntfy_key(self):
+        from gateway.channel_directory import build_channel_directory
+
+        with patch("gateway.channel_directory._build_from_sessions", return_value=[]):
+            with patch("gateway.channel_directory.DIRECTORY_PATH") as mock_path:
+                mock_path.parent.mkdir = MagicMock()
+                with patch("builtins.open", MagicMock()):
+                    with patch("json.dump"):
+                        result = build_channel_directory({})
+        assert "ntfy" in result.get("platforms", {})

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -372,7 +372,7 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             },
             "deliver": {
                 "type": "string",
-                "description": "Delivery target: origin, local, telegram, discord, slack, whatsapp, signal, matrix, mattermost, homeassistant, dingtalk, feishu, wecom, email, sms, or platform:chat_id or platform:chat_id:thread_id for Telegram topics. Examples: 'origin', 'local', 'telegram', 'telegram:-1001234567890:17585', 'discord:#engineering'"
+                "description": "Delivery target: origin, local, telegram, discord, slack, whatsapp, signal, matrix, mattermost, homeassistant, dingtalk, feishu, wecom, email, sms, ntfy, or platform:chat_id or platform:chat_id:thread_id for Telegram topics. Examples: 'origin', 'local', 'telegram', 'telegram:-1001234567890:17585', 'discord:#engineering', 'ntfy'"
             },
             "model": {
                 "type": "string",

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -133,6 +133,7 @@ def _handle_send(args):
         "wecom": Platform.WECOM,
         "email": Platform.EMAIL,
         "sms": Platform.SMS,
+        "ntfy": Platform.NTFY,
     }
     platform = platform_map.get(platform_name)
     if not platform:
@@ -371,6 +372,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             result = await _send_feishu(pconfig, chat_id, chunk, thread_id=thread_id)
         elif platform == Platform.WECOM:
             result = await _send_wecom(pconfig.extra, chat_id, chunk)
+        elif platform == Platform.NTFY:
+            result = await _send_ntfy(pconfig.extra, chat_id, chunk)
         else:
             result = {"error": f"Direct sending not yet implemented for {platform.value}"}
 
@@ -822,6 +825,47 @@ async def _send_wecom(extra, chat_id, message):
             await adapter.disconnect()
     except Exception as e:
         return {"error": f"WeCom send failed: {e}"}
+
+
+async def _send_ntfy(extra, chat_id, message):
+    """Publish a message to an ntfy topic via HTTP POST."""
+    try:
+        import httpx
+    except ImportError:
+        return {"error": "httpx not installed"}
+
+    server = (extra.get("server") or os.getenv("NTFY_SERVER_URL", "https://ntfy.sh")).rstrip("/")
+    publish_topic = (
+        extra.get("publish_topic")
+        or os.getenv("NTFY_PUBLISH_TOPIC", "")
+        or extra.get("topic")
+        or os.getenv("NTFY_TOPIC", "")
+        or chat_id
+    )
+    token = extra.get("token") or os.getenv("NTFY_TOKEN", "")
+
+    if not publish_topic:
+        return {"error": "ntfy not configured. Set NTFY_TOPIC env var or topic in ntfy platform extra config."}
+
+    headers: dict = {"Content-Type": "text/plain; charset=utf-8"}
+    if token:
+        if ":" in token:
+            import base64
+            encoded = base64.b64encode(token.encode()).decode()
+            headers["Authorization"] = f"Basic {encoded}"
+        else:
+            headers["Authorization"] = f"Bearer {token}"
+
+    url = f"{server}/{publish_topic}"
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.post(url, content=message.encode("utf-8"), headers=headers)
+            resp.raise_for_status()
+        return {"success": True, "platform": "ntfy", "chat_id": publish_topic}
+    except httpx.HTTPStatusError as e:
+        return {"error": f"ntfy HTTP {e.response.status_code}: {e.response.text[:200]}"}
+    except Exception as e:
+        return {"error": f"ntfy send failed: {e}"}
 
 
 async def _send_feishu(pconfig, chat_id, message, media_files=None, thread_id=None):

--- a/toolsets.py
+++ b/toolsets.py
@@ -369,10 +369,16 @@ TOOLSETS = {
         "includes": []
     },
 
+    "hermes-ntfy": {
+        "description": "ntfy bot toolset - receive and send push notifications via ntfy.sh or self-hosted ntfy",
+        "tools": _HERMES_CORE_TOOLS,
+        "includes": []
+    },
+
     "hermes-gateway": {
         "description": "Gateway toolset - union of all messaging platform tools",
         "tools": [],
-        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom"]
+        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-ntfy"]
     }
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes an `AttributeError` crash in `extract_skill_conditions()` when a skill's YAML frontmatter contains a `metadata` field that is not a dict (e.g. `metadata: "some text"` or `metadata: 42`).

The previous code used a chained `.get()` call that assumed `metadata` was always a dict. A truthy non-dict value bypassed the `or {}` fallback, causing `.get("hermes")` to be called on a string or other non-dict type.

The fix applies the same `isinstance(metadata, dict)` guard already used in `tools/skills_tool.py:1077`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- `agent/skill_utils.py` — replaced unsafe chained `.get()` with `isinstance` guard
- `tests/agent/test_skill_utils.py` — new tests covering dict metadata, string metadata (bug case), None, and missing key

## How to Test
```bash
python -m pytest tests/agent/test_skill_utils.py -v
```

## Checklist
- [x] Tests pass
- [x] No new dependencies
- [x] Consistent with existing pattern in tools/skills_tool.py