### PR TITLE
fix(gateway): auto-continue execution when history ends on tool response after restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2217,7 +2217,25 @@ class GatewayRunner:
 
         # Load conversation history from transcript
         history = self.session_store.load_transcript(session_entry.session_id)
-        
+
+        # -----------------------------------------------------------------
+        # Auto-continue: if history ends on a tool response, execution was
+        # interrupted mid-turn (e.g. gateway restart).  Inject a system note
+        # so the agent resumes from the existing tool results instead of
+        # treating the incoming message as a fresh turn.  (#4493)
+        # -----------------------------------------------------------------
+        if history and history[-1].get("role") in ("tool", "function"):
+            logger.info(
+                "[Gateway] Session %s history ends on tool response — "
+                "injecting continuation note (gateway may have restarted mid-execution)",
+                session_entry.session_id,
+            )
+            context_prompt += (
+                "\n\n[System note: The previous execution was interrupted (e.g. gateway restart). "
+                "Tool results above are already complete. Continue the task from where it left off "
+                "without re-running completed steps.]"
+            )
+
         # -----------------------------------------------------------------
         # Session hygiene: auto-compress pathologically large transcripts
         #


### PR DESCRIPTION
## Summary

When a gateway restart interrupts mid-execution, the session history ends on a `tool` role message with no following `assistant` message. On the next incoming user message, the agent treats it as a fresh turn and ignores the pending tool results — requiring the user to manually write "continue" or use `/retry`.

This fix detects that condition after `load_transcript` and injects a system note into `context_prompt` so the agent resumes from the existing tool results instead of starting fresh.

## Root cause

`_handle_message_with_agent` loads history but never checks whether the last message role indicates interrupted execution. No action was taken for the `tool`-terminated case.

## Change

Single addition in `gateway/run.py` after `load_transcript`: if `history[-1].get("role") in ("tool", "function")`, append a continuation note to `context_prompt` and log the event.

- No new flags or config options — the correct behavior is always to resume when execution was interrupted
- No startup scan — continuation fires lazily on the next user message, avoiding parallel agent startup on multi-session restarts
- `/retry` behavior unchanged

Closes #4493