### PR TITLE
fix(agent): append /v1 to custom openai-compatible base URLs (#4600)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -818,11 +818,20 @@ class AIAgent:
             if api_key and base_url:
                 # Explicit credentials from CLI/gateway — construct directly.
                 # The runtime provider resolver already handled auth for us.
-                client_kwargs = {"api_key": api_key, "base_url": base_url}
+                
+                # Ensure custom OpenAI-compatible base URLs correctly target the /v1 path
+                # Required for providers like xAI, vLLM, or Ollama that expect /v1/chat/completions
+                normalized_base_url = base_url
+                if normalized_base_url and self.api_mode == "chat_completions" and self.provider not in ("copilot-acp", "openrouter"):
+                    stripped_url = normalized_base_url.rstrip("/")
+                    if not stripped_url.endswith("/v1"):
+                        normalized_base_url = f"{stripped_url}/v1/"
+                
+                client_kwargs = {"api_key": api_key, "base_url": normalized_base_url}
                 if self.provider == "copilot-acp":
                     client_kwargs["command"] = self.acp_command
                     client_kwargs["args"] = self.acp_args
-                effective_base = base_url
+                effective_base = normalized_base_url
                 if "openrouter" in effective_base.lower():
                     client_kwargs["default_headers"] = {
                         "HTTP-Referer": "https://hermes-agent.nousresearch.com",


### PR DESCRIPTION
## What does this PR do?

## Description
This PR resolves an issue where custom OpenAI-compatible base URLs (e.g., `https://api.x.ai`) were dropping the required `/v1` path segment during `chat_completions` API calls, leading to 404 upstream errors.

**Fixes #4600**

## Root Cause
The `AIAgent` initialization explicitly passed the user-provided `base_url` directly into `client_kwargs`. The underlying `openai` python client strictly appends the endpoint (like `chat/completions`) directly to the base URL. If the user didn't manually include `/v1` at the end of their `OPENAI_BASE_URL`, the resulting upstream path became `/chat/completions` instead of `/v1/chat/completions`, which breaks standard OpenAI-compatible providers (xAI, vLLM, Ollama, etc.).

## Changes
- Intercepts the `base_url` right before the `openai` client is constructed.
- Strips any trailing slashes and checks if the URL ends with `/v1`.
- Automatically appends `/v1/` if it's missing.
- Scoped strictly to `api_mode == "chat_completions"`.
- Safely excluded custom-routed providers like `copilot-acp` and `openrouter` to prevent side effects.

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

