### PR TITLE
fix: allow running gateway service as root for LXC/container environments

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -258,8 +258,11 @@ def _system_service_identity(run_as_user: str | None = None) -> tuple[str, str, 
     username = (run_as_user or os.getenv("SUDO_USER") or os.getenv("USER") or os.getenv("LOGNAME") or getpass.getuser()).strip()
     if not username:
         raise ValueError("Could not determine which user the gateway service should run as")
+    if username == "root" and not run_as_user:
+        raise ValueError("Refusing to install the gateway system service as root; pass --run-as-user root to override (e.g. in LXC containers)")
     if username == "root":
-        raise ValueError("Refusing to install the gateway system service as root; pass --run-as USER")
+        print_warning("Installing gateway service to run as root.")
+        print_info("  This is fine for LXC/container environments but not recommended on bare-metal hosts.")
 
     try:
         user_info = pwd.getpwnam(username)
@@ -321,9 +324,9 @@ def install_linux_gateway_from_setup(force: bool = False) -> tuple[str | None, b
             while True:
                 run_as_user = prompt("  Run the system gateway service as which user?", default="")
                 run_as_user = (run_as_user or "").strip()
-                if run_as_user and run_as_user != "root":
+                if run_as_user:
                     break
-                print_error("  Enter a non-root username.")
+                print_error("  Enter a username.")
 
         systemd_install(force=force, system=True, run_as_user=run_as_user)
         return scope, True

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -466,6 +466,51 @@ class TestGeneratedUnitIncludesLocalBin:
         assert "/.local/bin" in unit
 
 
+class TestSystemServiceIdentityRootHandling:
+    """Root user handling in _system_service_identity()."""
+
+    def test_auto_detected_root_is_rejected(self, monkeypatch):
+        """When root is auto-detected (not explicitly requested), raise."""
+        import pwd
+        import grp
+
+        monkeypatch.delenv("SUDO_USER", raising=False)
+        monkeypatch.setenv("USER", "root")
+        monkeypatch.setenv("LOGNAME", "root")
+
+        import pytest
+        with pytest.raises(ValueError, match="pass --run-as-user root to override"):
+            gateway_cli._system_service_identity(run_as_user=None)
+
+    def test_explicit_root_is_allowed(self, monkeypatch):
+        """When root is explicitly passed via --run-as-user root, allow it."""
+        import pwd
+        import grp
+
+        root_info = pwd.getpwnam("root")
+        root_group = grp.getgrgid(root_info.pw_gid).gr_name
+
+        username, group, home = gateway_cli._system_service_identity(run_as_user="root")
+        assert username == "root"
+        assert home == root_info.pw_dir
+
+    def test_non_root_user_passes_through(self, monkeypatch):
+        """Normal non-root user works as before."""
+        import pwd
+        import grp
+
+        monkeypatch.delenv("SUDO_USER", raising=False)
+        monkeypatch.setenv("USER", "nobody")
+        monkeypatch.setenv("LOGNAME", "nobody")
+
+        try:
+            username, group, home = gateway_cli._system_service_identity(run_as_user=None)
+            assert username == "nobody"
+        except ValueError as e:
+            # "nobody" might not exist on all systems
+            assert "Unknown user" in str(e)
+
+
 class TestEnsureUserSystemdEnv:
     """Tests for _ensure_user_systemd_env() D-Bus session bus auto-detection."""
 


### PR DESCRIPTION
## Summary

Community users running Hermes in LXC containers (where root is the only user) were forced to comment out source code to install the gateway as a systemd service. The root check in `_system_service_identity()` hard-refused `username == "root"` regardless of whether it was explicitly requested.

**What changed:**
- Auto-detected root (env vars resolve to root, no `--run-as-user` flag) → still refused, but error message now explains how to override
- Explicit `--run-as-user root` → allowed with a warning about security implications
- Interactive setup wizard prompt → accepts "root" as a valid username (warning comes downstream)

**Behavior:**
```bash
# In LXC as root — this now works:
sudo hermes gateway install --system --run-as-user root

# Without explicit flag — still refused with helpful message:
sudo hermes gateway install --system
# → 'Refusing to install ... pass --run-as-user root to override (e.g. in LXC containers)'
```

## Files changed
- `hermes_cli/gateway.py` — 3 touch points: `_system_service_identity()`, `install_linux_gateway_from_setup()`
- `tests/hermes_cli/test_gateway_service.py` — 3 new tests covering auto-detected rejection, explicit allowance, non-root passthrough

## Test plan
- `pytest tests/hermes_cli/test_gateway_service.py` — 39 passed
- Full suite: 7774 passed (13 pre-existing failures unrelated to this change)

Addresses community feedback from NathanOP and marioo9277 on Discord.