### PR TITLE
fix(honcho): auto-enable honcho toolset when configured

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -547,6 +547,18 @@ def _get_platform_tools(
                 enabled_toolsets.add(pts)
             # else: known but not in config = user disabled it
 
+    # Honcho toolset: auto-enable when configured, similar to plugins.
+    # Honcho is not in CONFIGURABLE_TOOLSETS (it's enabled via `hermes honcho setup`),
+    # so it would be filtered out when platform_toolsets is explicitly configured.
+    if "honcho" not in enabled_toolsets:
+        try:
+            from honcho_integration.client import HonchoClientConfig
+            hcfg = HonchoClientConfig.from_global_config()
+            if hcfg.enabled and (hcfg.api_key or hcfg.base_url):
+                enabled_toolsets.add("honcho")
+        except Exception:
+            pass
+
     # Preserve any explicit non-configurable toolset entries (for example,
     # custom toolsets or MCP server names saved in platform_toolsets).
     platform_default_keys = {p["default_toolset"] for p in PLATFORMS.values()}

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -381,3 +381,63 @@ class TestPlatformToolsetConsistency:
                 f"Platform {platform!r} in tools_config but missing from "
                 f"skills_config PLATFORMS"
             )
+
+
+def test_get_platform_tools_auto_enables_honcho_when_configured():
+    """Honcho toolset is auto-enabled when configured, even with explicit platform_toolsets.
+
+    This ensures honcho tools are available when:
+    1. User has run `hermes tools` to customize toolset config (platform_toolsets exists)
+    2. User has run `hermes honcho setup` (valid HonchoClientConfig exists)
+
+    Regression test for https://github.com/NousResearch/hermes-agent/issues/4523
+    """
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    config = {"platform_toolsets": {"cli": ["web", "memory"]}}
+
+    # Mock HonchoClientConfig to simulate a configured Honcho instance
+    mock_config = SimpleNamespace(enabled=True, api_key="test-key", base_url="https://honcho.example.com")
+
+    with patch(
+        "honcho_integration.client.HonchoClientConfig.from_global_config",
+        return_value=mock_config,
+    ):
+        enabled = _get_platform_tools(config, "cli")
+
+    assert "honcho" in enabled, "honcho toolset should be auto-enabled when configured"
+    assert "web" in enabled, "explicitly selected toolsets should still be present"
+    assert "memory" in enabled, "explicitly selected toolsets should still be present"
+
+
+def test_get_platform_tools_does_not_enable_honcho_when_not_configured():
+    """Honcho toolset is NOT auto-enabled when not configured."""
+    from unittest.mock import patch
+
+    config = {"platform_toolsets": {"cli": ["web", "memory"]}}
+
+    # Simulate honcho_integration not being configured (import error)
+    with patch.dict("sys.modules", {"honcho_integration": None, "honcho_integration.client": None}):
+        enabled = _get_platform_tools(config, "cli")
+
+    assert "honcho" not in enabled, "honcho should not be enabled when not configured"
+
+
+def test_get_platform_tools_does_not_enable_honcho_when_disabled():
+    """Honcho toolset is NOT auto-enabled when explicitly disabled."""
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    config = {"platform_toolsets": {"cli": ["web", "memory"]}}
+
+    # Mock HonchoClientConfig with enabled=False
+    mock_config = SimpleNamespace(enabled=False, api_key="test-key", base_url="https://honcho.example.com")
+
+    with patch(
+        "honcho_integration.client.HonchoClientConfig.from_global_config",
+        return_value=mock_config,
+    ):
+        enabled = _get_platform_tools(config, "cli")
+
+    assert "honcho" not in enabled, "honcho should not be enabled when disabled in config"

--- a/uv.lock
+++ b/uv.lock
@@ -1643,7 +1643,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.7.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -1682,6 +1682,7 @@ all = [
     { name = "faster-whisper" },
     { name = "honcho-ai" },
     { name = "lark-oapi" },
+    { name = "matrix-nio", extra = ["e2e"] },
     { name = "mcp" },
     { name = "modal" },
     { name = "numpy" },
@@ -1800,6 +1801,7 @@ requires-dist = [
     { name = "hermes-agent", extras = ["feishu"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["homeassistant"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["honcho"], marker = "extra == 'all'" },
+    { name = "hermes-agent", extras = ["matrix"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["mcp"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["messaging"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["modal"], marker = "extra == 'all'" },


### PR DESCRIPTION
## Summary

When users have explicit `platform_toolsets` configured in config.yaml (created by running `hermes tools`), the Honcho tools (`honcho_context`, `honcho_profile`, `honcho_search`, `honcho_conclude`) were missing from the tool surface despite Honcho being active and context injection working correctly.

## Root Cause

The `honcho` toolset is defined in `toolsets.py` but is **not** in `CONFIGURABLE_TOOLSETS` in `hermes_cli/tools_config.py`. When `_get_platform_tools()` resolves which toolsets to enable for a platform, it only considers `CONFIGURABLE_TOOLSETS` entries (plus plugin toolsets). Since `honcho` is not in either list, it was excluded from `enabled_toolsets`.

## Fix

Auto-inject the `honcho` toolset in `_get_platform_tools()` when a valid Honcho config exists (enabled=True with api_key or base_url set), following the same pattern used for plugin toolsets.

## Changes

- Add honcho auto-enable check in `_get_platform_tools()` after plugin toolset handling
- Add tests for:
  - Honcho auto-enabled when configured
  - Honcho NOT enabled when not configured (import fails)
  - Honcho NOT enabled when explicitly disabled

## Testing

All new tests pass:
```
pytest tests/hermes_cli/test_tools_config.py -k honcho -xvs
======================== 3 passed, 3 warnings in 4.74s =========================
```

Fixes #4523