### PR TITLE
fix: clarify interrupt re-queue label, document busy_input_mode behaviour

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6263,8 +6263,11 @@ class HermesCLI:
                 ).start()
 
 
-            # Combine all interrupt messages (user may have typed multiple while waiting)
-            # and re-queue as one prompt for process_loop
+            # Re-queue the interrupt message (and any that arrived while we were
+            # processing the first) as the next prompt for process_loop.
+            # Only reached when busy_input_mode == "interrupt" (the default).
+            # In "queue" mode Enter routes directly to _pending_input so this
+            # block is never hit.
             if pending_message and hasattr(self, '_pending_input'):
                 all_parts = [pending_message]
                 while not self._interrupt_queue.empty():
@@ -6275,7 +6278,12 @@ class HermesCLI:
                     except queue.Empty:
                         break
                 combined = "\n".join(all_parts)
-                print(f"\n📨 Queued: '{combined[:50]}{'...' if len(combined) > 50 else ''}'")
+                n = len(all_parts)
+                preview = combined[:50] + ("..." if len(combined) > 50 else "")
+                if n > 1:
+                    print(f"\n⚡ Sending {n} messages after interrupt: '{preview}'")
+                else:
+                    print(f"\n⚡ Sending after interrupt: '{preview}'")
                 self._pending_input.put(combined)
             
             return response


### PR DESCRIPTION
The `📨 Queued:` label printed after an interrupt was confusing — it looked like the message was silently deferred when the opposite had happened: Enter had just *interrupted* the agent, and the message was being re-queued to send immediately after.

**Before:**
```
⚡ New message detected, interrupting...
⚡ Interrupted during API call.
📨 Queued: 'would be great to show bigger icons...'   ← confusing
```

**After:**
```
⚡ New message detected, interrupting...
⚡ Interrupted during API call.
⚡ Sending after interrupt: 'would be great to show bigger icons...'
```

Also handles the case where the user types multiple messages while the agent is running — they get combined and the count is shown:
```
⚡ Sending 3 messages after interrupt: '...'
```

**Note on `busy_input_mode`:** this code path is only reached when `display.busy_input_mode: interrupt` (the default). With `busy_input_mode: queue`, Enter routes directly to `_pending_input` without interrupting, so this block is never hit. Added a comment to make that explicit.