### PR TITLE
fix(security): add Twilio webhook signature validation [HIGH]

### DIFF
--- a/gateway/platforms/sms.py
+++ b/gateway/platforms/sms.py
@@ -79,6 +79,9 @@ class SmsAdapter(BasePlatformAdapter):
         )
         self._runner = None
         self._http_session: Optional["aiohttp.ClientSession"] = None
+        self._validate_signatures: bool = os.getenv(
+            "TWILIO_VALIDATE_SIGNATURES", "true"
+        ).lower() not in ("0", "false", "no")
 
     def _basic_auth_header(self) -> str:
         """Build HTTP Basic auth header value for Twilio."""
@@ -207,6 +210,24 @@ class SmsAdapter(BasePlatformAdapter):
     # Twilio webhook handler
     # ------------------------------------------------------------------
 
+    def _verify_twilio_signature(self, request, raw_body: bytes) -> bool:
+        """Validate inbound webhook using Twilio request signature."""
+        if not self._validate_signatures:
+            return True
+        try:
+            from twilio.request_validator import RequestValidator
+        except ImportError:
+            logger.warning(
+                "[sms] twilio package not installed — skipping signature "
+                "validation. Install with: pip install twilio"
+            )
+            return True
+        validator = RequestValidator(self._auth_token)
+        url = str(request.url)
+        signature = request.headers.get("X-Twilio-Signature", "")
+        params = dict(urllib.parse.parse_qsl(raw_body.decode("utf-8")))
+        return validator.validate(url, params, signature)
+
     async def _handle_webhook(self, request) -> "aiohttp.web.Response":
         from aiohttp import web
 
@@ -220,6 +241,14 @@ class SmsAdapter(BasePlatformAdapter):
                 text='<?xml version="1.0" encoding="UTF-8"?><Response></Response>',
                 content_type="application/xml",
                 status=400,
+            )
+
+        if not self._verify_twilio_signature(request, raw):
+            logger.warning("[sms] invalid Twilio signature — rejecting request")
+            return web.Response(
+                text='<?xml version="1.0" encoding="UTF-8"?><Response></Response>',
+                content_type="application/xml",
+                status=403,
             )
 
         # Extract fields (parse_qs returns lists)


### PR DESCRIPTION
## Security Finding: Twilio Webhook Authentication Bypass

**Severity:** HIGH
**Reported by:** FailSafe Security Researcher
**Component:** `gateway/platforms/sms.py` — `_handle_webhook()`

### Description

The Twilio webhook endpoint at `/webhooks/twilio` does not validate the `X-Twilio-Signature` header. The `TWILIO_AUTH_TOKEN` is used for outbound API auth but never for inbound webhook verification. Any network-reachable attacker who discovers the webhook URL can forge requests with arbitrary `From` numbers, bypassing `SMS_ALLOWED_USERS` and impersonating authorized users.

The webhook binds to `0.0.0.0` with no signature validation or IP-based restriction. Twilio's `RequestValidator` is not imported or referenced anywhere in the file.

### Fix

- Add `_verify_twilio_signature()` using Twilio's official `RequestValidator` to validate every inbound request
- Requests with invalid or missing signatures are rejected with 403
- Validation can be disabled via `TWILIO_VALIDATE_SIGNATURES=false` for local development
- Graceful fallback if `twilio` package is not installed (logs warning, allows request)

### Test plan

- [ ] Verify legitimate Twilio webhooks are accepted (valid signature)
- [ ] Verify forged requests without signature are rejected (403)
- [ ] Verify `TWILIO_VALIDATE_SIGNATURES=false` disables validation for dev