### PR TITLE
fix(security): validate media file paths to prevent arbitrary file read [HIGH]

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -765,6 +765,23 @@ class BasePlatformAdapter(ABC):
         return await self.send(chat_id=chat_id, content=text, reply_to=reply_to)
 
     @staticmethod
+    def _is_safe_media_path(path: str) -> bool:
+        """Validate that a MEDIA: path is within the Hermes cache directory.
+
+        Rejects absolute paths, parent-directory traversal, and paths outside
+        the designated media cache to prevent arbitrary file reads via prompt
+        injection.
+        """
+        cache_dir = os.path.realpath(os.path.join(
+            os.path.expanduser("~"), ".hermes", "media_cache"
+        ))
+        try:
+            resolved = os.path.realpath(os.path.expanduser(path))
+        except (ValueError, OSError):
+            return False
+        return resolved.startswith(cache_dir + os.sep) or resolved == cache_dir
+
+    @staticmethod
     def extract_media(content: str) -> Tuple[List[Tuple[str, bool]], str]:
         """
         Extract MEDIA:<path> tags and [[audio_as_voice]] directives from response text.
@@ -796,7 +813,7 @@ class BasePlatformAdapter(ABC):
             if len(path) >= 2 and path[0] == path[-1] and path[0] in "`\"'":
                 path = path[1:-1].strip()
             path = path.lstrip("`\"'").rstrip("`\"',.;:)}]")
-            if path:
+            if path and _is_safe_media_path(path):
                 media.append((path, has_voice_tag))
 
         # Remove MEDIA tags from content (including surrounding quote/backtick wrappers)


### PR DESCRIPTION
## Security Finding: Arbitrary File Read via LLM Media Tag Injection

**Severity:** HIGH
**Reported by:** FailSafe Security Researcher
**Component:** `gateway/platforms/base.py` — `extract_media()`

### Description

`extract_media()` parses `MEDIA:<path>` tags from LLM response text and passes extracted paths directly to platform send methods (`send_image_file`, `send_voice`, `send_video`, `send_document`) without validating that the path resides within an allowed directory. The regex includes a `\S+` catch-all that accepts any non-whitespace path, including absolute paths like `/etc/passwd`.

An indirect prompt injection (via poisoned web content, malicious document, or injected tool output) can cause the LLM to emit a `MEDIA:` tag referencing a sensitive file. The file is read and sent to the chat with no validation.

### Fix

Add `_is_safe_media_path()` which resolves the path and verifies it resides within `~/.hermes/media_cache` before allowing delivery. Paths outside the cache directory are silently dropped.

### Test plan

- [ ] Verify TTS/media tool outputs still work (paths within media cache)
- [ ] Verify `MEDIA:/etc/passwd` is rejected (path outside cache)
- [ ] Verify `MEDIA:../../etc/shadow` is rejected (traversal)