### PR TITLE
fix: skill_manage now finds skills from external_dirs

### DIFF
--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -203,14 +203,20 @@ def _resolve_skill_dir(name: str, category: str = None) -> Path:
 
 def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     """
-    Find a skill by name in ~/.hermes/skills/.
+    Find a skill by name in ~/.hermes/skills/ and external_dirs.
     Returns {"path": Path} or None.
     """
-    if not SKILLS_DIR.exists():
-        return None
-    for skill_md in SKILLS_DIR.rglob("SKILL.md"):
-        if skill_md.parent.name == name:
-            return {"path": skill_md.parent}
+    from agent.skill_utils import get_external_skills_dirs
+
+    dirs_to_scan = []
+    if SKILLS_DIR.exists():
+        dirs_to_scan.append(SKILLS_DIR)
+    dirs_to_scan.extend(get_external_skills_dirs())
+
+    for scan_dir in dirs_to_scan:
+        for skill_md in scan_dir.rglob("SKILL.md"):
+            if skill_md.parent.name == name:
+                return {"path": skill_md.parent}
     return None
 
 


### PR DESCRIPTION
## Summary

Fixes #4759 — `skill_manage` operations (patch, edit, delete, write_file, remove_file) fail with "Skill not found" for skills loaded from `external_dirs`.

**Root cause:** `_find_skill()` in `tools/skill_manager_tool.py` only scanned `SKILLS_DIR` (`~/.hermes/skills/`) via `rglob("SKILL.md")`. Skills from `external_dirs` configured in `config.yaml` were invisible to it, even though `_find_all_skills()` (used for listing/viewing) correctly scanned them.

**Fix:** Mirror the `dirs_to_scan` pattern from `_find_all_skills()` — scan both `SKILLS_DIR` and `get_external_skills_dirs()`.

## Changes

- `tools/skill_manager_tool.py`: `_find_skill()` now imports `get_external_skills_dirs` from `agent.skill_utils` and scans all configured directories

## Test plan

- [ ] Configure `skills.external_dirs` in config.yaml pointing to a skill directory
- [ ] `skill_manage(action='patch', name='skill-from-external-dir', ...)` succeeds
- [ ] Skills in `~/.hermes/skills/` still found correctly
- [ ] Skills not in any scanned directory still return "Skill not found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)