### PR TITLE
fix(fallback): honor custom fallback base_url/api_key_env in activation path

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4505,8 +4505,25 @@ class AIAgent:
         # access for Codex providers.
         try:
             from agent.auxiliary_client import resolve_provider_client
+
+            # Optional per-fallback endpoint overrides (config-driven), used
+            # primarily for local OpenAI-compatible failover targets.
+            fb_base_url = (fb.get("base_url") or "").strip() if isinstance(fb, dict) else ""
+            fb_api_key = ""
+            if isinstance(fb, dict):
+                fb_api_key = (fb.get("api_key") or "").strip()
+                if not fb_api_key:
+                    fb_api_key_env = (fb.get("api_key_env") or "").strip()
+                    if fb_api_key_env:
+                        fb_api_key = os.getenv(fb_api_key_env, "").strip()
+
             fb_client, _ = resolve_provider_client(
-                fb_provider, model=fb_model, raw_codex=True)
+                fb_provider,
+                model=fb_model,
+                raw_codex=True,
+                explicit_base_url=fb_base_url or None,
+                explicit_api_key=fb_api_key or None,
+            )
             if fb_client is None:
                 logging.warning(
                     "Fallback to %s failed: provider not configured",


### PR DESCRIPTION
## Summary
- Make fallback activation pass per-entry `base_url` / `api_key` / `api_key_env` through to `resolve_provider_client(...)`.
- This ensures `fallback_model` entries using `provider: custom` actually route to the configured OpenAI-compatible endpoint (for example local MLX/vLLM/LM Studio), instead of silently resolving to another provider path.

## Why
Hermes already supports OpenAI-compatible APIs. The issue here is specific to the fallback activation codepath, which previously ignored fallback entry endpoint overrides.

## Validation
- Verified direct local endpoint call succeeds against `http://127.0.0.1:8890/v1` with model `mlx-community/gemma-4-26b-a4b-it-4bit`.
- Verified `_try_activate_fallback()` switches runtime to provider `custom`, base URL `http://127.0.0.1:8890/v1`, and completes a test generation.

## Scope
- Single-file change in `run_agent.py`.
- No behavior change for non-custom fallback providers.
