### PR TITLE
fix: forward base_url and api_key from fallback config to resolve_provider_client

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4506,7 +4506,9 @@ class AIAgent:
         try:
             from agent.auxiliary_client import resolve_provider_client
             fb_client, _ = resolve_provider_client(
-                fb_provider, model=fb_model, raw_codex=True)
+                fb_provider, model=fb_model, raw_codex=True,
+                explicit_base_url=fb.get("base_url"),
+                explicit_api_key=fb.get("api_key"))
             if fb_client is None:
                 logging.warning(
                     "Fallback to %s failed: provider not configured",

--- a/tests/test_fallback_model.py
+++ b/tests/test_fallback_model.py
@@ -191,10 +191,43 @@ class TestTryActivateFallback:
         with patch(
             "agent.auxiliary_client.resolve_provider_client",
             return_value=(mock_client, "my-model"),
-        ):
+        ) as mock_resolve:
             assert agent._try_activate_fallback() is True
             assert agent.client is mock_client
             assert agent.model == "my-model"
+            # Verify explicit_base_url was forwarded — without this the custom
+            # provider falls through to wrong credentials and the wrong endpoint.
+            _, kwargs = mock_resolve.call_args
+            assert kwargs.get("explicit_base_url") == "http://localhost:8080/v1"
+
+    def test_ollama_base_url_forwarded(self):
+        """base_url from fallback config must be passed to resolve_provider_client.
+
+        Regression test: when explicit_base_url is not forwarded, the custom
+        provider falls through to the primary provider's credentials and sends
+        the fallback model name to the wrong endpoint (e.g. a local model slug
+        sent to a cloud API), causing a 404.
+        """
+        agent = _make_agent(
+            fallback_model={
+                "provider": "custom",
+                "model": "mistral:latest",
+                "base_url": "http://127.0.0.1:11434/v1",
+            },
+        )
+        mock_client = _mock_resolve(
+            api_key="no-key-required",
+            base_url="http://127.0.0.1:11434/v1",
+        )
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, "mistral:latest"),
+        ) as mock_resolve:
+            assert agent._try_activate_fallback() is True
+            _, kwargs = mock_resolve.call_args
+            assert kwargs.get("explicit_base_url") == "http://127.0.0.1:11434/v1", (
+                "explicit_base_url not forwarded — fallback would route to wrong endpoint"
+            )
 
     def test_prompt_caching_enabled_for_claude_on_openrouter(self):
         agent = _make_agent(


### PR DESCRIPTION
## Summary

- `_try_activate_fallback` was calling `resolve_provider_client` without forwarding `base_url` or `api_key` from the fallback config
- For `provider: custom` with an explicit `base_url`, this caused the router to fall through to the primary provider's credentials — routing the fallback model slug to the wrong endpoint and returning a 404
- Fix: pass `explicit_base_url=fb.get("base_url")` and `explicit_api_key=fb.get("api_key")` in the call


🤖 Generated with [Claude Code](https://claude.com/claude-code)