### PR TITLE
feat(gateway): apply terminal sandbox overrides to messaging sessions

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1478,6 +1478,7 @@ _DOCKER_MEDIA_OUTPUT_CONTAINER_PATHS = {"/output", "/outputs"}
 # Bridge config.yaml values into the environment so os.getenv() picks them up.
 # config.yaml is authoritative for terminal settings — overrides .env.
 _config_path = _hermes_home / 'config.yaml'
+_cfg = {}
 if _config_path.exists():
     try:
         import yaml as _yaml
@@ -1561,20 +1562,6 @@ if _config_path.exists():
                         os.environ[_env_var] = json.dumps(_val)
                     else:
                         os.environ[_env_var] = str(_val)
-        # Gateway-only values overlay the same TERMINAL_* bridge.  This keeps
-        # CLI behavior unchanged and preserves native remote execute_code
-        # routing through the selected terminal environment.
-        from gateway.sandbox_config import (
-            apply_gateway_backend_to_env,
-            should_warn_insecure_gateway,
-        )
-        apply_gateway_backend_to_env(_cfg)
-        if should_warn_insecure_gateway(_cfg):
-            logging.getLogger(__name__).warning(
-                "Gateway terminal backend is local; messaging sessions do not "
-                "have sandbox isolation. Set gateway.terminal_backend to a "
-                "remote backend (for example, docker)."
-            )
         # Compression config is read directly from config.yaml by run_agent.py
         # and auxiliary_client.py — no env var bridging needed.
         # Auxiliary model/direct-endpoint overrides (vision, web_extract,
@@ -1722,6 +1709,18 @@ if _config_path.exists():
             "your current config.yaml. Run `hermes doctor` to investigate.",
             file=sys.stderr,
         )
+
+# Apply gateway-only overrides after the normal terminal bridge, even when
+# config.yaml is absent, so the effective local backend is warned about.
+from gateway.sandbox_config import apply_gateway_backend_to_env, should_warn_insecure_gateway
+
+apply_gateway_backend_to_env(_cfg)
+if should_warn_insecure_gateway(_cfg):
+    logging.getLogger(__name__).warning(
+        "Gateway terminal backend is local; messaging sessions do not "
+        "have sandbox isolation. Set gateway.terminal_backend to a "
+        "remote backend (for example, docker)."
+    )
 
 # Apply IPv4 preference if configured (before any HTTP clients are created).
 try:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1561,6 +1561,20 @@ if _config_path.exists():
                         os.environ[_env_var] = json.dumps(_val)
                     else:
                         os.environ[_env_var] = str(_val)
+        # Gateway-only values overlay the same TERMINAL_* bridge.  This keeps
+        # CLI behavior unchanged and preserves native remote execute_code
+        # routing through the selected terminal environment.
+        from gateway.sandbox_config import (
+            apply_gateway_backend_to_env,
+            should_warn_insecure_gateway,
+        )
+        apply_gateway_backend_to_env(_cfg)
+        if should_warn_insecure_gateway(_cfg):
+            logging.getLogger(__name__).warning(
+                "Gateway terminal backend is local; messaging sessions do not "
+                "have sandbox isolation. Set gateway.terminal_backend to a "
+                "remote backend (for example, docker)."
+            )
         # Compression config is read directly from config.yaml by run_agent.py
         # and auxiliary_client.py — no env var bridging needed.
         # Auxiliary model/direct-endpoint overrides (vision, web_extract,

--- a/gateway/sandbox_config.py
+++ b/gateway/sandbox_config.py
@@ -1,0 +1,110 @@
+"""Gateway-only overlay for the existing terminal environment bridge."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_VALID_BACKENDS = frozenset({"local", "docker", "modal", "daytona", "ssh", "singularity"})
+_DEFAULT_SANDBOX_LIFETIME = 3600
+
+
+def _gateway_config(config: dict) -> dict:
+    gateway = config.get("gateway", {})
+    return gateway if isinstance(gateway, dict) else {}
+
+
+def get_gateway_terminal_backend(config: dict) -> Optional[str]:
+    """Return the configured gateway backend override, if any."""
+    backend = _gateway_config(config).get("terminal_backend")
+    return backend if backend is None or isinstance(backend, str) else str(backend)
+
+
+def get_gateway_sandbox_lifetime(config: dict) -> int:
+    """Return the configured gateway lifetime, or the historical default."""
+    value = _gateway_config(config).get("sandbox_lifetime", _DEFAULT_SANDBOX_LIFETIME)
+    try:
+        if isinstance(value, bool):
+            raise ValueError
+        lifetime = int(value)
+        if lifetime < 0:
+            raise ValueError
+        return lifetime
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid gateway.sandbox_lifetime %r; using %ss",
+            value,
+            _DEFAULT_SANDBOX_LIFETIME,
+        )
+        return _DEFAULT_SANDBOX_LIFETIME
+
+
+def should_warn_insecure_gateway(config: dict) -> bool:
+    """Return whether the effective gateway backend is local."""
+    terminal = config.get("terminal", {})
+    if isinstance(terminal, dict) and "backend" in terminal:
+        terminal_backend = terminal.get("backend")
+    else:
+        terminal_backend = os.environ.get("TERMINAL_ENV", "local")
+    gateway_backend = get_gateway_terminal_backend(config)
+    effective_backend = gateway_backend if gateway_backend is not None else terminal_backend
+    return effective_backend == "local"
+
+
+
+def apply_gateway_backend_to_env(config: dict) -> None:
+    """Apply explicit gateway backend/image/lifetime settings to ``TERMINAL_*``.
+
+    The gateway imports this after the normal ``terminal`` config bridge.  Only
+    explicitly supplied gateway values are written, so the CLI and an omitted
+    gateway section keep the existing terminal behavior.
+    """
+    gateway = _gateway_config(config)
+    backend = gateway.get("terminal_backend")
+    if backend is not None:
+        if not isinstance(backend, str) or backend not in _VALID_BACKENDS:
+            logger.warning(
+                "Invalid gateway.terminal_backend %r; keeping the terminal backend. "
+                "Valid values: %s",
+                backend,
+                ", ".join(sorted(_VALID_BACKENDS)),
+            )
+        else:
+            os.environ["TERMINAL_ENV"] = backend
+
+    image = gateway.get("sandbox_image")
+    if image is not None:
+        if not isinstance(image, str) or not image.strip():
+            logger.warning(
+                "Invalid gateway.sandbox_image %r; keeping the terminal Docker image.",
+                image,
+            )
+        else:
+            os.environ["TERMINAL_DOCKER_IMAGE"] = image
+
+    lifetime = gateway.get("sandbox_lifetime")
+    if lifetime is not None:
+        try:
+            if isinstance(lifetime, bool):
+                raise ValueError
+            lifetime_value = int(lifetime)
+            if lifetime_value < 0:
+                raise ValueError
+        except (TypeError, ValueError):
+            logger.warning(
+                "Invalid gateway.sandbox_lifetime %r; keeping TERMINAL_LIFETIME_SECONDS.",
+                lifetime,
+            )
+        else:
+            os.environ["TERMINAL_LIFETIME_SECONDS"] = str(lifetime_value)
+
+    if isinstance(backend, str) and backend in _VALID_BACKENDS:
+        logger.info(
+            "Gateway terminal override: backend=%s image=%s lifetime=%s",
+            os.environ.get("TERMINAL_ENV", "local"),
+            os.environ.get("TERMINAL_DOCKER_IMAGE", "(terminal default)"),
+            os.environ.get("TERMINAL_LIFETIME_SECONDS", "(terminal default)"),
+        )

--- a/gateway/sandbox_config.py
+++ b/gateway/sandbox_config.py
@@ -3,65 +3,53 @@
 from __future__ import annotations
 
 import logging
+import math
 import os
 from typing import Optional
 
 logger = logging.getLogger(__name__)
 
 _VALID_BACKENDS = frozenset({"local", "docker", "modal", "daytona", "ssh", "singularity"})
-_DEFAULT_SANDBOX_LIFETIME = 3600
 
 
-def _is_valid_backend(value: object) -> bool:
+def is_valid_gateway_backend(value: object) -> bool:
+    """Return whether a gateway backend is supported by the terminal factory."""
     return isinstance(value, str) and value in _VALID_BACKENDS
 
 
-def _gateway_config(config: dict) -> dict:
-    gateway = config.get("gateway", {})
-    return gateway if isinstance(gateway, dict) else {}
-
-
-def get_gateway_terminal_backend(config: dict) -> Optional[str]:
-    """Return the configured gateway backend override, if any."""
-    backend = _gateway_config(config).get("terminal_backend")
-    return backend if backend is None or isinstance(backend, str) else str(backend)
-
-
-def get_gateway_sandbox_lifetime(config: dict) -> int:
-    """Return the configured gateway lifetime, or the historical default."""
-    value = _gateway_config(config).get("sandbox_lifetime", _DEFAULT_SANDBOX_LIFETIME)
+def parse_gateway_sandbox_lifetime(value: object, default: Optional[int] = None) -> Optional[int]:
+    """Parse an integer gateway lifetime without truncating or propagating errors."""
     try:
         if isinstance(value, bool):
+            raise ValueError
+        if isinstance(value, float) and (not math.isfinite(value) or not value.is_integer()):
             raise ValueError
         lifetime = int(value)
         if lifetime < 0:
             raise ValueError
         return lifetime
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         logger.warning(
-            "Invalid gateway.sandbox_lifetime %r; using %ss",
+            "Invalid gateway.sandbox_lifetime %r; using %s",
             value,
-            _DEFAULT_SANDBOX_LIFETIME,
+            f"{default}s" if default is not None else "the terminal lifetime",
         )
-        return _DEFAULT_SANDBOX_LIFETIME
+        return default
 
 
-def should_warn_insecure_gateway(config: dict) -> bool:
-    """Return whether the effective gateway backend is local."""
-    terminal = config.get("terminal", {})
-    if isinstance(terminal, dict) and "backend" in terminal:
-        terminal_backend = terminal.get("backend")
-    else:
-        terminal_backend = os.environ.get("TERMINAL_ENV", "local")
-    gateway_backend = get_gateway_terminal_backend(config)
-    effective_backend = (
-        gateway_backend if _is_valid_backend(gateway_backend) else terminal_backend
-    )
-    return effective_backend == "local"
+def _gateway_config(config: object) -> dict:
+    if not isinstance(config, dict):
+        return {}
+    gateway = config.get("gateway", {})
+    return gateway if isinstance(gateway, dict) else {}
 
 
+def should_warn_insecure_gateway(config: object) -> bool:
+    """Return whether the applied gateway backend is local."""
+    return os.environ.get("TERMINAL_ENV", "local") == "local"
 
-def apply_gateway_backend_to_env(config: dict) -> None:
+
+def apply_gateway_backend_to_env(config: object) -> None:
     """Apply explicit gateway backend/image/lifetime settings to ``TERMINAL_*``.
 
     The gateway imports this after the normal ``terminal`` config bridge.  Only
@@ -71,7 +59,7 @@ def apply_gateway_backend_to_env(config: dict) -> None:
     gateway = _gateway_config(config)
     backend = gateway.get("terminal_backend")
     if backend is not None:
-        if not _is_valid_backend(backend):
+        if not is_valid_gateway_backend(backend):
             logger.warning(
                 "Invalid gateway.terminal_backend %r; keeping the terminal backend. "
                 "Valid values: %s",
@@ -89,25 +77,14 @@ def apply_gateway_backend_to_env(config: dict) -> None:
                 image,
             )
         else:
-            os.environ["TERMINAL_DOCKER_IMAGE"] = image
+            os.environ["TERMINAL_DOCKER_IMAGE"] = image.strip()
 
     lifetime = gateway.get("sandbox_lifetime")
     if lifetime is not None:
-        try:
-            if isinstance(lifetime, bool):
-                raise ValueError
-            lifetime_value = int(lifetime)
-            if lifetime_value < 0:
-                raise ValueError
-        except (TypeError, ValueError):
-            logger.warning(
-                "Invalid gateway.sandbox_lifetime %r; keeping TERMINAL_LIFETIME_SECONDS.",
-                lifetime,
-            )
-        else:
+        lifetime_value = parse_gateway_sandbox_lifetime(lifetime)
+        if lifetime_value is not None:
             os.environ["TERMINAL_LIFETIME_SECONDS"] = str(lifetime_value)
-
-    if isinstance(backend, str) and backend in _VALID_BACKENDS:
+    if is_valid_gateway_backend(backend):
         logger.info(
             "Gateway terminal override: backend=%s image=%s lifetime=%s",
             os.environ.get("TERMINAL_ENV", "local"),

--- a/gateway/sandbox_config.py
+++ b/gateway/sandbox_config.py
@@ -12,6 +12,10 @@ _VALID_BACKENDS = frozenset({"local", "docker", "modal", "daytona", "ssh", "sing
 _DEFAULT_SANDBOX_LIFETIME = 3600
 
 
+def _is_valid_backend(value: object) -> bool:
+    return isinstance(value, str) and value in _VALID_BACKENDS
+
+
 def _gateway_config(config: dict) -> dict:
     gateway = config.get("gateway", {})
     return gateway if isinstance(gateway, dict) else {}
@@ -50,7 +54,9 @@ def should_warn_insecure_gateway(config: dict) -> bool:
     else:
         terminal_backend = os.environ.get("TERMINAL_ENV", "local")
     gateway_backend = get_gateway_terminal_backend(config)
-    effective_backend = gateway_backend if gateway_backend is not None else terminal_backend
+    effective_backend = (
+        gateway_backend if _is_valid_backend(gateway_backend) else terminal_backend
+    )
     return effective_backend == "local"
 
 
@@ -65,7 +71,7 @@ def apply_gateway_backend_to_env(config: dict) -> None:
     gateway = _gateway_config(config)
     backend = gateway.get("terminal_backend")
     if backend is not None:
-        if not isinstance(backend, str) or backend not in _VALID_BACKENDS:
+        if not _is_valid_backend(backend):
             logger.warning(
                 "Invalid gateway.terminal_backend %r; keeping the terminal backend. "
                 "Valid values: %s",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2471,6 +2471,14 @@ DEFAULT_CONFIG = {
         "channel_prompts": {},         # Per-channel ephemeral system prompts
     },
 
+    # Gateway-only terminal overrides. ``None`` preserves terminal settings
+    # when no explicit gateway override is configured.
+    "gateway": {
+        "terminal_backend": None,
+        "sandbox_image": None,
+        "sandbox_lifetime": None,
+    },
+
     # Discord platform settings (gateway mode)
     "discord": {
         "require_mention": True,       # Require @mention to respond in server channels

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2471,13 +2471,6 @@ DEFAULT_CONFIG = {
         "channel_prompts": {},         # Per-channel ephemeral system prompts
     },
 
-    # Gateway-only terminal overrides. ``None`` preserves terminal settings
-    # when no explicit gateway override is configured.
-    "gateway": {
-        "terminal_backend": None,
-        "sandbox_image": None,
-        "sandbox_lifetime": None,
-    },
 
     # Discord platform settings (gateway mode)
     "discord": {
@@ -2906,6 +2899,12 @@ DEFAULT_CONFIG = {
     # Gateway settings — control how messaging platforms (Telegram, Discord,
     # Slack, etc.) deliver agent-produced files as native attachments.
     "gateway": {
+        # Gateway-only terminal overrides. ``None`` preserves terminal
+        # settings when no explicit gateway override is configured.
+        "terminal_backend": None,
+        "sandbox_image": None,
+        "sandbox_lifetime": None,
+
         # Seconds the gateway waits for a single messaging platform to finish
         # connecting during startup (and on reconnect). Discord in particular
         # can blow past the old fixed 30s when an account has many slash

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -427,6 +427,29 @@ def show_status(args):
     elif terminal_env == "daytona":
         daytona_image = os.getenv("TERMINAL_DAYTONA_IMAGE", "nikolaik/python-nodejs:python3.11-nodejs20")
         print(f"  Daytona Image: {daytona_image}")
+    try:
+        _gw_cfg = load_config()
+        gateway_cfg = _gw_cfg.get("gateway", {})
+        terminal_cfg = _gw_cfg.get("terminal", {})
+        if not isinstance(gateway_cfg, dict):
+            gateway_cfg = {}
+        if not isinstance(terminal_cfg, dict):
+            terminal_cfg = {}
+    except Exception:
+        _gw_cfg = {}
+        gateway_cfg = {}
+        terminal_cfg = {}
+    gw_backend = gateway_cfg.get("terminal_backend")
+    if gw_backend:
+        print(f"  Gateway sandbox: {gw_backend}")
+        if gw_backend == "docker":
+            image = gateway_cfg.get("sandbox_image") or terminal_cfg.get(
+                "docker_image", "python:3.11-slim"
+            )
+            print(f"  Sandbox image:  {image}")
+        lifetime = gateway_cfg.get("sandbox_lifetime")
+        if lifetime is not None:
+            print(f"  Sandbox lifetime: {lifetime}s")
 
     sudo_password = os.getenv("SUDO_PASSWORD", "")
     print(f"  Sudo:         {check_mark(bool(sudo_password))} {'enabled' if sudo_password else 'disabled'}")

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -14,6 +14,7 @@ PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 from hermes_cli.auth import AuthError, resolve_provider
 from hermes_cli.colors import Colors, color
 from hermes_cli.config import get_env_path, get_env_value, get_hermes_home, load_config
+from gateway.sandbox_config import is_valid_gateway_backend, parse_gateway_sandbox_lifetime
 from hermes_cli.models import provider_label
 from hermes_cli.nous_account import (
     format_nous_portal_entitlement_message,
@@ -427,29 +428,48 @@ def show_status(args):
     elif terminal_env == "daytona":
         daytona_image = os.getenv("TERMINAL_DAYTONA_IMAGE", "nikolaik/python-nodejs:python3.11-nodejs20")
         print(f"  Daytona Image: {daytona_image}")
-    try:
-        _gw_cfg = load_config()
-        gateway_cfg = _gw_cfg.get("gateway", {})
-        terminal_cfg = _gw_cfg.get("terminal", {})
-        if not isinstance(gateway_cfg, dict):
-            gateway_cfg = {}
-        if not isinstance(terminal_cfg, dict):
-            terminal_cfg = {}
-    except Exception:
-        _gw_cfg = {}
-        gateway_cfg = {}
-        terminal_cfg = {}
-    gw_backend = gateway_cfg.get("terminal_backend")
-    if gw_backend:
-        print(f"  Gateway sandbox: {gw_backend}")
-        if gw_backend == "docker":
-            image = gateway_cfg.get("sandbox_image") or terminal_cfg.get(
-                "docker_image", "python:3.11-slim"
+
+    gateway_cfg = config.get("gateway", {}) if isinstance(config.get("gateway"), dict) else {}
+    gateway_backend = gateway_cfg.get("terminal_backend")
+    if gateway_backend is not None:
+        effective_gateway_backend = (
+            gateway_backend if is_valid_gateway_backend(gateway_backend) else terminal_env
+        )
+        if is_valid_gateway_backend(gateway_backend):
+            print(f"  Gateway sandbox: {effective_gateway_backend}")
+        else:
+            print(
+                f"  Gateway sandbox: {effective_gateway_backend} "
+                "(invalid gateway override ignored)"
             )
-            print(f"  Sandbox image:  {image}")
-        lifetime = gateway_cfg.get("sandbox_lifetime")
-        if lifetime is not None:
-            print(f"  Sandbox lifetime: {lifetime}s")
+
+    gateway_image = gateway_cfg.get("sandbox_image")
+    if gateway_image is not None:
+        if isinstance(gateway_image, str) and gateway_image.strip():
+            print(f"  Sandbox image:  {gateway_image.strip()}")
+        else:
+            terminal_image = terminal_cfg.get("docker_image")
+            if not isinstance(terminal_image, str) or not terminal_image.strip():
+                terminal_image = os.getenv("TERMINAL_DOCKER_IMAGE", "python:3.11-slim")
+            print(
+                f"  Sandbox image:  {terminal_image} "
+                "(invalid gateway override ignored)"
+            )
+
+    gateway_lifetime = gateway_cfg.get("sandbox_lifetime")
+    if gateway_lifetime is not None:
+        resolved_lifetime = parse_gateway_sandbox_lifetime(gateway_lifetime)
+        if resolved_lifetime is None:
+            if "lifetime_seconds" in terminal_cfg and terminal_cfg["lifetime_seconds"] is not None:
+                terminal_lifetime = terminal_cfg["lifetime_seconds"]
+            else:
+                terminal_lifetime = os.getenv("TERMINAL_LIFETIME_SECONDS", 300)
+            print(
+                f"  Sandbox lifetime: {terminal_lifetime}s "
+                "(invalid gateway override ignored)"
+            )
+        else:
+            print(f"  Sandbox lifetime: {resolved_lifetime}s")
 
     sudo_password = os.getenv("SUDO_PASSWORD", "")
     print(f"  Sudo:         {check_mark(bool(sudo_password))} {'enabled' if sudo_password else 'disabled'}")

--- a/tests/gateway/test_sandbox_config.py
+++ b/tests/gateway/test_sandbox_config.py
@@ -6,8 +6,6 @@ import os
 
 from gateway.sandbox_config import (
     apply_gateway_backend_to_env,
-    get_gateway_sandbox_lifetime,
-    get_gateway_terminal_backend,
     should_warn_insecure_gateway,
 )
 
@@ -36,6 +34,14 @@ def test_gateway_backend_image_and_lifetime_override_terminal_settings(monkeypat
     assert os.environ["TERMINAL_LIFETIME_SECONDS"] == "42"
 
 
+def test_gateway_image_override_is_stripped_before_env_write(monkeypatch):
+    monkeypatch.setenv("TERMINAL_DOCKER_IMAGE", "terminal:image")
+
+    apply_gateway_backend_to_env({"gateway": {"sandbox_image": " gateway:image "}})
+
+    assert os.environ["TERMINAL_DOCKER_IMAGE"] == "gateway:image"
+
+
 def test_absent_gateway_settings_preserve_terminal_behavior(monkeypatch):
     config = {"terminal": {"backend": "ssh", "docker_image": "terminal:image", "lifetime_seconds": 90}}
     monkeypatch.setenv("TERMINAL_ENV", "ssh")
@@ -49,15 +55,19 @@ def test_absent_gateway_settings_preserve_terminal_behavior(monkeypatch):
     assert os.environ["TERMINAL_LIFETIME_SECONDS"] == "90"
 
 
-def test_gateway_local_override_warns_based_on_effective_backend():
+def test_gateway_local_override_warns_based_on_effective_backend(monkeypatch):
     config = {"terminal": {"backend": "docker"}, "gateway": {"terminal_backend": "local"}}
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
 
+    apply_gateway_backend_to_env(config)
     assert should_warn_insecure_gateway(config) is True
 
 
-def test_gateway_remote_override_suppresses_local_warning():
+def test_gateway_remote_override_suppresses_local_warning(monkeypatch):
     config = {"terminal": {"backend": "local"}, "gateway": {"terminal_backend": "docker"}}
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
 
+    apply_gateway_backend_to_env(config)
     assert should_warn_insecure_gateway(config) is False
 
 
@@ -65,6 +75,29 @@ def test_warning_uses_terminal_env_when_config_omits_backend(monkeypatch):
     monkeypatch.setenv("TERMINAL_ENV", "docker")
 
     assert should_warn_insecure_gateway({}) is False
+
+
+def test_missing_gateway_config_warns_for_local_default(monkeypatch):
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+    apply_gateway_backend_to_env({})
+    assert should_warn_insecure_gateway({}) is True
+
+
+def test_none_terminal_backend_warns_for_local_default(monkeypatch):
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+    config = {"terminal": {"backend": None}}
+    apply_gateway_backend_to_env(config)
+    assert should_warn_insecure_gateway(config) is True
+
+
+def test_non_mapping_gateway_config_warns_without_crashing(monkeypatch):
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+    config = []
+    apply_gateway_backend_to_env(config)
+    assert should_warn_insecure_gateway(config) is True
 
 
 def test_invalid_gateway_backend_is_visible_and_preserves_terminal_env(monkeypatch, caplog):
@@ -83,6 +116,7 @@ def test_invalid_gateway_backend_keeps_local_warning(monkeypatch):
     config = {"terminal": {"backend": "local"}, "gateway": {"terminal_backend": "invalid"}}
     monkeypatch.delenv("TERMINAL_ENV", raising=False)
 
+    apply_gateway_backend_to_env(config)
     assert should_warn_insecure_gateway(config) is True
 
 
@@ -98,10 +132,25 @@ def test_invalid_gateway_lifetime_is_visible_and_preserves_terminal_env(monkeypa
     assert "forever" in caplog.text
 
 
-def test_lifetime_helper_returns_default_and_custom_values():
-    assert get_gateway_sandbox_lifetime({}) == 3600
-    assert get_gateway_sandbox_lifetime({"gateway": {"sandbox_lifetime": 15}}) == 15
+def test_fractional_gateway_lifetime_warns_and_preserves_terminal_env(monkeypatch, caplog):
+    config = {"gateway": {"sandbox_lifetime": 1.5}}
+    monkeypatch.setenv("TERMINAL_LIFETIME_SECONDS", "90")
+
+    with caplog.at_level(logging.WARNING):
+        apply_gateway_backend_to_env(config)
+
+    assert os.environ["TERMINAL_LIFETIME_SECONDS"] == "90"
+    assert "gateway.sandbox_lifetime" in caplog.text
 
 
-def test_backend_helper_handles_missing_gateway_section():
-    assert get_gateway_terminal_backend({}) is None
+
+
+def test_non_finite_gateway_lifetime_warns_without_aborting(monkeypatch, caplog):
+    config = {"gateway": {"sandbox_lifetime": float("inf")}}
+    monkeypatch.setenv("TERMINAL_LIFETIME_SECONDS", "90")
+
+    with caplog.at_level(logging.WARNING):
+        apply_gateway_backend_to_env(config)
+
+    assert os.environ["TERMINAL_LIFETIME_SECONDS"] == "90"
+    assert "gateway.sandbox_lifetime" in caplog.text

--- a/tests/gateway/test_sandbox_config.py
+++ b/tests/gateway/test_sandbox_config.py
@@ -79,6 +79,13 @@ def test_invalid_gateway_backend_is_visible_and_preserves_terminal_env(monkeypat
     assert "invalid" in caplog.text
 
 
+def test_invalid_gateway_backend_keeps_local_warning(monkeypatch):
+    config = {"terminal": {"backend": "local"}, "gateway": {"terminal_backend": "invalid"}}
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+    assert should_warn_insecure_gateway(config) is True
+
+
 def test_invalid_gateway_lifetime_is_visible_and_preserves_terminal_env(monkeypatch, caplog):
     config = {"terminal": {"lifetime_seconds": 90}, "gateway": {"sandbox_lifetime": "forever"}}
     monkeypatch.setenv("TERMINAL_LIFETIME_SECONDS", "90")

--- a/tests/gateway/test_sandbox_config.py
+++ b/tests/gateway/test_sandbox_config.py
@@ -1,0 +1,100 @@
+"""Focused behavior tests for gateway terminal configuration overlays."""
+
+import logging
+import os
+
+
+from gateway.sandbox_config import (
+    apply_gateway_backend_to_env,
+    get_gateway_sandbox_lifetime,
+    get_gateway_terminal_backend,
+    should_warn_insecure_gateway,
+)
+
+
+def test_gateway_backend_image_and_lifetime_override_terminal_settings(monkeypatch):
+    config = {
+        "terminal": {
+            "backend": "local",
+            "docker_image": "terminal:image",
+            "lifetime_seconds": 120,
+        },
+        "gateway": {
+            "terminal_backend": "docker",
+            "sandbox_image": "gateway:image",
+            "sandbox_lifetime": 42,
+        },
+    }
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setenv("TERMINAL_DOCKER_IMAGE", "terminal:image")
+    monkeypatch.setenv("TERMINAL_LIFETIME_SECONDS", "120")
+
+    apply_gateway_backend_to_env(config)
+
+    assert os.environ["TERMINAL_ENV"] == "docker"
+    assert os.environ["TERMINAL_DOCKER_IMAGE"] == "gateway:image"
+    assert os.environ["TERMINAL_LIFETIME_SECONDS"] == "42"
+
+
+def test_absent_gateway_settings_preserve_terminal_behavior(monkeypatch):
+    config = {"terminal": {"backend": "ssh", "docker_image": "terminal:image", "lifetime_seconds": 90}}
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+    monkeypatch.setenv("TERMINAL_DOCKER_IMAGE", "terminal:image")
+    monkeypatch.setenv("TERMINAL_LIFETIME_SECONDS", "90")
+
+    apply_gateway_backend_to_env(config)
+
+    assert os.environ["TERMINAL_ENV"] == "ssh"
+    assert os.environ["TERMINAL_DOCKER_IMAGE"] == "terminal:image"
+    assert os.environ["TERMINAL_LIFETIME_SECONDS"] == "90"
+
+
+def test_gateway_local_override_warns_based_on_effective_backend():
+    config = {"terminal": {"backend": "docker"}, "gateway": {"terminal_backend": "local"}}
+
+    assert should_warn_insecure_gateway(config) is True
+
+
+def test_gateway_remote_override_suppresses_local_warning():
+    config = {"terminal": {"backend": "local"}, "gateway": {"terminal_backend": "docker"}}
+
+    assert should_warn_insecure_gateway(config) is False
+
+
+def test_warning_uses_terminal_env_when_config_omits_backend(monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+    assert should_warn_insecure_gateway({}) is False
+
+
+def test_invalid_gateway_backend_is_visible_and_preserves_terminal_env(monkeypatch, caplog):
+    config = {"terminal": {"backend": "ssh"}, "gateway": {"terminal_backend": "invalid"}}
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+
+    with caplog.at_level(logging.WARNING):
+        apply_gateway_backend_to_env(config)
+
+    assert os.environ["TERMINAL_ENV"] == "ssh"
+    assert "gateway.terminal_backend" in caplog.text
+    assert "invalid" in caplog.text
+
+
+def test_invalid_gateway_lifetime_is_visible_and_preserves_terminal_env(monkeypatch, caplog):
+    config = {"terminal": {"lifetime_seconds": 90}, "gateway": {"sandbox_lifetime": "forever"}}
+    monkeypatch.setenv("TERMINAL_LIFETIME_SECONDS", "90")
+
+    with caplog.at_level(logging.WARNING):
+        apply_gateway_backend_to_env(config)
+
+    assert os.environ["TERMINAL_LIFETIME_SECONDS"] == "90"
+    assert "gateway.sandbox_lifetime" in caplog.text
+    assert "forever" in caplog.text
+
+
+def test_lifetime_helper_returns_default_and_custom_values():
+    assert get_gateway_sandbox_lifetime({}) == 3600
+    assert get_gateway_sandbox_lifetime({"gateway": {"sandbox_lifetime": 15}}) == 15
+
+
+def test_backend_helper_handles_missing_gateway_section():
+    assert get_gateway_terminal_backend({}) is None

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -373,3 +373,48 @@ def test_show_status_includes_gateway_sandbox_settings(monkeypatch, capsys, tmp_
     assert "Gateway sandbox: docker" in output
     assert "Sandbox image:  gateway:test" in output
     assert "Sandbox lifetime: 42s" in output
+
+
+def test_show_status_reports_invalid_gateway_values_as_ignored(monkeypatch, capsys, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "terminal:\n"
+        "  backend: local\n"
+        "  lifetime_seconds: 90\n"
+        "gateway:\n"
+        "  terminal_backend: invalid\n"
+        "  sandbox_lifetime: 1.5\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+    monkeypatch.setenv("TERMINAL_LIFETIME_SECONDS", "60")
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "invalid" in output.lower()
+    assert "1.5s" not in output
+    assert "90s" in output
+
+
+def test_show_status_reports_image_and_lifetime_without_backend_override(
+    monkeypatch, capsys, tmp_path
+):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "gateway:\n"
+        "  sandbox_image: gateway:test\n"
+        "  sandbox_lifetime: 42\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "Sandbox image:  gateway:test" in output
+    assert "Sandbox lifetime: 42s" in output

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -352,3 +352,24 @@ class TestShowStatusXaiOAuth:
 
         assert "xAI OAuth" in out
         assert "not logged in (run: hermes auth add xai-oauth)" in out
+
+
+def test_show_status_includes_gateway_sandbox_settings(monkeypatch, capsys, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "gateway:\n"
+        "  terminal_backend: docker\n"
+        "  sandbox_image: gateway:test\n"
+        "  sandbox_lifetime: 42\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "Gateway sandbox: docker" in output
+    assert "Sandbox image:  gateway:test" in output
+    assert "Sandbox lifetime: 42s" in output


### PR DESCRIPTION
## Summary

Rebased onto the current upstream `main` (`3f2a389c7e1f`) and reduced to the gateway configuration overlay requested for messaging sessions.

- Adds optional `gateway.terminal_backend`, `gateway.sandbox_image`, and `gateway.sandbox_lifetime` settings.
- Applies explicit gateway values only in the gateway process, after current main's `terminal` → `TERMINAL_*` bridge.
- Gateway values override terminal backend/image/lifetime; absent gateway values preserve existing terminal behavior.
- The unsafe-local warning uses the effective backend (gateway override, terminal config, or `TERMINAL_ENV`).
- `hermes status` reports configured gateway sandbox backend, Docker image, and lifetime.
- Non-local `execute_code` continues to use current main's native terminal-environment `_execute_remote` path.

This intentionally removes the custom Docker/UDS execute-code wrapper. There is no host `/tmp` bind mount, forced host networking, custom Docker subprocess, or duplicate execute-code transport in this PR.

## Configuration

```yaml
gateway:
  terminal_backend: docker       # optional; any existing terminal backend
  sandbox_image: python:3.11     # optional; overrides terminal.docker_image
  sandbox_lifetime: 3600         # optional seconds; overrides terminal.lifetime_seconds
```

The gateway process maps these values to the existing `TERMINAL_ENV`, `TERMINAL_DOCKER_IMAGE`, and `TERMINAL_LIFETIME_SECONDS` bridge, so the existing terminal environment factory and cleanup thread own execution and lifetime behavior. Invalid gateway values are warned and the corresponding terminal setting is preserved.

## Limitations

- This PR does not add a second execution transport or promise isolation beyond the selected terminal backend's existing policy.
- Docker image selection is meaningful when the effective backend is Docker; other backends keep their existing image settings.
- Focused verification was run on Linux (x86_64, Python 3.13 in the worktree environment); Windows/macOS runtime verification was not performed.

## Tests

Initial red test:

```text
uv run pytest -q tests/gateway/test_sandbox_config.py
1 error during collection: ModuleNotFoundError: No module named 'gateway.sandbox_config'
```

Final focused verification at commit `3222b9d03`:

```text
uv run pytest -q tests/gateway/test_sandbox_config.py tests/gateway/test_config_cwd_bridge.py tests/gateway/test_config.py tests/hermes_cli/test_status.py tests/hermes_cli/test_config.py tests/hermes_cli/test_config_validation.py tests/hermes_cli/test_config_env_expansion.py tests/tools/test_code_execution.py
436 passed, 1 third-party deprecation warning
```

Additional checks:

```text
uv run python -m py_compile gateway/run.py gateway/sandbox_config.py hermes_cli/config.py hermes_cli/status.py tests/gateway/test_sandbox_config.py tests/hermes_cli/test_status.py tools/code_execution_tool.py
git diff --check
```

Final CI: [run 29465867139](https://github.com/NousResearch/hermes-agent/actions/runs/29465867139) — all 31 jobs completed successfully, including Python slices/E2E, Ruff/ty, Windows footguns, attribution, supply-chain checks, and Docker amd64/arm64 builds.
