### PR TITLE
fix: persist API server sessions to shared SessionDB

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -373,6 +373,24 @@ class APIServerAdapter(BasePlatformAdapter):
         )
 
     # ------------------------------------------------------------------
+    # Session DB helper
+    # ------------------------------------------------------------------
+
+    def _ensure_session_db(self):
+        """Lazily initialise and return the shared SessionDB instance.
+
+        Sessions are persisted to ``state.db`` so that ``hermes sessions list``
+        shows API-server conversations alongside CLI and gateway ones.
+        """
+        if self._session_db is None:
+            try:
+                from hermes_state import SessionDB
+                self._session_db = SessionDB()
+            except Exception as e:
+                logger.debug("SessionDB unavailable for API server: %s", e)
+        return self._session_db
+
+    # ------------------------------------------------------------------
     # Agent creation helper
     # ------------------------------------------------------------------
 
@@ -415,6 +433,7 @@ class APIServerAdapter(BasePlatformAdapter):
             platform="api_server",
             stream_delta_callback=stream_delta_callback,
             tool_progress_callback=tool_progress_callback,
+            session_db=self._ensure_session_db(),
         )
         return agent
 
@@ -503,10 +522,9 @@ class APIServerAdapter(BasePlatformAdapter):
         if provided_session_id:
             session_id = provided_session_id
             try:
-                if self._session_db is None:
-                    from hermes_state import SessionDB
-                    self._session_db = SessionDB()
-                history = self._session_db.get_messages_as_conversation(session_id)
+                db = self._ensure_session_db()
+                if db is not None:
+                    history = db.get_messages_as_conversation(session_id)
             except Exception as e:
                 logger.warning("Failed to load session history for %s: %s", session_id, e)
                 history = []


### PR DESCRIPTION
## Summary

The API server adapter (`gateway/platforms/api_server.py`) created `AIAgent` instances without passing `session_db`, so conversations via Open WebUI and other OpenAI-compatible frontends were never persisted to `state.db`. This meant `hermes sessions list` showed no API server sessions — they were effectively stateless from Hermes's perspective.

Reported by angelitusss in community chat.

## Changes

- Add `_ensure_session_db()` helper method for lazy `SessionDB` initialization (same pattern as `gateway/run.py`)
- Pass `session_db=self._ensure_session_db()` in `_create_agent()` so every agent created by the API server persists to `state.db`
- Refactor existing `X-Hermes-Session-Id` handler to use the shared helper instead of its own inline init

## Result

Sessions now persist with `source='api_server'` and are visible alongside CLI and gateway sessions in `hermes sessions list` / `hermes sessions search`.

## Tests

- All 138 existing API server tests pass (106 + 32)
- E2E verified with isolated HERMES_HOME:
  - SessionDB created and points to correct `state.db`
  - Agent receives `session_db` parameter
  - Session rows created with `source='api_server'`
  - Messages persist after conversation run
  - Sessions visible via `list_sessions_rich()` with source filtering