### PR TITLE
fix: handle None content in message merge preventing TypeError

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1040,7 +1040,7 @@ def convert_messages_to_anthropic(
 
     for m in messages:
         role = m.get("role", "user")
-        content = m.get("content", "")
+        content = m.get("content") or ""
 
         if role == "system":
             if isinstance(content, list):
@@ -1174,8 +1174,8 @@ def convert_messages_to_anthropic(
         if fixed and fixed[-1]["role"] == m["role"]:
             if m["role"] == "user":
                 # Merge consecutive user messages
-                prev_content = fixed[-1]["content"]
-                curr_content = m["content"]
+                prev_content = fixed[-1]["content"] or ""
+                curr_content = m["content"] or ""
                 if isinstance(prev_content, str) and isinstance(curr_content, str):
                     fixed[-1]["content"] = prev_content + "\n" + curr_content
                 elif isinstance(prev_content, list) and isinstance(curr_content, list):
@@ -1189,8 +1189,8 @@ def convert_messages_to_anthropic(
                     fixed[-1]["content"] = prev_content + curr_content
             else:
                 # Consecutive assistant messages — merge text content
-                prev_blocks = fixed[-1]["content"]
-                curr_blocks = m["content"]
+                prev_blocks = fixed[-1]["content"] or ""
+                curr_blocks = m["content"] or ""
                 if isinstance(prev_blocks, list) and isinstance(curr_blocks, list):
                     fixed[-1]["content"] = prev_blocks + curr_blocks
                 elif isinstance(prev_blocks, str) and isinstance(curr_blocks, str):


### PR DESCRIPTION
## Summary

Fixes #4841 — WebAPI cannot resume Telegram sessions due to `TypeError: unsupported operand type(s) for +: 'NoneType' and 'list'` in `convert_messages_to_anthropic()`.

**Root cause:** When Telegram sessions are loaded, some messages have `"content": None` (explicitly set). The existing `m.get("content", "")` only returns the default `""` when the key is *missing*, not when it's explicitly `None`. This `None` content then hits the consecutive-message merge logic which tries `None + list`, causing the TypeError. The error is caught by the retry loop, leaving `api_kwargs` unbound, which surfaces as the reported `UnboundLocalError`.

**Fix:** Use `m.get("content") or ""` to normalize explicit `None` to empty string, both at the initial content extraction (line 691) and at the two merge points (user messages merge + assistant messages merge).

## Changes

- `agent/anthropic_adapter.py` L691: `m.get("content", "")` → `m.get("content") or ""`
- `agent/anthropic_adapter.py` L825-826: Guard `prev_content`/`curr_content` with `or ""`
- `agent/anthropic_adapter.py` L840-841: Guard `prev_blocks`/`curr_blocks` with `or ""`

## Test plan

- [ ] Resume a Telegram-sourced session via WebAPI `/api/sessions/<id>/chat/stream`
- [ ] Verify no TypeError in SSE stream or uvicorn logs
- [ ] Verify message history displays correctly with merged consecutive messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)