### PR TITLE
fix: exclude matrix from [all] extras — python-olm is upstream-broken

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,10 @@ all = [
   "hermes-agent[modal]",
   "hermes-agent[daytona]",
   "hermes-agent[messaging]",
-  "hermes-agent[matrix]",
+  # matrix excluded: python-olm (required by matrix-nio[e2e]) is upstream-broken
+  # on modern macOS (archived libolm, C++ errors with Clang 21+). Including it
+  # here causes the entire [all] install to fail, dropping all other extras.
+  # Users who need Matrix can install manually: pip install 'hermes-agent[matrix]'
   "hermes-agent[cron]",
   "hermes-agent[cli]",
   "hermes-agent[dev]",

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -11,8 +11,12 @@ def _load_optional_dependencies():
     return project["optional-dependencies"]
 
 
-def test_all_extra_includes_matrix_dependency():
+def test_matrix_extra_exists_but_excluded_from_all():
+    """matrix-nio[e2e] depends on python-olm which is upstream-broken on modern
+    macOS (archived libolm, C++ errors with Clang 21+).  The [matrix] extra is
+    kept for opt-in install but deliberately excluded from [all] so one broken
+    upstream dep doesn't nuke every other extra during ``hermes update``."""
     optional_dependencies = _load_optional_dependencies()
 
     assert "matrix" in optional_dependencies
-    assert "hermes-agent[matrix]" in optional_dependencies["all"]
+    assert "hermes-agent[matrix]" not in optional_dependencies["all"]


### PR DESCRIPTION
## Summary

Removes `hermes-agent[matrix]` from the `[all]` extras group in pyproject.toml.

**Problem:** `python-olm` (required by `matrix-nio[e2e]`) is upstream-broken on modern macOS:
- CMake 4 rejects vendored libolm's `cmake_minimum_required(VERSION 3.4)`
- Apple Clang 21+ (Xcode 26 / macOS Tahoe) rejects a C++ type error in `include/olm/list.hh`
- Upstream libolm repo is archived/deprecated in favor of vodozemac — no fix coming

Including matrix in `[all]` causes the entire extras install to fail during `hermes update`, and the fallback to bare `.` silently drops **all** other optional extras (telegram, discord, slack, cron, etc.).

**Fix:** Remove matrix from `[all]`. The `[matrix]` extra is preserved for opt-in:
```bash
pip install 'hermes-agent[matrix]'
```

**Changes:**
- `pyproject.toml` — removed `hermes-agent[matrix]` from `all` extras with explanatory comment
- `tests/test_project_metadata.py` — updated regression test to assert matrix is excluded from `[all]`

Closes #4178