### PR TITLE
fix: route memory provider tools in sequential execution path

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6009,6 +6009,30 @@ class AIAgent:
                         spinner.stop(cute_msg)
                     elif self.quiet_mode:
                         self._vprint(f"  {cute_msg}")
+            elif self._memory_manager and self._memory_manager.has_tool(function_name):
+                # Memory provider tools (hindsight_retain, honcho_search, etc.)
+                # These are not in the tool registry — route through MemoryManager.
+                spinner = None
+                if self.quiet_mode and not self.tool_progress_callback:
+                    face = random.choice(KawaiiSpinner.KAWAII_WAITING)
+                    emoji = _get_tool_emoji(function_name)
+                    preview = _build_tool_preview(function_name, function_args) or function_name
+                    spinner = KawaiiSpinner(f"{face} {emoji} {preview}", spinner_type='dots', print_fn=self._print_fn)
+                    spinner.start()
+                _mem_result = None
+                try:
+                    function_result = self._memory_manager.handle_tool_call(function_name, function_args)
+                    _mem_result = function_result
+                except Exception as tool_error:
+                    function_result = json.dumps({"error": f"Memory tool '{function_name}' failed: {tool_error}"})
+                    logger.error("memory_manager.handle_tool_call raised for %s: %s", function_name, tool_error, exc_info=True)
+                finally:
+                    tool_duration = time.time() - tool_start_time
+                    cute_msg = _get_cute_tool_message_impl(function_name, function_args, tool_duration, result=_mem_result)
+                    if spinner:
+                        spinner.stop(cute_msg)
+                    elif self.quiet_mode:
+                        self._vprint(f"  {cute_msg}")
             elif self.quiet_mode:
                 spinner = None
                 if not self.tool_progress_callback:


### PR DESCRIPTION
## Summary

Memory provider tools (like `hindsight_retain`, `hindsight_recall`, `honcho_search`, etc.) were advertised to the model via tool schemas but failed with **"Unknown tool"** at execution time. Every memory provider plugin (Honcho, Hindsight, Holographic, Mem0, etc.) was affected.

## Root Cause

Two tool dispatch paths exist in `run_agent.py`:

1. **`_invoke_tool()`** (concurrent path) — correctly checks `self._memory_manager.has_tool(function_name)` before falling through to the registry
2. **`_execute_tool_calls_sequential()`** (sequential path) — was **missing** this check entirely

Since sequential is the default for single tool calls, memory provider tools always went through `handle_function_call()` → `registry.dispatch()`, which returned `{"error": "Unknown tool: hindsight_retain"}` because memory provider tools are not registered in the tool registry — they live in `MemoryManager._tool_to_provider`.

## Fix

Add the `memory_manager.has_tool()` dispatch check between the `delegate_task` handler and the `quiet_mode` fallthrough in the sequential path, with proper spinner/display handling matching the existing pattern.

## Testing

- ✅ 727 agent tests pass (0 new failures)
- ✅ 4090 tools+gateway tests pass (0 new failures)  
- ✅ 867 CLI tests pass (0 new failures)
- ✅ E2E verification: confirmed registry returns "Unknown tool" for memory provider tools, MemoryManager routes correctly, and both execution paths now have the dispatch check

## Reported by

KiBenderOP — tested with Honcho, Hindsight, and Holographic providers.