### PR TITLE
feat: api_key_env for custom_providers

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -764,10 +764,11 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
     changed = False
     active_sources: Set[str] = set()
 
-    # Seed from the custom_providers config entry's api_key field
+    # Seed from the custom_providers config entry's api_key / api_key_env field
     cp_config = _get_custom_provider_config(pool_key)
     if cp_config:
-        api_key = str(cp_config.get("api_key") or "").strip()
+        from hermes_cli.runtime_provider import resolve_custom_api_key
+        api_key = resolve_custom_api_key(cp_config)
         base_url = str(cp_config.get("base_url") or "").strip().rstrip("/")
         name = str(cp_config.get("name") or "").strip()
         if api_key:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1548,8 +1548,14 @@ def _model_flow_named_custom(config, provider_info):
 
     name = provider_info["name"]
     base_url = provider_info["base_url"]
-    api_key = provider_info.get("api_key", "")
-    _from_env = bool(provider_info.get("api_key_env"))  # don't leak env-resolved keys to config
+    api_key_env = provider_info.get("api_key_env", "")
+    env_api_key = os.getenv(api_key_env, "") if api_key_env else ""
+    if env_api_key:
+        api_key = env_api_key
+        _from_env = True
+    else:
+        api_key = provider_info.get("api_key", "")
+        _from_env = False
     saved_model = provider_info.get("model", "")
 
     # If a model is saved, just activate immediately — no probing needed

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -970,10 +970,12 @@ def select_provider_and_model(args=None):
             saved_model = entry.get("model", "")
             model_hint = f" — {saved_model}" if saved_model else ""
             providers.append((key, f"{name} ({short_url}){model_hint}"))
+            from hermes_cli.runtime_provider import resolve_custom_api_key
             _custom_provider_map[key] = {
                 "name": name,
                 "base_url": base_url,
-                "api_key": entry.get("api_key", ""),
+                "api_key": resolve_custom_api_key(entry),
+                "api_key_env": entry.get("api_key_env", ""),  # preserve source flag
                 "model": saved_model,
             }
 
@@ -1547,6 +1549,7 @@ def _model_flow_named_custom(config, provider_info):
     name = provider_info["name"]
     base_url = provider_info["base_url"]
     api_key = provider_info.get("api_key", "")
+    _from_env = bool(provider_info.get("api_key_env"))  # don't leak env-resolved keys to config
     saved_model = provider_info.get("model", "")
 
     # If a model is saved, just activate immediately — no probing needed
@@ -1560,7 +1563,7 @@ def _model_flow_named_custom(config, provider_info):
             cfg["model"] = model
         model["provider"] = "custom"
         model["base_url"] = base_url
-        if api_key:
+        if api_key and not _from_env:
             model["api_key"] = api_key
         save_config(cfg)
         deactivate_provider()
@@ -1633,13 +1636,14 @@ def _model_flow_named_custom(config, provider_info):
         cfg["model"] = model
     model["provider"] = "custom"
     model["base_url"] = base_url
-    if api_key:
+    if api_key and not _from_env:
         model["api_key"] = api_key
     save_config(cfg)
     deactivate_provider()
 
     # Save model name to the custom_providers entry for next time
-    _save_custom_provider(base_url, api_key, model_name)
+    # Don't pass the resolved secret when it came from an env var
+    _save_custom_provider(base_url, "" if _from_env else api_key, model_name)
 
     print(f"\n✅ Model set to: {model_name}")
     print(f"   Provider: {name} ({base_url})")

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -23,6 +23,19 @@ from hermes_cli.config import load_config
 from hermes_constants import OPENROUTER_BASE_URL
 
 
+def resolve_custom_api_key(entry: dict) -> str:
+    """Resolve API key from a custom_providers entry.
+
+    Supports ``api_key_env`` (environment variable name) as an alternative to
+    the literal ``api_key`` field.  When both are present, ``api_key_env`` wins
+    so that operators can migrate to env-based secrets incrementally.
+    """
+    env_var = (entry.get("api_key_env") or "").strip()
+    if env_var:
+        return os.environ.get(env_var, "").strip()
+    return str(entry.get("api_key", "") or "").strip()
+
+
 def _normalize_custom_provider_name(value: str) -> str:
     return value.strip().lower().replace(" ", "-")
 
@@ -266,7 +279,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
         result = {
             "name": name.strip(),
             "base_url": base_url.strip(),
-            "api_key": str(entry.get("api_key", "") or "").strip(),
+            "api_key": resolve_custom_api_key(entry),
         }
         api_mode = _parse_api_mode(entry.get("api_mode"))
         if api_mode:
@@ -300,7 +313,7 @@ def _resolve_named_custom_runtime(
 
     api_key_candidates = [
         (explicit_api_key or "").strip(),
-        str(custom_provider.get("api_key", "") or "").strip(),
+        custom_provider.get("api_key", ""),  # already resolved by _get_named_custom_provider
         os.getenv("OPENAI_API_KEY", "").strip(),
         os.getenv("OPENROUTER_API_KEY", "").strip(),
     ]

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -28,11 +28,14 @@ def resolve_custom_api_key(entry: dict) -> str:
 
     Supports ``api_key_env`` (environment variable name) as an alternative to
     the literal ``api_key`` field.  When both are present, ``api_key_env`` wins
-    so that operators can migrate to env-based secrets incrementally.
+    if it resolves to a usable secret, otherwise the literal ``api_key`` is
+    used as a fallback to support incremental migration.
     """
     env_var = (entry.get("api_key_env") or "").strip()
     if env_var:
-        return os.environ.get(env_var, "").strip()
+        env_value = os.environ.get(env_var, "").strip()
+        if has_usable_secret(env_value):
+            return env_value
     return str(entry.get("api_key", "") or "").strip()
 
 


### PR DESCRIPTION
## Summary

- Adds `api_key_env` field to `custom_providers` entries in config.yaml — names an environment variable to resolve at runtime instead of storing the literal API key in the config file
- When both `api_key` and `api_key_env` are present, `api_key_env` wins (incremental migration)
- Write-back paths are guarded so resolved secrets are never leaked back into config.yaml or auth.json

## Motivation

Custom providers currently require hardcoding API keys in `config.yaml` and `auth.json`. This is a security concern — config files end up in backups, dotfile repos, and are readable by any process. Environment variables are the standard way to manage secrets, and every other provider type in Hermes already supports env var resolution.

## Example

```yaml
# Before (literal key in config file)
custom_providers:
- name: Api.x.ai
  base_url: https://api.x.ai/v1
  api_key: xai-LITERAL-SECRET-HERE

# After (secret stays in env)
custom_providers:
- name: Api.x.ai
  base_url: https://api.x.ai/v1
  api_key_env: XAI_API_KEY
```

## Changes

| File | What |
|------|------|
| `hermes_cli/runtime_provider.py` | New `resolve_custom_api_key()` helper; patched `_get_named_custom_provider` and `_resolve_named_custom_runtime` |
| `agent/credential_pool.py` | `_seed_custom_pool()` uses resolver instead of literal read |
| `hermes_cli/main.py` | Menu builder resolves via helper; `_model_flow_named_custom` guards write-back to prevent secret leakage |

## Test plan

- [x] Unit smoke tests: env resolution, precedence, fallback, missing var
- [x] Full test suite: 4007 passed (2 pre-existing failures unrelated to this change)
- [ ] Manual: configure `api_key_env`, verify `hermes` resolves and authenticates
- [ ] Manual: run `hermes model` flow, verify config.yaml is not polluted with resolved secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)