### PR TITLE
Clarify WSL shell requirement for Windows users in Quick Install

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scri
 Works on Linux, macOS, and WSL2. The installer handles everything — Python, Node.js, dependencies, and the `hermes` command. No prerequisites except git.
 
 > **Windows:** Native Windows is not supported. Please install [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) and run the command above.
+> Open a WSL shell (Ubuntu, Debian, etc.) before running install/update commands.
 
 After installation:
 


### PR DESCRIPTION

This PR adds a small but practical clarification to the README Quick Install section for Windows users by explicitly noting that install and update commands should be run inside a WSL shell (for example Ubuntu or Debian), which reduces setup confusion and helps prevent users from trying to run Unix-based commands directly in native Windows terminals.