### PR TITLE
fix: validate tool calls before persisting to prevent session poisoning

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5272,6 +5272,18 @@ class AIAgent:
         if assistant_message.tool_calls:
             tool_calls = []
             for tool_call in assistant_message.tool_calls:
+                # Validate tool call before persisting to prevent session poisoning.
+                # Malformed tool calls (empty name, invalid arguments) can cause
+                # repeated 400 errors when replayed to strict providers.
+                if not self._is_valid_tool_call(tool_call):
+                    fn = getattr(tool_call, "function", None)
+                    fn_name = getattr(fn, "name", "<empty>") if fn else "<missing>"
+                    fn_args = getattr(fn, "arguments", "<empty>") if fn else "<missing>"
+                    logging.warning(
+                        f"Skipping malformed tool call: name={fn_name!r}, "
+                        f"arguments={fn_args[:100] if isinstance(fn_args, str) else fn_args!r}"
+                    )
+                    continue
                 raw_id = getattr(tool_call, "id", None)
                 call_id = getattr(tool_call, "call_id", None)
                 if not isinstance(call_id, str) or not call_id.strip():
@@ -5321,13 +5333,58 @@ class AIAgent:
         return msg
 
     @staticmethod
+    def _is_valid_tool_call(tool_call) -> bool:
+        """Validate a tool call before persisting to session history.
+
+        Malformed tool calls (empty function name, invalid arguments) can poison
+        a session and cause repeated 400 errors when replayed to strict providers.
+        This validation prevents such tool calls from being persisted.
+
+        Returns True if the tool call is valid, False otherwise.
+        """
+        fn = getattr(tool_call, "function", None)
+        if fn is None:
+            return False
+
+        # Validate function name - must be a non-empty string
+        fn_name = getattr(fn, "name", None)
+        if not isinstance(fn_name, str) or not fn_name.strip():
+            return False
+
+        # Validate function arguments - must be valid JSON object string
+        fn_args = getattr(fn, "arguments", None)
+        if fn_args is None:
+            # Some providers may return None for empty args - allow this
+            return True
+        if not isinstance(fn_args, str):
+            return False
+        if not fn_args.strip():
+            # Empty string is invalid - should be "{}" at minimum
+            return False
+
+        # Verify arguments parse as valid JSON object
+        try:
+            parsed = json.loads(fn_args)
+            # Arguments must be a dict/object, not a list or primitive
+            if not isinstance(parsed, dict):
+                return False
+        except (json.JSONDecodeError, TypeError):
+            return False
+
+        return True
+
+    @staticmethod
     def _sanitize_tool_calls_for_strict_api(api_msg: dict) -> dict:
-        """Strip Codex Responses API fields from tool_calls for strict providers.
+        """Strip Codex Responses API fields and filter malformed tool_calls.
 
         Providers like Mistral strictly validate the Chat Completions schema
         and reject unknown fields (call_id, response_item_id) with 422.
         These fields are preserved in the internal message history — this
         method only modifies the outgoing API copy.
+
+        Additionally filters out malformed tool calls (empty function name,
+        invalid arguments) that could cause 400 errors when replayed.
+        This provides a second layer of defense against session poisoning.
 
         Creates new tool_call dicts rather than mutating in-place, so the
         original messages list retains call_id/response_item_id for Codex
@@ -5338,11 +5395,36 @@ class AIAgent:
         if not isinstance(tool_calls, list):
             return api_msg
         _STRIP_KEYS = {"call_id", "response_item_id"}
-        api_msg["tool_calls"] = [
-            {k: v for k, v in tc.items() if k not in _STRIP_KEYS}
-            if isinstance(tc, dict) else tc
-            for tc in tool_calls
-        ]
+        sanitized = []
+        for tc in tool_calls:
+            if not isinstance(tc, dict):
+                continue
+            fn = tc.get("function", {})
+            if not isinstance(fn, dict):
+                continue
+            # Skip malformed tool calls: empty name or invalid arguments
+            fn_name = fn.get("name", "")
+            if not isinstance(fn_name, str) or not fn_name.strip():
+                logging.warning(f"Filtering malformed tool call with empty name from API payload")
+                continue
+            fn_args = fn.get("arguments", "{}")
+            if isinstance(fn_args, str) and fn_args.strip():
+                try:
+                    parsed = json.loads(fn_args)
+                    if not isinstance(parsed, dict):
+                        logging.warning(f"Filtering tool call with non-object arguments: {fn_name}")
+                        continue
+                except (json.JSONDecodeError, TypeError):
+                    logging.warning(f"Filtering tool call with invalid JSON arguments: {fn_name}")
+                    continue
+            elif fn_args is not None and fn_args != "":
+                # Empty string or non-string (but not None) is invalid
+                if fn_args == "":
+                    logging.warning(f"Filtering tool call with empty arguments string: {fn_name}")
+                    continue
+            # Tool call is valid - strip extra keys and add to result
+            sanitized.append({k: v for k, v in tc.items() if k not in _STRIP_KEYS})
+        api_msg["tool_calls"] = sanitized
         return api_msg
 
     def flush_memories(self, messages: list = None, min_turns: int = None):

--- a/tests/test_tool_call_validation.py
+++ b/tests/test_tool_call_validation.py
@@ -1,0 +1,194 @@
+"""Tests for tool call validation to prevent session poisoning."""
+
+import json
+import pytest
+from unittest.mock import MagicMock
+
+
+class TestToolCallValidation:
+    """Test _is_valid_tool_call and _sanitize_tool_calls_for_strict_api."""
+
+    def _make_tool_call(self, name, arguments):
+        """Create a mock tool call object."""
+        tc = MagicMock()
+        tc.function = MagicMock()
+        tc.function.name = name
+        tc.function.arguments = arguments
+        return tc
+
+    def test_valid_tool_call(self):
+        """Valid tool calls should pass validation."""
+        from run_agent import AIAgent as Agent
+
+        tc = self._make_tool_call("read_file", '{"path": "/tmp/test.txt"}')
+        assert Agent._is_valid_tool_call(tc) is True
+
+    def test_empty_function_name(self):
+        """Empty function name should fail validation."""
+        from run_agent import AIAgent as Agent
+
+        tc = self._make_tool_call("", '{"key": "value"}')
+        assert Agent._is_valid_tool_call(tc) is False
+
+    def test_whitespace_function_name(self):
+        """Whitespace-only function name should fail validation."""
+        from run_agent import AIAgent as Agent
+
+        tc = self._make_tool_call("   ", '{"key": "value"}')
+        assert Agent._is_valid_tool_call(tc) is False
+
+    def test_none_function_name(self):
+        """None function name should fail validation."""
+        from run_agent import AIAgent as Agent
+
+        tc = self._make_tool_call(None, '{"key": "value"}')
+        assert Agent._is_valid_tool_call(tc) is False
+
+    def test_empty_arguments_string(self):
+        """Empty arguments string should fail validation."""
+        from run_agent import AIAgent as Agent
+
+        tc = self._make_tool_call("test_tool", "")
+        assert Agent._is_valid_tool_call(tc) is False
+
+    def test_invalid_json_arguments(self):
+        """Invalid JSON arguments should fail validation."""
+        from run_agent import AIAgent as Agent
+
+        tc = self._make_tool_call("test_tool", "{invalid json}")
+        assert Agent._is_valid_tool_call(tc) is False
+
+    def test_array_arguments(self):
+        """Array arguments (not object) should fail validation."""
+        from run_agent import AIAgent as Agent
+
+        tc = self._make_tool_call("test_tool", '["item1", "item2"]')
+        assert Agent._is_valid_tool_call(tc) is False
+
+    def test_primitive_arguments(self):
+        """Primitive arguments should fail validation."""
+        from run_agent import AIAgent as Agent
+
+        tc = self._make_tool_call("test_tool", '"just a string"')
+        assert Agent._is_valid_tool_call(tc) is False
+
+    def test_empty_object_arguments(self):
+        """Empty object arguments {} should pass validation."""
+        from run_agent import AIAgent as Agent
+
+        tc = self._make_tool_call("test_tool", '{}')
+        assert Agent._is_valid_tool_call(tc) is True
+
+    def test_none_arguments(self):
+        """None arguments should pass validation (provider may omit)."""
+        from run_agent import AIAgent as Agent
+
+        tc = self._make_tool_call("test_tool", None)
+        assert Agent._is_valid_tool_call(tc) is True
+
+    def test_missing_function_attribute(self):
+        """Missing function attribute should fail validation."""
+        from run_agent import AIAgent as Agent
+
+        tc = MagicMock(spec=[])  # No function attribute
+        assert Agent._is_valid_tool_call(tc) is False
+
+
+class TestSanitizeToolCallsForStrictAPI:
+    """Test the API sanitization filters malformed tool calls."""
+
+    def test_filters_empty_function_name(self):
+        """Malformed tool calls with empty name should be filtered."""
+        from run_agent import AIAgent as Agent
+
+        api_msg = {
+            "role": "assistant",
+            "tool_calls": [
+                {"id": "1", "function": {"name": "", "arguments": "{}"}},
+                {"id": "2", "function": {"name": "valid_tool", "arguments": "{}"}},
+            ]
+        }
+        result = Agent._sanitize_tool_calls_for_strict_api(api_msg)
+        assert len(result["tool_calls"]) == 1
+        assert result["tool_calls"][0]["function"]["name"] == "valid_tool"
+
+    def test_filters_invalid_json_arguments(self):
+        """Tool calls with invalid JSON arguments should be filtered."""
+        from run_agent import AIAgent as Agent
+
+        api_msg = {
+            "role": "assistant",
+            "tool_calls": [
+                {"id": "1", "function": {"name": "bad_tool", "arguments": "not json"}},
+                {"id": "2", "function": {"name": "good_tool", "arguments": '{"x": 1}'}},
+            ]
+        }
+        result = Agent._sanitize_tool_calls_for_strict_api(api_msg)
+        assert len(result["tool_calls"]) == 1
+        assert result["tool_calls"][0]["function"]["name"] == "good_tool"
+
+    def test_filters_array_arguments(self):
+        """Tool calls with array arguments should be filtered."""
+        from run_agent import AIAgent as Agent
+
+        api_msg = {
+            "role": "assistant",
+            "tool_calls": [
+                {"id": "1", "function": {"name": "array_args", "arguments": '["a", "b"]'}},
+                {"id": "2", "function": {"name": "obj_args", "arguments": '{"a": "b"}'}},
+            ]
+        }
+        result = Agent._sanitize_tool_calls_for_strict_api(api_msg)
+        assert len(result["tool_calls"]) == 1
+        assert result["tool_calls"][0]["function"]["name"] == "obj_args"
+
+    def test_strips_extra_keys(self):
+        """Extra keys like call_id should be stripped."""
+        from run_agent import AIAgent as Agent
+
+        api_msg = {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "1",
+                    "call_id": "extra_1",
+                    "response_item_id": "extra_2",
+                    "function": {"name": "test", "arguments": "{}"}
+                },
+            ]
+        }
+        result = Agent._sanitize_tool_calls_for_strict_api(api_msg)
+        assert len(result["tool_calls"]) == 1
+        assert "call_id" not in result["tool_calls"][0]
+        assert "response_item_id" not in result["tool_calls"][0]
+        assert result["tool_calls"][0]["id"] == "1"
+
+    def test_preserves_valid_tool_calls(self):
+        """Valid tool calls should be preserved unchanged (except stripped keys)."""
+        from run_agent import AIAgent as Agent
+
+        api_msg = {
+            "role": "assistant",
+            "tool_calls": [
+                {"id": "1", "type": "function", "function": {"name": "read", "arguments": '{"file": "x.txt"}'}},
+                {"id": "2", "type": "function", "function": {"name": "write", "arguments": '{"file": "y.txt", "content": "hi"}'}},
+            ]
+        }
+        result = Agent._sanitize_tool_calls_for_strict_api(api_msg)
+        assert len(result["tool_calls"]) == 2
+
+    def test_handles_empty_tool_calls(self):
+        """Empty tool_calls list should be handled gracefully."""
+        from run_agent import AIAgent as Agent
+
+        api_msg = {"role": "assistant", "tool_calls": []}
+        result = Agent._sanitize_tool_calls_for_strict_api(api_msg)
+        assert result["tool_calls"] == []
+
+    def test_handles_missing_tool_calls(self):
+        """Missing tool_calls key should be handled gracefully."""
+        from run_agent import AIAgent as Agent
+
+        api_msg = {"role": "assistant", "content": "Hello"}
+        result = Agent._sanitize_tool_calls_for_strict_api(api_msg)
+        assert "tool_calls" not in result or result.get("tool_calls") is None

--- a/uv.lock
+++ b/uv.lock
@@ -1643,7 +1643,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.7.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Problem

Malformed tool calls can poison a session and cause repeated 400 errors when replayed to strict providers. Once invalid tool calls are persisted in session history, every subsequent request fails because the same malformed history is replayed.

Observed failure mode:
```
HTTP 400: InternalError.Algo.InvalidParameter: The "function.arguments" parameter of the code model must be in JSON format.
```

This happens when persisted tool calls contain:
- Empty `function.name`
- Empty `function.arguments` string
- Non-JSON or invalid JSON arguments
- JSON arguments that are arrays or primitives instead of objects

## Solution

Adds two layers of defense:

### 1. `_is_valid_tool_call()` - Validation at persist time

Validates tool calls before persisting to session history in `_build_assistant_message()`. Invalid tool calls are logged and skipped rather than persisted:

```python
if not self._is_valid_tool_call(tool_call):
    logging.warning(f"Skipping malformed tool call: name={fn_name!r}, arguments=...")
    continue
```

### 2. `_sanitize_tool_calls_for_strict_api()` - Enhanced API-level filtering

Provides a second layer of defense by filtering malformed tool calls when preparing messages for API calls. This helps with existing poisoned sessions.

### Validation rules

- Function name must be a non-empty string
- Arguments must be valid JSON object (dict), not array or primitive
- Empty arguments string is invalid (should be `"{}"` at minimum)
- None arguments are allowed (some providers omit for empty args)

## Testing

Added comprehensive test coverage in `tests/test_tool_call_validation.py`:
- 18 tests covering all validation scenarios
- Tests for both validation function and sanitization function
- All tests pass ✅

## Fixes

Fixes #4662