### PR TITLE
fix(gateway): prevent stuck sessions with agent timeout and staleness eviction

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -9,6 +9,7 @@ runs at a time if multiple processes overlap.
 """
 
 import asyncio
+import concurrent.futures
 import json
 import logging
 import os
@@ -442,8 +443,29 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             session_db=_session_db,
         )
         
-        result = agent.run_conversation(prompt)
-        
+        # Run the agent with a timeout so a hung API call or tool doesn't
+        # block the cron ticker thread indefinitely.  Default 10 minutes;
+        # override via env var.
+        _cron_timeout = float(os.getenv("HERMES_CRON_TIMEOUT", 600))
+        _cron_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        _cron_future = _cron_pool.submit(agent.run_conversation, prompt)
+        try:
+            result = _cron_future.result(timeout=_cron_timeout)
+        except concurrent.futures.TimeoutError:
+            logger.error(
+                "Job '%s' timed out after %.0fs — interrupting agent",
+                job_name, _cron_timeout,
+            )
+            if hasattr(agent, "interrupt"):
+                agent.interrupt("Cron job timed out")
+            _cron_pool.shutdown(wait=False, cancel_futures=True)
+            raise TimeoutError(
+                f"Cron job '{job_name}' timed out after "
+                f"{int(_cron_timeout // 60)} minutes"
+            )
+        finally:
+            _cron_pool.shutdown(wait=False)
+
         final_response = result.get("final_response", "") or ""
         # Use a separate variable for log display; keep final_response clean
         # for delivery logic (empty response = no delivery).

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -409,9 +409,13 @@ def _resolve_hermes_bin() -> Optional[list[str]]:
 
 
 class GatewayRunner:
+    # Class-level default so partial construction in tests doesn't
+    # blow up on attribute access.
+    _running_agents_ts: Dict[str, float] = {}
+
     """
     Main gateway controller.
-    
+
     Manages the lifecycle of all platform adapters and routes
     messages to/from the agent.
     """
@@ -446,6 +450,7 @@ class GatewayRunner:
         # Track running agents per session for interrupt support
         # Key: session_key, Value: AIAgent instance
         self._running_agents: Dict[str, Any] = {}
+        self._running_agents_ts: Dict[str, float] = {}  # start timestamp per session
         self._pending_messages: Dict[str, str] = {}  # Queued messages during interrupt
 
         # Cache AIAgent instances per session to preserve prompt caching.
@@ -1750,6 +1755,20 @@ class GatewayRunner:
         # simultaneous updates. Do NOT interrupt for photo-only follow-ups here;
         # let the adapter-level batching/queueing logic absorb them.
         _quick_key = self._session_key_for_source(source)
+
+        # Staleness eviction: if an entry has been in _running_agents for
+        # longer than the agent timeout, it's a leaked lock from a hung or
+        # crashed handler.  Evict it so the session isn't permanently stuck.
+        _STALE_TTL = float(os.getenv("HERMES_AGENT_TIMEOUT", 600)) + 60
+        _stale_ts = self._running_agents_ts.get(_quick_key, 0)
+        if _quick_key in self._running_agents and _stale_ts and (time.time() - _stale_ts) > _STALE_TTL:
+            logger.warning(
+                "Evicting stale _running_agents entry for %s (age: %.0fs)",
+                _quick_key[:30], time.time() - _stale_ts,
+            )
+            del self._running_agents[_quick_key]
+            self._running_agents_ts.pop(_quick_key, None)
+
         if _quick_key in self._running_agents:
             if event.get_command() == "status":
                 return await self._handle_status_command(event)
@@ -2075,6 +2094,7 @@ class GatewayRunner:
         # "already running" guard and spin up a duplicate agent for the
         # same session — corrupting the transcript.
         self._running_agents[_quick_key] = _AGENT_PENDING_SENTINEL
+        self._running_agents_ts[_quick_key] = time.time()
 
         try:
             return await self._handle_message_with_agent(event, source, _quick_key)
@@ -2085,6 +2105,7 @@ class GatewayRunner:
             # not linger or the session would be permanently locked out.
             if self._running_agents.get(_quick_key) is _AGENT_PENDING_SENTINEL:
                 del self._running_agents[_quick_key]
+            self._running_agents_ts.pop(_quick_key, None)
 
     async def _handle_message_with_agent(self, event, source, _quick_key: str):
         """Inner handler that runs under the _running_agents sentinel guard."""
@@ -5998,9 +6019,36 @@ class GatewayRunner:
         interrupt_monitor = asyncio.create_task(monitor_for_interrupt())
         
         try:
-            # Run in thread pool to not block
+            # Run in thread pool to not block.  Cap total execution time
+            # so a hung API call or runaway tool doesn't permanently lock
+            # the session.  Default 10 minutes; override with env var.
+            _agent_timeout = float(os.getenv("HERMES_AGENT_TIMEOUT", 600))
             loop = asyncio.get_event_loop()
-            response = await loop.run_in_executor(None, run_sync)
+            try:
+                response = await asyncio.wait_for(
+                    loop.run_in_executor(None, run_sync),
+                    timeout=_agent_timeout,
+                )
+            except asyncio.TimeoutError:
+                logger.error(
+                    "Agent execution timed out after %.0fs for session %s",
+                    _agent_timeout, session_key,
+                )
+                _timed_out_agent = agent_holder[0]
+                if _timed_out_agent and hasattr(_timed_out_agent, "interrupt"):
+                    _timed_out_agent.interrupt("Execution timed out")
+                response = {
+                    "final_response": (
+                        f"⏱️ Request timed out after {int(_agent_timeout // 60)} minutes. "
+                        "The agent may have been stuck on a tool or API call.\n"
+                        "Try again, or use /reset to start fresh."
+                    ),
+                    "messages": result_holder[0].get("messages", []) if result_holder[0] else [],
+                    "api_calls": 0,
+                    "tools": tools_holder[0] or [],
+                    "history_offset": 0,
+                    "failed": True,
+                }
 
             # Track fallback model state: if the agent switched to a
             # fallback model during this run, persist it so /model shows
@@ -6115,6 +6163,8 @@ class GatewayRunner:
             tracking_task.cancel()
             if session_key and session_key in self._running_agents:
                 del self._running_agents[session_key]
+            if session_key:
+                self._running_agents_ts.pop(session_key, None)
             
             # Wait for cancelled tasks
             for task in [progress_task, interrupt_monitor, tracking_task]:


### PR DESCRIPTION
## Summary

Fixes sessions getting permanently locked when an agent hangs, requiring a gateway restart. Also fixes hung cron jobs blocking all subsequent cron execution.

## Problem

1. **Stuck message sessions**: `run_in_executor(None, run_sync)` in `_run_agent` had no timeout. A hung API call (httpx timeout is 30 minutes) or runaway tool locked the session indefinitely — the `finally` block that cleans up `_running_agents` never ran. All subsequent messages for that session were routed to the interrupt/queue path and never processed.

2. **Stuck cron jobs**: `agent.run_conversation(prompt)` is synchronous and blocked the cron ticker thread. One hung cron job prevented all subsequent cron jobs from firing until gateway restart.

## Fix

- **Agent timeout** (`gateway/run.py`): Wrap `run_in_executor` with `asyncio.wait_for(timeout=HERMES_AGENT_TIMEOUT)` (default 10min). On timeout, the agent is interrupted and the user gets an actionable error message. The `finally` block runs normally and unlocks the session.

- **Staleness eviction** (`gateway/run.py`): `_running_agents_ts` tracks start timestamps. When a new message arrives and finds an entry older than timeout + 1min grace, it's auto-evicted. Safety net for any cleanup path that fails.

- **Cron timeout** (`cron/scheduler.py`): Run `run_conversation` in a 1-worker `ThreadPoolExecutor` with `future.result(timeout=HERMES_CRON_TIMEOUT)` (default 10min). On timeout, the agent is interrupted and the pool is shut down with `wait=False, cancel_futures=True` so the ticker thread isn't blocked.

## New env vars

| Variable | Default | Purpose |
|----------|---------|---------|
| `HERMES_AGENT_TIMEOUT` | `600` (10min) | Max agent execution time per message |
| `HERMES_CRON_TIMEOUT` | `600` (10min) | Max cron job execution time |

## Files changed

| File | Changes |
|------|---------|
| `gateway/run.py` | `asyncio.wait_for` timeout, `_running_agents_ts` staleness tracking |
| `cron/scheduler.py` | `ThreadPoolExecutor` with timeout and non-blocking shutdown |

## Test plan

- [x] `pytest tests/gateway/ tests/cron/` — 1932 passed, 6 failed (all pre-existing: approval flaky + whatsapp + progress emoji)
- [ ] Let agent run a tool that hangs >10min → should timeout, user gets error, session unlocks
- [ ] Schedule a cron job with a prompt that causes a hang → should timeout after 10min, ticker continues
- [ ] Normal messages and cron jobs under 10min → no change in behavior