### PR TITLE
feat(signal): add reactions, native audio, and threading

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -258,8 +258,16 @@ PLATFORM_HINTS = {
         "You can send media files natively: to deliver a file to the user, "
         "include MEDIA:/absolute/path/to/file in your response. Images "
         "(.png, .jpg, .webp) appear as photos, audio as attachments, and other "
-        "files arrive as downloadable documents. You can also include image "
-        "URLs in markdown format ![alt](url) and they will be sent as photos."
+        "files arrive as downloadable documents. The text_to_speech tool is "
+        "available for voice replies. You can also include image URLs in "
+        "markdown format ![alt](url) and they will be sent as photos. "
+        "You also have a react_message tool for native emoji reactions. Use it "
+        "like a normal human when it feels natural — for funny, sweet, surprising, "
+        "or celebratory messages — aiming for roughly 30% of socially expressive "
+        "messages, but avoid reacting to dry transactional requests. Normal "
+        "Signal responses are not threaded by default. If you specifically want "
+        "to send your next response as a native Signal reply to the current user "
+        "message, include [[reply_to_current]] somewhere in that response."
     ),
     "email": (
         "You are communicating via email. Write clear, well-structured responses "

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -568,6 +568,15 @@ class BasePlatformAdapter(ABC):
         """Whether reply delivery needs author/text metadata in addition to reply_to."""
         return False
 
+    def should_send_text_after_auto_tts(self, event: MessageEvent) -> bool:
+        """Whether a successful auto-TTS voice reply should still be followed by text.
+
+        Most platforms keep the historical Hermes behavior of sending both
+        audio and text. Platforms can override this for a more native voice-note
+        experience.
+        """
+        return True
+
     async def edit_message(
         self,
         chat_id: str,
@@ -1244,6 +1253,7 @@ class BasePlatformAdapter(ABC):
                         logger.warning("[%s] Auto-TTS failed: %s", self.name, tts_err)
 
                 # Play TTS audio before text (voice-first experience)
+                auto_tts_sent = False
                 if _tts_path and Path(_tts_path).exists():
                     try:
                         tts_result = await self.play_tts(
@@ -1253,6 +1263,7 @@ class BasePlatformAdapter(ABC):
                             metadata=delivery_metadata,
                         )
                         _record_delivery(tts_result)
+                        auto_tts_sent = bool(tts_result and getattr(tts_result, "success", False))
                     finally:
                         try:
                             os.remove(_tts_path)
@@ -1260,7 +1271,9 @@ class BasePlatformAdapter(ABC):
                             pass
 
                 # Send the text portion
-                if text_content:
+                if text_content and not (
+                    auto_tts_sent and not self.should_send_text_after_auto_tts(event)
+                ):
                     logger.info("[%s] Sending response (%d chars) to %s", self.name, len(text_content), event.source.chat_id)
                     result = await self._send_with_retry(
                         chat_id=event.source.chat_id,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -555,6 +555,19 @@ class BasePlatformAdapter(ABC):
         """
         pass
 
+    def get_default_reply_target(self, event: MessageEvent) -> Optional[str]:
+        """Return the platform's default reply target for normal assistant responses.
+
+        Most messaging adapters keep the existing Hermes behavior of replying to
+        the inbound message by default. Platforms can override this to opt out
+        and rely on explicit agent directives instead.
+        """
+        return event.message_id
+
+    def requires_reply_context_metadata(self) -> bool:
+        """Whether reply delivery needs author/text metadata in addition to reply_to."""
+        return False
+
     async def edit_message(
         self,
         chat_id: str,
@@ -1146,6 +1159,19 @@ class BasePlatformAdapter(ABC):
             if getattr(result, "success", False):
                 delivery_succeeded = True
 
+        def _build_response_metadata(include_reply_context: bool = False) -> Optional[Dict[str, Any]]:
+            metadata: Dict[str, Any] = {}
+            if event.source.thread_id:
+                metadata["thread_id"] = event.source.thread_id
+            if include_reply_context and event.message_id:
+                metadata["reply_to_message_id"] = event.message_id
+                metadata["reply_to_author"] = event.source.user_id
+                if event.source.user_id_alt:
+                    metadata["reply_to_author_alt"] = event.source.user_id_alt
+            if include_reply_context and event.text:
+                metadata["reply_to_text"] = event.text[:1000]
+            return metadata or None
+
         # Reuse the interrupt event set by handle_message() (which marks
         # the session active before spawning this task to prevent races).
         # Fall back to a new Event only if the entry was removed externally.
@@ -1153,7 +1179,7 @@ class BasePlatformAdapter(ABC):
         self._active_sessions[session_key] = interrupt_event
         
         # Start continuous typing indicator (refreshes every 2 seconds)
-        _thread_metadata = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+        _thread_metadata = _build_response_metadata()
         typing_task = asyncio.create_task(self._keep_typing(event.source.chat_id, metadata=_thread_metadata))
         
         try:
@@ -1171,11 +1197,20 @@ class BasePlatformAdapter(ABC):
             if response:
                 # Extract MEDIA:<path> tags (from TTS tool) before other processing
                 media_files, response = self.extract_media(response)
+                force_reply_to_current = "[[reply_to_current]]" in response
+                default_reply_to = self.get_default_reply_target(event)
+                reply_target = event.message_id if force_reply_to_current else default_reply_to
+                delivery_metadata = _build_response_metadata(
+                    include_reply_context=bool(
+                        reply_target and self.requires_reply_context_metadata()
+                    )
+                )
                 
                 # Extract image URLs and send them as native platform attachments
                 images, text_content = self.extract_images(response)
                 # Strip any remaining internal directives from message body (fixes #1561)
                 text_content = text_content.replace("[[audio_as_voice]]", "").strip()
+                text_content = text_content.replace("[[reply_to_current]]", "").strip()
                 text_content = re.sub(r"MEDIA:\s*\S+", "", text_content).strip()
                 if images:
                     logger.info("[%s] extract_images found %d image(s) in response (%d chars)", self.name, len(images), len(response))
@@ -1211,11 +1246,13 @@ class BasePlatformAdapter(ABC):
                 # Play TTS audio before text (voice-first experience)
                 if _tts_path and Path(_tts_path).exists():
                     try:
-                        await self.play_tts(
+                        tts_result = await self.play_tts(
                             chat_id=event.source.chat_id,
                             audio_path=_tts_path,
-                            metadata=_thread_metadata,
+                            reply_to=reply_target,
+                            metadata=delivery_metadata,
                         )
+                        _record_delivery(tts_result)
                     finally:
                         try:
                             os.remove(_tts_path)
@@ -1228,8 +1265,8 @@ class BasePlatformAdapter(ABC):
                     result = await self._send_with_retry(
                         chat_id=event.source.chat_id,
                         content=text_content,
-                        reply_to=event.message_id,
-                        metadata=_thread_metadata,
+                        reply_to=reply_target,
+                        metadata=delivery_metadata,
                     )
                     _record_delivery(result)
 
@@ -1250,15 +1287,18 @@ class BasePlatformAdapter(ABC):
                                 chat_id=event.source.chat_id,
                                 animation_url=image_url,
                                 caption=alt_text if alt_text else None,
-                                metadata=_thread_metadata,
+                                reply_to=reply_target,
+                                metadata=delivery_metadata,
                             )
                         else:
                             img_result = await self.send_image(
                                 chat_id=event.source.chat_id,
                                 image_url=image_url,
                                 caption=alt_text if alt_text else None,
-                                metadata=_thread_metadata,
+                                reply_to=reply_target,
+                                metadata=delivery_metadata,
                             )
+                        _record_delivery(img_result)
                         if not img_result.success:
                             logger.error("[%s] Failed to send image: %s", self.name, img_result.error)
                     except Exception as img_err:
@@ -1278,27 +1318,32 @@ class BasePlatformAdapter(ABC):
                             media_result = await self.send_voice(
                                 chat_id=event.source.chat_id,
                                 audio_path=media_path,
-                                metadata=_thread_metadata,
+                                reply_to=reply_target,
+                                metadata=delivery_metadata,
                             )
                         elif ext in _VIDEO_EXTS:
                             media_result = await self.send_video(
                                 chat_id=event.source.chat_id,
                                 video_path=media_path,
-                                metadata=_thread_metadata,
+                                reply_to=reply_target,
+                                metadata=delivery_metadata,
                             )
                         elif ext in _IMAGE_EXTS:
                             media_result = await self.send_image_file(
                                 chat_id=event.source.chat_id,
                                 image_path=media_path,
-                                metadata=_thread_metadata,
+                                reply_to=reply_target,
+                                metadata=delivery_metadata,
                             )
                         else:
                             media_result = await self.send_document(
                                 chat_id=event.source.chat_id,
                                 file_path=media_path,
-                                metadata=_thread_metadata,
+                                reply_to=reply_target,
+                                metadata=delivery_metadata,
                             )
 
+                        _record_delivery(media_result)
                         if not media_result.success:
                             logger.warning("[%s] Failed to send media (%s): %s", self.name, ext, media_result.error)
                     except Exception as media_err:
@@ -1311,23 +1356,27 @@ class BasePlatformAdapter(ABC):
                     try:
                         ext = Path(file_path).suffix.lower()
                         if ext in _IMAGE_EXTS:
-                            await self.send_image_file(
+                            file_result = await self.send_image_file(
                                 chat_id=event.source.chat_id,
                                 image_path=file_path,
-                                metadata=_thread_metadata,
+                                reply_to=reply_target,
+                                metadata=delivery_metadata,
                             )
                         elif ext in _VIDEO_EXTS:
-                            await self.send_video(
+                            file_result = await self.send_video(
                                 chat_id=event.source.chat_id,
                                 video_path=file_path,
-                                metadata=_thread_metadata,
+                                reply_to=reply_target,
+                                metadata=delivery_metadata,
                             )
                         else:
-                            await self.send_document(
+                            file_result = await self.send_document(
                                 chat_id=event.source.chat_id,
                                 file_path=file_path,
-                                metadata=_thread_metadata,
+                                reply_to=reply_target,
+                                metadata=delivery_metadata,
                             )
+                        _record_delivery(file_result)
                     except Exception as file_err:
                         logger.error("[%s] Error sending local file %s: %s", self.name, file_path, file_err)
 
@@ -1361,7 +1410,7 @@ class BasePlatformAdapter(ABC):
             try:
                 error_type = type(e).__name__
                 error_detail = str(e)[:300] if str(e) else "no details available"
-                _thread_metadata = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+                _thread_metadata = _build_response_metadata()
                 await self.send(
                     chat_id=event.source.chat_id,
                     content=(

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -215,6 +215,10 @@ class SignalAdapter(BasePlatformAdapter):
         """Signal quote replies need author/text metadata in the send payload."""
         return True
 
+    def should_send_text_after_auto_tts(self, event: MessageEvent) -> bool:
+        """Signal voice-note replies should not duplicate the same content as text."""
+        return False
+
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -118,6 +118,23 @@ def _ext_to_mime(ext: str) -> str:
     return _EXT_TO_MIME.get(ext.lower(), "application/octet-stream")
 
 
+def _file_to_data_uri(file_path: str, mime_type: str) -> str:
+    """Encode a local file as a filename-less data URI for Signal attachments."""
+    raw = Path(file_path).read_bytes()
+    encoded = base64.b64encode(raw).decode("ascii")
+    return f"data:{mime_type};base64,{encoded}"
+
+
+def _coerce_timestamp(value: Any) -> Optional[int]:
+    """Normalize timestamp-like values to Signal millisecond integers."""
+    if value in (None, ""):
+        return None
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
 def _render_mentions(text: str, mentions: list) -> str:
     """Replace Signal mention placeholders (\\uFFFC) with readable @identifiers.
 
@@ -189,6 +206,14 @@ class SignalAdapter(BasePlatformAdapter):
         logger.info("Signal adapter initialized: url=%s account=%s groups=%s",
                      self.http_url, _redact_phone(self.account),
                      "enabled" if self.group_allow_from else "disabled")
+
+    def get_default_reply_target(self, event: MessageEvent) -> Optional[str]:
+        """Signal should only use native quote replies when the agent opts in."""
+        return None
+
+    def requires_reply_context_metadata(self) -> bool:
+        """Signal quote replies need author/text metadata in the send payload."""
+        return True
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -450,6 +475,10 @@ class SignalAdapter(BasePlatformAdapter):
         if not data_message:
             return
 
+        # Reaction events are transport state, not chat prompts for Hermes.
+        if data_message.get("reaction") and not data_message.get("message") and not data_message.get("attachments"):
+            return
+
         # Check for group message
         group_info = data_message.get("groupInfo")
         group_id = group_info.get("groupId") if group_info else None
@@ -477,6 +506,10 @@ class SignalAdapter(BasePlatformAdapter):
         mentions = data_message.get("mentions", [])
         if text and mentions:
             text = _render_mentions(text, mentions)
+
+        quote_data = data_message.get("quote") if isinstance(data_message.get("quote"), dict) else {}
+        reply_to_id = str(quote_data.get("id")) if quote_data.get("id") is not None else None
+        reply_to_text = str(quote_data.get("text") or "").strip() or None
 
         # Process attachments
         attachments_data = data_message.get("attachments", [])
@@ -536,8 +569,12 @@ class SignalAdapter(BasePlatformAdapter):
             source=source,
             text=text or "",
             message_type=msg_type,
+            raw_message=envelope_data,
+            message_id=str(ts_ms) if ts_ms else None,
             media_urls=media_urls,
             media_types=media_types,
+            reply_to_message_id=reply_to_id,
+            reply_to_text=reply_to_text,
             timestamp=timestamp,
         )
 
@@ -633,21 +670,19 @@ class SignalAdapter(BasePlatformAdapter):
         """Send a text message."""
         await self._stop_typing_indicator(chat_id)
 
-        params: Dict[str, Any] = {
-            "account": self.account,
-            "message": content,
-        }
-
-        if chat_id.startswith("group:"):
-            params["groupId"] = chat_id[6:]
-        else:
-            params["recipient"] = [chat_id]
+        params = self._build_send_params(
+            chat_id=chat_id,
+            message=content,
+            reply_to=reply_to,
+            metadata=metadata,
+        )
 
         result = await self._rpc("send", params)
 
         if result is not None:
             self._track_sent_timestamp(result)
-            return SendResult(success=True)
+            message_id = str(result.get("timestamp")) if isinstance(result, dict) and result.get("timestamp") else None
+            return SendResult(success=True, message_id=message_id, raw_response=result)
         return SendResult(success=False, error="RPC send failed")
 
     def _track_sent_timestamp(self, rpc_result) -> None:
@@ -658,16 +693,54 @@ class SignalAdapter(BasePlatformAdapter):
             if len(self._recent_sent_timestamps) > self._max_recent_timestamps:
                 self._recent_sent_timestamps.pop()
 
-    async def send_typing(self, chat_id: str, metadata=None) -> None:
-        """Send a typing indicator."""
+    @staticmethod
+    def _reply_author_from_metadata(metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+        """Resolve the best Signal author identifier for quote/reaction targeting."""
+        if not metadata:
+            return None
+        return metadata.get("reply_to_author") or metadata.get("reply_to_author_alt")
+
+    def _build_recipient_params(self, chat_id: str) -> Dict[str, Any]:
+        """Build destination parameters for a DM or Signal group."""
+        if chat_id.startswith("group:"):
+            return {"groupId": chat_id[6:]}
+        return {"recipient": [chat_id]}
+
+    def _build_send_params(
+        self,
+        chat_id: str,
+        *,
+        message: str = "",
+        attachments: Optional[List[str]] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Build a Signal send payload, including quote metadata when available."""
         params: Dict[str, Any] = {
             "account": self.account,
+            "message": message,
+            **self._build_recipient_params(chat_id),
         }
+        if attachments:
+            params["attachments"] = attachments
 
-        if chat_id.startswith("group:"):
-            params["groupId"] = chat_id[6:]
-        else:
-            params["recipient"] = [chat_id]
+        quote_timestamp = _coerce_timestamp(reply_to)
+        if not quote_timestamp and metadata:
+            quote_timestamp = _coerce_timestamp(metadata.get("reply_to_message_id"))
+        quote_author = self._reply_author_from_metadata(metadata)
+        quote_text = metadata.get("reply_to_text") if metadata else None
+
+        if quote_timestamp and quote_author:
+            params["quoteTimestamp"] = quote_timestamp
+            params["quoteAuthor"] = quote_author
+            if quote_text:
+                params["quoteMessage"] = str(quote_text)[:MAX_MESSAGE_LENGTH]
+
+        return params
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        """Send a typing indicator."""
+        params: Dict[str, Any] = {"account": self.account, **self._build_recipient_params(chat_id)}
 
         await self._rpc("sendTyping", params, rpc_id="typing")
 
@@ -676,6 +749,8 @@ class SignalAdapter(BasePlatformAdapter):
         chat_id: str,
         image_url: str,
         caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
         """Send an image. Supports http(s):// and file:// URLs."""
@@ -700,21 +775,19 @@ class SignalAdapter(BasePlatformAdapter):
         if file_size > SIGNAL_MAX_ATTACHMENT_SIZE:
             return SendResult(success=False, error=f"Image too large ({file_size} bytes)")
 
-        params: Dict[str, Any] = {
-            "account": self.account,
-            "message": caption or "",
-            "attachments": [file_path],
-        }
-
-        if chat_id.startswith("group:"):
-            params["groupId"] = chat_id[6:]
-        else:
-            params["recipient"] = [chat_id]
+        params = self._build_send_params(
+            chat_id=chat_id,
+            message=caption or "",
+            attachments=[file_path],
+            reply_to=reply_to,
+            metadata=metadata,
+        )
 
         result = await self._rpc("send", params)
         if result is not None:
             self._track_sent_timestamp(result)
-            return SendResult(success=True)
+            message_id = str(result.get("timestamp")) if isinstance(result, dict) and result.get("timestamp") else None
+            return SendResult(success=True, message_id=message_id, raw_response=result)
         return SendResult(success=False, error="RPC send with attachment failed")
 
     async def send_document(
@@ -723,6 +796,8 @@ class SignalAdapter(BasePlatformAdapter):
         file_path: str,
         caption: Optional[str] = None,
         filename: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
         """Send a document/file attachment."""
@@ -731,22 +806,62 @@ class SignalAdapter(BasePlatformAdapter):
         if not Path(file_path).exists():
             return SendResult(success=False, error="File not found")
 
-        params: Dict[str, Any] = {
-            "account": self.account,
-            "message": caption or "",
-            "attachments": [file_path],
-        }
-
-        if chat_id.startswith("group:"):
-            params["groupId"] = chat_id[6:]
-        else:
-            params["recipient"] = [chat_id]
+        params = self._build_send_params(
+            chat_id=chat_id,
+            message=caption or "",
+            attachments=[file_path],
+            reply_to=reply_to,
+            metadata=metadata,
+        )
 
         result = await self._rpc("send", params)
         if result is not None:
             self._track_sent_timestamp(result)
-            return SendResult(success=True)
+            message_id = str(result.get("timestamp")) if isinstance(result, dict) and result.get("timestamp") else None
+            return SendResult(success=True, message_id=message_id, raw_response=result)
         return SendResult(success=False, error="RPC send document failed")
+
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send voice/audio via stock signal-cli without a filename title."""
+        await self._stop_typing_indicator(chat_id)
+
+        audio_file = Path(audio_path)
+        if not audio_file.exists():
+            return SendResult(success=False, error="Audio file not found")
+
+        file_size = audio_file.stat().st_size
+        if file_size > SIGNAL_MAX_ATTACHMENT_SIZE:
+            return SendResult(success=False, error=f"Audio too large ({file_size} bytes)")
+
+        mime_type = _ext_to_mime(audio_file.suffix or "")
+        try:
+            attachment = _file_to_data_uri(str(audio_file), mime_type)
+        except Exception as e:
+            logger.warning("Signal: failed to encode voice attachment as data URI: %s", e)
+            return SendResult(success=False, error=str(e))
+
+        params = self._build_send_params(
+            chat_id=chat_id,
+            message=caption or "",
+            attachments=[attachment],
+            reply_to=reply_to,
+            metadata=metadata,
+        )
+
+        result = await self._rpc("send", params)
+        if result is not None:
+            self._track_sent_timestamp(result)
+            message_id = str(result.get("timestamp")) if isinstance(result, dict) and result.get("timestamp") else None
+            return SendResult(success=True, message_id=message_id, raw_response=result)
+        return SendResult(success=False, error="RPC send voice failed")
 
     # ------------------------------------------------------------------
     # Typing Indicators

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2189,7 +2189,7 @@ class GatewayRunner:
         context = build_session_context(source, self.config, session_entry)
         
         # Set environment variables for tools
-        self._set_session_env(context)
+        self._set_session_env(context, event=event)
         
         # Read privacy.redact_pii from config (re-read per message)
         _redact_pii = False
@@ -5555,7 +5555,7 @@ class GatewayRunner:
 
         return True
 
-    def _set_session_env(self, context: SessionContext) -> None:
+    def _set_session_env(self, context: SessionContext, event=None) -> None:
         """Set environment variables for the current session."""
         os.environ["HERMES_SESSION_PLATFORM"] = context.source.platform.value
         os.environ["HERMES_SESSION_CHAT_ID"] = context.source.chat_id
@@ -5563,10 +5563,25 @@ class GatewayRunner:
             os.environ["HERMES_SESSION_CHAT_NAME"] = context.source.chat_name
         if context.source.thread_id:
             os.environ["HERMES_SESSION_THREAD_ID"] = str(context.source.thread_id)
+        if event is not None:
+            if getattr(event, "message_id", None):
+                os.environ["HERMES_SESSION_MESSAGE_ID"] = str(event.message_id)
+            if getattr(context.source, "user_id", None):
+                os.environ["HERMES_SESSION_USER_ID"] = str(context.source.user_id)
+            if getattr(context.source, "user_id_alt", None):
+                os.environ["HERMES_SESSION_USER_ID_ALT"] = str(context.source.user_id_alt)
     
     def _clear_session_env(self) -> None:
         """Clear session environment variables."""
-        for var in ["HERMES_SESSION_PLATFORM", "HERMES_SESSION_CHAT_ID", "HERMES_SESSION_CHAT_NAME", "HERMES_SESSION_THREAD_ID"]:
+        for var in [
+            "HERMES_SESSION_PLATFORM",
+            "HERMES_SESSION_CHAT_ID",
+            "HERMES_SESSION_CHAT_NAME",
+            "HERMES_SESSION_THREAD_ID",
+            "HERMES_SESSION_MESSAGE_ID",
+            "HERMES_SESSION_USER_ID",
+            "HERMES_SESSION_USER_ID_ALT",
+        ]:
             if var in os.environ:
                 del os.environ[var]
     

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -97,6 +97,7 @@ CONFIGURABLE_TOOLSETS = [
     ("memory",          "💾 Memory",                    "persistent memory across sessions"),
     ("session_search",  "🔎 Session Search",            "search past conversations"),
     ("clarify",         "❓ Clarifying Questions",      "clarify"),
+    ("messaging",       "💬 Messaging Actions",         "send_message, react_message"),
     ("delegation",      "👥 Task Delegation",           "delegate_task"),
     ("cronjob",         "⏰ Cron Jobs",                 "create/list/update/pause/resume/run, with optional attached skills"),
     ("rl",              "🧪 RL Training",               "Tinker-Atropos training tools"),

--- a/plugins/memory/atlas/README.md
+++ b/plugins/memory/atlas/README.md
@@ -1,0 +1,23 @@
+# Atlas Memory Provider
+
+This plugin exposes Atlas as an external Hermes memory provider.
+
+Setup path:
+
+1. Run `hermes memory setup`.
+2. Choose `atlas`.
+3. Enter:
+   - Supabase project URL
+   - Supabase service key
+   - optional schema / embedding config
+
+Atlas is now also available as a built-in Hermes memory plugin. This integration copy remains the source implementation and can still be linked as a user plugin override when needed.
+
+Non-secret Atlas config is saved to `~/.hermes/atlas.json`.
+Secrets are saved to `~/.hermes/.env`.
+
+The provider keeps Hermes built-in memory active and adds Atlas as an external memory layer for:
+
+- pre-turn context enrichment
+- post-turn turn sync
+- session-end closeout

--- a/plugins/memory/atlas/__init__.py
+++ b/plugins/memory/atlas/__init__.py
@@ -1,0 +1,536 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import logging
+import os
+import queue
+import select
+import subprocess
+import sys
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from uuid import NAMESPACE_URL, UUID, uuid5
+
+from agent.memory_provider import MemoryProvider
+
+logger = logging.getLogger(__name__)
+
+_MEMORY_LIVE_SESSION_NAMESPACE = uuid5(NAMESPACE_URL, "memory://hermes-live-session")
+_SESSION_TIMEOUT_SECONDS = 30.0
+_PING_TIMEOUT_SECONDS = 10.0
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _normalize_memory_session_id(session_id: str | None) -> str | None:
+    if session_id is None:
+        return None
+    value = str(session_id).strip()
+    if not value:
+        return None
+    try:
+        return str(UUID(value))
+    except (ValueError, TypeError, AttributeError):
+        return str(uuid5(_MEMORY_LIVE_SESSION_NAMESPACE, value))
+
+
+def _normalize_agent_namespace(agent_identity: str | None) -> str:
+    value = str(agent_identity or "").strip().lower()
+    if value in {"", "primary"}:
+        return "default"
+    return value
+
+
+def _hermes_home_path(hermes_home: str | None = None) -> Path:
+    return Path(hermes_home or os.environ.get("HERMES_HOME", "~/.hermes")).expanduser()
+
+
+def _plugin_root() -> Path:
+    return Path(__file__).resolve().parent
+
+
+def _has_packaged_bridge_server() -> bool:
+    """Return True when memory.bridge_server is importable from installed packages."""
+    try:
+        return importlib.util.find_spec("memory.bridge_server") is not None
+    except Exception:
+        return False
+
+
+def _find_local_atlas_root() -> Path | None:
+    """Locate a local Atlas source tree for development fallback mode."""
+    override = os.environ.get("ATLAS_ROOT")
+    if override:
+        candidate = Path(override).expanduser().resolve()
+        if (candidate / "src" / "memory" / "bridge_server.py").exists():
+            return candidate
+
+    plugin_root = _plugin_root()
+    hermes_home = _hermes_home_path()
+    candidates: list[Path] = []
+
+    # atlas/integrations/hermes/plugins/memory/atlas/__init__.py -> atlas/
+    if len(plugin_root.parents) > 5:
+        candidates.append(plugin_root.parents[5])
+    # hermes-agent/plugins/memory/atlas/__init__.py -> ~/.hermes/atlas
+    if len(plugin_root.parents) > 4:
+        candidates.append(plugin_root.parents[4] / "atlas")
+
+    candidates.extend(
+        [
+            hermes_home / "atlas",
+            Path.cwd() / "atlas",
+        ]
+    )
+
+    seen: set[Path] = set()
+    for candidate in candidates:
+        resolved = candidate.expanduser().resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        if (resolved / "src" / "memory" / "bridge_server.py").exists():
+            return resolved
+
+    return None
+
+
+def _atlas_python(atlas_root: Path) -> Path:
+    for candidate in (
+        atlas_root / "venv" / "bin" / "python",
+        atlas_root / ".venv" / "bin" / "python",
+    ):
+        if candidate.exists():
+            return candidate
+    return Path(sys.executable)
+
+
+def _atlas_config_path(hermes_home: str | None = None) -> Path:
+    return _hermes_home_path(hermes_home) / "atlas.json"
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _read_env_file(hermes_home: str | None = None) -> dict[str, str]:
+    env_path = _hermes_home_path(hermes_home) / ".env"
+    values: dict[str, str] = {}
+    if not env_path.exists():
+        return values
+    for raw_line in env_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip().strip("'").strip('"')
+    return values
+
+
+def _build_runtime_env(hermes_home: str | None = None, *, atlas_root: Path | None = None) -> dict[str, str]:
+    root = _hermes_home_path(hermes_home)
+    config = _read_json(_atlas_config_path(root))
+    file_env = _read_env_file(root)
+    env = dict(os.environ)
+
+    if atlas_root is not None:
+        atlas_src = str(atlas_root / "src")
+        existing_pythonpath = env.get("PYTHONPATH", "")
+        env["PYTHONPATH"] = atlas_src if not existing_pythonpath else atlas_src + os.pathsep + existing_pythonpath
+    env["HERMES_HOME"] = str(root)
+
+    for key in (
+        "MEMORY_SUPABASE_URL",
+        "MEMORY_SUPABASE_SCHEMA",
+        "MEMORY_OPENAI_BASE_URL",
+        "MEMORY_OPENAI_EMBEDDING_MODEL",
+        "MEMORY_EMBEDDING_DIMENSIONS",
+        "MEMORY_SUPABASE_KEY",
+        "MEMORY_OPENAI_API_KEY",
+        "OPENAI_API_KEY",
+    ):
+        if key in file_env and key not in env:
+            env[key] = file_env[key]
+
+    config_to_env = {
+        "supabase_url": "MEMORY_SUPABASE_URL",
+        "supabase_schema": "MEMORY_SUPABASE_SCHEMA",
+        "openai_base_url": "MEMORY_OPENAI_BASE_URL",
+        "embedding_model": "MEMORY_OPENAI_EMBEDDING_MODEL",
+        "embedding_dimensions": "MEMORY_EMBEDDING_DIMENSIONS",
+    }
+    for config_key, env_key in config_to_env.items():
+        if config.get(config_key):
+            env.setdefault(env_key, str(config[config_key]))
+
+    if not env.get("MEMORY_SUPABASE_KEY") and env.get("SUPABASE_SERVICE_KEY"):
+        env["MEMORY_SUPABASE_KEY"] = env["SUPABASE_SERVICE_KEY"]
+    if not env.get("MEMORY_SUPABASE_URL") and env.get("SUPABASE_URL"):
+        env["MEMORY_SUPABASE_URL"] = env["SUPABASE_URL"]
+    if not env.get("MEMORY_OPENAI_API_KEY") and env.get("OPENAI_API_KEY"):
+        env["MEMORY_OPENAI_API_KEY"] = env["OPENAI_API_KEY"]
+
+    return env
+
+
+class _AtlasBridgeClient:
+    def __init__(self, *, hermes_home: str) -> None:
+        self._hermes_home = _hermes_home_path(hermes_home)
+        self._process: subprocess.Popen[str] | None = None
+        self._lock = threading.Lock()
+        self._stderr_handle: Any = None
+
+    def _ensure_process_locked(self) -> None:
+        if self._process is not None and self._process.poll() is None:
+            return
+
+        log_dir = self._hermes_home / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        if self._stderr_handle is None or getattr(self._stderr_handle, "closed", False):
+            self._stderr_handle = open(log_dir / "atlas_memory_provider.log", "a", encoding="utf-8")
+
+        packaged_bridge = _has_packaged_bridge_server()
+        local_atlas_root = _find_local_atlas_root() if not packaged_bridge else None
+
+        if packaged_bridge:
+            argv = [str(Path(sys.executable)), "-m", "memory.bridge_server"]
+            cwd = str(self._hermes_home)
+            env = _build_runtime_env(str(self._hermes_home), atlas_root=None)
+        else:
+            if local_atlas_root is None:
+                raise RuntimeError(
+                    "Atlas runtime not available. Install a package exposing memory.bridge_server "
+                    "or provide a local Atlas source tree via ATLAS_ROOT."
+                )
+            argv = [str(_atlas_python(local_atlas_root)), "-m", "memory.bridge_server"]
+            cwd = str(local_atlas_root)
+            env = _build_runtime_env(str(self._hermes_home), atlas_root=local_atlas_root)
+
+        self._process = subprocess.Popen(
+            argv,
+            cwd=cwd,
+            env=env,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=self._stderr_handle,
+            text=True,
+            bufsize=1,
+        )
+        self._request_locked({"operation": "ping"}, timeout=_PING_TIMEOUT_SECONDS)
+
+    def _shutdown_locked(self) -> None:
+        process = self._process
+        self._process = None
+        if process is not None:
+            try:
+                if process.stdin:
+                    process.stdin.close()
+            except Exception:
+                pass
+            try:
+                process.terminate()
+                process.wait(timeout=2.0)
+            except Exception:
+                try:
+                    process.kill()
+                except Exception:
+                    pass
+        if self._stderr_handle is not None and not getattr(self._stderr_handle, "closed", False):
+            self._stderr_handle.close()
+            self._stderr_handle = None
+
+    def _request_locked(self, payload: dict[str, Any], *, timeout: float) -> dict[str, Any]:
+        if self._process is None or self._process.stdin is None or self._process.stdout is None:
+            raise RuntimeError("Atlas bridge server is not available.")
+
+        self._process.stdin.write(json.dumps(payload, ensure_ascii=False))
+        self._process.stdin.write("\n")
+        self._process.stdin.flush()
+
+        ready, _, _ = select.select([self._process.stdout], [], [], timeout)
+        if not ready:
+            raise TimeoutError(f"Atlas bridge request timed out after {timeout:.1f}s")
+
+        raw = self._process.stdout.readline()
+        if not raw:
+            raise RuntimeError("Atlas bridge server closed unexpectedly.")
+
+        response = json.loads(raw)
+        if not isinstance(response, dict):
+            raise RuntimeError("Atlas bridge returned a malformed response.")
+        if not response.get("success", False):
+            raise RuntimeError(str(response.get("error") or "Atlas bridge request failed."))
+        result = response.get("result", {})
+        return result if isinstance(result, dict) else {"value": result}
+
+    def request(self, payload: dict[str, Any], *, timeout: float = _SESSION_TIMEOUT_SECONDS) -> dict[str, Any]:
+        with self._lock:
+            self._ensure_process_locked()
+            try:
+                return self._request_locked(payload, timeout=timeout)
+            except Exception:
+                self._shutdown_locked()
+                raise
+
+    def shutdown(self) -> None:
+        with self._lock:
+            self._shutdown_locked()
+
+
+class AtlasMemoryProvider(MemoryProvider):
+    """Atlas external memory provider for Hermes."""
+
+    def __init__(self) -> None:
+        self._bridge: _AtlasBridgeClient | None = None
+        self._session_id = ""
+        self._memory_session_id: str | None = None
+        self._platform = "local"
+        self._agent_namespace = "default"
+        self._started_at = _utcnow_iso()
+        self._model: str | None = None
+        self._disabled = False
+        self._session_synced = False
+        self._sync_queue: queue.Queue[tuple[str, str] | None] | None = None
+        self._sync_thread: threading.Thread | None = None
+
+    @property
+    def name(self) -> str:
+        return "atlas"
+
+    def system_prompt_block(self) -> str:
+        return (
+            "# Atlas Memory\n"
+            "Atlas injects retrieved cross-session memory directly alongside the current user turn.\n"
+            "When an Atlas memory block is present, treat it as the primary retrieved evidence for\n"
+            "continuity, prior conversations, past work, active state, and long-term user context.\n"
+            "Do not say memory is empty, unavailable, or unprocessed if the Atlas block already contains\n"
+            "relevant evidence. Answer from that evidence first, and only express uncertainty when the\n"
+            "Atlas block is actually empty or clearly inconclusive.\n"
+        )
+
+    def is_available(self) -> bool:
+        if not (_has_packaged_bridge_server() or _find_local_atlas_root() is not None):
+            return False
+        config = _read_json(_atlas_config_path())
+        env_values = {**_read_env_file(), **os.environ}
+        supabase_url = (
+            config.get("supabase_url")
+            or env_values.get("MEMORY_SUPABASE_URL")
+            or env_values.get("SUPABASE_URL")
+        )
+        supabase_key = env_values.get("MEMORY_SUPABASE_KEY") or env_values.get("SUPABASE_SERVICE_KEY")
+        return bool(supabase_url and supabase_key)
+
+    def get_config_schema(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "key": "supabase_url",
+                "description": "Supabase project URL",
+                "required": True,
+                "default": "https://YOUR_PROJECT.supabase.co",
+            },
+            {
+                "key": "supabase_schema",
+                "description": "Database schema for Atlas memory",
+                "default": "memory",
+            },
+            {
+                "key": "openai_base_url",
+                "description": "Embeddings base URL",
+                "default": "https://api.openai.com/v1",
+            },
+            {
+                "key": "embedding_model",
+                "description": "Embedding model",
+                "default": "text-embedding-3-small",
+            },
+            {
+                "key": "embedding_dimensions",
+                "description": "Embedding dimensions",
+                "default": "512",
+            },
+            {
+                "key": "supabase_key",
+                "description": "Supabase service key",
+                "secret": True,
+                "required": True,
+                "env_var": "MEMORY_SUPABASE_KEY",
+            },
+            {
+                "key": "openai_api_key",
+                "description": "Embeddings API key (optional)",
+                "secret": True,
+                "required": False,
+                "env_var": "MEMORY_OPENAI_API_KEY",
+            },
+        ]
+
+    def save_config(self, values: dict[str, Any], hermes_home: str) -> None:
+        config_path = _atlas_config_path(hermes_home)
+        existing = _read_json(config_path)
+        existing.update(values)
+        config_path.write_text(json.dumps(existing, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        agent_context = str(kwargs.get("agent_context") or "primary").strip().lower()
+        if agent_context not in {"", "primary"}:
+            logger.debug("Atlas memory skipped for agent_context=%s", agent_context)
+            self._disabled = True
+            return
+
+        hermes_home = str(kwargs.get("hermes_home") or _hermes_home_path())
+        self._session_id = str(session_id or "").strip()
+        self._memory_session_id = _normalize_memory_session_id(self._session_id)
+        self._platform = str(kwargs.get("platform") or "local")
+        self._agent_namespace = _normalize_agent_namespace(kwargs.get("agent_identity"))
+        self._started_at = _utcnow_iso()
+        self._model = kwargs.get("model")
+        self._bridge = _AtlasBridgeClient(hermes_home=hermes_home)
+        self._sync_queue = queue.Queue()
+        self._sync_thread = threading.Thread(target=self._sync_worker, name="atlas-memory-sync", daemon=True)
+        self._sync_thread.start()
+
+        try:
+            self._ensure_session_synced()
+        except Exception as exc:
+            logger.warning("Atlas memory initialize failed to prewarm session: %s", exc)
+
+    def get_tool_schemas(self) -> list[dict[str, Any]]:
+        return []
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if self._disabled or not query.strip() or self._bridge is None:
+            return ""
+        active_session_id = _normalize_memory_session_id(session_id or self._session_id)
+        try:
+            result = self._bridge.request(
+                {
+                    "operation": "enrich",
+                    "user_message": query,
+                    "platform": self._platform,
+                    "active_session_id": active_session_id,
+                    "agent_namespace": self._agent_namespace,
+                }
+            )
+        except Exception as exc:
+            logger.warning("Atlas memory prefetch failed: %s", exc)
+            return ""
+        return self._format_prefetch_context(query, str(result.get("context") or "").strip())
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        if self._disabled or self._sync_queue is None:
+            return
+        effective_session_id = str(session_id or self._session_id).strip()
+        if effective_session_id and effective_session_id != self._session_id:
+            self._session_id = effective_session_id
+            self._memory_session_id = _normalize_memory_session_id(effective_session_id)
+            self._session_synced = False
+        self._sync_queue.put((user_content, assistant_content))
+
+    def on_session_end(self, messages: list[dict[str, Any]]) -> None:
+        if self._disabled or self._bridge is None or not self._memory_session_id:
+            return
+        try:
+            if self._sync_queue is not None:
+                self._sync_queue.join()
+            self._ensure_session_synced()
+            self._bridge.request(
+                {
+                    "operation": "live-session-end",
+                    "memory_session_id": self._memory_session_id,
+                    "hermes_session_id": self._session_id,
+                    "platform": self._platform,
+                    "started_at": self._started_at,
+                    "model": self._model,
+                    "agent_namespace": self._agent_namespace,
+                    "end_reason": "session_end",
+                }
+            )
+        except Exception as exc:
+            logger.warning("Atlas memory session end failed: %s", exc)
+
+    def shutdown(self) -> None:
+        if self._sync_queue is not None:
+            self._sync_queue.put(None)
+        if self._sync_thread is not None and self._sync_thread.is_alive():
+            self._sync_thread.join(timeout=2.0)
+        self._sync_thread = None
+        self._sync_queue = None
+        if self._bridge is not None:
+            self._bridge.shutdown()
+            self._bridge = None
+
+    def _ensure_session_synced(self) -> None:
+        if self._session_synced or self._bridge is None or not self._memory_session_id:
+            return
+        self._bridge.request(
+            {
+                "operation": "live-session-sync",
+                "memory_session_id": self._memory_session_id,
+                "hermes_session_id": self._session_id,
+                "platform": self._platform,
+                "started_at": self._started_at,
+                "model": self._model,
+                "agent_namespace": self._agent_namespace,
+                "updates": {"legacy_session_id": self._session_id},
+            }
+        )
+        self._session_synced = True
+
+    def _sync_worker(self) -> None:
+        while self._sync_queue is not None:
+            item = self._sync_queue.get()
+            try:
+                if item is None:
+                    return
+                user_content, assistant_content = item
+                if self._bridge is None or not self._memory_session_id:
+                    continue
+                self._ensure_session_synced()
+                self._bridge.request(
+                    {
+                        "operation": "live-session-append",
+                        "memory_session_id": self._memory_session_id,
+                        "hermes_session_id": self._session_id,
+                        "platform": self._platform,
+                        "started_at": self._started_at,
+                        "model": self._model,
+                        "agent_namespace": self._agent_namespace,
+                        "messages": [
+                            {"role": "user", "content": user_content},
+                            {"role": "assistant", "content": assistant_content},
+                        ],
+                    }
+                )
+            except Exception as exc:
+                logger.warning("Atlas memory sync failed: %s", exc)
+            finally:
+                if self._sync_queue is not None:
+                    self._sync_queue.task_done()
+
+    def _format_prefetch_context(self, query: str, context: str) -> str:
+        if not context:
+            return ""
+        return (
+            "## Atlas Memory Recall\n"
+            "Use the retrieved memory below as primary evidence for this user message.\n"
+            f"Current user message: {query.strip()}\n"
+            "If this block already answers the question, answer directly from it and do not claim you\n"
+            "cannot remember.\n\n"
+            f"{context}"
+        )
+
+
+def register(ctx) -> None:
+    ctx.register_memory_provider(AtlasMemoryProvider())

--- a/plugins/memory/atlas/plugin.yaml
+++ b/plugins/memory/atlas/plugin.yaml
@@ -1,0 +1,5 @@
+name: atlas
+version: 0.1.0
+description: "Atlas memory provider — continuity-first personal memory backed by Supabase."
+hooks:
+  - on_session_end

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -769,6 +769,13 @@ class TestPromptBuilderConstants:
         assert "cron" in PLATFORM_HINTS
         assert "cli" in PLATFORM_HINTS
 
+    def test_signal_platform_hint_mentions_reactions(self):
+        hint = PLATFORM_HINTS["signal"].lower()
+        assert "react_message" in hint
+        assert "30%" in hint
+        assert "text_to_speech" in hint
+        assert "[[reply_to_current]]" in hint
+
 
 # =========================================================================
 # Conditional skill activation

--- a/tests/gateway/test_base_topic_sessions.py
+++ b/tests/gateway/test_base_topic_sessions.py
@@ -1,12 +1,13 @@
 """Tests for BasePlatformAdapter topic-aware session handling."""
 
 import asyncio
+import json
 from types import SimpleNamespace
 
 import pytest
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import BasePlatformAdapter, MessageEvent, SendResult
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
 from gateway.session import SessionSource, build_session_key
 
 
@@ -52,6 +53,7 @@ class DummySignalAdapter(DummyTelegramAdapter):
     def __init__(self):
         super().__init__()
         self.platform = Platform.SIGNAL
+        self.voices = []
 
     def get_default_reply_target(self, event: MessageEvent):
         return None
@@ -59,8 +61,23 @@ class DummySignalAdapter(DummyTelegramAdapter):
     def requires_reply_context_metadata(self) -> bool:
         return True
 
+    def should_send_text_after_auto_tts(self, event: MessageEvent) -> bool:
+        return False
 
-def _make_event(chat_id: str, thread_id: str, message_id: str = "1") -> MessageEvent:
+    async def send_voice(self, chat_id, audio_path, caption=None, reply_to=None, metadata=None, **kwargs) -> SendResult:
+        self.voices.append(
+            {
+                "chat_id": chat_id,
+                "audio_path": audio_path,
+                "caption": caption,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id="voice-1")
+
+
+def _make_event(chat_id: str, thread_id: str, message_id: str = "1", message_type: MessageType = MessageType.TEXT) -> MessageEvent:
     return MessageEvent(
         text="hello",
         source=SessionSource(
@@ -71,6 +88,7 @@ def _make_event(chat_id: str, thread_id: str, message_id: str = "1") -> MessageE
             user_id="+15550001111",
         ),
         message_id=message_id,
+        message_type=message_type,
     )
 
 
@@ -212,6 +230,43 @@ class TestBasePlatformTopicSessions:
                     "reply_to_author": "+15550001111",
                     "reply_to_text": "hello",
                 },
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_process_message_background_signal_voice_input_sends_only_voice_reply(self, monkeypatch, tmp_path):
+        adapter = DummySignalAdapter()
+
+        async def handler(_event):
+            await asyncio.sleep(0)
+            return "spoken reply"
+
+        async def hold_typing(_chat_id, interval=2.0, metadata=None):
+            await asyncio.Event().wait()
+
+        tts_path = tmp_path / "reply.ogg"
+        tts_path.write_bytes(b"fake-voice")
+
+        monkeypatch.setattr("tools.tts_tool.check_tts_requirements", lambda: True)
+        monkeypatch.setattr(
+            "tools.tts_tool.text_to_speech_tool",
+            lambda text: json.dumps({"success": True, "file_path": str(tts_path)}),
+        )
+
+        adapter.set_message_handler(handler)
+        adapter._keep_typing = hold_typing
+
+        event = _make_event("-1001", "17585", message_type=MessageType.VOICE)
+        await adapter._process_message_background(event, build_session_key(event.source))
+
+        assert adapter.sent == []
+        assert adapter.voices == [
+            {
+                "chat_id": "-1001",
+                "audio_path": str(tts_path),
+                "caption": None,
+                "reply_to": None,
+                "metadata": {"thread_id": "17585"},
             }
         ]
 

--- a/tests/gateway/test_base_topic_sessions.py
+++ b/tests/gateway/test_base_topic_sessions.py
@@ -48,6 +48,18 @@ class DummyTelegramAdapter(BasePlatformAdapter):
         self.processing_hooks.append(("complete", event.message_id, success))
 
 
+class DummySignalAdapter(DummyTelegramAdapter):
+    def __init__(self):
+        super().__init__()
+        self.platform = Platform.SIGNAL
+
+    def get_default_reply_target(self, event: MessageEvent):
+        return None
+
+    def requires_reply_context_metadata(self) -> bool:
+        return True
+
+
 def _make_event(chat_id: str, thread_id: str, message_id: str = "1") -> MessageEvent:
     return MessageEvent(
         text="hello",
@@ -56,6 +68,7 @@ def _make_event(chat_id: str, thread_id: str, message_id: str = "1") -> MessageE
             chat_id=chat_id,
             chat_type="group",
             thread_id=thread_id,
+            user_id="+15550001111",
         ),
         message_id=message_id,
     )
@@ -143,6 +156,63 @@ class TestBasePlatformTopicSessions:
         assert adapter.processing_hooks == [
             ("start", "1"),
             ("complete", "1", True),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_process_message_background_signal_does_not_auto_reply(self):
+        adapter = DummySignalAdapter()
+
+        async def handler(_event):
+            await asyncio.sleep(0)
+            return "ack"
+
+        async def hold_typing(_chat_id, interval=2.0, metadata=None):
+            await asyncio.Event().wait()
+
+        adapter.set_message_handler(handler)
+        adapter._keep_typing = hold_typing
+
+        event = _make_event("-1001", "17585")
+        await adapter._process_message_background(event, build_session_key(event.source))
+
+        assert adapter.sent == [
+            {
+                "chat_id": "-1001",
+                "content": "ack",
+                "reply_to": None,
+                "metadata": {"thread_id": "17585"},
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_process_message_background_signal_reply_directive_forces_reply(self):
+        adapter = DummySignalAdapter()
+
+        async def handler(_event):
+            await asyncio.sleep(0)
+            return "[[reply_to_current]]\n\nack"
+
+        async def hold_typing(_chat_id, interval=2.0, metadata=None):
+            await asyncio.Event().wait()
+
+        adapter.set_message_handler(handler)
+        adapter._keep_typing = hold_typing
+
+        event = _make_event("-1001", "17585")
+        await adapter._process_message_background(event, build_session_key(event.source))
+
+        assert adapter.sent == [
+            {
+                "chat_id": "-1001",
+                "content": "ack",
+                "reply_to": "1",
+                "metadata": {
+                    "thread_id": "17585",
+                    "reply_to_message_id": "1",
+                    "reply_to_author": "+15550001111",
+                    "reply_to_text": "hello",
+                },
+            }
         ]
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch, AsyncMock
 from urllib.parse import quote
 
 from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
 
 
 # ---------------------------------------------------------------------------
@@ -368,3 +369,102 @@ class TestSignalSendMessage:
         # Just verify the import works and Signal is a valid platform
         from gateway.config import Platform
         assert Platform.SIGNAL.value == "signal"
+
+
+class TestSignalRepliesReactionsAndVoice:
+    @pytest.mark.asyncio
+    async def test_handle_envelope_sets_reply_context_and_message_id(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter.handle_message = AsyncMock()
+
+        await adapter._handle_envelope({
+            "envelope": {
+                "timestamp": 1712345678901,
+                "sourceNumber": "+15550001111",
+                "sourceName": "Alice",
+                "dataMessage": {
+                    "message": "Replying now",
+                    "quote": {
+                        "id": 1712345000000,
+                        "text": "Original question",
+                    },
+                },
+            }
+        })
+
+        event = adapter.handle_message.await_args.args[0]
+        assert event.message_id == "1712345678901"
+        assert event.reply_to_message_id == "1712345000000"
+        assert event.reply_to_text == "Original question"
+        assert event.source.user_id == "+15550001111"
+
+    @pytest.mark.asyncio
+    async def test_handle_envelope_ignores_reaction_only_event(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter.handle_message = AsyncMock()
+
+        await adapter._handle_envelope({
+            "envelope": {
+                "timestamp": 1712345678901,
+                "sourceNumber": "+15550001111",
+                "dataMessage": {
+                    "reaction": {
+                        "emoji": "👍",
+                        "targetAuthor": "+15551234567",
+                        "targetSentTimestamp": 1712345000000,
+                    },
+                },
+            }
+        })
+
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_send_includes_signal_quote_fields(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._rpc, captured = _stub_rpc({"timestamp": 1712345678999})
+
+        result = await adapter.send(
+            chat_id="+15550002222",
+            content="hello there",
+            reply_to="1712345000000",
+            metadata={
+                "reply_to_author": "+15550002222",
+                "reply_to_text": "quoted text",
+            },
+        )
+
+        assert result.success is True
+        assert result.message_id == "1712345678999"
+        call = captured[0]
+        assert call["method"] == "send"
+        assert call["params"]["recipient"] == ["+15550002222"]
+        assert call["params"]["quoteTimestamp"] == 1712345000000
+        assert call["params"]["quoteAuthor"] == "+15550002222"
+        assert call["params"]["quoteMessage"] == "quoted text"
+
+    @pytest.mark.asyncio
+    async def test_send_voice_uses_data_uri_without_filename(self, monkeypatch, tmp_path):
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._rpc, captured = _stub_rpc({"timestamp": 1712345678999})
+
+        audio_path = tmp_path / "voice.m4a"
+        audio_path.write_bytes(b"fake-m4a-bytes")
+
+        result = await adapter.send_voice(
+            chat_id="+15550003333",
+            audio_path=str(audio_path),
+            metadata={
+                "reply_to_message_id": "1712345000000",
+                "reply_to_author": "+15550003333",
+                "reply_to_text": "voice prompt",
+            },
+        )
+
+        assert result.success is True
+        call = captured[0]
+        assert call["method"] == "send"
+        assert call["params"]["attachments"][0].startswith("data:audio/mp4;base64,")
+        assert "voice.m4a" not in call["params"]["attachments"][0]
+        assert call["params"]["quoteTimestamp"] == 1712345000000
+        assert call["params"]["quoteAuthor"] == "+15550003333"

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -22,6 +22,17 @@ def test_get_platform_tools_uses_default_when_platform_not_configured():
     assert enabled
 
 
+def test_signal_default_platform_tools_include_messaging():
+    config = {
+        "platform_toolsets": {"signal": ["hermes-signal"]},
+    }
+
+    enabled = _get_platform_tools(config, "signal")
+
+    assert "messaging" in enabled
+    assert "tts" in enabled
+
+
 def test_get_platform_tools_preserves_explicit_empty_selection():
     config = {"platform_toolsets": {"cli": []}}
 

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -141,3 +141,7 @@ class TestToolsetConsistency:
         # All platform toolsets should be identical
         for ts in tool_sets[1:]:
             assert ts == tool_sets[0]
+
+    def test_signal_platform_toolset_includes_react_message(self):
+        assert "react_message" in TOOLSETS["hermes-signal"]["tools"]
+        assert "react_message" in TOOLSETS["messaging"]["tools"]

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -8,8 +8,10 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from gateway.config import Platform
-from tools.send_message_tool import _send_telegram, _send_to_platform, send_message_tool
+from tools.send_message_tool import _react_on_platform, _react_signal, _send_telegram, _send_to_platform, react_message_tool, send_message_tool
 
 
 def _run_async_immediately(coro):
@@ -238,6 +240,53 @@ class TestSendMessageTool:
             thread_id=None,
         )
 
+    def test_react_message_defaults_to_current_signal_session(self):
+        signal_cfg = SimpleNamespace(enabled=True, token=None, extra={"http_url": "http://localhost:8080", "account": "+14322517430"})
+        config = SimpleNamespace(
+            platforms={Platform.SIGNAL: signal_cfg},
+            get_home_channel=lambda _platform: None,
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "HERMES_SESSION_PLATFORM": "signal",
+                "HERMES_SESSION_CHAT_ID": "+15551230000",
+                "HERMES_SESSION_MESSAGE_ID": "1712345000000",
+                "HERMES_SESSION_USER_ID": "+15551230000",
+            },
+            clear=False,
+        ), \
+             patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._react_on_platform", new=AsyncMock(return_value={"success": True, "emoji": "😂"})) as react_mock:
+            result = json.loads(
+                react_message_tool(
+                    {
+                        "emoji": "😂",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        react_mock.assert_awaited_once_with(
+            Platform.SIGNAL,
+            signal_cfg,
+            "+15551230000",
+            message_id="1712345000000",
+            emoji="😂",
+            author_id="+15551230000",
+            thread_id=None,
+            remove=False,
+        )
+
+    def test_react_message_requires_current_message_context(self):
+        with patch.dict(os.environ, {}, clear=True):
+            result = json.loads(react_message_tool({"emoji": "😂"}))
+
+        assert "error" in result
+        assert "No active session target" in result["error"] or "No target message_id" in result["error"]
+
 
 class TestSendTelegramMediaDelivery:
     def test_sends_text_then_photo_for_media_tag(self, tmp_path, monkeypatch):
@@ -345,6 +394,77 @@ class TestSendTelegramMediaDelivery:
         assert "error" in result
         assert "No deliverable text or media remained" in result["error"]
         bot.send_message.assert_not_awaited()
+
+
+class TestSignalReactHelper:
+    def test_react_on_platform_routes_signal(self):
+        signal_cfg = SimpleNamespace(enabled=True, token=None, extra={"http_url": "http://localhost:8080", "account": "+14322517430"})
+
+        with patch("tools.send_message_tool._react_signal", new=AsyncMock(return_value={"success": True, "emoji": "😂"})) as react_mock:
+            result = asyncio.run(
+                _react_on_platform(
+                    Platform.SIGNAL,
+                    signal_cfg,
+                    "+15551230000",
+                    message_id="1712345000000",
+                    emoji="😂",
+                    author_id="+15551230000",
+                    remove=False,
+                )
+            )
+
+        assert result["success"] is True
+        react_mock.assert_awaited_once_with(
+            signal_cfg.extra,
+            "+15551230000",
+            "1712345000000",
+            "😂",
+            "+15551230000",
+            remove=False,
+        )
+
+    def test_send_signal_reaction_rpc_payload(self):
+        httpx = pytest.importorskip("httpx")
+        captured = {}
+
+        class _Response:
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {"result": {"ok": True}}
+
+        class _Client:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def post(self, url, json):
+                captured["url"] = url
+                captured["json"] = json
+                return _Response()
+
+        with patch.object(httpx, "AsyncClient", _Client):
+            result = asyncio.run(
+                _react_signal(
+                    {"http_url": "http://localhost:8080", "account": "+14322517430"},
+                    "+15551230000",
+                    "1712345000000",
+                    "😂",
+                    "+15551230000",
+                )
+            )
+
+        assert result["success"] is True
+        assert captured["json"]["method"] == "sendReaction"
+        assert captured["json"]["params"]["emoji"] == "😂"
+        assert captured["json"]["params"]["targetAuthor"] == "+15551230000"
+        assert captured["json"]["params"]["targetTimestamp"] == 1712345000000
 
 
 # ---------------------------------------------------------------------------

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -53,6 +53,42 @@ SEND_MESSAGE_SCHEMA = {
     }
 }
 
+REACT_MESSAGE_SCHEMA = {
+    "name": "react_message",
+    "description": (
+        "React to a message on a messaging platform with an emoji.\n\n"
+        "Use this for human-like reactions when it feels natural: funny messages, appreciation, surprise, agreement, etc.\n"
+        "Be sparing and socially normal. By default, this reacts to the current inbound message in the active session.\n"
+        "You may optionally override the target platform/chat/message details when needed."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "emoji": {
+                "type": "string",
+                "description": "Emoji to use for the reaction, for example '😂', '❤️', '🔥', '👍'."
+            },
+            "target": {
+                "type": "string",
+                "description": "Optional explicit delivery target, like 'signal:+15551234567'. If omitted, uses the current session chat."
+            },
+            "message_id": {
+                "type": "string",
+                "description": "Optional explicit target message id. If omitted, reacts to the current inbound message."
+            },
+            "author_id": {
+                "type": "string",
+                "description": "Optional explicit author identifier for the target message. If omitted, uses the current inbound sender."
+            },
+            "remove": {
+                "type": "boolean",
+                "description": "Set true to remove an existing reaction instead of adding one."
+            }
+        },
+        "required": ["emoji"]
+    }
+}
+
 
 def send_message_tool(args, **kw):
     """Handle cross-channel send_message tool calls."""
@@ -62,6 +98,11 @@ def send_message_tool(args, **kw):
         return _handle_list()
 
     return _handle_send(args)
+
+
+def react_message_tool(args, **kw):
+    """Handle cross-channel message reactions."""
+    return _handle_react(args)
 
 
 def _handle_list():
@@ -193,6 +234,93 @@ def _handle_send(args):
         return json.dumps(result)
     except Exception as e:
         return json.dumps({"error": f"Send failed: {e}"})
+
+
+def _handle_react(args):
+    """React to a platform message, defaulting to the current session context."""
+    emoji = (args.get("emoji") or "").strip()
+    if not emoji:
+        return json.dumps({"error": "'emoji' is required"})
+
+    target = args.get("target", "").strip()
+    message_id = str(args.get("message_id") or os.getenv("HERMES_SESSION_MESSAGE_ID", "")).strip()
+    author_id = str(args.get("author_id") or os.getenv("HERMES_SESSION_USER_ID", "") or os.getenv("HERMES_SESSION_USER_ID_ALT", "")).strip()
+    remove = bool(args.get("remove", False))
+
+    if target:
+        parts = target.split(":", 1)
+        platform_name = parts[0].strip().lower()
+        target_ref = parts[1].strip() if len(parts) > 1 else None
+        chat_id = None
+        thread_id = None
+        if target_ref:
+            chat_id, thread_id, is_explicit = _parse_target_ref(platform_name, target_ref)
+            if not is_explicit:
+                chat_id = target_ref
+        else:
+            chat_id = os.getenv("HERMES_SESSION_CHAT_ID", "").strip()
+            thread_id = os.getenv("HERMES_SESSION_THREAD_ID", "").strip() or None
+    else:
+        platform_name = os.getenv("HERMES_SESSION_PLATFORM", "").strip().lower()
+        chat_id = os.getenv("HERMES_SESSION_CHAT_ID", "").strip()
+        thread_id = os.getenv("HERMES_SESSION_THREAD_ID", "").strip() or None
+
+    if not platform_name:
+        return json.dumps({"error": "No active session target found for react_message"})
+    if not chat_id:
+        return json.dumps({"error": "No chat target found for react_message"})
+    if not message_id:
+        return json.dumps({"error": "No target message_id found for react_message"})
+    if not author_id and platform_name == "signal":
+        return json.dumps({"error": "Signal reactions require the target message author_id"})
+
+    try:
+        from gateway.config import load_gateway_config, Platform
+        config = load_gateway_config()
+    except Exception as e:
+        return json.dumps({"error": f"Failed to load gateway config: {e}"})
+
+    platform_map = {
+        "telegram": Platform.TELEGRAM,
+        "discord": Platform.DISCORD,
+        "slack": Platform.SLACK,
+        "whatsapp": Platform.WHATSAPP,
+        "signal": Platform.SIGNAL,
+        "matrix": Platform.MATRIX,
+        "mattermost": Platform.MATTERMOST,
+        "homeassistant": Platform.HOMEASSISTANT,
+        "dingtalk": Platform.DINGTALK,
+        "feishu": Platform.FEISHU,
+        "wecom": Platform.WECOM,
+        "email": Platform.EMAIL,
+        "sms": Platform.SMS,
+    }
+    platform = platform_map.get(platform_name)
+    if not platform:
+        avail = ", ".join(platform_map.keys())
+        return json.dumps({"error": f"Unknown platform: {platform_name}. Available: {avail}"})
+
+    pconfig = config.platforms.get(platform)
+    if not pconfig or not pconfig.enabled:
+        return json.dumps({"error": f"Platform '{platform_name}' is not configured."})
+
+    try:
+        from model_tools import _run_async
+        result = _run_async(
+            _react_on_platform(
+                platform,
+                pconfig,
+                chat_id,
+                message_id=message_id,
+                emoji=emoji,
+                author_id=author_id or None,
+                thread_id=thread_id,
+                remove=remove,
+            )
+        )
+        return json.dumps(result)
+    except Exception as e:
+        return json.dumps({"error": f"Reaction failed: {e}"})
 
 
 def _parse_target_ref(platform_name: str, target_ref: str):
@@ -383,6 +511,15 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         warnings.append(warning)
         last_result["warnings"] = warnings
     return last_result
+
+
+async def _react_on_platform(platform, pconfig, chat_id, message_id, emoji, author_id=None, thread_id=None, remove=False):
+    """React to an existing message on a supported platform."""
+    from gateway.config import Platform
+
+    if platform == Platform.SIGNAL:
+        return await _react_signal(pconfig.extra, chat_id, message_id, emoji, author_id, remove=remove)
+    return {"error": f"react_message is not yet implemented for {platform.value}"}
 
 
 async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None):
@@ -610,6 +747,55 @@ async def _send_signal(extra, chat_id, message):
             return {"success": True, "platform": "signal", "chat_id": chat_id}
     except Exception as e:
         return {"error": f"Signal send failed: {e}"}
+
+
+async def _react_signal(extra, chat_id, message_id, emoji, author_id, remove=False):
+    """React to a Signal message via signal-cli JSON-RPC."""
+    try:
+        import httpx
+    except ImportError:
+        return {"error": "httpx not installed"}
+    try:
+        http_url = extra.get("http_url", "http://127.0.0.1:8080").rstrip("/")
+        account = extra.get("account", "")
+        if not account:
+            return {"error": "Signal account not configured"}
+
+        params = {
+            "account": account,
+            "emoji": emoji,
+            "targetAuthor": author_id,
+            "targetTimestamp": int(str(message_id)),
+            "remove": bool(remove),
+        }
+        if chat_id.startswith("group:"):
+            params["groupId"] = chat_id[6:]
+        else:
+            params["recipient"] = [chat_id]
+
+        payload = {
+            "jsonrpc": "2.0",
+            "method": "sendReaction",
+            "params": params,
+            "id": f"react_{int(time.time() * 1000)}",
+        }
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(f"{http_url}/api/v1/rpc", json=payload)
+            resp.raise_for_status()
+            data = resp.json()
+            if "error" in data:
+                return {"error": f"Signal RPC error: {data['error']}"}
+            return {
+                "success": True,
+                "platform": "signal",
+                "chat_id": chat_id,
+                "message_id": str(message_id),
+                "emoji": emoji,
+                "removed": bool(remove),
+            }
+    except Exception as e:
+        return {"error": f"Signal reaction failed: {e}"}
 
 
 async def _send_email(extra, chat_id, message):
@@ -893,6 +1079,11 @@ def _check_send_message():
         return False
 
 
+def _check_react_message():
+    """Gate react_message on a live messaging session or running gateway."""
+    return _check_send_message()
+
+
 # --- Registry ---
 from tools.registry import registry
 
@@ -903,4 +1094,13 @@ registry.register(
     handler=send_message_tool,
     check_fn=_check_send_message,
     emoji="📨",
+)
+
+registry.register(
+    name="react_message",
+    toolset="messaging",
+    schema=REACT_MESSAGE_SCHEMA,
+    handler=react_message_tool,
+    check_fn=_check_react_message,
+    emoji="😀",
 )

--- a/toolsets.py
+++ b/toolsets.py
@@ -59,7 +59,7 @@ _HERMES_CORE_TOOLS = [
     # Cronjob management
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
-    "send_message",
+    "send_message", "react_message",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
 ]
@@ -130,7 +130,7 @@ TOOLSETS = {
     
     "messaging": {
         "description": "Cross-platform messaging: send messages to Telegram, Discord, Slack, SMS, etc.",
-        "tools": ["send_message"],
+        "tools": ["send_message", "react_message"],
         "includes": []
     },
     


### PR DESCRIPTION
## Summary
- add Signal-native reply context parsing plus opt-in native replies instead of forcing replies on every message
- expose `react_message` to Signal agents and route Signal reactions through `sendReaction`
- send Signal voice replies through stock `signal-cli` using filename-less data URI audio so they render in native audio UI
- fix Signal toolset expansion so `react_message` and `text_to_speech` are actually available at runtime
- update Signal prompting/session context so the agent can see replied-to content and choose human-like reactions

## Details
This PR keeps Signal on the stock `signal-cli` path and improves three core interaction patterns:

1. Reactions
- adds a model-facing `react_message` tool
- defaults reactions to the current inbound message using session message metadata
- passes arbitrary emoji through Signal `sendReaction`

2. Replies / threading
- preserves inbound Signal timestamps as stable `message_id`s
- parses Signal quote metadata into reply context
- stops auto-threading Signal responses by default
- adds explicit opt-in native replies via `[[reply_to_current]]`

3. Voice / native audio UI
- sends Signal voice/audio replies as filename-less data URI attachments
- preserves stock `signal-cli` compatibility while rendering in Signal's native audio UI

## Validation
- `venv/bin/python -m pytest tests/hermes_cli/test_tools_config.py tests/gateway/test_base_topic_sessions.py tests/agent/test_prompt_builder.py tests/gateway/test_signal.py tests/test_toolsets.py -q`
- `venv/bin/python -m pytest tests/tools/test_send_message_tool.py -q`

Both passed locally.
