### PR TITLE
fix(security): restrict local file extraction to agent-managed directories

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -10,6 +10,7 @@ import logging
 import os
 import random
 import re
+import tempfile
 import uuid
 from abc import ABC, abstractmethod
 
@@ -852,9 +853,20 @@ class BasePlatformAdapter(ABC):
             if _in_code(match.start()):
                 continue
             raw = match.group(0)
-            expanded = os.path.expanduser(raw)
-            if os.path.isfile(expanded):
-                found.append((raw, expanded))
+            expanded = os.path.realpath(os.path.expanduser(raw))
+            if not os.path.isfile(expanded):
+                continue
+            # Only allow files from agent-managed directories to prevent
+            # exfiltration of arbitrary local media via prompt injection
+            _safe_prefixes = (
+                os.path.realpath(tempfile.gettempdir()),
+                os.path.realpath(get_image_cache_dir()),
+                os.path.realpath(get_audio_cache_dir()),
+                os.path.realpath(str(DOCUMENT_CACHE_DIR)),
+            )
+            if not any(expanded.startswith(p + os.sep) or expanded.startswith(p + "/") for p in _safe_prefixes):
+                continue
+            found.append((raw, expanded))
 
         # Deduplicate by expanded path, preserving discovery order
         seen: set = set()

--- a/tests/gateway/test_local_file_exfil_guard.py
+++ b/tests/gateway/test_local_file_exfil_guard.py
@@ -1,0 +1,86 @@
+"""Tests for local file exfiltration guard in extract_local_files.
+
+extract_local_files scans model responses for bare file paths and sends
+matching files as chat attachments. Without restriction, a prompt
+injection can exfiltrate any local media file by making the model
+mention its path. The guard restricts extraction to agent-managed
+directories (tmp, image/audio/document caches).
+"""
+
+import os
+import tempfile
+from pathlib import Path
+
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    get_image_cache_dir,
+    get_audio_cache_dir,
+    DOCUMENT_CACHE_DIR,
+)
+
+
+class TestLocalFileExfilGuard:
+
+    def test_private_home_photo_blocked(self):
+        """Files in ~/Pictures or other home dirs must not be extracted."""
+        photo_dir = Path.home() / "Pictures"
+        photo_dir.mkdir(exist_ok=True)
+        photo = photo_dir / "_test_exfil_guard.jpg"
+        photo.write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 50)
+        try:
+            files, _ = BasePlatformAdapter.extract_local_files(
+                f"Check out {photo}"
+            )
+            assert files == [], "private file outside safe dirs should be blocked"
+        finally:
+            photo.unlink(missing_ok=True)
+
+    def test_tmp_file_allowed(self):
+        """Files in /tmp (agent-generated) should be allowed."""
+        tmp = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
+        tmp.write(b"\x89PNG\r\n\x1a\n" + b"\x00" * 50)
+        tmp.close()
+        try:
+            files, _ = BasePlatformAdapter.extract_local_files(
+                f"Chart saved to {tmp.name}"
+            )
+            assert len(files) == 1
+            assert files[0] == os.path.realpath(tmp.name)
+        finally:
+            os.unlink(tmp.name)
+
+    def test_image_cache_allowed(self):
+        """Files in the hermes image cache should be allowed."""
+        cache = get_image_cache_dir()
+        test_file = cache / "test_guard.png"
+        test_file.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 50)
+        try:
+            files, _ = BasePlatformAdapter.extract_local_files(
+                f"Here is the image: {test_file}"
+            )
+            assert len(files) == 1
+        finally:
+            test_file.unlink()
+
+    def test_arbitrary_absolute_path_blocked(self):
+        """Absolute paths outside safe dirs must be blocked."""
+        secret_dir = Path.home() / ".test_exfil_guard"
+        secret_dir.mkdir(exist_ok=True)
+        secret = secret_dir / "secret_screenshot.png"
+        secret.write_bytes(b"\x89PNG" + b"\x00" * 50)
+        try:
+            files, _ = BasePlatformAdapter.extract_local_files(
+                f"Found an interesting file at {secret}"
+            )
+            assert files == [], "arbitrary absolute path should be blocked"
+        finally:
+            secret.unlink(missing_ok=True)
+            secret_dir.rmdir()
+
+    def test_no_files_returns_empty(self):
+        """Response with no paths returns empty list."""
+        files, cleaned = BasePlatformAdapter.extract_local_files(
+            "Hello, how can I help you today?"
+        )
+        assert files == []
+        assert "Hello" in cleaned


### PR DESCRIPTION
## Summary

extract_local_files() in gateway/platforms/base.py auto-detects bare local file paths in model responses and sends them as native chat attachments. No MEDIA: tag needed — the model just has to mention a path like ~/Pictures/private.jpg in its response text and the file gets uploaded to Telegram/Discord/Slack/etc.

A prompt injection that steers the model to reference any existing local media file exfiltrates it to the chat platform.

## Root Cause

extract_local_files() at line 810 scans response text with a regex matching absolute or ~/... paths ending in media extensions (.png, .jpg, .mp4, etc.), then calls os.path.isfile() on each match. Any file that exists gets added to the send list — no allowlist, no directory restriction.

Verified on v0.6.0:

```python
>>> BasePlatformAdapter.extract_local_files("Check ~/Pictures/vacation.jpg")
(['/root/Pictures/vacation.jpg'], 'Check')
```

## Fix

After expanding and resolving each path, check it starts with one of the agent-managed directories before allowing extraction:

- tempfile.gettempdir() (/tmp)
- get_image_cache_dir() (~/.hermes/image_cache)
- get_audio_cache_dir() (~/.hermes/audio_cache)
- DOCUMENT_CACHE_DIR (~/.hermes/document_cache)

Paths outside these dirs are silently skipped. Uses os.path.realpath() to prevent symlink escapes.

## Tests

5 tests: private home photo blocked, /tmp file allowed, image cache allowed, arbitrary path blocked, no-paths response returns empty.

```
5 passed
```