### PR TITLE
fix(tools): validate per-call workdir and preserve resolved TERMINAL_CWD

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -130,6 +130,14 @@ if _config_path.exists():
             for _cfg_key, _env_var in _terminal_env_map.items():
                 if _cfg_key in _terminal_cfg:
                     _val = _terminal_cfg[_cfg_key]
+                    # Don't clobber an already-resolved absolute TERMINAL_CWD.
+                    # cli.py resolves "." to os.getcwd() at import time, but
+                    # this module-level code runs again when gateway/run.py is
+                    # imported as a plugin — it would overwrite the absolute
+                    # path with the raw "." and then line 208-211 falls back
+                    # to Path.home().
+                    if _cfg_key == "cwd" and os.path.isabs(os.environ.get(_env_var, "")):
+                        continue
                     if isinstance(_val, list):
                         os.environ[_env_var] = json.dumps(_val)
                     else:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1020,6 +1020,33 @@ def terminal_tool(
                     "status": "blocked"
                 }, ensure_ascii=False)
 
+        # Validate per-call workdir: fall back to session cwd if invalid.
+        # Prevents malformed paths (e.g. "/workspace/..???") from being passed
+        # directly to docker exec -w, which silently fails the command.
+        # See https://github.com/NousResearch/hermes-agent/issues/4669
+        if workdir:
+            _resolved = Path(workdir).resolve()
+            try:
+                _resolved.relative_to("/")
+            except ValueError:
+                # Path resolves outside root (malformed/relative jank) — ignore
+                logger.warning(
+                    "Invalid workdir %r resolved to %r, falling back to session cwd %r - Task: %s",
+                    workdir, str(_resolved), getattr(env, "cwd", cwd), effective_task_id,
+                )
+                workdir = None
+            # For non-local backends the path must exist inside the container.
+            # We can't stat inside the sandbox, so at minimum check it's absolute
+            # and looks sane. The backend will still fail if the dir doesn't exist
+            # inside the container, but that's an execution error, not a silent
+            # config-override bug.
+            elif not os.path.isabs(workdir):
+                logger.warning(
+                    "Relative workdir %r is ambiguous across backends, falling back to session cwd - Task: %s",
+                    workdir, effective_task_id,
+                )
+                workdir = None
+
         # Prepare command for execution
         if background:
             # Spawn a tracked background process via the process registry.


### PR DESCRIPTION
Fixes #4669 and #4672.

## Summary

Two related bugs where `terminal.cwd` gets silently overridden by downstream code that doesn't validate/resolve the path properly.

### #4672 — gateway/run.py clobbers resolved TERMINAL_CWD

`cli.py` resolves `terminal.cwd: "."` to `os.getcwd()` at import time, but `gateway/run.py` re-bridges the config and sets `TERMINAL_CWD = "."` (raw string) when imported as a plugin. This overwrites the absolute path, and later code falls back to `Path.home()`.

**Fix:** Skip the `cwd` key in gateway's terminal env bridge when `TERMINAL_CWD` is already an absolute path.

### #4669 — terminal tool passes invalid workdir to Docker exec

When a per-call `workdir` is provided but invalid (e.g. `/workspace/..???`), it gets passed straight to `docker exec -w <invalid-path>`, causing silent command failures. This makes it look like Docker is ignoring `terminal.cwd`, but the real problem is that invalid per-call `workdir` overrides the session cwd without validation.

**Fix:** Validate `workdir` before passing to `env.execute()`. If the path is malformed or relative (ambiguous in container backends), fall back to the session cwd with a warning log.

## Changes

- `gateway/run.py` — skip clobbering already-resolved TERMINAL_CWD
- `tools/terminal_tool.py` — validate workdir, fall back to session cwd if invalid