### PR TITLE
fix(feishu): write dedup state file atomically to prevent corruption

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2773,7 +2773,9 @@ class FeishuAdapter(BasePlatformAdapter):
             recent = self._seen_message_order[-self._dedup_cache_size:]
             # Save as {msg_id: timestamp} so TTL filtering works across restarts.
             payload = {"message_ids": {k: self._seen_message_ids[k] for k in recent if k in self._seen_message_ids}}
-            self._dedup_state_path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+            _tmp = self._dedup_state_path.with_suffix(".tmp")
+            _tmp.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+            _tmp.replace(self._dedup_state_path)
         except OSError:
             logger.warning("[Feishu] Failed to persist dedup state to %s", self._dedup_state_path, exc_info=True)
 


### PR DESCRIPTION
## What does this PR do?

The Feishu adapter persists its message deduplication state to
`~/.hermes/feishu_seen_message_ids.json` using `write_text()` directly,
which is not atomic. If the gateway crashes mid-write, the file is left
partially written and corrupt.

On the next gateway start, `json.loads()` fails to parse the corrupt
file and the dedup state is lost — causing duplicate message delivery
for any Feishu messages that were processed just before the crash.

## Fix

Write to a `.tmp` sibling file first, then use `Path.replace()` which
is atomic on POSIX systems (rename syscall). This guarantees the dedup
state file is either fully written or not written at all.
```python
# Before (non-atomic)
self._dedup_state_path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")

# After (atomic)
_tmp = self._dedup_state_path.with_suffix(".tmp")
_tmp.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
_tmp.replace(self._dedup_state_path)
```

This is consistent with the atomic write pattern already used in
`cron/jobs.py` (`save_jobs`) and `gateway/status.py`.

## Type of Change

- [x] 🐛 Bug fix (reliability)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Consistent with existing atomic write pattern in Hermes
- [x] No behavior change under normal operation
- [x] Prevents duplicate message delivery after gateway crash