### PR TITLE
fix: normalise \r\n and \r line endings in pasted text

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7010,6 +7010,9 @@ class HermesCLI:
             buffer.
             """
             pasted_text = event.data or ""
+            # Normalise line endings — Windows \r\n and old Mac \r both become \n
+            # so the 5-line collapse threshold and display are consistent.
+            pasted_text = pasted_text.replace('\r\n', '\n').replace('\r', '\n')
             if self._try_attach_clipboard_image():
                 event.app.invalidate()
             if pasted_text:


### PR DESCRIPTION
Markdown copied from Windows or browser sources often uses CRLF (\) or CR (\) line endings. Without normalisation, bare \ characters end up in the prompt_toolkit buffer, which some terminals render by returning the cursor to the start of the line — making a multi-line paste appear as a single overwritten line.

**Fix:** normalise to LF before any processing in \:
```python
pasted_text = pasted_text.replace('\r\n', '\n').replace('\r', '\n')
```

This also ensures the 5-line collapse threshold is consistent regardless of the source's line-ending style.