### PR TITLE
fix(honcho): make status run a real connectivity check

### DIFF
--- a/honcho_integration/cli.py
+++ b/honcho_integration/cli.py
@@ -237,6 +237,16 @@ def cmd_setup(args) -> None:
     print("    hermes honcho map <name> — map this directory to a session name\n")
 
 
+def _check_connection(hcfg) -> None:
+    """Perform a real Honcho connectivity check using the session path."""
+    from honcho_integration.client import get_honcho_client
+    from honcho_integration.session import HonchoSessionManager
+
+    client = get_honcho_client(hcfg)
+    manager = HonchoSessionManager(honcho=client, config=hcfg)
+    manager.get_or_create(hcfg.resolve_session_name())
+
+
 def cmd_status(args) -> None:
     """Show current Honcho config and connection status."""
     try:
@@ -256,7 +266,7 @@ def cmd_status(args) -> None:
         return
 
     try:
-        from honcho_integration.client import HonchoClientConfig, get_honcho_client
+        from honcho_integration.client import HonchoClientConfig
         hcfg = HonchoClientConfig.from_global_config()
     except Exception as e:
         print(f"  Config error: {e}\n")
@@ -287,7 +297,7 @@ def cmd_status(args) -> None:
     if hcfg.enabled and (hcfg.api_key or hcfg.base_url):
         print("\n  Connection... ", end="", flush=True)
         try:
-            get_honcho_client(hcfg)
+            _check_connection(hcfg)
             print("OK\n")
         except Exception as e:
             print(f"FAILED ({e})\n")

--- a/tests/honcho_integration/test_cli.py
+++ b/tests/honcho_integration/test_cli.py
@@ -27,3 +27,60 @@ class TestResolveApiKey:
         assert _resolve_api_key({}) == "env-key"
         monkeypatch.delenv("HONCHO_API_KEY", raising=False)
 
+
+class TestCmdStatus:
+    def test_reports_connection_failure_when_session_setup_fails(self, monkeypatch, capsys, tmp_path):
+        import sys
+        import types
+
+        import honcho_integration.cli as honcho_cli
+        import honcho_integration.client as client_mod
+        import honcho_integration.session as session_mod
+
+        cfg_path = tmp_path / "honcho.json"
+        cfg_path.write_text("{}")
+
+        monkeypatch.setitem(sys.modules, "honcho", types.SimpleNamespace())
+        monkeypatch.setattr(honcho_cli, "_read_config", lambda: {"apiKey": "root-key"})
+        monkeypatch.setattr(honcho_cli, "_config_path", lambda: cfg_path)
+        monkeypatch.setattr(honcho_cli, "_local_config_path", lambda: cfg_path)
+
+        class FakeConfig:
+            enabled = True
+            api_key = "root-key"
+            workspace_id = "hermes"
+            host = "hermes"
+            base_url = None
+            ai_peer = "hermes"
+            peer_name = "genos"
+            recall_mode = "hybrid"
+            memory_mode = "hybrid"
+            peer_memory_modes = {}
+            write_frequency = "async"
+
+            def resolve_session_name(self):
+                return "hermes"
+
+        class FakeHonchoClientConfig:
+            @classmethod
+            def from_global_config(cls):
+                return FakeConfig()
+
+        class FakeSessionManager:
+            def __init__(self, honcho, config):
+                self.honcho = honcho
+                self.config = config
+
+            def get_or_create(self, key):
+                raise RuntimeError("Invalid API key")
+
+        monkeypatch.setattr(client_mod, "HonchoClientConfig", FakeHonchoClientConfig)
+        monkeypatch.setattr(client_mod, "get_honcho_client", lambda cfg: object())
+        monkeypatch.setattr(session_mod, "HonchoSessionManager", FakeSessionManager)
+
+        honcho_cli.cmd_status(None)
+
+        out = capsys.readouterr().out
+        assert "FAILED (Invalid API key)" in out
+        assert "Connection... OK" not in out
+


### PR DESCRIPTION
Title
fix(honcho): make status run a real connectivity check

Summary
`hermes honcho status` can currently print `Connection... OK` after client initialization even when real Honcho session setup fails.

Root cause
`cmd_status()` only calls `get_honcho_client(hcfg)`, which proves that the client object can be constructed, but not that Hermes can actually create/use a Honcho session.

That creates false positives for cases where session setup later fails with errors like `Invalid API key`.

Fix
- add `_check_connection(hcfg)` in `honcho_integration/cli.py`
- have `cmd_status()` verify connectivity through the real session path:
  - create client
  - create `HonchoSessionManager`
  - call `get_or_create(hcfg.resolve_session_name())`
- add a regression test that reproduces the false-positive OK case and verifies `cmd_status()` now reports `FAILED (...)`

Why this is safe
- only affects the `hermes honcho status` connectivity check
- uses the same session creation path Hermes already relies on during real operation
- does not change setup or runtime behavior outside of making status reporting honest

Test plan
source /Users/genos/.hermes/hermes-agent/venv/bin/activate
pytest -q tests/honcho_integration/test_cli.py::TestCmdStatus::test_reports_connection_failure_when_session_setup_fails -v
pytest -q tests/honcho_integration/test_cli.py

Result
- regression test passed
- full `tests/honcho_integration/test_cli.py` passed (4 passed)
