### PR TITLE
feat(cli): add --no-context flag to skip SOUL.md/AGENTS.md/memory injection

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1103,6 +1103,7 @@ class HermesCLI:
         resume: str = None,
         checkpoints: bool = False,
         pass_session_id: bool = False,
+        no_context: bool = False,
     ):
         """
         Initialize the Hermes CLI.
@@ -1236,6 +1237,7 @@ class HermesCLI:
         self.checkpoints_enabled = checkpoints or cp_cfg.get("enabled", False)
         self.checkpoint_max_snapshots = cp_cfg.get("max_snapshots", 50)
         self.pass_session_id = pass_session_id
+        self.no_context = no_context
         
         # Ephemeral system prompt: env var takes precedence, then config
         self.system_prompt = (
@@ -2207,6 +2209,8 @@ class HermesCLI:
                 tool_complete_callback=self._on_tool_complete if self._inline_diffs_enabled else None,
                 stream_delta_callback=self._stream_delta if self.streaming_enabled else None,
                 tool_gen_callback=self._on_tool_gen_start if self.streaming_enabled else None,
+                skip_context_files=self.no_context,
+                skip_memory=self.no_context,
             )
             # Route agent status output through prompt_toolkit so ANSI escape
             # sequences aren't garbled by patch_stdout's StdoutProxy (#2262).
@@ -7848,6 +7852,7 @@ def main(
     w: bool = False,
     checkpoints: bool = False,
     pass_session_id: bool = False,
+    no_context: bool = False,
 ):
     """
     Hermes Agent CLI - Interactive AI Assistant
@@ -7955,6 +7960,7 @@ def main(
         resume=resume,
         checkpoints=checkpoints,
         pass_session_id=pass_session_id,
+        no_context=no_context,
     )
 
     if parsed_skills:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -644,6 +644,7 @@ def cmd_chat(args):
         "checkpoints": getattr(args, "checkpoints", False),
         "pass_session_id": getattr(args, "pass_session_id", False),
         "max_turns": getattr(args, "max_turns", None),
+        "no_context": getattr(args, "no_context", False),
     }
     # Filter out None values
     kwargs = {k: v for k, v in kwargs.items() if v is not None}
@@ -3933,6 +3934,12 @@ For more help on a command:
         action="store_true",
         default=False,
         help="Include the session ID in the agent's system prompt"
+    )
+    chat_parser.add_argument(
+        "--no-context",
+        action="store_true",
+        default=False,
+        help="Skip auto-injection of SOUL.md, AGENTS.md, .cursorrules, and memory into the session. Useful for headless/worker dispatch where the agent should only receive the prompt."
     )
     chat_parser.add_argument(
         "--source",


### PR DESCRIPTION
## Summary

Adds a `--no-context` flag to `hermes chat` that skips auto-injection of SOUL.md, AGENTS.md, .cursorrules, and memory into the session.

## Motivation

When using Hermes as a worker/agent dispatched programmatically (e.g., `hermes chat -Q --yolo -q "..."`), the auto-injected context files cause problems:

1. **Wrong cwd**: When dispatched to a target project directory, AGENTS.md discovery walks up from cwd and finds project-specific files (or none), while SOUL.md/USER.md/MEMORY.md load from HERMES_HOME — creating a confusing mix of contexts.
2. **Wasted context window**: For focused tasks like code audits or file analysis, workspace context consumes tokens that should go to the actual task.
3. **Worker isolation**: Headless dispatch should receive only the prompt, not the operator's personal memory and personality files.

## Implementation

The underlying `AIAgent` parameters (`skip_context_files`, `skip_memory`) already exist and are used internally by:
- `gateway/builtin_hooks/boot_md.py` (boot checklist agent)
- `/btw` side questions (ephemeral agent)

This PR simply wires them through to the CLI:
- `hermes_cli/main.py`: adds `--no-context` argparse flag, passes through kwargs
- `cli.py`: accepts `no_context` param in `main()`, `HermesCLI.__init__`, and `_init_agent()`

## Usage

```bash
# Normal session (unchanged)
hermes chat -q "What's in this project?"

# Headless worker dispatch — prompt only, no context files
hermes chat -Q --yolo --no-context -q "Read /path/to/project/package.json and summarize the dependencies"
```

## Changes

- 2 files changed, 13 insertions
- Zero impact on existing behavior (flag defaults to `false`)
- No new dependencies