### PR TITLE
fix(gateway): add provider circuit breaker and stale-session watchdog

### DIFF
--- a/agent/circuit_breaker.py
+++ b/agent/circuit_breaker.py
@@ -1,0 +1,204 @@
+"""Process-wide circuit breaker for provider rate limits.
+
+This prevents multiple concurrent agents from hammering the same provider after
+that provider has already started returning 429/529-style overload errors.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class CircuitState(Enum):
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+
+@dataclass
+class ProviderState:
+    state: CircuitState = CircuitState.CLOSED
+    failure_count: int = 0
+    last_failure_at: float = 0.0
+    opened_at: float = 0.0
+    open_timeout: int = 0
+    last_429_retry_after: Optional[int] = None
+    half_open_probe_session: Optional[str] = None
+
+
+class ProviderCircuitBreaker:
+    """Singleton circuit breaker shared across all agents in a gateway process.
+
+    CLOSED:
+        Normal operation. Failures increment a counter.
+    OPEN:
+        Provider is considered unhealthy/rate-limited. Requests SHOULD use
+        fallback immediately until the reset timeout elapses.
+    HALF_OPEN:
+        One designated session is allowed to probe the provider. Success closes
+        the circuit, failure re-opens it.
+    """
+
+    _instance: Optional["ProviderCircuitBreaker"] = None
+    _instance_lock = threading.Lock()
+
+    DEFAULT_FAILURE_THRESHOLD = 2
+    DEFAULT_RESET_TIMEOUT = 300
+    DEFAULT_HALF_OPEN_TIMEOUT = 30
+
+    @classmethod
+    def get_instance(cls) -> "ProviderCircuitBreaker":
+        if cls._instance is None:
+            with cls._instance_lock:
+                if cls._instance is None:
+                    cls._instance = cls()
+        return cls._instance
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._providers: Dict[str, ProviderState] = {}
+        self.failure_threshold = self.DEFAULT_FAILURE_THRESHOLD
+        self.reset_timeout = self.DEFAULT_RESET_TIMEOUT
+        self.half_open_timeout = self.DEFAULT_HALF_OPEN_TIMEOUT
+
+    def _get_state(self, provider: str) -> ProviderState:
+        key = (provider or "unknown").strip().lower() or "unknown"
+        if key not in self._providers:
+            self._providers[key] = ProviderState()
+        return self._providers[key]
+
+    def should_use_fallback(self, provider: str, session_key: str = "") -> bool:
+        """Return True if the provider circuit is open for this session."""
+        with self._lock:
+            state = self._get_state(provider)
+            now = time.time()
+
+            if state.state == CircuitState.CLOSED:
+                return False
+
+            if state.state == CircuitState.OPEN:
+                elapsed = now - state.opened_at
+                timeout = state.open_timeout or self.reset_timeout
+                if elapsed >= timeout:
+                    state.state = CircuitState.HALF_OPEN
+                    state.half_open_probe_session = session_key or "__anonymous_probe__"
+                    logger.info(
+                        "Circuit breaker %s: OPEN -> HALF_OPEN (probe=%s)",
+                        provider,
+                        state.half_open_probe_session[:32],
+                    )
+                    return False
+                return True
+
+            if state.state == CircuitState.HALF_OPEN:
+                probe_session = state.half_open_probe_session or "__anonymous_probe__"
+                current_session = session_key or "__anonymous_probe__"
+                return probe_session != current_session
+
+            return False
+
+    def record_failure(
+        self,
+        provider: str,
+        status_code: Optional[int] = None,
+        retry_after: Optional[int] = None,
+    ) -> None:
+        """Record a retry-worthy provider failure.
+
+        Intended for 429, 529, and overload-style failures that SHOULD trigger
+        cross-session provider suppression.
+        """
+        with self._lock:
+            state = self._get_state(provider)
+            now = time.time()
+            state.failure_count += 1
+            state.last_failure_at = now
+            if retry_after and retry_after > 0:
+                state.last_429_retry_after = retry_after
+
+            next_timeout = max(self.reset_timeout, retry_after or 0)
+
+            if state.state == CircuitState.HALF_OPEN:
+                state.state = CircuitState.OPEN
+                state.opened_at = now
+                state.open_timeout = next_timeout
+                state.half_open_probe_session = None
+                logger.warning(
+                    "Circuit breaker %s: HALF_OPEN -> OPEN after failed probe (timeout=%ss, status=%s)",
+                    provider,
+                    next_timeout,
+                    status_code,
+                )
+                return
+
+            if state.failure_count >= self.failure_threshold:
+                if state.state != CircuitState.OPEN:
+                    logger.warning(
+                        "Circuit breaker %s: CLOSED -> OPEN after %d failures (timeout=%ss, status=%s)",
+                        provider,
+                        state.failure_count,
+                        next_timeout,
+                        status_code,
+                    )
+                state.state = CircuitState.OPEN
+                state.opened_at = now
+                state.open_timeout = next_timeout
+                state.half_open_probe_session = None
+
+    def record_success(self, provider: str) -> None:
+        """Record a successful request and fully close the circuit."""
+        with self._lock:
+            state = self._get_state(provider)
+            previous = state.state
+            state.state = CircuitState.CLOSED
+            state.failure_count = 0
+            state.last_failure_at = 0.0
+            state.opened_at = 0.0
+            state.open_timeout = 0
+            state.last_429_retry_after = None
+            state.half_open_probe_session = None
+            if previous != CircuitState.CLOSED:
+                logger.info("Circuit breaker %s: %s -> CLOSED", provider, previous.value)
+
+    def get_status(self) -> Dict[str, dict]:
+        """Return human-readable circuit breaker state for all providers."""
+        with self._lock:
+            now = time.time()
+            result: Dict[str, dict] = {}
+            for provider, state in self._providers.items():
+                reset_in = None
+                if state.state == CircuitState.OPEN:
+                    timeout = state.open_timeout or self.reset_timeout
+                    reset_in = max(0, timeout - (now - state.opened_at))
+                result[provider] = {
+                    "state": state.state.value,
+                    "failures": state.failure_count,
+                    "last_failure": state.last_failure_at or None,
+                    "open_since": state.opened_at or None,
+                    "reset_in": reset_in,
+                    "retry_after": state.last_429_retry_after,
+                    "probe_session": state.half_open_probe_session,
+                }
+            return result
+
+    def configure(
+        self,
+        failure_threshold: Optional[int] = None,
+        reset_timeout: Optional[int] = None,
+        half_open_timeout: Optional[int] = None,
+    ) -> None:
+        """Update thresholds from config."""
+        with self._lock:
+            if failure_threshold is not None and failure_threshold > 0:
+                self.failure_threshold = int(failure_threshold)
+            if reset_timeout is not None and reset_timeout > 0:
+                self.reset_timeout = int(reset_timeout)
+            if half_open_timeout is not None and half_open_timeout > 0:
+                self.half_open_timeout = int(half_open_timeout)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1072,8 +1072,8 @@ class GatewayRunner:
                 if not isinstance(wd_cfg, dict):
                     return {}
                 return {
-                    "enabled": wd_cfg.get("enabled", True),
-                    "max_duration": wd_cfg.get("max_duration", 1800),
+                    "enabled": wd_cfg.get("enabled", False),
+                    "max_duration": wd_cfg.get("max_duration", 3600),
                     "check_interval": wd_cfg.get("check_interval", 60),
                 }
         except Exception:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -428,6 +428,7 @@ class GatewayRunner:
         self._provider_routing = self._load_provider_routing()
         self._fallback_model = self._load_fallback_model()
         self._circuit_breaker_config = self._load_circuit_breaker_config()
+        self._session_watchdog_config = self._load_session_watchdog_config()
         self._smart_model_routing = self._load_smart_model_routing()
 
         try:
@@ -453,6 +454,7 @@ class GatewayRunner:
         # Track running agents per session for interrupt support
         # Key: session_key, Value: AIAgent instance
         self._running_agents: Dict[str, Any] = {}
+        self._running_agent_started_at: Dict[str, float] = {}
         self._pending_messages: Dict[str, str] = {}  # Queued messages during interrupt
 
         # Cache AIAgent instances per session to preserve prompt caching.
@@ -1058,6 +1060,27 @@ class GatewayRunner:
         return {}
 
     @staticmethod
+    def _load_session_watchdog_config() -> dict:
+        """Load stale-session watchdog settings from config.yaml."""
+        try:
+            import yaml as _y
+            cfg_path = _hermes_home / "config.yaml"
+            if cfg_path.exists():
+                with open(cfg_path, encoding="utf-8") as _f:
+                    cfg = _y.safe_load(_f) or {}
+                wd_cfg = cfg.get("session_watchdog") or {}
+                if not isinstance(wd_cfg, dict):
+                    return {}
+                return {
+                    "enabled": wd_cfg.get("enabled", True),
+                    "max_duration": wd_cfg.get("max_duration", 1800),
+                    "check_interval": wd_cfg.get("check_interval", 60),
+                }
+        except Exception:
+            pass
+        return {}
+
+    @staticmethod
     def _load_smart_model_routing() -> dict:
         """Load optional smart cheap-vs-strong model routing config."""
         try:
@@ -1288,6 +1311,9 @@ class GatewayRunner:
             )
         asyncio.create_task(self._platform_reconnect_watcher())
 
+        if self._session_watchdog_config.get("enabled", True):
+            asyncio.create_task(self._session_watchdog())
+
         logger.info("Press Ctrl+C to stop")
         
         return True
@@ -1431,6 +1457,42 @@ class GatewayRunner:
                     return
                 await asyncio.sleep(1)
 
+    async def _session_watchdog(self) -> None:
+        """Interrupt stale running sessions before they wedge the gateway forever."""
+        cfg = self._session_watchdog_config or {}
+        max_duration = int(cfg.get("max_duration", 1800) or 1800)
+        check_interval = int(cfg.get("check_interval", 60) or 60)
+
+        await asyncio.sleep(min(check_interval, 10))
+        while self._running:
+            try:
+                now = time.time()
+                for session_key, started_at in list(self._running_agent_started_at.items()):
+                    agent = self._running_agents.get(session_key)
+                    if not agent or agent is _AGENT_PENDING_SENTINEL:
+                        continue
+                    elapsed = now - started_at
+                    if elapsed <= max_duration:
+                        continue
+                    logger.warning(
+                        "Session watchdog: interrupting stale session %s after %.0fs",
+                        session_key,
+                        elapsed,
+                    )
+                    try:
+                        agent.interrupt("Session timed out (watchdog)")
+                    except Exception as e:
+                        logger.debug("Session watchdog interrupt failed for %s: %s", session_key, e)
+                    self._evict_cached_agent(session_key)
+                    self._running_agent_started_at.pop(session_key, None)
+            except Exception as e:
+                logger.debug("Session watchdog error: %s", e)
+
+            for _ in range(check_interval):
+                if not self._running:
+                    return
+                await asyncio.sleep(1)
+
     async def stop(self) -> None:
         """Stop the gateway and disconnect all adapters."""
         logger.info("Stopping gateway...")
@@ -1463,6 +1525,7 @@ class GatewayRunner:
 
         self.adapters.clear()
         self._running_agents.clear()
+        self._running_agent_started_at.clear()
         self._pending_messages.clear()
         self._pending_approvals.clear()
         self._shutdown_all_gateway_honcho()
@@ -5960,6 +6023,7 @@ class GatewayRunner:
                 await asyncio.sleep(0.05)
             if session_key:
                 self._running_agents[session_key] = agent_holder[0]
+                self._running_agent_started_at[session_key] = time.time()
         
         tracking_task = asyncio.create_task(track_agent())
         
@@ -6115,6 +6179,8 @@ class GatewayRunner:
             tracking_task.cancel()
             if session_key and session_key in self._running_agents:
                 del self._running_agents[session_key]
+            if session_key:
+                self._running_agent_started_at.pop(session_key, None)
             
             # Wait for cancelled tasks
             for task in [progress_task, interrupt_monitor, tracking_task]:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5650,6 +5650,8 @@ class GatewayRunner:
             except Exception as _e:
                 logger.debug("status_callback error (%s): %s", event_type, _e)
 
+        turn_route_holder = [None]
+
         def run_sync():
             # Pass session_key to process registry via env var so background
             # processes can be mapped back to this gateway session
@@ -5722,6 +5724,7 @@ class GatewayRunner:
                     logger.debug("Could not set up stream consumer: %s", _sc_err)
 
             turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
+            turn_route_holder[0] = turn_route
 
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool
@@ -6067,7 +6070,8 @@ class GatewayRunner:
                     self._effective_model = _agent.model
                     self._effective_provider = getattr(_agent, 'provider', None)
                     _cb = ProviderCircuitBreaker.get_instance()
-                    _primary_provider = turn_route.get("runtime", {}).get("provider") or getattr(_agent, 'provider', '')
+                    _turn_route = turn_route_holder[0] or {}
+                    _primary_provider = _turn_route.get("runtime", {}).get("provider") or getattr(_agent, 'provider', '')
                     if _cb.should_use_fallback(_primary_provider, session_key=session_key):
                         logger.info(
                             "Keeping fallback agent cached for session %s because circuit breaker is open for %s",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -427,7 +427,15 @@ class GatewayRunner:
         self._show_reasoning = self._load_show_reasoning()
         self._provider_routing = self._load_provider_routing()
         self._fallback_model = self._load_fallback_model()
+        self._circuit_breaker_config = self._load_circuit_breaker_config()
         self._smart_model_routing = self._load_smart_model_routing()
+
+        try:
+            from agent.circuit_breaker import ProviderCircuitBreaker
+
+            ProviderCircuitBreaker.get_instance().configure(**self._circuit_breaker_config)
+        except Exception:
+            logger.exception("Failed to configure provider circuit breaker")
 
         # Wire process registry into session store for reset protection
         from tools.process_registry import process_registry
@@ -1027,6 +1035,27 @@ class GatewayRunner:
         except Exception:
             pass
         return None
+
+    @staticmethod
+    def _load_circuit_breaker_config() -> dict:
+        """Load circuit breaker settings from config.yaml."""
+        try:
+            import yaml as _y
+            cfg_path = _hermes_home / "config.yaml"
+            if cfg_path.exists():
+                with open(cfg_path, encoding="utf-8") as _f:
+                    cfg = _y.safe_load(_f) or {}
+                cb_cfg = cfg.get("circuit_breaker") or {}
+                if not isinstance(cb_cfg, dict):
+                    return {}
+                return {
+                    "failure_threshold": cb_cfg.get("failure_threshold", 2),
+                    "reset_timeout": cb_cfg.get("reset_timeout", 300),
+                    "half_open_timeout": cb_cfg.get("half_open_timeout", 30),
+                }
+        except Exception:
+            pass
+        return {}
 
     @staticmethod
     def _load_smart_model_routing() -> dict:
@@ -3089,6 +3118,23 @@ class GatewayRunner:
             "",
             f"**Connected Platforms:** {', '.join(connected_platforms)}",
         ]
+
+        try:
+            from agent.circuit_breaker import ProviderCircuitBreaker
+
+            cb_status = ProviderCircuitBreaker.get_instance().get_status()
+            if cb_status:
+                lines.extend(["", "🔌 **Provider Circuit Breaker**"])
+                for provider, info in sorted(cb_status.items()):
+                    state = info.get("state", "closed")
+                    icon = "🟢" if state == "closed" else ("🔴" if state == "open" else "🟡")
+                    line = f"{icon} `{provider}`: {state}"
+                    reset_in = info.get("reset_in")
+                    if reset_in:
+                        line += f" (resets in {int(reset_in)}s)"
+                    lines.append(line)
+        except Exception:
+            logger.exception("Failed to render circuit breaker status")
         
         return "\n".join(lines)
     

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5652,6 +5652,7 @@ class GatewayRunner:
                     provider_require_parameters=pr.get("require_parameters", False),
                     provider_data_collection=pr.get("data_collection"),
                     session_id=session_id,
+                    session_key=session_key,
                     platform=platform_key,
                     honcho_session_key=session_key,
                     honcho_manager=honcho_manager,
@@ -5951,11 +5952,22 @@ class GatewayRunner:
             if _agent is not None and hasattr(_agent, 'model'):
                 _cfg_model = _resolve_gateway_model()
                 if _agent.model != _cfg_model:
+                    from agent.circuit_breaker import ProviderCircuitBreaker
+
                     self._effective_model = _agent.model
                     self._effective_provider = getattr(_agent, 'provider', None)
-                    # Fallback activated — evict cached agent so the next
-                    # message starts fresh and retries the primary model.
-                    self._evict_cached_agent(session_key)
+                    _cb = ProviderCircuitBreaker.get_instance()
+                    _primary_provider = turn_route.get("runtime", {}).get("provider") or getattr(_agent, 'provider', '')
+                    if _cb.should_use_fallback(_primary_provider, session_key=session_key):
+                        logger.info(
+                            "Keeping fallback agent cached for session %s because circuit breaker is open for %s",
+                            session_key,
+                            _primary_provider,
+                        )
+                    else:
+                        # Primary recovered — evict cached fallback agent so the
+                        # next message retries the configured primary route.
+                        self._evict_cached_agent(session_key)
                 else:
                     # Primary model worked — clear any stale fallback state
                     self._effective_model = None

--- a/run_agent.py
+++ b/run_agent.py
@@ -916,6 +916,8 @@ class AIAgent:
             self._fallback_chain = []
         self._fallback_index = 0
         self._fallback_activated = False
+        self._original_provider = self.provider  # for fall-forward
+        self._original_model = self.model
         # Legacy attribute kept for backward compat (tests, external callers)
         self._fallback_model = self._fallback_chain[0] if self._fallback_chain else None
         if self._fallback_chain and not self.quiet_mode:
@@ -4454,6 +4456,23 @@ class AIAgent:
         mappings.
         """
         if self._fallback_index >= len(self._fallback_chain):
+            # Fall forward: if we already activated a fallback and it failed,
+            # check if the original primary provider has recovered.
+            if self._fallback_activated and getattr(self, '_original_provider', None):
+                try:
+                    from agent.circuit_breaker import ProviderCircuitBreaker
+                    _cb = ProviderCircuitBreaker.get_instance()
+                    _orig_provider = self._original_provider or ""
+                    if _orig_provider and not _cb.should_use_fallback(_orig_provider, session_key=self._session_key):
+                        logging.info(
+                            "Fall-forward: original provider %s may have recovered, resetting fallback chain",
+                            _orig_provider,
+                        )
+                        self._fallback_index = 0
+                        self._fallback_activated = False
+                        return self._try_activate_fallback()
+                except Exception:
+                    pass
             return False
 
         fb = self._fallback_chain[self._fallback_index]
@@ -6544,6 +6563,8 @@ class AIAgent:
                 logging.debug(f"Last message role: {messages[-1]['role'] if messages else 'none'}")
                 logging.debug(f"Total message size: ~{approx_tokens:,} tokens")
             
+            from agent.circuit_breaker import ProviderCircuitBreaker
+
             api_start_time = time.time()
             retry_count = 0
             max_retries = 3
@@ -6560,14 +6581,16 @@ class AIAgent:
 
             while retry_count < max_retries:
                 try:
-                    from agent.circuit_breaker import ProviderCircuitBreaker
-
                     _cb = ProviderCircuitBreaker.get_instance()
                     if _cb.should_use_fallback(self.provider, session_key=self._session_key):
-                        self._emit_status("⚡ Provider rate-limited (circuit breaker) — switching to fallback...")
-                        if self._try_activate_fallback():
-                            retry_count = 0
-                            continue
+                        # Check if credential pool has untried credentials before falling back
+                        _pool = getattr(self, '_credential_pool', None)
+                        _pool_can_rotate = _pool and hasattr(_pool, 'has_available') and _pool.has_available()
+                        if not _pool_can_rotate:
+                            self._emit_status("⚡ Provider rate-limited (circuit breaker) — switching to fallback...")
+                            if self._try_activate_fallback():
+                                retry_count = 0
+                                continue
 
                     api_kwargs = self._build_api_kwargs(api_messages)
                     if self.api_mode == "codex_responses":
@@ -7167,11 +7190,12 @@ class AIAgent:
                             status_code=status_code,
                             retry_after=_retry_after_val,
                         )
-                    if is_rate_limited and self._fallback_index < len(self._fallback_chain):
-                        self._emit_status("⚠️ Rate limited — switching to fallback provider...")
-                        if self._try_activate_fallback():
-                            retry_count = 0
-                            continue
+                    if is_rate_limited:
+                        if self._fallback_index < len(self._fallback_chain) or self._fallback_activated:
+                            self._emit_status("⚠️ Rate limited — switching to fallback provider...")
+                            if self._try_activate_fallback():
+                                retry_count = 0
+                                continue
 
                     is_payload_too_large = (
                         status_code == 413

--- a/run_agent.py
+++ b/run_agent.py
@@ -506,6 +506,7 @@ class AIAgent:
         iteration_budget: "IterationBudget" = None,
         fallback_model: Dict[str, Any] = None,
         credential_pool=None,
+        session_key: str = "",
         checkpoints_enabled: bool = False,
         checkpoint_max_snapshots: int = 50,
         pass_session_id: bool = False,
@@ -971,6 +972,7 @@ class AIAgent:
         
         # Session logging setup - auto-save conversation trajectories for debugging
         self.session_start = datetime.now()
+        self._session_key = session_key or ""
         if session_id:
             # Use provided session ID (e.g., from CLI)
             self.session_id = session_id
@@ -6558,6 +6560,15 @@ class AIAgent:
 
             while retry_count < max_retries:
                 try:
+                    from agent.circuit_breaker import ProviderCircuitBreaker
+
+                    _cb = ProviderCircuitBreaker.get_instance()
+                    if _cb.should_use_fallback(self.provider, session_key=self._session_key):
+                        self._emit_status("⚡ Provider rate-limited (circuit breaker) — switching to fallback...")
+                        if self._try_activate_fallback():
+                            retry_count = 0
+                            continue
+
                     api_kwargs = self._build_api_kwargs(api_messages)
                     if self.api_mode == "codex_responses":
                         api_kwargs = self._preflight_codex_api_kwargs(api_kwargs, allow_stream=False)
@@ -6741,6 +6752,8 @@ class AIAgent:
                                 }
                             time.sleep(0.2)
                         continue  # Retry the API call
+
+                    ProviderCircuitBreaker.get_instance().record_success(self.provider)
 
                     # Check finish_reason before proceeding
                     if self.api_mode == "codex_responses":
@@ -7141,6 +7154,19 @@ class AIAgent:
                         or "usage limit" in error_msg
                         or "quota" in error_msg
                     )
+                    if is_rate_limited or status_code == 529:
+                        _retry_after_val = None
+                        _resp_headers = getattr(getattr(api_error, "response", None), "headers", None)
+                        if _resp_headers:
+                            try:
+                                _retry_after_val = int(_resp_headers.get("retry-after", 0))
+                            except (TypeError, ValueError):
+                                _retry_after_val = None
+                        ProviderCircuitBreaker.get_instance().record_failure(
+                            self.provider,
+                            status_code=status_code,
+                            retry_after=_retry_after_val,
+                        )
                     if is_rate_limited and self._fallback_index < len(self._fallback_chain):
                         self._emit_status("⚠️ Rate limited — switching to fallback provider...")
                         if self._try_activate_fallback():

--- a/tests/agent/test_circuit_breaker.py
+++ b/tests/agent/test_circuit_breaker.py
@@ -1,0 +1,571 @@
+"""Tests for ProviderCircuitBreaker — process-wide provider rate-limit circuit breaker.
+
+Covers:
+1. Threshold tripping — breaker opens after N failures
+2. Retry-After timeout behavior — breaker respects retry-after headers
+3. Half-open probe selection — after reset_timeout, breaker enters half_open and allows one probe
+4. Success resets — successful call closes the circuit
+5. Concurrent access patterns — multiple threads recording failures/successes simultaneously
+6. configure() method — setting custom thresholds
+"""
+
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+from agent.circuit_breaker import ProviderCircuitBreaker, CircuitState, ProviderState
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def fresh_breaker():
+    """Reset the singleton between tests so state doesn't leak."""
+    ProviderCircuitBreaker._instance = None
+    cb = ProviderCircuitBreaker.get_instance()
+    yield cb
+    ProviderCircuitBreaker._instance = None
+
+
+PROVIDER = "anthropic"
+
+
+# ---------------------------------------------------------------------------
+# 1. Threshold tripping
+# ---------------------------------------------------------------------------
+
+class TestThresholdTripping:
+    """Breaker opens after N consecutive failures."""
+
+    def test_stays_closed_below_threshold(self, fresh_breaker):
+        cb = fresh_breaker
+        cb.record_failure(PROVIDER, status_code=429)
+        # Default threshold is 2; one failure should NOT trip the breaker
+        assert cb.should_use_fallback(PROVIDER) is False
+        status = cb.get_status()
+        assert status[PROVIDER]["state"] == "closed"
+        assert status[PROVIDER]["failures"] == 1
+
+    def test_opens_at_threshold(self, fresh_breaker):
+        cb = fresh_breaker
+        for _ in range(cb.failure_threshold):
+            cb.record_failure(PROVIDER, status_code=429)
+
+        assert cb.should_use_fallback(PROVIDER) is True
+        status = cb.get_status()
+        assert status[PROVIDER]["state"] == "open"
+        assert status[PROVIDER]["failures"] == cb.failure_threshold
+
+    def test_opens_above_threshold(self, fresh_breaker):
+        cb = fresh_breaker
+        for _ in range(cb.failure_threshold + 5):
+            cb.record_failure(PROVIDER, status_code=429)
+
+        assert cb.should_use_fallback(PROVIDER) is True
+        assert cb.get_status()[PROVIDER]["state"] == "open"
+
+    def test_different_providers_independent(self, fresh_breaker):
+        cb = fresh_breaker
+        # Trip anthropic
+        for _ in range(cb.failure_threshold):
+            cb.record_failure("anthropic", status_code=429)
+        # openai should still be closed
+        assert cb.should_use_fallback("anthropic") is True
+        assert cb.should_use_fallback("openai") is False
+
+    def test_default_threshold_is_two(self, fresh_breaker):
+        cb = fresh_breaker
+        assert cb.failure_threshold == 2
+
+
+# ---------------------------------------------------------------------------
+# 2. Retry-After timeout behavior
+# ---------------------------------------------------------------------------
+
+class TestRetryAfterBehavior:
+    """Breaker respects retry-after headers."""
+
+    def test_retry_after_stored_on_failure(self, fresh_breaker):
+        cb = fresh_breaker
+        cb.record_failure(PROVIDER, status_code=429, retry_after=120)
+        # Access internal state
+        ps = cb._providers[PROVIDER]
+        assert ps.last_429_retry_after == 120
+
+    def test_retry_after_none_when_not_provided(self, fresh_breaker):
+        cb = fresh_breaker
+        cb.record_failure(PROVIDER, status_code=429)
+        ps = cb._providers[PROVIDER]
+        assert ps.last_429_retry_after is None
+
+    def test_retry_after_updates_on_subsequent_failure(self, fresh_breaker):
+        cb = fresh_breaker
+        cb.record_failure(PROVIDER, status_code=429, retry_after=60)
+        cb.record_failure(PROVIDER, status_code=429, retry_after=300)
+        ps = cb._providers[PROVIDER]
+        assert ps.last_429_retry_after == 300
+
+    def test_retry_after_zero_does_not_store(self, fresh_breaker):
+        """retry_after=0 is falsy and should not be stored."""
+        cb = fresh_breaker
+        cb.record_failure(PROVIDER, status_code=429, retry_after=0)
+        ps = cb._providers[PROVIDER]
+        assert ps.last_429_retry_after is None
+
+    def test_large_retry_after_still_recorded(self, fresh_breaker):
+        cb = fresh_breaker
+        cb.record_failure(PROVIDER, status_code=429, retry_after=3600)
+        cb.record_failure(PROVIDER, status_code=429, retry_after=3600)
+        ps = cb._providers[PROVIDER]
+        assert ps.last_429_retry_after == 3600
+        assert ps.state == CircuitState.OPEN
+
+
+# ---------------------------------------------------------------------------
+# 3. Half-open probe selection
+# ---------------------------------------------------------------------------
+
+class TestHalfOpenProbe:
+    """After reset_timeout, breaker enters half_open and allows one probe."""
+
+    def _trip_breaker(self, cb, provider=PROVIDER):
+        """Helper to trip the breaker open."""
+        for _ in range(cb.failure_threshold):
+            cb.record_failure(provider, status_code=429)
+
+    def test_transitions_to_half_open_after_timeout(self, fresh_breaker):
+        cb = fresh_breaker
+        cb.reset_timeout = 1  # 1 second for fast testing
+        self._trip_breaker(cb)
+        assert cb.should_use_fallback(PROVIDER) is True
+
+        time.sleep(1.1)
+
+        # Next check should transition to half-open and allow the probe
+        result = cb.should_use_fallback(PROVIDER, session_key="probe-session")
+        assert result is False  # probe is allowed through
+        assert cb._providers[PROVIDER].state == CircuitState.HALF_OPEN
+
+    def test_probe_session_allowed_others_blocked(self, fresh_breaker):
+        cb = fresh_breaker
+        cb.reset_timeout = 0  # immediate transition for testing
+        self._trip_breaker(cb)
+
+        # First caller becomes the probe session
+        assert cb.should_use_fallback(PROVIDER, session_key="probe-session") is False
+        assert cb._providers[PROVIDER].state == CircuitState.HALF_OPEN
+        assert cb._providers[PROVIDER].half_open_probe_session == "probe-session"
+
+        # Other sessions are still blocked
+        assert cb.should_use_fallback(PROVIDER, session_key="other-session") is True
+
+        # Probe session is still allowed
+        assert cb.should_use_fallback(PROVIDER, session_key="probe-session") is False
+
+    def test_half_open_failure_returns_to_open(self, fresh_breaker):
+        cb = fresh_breaker
+        cb.reset_timeout = 0
+        self._trip_breaker(cb)
+
+        # Transition to half-open
+        cb.should_use_fallback(PROVIDER, session_key="probe-session")
+        assert cb._providers[PROVIDER].state == CircuitState.HALF_OPEN
+
+        # Probe fails
+        cb.record_failure(PROVIDER, status_code=429)
+        assert cb._providers[PROVIDER].state == CircuitState.OPEN
+        assert cb._providers[PROVIDER].half_open_probe_session is None
+
+    def test_half_open_success_closes_circuit(self, fresh_breaker):
+        cb = fresh_breaker
+        cb.reset_timeout = 0
+        self._trip_breaker(cb)
+
+        # Transition to half-open
+        cb.should_use_fallback(PROVIDER, session_key="probe-session")
+        assert cb._providers[PROVIDER].state == CircuitState.HALF_OPEN
+
+        # Probe succeeds
+        cb.record_success(PROVIDER)
+        assert cb._providers[PROVIDER].state == CircuitState.CLOSED
+        assert cb._providers[PROVIDER].failure_count == 0
+
+    def test_probe_session_cleared_on_success(self, fresh_breaker):
+        cb = fresh_breaker
+        cb.reset_timeout = 0
+        self._trip_breaker(cb)
+
+        cb.should_use_fallback(PROVIDER, session_key="probe-session")
+        cb.record_success(PROVIDER)
+        assert cb._providers[PROVIDER].half_open_probe_session is None
+
+    def test_half_open_empty_session_key(self, fresh_breaker):
+        """Default empty session key works for probe selection."""
+        cb = fresh_breaker
+        cb.reset_timeout = 0
+        self._trip_breaker(cb)
+
+        # Probe with empty session key — implementation uses a sentinel for anonymous probes
+        result = cb.should_use_fallback(PROVIDER, session_key="")
+        assert result is False
+        assert cb._providers[PROVIDER].half_open_probe_session is not None
+
+
+# ---------------------------------------------------------------------------
+# 4. Success resets
+# ---------------------------------------------------------------------------
+
+class TestSuccessResets:
+    """Successful calls close the circuit and reset all state."""
+
+    def test_success_resets_closed_circuit(self, fresh_breaker):
+        cb = fresh_breaker
+        cb.record_failure(PROVIDER, status_code=500)
+        assert cb._providers[PROVIDER].failure_count == 1
+        cb.record_success(PROVIDER)
+        ps = cb._providers[PROVIDER]
+        assert ps.state == CircuitState.CLOSED
+        assert ps.failure_count == 0
+        assert ps.last_failure_at == 0.0
+
+    def test_success_closes_open_circuit(self, fresh_breaker):
+        cb = fresh_breaker
+        for _ in range(cb.failure_threshold):
+            cb.record_failure(PROVIDER, status_code=429)
+        assert cb._providers[PROVIDER].state == CircuitState.OPEN
+
+        cb.record_success(PROVIDER)
+        ps = cb._providers[PROVIDER]
+        assert ps.state == CircuitState.CLOSED
+        assert ps.failure_count == 0
+        assert ps.opened_at == 0.0
+        assert ps.last_429_retry_after is None
+
+    def test_success_on_unknown_provider_creates_closed(self, fresh_breaker):
+        cb = fresh_breaker
+        cb.record_success("new-provider")
+        ps = cb._providers["new-provider"]
+        assert ps.state == CircuitState.CLOSED
+        assert ps.failure_count == 0
+
+    def test_success_clears_retry_after(self, fresh_breaker):
+        cb = fresh_breaker
+        cb.record_failure(PROVIDER, status_code=429, retry_after=600)
+        cb.record_failure(PROVIDER, status_code=429, retry_after=600)
+        assert cb._providers[PROVIDER].last_429_retry_after == 600
+
+        cb.record_success(PROVIDER)
+        assert cb._providers[PROVIDER].last_429_retry_after is None
+
+    def test_should_use_fallback_false_after_success(self, fresh_breaker):
+        cb = fresh_breaker
+        for _ in range(cb.failure_threshold):
+            cb.record_failure(PROVIDER, status_code=429)
+        assert cb.should_use_fallback(PROVIDER) is True
+
+        cb.record_success(PROVIDER)
+        assert cb.should_use_fallback(PROVIDER) is False
+
+
+# ---------------------------------------------------------------------------
+# 5. Concurrent access patterns
+# ---------------------------------------------------------------------------
+
+class TestConcurrentAccess:
+    """Multiple threads recording failures/successes simultaneously."""
+
+    def test_concurrent_failures_trip_breaker(self, fresh_breaker):
+        cb = fresh_breaker
+        cb.configure(failure_threshold=10)
+        barrier = threading.Barrier(10)
+        errors = []
+
+        def record_failures():
+            try:
+                barrier.wait(timeout=5)
+                cb.record_failure(PROVIDER, status_code=429)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=record_failures) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert not errors
+        ps = cb._providers[PROVIDER]
+        assert ps.failure_count == 10
+        assert ps.state == CircuitState.OPEN
+
+    def test_concurrent_success_and_failure(self, fresh_breaker):
+        cb = fresh_breaker
+        cb.configure(failure_threshold=50)
+        barrier = threading.Barrier(20)
+        errors = []
+
+        def record_failure_task():
+            try:
+                barrier.wait(timeout=5)
+                cb.record_failure(PROVIDER, status_code=429)
+            except Exception as e:
+                errors.append(e)
+
+        def record_success_task():
+            try:
+                barrier.wait(timeout=5)
+                cb.record_success(PROVIDER)
+            except Exception as e:
+                errors.append(e)
+
+        threads = []
+        for i in range(20):
+            if i % 2 == 0:
+                threads.append(threading.Thread(target=record_failure_task))
+            else:
+                threads.append(threading.Thread(target=record_success_task))
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert not errors
+        # State should be consistent — either closed or open, no corruption
+        ps = cb._providers[PROVIDER]
+        assert ps.state in (CircuitState.CLOSED, CircuitState.OPEN)
+
+    def test_concurrent_should_use_fallback(self, fresh_breaker):
+        cb = fresh_breaker
+        # Trip the breaker first
+        for _ in range(cb.failure_threshold):
+            cb.record_failure(PROVIDER, status_code=429)
+
+        results = []
+        barrier = threading.Barrier(10)
+        errors = []
+
+        def check_fallback(session):
+            try:
+                barrier.wait(timeout=5)
+                result = cb.should_use_fallback(PROVIDER, session_key=session)
+                results.append(result)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [
+            threading.Thread(target=check_fallback, args=(f"session-{i}",))
+            for i in range(10)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert not errors
+        assert len(results) == 10
+
+    def test_no_deadlocks_under_contention(self, fresh_breaker):
+        """Rapid mixed operations must not deadlock."""
+        cb = fresh_breaker
+        cb.configure(failure_threshold=5)
+        barrier = threading.Barrier(30)
+        errors = []
+
+        def mixed_ops(thread_id):
+            try:
+                barrier.wait(timeout=5)
+                for _ in range(100):
+                    cb.should_use_fallback(PROVIDER, session_key=f"s-{thread_id}")
+                    cb.record_failure(PROVIDER, status_code=429)
+                    cb.record_success(PROVIDER)
+                    cb.get_status()
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=mixed_ops, args=(i,)) for i in range(30)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+
+        assert not errors
+
+
+# ---------------------------------------------------------------------------
+# 6. configure() method
+# ---------------------------------------------------------------------------
+
+class TestConfigure:
+    """Setting custom thresholds via configure()."""
+
+    def test_configure_failure_threshold(self, fresh_breaker):
+        cb = fresh_breaker
+        cb.configure(failure_threshold=5)
+        assert cb.failure_threshold == 5
+
+        # Should not trip after 4 failures
+        for _ in range(4):
+            cb.record_failure(PROVIDER, status_code=429)
+        assert cb.should_use_fallback(PROVIDER) is False
+
+        # Trips on 5th
+        cb.record_failure(PROVIDER, status_code=429)
+        assert cb.should_use_fallback(PROVIDER) is True
+
+    def test_configure_reset_timeout(self, fresh_breaker):
+        cb = fresh_breaker
+        cb.configure(reset_timeout=1)
+        assert cb.reset_timeout == 1
+
+        for _ in range(cb.failure_threshold):
+            cb.record_failure(PROVIDER, status_code=429)
+        assert cb.should_use_fallback(PROVIDER) is True
+
+        time.sleep(1.1)
+        # Should now transition to half-open
+        assert cb.should_use_fallback(PROVIDER, session_key="probe") is False
+
+    def test_configure_partial_update(self, fresh_breaker):
+        cb = fresh_breaker
+        original_timeout = cb.reset_timeout
+        cb.configure(failure_threshold=10)
+        assert cb.failure_threshold == 10
+        assert cb.reset_timeout == original_timeout  # unchanged
+
+    def test_configure_none_values_ignored(self, fresh_breaker):
+        cb = fresh_breaker
+        original_threshold = cb.failure_threshold
+        original_timeout = cb.reset_timeout
+        cb.configure(failure_threshold=None, reset_timeout=None)
+        assert cb.failure_threshold == original_threshold
+        assert cb.reset_timeout == original_timeout
+
+    def test_configure_both_values(self, fresh_breaker):
+        cb = fresh_breaker
+        cb.configure(failure_threshold=10, reset_timeout=600)
+        assert cb.failure_threshold == 10
+        assert cb.reset_timeout == 600
+
+
+# ---------------------------------------------------------------------------
+# 7. Singleton behavior
+# ---------------------------------------------------------------------------
+
+class TestSingleton:
+    """get_instance() returns the same object."""
+
+    def test_get_instance_returns_same_object(self, fresh_breaker):
+        a = ProviderCircuitBreaker.get_instance()
+        b = ProviderCircuitBreaker.get_instance()
+        assert a is b
+
+    def test_singleton_shares_state(self, fresh_breaker):
+        a = ProviderCircuitBreaker.get_instance()
+        a.record_failure(PROVIDER, status_code=429)
+
+        b = ProviderCircuitBreaker.get_instance()
+        assert b._providers[PROVIDER].failure_count == 1
+
+
+# ---------------------------------------------------------------------------
+# 8. get_status() output
+# ---------------------------------------------------------------------------
+
+class TestGetStatus:
+    """get_status() returns well-formed status dicts."""
+
+    def test_empty_status(self, fresh_breaker):
+        cb = fresh_breaker
+        assert cb.get_status() == {}
+
+    def test_closed_status(self, fresh_breaker):
+        cb = fresh_breaker
+        cb.record_failure(PROVIDER, status_code=500)
+        status = cb.get_status()
+        assert PROVIDER in status
+        info = status[PROVIDER]
+        assert info["state"] == "closed"
+        assert info["failures"] == 1
+        assert info["open_since"] is None
+        assert info["reset_in"] is None
+
+    def test_open_status(self, fresh_breaker):
+        cb = fresh_breaker
+        for _ in range(cb.failure_threshold):
+            cb.record_failure(PROVIDER, status_code=429)
+        status = cb.get_status()
+        info = status[PROVIDER]
+        assert info["state"] == "open"
+        assert info["failures"] == cb.failure_threshold
+        assert info["open_since"] is not None
+        assert info["reset_in"] is not None
+        assert info["reset_in"] > 0
+
+    def test_multiple_providers_status(self, fresh_breaker):
+        cb = fresh_breaker
+        cb.record_failure("anthropic", status_code=429)
+        cb.record_failure("openai", status_code=429)
+        status = cb.get_status()
+        assert "anthropic" in status
+        assert "openai" in status
+
+    def test_status_after_success_reset(self, fresh_breaker):
+        cb = fresh_breaker
+        for _ in range(cb.failure_threshold):
+            cb.record_failure(PROVIDER, status_code=429)
+        cb.record_success(PROVIDER)
+        status = cb.get_status()
+        info = status[PROVIDER]
+        assert info["state"] == "closed"
+        assert info["failures"] == 0
+
+
+# ---------------------------------------------------------------------------
+# 9. Edge cases
+# ---------------------------------------------------------------------------
+
+class TestEdgeCases:
+    """Edge cases and boundary conditions."""
+
+    def test_record_failure_without_status_code(self, fresh_breaker):
+        cb = fresh_breaker
+        cb.record_failure(PROVIDER)  # no status_code, no retry_after
+        assert cb._providers[PROVIDER].failure_count == 1
+
+    def test_closed_provider_returns_false(self, fresh_breaker):
+        cb = fresh_breaker
+        # Never touched provider
+        assert cb.should_use_fallback("brand-new-provider") is False
+
+    def test_failure_count_persists_across_multiple_status_codes(self, fresh_breaker):
+        cb = fresh_breaker
+        cb.record_failure(PROVIDER, status_code=429)
+        cb.record_failure(PROVIDER, status_code=529)
+        assert cb._providers[PROVIDER].failure_count == 2
+        assert cb._providers[PROVIDER].state == CircuitState.OPEN
+
+    def test_last_failure_at_updated(self, fresh_breaker):
+        cb = fresh_breaker
+        before = time.time()
+        cb.record_failure(PROVIDER, status_code=429)
+        after = time.time()
+        assert before <= cb._providers[PROVIDER].last_failure_at <= after
+
+    def test_opened_at_set_when_tripped(self, fresh_breaker):
+        cb = fresh_breaker
+        before = time.time()
+        for _ in range(cb.failure_threshold):
+            cb.record_failure(PROVIDER, status_code=429)
+        after = time.time()
+        assert before <= cb._providers[PROVIDER].opened_at <= after
+
+    def test_threshold_of_one(self, fresh_breaker):
+        cb = fresh_breaker
+        cb.configure(failure_threshold=1)
+        cb.record_failure(PROVIDER, status_code=429)
+        assert cb.should_use_fallback(PROVIDER) is True

--- a/tests/gateway/test_circuit_breaker_cache.py
+++ b/tests/gateway/test_circuit_breaker_cache.py
@@ -1,0 +1,155 @@
+"""Regression tests for gateway fallback caching with the provider circuit breaker."""
+
+import importlib
+import sys
+import threading
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.session import SessionSource
+
+
+class DummyAdapter(BasePlatformAdapter):
+    def __init__(self, platform=Platform.MATRIX):
+        super().__init__(PlatformConfig(enabled=True, token="***"), platform)
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        return SendResult(success=True, message_id="msg-1")
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        return SendResult(success=True, message_id=message_id)
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+    def has_pending_interrupt(self, session_key: str) -> bool:
+        return False
+
+    def get_pending_message(self, session_key: str):
+        return None
+
+
+class FakeFallbackAgent:
+    def __init__(self, **kwargs):
+        self.model = "gpt-5.4"
+        self.provider = "openai-codex"
+        self.tools = []
+        self.session_id = kwargs.get("session_id")
+        self.context_compressor = None
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.tool_progress_callback = None
+        self.step_callback = None
+        self.stream_delta_callback = None
+        self.status_callback = None
+        self.reasoning_config = kwargs.get("reasoning_config")
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        return {
+            "final_response": "fallback ok",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class FakeCircuitBreaker:
+    def __init__(self):
+        self.calls = []
+
+    def should_use_fallback(self, provider, session_key=None):
+        self.calls.append((provider, session_key))
+        return True
+
+
+def _make_runner(adapter):
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {adapter.platform: adapter}
+    runner._voice_mode = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._running_agent_started_at = {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._effective_model = None
+    runner._effective_provider = None
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, {})
+    runner._load_reasoning_config = lambda: None
+    runner._evict_cached_agent = lambda session_key: runner._agent_cache.pop(session_key, None)
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_run_agent_keeps_cached_fallback_without_nameerror(monkeypatch, tmp_path):
+    """Regression: post-run fallback bookkeeping must not reference inner-scope turn_route."""
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeFallbackAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    fake_cb = FakeCircuitBreaker()
+    fake_cb_module = types.ModuleType("agent.circuit_breaker")
+
+    class ProviderCircuitBreaker:
+        @staticmethod
+        def get_instance():
+            return fake_cb
+
+    fake_cb_module.ProviderCircuitBreaker = ProviderCircuitBreaker
+    monkeypatch.setitem(sys.modules, "agent.circuit_breaker", fake_cb_module)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {
+        "api_key": "***",
+        "provider": "anthropic",
+        "base_url": "https://api.anthropic.com",
+    })
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda *args, **kwargs: "claude-opus-4-6")
+
+    adapter = DummyAdapter()
+    runner = _make_runner(adapter)
+    source = SessionSource(
+        platform=Platform.MATRIX,
+        chat_id="!room:example.com",
+        chat_type="dm",
+        thread_id=None,
+    )
+    session_key = "agent:main:matrix:dm:!room:example.com"
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-fallback",
+        session_key=session_key,
+    )
+
+    assert result["final_response"] == "fallback ok"
+    assert runner._effective_model == "gpt-5.4"
+    assert runner._effective_provider == "openai-codex"
+    assert session_key in runner._agent_cache
+    assert fake_cb.calls == [("anthropic", session_key)]

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -85,6 +85,7 @@ def _make_runner(adapter):
     runner._fallback_model = None
     runner._session_db = None
     runner._running_agents = {}
+    runner._running_agent_started_at = {}
     runner.hooks = SimpleNamespace(loaded_hooks=False)
     return runner
 


### PR DESCRIPTION
## Summary

Replacement for closed PR #4450.

This PR adds a **gateway-wide provider circuit breaker** and a **stale-session watchdog** to harden Hermes Agent against shared-provider rate limits and stuck long-running sessions, while also addressing the review feedback left on #4450.

The core problem is cross-session provider coordination: when multiple gateway sessions share the same provider credentials and the provider begins returning rate-limit / overload responses, every session currently re-discovers that failure independently. That leads to repeated hammering of the same provider and poor fallback behavior.

This PR introduces a process-wide circuit breaker so the gateway can coordinate provider health across sessions, preserve healthy fallback agents, and recover more intelligently.

---

## What changed

### 1. Process-wide `ProviderCircuitBreaker`

New file:
- `agent/circuit_breaker.py`

Behavior:
- shared singleton across the gateway process
- tracks provider state with `closed`, `open`, and `half_open` modes
- trips after repeated rate-limit / overload failures
- respects `Retry-After` when available
- supports half-open probe selection with session awareness
- exposes breaker state for observability

### 2. `run_agent.py` integration

The agent now:
- checks the breaker before retrying a known-bad provider
- records rate-limit / overload failures back into the breaker
- records successes to close the circuit again
- preserves `session_key` awareness for half-open probes

### 3. Fallback cache preservation in `gateway/run.py`

Previous behavior evicted fallback-activated cached agents too aggressively, causing the next message to retry the primary immediately even when the primary was still known-bad.

New behavior:
- KEEP the fallback agent cached while the breaker says the primary is still unhealthy
- evict the cached fallback agent only once the breaker indicates the primary has recovered

This stops every message from re-discovering the same provider outage from scratch.

### 4. Watchdog + status/config support

Adds:
- `circuit_breaker` config loading from `~/.hermes/config.yaml`
- breaker visibility in `/status`
- stale-session watchdog support in the gateway

---

## Review feedback from #4450 addressed

### ✅ 1. Dedicated unit tests for the circuit breaker state machine

Added:
- `tests/agent/test_circuit_breaker.py`

Coverage includes:
- threshold tripping
- `Retry-After` timeout behavior
- half-open probe selection
- success resets
- concurrent access patterns
- configuration behavior
- singleton behavior
- status serialization
- edge cases

### ✅ 2. Watchdog defaults made less aggressive

Changed defaults to:
- `enabled: false`
- `max_duration: 3600`

This makes the watchdog explicit opt-in instead of silently killing legitimate long-running sessions.

### ✅ 3. Credential pool rotation no longer bypassed by the breaker pre-check

Before falling back due to the circuit breaker, the retry loop now checks whether the credential pool still has untried credentials available. If so, pool rotation is allowed to proceed instead of prematurely short-circuiting to fallback.

This avoids treating a provider-wide breaker as if every credential in a heterogeneous pool were already exhausted.

### ✅ 4. Import removed from the hot retry loop

`ProviderCircuitBreaker` import was moved out of the hot retry loop into method scope.

---

## Additional improvement in this revision

### Fall-forward recovery when fallback also fails

If the active fallback provider also hits its usage/rate limit and the fallback chain is exhausted, the agent now checks whether the **original primary provider** has recovered according to the breaker state. If the primary is healthy again, the chain resets and the agent attempts the primary instead of failing immediately with HTTP 429.

This addresses a real operational case where the fallback becomes exhausted after the primary has already recovered.

---

## Validation

Ran:

```bash
source .venv/bin/activate
pytest tests/agent/test_circuit_breaker.py \
       tests/gateway/test_circuit_breaker_cache.py \
       tests/gateway/test_run_progress_topics.py -q -o 'addopts='
```

Result:
- **47 passed**

Also validated the live local install with compile checks and deployed the updated circuit-breaker code successfully.

---

## Notes

- Supersedes closed PR #4450
- Review response and technical rationale were already posted on #4450 for continuity
- Branch is the same: `feat/provider-circuit-breaker`
