### PR TITLE
feat(prompt): add Google model operational guidance for Gemini and Gemma

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -187,7 +187,29 @@ TOOL_USE_ENFORCEMENT_GUIDANCE = (
 
 # Model name substrings that trigger tool-use enforcement guidance.
 # Add new patterns here when a model family needs explicit steering.
-TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex")
+TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex", "gemini", "gemma")
+
+# Gemini/Gemma-specific operational guidance, adapted from OpenCode's gemini.txt.
+# Injected alongside TOOL_USE_ENFORCEMENT_GUIDANCE when the model is Gemini or Gemma.
+GOOGLE_MODEL_OPERATIONAL_GUIDANCE = (
+    "# Google model operational directives\n"
+    "Follow these operational rules strictly:\n"
+    "- **Absolute paths:** Always construct and use absolute file paths for all "
+    "file system operations. Combine the project root with relative paths.\n"
+    "- **Verify first:** Use read_file/search_files to check file contents and "
+    "project structure before making changes. Never guess at file contents.\n"
+    "- **Dependency checks:** Never assume a library is available. Check "
+    "package.json, requirements.txt, Cargo.toml, etc. before importing.\n"
+    "- **Conciseness:** Keep explanatory text brief — a few sentences, not "
+    "paragraphs. Focus on actions and results over narration.\n"
+    "- **Parallel tool calls:** When you need to perform multiple independent "
+    "operations (e.g. reading several files), make all the tool calls in a "
+    "single response rather than sequentially.\n"
+    "- **Non-interactive commands:** Use flags like -y, --yes, --non-interactive "
+    "to prevent CLI tools from hanging on prompts.\n"
+    "- **Keep going:** Work autonomously until the task is fully resolved. "
+    "Don't stop with a plan — execute it.\n"
+)
 
 # Model name substrings that should use the 'developer' role instead of
 # 'system' for the system prompt.  OpenAI's newer models (GPT-5, Codex)

--- a/run_agent.py
+++ b/run_agent.py
@@ -89,7 +89,7 @@ from agent.model_metadata import (
 )
 from agent.context_compressor import ContextCompressor
 from agent.prompt_caching import apply_anthropic_cache_control
-from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, DEVELOPER_ROLE_MODELS
+from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, DEVELOPER_ROLE_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from agent.display import (
     KawaiiSpinner, build_tool_preview as _build_tool_preview,
@@ -2654,6 +2654,11 @@ class AIAgent:
                 _inject = any(p in model_lower for p in TOOL_USE_ENFORCEMENT_MODELS)
             if _inject:
                 prompt_parts.append(TOOL_USE_ENFORCEMENT_GUIDANCE)
+                # Google model operational guidance (conciseness, absolute
+                # paths, parallel tool calls, verify-before-edit, etc.)
+                _model_lower = (self.model or "").lower()
+                if "gemini" in _model_lower or "gemma" in _model_lower:
+                    prompt_parts.append(GOOGLE_MODEL_OPERATIONAL_GUIDANCE)
 
         # Honcho CLI awareness: tell Hermes about its own management commands
         # so it can refer the user to them rather than reinventing answers.


### PR DESCRIPTION
## Summary

Adds operational guidance for Google model families (Gemini + Gemma), adapted from [OpenCode's gemini.txt](https://raw.githubusercontent.com/anomalyco/opencode/refs/heads/dev/packages/opencode/src/session/prompt/gemini.txt). Based on PR #4026, extended to also cover Gemma models.

## What gets injected (Gemini and Gemma models only)

- **Absolute paths** — always construct full paths for file operations
- **Verify first** — read_file/search_files before editing, never guess
- **Dependency checks** — check package manifests before importing
- **Conciseness** — brief explanations, focus on actions
- **Parallel tool calls** — independent operations in a single response
- **Non-interactive** — `-y`, `--yes` flags to prevent CLI hangs
- **Keep going** — work autonomously until the task is fully resolved

## Scoping

| Model | Tool-use enforcement | Google directives |
|---|---|---|
| Gemini | ✅ | ✅ |
| Gemma | ✅ | ✅ |
| GPT/Codex | ✅ | ✗ |
| Claude | ✗ | ✗ |

## Changes
- `agent/prompt_builder.py` — added `GOOGLE_MODEL_OPERATIONAL_GUIDANCE` constant, added `"gemini"` and `"gemma"` to `TOOL_USE_ENFORCEMENT_MODELS`
- `run_agent.py` — import + inject Google guidance when model name contains "gemini" or "gemma"

## Tests
- 714 passed (test_run_agent + test_cli_init + agent/ suite)
- E2E verified: injection matches Gemini/Gemma models, skips Claude/GPT/Codex

Supersedes #4026.