### PR TITLE
fix(gateway): don't clobber resolved TERMINAL_CWD with raw config value

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -132,6 +132,14 @@ if _config_path.exists():
             for _cfg_key, _env_var in _terminal_env_map.items():
                 if _cfg_key in _terminal_cfg:
                     _val = _terminal_cfg[_cfg_key]
+                    # Don't clobber an already-resolved absolute TERMINAL_CWD.
+                    # cli.py resolves "." to os.getcwd() at import time, but
+                    # this module-level code runs again when gateway/run.py is
+                    # imported as a plugin — it would overwrite the absolute
+                    # path with the raw "." and then line 208-211 falls back
+                    # to Path.home().
+                    if _cfg_key == "cwd" and os.path.isabs(os.environ.get(_env_var, "")):
+                        continue
                     if isinstance(_val, list):
                         os.environ[_env_var] = json.dumps(_val)
                     else:


### PR DESCRIPTION
## Summary

Fixes #4672

When `cli.py` resolves `terminal.cwd: "."` to `os.getcwd()` and sets `TERMINAL_CWD` to the absolute path, `gateway/run.py` is later imported as a plugin and its module-level config bridging code re-reads the raw `"."` from `config.yaml`, overwriting the resolved value. The subsequent fallback logic then defaults to `Path.home()`.

This causes the terminal to always open in `$HOME` instead of the directory where hermes was launched.

## Change

In `gateway/run.py`, skip setting `cwd` in the terminal env bridge when `TERMINAL_CWD` is already set to an absolute path:

```python
if _cfg_key == "cwd" and os.path.isabs(os.environ.get(_env_var, "")):
    continue
```