### PR TITLE
fix(mem0): merge env vars with mem0.json instead of either/or

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -38,23 +38,31 @@ _BREAKER_COOLDOWN_SECS = 120
 # ---------------------------------------------------------------------------
 
 def _load_config() -> dict:
-    """Load config from $HERMES_HOME/mem0.json or env vars."""
+    """Load config from env vars, with $HERMES_HOME/mem0.json overrides.
+
+    Environment variables provide defaults; mem0.json (if present) overrides
+    individual keys.  This avoids a silent failure when the JSON file exists
+    but is missing fields like ``api_key`` that the user set in ``.env``.
+    """
     from hermes_constants import get_hermes_home
-    config_path = get_hermes_home() / "mem0.json"
 
-    if config_path.exists():
-        try:
-            return json.loads(config_path.read_text(encoding="utf-8"))
-        except Exception:
-            pass
-
-    return {
+    config = {
         "api_key": os.environ.get("MEM0_API_KEY", ""),
         "user_id": os.environ.get("MEM0_USER_ID", "hermes-user"),
         "agent_id": os.environ.get("MEM0_AGENT_ID", "hermes"),
         "rerank": True,
         "keyword_search": False,
     }
+
+    config_path = get_hermes_home() / "mem0.json"
+    if config_path.exists():
+        try:
+            file_cfg = json.loads(config_path.read_text(encoding="utf-8"))
+            config.update({k: v for k, v in file_cfg.items() if v})
+        except Exception:
+            pass
+
+    return config
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Bug**: `hermes memory status` shows mem0 as "not available" even when `MEM0_API_KEY` is correctly set in `~/.hermes/.env`
- **Cause**: `_load_config()` in the mem0 plugin treats `mem0.json` and env vars as mutually exclusive. If `mem0.json` exists (created by `hermes memory setup` with just `user_id`/`agent_id`), it returns that file's contents and never checks env vars — so `api_key` is silently empty.
- **Fix**: Use env vars as the base config, then let `mem0.json` override individual keys on top. Both sources now work together instead of one replacing the other.

## Reproduction

1. `hermes memory setup` → configure user_id and agent_id
2. Add `MEM0_API_KEY=m0-xxx` to `~/.hermes/.env`
3. `hermes memory status` → shows "not available"

## Test plan

- [ ] Verify `hermes memory status` shows available with key only in `.env`
- [ ] Verify `hermes memory status` shows available with key only in `mem0.json`
- [ ] Verify `mem0.json` values override env vars when both are set
- [ ] Verify empty/falsy values in `mem0.json` don't clobber env var defaults