### PR TITLE
fix: mimo-v2-pro context window resolves to 128K instead of 1M

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -177,6 +177,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "api.githubcopilot.com": "copilot",
     "models.github.ai": "copilot",
     "api.fireworks.ai": "fireworks",
+    "opencode.ai": "opencode-go",
 }
 
 

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -222,10 +222,16 @@ def _format_context_length(tokens: int) -> str:
     """Format a token count for display (e.g. 128000 → '128K', 1048576 → '1M')."""
     if tokens >= 1_000_000:
         val = tokens / 1_000_000
-        return f"{val:g}M"
+        rounded = round(val)
+        if abs(val - rounded) < 0.05:
+            return f"{rounded}M"
+        return f"{val:.1f}M"
     elif tokens >= 1_000:
         val = tokens / 1_000
-        return f"{val:g}K"
+        rounded = round(val)
+        if abs(val - rounded) < 0.05:
+            return f"{rounded}K"
+        return f"{val:.1f}K"
     return str(tokens)
 
 


### PR DESCRIPTION
## Problem

mimo-v2-pro (served via opencode.ai) displays `128K` context in the status bar despite supporting 1M tokens. Two issues cause this:

1. **opencode.ai is not in `_URL_TO_PROVIDER`** (`agent/model_metadata.py`). Without the mapping, Hermes treats it as a custom endpoint and tries to probe `/models` — which returns 404. It then falls back to the 128K default, skipping the `models.dev` lookup that already has mimo-v2-pro correctly listed at 1M context.

2. **Display formatting shows ugly decimals** (`hermes_cli/banner.py`). Even after the context is resolved correctly, `_format_context_length` uses `:g` formatting which shows `1048576` as `1.048576M` instead of a clean `1M`.

## Fix

1. Add `"opencode.ai": "opencode-go"` to `_URL_TO_PROVIDER` so opencode.ai routes resolve through models.dev — same as how other known providers (nous, deepseek, fireworks, etc.) work.

2. Round context display cleanly: use nearest integer when within 0.05 tolerance, otherwise 1 decimal. So `1048576` → `1M`, `128000` → `128K`, `1500000` → `1.5M`.

## Files

- `agent/model_metadata.py` — 1 line added
- `hermes_cli/banner.py` — formatting logic updated

All 75 `test_model_metadata.py` tests pass.