### PR TITLE
fix: Ctrl+D deletes char under cursor, exits only on empty input

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8100,9 +8100,15 @@ class HermesCLI:
         
         @kb.add('c-d')
         def handle_ctrl_d(event):
-            """Handle Ctrl+D - exit."""
-            self._should_exit = True
-            event.app.exit()
+            """Ctrl+D: delete char under cursor (standard readline behaviour).
+            Only exit when the input is empty — same as bash/zsh.
+            """
+            buf = event.app.current_buffer
+            if buf.text:
+                buf.delete()
+            else:
+                self._should_exit = True
+                event.app.exit()
 
         @kb.add('c-z')
         def handle_ctrl_z(event):


### PR DESCRIPTION
Restores standard readline/bash/zsh behaviour for Ctrl+D:

- **With text in the buffer**: deletes the character under the cursor (forward delete)
- **Empty buffer**: exits (original behaviour preserved)

Currently Ctrl+D always exits immediately, making it impossible to use for forward-delete which is standard in every terminal application.