### PR TITLE
fix: remove faster-whisper from base deps in uv.lock (fixes aarch64-darwin Nix build)

### DIFF
--- a/nix/python.nix
+++ b/nix/python.nix
@@ -2,7 +2,6 @@
 {
   python311,
   lib,
-  stdenv,
   callPackage,
   uv2nix,
   pyproject-nix,
@@ -23,15 +22,7 @@ let
         pyproject-build-systems.overlays.default
         overlay
       ]);
-
-  # The "voice" extra pulls in faster-whisper → onnxruntime, which only ships
-  # wheel-only builds for macosx_14_0_arm64. uv2nix cannot match this tag on
-  # aarch64-darwin, so we exclude "voice" on Darwin and install all other extras.
-  extras =
-    if stdenv.hostPlatform.isDarwin then [
-      "messaging" "cron" "cli" "slack" "pty" "mcp"
-    ] else [ "all" ];
 in
 pythonSet.mkVirtualEnv "hermes-agent-env" {
-  hermes-agent = extras;
+  hermes-agent = [ "all" ];
 }

--- a/nix/python.nix
+++ b/nix/python.nix
@@ -3,6 +3,8 @@
   python311,
   lib,
   callPackage,
+  stdenv,
+  fetchurl,
   uv2nix,
   pyproject-nix,
   pyproject-build-systems,
@@ -14,6 +16,18 @@ let
     sourcePreference = "wheel";
   };
 
+  # uv2nix fails to match the macosx_14_0_arm64 wheel for onnxruntime on
+  # aarch64-darwin. Provide the wheel directly so platform detection is bypassed.
+  onnxruntimeOverlay = final: prev:
+    lib.optionalAttrs stdenv.hostPlatform.isDarwin {
+      onnxruntime = prev.onnxruntime.overrideAttrs (_: {
+        src = fetchurl {
+          url = "https://files.pythonhosted.org/packages/60/69/6c40720201012c6af9aa7d4ecdd620e521bd806dc6269d636fdd5c5aeebe/onnxruntime-1.24.4-cp311-cp311-macosx_14_0_arm64.whl";
+          hash = "sha256:0bdfce8e9a6497cec584aab407b71bf697dac5e1b7b7974adc50bf7533bdb3a2";
+        };
+      });
+    };
+
   pythonSet =
     (callPackage pyproject-nix.build.packages {
       python = python311;
@@ -21,6 +35,7 @@ let
       (lib.composeManyExtensions [
         pyproject-build-systems.overlays.default
         overlay
+        onnxruntimeOverlay
       ]);
 in
 pythonSet.mkVirtualEnv "hermes-agent-env" {

--- a/nix/python.nix
+++ b/nix/python.nix
@@ -29,9 +29,7 @@ let
   # aarch64-darwin, so we exclude "voice" on Darwin and install all other extras.
   extras =
     if stdenv.hostPlatform.isDarwin then [
-      "modal" "daytona" "messaging" "matrix" "cron" "cli"
-      "tts-premium" "slack" "pty" "honcho" "mcp"
-      "homeassistant" "sms" "acp" "dingtalk" "feishu"
+      "messaging" "cron" "cli" "slack" "pty" "mcp"
     ] else [ "all" ];
 in
 pythonSet.mkVirtualEnv "hermes-agent-env" {

--- a/nix/python.nix
+++ b/nix/python.nix
@@ -2,9 +2,8 @@
 {
   python311,
   lib,
-  callPackage,
   stdenv,
-  fetchurl,
+  callPackage,
   uv2nix,
   pyproject-nix,
   pyproject-build-systems,
@@ -16,18 +15,6 @@ let
     sourcePreference = "wheel";
   };
 
-  # uv2nix fails to match the macosx_14_0_arm64 wheel for onnxruntime on
-  # aarch64-darwin. Provide the wheel directly so platform detection is bypassed.
-  onnxruntimeOverlay = final: prev:
-    lib.optionalAttrs stdenv.hostPlatform.isDarwin {
-      onnxruntime = prev.onnxruntime.overrideAttrs (_: {
-        src = fetchurl {
-          url = "https://files.pythonhosted.org/packages/60/69/6c40720201012c6af9aa7d4ecdd620e521bd806dc6269d636fdd5c5aeebe/onnxruntime-1.24.4-cp311-cp311-macosx_14_0_arm64.whl";
-          hash = "sha256:0bdfce8e9a6497cec584aab407b71bf697dac5e1b7b7974adc50bf7533bdb3a2";
-        };
-      });
-    };
-
   pythonSet =
     (callPackage pyproject-nix.build.packages {
       python = python311;
@@ -35,9 +22,18 @@ let
       (lib.composeManyExtensions [
         pyproject-build-systems.overlays.default
         overlay
-        onnxruntimeOverlay
       ]);
+
+  # The "voice" extra pulls in faster-whisper → onnxruntime, which only ships
+  # wheel-only builds for macosx_14_0_arm64. uv2nix cannot match this tag on
+  # aarch64-darwin, so we exclude "voice" on Darwin and install all other extras.
+  extras =
+    if stdenv.hostPlatform.isDarwin then [
+      "modal" "daytona" "messaging" "matrix" "cron" "cli"
+      "tts-premium" "slack" "pty" "honcho" "mcp"
+      "homeassistant" "sms" "acp" "dingtalk" "feishu"
+    ] else [ "all" ];
 in
 pythonSet.mkVirtualEnv "hermes-agent-env" {
-  hermes-agent = [ "all" ];
+  hermes-agent = extras;
 }

--- a/uv.lock
+++ b/uv.lock
@@ -1606,7 +1606,6 @@ dependencies = [
     { name = "anthropic" },
     { name = "edge-tts" },
     { name = "fal-client" },
-    { name = "faster-whisper" },
     { name = "fire" },
     { name = "firecrawl-py" },
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Commit e64b0476 moved `faster-whisper` from base dependencies to the `voice` extra in `pyproject.toml` to fix Homebrew packaging, but `uv.lock` was not regenerated
- `faster-whisper` → `onnxruntime` is still listed as a base dependency in `uv.lock`, causing the Nix build to fail on `aarch64-darwin` with: `No compatible wheel, nor sdist found for package 'onnxruntime' 1.24.4`
- This breaks `nix run github:NousResearch/hermes-agent` and `nix profile install` for all macOS Apple Silicon users

## Root cause

`uv.lock` line 1609 still has `{ name = "faster-whisper" }` in the unconditional `dependencies` block for `hermes-agent`, even though `pyproject.toml` now gates it behind the `voice` extra.

## Fix

Remove `{ name = "faster-whisper" }` from the base `dependencies` block in `uv.lock` so it matches `pyproject.toml`. The proper fix is `uv lock --upgrade-package faster-whisper` or simply `uv lock`, but this minimal patch to `uv.lock` is sufficient.

## Test

```bash
nix run github:NousResearch/hermes-agent -- --version  # was failing, now works on aarch64-darwin
```