### PR TITLE
feat(telegram): add group_topics skill binding for supergroup forum topics

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2097,6 +2097,19 @@ class TelegramAdapter(BasePlatformAdapter):
                     if not chat_topic:
                         chat_topic = created_name
 
+        elif chat_type == "group" and thread_id_str:
+            # Group/supergroup forum topic skill binding via config.extra['group_topics']
+            group_topics_config: list = self.config.extra.get("group_topics", [])
+            for chat_entry in group_topics_config:
+                if str(chat_entry.get("chat_id", "")) == str(chat.id):
+                    for topic in chat_entry.get("topics", []):
+                        tid = topic.get("thread_id")
+                        if tid is not None and str(tid) == thread_id_str:
+                            chat_topic = topic.get("name")
+                            topic_skill = topic.get("skill")
+                            break
+                    break
+
         # Build source
         source = self.build_source(
             chat_id=str(chat.id),


### PR DESCRIPTION
## Summary

Extends the existing `dm_topics` skill binding pattern to work with supergroup forum topics (group chats with Topics mode enabled).

Currently, `auto_skill` injection on session start only works for DM topics. Group/supergroup forum topics have isolated sessions per `thread_id` natively, but there was no way to bind a skill to a specific topic. This adds that.

## What changed

Single addition to `_build_message_event` in `gateway/platforms/telegram.py`: an `elif` branch that handles `chat_type == "group"` with a `thread_id`, mirroring the existing DM topic lookup pattern but reading from `config.extra['group_topics']` instead.

## Config format

```yaml
platforms:
  telegram:
    extra:
      group_topics:
        - chat_id: -1001234567890   # supergroup ID
          topics:
            - name: "Engineering"
              thread_id: 5
              skill: "software-development"
            - name: "Sales"
              thread_id: 12
              skill: "sales-framework"
            - name: "General"
              thread_id: 1
              # no skill = general purpose topic
```

`thread_id` values are the Telegram forum topic IDs (visible in `t.me/c/<group_id>/<thread_id>` links).

## Behavior

- On a new session in a mapped group topic, the bound skill auto-loads exactly like DM topic skill binding does
- Topics without a `skill` key get session isolation only (existing behavior unchanged)
- Unmapped thread_ids fall through silently (no change to existing behavior)
- No new dependencies, no config migration required

## Why not auto-create topics like dm_topics does?

The `dm_topics` feature creates topics if they don't exist. For group forums, the admin typically creates topics manually through the Telegram UI — the bot doesn't need to manage topic lifecycle. So this is lookup-only, keeping it simpler and less surprising.
