### PR TITLE
fix(honcho): use get_or_create in sync_turn

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -551,12 +551,14 @@ class HonchoMemoryProvider(MemoryProvider):
         """Record the conversation turn in Honcho (non-blocking)."""
         if self._cron_skipped:
             return
-        if not self._manager or not self._session_key:
+
+        session_key = session_id or self._session_key
+        if not self._manager or not session_key:
             return
 
         def _sync():
             try:
-                session = self._manager.get_or_create(self._session_key)
+                session = self._manager.get_or_create(session_key)
                 session.add_message("user", user_content[:4000])
                 session.add_message("assistant", assistant_content[:4000])
                 # Flush to Honcho API

--- a/tests/honcho_plugin/test_async_memory.py
+++ b/tests/honcho_plugin/test_async_memory.py
@@ -263,6 +263,26 @@ class TestSaveRouting:
             mgr._cache[sess.key] = sess
         return sess
 
+    def test_sync_turn_uses_get_or_create(self):
+        from plugins.memory.honcho import HonchoMemoryProvider
+
+        provider = HonchoMemoryProvider()
+        manager = MagicMock()
+        session = MagicMock()
+        manager.get_or_create.return_value = session
+        provider._manager = manager
+        provider._session_key = "cli:test"
+        provider._cron_skipped = False
+        provider._sync_thread = None
+
+        provider.sync_turn("hello user", "hello assistant")
+        provider._sync_thread.join(timeout=2)
+
+        manager.get_or_create.assert_called_once_with("cli:test")
+        session.add_message.assert_any_call("user", "hello user")
+        session.add_message.assert_any_call("assistant", "hello assistant")
+        manager._flush_session.assert_called_once_with(session)
+
     def test_turn_flushes_immediately(self):
         mgr = _make_manager(write_frequency="turn")
         sess = self._make_session_with_message(mgr)

--- a/tests/honcho_plugin/test_async_memory.py
+++ b/tests/honcho_plugin/test_async_memory.py
@@ -263,6 +263,14 @@ class TestSaveRouting:
             mgr._cache[sess.key] = sess
         return sess
 
+    def _wait_for_thread(self, thread, timeout=2.0):
+        import time
+
+        deadline = time.time() + timeout
+        while thread.is_alive() and time.time() < deadline:
+            thread.join(timeout=0.05)
+        assert not thread.is_alive(), "background sync thread did not finish in time"
+
     def test_sync_turn_prefers_session_id(self):
         from plugins.memory.honcho import HonchoMemoryProvider
 
@@ -276,7 +284,7 @@ class TestSaveRouting:
         provider._sync_thread = None
 
         provider.sync_turn("hello user", "hello assistant", session_id="cli:live")
-        provider._sync_thread.join(timeout=2)
+        self._wait_for_thread(provider._sync_thread)
 
         manager.get_or_create.assert_called_once_with("cli:live")
         session.add_message.assert_any_call("user", "hello user")
@@ -296,7 +304,7 @@ class TestSaveRouting:
         provider._sync_thread = None
 
         provider.sync_turn("hello user", "hello assistant")
-        provider._sync_thread.join(timeout=2)
+        self._wait_for_thread(provider._sync_thread)
 
         manager.get_or_create.assert_called_once_with("cli:cached")
         session.add_message.assert_any_call("user", "hello user")

--- a/tests/honcho_plugin/test_async_memory.py
+++ b/tests/honcho_plugin/test_async_memory.py
@@ -263,7 +263,7 @@ class TestSaveRouting:
             mgr._cache[sess.key] = sess
         return sess
 
-    def test_sync_turn_uses_get_or_create(self):
+    def test_sync_turn_prefers_session_id(self):
         from plugins.memory.honcho import HonchoMemoryProvider
 
         provider = HonchoMemoryProvider()
@@ -271,14 +271,34 @@ class TestSaveRouting:
         session = MagicMock()
         manager.get_or_create.return_value = session
         provider._manager = manager
-        provider._session_key = "cli:test"
+        provider._session_key = "cli:cached"
+        provider._cron_skipped = False
+        provider._sync_thread = None
+
+        provider.sync_turn("hello user", "hello assistant", session_id="cli:live")
+        provider._sync_thread.join(timeout=2)
+
+        manager.get_or_create.assert_called_once_with("cli:live")
+        session.add_message.assert_any_call("user", "hello user")
+        session.add_message.assert_any_call("assistant", "hello assistant")
+        manager._flush_session.assert_called_once_with(session)
+
+    def test_sync_turn_falls_back_to_cached_session_key(self):
+        from plugins.memory.honcho import HonchoMemoryProvider
+
+        provider = HonchoMemoryProvider()
+        manager = MagicMock()
+        session = MagicMock()
+        manager.get_or_create.return_value = session
+        provider._manager = manager
+        provider._session_key = "cli:cached"
         provider._cron_skipped = False
         provider._sync_thread = None
 
         provider.sync_turn("hello user", "hello assistant")
         provider._sync_thread.join(timeout=2)
 
-        manager.get_or_create.assert_called_once_with("cli:test")
+        manager.get_or_create.assert_called_once_with("cli:cached")
         session.add_message.assert_any_call("user", "hello user")
         session.add_message.assert_any_call("assistant", "hello assistant")
         manager._flush_session.assert_called_once_with(session)


### PR DESCRIPTION
## What does this PR do?

This PR fixes the Honcho memory sync path so `sync_turn()` uses the provided `session_id` when one is available, and falls back to the cached session key otherwise.

That makes Honcho writes land in the correct session instead of always relying on the provider’s initialized session key, which is important for correctness in multi-session and gateway flows.

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- Updated `plugins/memory/honcho/__init__.py` so `sync_turn()` prefers the passed `session_id`
- Kept fallback behavior to `self._session_key` when no`session_id` is supplied
- Added regression coverage in `tests/honcho_plugin/test_async_memory.py`
- Verified both the preferred session-id path and the fallback path

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Run the Honcho async memory test suite:
   `python -m pytest tests/honcho_plugin/test_async_memory.py -q`
2. Confirm `sync_turn(..., session_id="cli:live")` calls `manager.get_or_create("cli:live")`
3. Confirm `sync_turn(...)` without a `session_id` falls back to the cached session key

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Test run:
`python -m pytest tests/honcho_plugin/test_async_memory.py -q`
→ 54 passed