### PR TITLE
fix: Azure AI Foundry / Azure Anthropic endpoint compatibility

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -152,13 +152,17 @@ def _is_oauth_token(key: str) -> bool:
 
     Regular API keys start with 'sk-ant-api'. Everything else (setup-tokens
     starting with 'sk-ant-oat', managed keys, JWTs, etc.) needs Bearer auth.
+    Azure AI Foundry keys (non sk-ant- prefixed) should use x-api-key, not Bearer.
     """
     if not key:
         return False
     # Regular Console API keys use x-api-key header
     if key.startswith("sk-ant-api"):
         return False
-    # Everything else (setup-tokens, managed keys, JWTs) uses Bearer auth
+    # Azure AI Foundry keys don't start with sk-ant- at all — treat as regular API key
+    if not key.startswith("sk-ant-"):
+        return False
+    # Everything else (setup-tokens sk-ant-oat, managed keys, JWTs) uses Bearer auth
     return True
 
 

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -212,7 +212,15 @@ def build_anthropic_client(api_key: str, base_url: str = None):
         "timeout": Timeout(timeout=900.0, connect=10.0),
     }
     if base_url:
-        kwargs["base_url"] = base_url
+        # Azure Anthropic endpoints require api-version query parameter.
+        # Pass it via default_query so the SDK appends it to every request URL
+        # without corrupting the base_url (appending to base_url causes the SDK
+        # to produce malformed paths like /anthropic?api-version=.../v1/messages).
+        if _is_azure_endpoint and "api-version" not in base_url:
+            kwargs["base_url"] = base_url.rstrip("/")
+            kwargs["default_query"] = {"api-version": "2025-04-15"}
+        else:
+            kwargs["base_url"] = base_url
 
     if _requires_bearer_auth(base_url):
         # Some Anthropic-compatible providers (e.g. MiniMax) expect the API key in

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -633,13 +633,6 @@ def resolve_runtime_provider(
 
     # Anthropic (native Messages API)
     if provider == "anthropic":
-        from agent.anthropic_adapter import resolve_anthropic_token
-        token = resolve_anthropic_token()
-        if not token:
-            raise AuthError(
-                "No Anthropic credentials found. Set ANTHROPIC_TOKEN or ANTHROPIC_API_KEY, "
-                "run 'claude setup-token', or authenticate with 'claude /login'."
-            )
         # Allow base URL override from config.yaml model.base_url, but only
         # when the configured provider is anthropic — otherwise a non-Anthropic
         # base_url (e.g. Codex endpoint) would leak into Anthropic requests.
@@ -648,6 +641,33 @@ def resolve_runtime_provider(
         if cfg_provider == "anthropic":
             cfg_base_url = (model_cfg.get("base_url") or "").strip().rstrip("/")
         base_url = cfg_base_url or "https://api.anthropic.com"
+
+        # For Azure AI Foundry endpoints, use ANTHROPIC_API_KEY directly —
+        # Claude Code OAuth tokens (sk-ant-oat01) are not accepted by Azure.
+        # Azure keys don't start with "sk-ant-" so resolve_anthropic_token()
+        # would find the Claude Code OAuth token first (priority 3) and return
+        # that instead, causing 401s. Detect Azure endpoints and use the env
+        # key directly to bypass the OAuth priority chain.
+        _is_azure_endpoint = "azure.com" in base_url.lower() or (
+            cfg_base_url and "azure.com" in cfg_base_url.lower()
+        )
+        if _is_azure_endpoint:
+            token = (
+                os.getenv("AZURE_ANTHROPIC_KEY", "").strip()
+                or os.getenv("ANTHROPIC_API_KEY", "").strip()
+            )
+            if not token:
+                raise AuthError(
+                    "No Azure Anthropic API key found. Set AZURE_ANTHROPIC_KEY or ANTHROPIC_API_KEY."
+                )
+        else:
+            from agent.anthropic_adapter import resolve_anthropic_token
+            token = resolve_anthropic_token()
+            if not token:
+                raise AuthError(
+                    "No Anthropic credentials found. Set ANTHROPIC_TOKEN or ANTHROPIC_API_KEY, "
+                    "run 'claude setup-token', or authenticate with 'claude /login'."
+                )
         return {
             "provider": "anthropic",
             "api_mode": "anthropic_messages",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -525,6 +525,26 @@ def resolve_runtime_provider(
     """Resolve runtime provider credentials for agent execution."""
     requested_provider = resolve_requested_provider(requested)
 
+    # Azure Anthropic short-circuit: when explicitly targeting an Azure endpoint
+    # with provider="anthropic", bypass _resolve_named_custom_runtime (which would
+    # return provider="custom" with chat_completions api_mode and no valid key).
+    # Instead, use the Azure key directly with anthropic_messages api_mode.
+    _eff_base = (explicit_base_url or "").strip()
+    if requested_provider == "anthropic" and "azure.com" in _eff_base:
+        _azure_key = (
+            (explicit_api_key or "").strip()
+            or os.getenv("AZURE_ANTHROPIC_KEY", "").strip()
+            or os.getenv("ANTHROPIC_API_KEY", "").strip()
+        )
+        return {
+            "provider": "anthropic",
+            "api_mode": "anthropic_messages",
+            "base_url": _eff_base.rstrip("/"),
+            "api_key": _azure_key,
+            "source": "azure-explicit",
+            "requested_provider": requested_provider,
+        }
+
     custom_runtime = _resolve_named_custom_runtime(
         requested_provider=requested_provider,
         explicit_api_key=explicit_api_key,

--- a/run_agent.py
+++ b/run_agent.py
@@ -3928,6 +3928,11 @@ class AIAgent:
         # Other anthropic_messages providers (MiniMax, Alibaba, etc.) use their own keys.
         if self.provider != "anthropic":
             return False
+        # Azure endpoints use static API keys — OAuth token rotation doesn't apply.
+        # Refreshing would pick up ~/.claude/.credentials.json OAuth token and break auth.
+        _base = getattr(self, "_anthropic_base_url", "") or ""
+        if "azure.com" in _base:
+            return False
 
         try:
             from agent.anthropic_adapter import resolve_anthropic_token, build_anthropic_client


### PR DESCRIPTION
## Problem

Hermes is completely broken when configured to use Azure AI Foundry's Anthropic-compatible endpoint. Multiple overlapping bugs cause every request to fail with HTTP 404 or HTTP 401.

## Root Causes (5 bugs, fixed in order of discovery)

### 1. Azure AI Foundry keys misidentified as OAuth tokens
`_is_oauth_token()` in `runtime_provider.py` only excluded `sk-ant-api` prefix keys, treating Azure keys (which don't start with `sk-ant-` at all) as OAuth tokens → wrong auth header sent.

### 2. OAuth token priority chain overrides Azure key
`resolve_anthropic_token()` checks `~/.claude/.credentials.json` at priority 3, before `ANTHROPIC_API_KEY` at priority 4. If the user has Claude Code installed, the OAuth token wins every time, regardless of what's in the environment.

### 3. `_resolve_named_custom_runtime` intercepts the `anthropic` provider
When `requested="anthropic"` + an Azure base_url is passed, the custom runtime resolver intercepts it and returns `provider="custom"` with no `api_mode` set → falls through to `chat_completions` path.

### 4. `_try_refresh_anthropic_client_credentials` overwrites Azure key mid-session
Called before every request. Finds the OAuth token in `~/.claude/.credentials.json`, sees it differs from the Azure key, and swaps it in → correct Azure key gets silently replaced on message 2+.

### 5. `api-version` appended to `base_url` produces malformed URLs
Previous fix attempt added `api-version=2025-04-15` directly to the base URL string. The Anthropic SDK then appended `/v1/messages` to that, producing:
```
.../anthropic?api-version=2025-04-15/v1/messages
```
instead of:
```
.../anthropic/v1/messages?api-version=2025-04-15
```
Azure returns 404 on the malformed path.

## Fixes

| Commit | Fix |
|--------|-----|
| `3125ea6f` | Non-`sk-ant-` keys are regular API keys, not OAuth tokens |
| `896d8157` | Use `AZURE_ANTHROPIC_KEY`/`ANTHROPIC_API_KEY` directly for Azure endpoints |
| `ad3fcf3b` | Short-circuit custom runtime resolver for `provider=anthropic` + Azure URL |
| `f3640168` | Skip OAuth credential refresh for Azure endpoints in `run_agent.py` |
| `7c00e15a` | Pass `api-version` via `default_query`, not baked into `base_url` |

## Configuration

After this fix, Azure AI Foundry works with the following `config.yaml`:

```yaml
model:
  provider: anthropic
  base_url: https://<resource>.services.ai.azure.com/anthropic
  api_key_env: AZURE_ANTHROPIC_KEY
  default: claude-sonnet-4-6
```

With `AZURE_ANTHROPIC_KEY` set to the Azure AI Foundry API key (no `sk-ant-` prefix).