### PR TITLE
fix: prevent background review from re-saving duplicate memory entries

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1425,7 +1425,10 @@ class AIAgent:
         "preferences, or personal details worth remembering?\n"
         "2. Has the user expressed expectations about how you should behave, their work "
         "style, or ways they want you to operate?\n\n"
-        "If something stands out, save it using the memory tool. "
+        "IMPORTANT: Check the existing memory contents below BEFORE saving. "
+        "Do NOT re-save information already stored. Only save genuinely NEW information.\n\n"
+        "{existing_memory}\n\n"
+        "If something NEW stands out, save it using the memory tool. "
         "If nothing is worth saving, just say 'Nothing to save.' and stop."
     )
 
@@ -1449,6 +1452,9 @@ class AIAgent:
         "and error, or changing course due to experiential findings along the way, or did "
         "the user expect or desire a different method or outcome? If a relevant skill "
         "already exists, update it. Otherwise, create a new one if the approach is reusable.\n\n"
+        "IMPORTANT: Check the existing memory contents below BEFORE saving to memory. "
+        "Do NOT re-save information already stored. Only save genuinely NEW information.\n\n"
+        "{existing_memory}\n\n"
         "Only act if there's something genuinely worth saving. "
         "If nothing stands out, just say 'Nothing to save.' and stop."
     )
@@ -1468,6 +1474,22 @@ class AIAgent:
         """
         import threading
 
+        # Read current memory so review agent avoids duplicate saves
+        _existing_memory_text = ""
+        if review_memory and self._memory_store:
+            try:
+                _mem = self._memory_store.memory_entries or []
+                _usr = self._memory_store.user_entries or []
+                _parts = []
+                if _mem:
+                    _parts.append("EXISTING MEMORY:" + chr(10) + chr(10).join(f"- {e}" for e in _mem))
+                if _usr:
+                    _parts.append("EXISTING USER PROFILE:" + chr(10) + chr(10).join(f"- {e}" for e in _usr))
+                if _parts:
+                    _existing_memory_text = chr(10).join(_parts)
+            except Exception:
+                pass
+
         # Pick the right prompt based on which triggers fired
         if review_memory and review_skills:
             prompt = self._COMBINED_REVIEW_PROMPT
@@ -1475,6 +1497,11 @@ class AIAgent:
             prompt = self._MEMORY_REVIEW_PROMPT
         else:
             prompt = self._SKILL_REVIEW_PROMPT
+
+        # Inject existing memory into prompt to prevent re-saving
+        if "{existing_memory}" in prompt:
+            _repl = _existing_memory_text if _existing_memory_text else "(No existing entries)"
+            prompt = prompt.replace("{existing_memory}", _repl)
 
         def _run_review():
             import contextlib, os as _os


### PR DESCRIPTION
## Problem

The background review system () spawns a fresh AIAgent to review conversations and save to memory/skills. However, this review agent had no visibility into what was already stored in memory, causing it to repeatedly save the same information every time the nudge interval triggers.

Users on messaging platforms (Telegram, Discord) see repeated  notifications for the same facts, sometimes 5-6 times in a single session.

## Root Cause

The review agent is a fresh fork with no context about existing memory entries. It reads the conversation, identifies facts worth saving, and saves them — even if they're already stored. The next trigger cycle does the same thing.

## Fix

1. **Read current memory** before spawning the review: extract  and  from the shared .
2. **Inject into prompt** via an  placeholder in  and .
3. **Instruct the review agent** to check existing contents and only save genuinely new information.

## Changes

- : 28 insertions, 1 deletion
  - Updated  and  with dedup instructions +  placeholder
  - Added memory reading code in  before prompt selection
  - Added placeholder replacement logic after prompt selection

## Testing

- Verified compilation passes
- The fix is backward-compatible: if  placeholder is not in a prompt (e.g. ), no replacement occurs
- If memory store is empty or unavailable, falls back to 