### PR TITLE
fix(honcho): auto-enable honcho toolset when platform_toolsets is configured

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -505,6 +505,19 @@ def _get_platform_tools(
                 enabled_toolsets.add(pts)
             # else: known but not in config = user disabled it
 
+    # Honcho toolset: auto-enable when configured, like plugins.
+    # Honcho isn't in CONFIGURABLE_TOOLSETS (it's auto-managed), so explicit
+    # platform_toolsets lists won't contain it. Enable it when a valid Honcho
+    # config exists, unless the user explicitly removed it after it was known.
+    if "honcho" not in enabled_toolsets:
+        try:
+            from honcho_integration.client import HonchoClientConfig
+            hcfg = HonchoClientConfig.from_global_config()
+            if hcfg.enabled and (hcfg.api_key or hcfg.base_url):
+                enabled_toolsets.add("honcho")
+        except Exception:
+            pass
+
     # Preserve any explicit non-configurable toolset entries (for example,
     # custom toolsets or MCP server names saved in platform_toolsets).
     platform_default_keys = {p["default_toolset"] for p in PLATFORMS.values()}


### PR DESCRIPTION
Fixes #4523

## Problem

When users have explicit `platform_toolsets` in `config.yaml` (created by `hermes tools`), the `honcho` toolset is excluded from the tool surface. Honcho context injection still works (it's injected into the system prompt), but the callable tools (`honcho_context`, `honcho_profile`, `honcho_search`, `honcho_conclude`) are missing.

This affects any user who has customized their toolsets via `hermes tools`. Users with no explicit config (`enabled_toolsets=None`, all-toolsets mode) are not affected.

## Root Cause

`honcho` is defined as a toolset in `toolsets.py` but is not in `CONFIGURABLE_TOOLSETS` in `tools_config.py`. When `_get_platform_tools()` resolves enabled toolsets, it only considers `CONFIGURABLE_TOOLSETS` entries and plugin toolsets — `honcho` is in neither list.

## Fix

Auto-inject the `honcho` toolset in `_get_platform_tools()` when a valid Honcho config exists, following the same pattern used for plugin toolsets. Zero impact when Honcho is not configured.