### PR TITLE
Fix install.sh silently aborting on macOS when uv Python path contains spaces

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -215,7 +215,8 @@ check_python() {
     # First check if a suitable Python is already available
     if $UV_CMD python find "$PYTHON_VERSION" &> /dev/null; then
         PYTHON_PATH=$($UV_CMD python find "$PYTHON_VERSION")
-        PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
+        # Quote PYTHON_PATH to handle spaces in paths (e.g., macOS uv: ~/Library/Application Support/uv/python/...)
+        PYTHON_FOUND_VERSION=$("$PYTHON_PATH" --version 2>/dev/null)
         log_success "Python found: $PYTHON_FOUND_VERSION"
         return 0
     fi
@@ -224,7 +225,8 @@ check_python() {
     log_info "Python $PYTHON_VERSION not found, installing via uv..."
     if $UV_CMD python install "$PYTHON_VERSION"; then
         PYTHON_PATH=$($UV_CMD python find "$PYTHON_VERSION")
-        PYTHON_FOUND_VERSION=$($PYTHON_PATH --version 2>/dev/null)
+        # Quote PYTHON_PATH to handle spaces in paths (e.g., macOS uv: ~/Library/Application Support/uv/python/...)
+        PYTHON_FOUND_VERSION=$("$PYTHON_PATH" --version 2>/dev/null)
         log_success "Python installed: $PYTHON_FOUND_VERSION"
     else
         log_error "Failed to install Python $PYTHON_VERSION"


### PR DESCRIPTION
## Fixes #3000

### Problem
`install.sh` silently aborts during `check_python()` on macOS when `uv python find` returns a path containing spaces (e.g. `~/Library/Application Support/uv/python/cpython-3.11/bin/python3`).

The unquoted `$PYTHON_PATH` gets word-split by the shell, causing a "command not found" error. With `set -e` active, the script exits immediately with no error message.

### Fix
Quote `$PYTHON_PATH` in both places where it's used as a command (lines 219 and 229). This preserves the full path as a single argument regardless of spaces.

### Testing
- Verified the only two unquoted command usages of `PYTHON_PATH` in the script are fixed
- Assignment (`PYTHON_PATH=$(...)`) doesn't need quoting — bash doesn't word-split on the RHS of variable assignments