### PR TITLE
fix(honcho): allow CLI flows with baseUrl-only config

### DIFF
--- a/honcho_integration/cli.py
+++ b/honcho_integration/cli.py
@@ -56,6 +56,25 @@ def _resolve_api_key(cfg: dict) -> str:
     return host_key or cfg.get("apiKey", "") or os.environ.get("HONCHO_API_KEY", "")
 
 
+def _resolve_base_url(cfg: dict) -> str:
+    """Resolve base URL with host -> root -> env fallback."""
+    host_cfg = ((cfg.get("hosts") or {}).get(HOST) or {})
+    for key in ("baseUrl", "base_url", "baseURL"):
+        value = host_cfg.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    for key in ("baseUrl", "base_url", "baseURL"):
+        value = cfg.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return os.environ.get("HONCHO_BASE_URL", "").strip()
+
+
+def _is_configured(cfg: dict) -> bool:
+    """Return True when an API key or self-hosted base URL is configured."""
+    return bool(_resolve_api_key(cfg) or _resolve_base_url(cfg))
+
+
 def _prompt(label: str, default: str | None = None, secret: bool = False) -> str:
     suffix = f" [{default}]" if default else ""
     sys.stdout.write(f"  {label}{suffix}: ")
@@ -124,17 +143,24 @@ def cmd_setup(args) -> None:
     hermes_host = hosts.setdefault(HOST, {})
 
     # API key — shared credential, lives at root so all hosts can read it
-    current_key = cfg.get("apiKey", "")
+    current_key = _resolve_api_key(cfg)
     masked = f"...{current_key[-8:]}" if len(current_key) > 8 else ("set" if current_key else "not set")
     print(f"  Current API key: {masked}")
     new_key = _prompt("Honcho API key (leave blank to keep current)", secret=True)
     if new_key:
         cfg["apiKey"] = new_key
 
-    effective_key = cfg.get("apiKey", "")
-    if not effective_key:
-        print("\n  No API key configured. Get your API key at https://app.honcho.dev")
-        print("  Run 'hermes honcho setup' again once you have a key.\n")
+    current_base_url = _resolve_base_url(cfg)
+    print(f"  Current base URL: {current_base_url or 'not set'}")
+    new_base_url = _prompt("Honcho base URL (leave blank to keep current)", default=current_base_url or None)
+    if new_base_url:
+        hermes_host["baseUrl"] = new_base_url
+
+    effective_key = _resolve_api_key(cfg)
+    effective_base_url = _resolve_base_url(cfg)
+    if not effective_key and not effective_base_url:
+        print("\n  No API key or base URL configured.")
+        print("  Get a cloud API key at https://app.honcho.dev or enter your self-hosted base URL.\n")
         return
 
     # Peer name
@@ -469,8 +495,8 @@ def cmd_tokens(args) -> None:
 def cmd_identity(args) -> None:
     """Seed AI peer identity or show both peer representations."""
     cfg = _read_config()
-    if not _resolve_api_key(cfg):
-        print("  No API key configured. Run 'hermes honcho setup' first.\n")
+    if not _is_configured(cfg):
+        print("  No API key or base URL configured. Run 'hermes honcho setup' first.\n")
         return
 
     file_path = getattr(args, "file", None)
@@ -567,7 +593,7 @@ def cmd_migrate(args) -> None:
                 agent_files.append(p)
 
     cfg = _read_config()
-    has_key = bool(_resolve_api_key(cfg))
+    has_config = _is_configured(cfg)
 
     print("\nHoncho migration: OpenClaw native memory → Hermes\n" + "─" * 50)
     print()
@@ -581,23 +607,27 @@ def cmd_migrate(args) -> None:
     # ── Step 1: Honcho account ────────────────────────────────────────────────
     print("Step 1  Create a Honcho account")
     print()
-    if has_key:
-        masked = f"...{cfg['apiKey'][-8:]}" if len(cfg["apiKey"]) > 8 else "set"
-        print(f"  Honcho API key already configured: {masked}")
+    if has_config:
+        api_key = _resolve_api_key(cfg)
+        base_url = _resolve_base_url(cfg)
+        if api_key:
+            masked = f"...{api_key[-8:]}" if len(api_key) > 8 else "set"
+            print(f"  Honcho API key already configured: {masked}")
+        if base_url:
+            print(f"  Honcho base URL already configured: {base_url}")
         print("  Skip to Step 2.")
     else:
-        print("  Honcho is a cloud memory service that gives Hermes persistent memory")
-        print("  across sessions. You need an API key to use it.")
+        print("  Honcho can use either a cloud API key or a self-hosted base URL.")
         print()
-        print("  1. Get your API key at https://app.honcho.dev")
+        print("  1. Get your API key at https://app.honcho.dev, or decide on your self-hosted Honcho URL")
         print("  2. Run:  hermes honcho setup")
-        print("     Paste the key when prompted.")
+        print("     Paste the key or enter the base URL when prompted.")
         print()
         answer = _prompt("  Run 'hermes honcho setup' now?", default="y")
         if answer.lower() in ("y", "yes"):
             cmd_setup(args)
             cfg = _read_config()
-            has_key = bool(cfg.get("apiKey", ""))
+            has_config = _is_configured(cfg)
         else:
             print()
             print("  Run 'hermes honcho setup' when ready, then re-run this walkthrough.")

--- a/tests/honcho_integration/test_cli.py
+++ b/tests/honcho_integration/test_cli.py
@@ -1,6 +1,6 @@
 """Tests for Honcho CLI helpers."""
 
-from honcho_integration.cli import _resolve_api_key
+from honcho_integration.cli import _is_configured, _resolve_api_key, _resolve_base_url
 
 
 class TestResolveApiKey:
@@ -26,4 +26,75 @@ class TestResolveApiKey:
         monkeypatch.setenv("HONCHO_API_KEY", "env-key")
         assert _resolve_api_key({}) == "env-key"
         monkeypatch.delenv("HONCHO_API_KEY", raising=False)
+
+
+class TestResolveBaseUrl:
+    def test_prefers_host_scoped_base_url(self, monkeypatch):
+        monkeypatch.setenv("HONCHO_BASE_URL", "http://env:9002")
+        cfg = {
+            "baseUrl": "http://root:9000",
+            "hosts": {"hermes": {"baseUrl": "http://host:9001"}},
+        }
+        assert _resolve_base_url(cfg) == "http://host:9001"
+
+    def test_supports_aliases(self, monkeypatch):
+        monkeypatch.delenv("HONCHO_BASE_URL", raising=False)
+        cfg = {
+            "baseURL": "http://root:9000",
+            "hosts": {"hermes": {"base_url": "http://host:9001"}},
+        }
+        assert _resolve_base_url(cfg) == "http://host:9001"
+
+
+class TestIsConfigured:
+    def test_true_when_base_url_only(self):
+        cfg = {"hosts": {"hermes": {"baseUrl": "https://example.test"}}}
+        assert _is_configured(cfg) is True
+
+    def test_false_when_no_key_or_base_url(self):
+        assert _is_configured({"hosts": {"hermes": {}}}) is False
+
+
+class TestCmdIdentity:
+    def test_allows_base_url_only_config(self, monkeypatch, capsys):
+        import honcho_integration.cli as honcho_cli
+        import honcho_integration.client as client_mod
+        import honcho_integration.session as session_mod
+
+        monkeypatch.setattr(
+            honcho_cli,
+            "_read_config",
+            lambda: {"hosts": {"hermes": {"baseUrl": "https://example.test"}}},
+        )
+
+        class FakeConfig:
+            peer_name = "genos"
+            ai_peer = "hermes"
+
+            def resolve_session_name(self):
+                return "hermes"
+
+        class FakeHonchoClientConfig:
+            @classmethod
+            def from_global_config(cls):
+                return FakeConfig()
+
+        class FakeSessionManager:
+            def __init__(self, honcho, config):
+                self.honcho = honcho
+                self.config = config
+
+            def get_or_create(self, key):
+                return object()
+
+        monkeypatch.setattr(client_mod, "HonchoClientConfig", FakeHonchoClientConfig)
+        monkeypatch.setattr(client_mod, "get_honcho_client", lambda cfg: object())
+        monkeypatch.setattr(session_mod, "HonchoSessionManager", FakeSessionManager)
+
+        args = type("Args", (), {"file": None, "show": False})()
+        honcho_cli.cmd_identity(args)
+
+        out = capsys.readouterr().out
+        assert "Honcho identity management" in out
+        assert "No API key configured" not in out
 


### PR DESCRIPTION
Title
fix(honcho): allow CLI flows with baseUrl-only config

Summary
Several Honcho CLI flows still assume an API key is required even when the user is intentionally using a self-hosted Honcho instance via `baseUrl`.

Root cause
`honcho_integration/cli.py` had API-key-only gating in multiple places:
- `hermes honcho setup`
- `hermes honcho identity`
- `hermes honcho migrate`

That blocks valid self-hosted setups where `baseUrl` is configured and auth is handled outside the cloud API-key path.

Fix
- add `_resolve_base_url()` helper in `honcho_integration/cli.py`
- add `_is_configured()` helper that accepts `(apiKey OR baseUrl)`
- update `cmd_setup()` to:
  - show current base URL
  - prompt for base URL
  - allow setup to continue when only base URL is configured
- update `cmd_identity()` to allow baseUrl-only config
- update `cmd_migrate()` messaging and gating so it recognizes self-hosted baseUrl config

Why this is safe
- only changes CLI gating and prompts
- does not change non-Honcho code paths
- keeps existing API-key flow intact while allowing the already-supported self-hosted baseUrl flow

Test plan
source /Users/genos/.hermes/hermes-agent/venv/bin/activate
pytest -q tests/honcho_integration/test_cli.py

Targeted checks covered by the new tests
- host-scoped base URL resolution
- base URL alias support
- `_is_configured()` returns true for baseUrl-only config
- `cmd_identity()` no longer rejects baseUrl-only Honcho config before attempting the real connection path

Result
- 8 passed
