### PR TITLE
fix(gateway): write update-pending state atomically to prevent corruption

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4871,7 +4871,9 @@ class GatewayRunner:
             "user_id": event.source.user_id,
             "timestamp": datetime.now().isoformat(),
         }
-        pending_path.write_text(json.dumps(pending))
+        _tmp_pending = pending_path.with_suffix(".tmp")
+        _tmp_pending.write_text(json.dumps(pending))
+        _tmp_pending.replace(pending_path)
         exit_code_path.unlink(missing_ok=True)
 
         # Spawn `hermes update` detached so it survives gateway restart.


### PR DESCRIPTION
## What does this PR do?

`gateway/run.py` writes the update-pending state file using
`pending_path.write_text()` directly, which is not atomic. If the
gateway process is killed mid-write, the file is left partially written
and corrupt.

On the next gateway start, `json.loads()` fails to parse the corrupt
file — the pending update state is lost and the scheduled `hermes update`
command is silently dropped.

## Fix

Write to a `.tmp` sibling file first, then use `Path.replace()` which
is atomic on POSIX systems (rename syscall).
```python
# Before (non-atomic)
pending_path.write_text(json.dumps(pending))

# After (atomic)
_tmp_pending = pending_path.with_suffix(".tmp")
_tmp_pending.write_text(json.dumps(pending))
_tmp_pending.replace(pending_path)
```

This is consistent with the atomic write pattern already used in
`cron/jobs.py`, `utils.py` (`atomic_yaml_write`), and `gateway/status.py`.

## Type of Change

- [x] 🐛 Bug fix (reliability)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Consistent with existing atomic write pattern in Hermes
- [x] No behavior change under normal operation
- [x] Prevents update state loss after gateway crash