### PR TITLE
fix: improve platform gateway reliability — multi-process protection, hook chat_id, and Feishu event queueing

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1060,6 +1060,10 @@ class FeishuAdapter(BasePlatformAdapter):
                 lambda data: self._on_reaction_event("im.message.reaction.deleted_v1", data)
             )
             .register_p2_card_action_trigger(self._on_card_action_trigger)
+            # Suppress noisy SDK errors for unhandled events (#4789)
+            .register_p2_im_chat_access_event_bot_p2p_chat_entered_v1(
+                lambda data: None  # Ignore bot p2p chat entered events
+            )
             .build()
         )
 

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1477,13 +1477,35 @@ class FeishuAdapter(BasePlatformAdapter):
     def _on_message_event(self, data: Any) -> None:
         """Normalize Feishu inbound events into MessageEvent."""
         if self._loop is None:
-            logger.warning("[Feishu] Dropping inbound message before adapter loop is ready")
+            # WebSocket callback fires before the main loop is ready.
+            # Queue the event and retry after a short delay.
+            if not hasattr(self, "_pending_events"):
+                self._pending_events = []
+            self._pending_events.append(data)
+            threading.Thread(target=self._drain_pending_events, daemon=True).start()
             return
         future = asyncio.run_coroutine_threadsafe(
             self._handle_message_event_data(data),
             self._loop,
         )
         future.add_done_callback(self._log_background_failure)
+
+    def _drain_pending_events(self) -> None:
+        """Wait for the main loop, then replay queued events."""
+        import time
+        deadline = time.time() + 5
+        while time.time() < deadline:
+            loop = getattr(self, "_loop", None)
+            if loop:
+                for ev in getattr(self, "_pending_events", []):
+                    asyncio.run_coroutine_threadsafe(
+                        self._handle_message_event_data(ev), loop
+                    )
+                self._pending_events = []
+                return
+            time.sleep(0.3)
+        logger.error("[Feishu] Loop never ready — dropped %d queued messages", len(getattr(self, "_pending_events", [])))
+        self._pending_events = []
 
     async def _handle_message_event_data(self, data: Any) -> None:
         """Shared inbound message handling for websocket and webhook transports."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2628,6 +2628,7 @@ class GatewayRunner:
                 "platform": source.platform.value if source.platform else "",
                 "user_id": source.user_id,
                 "session_id": session_entry.session_id,
+                "chat_id": source.chat_id,
                 "message": message_text[:500],
             }
             await self.hooks.emit("agent:start", hook_ctx)

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1107,6 +1107,15 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
     """
     sys.path.insert(0, str(PROJECT_ROOT))
     
+    # Prevent multiple concurrent gateway instances (protects Feishu WebSocket)
+    # Multiple processes share lark_oapi global state → only last one receives events
+    if not replace and os.environ.get("HERMES_GATEWAY_REPLACING") != "1":
+        existing_pids = find_gateway_pids()
+        if existing_pids:
+            print(f"⚠️  Gateway already running (PIDs: {existing_pids}). Aborting.")
+            print(f"   To replace it, run: hermes gateway run --replace")
+            sys.exit(1)
+    
     from gateway.run import start_gateway
     
     print("┌─────────────────────────────────────────────────────────┐")


### PR DESCRIPTION
# Problem

Platform gateways (Feishu, Telegram, etc.) suffer from three reliability issues:

1. **Silent message drops**: When the Feishu WebSocket callback fires before the main event loop is ready, inbound messages are dropped with a warning log but never delivered.
2. **Concurrent gateway processes**: Multiple gateway processes (e.g. `hermes run` + `hermes gateway`) share the *`lark_oapi`* global state, meaning only the last-started process receives events. This causes silent disconnections where Feishu shows connected but messages go unanswered.
3. **Missing `chat_id` in hook context**: Gateway hooks (e.g. card-streaming hooks) receive `session_id` but not `chat_id`, preventing platform adapters from creating platform-specific cards/messages without using internal session IDs.

# Changes

### `gateway/run.py`
- Add `chat_id` to `hook_ctx` for `agent:start` events, enabling hook handlers to target the correct platform destination

### `hermes_cli/gateway.py`
- Prevent concurrent gateway instances by checking for existing gateway processes before starting
- When an existing instance is detected, the new instance aborts with a helpful message (`hermes gateway run --replace` to override)

### `gateway/platforms/feishu.py`
- Queue inbound Feishu WebSocket events when the adapter loop is not yet ready, then replay them once the loop is available
- Previously these events were silently dropped, causing users to lose their first message after gateway restart

# Testing

- ✅ All three patches apply cleanly against latest `main` (cc54818d)
- ✅ Gateway syntax check passes for all modified files
- ✅ Tested on live Feishu gateway — messages flow correctly after restart
