### PR TITLE
perf: fix O(n²) catastrophic backtracking in redact regex

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -53,7 +53,7 @@ _PREFIX_PATTERNS = [
 # ENV assignment patterns: KEY=value where KEY contains a secret-like name
 _SECRET_ENV_NAMES = r"(?:API_?KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|AUTH)"
 _ENV_ASSIGN_RE = re.compile(
-    rf"([A-Z_]*{_SECRET_ENV_NAMES}[A-Z_]*)\s*=\s*(['\"]?)(\S+)\2",
+    rf"([A-Z_]{{0,50}}{_SECRET_ENV_NAMES}[A-Z_]{{0,50}})\s*=\s*(['\"]?)(\S+)\2",
     re.IGNORECASE,
 )
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -345,8 +345,6 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         # ── Perform the read ──────────────────────────────────────────
         file_ops = _get_file_ops(task_id)
         result = file_ops.read_file(path, offset, limit)
-        if result.content:
-            result.content = redact_sensitive_text(result.content)
         result_dict = result.to_dict()
 
         # ── Character-count guard ─────────────────────────────────────
@@ -355,6 +353,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         # amount of content, reject it and tell the model to narrow down.
         # Note: we check the formatted content (with line-number prefixes),
         # not the raw file size, because that's what actually enters context.
+        # Check BEFORE redaction to avoid expensive regex on huge content.
         content_len = len(result.content or "")
         file_size = result_dict.get("file_size", 0)
         max_chars = _get_max_read_chars()
@@ -371,6 +370,11 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 "total_lines": total_lines,
                 "file_size": file_size,
             }, ensure_ascii=False)
+
+        # ── Redact secrets (after guard check to skip oversized content) ──
+        if result.content:
+            result.content = redact_sensitive_text(result.content)
+            result_dict["content"] = result.content
 
         # Large-file hint: if the file is big and the caller didn't ask
         # for a narrow window, nudge toward targeted reads.


### PR DESCRIPTION
## Problem

Three tests in `test_file_read_guards.py` consistently time out on CI (30s limit):
- `TestCharacterCountGuard::test_content_under_limit_passes`
- `TestCharacterCountGuard::test_oversized_read_rejected`
- `TestConfigOverride::test_custom_config_raises_limit`

These are pre-existing issues unrelated to any feature PR.

## Root Cause

**1. O(n²) regex in `agent/redact.py`**

`_ENV_ASSIGN_RE` uses unbounded `[A-Z_]*` with `IGNORECASE`, which matches any letter or underscore. On 100K+ character uniform strings (like the test fixtures), the engine tries every start position, greedily matches to end-of-string, then backtracks character-by-character looking for `API_KEY`/`TOKEN`/etc. This is classic catastrophic backtracking.

Empirical timing: 5K chars → 0.2s, 10K → 0.6s, 20K → 2.4s, 100K → ~60s (extrapolated).

**2. Guard ordering in `tools/file_tools.py`**

`redact_sensitive_text()` ran BEFORE the character-count guard, so oversized content (that would be rejected anyway) went through the expensive regex first.

## Fix

1. **`agent/redact.py`**: Bound `[A-Z_]*` to `[A-Z_]{0,50}` — env var names are never 50K+ chars. Same matching for real-world input, eliminates pathological backtracking.

2. **`tools/file_tools.py`**: Move character-count guard before redaction. Content exceeding the limit is rejected immediately without touching the regex. Redaction only runs on content that passes the size check.

## Result

All 19 tests in `test_file_read_guards.py` pass in 2.6s (previously 3 timed out at 30s+).