### PR TITLE
feat(resume): add cross-platform and full session listing

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2705,9 +2705,12 @@ class GatewaySlashCommandsMixin:
             parts = shlex.split(raw_args)
         except ValueError as exc:
             return t("gateway.resume.parse_error", error=exc)
-        allow_all = "--all" in parts
-        allow_cross_room = "--cross-room" in parts
-        name = " ".join(p for p in parts if p not in {"--all", "--cross-room"}).strip()
+
+        known_flags = {"--all", "--full", "--cross-room"}
+        allow_all = any(p.lower() == "--all" for p in parts)
+        show_unnamed = any(p.lower() == "--full" for p in parts)
+        allow_cross_room = any(p.lower() == "--cross-room" for p in parts)
+        name = " ".join(p for p in parts if p.lower() not in known_flags).strip()
 
         # Strip common outer brackets/quotes users may type literally from the
         # usage hint (e.g. ``/resume <abc123>``). Mirrors the CLI behavior.
@@ -2719,69 +2722,125 @@ class GatewaySlashCommandsMixin:
         ):
             name = name[1:-1].strip()
 
-        def _list_titled_sessions() -> list[dict]:
-            user_source = source.platform.value if source.platform else None
-            sessions = self._session_db.list_sessions_rich(source=user_source, limit=10)
-            return [s for s in sessions if s.get("title")][:10]
+        def _matrix_room_scope(sessions: list[dict]) -> list[dict]:
+            if source.platform != Platform.MATRIX:
+                return sessions
+            scoped = []
+            for s in sessions:
+                origin = self._gateway_session_origin_for_id(str(s.get("id") or ""))
+                if self._same_matrix_room(source, origin):
+                    scoped.append(s)
+            return scoped
+
+        def _list_sessions_for_scope(*, cross_platform: bool, show_unnamed: bool, limit: int) -> list[dict]:
+            user_source = None if cross_platform else (source.platform.value if source.platform else None)
+            sessions = self._session_db.list_sessions_rich(source=user_source, limit=limit)
+            if source.platform == Platform.MATRIX and not cross_platform:
+                sessions = _matrix_room_scope(sessions)
+            if show_unnamed:
+                return sessions
+            return [s for s in sessions if s.get("title")]
+
+        def _list_titled_sessions(*, cross_platform: bool = False, limit: int = 10) -> list[dict]:
+            return _list_sessions_for_scope(
+                cross_platform=cross_platform,
+                show_unnamed=False,
+                limit=limit,
+            )[:limit]
 
         if not name:
-            # List recent titled sessions for this user/platform
+            # Listing modes:
+            #   /resume                    named sessions, current platform/scope
+            #   /resume --all              named sessions, all platforms
+            #   /resume --full             all sessions, current platform/scope
+            #   /resume --all --full       all sessions, all platforms
             try:
-                titled = _list_titled_sessions()
-                if source.platform == Platform.MATRIX and not allow_all:
-                    scoped = []
-                    for s in titled:
-                        origin = self._gateway_session_origin_for_id(str(s.get("id") or ""))
-                        if self._same_matrix_room(source, origin):
-                            scoped.append(s)
-                    titled = scoped
-                if not titled:
-                    if source.platform == Platform.MATRIX and not allow_all:
-                        return t("gateway.resume.matrix_no_named_sessions")
-                    return t("gateway.resume.no_named_sessions")
-                lines = [t("gateway.resume.list_header")]
-                for idx, s in enumerate(titled[:10], start=1):
-                    title = s["title"]
-                    if source.platform == Platform.MATRIX and allow_all:
-                        origin = self._gateway_session_origin_for_id(str(s.get("id") or ""))
-                        if origin:
-                            title = f"{title} — {origin.chat_name or origin.chat_id}"
-                    preview = s.get("preview", "")[:40]
+                if not allow_all and not show_unnamed:
+                    titled = _list_titled_sessions()
+                    if not titled:
+                        if source.platform == Platform.MATRIX:
+                            return t("gateway.resume.matrix_no_named_sessions")
+                        return t("gateway.resume.no_named_sessions")
+                    lines = [t("gateway.resume.list_header")]
+                    for idx, s in enumerate(titled[:10], start=1):
+                        title = s["title"]
+                        preview = s.get("preview", "")[:40]
+                        preview_part = t("gateway.resume.list_preview_suffix", preview=preview) if preview else ""
+                        lines.append(t("gateway.resume.list_item_numbered", index=idx, title=title, preview_part=preview_part))
+                    lines.append(t("gateway.resume.list_footer_numbered"))
+                    return "\n".join(lines)
+
+                sessions = _list_sessions_for_scope(
+                    cross_platform=allow_all,
+                    show_unnamed=show_unnamed,
+                    limit=50,
+                )
+                if not sessions:
+                    scope = "across all platforms" if allow_all else "on this platform"
+                    kind = "sessions" if show_unnamed else "named sessions"
+                    return (
+                        f"No {kind} found {scope}.\n"
+                        "Use `/title My Session` to name your current session, "
+                        "then `/resume My Session` to return to it later."
+                    )
+
+                scope_label = "All Platforms" if allow_all else (source.platform.value.title() if source.platform else "Unknown")
+                header_kind = "All Sessions" if show_unnamed else "Named Sessions"
+                lines = [f"📋 **{header_kind} — {scope_label}**\n"]
+                for idx, s in enumerate(sessions[:20], start=1):
+                    title = s.get("title")
+                    preview = (s.get("preview") or "")[:40]
                     preview_part = t("gateway.resume.list_preview_suffix", preview=preview) if preview else ""
-                    lines.append(t("gateway.resume.list_item_numbered", index=idx, title=title, preview_part=preview_part))
-                lines.append(t("gateway.resume.list_footer_numbered"))
+                    source_tag = ""
+                    if allow_all:
+                        source_name = str(s.get("source", "?") or "?")
+                        if source.platform == Platform.MATRIX and source_name == "matrix":
+                            origin = self._gateway_session_origin_for_id(str(s.get("id") or ""))
+                            if origin:
+                                source_tag = f" [matrix: {origin.chat_name or origin.chat_id}]"
+                        if not source_tag:
+                            source_tag = f" [{source_name}]"
+                    if title:
+                        label = f"**{title}**"
+                    else:
+                        label = f"`{str(s.get('id', '???'))[:20]}`"
+                    lines.append(f"{idx}. {label}{preview_part}{source_tag}")
+                lines.append("\nUsage: `/resume <session name>` or `/resume <session_id>`")
+                if not allow_all:
+                    lines.append("Tip: `/resume --all` for cross-platform, `/resume --full` to include unnamed sessions.")
+                elif not show_unnamed:
+                    lines.append("Tip: `/resume --all --full` to include unnamed sessions.")
                 return "\n".join(lines)
             except Exception as e:
-                logger.debug("Failed to list titled sessions: %s", e)
+                logger.debug("Failed to list sessions: %s", e)
                 return t("gateway.resume.list_failed", error=e)
 
-        # Resolve a numbered choice or a title to a session ID.
+        # Resolve a numbered choice, session ID/prefix, or title to a session ID.
         if name.isdigit():
             try:
-                titled = _list_titled_sessions()
-                if source.platform == Platform.MATRIX and not allow_all:
-                    scoped = []
-                    for s in titled:
-                        origin = self._gateway_session_origin_for_id(str(s.get("id") or ""))
-                        if self._same_matrix_room(source, origin):
-                            scoped.append(s)
-                    titled = scoped
+                choices = _list_sessions_for_scope(
+                    cross_platform=allow_all,
+                    show_unnamed=show_unnamed,
+                    limit=50 if (allow_all or show_unnamed) else 10,
+                )
             except Exception as e:
-                logger.debug("Failed to list titled sessions for numeric resume: %s", e)
+                logger.debug("Failed to list sessions for numeric resume: %s", e)
                 return t("gateway.resume.list_failed", error=e)
             index = int(name)
-            if index < 1 or index > len(titled):
+            if index < 1 or index > len(choices):
                 return t("gateway.resume.out_of_range", index=index)
-            target = titled[index - 1]
+            target = choices[index - 1]
             target_id = target.get("id")
-            name = target.get("title") or name
+            name = target.get("title") or target_id or name
         else:
-            # Try direct session ID lookup first (so `/resume <session_id>`
-            # works in the gateway, not just `/resume <title>`).
-            session = self._session_db.get_session(name)
-            if session:
-                target_id = session["id"]
-            else:
+            # Try direct/exact-or-unique-prefix session ID lookup first (so
+            # `/resume <session_id>` and `/resume <id-prefix>` work globally),
+            # then fall back to global title/lineage lookup.
+            try:
+                target_id = self._session_db.resolve_session_id(name)
+            except Exception:
+                target_id = None
+            if not target_id:
                 target_id = self._session_db.resolve_session_by_title(name)
         if not target_id:
             return t("gateway.resume.not_found", name=name)

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -114,8 +114,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("profile", "Show active profile name and home directory", "Info"),
     CommandDef("sethome", "Set this chat as the home channel", "Session",
                gateway_only=True, aliases=("set-home",)),
-    CommandDef("resume", "Resume a previously-named session", "Session",
-               args_hint="[name]"),
+    CommandDef("resume", "Resume or list sessions across platforms", "Session",
+               args_hint="[name|session_id|--all|--full]"),
 
     # Configuration
     CommandDef("sessions", "Browse and resume previous sessions", "Session"),

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -358,3 +358,91 @@ class TestHandleResumeCommand:
             f"session-id lookup failed: {result!r}"
         )
         db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_all_lists_named_sessions_across_platforms(self, tmp_path):
+        """`/resume --all` lists titled sessions from every platform, not just the current app."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("telegram_named", "telegram")
+        db.set_session_title("telegram_named", "Telegram Work")
+        db.append_message("telegram_named", "user", "telegram preview")
+        db.create_session("mattermost_named", "mattermost")
+        db.set_session_title("mattermost_named", "Mattermost Work")
+        db.append_message("mattermost_named", "user", "mattermost preview")
+
+        event = _make_event(text="/resume --all", platform=Platform.MATTERMOST)
+        runner = _make_runner(session_db=db, event=event)
+        result = await runner._handle_resume_command(event)
+
+        assert "Named Sessions — All Platforms" in result
+        assert "Telegram Work" in result
+        assert "Mattermost Work" in result
+        assert "[telegram]" in result
+        assert "[mattermost]" in result
+        assert "telegram_unnamed" not in result
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_full_lists_unnamed_sessions_on_current_platform_only(self, tmp_path):
+        """`/resume --full` includes unnamed sessions but still scopes to the current platform."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("telegram_unnamed", "telegram")
+        db.append_message("telegram_unnamed", "user", "telegram unnamed preview")
+        db.create_session("mattermost_unnamed", "mattermost")
+        db.append_message("mattermost_unnamed", "user", "mattermost unnamed preview")
+
+        event = _make_event(text="/resume --full", platform=Platform.MATTERMOST)
+        runner = _make_runner(session_db=db, event=event)
+        result = await runner._handle_resume_command(event)
+
+        assert "All Sessions — Mattermost" in result
+        assert "`mattermost_unnamed`" in result
+        assert "mattermost unnamed preview" in result
+        assert "telegram_unnamed" not in result
+        assert "telegram unnamed preview" not in result
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_all_full_lists_unnamed_sessions_across_platforms(self, tmp_path):
+        """`/resume --all --full` shows unnamed sessions from other platforms for cross-app restore."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("telegram_unnamed", "telegram")
+        db.append_message("telegram_unnamed", "user", "telegram unnamed preview")
+        db.create_session("mattermost_unnamed", "mattermost")
+        db.append_message("mattermost_unnamed", "user", "mattermost unnamed preview")
+
+        event = _make_event(text="/resume --all --full", platform=Platform.MATTERMOST)
+        runner = _make_runner(session_db=db, event=event)
+        result = await runner._handle_resume_command(event)
+
+        assert "All Sessions — All Platforms" in result
+        assert "`telegram_unnamed`" in result
+        assert "`mattermost_unnamed`" in result
+        assert "[telegram]" in result
+        assert "[mattermost]" in result
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_session_named_all_is_not_treated_as_flag(self, tmp_path):
+        """Only --all is a flag; a titled session named 'all' remains resumable."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("session_named_all", "telegram")
+        db.set_session_title("session_named_all", "all")
+        db.create_session("current_session_001", "telegram")
+
+        event = _make_event(text="/resume all")
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=event,
+        )
+        result = await runner._handle_resume_command(event)
+
+        assert "Resumed" in result
+        call_args = runner.session_store.switch_session.call_args
+        assert call_args[0][1] == "session_named_all"
+        db.close()


### PR DESCRIPTION
## Summary

Rebuilds this PR on current `upstream/main` and ports the still-needed cross-platform `/resume` listing semantics.

Gateway `/resume` now supports:

- `/resume` - named sessions for the current platform
- `/resume --all` - named sessions across all platforms
- `/resume --full` - named plus unnamed sessions for the current platform
- `/resume --all --full` - named plus unnamed sessions across all platforms
- `/resume <session_id>` and unique session-ID prefixes before falling back to title lookup

The flag syntax intentionally uses `--all` and `--full`, so a session titled `all` can still be resumed by title/ID instead of being treated as a listing flag.

## Motivation

Users can talk to Hermes across multiple gateways. A practical `/resume` command needs both direct session switching and discoverability: users should be able to list old sessions from another platform or include unnamed sessions when they only know an ID prefix.

## Verification

- `python3 -m py_compile gateway/run.py hermes_cli/commands.py tests/gateway/test_resume_command.py`
- `uv run pytest tests/gateway/test_resume_command.py::TestHandleResumeCommand::test_resume_all_lists_named_sessions_across_platforms tests/gateway/test_resume_command.py::TestHandleResumeCommand::test_resume_full_lists_unnamed_sessions_on_current_platform_only tests/gateway/test_resume_command.py::TestHandleResumeCommand::test_resume_all_full_lists_unnamed_sessions_across_platforms tests/gateway/test_resume_command.py::TestHandleResumeCommand::test_resume_session_named_all_is_not_treated_as_flag -q -o addopts=` -> 4 passed

## Notes

The old version of this PR referenced API-server JSON session support. Current upstream stores/resumes sessions through the SessionDB path, so this rebuild narrows the PR to the modern `/resume --all`/`--full`/ID-prefix behavior that still is not present on `upstream/main`.

This update force-pushes the existing PR branch from the current upstream base rather than opening a duplicate PR.