### PR TITLE
fix(gateway): seed DM thread sessions with parent transcript to preserve context

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -738,6 +738,43 @@ class SessionStore:
             except Exception as e:
                 print(f"[gateway] Warning: Failed to create SQLite session: {e}")
 
+        # Seed new DM thread sessions with parent DM session history.
+        # When a bot reply creates a Slack thread and the user responds in it,
+        # the thread gets a new session (keyed by thread_ts).  Without seeding,
+        # the thread session starts with zero context — the user's original
+        # question and the bot's answer are invisible.  Fix: copy the parent
+        # DM session's transcript into the new thread session so context carries
+        # over while still keeping threads isolated from each other.
+        if (
+            source.chat_type == "dm"
+            and source.thread_id
+            and entry.created_at == entry.updated_at  # brand-new session
+            and not was_auto_reset
+        ): 
+            parent_key = build_session_key(
+                SessionSource(
+                    platform=source.platform,
+                    chat_id=source.chat_id,
+                    chat_type="dm",
+                    user_id=source.user_id,
+                    # no thread_id — this is the parent DM session
+                ),
+                group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
+            )
+            with self._lock:
+                parent_entry = self._entries.get(parent_key)
+            if parent_entry and parent_entry.session_id != entry.session_id:
+                try:
+                    parent_history = self.load_transcript(parent_entry.session_id)
+                    if parent_history:
+                        self.rewrite_transcript(entry.session_id, parent_history)
+                        logger.info(
+                            "[Session] Seeded DM thread session %s with %d messages from parent %s",
+                            entry.session_id, len(parent_history), parent_entry.session_id,
+                        )
+                except Exception as e:
+                    logger.warning("[Session] Failed to seed thread session: %s", e)
+
         return entry
 
     def update_session(

--- a/tests/gateway/test_session_dm_thread_seeding.py
+++ b/tests/gateway/test_session_dm_thread_seeding.py
@@ -1,0 +1,221 @@
+"""Tests for DM thread session seeding.
+
+When a bot reply creates a thread in a DM (e.g. Slack), the user's reply
+in that thread gets a new session (keyed by thread_ts). The seeding logic
+copies the parent DM session's transcript into the new thread session so
+the bot retains context of the original conversation.
+
+Covers:
+- Basic seeding: parent transcript copied to new thread session
+- No seeding for group/channel chats
+- No seeding when parent session doesn't exist
+- No seeding on auto-reset sessions
+- No seeding on existing (non-new) thread sessions
+- Parent transcript is not mutated by seeding
+- Multiple threads from same parent each get independent copies
+- Cross-platform: works for any platform with DM threads (Slack, Telegram, Discord)
+"""
+
+import pytest
+from unittest.mock import patch
+
+from gateway.config import Platform, GatewayConfig
+from gateway.session import SessionSource, SessionStore, build_session_key
+
+
+@pytest.fixture()
+def store(tmp_path):
+    """SessionStore with no SQLite, for fast unit tests."""
+    config = GatewayConfig()
+    with patch("gateway.session.SessionStore._ensure_loaded"):
+        s = SessionStore(sessions_dir=tmp_path, config=config)
+    s._db = None
+    s._loaded = True
+    return s
+
+
+def _dm_source(platform=Platform.SLACK, chat_id="D123", thread_id=None, user_id="U1"):
+    return SessionSource(
+        platform=platform,
+        chat_id=chat_id,
+        chat_type="dm",
+        user_id=user_id,
+        thread_id=thread_id,
+    )
+
+
+def _group_source(platform=Platform.SLACK, chat_id="C456", thread_id=None, user_id="U1"):
+    return SessionSource(
+        platform=platform,
+        chat_id=chat_id,
+        chat_type="group",
+        user_id=user_id,
+        thread_id=thread_id,
+    )
+
+
+PARENT_HISTORY = [
+    {"role": "user", "content": "What's the weather?"},
+    {"role": "assistant", "content": "It's sunny and 72°F."},
+]
+
+
+class TestDMThreadSeeding:
+    """Core seeding behavior."""
+
+    def test_thread_session_seeded_from_parent(self, store):
+        """New DM thread session should contain the parent's transcript."""
+        # Create parent DM session with history
+        parent_source = _dm_source()
+        parent_entry = store.get_or_create_session(parent_source)
+        for msg in PARENT_HISTORY:
+            store.append_to_transcript(parent_entry.session_id, msg)
+
+        # Create thread session (user replied in thread)
+        thread_source = _dm_source(thread_id="1234567890.000001")
+        thread_entry = store.get_or_create_session(thread_source)
+
+        # Thread should have parent's history
+        thread_transcript = store.load_transcript(thread_entry.session_id)
+        assert len(thread_transcript) == 2
+        assert thread_transcript[0]["content"] == "What's the weather?"
+        assert thread_transcript[1]["content"] == "It's sunny and 72°F."
+
+    def test_parent_transcript_not_mutated(self, store):
+        """Seeding should not alter the parent session's transcript."""
+        parent_source = _dm_source()
+        parent_entry = store.get_or_create_session(parent_source)
+        for msg in PARENT_HISTORY:
+            store.append_to_transcript(parent_entry.session_id, msg)
+
+        # Create thread and add a message to it
+        thread_source = _dm_source(thread_id="1234567890.000001")
+        thread_entry = store.get_or_create_session(thread_source)
+        store.append_to_transcript(thread_entry.session_id, {
+            "role": "user", "content": "thread-only message"
+        })
+
+        # Parent should still have only its original messages
+        parent_transcript = store.load_transcript(parent_entry.session_id)
+        assert len(parent_transcript) == 2
+        assert all(m["content"] != "thread-only message" for m in parent_transcript)
+
+    def test_multiple_threads_get_independent_copies(self, store):
+        """Each thread from the same parent gets its own copy."""
+        parent_source = _dm_source()
+        parent_entry = store.get_or_create_session(parent_source)
+        for msg in PARENT_HISTORY:
+            store.append_to_transcript(parent_entry.session_id, msg)
+
+        # Thread A
+        thread_a_source = _dm_source(thread_id="1111.000001")
+        thread_a_entry = store.get_or_create_session(thread_a_source)
+        store.append_to_transcript(thread_a_entry.session_id, {
+            "role": "user", "content": "thread A message"
+        })
+
+        # Thread B
+        thread_b_source = _dm_source(thread_id="2222.000002")
+        thread_b_entry = store.get_or_create_session(thread_b_source)
+
+        # Thread B should have parent history, not thread A's additions
+        thread_b_transcript = store.load_transcript(thread_b_entry.session_id)
+        assert len(thread_b_transcript) == 2
+        assert all(m["content"] != "thread A message" for m in thread_b_transcript)
+
+        # Thread A should have parent history + its own message
+        thread_a_transcript = store.load_transcript(thread_a_entry.session_id)
+        assert len(thread_a_transcript) == 3
+
+    def test_existing_thread_session_not_reseeded(self, store):
+        """Returning to an existing thread session should not re-copy parent history."""
+        parent_source = _dm_source()
+        parent_entry = store.get_or_create_session(parent_source)
+        for msg in PARENT_HISTORY:
+            store.append_to_transcript(parent_entry.session_id, msg)
+
+        # Create thread session
+        thread_source = _dm_source(thread_id="1234567890.000001")
+        thread_entry = store.get_or_create_session(thread_source)
+        store.append_to_transcript(thread_entry.session_id, {
+            "role": "user", "content": "follow-up"
+        })
+
+        # Add more to parent after thread was created
+        store.append_to_transcript(parent_entry.session_id, {
+            "role": "user", "content": "new parent message"
+        })
+
+        # Get the same thread session again (not new — created_at != updated_at)
+        thread_entry_again = store.get_or_create_session(thread_source)
+        assert thread_entry_again.session_id == thread_entry.session_id
+
+        # Should still have 3 messages (2 seeded + 1 follow-up), not re-seeded
+        thread_transcript = store.load_transcript(thread_entry_again.session_id)
+        assert len(thread_transcript) == 3
+        assert thread_transcript[2]["content"] == "follow-up"
+
+
+class TestDMThreadSeedingEdgeCases:
+    """Edge cases and conditions where seeding should NOT happen."""
+
+    def test_no_seeding_for_group_threads(self, store):
+        """Group/channel threads should not trigger seeding."""
+        parent_source = _group_source()
+        parent_entry = store.get_or_create_session(parent_source)
+        for msg in PARENT_HISTORY:
+            store.append_to_transcript(parent_entry.session_id, msg)
+
+        thread_source = _group_source(thread_id="1234567890.000001")
+        thread_entry = store.get_or_create_session(thread_source)
+
+        thread_transcript = store.load_transcript(thread_entry.session_id)
+        assert len(thread_transcript) == 0
+
+    def test_no_seeding_without_parent_session(self, store):
+        """Thread session without a parent DM session should start empty."""
+        thread_source = _dm_source(thread_id="1234567890.000001")
+        thread_entry = store.get_or_create_session(thread_source)
+
+        thread_transcript = store.load_transcript(thread_entry.session_id)
+        assert len(thread_transcript) == 0
+
+    def test_no_seeding_with_empty_parent(self, store):
+        """If parent session exists but has no transcript, thread starts empty."""
+        parent_source = _dm_source()
+        store.get_or_create_session(parent_source)
+        # No messages appended to parent
+
+        thread_source = _dm_source(thread_id="1234567890.000001")
+        thread_entry = store.get_or_create_session(thread_source)
+
+        thread_transcript = store.load_transcript(thread_entry.session_id)
+        assert len(thread_transcript) == 0
+
+    def test_no_seeding_for_dm_without_thread_id(self, store):
+        """Top-level DMs (no thread_id) should not trigger seeding."""
+        source = _dm_source()
+        entry = store.get_or_create_session(source)
+
+        # Should just be a normal empty session
+        transcript = store.load_transcript(entry.session_id)
+        assert len(transcript) == 0
+
+
+class TestDMThreadSeedingCrossPlatform:
+    """Verify seeding works for platforms beyond Slack."""
+
+    @pytest.mark.parametrize("platform", [Platform.SLACK, Platform.TELEGRAM, Platform.DISCORD])
+    def test_seeding_works_across_platforms(self, store, platform):
+        """DM thread seeding should work for any platform that uses thread_id."""
+        parent_source = _dm_source(platform=platform)
+        parent_entry = store.get_or_create_session(parent_source)
+        for msg in PARENT_HISTORY:
+            store.append_to_transcript(parent_entry.session_id, msg)
+
+        thread_source = _dm_source(platform=platform, thread_id="thread_123")
+        thread_entry = store.get_or_create_session(thread_source)
+
+        thread_transcript = store.load_transcript(thread_entry.session_id)
+        assert len(thread_transcript) == 2
+        assert thread_transcript[0]["content"] == "What's the weather?"


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

This PR updates `gateway/session.py` to seed new DM thread sessions with the parent DM session's transcript so threaded replies don't lose conversational context.

## Problem

When I send a Slack DM to the bot, it replies in a new thread. If the user then replies in that thread, the gateway creates a new session keyed by `thread_ts`, **but that session starts completely empty**. The bot has no memory of the original question or its own answer, and thus, loses the context of the original DM and the bot's reply. 

> [!TIP]
> See screenshots below for examples

My understanding is this is what's happening:
1. Send a top-level DM to the bot → session key: `agent:main:slack:dm:{chat_id}`
2. Bot replies (Slack threads this under your message)
3. Reply to the bot in that thread → session key: `agent:main:slack:dm:{chat_id}:{thread_ts}`
4. Bot starts a brand new session with zero context: your original message and its answer are gone ❌

This affects any platform where bot replies create threads in DMs (Slack is one that I know of and happened to me, I am not sure about the other platforms. IIRC Telegram and Discord are similar).

## Solution

In `SessionStore.get_or_create_session()`, when a new DM thread session is created, look up the parent DM session (same key without `thread_id`) and copy its transcript into the new thread session via `rewrite_transcript()`.

**Conditions (all must be true):**
- `chat_type == "dm"`
- `thread_id` is present
- Session is brand-new (`created_at == updated_at`)
- Not an auto-reset (stale session expiry)

This preserves context while keeping threads fully isolated from each other going forward.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

n/a

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- **`gateway/session.py`**: Add seeding logic after session creation in `get_or_create_session()`
- **`tests/gateway/test_session_dm_thread_seeding.py`**: 11 new tests

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

> [!TIP]
> See screenshots below for examples of the before & after 

**Before fix:**

1. Send DM: "Remember the word 'banana'"
2. Bot replies in thread, acknowledging the word
3. Reply in that thread asking for the word => it will not know what word you're referring to ❌
4. Start a *new* top-level DM: "What word did I tell you to remember?"
5. Bot should **not** know, since sessions are isolated

**After fix:**

1. Send DM: "Remember the word 'banana'"
2. Bot replies in thread, acknowledging the word
3. Reply in that thread asking for the word => it will reply with "banana" ✅
4. Start a *new* top-level DM: "What word did I tell you to remember?"
5. Bot should **not** know, since sessions are still isolated ✅

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
  - There were 58 failures and 10 errors, but these are pre-existing on main 
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 --> Gateway running on Ubuntu 24.04.1 LTS + Slack Gateway

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

### Agent losing context in reply:

<img width="755" height="852" alt="CleanShot 2026-04-01 at 22 39 44" src="https://github.com/user-attachments/assets/4a6285c3-4b26-43e2-bc3e-4be030b401ab" />


<img width="750" height="970" alt="CleanShot 2026-04-01 at 22 49 22" src="https://github.com/user-attachments/assets/4784712d-d286-4065-9192-3ebac31a769e" />

### After fix: 

<img width="478" height="314" alt="CleanShot 2026-04-01 at 22 51 39" src="https://github.com/user-attachments/assets/6c22560d-76ff-4ec2-90ab-b9b9008da6a8" />