### PR TITLE
fix(mcp): drop undefined required fields from MCP tool schemas

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1401,7 +1401,19 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
         return {"type": "object", "properties": {}}
 
     if schema.get("type") == "object" and "properties" not in schema:
-        return {**schema, "properties": {}}
+        # Drop required — there are no properties for it to reference
+        result = {k: v for k, v in schema.items() if k != "required"}
+        return {**result, "properties": {}}
+
+    # Filter required to only include properties that actually exist
+    if schema.get("type") == "object" and "required" in schema:
+        properties = schema.get("properties", {})
+        valid_required = [r for r in schema["required"] if r in properties]
+        if len(valid_required) != len(schema["required"]):
+            if valid_required:
+                schema = {**schema, "required": valid_required}
+            else:
+                schema = {k: v for k, v in schema.items() if k != "required"}
 
     return schema
 


### PR DESCRIPTION
## What does this PR do?

`_normalize_mcp_input_schema` was adding an empty `properties: {}` to MCP tool schemas that lacked the field, but leaving any existing `required` array intact. This produces schemas where `required` references property names that don't exist in `properties`, which Google AI Studio (Gemini) rejects with a 400 `INVALID_ARGUMENT`:

```
GenerateContentRequest.tools[0].function_declarations[N].parameters.required[0]: property is not defined
```

OpenAI silently tolerates this, so the bug went unnoticed until Gemini support was attempted.

**Fix:** two cases covered in `_normalize_mcp_input_schema`:
1. When `properties` is missing entirely → drop `required` before adding empty `properties: {}`
2. When `properties` exists but `required` lists undefined keys → filter to only valid entries; drop `required` entirely if nothing remains

## Related Issue

Related #3236 (this fixes one specific failure mode when using Gemini — native Gemini provider support is tracked separately in #3241 and #3248)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py:1398–1406` — `_normalize_mcp_input_schema`: strip `required` entries that reference undefined properties

## How to Test

1. Configure a Gemini model via Google AI Studio in `cli-config.yaml`
2. Enable any MCP server that exposes a tool with an object schema missing `properties` (or with a `required` entry not in `properties`)
3. Run `hermes` and invoke a tool — previously got 400 `INVALID_ARGUMENT`, now succeeds

Alternatively, unit test the function directly:
```python
from tools.mcp_tool import _normalize_mcp_input_schema

# required with no properties → required dropped
assert "required" not in _normalize_mcp_input_schema({"type": "object", "required": ["x"]})

# required with undefined key → filtered out
result = _normalize_mcp_input_schema({"type": "object", "properties": {"a": {}}, "required": ["a", "b"]})
assert result["required"] == ["a"]
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 22.1.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Error before fix (from Google AI Studio provider):
```
Error code: 400 - {'error': {'message': 'Provider returned error', 'code': 400,
  'metadata': {'raw': '{"error": {"code": 400,
    "message": "* GenerateContentRequest.tools[0].function_declarations[31].parameters.required[0]: property is not defined",
    "status": "INVALID_ARGUMENT"}}'}}}
```