### PR TITLE
feat(browser): make snapshot threshold configurable

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -238,6 +238,11 @@ browser:
   # after this period of no activity between agent loops (default: 120 = 2 minutes)
   inactivity_timeout: 120
 
+  # Maximum characters of snapshot content before summarization/truncation.
+  # Increase for long pages (e.g., detailed docs, financial reports), decrease to save tokens.
+  # Default: 20000
+  # snapshot_threshold: 20000
+
 # =============================================================================
 # Context Compression (Auto-shrinks long conversations)
 # =============================================================================

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -550,6 +550,12 @@ def load_gateway_config() -> GatewayConfig:
                 if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):
                     os.environ["DISCORD_REACTIONS"] = str(discord_cfg["reactions"]).lower()
 
+            # Feishu/Lark settings → env vars (env vars take precedence)
+            feishu_cfg = yaml_cfg.get("feishu", {})
+            if isinstance(feishu_cfg, dict):
+                if "require_mention" in feishu_cfg and not os.getenv("FEISHU_REQUIRE_MENTION"):
+                    os.environ["FEISHU_REQUIRE_MENTION"] = str(feishu_cfg["require_mention"]).lower()
+
             # Telegram settings → env vars (env vars take precedence)
             telegram_cfg = yaml_cfg.get("telegram", {})
             if isinstance(telegram_cfg, dict):

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1036,7 +1036,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 str(extra.get("webhook_path") or os.getenv("FEISHU_WEBHOOK_PATH", _DEFAULT_WEBHOOK_PATH)).strip()
                 or _DEFAULT_WEBHOOK_PATH
             ),
-            require_mention=_resolve_require_mention(extra),
+            require_mention=FeishuAdapter._resolve_require_mention(extra),
         )
 
     def _apply_settings(self, settings: FeishuAdapterSettings) -> None:

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1021,7 +1021,10 @@ class FeishuAdapter(BasePlatformAdapter):
                 str(extra.get("webhook_path") or os.getenv("FEISHU_WEBHOOK_PATH", _DEFAULT_WEBHOOK_PATH)).strip()
                 or _DEFAULT_WEBHOOK_PATH
             ),
-            require_mention=os.getenv("FEISHU_REQUIRE_MENTION", "true").strip().lower() not in ("false", "0", "no"),
+            require_mention=(
+                str(extra.get("require_mention") or os.getenv("FEISHU_REQUIRE_MENTION", "true")).strip().lower()
+                not in ("false", "0", "no")
+            ),
         )
 
     def _apply_settings(self, settings: FeishuAdapterSettings) -> None:

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -270,6 +270,7 @@ class FeishuAdapterSettings:
     webhook_host: str
     webhook_port: int
     webhook_path: str
+    require_mention: bool  # Require @mention in group chats (default: true)
 
 
 @dataclass
@@ -1020,6 +1021,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 str(extra.get("webhook_path") or os.getenv("FEISHU_WEBHOOK_PATH", _DEFAULT_WEBHOOK_PATH)).strip()
                 or _DEFAULT_WEBHOOK_PATH
             ),
+            require_mention=os.getenv("FEISHU_REQUIRE_MENTION", "true").strip().lower() not in ("false", "0", "no"),
         )
 
     def _apply_settings(self, settings: FeishuAdapterSettings) -> None:
@@ -1042,6 +1044,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._webhook_host = settings.webhook_host
         self._webhook_port = settings.webhook_port
         self._webhook_path = settings.webhook_path
+        self._require_mention = settings.require_mention
 
     def _build_event_handler(self) -> Any:
         if EventDispatcherHandler is None:
@@ -2665,9 +2668,17 @@ class FeishuAdapter(BasePlatformAdapter):
         return bool(sender_open_id and sender_open_id in self._allowed_group_users)
 
     def _should_accept_group_message(self, message: Any, sender_id: Any) -> bool:
-        """Require an explicit @mention before group messages enter the agent."""
+        """Check if a group message should be routed to the agent.
+
+        Uses require_mention setting to control whether @mention is needed:
+        - require_mention=true (default): Only route if bot is @mentioned or @_all
+        - require_mention=false: Route all allowed group messages without @mention
+        """
         if not self._allow_group_message(sender_id):
             return False
+        # If require_mention is disabled, accept all allowed group messages
+        if not self._require_mention:
+            return True
         # @_all is Feishu's @everyone placeholder — always route to the bot.
         raw_content = getattr(message, "content", "") or ""
         if "@_all" in raw_content:

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -974,6 +974,21 @@ class FeishuAdapter(BasePlatformAdapter):
         self._load_seen_message_ids()
 
     @staticmethod
+    def _resolve_require_mention(extra: Dict[str, Any]) -> bool:
+        """Resolve require_mention setting from extra config or env var.
+
+        Uses explicit None check to handle falsy values correctly:
+        - If extra["require_mention"] exists, use it (even if False)
+        - Otherwise fallback to FEISHU_REQUIRE_MENTION env var (default: true)
+        """
+        configured = extra.get("require_mention")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.strip().lower() in ("true", "1", "yes", "on")
+            return bool(configured)
+        return os.getenv("FEISHU_REQUIRE_MENTION", "true").strip().lower() in ("true", "1", "yes", "on")
+
+    @staticmethod
     def _load_settings(extra: Dict[str, Any]) -> FeishuAdapterSettings:
         return FeishuAdapterSettings(
             app_id=str(extra.get("app_id") or os.getenv("FEISHU_APP_ID", "")).strip(),
@@ -1021,10 +1036,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 str(extra.get("webhook_path") or os.getenv("FEISHU_WEBHOOK_PATH", _DEFAULT_WEBHOOK_PATH)).strip()
                 or _DEFAULT_WEBHOOK_PATH
             ),
-            require_mention=(
-                str(extra.get("require_mention") or os.getenv("FEISHU_REQUIRE_MENTION", "true")).strip().lower()
-                not in ("false", "0", "no")
-            ),
+            require_mention=_resolve_require_mention(extra),
         )
 
     def _apply_settings(self, settings: FeishuAdapterSettings) -> None:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -485,6 +485,11 @@ DEFAULT_CONFIG = {
         "reactions": True,             # Add 👀/✅/❌ reactions to messages during processing
     },
 
+    # Feishu/Lark platform settings (gateway mode)
+    "feishu": {
+        "require_mention": True,       # Require @mention to respond in group chats (default: true)
+    },
+
     # WhatsApp platform settings (gateway mode)
     "whatsapp": {
         # Reply prefix prepended to every outgoing WhatsApp message.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -256,6 +256,7 @@ DEFAULT_CONFIG = {
         "command_timeout": 30,  # Timeout for browser commands in seconds (screenshot, navigate, etc.)
         "record_sessions": False,  # Auto-record browser sessions as WebM videos
         "allow_private_urls": False,  # Allow navigating to private/internal IPs (localhost, 192.168.x.x, etc.)
+        "snapshot_threshold": 20000,  # Max chars for snapshot content before summarization/truncation
         "camofox": {
             # When true, Hermes sends a stable profile-scoped userId to Camofox
             # so the server can map it to a persistent browser profile directory.

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2537,6 +2537,41 @@ class TestRequireMentionDisabled(unittest.TestCase):
         blocked_sender = SimpleNamespace(open_id="ou_blocked", user_id=None)
         self.assertFalse(adapter._should_accept_group_message(message, blocked_sender))
 
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
+    def test_require_mention_false_from_platform_config_extra(self):
+        """require_mention=False via PlatformConfig.extra should be honored (no falsy fallback bug)."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        # Explicit False via extra should work even without env var
+        adapter = FeishuAdapter(PlatformConfig(extra={"require_mention": False}))
+        message = SimpleNamespace(content='{"text":"hello"}', mentions=[])
+        sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
+        self.assertTrue(adapter._should_accept_group_message(message, sender_id))
+
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
+    def test_require_mention_true_from_platform_config_extra(self):
+        """require_mention=True via PlatformConfig.extra should be honored."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig(extra={"require_mention": True}))
+        message = SimpleNamespace(content='{"text":"hello"}', mentions=[])
+        sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
+        self.assertFalse(adapter._should_accept_group_message(message, sender_id))
+
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open", "FEISHU_REQUIRE_MENTION": "true"}, clear=True)
+    def test_require_mention_env_var_overridden_by_explicit_false_in_extra(self):
+        """extra.get("require_mention") takes precedence over env var (even when False)."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        # Env var says true, but extra explicitly says False — should use False
+        adapter = FeishuAdapter(PlatformConfig(extra={"require_mention": False}))
+        message = SimpleNamespace(content='{"text":"hello"}', mentions=[])
+        sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
+        self.assertTrue(adapter._should_accept_group_message(message, sender_id))
+
 
 @unittest.skipUnless(_HAS_LARK_OAPI, "lark-oapi not installed")
 class TestSenderNameResolution(unittest.TestCase):

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2474,6 +2474,70 @@ class TestGroupMentionAtAll(unittest.TestCase):
         self.assertTrue(adapter._should_accept_group_message(message, allowed_sender))
 
 
+class TestRequireMentionDisabled(unittest.TestCase):
+    """Tests for require_mention=false behavior in group chats."""
+
+    @patch.dict(
+        os.environ,
+        {"FEISHU_GROUP_POLICY": "open", "FEISHU_REQUIRE_MENTION": "false"},
+        clear=True,
+    )
+    def test_group_message_accepted_without_mention_when_require_mention_false(self):
+        """When require_mention=false, group messages are accepted without @mention."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        message = SimpleNamespace(content='{"text":"hello"}', mentions=[])
+        sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
+        self.assertTrue(adapter._should_accept_group_message(message, sender_id))
+
+    @patch.dict(
+        os.environ,
+        {"FEISHU_GROUP_POLICY": "open", "FEISHU_REQUIRE_MENTION": "true"},
+        clear=True,
+    )
+    def test_group_message_rejected_without_mention_when_require_mention_true(self):
+        """Default behavior: require_mention=true requires @mention."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        message = SimpleNamespace(content='{"text":"hello"}', mentions=[])
+        sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
+        self.assertFalse(adapter._should_accept_group_message(message, sender_id))
+
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
+    def test_require_mention_defaults_to_true_when_unset(self):
+        """When FEISHU_REQUIRE_MENTION is unset, default is true (require mention)."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        message = SimpleNamespace(content='{"text":"hello"}', mentions=[])
+        sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
+        self.assertFalse(adapter._should_accept_group_message(message, sender_id))
+
+    @patch.dict(
+        os.environ,
+        {"FEISHU_GROUP_POLICY": "allowlist", "FEISHU_ALLOWED_USERS": "ou_allowed", "FEISHU_REQUIRE_MENTION": "false"},
+        clear=True,
+    )
+    def test_require_mention_false_still_respects_allowlist_policy(self):
+        """require_mention=false bypasses mention check but NOT allowlist policy."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        message = SimpleNamespace(content='{"text":"hello"}', mentions=[])
+        # Allowlisted user — should pass.
+        allowed_sender = SimpleNamespace(open_id="ou_allowed", user_id=None)
+        self.assertTrue(adapter._should_accept_group_message(message, allowed_sender))
+        # Non-allowlisted user — should be blocked.
+        blocked_sender = SimpleNamespace(open_id="ou_blocked", user_id=None)
+        self.assertFalse(adapter._should_accept_group_message(message, blocked_sender))
+
+
 @unittest.skipUnless(_HAS_LARK_OAPI, "lark-oapi not installed")
 class TestSenderNameResolution(unittest.TestCase):
     """Tests for _resolve_sender_name_from_api."""

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -272,12 +272,12 @@ def camofox_snapshot(full: bool = False, task_id: Optional[str] = None,
 
         # Apply same summarization logic as the main browser tool
         from tools.browser_tool import (
-            _get_snapshot_threshold,
+            get_browser_snapshot_threshold,
             _extract_relevant_content,
             _truncate_snapshot,
         )
 
-        threshold = _get_snapshot_threshold()
+        threshold = get_browser_snapshot_threshold()
         if len(snapshot) > threshold:
             if user_task:
                 snapshot = _extract_relevant_content(snapshot, user_task)

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -272,16 +272,17 @@ def camofox_snapshot(full: bool = False, task_id: Optional[str] = None,
 
         # Apply same summarization logic as the main browser tool
         from tools.browser_tool import (
-            SNAPSHOT_SUMMARIZE_THRESHOLD,
+            _get_snapshot_threshold,
             _extract_relevant_content,
             _truncate_snapshot,
         )
 
-        if len(snapshot) > SNAPSHOT_SUMMARIZE_THRESHOLD:
+        threshold = _get_snapshot_threshold()
+        if len(snapshot) > threshold:
             if user_task:
                 snapshot = _extract_relevant_content(snapshot, user_task)
             else:
-                snapshot = _truncate_snapshot(snapshot)
+                snapshot = _truncate_snapshot(snapshot, max_chars=threshold)
 
         return json.dumps({
             "success": True,

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -80,6 +80,7 @@ from tools.browser_providers.base import CloudBrowserProvider
 from tools.browser_providers.browserbase import BrowserbaseProvider
 from tools.browser_providers.browser_use import BrowserUseProvider
 from tools.tool_backend_helpers import normalize_browser_cloud_provider
+from hermes_constants import get_hermes_home
 
 # Camofox local anti-detection browser backend (optional).
 # When CAMOFOX_URL is set, all browser operations route through the
@@ -167,8 +168,7 @@ def _get_snapshot_threshold() -> int:
     ``DEFAULT_SNAPSHOT_THRESHOLD`` (20000) if unset or unreadable.
     """
     try:
-        hermes_home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
-        config_path = hermes_home / "config.yaml"
+        config_path = get_hermes_home() / "config.yaml"
         if config_path.exists():
             import yaml
             with open(config_path, encoding="utf-8") as f:
@@ -179,6 +179,12 @@ def _get_snapshot_threshold() -> int:
     except Exception as e:
         logger.debug("Could not read snapshot_threshold from config: %s", e)
     return DEFAULT_SNAPSHOT_THRESHOLD
+
+
+# Public wrapper for camofox and other modules
+def get_browser_snapshot_threshold() -> int:
+    """Public API to get the configured browser snapshot threshold."""
+    return _get_snapshot_threshold()
 
 
 def _get_vision_model() -> Optional[str]:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -167,11 +167,15 @@ def _get_snapshot_threshold() -> int:
     ``DEFAULT_SNAPSHOT_THRESHOLD`` (20000) if unset or unreadable.
     """
     try:
-        from hermes_cli.config import load_config
-        cfg = load_config() or {}
-        val = cfg.get("browser", {}).get("snapshot_threshold")
-        if val is not None:
-            return max(int(val), 1000)  # Floor at 1000 to avoid too-small thresholds
+        hermes_home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+        config_path = hermes_home / "config.yaml"
+        if config_path.exists():
+            import yaml
+            with open(config_path, encoding="utf-8") as f:
+                cfg = yaml.safe_load(f) or {}
+            val = cfg.get("browser", {}).get("snapshot_threshold")
+            if val is not None:
+                return max(int(val), 1000)  # Floor at 1000 to avoid too-small thresholds
     except Exception as e:
         logger.debug("Could not read snapshot_threshold from config: %s", e)
     return DEFAULT_SNAPSHOT_THRESHOLD

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -134,8 +134,9 @@ DEFAULT_COMMAND_TIMEOUT = 30
 # Default session timeout (seconds)
 DEFAULT_SESSION_TIMEOUT = 300
 
-# Max tokens for snapshot content before summarization
-SNAPSHOT_SUMMARIZE_THRESHOLD = 8000
+# Default max chars for snapshot content before summarization
+# Can be overridden via config.yaml browser.snapshot_threshold
+DEFAULT_SNAPSHOT_THRESHOLD = 20000
 
 
 def _get_command_timeout() -> int:
@@ -157,6 +158,23 @@ def _get_command_timeout() -> int:
     except Exception as e:
         logger.debug("Could not read command_timeout from config: %s", e)
     return DEFAULT_COMMAND_TIMEOUT
+
+
+def _get_snapshot_threshold() -> int:
+    """Return the configured snapshot threshold from config.yaml.
+
+    Reads ``config["browser"]["snapshot_threshold"]`` and falls back to
+    ``DEFAULT_SNAPSHOT_THRESHOLD`` (20000) if unset or unreadable.
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config() or {}
+        val = cfg.get("browser", {}).get("snapshot_threshold")
+        if val is not None:
+            return max(int(val), 1000)  # Floor at 1000 to avoid too-small thresholds
+    except Exception as e:
+        logger.debug("Could not read snapshot_threshold from config: %s", e)
+    return DEFAULT_SNAPSHOT_THRESHOLD
 
 
 def _get_vision_model() -> Optional[str]:
@@ -1090,17 +1108,19 @@ def _extract_relevant_content(
         return _truncate_snapshot(snapshot_text)
 
 
-def _truncate_snapshot(snapshot_text: str, max_chars: int = 8000) -> str:
+def _truncate_snapshot(snapshot_text: str, max_chars: Optional[int] = None) -> str:
     """
     Simple truncation fallback for snapshots.
     
     Args:
         snapshot_text: The snapshot text to truncate
-        max_chars: Maximum characters to keep
+        max_chars: Maximum characters to keep (default from config browser.snapshot_threshold)
         
     Returns:
         Truncated text with indicator if truncated
     """
+    if max_chars is None:
+        max_chars = _get_snapshot_threshold()
     if len(snapshot_text) <= max_chars:
         return snapshot_text
     
@@ -1267,10 +1287,11 @@ def browser_snapshot(
         refs = data.get("refs", {})
         
         # Check if snapshot needs summarization
-        if len(snapshot_text) > SNAPSHOT_SUMMARIZE_THRESHOLD and user_task:
+        threshold = _get_snapshot_threshold()
+        if len(snapshot_text) > threshold and user_task:
             snapshot_text = _extract_relevant_content(snapshot_text, user_task)
-        elif len(snapshot_text) > SNAPSHOT_SUMMARIZE_THRESHOLD:
-            snapshot_text = _truncate_snapshot(snapshot_text)
+        elif len(snapshot_text) > threshold:
+            snapshot_text = _truncate_snapshot(snapshot_text, max_chars=threshold)
         
         response = {
             "success": True,


### PR DESCRIPTION
## Summary

Makes the browser snapshot threshold configurable via config.yaml, allowing users to adjust the max characters for snapshot content before summarization/truncation.

Previously hardcoded as SNAPSHOT_SUMMARIZE_THRESHOLD = 8000, now configurable as browser.snapshot_threshold (default 20000).

## Changes

- Add snapshot_threshold to DEFAULT_CONFIG["browser"] in hermes_cli/config.py
- Add _get_snapshot_threshold() function in tools/browser_tool.py to read from config
- Update _truncate_snapshot() to use configurable threshold
- Update browser_camofox.py to use _get_snapshot_threshold() instead of hardcoded constant

## Usage

Users can adjust the threshold via:

```yaml
# ~/.hermes/config.yaml
browser:
  snapshot_threshold: 30000  # Max chars before summarization
```

Or via command:

```bash
hermes config set browser.snapshot_threshold 30000
```

## Related Issue

Closes #4585

## Testing

- Verified _get_snapshot_threshold() returns correct default value (20000)
- Verified browser_camofox.py imports work correctly
- Default value increased from 8000 to 20000 to better handle long pages (e.g., financial news, documentation)