### PR TITLE
feat(discord): add per-channel auto-thread exclusion list

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -547,6 +547,11 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["DISCORD_FREE_RESPONSE_CHANNELS"] = str(frc)
                 if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
                     os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
+                natc = discord_cfg.get("no_auto_thread_channels")
+                if natc is not None and not os.getenv("DISCORD_NO_AUTO_THREAD_CHANNELS"):
+                    if isinstance(natc, list):
+                        natc = ",".join(str(v) for v in natc)
+                    os.environ["DISCORD_NO_AUTO_THREAD_CHANNELS"] = str(natc)
                 if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):
                     os.environ["DISCORD_REACTIONS"] = str(discord_cfg["reactions"]).lower()
 

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1989,6 +1989,7 @@ class DiscordAdapter(BasePlatformAdapter):
         #   discord.require_mention: Require @mention in server channels (default: true)
         #   discord.free_response_channels: Channel IDs where bot responds without mention
         #   discord.auto_thread: Auto-create thread on @mention in channels (default: true)
+        #   discord.no_auto_thread_channels: Channel IDs excluded from auto-threading
 
         thread_id = None
         parent_channel_id = None
@@ -2022,9 +2023,15 @@ class DiscordAdapter(BasePlatformAdapter):
         # Auto-thread: when enabled, automatically create a thread for every
         # @mention in a text channel so each conversation is isolated (like Slack).
         # Messages already inside threads or DMs are unaffected.
+        # Channels listed in DISCORD_NO_AUTO_THREAD_CHANNELS are excluded.
         auto_threaded_channel = None
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in ("true", "1", "yes")
+            if auto_thread:
+                no_auto_thread_raw = os.getenv("DISCORD_NO_AUTO_THREAD_CHANNELS", "")
+                no_auto_thread_channels = {ch.strip() for ch in no_auto_thread_raw.split(",") if ch.strip()}
+                if str(message.channel.id) in no_auto_thread_channels:
+                    auto_thread = False
             if auto_thread:
                 thread = await self._auto_create_thread(message)
                 if thread:

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -294,6 +294,45 @@ async def test_discord_auto_thread_can_be_disabled(adapter, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_discord_no_auto_thread_channels(adapter, monkeypatch):
+    """Channels in DISCORD_NO_AUTO_THREAD_CHANNELS should skip auto-threading."""
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_NO_AUTO_THREAD_CHANNELS", "123,456")
+
+    adapter._auto_create_thread = AsyncMock()
+
+    # Channel 123 is excluded — should NOT auto-thread
+    message = make_message(channel=FakeTextChannel(channel_id=123), content="hello")
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "group"
+
+
+@pytest.mark.asyncio
+async def test_discord_no_auto_thread_channels_allows_others(adapter, monkeypatch):
+    """Channels NOT in the exclusion list should still auto-thread normally."""
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_NO_AUTO_THREAD_CHANNELS", "999")
+
+    fake_thread = FakeThread(channel_id=888, name="auto-thread")
+    adapter._auto_create_thread = AsyncMock(return_value=fake_thread)
+
+    # Channel 123 is NOT excluded — should auto-thread
+    message = make_message(channel=FakeTextChannel(channel_id=123), content="hello")
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_awaited_once()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "thread"
+
+
+@pytest.mark.asyncio
 async def test_discord_bot_thread_skips_mention_requirement(adapter, monkeypatch):
     """Messages in a thread the bot has participated in should not require @mention."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")


### PR DESCRIPTION
## Summary

Adds a `discord.no_auto_thread_channels` config option that lets users exclude specific channels from auto-threading while keeping it enabled globally.

## Motivation

When `discord.auto_thread` is enabled, every @mention in a text channel spawns a new thread. This is great for most channels (keeps conversations isolated), but some channels — like shared collaboration channels with multiple bots or group discussion channels — work better without auto-threading.

Currently the only option is to disable `auto_thread` globally, which is all-or-nothing.

## Changes

- **`gateway/platforms/discord.py`**: Check `DISCORD_NO_AUTO_THREAD_CHANNELS` env var before creating auto-threads. If the message's channel ID is in the exclusion list, skip thread creation.
- **`gateway/config.py`**: Bridge `discord.no_auto_thread_channels` from config.yaml to the `DISCORD_NO_AUTO_THREAD_CHANNELS` env var. Supports both YAML list and comma-separated string formats (same pattern as `free_response_channels`).
- **`tests/gateway/test_discord_free_response.py`**: Two new tests — one verifying excluded channels skip auto-threading, one verifying non-excluded channels still auto-thread normally.

## Usage

```yaml
# config.yaml
discord:
  auto_thread: true
  no_auto_thread_channels:
    - '1489269514184032318'  # shared bot collaboration channel
```

Or via env var:
```
DISCORD_NO_AUTO_THREAD_CHANNELS=1489269514184032318,1234567890
```

## Tests

All 17 tests in `test_discord_free_response.py` pass (including 2 new ones).