### PR TITLE
feat(display): add independent thinking_progress config option

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -299,6 +299,8 @@ def init_agent(
     # would mangle the escape sequences.  None = use builtins.print.
     agent._print_fn = None
     agent.background_review_callback = None  # Optional sync callback for gateway delivery
+    agent.memory_notifications = "on"  # Memory update notifications: "off", "on", "verbose"
+    agent.thinking_progress = False  # Relay assistant thinking text between tool calls to gateway
     agent.skip_context_files = skip_context_files
     agent.load_soul_identity = load_soul_identity
     agent.pass_session_id = pass_session_id

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3557,20 +3557,29 @@ def run_conversation(
                 else:
                     agent._vprint(f"{agent.log_prefix}🤖 Assistant: {assistant_message.content[:100]}{'...' if len(assistant_message.content) > 100 else ''}")
 
-            # Notify progress callback of model's thinking (used by subagent
-            # delegation to relay the child's reasoning to the parent display).
-            if (assistant_message.content and agent.tool_progress_callback):
+            # Notify progress callback of model's thinking.  Subagents always
+            # relay a short first line to the parent display; gateway users can
+            # opt into complete between-tool-call thinking text independently
+            # via display.thinking_progress.
+            _should_relay_thinking = (
+                getattr(agent, '_delegate_depth', 0) > 0
+                or getattr(agent, 'thinking_progress', False)
+            )
+            if (assistant_message.content and agent.tool_progress_callback and _should_relay_thinking):
                 _think_text = assistant_message.content.strip()
                 # Strip reasoning XML tags that shouldn't leak to parent display
                 _think_text = re.sub(
                     r'</?(?:REASONING_SCRATCHPAD|think|reasoning)>', '', _think_text
                 ).strip()
-                # For subagents: relay first line to parent display (existing behaviour).
-                # For all agents with a structured callback: emit reasoning.available event.
-                first_line = _think_text.split('\n')[0][:80] if _think_text else ""
-                if first_line and getattr(agent, '_delegate_depth', 0) > 0:
+                if getattr(agent, 'thinking_progress', False):
+                    # Explicit thinking_progress: relay complete text, no limit.
+                    _relay_text = _think_text or ""
+                else:
+                    # Subagent relay: first line, truncated.
+                    _relay_text = _think_text.split('\n')[0][:80] if _think_text else ""
+                if _relay_text:
                     try:
-                        agent.tool_progress_callback("_thinking", first_line)
+                        agent.tool_progress_callback("_thinking", _relay_text)
                     except Exception:
                         pass
                 elif _think_text:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13507,9 +13507,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
             )
         )
-        
+        # thinking_progress is independent — if enabled, we need the progress
+        # queue even when tool_progress is off (thinking relay uses same infra)
+        _thinking_cfg = user_config.get("display", {}).get("thinking_progress")
+        _thinking_enabled = (
+            _thinking_cfg is True
+            or (isinstance(_thinking_cfg, str) and _thinking_cfg.lower() in ("true", "yes", "1", "on"))
+        )
+        needs_progress_queue = tool_progress_enabled or _thinking_enabled
+
+
         # Queue for progress messages (thread-safe)
-        progress_queue = queue.Queue() if tool_progress_enabled else None
+        progress_queue = queue.Queue() if needs_progress_queue else None
         last_tool = [None]  # Mutable container for tracking in closure
         last_progress_msg = [None]  # Track last message for dedup
         repeat_count = [0]  # How many times the same message repeated
@@ -13615,6 +13624,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     logger.debug("tool-progress onboarding hint failed: %s", _hint_err)
                 return
 
+
+            # If tool_progress is off, only _thinking passes through (above).
+            # Regular tool calls are suppressed.
+            if not tool_progress_enabled:
+                return
 
             # Only act on tool.started events (ignore tool.completed, reasoning.available, etc.)
             if event_type not in {"tool.started",}:
@@ -14466,7 +14480,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             # Per-message state — callbacks and reasoning config change every
             # turn and must not be baked into the cached agent constructor.
-            agent.tool_progress_callback = progress_callback if tool_progress_enabled else None
+            agent.tool_progress_callback = progress_callback if needs_progress_queue else None
             # Discord voice verbal-ack hook (fires once per turn on first tool
             # call; armed only when in a voice channel with the mixer running).
             agent.tool_start_callback = (
@@ -14638,6 +14652,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return response
 
             agent.clarify_callback = _clarify_callback_sync
+
+            # Show assistant thinking between tool calls — fully independent
+            # of tool_progress mode.  Config: display.thinking_progress: true
+            _thinking_progress = user_config.get("display", {}).get("thinking_progress")
+            if isinstance(_thinking_progress, bool):
+                agent.thinking_progress = _thinking_progress
+            elif isinstance(_thinking_progress, str):
+                agent.thinking_progress = _thinking_progress.lower() in ("true", "yes", "1", "on")
+            else:
+                agent.thinking_progress = False
 
             # Store agent reference for interrupt support
             agent_holder[0] = agent


### PR DESCRIPTION
## Summary

Rebuilds this PR on the current `upstream/main` and ports the current implementation of `display.thinking_progress`.

This decouples assistant interim/thinking text from tool-progress verbosity:

- `display.tool_progress` continues to control tool-call notifications.
- `display.thinking_progress` independently controls whether assistant text between tool calls is relayed to gateway progress callbacks.
- Default remains `false`, preserving existing behavior for users who do not opt in.
- When enabled, thinking text is relayed without the tool-argument truncation behavior used by tool progress previews.

## Motivation

Some users want to see assistant interim status text in gateway chats without also enabling the most verbose tool argument display. Bundling those two behaviors under `tool_progress: full` made the setting harder to reason about and forced unrelated verbosity choices together.

## Verification

- `python3 -m py_compile agent/agent_init.py agent/conversation_loop.py gateway/run.py`
- `uv run pytest tests/gateway/test_display_config.py -q -o addopts=` -> 34 passed

## Notes

This update force-pushes the existing PR branch from the current upstream base rather than opening a duplicate PR, preserving the original discussion and PR number.