### PR TITLE
fix: generate session titles in the conversation's language, not always English

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 _TITLE_PROMPT = (
     "Generate a short, descriptive title (3-7 words) for a conversation that starts with the "
     "following exchange. The title should capture the main topic or intent. "
+    "Write the title in the same language the user is using in the conversation. "
     "Return ONLY the title text, nothing else. No quotes, no punctuation at the end, no prefixes."
 )
 

--- a/tests/test_title_language.py
+++ b/tests/test_title_language.py
@@ -1,0 +1,13 @@
+"""Test that session title generation prompt includes language-matching.
+
+Session titles should be generated in the same language as the
+conversation. A Japanese user chatting in Japanese should get a
+Japanese title, not an English one.
+"""
+
+from agent.title_generator import _TITLE_PROMPT
+
+
+def test_title_prompt_includes_language_matching():
+    """The system prompt must instruct the LLM to match the conversation language."""
+    assert "same language" in _TITLE_PROMPT.lower()


### PR DESCRIPTION
## Summary

Session titles are always generated in English regardless of the conversation language. A Japanese user chatting in Japanese gets an English title like "Discussion About Python Decorators" instead of something in Japanese.

Companion to #4670 which fixes the same issue for context compression summaries.

## Root Cause

The title generator prompt in `agent/title_generator.py` has no language-matching instruction:

```
Generate a short, descriptive title (3-7 words) for a conversation...
```

The LLM defaults to English.

## Fix

Added one line to the prompt:

```
Write the title in the same language the user is using in the conversation.
```

Same approach as #4670 uses for compression summaries.

## Tests

```
1 passed
```