### PR TITLE
fix: resolve runtime stability issues across core, web, delegate, and browser tools (salvage #4828)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -349,13 +349,6 @@ class SessionDB:
 
         self._conn.commit()
 
-    def close(self):
-        """Close the database connection."""
-        with self._lock:
-            if self._conn:
-                self._conn.close()
-                self._conn = None
-
     # =========================================================================
     # Session lifecycle
     # =========================================================================

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -905,7 +905,7 @@ def _run_browser_command(
 
         # Ensure PATH includes Hermes-managed Node first, Homebrew versioned
         # node dirs (for macOS ``brew install node@24``), then standard system dirs.
-        hermes_home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+        hermes_home = get_hermes_home()
         hermes_node_bin = str(hermes_home / "node" / "bin")
 
         existing_path = browser_env.get("PATH", "")
@@ -1542,7 +1542,7 @@ def _maybe_start_recording(task_id: str):
     if task_id in _recording_sessions:
         return
     try:
-        hermes_home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+        hermes_home = get_hermes_home()
         config_path = hermes_home / "config.yaml"
         record_enabled = False
         if config_path.exists():
@@ -1831,7 +1831,7 @@ def _cleanup_old_recordings(max_age_hours=72):
     """Remove browser recordings older than max_age_hours to prevent disk bloat."""
     import time
     try:
-        hermes_home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+        hermes_home = get_hermes_home()
         recordings_dir = hermes_home / "browser_recordings"
         if not recordings_dir.exists():
             return

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -65,6 +65,7 @@ import requests
 from typing import Dict, Any, Optional, List
 from pathlib import Path
 from agent.auxiliary_client import call_llm
+from hermes_constants import get_hermes_home
 
 try:
     from tools.website_policy import check_website_access
@@ -144,7 +145,7 @@ def _get_command_timeout() -> int:
     ``DEFAULT_COMMAND_TIMEOUT`` (30s) if unset or unreadable.
     """
     try:
-        hermes_home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+        hermes_home = get_hermes_home()
         config_path = hermes_home / "config.yaml"
         if config_path.exists():
             import yaml
@@ -256,7 +257,7 @@ def _get_cloud_provider() -> Optional[CloudBrowserProvider]:
 
     _cloud_provider_resolved = True
     try:
-        hermes_home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+        hermes_home = get_hermes_home()
         config_path = hermes_home / "config.yaml"
         if config_path.exists():
             import yaml
@@ -327,7 +328,7 @@ def _allow_private_urls() -> bool:
     _allow_private_urls_resolved = True
     _cached_allow_private_urls = False  # safe default
     try:
-        hermes_home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+        hermes_home = get_hermes_home()
         config_path = hermes_home / "config.yaml"
         if config_path.exists():
             import yaml
@@ -777,7 +778,7 @@ def _find_agent_browser() -> str:
             extra_dirs.append(d)
     extra_dirs.extend(_discover_homebrew_node_dirs())
 
-    hermes_home = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))
+    hermes_home = get_hermes_home()
     hermes_node_bin = str(hermes_home / "node" / "bin")
     if os.path.isdir(hermes_node_bin):
         extra_dirs.append(hermes_node_bin)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -563,7 +563,7 @@ def delegate_task(
     if parent_agent and hasattr(parent_agent, '_memory_manager') and parent_agent._memory_manager:
         for entry in results:
             try:
-                _task_goal = tasks[entry["task_index"]]["goal"] if entry["task_index"] < len(tasks) else ""
+                _task_goal = task_list[entry["task_index"]]["goal"] if entry["task_index"] < len(task_list) else ""
                 parent_agent._memory_manager.on_delegation(
                     task=_task_goal,
                     result=entry.get("summary", "") or "",

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -788,6 +788,15 @@ Create a single, unified markdown summary."""
             logger.warning("Synthesis LLM returned empty content, retrying once")
             response = await async_call_llm(**call_kwargs)
             final_summary = extract_content_or_reasoning(response)
+
+        # If still None after retry, fall back to concatenated summaries
+        if not final_summary:
+            logger.warning("Synthesis failed after retry — concatenating chunk summaries")
+            fallback = "\n\n".join(summaries)
+            if len(fallback) > max_output_size:
+                fallback = fallback[:max_output_size] + "\n\n[... truncated ...]"
+            return fallback
+
         # Enforce hard cap
         if len(final_summary) > max_output_size:
             final_summary = final_summary[:max_output_size] + "\n\n[... summary truncated for context management ...]"


### PR DESCRIPTION
## Summary

Salvage of PR #4828 by @Dusk1e with completion of the browser_tool profile isolation fix.

Four surgical bugfixes for runtime stability issues found during a stability audit:

### Changes (from #4828)

**1. Fix unbounded WAL file growth on SessionDB.close() (hermes_state.py)**
A duplicate `close()` at line 352 silently overrode the WAL-checkpointing version at line 238. Python uses the last definition, so the checkpoint was never performed. Removed the duplicate.

**2. Fix TypeError crash in chunked web content synthesis (tools/web_tools.py)**
When both synthesis LLM calls return reasoning-only responses, `final_summary` stays None and `len(final_summary)` crashes. Added explicit None guard with fallback to concatenated chunk summaries.

**3. Fix silent memory loss in single-task delegation (tools/delegate_tool.py)**
Memory notification referenced `tasks` (raw input, None in single-task mode) instead of `task_list` (normalized list). TypeError silently swallowed by `except Exception: pass` — memory provider notifications never fired for single-task delegations.

**4. Fix profile isolation in browser tool config (tools/browser_tool.py)**
Hardcoded `Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes"))` pattern instead of `get_hermes_home()`. Breaks profile isolation when using `hermes -p <profile>`.

### Follow-up fix (our addition)
The original PR fixed 4 of 7 hardcoded HERMES_HOME instances in browser_tool.py. Our follow-up commit completes the remaining 3:
- `_launch_local_browser()` PATH setup
- `_start_recording()` config read  
- `_cleanup_old_recordings()` path

### Test results
- 383 directly related tests: all passed
- Full suite: 7,894 passed, 19 failed (all pre-existing, unrelated)

Closes #4828