### PR TITLE
fix(gateway): make plain /approve truly one-time

### DIFF
--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -417,6 +417,63 @@ class TestBlockingApprovalE2E:
         assert result_holder[0]["approved"] is True
         unregister_gateway_notify(session_key)
 
+    def test_approve_once_does_not_grant_session_wide_approval(self):
+        """A plain gateway /approve should require approval again on the next risky command."""
+        from tools.approval import (
+            check_all_command_guards,
+            detect_dangerous_command,
+            is_approved,
+            register_gateway_notify,
+            resolve_gateway_approval,
+            unregister_gateway_notify,
+        )
+
+        session_key = "e2e-once-no-persist"
+        notified = []
+        register_gateway_notify(session_key, lambda d: notified.append(d))
+        pattern_key = detect_dangerous_command("rm -rf /important")[1]
+        assert pattern_key is not None
+
+        first_result = [None]
+        second_result = [None]
+
+        def run_command(holder):
+            os.environ["HERMES_EXEC_ASK"] = "1"
+            os.environ["HERMES_SESSION_KEY"] = session_key
+            try:
+                holder[0] = check_all_command_guards("rm -rf /important", "local")
+            finally:
+                os.environ.pop("HERMES_EXEC_ASK", None)
+                os.environ.pop("HERMES_SESSION_KEY", None)
+
+        t1 = threading.Thread(target=run_command, args=(first_result,))
+        t1.start()
+        for _ in range(50):
+            if notified:
+                break
+            time.sleep(0.05)
+
+        assert len(notified) == 1
+        resolve_gateway_approval(session_key, "once")
+        t1.join(timeout=5)
+        assert first_result[0] == {"approved": True, "message": None}
+        assert not is_approved(session_key, pattern_key)
+
+        t2 = threading.Thread(target=run_command, args=(second_result,))
+        t2.start()
+        for _ in range(50):
+            if len(notified) >= 2:
+                break
+            time.sleep(0.05)
+
+        assert len(notified) == 2, "second dangerous command should require a fresh approval"
+        resolve_gateway_approval(session_key, "deny")
+        t2.join(timeout=5)
+        assert second_result[0] is not None
+        assert second_result[0]["approved"] is False
+        assert "BLOCKED" in second_result[0]["message"]
+        unregister_gateway_notify(session_key)
+
     def test_blocking_approval_deny(self):
         """check_all_command_guards returns BLOCKED when denied."""
         from tools.approval import (

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -456,7 +456,9 @@ class TestBlockingApprovalE2E:
         assert len(notified) == 1
         resolve_gateway_approval(session_key, "once")
         t1.join(timeout=5)
-        assert first_result[0] == {"approved": True, "message": None}
+        assert first_result[0] is not None
+        assert first_result[0]["approved"] is True
+        assert first_result[0]["message"] is None
         assert not is_approved(session_key, pattern_key)
 
         t2 = threading.Thread(target=run_command, args=(second_result,))


### PR DESCRIPTION
## What does this PR do?

Fixes gateway approval semantics so plain `/approve` is truly one-time. After a user approves one dangerous command with plain `/approve`, the same danger pattern now requires approval again on the next command instead of being silently session-approved.

## Related Issue

Fixes #4697

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Adjust gateway/blocking approval persistence in `tools/approval.py`
- Stop persisting session approval for `choice == "once"`
- Add regression coverage in `tests/gateway/test_approve_deny_commands.py` proving that:
  - the first plain `/approve` succeeds
  - the next identical dangerous command still requires a fresh approval

## How to Test

1. Activate the repo venv
2. Run:
   `python -m pytest tests/gateway/test_approve_deny_commands.py tests/tools/test_command_guards.py tests/tools/test_approval.py -q --tb=short -n 0`
3. Confirm all tests pass
4. Confirm the new regression `test_approve_once_does_not_grant_session_wide_approval` passes

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
python -m pytest tests/gateway/test_approve_deny_commands.py tests/tools/test_command_guards.py tests/tools/test_approval.py -q --tb=short -n 0
# all targeted tests pass, including test_approve_once_does_not_grant_session_wide_approval
```
