### PR TITLE
feat(slack): strengthen Slack formatting prompt guidance in session context

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -268,10 +268,18 @@ def build_session_context_prompt(
         lines.append("")
         lines.append(
             "**Platform notes:** You are running inside Slack. "
-            "You do NOT have access to Slack-specific APIs — you cannot search "
+            "You do NOT have access to Slack-specific APIs - you cannot search "
             "channel history, pin/unpin messages, manage channels, or list users. "
             "Do not promise to perform these actions. If the user asks, explain "
-            "that you can only read messages sent directly to you and respond."
+            "that you can only read messages sent directly to you and respond. "
+            "Format replies for Slack rather than terminal output: use short paragraphs, "
+            "bullets, and concise emphasis. For tabular data, output a standard "
+            "markdown pipe table with a header row and separator row. Do NOT use "
+            "triple-backtick code fences for tables, do NOT use ASCII aligned "
+            "columns, and do NOT use box-drawing divider characters. Slack rich "
+            "table rendering only activates for pipe-style markdown tables. If the "
+            "data is small, prefer bullets instead of a table. Use at most one "
+            "table per message."
         )
     elif context.source.platform == Platform.DISCORD:
         lines.append("")


### PR DESCRIPTION
## Summary

Expands the `Platform.SLACK` platform notes block in `build_session_context()` to give the model clearer guidance on Slack-native formatting.

## Motivation

Without explicit guidance, models tend to use ASCII-art aligned tables or triple-backtick fenced tables, both of which render poorly in Slack. Slack renders pipe-style markdown tables as rich structured tables (Block Kit under the hood), but only if the model uses the correct syntax.

## Changes

`gateway/session.py` — Platform.SLACK notes now include:
- Prefer pipe-style markdown tables with header + separator row
- Do NOT use triple-backtick fences for tables, ASCII-aligned columns, or box-drawing characters
- Prefer bullets for small data sets; use at most one table per message
- General formatting guidance: short paragraphs, bullets, concise emphasis