### PR TITLE
fix(memory): route memory provider tools in sequential dispatch path

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5963,6 +5963,16 @@ class AIAgent:
                     old_text=function_args.get("old_text"),
                     store=self._memory_store,
                 )
+                # Bridge: notify external memory provider of built-in memory writes
+                if self._memory_manager and function_args.get("action") in ("add", "replace"):
+                    try:
+                        self._memory_manager.on_memory_write(
+                            function_args.get("action", ""),
+                            target,
+                            function_args.get("content", ""),
+                        )
+                    except Exception:
+                        pass
                 tool_duration = time.time() - tool_start_time
                 if self.quiet_mode:
                     self._vprint(f"  {_get_cute_tool_message_impl('memory', function_args, tool_duration, result=function_result)}")
@@ -6009,6 +6019,11 @@ class AIAgent:
                         spinner.stop(cute_msg)
                     elif self.quiet_mode:
                         self._vprint(f"  {cute_msg}")
+            elif self._memory_manager and self._memory_manager.has_tool(function_name):
+                function_result = self._memory_manager.handle_tool_call(function_name, function_args)
+                tool_duration = time.time() - tool_start_time
+                if self.quiet_mode:
+                    self._vprint(f"  {_get_cute_tool_message_impl(function_name, function_args, tool_duration, result=function_result)}")
             elif self.quiet_mode:
                 spinner = None
                 if not self.tool_progress_callback:

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1301,6 +1301,81 @@ class TestConcurrentToolExecution:
         assert "ok" in result
 
 
+class TestMemoryProviderSequentialDispatch:
+    """Memory provider tools must be routed in the sequential dispatch path.
+
+    The concurrent path (_invoke_tool) checks memory_manager.has_tool(), but
+    single tool calls always use the sequential path.  Without routing, memory
+    provider tools like fact_store fall through to registry.dispatch() which
+    returns "Unknown tool".
+
+    Regression test for #4708.
+    """
+
+    def test_sequential_routes_memory_provider_tool(self, agent):
+        """Single fact_store call should route through memory_manager, not registry."""
+        mock_mgr = MagicMock()
+        mock_mgr.has_tool.return_value = True
+        mock_mgr.handle_tool_call.return_value = '{"fact_id": 1, "status": "added"}'
+        agent._memory_manager = mock_mgr
+        agent.valid_tool_names.add("fact_store")
+
+        tc = _mock_tool_call(
+            name="fact_store",
+            arguments='{"action": "add", "content": "test fact"}',
+            call_id="c1",
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+
+        agent._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+
+        mock_mgr.has_tool.assert_called_with("fact_store")
+        mock_mgr.handle_tool_call.assert_called_once_with(
+            "fact_store", {"action": "add", "content": "test fact"}
+        )
+        # Result should be appended to messages
+        tool_msgs = [m for m in messages if m.get("role") == "tool"]
+        assert len(tool_msgs) == 1
+        assert "added" in tool_msgs[0]["content"]
+
+    def test_sequential_memory_write_bridge(self, agent):
+        """Built-in memory writes in sequential path should notify memory_manager."""
+        mock_mgr = MagicMock()
+        agent._memory_manager = mock_mgr
+        agent.valid_tool_names.add("memory")
+
+        tc = _mock_tool_call(
+            name="memory",
+            arguments='{"action": "add", "target": "user", "content": "likes dark mode"}',
+            call_id="c1",
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+
+        with patch("tools.memory_tool.memory_tool", return_value='{"success": true}'):
+            agent._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+
+        mock_mgr.on_memory_write.assert_called_once_with("add", "user", "likes dark mode")
+
+    def test_sequential_no_memory_manager_falls_through(self, agent):
+        """When memory_manager is None, unknown tools should fall through normally."""
+        agent._memory_manager = None
+        agent.valid_tool_names.add("fact_store")
+
+        tc = _mock_tool_call(
+            name="fact_store",
+            arguments='{"action": "list"}',
+            call_id="c1",
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+
+        with patch("run_agent.handle_function_call", return_value='{"error": "Unknown tool: fact_store"}') as mock_hfc:
+            agent._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+            mock_hfc.assert_called_once()
+
+
 class TestPathsOverlap:
     """Unit tests for the _paths_overlap helper."""
 


### PR DESCRIPTION
### Summary

Adds memory provider tool routing to the sequential dispatch path in `_execute_tool_calls_sequential`, which was missing the `memory_manager.has_tool()` check that already exists in the concurrent path (`_invoke_tool`).

Fixes #4708

### Problem

After setting up the holographic memory provider plugin, calling `fact_store` or `fact_feedback` returns `{"error": "Unknown tool: fact_store"}`.

The root cause: `_should_parallelize_tool_batch()` returns `False` for single tool calls (`len <= 1`), so they always go through the sequential path. The sequential path's `elif` chain handles `todo`, `session_search`, `memory`, `clarify`, and `delegate_task` explicitly, then falls through to `handle_function_call()` → `registry.dispatch()` for everything else. Since memory provider tools are registered in `MemoryManager._tool_to_provider` (not the main tool registry), they get "Unknown tool."

The concurrent path (`_invoke_tool`) already handles this correctly at line ~5620:
```python
elif self._memory_manager and self._memory_manager.has_tool(function_name):
    return self._memory_manager.handle_tool_call(function_name, function_args)
```

### Changes

**1. Add memory_manager routing to sequential path** (`run_agent.py`) — inserted between the `delegate_task` handler and the `handle_function_call` fallthrough:

```python
elif self._memory_manager and self._memory_manager.has_tool(function_name):
    function_result = self._memory_manager.handle_tool_call(function_name, function_args)
    ...
```

**2. Add `on_memory_write` bridge to sequential memory handler** (`run_agent.py`) — the concurrent path already mirrors built-in memory writes to the external provider via `on_memory_write()`, but the sequential path was missing this. Added the same bridge after the `memory_tool()` call.

**3. Regression tests** (`tests/test_run_agent.py`) — three new tests in `TestMemoryProviderSequentialDispatch`:
- `test_sequential_routes_memory_provider_tool` — single fact_store call routes through memory_manager
- `test_sequential_memory_write_bridge` — built-in memory writes trigger on_memory_write on the provider
- `test_sequential_no_memory_manager_falls_through` — no provider configured → normal fallthrough

All 224 existing tests pass alongside the 3 new ones.

### Note

Filed as issue #4708 first — we're not 100% certain this is a bug vs. a misunderstanding of the architecture. If the sequential path intentionally doesn't route memory provider tools, please let us know and we'll close both.

*Bug found by Claude Opus 4.6 running through Hermes Agent during a debugging session.*