### PR TITLE
feat: credential proxy daemon Phase 1 — HTTP-only broker (#4656)

### DIFF
--- a/hermes_cli/cred_proxy.py
+++ b/hermes_cli/cred_proxy.py
@@ -1,0 +1,131 @@
+"""Credential proxy daemon lifecycle management.
+
+Provides ``hermes cred-proxy start|stop|status`` subcommands.
+Mirrors the structure of ``hermes_cli/gateway.py`` but much simpler —
+the proxy is a lightweight asyncio process.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+from pathlib import Path
+
+from proxy.config import get_proxy_pid_path, get_proxy_socket_path, is_proxy_enabled
+
+
+def _is_running() -> int | None:
+    """Return the PID if the proxy daemon is running, else None."""
+    pid_path = get_proxy_pid_path()
+    if not pid_path.exists():
+        return None
+    try:
+        pid = int(pid_path.read_text().strip())
+        os.kill(pid, 0)  # check if alive
+        return pid
+    except (ValueError, OSError):
+        # Stale PID file
+        pid_path.unlink(missing_ok=True)
+        return None
+
+
+def _start() -> None:
+    """Start the credential proxy daemon."""
+    if not is_proxy_enabled():
+        print("Credential proxy is not enabled in config.yaml.", file=sys.stderr)
+        print("Add to your config.yaml:", file=sys.stderr)
+        print("  credential_proxy:", file=sys.stderr)
+        print("    enabled: true", file=sys.stderr)
+        sys.exit(1)
+
+    pid = _is_running()
+    if pid is not None:
+        print(f"Credential proxy already running (PID {pid}).")
+        return
+
+    socket_path = get_proxy_socket_path()
+    pid_path = get_proxy_pid_path()
+
+    # Ensure state dir exists
+    socket_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Spawn the proxy as a detached subprocess
+    proc = subprocess.Popen(
+        [
+            sys.executable, "-m", "proxy.daemon",
+            "--socket", str(socket_path),
+            "--pid-file", str(pid_path),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+    print(f"Credential proxy started (PID {proc.pid}).")
+    print(f"Socket: {socket_path}")
+
+
+def _stop() -> None:
+    """Stop the credential proxy daemon."""
+    pid = _is_running()
+    if pid is None:
+        print("Credential proxy is not running.")
+        return
+
+    try:
+        os.kill(pid, signal.SIGTERM)
+        print(f"Credential proxy stopped (PID {pid}).")
+    except OSError as exc:
+        print(f"Failed to stop proxy (PID {pid}): {exc}", file=sys.stderr)
+
+    # Clean up
+    get_proxy_pid_path().unlink(missing_ok=True)
+    socket_path = get_proxy_socket_path()
+    if socket_path.exists():
+        socket_path.unlink(missing_ok=True)
+
+
+def _status() -> None:
+    """Show credential proxy status."""
+    pid = _is_running()
+    socket_path = get_proxy_socket_path()
+    enabled = is_proxy_enabled()
+
+    if pid:
+        print(f"Status:  running (PID {pid})")
+    else:
+        print("Status:  stopped")
+
+    print(f"Enabled: {enabled}")
+    print(f"Socket:  {socket_path}")
+
+    if socket_path.exists():
+        print("Socket:  exists ✓")
+    else:
+        print("Socket:  not found")
+
+
+def cred_proxy_command(args) -> None:
+    """Dispatch ``hermes cred-proxy`` subcommands.
+
+    Args:
+        args: argparse Namespace with ``cred_proxy_command`` attribute.
+    """
+    subcmd = getattr(args, "cred_proxy_command", None)
+    if not subcmd:
+        print("Usage: hermes cred-proxy <start|stop|status>", file=sys.stderr)
+        sys.exit(1)
+
+    subcmd = subcmd.lower()
+    if subcmd == "start":
+        _start()
+    elif subcmd == "stop":
+        _stop()
+    elif subcmd == "status":
+        _status()
+    else:
+        print(f"Unknown subcommand: {subcmd}", file=sys.stderr)
+        print("Usage: hermes cred-proxy <start|stop|status>", file=sys.stderr)
+        sys.exit(1)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -661,6 +661,12 @@ def cmd_gateway(args):
     gateway_command(args)
 
 
+def cmd_cred_proxy(args):
+    """Credential proxy management commands."""
+    from hermes_cli.cred_proxy import cred_proxy_command
+    cred_proxy_command(args)
+
+
 def cmd_whatsapp(args):
     """Set up WhatsApp: choose mode, configure, install bridge, pair via QR."""
     _require_tty("whatsapp")
@@ -3436,7 +3442,7 @@ def _coalesce_session_name_args(argv: list) -> list:
     or a known top-level subcommand.
     """
     _SUBCOMMANDS = {
-        "chat", "model", "gateway", "setup", "whatsapp", "login", "logout", "auth",
+        "chat", "model", "gateway", "cred-proxy", "setup", "whatsapp", "login", "logout", "auth",
         "status", "cron", "doctor", "config", "pairing", "skills", "tools",
         "mcp", "sessions", "insights", "version", "update", "uninstall",
         "profile",
@@ -3995,7 +4001,28 @@ For more help on a command:
     gateway_setup = gateway_subparsers.add_parser("setup", help="Configure messaging platforms")
 
     gateway_parser.set_defaults(func=cmd_gateway)
-    
+
+    # =========================================================================
+    # cred-proxy command
+    # =========================================================================
+    cred_proxy_parser = subparsers.add_parser(
+        "cred-proxy",
+        help="Credential proxy management",
+        description="Manage the credential proxy daemon (store/rotate secrets for tool subprocesses)",
+    )
+    cred_proxy_subparsers = cred_proxy_parser.add_subparsers(dest="cred_proxy_command")
+
+    # cred-proxy start
+    cred_proxy_subparsers.add_parser("start", help="Start credential proxy daemon")
+
+    # cred-proxy stop
+    cred_proxy_subparsers.add_parser("stop", help="Stop credential proxy daemon")
+
+    # cred-proxy status
+    cred_proxy_subparsers.add_parser("status", help="Show credential proxy status")
+
+    cred_proxy_parser.set_defaults(func=cmd_cred_proxy)
+
     # =========================================================================
     # setup command
     # =========================================================================

--- a/proxy/__init__.py
+++ b/proxy/__init__.py
@@ -1,0 +1,5 @@
+"""Credential proxy daemon — zero-knowledge HTTP broker for agent credentials.
+
+Phase 1: HTTP-only proxy with placeholder substitution.
+See https://github.com/NousResearch/hermes-agent/issues/4656
+"""

--- a/proxy/config.py
+++ b/proxy/config.py
@@ -1,0 +1,88 @@
+"""Credential proxy configuration helpers.
+
+Reads ``credential_proxy`` section from config.yaml::
+
+    credential_proxy:
+      enabled: true
+      socket: ~/.hermes/state/cred-proxy.sock   # optional, has default
+      proxy_credentials:                          # env var names to passthrough
+        - CLOUDFLARE_API_TOKEN
+        - SLACK_BOT_TOKEN
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_SOCKET_NAME = "cred-proxy.sock"
+_DEFAULT_PID_NAME = "cred-proxy.pid"
+
+
+def _hermes_home() -> Path:
+    """Resolve HERMES_HOME (profile-aware)."""
+    return Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+
+
+def _load_config_section() -> dict:
+    """Load the ``credential_proxy`` section from config.yaml."""
+    try:
+        import yaml
+    except ImportError:
+        logger.debug("PyYAML not available, credential_proxy config disabled")
+        return {}
+
+    config_path = _hermes_home() / "config.yaml"
+    if not config_path.exists():
+        return {}
+
+    try:
+        with open(config_path) as f:
+            cfg = yaml.safe_load(f) or {}
+        return cfg.get("credential_proxy", {}) or {}
+    except Exception as exc:
+        logger.debug("Could not read credential_proxy config: %s", exc)
+        return {}
+
+
+def is_proxy_enabled() -> bool:
+    """Check whether the credential proxy is enabled in config."""
+    section = _load_config_section()
+    return bool(section.get("enabled", False))
+
+
+def get_proxy_socket_path() -> Path:
+    """Return the resolved Unix socket path for the proxy.
+
+    The path is profile-aware: ``{HERMES_HOME}/state/cred-proxy.sock``.
+    """
+    section = _load_config_section()
+    custom = section.get("socket")
+    if custom:
+        path = Path(str(custom)).expanduser()
+        if not path.is_absolute():
+            path = _hermes_home() / "state" / path
+        return path
+    return _hermes_home() / "state" / _DEFAULT_SOCKET_NAME
+
+
+def get_proxy_pid_path() -> Path:
+    """Return the PID file path for the proxy daemon."""
+    return _hermes_home() / "state" / _DEFAULT_PID_NAME
+
+
+def get_proxy_credentials_list() -> List[str]:
+    """Return env var names that should bypass the blocklist.
+
+    These are vars whose values contain ``hermes-proxy://`` placeholders
+    and must survive ``_sanitize_subprocess_env()``.
+    """
+    section = _load_config_section()
+    raw = section.get("proxy_credentials", [])
+    if not isinstance(raw, list):
+        return []
+    return [str(item).strip() for item in raw if isinstance(item, str) and item.strip()]

--- a/proxy/daemon.py
+++ b/proxy/daemon.py
@@ -1,0 +1,80 @@
+"""Credential proxy daemon entry point.
+
+Spawned by ``hermes cred-proxy start`` as a detached subprocess.
+Writes its PID to the given pid-file, starts the asyncio proxy server,
+and waits for SIGTERM.
+
+Usage::
+
+    python -m proxy.daemon --socket /path/to/cred-proxy.sock --pid-file /path/to/cred-proxy.pid
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [cred-proxy] %(levelname)s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Hermes credential proxy daemon")
+    parser.add_argument("--socket", required=True, help="Unix socket path")
+    parser.add_argument("--pid-file", required=True, help="PID file path")
+    args = parser.parse_args()
+
+    socket_path = Path(args.socket)
+    pid_path = Path(args.pid_file)
+
+    # Write PID
+    pid_path.parent.mkdir(parents=True, exist_ok=True)
+    pid_path.write_text(str(os.getpid()))
+
+    # Load config-declared proxy credentials into env passthrough
+    try:
+        from proxy.config import get_proxy_credentials_list
+        from tools.env_passthrough import register_env_passthrough
+
+        creds = get_proxy_credentials_list()
+        if creds:
+            register_env_passthrough(creds)
+            logger.info("registered %d proxy credential vars for passthrough: %s", len(creds), creds)
+    except Exception as exc:
+        logger.warning("failed to register proxy credentials for passthrough: %s", exc)
+
+    # Create store and start server
+    from proxy.store import CredentialStore
+    from proxy.server import run_proxy
+
+    store = CredentialStore()
+
+    # Register store with secrets tool
+    try:
+        from tools.secrets_tool import set_store
+        set_store(store)
+    except Exception as exc:
+        logger.warning("failed to register store with secrets tool: %s", exc)
+
+    logger.info("starting credential proxy daemon (PID %d)", os.getpid())
+
+    try:
+        asyncio.run(run_proxy(socket_path, store))
+    except KeyboardInterrupt:
+        pass
+    finally:
+        pid_path.unlink(missing_ok=True)
+        if socket_path.exists():
+            socket_path.unlink(missing_ok=True)
+        logger.info("credential proxy daemon exited")
+
+
+if __name__ == "__main__":
+    main()

--- a/proxy/server.py
+++ b/proxy/server.py
@@ -1,0 +1,257 @@
+"""Asyncio HTTP proxy server for credential placeholder substitution.
+
+Phase 1: plain HTTP only.  CONNECT (HTTPS) tunnelling returns 501 — that
+requires the local-CA MITM layer in Phase 2.
+
+The proxy listens on a Unix domain socket and rewrites ``hermes-proxy://<name>``
+placeholders in request headers and bodies before forwarding to the real
+upstream server.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import signal
+import socket
+from http.client import HTTPConnection
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional, Tuple
+from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    from proxy.store import CredentialStore
+
+logger = logging.getLogger(__name__)
+
+# Matches hermes-proxy://<credential-name> where name is alphanumeric + _ + -
+_PLACEHOLDER_RE = re.compile(r"hermes-proxy://([A-Za-z0-9_-]+)")
+
+
+def _substitute_placeholders(text: str, store: "CredentialStore") -> str:
+    """Replace all ``hermes-proxy://<name>`` occurrences with real values."""
+    def _replace(match: re.Match) -> str:
+        name = match.group(1)
+        value = store._resolve(name)
+        if value is None:
+            logger.warning("unresolved credential placeholder: %s", name)
+            return match.group(0)  # leave as-is
+        return value
+
+    return _PLACEHOLDER_RE.sub(_replace, text)
+
+
+class _ProxyProtocol(asyncio.Protocol):
+    """Handle one inbound HTTP request from a tool subprocess."""
+
+    def __init__(self, store: "CredentialStore") -> None:
+        self._store = store
+        self._transport: Optional[asyncio.Transport] = None
+        self._buffer = b""
+
+    def connection_made(self, transport: asyncio.Transport) -> None:
+        self._transport = transport
+
+    def data_received(self, data: bytes) -> None:
+        self._buffer += data
+        # Wait until we have the full header block
+        if b"\r\n\r\n" not in self._buffer:
+            return
+        asyncio.ensure_future(self._handle_request())
+
+    def connection_lost(self, exc: Optional[Exception]) -> None:
+        self._transport = None
+
+    async def _handle_request(self) -> None:
+        """Parse, rewrite, forward, and relay the response."""
+        try:
+            raw = self._buffer
+            self._buffer = b""
+
+            # Split headers and body
+            header_end = raw.index(b"\r\n\r\n")
+            header_block = raw[:header_end].decode("utf-8", errors="replace")
+            body = raw[header_end + 4:]
+
+            lines = header_block.split("\r\n")
+            request_line = lines[0]
+            parts = request_line.split(" ", 2)
+            if len(parts) < 3:
+                self._send_error(400, "Bad Request")
+                return
+
+            method, url, version = parts
+
+            # CONNECT = HTTPS tunnel — not supported in Phase 1
+            if method.upper() == "CONNECT":
+                self._send_error(
+                    501,
+                    "Not Implemented",
+                    "HTTPS CONNECT tunnelling requires Phase 2 (local CA MITM).\n",
+                )
+                return
+
+            # Parse the target URL
+            parsed = urlparse(url)
+            host = parsed.hostname or ""
+            port = parsed.port or 80
+            path = parsed.path or "/"
+            if parsed.query:
+                path += "?" + parsed.query
+
+            # Rewrite headers — substitute placeholders
+            rewritten_headers: list[Tuple[str, str]] = []
+            content_length: Optional[int] = None
+            for line in lines[1:]:
+                if ":" not in line:
+                    continue
+                key, _, val = line.partition(":")
+                val = val.strip()
+                val = _substitute_placeholders(val, self._store)
+                rewritten_headers.append((key.strip(), val))
+                if key.strip().lower() == "content-length":
+                    try:
+                        content_length = int(val)
+                    except ValueError:
+                        pass
+
+            # If there's a body with a Content-Length, read remaining data
+            if content_length is not None and len(body) < content_length:
+                # For Phase 1, we handle small bodies only; large streaming
+                # bodies are a Phase 2 concern.
+                remaining = content_length - len(body)
+                # We already have everything in the buffer for typical API calls
+                if remaining > 0:
+                    logger.debug("body incomplete: have %d, need %d more", len(body), remaining)
+
+            # Substitute placeholders in body
+            body_str = body.decode("utf-8", errors="replace")
+            body_str = _substitute_placeholders(body_str, self._store)
+            body = body_str.encode("utf-8")
+
+            # Update Content-Length if body changed
+            new_content_length = len(body)
+
+            # Forward to upstream via blocking HTTPConnection in executor
+            loop = asyncio.get_event_loop()
+            response_data = await loop.run_in_executor(
+                None,
+                self._forward_request,
+                host, port, method, path, rewritten_headers, body, new_content_length,
+            )
+
+            if self._transport and not self._transport.is_closing():
+                self._transport.write(response_data)
+                self._transport.close()
+
+        except Exception as exc:
+            logger.exception("proxy request failed: %s", exc)
+            self._send_error(502, "Bad Gateway", str(exc))
+
+    def _forward_request(
+        self,
+        host: str,
+        port: int,
+        method: str,
+        path: str,
+        headers: list[Tuple[str, str]],
+        body: bytes,
+        content_length: int,
+    ) -> bytes:
+        """Synchronously forward the request and return the raw HTTP response."""
+        conn = HTTPConnection(host, port, timeout=30)
+        try:
+            conn.putrequest(method, path, skip_host=True, skip_accept_encoding=True)
+            host_written = False
+            cl_written = False
+            for key, val in headers:
+                if key.lower() == "content-length":
+                    conn.putheader("Content-Length", str(content_length))
+                    cl_written = True
+                elif key.lower() == "host":
+                    conn.putheader("Host", val)
+                    host_written = True
+                else:
+                    conn.putheader(key, val)
+            if not host_written:
+                conn.putheader("Host", host if port == 80 else f"{host}:{port}")
+            if body and not cl_written:
+                conn.putheader("Content-Length", str(content_length))
+            conn.endheaders(body if body else None)
+
+            resp = conn.getresponse()
+            resp_body = resp.read()
+
+            # Build raw HTTP response
+            status_line = f"HTTP/1.1 {resp.status} {resp.reason}\r\n"
+            resp_headers = "".join(
+                f"{k}: {v}\r\n" for k, v in resp.getheaders()
+            )
+            return (status_line + resp_headers + "\r\n").encode() + resp_body
+        finally:
+            conn.close()
+
+    def _send_error(self, code: int, reason: str, body: str = "") -> None:
+        """Send an HTTP error response and close."""
+        if not body:
+            body = f"{code} {reason}\n"
+        resp = (
+            f"HTTP/1.1 {code} {reason}\r\n"
+            f"Content-Length: {len(body)}\r\n"
+            f"Content-Type: text/plain\r\n"
+            f"\r\n"
+            f"{body}"
+        )
+        if self._transport and not self._transport.is_closing():
+            self._transport.write(resp.encode())
+            self._transport.close()
+
+
+async def run_proxy(
+    socket_path: Path,
+    store: "CredentialStore",
+    ready_event: Optional[asyncio.Event] = None,
+) -> None:
+    """Start the proxy server on a Unix domain socket.
+
+    Args:
+        socket_path: Path to the Unix socket.
+        store: The credential store instance.
+        ready_event: Optional event to set once the server is listening.
+    """
+    # Clean up stale socket
+    socket_path.parent.mkdir(parents=True, exist_ok=True)
+    if socket_path.exists():
+        socket_path.unlink()
+
+    loop = asyncio.get_event_loop()
+    server = await loop.create_unix_server(
+        lambda: _ProxyProtocol(store),
+        path=str(socket_path),
+    )
+
+    # Make socket accessible
+    os.chmod(str(socket_path), 0o600)
+
+    logger.info("credential proxy listening on %s", socket_path)
+    if ready_event:
+        ready_event.set()
+
+    stop_event = asyncio.Event()
+
+    def _shutdown(sig: int, frame) -> None:
+        logger.info("credential proxy received signal %d, shutting down", sig)
+        stop_event.set()
+
+    signal.signal(signal.SIGTERM, _shutdown)
+    signal.signal(signal.SIGINT, _shutdown)
+
+    await stop_event.wait()
+
+    server.close()
+    await server.wait_closed()
+    if socket_path.exists():
+        socket_path.unlink()
+    logger.info("credential proxy shut down")

--- a/proxy/store.py
+++ b/proxy/store.py
@@ -1,0 +1,86 @@
+"""In-memory credential store (Phase 1).
+
+Thread-safe, write-only external interface.  The ``_resolve`` method is
+internal — used only by the proxy server to substitute placeholders.
+No external read/get API is exposed; this is the core security invariant.
+
+Phase 3 will add AES-256-GCM encrypted persistence + Argon2id key derivation.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class CredentialStore:
+    """Thread-safe, write-only credential store.
+
+    External callers can *store*, *rotate*, *delete*, and *list* credential
+    names.  Only the proxy server (via ``_resolve``) can retrieve the actual
+    value — and that method is deliberately prefixed with ``_`` to signal
+    it is not part of the public API.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._creds: Dict[str, str] = {}
+
+    # ------------------------------------------------------------------
+    # Public (write-only) interface
+    # ------------------------------------------------------------------
+
+    def store(self, name: str, value: str) -> None:
+        """Store a credential.  Overwrites if the name already exists."""
+        with self._lock:
+            self._creds[name] = value
+            logger.info("credential stored: %s", name)
+
+    def rotate(self, name: str, value: str) -> None:
+        """Atomically replace a credential value.
+
+        Behaves identically to ``store`` but logs the operation as a
+        rotation for audit clarity.
+        """
+        with self._lock:
+            existed = name in self._creds
+            self._creds[name] = value
+            if existed:
+                logger.info("credential rotated: %s", name)
+            else:
+                logger.info("credential stored (rotate on new name): %s", name)
+
+    def delete(self, name: str) -> bool:
+        """Remove a credential.  Returns True if it existed."""
+        with self._lock:
+            existed = self._creds.pop(name, None) is not None
+            if existed:
+                logger.info("credential deleted: %s", name)
+            else:
+                logger.debug("credential delete (not found): %s", name)
+            return existed
+
+    def list_names(self) -> List[str]:
+        """Return a sorted list of stored credential names."""
+        with self._lock:
+            return sorted(self._creds.keys())
+
+    # ------------------------------------------------------------------
+    # Internal — proxy server only
+    # ------------------------------------------------------------------
+
+    def _resolve(self, name: str) -> Optional[str]:
+        """Resolve a credential name to its value.
+
+        **Internal use only** — called by the proxy server during header/body
+        rewriting.  Returns ``None`` if the name is not in the store.
+        """
+        with self._lock:
+            return self._creds.get(name)
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._creds)

--- a/tests/proxy/__init__.py
+++ b/tests/proxy/__init__.py
@@ -1,0 +1,1 @@
+# proxy tests

--- a/tests/proxy/test_passthrough.py
+++ b/tests/proxy/test_passthrough.py
@@ -1,0 +1,47 @@
+"""Tests for proxy credential env passthrough integration."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from tools.env_passthrough import (
+    register_env_passthrough,
+    is_env_passthrough,
+    clear_env_passthrough,
+    reset_config_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_passthrough():
+    """Reset passthrough state before/after each test."""
+    clear_env_passthrough()
+    reset_config_cache()
+    yield
+    clear_env_passthrough()
+    reset_config_cache()
+
+
+class TestProxyCredentialPassthrough:
+    """Proxy-declared env vars must survive the sanitize step."""
+
+    def test_register_makes_var_passthrough(self):
+        register_env_passthrough(["CLOUDFLARE_API_TOKEN"])
+        assert is_env_passthrough("CLOUDFLARE_API_TOKEN")
+
+    def test_unregistered_var_not_passthrough(self):
+        assert not is_env_passthrough("SOME_RANDOM_VAR")
+
+    def test_multiple_vars_registered(self):
+        register_env_passthrough(["VAR_A", "VAR_B", "VAR_C"])
+        assert is_env_passthrough("VAR_A")
+        assert is_env_passthrough("VAR_B")
+        assert is_env_passthrough("VAR_C")
+
+    def test_clear_removes_registered(self):
+        register_env_passthrough(["MY_TOKEN"])
+        assert is_env_passthrough("MY_TOKEN")
+        clear_env_passthrough()
+        assert not is_env_passthrough("MY_TOKEN")

--- a/tests/proxy/test_secrets_tool.py
+++ b/tests/proxy/test_secrets_tool.py
@@ -1,0 +1,77 @@
+"""Tests for the write-only secrets tool (tools/secrets_tool.py)."""
+
+from __future__ import annotations
+
+import pytest
+
+from proxy.store import CredentialStore
+from tools.secrets_tool import handle_secrets, set_store
+
+
+@pytest.fixture(autouse=True)
+def _setup_store():
+    """Provide a fresh store for each test."""
+    store = CredentialStore()
+    set_store(store)
+    yield store
+    set_store(None)
+
+
+@pytest.mark.asyncio
+class TestSecretsTool:
+    """Secrets tool must be write-only with no read/get action."""
+
+    async def test_store(self, _setup_store):
+        result = await handle_secrets({"action": "store", "name": "tok", "value": "secret"})
+        assert result == {"stored": True}
+        assert _setup_store._resolve("tok") == "secret"
+
+    async def test_store_missing_name(self):
+        result = await handle_secrets({"action": "store", "value": "v"})
+        assert "error" in result
+
+    async def test_store_missing_value(self):
+        result = await handle_secrets({"action": "store", "name": "n"})
+        assert "error" in result
+
+    async def test_rotate(self, _setup_store):
+        _setup_store.store("key", "old")
+        result = await handle_secrets({"action": "rotate", "name": "key", "value": "new"})
+        assert result == {"rotated": True}
+        assert _setup_store._resolve("key") == "new"
+
+    async def test_delete(self, _setup_store):
+        _setup_store.store("key", "val")
+        result = await handle_secrets({"action": "delete", "name": "key"})
+        assert result == {"deleted": True}
+        assert _setup_store._resolve("key") is None
+
+    async def test_delete_nonexistent(self):
+        result = await handle_secrets({"action": "delete", "name": "nope"})
+        assert result == {"deleted": False}
+
+    async def test_list(self, _setup_store):
+        _setup_store.store("beta", "b")
+        _setup_store.store("alpha", "a")
+        result = await handle_secrets({"action": "list"})
+        assert result == {"names": ["alpha", "beta"]}
+
+    async def test_list_empty(self):
+        result = await handle_secrets({"action": "list"})
+        assert result == {"names": []}
+
+    async def test_unknown_action(self):
+        result = await handle_secrets({"action": "read"})
+        assert "error" in result
+        assert "read" in result["error"]
+
+    async def test_no_read_action(self):
+        """The security invariant: there is no way to read credential values."""
+        result = await handle_secrets({"action": "get"})
+        assert "error" in result
+
+    async def test_no_store_returns_error(self):
+        set_store(None)
+        result = await handle_secrets({"action": "list"})
+        assert "error" in result
+        assert "not running" in result["error"]

--- a/tests/proxy/test_server.py
+++ b/tests/proxy/test_server.py
@@ -1,0 +1,82 @@
+"""Tests for the credential proxy server (proxy/server.py)."""
+
+from __future__ import annotations
+
+import pytest
+
+from proxy.server import _substitute_placeholders, _PLACEHOLDER_RE
+from proxy.store import CredentialStore
+
+
+class TestPlaceholderRegex:
+    """Regex must match hermes-proxy:// URIs correctly."""
+
+    def test_simple_name(self):
+        m = _PLACEHOLDER_RE.search("hermes-proxy://my_token")
+        assert m and m.group(1) == "my_token"
+
+    def test_hyphenated_name(self):
+        m = _PLACEHOLDER_RE.search("hermes-proxy://cf-dns-token")
+        assert m and m.group(1) == "cf-dns-token"
+
+    def test_no_match_on_partial(self):
+        m = _PLACEHOLDER_RE.search("hermes-proxy://")
+        assert m is None
+
+    def test_no_match_on_wrong_scheme(self):
+        m = _PLACEHOLDER_RE.search("http://my_token")
+        assert m is None
+
+    def test_multiple_in_string(self):
+        matches = _PLACEHOLDER_RE.findall(
+            "Bearer hermes-proxy://tok1 and hermes-proxy://tok2"
+        )
+        assert matches == ["tok1", "tok2"]
+
+
+class TestSubstitutePlaceholders:
+    """_substitute_placeholders rewrites matched names from the store."""
+
+    def test_single_header_value(self):
+        store = CredentialStore()
+        store.store("api_key", "real_secret_123")
+        result = _substitute_placeholders(
+            "Bearer hermes-proxy://api_key", store
+        )
+        assert result == "Bearer real_secret_123"
+
+    def test_multiple_placeholders(self):
+        store = CredentialStore()
+        store.store("tok1", "val1")
+        store.store("tok2", "val2")
+        result = _substitute_placeholders(
+            "hermes-proxy://tok1 and hermes-proxy://tok2", store
+        )
+        assert result == "val1 and val2"
+
+    def test_unresolved_placeholder_unchanged(self):
+        store = CredentialStore()
+        result = _substitute_placeholders(
+            "hermes-proxy://unknown_cred", store
+        )
+        assert result == "hermes-proxy://unknown_cred"
+
+    def test_no_placeholders(self):
+        store = CredentialStore()
+        text = "Authorization: Bearer sk-real-token"
+        assert _substitute_placeholders(text, store) == text
+
+    def test_json_body_substitution(self):
+        store = CredentialStore()
+        store.store("slack_token", "xoxb-real-token")
+        body = '{"token": "hermes-proxy://slack_token", "channel": "#general"}'
+        result = _substitute_placeholders(body, store)
+        assert result == '{"token": "xoxb-real-token", "channel": "#general"}'
+
+    def test_mixed_resolved_unresolved(self):
+        store = CredentialStore()
+        store.store("known", "resolved_value")
+        result = _substitute_placeholders(
+            "hermes-proxy://known hermes-proxy://unknown", store
+        )
+        assert result == "resolved_value hermes-proxy://unknown"

--- a/tests/proxy/test_store.py
+++ b/tests/proxy/test_store.py
@@ -1,0 +1,104 @@
+"""Tests for the credential store (proxy/store.py)."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from proxy.store import CredentialStore
+
+
+class TestCredentialStore:
+    """Basic CRUD operations on the credential store."""
+
+    def test_store_and_resolve(self):
+        s = CredentialStore()
+        s.store("token_a", "secret123")
+        assert s._resolve("token_a") == "secret123"
+
+    def test_resolve_unknown_returns_none(self):
+        s = CredentialStore()
+        assert s._resolve("nonexistent") is None
+
+    def test_store_overwrites(self):
+        s = CredentialStore()
+        s.store("key", "v1")
+        s.store("key", "v2")
+        assert s._resolve("key") == "v2"
+
+    def test_rotate_existing(self):
+        s = CredentialStore()
+        s.store("key", "old")
+        s.rotate("key", "new")
+        assert s._resolve("key") == "new"
+
+    def test_rotate_new_name(self):
+        s = CredentialStore()
+        s.rotate("fresh", "value")
+        assert s._resolve("fresh") == "value"
+
+    def test_delete_existing(self):
+        s = CredentialStore()
+        s.store("key", "val")
+        assert s.delete("key") is True
+        assert s._resolve("key") is None
+
+    def test_delete_nonexistent(self):
+        s = CredentialStore()
+        assert s.delete("nope") is False
+
+    def test_list_names_sorted(self):
+        s = CredentialStore()
+        s.store("zeta", "z")
+        s.store("alpha", "a")
+        s.store("mid", "m")
+        assert s.list_names() == ["alpha", "mid", "zeta"]
+
+    def test_list_names_empty(self):
+        s = CredentialStore()
+        assert s.list_names() == []
+
+    def test_len(self):
+        s = CredentialStore()
+        assert len(s) == 0
+        s.store("a", "1")
+        s.store("b", "2")
+        assert len(s) == 2
+        s.delete("a")
+        assert len(s) == 1
+
+
+class TestCredentialStoreThreadSafety:
+    """Concurrent access must not corrupt the store."""
+
+    def test_concurrent_store_and_list(self):
+        s = CredentialStore()
+        errors: list[Exception] = []
+
+        def writer(prefix: str, count: int):
+            try:
+                for i in range(count):
+                    s.store(f"{prefix}_{i}", f"val_{i}")
+            except Exception as e:
+                errors.append(e)
+
+        def reader(count: int):
+            try:
+                for _ in range(count):
+                    s.list_names()
+            except Exception as e:
+                errors.append(e)
+
+        threads = [
+            threading.Thread(target=writer, args=("a", 100)),
+            threading.Thread(target=writer, args=("b", 100)),
+            threading.Thread(target=reader, args=(100,)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        assert len(s) == 200

--- a/tools/env_passthrough.py
+++ b/tools/env_passthrough.py
@@ -93,7 +93,47 @@ def clear_env_passthrough() -> None:
     _allowed_env_vars.clear()
 
 
+def register_proxy_credentials() -> None:
+    """Register credential proxy env var names in the passthrough allowlist.
+
+    Reads the ``credential_proxy.proxy_credentials`` list from config.yaml
+    and registers those variable names so their ``hermes-proxy://`` placeholder
+    values survive :func:`_sanitize_subprocess_env`.
+
+    Called during proxy startup.  Failures are logged and swallowed so they
+    never prevent Hermes from starting.
+    """
+    try:
+        from proxy.config import get_proxy_credentials_list
+        cred_vars = get_proxy_credentials_list()
+        if cred_vars:
+            register_env_passthrough(cred_vars)
+            logger.info("proxy credentials registered for passthrough: %s", cred_vars)
+    except Exception as e:
+        logger.warning("could not register proxy credentials: %s", e)
+
+
 def reset_config_cache() -> None:
     """Force re-read of config on next access (for testing)."""
     global _config_passthrough
     _config_passthrough = None
+
+
+def register_proxy_credentials() -> None:
+    """Register credential proxy env vars in the passthrough allowlist.
+
+    Reads ``credential_proxy.proxy_credentials`` from config.yaml and
+    registers those var names so ``_sanitize_subprocess_env()`` does not
+    strip ``hermes-proxy://`` placeholder values.  Called during proxy
+    daemon startup.  See #4429 / #4656.
+    """
+    try:
+        from proxy.config import get_proxy_credentials_list
+    except ImportError:
+        logger.debug("proxy.config not available, skipping proxy credential registration")
+        return
+
+    creds = get_proxy_credentials_list()
+    if creds:
+        register_env_passthrough(creds)
+        logger.info("proxy credentials registered for passthrough: %s", creds)

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -287,6 +287,19 @@ def _make_run_env(env: dict) -> dict:
     existing_path = run_env.get("PATH", "")
     if "/usr/bin" not in existing_path.split(":"):
         run_env["PATH"] = f"{existing_path}:{_SANE_PATH}" if existing_path else _SANE_PATH
+
+    # Inject http_proxy pointing at the credential proxy Unix socket when
+    # the socket file exists.  Only HTTP for Phase 1 (no https_proxy yet).
+    try:
+        from proxy.config import get_proxy_socket_path
+        sock_path = get_proxy_socket_path()
+        if sock_path.exists():
+            proxy_url = f"http+unix://{sock_path}"
+            run_env.setdefault("http_proxy", proxy_url)
+            run_env.setdefault("HTTP_PROXY", proxy_url)
+    except Exception:
+        pass  # Proxy not available — don't block Hermes startup
+
     return run_env
 
 

--- a/tools/secrets_tool.py
+++ b/tools/secrets_tool.py
@@ -1,0 +1,107 @@
+"""Write-only secrets management tool for the credential proxy.
+
+Provides store/rotate/delete/list operations.  There is deliberately
+**no read/get action** — the agent must never be able to retrieve a
+real credential value.  This is the core security invariant of the
+credential proxy architecture (#4656).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict
+
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+# Lazily initialised — the proxy daemon sets this at startup.
+_store = None
+
+
+def set_store(store: Any) -> None:
+    """Set the backing credential store (called by proxy startup)."""
+    global _store
+    _store = store
+
+
+def _check_available() -> bool:
+    """Return True if the credential proxy store is available."""
+    return _store is not None
+
+
+async def handle_secrets(params: dict) -> Dict[str, Any]:
+    """Handle a secrets tool call."""
+    if _store is None:
+        return {"error": "Credential proxy is not running. Start it with: hermes cred-proxy start"}
+
+    action = params.get("action", "")
+    name = params.get("name", "").strip()
+    value = params.get("value", "")
+
+    if action == "store":
+        if not name:
+            return {"error": "Missing required parameter: name"}
+        if not value:
+            return {"error": "Missing required parameter: value"}
+        _store.store(name, value)
+        return {"stored": True}
+
+    elif action == "rotate":
+        if not name:
+            return {"error": "Missing required parameter: name"}
+        if not value:
+            return {"error": "Missing required parameter: value"}
+        _store.rotate(name, value)
+        return {"rotated": True}
+
+    elif action == "delete":
+        if not name:
+            return {"error": "Missing required parameter: name"}
+        existed = _store.delete(name)
+        return {"deleted": existed}
+
+    elif action == "list":
+        return {"names": _store.list_names()}
+
+    else:
+        return {"error": f"Unknown action: {action!r}. Valid: store, rotate, delete, list"}
+
+
+# Register with the tool registry
+registry.register(
+    name="secrets",
+    toolset="secrets",
+    schema={
+        "name": "secrets",
+        "description": (
+            "Manage credentials for the credential proxy. Values are stored "
+            "securely and are never readable by the agent. The proxy substitutes "
+            "real credentials at the HTTP transport layer."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["store", "rotate", "delete", "list"],
+                    "description": "Operation to perform.",
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Credential name (e.g. 'cf_dns_token').",
+                },
+                "value": {
+                    "type": "string",
+                    "description": "Credential value (required for store/rotate).",
+                },
+            },
+            "required": ["action"],
+        },
+    },
+    handler=handle_secrets,
+    check_fn=_check_available,
+    is_async=True,
+    description="Store credentials securely (write-only, never readable by agent).",
+    emoji="🔐",
+)


### PR DESCRIPTION
## Summary

Implements Phase 1 of the zero-knowledge credential proxy daemon proposed in #4656.

Tool subprocesses receive `hermes-proxy://<name>` placeholders instead of real credentials. A lightweight HTTP proxy running on a Unix domain socket intercepts outbound requests, substitutes placeholders with real values from an in-memory store, and forwards to the upstream server. **The agent process structurally cannot read credential values** — not as a matter of policy, but by design.

## Architecture

```
Agent process          Credential Proxy           Upstream API
    │                      │                          │
    │ Authorization:       │                          │
    │ hermes-proxy://tok1  │                          │
    │─────────────────────>│                          │
    │                      │  Authorization:          │
    │                      │  sk-real-secret-123      │
    │                      │─────────────────────────>│
    │                      │                          │
    │    <response>        │    <response>            │
    │<─────────────────────│<─────────────────────────│
```

## Changes (15 files, +1147 lines)

### New files

| File | Description |
|------|-------------|
| `proxy/store.py` | Thread-safe, write-only credential store. External API: store/rotate/delete/list. Internal `_resolve()` for proxy server only. No read/get API — this is the security invariant. |
| `proxy/server.py` | asyncio HTTP proxy on Unix socket. Rewrites `hermes-proxy://<name>` placeholders in request headers and bodies. CONNECT returns 501 (Phase 2). |
| `proxy/config.py` | Configuration helpers. Reads `credential_proxy` section from config.yaml. Profile-aware socket paths (uses HERMES_HOME). |
| `proxy/daemon.py` | Daemon entry point spawned by `hermes cred-proxy start`. Registers proxy credentials in passthrough allowlist, binds store to secrets tool. |
| `tools/secrets_tool.py` | Write-only `secrets` tool registered with `tools/registry.py`. Actions: store, rotate, delete, list. **No read/get action exists.** |
| `hermes_cli/cred_proxy.py` | CLI lifecycle: `hermes cred-proxy start\|stop\|status`. Mirrors gateway.py pattern. |

### Modified files

| File | Change |
|------|--------|
| `tools/env_passthrough.py` | Added `register_proxy_credentials()` — reads `credential_proxy.proxy_credentials` from config and registers those var names so `_sanitize_subprocess_env()` doesn't strip placeholder values. Addresses #4429. |
| `tools/environments/local.py` | `_make_run_env()` now injects `http_proxy`/`HTTP_PROXY` pointing at the proxy Unix socket when the socket file exists. |
| `hermes_cli/main.py` | Wired `hermes cred-proxy start\|stop\|status` subcommand. |

## Configuration

```yaml
credential_proxy:
  enabled: true
  socket: ~/.hermes/state/cred-proxy.sock   # optional, defaults to {HERMES_HOME}/state/cred-proxy.sock
  proxy_credentials:                          # env var names to bypass the blocklist
    - CLOUDFLARE_API_TOKEN
    - SLACK_BOT_TOKEN
```

Then in `.env`:
```
CLOUDFLARE_API_TOKEN=hermes-proxy://cf_dns_token
SLACK_BOT_TOKEN=hermes-proxy://slack_main
```

The agent sees the placeholder. The proxy substitutes the real value at the HTTP transport layer.

## Security invariant

There is **no** `secrets(action="read")` or `secrets(action="get")`. The store has no external read API. The only code path that resolves a credential name to its value is inside the proxy server process — never exposed to the agent.

## Tests

37 new tests across 4 test files:
- `test_store.py`: CRUD, thread safety, concurrent access
- `test_server.py`: placeholder regex, header/body substitution, mixed resolved/unresolved
- `test_passthrough.py`: env var registration, blocklist bypass
- `test_secrets_tool.py`: all actions, no-read invariant, error cases

All **4665 existing tests pass** (2 pre-existing failures in `test_api_key_providers` and `test_codex_execution_paths` unrelated to this PR).

## What's NOT in this PR (future phases)

- **Phase 2**: HTTPS MITM with local CA (CONNECT tunnelling, cert generation, SSL_CERT_FILE injection)
- **Phase 3**: Encrypted persistence (AES-256-GCM at rest, Argon2id key derivation)

## Dependencies

This PR includes the env passthrough mechanism needed for proxy-brokered credentials (#4429), making #4592 unnecessary.

Refs #4656, addresses #4429