### PR TITLE
fix(security): block /proc/*/environ, cmdline, maps from file read

### DIFF
--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -74,7 +74,23 @@ class TestDevicePathBlocking(unittest.TestCase):
 
     def test_proc_fd_other_not_blocked(self):
         self.assertFalse(_is_blocked_device("/proc/self/fd/3"))
-        self.assertFalse(_is_blocked_device("/proc/self/maps"))
+
+    def test_proc_sensitive_pseudo_files_blocked(self):
+        """environ/cmdline/maps under /proc/<pid> must be blocked (issue #4427)."""
+        for path in (
+            "/proc/self/environ",
+            "/proc/12345/environ",
+            "/proc/self/cmdline",
+            "/proc/99/cmdline",
+            "/proc/self/maps",
+            "/proc/1/maps",
+        ):
+            self.assertTrue(_is_blocked_device(path), f"{path} should be blocked")
+
+    def test_proc_legitimate_files_not_blocked(self):
+        """Top-level /proc files like cpuinfo and meminfo must remain accessible."""
+        for path in ("/proc/cpuinfo", "/proc/meminfo", "/proc/uptime", "/proc/version"):
+            self.assertFalse(_is_blocked_device(path), f"{path} should not be blocked")
 
     def test_normal_files_not_blocked(self):
         self.assertFalse(_is_blocked_device("/tmp/test.py"))

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -87,6 +87,12 @@ def _is_blocked_device(filepath: str) -> bool:
         ("/fd/0", "/fd/1", "/fd/2")
     ):
         return True
+    # /proc/*/environ, /proc/*/cmdline, /proc/*/maps can leak secrets,
+    # command-line args, and memory layout from the host process (issue #4427)
+    if normalized.startswith("/proc/") and normalized.endswith(
+        ("/environ", "/cmdline", "/maps")
+    ):
+        return True
     return False
 
 


### PR DESCRIPTION
## Summary

Blocks read_file access to `/proc/*/environ`, `/proc/*/cmdline`, and `/proc/*/maps` — sensitive proc pseudo-files that can leak secrets, command-line args, and memory layout.

## Problem

An agent can recover all process env vars (including API keys stripped by the subprocess blocklist) via:

```
read_file("/proc/self/environ")
```

Output redaction catches known-format tokens but misses custom/proprietary key formats.

## Fix

6 lines added to `_is_blocked_device()` in `tools/file_tools.py`:

| Pseudo-file | Risk |
|---|---|
| `/proc/*/environ` | Leaks full process env (API keys, tokens) |
| `/proc/*/cmdline` | Leaks command-line args (may contain passwords) |
| `/proc/*/maps` | Leaks memory layout (ASLR bypass) |

Legitimate `/proc` reads (cpuinfo, meminfo, uptime, version) remain accessible.

## Changes

| File | Lines | What |
|---|---|---|
| `tools/file_tools.py` | +6 | Block proc pseudo-files in `_is_blocked_device()` |
| `tests/tools/test_file_read_guards.py` | +18, -1 | Tests for blocked + legitimate proc paths |

Complements PR #4432 (PID namespace isolation for child processes). Partially addresses #4427.