### PR TITLE
feat: wire /model slash command into CLI and gateway dispatch

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3449,6 +3449,86 @@ class HermesCLI:
 
         print("  To change model or provider, use: hermes model")
 
+    def _handle_model_command(self, cmd: str):
+        """Handle /model — show or change the active model."""
+        parts = cmd.split(maxsplit=1)
+        raw_input = parts[1].strip() if len(parts) > 1 else ""
+
+        if not raw_input:
+            # No argument — show current model and provider
+            provider_label = self.provider or "auto"
+            try:
+                from hermes_cli.models import _PROVIDER_LABELS
+                provider_label = _PROVIDER_LABELS.get(self.provider, self.provider)
+            except Exception:
+                pass
+            print(f"\n  Model: {self.model}")
+            print(f"  Provider: {provider_label} ({self.provider})")
+            if self.base_url:
+                print(f"  Endpoint: {self.base_url}")
+            print()
+            return
+
+        # Handle bare "/model custom" — auto-detect from endpoint
+        if raw_input.lower() == "custom":
+            from hermes_cli.model_switch import switch_to_custom_provider
+            result = switch_to_custom_provider()
+            if not result.success:
+                print(f"\n  Error: {result.error_message}\n")
+                return
+            self.model = result.model
+            self.base_url = result.base_url
+            self.api_key = result.api_key
+            self.provider = "custom"
+            self.agent = None
+            print(f"\n  Switched to custom endpoint")
+            print(f"  Model: {result.model}")
+            print(f"  Endpoint: {result.base_url}\n")
+            return
+
+        from hermes_cli.model_switch import switch_model
+
+        result = switch_model(
+            raw_input=raw_input,
+            current_provider=self.provider,
+            current_base_url=self.base_url,
+            current_api_key=self.api_key,
+        )
+
+        if not result.success:
+            print(f"\n  Error: {result.error_message}\n")
+            return
+
+        # Apply the switch
+        self.model = result.new_model
+        if result.provider_changed:
+            self.provider = result.target_provider
+            self.api_key = result.api_key
+            self.base_url = result.base_url
+        if result.api_mode:
+            self.api_mode = result.api_mode
+
+        # Force agent re-init on next turn
+        self.agent = None
+
+        # Persist to config.yaml if validation said to
+        if result.persist:
+            try:
+                from hermes_cli.config import set_config_value
+                set_config_value("model.default", result.new_model)
+                if result.provider_changed:
+                    set_config_value("model.provider", result.target_provider)
+            except Exception:
+                pass
+
+        # User feedback
+        print(f"\n  Model: {result.new_model}")
+        if result.provider_changed:
+            print(f"  Provider: {result.provider_label} ({result.target_provider})")
+        if result.warning_message:
+            print(f"  Warning: {result.warning_message}")
+        print()
+
     def _handle_prompt_command(self, cmd: str):
         """Handle the /prompt command to view or set system prompt."""
         parts = cmd.split(maxsplit=1)
@@ -4000,6 +4080,8 @@ class HermesCLI:
             self._handle_resume_command(cmd_original)
         elif canonical == "provider":
             self._show_model_and_providers()
+        elif canonical == "model":
+            self._handle_model_command(cmd_original)
         elif canonical == "prompt":
             # Use original case so prompt text isn't lowercased
             self._handle_prompt_command(cmd_original)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1923,7 +1923,10 @@ class GatewayRunner:
 
         if canonical == "provider":
             return await self._handle_provider_command(event)
-        
+
+        if canonical == "model":
+            return await self._handle_model_command(event)
+
         if canonical == "personality":
             return await self._handle_personality_command(event)
 
@@ -3283,7 +3286,99 @@ class GatewayRunner:
         lines.append("Switch: `/model provider:model-name`")
         lines.append("Setup: `hermes setup`")
         return "\n".join(lines)
-    
+
+    async def _handle_model_command(self, event: MessageEvent) -> str:
+        """Handle /model — show or change the active model."""
+        import yaml
+
+        args = event.get_command_args().strip() if hasattr(event, 'get_command_args') else ""
+        if not args:
+            # Extract args from raw text fallback
+            text = event.text or ""
+            parts = text.split(maxsplit=1)
+            args = parts[1].strip() if len(parts) > 1 else ""
+
+        # Read current state from config.yaml
+        config_path = _hermes_home / "config.yaml"
+        cfg = {}
+        try:
+            if config_path.exists():
+                with open(config_path, encoding="utf-8") as f:
+                    cfg = yaml.safe_load(f) or {}
+        except Exception:
+            pass
+
+        model_cfg = cfg.get("model", {})
+        if isinstance(model_cfg, str):
+            model_cfg = {"default": model_cfg}
+        current_model = model_cfg.get("default") or model_cfg.get("model") or ""
+        current_provider = model_cfg.get("provider", "openrouter")
+        current_base_url = model_cfg.get("base_url", "")
+
+        if not args:
+            from hermes_cli.models import _PROVIDER_LABELS
+            provider_label = _PROVIDER_LABELS.get(current_provider, current_provider)
+            lines = [
+                f"**Model:** `{current_model}`",
+                f"**Provider:** {provider_label} (`{current_provider}`)",
+            ]
+            if current_base_url:
+                lines.append(f"**Endpoint:** `{current_base_url}`")
+            lines.append("")
+            lines.append("Change: `/model provider:model-name`")
+            return "\n".join(lines)
+
+        # Handle bare "/model custom"
+        if args.lower() == "custom":
+            from hermes_cli.model_switch import switch_to_custom_provider
+            result = switch_to_custom_provider()
+            if not result.success:
+                return f"❌ {result.error_message}"
+            model_cfg["default"] = result.model
+            model_cfg["provider"] = "custom"
+            model_cfg["base_url"] = result.base_url
+            cfg["model"] = model_cfg
+            config_path.write_text(yaml.safe_dump(cfg, sort_keys=False))
+            session_key = self._session_key_for_source(event.source)
+            self._evict_cached_agent(session_key)
+            return (
+                f"✅ Switched to custom endpoint\n"
+                f"**Model:** `{result.model}`\n"
+                f"**Endpoint:** `{result.base_url}`"
+            )
+
+        from hermes_cli.model_switch import switch_model
+
+        result = switch_model(
+            raw_input=args,
+            current_provider=current_provider,
+            current_base_url=current_base_url,
+        )
+
+        if not result.success:
+            return f"❌ {result.error_message}"
+
+        # Persist to config.yaml
+        if result.persist:
+            model_cfg["default"] = result.new_model
+            if result.provider_changed:
+                model_cfg["provider"] = result.target_provider
+                if result.base_url:
+                    model_cfg["base_url"] = result.base_url
+            cfg["model"] = model_cfg
+            config_path.write_text(yaml.safe_dump(cfg, sort_keys=False))
+
+        # Evict cached agent so next message uses new model
+        session_key = self._session_key_for_source(event.source)
+        self._evict_cached_agent(session_key)
+
+        lines = [f"✅ **Model:** `{result.new_model}`"]
+        if result.provider_changed:
+            lines.append(f"**Provider:** {result.provider_label} (`{result.target_provider}`)")
+        if result.warning_message:
+            lines.append(f"⚠️ {result.warning_message}")
+        return "\n".join(lines)
+
     async def _handle_personality_command(self, event: MessageEvent) -> str:
         """Handle /personality command - list or set a personality."""
         import yaml

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -102,6 +102,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True, args_hint="[name]"),
     CommandDef("voice", "Toggle voice mode", "Configuration",
                args_hint="[on|off|tts|status]", subcommands=("on", "off", "tts", "status")),
+    CommandDef("model", "Show or change the active model", "Configuration",
+               args_hint="[provider:]model-name"),
 
     # Tools & Skills
     CommandDef("tools", "Manage tools: /tools [list|disable|enable] [name...]", "Tools & Skills",


### PR DESCRIPTION
## Summary

Fixes #4829 — The `/model` slash command was documented in the official Slash Commands Reference but never registered or dispatched. The implementation logic already existed in `hermes_cli/model_switch.py` (`switch_model()`) but had zero production consumers.

This PR wires it up across all three missing pieces:

### 1. `hermes_cli/commands.py` — CommandDef registration
- Adds `CommandDef("model", "Show or change the active model", "Configuration", args_hint="[provider:]model-name")`
- Enables: autocomplete, `/help` listing, `GATEWAY_KNOWN_COMMANDS`, Telegram BotCommand menu

### 2. `cli.py` — CLI dispatch handler
- `/model` (no args) → shows current model, provider, endpoint
- `/model claude-sonnet-4` → switch model, auto-detect provider
- `/model zai:glm-5` → switch model + provider
- `/model custom` → auto-detect from configured endpoint
- Calls `switch_model()` from `model_switch.py`, applies state, persists to config.yaml, forces agent re-init

### 3. `gateway/run.py` — Gateway dispatch handler
- Same syntax support as CLI
- Reads/writes config.yaml (single source of truth for gateway)
- Evicts cached agent via `_evict_cached_agent()` so next message uses new model
- Returns markdown-formatted response for messaging platforms

## Test plan

- [ ] CLI: `/model` shows current model and provider
- [ ] CLI: `/model claude-sonnet-4` switches model (verify with `/model`)
- [ ] CLI: `/model anthropic:claude-sonnet-4` switches provider + model
- [ ] CLI: `/model custom` auto-detects from endpoint
- [ ] CLI: `/model nonexistent-model` shows validation error
- [ ] Gateway (Telegram): `/model` shows current state
- [ ] Gateway (Telegram): `/model gpt-4o` switches and persists
- [ ] `/help` output includes `/model`
- [ ] Tab completion offers `/model`

🤖 Generated with [Claude Code](https://claude.com/claude-code)