### PR TITLE
fix: resolve opencode.ai context window to 1M and clean up display formatting

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -177,6 +177,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "api.githubcopilot.com": "copilot",
     "models.github.ai": "copilot",
     "api.fireworks.ai": "fireworks",
+    "opencode.ai": "opencode-go",
 }
 
 

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -222,10 +222,16 @@ def _format_context_length(tokens: int) -> str:
     """Format a token count for display (e.g. 128000 → '128K', 1048576 → '1M')."""
     if tokens >= 1_000_000:
         val = tokens / 1_000_000
-        return f"{val:g}M"
+        rounded = round(val)
+        if abs(val - rounded) < 0.05:
+            return f"{rounded}M"
+        return f"{val:.1f}M"
     elif tokens >= 1_000:
         val = tokens / 1_000
-        return f"{val:g}K"
+        rounded = round(val)
+        if abs(val - rounded) < 0.05:
+            return f"{rounded}K"
+        return f"{val:.1f}K"
     return str(tokens)
 
 


### PR DESCRIPTION
## Summary

Two small fixes for providers using `opencode.ai` as their base URL (e.g. mimo-v2-pro via Nous Research):

### 1. Add opencode.ai to URL-to-provider mapping (`agent/model_metadata.py`)

Without this, `opencode.ai` is treated as a custom endpoint. Hermes tries to probe `/models` (which returns 404), then falls back to the 128K default — even though `models.dev` correctly lists mimo-v2-pro at 1M context.

Adding `"opencode.ai": "opencode-go"` to `_URL_TO_PROVIDER` routes it through the models.dev lookup, same as other known providers.

### 2. Clean up context length display formatting (`hermes_cli/banner.py`)

The `_format_context_length` function used `:g` formatting, which showed `1048576` as `1.048576M` instead of a clean `1M`. Same issue for K values.

Fix: round to nearest integer when within 0.05 tolerance, otherwise show 1 decimal place. So:
- `1048576` → `1M` ✓
- `128000` → `128K` ✓
- `1500000` → `1.5M` ✓

All 75 `test_model_metadata.py` tests pass.