### PR TITLE
fix: deliver cron MEDIA tags as native attachments

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -150,6 +150,7 @@ def _deliver_result(job: dict, content: str) -> None:
     chat_id = target["chat_id"]
     thread_id = target.get("thread_id")
 
+    from gateway.platforms.base import BasePlatformAdapter
     from tools.send_message_tool import _send_to_platform
     from gateway.config import load_gateway_config, Platform
 
@@ -205,8 +206,17 @@ def _deliver_result(job: dict, content: str) -> None:
     else:
         delivery_content = content
 
+    media_files, cleaned_content = BasePlatformAdapter.extract_media(delivery_content)
+
     # Run the async send in a fresh event loop (safe from any thread)
-    coro = _send_to_platform(platform, pconfig, chat_id, delivery_content, thread_id=thread_id)
+    coro = _send_to_platform(
+        platform,
+        pconfig,
+        chat_id,
+        cleaned_content,
+        thread_id=thread_id,
+        media_files=media_files,
+    )
     try:
         result = asyncio.run(coro)
     except RuntimeError:
@@ -217,7 +227,17 @@ def _deliver_result(job: dict, content: str) -> None:
         coro.close()
         import concurrent.futures
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-            future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, delivery_content, thread_id=thread_id))
+            future = pool.submit(
+                asyncio.run,
+                _send_to_platform(
+                    platform,
+                    pconfig,
+                    chat_id,
+                    cleaned_content,
+                    thread_id=thread_id,
+                    media_files=media_files,
+                ),
+            )
             result = future.result(timeout=30)
     except Exception as e:
         logger.error("Job '%s': delivery to %s:%s failed: %s", job["id"], platform_name, chat_id, e)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -234,6 +234,32 @@ class TestDeliverResultWrapping:
         assert sent_content == "Clean output only."
         assert "Cronjob Response" not in sent_content
         assert "The agent cannot see" not in sent_content
+        assert send_mock.call_args.kwargs["media_files"] == []
+
+    def test_delivery_extracts_media_before_sending(self):
+        """Cron delivery should strip MEDIA tags from text and pass attachments separately."""
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock:
+            job = {
+                "id": "test-job",
+                "name": "media-report",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+            }
+            _deliver_result(job, "Screenshot attached.\nMEDIA:/tmp/test.png")
+
+        send_mock.assert_called_once()
+        sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][3]
+        assert "MEDIA:/tmp/test.png" not in sent_content
+        assert "Screenshot attached." in sent_content
+        assert send_mock.call_args.kwargs["media_files"] == [("/tmp/test.png", False)]
 
     def test_no_mirror_to_session_call(self):
         """Cron deliveries should NOT mirror into the gateway session."""


### PR DESCRIPTION
## Summary

Cron-scheduled deliveries to Telegram were sending raw `MEDIA:/path/to/file` text instead of native image attachments. This fix routes cron delivery through the same media extraction path used by live chat responses.

## Root Cause

`_deliver_result()` in `cron/scheduler.py` (line 209) passed `delivery_content` directly to `_send_to_platform()` without extracting `MEDIA:` tags first. The live chat path handles this via `BasePlatformAdapter.extract_media()`, but the cron delivery path bypassed it entirely — so Telegram users received the literal tag string instead of an attached image.

**Evidence from gateway.error.log:**
```
WARNING gateway.platforms.base: [Telegram] Failed to send media (.png\nmedi): File not found: /tmp/analyst/charts/oil_30min.png\nMEDI
```
The error log shows the path was mangled into one long string with embedded newlines, proving the raw content was sent instead of extracting individual MEDIA lines.

## Investigation

The 2026-04-03 Argus morning scan (job `d7d7376d595b`) ran at 10:06 AM and produced a valid report with 4 charts generated in `/tmp/analyst/charts/`:
- `oil_30min.png`
- `near_7d.png`  
- `grass_7d.png`
- `silver_30min.png`

The response saved to `cron/output/d7d7376d595b/2026-04-03_10-06-05.md` shows proper MEDIA tags in the output (lines 386-389). The agent did its part perfectly — the failure was entirely in the delivery plumbing.

## Fix

- Import `BasePlatformAdapter.extract_media` in `_deliver_result()` and call it on `delivery_content` after optional wrapping.
- Pass `cleaned_content` (tags stripped) and `media_files` (extracted paths) into `_send_to_platform()` for both the normal `asyncio.run` path and the `ThreadPoolExecutor` fallback.

## Testing

- Added `test_delivery_extracts_media_before_sending` in `tests/cron/test_scheduler.py` to verify `MEDIA:` tags are stripped from sent text and forwarded as `media_files`.
- Extended the clean-output wrapping test to assert `media_files == []` when no tags are present.
- Verified locally with focused tests:
  - `source venv/bin/activate && python -m pytest tests/cron/test_scheduler.py -q -n0 -k \"TestDeliverResultWrapping\"`
  - Result: `6 passed, 34 deselected`

## Notes

- This is a targeted fix for the cron delivery path only.
- Broader scheduler test failures observed locally were pre-existing and unrelated to this change.
- Requires gateway restart after patching (the delivery logic runs in the gateway process).
- One-shot cron jobs with `deliver: "telegram"` (no chat ID) are silently skipped when `TELEGRAM_HOME_CHANNEL` env var is not set — use `deliver: "origin"` or `deliver: "telegram:<chat_id>"` for explicit targeting.