### PR TITLE
fix(security): add SSRF protection to outbound image URL extraction

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -243,6 +243,11 @@ from gateway.config import Platform, PlatformConfig
 from gateway.session import SessionSource, build_session_key
 from hermes_constants import get_hermes_dir
 
+try:
+    from tools.url_safety import is_safe_url as _is_safe_url
+except Exception:
+    _is_safe_url = lambda url: False  # noqa: E731 — fail-closed
+
 
 GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE = (
     "Secure secret entry is not supported over messaging. "
@@ -1710,8 +1715,18 @@ class BasePlatformAdapter(ABC):
                 human_delay = self._get_human_delay()
 
                 # Send extracted images as native attachments
+                # Filter out private/internal URLs to prevent SSRF — platform
+                # adapters fetch these URLs server-side via send_image()
                 if images:
-                    logger.info("[%s] Extracted %d image(s) to send as attachments", self.name, len(images))
+                    safe_images = []
+                    for url, alt in images:
+                        if url.startswith(("http://", "https://")) and not _is_safe_url(url):
+                            logger.warning("[%s] Blocked SSRF image URL: %s", self.name, url[:80])
+                        else:
+                            safe_images.append((url, alt))
+                    images = safe_images
+                    if images:
+                        logger.info("[%s] Extracted %d image(s) to send as attachments", self.name, len(images))
                 for image_url, alt_text in images:
                     if human_delay > 0:
                         await asyncio.sleep(human_delay)

--- a/tests/gateway/test_extract_images_ssrf.py
+++ b/tests/gateway/test_extract_images_ssrf.py
@@ -1,0 +1,58 @@
+"""Tests for SSRF protection in outbound image URL extraction.
+
+extract_images() parses model responses for image URLs. Platform adapters
+then fetch these URLs server-side via send_image(). Without SSRF
+protection, a model response containing <img src="http://169.254.169.254/...">
+causes the gateway to fetch cloud metadata endpoints.
+
+This is a different code path from cache_image_from_url() (inbound
+attachment caching, covered by PR #4687). This covers the outbound
+LLM-response → send_image() path.
+"""
+
+from gateway.platforms.base import BasePlatformAdapter
+
+
+class TestExtractImagesSSRF:
+
+    def test_metadata_endpoint_extracted(self):
+        """Verify extract_images picks up the URL (the raw bug)."""
+        images, _ = BasePlatformAdapter.extract_images(
+            '<img src="http://169.254.169.254/latest/meta-data/">'
+        )
+        # extract_images itself doesn't filter — it just parses
+        assert len(images) == 1
+        assert "169.254.169.254" in images[0][0]
+
+    def test_private_ip_extracted(self):
+        images, _ = BasePlatformAdapter.extract_images(
+            '![logo](http://192.168.1.1/admin/logo.png)'
+        )
+        assert len(images) == 1
+
+    def test_public_url_extracted(self):
+        images, _ = BasePlatformAdapter.extract_images(
+            '![chart](https://example.com/chart.png)'
+        )
+        assert len(images) == 1
+        assert "example.com" in images[0][0]
+
+    def test_safe_url_check_blocks_private(self):
+        """The is_safe_url guard in _process_message_background blocks SSRF."""
+        from gateway.platforms.base import _is_safe_url
+        assert _is_safe_url("http://169.254.169.254/meta-data/") is False
+        assert _is_safe_url("http://127.0.0.1:8080/secret") is False
+        assert _is_safe_url("http://192.168.1.1/admin") is False
+
+    def test_safe_url_allows_public(self, monkeypatch):
+        from gateway.platforms.base import _is_safe_url
+        from tools import url_safety
+
+        monkeypatch.setattr(
+            url_safety.socket,
+            "getaddrinfo",
+            lambda *args, **kwargs: [
+                (url_safety.socket.AF_INET, url_safety.socket.SOCK_STREAM, 0, "", ("93.184.216.34", 0))
+            ],
+        )
+        assert _is_safe_url("https://example.com/image.png") is True


### PR DESCRIPTION
## Summary

extract_images() parses model responses for image URLs (HTML img tags and markdown images). Platform adapters then fetch these URLs server-side via send_image(). There's no SSRF check on this path — a model response containing \`<img src="http://169.254.169.254/latest/meta-data/">\` causes the gateway to fetch cloud metadata.

This is a different code path from cache_image_from_url() (inbound attachment caching, covered by #4687). This covers the outbound LLM response → send_image() path, which hits Telegram, Slack, Matrix, Feishu, and WeCom adapters.

## Root Cause

extract_images() at base.py:627 accepts any http/https URL from HTML/markdown image syntax. _process_message_background() at line 1183 passes these URLs directly to send_image() with no validation. Multiple adapters download the URL server-side:

- telegram.py:1122
- slack.py:559
- matrix.py:500
- feishu.py:1380
- wecom.py:965

Verified on v0.6.0:
\`\`\`python
>>> BasePlatformAdapter.extract_images('<img src="http://169.254.169.254/latest/meta-data/">')
[('http://169.254.169.254/latest/meta-data/', '')]
\`\`\`

## Fix

Added is_safe_url() check in _process_message_background() before the send loop. Uses the existing url_safety module with fail-closed import guard. Private/internal URLs are logged and skipped; public URLs pass through unchanged.

## Tests

5 tests: metadata URL extracted (raw bug), private IP extracted, public URL passes, is_safe_url blocks private, is_safe_url allows public.

\`\`\`
5 passed
\`\`\`