### PR TITLE
feat(skills): add ascii-cinema creative skill

### DIFF
--- a/skills/creative/ascii-cinema/README.md
+++ b/skills/creative/ascii-cinema/README.md
@@ -1,0 +1,19 @@
+# ASCII Cinema
+
+Browser-playable ASCII storytelling for Hermes Agent.
+
+This skill teaches Hermes how to build self-contained HTML/CSS/JS microsites with:
+- living ASCII agents
+- scene-aware backgrounds
+- narrative captions
+- restrained playback controls
+- screenshot-friendly layouts
+
+Canonical upstream target:
+- `NousResearch/hermes-agent/skills/creative/ascii-cinema`
+
+This skill is complementary to:
+- `ascii-art` — banners and static ASCII pieces
+- `ascii-video` — rendered MP4/GIF/PNG ASCII video pipelines
+
+`ascii-cinema` is for interactive, public-facing browser explainers.

--- a/skills/creative/ascii-cinema/README.md
+++ b/skills/creative/ascii-cinema/README.md
@@ -2,18 +2,27 @@
 
 Browser-playable ASCII storytelling for Hermes Agent.
 
-This skill teaches Hermes how to build self-contained HTML/CSS/JS microsites with:
-- living ASCII agents
-- scene-aware backgrounds
-- narrative captions
-- restrained playback controls
-- screenshot-friendly layouts
+This bundled skill teaches Hermes to build a single self-contained HTML/CSS/JS
+explainer with:
+
+- a living ASCII focal subject;
+- scene-aware backgrounds;
+- narrative captions;
+- restrained playback and direct scene controls;
+- keyboard-accessible interaction;
+- reduced motion without losing manual navigation;
+- complete glyph visibility on narrow screens;
+- static, runtime, and real-browser verification.
+
+Use `ascii-cinema` for interactive browser explainers. Use `ascii-art` for a
+banner, logo, or single frame. Use `ascii-video` when the deliverable is MP4,
+GIF, or an image sequence.
+
+Supporting contract:
+
+- Scene design reference: `references/scene-grammar.md`
+- Hermetic skill tests: `tests/skills/test_ascii_cinema_skill.py`
 
 Canonical upstream target:
+
 - `NousResearch/hermes-agent/skills/creative/ascii-cinema`
-
-This skill is complementary to:
-- `ascii-art` — banners and static ASCII pieces
-- `ascii-video` — rendered MP4/GIF/PNG ASCII video pipelines
-
-`ascii-cinema` is for interactive, public-facing browser explainers.

--- a/skills/creative/ascii-cinema/SKILL.md
+++ b/skills/creative/ascii-cinema/SKILL.md
@@ -1,0 +1,303 @@
+---
+name: ascii-cinema
+description: Create browser-playable ASCII cinema explainers — living-agent scenes, scene-aware backgrounds, captions, and interactive controls in a single HTML file.
+version: 1.0.0
+author: Mustafa Sarac
+license: MIT
+metadata:
+  hermes:
+    tags: [ASCII, Cinema, HTML, Animation, Storytelling, Explainers, Creative]
+    related_skills: [ascii-video, ascii-art, excalidraw]
+---
+
+# ASCII Cinema
+
+ASCII Cinema is for browser-playable ASCII storytelling.
+
+Use it when the user wants:
+- an ASCII art explainer embedded in HTML
+- a "living agent" visual instead of a static diagram
+- a narrative walkthrough with multiple scenes
+- a retro-terminal microsite that actually teaches something
+- an animated ASCII landing page for a tool, workflow, or concept
+
+This skill is not for generating MP4/GIF video files.
+That is what `ascii-video` is for.
+
+This skill is for building a self-contained HTML/CSS/JS artifact that behaves like a small cinematic experience in the browser.
+
+## When to Use
+
+Use this skill when the task involves one or more of these:
+
+- the user explicitly asks for ASCII cinema, ASCII explainer, ASCII landing page, or terminal-style storytelling
+- the page should have a living animated agent
+- the page should show scene-by-scene progression
+- the background should change with the concept being explained
+- the output should be shareable as a public microsite
+- the goal is education, launch marketing, or product storytelling rather than pure decoration
+
+Do not use this skill when:
+- the user needs a real rendered video file → use `ascii-video`
+- a static diagram is enough → use `excalidraw`
+- a simple ASCII banner is enough → use `ascii-art`
+
+## Core Principle
+
+ASCII Cinema is not decoration.
+It is narrative interface.
+
+Every scene must answer:
+- what is happening?
+- why does it matter?
+- what should the viewer understand next?
+
+A good ASCII cinema piece has:
+- a clear story arc
+- scene-aware backgrounds
+- a living focal subject
+- restrained controls
+- readable captions
+- rhythm
+- visual coherence from start to finish
+
+## Output Shape
+
+Default output is a single self-contained HTML file with:
+- inline CSS
+- inline JavaScript
+- no build step required
+- browser-playable animation loop
+- keyboard/mouse-safe controls
+- mobile-friendly layout
+
+Preferred structure:
+
+1. hero / framing section
+2. cinematic ASCII section
+3. supporting explanation sections
+4. closing transformation or CTA
+
+## ASCII Cinema Design Rules
+
+### 1. Keep the agent alive
+The focal subject should not be static.
+Give it at least two or three kinds of motion, for example:
+- blink
+- bob
+- pulse
+- trail
+- scan beam
+- orbit motion
+
+The motion should fit the scene.
+
+### 2. Backgrounds must be scene-aware
+Do not use one generic terminal background for the whole piece.
+Each scene should have a background language that matches the concept:
+- chaos scene → prompt noise, drifting fragments, broken message streams
+- context scene → memory blocks, rails, anchors, stable nodes
+- inspect scene → repo trees, scans, crosshairs, logs
+- planning scene → boxes, arrows, dependencies, pathways
+- execution scene → tool panes, commands, browser frames, file grids
+- automation scene → rings, cycles, scheduler dots, orbits
+
+### 3. Captions explain, not merely label
+Each scene should have:
+- short scene title
+- one explanatory caption
+- one or two compact metadata tags at most
+
+Do not overload the viewer.
+
+### 4. Controls must be restrained
+Use only the controls that genuinely improve use:
+- play/pause
+- restart
+- optional speak/narrate
+- optional scene jump list
+
+Avoid dashboard clutter.
+
+### 5. The layout must preserve focus
+The viewer's attention should go here, in this order:
+1. main cinematic frame
+2. current scene title/caption
+3. scene progression / navigation
+4. playback controls
+
+If controls compete with the scene, simplify them.
+
+### 6. The piece should be screenshot-friendly
+The final page should work both as:
+- a live microsite
+- a source for still screenshots or carousel slices
+
+That means:
+- strong section boundaries
+- clean spacing
+- no fragile hover-only meaning
+- no dependence on hidden state for understanding
+
+## Recommended Workflow
+
+### Step 1: Define the narrative arc
+Before writing code, define:
+- audience
+- core message
+- transformation
+- scene list
+- final takeaway
+
+A useful default story arc:
+1. wrong model
+2. reframe
+3. context
+4. inspect
+5. plan
+6. act with tools
+7. preserve and automate
+8. transformation / CTA
+
+### Step 2: Map each scene to a visual grammar
+For each scene decide:
+- background motif
+- agent behavior
+- caption title
+- caption body
+- accent color/mood
+
+Do not improvise scene visuals after coding starts.
+
+### Step 3: Build the ASCII renderer
+Use a grid-based renderer in JavaScript.
+Recommended primitives:
+- `makeGrid()`
+- `setChar()`
+- `writeText()`
+- `writeCentered()`
+- `overlay()`
+- per-scene draw functions like `drawChaos()`, `drawInspect()`, `drawOrbit()`
+
+Render into a `<pre>` block with `white-space: pre` and monospace font.
+
+### Step 4: Separate scene logic from layout logic
+Keep these distinct:
+- scene data array
+- renderer functions
+- UI update functions
+- layout/style layer
+
+The page should be editable without touching the scene engine unnecessarily.
+
+### Step 5: Add restrained playback features
+Recommended:
+- autoplay loop
+- play/pause
+- restart
+- scene counter
+- progress bar
+- optional speech synthesis
+
+Optional means optional.
+Use only if it improves comprehension.
+
+### Step 6: Verify manually
+Check:
+- no duplicated IDs
+- JS syntax valid
+- no overflow in cinematic section
+- scene list readable
+- mobile layout sane
+- playback controls not dominant
+- captions readable at a glance
+- every scene background actually matches the concept
+
+## Scene Schema
+
+A useful scene object shape:
+
+```js
+{
+  id: 'inspect-state',
+  short: 'Inspect',
+  title: 'A good agent inspects before acting.',
+  themeLabel: 'repo map',
+  action: 'Inspect current reality',
+  background: 'directory trees, document rails, scan lines and map grids',
+  narration: 'Instead of guessing, the agent reads the current state first.',
+  duration: 7000,
+  mode: 'inspect',
+  pulse: 'scanning',
+  mood: 'analytic'
+}
+```
+
+## HTML/CSS Guidance
+
+### Typography
+Use a strong contrast between:
+- elegant display font for large headings
+- monospace for terminal / labels / scene chrome
+- clean sans serif for body copy
+
+### Layout
+Preferred structure for the cinematic section:
+- section header
+  - left: title and framing copy
+  - right: minimal playback controls
+- content row
+  - left: cinematic terminal
+  - right: compact scene navigation
+
+### Avoid
+- giant sidebars
+- long control explanations inside the cinematic block
+- duplicate playback controls in multiple places
+- excessive metadata chips
+- random neon cyberpunk aesthetics unless the story calls for it
+
+## Pitfalls
+
+### Pitfall 1: One background for all scenes
+This makes the piece feel decorative instead of narrative.
+
+### Pitfall 2: Too many controls
+ASCII cinema should feel composed, not like a control dashboard.
+
+### Pitfall 3: Static focal subject
+If the agent never feels alive, the entire illusion collapses.
+
+### Pitfall 4: Explanations that are too short or too long
+Too short = confusing.
+Too long = heavy and slow.
+
+### Pitfall 5: Scene list that overwhelms the page
+Navigation should support the cinematic frame, not compete with it.
+
+### Pitfall 6: Treating ASCII as the whole experience
+ASCII is the medium, not the message.
+The story still matters more.
+
+## Verification Checklist
+
+Before finishing, verify:
+- [ ] The main scene renders correctly in a browser
+- [ ] Every scene changes both content and background logic
+- [ ] The agent appears alive
+- [ ] Captions teach the process clearly
+- [ ] The controls are minimal and useful
+- [ ] The cinematic section feels premium, not gimmicky
+- [ ] The output can be deployed as a public static site
+- [ ] JS passes syntax validation
+- [ ] No duplicate element IDs exist
+
+## Deliverable Standard
+
+A good ASCII Cinema artifact should feel like:
+- a tiny product demo
+- a launch asset
+- an interactive explainer
+- a cinematic terminal page someone wants to share
+
+Not just a cute ASCII animation.

--- a/skills/creative/ascii-cinema/SKILL.md
+++ b/skills/creative/ascii-cinema/SKILL.md
@@ -1,303 +1,287 @@
 ---
 name: ascii-cinema
-description: Create browser-playable ASCII cinema explainers — living-agent scenes, scene-aware backgrounds, captions, and interactive controls in a single HTML file.
+description: Build browser-playable ASCII cinema explainers.
 version: 1.0.0
-author: Mustafa Sarac
+author: Mustafa Sarac (@mrsarac), Hermes Agent
 license: MIT
+platforms: [linux, macos, windows]
 metadata:
   hermes:
-    tags: [ASCII, Cinema, HTML, Animation, Storytelling, Explainers, Creative]
-    related_skills: [ascii-video, ascii-art, excalidraw]
+    tags: [ascii, cinema, html, animation, storytelling, explainers, creative]
+    category: creative
+    related_skills: [ascii-art, ascii-video, claude-design, excalidraw]
 ---
 
-# ASCII Cinema
+# ASCII Cinema Skill
 
-ASCII Cinema is for browser-playable ASCII storytelling.
-
-Use it when the user wants:
-- an ASCII art explainer embedded in HTML
-- a "living agent" visual instead of a static diagram
-- a narrative walkthrough with multiple scenes
-- a retro-terminal microsite that actually teaches something
-- an animated ASCII landing page for a tool, workflow, or concept
-
-This skill is not for generating MP4/GIF video files.
-That is what `ascii-video` is for.
-
-This skill is for building a self-contained HTML/CSS/JS artifact that behaves like a small cinematic experience in the browser.
+Build a self-contained browser explainer whose narrative is rendered as animated
+ASCII scenes. Use this for interactive HTML storytelling, not static text art or
+rendered video files.
 
 ## When to Use
 
-Use this skill when the task involves one or more of these:
+Use this skill when the user wants one or more of these:
 
-- the user explicitly asks for ASCII cinema, ASCII explainer, ASCII landing page, or terminal-style storytelling
-- the page should have a living animated agent
-- the page should show scene-by-scene progression
-- the background should change with the concept being explained
-- the output should be shareable as a public microsite
-- the goal is education, launch marketing, or product storytelling rather than pure decoration
+- an ASCII cinema, terminal story, or browser-playable ASCII explainer;
+- a living focal subject rather than a static diagram;
+- scene-by-scene progression with explanatory captions;
+- scene-aware backgrounds that reinforce each concept;
+- a shareable microsite, launch asset, or interactive teaching artifact;
+- a page that remains useful as both a live experience and still screenshots.
 
-Do not use this skill when:
-- the user needs a real rendered video file → use `ascii-video`
-- a static diagram is enough → use `excalidraw`
-- a simple ASCII banner is enough → use `ascii-art`
+Choose a neighboring skill instead when:
 
-## Core Principle
+- a banner, logo, or single frame is enough: use `ascii-art`;
+- the deliverable is MP4, GIF, or an image sequence: use `ascii-video`;
+- ASCII is only a small decorative detail in a broader page: use
+  `claude-design`;
+- a static relationship diagram communicates the idea better: use
+  `excalidraw`.
 
-ASCII Cinema is not decoration.
-It is narrative interface.
+## Prerequisites
 
-Every scene must answer:
-- what is happening?
-- why does it matter?
-- what should the viewer understand next?
+- A writable workspace for the final `.html` artifact.
+- A modern browser with JavaScript enabled.
+- The Hermes file tools: `read_file`, `search_files`, `write_file`, and `patch`.
+- The Hermes browser tools: `browser_navigate`, `browser_console`, and
+  `browser_vision`.
+- Optional Node.js access through `terminal` for inline JavaScript syntax
+  validation.
 
-A good ASCII cinema piece has:
-- a clear story arc
-- scene-aware backgrounds
-- a living focal subject
-- restrained controls
-- readable captions
-- rhythm
-- visual coherence from start to finish
+No framework, package install, network dependency, or build step is required for
+the default artifact.
 
-## Output Shape
+## How to Run
 
-Default output is a single self-contained HTML file with:
-- inline CSS
-- inline JavaScript
-- no build step required
-- browser-playable animation loop
-- keyboard/mouse-safe controls
-- mobile-friendly layout
+1. Inspect the target workspace with `search_files` and read relevant copy,
+   design tokens, and existing HTML with `read_file`.
+2. Define the audience, message, transformation, and ordered scene arc before
+   changing files.
+3. Read `references/scene-grammar.md` and map every scene to a teaching intent,
+   focal motion, background language, caption, and duration.
+4. Create one self-contained HTML file with `write_file`. Keep CSS, scene data,
+   and runtime JavaScript inline unless the user explicitly requests a larger
+   application structure.
+5. Improve small, isolated sections with `patch`; do not rewrite unrelated
+   content merely to polish the cinema.
+6. Start a loopback-only local preview with `terminal` when direct file
+   navigation is unavailable.
+7. Open the artifact with `browser_navigate`, inspect runtime failures with
+   `browser_console`, and review the composition with `browser_vision`.
+8. Verify controls, keyboard use, narrow screens, reduced motion, and full-glyph
+   visibility before delivery.
 
-Preferred structure:
+Completion means the real artifact has been opened and exercised in a browser,
+not merely written to disk.
 
-1. hero / framing section
-2. cinematic ASCII section
-3. supporting explanation sections
-4. closing transformation or CTA
+## Quick Reference
 
-## ASCII Cinema Design Rules
+| Concern | Required behavior |
+|---|---|
+| Output | One self-contained HTML file with inline CSS and inline JavaScript; no build step |
+| Story | Every scene advances one clear idea |
+| Focal subject | Visibly alive through restrained motion |
+| Background | Changes with the scene's teaching intent |
+| Caption | Explains why the scene matters |
+| Controls | Scene selection plus play/pause and restart |
+| Keyboard | Native buttons; Enter and Space activation |
+| Mobile | No body overflow; complete glyph rows remain visible |
+| Motion | Reduced-motion mode disables autoplay but keeps manual control |
+| Network | No external asset, font, or fetch dependency by default |
+| Verification | Static checks plus real browser interaction and visual review |
 
-### 1. Keep the agent alive
-The focal subject should not be static.
-Give it at least two or three kinds of motion, for example:
-- blink
-- bob
-- pulse
-- trail
-- scan beam
-- orbit motion
-
-The motion should fit the scene.
-
-### 2. Backgrounds must be scene-aware
-Do not use one generic terminal background for the whole piece.
-Each scene should have a background language that matches the concept:
-- chaos scene → prompt noise, drifting fragments, broken message streams
-- context scene → memory blocks, rails, anchors, stable nodes
-- inspect scene → repo trees, scans, crosshairs, logs
-- planning scene → boxes, arrows, dependencies, pathways
-- execution scene → tool panes, commands, browser frames, file grids
-- automation scene → rings, cycles, scheduler dots, orbits
-
-### 3. Captions explain, not merely label
-Each scene should have:
-- short scene title
-- one explanatory caption
-- one or two compact metadata tags at most
-
-Do not overload the viewer.
-
-### 4. Controls must be restrained
-Use only the controls that genuinely improve use:
-- play/pause
-- restart
-- optional speak/narrate
-- optional scene jump list
-
-Avoid dashboard clutter.
-
-### 5. The layout must preserve focus
-The viewer's attention should go here, in this order:
-1. main cinematic frame
-2. current scene title/caption
-3. scene progression / navigation
-4. playback controls
-
-If controls compete with the scene, simplify them.
-
-### 6. The piece should be screenshot-friendly
-The final page should work both as:
-- a live microsite
-- a source for still screenshots or carousel slices
-
-That means:
-- strong section boundaries
-- clean spacing
-- no fragile hover-only meaning
-- no dependence on hidden state for understanding
-
-## Recommended Workflow
-
-### Step 1: Define the narrative arc
-Before writing code, define:
-- audience
-- core message
-- transformation
-- scene list
-- final takeaway
-
-A useful default story arc:
-1. wrong model
-2. reframe
-3. context
-4. inspect
-5. plan
-6. act with tools
-7. preserve and automate
-8. transformation / CTA
-
-### Step 2: Map each scene to a visual grammar
-For each scene decide:
-- background motif
-- agent behavior
-- caption title
-- caption body
-- accent color/mood
-
-Do not improvise scene visuals after coding starts.
-
-### Step 3: Build the ASCII renderer
-Use a grid-based renderer in JavaScript.
-Recommended primitives:
-- `makeGrid()`
-- `setChar()`
-- `writeText()`
-- `writeCentered()`
-- `overlay()`
-- per-scene draw functions like `drawChaos()`, `drawInspect()`, `drawOrbit()`
-
-Render into a `<pre>` block with `white-space: pre` and monospace font.
-
-### Step 4: Separate scene logic from layout logic
-Keep these distinct:
-- scene data array
-- renderer functions
-- UI update functions
-- layout/style layer
-
-The page should be editable without touching the scene engine unnecessarily.
-
-### Step 5: Add restrained playback features
-Recommended:
-- autoplay loop
-- play/pause
-- restart
-- scene counter
-- progress bar
-- optional speech synthesis
-
-Optional means optional.
-Use only if it improves comprehension.
-
-### Step 6: Verify manually
-Check:
-- no duplicated IDs
-- JS syntax valid
-- no overflow in cinematic section
-- scene list readable
-- mobile layout sane
-- playback controls not dominant
-- captions readable at a glance
-- every scene background actually matches the concept
-
-## Scene Schema
-
-A useful scene object shape:
+A useful scene record contains:
 
 ```js
 {
-  id: 'inspect-state',
-  short: 'Inspect',
-  title: 'A good agent inspects before acting.',
-  themeLabel: 'repo map',
-  action: 'Inspect current reality',
-  background: 'directory trees, document rails, scan lines and map grids',
-  narration: 'Instead of guessing, the agent reads the current state first.',
-  duration: 7000,
-  mode: 'inspect',
-  pulse: 'scanning',
-  mood: 'analytic'
+  id: "inspect-state",
+  short: "Inspect",
+  title: "Inspect before acting.",
+  narration: "Read the real state before choosing a change.",
+  mode: "inspect",
+  duration: 6500,
+  accent: "#67e8f9"
 }
 ```
 
-## HTML/CSS Guidance
+## Procedure
 
-### Typography
-Use a strong contrast between:
-- elegant display font for large headings
-- monospace for terminal / labels / scene chrome
-- clean sans serif for body copy
+### 1. Establish the narrative contract
 
-### Layout
-Preferred structure for the cinematic section:
-- section header
-  - left: title and framing copy
-  - right: minimal playback controls
-- content row
-  - left: cinematic terminal
-  - right: compact scene navigation
+Write down:
 
-### Avoid
-- giant sidebars
-- long control explanations inside the cinematic block
-- duplicate playback controls in multiple places
-- excessive metadata chips
-- random neon cyberpunk aesthetics unless the story calls for it
+- audience;
+- initial misconception or tension;
+- final understanding or action;
+- ordered scene list;
+- one sentence each scene must teach.
+
+Prefer five to eight scenes. Combine scenes that teach the same idea. The arc is
+ready when removing or reordering a scene would make the explanation weaker.
+
+### 2. Assign scene grammar
+
+For every scene choose:
+
+- one background motif;
+- one focal-subject behavior;
+- one concise title;
+- one explanatory caption;
+- one accent or mood;
+- one duration.
+
+Use `references/scene-grammar.md` for motif patterns. A scene is ready when its
+motion and background communicate the same concept as its caption.
+
+### 3. Build the semantic shell
+
+Use semantic sections and native controls:
+
+- `<main>` for the experience;
+- one heading hierarchy;
+- `<pre aria-live="polite" aria-atomic="true">` for the cinematic frame when each
+  complete scene change should be announced;
+- `<button>` elements for playback and scene selection;
+- a visible caption and progress indicator;
+- an inline data-URI favicon to avoid a preview-only 404.
+
+Keep the first paint meaningful. The initial scene, caption, and controls must
+exist before animation begins.
+
+### 4. Separate data, rendering, and control state
+
+Keep these layers distinct inside the inline script:
+
+1. scene records;
+2. pure scene-to-frame rendering functions;
+3. DOM update functions;
+4. playback state and timer ownership;
+5. event handlers.
+
+Clamp or wrap scene indexes in one function. Maintain at most one active timer.
+Restart must clear the old timer before returning to the first scene.
+
+### 5. Make motion deliberate
+
+Use two or three restrained motion cues for the focal subject, such as blink,
+bob, pulse, scan, trail, or orbit. Do not animate every region at once.
+
+Honor `prefers-reduced-motion: reduce` in both CSS and JavaScript:
+
+- disable autoplay and nonessential transitions;
+- show the control state as paused when no timer exists;
+- preserve scene buttons, restart, and manual next/previous behavior.
+
+Reduced motion removes involuntary motion; it does not remove access to content.
+
+### 6. Protect narrow screens
+
+A container can fit while its final monospace glyph is clipped. Verify both:
+
+- document-level overflow; and
+- the rendered width of the longest complete ASCII row.
+
+Use a responsive grid-density or font-size rule when the full row exceeds its
+frame. Preserve character aspect ratio and meaning rather than shrinking text
+until it becomes unreadable. Put intentionally wide comparisons inside an
+explicit horizontal-scroll region; never make the page body scroll sideways.
+
+### 7. Add restrained controls
+
+Include only controls that improve comprehension:
+
+- play/pause;
+- restart;
+- direct scene selection;
+- optional previous/next when direct selection is not enough.
+
+The active scene needs more than color alone: use text, shape, `aria-current`, or
+another programmatic state. Focus indicators must remain visible.
+
+### 8. Verify the source contract
+
+Before browser review, check:
+
+- one document title and one viewport declaration;
+- no duplicate element IDs;
+- no external scripts, stylesheets, fonts, media, or data calls by default;
+- exactly the intended inline runtime;
+- valid inline JavaScript syntax;
+- labeled controls and reduced-motion handling;
+- no embedded credentials, tokens, personal data, or private operational paths.
+
+Use `terminal` to run `node --check` on extracted inline JavaScript when Node.js
+is available. Static checks are a preflight, not browser proof.
+
+### 9. Exercise the real browser
+
+Use `browser_navigate` to open the artifact. Then:
+
+- read `browser_console` for uncaught exceptions and warnings;
+- select the first, middle, and last scenes;
+- test play/pause, restart, rapid toggling, and wrap boundaries;
+- activate controls by keyboard;
+- inspect desktop, tablet, mobile, and narrow-mobile layouts;
+- emulate reduced motion;
+- confirm body overflow is zero and complete glyph rows are visible;
+- use `browser_vision` to judge hierarchy, caption readability, and whether the
+  focal subject remains visually dominant.
+
+When a check fails, reproduce it deterministically, fix the smallest responsible
+layer, and rerun the failed case plus the complete matrix.
+
+### 10. Deliver evidence
+
+Report:
+
+- the absolute artifact path;
+- scenes and controls exercised;
+- tested viewports and motion mode;
+- console/page/network result;
+- any intentionally scrollable region;
+- remaining limitations.
+
+Do not label the artifact complete from screenshots alone. Keep the source and
+reproducible checks available until the user accepts the result.
 
 ## Pitfalls
 
-### Pitfall 1: One background for all scenes
-This makes the piece feel decorative instead of narrative.
+1. **One background for every scene.** The experience becomes decorative.
+   Change the ambient grammar with the concept.
+2. **Static focal subject.** The cinema loses its living quality. Add restrained,
+   scene-relevant motion.
+3. **Controls competing with the frame.** Remove secondary controls and metadata.
+4. **Labels instead of teaching captions.** Explain why the scene matters, not
+   only what it is called.
+5. **More than one timer.** Rapid toggles accelerate playback and leak work.
+   Centralize timer ownership and clear before starting.
+6. **False pause state in reduced motion.** Derive the label from actual timer
+   state, not an autoplay assumption.
+7. **Mobile container fits but glyphs clip.** Measure the complete row, then
+   lower grid density or font size within a readable bound.
+8. **Screenshot-only confidence.** A still cannot prove keyboard control,
+   autoplay state, timer safety, or runtime cleanliness.
+9. **External convenience assets.** A font or icon request breaks offline use
+   and creates avoidable network noise. Inline or use system resources.
+10. **Generic terminal styling.** ASCII is the medium, not the concept. Let the
+    story determine palette, motion, and composition.
 
-### Pitfall 2: Too many controls
-ASCII cinema should feel composed, not like a control dashboard.
+## Verification
 
-### Pitfall 3: Static focal subject
-If the agent never feels alive, the entire illusion collapses.
-
-### Pitfall 4: Explanations that are too short or too long
-Too short = confusing.
-Too long = heavy and slow.
-
-### Pitfall 5: Scene list that overwhelms the page
-Navigation should support the cinematic frame, not compete with it.
-
-### Pitfall 6: Treating ASCII as the whole experience
-ASCII is the medium, not the message.
-The story still matters more.
-
-## Verification Checklist
-
-Before finishing, verify:
-- [ ] The main scene renders correctly in a browser
-- [ ] Every scene changes both content and background logic
-- [ ] The agent appears alive
-- [ ] Captions teach the process clearly
-- [ ] The controls are minimal and useful
-- [ ] The cinematic section feels premium, not gimmicky
-- [ ] The output can be deployed as a public static site
-- [ ] JS passes syntax validation
-- [ ] No duplicate element IDs exist
-
-## Deliverable Standard
-
-A good ASCII Cinema artifact should feel like:
-- a tiny product demo
-- a launch asset
-- an interactive explainer
-- a cinematic terminal page someone wants to share
-
-Not just a cute ASCII animation.
+- [ ] Frontmatter is parseable and the description is at most 60 characters.
+- [ ] Output is a self-contained HTML artifact with a useful first paint.
+- [ ] Scene data, rendering, UI updates, and playback state are separated.
+- [ ] Every scene changes content and background intent.
+- [ ] The focal subject has restrained, meaningful motion.
+- [ ] Captions teach the narrative rather than repeat scene labels.
+- [ ] Play/pause, restart, direct selection, and boundary behavior work.
+- [ ] Native buttons work with pointer, Enter, and Space.
+- [ ] No duplicate IDs or inline JavaScript syntax errors exist.
+- [ ] No unexpected console, page, or network errors occur.
+- [ ] Desktop, tablet, mobile, and narrow-mobile layouts were exercised.
+- [ ] Document-level horizontal overflow is absent.
+- [ ] The longest rendered ASCII row is fully visible or intentionally scrollable.
+- [ ] Reduced motion disables autoplay while preserving manual navigation.
+- [ ] No secret, private path, or unnecessary external dependency is embedded.
+- [ ] Visual review confirms hierarchy, contrast, caption readability, and focus.
+- [ ] Final report names the artifact path, real checks, and remaining limits.

--- a/skills/creative/ascii-cinema/references/scene-grammar.md
+++ b/skills/creative/ascii-cinema/references/scene-grammar.md
@@ -1,0 +1,88 @@
+# ASCII Cinema Scene Grammar
+
+Use this reference when designing scene-based ASCII explainers.
+
+## Core Idea
+
+Each scene should combine three layers:
+
+1. Meaning layer
+- what concept is being taught?
+
+2. Motion layer
+- how does the focal subject move?
+
+3. Background layer
+- what ambient visual language reinforces the concept?
+
+If all three layers are aligned, the scene feels intentional.
+
+## Useful Scene Patterns
+
+### Wrong model / chaos
+- drifting prompts
+- broken message streams
+- noisy fragments
+- unstable pulse
+
+### Context / memory
+- blocks
+- rails
+- anchored nodes
+- steady pulse
+
+### Inspect / analysis
+- repo trees
+- scan beams
+- logs
+- crosshairs
+- moving focal sensor
+
+### Plan / structure
+- boxes
+- arrows
+- dependencies
+- bounded routes
+- measured pulse
+
+### Act / tools
+- terminals
+- file panes
+- browser frames
+- command trails
+- engaged pulse
+
+### Preserve / forge
+- sparks
+- modules
+- templates
+- lattice structures
+- transformative pulse
+
+### Automate / orbit
+- rings
+- loops
+- recurring markers
+- scheduler dots
+- orbital pulse
+
+## Caption Rhythm
+
+For each scene:
+- title: short and declarative
+- narration: 1–3 sentences max
+- tags: action + background is usually enough
+
+## Visual Restraint
+
+Good ASCII cinema is expressive, not cluttered.
+
+Prefer:
+- one strong focal subject
+- one clear background language
+- one readable caption block
+
+Avoid:
+- five simultaneous ideas per scene
+- oversized control panels
+- random decorative particles with no meaning

--- a/skills/creative/ascii-cinema/references/scene-grammar.md
+++ b/skills/creative/ascii-cinema/references/scene-grammar.md
@@ -1,88 +1,175 @@
 # ASCII Cinema Scene Grammar
 
-Use this reference when designing scene-based ASCII explainers.
+Use this reference after defining the narrative arc and before writing the
+artifact. A scene is coherent when meaning, motion, background, and caption all
+teach the same idea.
 
-## Core Idea
+## Four Aligned Layers
 
-Each scene should combine three layers:
+### Meaning layer
 
-1. Meaning layer
-- what concept is being taught?
+What should the viewer understand after this scene?
 
-2. Motion layer
-- how does the focal subject move?
+### Motion layer
 
-3. Background layer
-- what ambient visual language reinforces the concept?
+How does the focal subject express the concept through blink, bob, pulse, scan,
+trail, orbit, or another restrained behavior?
 
-If all three layers are aligned, the scene feels intentional.
+### Background layer
 
-## Useful Scene Patterns
+What ambient visual language reinforces the concept without competing with the
+focal subject?
+
+### Caption layer
+
+Why does this moment matter, and what should the viewer understand next?
+
+If one layer communicates a different concept, redesign the scene before coding.
+
+## Scene Pattern Catalog
 
 ### Wrong model / chaos
-- drifting prompts
-- broken message streams
-- noisy fragments
-- unstable pulse
+
+- Meaning: isolated prompting creates noise rather than leverage.
+- Motion: unstable pulse, interrupted path, or repeated reset.
+- Background: drifting prompts, broken streams, incomplete fragments.
+- Caption rhythm: name the cost, then introduce the need for a new model.
 
 ### Context / memory
-- blocks
-- rails
-- anchored nodes
-- steady pulse
+
+- Meaning: durable context gives action continuity.
+- Motion: steady pulse or anchoring movement.
+- Background: blocks, rails, linked nodes, stable coordinates.
+- Caption rhythm: show what becomes possible when state persists.
 
 ### Inspect / analysis
-- repo trees
-- scan beams
-- logs
-- crosshairs
-- moving focal sensor
+
+- Meaning: current reality must be read before it is changed.
+- Motion: scan beam, sensor sweep, or moving crosshair.
+- Background: repository trees, logs, maps, evidence handles.
+- Caption rhythm: contrast evidence with guessing.
 
 ### Plan / structure
-- boxes
-- arrows
-- dependencies
-- bounded routes
-- measured pulse
+
+- Meaning: dependencies and gates make execution controllable.
+- Motion: measured movement from node to node.
+- Background: boxes, arrows, bounded routes, approval gates.
+- Caption rhythm: show how sequence reduces blast radius.
 
 ### Act / tools
-- terminals
-- file panes
-- browser frames
-- command trails
-- engaged pulse
+
+- Meaning: tools produce evidence, not just prose.
+- Motion: engaged pulse, command trail, or focused handoff.
+- Background: terminal surfaces, files, browser frames, test signals.
+- Caption rhythm: identify the action and the read-back that proves it.
 
 ### Preserve / forge
-- sparks
-- modules
-- templates
-- lattice structures
-- transformative pulse
+
+- Meaning: a successful solution becomes a reusable system.
+- Motion: assembly, joining, or crystallization.
+- Background: modules, templates, lattices, structured sparks.
+- Caption rhythm: show the conversion from one-off work to leverage.
 
 ### Automate / orbit
-- rings
-- loops
-- recurring markers
-- scheduler dots
-- orbital pulse
+
+- Meaning: repeatable work can run with bounded oversight.
+- Motion: orbit, recurring marker, or controlled cycle.
+- Background: rings, scheduler dots, loops, checkpoints.
+- Caption rhythm: distinguish automation from uncontrolled autonomy.
+
+### Transformation / release
+
+- Meaning: the viewer now sees or operates differently.
+- Motion: calm forward movement or resolved pulse.
+- Background: simplified field, open path, coherent system map.
+- Caption rhythm: state the new capability and next action.
 
 ## Caption Rhythm
 
-For each scene:
-- title: short and declarative
-- narration: 1–3 sentences max
-- tags: action + background is usually enough
+For each scene use:
+
+- a short declarative title;
+- one or two sentences of explanation;
+- at most two compact metadata tags;
+- language that advances the story rather than labels the drawing.
+
+Read all captions in sequence without the visuals. They should still form a
+complete argument.
+
+## Motion Contract
+
+### Timer ownership
+
+Playback has one owner and at most one active timer. Play, pause, restart, scene
+selection, and wrap behavior must all update the same state. Restart clears the
+existing timer before returning to the first scene. When the implementation also
+uses `requestAnimationFrame`, keep its handle and call `cancelAnimationFrame` on
+restart or teardown. Verification should exercise rapid toggles and assert that no
+more than one playback timer or animation loop remains active.
+
+### Reduced motion
+
+When `prefers-reduced-motion: reduce` is active:
+
+- autoplay remains off;
+- nonessential transitions are disabled;
+- the visible control state says paused when no timer exists;
+- direct scene selection, restart, and manual navigation remain available.
+
+Reduced motion changes delivery, not access to the narrative.
+
+## Interaction Contract
+
+### Keyboard
+
+Use native buttons for every control. Enter and Space activation, visible focus,
+and `aria-current` for the active scene should work without custom key emulation.
+
+### Pointer
+
+Targets must remain large enough to activate on mobile. Rapid play/pause and
+scene selection must not create duplicate timers or skip state.
+
+## Responsive Contract
+
+### Narrow screens
+
+Check both page overflow and the width of the longest rendered ASCII row. A
+container can fit while the final glyph is clipped. When a row is too wide,
+reduce grid density or font size within a readable bound.
+
+Keep intentionally wide comparisons inside a labeled horizontal-scroll region.
+The document body itself must not scroll sideways.
 
 ## Visual Restraint
 
-Good ASCII cinema is expressive, not cluttered.
-
 Prefer:
-- one strong focal subject
-- one clear background language
-- one readable caption block
+
+- one dominant focal subject;
+- one background language per scene;
+- one readable caption block;
+- a coherent palette across the full arc;
+- motion that serves meaning.
 
 Avoid:
-- five simultaneous ideas per scene
-- oversized control panels
-- random decorative particles with no meaning
+
+- several simultaneous ideas in one frame;
+- oversized control panels;
+- random particles without narrative purpose;
+- color as the only active-state signal;
+- tiny text used merely to force the grid to fit.
+
+## Scene Review Card
+
+Before accepting a scene, answer:
+
+```text
+MEANING: What is taught?
+FOCAL MOTION: What feels alive?
+BACKGROUND: What reinforces the idea?
+CAPTION: Why does it matter?
+CONTROL STATE: What happens if playback is paused?
+NARROW SCREEN: Is the complete glyph row visible?
+```
+
+The scene is ready only when all six answers agree with the intended lesson.

--- a/tests/skills/test_ascii_cinema_skill.py
+++ b/tests/skills/test_ascii_cinema_skill.py
@@ -1,0 +1,182 @@
+"""Hermetic contract tests for the bundled ascii-cinema skill."""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_DIR = REPO_ROOT / "skills" / "creative" / "ascii-cinema"
+SKILL_PATH = SKILL_DIR / "SKILL.md"
+
+
+def _skill_text() -> str:
+    return SKILL_PATH.read_text(encoding="utf-8")
+
+
+def _frontmatter_value(key: str) -> str:
+    match = re.search(rf"^{re.escape(key)}:\s*(.+)$", _skill_text(), re.MULTILINE)
+    assert match, f"missing frontmatter key: {key}"
+    return match.group(1).strip().strip('"')
+
+
+def test_description_matches_hardline_listing_contract() -> None:
+    description = _frontmatter_value("description")
+    assert len(description) <= 60
+    assert description.endswith(".")
+
+
+def test_author_credits_human_and_github_handle_first() -> None:
+    author = _frontmatter_value("author")
+    assert author.startswith("Mustafa Sarac (@mrsarac)")
+    assert author.endswith("Hermes Agent")
+
+
+def test_skill_uses_required_modern_section_order() -> None:
+    text = _skill_text()
+    required = (
+        "# ASCII Cinema Skill",
+        "## When to Use",
+        "## Prerequisites",
+        "## How to Run",
+        "## Quick Reference",
+        "## Procedure",
+        "## Pitfalls",
+        "## Verification",
+    )
+    positions = [text.index(heading) for heading in required]
+    assert positions == sorted(positions)
+
+
+def test_contract_suite_stays_hermetic() -> None:
+    tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+    imported_roots = {
+        alias.name.split(".", 1)[0]
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+        for alias in node.names
+    }
+    prohibited = {
+        "aiohttp",
+        "httpx",
+        "requests",
+        "socket",
+        "subprocess",
+        "urllib",
+    }
+    assert imported_roots.isdisjoint(prohibited)
+
+
+def test_frontmatter_is_portable_and_categorized() -> None:
+    text = _skill_text()
+    assert text.startswith("---\n")
+    assert "platforms: [linux, macos, windows]" in text
+    assert "category: creative" in text
+    assert "related_skills: [ascii-art, ascii-video, claude-design, excalidraw]" in text
+
+
+def test_how_to_run_names_native_hermes_tools() -> None:
+    text = _skill_text()
+    required_tools = (
+        "`read_file`",
+        "`search_files`",
+        "`write_file`",
+        "`patch`",
+        "`terminal`",
+        "`browser_navigate`",
+        "`browser_console`",
+        "`browser_vision`",
+    )
+    for tool in required_tools:
+        assert tool in text
+    assert not re.search(r"`(?:grep|cat|head|tail|sed|awk|find|ls)`", text)
+
+
+def test_scene_grammar_reference_is_real_and_linked() -> None:
+    reference = SKILL_DIR / "references" / "scene-grammar.md"
+    assert reference.is_file()
+    assert "references/scene-grammar.md" in _skill_text()
+    grammar = reference.read_text(encoding="utf-8")
+    assert "Meaning layer" in grammar
+    assert "Motion layer" in grammar
+    assert "Background layer" in grammar
+
+
+def test_scope_stays_distinct_from_neighboring_ascii_skills() -> None:
+    text = _skill_text()
+    assert "banner, logo, or single frame" in text
+    assert "MP4, GIF, or an image sequence" in text
+    assert "interactive HTML storytelling" in text
+    assert "use `ascii-art`" in text
+    assert "use `ascii-video`" in text
+
+
+def test_readme_points_to_the_contract_and_reference() -> None:
+    readme = (SKILL_DIR / "README.md").read_text(encoding="utf-8")
+    assert "self-contained" in readme
+    assert "references/scene-grammar.md" in readme
+    assert "tests/skills/test_ascii_cinema_skill.py" in readme
+    assert "reduced motion" in readme.lower()
+    assert "narrow screens" in readme.lower()
+
+
+def test_scene_grammar_covers_accessible_responsive_motion() -> None:
+    skill = _skill_text()
+    grammar = (SKILL_DIR / "references" / "scene-grammar.md").read_text(encoding="utf-8")
+    assert 'aria-atomic="true"' in skill
+    assert "Reduced motion" in grammar
+    assert "Narrow screens" in grammar
+    assert "Keyboard" in grammar
+    assert "Timer ownership" in grammar
+    assert "cancelAnimationFrame" in grammar
+
+
+def test_artifact_contract_covers_runtime_and_responsive_risks() -> None:
+    text = _skill_text().lower()
+    required = (
+        "inline css",
+        "inline javascript",
+        "no build step",
+        "no external asset",
+        "prefers-reduced-motion",
+        "complete glyph",
+        "at most one active timer",
+    )
+    for phrase in required:
+        assert phrase in text
+
+
+def test_verification_covers_static_and_real_browser_failures() -> None:
+    text = _skill_text()
+    required = (
+        "node --check",
+        "duplicate element IDs",
+        "`browser_console`",
+        "`browser_vision`",
+        "desktop, tablet, mobile, and narrow-mobile",
+        "console, page, or network errors",
+    )
+    for phrase in required:
+        assert phrase in text
+
+
+def test_skill_package_contains_no_obvious_sensitive_markers() -> None:
+    package_text = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in (
+            SKILL_PATH,
+            SKILL_DIR / "README.md",
+            SKILL_DIR / "references" / "scene-grammar.md",
+        )
+    )
+    forbidden_patterns = (
+        r"(?:/Users/|/home/|[A-Za-z]:\\Users\\)",
+        r"-----BEGIN [A-Z ]*PRIVATE KEY-----",
+        r"(?i)\b(?:api[_-]?key|access[_-]?token|password)\s*[:=]\s*[^\s<]{8,}",
+        r"(?i)\bBearer\s+[A-Za-z0-9._-]{8,}",
+        r"\b(?:sk-[A-Za-z0-9]{20,}|ghp_[A-Za-z0-9]{20,})\b",
+    )
+    for pattern in forbidden_patterns:
+        assert not re.search(pattern, package_text)


### PR DESCRIPTION
## Summary
- add a new bundled creative skill: `ascii-cinema`
- teach Hermes how to build browser-playable ASCII cinema explainers in a single HTML file
- cover living-agent motion, scene-aware backgrounds, restrained controls, caption rhythm, and deployment-friendly output
- include a small scene grammar reference for designing coherent multi-scene explainers

## Why
`ascii-video` is about rendered MP4/GIF pipelines.

This new skill covers a different use case: interactive ASCII storytelling in the browser — public-facing explainer pages, launch assets, terminal-style microsites, and scene-based demos that feel alive without requiring video rendering.

## What's included
- `skills/creative/ascii-cinema/SKILL.md`
- `skills/creative/ascii-cinema/README.md`
- `skills/creative/ascii-cinema/references/scene-grammar.md`

## Test plan
- loaded the skill locally and verified structure/format against existing bundled skills
- checked directory layout under `skills/creative/`
- confirmed the new skill is distinct from `ascii-video` and `ascii-art` in scope

## Notes
This was informed by building a public Hermes guide microsite with a living ASCII cinema section.

Per @Teknium's reply on X: "make a pr will review :)"
