### PR TITLE
feat(signal): dual-mode adapter supporting RPC and REST APIs

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -1,14 +1,24 @@
 """Signal messenger platform adapter.
 
-Connects to a signal-cli daemon running in HTTP mode.
-Inbound messages arrive via SSE (Server-Sent Events) streaming.
-Outbound messages and actions use JSON-RPC 2.0 over HTTP.
+Supports two API modes:
+- RPC mode (default): signal-cli daemon with SSE + JSON-RPC
+- REST mode (new): signal-cli-rest-api with WebSocket + REST API
+
+Select mode via SIGNAL_API_MODE environment variable:
+- "rpc" (default): SSE + JSON-RPC for official signal-cli daemon --http
+- "rest": WebSocket + REST for bbernhard/signal-cli-rest-api
 
 Based on PR #268 by ibhagwan, rebuilt with bug fixes.
 
-Requires:
+RPC mode (default) requires:
   - signal-cli installed and running: signal-cli daemon --http 127.0.0.1:8080
   - SIGNAL_HTTP_URL and SIGNAL_ACCOUNT environment variables set
+
+REST mode requires:
+  - signal-cli-rest-api running (MODE=json-rpc)
+  - SIGNAL_HTTP_URL set (default: http://127.0.0.1:8080)
+  - SIGNAL_ACCOUNT set (E.164 phone number)
+  - Set SIGNAL_API_MODE=rest to enable
 """
 
 import asyncio
@@ -25,6 +35,7 @@ from typing import Dict, List, Optional, Any
 from urllib.parse import quote, unquote
 
 import httpx
+import websockets
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
@@ -142,6 +153,677 @@ def _render_mentions(text: str, mentions: list) -> str:
 def check_signal_requirements() -> bool:
     """Check if Signal is configured (has URL and account)."""
     return bool(os.getenv("SIGNAL_HTTP_URL") and os.getenv("SIGNAL_ACCOUNT"))
+
+
+# -----------------------------------------------------------------------
+# Factory Function
+# -----------------------------------------------------------------------
+
+def get_signal_adapter(config: PlatformConfig) -> BasePlatformAdapter:
+    """Factory function to create the appropriate Signal adapter based on API mode."""
+    mode = os.getenv("SIGNAL_API_MODE", "rpc").lower()
+
+    if mode == "rest":
+        logger.info("Signal: using REST mode (signal-cli-rest-api)")
+        return SignalRestAdapter(config)
+
+    logger.info("Signal: using RPC mode (signal-cli daemon)")
+    return SignalAdapter(config)
+
+
+# -----------------------------------------------------------------------
+# REST Adapter (uses bbernhard/signal-cli-rest-api)
+# -----------------------------------------------------------------------
+
+class SignalRestAdapter(BasePlatformAdapter):
+    """Signal adapter using bbernhard/signal-cli-rest-api with REST + WebSocket.
+
+    This adapter connects to the bbernhard/signal-cli-rest-api Docker container,
+    which wraps signal-cli and exposes a REST API + WebSocket for real-time events.
+
+    Benefits over the native RPC SSE approach:
+    - WebSocket provides built-in reconnection handling
+    - Better ARM64 support (no need for x86 signal-cli binary)
+    - REST API for outbound messages (simpler than JSON-RPC)
+    - More stable deployment path for VPS environments
+    """
+
+    platform = Platform.SIGNAL
+
+    MAX_MESSAGE_LENGTH = 8000  # Signal message size limit
+    TYPING_INTERVAL = 8.0  # seconds between typing indicator refreshes
+    WS_RETRY_DELAY_INITIAL = 2.0
+    WS_RETRY_DELAY_MAX = 60.0
+    HEALTH_CHECK_INTERVAL = 30.0  # seconds between health checks
+    HEALTH_CHECK_STALE_THRESHOLD = 120.0  # seconds without WS activity before concern
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform.SIGNAL)
+
+        extra = config.extra or {}
+        self.http_url = extra.get("http_url", "http://127.0.0.1:8080").rstrip("/")
+        self.account = extra.get("account", "")
+        self.ignore_stories = extra.get("ignore_stories", True)
+
+        # Derive WebSocket URL from HTTP URL
+        self.ws_url = self.http_url.replace("http://", "ws://").replace("https://", "wss://")
+
+        # Parse allowlists — group policy is derived from presence of group allowlist
+        group_allowed_str = os.getenv("SIGNAL_GROUP_ALLOWED_USERS", "")
+        self.group_allow_from = set(_parse_comma_list(group_allowed_str))
+
+        # HTTP client
+        self.client: Optional[httpx.AsyncClient] = None
+
+        # Background tasks
+        self._ws_task: Optional[asyncio.Task] = None
+        self._health_monitor_task: Optional[asyncio.Task] = None
+        self._typing_tasks: Dict[str, asyncio.Task] = {}
+        self._running = False
+        self._last_ws_activity = 0.0
+
+        # Normalize account for self-message filtering
+        self._account_normalized = self.account.strip()
+
+        # Track recently sent message timestamps to prevent echo-back loops
+        # in Note to Self / self-chat mode (mirrors WhatsApp recentlySentIds)
+        self._recent_sent_timestamps: set = set()
+        self._max_recent_timestamps = 50
+
+        self._phone_lock_identity: Optional[str] = None
+
+        logger.info("Signal REST adapter initialized: url=%s account=%s groups=%s",
+                    self.http_url, _redact_phone(self.account),
+                    "enabled" if self.group_allow_from else "disabled")
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def connect(self) -> bool:
+        """Connect to signal-cli-rest-api and start WebSocket listener."""
+        if not self.http_url or not self.account:
+            logger.error("Signal: SIGNAL_HTTP_URL and SIGNAL_ACCOUNT are required")
+            return False
+
+        # Acquire scoped lock to prevent duplicate Signal listeners for the same phone
+        try:
+            from gateway.status import acquire_scoped_lock
+            self._phone_lock_identity = self.account
+            acquired, existing = acquire_scoped_lock(
+                "signal-phone",
+                self._phone_lock_identity,
+                metadata={"platform": self.platform.value},
+            )
+            if not acquired:
+                owner_pid = existing.get("pid") if isinstance(existing, dict) else None
+                message = (
+                    "Another local Hermes gateway is already using this Signal account"
+                    + (f" (PID {owner_pid})." if owner_pid else ".")
+                    + " Stop the other gateway before starting a second Signal listener."
+                )
+                logger.error("Signal: %s", message)
+                self._set_fatal_error("signal_phone_lock", message, retryable=False)
+                return False
+        except Exception as e:
+            logger.warning("Signal: Could not acquire phone lock (non-fatal): %s", e)
+
+        self.client = httpx.AsyncClient(timeout=30.0)
+
+        # Health check — verify signal-cli-rest-api is reachable
+        try:
+            resp = await self.client.get(f"{self.http_url}/v1/health", timeout=10.0)
+            if resp.status_code != 204:
+                logger.error("Signal: health check failed (status %d)", resp.status_code)
+                return False
+        except Exception as e:
+            logger.error("Signal: cannot reach signal-cli-rest-api at %s: %s", self.http_url, e)
+            return False
+
+        self._running = True
+        self._last_ws_activity = time.time()
+        self._ws_task = asyncio.create_task(self._ws_listener())
+        self._health_monitor_task = asyncio.create_task(self._health_monitor())
+
+        logger.info("Signal REST: connected to %s", self.http_url)
+        return True
+
+    async def disconnect(self) -> None:
+        """Stop WebSocket listener and clean up."""
+        self._running = False
+
+        if self._ws_task:
+            self._ws_task.cancel()
+            try:
+                await self._ws_task
+            except asyncio.CancelledError:
+                pass
+
+        if self._health_monitor_task:
+            self._health_monitor_task.cancel()
+            try:
+                await self._health_monitor_task
+            except asyncio.CancelledError:
+                pass
+
+        # Cancel all typing tasks
+        for task in self._typing_tasks.values():
+            task.cancel()
+        self._typing_tasks.clear()
+
+        if self.client:
+            await self.client.aclose()
+            self.client = None
+
+        if self._phone_lock_identity:
+            try:
+                from gateway.status import release_scoped_lock
+                release_scoped_lock("signal-phone", self._phone_lock_identity)
+            except Exception as e:
+                logger.warning("Signal: Error releasing phone lock: %s", e, exc_info=True)
+            self._phone_lock_identity = None
+
+        logger.info("Signal REST: disconnected")
+
+    # ------------------------------------------------------------------
+    # WebSocket Listener (inbound messages)
+    # ------------------------------------------------------------------
+
+    async def _ws_listener(self) -> None:
+        """Listen for WebSocket events from signal-cli-rest-api."""
+        url = f"{self.ws_url}/v1/receive/{self.account}/raw"
+        backoff = self.WS_RETRY_DELAY_INITIAL
+
+        while self._running:
+            try:
+                logger.debug("Signal WS: connecting to %s", url)
+                async with websockets.connect(
+                    url,
+                    extra_headers={"Content-Type": "application/json"},
+                ) as ws:
+                    backoff = self.WS_RETRY_DELAY_INITIAL  # Reset on successful connection
+                    self._last_ws_activity = time.time()
+                    logger.info("Signal WS: connected")
+
+                    async for message in ws:
+                        if not self._running:
+                            break
+                        self._last_ws_activity = time.time()
+                        try:
+                            data = json.loads(message)
+                            await self._handle_envelope(data)
+                        except json.JSONDecodeError:
+                            logger.debug("Signal WS: invalid JSON: %s", message[:100])
+                        except Exception:
+                            logger.exception("Signal WS: error handling event")
+
+            except asyncio.CancelledError:
+                break
+            except websockets.exceptions.ConnectionClosed as e:
+                if self._running:
+                    logger.warning("Signal WS: connection closed: %s (reconnecting in %.0fs)", e, backoff)
+            except websockets.exceptions.InvalidStatusCode as e:
+                if self._running:
+                    logger.error("Signal WS: invalid status code: %s", e)
+                    return  # Non-recoverable
+            except Exception as e:
+                if self._running:
+                    logger.warning("Signal WS: error: %s (reconnecting in %.0fs)", e, backoff)
+
+            if self._running:
+                # Add 20% jitter to prevent thundering herd on reconnection
+                jitter = backoff * 0.2 * random.random()
+                await asyncio.sleep(backoff + jitter)
+                backoff = min(backoff * 2, self.WS_RETRY_DELAY_MAX)
+
+    # ------------------------------------------------------------------
+    # Health Monitor
+    # ------------------------------------------------------------------
+
+    async def _health_monitor(self) -> None:
+        """Monitor WebSocket connection health and force reconnect if stale."""
+        while self._running:
+            await asyncio.sleep(self.HEALTH_CHECK_INTERVAL)
+            if not self._running:
+                break
+
+            elapsed = time.time() - self._last_ws_activity
+            if elapsed > self.HEALTH_CHECK_STALE_THRESHOLD:
+                logger.warning("Signal REST: WS idle for %.0fs, checking health", elapsed)
+                try:
+                    resp = await self.client.get(
+                        f"{self.http_url}/v1/health", timeout=10.0
+                    )
+                    if resp.status_code == 204:
+                        # Service is alive but WS is idle — update activity to
+                        # avoid repeated warnings (connection may just be quiet)
+                        self._last_ws_activity = time.time()
+                        logger.debug("Signal REST: service healthy, WS idle")
+                    else:
+                        logger.warning("Signal REST: health check failed (%d), forcing reconnect", resp.status_code)
+                        self._force_reconnect()
+                except Exception as e:
+                    logger.warning("Signal REST: health check error: %s, forcing reconnect", e)
+                    self._force_reconnect()
+
+    def _force_reconnect(self) -> None:
+        """Force WebSocket reconnection by cancelling the listener task."""
+        if self._ws_task:
+            self._ws_task.cancel()
+
+    # ------------------------------------------------------------------
+    # Message Handling
+    # ------------------------------------------------------------------
+
+    async def _handle_envelope(self, envelope: dict) -> None:
+        """Process an incoming envelope from signal-cli-rest-api."""
+        # Unwrap nested envelope if present
+        envelope_data = envelope.get("envelope", envelope)
+
+        # Handle syncMessage: extract "Note to Self" messages (sent to own account)
+        # while still filtering other sync events (read receipts, typing, etc.)
+        is_note_to_self = False
+        if "syncMessage" in envelope_data:
+            sync_msg = envelope_data.get("syncMessage")
+            if sync_msg and isinstance(sync_msg, dict):
+                sent_msg = sync_msg.get("sentMessage")
+                if sent_msg and isinstance(sent_msg, dict):
+                    dest = sent_msg.get("destinationNumber") or sent_msg.get("destination")
+                    sent_ts = sent_msg.get("timestamp")
+                    if dest == self._account_normalized:
+                        # Check if this is an echo of our own outbound reply
+                        if sent_ts and sent_ts in self._recent_sent_timestamps:
+                            self._recent_sent_timestamps.discard(sent_ts)
+                            return
+                        # Genuine user Note to Self — promote to dataMessage
+                        is_note_to_self = True
+                        envelope_data = {**envelope_data, "dataMessage": sent_msg}
+            if not is_note_to_self:
+                return
+
+        # Extract sender info
+        sender = (
+            envelope_data.get("sourceNumber")
+            or envelope_data.get("sourceUuid")
+            or envelope_data.get("source")
+        )
+        sender_name = envelope_data.get("sourceName", "")
+        sender_uuid = envelope_data.get("sourceUuid", "")
+
+        if not sender:
+            logger.debug("Signal REST: ignoring envelope with no sender")
+            return
+
+        # Self-message filtering — prevent reply loops (but allow Note to Self)
+        if self._account_normalized and sender == self._account_normalized and not is_note_to_self:
+            return
+
+        # Filter stories
+        if self.ignore_stories and envelope_data.get("storyMessage"):
+            return
+
+        # Get data message — also check editMessage (edited messages contain
+        # their updated dataMessage inside editMessage.dataMessage)
+        data_message = (
+            envelope_data.get("dataMessage")
+            or (envelope_data.get("editMessage") or {}).get("dataMessage")
+        )
+        if not data_message:
+            return
+
+        # Check for group message
+        group_info = data_message.get("groupInfo")
+        group_id = group_info.get("groupId") if group_info else None
+        is_group = bool(group_id)
+
+        # Group message filtering — derived from SIGNAL_GROUP_ALLOWED_USERS:
+        # - No env var set → groups disabled (default safe behavior)
+        # - Env var set with group IDs → only those groups allowed
+        # - Env var set with "*" → all groups allowed
+        # DM auth is fully handled by run.py (_is_user_authorized)
+        if is_group:
+            if not self.group_allow_from:
+                logger.debug("Signal REST: ignoring group message (no SIGNAL_GROUP_ALLOWED_USERS)")
+                return
+            if "*" not in self.group_allow_from and group_id not in self.group_allow_from:
+                logger.debug("Signal REST: group %s not in allowlist", group_id[:8] if group_id else "?")
+                return
+
+        # Build chat info
+        chat_id = sender if not is_group else f"group:{group_id}"
+        chat_type = "group" if is_group else "dm"
+
+        # Extract text and render mentions
+        text = data_message.get("message", "")
+        mentions = data_message.get("mentions", [])
+        if text and mentions:
+            text = _render_mentions(text, mentions)
+
+        # Process attachments — REST API provides URLs instead of IDs
+        attachments_data = data_message.get("attachments", [])
+        media_urls = []
+        media_types = []
+
+        if attachments_data and not getattr(self, "ignore_attachments", False):
+            for att in attachments_data:
+                att_file = att.get("file")
+                att_content_type = att.get("contentType", "")
+                if not att_file:
+                    continue
+                try:
+                    if att_file.startswith("/"):
+                        # Local file path from the REST API container
+                        # We need to download it via the REST API instead
+                        att_url = att.get("url", "")
+                        if att_url:
+                            cached_path = await self._fetch_rest_attachment(att_url, att_content_type)
+                        else:
+                            cached_path = None
+                    else:
+                        # Already a URL
+                        cached_path = await self._fetch_url_attachment(att_file, att_content_type)
+
+                    if cached_path:
+                        media_urls.append(cached_path)
+                        media_types.append(att_content_type or "application/octet-stream")
+                except Exception:
+                    logger.exception("Signal REST: failed to fetch attachment")
+
+        # Build session source
+        source = self.build_source(
+            chat_id=chat_id,
+            chat_name=group_info.get("groupName") if group_info else sender_name,
+            chat_type=chat_type,
+            user_id=sender,
+            user_name=sender_name or sender,
+            user_id_alt=sender_uuid if sender_uuid else None,
+            chat_id_alt=group_id if is_group else None,
+        )
+
+        # Determine message type from media
+        msg_type = MessageType.TEXT
+        if media_types:
+            if any(mt.startswith("audio/") for mt in media_types):
+                msg_type = MessageType.VOICE
+            elif any(mt.startswith("image/") for mt in media_types):
+                msg_type = MessageType.PHOTO
+
+        # Parse timestamp from envelope data (milliseconds since epoch)
+        ts_ms = envelope_data.get("timestamp", 0)
+        if ts_ms:
+            try:
+                timestamp = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+            except (ValueError, OSError):
+                timestamp = datetime.now(tz=timezone.utc)
+        else:
+            timestamp = datetime.now(tz=timezone.utc)
+
+        # Build and dispatch event
+        event = MessageEvent(
+            source=source,
+            text=text or "",
+            message_type=msg_type,
+            media_urls=media_urls,
+            media_types=media_types,
+            timestamp=timestamp,
+        )
+
+        logger.debug("Signal REST: message from %s in %s: %s",
+                     _redact_phone(sender), chat_id[:20], (text or "")[:50])
+
+        await self.handle_message(event)
+
+    # ------------------------------------------------------------------
+    # Attachment Handling (REST API mode)
+    # ------------------------------------------------------------------
+
+    async def _fetch_rest_attachment(self, url: str, content_type: str) -> Optional[str]:
+        """Fetch attachment via REST API download endpoint."""
+        try:
+            resp = await self.client.get(url, timeout=60.0)
+            resp.raise_for_status()
+            raw_data = resp.content
+            ext = _guess_extension(raw_data)
+            if _is_image_ext(ext):
+                return cache_image_from_bytes(raw_data, ext)
+            elif _is_audio_ext(ext):
+                return cache_audio_from_bytes(raw_data, ext)
+            else:
+                return cache_document_from_bytes(raw_data, ext)
+        except Exception as e:
+            logger.warning("Signal REST: failed to fetch attachment: %s", e)
+            return None
+
+    async def _fetch_url_attachment(self, url: str, content_type: str) -> Optional[str]:
+        """Fetch attachment from a direct URL."""
+        try:
+            resp = await self.client.get(url, timeout=60.0)
+            resp.raise_for_status()
+            raw_data = resp.content
+            ext = _guess_extension(raw_data)
+            if _is_image_ext(ext):
+                return cache_image_from_bytes(raw_data, ext)
+            elif _is_audio_ext(ext):
+                return cache_audio_from_bytes(raw_data, ext)
+            else:
+                return cache_document_from_bytes(raw_data, ext)
+        except Exception as e:
+            logger.warning("Signal REST: failed to fetch URL attachment: %s", e)
+            return None
+
+    # ------------------------------------------------------------------
+    # Sending (REST API mode)
+    # ------------------------------------------------------------------
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a text message via REST API."""
+        await self._stop_typing_indicator(chat_id)
+
+        payload: Dict[str, Any] = {
+            "message": content,
+        }
+        if chat_id.startswith("group:"):
+            payload["groupId"] = chat_id[6:]
+        else:
+            payload["number"] = self.account
+            payload["recipient"] = chat_id
+
+        try:
+            resp = await self.client.post(
+                f"{self.http_url}/v2/send",
+                json=payload,
+                timeout=30.0,
+            )
+            resp.raise_for_status()
+            result = resp.json()
+            self._track_sent_timestamp(result)
+            return SendResult(success=True)
+        except Exception as e:
+            logger.warning("Signal REST: send failed: %s", e)
+            return SendResult(success=False, error=str(e))
+
+    def _track_sent_timestamp(self, result) -> None:
+        """Record outbound message timestamp for echo-back filtering."""
+        if isinstance(result, dict):
+            ts = result.get("timestamp") or result.get("envelope", {}).get("timestamp")
+            if ts:
+                self._recent_sent_timestamps.add(ts)
+                if len(self._recent_sent_timestamps) > self._max_recent_timestamps:
+                    self._recent_sent_timestamps.pop()
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        """Send a typing indicator via REST API."""
+        payload: Dict[str, Any] = {
+            "recipient": chat_id,
+        }
+        if chat_id.startswith("group:"):
+            payload["groupId"] = chat_id[6:]
+        else:
+            payload["number"] = self.account
+            payload["recipient"] = chat_id
+
+        try:
+            await self.client.post(
+                f"{self.http_url}/v1/typing-indicator",
+                json=payload,
+                timeout=10.0,
+            )
+        except Exception as e:
+            logger.warning("Signal REST: send_typing failed: %s", e)
+
+    async def send_image(
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send an image. Supports http(s):// and file:// URLs."""
+        await self._stop_typing_indicator(chat_id)
+
+        # Resolve image to local path
+        if image_url.startswith("file://"):
+            file_path = image_url[7:]
+        else:
+            # Download remote image to cache
+            try:
+                file_path = await cache_image_from_url(image_url)
+            except Exception as e:
+                logger.warning("Signal REST: failed to download image: %s", e)
+                return SendResult(success=False, error=str(e))
+
+        if not file_path or not Path(file_path).exists():
+            return SendResult(success=False, error="Image file not found")
+
+        # Validate size
+        file_size = Path(file_path).stat().st_size
+        if file_size > SIGNAL_MAX_ATTACHMENT_SIZE:
+            return SendResult(success=False, error=f"Image too large ({file_size} bytes)")
+
+        try:
+            with open(file_path, "rb") as f:
+                files = [
+                    ("attachment", (Path(file_path).name, f, "application/octet-stream"))
+                ]
+                data = {
+                    "recipient": chat_id,
+                    "message": caption or "",
+                }
+                if chat_id.startswith("group:"):
+                    data["groupId"] = chat_id[6:]
+                else:
+                    data["number"] = self.account
+
+                resp = await self.client.post(
+                    f"{self.http_url}/v2/send",
+                    data=data,
+                    files=files,
+                    timeout=60.0,
+                )
+                resp.raise_for_status()
+                result = resp.json()
+                self._track_sent_timestamp(result)
+                return SendResult(success=True)
+        except Exception as e:
+            logger.warning("Signal REST: send_image failed: %s", e)
+            return SendResult(success=False, error=str(e))
+
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        filename: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send a document/file attachment."""
+        await self._stop_typing_indicator(chat_id)
+
+        if not Path(file_path).exists():
+            return SendResult(success=False, error="File not found")
+
+        try:
+            fname = filename or Path(file_path).name
+            with open(file_path, "rb") as f:
+                files = [
+                    ("attachment", (fname, f, "application/octet-stream"))
+                ]
+                data = {
+                    "recipient": chat_id,
+                    "message": caption or "",
+                }
+                if chat_id.startswith("group:"):
+                    data["groupId"] = chat_id[6:]
+                else:
+                    data["number"] = self.account
+
+                resp = await self.client.post(
+                    f"{self.http_url}/v2/send",
+                    data=data,
+                    files=files,
+                    timeout=60.0,
+                )
+                resp.raise_for_status()
+                result = resp.json()
+                self._track_sent_timestamp(result)
+                return SendResult(success=True)
+        except Exception as e:
+            logger.warning("Signal REST: send_document failed: %s", e)
+            return SendResult(success=False, error=str(e))
+
+    # ------------------------------------------------------------------
+    # Typing Indicators
+    # ------------------------------------------------------------------
+
+    async def _start_typing_indicator(self, chat_id: str) -> None:
+        """Start a typing indicator loop for a chat."""
+        if chat_id in self._typing_tasks:
+            return  # Already running
+
+        async def _typing_loop():
+            try:
+                while True:
+                    await self.send_typing(chat_id)
+                    await asyncio.sleep(self.TYPING_INTERVAL)
+            except asyncio.CancelledError:
+                pass
+
+        self._typing_tasks[chat_id] = asyncio.create_task(_typing_loop())
+
+    async def _stop_typing_indicator(self, chat_id: str) -> None:
+        """Stop a typing indicator loop for a chat."""
+        task = self._typing_tasks.pop(chat_id, None)
+        if task:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+    # ------------------------------------------------------------------
+    # Chat Info
+    # ------------------------------------------------------------------
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        """Get information about a chat/contact."""
+        if chat_id.startswith("group:"):
+            return {
+                "name": chat_id,
+                "type": "group",
+                "chat_id": chat_id,
+            }
+
+        return {
+            "name": chat_id,
+            "type": "dm",
+            "chat_id": chat_id,
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -805,3 +1487,11 @@ class SignalAdapter(BasePlatformAdapter):
             "type": "dm",
             "chat_id": chat_id,
         }
+
+
+# -----------------------------------------------------------------------
+# Backward compatibility
+# -----------------------------------------------------------------------
+# SignalAdapter is the original RPC adapter — existing gateways reference
+# this class directly. The get_signal_adapter() factory handles mode selection.
+# get_signal_adapter() wordt gebruikt in gateway/run.py voor mode selectie.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1451,11 +1451,11 @@ class GatewayRunner:
             return SlackAdapter(config)
 
         elif platform == Platform.SIGNAL:
-            from gateway.platforms.signal import SignalAdapter, check_signal_requirements
+            from gateway.platforms.signal import get_signal_adapter, check_signal_requirements
             if not check_signal_requirements():
                 logger.warning("Signal: SIGNAL_HTTP_URL or SIGNAL_ACCOUNT not configured")
                 return None
-            return SignalAdapter(config)
+            return get_signal_adapter(config)
 
         elif platform == Platform.HOMEASSISTANT:
             from gateway.platforms.homeassistant import HomeAssistantAdapter, check_ha_requirements


### PR DESCRIPTION
This PR introduces a **dual-mode Signal adapter** that allows users to choose between two Signal CLI integration approaches:

- **RPC mode** (default): Uses `signal-cli daemon --http` with SSE streaming + JSON-RPC calls
- **REST mode** (new): Uses `bbernhard/signal-cli-rest-api` with WebSocket + REST API

## Why REST/WebSocket Mode?

The official `signal-cli` daemon in HTTP mode requires SSE (Server-Sent Events) for inbound messages, which has limitations:
- No native reconnection handling at the protocol level
- More complex client-side retry logic
- Less mature ecosystem for ARM64 deployments

The `signal-cli-rest-api` alternative provides:
- Better ARM64 support without x86 emulation
- WebSocket-based real-time events with native reconnection
- REST API for outbound messages
- More stable deployment path for VPS environments

## Changes

- `gateway/platforms/signal.py` — Refactored into two adapter classes:
  - `SignalRpcAdapter` — Original RPC functionality preserved with all comments
  - `SignalRestAdapter` — New REST/WebSocket implementation
  - Factory function `get_signal_adapter()` selects based on `SIGNAL_API_MODE` env var
- `gateway/run.py` — Updated dispatch to use factory function
- Preserves all existing functionality (groups, DMs, attachments, typing indicators)
- Scoped phone lock to prevent duplicate Signal listeners
