### PR TITLE
fix: /approve and /deny bypass running-agent guard + warn on unknown approval mode

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1748,6 +1748,16 @@ class GatewayRunner:
                     del self._running_agents[_quick_key]
                 return await self._handle_reset_command(event)
 
+            # /approve and /deny must bypass the running-agent interrupt guard
+            # so they can signal the blocked agent thread during approval waits.
+            # Without this bypass, /approve is treated as a plain interrupt and
+            # never reaches _handle_approve_command — making it impossible to
+            # unblock a pending dangerous command from Discord or other gateways.
+            if _cmd_def_inner and _cmd_def_inner.name in ("approve", "deny"):
+                if _cmd_def_inner.name == "approve":
+                    return await self._handle_approve_command(event)
+                return await self._handle_deny_command(event)
+
             # /queue <prompt> — queue without interrupting
             if event.get_command() in ("queue", "q"):
                 queued_text = event.get_command_args().strip()

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -423,12 +423,26 @@ def _normalize_approval_mode(mode) -> str:
     YAML 1.1 treats bare words like `off` as booleans, so a config entry like
     `approvals:\n  mode: off` is parsed as False unless quoted. Treat that as the
     intended string mode instead of falling back to manual approvals.
+
+    Unknown string values (e.g. 'auto') are rejected with a warning rather than
+    being silently accepted and causing unpredictable approval behaviour.
     """
+    _VALID_MODES = ("manual", "smart", "off")
     if isinstance(mode, bool):
         return "off" if mode is False else "manual"
     if isinstance(mode, str):
         normalized = mode.strip().lower()
-        return normalized or "manual"
+        if not normalized:
+            return "manual"
+        if normalized in _VALID_MODES:
+            return normalized
+        logger.warning(
+            "Unknown approvals.mode %r — defaulting to 'smart'. "
+            "Valid values: %s",
+            mode,
+            ", ".join(_VALID_MODES),
+        )
+        return "smart"
     return "manual"
 
 


### PR DESCRIPTION
## Problem

Two related bugs in the dangerous command approval flow:

### Bug 1: `/approve` is swallowed as an interrupt when an agent is running

When an agent is blocked waiting for approval (e.g. a dangerous command triggered `manual` mode), sending `/approve` from Discord has no effect — the session appears permanently frozen.

**Root cause:** The running-agent guard in `_handle_message` intercepts *all* messages while a session is active and either routes them to `/stop`, `/new`, `/queue`, or falls through to `running_agent.interrupt(event.text) + return None`. `/approve` and `/deny` have no early-intercept entry, so they hit the fallthrough: the agent thread receives an interrupt signal, the approval event is never resolved, and the session stays locked.

**Fix:** Add an early-intercept entry for `approve` and `deny` alongside the existing `stop`/`new` bypasses. When triggered, they call `_handle_approve_command` / `_handle_deny_command` directly, which resolves the `threading.Event` and unblocks the agent thread.

Related: #3614

### Bug 2: Unknown `approvals.mode` values are silently accepted

Setting `approvals.mode: auto` (or any unrecognised string) in `config.yaml` is silently accepted by `_normalize_approval_mode()`. The value falls through every mode check in the approval logic (`off`, `smart`), resulting in unpredictable behaviour with no warning.

**Fix:** Validate against `("manual", "smart", "off")`, emit `logger.warning` for unknown values, and default to `smart`.

Fixes #4261

## Changes

- `gateway/run.py`: add `approve`/`deny` to the running-agent early-intercept block
- `tools/approval.py`: validate mode in `_normalize_approval_mode`, warn + default to `smart`

## Testing

Reproduced locally: with `approvals.mode: manual` and an agent blocked on a `bash -c` command, `/approve` from Discord previously returned no response and left the session frozen. After this fix the command is resolved and the agent resumes normally.