### PR TITLE
fix: add memory provider dispatch to sequential tool execution path

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5966,6 +5966,11 @@ class AIAgent:
                 tool_duration = time.time() - tool_start_time
                 if self.quiet_mode:
                     self._vprint(f"  {_get_cute_tool_message_impl('memory', function_args, tool_duration, result=function_result)}")
+            elif self._memory_manager and self._memory_manager.has_tool(function_name):
+                function_result = self._memory_manager.handle_tool_call(function_name, function_args)
+                tool_duration = time.time() - tool_start_time
+                if self.quiet_mode:
+                    self._vprint(f"  {_get_cute_tool_message_impl(function_name, function_args, tool_duration, result=function_result)}")
             elif function_name == "clarify":
                 from tools.clarify_tool import clarify_tool as _clarify_tool
                 function_result = _clarify_tool(


### PR DESCRIPTION
## Summary

- External memory provider tools (mem0_profile, mem0_search, mem0_conclude) were returning "Unknown tool" errors when called through the gateway (Telegram, Discord, etc.)
- Root cause: `_execute_tool_calls_sequential()` was missing the `_memory_manager.has_tool()` check that exists in the concurrent path (`_invoke_tool()`)
- Single tool calls in `quiet_mode` (always used by the gateway) take the sequential path, so memory provider tools were completely broken on all gateway platforms

## Fix

Added the memory manager dispatch (5 lines) to the sequential tool execution path, matching what already exists in `_invoke_tool()` at line ~5620.

## Test plan

- [x] Verified mem0_profile, mem0_search, mem0_conclude work via Telegram gateway after fix
- [x] Confirmed concurrent path (multi-tool calls) was already working
- [x] No changes to existing tool dispatch behavior — only adds a missing elif branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)