### PR TITLE
fix: preserve allowed_users during setup and quiet unconfigured provider warnings

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1078,9 +1078,9 @@ def resolve_provider_client(
             tried_sources = list(pconfig.api_key_env_vars)
             if provider == "copilot":
                 tried_sources.append("gh auth token")
-            logger.warning("resolve_provider_client: provider %s has no API "
-                           "key configured (tried: %s)",
-                           provider, ", ".join(tried_sources))
+            logger.debug("resolve_provider_client: provider %s has no API "
+                         "key configured (tried: %s)",
+                         provider, ", ".join(tried_sources))
             return None, None
 
         base_url = str(creds.get("base_url", "")).strip().rstrip("/") or pconfig.inference_base_url

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1808,13 +1808,22 @@ def setup_gateway(config: dict):
             print_info("   1. Message @userinfobot on Telegram")
             print_info("   2. It will reply with your numeric ID (e.g., 123456789)")
             print()
+            existing_allowlist = get_env_value("TELEGRAM_ALLOWED_USERS")
+            if existing_allowlist:
+                print_info(f"   Current allowlist: {existing_allowlist}")
             allowed_users = prompt(
-                "Allowed user IDs (comma-separated, leave empty for open access)"
+                "Allowed user IDs (comma-separated, leave empty to "
+                + ("keep current" if existing_allowlist else "allow open access")
+                + ")"
             )
             if allowed_users:
                 save_env_value("TELEGRAM_ALLOWED_USERS", allowed_users.replace(" ", ""))
                 print_success(
                     "Telegram allowlist configured - only listed users can use the bot"
+                )
+            elif existing_allowlist:
+                print_success(
+                    f"Keeping existing Telegram allowlist: {existing_allowlist}"
                 )
             else:
                 print_info(
@@ -1887,8 +1896,13 @@ def setup_gateway(config: dict):
                 "   You can also use Discord usernames (resolved on gateway start)."
             )
             print()
+            existing_allowlist = get_env_value("DISCORD_ALLOWED_USERS")
+            if existing_allowlist:
+                print_info(f"   Current allowlist: {existing_allowlist}")
             allowed_users = prompt(
-                "Allowed user IDs or usernames (comma-separated, leave empty for open access)"
+                "Allowed user IDs or usernames (comma-separated, leave empty to "
+                + ("keep current" if existing_allowlist else "allow open access")
+                + ")"
             )
             if allowed_users:
                 # Clean up common prefixes (user:123, <@123>, <@!123>)
@@ -1903,6 +1917,10 @@ def setup_gateway(config: dict):
                         cleaned_ids.append(uid)
                 save_env_value("DISCORD_ALLOWED_USERS", ",".join(cleaned_ids))
                 print_success("Discord allowlist configured")
+            elif existing_allowlist:
+                print_success(
+                    f"Keeping existing Discord allowlist: {existing_allowlist}"
+                )
             else:
                 print_info(
                     "⚠️  No allowlist set - anyone in servers with your bot can use it!"
@@ -1999,12 +2017,21 @@ def setup_gateway(config: dict):
                 "   To find a Member ID: click a user's name → View full profile → ⋮ → Copy member ID"
             )
             print()
+            existing_allowlist = get_env_value("SLACK_ALLOWED_USERS")
+            if existing_allowlist:
+                print_info(f"   Current allowlist: {existing_allowlist}")
             allowed_users = prompt(
-                "Allowed user IDs (comma-separated, leave empty to deny everyone except paired users)"
+                "Allowed user IDs (comma-separated, leave empty to "
+                + ("keep current" if existing_allowlist else "deny everyone except paired users")
+                + ")"
             )
             if allowed_users:
                 save_env_value("SLACK_ALLOWED_USERS", allowed_users.replace(" ", ""))
                 print_success("Slack allowlist configured")
+            elif existing_allowlist:
+                print_success(
+                    f"Keeping existing Slack allowlist: {existing_allowlist}"
+                )
             else:
                 print_warning(
                     "⚠️  No Slack allowlist set - unpaired users will be denied by default."
@@ -2088,12 +2115,21 @@ def setup_gateway(config: dict):
             print_info("🔒 Security: Restrict who can use your bot")
             print_info("   Matrix user IDs look like @username:server")
             print()
+            existing_allowlist = get_env_value("MATRIX_ALLOWED_USERS")
+            if existing_allowlist:
+                print_info(f"   Current allowlist: {existing_allowlist}")
             allowed_users = prompt(
-                "Allowed user IDs (comma-separated, leave empty for open access)"
+                "Allowed user IDs (comma-separated, leave empty to "
+                + ("keep current" if existing_allowlist else "allow open access")
+                + ")"
             )
             if allowed_users:
                 save_env_value("MATRIX_ALLOWED_USERS", allowed_users.replace(" ", ""))
                 print_success("Matrix allowlist configured")
+            elif existing_allowlist:
+                print_success(
+                    f"Keeping existing Matrix allowlist: {existing_allowlist}"
+                )
             else:
                 print_info(
                     "⚠️  No allowlist set - anyone who can message the bot can use it!"
@@ -2134,12 +2170,21 @@ def setup_gateway(config: dict):
             print_info("   To find your user ID: click your avatar → Profile")
             print_info("   or use the API: GET /api/v4/users/me")
             print()
+            existing_allowlist = get_env_value("MATTERMOST_ALLOWED_USERS")
+            if existing_allowlist:
+                print_info(f"   Current allowlist: {existing_allowlist}")
             allowed_users = prompt(
-                "Allowed user IDs (comma-separated, leave empty for open access)"
+                "Allowed user IDs (comma-separated, leave empty to "
+                + ("keep current" if existing_allowlist else "allow open access")
+                + ")"
             )
             if allowed_users:
                 save_env_value("MATTERMOST_ALLOWED_USERS", allowed_users.replace(" ", ""))
                 print_success("Mattermost allowlist configured")
+            elif existing_allowlist:
+                print_success(
+                    f"Keeping existing Mattermost allowlist: {existing_allowlist}"
+                )
             else:
                 print_info(
                     "⚠️  No allowlist set - anyone who can message the bot can use it!"


### PR DESCRIPTION
## Summary
- **Setup wizard preserves `allowed_users` on reconfigure**: When reconfiguring a messaging platform (Telegram, Discord, Slack, Matrix, Mattermost), the wizard now shows the existing allowlist from `.env` and lets the user press Enter to keep it. Previously it showed a misleading "No allowlist set" warning even when the old IDs were safely preserved in `.env`.
- **Quiet unconfigured provider warnings**: Downgrades the "provider X has no API key configured" log from `WARNING` to `DEBUG` in `resolve_provider_client()`. Callers already handle the `None` return with their own contextual messages. This eliminates noisy startup warnings for providers in the fallback chain that the user never explicitly configured (e.g. minimax appearing on every fresh session).

## Test plan
- [ ] Run `hermes setup` → reconfigure an existing platform → verify existing allowlist is shown and preserved when Enter is pressed
- [ ] Run `hermes setup` → reconfigure a platform → enter new IDs → verify new IDs are saved
- [ ] Start a fresh session with an unconfigured fallback provider → verify no WARNING-level "no API key" messages in logs
- [ ] `python -m pytest tests/agent/test_auxiliary_client.py tests/test_provider_fallback.py tests/test_fallback_model.py -q` — all pass (2 pre-existing flaky failures unrelated)