### PR TITLE
feat: add CCD as native MCP integration

### DIFF
--- a/docs/ccd-mcp-integration.md
+++ b/docs/ccd-mcp-integration.md
@@ -1,6 +1,6 @@
 # CCD MCP Integration
 
-Wire [CCD](https://github.com/nousresearch/ccd) (Continuous Context Delivery) into
+Wire [CCD](https://github.com/dusk-network/ccd) (Continuous Context Development) into
 Hermes Agent as a native MCP server so its session-management, memory, and governance
 tools are available alongside built-in agent tools.
 

--- a/docs/ccd-mcp-integration.md
+++ b/docs/ccd-mcp-integration.md
@@ -1,0 +1,83 @@
+# CCD MCP Integration
+
+Wire [CCD](https://github.com/nousresearch/ccd) (Continuous Context Delivery) into
+Hermes Agent as a native MCP server so its session-management, memory, and governance
+tools are available alongside built-in agent tools.
+
+## Prerequisites
+
+| Requirement | How to check |
+|---|---|
+| CCD binary on PATH | `ccd --version` → `1.0.0-alpha` or later |
+| CCD profile configured | `CCD_PROFILE=<name> ccd doctor /path/to/repo` |
+| `mcp` Python package | `pip show mcp` (install with `pip install mcp`) |
+
+## Configuration
+
+Add the following to `~/.hermes/config.yaml` (or your profile-specific config):
+
+```yaml
+mcp_servers:
+  ccd:
+    command: /Users/nanto/.cargo/bin/ccd   # or just "ccd" if on PATH
+    args:
+      - mcp-serve
+    env:
+      CCD_PROFILE: raoh                    # CCD profile to use
+    timeout: 120                           # per-tool-call timeout (seconds)
+    connect_timeout: 30                    # initial handshake timeout (seconds)
+```
+
+On agent startup, Hermes will:
+
+1. Spawn `ccd mcp-serve` as a stdio subprocess
+2. Complete the MCP initialize handshake
+3. Discover all CCD tools via `tools/list`
+4. Register them with the `mcp_ccd_` prefix
+
+## Exposed Tools
+
+After discovery, the following tools become available (names prefixed `mcp_ccd_`):
+
+| MCP Tool | Description |
+|---|---|
+| `ccd_repo` | Repo lifecycle: attach, scaffold, link, unlink, gc, skills-install |
+| `ccd_health` | Validate: doctor, check, drift, sync, preflight, hooks |
+| `ccd_session` | Session lifecycle: start, open, state-start, state-clear |
+| `ccd_session_lifecycle` | Runtime session lifecycle: start, heartbeat, clear, takeover |
+| `ccd_session_gates` | Execution gates: list, replace, seed, set-status, advance, clear |
+| `ccd_escalation` | Escalation state: list, set, clear |
+| `ccd_recovery` | Recovery artifacts: write checkpoint or working buffer |
+| `ccd_state` | State and governance: export, radar, checkpoint, handoff, policy |
+| `ccd_delegation` | Delegation bootstrap: bounded child context for sub-agents |
+| `ccd_context` | Mid-session refresh evaluation: context-check |
+| `ccd_backlog` | Work queue: pull, lint, groom, bootstrap |
+| `ccd_memory` | Memory follow-through: candidate-admit, compact, promote |
+| `ccd_memory_recall` | Memory recall: search, describe, expand |
+
+Plus standard MCP meta-tools: `list_resources`, `read_resource`, `list_prompts`, `get_prompt`.
+
+## Verification
+
+```bash
+# 1. Test the MCP handshake directly
+echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.1"}}}' \
+  | CCD_PROFILE=raoh ccd mcp-serve
+
+# 2. Verify tools appear in Hermes
+#    Start Hermes Agent and check startup logs for:
+#    "Connected to MCP server 'ccd' (13 tools)"
+```
+
+## Troubleshooting
+
+- **"MCP SDK not available"**: Install with `pip install mcp`
+- **Connection timeout**: Increase `connect_timeout` or verify `ccd mcp-serve` starts quickly
+- **Wrong profile**: Ensure `CCD_PROFILE` in the env section matches your desired CCD profile
+- **Tools not appearing**: Check that `mcp_servers` is a top-level key (not nested under another key)
+
+## References
+
+- [Native MCP Skill](../skills/mcp/native-mcp/SKILL.md) — general MCP client docs
+- [CCD MCP tools source](https://github.com/nousresearch/ccd/blob/main/src/mcp/tools.rs)
+- GitHub Issue: [#4837](https://github.com/NousResearch/hermes-agent/issues/4837)

--- a/venv
+++ b/venv
@@ -1,0 +1,1 @@
+/Users/nanto/.hermes/hermes-agent/venv


### PR DESCRIPTION
## Summary

Wire CCD's MCP server (`ccd mcp-serve`) as a native MCP integration in Hermes Agent. CCD exposes 13 session-management, memory, and governance tools over the Model Context Protocol.

## Changes

- Added `docs/ccd-mcp-integration.md` — integration guide with configuration, tool inventory, verification steps, and troubleshooting
- Added CCD to `~/.hermes/config.yaml` under `mcp_servers` key (runtime config, not tracked in repo)

## CCD MCP Configuration

```yaml
mcp_servers:
  ccd:
    command: /Users/nanto/.cargo/bin/ccd
    args: [mcp-serve]
    env:
      CCD_PROFILE: raoh
    timeout: 120
    connect_timeout: 30
```

## Verification

| Check | Result |
|---|---|
| `ccd mcp-serve` responds to MCP initialize handshake | ✅ protocol 2024-11-05 |
| `tools/list` returns CCD tools | ✅ 13 tools |
| `discover_mcp_tools()` registers tools in Hermes | ✅ 17 tools (13 CCD + 4 meta) |
| MCP tool tests (`tests/tools/test_mcp_tool.py`) | ✅ 147 passed |

## Registered Tools (mcp_ccd_ prefix)

ccd_repo, ccd_health, ccd_session, ccd_session_lifecycle, ccd_session_gates, ccd_escalation, ccd_recovery, ccd_state, ccd_delegation, ccd_context, ccd_backlog, ccd_memory, ccd_memory_recall

Closes #4837