### PR TITLE
fix(gateway): auto-approve first user when no auth is configured

### DIFF
--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -94,6 +94,11 @@ class PairingStore:
         approved = self._load_json(self._approved_path(platform))
         return user_id in approved
 
+    def has_approved_users(self, platform: str) -> bool:
+        """Check if any users have been approved on a platform."""
+        approved = self._load_json(self._approved_path(platform))
+        return bool(approved)
+
     def list_approved(self, platform: str = None) -> list:
         """List approved users, optionally filtered by platform."""
         results = []

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1641,7 +1641,22 @@ class GatewayRunner:
 
         if not platform_allowlist and not global_allowlist:
             # No allowlists configured -- check global allow-all flag
-            return os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes")
+            if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in ("true", "1", "yes"):
+                return True
+            # No auth configured at all -- auto-approve the first user on this
+            # platform so the bot owner doesn't hit a chicken-and-egg problem
+            # ("ask the bot owner to approve" when you ARE the bot owner).
+            platform_name = source.platform.value if source.platform else ""
+            if platform_name and not self.pairing_store.has_approved_users(platform_name):
+                self.pairing_store._approve_user(
+                    platform_name, user_id, source.user_name or ""
+                )
+                logger.info(
+                    "Auto-approved first user %s (%s) on %s (no auth configured)",
+                    user_id, source.user_name, platform_name,
+                )
+                return True
+            return False
 
         # Check if user is in any allowlist
         allowed_ids = set()

--- a/tests/gateway/test_pairing.py
+++ b/tests/gateway/test_pairing.py
@@ -152,6 +152,27 @@ class TestMaxPending:
 # ---------------------------------------------------------------------------
 
 
+class TestHasApprovedUsers:
+    def test_no_approved_users(self, tmp_path):
+        with patch("gateway.pairing.PAIRING_DIR", tmp_path):
+            store = PairingStore()
+            assert store.has_approved_users("telegram") is False
+
+    def test_has_approved_users_after_approval(self, tmp_path):
+        with patch("gateway.pairing.PAIRING_DIR", tmp_path):
+            store = PairingStore()
+            code = store.generate_code("telegram", "user1", "Alice")
+            store.approve_code("telegram", code)
+            assert store.has_approved_users("telegram") is True
+
+    def test_has_approved_users_platform_isolated(self, tmp_path):
+        with patch("gateway.pairing.PAIRING_DIR", tmp_path):
+            store = PairingStore()
+            code = store.generate_code("telegram", "user1", "Alice")
+            store.approve_code("telegram", code)
+            assert store.has_approved_users("discord") is False
+
+
 class TestApprovalFlow:
     def test_approve_valid_code(self, tmp_path):
         with patch("gateway.pairing.PAIRING_DIR", tmp_path):

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -90,6 +90,87 @@ def test_whatsapp_lid_user_matches_phone_allowlist_via_session_mapping(monkeypat
     assert runner._is_user_authorized(source) is True
 
 
+def test_auto_approve_first_user_when_no_auth_configured(monkeypatch, tmp_path):
+    """When no auth mechanism is configured and no users are approved,
+    the first user to DM is auto-approved (bot-owner bootstrap)."""
+    _clear_auth_env(monkeypatch)
+    from gateway.pairing import PairingStore
+    from unittest.mock import patch as _patch
+
+    config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")},
+    )
+    runner, _adapter = _make_runner(Platform.TELEGRAM, config)
+    # Use a real PairingStore so auto-approve writes persist
+    with _patch("gateway.pairing.PAIRING_DIR", tmp_path):
+        runner.pairing_store = PairingStore()
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="owner123",
+            chat_id="owner123",
+            user_name="Owner",
+            chat_type="dm",
+        )
+        assert runner._is_user_authorized(source) is True
+        assert runner.pairing_store.is_approved("telegram", "owner123") is True
+
+
+def test_second_user_not_auto_approved(monkeypatch, tmp_path):
+    """After the first user is auto-approved, subsequent users must pair."""
+    _clear_auth_env(monkeypatch)
+    from gateway.pairing import PairingStore
+    from unittest.mock import patch as _patch
+
+    config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")},
+    )
+    runner, _adapter = _make_runner(Platform.TELEGRAM, config)
+    with _patch("gateway.pairing.PAIRING_DIR", tmp_path):
+        runner.pairing_store = PairingStore()
+        # First user auto-approved
+        source1 = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="owner123",
+            chat_id="owner123",
+            user_name="Owner",
+            chat_type="dm",
+        )
+        assert runner._is_user_authorized(source1) is True
+
+        # Second user is NOT auto-approved
+        source2 = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="stranger456",
+            chat_id="stranger456",
+            user_name="Stranger",
+            chat_type="dm",
+        )
+        assert runner._is_user_authorized(source2) is False
+
+
+def test_no_auto_approve_when_allowlist_configured(monkeypatch, tmp_path):
+    """Auto-approve should not trigger when an allowlist env var is set."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "someone_else")
+    from gateway.pairing import PairingStore
+    from unittest.mock import patch as _patch
+
+    config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")},
+    )
+    runner, _adapter = _make_runner(Platform.TELEGRAM, config)
+    with _patch("gateway.pairing.PAIRING_DIR", tmp_path):
+        runner.pairing_store = PairingStore()
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="owner123",
+            chat_id="owner123",
+            user_name="Owner",
+            chat_type="dm",
+        )
+        assert runner._is_user_authorized(source) is False
+
+
 @pytest.mark.asyncio
 async def test_unauthorized_dm_pairs_by_default(monkeypatch):
     _clear_auth_env(monkeypatch)


### PR DESCRIPTION
## What does this PR do?

When no authorization mechanism is configured (no allowlists, no allow-all flags, no approved users), the first user to DM the bot is automatically approved. This fixes the chicken-and-egg problem where the bot tells you to "ask the bot owner to approve" — but you ARE the bot owner.

After the first user is auto-approved, all subsequent unknown users go through the normal pairing flow.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/pairing.py`: Added `has_approved_users(platform)` method to check if any users have been approved on a platform
- `gateway/run.py`: In `_is_user_authorized()`, auto-approve the first user when no auth is configured (no env var allowlists, no allow-all flags, no existing approved users)
- `tests/gateway/test_pairing.py`: Added `TestHasApprovedUsers` test class (3 tests)
- `tests/gateway/test_unauthorized_dm_behavior.py`: Added 3 tests covering auto-approve first user, second user denied, and allowlist-configured bypass

## How to Test

1. Start Hermes with no `TELEGRAM_ALLOWED_USERS`, `GATEWAY_ALLOWED_USERS`, or allow-all env vars set
2. Send the bot a DM on Telegram
3. Verify you are auto-approved and the message goes through (no pairing code prompt)
4. Send a DM from a different Telegram account
5. Verify the second user gets the normal pairing code flow

## Checklist

### Code

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've considered cross-platform impact — or N/A