### PR TITLE
fix(tests): mock redact_sensitive_text in large-content test cases

### DIFF
--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -100,9 +100,10 @@ class TestCharacterCountGuard(unittest.TestCase):
     def tearDown(self):
         clear_read_tracker()
 
+    @patch("tools.file_tools.redact_sensitive_text", side_effect=lambda x: x)
     @patch("tools.file_tools._get_file_ops")
     @patch("tools.file_tools._get_max_read_chars", return_value=_DEFAULT_MAX_READ_CHARS)
-    def test_oversized_read_rejected(self, _mock_limit, mock_ops):
+    def test_oversized_read_rejected(self, _mock_limit, mock_ops, _mock_redact):
         """A read that returns >max chars is rejected."""
         big_content = "x" * (_DEFAULT_MAX_READ_CHARS + 1)
         mock_ops.return_value = _make_fake_ops(
@@ -124,9 +125,10 @@ class TestCharacterCountGuard(unittest.TestCase):
         self.assertNotIn("error", result)
         self.assertIn("content", result)
 
+    @patch("tools.file_tools.redact_sensitive_text", side_effect=lambda x: x)
     @patch("tools.file_tools._get_file_ops")
     @patch("tools.file_tools._get_max_read_chars", return_value=_DEFAULT_MAX_READ_CHARS)
-    def test_content_under_limit_passes(self, _mock_limit, mock_ops):
+    def test_content_under_limit_passes(self, _mock_limit, mock_ops, _mock_redact):
         """Content just under the limit should pass through fine."""
         mock_ops.return_value = _make_fake_ops(
             content="y" * (_DEFAULT_MAX_READ_CHARS - 1),
@@ -361,9 +363,10 @@ class TestConfigOverride(unittest.TestCase):
         self.assertIn("safety limit", result["error"])
         self.assertIn("50", result["error"])  # should show the configured limit
 
+    @patch("tools.file_tools.redact_sensitive_text", side_effect=lambda x: x)
     @patch("tools.file_tools._get_file_ops")
     @patch("hermes_cli.config.load_config", return_value={"file_read_max_chars": 500_000})
-    def test_custom_config_raises_limit(self, _mock_cfg, mock_ops):
+    def test_custom_config_raises_limit(self, _mock_cfg, mock_ops, _mock_redact):
         """A config value of 500K should allow reads up to 500K chars."""
         # 200K chars would be rejected at the default 100K but passes at 500K
         mock_ops.return_value = _make_fake_ops(


### PR DESCRIPTION
## Problem

`redact_sensitive_text` runs a multi-pass regex scan that is O(n) but slow enough on 100K+ char inputs to exceed the 30s per-test `signal.alarm` in conftest.py. This caused three tests in `test_file_read_guards.py` to return `{'error': 'Test exceeded 30 second timeout'}` as a JSON result instead of the expected response — tests appeared to pass in pytest but produced wrong output.

## Fix

Mock `redact_sensitive_text` as a no-op in the three affected tests. These tests exercise the **character-count guard** and **config override** logic, not redaction behaviour — bypassing redaction is correct here.

## Affected tests

- `TestCharacterCountGuard::test_oversized_read_rejected` — 100,001 chars through redact before the guard rejects it
- `TestCharacterCountGuard::test_content_under_limit_passes` — 99,999 chars through redact
- `TestConfigOverride::test_custom_config_raises_limit` — 200,000 chars through redact

## Verification

```
pytest tests/tools/test_file_read_guards.py::TestCharacterCountGuard tests/tools/test_file_read_guards.py::TestConfigOverride -v
5 passed in 0.70s
```