### PR TITLE
fix(gateway): write lock files atomically to prevent corruption on crash

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -152,7 +152,11 @@ def _read_json_file(path: Path) -> Optional[dict[str, Any]]:
 
 def _write_json_file(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload))
+    # Write atomically via a temp file so a crash mid-write never leaves
+    # a partially-written (corrupt) lock file that blocks gateway restart.
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(payload))
+    tmp.replace(path)
 
 
 def _read_pid_record() -> Optional[dict]:


### PR DESCRIPTION
## What does this PR do?

`_write_json_file()` in `gateway/status.py` writes lock files using
`path.write_text()` which is not atomic. If the gateway process crashes
mid-write, the lock file is left partially written and corrupt.

On the next gateway start, `_read_json_file()` fails to parse the
corrupt JSON and returns `None` — but `acquire_scoped_lock()` then
falls through to `os.open(..., O_CREAT | O_EXCL)` which fails because
the file already exists. This leaves a ghost lock that prevents the
gateway from restarting without manual intervention.

## Fix

Write to a `.tmp` sibling file first, then use `Path.replace()` which
is atomic on POSIX systems (rename syscall). This guarantees the lock
file is either fully written or not written at all — never corrupt.
```python
# Before (non-atomic)
path.write_text(json.dumps(payload))

# After (atomic)
tmp = path.with_suffix(".tmp")
tmp.write_text(json.dumps(payload))
tmp.replace(path)
```

This is consistent with the atomic write pattern already used in
`cron/jobs.py` (`save_jobs`) and `utils.py` (`atomic_yaml_write`).

## Type of Change

- [x] 🐛 Bug fix (reliability)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Consistent with existing atomic write pattern in Hermes
- [x] No behavior change under normal operation
- [x] Prevents ghost locks after gateway crash