### PR TITLE
fix: normalise \r\n and \r line endings in pasted text

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7010,6 +7010,9 @@ class HermesCLI:
             buffer.
             """
             pasted_text = event.data or ""
+            # Normalise line endings — Windows \r\n and old Mac \r both become \n
+            # so the 5-line collapse threshold and display are consistent.
+            pasted_text = pasted_text.replace('\r\n', '\n').replace('\r', '\n')
             if self._try_attach_clipboard_image():
                 event.app.invalidate()
             if pasted_text:


### PR DESCRIPTION
Cherry-pick of PR #4826 by @iRonin onto current main.

Normalises Windows CRLF and old Mac CR line endings to LF in `handle_paste()` before any processing. Without this, bare \\r characters cause cursor-return rendering issues in some terminals, and the 5-line collapse threshold miscounts lines from CRLF sources.

Credit: @iRonin (original PR #4826)