### PR TITLE
security(approval): prevent unintended session wide command approval in Gateways

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -784,12 +784,14 @@ def check_all_command_guards(command: str, env_type: str,
 
             # User approved — persist based on scope (same logic as CLI)
             for key, _, is_tirith in warnings:
-                if choice in ("once", "session") or (choice == "always" and is_tirith):
+                if choice == "session" or (choice == "always" and is_tirith):
                     approve_session(session_key, key)
                 elif choice == "always":
                     approve_session(session_key, key)
                     approve_permanent(key)
                     save_permanent_allowlist(_permanent_approved)
+                # choice == "once": no persistence — command allowed this
+                # single time only, matching the CLI's behavior.
 
             return {"approved": True, "message": None}
 


### PR DESCRIPTION
Summary
Identified a critical security vulnerability (Privilege Escalation) in the gateway approval flow where the "once" option incorrectly granted session-wide permission.

The Problem
In Gateway providers (Telegram, Discord, etc.), when a user approves a dangerous command with the once option, the system inadvertently persists this as a session approval.

Scenario: If a user authorizes rm -rf /tmp/test for "just once", they are silently granting blanket approval for all rm -rf operations for the rest of that session.

Root Cause
In tools/approval.py (around line 787), "once" and "session" choices were grouped together, both triggering approve_session():

Python
# The Buggy Logic
if choice in ("once", "session") or (choice == "always" and is_tirith):
    approve_session(session_key, key) # ERROR: 'once' shouldn't persist
The Fix
Segregated the logic to ensure that the "once" choice explicitly bypasses approve_session(), strictly adhering to the principle of least privilege.

Impact
Eliminates a significant security loophole that could lead to accidental or malicious resource destruction after a single-use authorization.

Validation
Tests: Verified with 119 automated tests (Gateway & Approval suites). All passed.

Manual Check: Confirmed fixed behavior via trajectory logs.