### PR TITLE
feat(skills): log patch/edit history to per-skill patch_history.jsonl

### DIFF
--- a/tests/tools/test_log_patch.py
+++ b/tests/tools/test_log_patch.py
@@ -1,0 +1,117 @@
+"""Tests for _log_patch() — skill patch/edit history logging."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from tools.skill_manager_tool import _log_patch
+
+
+SKILL_NAME = "test-skill"
+
+
+def _make_skill_dir(tmp_path):
+    skill_dir = tmp_path / "skills" / SKILL_NAME
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# Test", encoding="utf-8")
+    return skill_dir
+
+
+def _read_history(skill_dir):
+    history = skill_dir / "patch_history.jsonl"
+    if not history.exists():
+        return []
+    return [json.loads(line) for line in history.read_text(encoding="utf-8").splitlines()]
+
+
+class TestLogPatch:
+    def test_patch_creates_record(self, tmp_path):
+        skill_dir = _make_skill_dir(tmp_path)
+        with patch("tools.skill_manager_tool._find_skill", return_value={"path": skill_dir}):
+            _log_patch(SKILL_NAME, "patch", None, "old text", "new text")
+        records = _read_history(skill_dir)
+        assert len(records) == 1
+        r = records[0]
+        assert r["schema_version"] == 1
+        assert r["skill"] == SKILL_NAME
+        assert r["action"] == "patch"
+        assert r["file"] == "SKILL.md"
+        assert r["old_text_preview"] == "old text"
+        assert r["new_text_preview"] == "new text"
+        assert "timestamp" in r
+
+    def test_edit_creates_record_with_content(self, tmp_path):
+        skill_dir = _make_skill_dir(tmp_path)
+        with patch("tools.skill_manager_tool._find_skill", return_value={"path": skill_dir}):
+            _log_patch(SKILL_NAME, "edit", old_text="old content", new_text="new content")
+        records = _read_history(skill_dir)
+        assert len(records) == 1
+        assert records[0]["action"] == "edit"
+        assert records[0]["old_text_preview"] == "old content"
+        assert records[0]["new_text_preview"] == "new content"
+
+    def test_empty_string_replacement_is_logged(self, tmp_path):
+        """Replacing text with empty string should still log previews."""
+        skill_dir = _make_skill_dir(tmp_path)
+        with patch("tools.skill_manager_tool._find_skill", return_value={"path": skill_dir}):
+            _log_patch(SKILL_NAME, "patch", None, "delete me", "")
+        records = _read_history(skill_dir)
+        assert len(records) == 1
+        assert records[0]["old_text_preview"] == "delete me"
+        assert records[0]["new_text_preview"] == ""
+
+    def test_none_text_omits_preview_fields(self, tmp_path):
+        skill_dir = _make_skill_dir(tmp_path)
+        with patch("tools.skill_manager_tool._find_skill", return_value={"path": skill_dir}):
+            _log_patch(SKILL_NAME, "edit")
+        records = _read_history(skill_dir)
+        assert "old_text_preview" not in records[0]
+        assert "new_text_preview" not in records[0]
+
+    def test_truncation_at_200_chars(self, tmp_path):
+        skill_dir = _make_skill_dir(tmp_path)
+        long_text = "x" * 500
+        with patch("tools.skill_manager_tool._find_skill", return_value={"path": skill_dir}):
+            _log_patch(SKILL_NAME, "patch", None, long_text, long_text)
+        records = _read_history(skill_dir)
+        assert len(records[0]["old_text_preview"]) == 200
+        assert len(records[0]["new_text_preview"]) == 200
+
+    def test_multiple_appends_preserve_prior(self, tmp_path):
+        skill_dir = _make_skill_dir(tmp_path)
+        with patch("tools.skill_manager_tool._find_skill", return_value={"path": skill_dir}):
+            _log_patch(SKILL_NAME, "patch", None, "a", "b")
+            _log_patch(SKILL_NAME, "edit", old_text="c", new_text="d")
+            _log_patch(SKILL_NAME, "patch", "refs/notes.md", "e", "f")
+        records = _read_history(skill_dir)
+        assert len(records) == 3
+        assert records[0]["action"] == "patch"
+        assert records[1]["action"] == "edit"
+        assert records[2]["file"] == "refs/notes.md"
+
+    def test_missing_skill_does_not_crash(self):
+        with patch("tools.skill_manager_tool._find_skill", return_value=None):
+            _log_patch("nonexistent", "patch", None, "a", "b")  # should not raise
+
+    def test_write_failure_does_not_crash(self, tmp_path):
+        """Logging failure must not break the skill edit/patch operation."""
+        skill_dir = _make_skill_dir(tmp_path)
+        # Make history file a directory to force write error
+        (skill_dir / "patch_history.jsonl").mkdir()
+        with patch("tools.skill_manager_tool._find_skill", return_value={"path": skill_dir}):
+            _log_patch(SKILL_NAME, "patch", None, "a", "b")  # should not raise
+
+    def test_unicode_content(self, tmp_path):
+        skill_dir = _make_skill_dir(tmp_path)
+        with patch("tools.skill_manager_tool._find_skill", return_value={"path": skill_dir}):
+            _log_patch(SKILL_NAME, "patch", None, "stary tekst ąęół", "nowy tekst 日本語")
+        records = _read_history(skill_dir)
+        assert "ąęół" in records[0]["old_text_preview"]
+        assert "日本語" in records[0]["new_text_preview"]
+
+    def test_custom_file_path(self, tmp_path):
+        skill_dir = _make_skill_dir(tmp_path)
+        with patch("tools.skill_manager_tool._find_skill", return_value={"path": skill_dir}):
+            _log_patch(SKILL_NAME, "patch", "scripts/helper.py", "old", "new")
+        records = _read_history(skill_dir)
+        assert records[0]["file"] == "scripts/helper.py"

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -40,6 +40,7 @@ import shutil
 import tempfile
 from pathlib import Path
 from hermes_constants import get_hermes_home
+from datetime import datetime, timezone
 from typing import Dict, Any, Optional
 
 logger = logging.getLogger(__name__)
@@ -214,6 +215,37 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     return None
 
 
+# Note: Assumes single-process execution. No file locking needed.
+def _log_patch(
+    skill_name: str,
+    action: str,
+    file_path: str = None,
+    old_text: str = None,
+    new_text: str = None,
+) -> None:
+    """Append a patch/edit record to the skill's patch_history.jsonl for auditability."""
+    skill_info = _find_skill(skill_name)
+    if not skill_info:
+        return
+    history_file = skill_info["path"] / "patch_history.jsonl"
+    record = {
+        "schema_version": 1,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "skill": skill_name,
+        "action": action,
+        "file": file_path or "SKILL.md",
+    }
+    if old_text is not None:
+        record["old_text_preview"] = old_text[:200]
+    if new_text is not None:
+        record["new_text_preview"] = new_text[:200]
+    try:
+        with open(history_file, "a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+    except Exception as e:
+        logger.warning("Failed to log patch history for %s", skill_name, exc_info=True)
+
+
 def _validate_file_path(file_path: str) -> Optional[str]:
     """
     Validate a file path for write_file/remove_file.
@@ -359,6 +391,7 @@ def _edit_skill(name: str, content: str) -> Dict[str, Any]:
             _atomic_write_text(skill_md, original_content)
         return {"success": False, "error": scan_error}
 
+    _log_patch(name, "edit", old_text=original_content, new_text=content)
     return {
         "success": True,
         "message": f"Skill '{name}' updated.",
@@ -446,6 +479,7 @@ def _patch_skill(
         _atomic_write_text(target, original_content)
         return {"success": False, "error": scan_error}
 
+    _log_patch(name, "patch", file_path, old_string, new_string)
     return {
         "success": True,
         "message": f"Patched {'SKILL.md' if not file_path else file_path} in skill '{name}' ({match_count} replacement{'s' if match_count > 1 else ''}).",


### PR DESCRIPTION
## What does this PR do?

Adds a lightweight audit trail for skill modifications. Each time a skill is edited or patched via `skill_manage()`, a JSONL record is appended to `patch_history.jsonl` in the skill's directory.

## Related Issue

Closes #3626

## Type of Change

- ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- Added `_log_patch()` helper (+30 lines) in `tools/skill_manager_tool.py`, inserted after `_find_skill()`
- Two call sites: `_edit_skill()` and `_patch_skill()`, both called after successful write + security scan
- New test file: `tests/tools/test_log_patch.py` (10 tests)

### Record schema

```json
{"schema_version": 1, "timestamp": "2026-04-03T09:15:00+00:00", "skill": "my-skill", "action": "patch", "file": "SKILL.md", "old_text_preview": "...", "new_text_preview": "..."}
```

### Design decisions

- **Per-skill JSONL** (Option A from #3626): history travels with the skill, no global lock, simple to inspect
- **Append-only**: single `open("a")` per record, single-process assumption documented
- **Best-effort**: logging failure emits `logger.warning` with traceback but never blocks the skill operation
- **Truncation**: old/new text previews capped at 200 chars
- **`is not None` checks**: empty-string replacements are correctly logged (not skipped)

## How to Test

```bash
source venv/bin/activate
python -m pytest tests/tools/test_log_patch.py tests/tools/test_skill_manager_tool.py -q
# Expected: 61 passed
```

Or manually:
1. Edit or patch any skill via the agent
2. Check `~/.hermes/skills/<skill-name>/patch_history.jsonl`

## Checklist

### Code
- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Searched for existing PRs
- [x] PR contains only changes related to this feature
- [x] `pytest tests/tools/test_log_patch.py tests/tools/test_skill_manager_tool.py -q` — 61 passed
- [x] Added tests (10 new tests)
- [x] Tested on: Ubuntu Linux

### Documentation & Housekeeping
- [x] N/A — no config keys added
- [x] N/A — no tool schema changes
- [x] Considered cross-platform impact: uses only stdlib (`json`, `datetime`, `open`)