### PR TITLE
fix(approval): load permanent command allowlist on startup

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -588,3 +588,7 @@ def check_all_command_guards(command: str, env_type: str,
             save_permanent_allowlist(_permanent_approved)
 
     return {"approved": True, "message": None}
+
+
+# Load permanent allowlist from config on module import
+load_permanent_allowlist()


### PR DESCRIPTION
## What does this PR do?

Calls `load_permanent_allowlist()` at module import time in `tools/approval.py` so that permanently approved command patterns persisted in `config.yaml` are actually loaded back into memory on restart.

Currently, `save_permanent_allowlist()` correctly writes patterns to disk when a user chooses `/approve always`, but `load_permanent_allowlist()` — though fully implemented — is never called anywhere. This means all "permanent" approvals are silently lost after every restart.

## Related Issue

Fixes #4739

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/approval.py`: Added `load_permanent_allowlist()` call at module level (end of file) so it executes on import

## How to Test

1. Run hermes with `approvals.mode: manual`
2. Trigger a dangerous command (e.g., `python3 -c "print('hello')"`)
3. Approve with `/approve always`
4. Verify `command_allowlist` in `config.yaml` contains the pattern
5. Restart the gateway
6. Trigger the same command again
7. Confirm the command is auto-approved without re-prompting

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 24.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A