### PR TITLE
fix(deps): remove [e2e] extra from matrix-nio to fix python-olm build failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "py
 messaging = ["python-telegram-bot>=22.6,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]
 cron = ["croniter>=6.0.0,<7"]
 slack = ["slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]
-matrix = ["matrix-nio[e2e]>=0.24.0,<1"]
+matrix = ["matrix-nio>=0.24.0,<1"]  # E2EE: install libolm system-wide (brew install libolm / apt install libolm-dev), then pip install python-olm
 cli = ["simple-term-menu>=1.0,<2"]
 tts-premium = ["elevenlabs>=1.0,<2"]
 voice = [

--- a/uv.lock
+++ b/uv.lock
@@ -1675,7 +1675,7 @@ honcho = [
     { name = "honcho-ai" },
 ]
 matrix = [
-    { name = "matrix-nio", extra = ["e2e"] },
+    { name = "matrix-nio" },
 ]
 mcp = [
     { name = "mcp" },
@@ -1757,7 +1757,7 @@ requires-dist = [
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = ">=2.0.1,<3" },
     { name = "httpx", specifier = ">=0.28.1,<1" },
     { name = "jinja2", specifier = ">=3.1.5,<4" },
-    { name = "matrix-nio", extras = ["e2e"], marker = "extra == 'matrix'", specifier = ">=0.24.0,<1" },
+    { name = "matrix-nio", marker = "extra == 'matrix'", specifier = ">=0.24.0,<1" },
     { name = "mcp", marker = "extra == 'dev'", specifier = ">=1.2.0,<2" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.2.0,<2" },
     { name = "modal", marker = "extra == 'modal'", specifier = ">=1.0.0,<2" },


### PR DESCRIPTION
## Problem

`hermes update` fails to build `python-olm==3.2.16` on macOS (and any system with CMake 4+):

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
```

`python-olm` is an archived package whose CMakeLists.txt requires CMake < 3.5 compat, which CMake 4+ removed. It gets pulled in transitively via `matrix-nio[e2e]`.

## Fix

Remove the `[e2e]` extra from the matrix dependency in pyproject.toml. The base `matrix-nio` package works fine for unencrypted Matrix rooms. Users who need E2EE can:
1. Install libolm system-wide (`brew install libolm` / `apt install libolm-dev`)
2. Then `pip install python-olm` manually

Also updated uv.lock to match.