### PR TITLE
fix(gateway): add message deduplication to Discord and Slack adapters

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -449,6 +449,11 @@ class DiscordAdapter(BasePlatformAdapter):
         self._bot_task: Optional[asyncio.Task] = None
         # Cap to prevent unbounded growth (Discord threads get archived).
         self._MAX_TRACKED_THREADS = 500
+        # Dedup cache: message_id → timestamp.  Prevents duplicate bot
+        # responses when Discord RESUME replays events after reconnects.
+        self._seen_messages: Dict[str, float] = {}
+        self._SEEN_TTL = 300   # 5 minutes
+        self._SEEN_MAX = 2000  # prune threshold
 
     async def connect(self) -> bool:
         """Connect to Discord and start receiving events."""
@@ -539,6 +544,19 @@ class DiscordAdapter(BasePlatformAdapter):
 
             @self._client.event
             async def on_message(message: DiscordMessage):
+                # Dedup: Discord RESUME replays events after reconnects (#4777)
+                msg_id = str(message.id)
+                now = time.time()
+                if msg_id in adapter_self._seen_messages:
+                    return
+                adapter_self._seen_messages[msg_id] = now
+                if len(adapter_self._seen_messages) > adapter_self._SEEN_MAX:
+                    cutoff = now - adapter_self._SEEN_TTL
+                    adapter_self._seen_messages = {
+                        k: v for k, v in adapter_self._seen_messages.items()
+                        if v > cutoff
+                    }
+
                 # Always ignore our own messages
                 if message.author == self._client.user:
                     return

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import re
+import time
 from typing import Dict, Optional, Any
 
 try:
@@ -78,6 +79,11 @@ class SlackAdapter(BasePlatformAdapter):
         self._team_clients: Dict[str, AsyncWebClient] = {}   # team_id → WebClient
         self._team_bot_user_ids: Dict[str, str] = {}          # team_id → bot_user_id
         self._channel_team: Dict[str, str] = {}                # channel_id → team_id
+        # Dedup cache: event_ts → timestamp.  Prevents duplicate bot
+        # responses when Socket Mode reconnects redeliver events.
+        self._seen_messages: Dict[str, float] = {}
+        self._SEEN_TTL = 300   # 5 minutes
+        self._SEEN_MAX = 2000  # prune threshold
 
     async def connect(self) -> bool:
         """Connect to Slack via Socket Mode."""
@@ -710,6 +716,20 @@ class SlackAdapter(BasePlatformAdapter):
 
     async def _handle_slack_message(self, event: dict) -> None:
         """Handle an incoming Slack message event."""
+        # Dedup: Slack Socket Mode can redeliver events after reconnects (#4777)
+        event_ts = event.get("ts", "")
+        if event_ts:
+            now = time.time()
+            if event_ts in self._seen_messages:
+                return
+            self._seen_messages[event_ts] = now
+            if len(self._seen_messages) > self._SEEN_MAX:
+                cutoff = now - self._SEEN_TTL
+                self._seen_messages = {
+                    k: v for k, v in self._seen_messages.items()
+                    if v > cutoff
+                }
+
         # Ignore bot messages (including our own)
         if event.get("bot_id") or event.get("subtype") == "bot_message":
             return


### PR DESCRIPTION
## Summary

Fixes #4777 — Discord and Slack adapters process replayed events after reconnects, causing duplicate bot responses.

Discord's gateway RESUME replays events from the disconnect window (~7/day observed). Slack Socket Mode reconnects can redeliver events if the ack was lost. Neither adapter tracked which messages were already processed.

Six other adapters already implement this correctly (Mattermost, Matrix, WeCom, Feishu, DingTalk, Email). This PR brings Discord and Slack in line with the established pattern.

## Changes

**Discord** (`gateway/platforms/discord.py`):
- Add `_seen_messages` dict (message ID → timestamp) with 5-min TTL, 2000-entry cap
- Dedup check at top of `on_message`, before all other logic
- Prune on threshold exceeded

**Slack** (`gateway/platforms/slack.py`):
- Add `_seen_messages` dict (event `ts` → timestamp) with same TTL/cap
- Dedup check at top of `_handle_slack_message`, before all other logic
- Add `import time`

## Test plan

- [ ] Discord: Simulate RESUME by restarting gateway — no duplicate responses
- [ ] Discord: Normal messages still processed correctly (single response)
- [ ] Slack: Reconnect Socket Mode — no duplicate responses
- [ ] Slack: Normal messages still processed correctly
- [ ] Verify dedup cache doesn't grow unbounded (>2000 entries triggers prune)

🤖 Generated with [Claude Code](https://claude.com/claude-code)