### PR TITLE
fix(session): persist rolled-back history in rollback branches

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7142,7 +7142,7 @@ class AIAgent:
                             rolled_back_messages = self._get_messages_up_to_last_assistant(messages)
 
                             self._cleanup_task_resources(effective_task_id)
-                            self._persist_session(messages, conversation_history)
+                            self._persist_session(rolled_back_messages, conversation_history)
 
                             return {
                                 "final_response": None,
@@ -7869,7 +7869,7 @@ class AIAgent:
                         
                         rolled_back_messages = self._get_messages_up_to_last_assistant(messages)
                         self._cleanup_task_resources(effective_task_id)
-                        self._persist_session(messages, conversation_history)
+                        self._persist_session(rolled_back_messages, conversation_history)
                         
                         return {
                             "final_response": None,

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -5,6 +5,7 @@ pieces. The OpenAI client and tool loading are mocked so no network calls
 are made.
 """
 
+import copy
 import json
 import logging
 import re
@@ -1659,6 +1660,63 @@ class TestRunConversation:
         # User-friendly message is returned
         assert result["final_response"] is not None
         assert "Thinking Budget Exhausted" in result["final_response"]
+
+    def test_length_rollback_persists_same_history_as_returned(self, agent):
+        self._setup_agent(agent)
+        tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
+        resp = _mock_response(content="Partial answer", finish_reason="length", tool_calls=[tc])
+        agent.client.chat.completions.create.return_value = resp
+
+        persisted = {}
+
+        def _capture_persist(messages, conversation_history=None):
+            persisted["messages"] = copy.deepcopy(messages)
+            persisted["conversation_history"] = copy.deepcopy(conversation_history)
+
+        history = [
+            {"role": "user", "content": "old question"},
+            {"role": "assistant", "content": "old answer"},
+        ]
+
+        with (
+            patch.object(agent, "_persist_session", side_effect=_capture_persist),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("new question", conversation_history=history)
+
+        assert result["error"] == "Response truncated due to output length limit"
+        assert persisted["messages"] == result["messages"]
+
+    def test_incomplete_scratchpad_rollback_persists_same_history_as_returned(self, agent):
+        self._setup_agent(agent)
+        bad = "<REASONING_SCRATCHPAD>unfinished"
+        agent.client.chat.completions.create.side_effect = [
+            _mock_response(content=bad, finish_reason="stop"),
+            _mock_response(content=bad, finish_reason="stop"),
+            _mock_response(content=bad, finish_reason="stop"),
+        ]
+
+        persisted = {}
+
+        def _capture_persist(messages, conversation_history=None):
+            persisted["messages"] = copy.deepcopy(messages)
+            persisted["conversation_history"] = copy.deepcopy(conversation_history)
+
+        history = [
+            {"role": "user", "content": "old question"},
+            {"role": "assistant", "content": "old answer"},
+        ]
+
+        with (
+            patch.object(agent, "_persist_session", side_effect=_capture_persist),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("new question", conversation_history=history)
+
+        assert result["error"] == "Incomplete REASONING_SCRATCHPAD after 2 retries"
+        assert persisted["messages"] == result["messages"]
 
 
 class TestRetryExhaustion:


### PR DESCRIPTION
## Summary

This fixes a session-history mismatch in `run_conversation`.

In the rollback paths, Hermes was returning the rolled-back message list to the immediate caller, but persisting the pre-rollback list to session storage first. That could leave session history out of sync with what the caller actually received.

## What changed

- persist `rolled_back_messages` instead of `messages` in the proven rollback branches
- add regression coverage for:
  - the length rollback path
  - the incomplete scratchpad rollback path

## Why this matters

Without this, resume/search/replay can end up using a different history than the one returned at the time of the rollback. This patch keeps persisted session state aligned with the rolled-back state the caller actually sees.

## Tests

Ran targeted regression coverage in `tests/test_run_agent.py`, including:
- `test_length_rollback_persists_same_history_as_returned`
- `test_incomplete_scratchpad_rollback_persists_same_history_as_returned`

Also ran a small related rollback test slice around the affected behavior.