### PR TITLE
feat(gateway): support custom slash commands

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -448,6 +448,10 @@ class GatewayRunner:
         self._running_agents: Dict[str, Any] = {}
         self._pending_messages: Dict[str, str] = {}  # Queued messages during interrupt
 
+        # Load user-defined script commands from ~/.hermes/commands/
+        from hermes_cli.commands import load_user_commands
+        self._user_commands: dict[str, str] = load_user_commands()
+
         # Cache AIAgent instances per session to preserve prompt caching.
         # Without this, a new AIAgent is created per message, rebuilding the
         # system prompt (including memory) every turn — breaking prefix cache
@@ -1984,6 +1988,7 @@ class GatewayRunner:
             return await self._handle_voice_command(event)
 
         # User-defined quick commands (bypass agent loop, no LLM call)
+        # Also checks user script commands from ~/.hermes/commands/
         if command:
             if isinstance(self.config, dict):
                 quick_commands = self.config.get("quick_commands", {}) or {}
@@ -1991,6 +1996,30 @@ class GatewayRunner:
                 quick_commands = getattr(self.config, "quick_commands", {}) or {}
             if not isinstance(quick_commands, dict):
                 quick_commands = {}
+
+            # Check user script commands first
+            if canonical in self._user_commands or command in self._user_commands:
+                script_path = self._user_commands.get(canonical) or self._user_commands.get(command)
+                args = event.text.strip()[len(f"/{command}"):].strip() if event.text else ""
+                env = {**__import__("os").environ,
+                       "HERMES_CHAT_ID": str(event.source.chat_id),
+                       "HERMES_PLATFORM": str(event.source.platform.value if hasattr(event.source.platform, "value") else event.source.platform),
+                       "HERMES_ARGS": args}
+                try:
+                    proc = await asyncio.create_subprocess_exec(
+                        script_path, *args.split() if args else [],
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.PIPE,
+                        env=env,
+                    )
+                    stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
+                    output = stdout.decode().strip() or stderr.decode().strip()
+                    return output if output else "Command returned no output."
+                except asyncio.TimeoutError:
+                    return "User command timed out (30s)."
+                except Exception as e:
+                    return f"User command error: {e}"
+
             if command in quick_commands:
                 qcmd = quick_commands[command]
                 if qcmd.get("type") == "exec":

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -173,6 +173,53 @@ def register_plugin_command(cmd: CommandDef) -> None:
     rebuild_lookups()
 
 
+def load_user_commands(commands_dir: str | None = None) -> dict[str, str]:
+    """Scan ~/.hermes/commands/ for executable scripts and register them.
+
+    Each executable file becomes a slash command named after the file
+    (without extension). Returns a dict mapping command name -> script path
+    for use at dispatch time.
+
+    Example: ~/.hermes/commands/digest -> /digest runs the script, zero LLM.
+    """
+    from pathlib import Path
+
+    if commands_dir is None:
+        try:
+            from hermes_constants import get_hermes_home
+            commands_dir = str(Path(get_hermes_home()) / "commands")
+        except ImportError:
+            commands_dir = str(Path.home() / ".hermes" / "commands")
+
+    user_commands: dict[str, str] = {}
+    cmds_path = Path(commands_dir)
+    if not cmds_path.exists():
+        return user_commands
+
+    existing_names = {cmd.name for cmd in COMMAND_REGISTRY}
+
+    for script in sorted(cmds_path.iterdir()):
+        if not script.is_file():
+            continue
+        if not os.access(script, os.X_OK):
+            continue
+        # Use stem (filename without extension) as command name
+        name = script.stem.lower()
+        if not name or not re.match(r'^[a-z][a-z0-9_-]*$', name):
+            continue
+        user_commands[name] = str(script)
+        if name not in existing_names:
+            register_plugin_command(CommandDef(
+                name=name,
+                description=f"User script: {script.name}",
+                category="Tools & Skills",
+                args_hint="[args]",
+            ))
+            existing_names.add(name)
+
+    return user_commands
+
+
 def rebuild_lookups() -> None:
     """Rebuild all derived lookup dicts from the current COMMAND_REGISTRY.
 


### PR DESCRIPTION
## What does this PR do?

Scan executable files dropped into ~/.hermes/commands/ at gateway startup and register them as slash commands. Matching commands bypass the LLM loop entirely - the script is executed directly with HERMES_CHAT_ID, HERMES_PLATFORM, and HERMES_ARGS injected as env vars, and its stdout is returned as the response.

Previously, adding a custom quick command required either a source edit or a config entry with a specific schema. A drop-in directory with zero-config auto-discovery is lower friction, and the LLM-bypass is intentional: these are deterministic, token-free invocations — suited for things like /digest or /status where you want instant output without an agent round-trip.

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)


## How to Test

1. Ask the agent to create a custom command.
2. Trigger the command on whatever channel you use (I tested on Telegram)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
