### PR TITLE
feat: double ESC clears the input buffer

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7924,6 +7924,20 @@ class HermesCLI:
             """Alt+Enter inserts a newline for multi-line input."""
             event.current_buffer.insert_text('\n')
 
+        @kb.add('escape', 'escape')
+        def handle_double_escape(event):
+            """Double ESC: clear the input buffer and any attached images.
+
+            Press ESC twice quickly to discard the current draft.
+            Single ESC is the prefix for Alt key sequences (escape+enter,
+            escape+up, escape+v etc.) so the double-press avoids conflicts.
+            """
+            buf = event.app.current_buffer
+            if buf.text or cli_ref._attached_images:
+                buf.reset()
+                cli_ref._attached_images.clear()
+                event.app.invalidate()
+
         @kb.add('c-j')
         def handle_ctrl_enter(event):
             """Ctrl+Enter (c-j) inserts a newline. Most terminals send c-j for Ctrl+Enter."""


### PR DESCRIPTION
Press ESC twice quickly to discard the current draft and any attached images — same effect as Ctrl+C when the buffer has content.

Single ESC is already the prefix for Alt key sequences (\, \, \) so binding \ has no conflicts. prompt_toolkit waits for the second key within its \ window before dispatching, so the sequence is distinct from two separate ESC presses.