### PR TITLE
fix(tests): align run_agent expectations with current routing

### DIFF
--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -411,8 +411,9 @@ class TestInit:
             patch("run_agent.OpenAI"),
         ):
             a = AIAgent(
-                api_key="test-key-1234567890",
+                api_key="test-k...7890",
                 model="anthropic/claude-sonnet-4-20250514",
+                base_url="https://openrouter.ai/api/v1",
                 quiet_mode=True,
                 skip_context_files=True,
                 skip_memory=True,
@@ -478,7 +479,7 @@ class TestInit:
             patch("run_agent.OpenAI"),
         ):
             a = AIAgent(
-                api_key="test-key-1234567890",
+                api_key="***",
                 quiet_mode=True,
                 skip_context_files=True,
                 skip_memory=True,
@@ -792,6 +793,7 @@ class TestBuildApiKwargs:
         assert kwargs["timeout"] == 1800.0
 
     def test_provider_preferences_injected(self, agent):
+        agent.base_url = "https://openrouter.ai/api/v1"
         agent.providers_allowed = ["Anthropic"]
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
@@ -799,6 +801,8 @@ class TestBuildApiKwargs:
 
     def test_reasoning_config_default_openrouter(self, agent):
         """Default reasoning config for OpenRouter should be medium."""
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent.model = "qwen/qwen3.5-plus-02-15"
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         reasoning = kwargs["extra_body"]["reasoning"]
@@ -806,6 +810,8 @@ class TestBuildApiKwargs:
         assert reasoning["effort"] == "medium"
 
     def test_reasoning_config_custom(self, agent):
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent.model = "qwen/qwen3.5-plus-02-15"
         agent.reasoning_config = {"enabled": False}
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
@@ -818,6 +824,7 @@ class TestBuildApiKwargs:
         assert "reasoning" not in kwargs.get("extra_body", {})
 
     def test_reasoning_sent_for_supported_openrouter_model(self, agent):
+        agent.base_url = "https://openrouter.ai/api/v1"
         agent.model = "qwen/qwen3.5-plus-02-15"
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
@@ -3156,9 +3163,14 @@ class TestStreamingApiCall:
     def test_api_exception_falls_back_to_non_streaming(self, agent):
         """When streaming fails before any deltas, fallback to non-streaming is attempted."""
         agent.client.chat.completions.create.side_effect = ConnectionError("fail")
-        # The fallback also uses the same client, so it'll fail too
-        with pytest.raises(ConnectionError, match="fail"):
-            agent._interruptible_streaming_api_call({"messages": []})
+        # Request-scoped clients are now created through _create_request_openai_client.
+        # Patch it so both the streaming path and the non-streaming fallback use the
+        # same mocked client and raise the expected ConnectionError.
+        with (
+            patch.object(agent, "_create_request_openai_client", return_value=agent.client),
+            pytest.raises(ConnectionError, match="fail"),
+        ):
+            agent._interruptible_streaming_api_call({"messages": [], "model": agent.model})
 
     def test_response_has_uuid_id(self, agent):
         chunks = [_make_chunk(content="x"), _make_chunk(finish_reason="stop")]


### PR DESCRIPTION
## Summary

- make `TestBuildApiKwargs` explicitly target the current OpenRouter route/model combinations required for `extra_body` assertions
- make the Claude prompt-caching test explicitly use the OpenRouter base URL instead of relying on implicit defaults
- patch the streaming fallback test to mock the request-scoped OpenAI client factory introduced in the current `run_agent.py` path

## Problem

While validating #4552, the broader `tests/test_run_agent.py tests/test_run_agent_codex_responses.py -q` run hit unrelated failures on current `main` in `tests/test_run_agent.py`:

- `TestBuildApiKwargs::*` expected `extra_body` on a fixture that no longer explicitly targeted an OpenRouter-compatible route/model
- `TestInit.test_prompt_caching_claude_openrouter` expected Claude-via-OpenRouter prompt caching without explicitly setting the OpenRouter base URL
- `TestStreamingApiCall.test_api_exception_falls_back_to_non_streaming` only patched `agent.client`, but the current implementation now creates request-scoped clients through `_create_request_openai_client`

These were test-drift issues, not production regressions in `run_agent.py`.

## Fix

### 1. Make routing assumptions explicit in `TestBuildApiKwargs`

The `extra_body` assertions now set:
- `agent.base_url = "https://openrouter.ai/api/v1"`
- a reasoning-capable OpenRouter model where needed

This matches the current `_build_api_kwargs()` gates instead of relying on fixture defaults.

### 2. Make the Claude prompt-caching test explicitly OpenRouter

`test_prompt_caching_claude_openrouter` now passes the OpenRouter base URL directly, so it tests the intended path instead of an implicit default that has drifted.

### 3. Patch request-scoped client creation in the streaming fallback test

`test_api_exception_falls_back_to_non_streaming` now mocks `_create_request_openai_client` so both the streaming path and the non-streaming fallback use the same mocked client and raise the expected `ConnectionError`.

## Test Results

Passed:
- `python -m pytest tests/test_run_agent.py -q -k "TestBuildApiKwargs or test_prompt_caching_claude_openrouter or test_api_exception_falls_back_to_non_streaming"`
- `python -m pytest tests/test_run_agent.py tests/test_run_agent_codex_responses.py -q`

This follow-up is intentionally test-only and separate from #4552.
