### PR TITLE
fix(cli): check upstream even when origin/main has no new commits

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8538,6 +8538,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
         if commit_count == 0:
             _invalidate_update_cache()
+
+            # Even if origin is up to date, the fork may be behind upstream
+            if is_fork and branch == "main":
+                _sync_with_upstream_if_needed(git_cmd, PROJECT_ROOT)
+
             # Restore stash and switch back to original branch if we moved
             if auto_stash_ref is not None:
                 _restore_stashed_changes(


### PR DESCRIPTION
> **Note:** This PR was authored and tested by Avery — a Hermes agent, with guidance from @francip.

## Summary

- **Bug:** `hermes update` on a fork never checks upstream when `origin/main` is already in sync with the local checkout. The upstream sync logic (`_sync_with_upstream_if_needed`) only runs after a successful origin pull, so if `origin/main` has 0 new commits the function returns early with "Already up to date!" — even when `origin/main` is behind `upstream/main`.
- **Fix:** Added the upstream sync check inside the `commit_count == 0` early-return path, so forks always check upstream regardless of whether origin had new commits.

## Relationship to #19696 (not superseded)

#19696 (merged) and this PR fix related but **different** functions:

- **#19696** patches `_cmd_update_check()` — the `hermes update --check` path. It now fetches `upstream` first and falls back to `origin`, so the "is there an update?" probe works correctly on forks.
- **This PR (#4873)** patches `_cmd_update_impl()` — the actual `hermes update` apply path. Specifically, the `commit_count == 0` early-return branch never invoked `_sync_with_upstream_if_needed()`, so forks whose `origin/main` matches local HEAD still print "Already up to date!" and bail without ever consulting `upstream/main`.

So `--check` correctly reports updates available after #19696, but plain `hermes update` still no-ops on forks until this lands.

## How to reproduce

1. Fork the repo, clone your fork
2. Let your fork's `origin/main` fall behind `upstream/main`
3. Run `hermes update` — it reports "Already up to date!" without checking upstream

## How to test

1. Set up a fork where both local and `origin/main` are behind `upstream/main`
2. Run `hermes update` with this fix applied
3. Verify it fetches from upstream and pulls the missing commits

## Platforms tested

- macOS (Apple Silicon)