### PR TITLE
fix(discord): write thread participation state atomically to prevent corruption

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1969,7 +1969,9 @@ class DiscordAdapter(BasePlatformAdapter):
                 thread_list = thread_list[-self._MAX_TRACKED_THREADS:]
                 self._bot_participated_threads = set(thread_list)
             path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(json.dumps(thread_list), encoding="utf-8")
+            _tmp = path.with_suffix(".tmp")
+            _tmp.write_text(json.dumps(thread_list), encoding="utf-8")
+            _tmp.replace(path)
         except Exception as e:
             logger.debug("Could not save discord thread state: %s", e)
 


### PR DESCRIPTION
## What does this PR do?

The Discord adapter persists its thread participation state to disk using
`path.write_text()` directly, which is not atomic. If the gateway crashes
mid-write, the file is left partially written and corrupt.

On the next gateway start, `json.loads()` fails to parse the corrupt file
and the thread state is silently lost — the bot forgets which threads it
participated in and may miss thread replies.

## Fix

Write to a `.tmp` sibling file first, then use `Path.replace()` which
is atomic on POSIX systems (rename syscall).
```python
# Before (non-atomic)
path.write_text(json.dumps(thread_list), encoding="utf-8")

# After (atomic)
_tmp = path.with_suffix(".tmp")
_tmp.write_text(json.dumps(thread_list), encoding="utf-8")
_tmp.replace(path)
```

This is consistent with the atomic write pattern already used in
`cron/jobs.py`, `gateway/status.py`, and `gateway/platforms/feishu.py`.

## Type of Change

- [x] 🐛 Bug fix (reliability)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Consistent with existing atomic write pattern in Hermes
- [x] No behavior change under normal operation
- [x] Prevents thread state loss after gateway crash