### PR TITLE
fix(api): enforce maximum 100 cron jobs limit in API server

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1003,6 +1003,12 @@ class APIServerAdapter(BasePlatformAdapter):
             skills = body.get("skills")
             repeat = body.get("repeat")
 
+            existing_jobs = self._cron_list()
+            if len(existing_jobs) >= 100:
+                return web.json_response(
+                    {"error": "Job limit reached. Maximum 100 cron jobs allowed."},
+                    status=400,
+                )
             if not name:
                 return web.json_response({"error": "Name is required"}, status=400)
             if len(name) > self._MAX_NAME_LENGTH:


### PR DESCRIPTION
## What does this PR do?

The `/api/jobs` POST endpoint in the API server had no limit on how many
cron jobs could be created. An authenticated client could create thousands
of jobs, causing unbounded disk usage and degraded scheduler performance.

## Fix

Added a check before job creation that returns HTTP 400 when the job
count reaches 100. This is consistent with the existing per-platform
limit (`MAX_PENDING_PER_PLATFORM = 3`) already applied in the pairing
system.

## Type of Change

- [x] 🐛 Bug fix (DoS / resource exhaustion)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] No behavior change for users with fewer than 100 jobs
- [x] Returns a clear error message when limit is reached