### PR TITLE
feat: async inter-profile task system (fire-and-forget)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,12 +49,14 @@ hermes-agent/
 │   ├── web_tools.py      # Web search/extract (Parallel + Firecrawl)
 │   ├── browser_tool.py   # Browserbase browser automation
 │   ├── code_execution_tool.py # execute_code sandbox
-│   ├── delegate_tool.py  # Subagent delegation
+│   ├── delegate_tool.py  # Subagent delegation (synchronous)
+│   ├── async_task_tool.py # Fire-and-forget async inter-profile delegation
 │   ├── mcp_tool.py       # MCP client (~1050 lines)
 │   └── environments/     # Terminal backends (local, docker, ssh, modal, daytona, singularity)
 ├── gateway/              # Messaging platform gateway
 │   ├── run.py            # Main loop, slash commands, message dispatch
 │   ├── session.py        # SessionStore — conversation persistence
+│   ├── async_task_registry.py # Registry + delivery for async inter-profile tasks
 │   └── platforms/        # Adapters: telegram, discord, slack, whatsapp, homeassistant, signal
 ├── acp_adapter/          # ACP server (VS Code / Zed / JetBrains integration)
 ├── cron/                 # Scheduler (jobs.py, scheduler.py)

--- a/gateway/async_task_registry.py
+++ b/gateway/async_task_registry.py
@@ -1,0 +1,200 @@
+"""
+AsyncTaskRegistry -- Fire-and-Forget Inter-Profile Task Management
+
+Tracks async subprocess tasks launched via the async_task tool.
+When a subprocess completes, the registry injects the result
+into the originating chat via the gateway adapter, exactly like
+_run_background_task does for /background commands.
+"""
+
+import asyncio
+import logging
+import os
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    pass
+
+
+class AsyncTaskEntry:
+    """Represents a single async inter-profile task."""
+
+    def __init__(
+        self,
+        task_id: str,
+        profile: str,
+        prompt: str,
+        source: Any,  # SessionSource
+        process: Any,  # subprocess.Popen
+        timeout_seconds: int = 600,
+    ):
+        self.task_id = task_id
+        self.profile = profile
+        self.prompt = prompt
+        self.source = source
+        self.process = process
+        self.status = "running"
+        self.started_at = datetime.now()
+        self.completed_at: Optional[datetime] = None
+        self.timeout_seconds = timeout_seconds
+
+    @property
+    def duration_str(self) -> str:
+        end = self.completed_at or datetime.now()
+        delta = end - self.started_at
+        total = int(delta.total_seconds())
+        m, s = divmod(total, 60)
+        if m > 0:
+            return f"{m}m {s}s"
+        return f"{s}s"
+
+    @property
+    def is_timed_out(self) -> bool:
+        elapsed = (datetime.now() - self.started_at).total_seconds()
+        return elapsed > self.timeout_seconds
+
+
+class AsyncTaskRegistry:
+    """
+    Thread-safe registry (asyncio.Lock) for async inter-profile tasks.
+
+    Usage:
+        registry = AsyncTaskRegistry(gateway)
+        task_id = await registry.register(profile, prompt, source, process)
+        # ... watcher loop calls registry.check_and_complete(task_id, result)
+    """
+
+    def __init__(self, gateway: Any = None):
+        self._lock = asyncio.Lock()
+        self._tasks: Dict[str, AsyncTaskEntry] = {}
+        self._gateway = gateway  # HermesGateway reference, set after construction
+
+    def set_gateway(self, gateway: Any) -> None:
+        self._gateway = gateway
+
+    async def register(
+        self,
+        task_id: str,
+        profile: str,
+        prompt: str,
+        source: Any,
+        process: Any,
+    ) -> str:
+        """Register a new async task. Returns task_id."""
+        async with self._lock:
+            entry = AsyncTaskEntry(
+                task_id=task_id,
+                profile=profile,
+                prompt=prompt,
+                source=source,
+                process=process,
+            )
+            self._tasks[task_id] = entry
+            logger.info(
+                "AsyncTask registered: %s [profile=%s] for chat=%s",
+                task_id, profile, getattr(source, "chat_id", "?"),
+            )
+        return task_id
+
+    async def list_active(self) -> list:
+        """Return list of active (running) task entries."""
+        async with self._lock:
+            return [
+                entry for entry in self._tasks.values()
+                if entry.status == "running"
+            ]
+
+    async def list_all(self) -> list:
+        """Return all task entries (active + completed)."""
+        async with self._lock:
+            return list(self._tasks.values())
+
+    async def get(self, task_id: str) -> Optional[AsyncTaskEntry]:
+        async with self._lock:
+            return self._tasks.get(task_id)
+
+    async def complete(self, task_id: str, result: str, error: bool = False) -> None:
+        """Mark task complete and inject result into originating chat."""
+        async with self._lock:
+            entry = self._tasks.get(task_id)
+            if not entry:
+                logger.warning("AsyncTask complete called for unknown task_id: %s", task_id)
+                return
+            entry.status = "error" if error else "done"
+            entry.completed_at = datetime.now()
+
+        await self._deliver_result(entry, result, error=error)
+
+    async def _deliver_result(
+        self, entry: AsyncTaskEntry, result: str, error: bool = False
+    ) -> None:
+        """Send result message into the originating chat."""
+        if not self._gateway:
+            logger.error("AsyncTaskRegistry has no gateway reference — cannot deliver result")
+            return
+
+        adapter = self._gateway.adapters.get(entry.source.platform)
+        if not adapter:
+            logger.warning(
+                "No adapter for platform %s — cannot deliver async task result %s",
+                entry.source.platform, entry.task_id,
+            )
+            return
+
+        _thread_metadata = (
+            {"thread_id": entry.source.thread_id}
+            if getattr(entry.source, "thread_id", None)
+            else None
+        )
+
+        preview = entry.prompt[:60] + ("..." if len(entry.prompt) > 60 else "")
+
+        if error:
+            header = (
+                f"❌ Async task fallito [profile: {entry.profile}]\n"
+                f'Task ID: {entry.task_id}\n'
+                f'Durata: {entry.duration_str}\n'
+                f'Prompt: "{preview}"\n\n'
+            )
+        else:
+            header = (
+                f"✅ Async task completato [profile: {entry.profile}]\n"
+                f"Task ID: {entry.task_id}\n"
+                f"Durata: {entry.duration_str}\n\n"
+            )
+
+        try:
+            await adapter.send(
+                chat_id=entry.source.chat_id,
+                content=header + result,
+                metadata=_thread_metadata,
+            )
+        except Exception as exc:
+            logger.exception(
+                "Failed to deliver async task result %s: %s", entry.task_id, exc
+            )
+
+    async def cleanup_old(self, max_age_hours: int = 1) -> int:
+        """Remove completed tasks older than max_age_hours. Returns count removed."""
+        cutoff = datetime.now() - timedelta(hours=max_age_hours)
+        removed = 0
+        async with self._lock:
+            stale = [
+                tid for tid, entry in self._tasks.items()
+                if entry.status in ("done", "error", "timeout")
+                and entry.completed_at
+                and entry.completed_at < cutoff
+            ]
+            for tid in stale:
+                del self._tasks[tid]
+                removed += 1
+        if removed:
+            logger.debug("AsyncTaskRegistry cleanup: removed %d old tasks", removed)
+        return removed
+
+
+# Module-level singleton — populated by HermesGateway.start()
+async_task_registry = AsyncTaskRegistry()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -29,6 +29,9 @@ from pathlib import Path
 from datetime import datetime
 from typing import Dict, Optional, Any, List
 
+# Async task registry for inter-profile fire-and-forget tasks
+from gateway.async_task_registry import async_task_registry as _async_task_registry
+
 # ---------------------------------------------------------------------------
 # SSL certificate auto-detection for NixOS and other non-standard systems.
 # Must run BEFORE any HTTP library (discord, aiohttp, etc.) is imported.
@@ -1264,6 +1267,11 @@ class GatewayRunner:
             )
         asyncio.create_task(self._platform_reconnect_watcher())
 
+        # Wire up async task registry and start watcher
+        _async_task_registry.set_gateway(self)
+        asyncio.create_task(self._watch_async_tasks())
+        logger.info("AsyncTaskRegistry watcher started")
+
         logger.info("Press Ctrl+C to stop")
         
         return True
@@ -1959,6 +1967,9 @@ class GatewayRunner:
 
         if canonical == "background":
             return await self._handle_background_command(event)
+
+        if canonical == "tasks":
+            return await self._handle_tasks_command(event)
 
         if canonical == "voice":
             return await self._handle_voice_command(event)
@@ -4076,6 +4087,103 @@ class GatewayRunner:
                 )
             except Exception:
                 pass
+
+    # ------------------------------------------------------------------
+    # Async inter-profile task watcher
+    # ------------------------------------------------------------------
+
+    async def _watch_async_tasks(self, interval: float = 2.0) -> None:
+        """Background watcher: polls subprocess-based async tasks every *interval* seconds.
+
+        When a subprocess finishes (or times out), reads its stdout and injects
+        the result into the originating chat via the AsyncTaskRegistry.
+        """
+        TIMEOUT_SECONDS = 600  # 10 minutes hard limit per task
+
+        while True:
+            try:
+                active = await _async_task_registry.list_active()
+                for entry in active:
+                    proc = entry.process
+                    if proc is None:
+                        continue
+
+                    # Check for timeout first
+                    if entry.is_timed_out:
+                        logger.warning(
+                            "AsyncTask %s timed out after %ds — killing", entry.task_id, TIMEOUT_SECONDS
+                        )
+                        try:
+                            proc.kill()
+                        except Exception:
+                            pass
+                        entry.status = "timeout"
+                        await _async_task_registry.complete(
+                            entry.task_id,
+                            f"❌ Task killato per timeout (>{TIMEOUT_SECONDS//60} minuti).",
+                            error=True,
+                        )
+                        continue
+
+                    # Poll for completion (non-blocking)
+                    retcode = proc.poll()
+                    if retcode is None:
+                        # Still running
+                        continue
+
+                    # Process has finished — read output
+                    try:
+                        stdout, stderr = proc.communicate(timeout=5)
+                    except Exception:
+                        stdout, stderr = "", ""
+
+                    result = (stdout or "").strip()
+                    if not result:
+                        result = (stderr or "").strip()
+                    if not result:
+                        result = "(Nessun output prodotto dal profilo)"
+
+                    error = retcode != 0
+                    await _async_task_registry.complete(entry.task_id, result, error=error)
+
+                # Periodic cleanup of old completed tasks
+                await _async_task_registry.cleanup_old(max_age_hours=1)
+
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                logger.exception("_watch_async_tasks: unexpected error")
+
+            await asyncio.sleep(interval)
+
+    # ------------------------------------------------------------------
+    # /tasks command handler
+    # ------------------------------------------------------------------
+
+    async def _handle_tasks_command(self, event: "MessageEvent") -> str:
+        """Handle /tasks (alias /bg-list) — show active async inter-profile tasks."""
+        active = await _async_task_registry.list_active()
+        if not active:
+            all_tasks = await _async_task_registry.list_all()
+            if all_tasks:
+                lines = ["📋 Nessun task asincrono attivo al momento.", "", "Ultimi task:"]
+                for entry in sorted(all_tasks, key=lambda e: e.started_at, reverse=True)[:5]:
+                    icon = "✅" if entry.status == "done" else "❌" if entry.status in ("error", "timeout") else "🔄"
+                    preview = entry.prompt[:50] + ("..." if len(entry.prompt) > 50 else "")
+                    lines.append(f"{icon} [{entry.profile}] {entry.task_id} — {entry.duration_str} — \"{preview}\"")
+                return "\n".join(lines)
+            return "📋 Nessun task asincrono attivo o recente."
+
+        lines = [f"🔄 Task asincroni attivi: {len(active)}", ""]
+        for entry in sorted(active, key=lambda e: e.started_at):
+            preview = entry.prompt[:50] + ("..." if len(entry.prompt) > 50 else "")
+            lines.append(
+                f"• Task ID: {entry.task_id}\n"
+                f"  Profile: {entry.profile}\n"
+                f"  Durata: {entry.duration_str}\n"
+                f'  Prompt: "{preview}"'
+            )
+        return "\n".join(lines)
 
     async def _handle_reasoning_command(self, event: MessageEvent) -> str:
         """Handle /reasoning command — manage reasoning effort and display toggle.

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -67,6 +67,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True),
     CommandDef("background", "Run a prompt in the background", "Session",
                aliases=("bg",), args_hint="<prompt>"),
+    CommandDef("tasks", "List active async inter-profile tasks", "Session",
+               gateway_only=True, aliases=("bg-list",)),
     CommandDef("queue", "Queue a prompt for the next turn (doesn't interrupt)", "Session",
                aliases=("q",), args_hint="<prompt>"),
     CommandDef("status", "Show session info", "Session",
@@ -361,7 +363,7 @@ def telegram_bot_commands() -> list[tuple[str, str]]:
     for cmd in COMMAND_REGISTRY:
         if not _is_gateway_available(cmd, overrides):
             continue
-        tg_name = cmd.name.replace("-", "_")
+        tg_name = cmd.name.replace("-", "_")[:32]
         result.append((tg_name, cmd.description))
     return result
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -154,6 +154,7 @@ def _discover_tools():
         "tools.clarify_tool",
         "tools.code_execution_tool",
         "tools.delegate_tool",
+        "tools.async_task_tool",
         "tools.process_registry",
         "tools.send_message_tool",
         "tools.honcho_tools",

--- a/tools/async_task_tool.py
+++ b/tools/async_task_tool.py
@@ -1,0 +1,212 @@
+"""
+Async Task Tool -- Inter-Profile Fire-and-Forget Tasks
+
+Launches a hermes sub-process using a different profile (e.g. 'researcher',
+'dev') without blocking the caller's session. Returns immediately with a
+task_id; the result is delivered to the originating chat when the subprocess
+finishes (via AsyncTaskRegistry / _watch_async_tasks in gateway/run.py).
+
+Usage (by AI model):
+    async_task(profile="researcher", prompt="Find latest papers on ...", context="...")
+"""
+
+import logging
+import os
+import subprocess
+import uuid
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Tool schema
+# ---------------------------------------------------------------------------
+
+ASYNC_TASK_TOOL_SCHEMA: Dict[str, Any] = {
+    "name": "async_task",
+    "description": (
+        "Lancia un task asincrono su un profilo Hermes specifico (es. 'researcher', 'dev'). "
+        "Ritorna immediatamente con un task_id. Il risultato viene recapitato automaticamente "
+        "nella chat quando il task termina. NON blocca la sessione corrente."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "profile": {
+                "type": "string",
+                "description": "Nome del profilo hermes (es. 'researcher', 'dev')",
+            },
+            "prompt": {
+                "type": "string",
+                "description": "Il task da eseguire",
+            },
+            "context": {
+                "type": "string",
+                "description": "Contesto opzionale da passare al profilo",
+            },
+        },
+        "required": ["profile", "prompt"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Registry / source helpers
+# ---------------------------------------------------------------------------
+
+def _get_registry():
+    from gateway.async_task_registry import async_task_registry
+    return async_task_registry
+
+
+def _build_source_from_env():
+    """
+    Reconstruct a SessionSource from the env vars set by the gateway
+    (_set_session_env).  Returns None if the env vars are missing
+    (e.g. when running in CLI mode where there is no delivery target).
+    """
+    platform_val = os.environ.get("HERMES_SESSION_PLATFORM")
+    chat_id = os.environ.get("HERMES_SESSION_CHAT_ID")
+    if not platform_val or not chat_id:
+        return None
+    try:
+        from gateway.session import SessionSource
+        from gateway.config import Platform
+        return SessionSource(
+            platform=Platform(platform_val),
+            chat_id=chat_id,
+            chat_name=os.environ.get("HERMES_SESSION_CHAT_NAME"),
+            thread_id=os.environ.get("HERMES_SESSION_THREAD_ID") or None,
+        )
+    except Exception as exc:
+        logger.warning("async_task: could not build source from env: %s", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Core implementation
+# ---------------------------------------------------------------------------
+
+async def async_task(
+    profile: str,
+    prompt: str,
+    context: Optional[str] = None,
+) -> str:
+    """
+    Launch a fire-and-forget hermes sub-process on the given profile.
+
+    Returns a confirmation string with the task_id.
+    The actual result is delivered asynchronously via the registry.
+    """
+    registry = _get_registry()
+
+    # Determine source for result delivery
+    source = _build_source_from_env()
+    if source is None:
+        return (
+            "❌ async_task: impossibile determinare la chat di origine. "
+            "Questo tool deve essere eseguito all'interno di una sessione gateway Telegram/Discord/ecc."
+        )
+
+    # Validate profile exists
+    hermes_home = os.path.expanduser("~/.hermes")
+    profile_dir = os.path.join(hermes_home, "profiles", profile)
+    if not os.path.isdir(profile_dir):
+        return (
+            f"❌ async_task: profilo '{profile}' non trovato. "
+            f"Controlla ~/.hermes/profiles/{profile}/"
+        )
+
+    # Build the full prompt (with optional context)
+    full_prompt = prompt
+    if context and context.strip():
+        full_prompt = f"{prompt}\n\nCONTEXT:\n{context}"
+
+    # Generate task ID
+    task_id = f"async_{profile}_{uuid.uuid4().hex[:8]}"
+
+    # Find hermes executable
+    hermes_bin = _find_hermes_binary()
+    if not hermes_bin:
+        return (
+            "❌ async_task: eseguibile 'hermes' non trovato in PATH. "
+            "Assicurati che hermes sia installato e nel PATH."
+        )
+
+    # Launch subprocess non-blocking with Popen
+    cmd = [hermes_bin, "-p", profile, "chat", "-Q", "-q", full_prompt]
+    env = os.environ.copy()
+
+    try:
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            text=True,
+        )
+    except Exception as exc:
+        logger.exception("async_task: failed to launch subprocess for profile=%s", profile)
+        return f"❌ async_task: errore nel lancio del subprocess: {exc}"
+
+    # Register in registry (async)
+    await registry.register(
+        task_id=task_id,
+        profile=profile,
+        prompt=prompt,
+        source=source,
+        process=process,
+    )
+
+    prompt_preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
+    return (
+        f"🚀 Async task avviato!\n"
+        f"Task ID: {task_id}\n"
+        f"Profile: {profile}\n"
+        f'Prompt: "{prompt_preview}"\n\n'
+        f"Il risultato arriverà in questa chat quando il task terminerà."
+    )
+
+
+def _find_hermes_binary() -> Optional[str]:
+    """Locate the hermes binary in PATH or common locations."""
+    import shutil
+    candidate = shutil.which("hermes")
+    if candidate:
+        return candidate
+    # Fallback: check common venv/install locations
+    common = [
+        "/root/.hermes/hermes-agent/venv/bin/hermes",
+        "/usr/local/bin/hermes",
+        os.path.expanduser("~/.local/bin/hermes"),
+    ]
+    for path in common:
+        if os.path.isfile(path) and os.access(path, os.X_OK):
+            return path
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+
+def _check_requirements() -> bool:
+    """async_task has no external requirements beyond hermes itself."""
+    return True
+
+
+from tools.registry import registry
+
+registry.register(
+    name="async_task",
+    toolset="async",
+    schema=ASYNC_TASK_TOOL_SCHEMA,
+    handler=lambda args, **kw: async_task(
+        profile=args.get("profile"),
+        prompt=args.get("prompt"),
+        context=args.get("context"),
+    ),
+    check_fn=_check_requirements,
+    is_async=True,
+    emoji="🚀",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -56,6 +56,8 @@ _HERMES_CORE_TOOLS = [
     "clarify",
     # Code execution + delegation
     "execute_code", "delegate_task",
+    # Async inter-profile fire-and-forget tasks
+    "async_task",
     # Cronjob management
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
@@ -193,6 +195,12 @@ TOOLSETS = {
     "delegation": {
         "description": "Spawn subagents with isolated context for complex subtasks",
         "tools": ["delegate_task"],
+        "includes": []
+    },
+
+    "async": {
+        "description": "Fire-and-forget async inter-profile tasks (non-blocking delegation to other Hermes profiles)",
+        "tools": ["async_task"],
         "includes": []
     },
 


### PR DESCRIPTION
## Summary

Implements a complete async task system for non-blocking delegation from the main gateway session to other Hermes profiles (e.g. researcher, dev).

## Problem

Using `delegate_task` or `hermes -p researcher -Q -q '...'` is synchronous — it blocks the entire gateway session until completion. No messages can be received during execution.

## Solution

Fire-and-forget subprocess delegation with automatic result injection into the originating chat.

## New Files

### `gateway/async_task_registry.py`
- `AsyncTaskRegistry` with `asyncio.Lock` (thread-safe)
- Tracks tasks: `{task_id: AsyncTaskEntry{profile, prompt, status, source, started_at, process}}`
- `register()`, `complete()`, `list_active()`, `list_all()`
- Auto-delivers results to originating chat via `adapter.send()`
- Cleanup of completed tasks after 1 hour

### `tools/async_task_tool.py`
- `async_task(profile, prompt, context)` tool schema + implementation
- Launches `hermes -p {profile} chat -Q -q "{prompt}"` via `subprocess.Popen` (non-blocking)
- Reads source from `HERMES_SESSION_*` env vars (set by gateway per message)
- Validates profile exists, finds hermes binary, registers task
- Returns immediately with task_id

## Modified Files

### `gateway/run.py`
- `_watch_async_tasks()`: background asyncio loop (2s poll interval), kills on 10min timeout
- `_handle_tasks_command()`: shows active/recent tasks
- Routes `/tasks` command
- Wires `async_task_registry` + starts watcher in `start()`

### `hermes_cli/commands.py`
- Adds `/tasks` command (alias: `/bg-list`) to `COMMAND_REGISTRY`

### `model_tools.py`
- Adds `tools.async_task_tool` to `_discover_tools()`

### `toolsets.py`
- Adds `'async'` toolset definition
- Adds `async_task` to `_HERMES_CORE_TOOLS` (available on all platforms)

## Behavior

```
User: /tasks researcher → find latest papers on X
Bot: 🚀 Async task avviato!
     Task ID: async_researcher_a1b2c3d4
     Profile: researcher
     Prompt: "find latest papers on X"
     Il risultato arriverà in questa chat quando il task terminerà.

... (chat continues freely) ...

Bot: ✅ Async task completato [profile: researcher]
     Task ID: async_researcher_a1b2c3d4
     Durata: 4m 32s
     
     {result from researcher profile}
```

## Tests

2692 passed, 1 pre-existing failure (systemd unit test fails when running as root).