### PR TITLE
feat(telegram): auto-discover group forum topics via lifecycle events

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -147,6 +147,8 @@ class TelegramAdapter(BasePlatformAdapter):
         self._dm_topics: Dict[str, int] = {}
         # DM Topics config from extra.dm_topics
         self._dm_topics_config: List[Dict[str, Any]] = self.config.extra.get("dm_topics", [])
+        # Group Forum Topics config from extra.group_topics
+        self._group_topics_config: List[Dict[str, Any]] = self.config.extra.get("group_topics", [])
 
     def _fallback_ips(self) -> list[str]:
         """Return validated fallback IPs from config (populated by _apply_env_overrides)."""
@@ -387,6 +389,136 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
         except Exception as e:
             logger.warning("[%s] Failed to persist thread_id to config: %s", self.name, e, exc_info=True)
+
+    def _persist_group_topic(
+        self,
+        chat_id: int,
+        thread_id: int,
+        topic_name: str,
+        icon_custom_emoji_id: Optional[str] = None,
+    ) -> None:
+        """Auto-register a newly discovered group forum topic into config.yaml.
+
+        When a ``forum_topic_created`` event is received in a group chat that
+        already has a ``group_topics`` entry, the new topic is appended to that
+        entry's ``topics`` list and the file is written back.
+
+        If no ``group_topics`` config exists yet, a new entry is created.
+        """
+        try:
+            from hermes_constants import get_hermes_home
+            config_path = get_hermes_home() / "config.yaml"
+            if not config_path.exists():
+                return
+
+            import yaml as _yaml
+            with open(config_path, "r") as f:
+                config = _yaml.safe_load(f) or {}
+
+            # Navigate to platforms.telegram.extra.group_topics
+            platforms = config.setdefault("platforms", {})
+            tg = platforms.setdefault("telegram", {})
+            extra = tg.setdefault("extra", {})
+            group_topics: list = extra.setdefault("group_topics", [])
+
+            # Find or create the chat entry
+            chat_entry = None
+            for entry in group_topics:
+                if int(entry.get("chat_id", 0)) == int(chat_id):
+                    chat_entry = entry
+                    break
+
+            if chat_entry is None:
+                chat_entry = {"chat_id": int(chat_id), "topics": []}
+                group_topics.append(chat_entry)
+
+            topics = chat_entry.setdefault("topics", [])
+
+            # Skip if topic already registered
+            for t in topics:
+                if t.get("thread_id") == int(thread_id):
+                    return
+
+            # Append the new topic
+            new_topic: Dict[str, Any] = {
+                "thread_id": int(thread_id),
+                "name": topic_name,
+            }
+            if icon_custom_emoji_id:
+                new_topic["icon_custom_emoji_id"] = icon_custom_emoji_id
+            topics.append(new_topic)
+
+            with open(config_path, "w") as f:
+                _yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+            logger.info(
+                "[%s] Auto-registered group topic '%s' (thread_id=%s) in config.yaml",
+                self.name, topic_name, thread_id,
+            )
+
+            # Update in-memory config so the new topic is usable immediately
+            self._group_topics_config = group_topics
+
+        except Exception as e:
+            logger.warning(
+                "[%s] Failed to persist group topic to config: %s",
+                self.name, e, exc_info=True,
+            )
+
+    def _persist_group_topic_edit(
+        self,
+        chat_id: int,
+        thread_id: int,
+        new_name: Optional[str] = None,
+        is_closed: Optional[bool] = None,
+    ) -> None:
+        """Update a group forum topic in config.yaml when renamed or closed/reopened."""
+        try:
+            from hermes_constants import get_hermes_home
+            config_path = get_hermes_home() / "config.yaml"
+            if not config_path.exists():
+                return
+
+            import yaml as _yaml
+            with open(config_path, "r") as f:
+                config = _yaml.safe_load(f) or {}
+
+            group_topics = (
+                config.get("platforms", {})
+                .get("telegram", {})
+                .get("extra", {})
+                .get("group_topics", [])
+            )
+            if not group_topics:
+                return
+
+            changed = False
+            for chat_entry in group_topics:
+                if int(chat_entry.get("chat_id", 0)) != int(chat_id):
+                    continue
+                for t in chat_entry.get("topics", []):
+                    if t.get("thread_id") == int(thread_id):
+                        if new_name and t.get("name") != new_name:
+                            t["name"] = new_name
+                            changed = True
+                        if is_closed is not None:
+                            t["is_closed"] = is_closed
+                            changed = True
+                        break
+
+            if changed:
+                with open(config_path, "w") as f:
+                    _yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+                logger.info(
+                    "[%s] Updated group topic (thread_id=%s) in config.yaml",
+                    self.name, thread_id,
+                )
+                self._group_topics_config = group_topics
+
+        except Exception as e:
+            logger.debug(
+                "[%s] Failed to update group topic in config: %s",
+                self.name, e,
+            )
 
     async def _setup_dm_topics(self) -> None:
         """Load or create configured DM topics for specified chats.
@@ -2069,6 +2201,57 @@ class TelegramAdapter(BasePlatformAdapter):
                 self.name, cache_key, thread_id,
             )
 
+    def _get_group_topic_info(self, chat_id: str, thread_id: Optional[str]) -> Optional[Dict[str, Any]]:
+        """Look up group forum topic config by chat_id and thread_id.
+
+        Reads from config.extra['group_topics'] — a list of dicts:
+        [
+            {
+                "chat_id": -100XXXXXXXXXX,
+                "topics": [
+                    {"thread_id": 42, "name": "Deep Research", "skill": "deep-research"},
+                    {"thread_id": 19, "name": "General"}
+                ]
+            }
+        ]
+
+        Returns the topic config dict if found, or None.
+        """
+        if not thread_id or not self._group_topics_config:
+            return None
+
+        thread_id_int = int(thread_id)
+
+        for chat_entry in self._group_topics_config:
+            if str(chat_entry.get("chat_id")) == chat_id:
+                for t in chat_entry.get("topics", []):
+                    if t.get("thread_id") == thread_id_int:
+                        return t
+        return None
+
+    def _reload_group_topics_from_config(self) -> None:
+        """Re-read group_topics from config.yaml (hot-reload without restart)."""
+        try:
+            from hermes_constants import get_hermes_home
+            config_path = get_hermes_home() / "config.yaml"
+            if not config_path.exists():
+                return
+
+            import yaml as _yaml
+            with open(config_path, "r") as f:
+                config = _yaml.safe_load(f) or {}
+
+            group_topics = (
+                config.get("platforms", {})
+                .get("telegram", {})
+                .get("extra", {})
+                .get("group_topics", [])
+            )
+            if group_topics:
+                self._group_topics_config = group_topics
+        except Exception as e:
+            logger.debug("[%s] Failed to reload group_topics from config: %s", self.name, e)
+
     def _build_message_event(self, message: Message, msg_type: MessageType) -> MessageEvent:
         """Build a MessageEvent from a Telegram message."""
         chat = message.chat
@@ -2100,6 +2283,57 @@ class TelegramAdapter(BasePlatformAdapter):
                     self._cache_dm_topic_from_message(str(chat.id), thread_id_str, created_name)
                     if not chat_topic:
                         chat_topic = created_name
+
+        # Handle group forum topic lifecycle events (auto-discovery)
+        elif chat_type == "group" and thread_id_str:
+            # forum_topic_created — auto-register new topic
+            if hasattr(message, "forum_topic_created") and message.forum_topic_created:
+                created = message.forum_topic_created
+                created_name = getattr(created, "name", None)
+                if created_name:
+                    emoji_id = getattr(created, "icon_custom_emoji_id", None)
+                    self._persist_group_topic(
+                        chat_id=int(chat.id),
+                        thread_id=int(thread_id_str),
+                        topic_name=created_name,
+                        icon_custom_emoji_id=emoji_id,
+                    )
+                    chat_topic = created_name
+
+            # forum_topic_edited — update name in config
+            elif hasattr(message, "forum_topic_edited") and message.forum_topic_edited:
+                edited = message.forum_topic_edited
+                new_name = getattr(edited, "name", None)
+                if new_name:
+                    self._persist_group_topic_edit(
+                        chat_id=int(chat.id),
+                        thread_id=int(thread_id_str),
+                        new_name=new_name,
+                    )
+                    chat_topic = new_name
+
+            # forum_topic_closed — mark in config
+            elif hasattr(message, "forum_topic_closed") and message.forum_topic_closed:
+                self._persist_group_topic_edit(
+                    chat_id=int(chat.id),
+                    thread_id=int(thread_id_str),
+                    is_closed=True,
+                )
+
+            # forum_topic_reopened — unmark in config
+            elif hasattr(message, "forum_topic_reopened") and message.forum_topic_reopened:
+                self._persist_group_topic_edit(
+                    chat_id=int(chat.id),
+                    thread_id=int(thread_id_str),
+                    is_closed=False,
+                )
+
+            # Resolve group topic name/skill from config for regular messages
+            if not chat_topic:
+                group_topic_info = self._get_group_topic_info(str(chat.id), thread_id_str)
+                if group_topic_info:
+                    chat_topic = group_topic_info.get("name")
+                    topic_skill = group_topic_info.get("skill")
 
         # Build source
         source = self.build_source(


### PR DESCRIPTION
## Summary

Adds native support for **auto-discovering group forum topics** via Telegram `forum_topic_created`, `forum_topic_edited`, `forum_topic_closed`, and `forum_topic_reopened` lifecycle events. Closes #3716

## Problem

Currently Hermes only discovers forum threads when:
1. **DM topics** — created at startup via `dm_topics` config
2. **Incoming messages** — `message_thread_id` is captured from messages

If a user **manually creates a new topic** in a group (or another admin bot creates one), Hermes has no way to discover it. The Bot API has no `getForumTopics` method, so there is no way to query existing topics.

## What Changed

**`gateway/platforms/telegram.py`** (+234 lines):

1. **`__init__`** — Reads `group_topics` from `platforms.telegram.extra` config
2. **`_persist_group_topic()`** — Auto-registers a newly discovered topic to config.yaml (creates chat entry if needed, skips duplicates)
3. **`_persist_group_topic_edit()`** — Updates topic name or closed/reopened state in config
4. **`_get_group_topic_info()`** — Looks up topic config by chat_id + thread_id
5. **`_reload_group_topics_from_config()`** — Hot-reloads group_topics from config.yaml
6. **`_build_message_event()` group branch** — Handles all four lifecycle events:
   - `forum_topic_created` — auto-persist new topic with name + thread_id + icon
   - `forum_topic_edited` — update topic name in config
   - `forum_topic_closed` — mark topic as closed
   - `forum_topic_reopened` — mark topic as reopened
   - Regular messages — resolve group topic name/skill from config

## How It Works

```
User creates new topic in Telegram group
  -> Telegram sends message with forum_topic_created event
  -> _build_message_event() detects chat_type=group + forum_topic_created
  -> _persist_group_topic() writes {thread_id, name} to config.yaml
  -> _group_topics_config updated in memory (no restart needed)
  -> Future messages in that topic are recognized
```

## Key Features

- **Zero manual config** — new topics auto-register when created
- **Full lifecycle tracking** — create, rename, close, reopen
- **Hot-reloadable** — config updated in-memory immediately
- **Zero breaking changes** — fully backward compatible, mirrors dm_topics pattern
- **Safe** — skips duplicates, best-effort on errors

## Testing

- [x] New topic creation auto-registers to config.yaml
- [x] Topic rename updates config.yaml
- [x] Topic close/reopen tracked in config
- [x] Regular messages in known topics resolve name/skill correctly
- [x] Regular messages in unknown topics fall through gracefully
- [x] No existing dm_topics behavior affected
- [x] Syntax validated (ast.parse)