### PR TITLE
fix: per-profile HOME isolation (#4426)

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -9,7 +9,13 @@ INSTALL_DIR="/opt/hermes"
 # (cache/images, cache/audio, platforms/whatsapp, etc.) are created on
 # demand by the application — don't pre-create them here so new installs
 # get the consolidated layout from get_hermes_dir().
-mkdir -p "$HERMES_HOME"/{cron,sessions,logs,hooks,memories,skills}
+#
+# The "home/" subdirectory is the per-profile HOME for system tools (git,
+# ssh, gh, npm etc.).  Without it those tools would write to /root which is
+# ephemeral in Docker and shared across profiles.  Bootstrapping it here
+# ensures the directory exists inside the persistent volume before Hermes
+# sets HOME=$HERMES_HOME/home on startup.  See issue #4426.
+mkdir -p "$HERMES_HOME"/{cron,sessions,logs,hooks,memories,skills,home}
 
 # .env
 if [ ! -f "$HERMES_HOME/.env" ]; then

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -117,8 +117,10 @@ def _apply_profile_override() -> None:
     if profile_name is None:
         try:
             from hermes_cli.profiles import apply_profile_home_isolation as _isolate_home
-            import os as _os
-            _default_home = Path.home() / ".hermes"
+            # Use HERMES_HOME if set (e.g. Docker: /opt/data), otherwise
+            # fall back to the default ~/.hermes.  Path.home() / ".hermes"
+            # would be wrong when HERMES_HOME points elsewhere.  (#4426)
+            _default_home = Path(os.environ["HERMES_HOME"]) if "HERMES_HOME" in os.environ else Path.home() / ".hermes"
             _isolate_home(_default_home)
         except Exception:
             pass  # HOME isolation must never block startup

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -109,10 +109,24 @@ def _apply_profile_override() -> None:
         except (UnicodeDecodeError, OSError):
             pass  # corrupted file, skip
 
-    # 3. If we found a profile, resolve and set HERMES_HOME
+    # 3a. Apply HOME isolation for the default profile (no named profile active).
+    #     Isolate HOME to {HERMES_HOME}/home/ so system tools (git, ssh, gh,
+    #     npm) write configs inside the Hermes data directory instead of /root
+    #     or the OS home dir.  This keeps the default profile's tool configs
+    #     inside the Docker persistent volume.  (#4426)
+    if profile_name is None:
+        try:
+            from hermes_cli.profiles import apply_profile_home_isolation as _isolate_home
+            import os as _os
+            _default_home = Path.home() / ".hermes"
+            _isolate_home(_default_home)
+        except Exception:
+            pass  # HOME isolation must never block startup
+
+    # 3b. If we found a named profile, resolve and set HERMES_HOME
     if profile_name is not None:
         try:
-            from hermes_cli.profiles import resolve_profile_env
+            from hermes_cli.profiles import resolve_profile_env, apply_profile_home_isolation
             hermes_home = resolve_profile_env(profile_name)
         except (ValueError, FileNotFoundError) as exc:
             print(f"Error: {exc}", file=sys.stderr)
@@ -122,6 +136,15 @@ def _apply_profile_override() -> None:
             print(f"Warning: profile override failed ({exc}), using default", file=sys.stderr)
             return
         os.environ["HERMES_HOME"] = hermes_home
+        # Isolate HOME to the profile directory so system tools (git, ssh,
+        # gh, npm) write configs there instead of /root or ~/.  This keeps
+        # credentials separate between profiles and ensures Docker volumes
+        # persist tool configuration across container restarts. (#4426)
+        try:
+            from pathlib import Path as _Path
+            apply_profile_home_isolation(_Path(hermes_home))
+        except Exception as exc:
+            print(f"Warning: HOME isolation failed ({exc}), using system HOME", file=sys.stderr)
         # Strip the flag from argv so argparse doesn't choke
         if consume > 0:
             for i, arg in enumerate(argv):

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -42,6 +42,10 @@ _PROFILE_DIRS = [
     "plans",
     "workspace",
     "cron",
+    # Per-profile HOME directory: isolates system tool configs (git, ssh, gh,
+    # npm, etc.) so credentials and settings don't bleed between profiles or
+    # leak outside the persistent volume in Docker. See issue #4426.
+    "home",
 ]
 
 # Files copied during --clone (if they exist in the source)
@@ -1052,3 +1056,56 @@ def resolve_profile_env(profile_name: str) -> str:
         )
 
     return str(profile_dir)
+
+
+def get_profile_home_dir(profile_dir: Path) -> Path:
+    """Return the per-profile HOME directory path.
+
+    Each profile gets its own ``home/`` subdirectory so system tools
+    (git, ssh, gh, npm, etc.) write their configs there instead of to
+    the OS-level ``/root`` or ``~``.  In Docker this directory lands inside
+    the persistent volume, so tool configuration survives container restarts.
+
+    Args:
+        profile_dir: The resolved HERMES_HOME for the profile.
+
+    Returns:
+        ``profile_dir / "home"`` — created on demand if it doesn't exist.
+    """
+    home_dir = profile_dir / "home"
+    home_dir.mkdir(parents=True, exist_ok=True)
+    return home_dir
+
+
+def apply_profile_home_isolation(profile_dir: Path) -> Optional[Path]:
+    """Set ``HOME`` in the current process environment to the per-profile dir.
+
+    This isolates system-level tool configuration (git, ssh, gh, npm, etc.)
+    so credentials and settings don't bleed between profiles or leak outside
+    the persistent volume in Docker.  See issue #4426.
+
+    The override is intentionally skipped when ``HOME`` is already set in the
+    profile's ``.env`` file — explicit user config takes precedence.
+
+    Args:
+        profile_dir: The resolved HERMES_HOME for the profile.
+
+    Returns:
+        The path that HOME was set to, or None if skipped.
+    """
+    # Respect an explicit HOME= in the profile's .env file.
+    # We peek at the file directly (dotenv not yet loaded at call time).
+    env_file = profile_dir / ".env"
+    if env_file.exists():
+        try:
+            for line in env_file.read_text(encoding="utf-8", errors="replace").splitlines():
+                stripped = line.strip()
+                if stripped.startswith("HOME=") and not stripped.startswith("#"):
+                    # User explicitly configured HOME — don't override.
+                    return None
+        except OSError:
+            pass
+
+    home_dir = get_profile_home_dir(profile_dir)
+    os.environ["HOME"] = str(home_dir)
+    return home_dir

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -30,8 +30,11 @@ from hermes_cli.profiles import (
     import_profile,
     generate_bash_completion,
     generate_zsh_completion,
+    get_profile_home_dir,
+    apply_profile_home_isolation,
     _get_profiles_root,
     _get_default_hermes_home,
+    _PROFILE_DIRS,
 )
 
 
@@ -798,3 +801,108 @@ class TestEdgeCases:
             delete_profile("coder", yes=True)
 
         assert get_active_profile() == "default"
+
+
+# ===================================================================
+# TestPerProfileHomeIsolation — issue #4426
+# ===================================================================
+
+class TestPerProfileHomeIsolation:
+    """Tests for per-profile HOME isolation (#4426).
+
+    Profiles must isolate system tool configs (git, ssh, gh, npm …) so
+    credentials don't bleed between profiles or leak outside the Docker
+    persistent volume.
+    """
+
+    # ------------------------------------------------------------------
+    # get_profile_home_dir
+    # ------------------------------------------------------------------
+
+    def test_home_dir_created_inside_profile(self, profile_env, tmp_path):
+        """get_profile_home_dir() creates {profile_dir}/home/ on demand."""
+        profile_dir = tmp_path / ".hermes" / "profiles" / "coder"
+        profile_dir.mkdir(parents=True)
+        home_dir = get_profile_home_dir(profile_dir)
+        assert home_dir == profile_dir / "home"
+        assert home_dir.is_dir()
+
+    def test_home_dir_idempotent(self, profile_env, tmp_path):
+        """Calling get_profile_home_dir() twice doesn't raise."""
+        profile_dir = tmp_path / ".hermes" / "profiles" / "coder"
+        profile_dir.mkdir(parents=True)
+        first = get_profile_home_dir(profile_dir)
+        second = get_profile_home_dir(profile_dir)
+        assert first == second
+
+    # ------------------------------------------------------------------
+    # _PROFILE_DIRS includes "home"
+    # ------------------------------------------------------------------
+
+    def test_profile_dirs_includes_home(self):
+        """home/ must be bootstrapped with every new profile."""
+        assert "home" in _PROFILE_DIRS
+
+    def test_create_profile_bootstraps_home_dir(self, profile_env):
+        """create_profile() must create a home/ subdirectory."""
+        profile_dir = create_profile("newbot", no_alias=True)
+        assert (profile_dir / "home").is_dir()
+
+    # ------------------------------------------------------------------
+    # apply_profile_home_isolation
+    # ------------------------------------------------------------------
+
+    def test_apply_sets_home_env_var(self, profile_env, tmp_path, monkeypatch):
+        """apply_profile_home_isolation() sets os.environ['HOME']."""
+        profile_dir = tmp_path / ".hermes" / "profiles" / "coder"
+        profile_dir.mkdir(parents=True)
+        result = apply_profile_home_isolation(profile_dir)
+        assert result == profile_dir / "home"
+        assert os.environ["HOME"] == str(profile_dir / "home")
+
+    def test_apply_creates_home_dir_if_missing(self, profile_env, tmp_path, monkeypatch):
+        """apply_profile_home_isolation() creates home/ for existing profiles without it."""
+        profile_dir = tmp_path / ".hermes" / "profiles" / "legacy"
+        profile_dir.mkdir(parents=True)
+        # No home/ yet — simulates a profile created before the fix
+        assert not (profile_dir / "home").exists()
+        apply_profile_home_isolation(profile_dir)
+        assert (profile_dir / "home").is_dir()
+
+    def test_apply_skips_when_env_sets_home(self, profile_env, tmp_path, monkeypatch):
+        """apply_profile_home_isolation() must not override HOME from .env file."""
+        profile_dir = tmp_path / ".hermes" / "profiles" / "coder"
+        profile_dir.mkdir(parents=True)
+        # Write a .env that explicitly sets HOME
+        (profile_dir / ".env").write_text("HOME=/custom/home\n")
+        original_home = os.environ.get("HOME", "")
+        result = apply_profile_home_isolation(profile_dir)
+        assert result is None
+        # HOME must NOT have been changed by our code
+        assert os.environ.get("HOME", "") == original_home
+
+    def test_apply_skips_commented_home_in_env(self, profile_env, tmp_path, monkeypatch):
+        """Commented HOME= lines in .env must not suppress isolation."""
+        profile_dir = tmp_path / ".hermes" / "profiles" / "coder"
+        profile_dir.mkdir(parents=True)
+        (profile_dir / ".env").write_text("# HOME=/custom/home\n")
+        result = apply_profile_home_isolation(profile_dir)
+        assert result == profile_dir / "home"
+
+    def test_apply_no_env_file_still_isolates(self, profile_env, tmp_path, monkeypatch):
+        """apply_profile_home_isolation() works with no .env file present."""
+        profile_dir = tmp_path / ".hermes" / "profiles" / "bare"
+        profile_dir.mkdir(parents=True)
+        result = apply_profile_home_isolation(profile_dir)
+        assert result == profile_dir / "home"
+        assert os.environ["HOME"] == str(profile_dir / "home")
+
+    def test_different_profiles_get_different_homes(self, profile_env, tmp_path, monkeypatch):
+        """Two profiles must have different HOME paths."""
+        dir_a = tmp_path / ".hermes" / "profiles" / "alpha"
+        dir_b = tmp_path / ".hermes" / "profiles" / "beta"
+        dir_a.mkdir(parents=True)
+        dir_b.mkdir(parents=True)
+        home_a = get_profile_home_dir(dir_a)
+        home_b = get_profile_home_dir(dir_b)
+        assert home_a != home_b


### PR DESCRIPTION
## Summary

Adds per-profile `HOME` directory isolation so system tools (git, ssh, gh, npm, etc.) write configs inside the Hermes data directory instead of `/root` or the OS home dir. This fixes both bugs described in #4426:

1. **Docker persistence**: tool configs now survive container recreates (they live in the persistent volume)
2. **Profile isolation**: each profile gets its own `HOME`, so credentials don't bleed between profiles

## Changes

### `hermes_cli/profiles.py`
- Added `"home"` to `_PROFILE_DIRS` — new profiles get a `home/` subdirectory automatically
- `get_profile_home_dir(profile_dir)` — returns and creates `{profile_dir}/home/`
- `apply_profile_home_isolation(profile_dir)` — sets `os.environ["HOME"]` to the per-profile home dir. Respects explicit `HOME=` in `.env` (user config takes precedence). Silently skips commented lines.

### `hermes_cli/main.py`
- Calls `apply_profile_home_isolation()` for both default and named profiles during `_apply_profile_override()`
- Default profile: uses `os.environ["HERMES_HOME"]` when set (Docker: `/opt/data`), falls back to `Path.home() / ".hermes"`
- Named profiles: uses the resolved profile directory from `resolve_profile_env()`
- Failures log warnings but never block startup

### `docker/entrypoint.sh`
- Bootstraps `home/` inside the persistent volume alongside other Hermes directories

### `tests/hermes_cli/test_profiles.py`
- 10 new tests covering: directory creation, idempotency, `_PROFILE_DIRS` inclusion, env var setting, `.env` override respect, commented line handling, missing `.env`, legacy profile migration, profile isolation

## Design decisions

- If `HOME=` is explicitly set in the profile's `.env`, it takes precedence (backward compat)
- Failures log warnings but don't block startup (`except Exception: pass`)
- Existing profiles without `home/` get it created on first activation (automatic migration)

## Known limitation

As noted in the issue: some programs resolve home via `getpwuid(getuid())` which always returns `/root` for the root user regardless of `$HOME`. Full isolation would require per-profile UIDs, which is out of scope here.

## Tests

All 90 profile tests pass.

Closes #4426