### PR TITLE
fix: resolve critical runtime stability issues across core, web, delegate, and browser tools

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -349,13 +349,6 @@ class SessionDB:
 
         self._conn.commit()
 
-    def close(self):
-        """Close the database connection."""
-        with self._lock:
-            if self._conn:
-                self._conn.close()
-                self._conn = None
-
     # =========================================================================
     # Session lifecycle
     # =========================================================================

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -65,6 +65,7 @@ import requests
 from typing import Dict, Any, Optional, List
 from pathlib import Path
 from agent.auxiliary_client import call_llm
+from hermes_constants import get_hermes_home
 
 try:
     from tools.website_policy import check_website_access
@@ -144,7 +145,7 @@ def _get_command_timeout() -> int:
     ``DEFAULT_COMMAND_TIMEOUT`` (30s) if unset or unreadable.
     """
     try:
-        hermes_home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+        hermes_home = get_hermes_home()
         config_path = hermes_home / "config.yaml"
         if config_path.exists():
             import yaml
@@ -256,7 +257,7 @@ def _get_cloud_provider() -> Optional[CloudBrowserProvider]:
 
     _cloud_provider_resolved = True
     try:
-        hermes_home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+        hermes_home = get_hermes_home()
         config_path = hermes_home / "config.yaml"
         if config_path.exists():
             import yaml
@@ -327,7 +328,7 @@ def _allow_private_urls() -> bool:
     _allow_private_urls_resolved = True
     _cached_allow_private_urls = False  # safe default
     try:
-        hermes_home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+        hermes_home = get_hermes_home()
         config_path = hermes_home / "config.yaml"
         if config_path.exists():
             import yaml
@@ -777,7 +778,7 @@ def _find_agent_browser() -> str:
             extra_dirs.append(d)
     extra_dirs.extend(_discover_homebrew_node_dirs())
 
-    hermes_home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+    hermes_home = get_hermes_home()
     hermes_node_bin = str(hermes_home / "node" / "bin")
     if os.path.isdir(hermes_node_bin):
         extra_dirs.append(hermes_node_bin)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -563,7 +563,7 @@ def delegate_task(
     if parent_agent and hasattr(parent_agent, '_memory_manager') and parent_agent._memory_manager:
         for entry in results:
             try:
-                _task_goal = tasks[entry["task_index"]]["goal"] if entry["task_index"] < len(tasks) else ""
+                _task_goal = task_list[entry["task_index"]]["goal"] if entry["task_index"] < len(task_list) else ""
                 parent_agent._memory_manager.on_delegation(
                     task=_task_goal,
                     result=entry.get("summary", "") or "",

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -788,6 +788,15 @@ Create a single, unified markdown summary."""
             logger.warning("Synthesis LLM returned empty content, retrying once")
             response = await async_call_llm(**call_kwargs)
             final_summary = extract_content_or_reasoning(response)
+
+        # If still None after retry, fall back to concatenated summaries
+        if not final_summary:
+            logger.warning("Synthesis failed after retry — concatenating chunk summaries")
+            fallback = "\n\n".join(summaries)
+            if len(fallback) > max_output_size:
+                fallback = fallback[:max_output_size] + "\n\n[... truncated ...]"
+            return fallback
+
         # Enforce hard cap
         if len(final_summary) > max_output_size:
             final_summary = final_summary[:max_output_size] + "\n\n[... summary truncated for context management ...]"


### PR DESCRIPTION
Summary
Surgical fixes for 4 runtime bugs found during a stability audit of the tool orchestration layer. Each fix is minimal and isolated — no refactoring, no behavioral changes beyond the bug corrections.

Changes
1. Fix unbounded WAL file growth on SessionDB.close() (hermes_state.py)
A second close() definition at line 352 silently overrode the first one at line 238. The first (correct) implementation performs PRAGMA wal_checkpoint(PASSIVE) before closing, which flushes committed WAL frames back to the main database. The override skipped this entirely.

Impact: In long-running gateway/daemon sessions, the WAL file grows without bound as no exiting process ever checkpoints it. This degrades read performance and wastes disk over time.

Fix: Removed the duplicate method, preserving the WAL-checkpointing version.

2. Fix TypeError crash in chunked web content synthesis (tools/web_tools.py)
In _process_large_content_chunked(), when both synthesis LLM calls return reasoning-only responses (empty text content), final_summary remains None. The subsequent len(final_summary) call crashes with TypeError.

Impact: Runtime crash during large web page extraction when the synthesis model produces reasoning-only output. The outer except catches it, but the useful partial summaries are lost.

Fix: Added explicit None guard after retry — falls back to concatenating chunk summaries directly.

3. Fix silent memory loss in single-task delegation (tools/delegate_tool.py)
The memory notification block referenced tasks (the raw input parameter) instead of task_list (the normalized list). In single-task mode (goal="...", tasks=None), this crashes with TypeError on None subscript. The crash is silently swallowed by except Exception: pass.

Impact: Delegation outcomes are never recorded in the memory provider during single-task delegations — the most common delegation path.

Fix: Changed tasks → task_list.

4. Fix profile isolation in browser tool config (tools/browser_tool.py)
Four locations used Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) instead of the canonical get_hermes_home() from hermes_constants. This is the exact pattern that AGENTS.md warns against.

Impact: When running with profiles (hermes -p coder), browser configuration (command timeout, cloud provider selection, private URL policy, node binary discovery) reads from the default ~/.hermes/ instead of the active profile's directory.

Fix: Replaced all 4 instances with get_hermes_home() and added the import.

Testing
All modified modules verified with import tests:

hermes_state.SessionDB ✅
tools.web_tools ✅
tools.delegate_tool ✅
tools.browser_tool ✅
run_agent.AIAgent ✅

### 📂 Files Changed Summary

| File | Change |
| :--- | :--- |
| `hermes_state.py` | Remove duplicate `close()` (-6 lines) |
| `tools/web_tools.py` | Add `None` guard in synthesis fallback (+8 lines) |
| `tools/delegate_tool.py` | Fix variable reference `tasks` → `task_list` (1 line) |
| `tools/browser_tool.py` | Use `get_hermes_home()` in 4 locations (+1 import) |