### PR TITLE
fix(security): extend secret redaction to Slack xapp, GitLab, Deepgram, Linear

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -48,6 +48,10 @@ _PREFIX_PATTERNS = [
     r"sk_[A-Za-z0-9_]{10,}",            # ElevenLabs TTS key (sk_ underscore, not sk- dash)
     r"tvly-[A-Za-z0-9]{10,}",           # Tavily search API key
     r"exa_[A-Za-z0-9]{10,}",            # Exa search API key
+    r"xapp-[A-Za-z0-9_-]{10,}",          # Slack app-level token (Socket Mode)
+    r"glpat-[A-Za-z0-9_-]{10,}",         # GitLab PAT
+    r"dp-[A-Za-z0-9]{10,}",              # Deepgram API key
+    r"lin_api_[A-Za-z0-9]{10,}",         # Linear API key
 ]
 
 # ENV assignment patterns: KEY=value where KEY contains a secret-like name


### PR DESCRIPTION
## What does this PR do?

Extends `_PREFIX_PATTERNS` in `agent/redact.py` with four token types
that were missing and could leak in plaintext through logs or LLM context:

| Token prefix | Service | Why it matters |
|---|---|---|
| `xapp-` | Slack app-level token | Used directly in Hermes Slack setup (`SLACK_APP_TOKEN`) |
| `glpat-` | GitLab PAT | Common in dev environments using GitLab |
| `dp-` | Deepgram API key | Used with Hermes voice/transcription features |
| `lin_api_` | Linear API key | Common project management integration |

The `xapp-` token is especially important: Hermes' own setup wizard
prompts users for it (`hermes setup` → Slack → "App Token (xapp-...)"),
making it highly likely to appear in user environments.

This follows the same pattern as the previous redaction expansion
(ElevenLabs, Tavily, Exa — #3920).

## Type of Change

- [x] 🔒 Security fix

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Consistent with existing `_PREFIX_PATTERNS` format
- [x] No behavior change for non-secret strings