### PR TITLE
fix(compression): include reasoning tokens in context tracking

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8140,6 +8140,13 @@ class AIAgent:
                         _compressor.last_prompt_tokens
                         + _compressor.last_completion_tokens
                     )
+                    # Some providers (z.ai/GLM, DeepSeek) do not include
+                    # reasoning tokens in usage, causing context tracking to
+                    # underestimate actual usage.  Estimate reasoning token
+                    # count from the reasoning text when present.
+                    _reasoning_text = getattr(assistant_message, "reasoning", "") or ""
+                    if _reasoning_text:
+                        _real_tokens += estimate_tokens_rough(_reasoning_text)
 
                     # ── Context pressure warnings (user-facing only) ──────────
                     # Notify the user (NOT the LLM) as context approaches the


### PR DESCRIPTION
### What changed

Add reasoning token estimation to the context tracking calculation in the main agent loop. When an assistant response includes a \`reasoning\` field, its token count is estimated and added to \`_real_tokens\`.

### Why

Providers like z.ai (GLM-5-Turbo) and DeepSeek do not include reasoning tokens in API usage responses. The compressor only tracked \`prompt_tokens + completion_tokens\`, severely underestimating actual context usage.

With thinking-enabled models that produce large reasoning blocks (sometimes 30-50K tokens), this caused \`model_context_window_exceeded\` errors before the compression threshold was ever reached — compression simply never triggered.

Example from a real session:
- Reported usage: 119K prompt + 2K completion = 121K tokens
- Actual usage with reasoning: likely 170K+ tokens (over 200K context limit)
- Compression threshold (70% of 202K = 142K) was never reached on paper

### How it fixes it

After calculating \`_real_tokens = prompt + completion\`, the fix checks if the assistant message has a \`reasoning\` field. If so, it estimates token count via \`estimate_tokens_rough()\` (already imported) and adds it to \`_real_tokens\`.

This gives the compressor an accurate picture of actual context consumption, allowing it to trigger compression before hitting the hard context limit.

### Related

- Complements #4603 (compressor reasoning extraction) — these fix different parts of the same problem
- #4243 (summary fallback on provider failure)

### Impact

- More accurate context pressure warnings for reasoning models
- Compression triggers at the correct time instead of too late
- No impact on non-reasoning models (no \`reasoning\` field = no change)