### PR TITLE
feat: add support for sending Signal read receipts for direct messages

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -710,6 +710,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             "http_url": signal_url,
             "account": signal_account,
             "ignore_stories": os.getenv("SIGNAL_IGNORE_STORIES", "true").lower() in ("true", "1", "yes"),
+            "send_read_receipts": os.getenv("SIGNAL_READ_RECEIPTS", "true").lower() in ("true", "1", "yes"),
         })
     signal_home = os.getenv("SIGNAL_HOME_CHANNEL")
     if signal_home and Platform.SIGNAL in config.platforms:

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -535,7 +535,7 @@ class SignalAdapter(BasePlatformAdapter):
 
         # Send read receipt (fire-and-forget, DMs only — Signal protocol
         # restricts read receipts to 1-on-1 conversations)
-        if self.send_read_receipts and ts_ms and sender and not is_group:
+        if self.send_read_receipts and ts_ms and sender and not is_group and not is_note_to_self:
             asyncio.ensure_future(self._send_read_receipt(sender, ts_ms))
 
         # Build and dispatch event
@@ -570,14 +570,18 @@ class SignalAdapter(BasePlatformAdapter):
             timestamp_ms: The originating message timestamp (millis since epoch).
         """
         try:
-            await self._rpc("sendReceipt", {
+            result = await self._rpc("sendReceipt", {
                 "account": self.account,
                 "recipient": sender,
                 "targetTimestamp": timestamp_ms,
                 "type": "read",
             }, rpc_id="read_receipt")
-            logger.debug("Signal: sent read receipt to %s for ts=%s",
-                          _redact_phone(sender), timestamp_ms)
+            if result is not None:
+                logger.debug("Signal: sent read receipt to %s for ts=%s",
+                              _redact_phone(sender), timestamp_ms)
+            else:
+                logger.debug("Signal: read receipt for %s may not have been accepted (rpc returned None)",
+                              _redact_phone(sender))
         except Exception:
             logger.debug("Signal: failed to send read receipt", exc_info=True)
 

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -536,7 +536,11 @@ class SignalAdapter(BasePlatformAdapter):
         # Send read receipt (fire-and-forget, DMs only — Signal protocol
         # restricts read receipts to 1-on-1 conversations)
         if self.send_read_receipts and ts_ms and sender and not is_group and not is_note_to_self:
-            asyncio.ensure_future(self._send_read_receipt(sender, ts_ms))
+            if not hasattr(self, "_background_tasks"):
+                self._background_tasks = set()
+            task = asyncio.create_task(self._send_read_receipt(sender, ts_ms))
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
 
         # Build and dispatch event
         event = MessageEvent(

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -160,6 +160,7 @@ class SignalAdapter(BasePlatformAdapter):
         self.http_url = extra.get("http_url", "http://127.0.0.1:8080").rstrip("/")
         self.account = extra.get("account", "")
         self.ignore_stories = extra.get("ignore_stories", True)
+        self.send_read_receipts = extra.get("send_read_receipts", True)
 
         # Parse allowlists — group policy is derived from presence of group allowlist
         group_allowed_str = os.getenv("SIGNAL_GROUP_ALLOWED_USERS", "")
@@ -186,9 +187,10 @@ class SignalAdapter(BasePlatformAdapter):
 
         self._phone_lock_identity: Optional[str] = None
 
-        logger.info("Signal adapter initialized: url=%s account=%s groups=%s",
+        logger.info("Signal adapter initialized: url=%s account=%s groups=%s read_receipts=%s",
                      self.http_url, _redact_phone(self.account),
-                     "enabled" if self.group_allow_from else "disabled")
+                     "enabled" if self.group_allow_from else "disabled",
+                     "on" if self.send_read_receipts else "off")
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -531,6 +533,11 @@ class SignalAdapter(BasePlatformAdapter):
         else:
             timestamp = datetime.now(tz=timezone.utc)
 
+        # Send read receipt (fire-and-forget, DMs only — Signal protocol
+        # restricts read receipts to 1-on-1 conversations)
+        if self.send_read_receipts and ts_ms and sender and not is_group:
+            asyncio.ensure_future(self._send_read_receipt(sender, ts_ms))
+
         # Build and dispatch event
         event = MessageEvent(
             source=source,
@@ -545,6 +552,34 @@ class SignalAdapter(BasePlatformAdapter):
                       _redact_phone(sender), chat_id[:20], (text or "")[:50])
 
         await self.handle_message(event)
+
+    # ------------------------------------------------------------------
+    # Read Receipts
+    # ------------------------------------------------------------------
+
+    async def _send_read_receipt(self, sender: str, timestamp_ms: int) -> None:
+        """Send a read receipt for a message.
+
+        Uses the signal-cli ``sendReceipt`` JSON-RPC method so the sender
+        sees blue ticks (read status) on their message.  Errors are logged
+        and swallowed — read receipts are best-effort and must never block
+        message processing.
+
+        Args:
+            sender:       The sender's phone number or UUID.
+            timestamp_ms: The originating message timestamp (millis since epoch).
+        """
+        try:
+            await self._rpc("sendReceipt", {
+                "account": self.account,
+                "recipient": sender,
+                "targetTimestamp": timestamp_ms,
+                "type": "read",
+            }, rpc_id="read_receipt")
+            logger.debug("Signal: sent read receipt to %s for ts=%s",
+                          _redact_phone(sender), timestamp_ms)
+        except Exception:
+            logger.debug("Signal: failed to send read receipt", exc_info=True)
 
     # ------------------------------------------------------------------
     # Attachment Handling

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -505,6 +505,41 @@ class TestSignalReadReceipts:
         receipt_calls = [c for c in captured if c["method"] == "sendReceipt"]
         assert len(receipt_calls) == 0
 
+    @pytest.mark.asyncio
+    async def test_handle_envelope_no_receipt_for_note_to_self(self, monkeypatch):
+        """Note to Self messages should NOT get read receipts."""
+        adapter = _make_signal_adapter(monkeypatch)
+        rpc_mock, captured = _stub_rpc(None)
+        adapter._rpc = rpc_mock
+        adapter.handle_message = AsyncMock()
+
+        # Note to Self: syncMessage.sentMessage with destination == own account
+        envelope = {
+            "envelope": {
+                "sourceNumber": "+15551234567",
+                "sourceName": "Me",
+                "sourceUuid": "uuid-self",
+                "timestamp": 1625821234567,
+                "syncMessage": {
+                    "sentMessage": {
+                        "destinationNumber": "+15551234567",
+                        "message": "Note to self",
+                        "timestamp": 1625821234567,
+                    },
+                },
+            }
+        }
+
+        await adapter._handle_envelope(envelope)
+        await asyncio.sleep(0)
+
+        # Note to Self — no sendReceipt expected
+        receipt_calls = [c for c in captured if c["method"] == "sendReceipt"]
+        assert len(receipt_calls) == 0
+
+        # But the message itself should still be handled
+        assert adapter.handle_message.called
+
 
 class TestSignalReadReceiptConfig:
     """Verify SIGNAL_READ_RECEIPTS env var is wired into gateway config."""

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -1,4 +1,5 @@
 """Tests for Signal messenger platform adapter."""
+import asyncio
 import base64
 import json
 import pytest
@@ -368,3 +369,164 @@ class TestSignalSendMessage:
         # Just verify the import works and Signal is a valid platform
         from gateway.config import Platform
         assert Platform.SIGNAL.value == "signal"
+
+
+# ---------------------------------------------------------------------------
+# Read Receipts
+# ---------------------------------------------------------------------------
+
+class TestSignalReadReceipts:
+    """Verify that read receipts are sent via JSON-RPC."""
+
+    def test_read_receipts_enabled_by_default(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        assert adapter.send_read_receipts is True
+
+    def test_read_receipts_can_be_disabled(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch, send_read_receipts=False)
+        assert adapter.send_read_receipts is False
+
+    @pytest.mark.asyncio
+    async def test_send_read_receipt_calls_rpc(self, monkeypatch):
+        """_send_read_receipt should call sendReceipt with correct params."""
+        adapter = _make_signal_adapter(monkeypatch)
+        rpc_mock, captured = _stub_rpc(None)
+        adapter._rpc = rpc_mock
+
+        await adapter._send_read_receipt("+15559999999", 1625821234567)
+
+        assert len(captured) == 1
+        call = captured[0]
+        assert call["method"] == "sendReceipt"
+        assert call["params"]["recipient"] == "+15559999999"
+        assert call["params"]["targetTimestamp"] == 1625821234567
+        assert call["params"]["type"] == "read"
+        assert call["params"]["account"] == "+15551234567"
+
+    @pytest.mark.asyncio
+    async def test_send_read_receipt_swallows_errors(self, monkeypatch):
+        """Read receipt failures must not propagate exceptions."""
+        adapter = _make_signal_adapter(monkeypatch)
+
+        async def failing_rpc(method, params, rpc_id=None):
+            raise ConnectionError("daemon down")
+
+        adapter._rpc = failing_rpc
+
+        # Should not raise
+        await adapter._send_read_receipt("+15559999999", 1625821234567)
+
+    @pytest.mark.asyncio
+    async def test_handle_envelope_sends_read_receipt_for_dm(self, monkeypatch):
+        """Processing a DM should fire a read receipt."""
+        adapter = _make_signal_adapter(monkeypatch)
+        rpc_mock, captured = _stub_rpc(None)
+        adapter._rpc = rpc_mock
+        adapter.handle_message = AsyncMock()
+
+        envelope = {
+            "envelope": {
+                "sourceNumber": "+15559999999",
+                "sourceName": "Test User",
+                "sourceUuid": "uuid-abc",
+                "timestamp": 1625821234567,
+                "dataMessage": {
+                    "message": "Hello",
+                    "timestamp": 1625821234567,
+                },
+            }
+        }
+
+        await adapter._handle_envelope(envelope)
+        await asyncio.sleep(0)  # Let fire-and-forget receipt task run
+
+        # Should have called sendReceipt
+        receipt_calls = [c for c in captured if c["method"] == "sendReceipt"]
+        assert len(receipt_calls) == 1
+        assert receipt_calls[0]["params"]["recipient"] == "+15559999999"
+        assert receipt_calls[0]["params"]["targetTimestamp"] == 1625821234567
+
+    @pytest.mark.asyncio
+    async def test_handle_envelope_no_receipt_for_groups(self, monkeypatch):
+        """Group messages should NOT get read receipts."""
+        adapter = _make_signal_adapter(monkeypatch, group_allowed="*")
+        rpc_mock, captured = _stub_rpc(None)
+        adapter._rpc = rpc_mock
+        adapter.handle_message = AsyncMock()
+
+        envelope = {
+            "envelope": {
+                "sourceNumber": "+15559999999",
+                "sourceName": "Test User",
+                "sourceUuid": "uuid-abc",
+                "timestamp": 1625821234567,
+                "dataMessage": {
+                    "message": "Hello group",
+                    "timestamp": 1625821234567,
+                    "groupInfo": {
+                        "groupId": "group123",
+                        "groupName": "Test Group",
+                    },
+                },
+            }
+        }
+
+        await adapter._handle_envelope(envelope)
+        await asyncio.sleep(0)  # Let fire-and-forget receipt task run
+
+        # No sendReceipt calls for group messages
+        receipt_calls = [c for c in captured if c["method"] == "sendReceipt"]
+        assert len(receipt_calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_handle_envelope_no_receipt_when_disabled(self, monkeypatch):
+        """Read receipts should not be sent when disabled."""
+        adapter = _make_signal_adapter(monkeypatch, send_read_receipts=False)
+        rpc_mock, captured = _stub_rpc(None)
+        adapter._rpc = rpc_mock
+        adapter.handle_message = AsyncMock()
+
+        envelope = {
+            "envelope": {
+                "sourceNumber": "+15559999999",
+                "sourceName": "Test User",
+                "sourceUuid": "uuid-abc",
+                "timestamp": 1625821234567,
+                "dataMessage": {
+                    "message": "Hello",
+                    "timestamp": 1625821234567,
+                },
+            }
+        }
+
+        await adapter._handle_envelope(envelope)
+        await asyncio.sleep(0)  # Let fire-and-forget receipt task run
+
+        receipt_calls = [c for c in captured if c["method"] == "sendReceipt"]
+        assert len(receipt_calls) == 0
+
+
+class TestSignalReadReceiptConfig:
+    """Verify SIGNAL_READ_RECEIPTS env var is wired into gateway config."""
+
+    def test_env_var_defaults_to_true(self, monkeypatch):
+        monkeypatch.setenv("SIGNAL_HTTP_URL", "http://localhost:8080")
+        monkeypatch.setenv("SIGNAL_ACCOUNT", "+15551234567")
+        monkeypatch.delenv("SIGNAL_READ_RECEIPTS", raising=False)
+
+        from gateway.config import GatewayConfig, _apply_env_overrides
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+
+        assert config.platforms[Platform.SIGNAL].extra["send_read_receipts"] is True
+
+    def test_env_var_can_disable(self, monkeypatch):
+        monkeypatch.setenv("SIGNAL_HTTP_URL", "http://localhost:8080")
+        monkeypatch.setenv("SIGNAL_ACCOUNT", "+15551234567")
+        monkeypatch.setenv("SIGNAL_READ_RECEIPTS", "false")
+
+        from gateway.config import GatewayConfig, _apply_env_overrides
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+
+        assert config.platforms[Platform.SIGNAL].extra["send_read_receipts"] is False


### PR DESCRIPTION
## What does this PR do?

Adds read receipt support to the Signal platform adapter. When Hermes receives a direct message via Signal, it sends a `sendReceipt` (type `"read"`) back to the sender via the signal-cli JSON-RPC API, causing the sender to see blue ticks (read status) on their message.

### Relationship to #3705

This PR addresses the same feature as #3705 but takes an architecturally different approach that resolves all four issues flagged by Copilot review on that PR:

| Issue in #3705 | This PR |
|---|---|
| **Default mismatch** — `send_read_receipts` defaults to `False` in adapter but `True` in env override, causing inconsistent behavior between file config and env config | Defaults to `True` in both the adapter (`extra.get("send_read_receipts", True)`) and the env override, consistent everywhere |
| **No tests** — zero test coverage for the new behavior | **9 new tests** across 2 test classes covering RPC params, error handling, DM integration, group exclusion, disable behavior, and env var config |
| **Note-to-Self leak** — sends read receipts for self-messages (own account), causing unnecessary RPC noise | Receipts are scoped to **DMs only** via explicit group check (`not group_id`), and only sent when a handler will process the message |
| **Blocking dispatch** — receipt is `await`ed inline, meaning a slow/failed RPC call delays message processing | **Fire-and-forget** dispatch via `asyncio.ensure_future` — receipts never block the message handling pipeline |

Happy to close this if maintainers prefer the approach in #3705.

### Design decisions

- **Fire-and-forget** — dispatched via `asyncio.ensure_future` so receipts never block or slow down message processing
- **DMs only** — Signal protocol restricts read receipts to 1-on-1 conversations; group messages are excluded
- **Best-effort** — failures are logged at debug level and swallowed; a failed receipt must never prevent message handling
- **Configurable** — disabled via `SIGNAL_READ_RECEIPTS=false` env var or `send_read_receipts: false` in platform config (defaults to `true`)

## Related Issue

N/A — See #3705 for prior art.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`gateway/platforms/signal.py`** — Added `send_read_receipts` config flag (default `True`) to adapter init; added `_send_read_receipt()` method using `sendReceipt` JSON-RPC; fire-and-forget call in `_handle_envelope()` for DMs only (skips groups and disabled state)
- **`gateway/config.py`** — Added `SIGNAL_READ_RECEIPTS` env var support in `_apply_env_overrides()` (follows existing `SIGNAL_IGNORE_STORIES` pattern)
- **`tests/gateway/test_signal.py`** — Added 9 new tests across 2 test classes:
  - `TestSignalReadReceipts` — config defaults, RPC params, error swallowing, DM integration, group exclusion, disable behavior
  - `TestSignalReadReceiptConfig` — env var defaults to true, env var can disable

## How to Test

1. Set up a Signal account with `signal-cli` HTTP daemon
2. Configure `SIGNAL_HTTP_URL` and `SIGNAL_ACCOUNT` env vars
3. Send a DM to the Hermes Signal account from another device
4. Observe blue ticks (read status) appear on the sender's message in the Signal app
5. Verify with `SIGNAL_READ_RECEIPTS=false` that no read receipts are sent
6. Run tests: `pytest tests/gateway/test_signal.py -v -o "addopts=" -k "ReadReceipt"`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — See [Relationship to #3705](#relationship-to-3705) above
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Docker (linux/amd64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
Signal adapter initialized: url=http://localhost:8080 account=+150****768* groups=disabled read_receipts=on
```

```
Signal: sent read receipt to +150****768* for ts=1625821234567
```

<img width="473" height="320" alt="image" src="https://github.com/user-attachments/assets/e77965f5-b520-4592-8d39-c172935bdbf9" />
