### PR TITLE
feat(gateway): add SimpleX Chat adapter

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,26 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git fetch:*)",
+      "Bash(git checkout:*)",
+      "Bash(git cherry-pick:*)",
+      "Bash(git add:*)",
+      "Bash(git merge:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(ssh juja:*)",
+      "Bash(gh repo:*)",
+      "Bash(gh api:*)",
+      "Bash(ls:*)",
+      "Bash(ssh:*)",
+      "Bash(gh pr:*)",
+      "Bash(git rebase:*)",
+      "Bash(GIT_EDITOR=true git rebase --continue)",
+      "Bash(git diff:*)",
+      "Bash(GIT_EDITOR=true git merge upstream/main -m \"Merge upstream/main into feature/simplex-adapter\")",
+      "Bash(GIT_EDITOR=true git commit --no-edit)",
+      "Bash(grep:*)",
+      "Bash(uv run:*)"
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Use any model you want — [Nous Portal](https://portal.nousresearch.com), [Open
 
 <table>
 <tr><td><b>A real terminal interface</b></td><td>Full TUI with multiline editing, slash-command autocomplete, conversation history, interrupt-and-redirect, and streaming tool output.</td></tr>
-<tr><td><b>Lives where you do</b></td><td>Telegram, Discord, Slack, WhatsApp, Signal, and CLI — all from a single gateway process. Voice memo transcription, cross-platform conversation continuity.</td></tr>
+<tr><td><b>Lives where you do</b></td><td>Telegram, Discord, Slack, WhatsApp, Signal, SimpleX, and CLI — all from a single gateway process. Voice memo transcription, cross-platform conversation continuity.</td></tr>
 <tr><td><b>A closed learning loop</b></td><td>Agent-curated memory with periodic nudges. Autonomous skill creation after complex tasks. Skills self-improve during use. FTS5 session search with LLM summarization for cross-session recall. <a href="https://github.com/plastic-labs/honcho">Honcho</a> dialectic user modeling. Compatible with the <a href="https://agentskills.io">agentskills.io</a> open standard.</td></tr>
 <tr><td><b>Scheduled automations</b></td><td>Built-in cron scheduler with delivery to any platform. Daily reports, nightly backups, weekly audits — all in natural language, running unattended.</td></tr>
 <tr><td><b>Delegates and parallelizes</b></td><td>Spawn isolated subagents for parallel workstreams. Write Python scripts that call tools via RPC, collapsing multi-step pipelines into zero-context-cost turns.</td></tr>
@@ -108,7 +108,7 @@ All documentation lives at **[hermes-agent.nousresearch.com/docs](https://hermes
 | [Quickstart](https://hermes-agent.nousresearch.com/docs/getting-started/quickstart) | Install → setup → first conversation in 2 minutes |
 | [CLI Usage](https://hermes-agent.nousresearch.com/docs/user-guide/cli) | Commands, keybindings, personalities, sessions |
 | [Configuration](https://hermes-agent.nousresearch.com/docs/user-guide/configuration) | Config file, providers, models, all options |
-| [Messaging Gateway](https://hermes-agent.nousresearch.com/docs/user-guide/messaging) | Telegram, Discord, Slack, WhatsApp, Signal, Home Assistant |
+| [Messaging Gateway](https://hermes-agent.nousresearch.com/docs/user-guide/messaging) | Telegram, Discord, Slack, WhatsApp, Signal, SimpleX, Home Assistant |
 | [Security](https://hermes-agent.nousresearch.com/docs/user-guide/security) | Command approval, DM pairing, container isolation |
 | [Tools & Toolsets](https://hermes-agent.nousresearch.com/docs/user-guide/features/tools) | 40+ tools, toolset system, terminal backends |
 | [Skills System](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills) | Procedural memory, Skills Hub, creating skills |

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -461,6 +461,15 @@ PLATFORM_HINTS = {
         "files arrive as downloadable documents. You can also include image "
         "URLs in markdown format ![alt](url) and they will be sent as photos."
     ),
+    "simplex": (
+        "You are on SimpleX Chat, a private decentralized messaging platform. "
+        "Please do not use markdown as it does not render. "
+        "You can send media files natively: to deliver a file to the user, "
+        "include MEDIA:/absolute/path/to/file in your response. Images "
+        "(.png, .jpg, .webp) appear as photos, and other files arrive as "
+        "downloadable documents. You can also include image URLs in markdown "
+        "format ![alt](url) and they will be sent as photos."
+    ),
     "email": (
         "You are communicating via email. Write clear, well-structured responses "
         "suitable for email. Use plain text formatting (no markdown). "

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -91,7 +91,7 @@ _KNOWN_DELIVERY_PLATFORMS = frozenset({
     "telegram", "discord", "slack", "whatsapp", "signal",
     "matrix", "mattermost", "homeassistant", "dingtalk", "feishu",
     "wecom", "wecom_callback", "weixin", "sms", "email", "webhook", "bluebubbles",
-    "qqbot", "yuanbao",
+    "qqbot", "simplex", "yuanbao",
 })
 
 # Platforms that support a configured cron/notification home target, mapped to

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -126,6 +126,7 @@ class Platform(Enum):
     WEIXIN = "weixin"
     BLUEBUBBLES = "bluebubbles"
     QQBOT = "qqbot"
+    SIMPLEX = "simplex"
     YUANBAO = "yuanbao"
     @classmethod
     def _missing_(cls, value):
@@ -429,6 +430,7 @@ _PLATFORM_CONNECTED_CHECKERS: dict[Platform, Callable[[PlatformConfig], bool]] =
     Platform.QQBOT: lambda cfg: bool(
         cfg.extra.get("app_id") and cfg.extra.get("client_secret")
     ),
+    Platform.SIMPLEX: lambda cfg: bool(cfg.extra.get("ws_url")),
     Platform.YUANBAO: lambda cfg: bool(
         cfg.extra.get("app_id") and cfg.extra.get("app_secret")
     ),
@@ -1762,6 +1764,24 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                     or None
                 ),
             )
+
+    # SimpleX Chat
+    simplex_ws_url = os.getenv("SIMPLEX_WS_URL")
+    if simplex_ws_url:
+        if Platform.SIMPLEX not in config.platforms:
+            config.platforms[Platform.SIMPLEX] = PlatformConfig()
+        config.platforms[Platform.SIMPLEX].enabled = True
+        config.platforms[Platform.SIMPLEX].extra.update({
+            "ws_url": simplex_ws_url,
+            "auto_accept": os.getenv("SIMPLEX_AUTO_ACCEPT", "true").lower() in ("true", "1", "yes"),
+        })
+    simplex_home = os.getenv("SIMPLEX_HOME_CHANNEL")
+    if simplex_home and Platform.SIMPLEX in config.platforms:
+        config.platforms[Platform.SIMPLEX].home_channel = HomeChannel(
+            platform=Platform.SIMPLEX,
+            chat_id=simplex_home,
+            name=os.getenv("SIMPLEX_HOME_CHANNEL_NAME", "Home"),
+        )
 
     # Yuanbao — YUANBAO_APP_ID preferred
     yuanbao_app_id = os.getenv("YUANBAO_APP_ID") or os.getenv("YUANBAO_APP_KEY")

--- a/gateway/platforms/simplex.py
+++ b/gateway/platforms/simplex.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import random
+import re
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -638,44 +639,69 @@ class SimplexAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Send a text message."""
-        if chat_id.startswith("group:"):
-            group_id = chat_id[6:]
-            # Use the /_send structured API with numeric group ID (#<id>) to
-            # avoid ambiguity when multiple groups share the same display name.
-            # Use json.dumps for the full payload to correctly escape newlines,
-            # backslashes, and other special characters in the message text.
-            composed = json.dumps([{"msgContent": {"type": "text", "text": content}}])
-            command = f"/_send #{group_id} json {composed}"
-        else:
-            command = f"@{chat_id} {content}"
+        """Send a text message.
 
-        # SimpleX CLI uses @ prefix for DMs and # prefix for groups:
-        #   @<contactId> <message>  or  #<groupId> <message>
-        # The structured API form is:
-        #   /_send @<contactId> json [{"msgContent":{"type":"text","text":"..."}}]
-        # The simpler chat command form also works for plain text.
+        If *content* contains ``MEDIA:<path>`` tags (embedded by TTS/audio
+        tools to signal file attachments), they are stripped from the text
+        and sent as native voice notes via :meth:`send_voice`.
+        """
+        # Extract and strip MEDIA:<path> tags before sending as text.
+        _voice_exts = {".ogg", ".mp3", ".wav", ".m4a", ".opus"}
+        media_paths = re.findall(r'MEDIA:(\S+)', content)
+        if media_paths:
+            content = re.sub(r'MEDIA:\S+', '', content).strip()
 
-        result = await self._send_command(command)
-
-        if result is not None:
-            result_type = result.get("type", "")
-            if result_type in ("newChatItems", "newChatItem"):
-                return SendResult(success=True)
-            elif "error" in str(result_type).lower():
-                return SendResult(
-                    success=False,
-                    error=f"SimpleX error: {result.get('chatError', result)}",
-                )
+        text_result = SendResult(success=True)
+        if content:
+            if chat_id.startswith("group:"):
+                group_id = chat_id[6:]
+                # Use the /_send structured API with numeric group ID (#<id>) to
+                # avoid ambiguity when multiple groups share the same display name.
+                # The plain '#<name>' chat command looks up by display name and
+                # fails if the name is not unique or matches the wrong group.
+                # Use json.dumps for the full payload to correctly escape newlines,
+                # backslashes, and other special characters in the message text.
+                composed = json.dumps([{"msgContent": {"type": "text", "text": content}}])
+                command = f"/_send #{group_id} json {composed}"
             else:
-                # Got a response we don't recognize — treat as success
-                return SendResult(success=True)
+                command = f"@{chat_id} {content}"
 
-        # If we got no response but no error either, consider it sent
-        # (simplex-chat may not always send a correlation response)
-        if result is None and self._ws:
-            return SendResult(success=True)
-        return SendResult(success=False, error="WebSocket not connected")
+            # SimpleX CLI uses @ prefix for DMs and # prefix for groups:
+            #   @<contactId> <message>  or  #<groupId> <message>
+            # The structured API form is:
+            #   /_send @<contactId> json [{"msgContent":{"type":"text","text":"..."}}]
+            # The simpler chat command form also works for plain text.
+
+            result = await self._send_command(command)
+
+            if result is not None:
+                result_type = result.get("type", "")
+                if result_type in ("newChatItems", "newChatItem"):
+                    text_result = SendResult(success=True)
+                elif "error" in str(result_type).lower():
+                    text_result = SendResult(
+                        success=False,
+                        error=f"SimpleX error: {result.get('chatError', result)}",
+                    )
+                # else: unrecognised response type — treat as success
+            elif not self._ws:
+                # No response and no WebSocket — connection is gone
+                text_result = SendResult(success=False, error="WebSocket not connected")
+
+        if not text_result.success:
+            return text_result
+
+        # Send any MEDIA attachments extracted at the top of this method.
+        for path in media_paths:
+            is_voice = os.path.splitext(path)[1].lower() in _voice_exts
+            if is_voice:
+                media_result = await self.send_voice(chat_id, path)
+            else:
+                media_result = await self.send_document(chat_id, path)
+            if not media_result.success:
+                return media_result
+
+        return text_result
 
     async def send_image(
         self,

--- a/gateway/platforms/simplex.py
+++ b/gateway/platforms/simplex.py
@@ -135,6 +135,11 @@ class SimplexAdapter(BasePlatformAdapter):
         self._pending_responses: Dict[str, asyncio.Future] = {}
         self._corr_counter = 0
 
+        # File transfers awaiting rcvFileComplete (keyed by fileId). Populated
+        # when a newChatItems event carries a rcvFileTransfer, consumed when
+        # the file finishes downloading.
+        self._pending_file_transfers: Dict[int, dict] = {}
+
         logger.info(
             "SimpleX adapter initialized: ws_url=%s auto_accept=%s groups=%s",
             self.ws_url,

--- a/gateway/platforms/simplex.py
+++ b/gateway/platforms/simplex.py
@@ -1,0 +1,674 @@
+"""SimpleX Chat platform adapter.
+
+Connects to a simplex-chat terminal app running with WebSocket API enabled.
+Inbound messages arrive via WebSocket JSON events.
+Outbound messages and actions use WebSocket JSON commands.
+
+Requires:
+  - simplex-chat installed and running: simplex-chat -p 5225
+  - SIMPLEX_WS_URL environment variable set (e.g., ws://127.0.0.1:5225)
+"""
+
+import asyncio
+import base64
+import json
+import logging
+import os
+import random
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional, Any
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+    cache_image_from_bytes,
+    cache_audio_from_bytes,
+    cache_document_from_bytes,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+MAX_MESSAGE_LENGTH = 8000  # SimpleX message size limit
+WS_RETRY_DELAY_INITIAL = 2.0
+WS_RETRY_DELAY_MAX = 60.0
+HEALTH_CHECK_INTERVAL = 30.0  # seconds between health checks
+HEALTH_CHECK_STALE_THRESHOLD = 120.0  # seconds without WS activity before concern
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _parse_comma_list(value: str) -> List[str]:
+    """Split a comma-separated string into a list, stripping whitespace."""
+    return [v.strip() for v in value.split(",") if v.strip()]
+
+
+def _redact_id(contact_id: str) -> str:
+    """Redact a contact/group ID for logging."""
+    if not contact_id:
+        return "<none>"
+    s = str(contact_id)
+    if len(s) <= 4:
+        return s
+    return s[:2] + "**" + s[-2:]
+
+
+def _guess_extension(data: bytes) -> str:
+    """Guess file extension from magic bytes."""
+    if data[:4] == b"\x89PNG":
+        return ".png"
+    if data[:2] == b"\xff\xd8":
+        return ".jpg"
+    if data[:4] == b"GIF8":
+        return ".gif"
+    if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return ".webp"
+    if data[:4] == b"%PDF":
+        return ".pdf"
+    if len(data) >= 8 and data[4:8] == b"ftyp":
+        return ".mp4"
+    if data[:4] == b"OggS":
+        return ".ogg"
+    if len(data) >= 2 and data[0] == 0xFF and (data[1] & 0xE0) == 0xE0:
+        return ".mp3"
+    return ".bin"
+
+
+def _is_image_ext(ext: str) -> bool:
+    return ext.lower() in (".jpg", ".jpeg", ".png", ".gif", ".webp")
+
+
+def _is_audio_ext(ext: str) -> bool:
+    return ext.lower() in (".mp3", ".wav", ".ogg", ".m4a", ".aac")
+
+
+def check_simplex_requirements() -> bool:
+    """Check if SimpleX is configured (has WebSocket URL)."""
+    return bool(os.getenv("SIMPLEX_WS_URL"))
+
+
+# ---------------------------------------------------------------------------
+# SimpleX Adapter
+# ---------------------------------------------------------------------------
+
+class SimplexAdapter(BasePlatformAdapter):
+    """SimpleX Chat adapter using simplex-chat WebSocket API."""
+
+    platform = Platform.SIMPLEX
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform.SIMPLEX)
+
+        extra = config.extra or {}
+        self.ws_url = extra.get("ws_url", "ws://127.0.0.1:5225").rstrip("/")
+        self.auto_accept = extra.get("auto_accept", True)
+
+        # Parse group allowlist
+        group_allowed_str = os.getenv("SIMPLEX_GROUP_ALLOWED", "")
+        self.group_allow_from = set(_parse_comma_list(group_allowed_str))
+
+        # WebSocket connection
+        self._ws = None
+
+        # Background tasks
+        self._ws_task: Optional[asyncio.Task] = None
+        self._health_monitor_task: Optional[asyncio.Task] = None
+        self._running = False
+        self._last_ws_activity = 0.0
+
+        # Track sent message IDs to prevent echo loops
+        self._recent_sent_ids: set = set()
+        self._max_recent_ids = 50
+
+        # Correlation tracking for send commands
+        self._pending_responses: Dict[str, asyncio.Future] = {}
+        self._corr_counter = 0
+
+        logger.info(
+            "SimpleX adapter initialized: ws_url=%s auto_accept=%s groups=%s",
+            self.ws_url,
+            self.auto_accept,
+            "enabled" if self.group_allow_from else "disabled",
+        )
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def connect(self) -> bool:
+        """Connect to simplex-chat WebSocket and start listener."""
+        if not self.ws_url:
+            logger.error("SimpleX: SIMPLEX_WS_URL is required")
+            return False
+
+        try:
+            import websockets  # noqa: F401
+        except ImportError:
+            logger.error(
+                "SimpleX: 'websockets' package not installed. "
+                "Run: pip install websockets"
+            )
+            return False
+
+        # Test connectivity
+        try:
+            import websockets
+            async with websockets.connect(self.ws_url, open_timeout=10) as ws:
+                logger.debug("SimpleX: WebSocket test connection succeeded")
+        except Exception as e:
+            logger.error("SimpleX: cannot reach simplex-chat at %s: %s", self.ws_url, e)
+            return False
+
+        self._running = True
+        self._last_ws_activity = time.time()
+        self._ws_task = asyncio.create_task(self._ws_listener())
+        self._health_monitor_task = asyncio.create_task(self._health_monitor())
+
+        self._mark_connected()
+        logger.info("SimpleX: connected to %s", self.ws_url)
+        return True
+
+    async def disconnect(self) -> None:
+        """Stop WebSocket listener and clean up."""
+        self._running = False
+
+        if self._ws_task:
+            self._ws_task.cancel()
+            try:
+                await self._ws_task
+            except asyncio.CancelledError:
+                pass
+
+        if self._health_monitor_task:
+            self._health_monitor_task.cancel()
+            try:
+                await self._health_monitor_task
+            except asyncio.CancelledError:
+                pass
+
+        if self._ws:
+            try:
+                await self._ws.close()
+            except Exception:
+                pass
+            self._ws = None
+
+        # Cancel pending futures
+        for fut in self._pending_responses.values():
+            if not fut.done():
+                fut.cancel()
+        self._pending_responses.clear()
+
+        self._mark_disconnected()
+        logger.info("SimpleX: disconnected")
+
+    # ------------------------------------------------------------------
+    # WebSocket Listener (inbound messages)
+    # ------------------------------------------------------------------
+
+    async def _ws_listener(self) -> None:
+        """Listen for WebSocket events from simplex-chat."""
+        import websockets
+        from websockets.exceptions import ConnectionClosed
+
+        backoff = WS_RETRY_DELAY_INITIAL
+
+        while self._running:
+            try:
+                logger.debug("SimpleX WS: connecting to %s", self.ws_url)
+                async with websockets.connect(
+                    self.ws_url,
+                    ping_interval=20,
+                    ping_timeout=20,
+                    close_timeout=10,
+                ) as ws:
+                    self._ws = ws
+                    backoff = WS_RETRY_DELAY_INITIAL  # Reset on successful connection
+                    self._last_ws_activity = time.time()
+                    logger.info("SimpleX WS: connected")
+
+                    async for raw_message in ws:
+                        if not self._running:
+                            break
+                        self._last_ws_activity = time.time()
+
+                        try:
+                            data = json.loads(raw_message)
+                            await self._handle_event(data)
+                        except json.JSONDecodeError:
+                            logger.debug(
+                                "SimpleX WS: invalid JSON: %s",
+                                str(raw_message)[:100],
+                            )
+                        except Exception:
+                            logger.exception("SimpleX WS: error handling event")
+
+            except asyncio.CancelledError:
+                break
+            except ConnectionClosed as e:
+                if self._running:
+                    logger.warning(
+                        "SimpleX WS: connection closed: %s (reconnecting in %.0fs)",
+                        e,
+                        backoff,
+                    )
+            except Exception as e:
+                if self._running:
+                    logger.warning(
+                        "SimpleX WS: error: %s (reconnecting in %.0fs)",
+                        e,
+                        backoff,
+                    )
+
+            self._ws = None
+            if self._running:
+                jitter = backoff * 0.2 * random.random()
+                await asyncio.sleep(backoff + jitter)
+                backoff = min(backoff * 2, WS_RETRY_DELAY_MAX)
+
+    # ------------------------------------------------------------------
+    # Health Monitor
+    # ------------------------------------------------------------------
+
+    async def _health_monitor(self) -> None:
+        """Monitor WebSocket connection health."""
+        while self._running:
+            await asyncio.sleep(HEALTH_CHECK_INTERVAL)
+            if not self._running:
+                break
+
+            elapsed = time.time() - self._last_ws_activity
+            if elapsed > HEALTH_CHECK_STALE_THRESHOLD:
+                logger.warning(
+                    "SimpleX: WS idle for %.0fs, forcing reconnect", elapsed
+                )
+                self._force_reconnect()
+
+    def _force_reconnect(self) -> None:
+        """Force WebSocket reconnection by closing the current connection."""
+        ws = self._ws
+        if ws:
+            try:
+                task = asyncio.create_task(ws.close())
+                self._background_tasks.add(task)
+                task.add_done_callback(self._background_tasks.discard)
+            except Exception:
+                pass
+            self._ws = None
+
+    # ------------------------------------------------------------------
+    # Event Handling
+    # ------------------------------------------------------------------
+
+    async def _handle_event(self, event: dict) -> None:
+        """Process an incoming simplex-chat WebSocket event."""
+        # simplex-chat WebSocket API sends JSON with a "resp" key containing
+        # the event type, and a "corrId" for correlated request-response.
+        resp = event.get("resp", {})
+        corr_id = event.get("corrId")
+
+        # Handle correlated responses (replies to our commands)
+        if corr_id and corr_id in self._pending_responses:
+            fut = self._pending_responses.pop(corr_id)
+            if not fut.done():
+                fut.set_result(resp)
+            return
+
+        resp_type = resp.get("type", "")
+
+        # Auto-accept contact requests
+        if resp_type == "contactRequest" and self.auto_accept:
+            contact_req = resp.get("contactRequest", {})
+            contact_req_id = contact_req.get("contactRequestId")
+            if contact_req_id is not None:
+                logger.info(
+                    "SimpleX: auto-accepting contact request %s",
+                    _redact_id(str(contact_req_id)),
+                )
+                await self._send_command(
+                    f"/accept {contact_req_id}"
+                )
+            return
+
+        # Handle new messages (simplex-chat sends "newChatItems" with an array)
+        if resp_type == "newChatItems":
+            chat_items = resp.get("chatItems", [])
+            if not isinstance(chat_items, list):
+                chat_items = [chat_items]
+            for item in chat_items:
+                try:
+                    await self._handle_chat_item(item)
+                except Exception:
+                    logger.exception("SimpleX: error processing chat item")
+            return
+
+        # Log other events at debug level
+        if resp_type:
+            logger.debug("SimpleX: unhandled event type: %s", resp_type)
+
+    async def _handle_chat_item(self, chat_item: dict) -> None:
+        """Process a single chat item from a newChatItems event."""
+        chat_info = chat_item.get("chatInfo", {})
+        chat_item_data = chat_item.get("chatItem", {})
+
+        # Determine chat type and IDs
+        chat_type = chat_info.get("type", "")
+
+        # Extract message content
+        meta = chat_item_data.get("meta", {})
+        content = chat_item_data.get("content", {})
+        msg_content = content.get("msgContent", {})
+
+        # Filter out our own messages (sent items)
+        item_direction = chat_item_data.get("chatDir", {})
+        direction_type = item_direction.get("type", "") if isinstance(item_direction, dict) else ""
+        if direction_type in ("directSnd", "groupSnd"):
+            return  # Skip messages we sent
+
+        # Only process received message content
+        content_type = content.get("type", "") if isinstance(content, dict) else ""
+        if content_type != "rcvMsgContent":
+            return  # Not a received message (e.g. sndMsgContent, rcvDeleted, etc.)
+
+        # Get text content
+        text = ""
+        msg_type_str = msg_content.get("type", "") if isinstance(msg_content, dict) else ""
+        if msg_type_str in ("text", "file", "image", "voice", "link", "video"):
+            text = msg_content.get("text", "")
+
+        if not text and msg_type_str not in ("image", "file", "voice"):
+            return  # No text content and not a media message
+
+        # Extract sender info based on chat type
+        sender_id = ""
+        sender_name = ""
+        chat_id = ""
+        is_group = False
+
+        if chat_type == "direct":
+            contact = chat_info.get("contact", {})
+            sender_id = str(contact.get("contactId", ""))
+            sender_name = contact.get("localDisplayName", "") or contact.get("profile", {}).get("displayName", "")
+            chat_id = sender_id
+        elif chat_type == "group":
+            group_info = chat_info.get("groupInfo", {})
+            group_id = str(group_info.get("groupId", ""))
+            chat_id = f"group:{group_id}"
+            is_group = True
+
+            # Extract sender from chatDir
+            member = item_direction.get("groupMember", {})
+            sender_id = str(member.get("memberId", ""))
+            sender_name = member.get("localDisplayName", "") or member.get("memberProfile", {}).get("displayName", "")
+
+            # Group filtering
+            if self.group_allow_from:
+                if "*" not in self.group_allow_from and group_id not in self.group_allow_from:
+                    logger.debug(
+                        "SimpleX: group %s not in allowlist",
+                        _redact_id(group_id),
+                    )
+                    return
+            else:
+                # No group allowlist → groups disabled by default
+                logger.debug("SimpleX: ignoring group message (no SIMPLEX_GROUP_ALLOWED)")
+                return
+        else:
+            logger.debug("SimpleX: unhandled chat type: %s", chat_type)
+            return
+
+        if not sender_id:
+            logger.debug("SimpleX: ignoring message with no sender")
+            return
+
+        # Process file/image attachments
+        # File info is at chatItem.chatItem.file (sibling of meta, content, chatDir)
+        media_urls = []
+        media_types = []
+        file_info = chat_item_data.get("file")
+
+        if file_info and isinstance(file_info, dict):
+            file_source = file_info.get("fileSource", {})
+            file_path = file_source.get("filePath") if isinstance(file_source, dict) else None
+            file_name = file_info.get("fileName", "")
+
+            if file_path:
+                ext = Path(file_path).suffix.lower() or (Path(file_name).suffix.lower() if file_name else "")
+                if _is_image_ext(ext):
+                    media_urls.append(file_path)
+                    media_types.append(f"image/{ext.lstrip('.')}")
+                elif _is_audio_ext(ext):
+                    media_urls.append(file_path)
+                    media_types.append(f"audio/{ext.lstrip('.')}")
+                else:
+                    media_urls.append(file_path)
+                    media_types.append("application/octet-stream")
+
+        # Build session source
+        chat_name = sender_name
+        if is_group:
+            group_info = chat_info.get("groupInfo", {})
+            chat_name = group_info.get("localDisplayName", "") or group_info.get("groupProfile", {}).get("displayName", chat_id)
+
+        source = self.build_source(
+            chat_id=chat_id,
+            chat_name=chat_name,
+            chat_type="group" if is_group else "dm",
+            user_id=sender_id,
+            user_name=sender_name or sender_id,
+        )
+
+        # Determine message type
+        msg_type = MessageType.TEXT
+        if media_types:
+            if any(mt.startswith("audio/") for mt in media_types):
+                msg_type = MessageType.VOICE
+            elif any(mt.startswith("image/") for mt in media_types):
+                msg_type = MessageType.PHOTO
+
+        # Parse timestamp
+        item_ts = meta.get("itemTs") or meta.get("createdAt", "")
+        try:
+            if item_ts:
+                timestamp = datetime.fromisoformat(item_ts.replace("Z", "+00:00"))
+            else:
+                timestamp = datetime.now(tz=timezone.utc)
+        except (ValueError, AttributeError):
+            timestamp = datetime.now(tz=timezone.utc)
+
+        # Build and dispatch event
+        msg_event = MessageEvent(
+            source=source,
+            text=text or "",
+            message_type=msg_type,
+            media_urls=media_urls,
+            media_types=media_types,
+            timestamp=timestamp,
+        )
+
+        logger.debug(
+            "SimpleX: message from %s in %s: %s",
+            _redact_id(sender_id),
+            chat_id[:20],
+            (text or "")[:50],
+        )
+
+        await self.handle_message(msg_event)
+
+    # ------------------------------------------------------------------
+    # Command Interface
+    # ------------------------------------------------------------------
+
+    async def _send_command(self, command: str, timeout: float = 30.0) -> Optional[dict]:
+        """Send a command to simplex-chat via WebSocket and optionally wait for response."""
+        ws = self._ws
+        if not ws:
+            logger.warning("SimpleX: command sent but WebSocket not connected")
+            return None
+
+        self._corr_counter += 1
+        corr_id = f"hermes_{self._corr_counter}_{int(time.time() * 1000)}"
+
+        payload = json.dumps({
+            "corrId": corr_id,
+            "cmd": command,
+        })
+
+        # Create a future to receive the correlated response
+        loop = asyncio.get_event_loop()
+        fut: asyncio.Future = loop.create_future()
+        self._pending_responses[corr_id] = fut
+
+        try:
+            await ws.send(payload)
+            result = await asyncio.wait_for(fut, timeout=timeout)
+            return result
+        except asyncio.TimeoutError:
+            logger.warning("SimpleX: command timed out: %s", command[:50])
+            self._pending_responses.pop(corr_id, None)
+            return None
+        except Exception as e:
+            logger.warning("SimpleX: command failed: %s — %s", command[:50], e)
+            self._pending_responses.pop(corr_id, None)
+            return None
+
+    # ------------------------------------------------------------------
+    # Sending
+    # ------------------------------------------------------------------
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a text message."""
+        if chat_id.startswith("group:"):
+            group_id = chat_id[6:]
+            command = f"#{group_id} {content}"
+        else:
+            command = f"@{chat_id} {content}"
+
+        # SimpleX CLI uses @ prefix for DMs and # prefix for groups:
+        #   @<contactId> <message>  or  #<groupId> <message>
+        # The structured API form is:
+        #   /_send @<contactId> json [{"msgContent":{"type":"text","text":"..."}}]
+        # The simpler chat command form also works for plain text.
+
+        result = await self._send_command(command)
+
+        if result is not None:
+            result_type = result.get("type", "")
+            if result_type in ("newChatItems", "newChatItem"):
+                return SendResult(success=True)
+            elif "error" in str(result_type).lower():
+                return SendResult(
+                    success=False,
+                    error=f"SimpleX error: {result.get('chatError', result)}",
+                )
+            else:
+                # Got a response we don't recognize — treat as success
+                return SendResult(success=True)
+
+        # If we got no response but no error either, consider it sent
+        # (simplex-chat may not always send a correlation response)
+        if result is None and self._ws:
+            return SendResult(success=True)
+        return SendResult(success=False, error="WebSocket not connected")
+
+    async def send_image(
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send an image. Supports file:// URLs and http(s):// URLs."""
+        from urllib.parse import unquote
+
+        if image_url.startswith("file://"):
+            file_path = unquote(image_url[7:])
+        else:
+            # Download remote image to cache
+            try:
+                from gateway.platforms.base import cache_image_from_url
+                file_path = await cache_image_from_url(image_url)
+            except Exception as e:
+                logger.warning("SimpleX: failed to download image: %s", e)
+                return SendResult(success=False, error=str(e))
+
+        if not file_path or not Path(file_path).exists():
+            return SendResult(success=False, error="Image file not found")
+
+        # Send file via simplex-chat command
+        if chat_id.startswith("group:"):
+            group_id = chat_id[6:]
+            command = f"/f #{group_id} {file_path}"
+        else:
+            command = f"/f @{chat_id} {file_path}"
+
+        result = await self._send_command(command)
+
+        # Send caption as a separate message if provided
+        if caption and result is not None:
+            await self.send(chat_id, caption)
+
+        if result is not None:
+            return SendResult(success=True)
+        return SendResult(success=False, error="Failed to send image")
+
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        filename: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send a document/file attachment."""
+        if not Path(file_path).exists():
+            return SendResult(success=False, error="File not found")
+
+        if chat_id.startswith("group:"):
+            group_id = chat_id[6:]
+            command = f"/f #{group_id} {file_path}"
+        else:
+            command = f"/f @{chat_id} {file_path}"
+
+        result = await self._send_command(command)
+
+        if caption and result is not None:
+            await self.send(chat_id, caption)
+
+        if result is not None:
+            return SendResult(success=True)
+        return SendResult(success=False, error="Failed to send document")
+
+    # ------------------------------------------------------------------
+    # Chat Info
+    # ------------------------------------------------------------------
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        """Get information about a chat/contact."""
+        if chat_id.startswith("group:"):
+            return {
+                "name": chat_id,
+                "type": "group",
+                "chat_id": chat_id,
+            }
+
+        return {
+            "name": chat_id,
+            "type": "dm",
+            "chat_id": chat_id,
+        }

--- a/gateway/platforms/simplex.py
+++ b/gateway/platforms/simplex.py
@@ -643,7 +643,12 @@ class SimplexAdapter(BasePlatformAdapter):
         """Send a text message."""
         if chat_id.startswith("group:"):
             group_id = chat_id[6:]
-            command = f"#{group_id} {content}"
+            # Use the /_send structured API with numeric group ID (#<id>) to
+            # avoid ambiguity when multiple groups share the same display name.
+            # Use json.dumps for the full payload to correctly escape newlines,
+            # backslashes, and other special characters in the message text.
+            composed = json.dumps([{"msgContent": {"type": "text", "text": content}}])
+            command = f"/_send #{group_id} json {composed}"
         else:
             command = f"@{chat_id} {content}"
 

--- a/gateway/platforms/simplex.py
+++ b/gateway/platforms/simplex.py
@@ -140,6 +140,12 @@ class SimplexAdapter(BasePlatformAdapter):
         # the file finishes downloading.
         self._pending_file_transfers: Dict[int, dict] = {}
 
+        # Text message batching — concatenate rapid-fire messages into one
+        # event before dispatching, like Telegram's built-in text batching.
+        self._text_batch_delay = float(os.getenv("HERMES_SIMPLEX_TEXT_BATCH_DELAY", "0.8"))
+        self._pending_text_batches: Dict[str, MessageEvent] = {}
+        self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
+
         logger.info(
             "SimpleX adapter initialized: ws_url=%s auto_accept=%s groups=%s",
             self.ws_url,
@@ -570,7 +576,63 @@ class SimplexAdapter(BasePlatformAdapter):
             (text or "")[:50],
         )
 
-        await self.handle_message(msg_event)
+        # Batch consecutive text messages (users sending multiple lines quickly)
+        # so the agent sees one combined message instead of dropping earlier ones.
+        if msg_type == MessageType.TEXT and text:
+            self._enqueue_text_event(msg_event)
+        else:
+            await self.handle_message(msg_event)
+
+    # ------------------------------------------------------------------
+    # Text message batching
+    # ------------------------------------------------------------------
+
+    def _text_batch_key(self, event: MessageEvent) -> str:
+        """Session-scoped key for text message batching."""
+        return f"{event.source.platform.value}:{event.source.chat_id}"
+
+    def _enqueue_text_event(self, event: MessageEvent) -> None:
+        """Buffer a text event and reset the flush timer.
+
+        When a user sends multiple messages in quick succession, they are
+        concatenated into a single event before dispatching — same approach
+        as Telegram's built-in text batching.
+        """
+        key = self._text_batch_key(event)
+        existing = self._pending_text_batches.get(key)
+        if existing is None:
+            self._pending_text_batches[key] = event
+        else:
+            if event.text:
+                existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
+            if event.media_urls:
+                existing.media_urls.extend(event.media_urls)
+                existing.media_types.extend(event.media_types)
+
+        # Cancel any pending flush and restart the timer
+        prior_task = self._pending_text_batch_tasks.get(key)
+        if prior_task and not prior_task.done():
+            prior_task.cancel()
+        self._pending_text_batch_tasks[key] = asyncio.create_task(
+            self._flush_text_batch(key)
+        )
+
+    async def _flush_text_batch(self, key: str) -> None:
+        """Wait for the quiet period then dispatch the aggregated text."""
+        current_task = asyncio.current_task()
+        try:
+            await asyncio.sleep(self._text_batch_delay)
+            event = self._pending_text_batches.pop(key, None)
+            if not event:
+                return
+            logger.info(
+                "[SimpleX] Flushing text batch %s (%d chars)",
+                key, len(event.text or ""),
+            )
+            await self.handle_message(event)
+        finally:
+            if self._pending_text_batch_tasks.get(key) is current_task:
+                self._pending_text_batch_tasks.pop(key, None)
 
     # ------------------------------------------------------------------
     # Command Interface

--- a/gateway/platforms/simplex.py
+++ b/gateway/platforms/simplex.py
@@ -824,6 +824,17 @@ class SimplexAdapter(BasePlatformAdapter):
             chat_id, f"file://{image_path}", caption=caption, **kwargs
         )
 
+    async def send_video(
+        self,
+        chat_id: str,
+        video_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send a video file via SimpleX (sent as file attachment)."""
+        return await self.send_document(chat_id, video_path, caption=caption)
+
     async def send_document(
         self,
         chat_id: str,

--- a/gateway/platforms/simplex.py
+++ b/gateway/platforms/simplex.py
@@ -104,6 +104,7 @@ class SimplexAdapter(BasePlatformAdapter):
     """SimpleX Chat adapter using simplex-chat WebSocket API."""
 
     platform = Platform.SIMPLEX
+    MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.SIMPLEX)

--- a/gateway/platforms/simplex.py
+++ b/gateway/platforms/simplex.py
@@ -770,6 +770,67 @@ class SimplexAdapter(BasePlatformAdapter):
 
         return text_result
 
+    @staticmethod
+    def _prepare_image(file_path: str) -> tuple[str, str]:
+        """Ensure *file_path* is a PNG and return ``(png_path, thumb_data_uri)``.
+
+        SimpleX clients cannot display WebP (and some other formats) inline.
+        This converts to PNG when needed and generates a small JPEG thumbnail
+        for the ``image`` field in the ``/_send`` payload so the chat shows an
+        inline preview.
+
+        Uses Pillow when available, falls back to ImageMagick ``convert``.
+        Returns the (possibly new) PNG path and a ``data:image/jpg;base64,…``
+        string for the thumbnail.
+        """
+        import subprocess
+        import tempfile
+
+        p = Path(file_path)
+        png_path = file_path
+        thumb_uri = ""
+
+        try:
+            from PIL import Image
+
+            img = Image.open(file_path)
+            # Convert to PNG if not already PNG or JPEG
+            if p.suffix.lower() not in (".png", ".jpg", ".jpeg"):
+                png_path = str(p.with_suffix(".png"))
+                img.save(png_path, "PNG")
+            # Thumbnail
+            thumb = img.copy()
+            thumb.thumbnail((128, 128))
+            import io
+            buf = io.BytesIO()
+            thumb.save(buf, "JPEG", quality=70)
+            thumb_uri = "data:image/jpg;base64," + base64.b64encode(buf.getvalue()).decode()
+        except ImportError:
+            # Pillow not available — try ImageMagick
+            try:
+                if p.suffix.lower() not in (".png", ".jpg", ".jpeg"):
+                    png_path = str(p.with_suffix(".png"))
+                    subprocess.run(
+                        ["convert", file_path, png_path],
+                        check=True, capture_output=True, timeout=30,
+                    )
+                # Thumbnail
+                with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp:
+                    tmp_path = tmp.name
+                subprocess.run(
+                    ["convert", file_path, "-resize", "128x128",
+                     "-quality", "70", tmp_path],
+                    check=True, capture_output=True, timeout=30,
+                )
+                with open(tmp_path, "rb") as f:
+                    thumb_uri = "data:image/jpg;base64," + base64.b64encode(f.read()).decode()
+                os.remove(tmp_path)
+            except (FileNotFoundError, subprocess.SubprocessError) as exc:
+                logger.warning("SimpleX: image conversion unavailable: %s", exc)
+                # Fall through — send original file without thumbnail
+
+        return png_path, thumb_uri
+
     async def send_image(
         self,
         chat_id: str,
@@ -794,16 +855,20 @@ class SimplexAdapter(BasePlatformAdapter):
         if not file_path or not Path(file_path).exists():
             return SendResult(success=False, error="Image file not found")
 
+        # Convert to PNG (SimpleX can't display WebP inline) and
+        # generate a JPEG thumbnail for the inline preview.
+        png_path, thumb_uri = self._prepare_image(file_path)
+
         # Use /_send with filePath and msgContent type "image" so we can
         # address the chat by numeric ID (the /f command only accepts
         # display names, which breaks for group IDs).
         composed = json.dumps(
             [
                 {
-                    "filePath": file_path,
+                    "filePath": png_path,
                     "msgContent": {
                         "type": "image",
-                        "image": "",
+                        "image": thumb_uri,
                         "text": caption or "",
                     },
                 }

--- a/gateway/platforms/simplex.py
+++ b/gateway/platforms/simplex.py
@@ -288,10 +288,7 @@ class SimplexAdapter(BasePlatformAdapter):
 
             elapsed = time.time() - self._last_ws_activity
             if elapsed > HEALTH_CHECK_STALE_THRESHOLD:
-                logger.warning(
-                    "SimpleX: WS idle for %.0fs, forcing reconnect", elapsed
-                )
-                self._force_reconnect()
+                logger.debug("SimpleX: WS idle for %.0fs (no user messages, connection healthy via ping/pong)", elapsed)
 
     def _force_reconnect(self) -> None:
         """Force WebSocket reconnection by closing the current connection."""

--- a/gateway/platforms/simplex.py
+++ b/gateway/platforms/simplex.py
@@ -794,18 +794,29 @@ class SimplexAdapter(BasePlatformAdapter):
         if not file_path or not Path(file_path).exists():
             return SendResult(success=False, error="Image file not found")
 
-        # Send file via simplex-chat command
+        # Use /_send with filePath and msgContent type "image" so we can
+        # address the chat by numeric ID (the /f command only accepts
+        # display names, which breaks for group IDs).
+        composed = json.dumps(
+            [
+                {
+                    "filePath": file_path,
+                    "msgContent": {
+                        "type": "image",
+                        "image": "",
+                        "text": caption or "",
+                    },
+                }
+            ]
+        )
+
         if chat_id.startswith("group:"):
             group_id = chat_id[6:]
-            command = f"/f #{group_id} {file_path}"
+            command = f"/_send #{group_id} json {composed}"
         else:
-            command = f"/f @{chat_id} {file_path}"
+            command = f"/_send @{chat_id} json {composed}"
 
         result = await self._send_command(command)
-
-        # Send caption as a separate message if provided
-        if caption and result is not None:
-            await self.send(chat_id, caption)
 
         if result is not None:
             return SendResult(success=True)
@@ -847,16 +858,26 @@ class SimplexAdapter(BasePlatformAdapter):
         if not Path(file_path).exists():
             return SendResult(success=False, error="File not found")
 
+        # Use /_send with filePath to address by numeric ID (see send_image).
+        composed = json.dumps(
+            [
+                {
+                    "filePath": file_path,
+                    "msgContent": {
+                        "type": "file",
+                        "text": caption or "",
+                    },
+                }
+            ]
+        )
+
         if chat_id.startswith("group:"):
             group_id = chat_id[6:]
-            command = f"/f #{group_id} {file_path}"
+            command = f"/_send #{group_id} json {composed}"
         else:
-            command = f"/f @{chat_id} {file_path}"
+            command = f"/_send @{chat_id} json {composed}"
 
         result = await self._send_command(command)
-
-        if caption and result is not None:
-            await self.send(chat_id, caption)
 
         if result is not None:
             return SendResult(success=True)

--- a/gateway/platforms/simplex.py
+++ b/gateway/platforms/simplex.py
@@ -40,7 +40,7 @@ MAX_MESSAGE_LENGTH = 8000  # SimpleX message size limit
 WS_RETRY_DELAY_INITIAL = 2.0
 WS_RETRY_DELAY_MAX = 60.0
 HEALTH_CHECK_INTERVAL = 30.0  # seconds between health checks
-HEALTH_CHECK_STALE_THRESHOLD = 120.0  # seconds without WS activity before concern
+HEALTH_CHECK_STALE_THRESHOLD = 300.0  # seconds without WS activity before concern
 
 
 # ---------------------------------------------------------------------------

--- a/gateway/platforms/simplex.py
+++ b/gateway/platforms/simplex.py
@@ -811,6 +811,19 @@ class SimplexAdapter(BasePlatformAdapter):
             return SendResult(success=True)
         return SendResult(success=False, error="Failed to send image")
 
+    async def send_image_file(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send a local image file via SimpleX."""
+        return await self.send_image(
+            chat_id, f"file://{image_path}", caption=caption, **kwargs
+        )
+
     async def send_document(
         self,
         chat_id: str,

--- a/gateway/platforms/simplex.py
+++ b/gateway/platforms/simplex.py
@@ -339,6 +339,22 @@ class SimplexAdapter(BasePlatformAdapter):
                 )
             return
 
+        # Early file-descriptor ready: simplex fires this before newChatItems for
+        # some file types (especially large files and voice messages transferred via
+        # XFTP).  We must send /freceive immediately so the download starts; the
+        # corresponding chat item will arrive in a subsequent newChatItems event and
+        # populate _pending_file_transfers as normal.
+        if resp_type == "rcvFileDescrReady":
+            rcv_file = resp.get("rcvFileTransfer", {})
+            file_id = rcv_file.get("fileId") if isinstance(rcv_file, dict) else None
+            if file_id is not None:
+                logger.debug(
+                    "SimpleX: rcvFileDescrReady for fileId=%s — sending /freceive",
+                    file_id,
+                )
+                await self._send_fire_and_forget(f"/freceive {file_id}")
+            return
+
         # Handle new messages (simplex-chat sends "newChatItems" with an array)
         if resp_type == "newChatItems":
             chat_items = resp.get("chatItems", [])
@@ -349,6 +365,34 @@ class SimplexAdapter(BasePlatformAdapter):
                     await self._handle_chat_item(item)
                 except Exception:
                     logger.exception("SimpleX: error processing chat item")
+            return
+
+        # Handle file transfer completion — deliver pending voice messages
+        if resp_type == "rcvFileComplete":
+            chat_item = resp.get("chatItem", {})
+            chat_item_data = chat_item.get("chatItem", {})
+            file_info = chat_item_data.get("file", {})
+            file_id = file_info.get("fileId") if isinstance(file_info, dict) else None
+            if file_id is not None and file_id in self._pending_file_transfers:
+                pending = self._pending_file_transfers.pop(file_id)
+                file_source = file_info.get("fileSource", {})
+                file_path = (
+                    file_source.get("filePath")
+                    if isinstance(file_source, dict)
+                    else None
+                )
+                if file_path:
+                    pending_item_data = pending.get("chatItem", {})
+                    pending_item_data.setdefault("file", {})["fileSource"] = {
+                        "filePath": file_path
+                    }
+                    pending["chatItem"] = pending_item_data
+                    try:
+                        await self._handle_chat_item(pending)
+                    except Exception:
+                        logger.exception(
+                            "SimpleX: error processing deferred voice message"
+                        )
             return
 
         # Log other events at debug level
@@ -440,6 +484,26 @@ class SimplexAdapter(BasePlatformAdapter):
             file_source = file_info.get("fileSource", {})
             file_path = file_source.get("filePath") if isinstance(file_source, dict) else None
             file_name = file_info.get("fileName", "")
+            file_id = file_info.get("fileId")
+
+            # Determine extension from path or filename
+            ext = ""
+            if file_path:
+                ext = Path(file_path).suffix.lower()
+            if not ext and file_name:
+                ext = Path(file_name).suffix.lower()
+
+            if not file_path and _is_audio_ext(ext) and file_id is not None:
+                # File transfer not yet complete — accept and wait for rcvFileComplete.
+                # Use fire-and-forget because simplex-chat never sends a corr-id reply
+                # for /freceive; waiting for one would block the event loop for 30 s.
+                logger.info(
+                    "SimpleX: voice message file %d not yet received, accepting transfer",
+                    file_id,
+                )
+                self._pending_file_transfers[file_id] = chat_item
+                await self._send_fire_and_forget(f"/freceive {file_id}")
+                return
 
             if file_path:
                 ext = Path(file_path).suffix.lower() or (Path(file_name).suffix.lower() if file_name else "")
@@ -540,6 +604,30 @@ class SimplexAdapter(BasePlatformAdapter):
             logger.warning("SimpleX: command failed: %s — %s", command[:50], e)
             self._pending_responses.pop(corr_id, None)
             return None
+
+    async def _send_fire_and_forget(self, command: str) -> None:
+        """Send a command to simplex-chat without waiting for a correlated response.
+
+        Use this for commands that simplex-chat never sends a corrId reply for,
+        such as /freceive.  Waiting for a corr-id response on these commands
+        would block the event loop for the full timeout period.
+        """
+        ws = self._ws
+        if not ws:
+            logger.warning(
+                "SimpleX: fire-and-forget command sent but WebSocket not connected"
+            )
+            return
+
+        self._corr_counter += 1
+        corr_id = f"hermes_{self._corr_counter}_{int(time.time() * 1000)}"
+        payload = json.dumps({"corrId": corr_id, "cmd": command})
+        try:
+            await ws.send(payload)
+        except Exception as e:
+            logger.warning(
+                "SimpleX: fire-and-forget send failed: %s — %s", command[:50], e
+            )
 
     # ------------------------------------------------------------------
     # Sending
@@ -653,6 +741,50 @@ class SimplexAdapter(BasePlatformAdapter):
         if result is not None:
             return SendResult(success=True)
         return SendResult(success=False, error="Failed to send document")
+
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        duration: int = 0,
+        **kwargs,
+    ) -> SendResult:
+        """Send an audio file as a SimpleX voice message (plays inline).
+
+        SimpleX differentiates between a generic file attachment (type:"file")
+        and an inline voice note (type:"voice").  Using the plain /f command
+        sends a downloadable file.  To get the voice-note player the client
+        must receive a /_send command whose msgContent.type is "voice".
+        """
+        if not Path(audio_path).exists():
+            return SendResult(success=False, error="Voice file not found")
+
+        caption_text = caption or ""
+        composed = json.dumps(
+            [
+                {
+                    "msgContent": {
+                        "type": "voice",
+                        "text": caption_text,
+                        "duration": duration,
+                    },
+                    "fileSource": {"filePath": audio_path},
+                }
+            ]
+        )
+
+        if chat_id.startswith("group:"):
+            group_id = chat_id[6:]
+            command = f"/_send #{group_id} json {composed}"
+        else:
+            command = f"/_send @{chat_id} json {composed}"
+
+        result = await self._send_command(command)
+        if result is not None:
+            return SendResult(success=True)
+        return SendResult(success=False, error="Failed to send voice message")
 
     # ------------------------------------------------------------------
     # Chat Info

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3416,6 +3416,7 @@ class GatewayRunner:
             "WEIXIN_ALLOWED_USERS",
             "BLUEBUBBLES_ALLOWED_USERS",
             "QQ_ALLOWED_USERS",
+            "SIMPLEX_ALLOWED_USERS",
             "YUANBAO_ALLOWED_USERS",
             "GATEWAY_ALLOWED_USERS",
         )
@@ -3431,6 +3432,7 @@ class GatewayRunner:
             "WEIXIN_ALLOW_ALL_USERS",
             "BLUEBUBBLES_ALLOW_ALL_USERS",
             "QQ_ALLOW_ALL_USERS",
+            "SIMPLEX_ALLOW_ALL_USERS",
             "YUANBAO_ALLOW_ALL_USERS",
         )
         # Also pick up plugin-registered platforms — each entry can declare
@@ -5686,6 +5688,13 @@ class GatewayRunner:
                 return None
             return QQAdapter(config)
 
+        elif platform == Platform.SIMPLEX:
+            from gateway.platforms.simplex import SimplexAdapter, check_simplex_requirements
+            if not check_simplex_requirements():
+                logger.warning("SimpleX: SIMPLEX_WS_URL not configured")
+                return None
+            return SimplexAdapter(config)
+
         elif platform == Platform.YUANBAO:
             from gateway.platforms.yuanbao import YuanbaoAdapter, WEBSOCKETS_AVAILABLE
             if not WEBSOCKETS_AVAILABLE:
@@ -5734,6 +5743,7 @@ class GatewayRunner:
             Platform.WEIXIN: "WEIXIN_ALLOWED_USERS",
             Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOWED_USERS",
             Platform.QQBOT: "QQ_ALLOWED_USERS",
+            Platform.SIMPLEX: "SIMPLEX_ALLOWED_USERS",
             Platform.YUANBAO: "YUANBAO_ALLOWED_USERS",
         }
         platform_group_user_env_map = {
@@ -5760,6 +5770,7 @@ class GatewayRunner:
             Platform.WEIXIN: "WEIXIN_ALLOW_ALL_USERS",
             Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOW_ALL_USERS",
             Platform.QQBOT: "QQ_ALLOW_ALL_USERS",
+            Platform.SIMPLEX: "SIMPLEX_ALLOW_ALL_USERS",
             Platform.YUANBAO: "YUANBAO_ALLOW_ALL_USERS",
         }
         # Bots admitted by {PLATFORM}_ALLOW_BOTS bypass the human allowlist (#4466).

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3661,6 +3661,28 @@ _PLATFORMS = [
         ],
     },
     {
+        "key": "simplex",
+        "label": "SimpleX Chat",
+        "emoji": "🔒",
+        "token_var": "SIMPLEX_WS_URL",
+        "setup_instructions": [
+            "1. Install simplex-chat from https://simplex.chat/docs/cli.html",
+            "2. Start the chat daemon with WebSocket API: simplex-chat -p 5225",
+            "3. The bot connects via WebSocket — no public endpoint needed",
+            "4. Add a contact by sharing your SimpleX address, or scan QR code",
+            "5. Restrict access with SIMPLEX_ALLOWED_USERS for production use",
+        ],
+        "vars": [
+            {"name": "SIMPLEX_WS_URL", "prompt": "WebSocket URL (e.g. ws://127.0.0.1:5225)", "password": False,
+             "help": "The WebSocket URL where simplex-chat is listening (started with -p flag)."},
+            {"name": "SIMPLEX_ALLOWED_USERS", "prompt": "Allowed contact IDs (comma-separated, or empty)", "password": False,
+             "is_allowlist": True,
+             "help": "Restrict which SimpleX contacts can interact with the bot."},
+            {"name": "SIMPLEX_HOME_CHANNEL", "prompt": "Home contact/group ID (optional, for cron/notifications)", "password": False,
+             "help": "Contact or group ID for scheduled results and notifications."},
+        ],
+    },
+    {
         "key": "yuanbao",
         "label": "Yuanbao",
         "emoji": "💎",
@@ -3778,6 +3800,10 @@ def _platform_status(platform: dict) -> str:
             return "configured"
         if val or account:
             return "partially configured"
+        return "not configured"
+    if platform.get("key") == "simplex":
+        if val:
+            return "configured"
         return "not configured"
     if platform.get("key") == "email":
         pwd = get_env_value("EMAIL_PASSWORD")

--- a/hermes_cli/platforms.py
+++ b/hermes_cli/platforms.py
@@ -25,6 +25,7 @@ PLATFORMS: OrderedDict[str, PlatformInfo] = OrderedDict([
     ("slack",          PlatformInfo(label="💼 Slack",           default_toolset="hermes-slack")),
     ("whatsapp",       PlatformInfo(label="📱 WhatsApp",        default_toolset="hermes-whatsapp")),
     ("signal",         PlatformInfo(label="📡 Signal",          default_toolset="hermes-signal")),
+    ("simplex",        PlatformInfo(label="🔒 SimpleX",         default_toolset="hermes-simplex")),
     ("bluebubbles",    PlatformInfo(label="💙 BlueBubbles",     default_toolset="hermes-bluebubbles")),
     ("email",          PlatformInfo(label="📧 Email",           default_toolset="hermes-email")),
     ("homeassistant",  PlatformInfo(label="🏠 Home Assistant",  default_toolset="hermes-homeassistant")),

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -421,7 +421,8 @@ def show_status(args):
         "WeCom Callback": ("WECOM_CALLBACK_CORP_ID", None),
         "Weixin": ("WEIXIN_ACCOUNT_ID", "WEIXIN_HOME_CHANNEL"),
         "BlueBubbles": ("BLUEBUBBLES_SERVER_URL", "BLUEBUBBLES_HOME_CHANNEL"),
-        "QQBot": ("QQ_APP_ID", "QQ_HOME_CHANNEL"),
+        "QQBot": ("QQ_APP_ID", "QQBOT_HOME_CHANNEL"),
+        "SimpleX": ("SIMPLEX_WS_URL", "SIMPLEX_HOME_CHANNEL"),
         "Yuanbao": ("YUANBAO_APP_ID", "YUANBAO_HOME_CHANNEL"),
     }
 

--- a/tests/gateway/test_simplex.py
+++ b/tests/gateway/test_simplex.py
@@ -1,0 +1,834 @@
+"""Tests for SimpleX Chat platform adapter."""
+
+import json
+import pytest
+from unittest.mock import MagicMock, patch, AsyncMock
+from datetime import datetime, timezone
+
+from gateway.config import Platform, PlatformConfig
+
+
+# ---------------------------------------------------------------------------
+# Shared Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_simplex_adapter(monkeypatch, ws_url="ws://127.0.0.1:5225", **extra):
+    """Create a SimplexAdapter with sensible test defaults."""
+    monkeypatch.setenv("SIMPLEX_WS_URL", ws_url)
+    monkeypatch.setenv("SIMPLEX_GROUP_ALLOWED", extra.pop("group_allowed", ""))
+    from gateway.platforms.simplex import SimplexAdapter
+
+    config = PlatformConfig()
+    config.enabled = True
+    config.extra = {
+        "ws_url": ws_url,
+        "auto_accept": extra.pop("auto_accept", True),
+        **extra,
+    }
+    adapter = SimplexAdapter(config)
+    adapter.handle_message = AsyncMock()
+    return adapter
+
+
+def _make_chat_item(
+    chat_type="direct",
+    contact_id=42,
+    contact_name="alice",
+    group_id=None,
+    group_name=None,
+    member_id=None,
+    member_name=None,
+    msg_type="text",
+    text="Hello world",
+    direction="directRcv",
+    content_type="rcvMsgContent",
+    file_info=None,
+    item_ts="2025-01-15T12:00:00Z",
+):
+    """Build a simplex-chat newChatItems event payload."""
+    chat_info = {"type": chat_type}
+    chat_dir = {"type": direction}
+
+    if chat_type == "direct":
+        chat_info["contact"] = {
+            "contactId": contact_id,
+            "localDisplayName": contact_name,
+            "profile": {"displayName": contact_name},
+        }
+    elif chat_type == "group":
+        chat_info["groupInfo"] = {
+            "groupId": group_id or 99,
+            "localDisplayName": group_name or "test-group",
+            "groupProfile": {"displayName": group_name or "test-group"},
+        }
+        chat_dir["groupMember"] = {
+            "memberId": member_id or "m1",
+            "localDisplayName": member_name or "bob",
+            "memberProfile": {"displayName": member_name or "bob"},
+        }
+
+    inner_chat_item = {
+        "chatDir": chat_dir,
+        "meta": {"itemId": 1001, "itemTs": item_ts, "createdAt": item_ts},
+        "content": {
+            "type": content_type,
+            "msgContent": {"type": msg_type, "text": text},
+        },
+    }
+
+    if file_info:
+        inner_chat_item["file"] = file_info
+
+    return {
+        "chatInfo": chat_info,
+        "chatItem": inner_chat_item,
+    }
+
+
+def _make_event(resp_type, **kwargs):
+    """Build a simplex-chat WS event wrapper."""
+    resp = {"type": resp_type, **kwargs}
+    return {"resp": resp}
+
+
+# ---------------------------------------------------------------------------
+# Platform & Config
+# ---------------------------------------------------------------------------
+
+
+class TestSimplexPlatformEnum:
+    def test_simplex_enum_exists(self):
+        assert Platform.SIMPLEX.value == "simplex"
+
+    def test_simplex_in_platform_list(self):
+        platforms = [p.value for p in Platform]
+        assert "simplex" in platforms
+
+
+class TestSimplexConfigLoading:
+    def test_apply_env_overrides_simplex(self, monkeypatch):
+        monkeypatch.setenv("SIMPLEX_WS_URL", "ws://localhost:5225")
+
+        from gateway.config import GatewayConfig, _apply_env_overrides
+
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+
+        assert Platform.SIMPLEX in config.platforms
+        sc = config.platforms[Platform.SIMPLEX]
+        assert sc.enabled is True
+        assert sc.extra["ws_url"] == "ws://localhost:5225"
+        assert sc.extra["auto_accept"] is True
+
+    def test_simplex_auto_accept_disabled(self, monkeypatch):
+        monkeypatch.setenv("SIMPLEX_WS_URL", "ws://localhost:5225")
+        monkeypatch.setenv("SIMPLEX_AUTO_ACCEPT", "false")
+
+        from gateway.config import GatewayConfig, _apply_env_overrides
+
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+
+        sc = config.platforms[Platform.SIMPLEX]
+        assert sc.extra["auto_accept"] is False
+
+    def test_simplex_not_loaded_without_ws_url(self, monkeypatch):
+        monkeypatch.delenv("SIMPLEX_WS_URL", raising=False)
+
+        from gateway.config import GatewayConfig, _apply_env_overrides
+
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+
+        assert Platform.SIMPLEX not in config.platforms
+
+    def test_connected_platforms_includes_simplex(self, monkeypatch):
+        monkeypatch.setenv("SIMPLEX_WS_URL", "ws://localhost:5225")
+
+        from gateway.config import GatewayConfig, _apply_env_overrides
+
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+
+        connected = config.get_connected_platforms()
+        assert Platform.SIMPLEX in connected
+
+    def test_home_channel_loading(self, monkeypatch):
+        monkeypatch.setenv("SIMPLEX_WS_URL", "ws://localhost:5225")
+        monkeypatch.setenv("SIMPLEX_HOME_CHANNEL", "42")
+        monkeypatch.setenv("SIMPLEX_HOME_CHANNEL_NAME", "Hermes Home")
+
+        from gateway.config import GatewayConfig, _apply_env_overrides
+
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+
+        hc = config.platforms[Platform.SIMPLEX].home_channel
+        assert hc is not None
+        assert hc.chat_id == "42"
+        assert hc.name == "Hermes Home"
+
+
+# ---------------------------------------------------------------------------
+# Adapter Init & Helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSimplexAdapterInit:
+    def test_init_parses_config(self, monkeypatch):
+        adapter = _make_simplex_adapter(monkeypatch)
+        assert adapter.ws_url == "ws://127.0.0.1:5225"
+        assert adapter.auto_accept is True
+        assert adapter.platform == Platform.SIMPLEX
+
+    def test_init_group_allowlist(self, monkeypatch):
+        adapter = _make_simplex_adapter(monkeypatch, group_allowed="1,2,3")
+        assert "1" in adapter.group_allow_from
+        assert "2" in adapter.group_allow_from
+        assert "3" in adapter.group_allow_from
+
+    def test_init_empty_group_allowlist(self, monkeypatch):
+        adapter = _make_simplex_adapter(monkeypatch)
+        assert len(adapter.group_allow_from) == 0
+
+    def test_init_strips_trailing_slash(self, monkeypatch):
+        adapter = _make_simplex_adapter(monkeypatch, ws_url="ws://localhost:5225/")
+        assert adapter.ws_url == "ws://localhost:5225"
+
+
+class TestSimplexHelpers:
+    def test_parse_comma_list(self):
+        from gateway.platforms.simplex import _parse_comma_list
+
+        assert _parse_comma_list("a, b , c") == ["a", "b", "c"]
+        assert _parse_comma_list("") == []
+        assert _parse_comma_list("  ,  ,  ") == []
+
+    def test_redact_id_long(self):
+        from gateway.platforms.simplex import _redact_id
+
+        assert _redact_id("12345678") == "12**78"
+
+    def test_redact_id_short(self):
+        from gateway.platforms.simplex import _redact_id
+
+        assert _redact_id("42") == "42"
+
+    def test_redact_id_empty(self):
+        from gateway.platforms.simplex import _redact_id
+
+        assert _redact_id("") == "<none>"
+
+    def test_guess_extension_png(self):
+        from gateway.platforms.simplex import _guess_extension
+
+        assert _guess_extension(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100) == ".png"
+
+    def test_guess_extension_jpeg(self):
+        from gateway.platforms.simplex import _guess_extension
+
+        assert _guess_extension(b"\xff\xd8\xff\xe0" + b"\x00" * 100) == ".jpg"
+
+    def test_guess_extension_pdf(self):
+        from gateway.platforms.simplex import _guess_extension
+
+        assert _guess_extension(b"%PDF-1.4" + b"\x00" * 100) == ".pdf"
+
+    def test_guess_extension_mp4(self):
+        from gateway.platforms.simplex import _guess_extension
+
+        assert _guess_extension(b"\x00\x00\x00\x18ftypisom" + b"\x00" * 100) == ".mp4"
+
+    def test_guess_extension_ogg(self):
+        from gateway.platforms.simplex import _guess_extension
+
+        assert _guess_extension(b"OggS" + b"\x00" * 100) == ".ogg"
+
+    def test_guess_extension_unknown(self):
+        from gateway.platforms.simplex import _guess_extension
+
+        assert _guess_extension(b"\x00\x01\x02\x03" * 10) == ".bin"
+
+    def test_is_image_ext(self):
+        from gateway.platforms.simplex import _is_image_ext
+
+        assert _is_image_ext(".png") is True
+        assert _is_image_ext(".jpg") is True
+        assert _is_image_ext(".gif") is True
+        assert _is_image_ext(".pdf") is False
+
+    def test_is_audio_ext(self):
+        from gateway.platforms.simplex import _is_audio_ext
+
+        assert _is_audio_ext(".mp3") is True
+        assert _is_audio_ext(".ogg") is True
+        assert _is_audio_ext(".png") is False
+
+    def test_check_requirements_true(self, monkeypatch):
+        from gateway.platforms.simplex import check_simplex_requirements
+
+        monkeypatch.setenv("SIMPLEX_WS_URL", "ws://localhost:5225")
+        assert check_simplex_requirements() is True
+
+    def test_check_requirements_false(self, monkeypatch):
+        from gateway.platforms.simplex import check_simplex_requirements
+
+        monkeypatch.delenv("SIMPLEX_WS_URL", raising=False)
+        assert check_simplex_requirements() is False
+
+
+# ---------------------------------------------------------------------------
+# Event Handling — newChatItems
+# ---------------------------------------------------------------------------
+
+
+class TestSimplexEventHandling:
+    @pytest.mark.asyncio
+    async def test_handle_direct_text_message(self, monkeypatch):
+        adapter = _make_simplex_adapter(monkeypatch)
+        item = _make_chat_item(
+            chat_type="direct",
+            contact_id=42,
+            contact_name="alice",
+            text="Hello!",
+        )
+        event = _make_event("newChatItems", chatItems=[item])
+        await adapter._handle_event(event)
+
+        adapter.handle_message.assert_awaited_once()
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "Hello!"
+        assert msg_event.source.chat_id == "42"
+        assert msg_event.source.user_id == "42"
+        assert msg_event.source.user_name == "alice"
+
+    @pytest.mark.asyncio
+    async def test_handle_multiple_chat_items(self, monkeypatch):
+        adapter = _make_simplex_adapter(monkeypatch)
+        item1 = _make_chat_item(text="First")
+        item2 = _make_chat_item(text="Second", contact_id=43, contact_name="bob")
+        event = _make_event("newChatItems", chatItems=[item1, item2])
+        await adapter._handle_event(event)
+
+        assert adapter.handle_message.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_skip_sent_messages(self, monkeypatch):
+        adapter = _make_simplex_adapter(monkeypatch)
+        item = _make_chat_item(direction="directSnd")
+        event = _make_event("newChatItems", chatItems=[item])
+        await adapter._handle_event(event)
+
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_skip_group_sent_messages(self, monkeypatch):
+        adapter = _make_simplex_adapter(monkeypatch, group_allowed="*")
+        item = _make_chat_item(
+            chat_type="group",
+            direction="groupSnd",
+            group_id=99,
+        )
+        event = _make_event("newChatItems", chatItems=[item])
+        await adapter._handle_event(event)
+
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_skip_non_rcv_content(self, monkeypatch):
+        """Messages with content.type != 'rcvMsgContent' should be skipped."""
+        adapter = _make_simplex_adapter(monkeypatch)
+        item = _make_chat_item(content_type="sndMsgContent")
+        event = _make_event("newChatItems", chatItems=[item])
+        await adapter._handle_event(event)
+
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_handle_group_message_with_allowlist(self, monkeypatch):
+        adapter = _make_simplex_adapter(monkeypatch, group_allowed="99")
+        item = _make_chat_item(
+            chat_type="group",
+            direction="groupRcv",
+            group_id=99,
+            group_name="test-group",
+            member_id="m1",
+            member_name="bob",
+            text="Group hello",
+        )
+        event = _make_event("newChatItems", chatItems=[item])
+        await adapter._handle_event(event)
+
+        adapter.handle_message.assert_awaited_once()
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.text == "Group hello"
+        assert msg_event.source.chat_id == "group:99"
+        assert msg_event.source.user_id == "m1"
+
+    @pytest.mark.asyncio
+    async def test_handle_group_message_wildcard(self, monkeypatch):
+        adapter = _make_simplex_adapter(monkeypatch, group_allowed="*")
+        item = _make_chat_item(
+            chat_type="group",
+            direction="groupRcv",
+            group_id=55,
+        )
+        event = _make_event("newChatItems", chatItems=[item])
+        await adapter._handle_event(event)
+
+        adapter.handle_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_reject_group_not_in_allowlist(self, monkeypatch):
+        adapter = _make_simplex_adapter(monkeypatch, group_allowed="100")
+        item = _make_chat_item(
+            chat_type="group",
+            direction="groupRcv",
+            group_id=99,
+        )
+        event = _make_event("newChatItems", chatItems=[item])
+        await adapter._handle_event(event)
+
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_reject_group_no_allowlist(self, monkeypatch):
+        """Groups disabled when SIMPLEX_GROUP_ALLOWED not set."""
+        adapter = _make_simplex_adapter(monkeypatch)
+        item = _make_chat_item(
+            chat_type="group",
+            direction="groupRcv",
+            group_id=99,
+        )
+        event = _make_event("newChatItems", chatItems=[item])
+        await adapter._handle_event(event)
+
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_empty_text_non_media_skipped(self, monkeypatch):
+        adapter = _make_simplex_adapter(monkeypatch)
+        item = _make_chat_item(text="", msg_type="text")
+        event = _make_event("newChatItems", chatItems=[item])
+        await adapter._handle_event(event)
+
+        adapter.handle_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_timestamp_parsing(self, monkeypatch):
+        adapter = _make_simplex_adapter(monkeypatch)
+        item = _make_chat_item(item_ts="2025-06-15T10:30:00Z")
+        event = _make_event("newChatItems", chatItems=[item])
+        await adapter._handle_event(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert msg_event.timestamp.year == 2025
+        assert msg_event.timestamp.month == 6
+
+    @pytest.mark.asyncio
+    async def test_timestamp_fallback_on_invalid(self, monkeypatch):
+        adapter = _make_simplex_adapter(monkeypatch)
+        item = _make_chat_item(item_ts="not-a-date")
+        event = _make_event("newChatItems", chatItems=[item])
+        await adapter._handle_event(event)
+
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert isinstance(msg_event.timestamp, datetime)
+
+
+# ---------------------------------------------------------------------------
+# Event Handling — File Attachments
+# ---------------------------------------------------------------------------
+
+
+class TestSimplexFileAttachments:
+    @pytest.mark.asyncio
+    async def test_image_attachment(self, monkeypatch, tmp_path):
+        adapter = _make_simplex_adapter(monkeypatch)
+        img_path = tmp_path / "photo.jpg"
+        img_path.write_bytes(b"\xff\xd8" + b"\x00" * 100)
+
+        item = _make_chat_item(
+            msg_type="image",
+            text="Look at this",
+            file_info={
+                "fileId": 1,
+                "fileName": "photo.jpg",
+                "fileSize": 102,
+                "fileSource": {"filePath": str(img_path)},
+            },
+        )
+        event = _make_event("newChatItems", chatItems=[item])
+        await adapter._handle_event(event)
+
+        adapter.handle_message.assert_awaited_once()
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert str(img_path) in msg_event.media_urls
+        assert any("image" in mt for mt in msg_event.media_types)
+
+    @pytest.mark.asyncio
+    async def test_audio_attachment(self, monkeypatch, tmp_path):
+        adapter = _make_simplex_adapter(monkeypatch)
+        audio_path = tmp_path / "voice.ogg"
+        audio_path.write_bytes(b"OggS" + b"\x00" * 100)
+
+        item = _make_chat_item(
+            msg_type="voice",
+            text="",
+            file_info={
+                "fileId": 2,
+                "fileName": "voice.ogg",
+                "fileSize": 104,
+                "fileSource": {"filePath": str(audio_path)},
+            },
+        )
+        event = _make_event("newChatItems", chatItems=[item])
+        await adapter._handle_event(event)
+
+        adapter.handle_message.assert_awaited_once()
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert any("audio" in mt for mt in msg_event.media_types)
+
+    @pytest.mark.asyncio
+    async def test_no_file_source(self, monkeypatch):
+        """File info without fileSource should not produce media_urls."""
+        adapter = _make_simplex_adapter(monkeypatch)
+        item = _make_chat_item(
+            msg_type="file",
+            text="document",
+            file_info={
+                "fileId": 3,
+                "fileName": "doc.pdf",
+                "fileSize": 1024,
+                # No fileSource
+            },
+        )
+        event = _make_event("newChatItems", chatItems=[item])
+        await adapter._handle_event(event)
+
+        adapter.handle_message.assert_awaited_once()
+        msg_event = adapter.handle_message.call_args[0][0]
+        assert len(msg_event.media_urls) == 0
+
+
+# ---------------------------------------------------------------------------
+# Contact Request Handling
+# ---------------------------------------------------------------------------
+
+
+class TestSimplexContactRequest:
+    @pytest.mark.asyncio
+    async def test_auto_accept_contact_request(self, monkeypatch):
+        adapter = _make_simplex_adapter(monkeypatch, auto_accept=True)
+        adapter._send_command = AsyncMock(return_value={"type": "contactConnected"})
+
+        event = _make_event(
+            "contactRequest",
+            contactRequest={"contactRequestId": 7},
+        )
+        await adapter._handle_event(event)
+
+        adapter._send_command.assert_awaited_once()
+        cmd = adapter._send_command.call_args[0][0]
+        assert "/accept 7" in cmd
+
+    @pytest.mark.asyncio
+    async def test_no_accept_when_disabled(self, monkeypatch):
+        adapter = _make_simplex_adapter(monkeypatch, auto_accept=False)
+        adapter._send_command = AsyncMock()
+
+        event = _make_event(
+            "contactRequest",
+            contactRequest={"contactRequestId": 7},
+        )
+        await adapter._handle_event(event)
+
+        adapter._send_command.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Correlated Response Handling
+# ---------------------------------------------------------------------------
+
+
+class TestSimplexCorrelation:
+    @pytest.mark.asyncio
+    async def test_correlated_response_resolves_future(self, monkeypatch):
+        import asyncio
+
+        adapter = _make_simplex_adapter(monkeypatch)
+        loop = asyncio.get_event_loop()
+        fut = loop.create_future()
+        adapter._pending_responses["corr_1"] = fut
+
+        raw_event = {"corrId": "corr_1", "resp": {"type": "newChatItems"}}
+        await adapter._handle_event(raw_event.get("resp", {}))
+
+        # corrId handling is in the outer wrapper, let's test it directly
+        # The _handle_event receives resp, but corrId is checked in _ws_listener
+        # Actually, looking at the code, corrId IS checked in _handle_event
+        # Let me re-read...
+
+    @pytest.mark.asyncio
+    async def test_unhandled_event_type_ignored(self, monkeypatch):
+        """Unknown event types should not raise."""
+        adapter = _make_simplex_adapter(monkeypatch)
+        event = _make_event("someUnknownEvent")
+        await adapter._handle_event(event)
+        # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# Sending
+# ---------------------------------------------------------------------------
+
+
+class TestSimplexSend:
+    @pytest.mark.asyncio
+    async def test_send_dm_format(self, monkeypatch):
+        adapter = _make_simplex_adapter(monkeypatch)
+        adapter._send_command = AsyncMock(return_value={"type": "newChatItems"})
+
+        result = await adapter.send("42", "Hello!")
+        assert result.success is True
+
+        cmd = adapter._send_command.call_args[0][0]
+        assert cmd == "@42 Hello!"
+
+    @pytest.mark.asyncio
+    async def test_send_group_format(self, monkeypatch):
+        adapter = _make_simplex_adapter(monkeypatch)
+        adapter._send_command = AsyncMock(return_value={"type": "newChatItems"})
+
+        result = await adapter.send("group:99", "Hello group!")
+        assert result.success is True
+
+        cmd = adapter._send_command.call_args[0][0]
+        assert cmd == "#99 Hello group!"
+        assert "#group:" not in cmd
+
+    @pytest.mark.asyncio
+    async def test_send_error_response(self, monkeypatch):
+        adapter = _make_simplex_adapter(monkeypatch)
+        adapter._send_command = AsyncMock(
+            return_value={"type": "chatCmdError", "chatError": "not found"}
+        )
+
+        result = await adapter.send("42", "Hello!")
+        assert result.success is False
+        assert "error" in result.error.lower() or "not found" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_send_no_ws_connected(self, monkeypatch):
+        adapter = _make_simplex_adapter(monkeypatch)
+        adapter._send_command = AsyncMock(return_value=None)
+        adapter._ws = None
+
+        result = await adapter.send("42", "Hello!")
+        assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_send_no_response_but_ws_connected(self, monkeypatch):
+        adapter = _make_simplex_adapter(monkeypatch)
+        adapter._send_command = AsyncMock(return_value=None)
+        adapter._ws = MagicMock()
+
+        result = await adapter.send("42", "Hello!")
+        assert result.success is True
+
+    @pytest.mark.asyncio
+    async def test_send_image_dm(self, monkeypatch, tmp_path):
+        adapter = _make_simplex_adapter(monkeypatch)
+        adapter._send_command = AsyncMock(return_value={"type": "newChatItems"})
+        adapter.send = AsyncMock(return_value=MagicMock(success=True))
+
+        img_path = tmp_path / "test.png"
+        img_path.write_bytes(b"\x89PNG" + b"\x00" * 100)
+
+        result = await adapter.send_image("42", f"file://{img_path}", caption="A photo")
+        assert result.success is True
+
+        cmd = adapter._send_command.call_args[0][0]
+        assert cmd.startswith("/f @42 ")
+
+    @pytest.mark.asyncio
+    async def test_send_image_group(self, monkeypatch, tmp_path):
+        adapter = _make_simplex_adapter(monkeypatch)
+        adapter._send_command = AsyncMock(return_value={"type": "newChatItems"})
+        adapter.send = AsyncMock(return_value=MagicMock(success=True))
+
+        img_path = tmp_path / "test.png"
+        img_path.write_bytes(b"\x89PNG" + b"\x00" * 100)
+
+        result = await adapter.send_image("group:99", f"file://{img_path}")
+        assert result.success is True
+
+        cmd = adapter._send_command.call_args[0][0]
+        assert "/f #99 " in cmd
+        assert "#group:" not in cmd
+
+    @pytest.mark.asyncio
+    async def test_send_document_not_found(self, monkeypatch):
+        adapter = _make_simplex_adapter(monkeypatch)
+        result = await adapter.send_document("42", "/nonexistent/file.pdf")
+        assert result.success is False
+        assert "not found" in result.error.lower()
+
+
+# ---------------------------------------------------------------------------
+# Chat Info
+# ---------------------------------------------------------------------------
+
+
+class TestSimplexChatInfo:
+    @pytest.mark.asyncio
+    async def test_dm_chat_info(self, monkeypatch):
+        adapter = _make_simplex_adapter(monkeypatch)
+        info = await adapter.get_chat_info("42")
+        assert info["type"] == "dm"
+        assert info["chat_id"] == "42"
+
+    @pytest.mark.asyncio
+    async def test_group_chat_info(self, monkeypatch):
+        adapter = _make_simplex_adapter(monkeypatch)
+        info = await adapter.get_chat_info("group:99")
+        assert info["type"] == "group"
+        assert info["chat_id"] == "group:99"
+
+
+# ---------------------------------------------------------------------------
+# Session Source
+# ---------------------------------------------------------------------------
+
+
+class TestSimplexSessionSource:
+    def test_session_source_roundtrip(self):
+        from gateway.session import SessionSource
+
+        source = SessionSource(
+            platform=Platform.SIMPLEX,
+            chat_id="42",
+            chat_type="dm",
+            user_id="42",
+            user_name="alice",
+        )
+        d = source.to_dict()
+        restored = SessionSource.from_dict(d)
+        assert restored.platform == Platform.SIMPLEX
+        assert restored.chat_id == "42"
+        assert restored.user_id == "42"
+
+    def test_session_source_group(self):
+        from gateway.session import SessionSource
+
+        source = SessionSource(
+            platform=Platform.SIMPLEX,
+            chat_id="group:99",
+            chat_type="group",
+            user_id="m1",
+            user_name="bob",
+        )
+        d = source.to_dict()
+        restored = SessionSource.from_dict(d)
+        assert restored.chat_id == "group:99"
+        assert restored.chat_type == "group"
+
+
+# ---------------------------------------------------------------------------
+# Authorization in run.py
+# ---------------------------------------------------------------------------
+
+
+class TestSimplexAuthorization:
+    def test_simplex_in_allowlist_maps(self):
+        """SimpleX should be in the platform auth maps."""
+        from gateway.run import GatewayRunner
+        from gateway.config import GatewayConfig
+
+        gw = GatewayRunner.__new__(GatewayRunner)
+        gw.config = GatewayConfig()
+        gw.pairing_store = MagicMock()
+        gw.pairing_store.is_approved.return_value = False
+
+        source = MagicMock()
+        source.platform = Platform.SIMPLEX
+        source.user_id = "42"
+
+        with patch.dict("os.environ", {}, clear=True):
+            result = gw._is_user_authorized(source)
+            assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Send Message Tool
+# ---------------------------------------------------------------------------
+
+
+class TestSimplexSendMessage:
+    def test_simplex_in_platform_map(self):
+        """SimpleX should be in the send_message tool's platform map."""
+        from gateway.config import Platform
+
+        assert Platform.SIMPLEX.value == "simplex"
+
+    @pytest.mark.asyncio
+    async def test_send_simplex_standalone_dm_format(self, monkeypatch):
+        """The standalone _send_simplex should use @<id> for DMs."""
+        from tools.send_message_tool import _send_simplex
+
+        mock_ws = AsyncMock()
+        mock_ws.send = AsyncMock()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps(
+                {
+                    "corrId": "test",
+                    "resp": {"type": "newChatItems"},
+                }
+            )
+        )
+
+        with patch("websockets.connect") as mock_connect:
+            mock_connect.return_value.__aenter__ = AsyncMock(return_value=mock_ws)
+            mock_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _send_simplex(
+                {"ws_url": "ws://localhost:5225"},
+                "42",
+                "Hello!",
+            )
+
+        assert result.get("success") is True
+        sent_payload = json.loads(mock_ws.send.call_args[0][0])
+        assert sent_payload["cmd"] == "@42 Hello!"
+
+    @pytest.mark.asyncio
+    async def test_send_simplex_standalone_group_format(self, monkeypatch):
+        """The standalone _send_simplex should use #<id> for groups (not #group:<id>)."""
+        from tools.send_message_tool import _send_simplex
+
+        mock_ws = AsyncMock()
+        mock_ws.send = AsyncMock()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps(
+                {
+                    "corrId": "test",
+                    "resp": {"type": "newChatItems"},
+                }
+            )
+        )
+
+        with patch("websockets.connect") as mock_connect:
+            mock_connect.return_value.__aenter__ = AsyncMock(return_value=mock_ws)
+            mock_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await _send_simplex(
+                {"ws_url": "ws://localhost:5225"},
+                "group:99",
+                "Hello group!",
+            )
+
+        assert result.get("success") is True
+        sent_payload = json.loads(mock_ws.send.call_args[0][0])
+        assert sent_payload["cmd"] == "#99 Hello group!"
+        assert "#group:" not in sent_payload["cmd"]

--- a/tests/gateway/test_simplex.py
+++ b/tests/gateway/test_simplex.py
@@ -1,5 +1,6 @@
 """Tests for SimpleX Chat platform adapter."""
 
+import asyncio
 import json
 import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
@@ -28,7 +29,18 @@ def _make_simplex_adapter(monkeypatch, ws_url="ws://127.0.0.1:5225", **extra):
     }
     adapter = SimplexAdapter(config)
     adapter.handle_message = AsyncMock()
+    # Text batching schedules handle_message via asyncio.create_task + sleep.
+    # Zero the delay so tests can flush with _flush_text_batches() instead of
+    # waiting on a wall-clock timer.
+    adapter._text_batch_delay = 0
     return adapter
+
+
+async def _flush_text_batches(adapter):
+    """Await any pending SimpleX text-batch flush tasks so handle_message fires."""
+    tasks = list(adapter._pending_text_batch_tasks.values())
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
 
 
 def _make_chat_item(
@@ -295,6 +307,7 @@ class TestSimplexEventHandling:
         )
         event = _make_event("newChatItems", chatItems=[item])
         await adapter._handle_event(event)
+        await _flush_text_batches(adapter)
 
         adapter.handle_message.assert_awaited_once()
         msg_event = adapter.handle_message.call_args[0][0]
@@ -310,6 +323,7 @@ class TestSimplexEventHandling:
         item2 = _make_chat_item(text="Second", contact_id=43, contact_name="bob")
         event = _make_event("newChatItems", chatItems=[item1, item2])
         await adapter._handle_event(event)
+        await _flush_text_batches(adapter)
 
         assert adapter.handle_message.await_count == 2
 
@@ -359,6 +373,7 @@ class TestSimplexEventHandling:
         )
         event = _make_event("newChatItems", chatItems=[item])
         await adapter._handle_event(event)
+        await _flush_text_batches(adapter)
 
         adapter.handle_message.assert_awaited_once()
         msg_event = adapter.handle_message.call_args[0][0]
@@ -376,6 +391,7 @@ class TestSimplexEventHandling:
         )
         event = _make_event("newChatItems", chatItems=[item])
         await adapter._handle_event(event)
+        await _flush_text_batches(adapter)
 
         adapter.handle_message.assert_awaited_once()
 
@@ -421,6 +437,7 @@ class TestSimplexEventHandling:
         item = _make_chat_item(item_ts="2025-06-15T10:30:00Z")
         event = _make_event("newChatItems", chatItems=[item])
         await adapter._handle_event(event)
+        await _flush_text_batches(adapter)
 
         msg_event = adapter.handle_message.call_args[0][0]
         assert msg_event.timestamp.year == 2025
@@ -432,6 +449,7 @@ class TestSimplexEventHandling:
         item = _make_chat_item(item_ts="not-a-date")
         event = _make_event("newChatItems", chatItems=[item])
         await adapter._handle_event(event)
+        await _flush_text_batches(adapter)
 
         msg_event = adapter.handle_message.call_args[0][0]
         assert isinstance(msg_event.timestamp, datetime)
@@ -506,6 +524,7 @@ class TestSimplexFileAttachments:
         )
         event = _make_event("newChatItems", chatItems=[item])
         await adapter._handle_event(event)
+        await _flush_text_batches(adapter)
 
         adapter.handle_message.assert_awaited_once()
         msg_event = adapter.handle_message.call_args[0][0]
@@ -654,7 +673,10 @@ class TestSimplexSend:
         assert result.success is True
 
         cmd = adapter._send_command.call_args[0][0]
-        assert cmd.startswith("/f @42 ")
+        # Uses /_send with JSON payload so chats can be addressed by numeric ID.
+        assert cmd.startswith("/_send @42 json ")
+        assert '"type": "image"' in cmd
+        assert '"text": "A photo"' in cmd
 
     @pytest.mark.asyncio
     async def test_send_image_group(self, monkeypatch, tmp_path):
@@ -669,7 +691,7 @@ class TestSimplexSend:
         assert result.success is True
 
         cmd = adapter._send_command.call_args[0][0]
-        assert "/f #99 " in cmd
+        assert cmd.startswith("/_send #99 json ")
         assert "#group:" not in cmd
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_simplex.py
+++ b/tests/gateway/test_simplex.py
@@ -555,20 +555,20 @@ class TestSimplexContactRequest:
 class TestSimplexCorrelation:
     @pytest.mark.asyncio
     async def test_correlated_response_resolves_future(self, monkeypatch):
+        """An event whose corrId matches a pending response should resolve
+        the future with the inner resp dict and clear the pending entry."""
         import asyncio
 
         adapter = _make_simplex_adapter(monkeypatch)
-        loop = asyncio.get_event_loop()
-        fut = loop.create_future()
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
         adapter._pending_responses["corr_1"] = fut
 
         raw_event = {"corrId": "corr_1", "resp": {"type": "newChatItems"}}
-        await adapter._handle_event(raw_event.get("resp", {}))
+        await adapter._handle_event(raw_event)
 
-        # corrId handling is in the outer wrapper, let's test it directly
-        # The _handle_event receives resp, but corrId is checked in _ws_listener
-        # Actually, looking at the code, corrId IS checked in _handle_event
-        # Let me re-read...
+        assert fut.done()
+        assert fut.result() == {"type": "newChatItems"}
+        assert "corr_1" not in adapter._pending_responses
 
     @pytest.mark.asyncio
     async def test_unhandled_event_type_ignored(self, monkeypatch):
@@ -598,6 +598,8 @@ class TestSimplexSend:
 
     @pytest.mark.asyncio
     async def test_send_group_format(self, monkeypatch):
+        """Groups use the structured ``/_send #<id> json [...]`` form so
+        delivery is keyed on the numeric group ID, not a display name."""
         adapter = _make_simplex_adapter(monkeypatch)
         adapter._send_command = AsyncMock(return_value={"type": "newChatItems"})
 
@@ -605,8 +607,10 @@ class TestSimplexSend:
         assert result.success is True
 
         cmd = adapter._send_command.call_args[0][0]
-        assert cmd == "#99 Hello group!"
+        assert cmd.startswith("/_send #99 json ")
         assert "#group:" not in cmd
+        payload = json.loads(cmd[len("/_send #99 json "):])
+        assert payload == [{"msgContent": {"type": "text", "text": "Hello group!"}}]
 
     @pytest.mark.asyncio
     async def test_send_error_response(self, monkeypatch):
@@ -773,62 +777,54 @@ class TestSimplexSendMessage:
         assert Platform.SIMPLEX.value == "simplex"
 
     @pytest.mark.asyncio
-    async def test_send_simplex_standalone_dm_format(self, monkeypatch):
-        """The standalone _send_simplex should use @<id> for DMs."""
+    async def test_send_simplex_standalone_dm(self, monkeypatch):
+        """_send_simplex routes text chunks through SimplexAdapter.send() for DMs."""
         from tools.send_message_tool import _send_simplex
+        from gateway.platforms.base import SendResult
 
-        mock_ws = AsyncMock()
-        mock_ws.send = AsyncMock()
-        mock_ws.recv = AsyncMock(
-            return_value=json.dumps(
-                {
-                    "corrId": "test",
-                    "resp": {"type": "newChatItems"},
-                }
-            )
-        )
+        mock_adapter = MagicMock()
+        mock_adapter.connect = AsyncMock(return_value=True)
+        mock_adapter.disconnect = AsyncMock()
+        mock_adapter.send = AsyncMock(return_value=SendResult(success=True))
+        mock_adapter._ws = object()  # simulate connected WebSocket
 
-        with patch("websockets.connect") as mock_connect:
-            mock_connect.return_value.__aenter__ = AsyncMock(return_value=mock_ws)
-            mock_connect.return_value.__aexit__ = AsyncMock(return_value=False)
-
+        with patch("gateway.platforms.simplex.SimplexAdapter", return_value=mock_adapter):
             result = await _send_simplex(
                 {"ws_url": "ws://localhost:5225"},
                 "42",
                 "Hello!",
+                ["Hello!"],
+                [],
             )
 
         assert result.get("success") is True
-        sent_payload = json.loads(mock_ws.send.call_args[0][0])
-        assert sent_payload["cmd"] == "@42 Hello!"
+        mock_adapter.send.assert_awaited_once_with("42", "Hello!")
 
     @pytest.mark.asyncio
-    async def test_send_simplex_standalone_group_format(self, monkeypatch):
-        """The standalone _send_simplex should use #<id> for groups (not #group:<id>)."""
+    async def test_send_simplex_standalone_group(self, monkeypatch):
+        """_send_simplex passes a group chat_id through to SimplexAdapter.send() unchanged.
+
+        The adapter itself is responsible for turning ``group:99`` into the
+        SimpleX CLI's ``#99`` group reference — that's covered by
+        ``TestSimplexSend.test_send_group_format``.
+        """
         from tools.send_message_tool import _send_simplex
+        from gateway.platforms.base import SendResult
 
-        mock_ws = AsyncMock()
-        mock_ws.send = AsyncMock()
-        mock_ws.recv = AsyncMock(
-            return_value=json.dumps(
-                {
-                    "corrId": "test",
-                    "resp": {"type": "newChatItems"},
-                }
-            )
-        )
+        mock_adapter = MagicMock()
+        mock_adapter.connect = AsyncMock(return_value=True)
+        mock_adapter.disconnect = AsyncMock()
+        mock_adapter.send = AsyncMock(return_value=SendResult(success=True))
+        mock_adapter._ws = object()
 
-        with patch("websockets.connect") as mock_connect:
-            mock_connect.return_value.__aenter__ = AsyncMock(return_value=mock_ws)
-            mock_connect.return_value.__aexit__ = AsyncMock(return_value=False)
-
+        with patch("gateway.platforms.simplex.SimplexAdapter", return_value=mock_adapter):
             result = await _send_simplex(
                 {"ws_url": "ws://localhost:5225"},
                 "group:99",
                 "Hello group!",
+                ["Hello group!"],
+                [],
             )
 
         assert result.get("success") is True
-        sent_payload = json.loads(mock_ws.send.call_args[0][0])
-        assert sent_payload["cmd"] == "#99 Hello group!"
-        assert "#group:" not in sent_payload["cmd"]
+        mock_adapter.send.assert_awaited_once_with("group:99", "Hello group!")

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -348,8 +348,15 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         if match:
             return match.group(1), None, True
     if platform_name == "simplex":
-        # SimpleX chat_id is either a numeric contact ID or "group:<N>"
+        # SimpleX chat_id is either a numeric contact ID or "group:<N>".
+        # The agent sometimes appends a base64 invitation-hash suffix
+        # (e.g. "group:1:bGlYMXIxRjNTQ3hqZHIzZg==") when it saves jobs —
+        # strip anything after the numeric group ID so the SimpleX CLI
+        # sees a clean "#<N>" reference.
         if target_ref.startswith("group:"):
+            parts = target_ref.split(":", 2)
+            if len(parts) >= 2 and parts[1].lstrip("-").isdigit():
+                return f"group:{parts[1]}", None, True
             return target_ref, None, True
         if target_ref.lstrip("-").isdigit():
             return target_ref, None, True

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -738,6 +738,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             result = await _send_bluebubbles(pconfig.extra, chat_id, chunk)
         elif platform == Platform.QQBOT:
             result = await _send_qqbot(pconfig, chat_id, chunk)
+        elif platform == Platform.SIMPLEX:
+            result = await _send_simplex(pconfig.extra, chat_id, chunk)
         elif platform == Platform.YUANBAO:
             result = await _send_yuanbao(chat_id, chunk)
         else:
@@ -1908,3 +1910,41 @@ registry.register(
     check_fn=_check_send_message,
     emoji="📨",
 )
+
+async def _send_simplex(extra, chat_id, message):
+    """Send via SimpleX Chat WebSocket API (one-shot connection)."""
+    import asyncio
+    try:
+        import websockets
+    except ImportError:
+        return {"error": "websockets not installed. Run: pip install websockets"}
+    try:
+        ws_url = extra.get("ws_url") or os.getenv("SIMPLEX_WS_URL", "")
+        if not ws_url:
+            return {"error": "SimpleX not configured (SIMPLEX_WS_URL required)"}
+
+        if chat_id.startswith("group:"):
+            group_id = chat_id[6:]
+            command = f"#{group_id} {message}"
+        else:
+            command = f"@{chat_id} {message}"
+
+        corr_id = f"send_{int(time.time() * 1000)}"
+        payload = json.dumps({"corrId": corr_id, "cmd": command})
+
+        async with websockets.connect(ws_url, open_timeout=10, close_timeout=5) as ws:
+            await ws.send(payload)
+            # Wait for correlated response
+            try:
+                raw = await asyncio.wait_for(ws.recv(), timeout=15.0)
+                data = json.loads(raw)
+                resp = data.get("resp", {})
+                resp_type = resp.get("type", "")
+                if "error" in resp_type.lower():
+                    return {"error": f"SimpleX error: {resp.get('chatError', resp)}"}
+            except asyncio.TimeoutError:
+                pass  # No response is acceptable for simplex-chat
+
+        return {"success": True, "platform": "simplex", "chat_id": chat_id}
+    except Exception as e:
+        return {"error": f"SimpleX send failed: {e}"}

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1945,6 +1945,16 @@ async def _send_simplex(extra, chat_id, message, chunks, media_files):
         if not connected:
             return {"error": "SimpleX: failed to connect to simplex-chat WebSocket"}
 
+        # connect() schedules _ws_listener via create_task; the actual WebSocket
+        # object (adapter._ws) is set inside that task on its first iteration.
+        # Yield to the event loop until _ws is populated (normally < 0.5s).
+        for _ in range(50):
+            if adapter._ws is not None:
+                break
+            await asyncio.sleep(0.1)
+        else:
+            return {"error": "SimpleX: WebSocket not ready after connect()"}
+
         last_result = None
 
         # Send text chunks

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -347,6 +347,13 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         match = _WEIXIN_TARGET_RE.fullmatch(target_ref)
         if match:
             return match.group(1), None, True
+    if platform_name == "simplex":
+        # SimpleX chat_id is either a numeric contact ID or "group:<N>"
+        if target_ref.startswith("group:"):
+            return target_ref, None, True
+        if target_ref.lstrip("-").isdigit():
+            return target_ref, None, True
+        return None, None, False
     if platform_name == "yuanbao":
         match = _YUANBAO_TARGET_RE.fullmatch(target_ref)
         if match:
@@ -561,10 +568,12 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             logger.debug("Failed to apply Slack mrkdwn formatting in _send_to_platform", exc_info=True)
 
     # Platform message length limits (from adapter class attributes)
+    from gateway.platforms.simplex import SimplexAdapter as _SimplexAdapter
     _MAX_LENGTHS = {
         Platform.TELEGRAM: TelegramAdapter.MAX_MESSAGE_LENGTH if _telegram_available else 4096,
         Platform.DISCORD: DiscordAdapter.MAX_MESSAGE_LENGTH,
         Platform.SLACK: SlackAdapter.MAX_MESSAGE_LENGTH,
+        Platform.SIMPLEX: _SimplexAdapter.MAX_MESSAGE_LENGTH,
     }
     if _feishu_available:
         _MAX_LENGTHS[Platform.FEISHU] = FeishuAdapter.MAX_MESSAGE_LENGTH
@@ -647,6 +656,10 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- SimpleX: supports text + voice/file media via WebSocket adapter ---
+    if platform == Platform.SIMPLEX:
+        return await _send_simplex(pconfig.extra, chat_id, message, chunks, media_files)
+
     # --- Signal: native attachment support via JSON-RPC attachments param ---
     if platform == Platform.SIGNAL and media_files:
         last_result = None
@@ -699,7 +712,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, simplex, weixin, signal, yuanbao and feishu; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -707,7 +720,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, simplex, weixin, signal, yuanbao and feishu"
         )
 
     last_result = None
@@ -1911,40 +1924,68 @@ registry.register(
     emoji="📨",
 )
 
-async def _send_simplex(extra, chat_id, message):
-    """Send via SimpleX Chat WebSocket API (one-shot connection)."""
-    import asyncio
+async def _send_simplex(extra, chat_id, message, chunks, media_files):
+    """Send text and/or media to SimpleX Chat via a short-lived WebSocket connection.
+
+    Creates a transient SimplexAdapter, sends all content, then disconnects.
+    SimpleX-chat supports multiple simultaneous WebSocket clients.
+    """
     try:
-        import websockets
-    except ImportError:
-        return {"error": "websockets not installed. Run: pip install websockets"}
+        from gateway.platforms.simplex import SimplexAdapter
+        from gateway.config import PlatformConfig
+    except ImportError as e:
+        return {"error": f"SimpleX adapter unavailable: {e}"}
+
+    pconfig = PlatformConfig()
+    pconfig.extra = dict(extra or {})
+    adapter = SimplexAdapter(pconfig)
+
     try:
-        ws_url = extra.get("ws_url") or os.getenv("SIMPLEX_WS_URL", "")
-        if not ws_url:
-            return {"error": "SimpleX not configured (SIMPLEX_WS_URL required)"}
+        connected = await adapter.connect()
+        if not connected:
+            return {"error": "SimpleX: failed to connect to simplex-chat WebSocket"}
 
-        if chat_id.startswith("group:"):
-            group_id = chat_id[6:]
-            command = f"#{group_id} {message}"
-        else:
-            command = f"@{chat_id} {message}"
+        last_result = None
 
-        corr_id = f"send_{int(time.time() * 1000)}"
-        payload = json.dumps({"corrId": corr_id, "cmd": command})
+        # Send text chunks
+        for chunk in chunks:
+            if chunk.strip():
+                send_result = await adapter.send(chat_id, chunk)
+                last_result = (
+                    {"success": True, "platform": "simplex", "chat_id": chat_id}
+                    if send_result.success
+                    else {"error": send_result.error or "SimpleX send failed"}
+                )
+                if last_result.get("error"):
+                    return last_result
 
-        async with websockets.connect(ws_url, open_timeout=10, close_timeout=5) as ws:
-            await ws.send(payload)
-            # Wait for correlated response
-            try:
-                raw = await asyncio.wait_for(ws.recv(), timeout=15.0)
-                data = json.loads(raw)
-                resp = data.get("resp", {})
-                resp_type = resp.get("type", "")
-                if "error" in resp_type.lower():
-                    return {"error": f"SimpleX error: {resp.get('chatError', resp)}"}
-            except asyncio.TimeoutError:
-                pass  # No response is acceptable for simplex-chat
+        # Send media files
+        for media_path, is_voice in (media_files or []):
+            if not os.path.exists(media_path):
+                logger.warning("SimpleX: media file not found, skipping: %s", media_path)
+                continue
+            ext = os.path.splitext(media_path)[1].lower()
+            if is_voice and ext in _VOICE_EXTS:
+                send_result = await adapter.send_voice(chat_id, media_path)
+            elif ext in _AUDIO_EXTS:
+                send_result = await adapter.send_voice(chat_id, media_path)
+            elif ext in _IMAGE_EXTS:
+                send_result = await adapter.send_image(chat_id, f"file://{media_path}")
+            else:
+                send_result = await adapter.send_document(chat_id, media_path)
+            last_result = (
+                {"success": True, "platform": "simplex", "chat_id": chat_id}
+                if send_result.success
+                else {"error": send_result.error or "SimpleX media send failed"}
+            )
+            if last_result.get("error"):
+                return last_result
 
-        return {"success": True, "platform": "simplex", "chat_id": chat_id}
+        return last_result or {"success": True, "platform": "simplex", "chat_id": chat_id}
     except Exception as e:
         return {"error": f"SimpleX send failed: {e}"}
+    finally:
+        try:
+            await adapter.disconnect()
+        except Exception:
+            pass

--- a/toolsets.py
+++ b/toolsets.py
@@ -527,10 +527,16 @@ TOOLSETS = {
         "includes": []
     },
 
+    "hermes-simplex": {
+        "description": "SimpleX Chat bot toolset - private decentralized messaging (full access)",
+        "tools": _HERMES_CORE_TOOLS,
+        "includes": []
+    },
+
     "hermes-gateway": {
         "description": "Gateway toolset - union of all messaging platform tools",
         "tools": [],
-        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-wecom-callback", "hermes-weixin", "hermes-qqbot", "hermes-webhook", "hermes-yuanbao"]
+        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-wecom-callback", "hermes-weixin", "hermes-qqbot", "hermes-webhook", "hermes-simplex", "hermes-yuanbao"]
     }
 }
 

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -6,7 +6,7 @@ description: "Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, 
 
 # Messaging Gateway
 
-Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Feishu/Lark, WeCom, Weixin, BlueBubbles (iMessage), QQ, Yuanbao, Microsoft Teams, LINE, or your browser. The gateway is a single background process that connects to all your configured platforms, handles sessions, runs cron jobs, and delivers voice messages.
+Chat with Hermes from Telegram, Discord, Slack, WhatsApp, Signal, SimpleX, SMS, Email, Home Assistant, Mattermost, Matrix, DingTalk, Feishu/Lark, WeCom, Weixin, BlueBubbles (iMessage), QQ, Yuanbao, Microsoft Teams, LINE, or your browser. The gateway is a single background process that connects to all your configured platforms, handles sessions, runs cron jobs, and delivers voice messages.
 
 For the full voice feature set — including CLI microphone mode, spoken replies in messaging, and Discord voice-channel conversations — see [Voice Mode](/docs/user-guide/features/voice-mode) and [Use Voice Mode with Hermes](/docs/guides/use-voice-mode-with-hermes).
 
@@ -20,6 +20,7 @@ For the full voice feature set — including CLI microphone mode, spoken replies
 | Google Chat | — | ✅ | ✅ | ✅ | — | ✅ | — |
 | WhatsApp | — | ✅ | ✅ | — | — | ✅ | ✅ |
 | Signal | — | ✅ | ✅ | — | — | ✅ | ✅ |
+| SimpleX | — | ✅ | ✅ | — | — | — | — |
 | SMS | — | — | — | — | — | — | — |
 | Email | — | ✅ | ✅ | ✅ | — | — | — |
 | Home Assistant | — | — | — | — | — | — | — |
@@ -50,6 +51,7 @@ flowchart TB
             sl[Slack]
             gc[Google Chat]
             sig[Signal]
+            sx[SimpleX]
             sms[SMS]
             em[Email]
             ha[Home Assistant]
@@ -79,6 +81,7 @@ flowchart TB
     sl --> store
     gc --> store
     sig --> store
+    sx --> store
     sms --> store
     em --> store
     ha --> store
@@ -426,6 +429,7 @@ Each platform has its own toolset:
 | Slack | `hermes-slack` | Full tools including terminal |
 | Google Chat | `hermes-google_chat` | Full tools including terminal |
 | Signal | `hermes-signal` | Full tools including terminal |
+| SimpleX | `hermes-simplex` | Full tools including terminal |
 | SMS | `hermes-sms` | Full tools including terminal |
 | Email | `hermes-email` | Full tools including terminal |
 | Home Assistant | `hermes-homeassistant` | Full tools + HA device control (ha_list_entities, ha_get_state, ha_call_service, ha_list_services) |
@@ -451,6 +455,7 @@ Each platform has its own toolset:
 - [Google Chat Setup](google_chat.md)
 - [WhatsApp Setup](whatsapp.md)
 - [Signal Setup](signal.md)
+- [SimpleX Setup](simplex.md)
 - [SMS Setup (Twilio)](sms.md)
 - [Email Setup](email.md)
 - [Home Assistant Integration](homeassistant.md)

--- a/website/docs/user-guide/messaging/simplex.md
+++ b/website/docs/user-guide/messaging/simplex.md
@@ -164,11 +164,17 @@ The adapter supports sending and receiving:
 - **Audio** — MP3, OGG, WAV, M4A (voice messages transcribed if Whisper is configured)
 - **Documents** — PDF and other file types
 
+### Voice Messages
+
+SimpleX voice messages are fully supported:
+- **Inbound**: Voice notes are received via file transfer, transcribed via STT (if configured), and delivered as text to the agent.
+- **Outbound**: When the agent generates TTS audio, it is sent as a native SimpleX voice note (plays inline in the app, not as a downloadable file).
+
 ### Health Monitoring
 
 The adapter monitors the WebSocket connection and automatically reconnects if:
 - The connection drops (with exponential backoff: 2s → 60s, with jitter)
-- No activity is detected for 120 seconds (forces reconnect)
+- WebSocket ping/pong keepalives (20s interval) detect stale connections
 
 ### Contact ID Redaction
 

--- a/website/docs/user-guide/messaging/simplex.md
+++ b/website/docs/user-guide/messaging/simplex.md
@@ -1,99 +1,218 @@
-# SimpleX Chat
+---
+sidebar_position: 17
+title: "SimpleX"
+description: "Set up Hermes Agent as a SimpleX Chat bot via simplex-chat WebSocket API"
+---
 
-[SimpleX Chat](https://simplex.chat/) is a private, decentralised messaging platform where users own their contacts and groups. Unlike other platforms, SimpleX assigns no persistent user IDs — every contact is identified by an opaque internal ID generated at connection time, which makes it one of the most private messengers available.
+# SimpleX Setup
+
+Hermes connects to SimpleX Chat through the [simplex-chat](https://simplex.chat/) terminal app running with its WebSocket API enabled. The adapter streams messages in real-time via WebSocket JSON events and sends responses via WebSocket JSON commands.
+
+SimpleX Chat is the first messenger with no user identifiers — not even random numbers. It uses pairwise per-queue identifiers and routes messages through relay servers, providing strong metadata privacy. This makes it an excellent choice for privacy-sensitive agent deployments.
+
+:::info Dependency
+The SimpleX adapter requires the `websockets` Python package. Install it with: `pip install websockets` (or `uv pip install websockets`).
+:::
+
+---
 
 ## Prerequisites
 
-- The **simplex-chat** CLI installed and running as a daemon
-- Python package **websockets** (`pip install websockets`)
+- **simplex-chat** — SimpleX Chat terminal client ([GitHub](https://github.com/simplex-chat/simplex-chat), [Downloads](https://simplex.chat/downloads/))
+- **websockets** Python package — `pip install websockets`
 
-## Install simplex-chat
-
-Download the latest release from the [simplex-chat GitHub releases](https://github.com/simplex-chat/simplex-chat/releases) page, or via Docker:
+### Installing simplex-chat
 
 ```bash
-# Linux / macOS binary
+# Linux (static binary)
 curl -L https://github.com/simplex-chat/simplex-chat/releases/latest/download/simplex-chat-ubuntu-22_04-x86-64 -o simplex-chat
 chmod +x simplex-chat
+sudo mv simplex-chat /usr/local/bin/
 
-# Or Docker
-docker run -p 5225:5225 simplexchat/simplex-chat -p 5225
+# Arch Linux (AUR)
+yay -S simplex-chat-bin
+
+# macOS
+brew install simplex-chat
 ```
 
-## Start the daemon
+---
+
+## Step 1: Create a SimpleX Identity
+
+SimpleX doesn't use phone numbers, emails, or usernames. Each instance has its own identity, created on first run.
 
 ```bash
+# Start simplex-chat interactively to create an identity
+simplex-chat
+
+# At the prompt, set a display name:
+> /profile HermesAgent
+
+# Generate a one-time invitation link for connecting:
+> /connect
+# This prints a simplex:// URI — share it with users who should be able to talk to the bot
+
+# Exit interactive mode
+> /quit
+```
+
+---
+
+## Step 2: Start simplex-chat with WebSocket API
+
+```bash
+# Start with WebSocket API on port 5225
 simplex-chat -p 5225
 ```
 
-The daemon listens on WebSocket at `ws://127.0.0.1:5225` by default.
+:::tip
+Keep this running in the background. Use `systemd`, `tmux`, or `screen`. For production, create a systemd service:
 
-## Configure Hermes
+```ini
+[Unit]
+Description=SimpleX Chat WebSocket API
+After=network.target
 
-### Via setup wizard
+[Service]
+Type=simple
+User=hermes
+ExecStart=/usr/local/bin/simplex-chat -p 5225
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+:::
+
+---
+
+## Step 3: Configure Hermes
+
+The easiest way:
 
 ```bash
-hermes setup gateway
+hermes gateway setup
 ```
 
-Select **SimpleX Chat** and follow the prompts.
+Select **SimpleX** from the platform menu. The wizard will prompt for the WebSocket URL and configure access settings.
 
-### Via environment variables
+### Manual Configuration
 
-Add these to `~/.hermes/.env`:
+Add to `~/.hermes/.env`:
 
-```
+```bash
+# Required
 SIMPLEX_WS_URL=ws://127.0.0.1:5225
-SIMPLEX_ALLOWED_USERS=<contact-id-1>,<contact-id-2>
-SIMPLEX_HOME_CHANNEL=<contact-id>
+
+# Security (recommended)
+SIMPLEX_ALLOWED_USERS=42,108                     # Comma-separated contact IDs
+# Or allow all contacts:
+# SIMPLEX_ALLOW_ALL_USERS=true
+
+# Optional
+SIMPLEX_AUTO_ACCEPT=true                          # Auto-accept incoming contact requests (default: true)
+SIMPLEX_GROUP_ALLOWED=99,201                      # Group IDs to monitor, or * for all (omit to disable)
+SIMPLEX_HOME_CHANNEL=42                           # Default delivery target for cron jobs
+SIMPLEX_HOME_CHANNEL_NAME=Home                    # Display name for the home channel
 ```
 
-| Variable | Required | Description |
-|---|---|---|
-| `SIMPLEX_WS_URL` | Yes | WebSocket URL of the simplex-chat daemon |
-| `SIMPLEX_ALLOWED_USERS` | Recommended | Comma-separated contact IDs allowed to use the agent |
-| `SIMPLEX_ALLOW_ALL_USERS` | Optional | Set `true` to allow every contact (use carefully) |
-| `SIMPLEX_HOME_CHANNEL` | Optional | Default contact ID for cron job delivery |
-| `SIMPLEX_HOME_CHANNEL_NAME` | Optional | Human label for the home channel |
+Then start the gateway:
 
-## Find your contact ID
-
-After starting the daemon, open a conversation with your agent contact. The contact ID will appear in session logs or via `hermes send_message action=list`.
-
-## Authorization
-
-By default **all contacts are denied**. You must either:
-
-1. Set `SIMPLEX_ALLOWED_USERS` to a comma-separated list of contact IDs, or
-2. Use **DM pairing** — send any message to the bot and it will reply with a pairing code. Enter that code via `hermes gateway pair`.
-
-## Using SimpleX with cron jobs
-
-```python
-cronjob(
-    action="create",
-    schedule="every 1h",
-    deliver="simplex",          # uses SIMPLEX_HOME_CHANNEL
-    prompt="Check for alerts and summarise."
-)
+```bash
+hermes gateway              # Foreground
+hermes gateway install      # Install as a user service
+sudo hermes gateway install --system   # Linux only: boot-time system service
 ```
 
-Or target a specific contact:
+---
 
-```python
-send_message(target="simplex:<contact-id>", message="Done!")
-```
+## Access Control
 
-## Privacy notes
+### DM Access
 
-- SimpleX never reveals phone numbers or email addresses — contacts use opaque IDs
-- The connection between Hermes and the daemon is local WebSocket (`ws://127.0.0.1:5225`) — no data leaves your machine
-- Messages are end-to-end encrypted by the SimpleX protocol before reaching the daemon
+DM access follows the same pattern as all other Hermes platforms:
+
+1. **`SIMPLEX_ALLOWED_USERS` set** — only those contact IDs can message
+2. **No allowlist set** — unknown users get a DM pairing code (approve via `hermes pairing approve simplex CODE`)
+3. **`SIMPLEX_ALLOW_ALL_USERS=true`** — anyone can message (use with caution)
+
+### Contact Requests
+
+When `SIMPLEX_AUTO_ACCEPT=true` (the default), the bot automatically accepts incoming contact requests. Set to `false` to require manual approval.
+
+### Group Access
+
+Group access is controlled by the `SIMPLEX_GROUP_ALLOWED` env var:
+
+| Configuration | Behavior |
+|---------------|----------|
+| Not set (default) | All group messages are ignored. The bot only responds to DMs. |
+| Set with group IDs | Only listed groups are monitored (e.g., `99,201`). |
+| Set to `*` | The bot responds in any group it's a member of. |
+
+---
+
+## Features
+
+### Attachments
+
+The adapter supports sending and receiving:
+
+- **Images** — PNG, JPEG, GIF, WebP (auto-detected via magic bytes)
+- **Audio** — MP3, OGG, WAV, M4A (voice messages transcribed if Whisper is configured)
+- **Documents** — PDF and other file types
+
+### Health Monitoring
+
+The adapter monitors the WebSocket connection and automatically reconnects if:
+- The connection drops (with exponential backoff: 2s → 60s, with jitter)
+- No activity is detected for 120 seconds (forces reconnect)
+
+### Contact ID Redaction
+
+Contact IDs are partially redacted in logs for privacy:
+- `12345678` → `12**78`
+
+---
 
 ## Troubleshooting
 
-**"Cannot reach daemon"** — Ensure `simplex-chat -p 5225` is running and the port matches `SIMPLEX_WS_URL`.
+| Problem | Solution |
+|---------|----------|
+| **"Cannot reach simplex-chat"** during setup | Ensure simplex-chat is running with WebSocket API: `simplex-chat -p 5225` |
+| **Messages not received** | Check that `SIMPLEX_ALLOWED_USERS` includes the sender's contact ID, or enable `SIMPLEX_ALLOW_ALL_USERS` |
+| **"websockets not installed"** | Install the dependency: `pip install websockets` |
+| **Connection keeps dropping** | Check simplex-chat logs. Ensure the WebSocket port isn't blocked by a firewall. |
+| **Group messages ignored** | Configure `SIMPLEX_GROUP_ALLOWED` with specific group IDs, or `*` to allow all groups. |
+| **Bot responds to no one** | Configure `SIMPLEX_ALLOWED_USERS`, use DM pairing, or set `SIMPLEX_ALLOW_ALL_USERS=true`. |
+| **Contact requests not accepted** | Ensure `SIMPLEX_AUTO_ACCEPT=true` (default) or manually accept via simplex-chat CLI. |
 
-**"websockets not installed"** — Run `pip install websockets`.
+---
 
-**Messages not received** — Check that the contact's ID is in `SIMPLEX_ALLOWED_USERS` or approve them via DM pairing.
+## Security
+
+:::warning
+**Always configure access controls.** The bot has terminal access by default. Without `SIMPLEX_ALLOWED_USERS` or DM pairing, the gateway denies all incoming messages as a safety measure.
+:::
+
+- Contact IDs are redacted in all log output
+- Use DM pairing or explicit allowlists for safe onboarding of new users
+- Keep groups disabled unless you specifically need group support
+- SimpleX provides strong metadata privacy — no user identifiers, pairwise connections, onion routing available
+- The simplex-chat data directory (`~/.simplex/`) contains identity keys — protect it like a password
+
+---
+
+## Environment Variables Reference
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `SIMPLEX_WS_URL` | Yes | — | simplex-chat WebSocket endpoint (e.g., `ws://127.0.0.1:5225`) |
+| `SIMPLEX_ALLOWED_USERS` | No | — | Comma-separated contact IDs allowed to interact |
+| `SIMPLEX_ALLOW_ALL_USERS` | No | `false` | Allow any contact to interact (skip allowlist) |
+| `SIMPLEX_AUTO_ACCEPT` | No | `true` | Auto-accept incoming contact requests |
+| `SIMPLEX_GROUP_ALLOWED` | No | — | Group IDs to monitor, or `*` for all (omit to disable groups) |
+| `SIMPLEX_HOME_CHANNEL` | No | — | Default delivery target for cron jobs |
+| `SIMPLEX_HOME_CHANNEL_NAME` | No | `Home` | Display name for the home channel |

--- a/website/docs/user-guide/messaging/simplex.md
+++ b/website/docs/user-guide/messaging/simplex.md
@@ -10,6 +10,15 @@ Hermes connects to SimpleX Chat through the [simplex-chat](https://simplex.chat/
 
 SimpleX Chat is the first messenger with no user identifiers — not even random numbers. It uses pairwise per-queue identifiers and routes messages through relay servers, providing strong metadata privacy. This makes it an excellent choice for privacy-sensitive agent deployments.
 
+## Why SimpleX Works Well for Bots
+
+- No user accounts required. Bot-to-bot or bot-to-user connections work through one-time invite links.
+- Only explicitly invited contacts can reach the bot, which eliminates the usual spam and unsolicited bot traffic.
+- No CAPTCHA or phone-number onboarding flow, so automation is simpler.
+- No SIM card to provision, rotate, or keep alive.
+- End-to-end encrypted, without depending on a single operator.
+- Lower operational dependence on specific server operators or domain names than more centralized messaging setups. If infrastructure changes, you can accept a new invite link and continue.
+
 :::info Dependency
 The SimpleX adapter requires the `websockets` Python package. Install it with: `pip install websockets` (or `uv pip install websockets`).
 :::


### PR DESCRIPTION
## Summary
- add a full SimpleX Chat gateway adapter with WebSocket event handling, DM and group delivery, voice/file support, cron home-channel delivery, and `send_message` integration
- wire SimpleX through gateway/tooling configuration and add end-user docs, including setup, access control, and operational guidance
- cover the adapter with dedicated gateway tests and document SimpleX as a first-class messaging option in Hermes

## Why SimpleX belongs in Hermes
- SimpleX is unusually well-suited to agent deployments because it does not require user accounts, phone numbers, SIM cards, or CAPTCHA-based onboarding
- communication is invite-driven, so only explicitly invited contacts can reach the bot; this is a strong default for bot security and sharply reduces spam and unsolicited traffic
- it is end-to-end encrypted and less dependent on a single operator than account-centric messaging networks, which makes it attractive for privacy-sensitive and self-hosted workflows
- if a relay or deployment setup changes, operators can often recover by accepting a new invite link instead of reworking gateway identity/config around a fixed phone number or server identity

## Documentation
- add a dedicated SimpleX setup guide at `website/docs/user-guide/messaging/simplex.md`
- mention SimpleX in the top-level README and messaging docs so users can discover it alongside the existing gateway platforms

## Notes
- SimpleX project: https://simplex.chat/