### PR TITLE
feat: language-aware context compression summaries

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -301,6 +301,8 @@ Update the summary using this exact structure. PRESERVE all existing information
 
 Target ~{summary_budget} tokens. Be specific — include file paths, command outputs, error messages, and concrete values rather than vague descriptions.
 
+Write the summary in the same language the user was using in the conversation.
+
 Write only the summary body. Do not include any preamble or prefix."""
         else:
             # First compaction: summarize from scratch
@@ -338,6 +340,8 @@ Use this exact structure:
 [Any specific values, error messages, configuration details, or data that would be lost without explicit preservation]
 
 Target ~{summary_budget} tokens. Be specific — include file paths, command outputs, error messages, and concrete values rather than vague descriptions. The goal is to prevent the next assistant from repeating work or losing important details.
+
+Write the summary in the same language the user was using in the conversation.
 
 Write only the summary body. Do not include any preamble or prefix."""
 


### PR DESCRIPTION
## Summary

Context compaction now generates summaries in the same language the user was using in the conversation. Previously, summaries were always produced in English regardless of the conversation language — injecting English context into non-English conversations.

## Source

Ported from [anomalyco/opencode#20581](https://github.com/anomalyco/opencode/pull/20581).

## Changes

- Added language-matching instruction to both the **initial** and **iterative update** summarization prompts in `agent/context_compressor.py`
- Instruction: *"Write the summary in the same language the user was using in the conversation."*

## Architectural Notes

OpenCode's fix was a single line in their compaction prompt. Same approach here — the instruction is placed just before the "write only the summary body" closing line in both prompt paths (first compaction and iterative update).

## Test Plan

- All 34 existing context compressor tests pass
- Verified both prompt templates now include the language-matching instruction