### PR TITLE
feat(gateway): add 'latest' tool_progress mode — show only most recent tool

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5445,6 +5445,8 @@ class GatewayRunner:
             progress_lines = []      # Accumulated tool lines
             progress_msg_id = None   # ID of the progress message to edit
             can_edit = True          # False once an edit fails (platform doesn't support it)
+            tool_count = [0]         # Total tools invoked (for "latest" mode counter)
+            _latest_mode = progress_mode == "latest"  # Show only the most recent tool
 
             while True:
                 try:
@@ -5459,14 +5461,26 @@ class GatewayRunner:
                     else:
                         msg = raw
                         progress_lines.append(msg)
+                        tool_count[0] += 1
+
+                    # Build display text based on mode
+                    if _latest_mode:
+                        # "latest" mode: show only the most recent tool with a step counter
+                        latest_line = progress_lines[-1] if progress_lines else msg
+                        if tool_count[0] > 1:
+                            display_text = f"[{tool_count[0]}] {latest_line}"
+                        else:
+                            display_text = latest_line
+                    else:
+                        # Default: show all accumulated tool lines
+                        display_text = "\n".join(progress_lines)
 
                     if can_edit and progress_msg_id is not None:
                         # Try to edit the existing progress message
-                        full_text = "\n".join(progress_lines)
                         result = await adapter.edit_message(
                             chat_id=source.chat_id,
                             message_id=progress_msg_id,
-                            content=full_text,
+                            content=display_text,
                         )
                         if not result.success:
                             # Platform doesn't support editing — stop trying,
@@ -5475,9 +5489,8 @@ class GatewayRunner:
                             await adapter.send(chat_id=source.chat_id, content=msg, metadata=_progress_metadata)
                     else:
                         if can_edit:
-                            # First tool: send all accumulated text as new message
-                            full_text = "\n".join(progress_lines)
-                            result = await adapter.send(chat_id=source.chat_id, content=full_text, metadata=_progress_metadata)
+                            # First tool: send as new message
+                            result = await adapter.send(chat_id=source.chat_id, content=display_text, metadata=_progress_metadata)
                         else:
                             # Editing unsupported: send just this line
                             result = await adapter.send(chat_id=source.chat_id, content=msg, metadata=_progress_metadata)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5518,7 +5518,11 @@ class GatewayRunner:
                             break
                     # Final edit with all remaining tools (only if editing works)
                     if can_edit and progress_lines and progress_msg_id:
-                        full_text = "\n".join(progress_lines)
+                        if _latest_mode:
+                            latest_line = progress_lines[-1]
+                            full_text = f"[{len(progress_lines)}] {latest_line}" if len(progress_lines) > 1 else latest_line
+                        else:
+                            full_text = "\n".join(progress_lines)
                         try:
                             await adapter.edit_message(
                                 chat_id=source.chat_id,

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -217,3 +217,58 @@ async def test_run_agent_progress_uses_event_message_id_for_slack_dm(monkeypatch
     assert adapter.sent
     assert adapter.sent[0]["metadata"] == {"thread_id": "1234567890.000001"}
     assert all(call["metadata"] == {"thread_id": "1234567890.000001"} for call in adapter.typing)
+
+
+@pytest.mark.asyncio
+async def test_run_agent_progress_latest_mode_shows_single_line(monkeypatch, tmp_path):
+    """'latest' mode should show only the most recent tool with a step counter."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "latest")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+    # Write a config.yaml so _load_gateway_config picks up "latest" mode
+    import yaml
+    (tmp_path / "config.yaml").write_text(
+        yaml.dump({"display": {"tool_progress": "latest"}}), encoding="utf-8"
+    )
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="99999",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-latest",
+        session_key="agent:main:telegram:dm:99999",
+    )
+
+    assert result["final_response"] == "done"
+
+    # First tool: sent as a new message (no counter prefix for step 1)
+    assert len(adapter.sent) == 1
+    first_msg = adapter.sent[0]["content"]
+    assert "terminal" in first_msg
+    assert not first_msg.startswith("[")
+
+    # Second tool: edited in-place with step counter [2]
+    assert len(adapter.edits) >= 1
+    last_edit = adapter.edits[-1]["content"]
+    assert last_edit.startswith("[2]")
+    assert "browser_navigate" in last_edit


### PR DESCRIPTION
## Summary

Adds a new `latest` mode for `display.tool_progress` in the gateway that shows only the **most recent tool invocation** as a single line, replacing the previous one via message edit.

### Problem

On chat platforms like Telegram, the accumulated tool progress messages can get long and noisy (e.g. 10+ lines of 🔍 web_search, 💻 terminal, etc.). The existing modes are either all-or-nothing:
- `all` / `verbose`: shows every tool (too much)
- `new`: shows each new tool but still accumulates
- `off`: shows nothing (no feedback at all)

### Solution

The new `latest` mode:
- Displays **only the most recent tool** with a step counter: `[3] 🔍 web_search: query...`
- Edits the same message in-place, so it's always just **one line**
- Gives the user feedback that work is happening without flooding the chat

### Config

```yaml
display:
  tool_progress: latest
  tool_preview_length: 30  # optional, truncate preview
```

### Modes comparison

| Mode | Behavior |
|------|----------|
| `off` | No progress messages |
| `new` | Show only when tool changes |
| `latest` | **Single line, most recent tool + counter** |
| `all` | Accumulate all tool lines |
| `verbose` | All lines with extra detail |
