### PR TITLE
fix(discord): wire DISCORD_REPLY_TO_MODE env var into PlatformConfig

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -657,6 +657,13 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         config.platforms[Platform.DISCORD].enabled = True
         config.platforms[Platform.DISCORD].token = discord_token
     
+    # Reply threading mode for Discord (off/first/all)
+    discord_reply_mode = os.getenv("DISCORD_REPLY_TO_MODE", "").lower()
+    if discord_reply_mode in ("off", "first", "all"):
+        if Platform.DISCORD not in config.platforms:
+            config.platforms[Platform.DISCORD] = PlatformConfig()
+        config.platforms[Platform.DISCORD].reply_to_mode = discord_reply_mode
+
     discord_home = os.getenv("DISCORD_HOME_CHANNEL")
     if discord_home and Platform.DISCORD in config.platforms:
         config.platforms[Platform.DISCORD].home_channel = HomeChannel(

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1166,10 +1166,12 @@ class BasePlatformAdapter(ABC):
                 # Send the text portion
                 if text_content:
                     logger.info("[%s] Sending response (%d chars) to %s", self.name, len(text_content), event.source.chat_id)
+                    _reply_to_mode = getattr(self.config, 'reply_to_mode', 'first') or 'first'
+                    _reply_ref = event.message_id if _reply_to_mode != 'off' else None
                     result = await self._send_with_retry(
                         chat_id=event.source.chat_id,
                         content=text_content,
-                        reply_to=event.message_id,
+                        reply_to=_reply_ref,
                         metadata=_thread_metadata,
                     )
                     _record_delivery(result)


### PR DESCRIPTION
## Problem

`_apply_env_overrides()` in `gateway/config.py` reads `TELEGRAM_REPLY_TO_MODE` and applies it to the Telegram `PlatformConfig` (lines 630–634), but had no equivalent block for Discord. Setting `DISCORD_REPLY_TO_MODE=off` in a profile's `.env` file was silently ignored — the env var was never read into the Discord `PlatformConfig` object, so `config.platforms[Platform.DISCORD].reply_to_mode` always stayed at the dataclass default of `'first'`.

Additionally, `gateway/platforms/base.py` hardcoded `reply_to=event.message_id` unconditionally when sending text responses. Even if `PlatformConfig` had the correct value, the hardcoded call would still produce a Discord reply.

## Fix

1. **`gateway/config.py`** — Add a Discord `reply_to_mode` block to `_apply_env_overrides()`, modeled directly after the existing Telegram block.
2. **`gateway/platforms/base.py`** — Check `self.config.reply_to_mode` before passing `reply_to`, passing `None` (no reply) when the mode is `'off'`.

## Behaviour

| `DISCORD_REPLY_TO_MODE` | Result |
|---|---|
| `off` | Plain channel message, no reply link |
| `first` (default) | Reply linked to the triggering message |
| `all` | All messages linked as replies |

This mirrors the existing Telegram behaviour controlled by `TELEGRAM_REPLY_TO_MODE`.