### PR TITLE
Add Cyber Memory memory provider (local) No API with Graph/Vector

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4803,7 +4803,7 @@ For more help on a command:
         description=(
             "Set up and manage external memory provider plugins.\n\n"
             "Available providers: honcho, openviking, mem0, hindsight,\n"
-            "holographic, retaindb, byterover.\n\n"
+            "holographic, retaindb, byterover, cyber_memory.\n\n"
             "Only one external provider can be active at a time.\n"
             "Built-in memory (MEMORY.md/USER.md) is always active."
         ),

--- a/plugins/memory/cyber_memory/README.md
+++ b/plugins/memory/cyber_memory/README.md
@@ -1,0 +1,66 @@
+# Cyber Memory Memory Provider
+
+Cyber Memory adds first-class Hermes memory support backed by the
+[`cyber-memory`](https://github.com/RamboRogers/cyber-memory) single-binary
+MCP server.
+
+## Requirements
+
+- `cyber-memory` binary installed
+- Python MCP client available (the Hermes memory setup flow installs `mcp`)
+
+## Setup
+
+```bash
+hermes memory setup    # select "cyber_memory"
+```
+
+Or manually:
+
+```bash
+hermes config set memory.provider cyber_memory
+```
+
+The provider stores its config at:
+
+```text
+$HERMES_HOME/cyber-memory.json
+```
+
+Default profile-scoped database path:
+
+```text
+$HERMES_HOME/cyber-memory/db.sqlite3
+```
+
+The provider launches `cyber-memory` over stdio MCP internally and sets
+`CYBER_MEMORY_DB` so each Hermes profile gets isolated storage.
+
+## Config
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `command` | `cyber-memory` | Binary name or absolute path |
+| `db_path` | `$HERMES_HOME/cyber-memory/db.sqlite3` | Profile-scoped SQLite database |
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `cyber_memory_store` | Store a new memory |
+| `cyber_memory_recall` | Semantic recall with ranking |
+| `cyber_memory_search` | Full-text search |
+| `cyber_memory_relate` | Create a graph relation |
+| `cyber_memory_graph` | Traverse connected memories |
+| `cyber_memory_update` | Update content/tags/importance |
+| `cyber_memory_forget` | Delete a memory |
+| `cyber_memory_stats` | Show database stats |
+
+## Troubleshooting
+
+- **Provider unavailable** — ensure `cyber-memory -version` works and Hermes has
+  the Python `mcp` package available.
+- **Wrong database location** — set `db_path` explicitly via `hermes memory setup`
+  or edit `$HERMES_HOME/cyber-memory.json`.
+- **First run is slow** — Cyber Memory may download its embedded model assets on
+  first use.

--- a/plugins/memory/cyber_memory/__init__.py
+++ b/plugins/memory/cyber_memory/__init__.py
@@ -1,0 +1,460 @@
+"""Cyber Memory provider — first-class Hermes memory via a local stdio MCP client."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import threading
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agent.memory_provider import MemoryProvider
+from .client import CyberMemoryClient, cyber_memory_mcp_available
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_COMMAND = "cyber-memory"
+_CONFIG_NAME = "cyber-memory.json"
+_MIN_QUERY_LEN = 8
+_REQUIRED_BACKEND_TOOLS = {
+    "memory_store",
+    "memory_recall",
+    "memory_search",
+    "memory_relate",
+    "memory_graph",
+    "memory_update",
+    "memory_forget",
+    "memory_stats",
+}
+
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+def _config_path(hermes_home: str | Path) -> Path:
+    return Path(hermes_home) / _CONFIG_NAME
+
+
+def _default_db_path(hermes_home: str | Path) -> str:
+    return str(Path(hermes_home) / "cyber-memory" / "db.sqlite3")
+
+
+def _load_config(hermes_home: str | Path | None = None) -> dict:
+    from hermes_constants import get_hermes_home
+
+    home = Path(hermes_home) if hermes_home is not None else get_hermes_home()
+    config = {
+        "command": _DEFAULT_COMMAND,
+        "db_path": _default_db_path(home),
+    }
+    path = _config_path(home)
+    if path.exists():
+        try:
+            loaded = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                config.update(loaded)
+        except Exception:
+            pass
+    return config
+
+
+def _resolve_command(command: str) -> Optional[str]:
+    if not command:
+        return None
+    if os.path.sep in command:
+        path = Path(command).expanduser()
+        return str(path) if path.exists() else None
+    return shutil.which(command)
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas
+# ---------------------------------------------------------------------------
+
+STORE_SCHEMA = {
+    "name": "cyber_memory_store",
+    "description": (
+        "Store content in Cyber Memory. The backend generates embeddings and "
+        "stores the memory locally with optional tags, importance, kind, and source."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string", "description": "The memory content to store."},
+            "kind": {
+                "type": "string",
+                "enum": ["episodic", "semantic", "procedural"],
+                "description": "Memory kind (default: semantic).",
+            },
+            "importance": {"type": "number", "description": "Importance multiplier (default: 1.0)."},
+            "tags": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional tags to attach to the memory.",
+            },
+            "source": {"type": "string", "description": "Optional source label."},
+        },
+        "required": ["content"],
+    },
+}
+
+RECALL_SCHEMA = {
+    "name": "cyber_memory_recall",
+    "description": (
+        "Recall semantically related memories from Cyber Memory using vector "
+        "similarity, recency, and importance scoring."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Natural-language recall query."},
+            "limit": {"type": "integer", "description": "Maximum results to return (default: 5)."},
+            "kind": {
+                "type": "string",
+                "enum": ["episodic", "semantic", "procedural"],
+                "description": "Optional kind filter.",
+            },
+            "min_score": {"type": "number", "description": "Minimum recall score threshold."},
+        },
+        "required": ["query"],
+    },
+}
+
+SEARCH_SCHEMA = {
+    "name": "cyber_memory_search",
+    "description": "Run keyword/full-text search against locally stored Cyber Memory entries.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Keyword query."},
+            "limit": {"type": "integer", "description": "Maximum results to return (default: 10)."},
+        },
+        "required": ["query"],
+    },
+}
+
+RELATE_SCHEMA = {
+    "name": "cyber_memory_relate",
+    "description": "Create a typed relation edge between two Cyber Memory entries.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "src_id": {"type": "integer", "description": "Source memory ID."},
+            "dst_id": {"type": "integer", "description": "Destination memory ID."},
+            "kind": {
+                "type": "string",
+                "enum": ["supports", "contradicts", "precedes", "relates_to"],
+                "description": "Edge relationship type.",
+            },
+            "weight": {"type": "number", "description": "Optional edge weight (default: 1.0)."},
+        },
+        "required": ["src_id", "dst_id", "kind"],
+    },
+}
+
+GRAPH_SCHEMA = {
+    "name": "cyber_memory_graph",
+    "description": "Traverse the Cyber Memory knowledge graph from a root memory ID.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "id": {"type": "integer", "description": "Root memory ID."},
+            "depth": {"type": "integer", "description": "Traversal depth (default: 2)."},
+        },
+        "required": ["id"],
+    },
+}
+
+UPDATE_SCHEMA = {
+    "name": "cyber_memory_update",
+    "description": "Update stored Cyber Memory content, tags, importance, or kind.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "id": {"type": "integer", "description": "Memory ID to update."},
+            "content": {"type": "string", "description": "Replacement content."},
+            "kind": {
+                "type": "string",
+                "enum": ["episodic", "semantic", "procedural"],
+                "description": "Optional replacement kind.",
+            },
+            "importance": {"type": "number", "description": "Optional replacement importance."},
+            "tags": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional replacement tags.",
+            },
+        },
+        "required": ["id"],
+    },
+}
+
+FORGET_SCHEMA = {
+    "name": "cyber_memory_forget",
+    "description": "Delete a Cyber Memory entry and its graph relations.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "id": {"type": "integer", "description": "Memory ID to delete."},
+        },
+        "required": ["id"],
+    },
+}
+
+STATS_SCHEMA = {
+    "name": "cyber_memory_stats",
+    "description": "Return Cyber Memory database statistics and timestamps.",
+    "parameters": {"type": "object", "properties": {}, "required": []},
+}
+
+_TOOL_SCHEMAS = [
+    STORE_SCHEMA,
+    RECALL_SCHEMA,
+    SEARCH_SCHEMA,
+    RELATE_SCHEMA,
+    GRAPH_SCHEMA,
+    UPDATE_SCHEMA,
+    FORGET_SCHEMA,
+    STATS_SCHEMA,
+]
+
+
+class CyberMemoryProvider(MemoryProvider):
+    """First-class Hermes MemoryProvider backed by the cyber-memory binary."""
+
+    def __init__(self):
+        self._config: dict = {}
+        self._client: Optional[CyberMemoryClient] = None
+        self._command: str = _DEFAULT_COMMAND
+        self._db_path: str = ""
+        self._session_id: str = ""
+        self._available_tools: set[str] = set()
+        self._prefetch_result: str = ""
+        self._prefetch_lock = threading.Lock()
+        self._prefetch_thread: Optional[threading.Thread] = None
+        self._sync_thread: Optional[threading.Thread] = None
+
+    @property
+    def name(self) -> str:
+        return "cyber_memory"
+
+    def is_available(self) -> bool:
+        cfg = _load_config()
+        return cyber_memory_mcp_available() and bool(_resolve_command(cfg.get("command", _DEFAULT_COMMAND)))
+
+    def get_config_schema(self):
+        from hermes_constants import display_hermes_home
+
+        return [
+            {
+                "key": "command",
+                "description": "Cyber Memory command or absolute binary path",
+                "default": _DEFAULT_COMMAND,
+            },
+            {
+                "key": "db_path",
+                "description": "SQLite database path",
+                "default": f"{display_hermes_home()}/cyber-memory/db.sqlite3",
+            },
+        ]
+
+    def save_config(self, values, hermes_home):
+        path = _config_path(hermes_home)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        existing = {}
+        if path.exists():
+            try:
+                existing = json.loads(path.read_text(encoding="utf-8"))
+            except Exception:
+                pass
+        existing.update(values)
+        path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        hermes_home = kwargs.get("hermes_home")
+        if not hermes_home:
+            from hermes_constants import get_hermes_home
+            hermes_home = str(get_hermes_home())
+
+        self._config = _load_config(hermes_home)
+        self._command = self._config.get("command", _DEFAULT_COMMAND)
+        self._db_path = self._config.get("db_path") or _default_db_path(hermes_home)
+        self._session_id = session_id
+
+        resolved = _resolve_command(self._command)
+        if not resolved:
+            raise RuntimeError(
+                f"Cyber Memory command not found: {self._command}. "
+                "Install it first or configure memory.cyber_memory.command."
+            )
+
+        Path(self._db_path).expanduser().parent.mkdir(parents=True, exist_ok=True)
+        env = os.environ.copy()
+        env["CYBER_MEMORY_DB"] = str(Path(self._db_path).expanduser())
+
+        self._client = CyberMemoryClient()
+        self._client.start(resolved, [], env)
+        self._available_tools = set(self._client.list_tools())
+        missing = sorted(_REQUIRED_BACKEND_TOOLS - self._available_tools)
+        if missing:
+            self.shutdown()
+            raise RuntimeError(
+                "Cyber Memory binary is missing required MCP tools: "
+                + ", ".join(missing)
+            )
+
+    def system_prompt_block(self) -> str:
+        if not self._client:
+            return ""
+        tool_count = len(self._available_tools) or len(_TOOL_SCHEMAS)
+        return (
+            "# Cyber Memory\n"
+            f"Active. Local persistent memory at {self._db_path}.\n"
+            f"{tool_count} memory tools available for storage, semantic recall, "
+            "graph traversal, updates, deletion, and stats."
+        )
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if self._prefetch_thread and self._prefetch_thread.is_alive():
+            self._prefetch_thread.join(timeout=3.0)
+        with self._prefetch_lock:
+            result = self._prefetch_result
+            self._prefetch_result = ""
+        return result
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        if not self._client or not query or len(query.strip()) < _MIN_QUERY_LEN:
+            return
+
+        def _run():
+            data = self._invoke_backend(
+                "memory_recall",
+                {"query": query.strip()[:5000], "limit": 5, "min_score": 0.25},
+            )
+            formatted = self._format_prefetch(data)
+            if formatted:
+                with self._prefetch_lock:
+                    self._prefetch_result = formatted
+
+        self._prefetch_thread = threading.Thread(
+            target=_run, daemon=True, name="cyber-memory-prefetch"
+        )
+        self._prefetch_thread.start()
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        if not self._client or len(user_content.strip()) < _MIN_QUERY_LEN:
+            return
+
+        def _sync():
+            content = (
+                f"User: {user_content[:2000]}\n"
+                f"Assistant: {assistant_content[:2000]}"
+            )
+            self._invoke_backend(
+                "memory_store",
+                {
+                    "content": content,
+                    "kind": "episodic",
+                    "importance": 1.0,
+                    "tags": ["conversation", "hermes"],
+                    "source": "hermes",
+                },
+            )
+
+        if self._sync_thread and self._sync_thread.is_alive():
+            self._sync_thread.join(timeout=5.0)
+        self._sync_thread = threading.Thread(
+            target=_sync, daemon=True, name="cyber-memory-sync"
+        )
+        self._sync_thread.start()
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return list(_TOOL_SCHEMAS)
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+        if not tool_name.startswith("cyber_memory_"):
+            return json.dumps({"error": f"Unknown Cyber Memory tool: {tool_name}"})
+        backend_tool = "memory_" + tool_name[len("cyber_memory_"):]
+        result = self._invoke_backend(backend_tool, args)
+        return json.dumps(result)
+
+    def on_memory_write(self, action: str, target: str, content: str) -> None:
+        if not self._client or action not in ("add", "replace") or not content:
+            return
+
+        def _write():
+            tags = ["builtin", target]
+            self._invoke_backend(
+                "memory_store",
+                {
+                    "content": content[:4000],
+                    "kind": "semantic",
+                    "importance": 1.3 if target == "user" else 1.0,
+                    "tags": tags,
+                    "source": f"hermes_{target}",
+                },
+            )
+
+        t = threading.Thread(target=_write, daemon=True, name="cyber-memory-mirror")
+        t.start()
+
+    def shutdown(self) -> None:
+        for t in (self._sync_thread, self._prefetch_thread):
+            if t and t.is_alive():
+                t.join(timeout=10.0)
+        if self._client:
+            self._client.close()
+            self._client = None
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _invoke_backend(self, tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
+        if not self._client:
+            return {"error": "Cyber Memory provider is not initialized"}
+
+        result = self._client.call_tool(tool_name, args)
+        if isinstance(result, dict):
+            return result
+        return {"result": result}
+
+    def _format_prefetch(self, data: Dict[str, Any]) -> str:
+        if not data or data.get("error"):
+            return ""
+
+        text = data.get("result")
+        if isinstance(text, str) and text.strip():
+            return f"## Cyber Memory\n{text.strip()}"
+
+        items = None
+        for key in ("results", "memories", "items"):
+            value = data.get(key)
+            if isinstance(value, list):
+                items = value
+                break
+        if not items:
+            return ""
+
+        lines = []
+        for item in items[:5]:
+            if isinstance(item, dict):
+                content = str(item.get("content", "")).strip()
+                score = item.get("score")
+                prefix = f"[{score:.2f}] " if isinstance(score, (int, float)) else ""
+                if content:
+                    lines.append(f"- {prefix}{content}")
+            elif item:
+                lines.append(f"- {item}")
+
+        if not lines:
+            return ""
+        return "## Cyber Memory\n" + "\n".join(lines)
+
+
+def register(ctx) -> None:
+    """Register Cyber Memory as a Hermes memory provider."""
+    ctx.register_memory_provider(CyberMemoryProvider())

--- a/plugins/memory/cyber_memory/client.py
+++ b/plugins/memory/cyber_memory/client.py
@@ -1,0 +1,259 @@
+"""Provider-local stdio MCP client for Cyber Memory.
+
+This client is intentionally narrow in scope: it launches the ``cyber-memory``
+binary as a stdio MCP server, maintains a single MCP session, exposes a sync
+``call_tool()`` API for the memory provider, and shuts everything down cleanly.
+
+It does NOT participate in Hermes's global MCP registry/runtime. The Cyber
+Memory provider is the public interface; MCP is only the transport layer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from typing import Any, Dict, List, Optional
+
+
+def cyber_memory_mcp_available() -> bool:
+    """Return True when the Python MCP client dependency is importable."""
+    try:
+        from mcp import ClientSession, StdioServerParameters  # noqa: F401
+        from mcp.client.stdio import stdio_client  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+class CyberMemoryClient:
+    """Small persistent stdio MCP client for the Cyber Memory provider."""
+
+    def __init__(self) -> None:
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._thread: Optional[threading.Thread] = None
+        self._session = None
+        self._tool_names: List[str] = []
+        self._task = None
+        self._ready = None
+        self._shutdown_event = None
+        self._error: Optional[Exception] = None
+        self._lock = threading.RLock()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(
+        self,
+        command: str,
+        args: List[str] | None = None,
+        env: Optional[Dict[str, str]] = None,
+        *,
+        timeout: float = 25.0,
+    ) -> None:
+        """Start the Cyber Memory MCP subprocess and initialize a session."""
+        if not cyber_memory_mcp_available():
+            raise RuntimeError(
+                "mcp package not installed. Install Hermes with MCP support "
+                "(e.g. hermes-agent[mcp])."
+            )
+
+        with self._lock:
+            if self._loop is not None:
+                return
+
+            self._loop = asyncio.new_event_loop()
+            self._ready = asyncio.Event()
+            self._shutdown_event = asyncio.Event()
+            self._error = None
+            self._thread = threading.Thread(
+                target=self._run_loop,
+                daemon=True,
+                name="cyber-memory-mcp",
+            )
+            self._thread.start()
+
+        future = asyncio.run_coroutine_threadsafe(
+            self._async_boot(command, args or [], env or {}),
+            self._loop,
+        )
+        try:
+            future.result(timeout=timeout)
+        except Exception:
+            self.close()
+            raise
+
+    def close(self, *, timeout: float = 10.0) -> None:
+        """Close the MCP session and stop the loop thread."""
+        with self._lock:
+            loop = self._loop
+            thread = self._thread
+            if loop is None:
+                return
+
+        try:
+            future = asyncio.run_coroutine_threadsafe(self._async_shutdown(), loop)
+            future.result(timeout=timeout)
+        except Exception:
+            pass
+        finally:
+            try:
+                loop.call_soon_threadsafe(loop.stop)
+            except Exception:
+                pass
+            if thread and thread.is_alive():
+                thread.join(timeout=timeout)
+            with self._lock:
+                self._loop = None
+                self._thread = None
+                self._session = None
+                self._tool_names = []
+                self._task = None
+                self._ready = None
+                self._shutdown_event = None
+                self._error = None
+
+    def list_tools(self) -> List[str]:
+        """Return the most recently discovered backend MCP tool names."""
+        with self._lock:
+            return list(self._tool_names)
+
+    # ------------------------------------------------------------------
+    # Tool calls
+    # ------------------------------------------------------------------
+
+    def call_tool(
+        self, tool_name: str, arguments: Optional[Dict[str, Any]] = None, *,
+        timeout: float = 45.0,
+    ) -> Dict[str, Any]:
+        """Call a backend MCP tool and return a JSON-compatible result."""
+        with self._lock:
+            loop = self._loop
+        if loop is None:
+            return {"error": "Cyber Memory client is not running"}
+
+        future = asyncio.run_coroutine_threadsafe(
+            self._async_call_tool(tool_name, arguments or {}),
+            loop,
+        )
+        try:
+            return future.result(timeout=timeout)
+        except Exception as exc:
+            return {"error": f"Cyber Memory MCP call failed: {type(exc).__name__}: {exc}"}
+
+    # ------------------------------------------------------------------
+    # Async internals
+    # ------------------------------------------------------------------
+
+    def _run_loop(self) -> None:
+        loop = self._loop
+        if loop is None:
+            return
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_forever()
+        finally:
+            try:
+                loop.run_until_complete(loop.shutdown_asyncgens())
+            except Exception:
+                pass
+            loop.close()
+
+    async def _async_boot(
+        self, command: str, args: List[str], env: Dict[str, str]
+    ) -> None:
+        assert self._ready is not None
+        self._task = asyncio.ensure_future(self._run(command, args, env))
+        await self._ready.wait()
+        if self._error:
+            raise self._error
+
+    async def _run(
+        self, command: str, args: List[str], env: Dict[str, str]
+    ) -> None:
+        from mcp import ClientSession, StdioServerParameters
+        from mcp.client.stdio import stdio_client
+
+        params = StdioServerParameters(
+            command=command,
+            args=args,
+            env=env or None,
+        )
+
+        try:
+            async with stdio_client(params) as (read_stream, write_stream):
+                async with ClientSession(read_stream, write_stream) as session:
+                    self._session = session
+                    await self._session.initialize()
+                    await self._refresh_tools()
+                    if self._ready is not None:
+                        self._ready.set()
+                    if self._shutdown_event is not None:
+                        await self._shutdown_event.wait()
+        except Exception as exc:
+            self._session = None
+            if self._ready is not None and not self._ready.is_set():
+                self._error = exc
+                self._ready.set()
+            raise
+        finally:
+            self._session = None
+
+    async def _refresh_tools(self) -> None:
+        if self._session is None:
+            return
+        tools_result = await self._session.list_tools()
+        tools = getattr(tools_result, "tools", []) or []
+        with self._lock:
+            self._tool_names = [
+                getattr(tool, "name", "")
+                for tool in tools
+                if getattr(tool, "name", "")
+            ]
+
+    async def _async_call_tool(
+        self, tool_name: str, arguments: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        if self._session is None:
+            return {"error": "Cyber Memory session is not initialized"}
+
+        result = await self._session.call_tool(tool_name, arguments=arguments)
+        blocks = getattr(result, "content", []) or []
+        text = self._extract_text(blocks).strip()
+
+        if getattr(result, "isError", False):
+            return {"error": text or f"Cyber Memory MCP tool '{tool_name}' returned an error"}
+
+        if not text:
+            return {"result": ""}
+
+        try:
+            parsed = json.loads(text)
+            if isinstance(parsed, dict):
+                return parsed
+            return {"result": parsed}
+        except Exception:
+            return {"result": text}
+
+    async def _async_shutdown(self) -> None:
+        if self._shutdown_event is not None:
+            self._shutdown_event.set()
+        if self._task and not self._task.done():
+            try:
+                await asyncio.wait_for(self._task, timeout=10.0)
+            except asyncio.TimeoutError:
+                self._task.cancel()
+                try:
+                    await self._task
+                except asyncio.CancelledError:
+                    pass
+
+    @staticmethod
+    def _extract_text(blocks: List[Any]) -> str:
+        parts: List[str] = []
+        for block in blocks:
+            text = getattr(block, "text", None)
+            if text:
+                parts.append(text)
+        return "\n".join(parts)

--- a/plugins/memory/cyber_memory/plugin.yaml
+++ b/plugins/memory/cyber_memory/plugin.yaml
@@ -1,0 +1,9 @@
+name: cyber_memory
+version: 0.1.0
+description: "Cyber Memory — local vector + graph memory via a single-binary MCP server."
+pip_dependencies:
+  - mcp>=1.2.0,<2
+external_dependencies:
+  - name: cyber-memory
+    install: "curl -fsSL https://raw.githubusercontent.com/RamboRogers/cyber-memory/master/install.sh | sh"
+    check: "cyber-memory -version"

--- a/tests/agent/test_cyber_memory_provider.py
+++ b/tests/agent/test_cyber_memory_provider.py
@@ -1,0 +1,167 @@
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from plugins.memory import load_memory_provider
+from plugins.memory.cyber_memory import (
+    CyberMemoryProvider,
+    _load_config,
+    _default_db_path,
+)
+
+
+class _ImmediateThread:
+    def __init__(self, target=None, args=(), kwargs=None, **_ignored):
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs or {}
+        self._alive = False
+
+    def start(self):
+        self._alive = True
+        if self._target:
+            self._target(*self._args, **self._kwargs)
+        self._alive = False
+
+    def is_alive(self):
+        return self._alive
+
+    def join(self, timeout=None):
+        return None
+
+
+def test_load_provider_by_name():
+    provider = load_memory_provider("cyber_memory")
+    assert provider is not None
+    assert provider.name == "cyber_memory"
+
+
+def test_is_available_true_when_binary_and_mcp_present():
+    provider = CyberMemoryProvider()
+    with patch("plugins.memory.cyber_memory._load_config", return_value={"command": "cyber-memory"}), \
+         patch("plugins.memory.cyber_memory._resolve_command", return_value="/usr/local/bin/cyber-memory"), \
+         patch("plugins.memory.cyber_memory.cyber_memory_mcp_available", return_value=True):
+        assert provider.is_available() is True
+
+
+def test_is_available_false_without_mcp():
+    provider = CyberMemoryProvider()
+    with patch("plugins.memory.cyber_memory._load_config", return_value={"command": "cyber-memory"}), \
+         patch("plugins.memory.cyber_memory._resolve_command", return_value="/usr/local/bin/cyber-memory"), \
+         patch("plugins.memory.cyber_memory.cyber_memory_mcp_available", return_value=False):
+        assert provider.is_available() is False
+
+
+def test_save_and_load_config_roundtrip(tmp_path):
+    provider = CyberMemoryProvider()
+    provider.save_config(
+        {
+            "command": "/usr/local/bin/cyber-memory",
+            "db_path": str(tmp_path / "profile" / "db.sqlite3"),
+        },
+        str(tmp_path),
+    )
+
+    loaded = _load_config(str(tmp_path))
+    assert loaded["command"] == "/usr/local/bin/cyber-memory"
+    assert loaded["db_path"] == str(tmp_path / "profile" / "db.sqlite3")
+
+
+def test_initialize_uses_profile_scoped_db_path(tmp_path):
+    provider = CyberMemoryProvider()
+    fake_client = MagicMock()
+    fake_client.list_tools.return_value = [
+        "memory_store", "memory_recall", "memory_search", "memory_relate",
+        "memory_graph", "memory_update", "memory_forget", "memory_stats",
+    ]
+
+    with patch("plugins.memory.cyber_memory._resolve_command", return_value="/usr/local/bin/cyber-memory"), \
+         patch("plugins.memory.cyber_memory.CyberMemoryClient", return_value=fake_client):
+        provider.initialize("session-1", hermes_home=str(tmp_path), platform="cli")
+
+    expected_db = str(Path(_default_db_path(tmp_path)).expanduser())
+    start_args = fake_client.start.call_args[0]
+    assert start_args[0] == "/usr/local/bin/cyber-memory"
+    assert start_args[2]["CYBER_MEMORY_DB"] == expected_db
+    assert provider._db_path == expected_db
+
+
+def test_initialize_fails_if_backend_missing_required_tools(tmp_path):
+    provider = CyberMemoryProvider()
+    fake_client = MagicMock()
+    fake_client.list_tools.return_value = ["memory_store", "memory_recall"]
+
+    with patch("plugins.memory.cyber_memory._resolve_command", return_value="/usr/local/bin/cyber-memory"), \
+         patch("plugins.memory.cyber_memory.CyberMemoryClient", return_value=fake_client):
+        try:
+            provider.initialize("session-1", hermes_home=str(tmp_path), platform="cli")
+            assert False, "expected initialize() to fail"
+        except RuntimeError as exc:
+            assert "missing required MCP tools" in str(exc)
+
+    fake_client.close.assert_called_once()
+
+
+def test_handle_tool_call_maps_to_backend_tool():
+    provider = CyberMemoryProvider()
+    provider._client = MagicMock()
+    provider._client.call_tool.return_value = {"result": "ok"}
+
+    result = json.loads(provider.handle_tool_call("cyber_memory_search", {"query": "oauth"}))
+    provider._client.call_tool.assert_called_once_with("memory_search", {"query": "oauth"})
+    assert result["result"] == "ok"
+
+
+def test_queue_prefetch_formats_results():
+    provider = CyberMemoryProvider()
+    provider._client = MagicMock()
+    provider._client.call_tool.return_value = {
+        "results": [
+            {"content": "User prefers terse answers", "score": 0.92},
+            {"content": "Project uses uv", "score": 0.75},
+        ]
+    }
+
+    with patch("plugins.memory.cyber_memory.threading.Thread", _ImmediateThread):
+        provider.queue_prefetch("what does the user prefer?")
+
+    prefetched = provider.prefetch("what does the user prefer?")
+    assert "Cyber Memory" in prefetched
+    assert "terse answers" in prefetched
+
+
+def test_sync_turn_stores_conversation():
+    provider = CyberMemoryProvider()
+    provider._client = MagicMock()
+    provider._client.call_tool.return_value = {"result": "stored"}
+
+    with patch("plugins.memory.cyber_memory.threading.Thread", _ImmediateThread):
+        provider.sync_turn("remember this preference", "Got it, I will.")
+
+    provider._client.call_tool.assert_called_once()
+    tool_name, payload = provider._client.call_tool.call_args[0]
+    assert tool_name == "memory_store"
+    assert "User:" in payload["content"]
+    assert payload["kind"] == "episodic"
+
+
+def test_on_memory_write_mirrors_to_backend():
+    provider = CyberMemoryProvider()
+    provider._client = MagicMock()
+    provider._client.call_tool.return_value = {"result": "stored"}
+
+    with patch("plugins.memory.cyber_memory.threading.Thread", _ImmediateThread):
+        provider.on_memory_write("add", "user", "Timezone: America/New_York")
+
+    tool_name, payload = provider._client.call_tool.call_args[0]
+    assert tool_name == "memory_store"
+    assert payload["source"] == "hermes_user"
+    assert "user" in payload["tags"]
+
+
+def test_shutdown_closes_client():
+    provider = CyberMemoryProvider()
+    client = MagicMock()
+    provider._client = client
+    provider.shutdown()
+    client.close.assert_called_once()

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 4
 title: "Memory Providers"
-description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover"
+description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Cyber Memory"
 ---
 
 # Memory Providers
 
-Hermes Agent ships with 7 external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
+Hermes Agent ships with 8 external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
 
 ## Quick Start
 
@@ -20,7 +20,7 @@ Or set manually in `~/.hermes/config.yaml`:
 
 ```yaml
 memory:
-  provider: openviking   # or honcho, mem0, hindsight, holographic, retaindb, byterover
+  provider: openviking   # or honcho, mem0, hindsight, holographic, retaindb, byterover, cyber_memory
 ```
 
 ## How It Works
@@ -251,6 +251,45 @@ hermes config set memory.provider byterover
 
 ---
 
+### Cyber Memory
+
+Single-binary local memory server with semantic recall, full-text search, and a lightweight knowledge graph — integrated into Hermes as a first-class memory provider.
+
+| | |
+|---|---|
+| **Best for** | Local-first persistent memory with semantic + graph recall and no cloud service |
+| **Requires** | `cyber-memory` binary + Hermes MCP dependency |
+| **Data storage** | Local SQLite |
+| **Cost** | Free |
+
+**Tools:** `cyber_memory_store`, `cyber_memory_recall`, `cyber_memory_search`, `cyber_memory_relate`, `cyber_memory_graph`, `cyber_memory_update`, `cyber_memory_forget`, `cyber_memory_stats`
+
+**Setup:**
+```bash
+# Install Cyber Memory first
+curl -fsSL https://raw.githubusercontent.com/RamboRogers/cyber-memory/master/install.sh | sh
+
+# Then configure Hermes
+hermes memory setup    # select "cyber_memory"
+# Or manually:
+hermes config set memory.provider cyber_memory
+```
+
+**Config:** `$HERMES_HOME/cyber-memory.json`
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `command` | `cyber-memory` | Binary name or absolute path |
+| `db_path` | `$HERMES_HOME/cyber-memory/db.sqlite3` | Profile-scoped SQLite database path |
+
+**Key features:**
+- Local-only persistent memory in a single SQLite file
+- Semantic recall with recency/importance-aware ranking
+- Full-text search for exact keyword lookups
+- Graph relations between memories (`supports`, `contradicts`, `precedes`, `relates_to`)
+
+---
+
 ## Provider Comparison
 
 | Provider | Storage | Cost | Tools | Dependencies | Unique Feature |
@@ -262,12 +301,13 @@ hermes config set memory.provider byterover
 | **Holographic** | Local | Free | 2 | None | HRR algebra + trust scoring |
 | **RetainDB** | Cloud | $20/mo | 5 | `requests` | Delta compression |
 | **ByteRover** | Local/Cloud | Free/Paid | 3 | `brv` CLI | Pre-compression extraction |
+| **Cyber Memory** | Local | Free | 8 | `cyber-memory` + Python `mcp` | Single-binary vector + graph memory |
 
 ## Profile Isolation
 
 Each provider's data is isolated per [profile](/docs/user-guide/profiles):
 
-- **Local storage providers** (Holographic, ByteRover) use `$HERMES_HOME/` paths which differ per profile
+- **Local storage providers** (Holographic, ByteRover, Cyber Memory) use `$HERMES_HOME/` paths which differ per profile
 - **Config file providers** (Honcho, Mem0, Hindsight) store config in `$HERMES_HOME/` so each profile has its own credentials
 - **Cloud providers** (RetainDB) auto-derive profile-scoped project names
 - **Env var providers** (OpenViking) are configured via each profile's `.env` file

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -209,7 +209,7 @@ memory:
 
 ## External Memory Providers
 
-For deeper, persistent memory that goes beyond MEMORY.md and USER.md, Hermes ships with 7 external memory provider plugins — including Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, and ByteRover.
+For deeper, persistent memory that goes beyond MEMORY.md and USER.md, Hermes ships with 8 external memory provider plugins — including Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, and Cyber Memory.
 
 External providers run **alongside** built-in memory (never replacing it) and add capabilities like knowledge graphs, semantic search, automatic fact extraction, and cross-session user modeling.
 


### PR DESCRIPTION
## Summary
- add Cyber Memory as a first-class Hermes memory provider plugin
- back the provider with a provider-local stdio MCP client for the `cyber-memory` binary
- add setup/config/docs/tests for the new provider

## What changed
- added `plugins/memory/cyber_memory/` with:
  - provider implementation
  - provider-local stdio MCP client
  - plugin metadata
  - provider README
- added provider tests in `tests/agent/test_cyber_memory_provider.py`
- updated `hermes memory` CLI help text to include `cyber_memory`
- updated memory provider docs and provider count from 7 to 8

## Design notes
- uses a provider-local MCP client instead of `mcp_servers`, so Cyber Memory is a true first-class memory provider
- stores config in `$HERMES_HOME/cyber-memory.json`
- defaults the DB to `$HERMES_HOME/cyber-memory/db.sqlite3` for profile isolation
- validates required backend MCP tools at init
- declares Python `mcp` as a plugin pip dependency and `cyber-memory` as an external dependency

## Validation
- `python3 -m py_compile` on changed Python files
- mocked provider smoke tests executed successfully via direct Python harness
- note: `pytest` is not installed in this local environment, so full pytest execution was not available here

## Follow-ups / reviewer notes
- this keeps MCP local to the provider and does not refactor Hermes's global MCP runtime
- the client lifecycle was adjusted so stdio/session connect and teardown happen in one owning async task, matching Hermes MCP runtime expectations
