### PR TITLE
fix(state): quote dotted terms in FTS5 queries

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1009,8 +1009,9 @@ class SessionDB:
         Strategy:
         - Preserve properly paired quoted phrases (``"exact phrase"``)
         - Strip unmatched FTS5-special characters that would cause errors
-        - Wrap unquoted hyphenated terms in quotes so FTS5 matches them
-          as exact phrases instead of splitting on the hyphen
+        - Wrap unquoted hyphenated and dotted terms in quotes so FTS5
+          matches them as exact phrases instead of splitting on the
+          hyphen/dot (e.g. ``chat-send``, ``P2.2``, ``my-app.config.ts``)
         """
         # Step 1: Extract balanced double-quoted phrases and protect them
         # from further processing via numbered placeholders.
@@ -1035,17 +1036,13 @@ class SessionDB:
         sanitized = re.sub(r"(?i)^(AND|OR|NOT)\b\s*", "", sanitized.strip())
         sanitized = re.sub(r"(?i)\s+(AND|OR|NOT)\s*$", "", sanitized.strip())
 
-        # Step 5: Wrap unquoted dotted terms (e.g. ``P2.2``, ``simulate.p2.test.ts``)
-        # in double quotes. In practice, FTS5 query parsing can treat dots as
-        # syntax boundaries, which may produce OperationalError or zero results.
-        # Quoting forces phrase semantics and avoids query parse edge cases.
-        sanitized = re.sub(r"\b([\w-]+(?:\.[\w-]+)+)\b", r'"\1"', sanitized)
-
-        # Step 6: Wrap unquoted hyphenated terms (e.g. ``chat-send``) in
-        # double quotes.  FTS5's tokenizer splits on hyphens, turning
-        # ``chat-send`` into ``chat AND send``.  Quoting preserves the
-        # intended phrase match.
-        sanitized = re.sub(r"\b(\w+(?:-\w+)+)\b", r'"\1"', sanitized)
+        # Step 5: Wrap unquoted dotted and/or hyphenated terms in double
+        # quotes.  FTS5's tokenizer splits on dots and hyphens, turning
+        # ``chat-send`` into ``chat AND send`` and ``P2.2`` into ``p2 AND 2``.
+        # Quoting preserves phrase semantics.  A single pass avoids the
+        # double-quoting bug that would occur if dotted and hyphenated
+        # patterns were applied sequentially (e.g. ``my-app.config``).
+        sanitized = re.sub(r"\b(\w+(?:[.-]\w+)+)\b", r'"\1"', sanitized)
 
         # Step 6: Restore preserved quoted phrases
         for i, quoted in enumerate(_quoted_parts):

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1035,7 +1035,13 @@ class SessionDB:
         sanitized = re.sub(r"(?i)^(AND|OR|NOT)\b\s*", "", sanitized.strip())
         sanitized = re.sub(r"(?i)\s+(AND|OR|NOT)\s*$", "", sanitized.strip())
 
-        # Step 5: Wrap unquoted hyphenated terms (e.g. ``chat-send``) in
+        # Step 5: Wrap unquoted dotted terms (e.g. ``P2.2``, ``simulate.p2.test.ts``)
+        # in double quotes. In practice, FTS5 query parsing can treat dots as
+        # syntax boundaries, which may produce OperationalError or zero results.
+        # Quoting forces phrase semantics and avoids query parse edge cases.
+        sanitized = re.sub(r"\b([\w-]+(?:\.[\w-]+)+)\b", r'"\1"', sanitized)
+
+        # Step 6: Wrap unquoted hyphenated terms (e.g. ``chat-send``) in
         # double quotes.  FTS5's tokenizer splits on hyphens, turning
         # ``chat-send`` into ``chat AND send``.  Quoting preserves the
         # intended phrase match.

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -474,6 +474,10 @@ class TestFTS5Search:
         assert '"P2.2"' in result
         assert '"simulate.p2"' in result
 
+        # Mixed dots and hyphens — single pass avoids double-quoting
+        assert s('my-app.config') == '"my-app.config"'
+        assert s('my-app.config.ts') == '"my-app.config.ts"'
+
 
 # =========================================================================
 # Session search and listing

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -376,6 +376,20 @@ class TestFTS5Search:
         assert any("chat-send" in (r.get("snippet") or r.get("content", "")).lower()
                     for r in results)
 
+    def test_search_dotted_term_does_not_crash(self, db):
+        """Dotted terms like 'P2.2' or 'simulate.p2.test.ts' should not crash FTS5."""
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="Working on P2.2 session_search edge cases")
+        db.append_message("s1", role="assistant", content="See simulate.p2.test.ts for details")
+
+        results = db.search_messages("P2.2")
+        assert isinstance(results, list)
+        assert len(results) >= 1
+
+        results2 = db.search_messages("simulate.p2.test.ts")
+        assert isinstance(results2, list)
+        assert len(results2) >= 1
+
     def test_search_quoted_phrase_preserved(self, db):
         """User-provided quoted phrases should be preserved for exact matching."""
         db.create_session(session_id="s1", source="cli")
@@ -442,6 +456,23 @@ class TestFTS5Search:
         assert s('"chat-send"') == '"chat-send"'
         # Hyphenated inside a quoted phrase stays as-is
         assert s('"my chat-send thing"') == '"my chat-send thing"'
+
+    def test_sanitize_fts5_quotes_dotted_terms(self):
+        """Dotted terms should be wrapped in quotes to avoid FTS5 query parse edge cases."""
+        from hermes_state import SessionDB
+        s = SessionDB._sanitize_fts5_query
+
+        assert s('P2.2') == '"P2.2"'
+        assert s('simulate.p2') == '"simulate.p2"'
+        assert s('simulate.p2.test.ts') == '"simulate.p2.test.ts"'
+
+        # Already quoted — no double quoting
+        assert s('"P2.2"') == '"P2.2"'
+
+        # Works with boolean syntax
+        result = s('P2.2 OR simulate.p2')
+        assert '"P2.2"' in result
+        assert '"simulate.p2"' in result
 
 
 # =========================================================================


### PR DESCRIPTION
## Summary

Salvage of PR #4246 by @lumethegreat — cherry-picked onto current main with a bug fix.

**What changed:** `_sanitize_fts5_query()` now wraps dotted tokens (e.g. `P2.2`, `simulate.p2.test.ts`) in double quotes so FTS5 treats them as phrase matches instead of splitting on dots.

**Bug fixed during salvage:** The original PR applied dotted and hyphenated quoting in two sequential regex steps. For terms containing both dots and hyphens (e.g. `my-app.config.ts`), the second step would re-match inside the already-quoted output from step one, producing malformed double-quoted FTS5 syntax like `""my-app".config.ts"`. Merged both patterns into a single regex pass: `\w+(?:[.-]\w+)+`.

## Files changed
- `hermes_state.py` — combined regex in `_sanitize_fts5_query()`, updated docstring
- `tests/test_hermes_state.py` — contributor's dotted-term tests + new mixed dot-hyphen test

## Test results
- `pytest tests/test_hermes_state.py` — 134 passed
- E2E verified: dotted, hyphenated, and mixed terms all produce correct FTS5 queries and return expected search results