### PR TITLE
fix(status): detect gateway process when running as PID 1 in Docker/Kubernetes

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -295,8 +295,23 @@ def show_status(args):
             is_active = result.stdout.strip() == "active"
         except subprocess.TimeoutExpired:
             is_active = False
+
+        # Fallback: check if hermes gateway is running as a process (Docker/Kubernetes/PID 1)
+        manager = "systemd (user)"
+        if not is_active:
+            try:
+                pgrep = subprocess.run(
+                    ["pgrep", "-f", "hermes.*gateway"],
+                    capture_output=True, text=True, timeout=5
+                )
+                if pgrep.returncode == 0:
+                    is_active = True
+                    manager = "direct process (non-systemd)"
+            except Exception:
+                pass
+
         print(f"  Status:       {check_mark(is_active)} {'running' if is_active else 'stopped'}")
-        print("  Manager:      systemd (user)")
+        print(f"  Manager:      {manager}")
         
     elif sys.platform == 'darwin':
         from hermes_cli.gateway import get_launchd_label


### PR DESCRIPTION
Fixes #4776

## Problem
hermes status reported gateway as "stopped" in Docker/Kubernetes because it only checked systemctl --user is-active, which returns "inactive" when gateway runs as PID 1 (not via systemd).

## Fix
Added process-based fallback using pgrep when systemd reports inactive. Shows "direct process (non-systemd)" as manager label when detected this way.
