### PR TITLE
docs(setup): clarify OPENAI_BASE_URL should include /v1 for OpenAI-compatible endpoints

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1101,7 +1101,7 @@ def _configure_simple_requirements(ts_key: str):
             else:
                 _print_warning("    Skipped")
         elif idx == 1:
-            base_url = _prompt("    OPENAI_BASE_URL (blank for OpenAI)").strip() or "https://api.openai.com/v1"
+            base_url = _prompt("    OPENAI_BASE_URL (blank for OpenAI; include /v1 if your provider expects it)").strip() or "https://api.openai.com/v1"
             key_label = "    OPENAI_API_KEY" if "api.openai.com" in base_url.lower() else "    API key"
             api_key = _prompt(key_label, password=True)
             if api_key and api_key.strip():


### PR DESCRIPTION
Fixes #4600 (documentation/workaround).

Hermes constructs the Chat Completions path relative to the configured base URL for OpenAI-compatible endpoints. Many providers expect the base URL to include the `/v1` prefix (e.g. `https://api.x.ai/v1`).

This PR improves the setup prompt to explicitly mention that `/v1` should be included when required by the provider.

Notes:
- This is a small UX/docs improvement; it does not change runtime URL normalization logic.
- Default remains `https://api.openai.com/v1`.
