### PR TITLE
fix(agent): route memory provider tools in sequential execution path

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5963,6 +5963,16 @@ class AIAgent:
                     old_text=function_args.get("old_text"),
                     store=self._memory_store,
                 )
+                # Bridge: notify external memory provider of built-in memory writes
+                if self._memory_manager and function_args.get("action") in ("add", "replace"):
+                    try:
+                        self._memory_manager.on_memory_write(
+                            function_args.get("action", ""),
+                            target,
+                            function_args.get("content", ""),
+                        )
+                    except Exception:
+                        pass
                 tool_duration = time.time() - tool_start_time
                 if self.quiet_mode:
                     self._vprint(f"  {_get_cute_tool_message_impl('memory', function_args, tool_duration, result=function_result)}")
@@ -6009,6 +6019,11 @@ class AIAgent:
                         spinner.stop(cute_msg)
                     elif self.quiet_mode:
                         self._vprint(f"  {cute_msg}")
+            elif self._memory_manager and self._memory_manager.has_tool(function_name):
+                function_result = self._memory_manager.handle_tool_call(function_name, function_args)
+                tool_duration = time.time() - tool_start_time
+                if self.quiet_mode:
+                    self._vprint(f"  {_get_cute_tool_message_impl(function_name, function_args, tool_duration, result=function_result)}")
             elif self.quiet_mode:
                 spinner = None
                 if not self.tool_progress_callback:


### PR DESCRIPTION
## Summary

The sequential tool execution path (`_execute_tool_calls_sequential`) was missing two dispatches that exist in the concurrent path (`_invoke_tool`):

1. **Memory provider tool routing** — tools like `fact_store` and `fact_feedback` (from holographic, hindsight, etc.) were registered in `valid_tool_names` and passed validation, but fell through to `handle_function_call()` which doesn't know about memory provider tools, causing "Unknown tool" errors.

2. **Memory write bridge** — when the built-in `memory` tool writes to MEMORY.md/USER.md, the concurrent path notifies external memory providers via `on_memory_write()` so they can mirror the data. The sequential path was missing this bridge, so holographic/hindsight/etc. never received built-in memory writes.

## Root Cause

`_invoke_tool` (used by concurrent execution) has both dispatches. `_execute_tool_calls_sequential` (used for single tool calls and interactive tools) had its own inline dispatch that was missing them. Single tool calls are the common case for gateway/Telegram, so this affected most real-world usage.

## Fix

15-line addition to `_execute_tool_calls_sequential`:
- `elif` branch routing memory provider tools through `_memory_manager.handle_tool_call()`
- `on_memory_write()` bridge after built-in `memory` tool execution

Both match the existing behavior in `_invoke_tool`.

## Testing

- Confirmed memory provider registers and activates correctly (tools in `valid_tool_names`)
- Confirmed model generates proper `fact_store` tool calls (raw API test to llama-server)
- Confirmed tool validation passes (`fact_store in valid_tool_names = True`)
- Confirmed `on_memory_write` bridge works: built-in memory writes now mirror to holographic SQLite store with HRR vectors
- Tested with both Qwen3.5-27B and Gemma 4 31B via local llama-server

Fixes #4781