### PR TITLE
Fix gateway session end memory flush for cached agents

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -717,9 +717,67 @@ class GatewayRunner:
         except Exception as e:
             logger.debug("Pre-reset memory flush failed for session %s: %s", old_session_id, e)
 
+    def _load_session_end_messages(self, session_id: str) -> List[Dict[str, Any]]:
+        """Load transcript history for provider on_session_end hooks."""
+        if not session_id:
+            return []
+        session_store = getattr(self, "session_store", None)
+        if session_store is None or not hasattr(session_store, "load_transcript"):
+            return []
+        try:
+            history = session_store.load_transcript(session_id)
+        except Exception as e:
+            logger.debug("Failed loading transcript for session-end hook %s: %s", session_id, e)
+            return []
+
+        if not isinstance(history, list):
+            return []
+
+        messages: List[Dict[str, Any]] = []
+        for message in history:
+            if not isinstance(message, dict):
+                continue
+            role = message.get("role")
+            if not role or "content" not in message:
+                continue
+            messages.append({
+                "role": role,
+                "content": message.get("content"),
+            })
+        return messages
+
+    def _shutdown_agent_memory_provider(self, agent: Any, session_id: str) -> None:
+        """Run provider session-end hooks with transcript-backed messages."""
+        if not agent or not hasattr(agent, "shutdown_memory_provider"):
+            return
+        try:
+            messages = self._load_session_end_messages(session_id)
+            agent.shutdown_memory_provider(messages)
+        except Exception as e:
+            logger.debug("Memory provider shutdown failed for session %s: %s", session_id, e)
+
+    def _pop_cached_agent(self, session_key: Optional[str]) -> Any:
+        """Remove and return the cached agent for a session, if any."""
+        if not session_key:
+            return None
+        _lock = getattr(self, "_agent_cache_lock", None)
+        _cache = getattr(self, "_agent_cache", None)
+        if _cache is None:
+            return None
+        if _lock:
+            with _lock:
+                cached = _cache.pop(session_key, None)
+        else:
+            cached = _cache.pop(session_key, None)
+        if not cached:
+            return None
+        return cached[0]
+
     async def _async_flush_memories(
         self,
         old_session_id: str,
+        session_key: Optional[str] = None,
+        cached_agent: Any = None,
     ):
         """Run the sync memory flush in a thread pool so it won't block the event loop."""
         loop = asyncio.get_event_loop()
@@ -728,6 +786,14 @@ class GatewayRunner:
             self._flush_memories_for_session,
             old_session_id,
         )
+        agent = cached_agent or self._pop_cached_agent(session_key)
+        if agent is not None:
+            await loop.run_in_executor(
+                None,
+                self._shutdown_agent_memory_provider,
+                agent,
+                old_session_id,
+            )
 
     @property
     def should_exit_cleanly(self) -> bool:
@@ -1268,15 +1334,12 @@ class GatewayRunner:
                         entry.session_id, key,
                     )
                     try:
-                        await self._async_flush_memories(entry.session_id, key)
-                        # Shut down memory provider on the cached agent
-                        cached_agent = self._running_agents.get(key)
-                        if cached_agent and cached_agent is not _AGENT_PENDING_SENTINEL:
-                            try:
-                                if hasattr(cached_agent, 'shutdown_memory_provider'):
-                                    cached_agent.shutdown_memory_provider()
-                            except Exception:
-                                pass
+                        cached_agent = self._pop_cached_agent(key)
+                        await self._async_flush_memories(
+                            entry.session_id,
+                            session_key=key,
+                            cached_agent=cached_agent,
+                        )
                         # Mark as flushed and persist to disk so the flag
                         # survives gateway restarts.
                         with self.session_store._lock:
@@ -1401,6 +1464,8 @@ class GatewayRunner:
         """Stop the gateway and disconnect all adapters."""
         logger.info("Stopping gateway...")
         self._running = False
+        session_store = getattr(self, "session_store", None)
+        session_entries = getattr(session_store, "_entries", {}) if session_store is not None else {}
 
         for session_key, agent in list(self._running_agents.items()):
             if agent is _AGENT_PENDING_SENTINEL:
@@ -1412,8 +1477,37 @@ class GatewayRunner:
                 logger.debug("Failed interrupting agent during shutdown: %s", e)
             # Shut down memory provider at actual session boundary
             try:
-                if hasattr(agent, 'shutdown_memory_provider'):
-                    agent.shutdown_memory_provider()
+                entry = session_entries.get(session_key) if isinstance(session_entries, dict) else None
+                session_id = entry.session_id if entry else getattr(agent, "session_id", "")
+                self._shutdown_agent_memory_provider(agent, session_id)
+            except Exception:
+                pass
+
+        _seen_agents = {
+            id(agent)
+            for agent in self._running_agents.values()
+            if agent is not _AGENT_PENDING_SENTINEL
+        }
+        _cache_lock = getattr(self, "_agent_cache_lock", None)
+        _cache = getattr(self, "_agent_cache", None)
+        cached_items = []
+        if _cache is not None:
+            if _cache_lock:
+                with _cache_lock:
+                    cached_items = list(_cache.items())
+                    _cache.clear()
+            else:
+                cached_items = list(_cache.items())
+                _cache.clear()
+
+        for session_key, cached in cached_items:
+            agent = cached[0] if cached else None
+            if agent is None or id(agent) in _seen_agents:
+                continue
+            try:
+                entry = session_entries.get(session_key) if isinstance(session_entries, dict) else None
+                session_id = entry.session_id if entry else getattr(agent, "session_id", "")
+                self._shutdown_agent_memory_provider(agent, session_id)
             except Exception:
                 pass
 
@@ -3021,17 +3115,24 @@ class GatewayRunner:
         
         # Flush memories in the background (fire-and-forget) so the user
         # gets the "Session reset!" response immediately.
+        cached_agent = None
         try:
             old_entry = self.session_store._entries.get(session_key)
             if old_entry:
+                cached_agent = self._pop_cached_agent(session_key)
                 _flush_task = asyncio.create_task(
-                    self._async_flush_memories(old_entry.session_id, session_key)
+                    self._async_flush_memories(
+                        old_entry.session_id,
+                        session_key=session_key,
+                        cached_agent=cached_agent,
+                    )
                 )
                 self._background_tasks.add(_flush_task)
                 _flush_task.add_done_callback(self._background_tasks.discard)
         except Exception as e:
             logger.debug("Gateway memory flush on reset failed: %s", e)
-        self._evict_cached_agent(session_key)
+        if cached_agent is None:
+            self._evict_cached_agent(session_key)
         
         # Reset the session
         new_entry = self.session_store.reset_session(session_key)
@@ -4553,14 +4654,22 @@ class GatewayRunner:
             return f"📌 Already on session **{name}**."
 
         # Flush memories for current session before switching
+        cached_agent = None
         try:
+            cached_agent = self._pop_cached_agent(session_key)
             _flush_task = asyncio.create_task(
-                self._async_flush_memories(current_entry.session_id, session_key)
+                self._async_flush_memories(
+                    current_entry.session_id,
+                    session_key=session_key,
+                    cached_agent=cached_agent,
+                )
             )
             self._background_tasks.add(_flush_task)
             _flush_task.add_done_callback(self._background_tasks.discard)
         except Exception as e:
             logger.debug("Memory flush on resume failed: %s", e)
+        if cached_agent is None:
+            self._evict_cached_agent(session_key)
 
         # Clear any running agent for this session key
         if session_key in self._running_agents:

--- a/tests/gateway/test_async_memory_flush.py
+++ b/tests/gateway/test_async_memory_flush.py
@@ -7,6 +7,7 @@ Verifies that:
 4. The background watcher can detect expired sessions
 """
 
+import asyncio
 import pytest
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -247,3 +248,52 @@ class TestMemoryFlushedFlag:
         }
         entry = SessionEntry.from_dict(data)
         assert entry.memory_flushed is False
+
+
+class TestGatewayMemoryProviderShutdown:
+    def test_shutdown_uses_transcript_messages(self):
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner.session_store = MagicMock()
+        runner.session_store.load_transcript.return_value = [
+            {"role": "user", "content": "remember my timezone"},
+            {"role": "assistant", "content": "noted"},
+            {"role": "tool", "content": "{\"ok\": true}"},
+            {"role": "assistant"},  # missing content -> ignored
+            "not-a-message",
+        ]
+        agent = MagicMock()
+
+        runner._shutdown_agent_memory_provider(agent, "sid_memory")
+
+        agent.shutdown_memory_provider.assert_called_once_with([
+            {"role": "user", "content": "remember my timezone"},
+            {"role": "assistant", "content": "noted"},
+            {"role": "tool", "content": "{\"ok\": true}"},
+        ])
+
+    def test_async_flush_accepts_session_key_and_cached_agent(self):
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner._flush_memories_for_session = MagicMock()
+        runner._shutdown_agent_memory_provider = MagicMock()
+        runner._pop_cached_agent = MagicMock()
+        cached_agent = MagicMock()
+
+        asyncio.run(
+            GatewayRunner._async_flush_memories(
+                runner,
+                "sid_flush",
+                session_key="agent:main:telegram:dm:123",
+                cached_agent=cached_agent,
+            )
+        )
+
+        runner._flush_memories_for_session.assert_called_once_with("sid_flush")
+        runner._shutdown_agent_memory_provider.assert_called_once_with(
+            cached_agent,
+            "sid_flush",
+        )
+        runner._pop_cached_agent.assert_not_called()

--- a/tests/gateway/test_gateway_shutdown.py
+++ b/tests/gateway/test_gateway_shutdown.py
@@ -1,4 +1,5 @@
 import asyncio
+import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -105,3 +106,42 @@ async def test_gateway_stop_interrupts_running_agents_and_cancels_adapter_tasks(
     assert runner._pending_messages == {}
     assert runner._pending_approvals == {}
     assert runner._shutdown_event.is_set() is True
+
+
+def test_gateway_stop_shuts_down_cached_agents_with_transcript():
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")})
+    runner._running = True
+    runner._shutdown_event = asyncio.Event()
+    runner._exit_reason = None
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._background_tasks = set()
+    runner._shutdown_all_gateway_honcho = lambda: None
+    runner._running_agents = {}
+    runner.session_store = MagicMock()
+    runner.session_store._entries = {
+        "agent:main:telegram:dm:123456": MagicMock(session_id="sid_cached")
+    }
+    runner.session_store.load_transcript.return_value = [
+        {"role": "user", "content": "remember this preference"},
+        {"role": "assistant", "content": "saved"},
+    ]
+    runner._agent_cache_lock = threading.Lock()
+    cached_agent = MagicMock()
+    runner._agent_cache = {
+        "agent:main:telegram:dm:123456": (cached_agent, "sig-1")
+    }
+
+    adapter = StubAdapter()
+    adapter.disconnect = AsyncMock()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+
+    with patch("gateway.status.remove_pid_file"), patch("gateway.status.write_runtime_status"):
+        asyncio.run(runner.stop())
+
+    cached_agent.shutdown_memory_provider.assert_called_once_with([
+        {"role": "user", "content": "remember this preference"},
+        {"role": "assistant", "content": "saved"},
+    ])
+    assert runner._agent_cache == {}

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -221,6 +221,7 @@ class TestHandleResumeCommand:
 
         runner._async_flush_memories.assert_called_once_with(
             "current_session_001",
-            _session_key_for_event(event),
+            session_key=_session_key_for_event(event),
+            cached_agent=None,
         )
         db.close()


### PR DESCRIPTION
## Summary

This fixes a silent v0.7.0 regression in gateway mode where session-end memory flushing could fail before the coroutine even started, and external memory providers often never received their real `on_session_end(messages)` payload.

Hermes should preserve user continuity across reset, resume, expiry, and shutdown. This patch restores that behavior for cached gateway agents.

## Root Cause

`GatewayRunner._async_flush_memories()` still accepted only `old_session_id`, but its callers in the expiry watcher, `/reset`, and `/resume` had been updated to pass `session_key` as well. That raised a `TypeError` at call time, the exception was swallowed by defensive logging, and the async flush path silently never ran.

Separately, gateway session-end cleanup was looking at `_running_agents`, while reusable agents actually live in `_agent_cache`. That meant the real provider-bearing agent was often evicted or left behind without `shutdown_memory_provider()` ever firing.

Finally, even when shutdown happened, transcript history was not passed through, so providers depending on `on_session_end(messages)` could not extract or flush session state correctly.

## What Changed

- extended `_async_flush_memories()` to accept `session_key` and an optional detached cached agent
- added transcript-backed session-end message loading for provider shutdown
- switched reset/resume/expiry cleanup to pop from `_agent_cache`
- shut down cached agents cleanly during gateway stop
- added regression coverage for:
  - transcript delivery into provider shutdown
  - async flush invocation with cached agents
  - cached-agent shutdown during gateway stop

## Impact

This closes a silent data-loss path in gateway mode and makes pluggable memory providers behave correctly at real session boundaries again.

## Testing

Passed:
- targeted gateway regression tests for transcript-backed provider shutdown
- targeted async flush signature regression test
- targeted cached-agent shutdown test
- adjacent existing flush guard sanity checks

Note:
- an existing Windows-side test in `test_flush_memory_stale_guard.py::TestMemoryInjection::test_memory_content_injected_into_flush_prompt` still fails independently of this patch
