### PR TITLE
Fire on_session_start before building the system prompt

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6500,12 +6500,13 @@ class AIAgent:
                 # the previous turn so the Anthropic cache prefix matches.
                 self._cached_system_prompt = stored_prompt
             else:
-                # First turn of a new session — build from scratch.
-                self._cached_system_prompt = self._build_system_prompt(system_message)
                 # Plugin hook: on_session_start
                 # Fired once when a brand-new session is created (not on
                 # continuation).  Plugins can use this to initialise
                 # session-scoped state (e.g. warm a memory cache).
+                # Runs BEFORE _build_system_prompt so plugins that write
+                # context files (AGENTS.md, CLAUDE.md, etc.) are visible
+                # to the system prompt builder on the first session.
                 try:
                     from hermes_cli.plugins import invoke_hook as _invoke_hook
                     _invoke_hook(
@@ -6516,6 +6517,9 @@ class AIAgent:
                     )
                 except Exception as exc:
                     logger.warning("on_session_start hook failed: %s", exc)
+
+                # First turn of a new session — build from scratch.
+                self._cached_system_prompt = self._build_system_prompt(system_message)
 
                 # Store the system prompt snapshot in SQLite
                 if self._session_db:


### PR DESCRIPTION
## Summary

- Move the `on_session_start` plugin hook to fire **before** `_build_system_prompt()` instead of after
- Plugins that write context files (AGENTS.md, CLAUDE.md, .hermes.md) during `on_session_start` need those files to exist before the system prompt builder reads them
- Previously the hook fired after the prompt was already built and cached, so plugin-written context files were invisible until the second session

## Motivation

The enzyme plugin runs `enzyme init` during `on_session_start`, which writes an enzyme instruction section to the vault's context file (AGENTS.md or CLAUDE.md). Because `_build_system_prompt` runs first, the context file isn't picked up until the next session — making the first session a degraded experience that requires a `pre_llm_call` workaround.

## Change

One-line reorder — the hook block moves above the `_build_system_prompt` call. No change to hook semantics, API, or return value handling. Hooks that don't write context files are unaffected.

## Test plan

- [ ] Verify existing plugins still work (on_session_start fires, tools register, hooks execute)
- [ ] Verify a plugin that writes AGENTS.md in on_session_start has its content visible in the system prompt on the first session
- [ ] Verify continued sessions still reuse the stored prompt (the `stored_prompt` path is unchanged)