### PR TITLE
fix(cli): fully filter session_meta from restored conversations

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2164,7 +2164,7 @@ class HermesCLI:
                 _cprint(f"\033[1;31mSession not found: {self.session_id}{_RST}")
                 _cprint(f"{_DIM}Use a session ID from a previous CLI run (hermes sessions list).{_RST}")
                 return False
-            restored = self._session_db.get_messages_as_conversation(self.session_id)
+            restored = self._load_restored_conversation(self.session_id)
             if restored:
                 self.conversation_history = restored
                 msg_count = len([m for m in restored if m.get("role") == "user"])
@@ -2334,6 +2334,39 @@ class HermesCLI:
 
         self.console.print()
 
+    @staticmethod
+    def _normalize_restored_conversation(
+        messages: List[Dict[str, Any]] | None,
+    ) -> List[Dict[str, Any]]:
+        """Drop transcript-only metadata before reusing session history."""
+        if not messages:
+            return []
+
+        normalized: List[Dict[str, Any]] = []
+        dropped_roles: set[str] = set()
+        for msg in messages:
+            if not isinstance(msg, dict):
+                continue
+            role = msg.get("role")
+            if role == "session_meta":
+                dropped_roles.add("session_meta")
+                continue
+            normalized.append(msg)
+
+        if dropped_roles:
+            logger.debug(
+                "Filtered transcript-only restored role(s): %s",
+                ", ".join(sorted(dropped_roles)),
+            )
+        return normalized
+
+    def _load_restored_conversation(self, session_id: str) -> List[Dict[str, Any]]:
+        """Load and normalize persisted conversation history for CLI restore paths."""
+        if not self._session_db:
+            return []
+        restored = self._session_db.get_messages_as_conversation(session_id)
+        return self._normalize_restored_conversation(restored)
+
     def _preload_resumed_session(self) -> bool:
         """Load a resumed session's history from the DB early (before first chat).
 
@@ -2359,7 +2392,7 @@ class HermesCLI:
             )
             return False
 
-        restored = self._session_db.get_messages_as_conversation(self.session_id)
+        restored = self._load_restored_conversation(self.session_id)
         if restored:
             self.conversation_history = restored
             msg_count = len([m for m in restored if m.get("role") == "user"])
@@ -3214,7 +3247,7 @@ class HermesCLI:
         self._pending_title = None
 
         # Load conversation history
-        restored = self._session_db.get_messages_as_conversation(target_id)
+        restored = self._load_restored_conversation(target_id)
         self.conversation_history = restored or []
 
         # Re-open the target session so it's not marked as ended

--- a/run_agent.py
+++ b/run_agent.py
@@ -2593,6 +2593,26 @@ class AIAgent:
         is present — so orphans from session loading or manual message
         manipulation are always caught.
         """
+        allowed_roles = {"system", "user", "assistant", "tool", "function", "developer"}
+        filtered_messages: List[Dict[str, Any]] = []
+        dropped_roles: set[str] = set()
+        for msg in messages:
+            if not isinstance(msg, dict):
+                continue
+            role = msg.get("role")
+            if role not in allowed_roles:
+                if role:
+                    dropped_roles.add(str(role))
+                continue
+            filtered_messages.append(msg)
+
+        if dropped_roles:
+            logger.debug(
+                "Pre-call sanitizer: dropped message(s) with unsupported role(s): %s",
+                ", ".join(sorted(dropped_roles)),
+            )
+
+        messages = filtered_messages
         surviving_call_ids: set = set()
         for msg in messages:
             if msg.get("role") == "assistant":

--- a/tests/test_agent_guardrails.py
+++ b/tests/test_agent_guardrails.py
@@ -106,6 +106,18 @@ class TestSanitizeApiMessages:
         assert len(out) == 2
         assert out[1]["tool_call_id"] == "c6"
 
+    def test_invalid_roles_are_dropped_before_api_call(self):
+        msgs = [
+            {"role": "session_meta", "content": ""},
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        assert out == [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+
 
 # ---------------------------------------------------------------------------
 # Phase 2a — _cap_delegate_task_calls

--- a/tests/test_cli_resume_command.py
+++ b/tests/test_cli_resume_command.py
@@ -1,0 +1,35 @@
+"""Method-level tests for CLI /resume history restoration."""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from tests.test_resume_display import _make_cli
+
+
+class TestCliResumeCommand:
+
+    def test_handle_resume_command_filters_session_meta(self):
+        cli = _make_cli()
+        cli.session_id = "current_session"
+
+        mock_db = MagicMock()
+        mock_db.get_session.return_value = {"id": "target_session", "title": "Saved Session"}
+        mock_db.get_messages_as_conversation.return_value = [
+            {"role": "session_meta", "content": None, "tools": []},
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        cli._session_db = mock_db
+
+        with patch("hermes_cli.main._resolve_session_by_name_or_id", return_value="target_session"):
+            cli._handle_resume_command("/resume Saved Session")
+
+        assert cli.session_id == "target_session"
+        assert cli.conversation_history == [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        mock_db.reopen_session.assert_called_once_with("target_session")

--- a/tests/test_resume_display.py
+++ b/tests/test_resume_display.py
@@ -394,6 +394,25 @@ class TestPreloadResumedSession:
         assert "Test Session" in output
         assert "2 user messages" in output
 
+    def test_preload_filters_session_meta_from_restored_history(self):
+        cli = _make_cli(resume="filtered_session")
+        messages = [
+            {"role": "session_meta", "content": None, "tools": []},
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        mock_db = MagicMock()
+        mock_db.get_session.return_value = {"id": "filtered_session", "title": None}
+        mock_db.get_messages_as_conversation.return_value = messages
+        mock_db._conn = MagicMock()
+        cli._session_db = mock_db
+
+        assert cli._preload_resumed_session() is True
+        assert cli.conversation_history == [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+
     def test_reopens_session_in_db(self):
         cli = _make_cli(resume="reopen_session")
         messages = [{"role": "user", "content": "hi"}]
@@ -458,6 +477,32 @@ class TestInitAgentSkipsPreloaded:
 
         # get_messages_as_conversation should NOT have been called
         mock_db.get_messages_as_conversation.assert_not_called()
+
+    def test_init_agent_filters_session_meta_when_loading_resumed_history(self):
+        cli = _make_cli(resume="restored_session")
+        cli._resumed = True
+        cli.conversation_history = []
+
+        mock_db = MagicMock()
+        mock_db.get_session.return_value = {"id": "restored_session", "title": None}
+        mock_db.get_messages_as_conversation.return_value = [
+            {"role": "session_meta", "content": None, "tools": []},
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": "answer"},
+        ]
+        mock_db._conn = MagicMock()
+        cli._session_db = mock_db
+
+        with (
+            patch.object(cli, "_ensure_runtime_credentials", return_value=True),
+            patch("cli.AIAgent", return_value=MagicMock()),
+        ):
+            assert cli._init_agent() is True
+
+        assert cli.conversation_history == [
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": "answer"},
+        ]
 
 
 # ── Config default tests ─────────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

This PR fixes the CLI restored-session path so transcript-only metadata such as `session_meta` does not leak back into provider-facing conversation history.

The issue is that resumed CLI conversations could restore raw session rows and reuse them as normal chat history. When those rows included non-transcript entries like `session_meta`, strict chat-completions providers could reject the outgoing request because of unsupported roles.

This change fixes that in two places:

1. CLI restored history is now normalized before being reused, so resumed conversations only keep transcript-safe roles.
2. The shared API-boundary sanitizer also drops unsupported roles before sending provider requests.

This keeps the fix narrow and defensive:
- restored CLI conversations behave consistently
- internal metadata rows do not re-enter `conversation_history`
- unsupported roles do not cross the provider boundary even if they appear upstream

## Related Issue

Fixes #4715

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added shared restored-conversation normalization in `cli.py`
- Routed all CLI restored-session entry points through the same normalization path:
  - `_init_agent()`
  - `_preload_resumed_session()`
  - `_handle_resume_command()`
- Ensured restored conversation history drops non-transcript roles such as `session_meta`
- Kept API-boundary filtering in `run_agent.py` so unsupported roles are removed before provider calls
- Added regression tests covering:
  - `_sanitize_api_messages()` dropping unsupported roles
  - `_preload_resumed_session()` filtering restored history
  - `_init_agent()` resumed-session loading behavior
  - `_handle_resume_command()` filtering `/resume` history

## How to Test

1. Create or use a saved CLI session whose restored rows include `session_meta`
2. Resume the session through CLI startup resume or the `/resume` command
3. Confirm that restored `conversation_history` contains only transcript-safe roles
4. Confirm that provider-facing requests no longer include unsupported roles such as `session_meta`
5. Run:
   `pytest -q tests/test_agent_guardrails.py tests/test_resume_display.py tests/test_cli_resume_command.py`

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04.4 LTS (WSL2), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
Targeted regression tests passed:

pytest -q tests/test_agent_guardrails.py tests/test_resume_display.py tests/test_cli_resume_command.py
60 passed in 8.05s

I also ran `pytest tests/ -q` for broader signal, but did not use it as a merge gate because the repository test suite surfaced unrelated distributed failures outside this change set before a clean final summary could be captured.
````

```
```
