### PR TITLE
fix(gateway): streaming truncation on Telegram flood control

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -900,7 +900,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 except Exception:
                     pass  # best-effort truncation
                 return SendResult(success=True, message_id=message_id)
-            # Flood control / RetryAfter — back off and retry once
+            # Flood control / RetryAfter — short waits are retried inline,
+            # long waits return a failure immediately so streaming can fall back
+            # to a normal final send instead of leaving a truncated partial.
             retry_after = getattr(e, "retry_after", None)
             if retry_after is not None or "retry after" in err_str:
                 wait = retry_after if retry_after else 1.0
@@ -908,6 +910,8 @@ class TelegramAdapter(BasePlatformAdapter):
                     "[%s] Telegram flood control, waiting %.1fs",
                     self.name, wait,
                 )
+                if wait > 5.0:
+                    return SendResult(success=False, error=f"flood_control:{wait}")
                 await asyncio.sleep(wait)
                 try:
                     await self._bot.edit_message_text(

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -174,12 +174,12 @@ class GatewayStreamConsumer:
                         self._already_sent = True
                         self._last_sent_text = text
                     else:
-                        # Edit not supported by this adapter — stop streaming,
-                        # let the normal send path handle the final response.
-                        # Without this guard, adapters like Signal/Email would
-                        # flood the chat with a new message every edit_interval.
+                        # If an edit fails mid-stream (especially Telegram flood control),
+                        # stop progressive edits and let the normal final send path deliver
+                        # the complete answer instead of leaving the user with a partial.
                         logger.debug("Edit failed, disabling streaming for this adapter")
                         self._edit_supported = False
+                        self._already_sent = False
                 else:
                     # Editing not supported — skip intermediate updates.
                     # The final response will be sent by the normal path.


### PR DESCRIPTION
## Summary

Fixes truncated streaming responses on Telegram when flood control hits during progressive message edits.

## Problem

When streaming is enabled, Hermes progressively edits a single Telegram message with incoming tokens. If Telegram rate-limits an `editMessageText` call mid-stream:

1. The stream consumer disables further edits (`_edit_supported = False`)
2. But `_already_sent` stays `True`
3. The handler sees `already_sent=True` and skips the normal final send
4. The user is left with whatever partial text was last successfully edited

## Fix

**`stream_consumer.py`**: Reset `_already_sent = False` when an edit fails, so the handler's normal send path delivers the complete response.

**`telegram.py`**: Return `SendResult(success=False)` for flood control waits >5s instead of blocking the caller. This lets the stream consumer see the failure immediately and fall back cleanly, rather than blocking for 23s+ and potentially getting cancelled by the 5-second cleanup timeout.

## Test plan

- [x] `pytest tests/gateway/` — 1838 passed, 9 failed (all pre-existing)
- [ ] Send a message that triggers a long streaming response while the bot is near Telegram's rate limit → response should arrive complete via normal send, not truncated