### PR TITLE
fix(gateway): update /provider response to stop recommending deprecated /model

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3205,6 +3205,7 @@ class GatewayRunner:
     async def _handle_provider_command(self, event: MessageEvent) -> str:
         """Handle /provider command - show available providers."""
         import yaml
+        from hermes_constants import display_hermes_home
         from hermes_cli.models import (
             list_available_providers,
             normalize_provider,
@@ -3254,7 +3255,8 @@ class GatewayRunner:
             lines.append(f"{auth} `{p['id']}` — {p['label']}{aliases}{marker}")
 
         lines.append("")
-        lines.append("Switch: `/model provider:model-name`")
+        lines.append("Change model locally: `hermes model`")
+        lines.append(f"Or edit: `{display_hermes_home()}/config.yaml`")
         lines.append("Setup: `hermes setup`")
         return "\n".join(lines)
     

--- a/tests/gateway/test_provider_command.py
+++ b/tests/gateway/test_provider_command.py
@@ -1,0 +1,62 @@
+"""Tests for gateway /provider output."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+from hermes_constants import display_hermes_home
+
+
+def _make_event(text="/provider", platform=Platform.TELEGRAM,
+                user_id="12345", chat_id="67890"):
+    """Build a MessageEvent for testing."""
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner():
+    """Create a bare GatewayRunner without calling __init__."""
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._session_db = None
+    runner.session_store = MagicMock()
+    return runner
+
+
+class TestProviderCommand:
+    @pytest.mark.asyncio
+    async def test_provider_command_points_to_supported_model_workflow(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "model:\n  provider: openai-codex\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+        monkeypatch.setattr(
+            "hermes_cli.models.list_available_providers",
+            lambda: [
+                {"id": "openrouter", "label": "OpenRouter", "authenticated": True, "aliases": []},
+                {"id": "openai-codex", "label": "OpenAI Codex", "authenticated": True, "aliases": []},
+            ],
+        )
+
+        runner = _make_runner()
+        result = await runner._handle_provider_command(_make_event())
+
+        assert "Current provider" in result
+        assert "Change model locally: `hermes model`" in result
+        assert f"Or edit: `{display_hermes_home()}/config.yaml`" in result
+        assert "/model provider:model-name" not in result


### PR DESCRIPTION
Summary
- update the gateway /provider response to recommend the supported model-switching workflows
- replace the stale /model provider:model-name guidance with hermes model and the profile-aware config.yaml path
- add a regression test covering the /provider output

Problem
/model was intentionally removed from the CLI and gateway in #3080, but /provider still tells messaging users to use it.

This is what the old /provider response looks like in practice:

/provider

🔌 Current provider: OpenAI Codex (openai-codex)

Available providers:
✅ openrouter — OpenRouter
❌ nous — Nous Portal
✅ openai-codex — OpenAI Codex ← active
✅ copilot — GitHub Copilot  _(also: github, github-copilot, github-models, github-model)_
❌ copilot-acp — GitHub Copilot ACP  _(also: github-copilot-acp, copilot-acp-agent)_
❌ huggingface — Hugging Face  _(also: hf, hugging-face, huggingface-hub)_
❌ zai — Z.AI / GLM  _(also: glm, z-ai, z.ai, zhipu)_
❌ kimi-coding — Kimi / Moonshot  _(also: kimi, moonshot)_
❌ minimax — MiniMax
❌ minimax-cn — MiniMax (China)  _(also: minimax-china, minimax_cn)_
❌ kilocode — Kilo Code  _(also: kilo, kilo-code, kilo-gateway)_
✅ anthropic — Anthropic  _(also: claude, claude-code)_
❌ alibaba — Alibaba Cloud (DashScope)  _(also: dashscope, aliyun, qwen, alibaba-cloud)_
❌ opencode-zen — OpenCode Zen  _(also: opencode, zen)_
❌ opencode-go — OpenCode Go  _(also: go, opencode-go-sub)_
❌ ai-gateway — AI Gateway  _(also: aigateway, vercel, vercel-ai-gateway)_
❌ deepseek — DeepSeek  _(also: deep-seek)_
✅ custom — Custom endpoint

Switch: /model provider:model-name
Setup: hermes setup

That stale guidance makes Telegram users think in-chat model switching is still supported. In practice, /model is no longer a registered gateway command, so the message can fall through to the normal agent loop and the model may hallucinate that it switched.

Testing
- /Users/butler/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_provider_command.py -q
- /Users/butler/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_commands.py -q