### PR TITLE
fix: webhook platform support — skip home channel prompt, disable tool progress (salvage #4363)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2449,7 +2449,8 @@ class GatewayRunner:
             )
         
         # One-time prompt if no home channel is set for this platform
-        if not history and source.platform and source.platform != Platform.LOCAL:
+        # Skip for webhooks - they deliver directly to configured targets (github_comment, etc.)
+        if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK:
             platform_name = source.platform.value
             env_key = f"{platform_name.upper()}_HOME_CHANNEL"
             if not os.getenv(env_key):
@@ -5356,7 +5357,10 @@ class GatewayRunner:
             or os.getenv("HERMES_TOOL_PROGRESS_MODE")
             or "all"
         )
-        tool_progress_enabled = progress_mode != "off"
+        # Disable tool progress for webhooks - they don't support message editing,
+        # so each progress line would be sent as a separate message.
+        from gateway.config import Platform
+        tool_progress_enabled = progress_mode != "off" and source.platform != Platform.WEBHOOK
         
         # Queue for progress messages (thread-safe)
         progress_queue = queue.Queue() if tool_progress_enabled else None

--- a/hermes_cli/skills_config.py
+++ b/hermes_cli/skills_config.py
@@ -30,6 +30,7 @@ PLATFORMS = {
     "dingtalk": "💬 DingTalk",
     "feishu": "🪽 Feishu",
     "wecom": "💬 WeCom",
+    "webhook": "🔗 Webhook",
 }
 
 # ─── Config Helpers ───────────────────────────────────────────────────────────

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -150,6 +150,7 @@ PLATFORMS = {
     "wecom": {"label": "💬 WeCom", "default_toolset": "hermes-wecom"},
     "api_server": {"label": "🌐 API Server", "default_toolset": "hermes-api-server"},
     "mattermost": {"label": "💬 Mattermost", "default_toolset": "hermes-mattermost"},
+    "webhook": {"label": "🔗 Webhook", "default_toolset": "hermes-webhook"},
 }
 
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -369,10 +369,16 @@ TOOLSETS = {
         "includes": []
     },
 
+    "hermes-webhook": {
+        "description": "Webhook toolset - receive and process external webhook events",
+        "tools": _HERMES_CORE_TOOLS,
+        "includes": []
+    },
+
     "hermes-gateway": {
         "description": "Gateway toolset - union of all messaging platform tools",
         "tools": [],
-        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom"]
+        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-webhook"]
     }
 }
 


### PR DESCRIPTION
## Summary

Cherry-picked from PR #4363 by @bennyhodl with follow-up fixes.

Fixes three webhook platform issues reported by users:

1. **Skip home channel prompt for webhooks** — Webhooks deliver to configured targets (github_comment, telegram, etc.), not a home channel. Previously every webhook delivery triggered the "No home channel is set" message.

2. **Disable tool progress for webhooks** — Webhooks don't support message editing, so each tool progress line was sent as a separate message/comment. Now disabled at the source in `_run_agent`.

3. **Add webhook to platform registries** — Missing from `tools_config.py` PLATFORMS (caused KeyError), `skills_config.py`, and `toolsets.py`.

### Follow-up fixes (not in original PR)
- Added `hermes-webhook` toolset to `toolsets.py` + `hermes-gateway` includes (fixes test consistency checks)
- Added `webhook` to `skills_config.py` PLATFORMS (fixes test consistency checks)  
- Removed <50 char content filter from github_comment delivery — it was a holdover from an intermediate approach and blocked legitimate short responses like "LGTM! The code looks great." Tool progress is already handled at source.

## Test Results
- gateway + tools_config: 1863 passed, 4 failed (pre-existing signal/nous), 38 skipped

Credit: @bennyhodl (original author)