### PR TITLE
fix(streaming): strip thinking blocks, prevent duplicate messages, suppress false warnings

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -30,6 +30,11 @@ from hermes_cli.config import get_hermes_home
 from hermes_constants import get_hermes_dir
 
 
+# Sentinel returned by the message handler when streaming already delivered the
+# response.  Lets _process_message_background distinguish "nothing to send"
+# (legitimate) from "handler failed" so it can log at the appropriate level.
+RESPONSE_ALREADY_STREAMED = object()
+
 GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE = (
     "Secure secret entry is not supported over messaging. "
     "Load this skill in the local CLI to be prompted, or add the key to ~/.hermes/.env manually."
@@ -1107,7 +1112,10 @@ class BasePlatformAdapter(ABC):
             response = await self._message_handler(event)
             
             # Send response if any
-            if not response:
+            if response is RESPONSE_ALREADY_STREAMED:
+                # Streaming consumer already delivered the response — nothing to send.
+                response = None
+            elif not response:
                 logger.warning("[%s] Handler returned empty/None response for %s", self.name, event.source.chat_id)
             if response:
                 # Extract MEDIA:<path> tags (from TTS tool) before other processing

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -224,7 +224,7 @@ from gateway.session import (
     build_session_key,
 )
 from gateway.delivery import DeliveryRouter
-from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, RESPONSE_ALREADY_STREAMED
 
 
 def _normalize_whatsapp_identifier(value: str) -> str:
@@ -2841,11 +2841,11 @@ class GatewayRunner:
                 await self._send_voice_reply(event, response)
 
             # If streaming already delivered the response, extract and
-            # deliver any MEDIA: files before returning None.  Streaming
-            # sends raw text chunks that include MEDIA: tags — the normal
-            # post-processing in _process_message_background is skipped
-            # when already_sent is True, so media files would never be
-            # delivered without this.
+            # deliver any MEDIA: files before returning the sentinel.
+            # Streaming sends raw text chunks that include MEDIA: tags —
+            # the normal post-processing in _process_message_background is
+            # skipped when already_sent is True, so media files would never
+            # be delivered without this.
             if agent_result.get("already_sent"):
                 if response:
                     _media_adapter = self.adapters.get(source.platform)
@@ -2853,7 +2853,7 @@ class GatewayRunner:
                         await self._deliver_media_from_response(
                             response, event, _media_adapter,
                         )
-                return None
+                return RESPONSE_ALREADY_STREAMED
 
             return response
             

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import queue
+import re
 import time
 from dataclasses import dataclass
 from typing import Any, Optional
@@ -26,6 +27,35 @@ logger = logging.getLogger("gateway.stream_consumer")
 
 # Sentinel to signal the stream is complete
 _DONE = object()
+
+# Patterns for stripping thinking/reasoning blocks from streamed content.
+# Matches complete blocks and also unclosed trailing blocks (still being generated).
+_THINK_TAGS = ("think", "thinking", "reasoning", "REASONING_SCRATCHPAD")
+_COMPLETE_THINK_RE = re.compile(
+    r'<(?:think|thinking|reasoning|REASONING_SCRATCHPAD)>.*?</(?:think|thinking|reasoning|REASONING_SCRATCHPAD)>',
+    re.DOTALL | re.IGNORECASE,
+)
+_UNCLOSED_THINK_RE = re.compile(
+    r'<(?:think|thinking|reasoning|REASONING_SCRATCHPAD)>(?:(?!</(?:think|thinking|reasoning|REASONING_SCRATCHPAD)>).)*$',
+    re.DOTALL | re.IGNORECASE,
+)
+
+
+def _strip_think_blocks(text: str) -> str:
+    """Remove complete and unclosed thinking/reasoning blocks from streamed text.
+
+    Handles both fully closed blocks like ``<think>...</think>`` and
+    partially streamed blocks where the closing tag hasn't arrived yet.
+    """
+    if not text or "<" not in text:
+        return text
+    # Strip complete blocks first
+    text = _COMPLETE_THINK_RE.sub("", text)
+    # Strip any trailing unclosed block (still being streamed)
+    text = _UNCLOSED_THINK_RE.sub("", text)
+    # Collapse excessive blank lines left behind by removed blocks
+    text = re.sub(r'\n{3,}', '\n\n', text)
+    return text.strip()
 
 
 @dataclass
@@ -116,22 +146,31 @@ class GatewayStreamConsumer:
                 )
 
                 if should_edit and self._accumulated:
-                    # Split overflow: if accumulated text exceeds the platform
+                    # Strip thinking/reasoning blocks before display
+                    display_text = _strip_think_blocks(self._accumulated)
+                    if not display_text:
+                        # All content so far is inside a thinking block —
+                        # skip this edit cycle and wait for real content.
+                        if got_done:
+                            return
+                        await asyncio.sleep(0.05)
+                        continue
+
+                    # Split overflow: if clean text exceeds the platform
                     # limit, finalize the current message and start a new one.
                     while (
-                        len(self._accumulated) > _safe_limit
+                        len(display_text) > _safe_limit
                         and self._message_id is not None
                     ):
-                        split_at = self._accumulated.rfind("\n", 0, _safe_limit)
+                        split_at = display_text.rfind("\n", 0, _safe_limit)
                         if split_at < _safe_limit // 2:
                             split_at = _safe_limit
-                        chunk = self._accumulated[:split_at]
+                        chunk = display_text[:split_at]
                         await self._send_or_edit(chunk)
-                        self._accumulated = self._accumulated[split_at:].lstrip("\n")
+                        display_text = display_text[split_at:].lstrip("\n")
                         self._message_id = None
                         self._last_sent_text = ""
 
-                    display_text = self._accumulated
                     if not got_done:
                         display_text += self.cfg.cursor
 
@@ -139,9 +178,10 @@ class GatewayStreamConsumer:
                     self._last_edit_time = time.monotonic()
 
                 if got_done:
-                    # Final edit without cursor
-                    if self._accumulated and self._message_id:
-                        await self._send_or_edit(self._accumulated)
+                    # Final edit without cursor — strip thinking blocks
+                    final_text = _strip_think_blocks(self._accumulated)
+                    if final_text and self._message_id:
+                        await self._send_or_edit(final_text)
                     return
 
                 await asyncio.sleep(0.05)  # Small yield to not busy-loop
@@ -150,7 +190,7 @@ class GatewayStreamConsumer:
             # Best-effort final edit on cancellation
             if self._accumulated and self._message_id:
                 try:
-                    await self._send_or_edit(self._accumulated)
+                    await self._send_or_edit(_strip_think_blocks(self._accumulated) or self._last_sent_text)
                 except Exception:
                     pass
         except Exception as e:

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -99,6 +99,7 @@ class GatewayStreamConsumer:
         self._edit_supported = True  # Disabled on first edit failure (Signal/Email/HA)
         self._last_edit_time = 0.0
         self._last_sent_text = ""   # Track last-sent text to skip redundant edits
+        self._finalized_offset = 0  # Characters of clean text finalized in previous messages
 
     @property
     def already_sent(self) -> bool:
@@ -147,8 +148,8 @@ class GatewayStreamConsumer:
 
                 if should_edit and self._accumulated:
                     # Strip thinking/reasoning blocks before display
-                    display_text = _strip_think_blocks(self._accumulated)
-                    if not display_text:
+                    full_clean = _strip_think_blocks(self._accumulated)
+                    if not full_clean:
                         # All content so far is inside a thinking block —
                         # skip this edit cycle and wait for real content.
                         if got_done:
@@ -156,32 +157,39 @@ class GatewayStreamConsumer:
                         await asyncio.sleep(0.05)
                         continue
 
-                    # Split overflow: if clean text exceeds the platform
-                    # limit, finalize the current message and start a new one.
+                    # Only show text belonging to the current message
+                    # (prior messages were finalized during earlier splits).
+                    current_text = full_clean[self._finalized_offset:]
+
+                    # Split overflow: if current-message text exceeds the
+                    # platform limit, finalize this message and start a new one.
                     while (
-                        len(display_text) > _safe_limit
+                        len(current_text) > _safe_limit
                         and self._message_id is not None
                     ):
-                        split_at = display_text.rfind("\n", 0, _safe_limit)
+                        split_at = current_text.rfind("\n", 0, _safe_limit)
                         if split_at < _safe_limit // 2:
                             split_at = _safe_limit
-                        chunk = display_text[:split_at]
+                        chunk = current_text[:split_at]
                         await self._send_or_edit(chunk)
-                        display_text = display_text[split_at:].lstrip("\n")
+                        remaining = current_text[split_at:].lstrip("\n")
+                        self._finalized_offset += len(current_text) - len(remaining)
+                        current_text = remaining
                         self._message_id = None
                         self._last_sent_text = ""
 
                     if not got_done:
-                        display_text += self.cfg.cursor
+                        current_text += self.cfg.cursor
 
-                    await self._send_or_edit(display_text)
+                    await self._send_or_edit(current_text)
                     self._last_edit_time = time.monotonic()
 
                 if got_done:
                     # Final edit without cursor — strip thinking blocks
                     final_text = _strip_think_blocks(self._accumulated)
-                    if final_text and self._message_id:
-                        await self._send_or_edit(final_text)
+                    final_current = final_text[self._finalized_offset:] if final_text else ""
+                    if final_current and self._message_id:
+                        await self._send_or_edit(final_current)
                     return
 
                 await asyncio.sleep(0.05)  # Small yield to not busy-loop
@@ -190,7 +198,9 @@ class GatewayStreamConsumer:
             # Best-effort final edit on cancellation
             if self._accumulated and self._message_id:
                 try:
-                    await self._send_or_edit(_strip_think_blocks(self._accumulated) or self._last_sent_text)
+                    final = _strip_think_blocks(self._accumulated)
+                    final_current = final[self._finalized_offset:] if final else ""
+                    await self._send_or_edit(final_current or self._last_sent_text)
                 except Exception:
                     pass
         except Exception as e:


### PR DESCRIPTION
## Summary

- Models like MiniMax M2.7 emit `<think>...</think>` blocks inline in their text content
- The existing `_strip_think_blocks()` in `run_agent.py` only cleans `final_response` **after** streaming completes
- But `GatewayStreamConsumer` has already delivered the raw text (including thinking blocks) to the user via progressive message edits
- This adds thinking block filtering directly in the stream consumer, so users never see reasoning tags

Additionally fixes two related streaming bugs:

### Bug fix: Duplicate messages on long responses
The think-block stripping changed the split logic to operate on a local `display_text` variable instead of mutating `self._accumulated`. This meant every loop iteration recomputed `display_text` from the **full** accumulated text (starting from the beginning), causing each split to overwrite the current message with the **first** ~1900 chars instead of its continuation — resulting in 10-15 identical messages for long responses.

**Fix:** Added `_finalized_offset` to track how many characters of clean text have been finalized in previous messages. Each loop iteration only processes `full_clean[self._finalized_offset:]`.

### Bug fix: False "Handler returned empty/None response" warnings
When streaming successfully delivered a response, the handler returned `None` to signal "don't re-send". But `base.py` logged this as a WARNING, making the log noisy with false positives for every streamed response.

**Fix:** Introduced `RESPONSE_ALREADY_STREAMED` sentinel in `base.py`. The handler returns this instead of `None` when streaming delivered the response, so `base.py` can distinguish "streaming handled it" from "handler actually failed".

## Changes

- Add `_strip_think_blocks()` to `gateway/stream_consumer.py` — strips `<think>`, `<thinking>`, `<reasoning>`, `<REASONING_SCRATCHPAD>` tags
- Handles unclosed blocks still being streamed (suppresses partial thinking content mid-stream)
- Add `_finalized_offset` tracking to `GatewayStreamConsumer` — prevents message duplication during overflow splits
- Add `RESPONSE_ALREADY_STREAMED` sentinel to `gateway/platforms/base.py` — suppresses false "empty response" warnings
- Update `gateway/run.py` to return the sentinel instead of `None` when streaming delivered the response

## Test plan

- [x] Verified `_strip_think_blocks` handles complete blocks, unclosed blocks, mixed content, and edge cases
- [x] Module imports correctly (`python3 -c "import py_compile; py_compile.compile(...)"`)
- [ ] Manual test with a reasoning model (MiniMax M2.7) on Discord — thinking blocks no longer appear
- [ ] Manual test with a long response (>2000 chars) on Discord — no duplicate messages
- [ ] Verify gateway log no longer shows "Handler returned empty/None response" for streamed responses
- [ ] Verify the warning still appears for genuinely empty responses (non-streaming failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)