### PR TITLE
fix(hindsight): correct client constructor, add configurable base_url, and fix sequential tool dispatch

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -140,6 +140,7 @@ def _load_config() -> dict:
 
     return {
         "mode": os.environ.get("HINDSIGHT_MODE", "cloud"),
+        "api_url": os.environ.get("HINDSIGHT_API_URL", ""),
         "apiKey": os.environ.get("HINDSIGHT_API_KEY", ""),
         "banks": {
             "hermes": {
@@ -204,6 +205,7 @@ class HindsightMemoryProvider(MemoryProvider):
     def get_config_schema(self):
         return [
             {"key": "mode", "description": "Cloud API or local embedded mode", "default": "cloud", "choices": ["cloud", "local"]},
+            {"key": "api_url", "description": "Hindsight API endpoint URL (for self-hosted instances)", "default": _DEFAULT_API_URL, "env_var": "HINDSIGHT_API_URL"},
             {"key": "api_key", "description": "Hindsight Cloud API key", "secret": True, "env_var": "HINDSIGHT_API_KEY", "url": "https://app.hindsight.vectorize.io"},
             {"key": "bank_id", "description": "Memory bank identifier", "default": "hermes"},
             {"key": "budget", "description": "Recall thoroughness", "default": "mid", "choices": ["low", "mid", "high"]},
@@ -224,7 +226,8 @@ class HindsightMemoryProvider(MemoryProvider):
                 llm_model=embed.get("llmModel", ""),
             )
         from hindsight_client import Hindsight
-        return Hindsight(api_key=self._api_key, timeout=30.0)
+        base_url = self._config.get("api_url", "") or os.environ.get("HINDSIGHT_API_URL", "") or _DEFAULT_API_URL
+        return Hindsight(base_url=base_url, api_key=self._api_key, timeout=120.0)
 
     def initialize(self, session_id: str, **kwargs) -> None:
         self._config = _load_config()

--- a/run_agent.py
+++ b/run_agent.py
@@ -6009,6 +6009,11 @@ class AIAgent:
                         spinner.stop(cute_msg)
                     elif self.quiet_mode:
                         self._vprint(f"  {cute_msg}")
+            elif self._memory_manager and self._memory_manager.has_tool(function_name):
+                function_result = self._memory_manager.handle_tool_call(function_name, function_args)
+                tool_duration = time.time() - tool_start_time
+                if self.quiet_mode:
+                    self._vprint(f"  {_get_cute_tool_message_impl(function_name, function_args, tool_duration, result=function_result)}")
             elif self.quiet_mode:
                 spinner = None
                 if not self.tool_progress_callback:


### PR DESCRIPTION
## Summary

Two related fixes for the Hindsight memory plugin.

### Fix 1: incorrect constructor arguments (broken in cloud mode)

`_make_client()` passed `api_key` as the first positional argument to `Hindsight()`, but the constructor expects `base_url` first. The plugin never worked in cloud mode.

```python
# Before (broken)
return Hindsight(api_key=*** timeout=30.0)

# After (fixed)
return Hindsight(base_url=base_url, api_key=*** timeout=120.0)
```

Also adds configurable `api_url` for self-hosted Docker instances (config, env var, setup wizard).

### Fix 2: memory tools not dispatched in sequential path

Memory provider tools (`hindsight_retain/recall/reflect`) were only dispatched in the concurrent tool call path (`_invoke_tool`). The sequential path (`_execute_tool_calls_sequential`) fell through to `handle_function_call()` which returned `"Unknown tool"` — so the tools only worked when multiple tools were called concurrently.

## Changes

**`plugins/memory/hindsight/__init__.py`**
- `_load_config()`: add `api_url` from `HINDSIGHT_API_URL` env var
- `get_config_schema()`: add `api_url` field with env var hint
- `_make_client()`: resolve `base_url` from config → env → default; pass as first arg; timeout 120s

**`run_agent.py`**
- `_execute_tool_calls_sequential()`: add `memory_manager.has_tool()` guard matching the concurrent path

## Pre-existing code referenced in this PR

These are **not** introduced by this PR — they already exist on `main`:

- `_DEFAULT_API_URL` → `plugins/memory/hindsight/__init__.py:32`
- `has_tool()` → `agent/memory_manager.py:207`
- `handle_tool_call()` → `agent/memory_manager.py:211` (dispatcher, implemented by every memory plugin)

Verifiable on `main`:

```bash
gh api 'repos/NousResearch/hermes-agent/contents/plugins/memory/hindsight/__init__.py?ref=main' -q '.content' | base64 -d | grep -n _DEFAULT_API_URL
# Output: 32:_DEFAULT_API_URL = "https://api.hindsight.vectorize.io"

gh api 'repos/NousResearch/hermes-agent/contents/agent/memory_manager.py?ref=main' -q '.content' | base64 -d | grep -nE 'def has_tool|def handle_tool_call'
# Output:
# 207:    def has_tool(self, tool_name: str) -> bool:
# 211:    def handle_tool_call(
```

## Testing

- ✅ Tested locally with self-hosted Docker Hindsight (localhost:8888)
- ✅ Pipeline works: `retain` → `recall` → `reflect` all functional
- ✅ Sequential and concurrent tool dispatch both work
- ✅ No existing tests broken (Hindsight tests use FakeMemoryProvider)