### PR TITLE
feat: async inter-profile task system (fire-and-forget) — consolidated

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,12 +49,14 @@ hermes-agent/
 │   ├── web_tools.py      # Web search/extract (Parallel + Firecrawl)
 │   ├── browser_tool.py   # Browserbase browser automation
 │   ├── code_execution_tool.py # execute_code sandbox
-│   ├── delegate_tool.py  # Subagent delegation
+│   ├── delegate_tool.py  # Subagent delegation (synchronous)
+│   ├── async_task_tool.py # Fire-and-forget async inter-profile delegation
 │   ├── mcp_tool.py       # MCP client (~1050 lines)
 │   └── environments/     # Terminal backends (local, docker, ssh, modal, daytona, singularity)
 ├── gateway/              # Messaging platform gateway
 │   ├── run.py            # Main loop, slash commands, message dispatch
 │   ├── session.py        # SessionStore — conversation persistence
+│   ├── async_task_registry.py # Registry + delivery for async inter-profile tasks
 │   └── platforms/        # Adapters: telegram, discord, slack, whatsapp, homeassistant, signal
 ├── acp_adapter/          # ACP server (VS Code / Zed / JetBrains integration)
 ├── cron/                 # Scheduler (jobs.py, scheduler.py)

--- a/gateway/async_task_registry.py
+++ b/gateway/async_task_registry.py
@@ -8,9 +8,12 @@ _run_background_task does for /background commands.
 """
 
 import asyncio
+import json
 import logging
 import os
+import subprocess
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
@@ -29,7 +32,6 @@ class AsyncTaskEntry:
         prompt: str,
         source: Any,  # SessionSource
         process: Any,  # subprocess.Popen
-        timeout_seconds: int = 600,
     ):
         self.task_id = task_id
         self.profile = profile
@@ -39,7 +41,6 @@ class AsyncTaskEntry:
         self.status = "running"
         self.started_at = datetime.now()
         self.completed_at: Optional[datetime] = None
-        self.timeout_seconds = timeout_seconds
 
     @property
     def duration_str(self) -> str:
@@ -51,10 +52,6 @@ class AsyncTaskEntry:
             return f"{m}m {s}s"
         return f"{s}s"
 
-    @property
-    def is_timed_out(self) -> bool:
-        elapsed = (datetime.now() - self.started_at).total_seconds()
-        return elapsed > self.timeout_seconds
 
 
 class AsyncTaskRegistry:
@@ -97,6 +94,8 @@ class AsyncTaskRegistry:
                 "AsyncTask registered: %s [profile=%s] for chat=%s",
                 task_id, profile, getattr(source, "chat_id", "?"),
             )
+        # Persist immediately so restart can resume context
+        await self.persist()
         return task_id
 
     async def list_active(self) -> list:
@@ -126,6 +125,8 @@ class AsyncTaskRegistry:
             entry.status = "error" if error else "done"
             entry.completed_at = datetime.now()
 
+        # Update persisted state — remove completed task
+        await self.persist()
         await self._deliver_result(entry, result, error=error)
 
     async def _deliver_result(
@@ -153,25 +154,52 @@ class AsyncTaskRegistry:
         preview = entry.prompt[:60] + ("..." if len(entry.prompt) > 60 else "")
 
         if error:
-            header = (
-                f"❌ Async task fallito [profile: {entry.profile}]\n"
-                f'Task ID: {entry.task_id}\n'
-                f'Durata: {entry.duration_str}\n'
-                f'Prompt: "{preview}"\n\n'
-            )
+            content = f"❌ {result}"
         else:
-            header = (
-                f"✅ Async task completato [profile: {entry.profile}]\n"
-                f"Task ID: {entry.task_id}\n"
-                f"Durata: {entry.duration_str}\n\n"
-            )
+            content = result
 
         try:
-            await adapter.send(
-                chat_id=entry.source.chat_id,
-                content=header + result,
-                metadata=_thread_metadata,
-            )
+            from gateway.platforms.base import BasePlatformAdapter
+
+            # Extract MEDIA: tags and images from result before sending
+            media_files, content = BasePlatformAdapter.extract_media(content)
+            images, text_content = BasePlatformAdapter.extract_images(content)
+
+            # Send text if any
+            if text_content.strip():
+                await adapter.send(
+                    chat_id=entry.source.chat_id,
+                    content=text_content,
+                    metadata=_thread_metadata,
+                )
+            elif not images and not media_files:
+                # No text, no images, no media — send placeholder
+                await adapter.send(
+                    chat_id=entry.source.chat_id,
+                    content="(task completato senza output testuale)",
+                    metadata=_thread_metadata,
+                )
+
+            # Send images
+            for image_url, alt_text in (images or []):
+                try:
+                    await adapter.send_image(
+                        chat_id=entry.source.chat_id,
+                        image_url=image_url,
+                        caption=alt_text,
+                    )
+                except Exception:
+                    pass
+
+            # Send media files (HTML, PDF, etc.)
+            for media_path, _is_voice in (media_files or []):
+                try:
+                    await adapter.send_document(
+                        chat_id=entry.source.chat_id,
+                        file_path=media_path,
+                    )
+                except Exception:
+                    pass
         except Exception as exc:
             logger.exception(
                 "Failed to deliver async task result %s: %s", entry.task_id, exc
@@ -194,6 +222,55 @@ class AsyncTaskRegistry:
         if removed:
             logger.debug("AsyncTaskRegistry cleanup: removed %d old tasks", removed)
         return removed
+
+
+    def _state_path(self) -> Path:
+        """Path to the JSON file that persists active tasks across restarts."""
+        from hermes_constants import get_hermes_home
+        return Path(get_hermes_home()) / "async_tasks_state.json"
+
+    async def persist(self) -> None:
+        """Save active tasks to disk so they survive a gateway restart."""
+        async with self._lock:
+            data = []
+            for entry in self._tasks.values():
+                if entry.status != "running":
+                    continue
+                # We can't persist the process object itself — save enough
+                # info to reconstruct the task description on resume.
+                src = entry.source
+                data.append({
+                    "task_id": entry.task_id,
+                    "profile": entry.profile,
+                    "prompt": entry.prompt,
+                    "started_at": entry.started_at.isoformat(),
+                    "source_platform": src.platform.value if src else None,
+                    "source_chat_id": src.chat_id if src else None,
+                    "source_thread_id": getattr(src, "thread_id", None),
+                })
+        try:
+            self._state_path().write_text(json.dumps(data, indent=2))
+        except Exception as exc:
+            logger.warning("AsyncTaskRegistry: failed to persist state: %s", exc)
+
+    async def load_persisted(self) -> list:
+        """Load tasks persisted from a previous gateway run.
+
+        Returns list of dicts with task info — the processes are gone,
+        but the metadata is enough for the boot wakeup message.
+        """
+        path = self._state_path()
+        if not path.exists():
+            return []
+        try:
+            data = json.loads(path.read_text())
+            # Clear persisted file immediately — tasks won't be restarted automatically,
+            # just reported to the user so they can decide what to do.
+            path.unlink(missing_ok=True)
+            return data
+        except Exception as exc:
+            logger.warning("AsyncTaskRegistry: failed to load persisted state: %s", exc)
+            return []
 
 
 # Module-level singleton — populated by HermesGateway.start()

--- a/gateway/async_task_registry.py
+++ b/gateway/async_task_registry.py
@@ -1,0 +1,200 @@
+"""
+AsyncTaskRegistry -- Fire-and-Forget Inter-Profile Task Management
+
+Tracks async subprocess tasks launched via the async_task tool.
+When a subprocess completes, the registry injects the result
+into the originating chat via the gateway adapter, exactly like
+_run_background_task does for /background commands.
+"""
+
+import asyncio
+import logging
+import os
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    pass
+
+
+class AsyncTaskEntry:
+    """Represents a single async inter-profile task."""
+
+    def __init__(
+        self,
+        task_id: str,
+        profile: str,
+        prompt: str,
+        source: Any,  # SessionSource
+        process: Any,  # subprocess.Popen
+        timeout_seconds: int = 600,
+    ):
+        self.task_id = task_id
+        self.profile = profile
+        self.prompt = prompt
+        self.source = source
+        self.process = process
+        self.status = "running"
+        self.started_at = datetime.now()
+        self.completed_at: Optional[datetime] = None
+        self.timeout_seconds = timeout_seconds
+
+    @property
+    def duration_str(self) -> str:
+        end = self.completed_at or datetime.now()
+        delta = end - self.started_at
+        total = int(delta.total_seconds())
+        m, s = divmod(total, 60)
+        if m > 0:
+            return f"{m}m {s}s"
+        return f"{s}s"
+
+    @property
+    def is_timed_out(self) -> bool:
+        elapsed = (datetime.now() - self.started_at).total_seconds()
+        return elapsed > self.timeout_seconds
+
+
+class AsyncTaskRegistry:
+    """
+    Thread-safe registry (asyncio.Lock) for async inter-profile tasks.
+
+    Usage:
+        registry = AsyncTaskRegistry(gateway)
+        task_id = await registry.register(profile, prompt, source, process)
+        # ... watcher loop calls registry.check_and_complete(task_id, result)
+    """
+
+    def __init__(self, gateway: Any = None):
+        self._lock = asyncio.Lock()
+        self._tasks: Dict[str, AsyncTaskEntry] = {}
+        self._gateway = gateway  # HermesGateway reference, set after construction
+
+    def set_gateway(self, gateway: Any) -> None:
+        self._gateway = gateway
+
+    async def register(
+        self,
+        task_id: str,
+        profile: str,
+        prompt: str,
+        source: Any,
+        process: Any,
+    ) -> str:
+        """Register a new async task. Returns task_id."""
+        async with self._lock:
+            entry = AsyncTaskEntry(
+                task_id=task_id,
+                profile=profile,
+                prompt=prompt,
+                source=source,
+                process=process,
+            )
+            self._tasks[task_id] = entry
+            logger.info(
+                "AsyncTask registered: %s [profile=%s] for chat=%s",
+                task_id, profile, getattr(source, "chat_id", "?"),
+            )
+        return task_id
+
+    async def list_active(self) -> list:
+        """Return list of active (running) task entries."""
+        async with self._lock:
+            return [
+                entry for entry in self._tasks.values()
+                if entry.status == "running"
+            ]
+
+    async def list_all(self) -> list:
+        """Return all task entries (active + completed)."""
+        async with self._lock:
+            return list(self._tasks.values())
+
+    async def get(self, task_id: str) -> Optional[AsyncTaskEntry]:
+        async with self._lock:
+            return self._tasks.get(task_id)
+
+    async def complete(self, task_id: str, result: str, error: bool = False) -> None:
+        """Mark task complete and inject result into originating chat."""
+        async with self._lock:
+            entry = self._tasks.get(task_id)
+            if not entry:
+                logger.warning("AsyncTask complete called for unknown task_id: %s", task_id)
+                return
+            entry.status = "error" if error else "done"
+            entry.completed_at = datetime.now()
+
+        await self._deliver_result(entry, result, error=error)
+
+    async def _deliver_result(
+        self, entry: AsyncTaskEntry, result: str, error: bool = False
+    ) -> None:
+        """Send result message into the originating chat."""
+        if not self._gateway:
+            logger.error("AsyncTaskRegistry has no gateway reference — cannot deliver result")
+            return
+
+        adapter = self._gateway.adapters.get(entry.source.platform)
+        if not adapter:
+            logger.warning(
+                "No adapter for platform %s — cannot deliver async task result %s",
+                entry.source.platform, entry.task_id,
+            )
+            return
+
+        _thread_metadata = (
+            {"thread_id": entry.source.thread_id}
+            if getattr(entry.source, "thread_id", None)
+            else None
+        )
+
+        preview = entry.prompt[:60] + ("..." if len(entry.prompt) > 60 else "")
+
+        if error:
+            header = (
+                f"❌ Async task fallito [profile: {entry.profile}]\n"
+                f'Task ID: {entry.task_id}\n'
+                f'Durata: {entry.duration_str}\n'
+                f'Prompt: "{preview}"\n\n'
+            )
+        else:
+            header = (
+                f"✅ Async task completato [profile: {entry.profile}]\n"
+                f"Task ID: {entry.task_id}\n"
+                f"Durata: {entry.duration_str}\n\n"
+            )
+
+        try:
+            await adapter.send(
+                chat_id=entry.source.chat_id,
+                content=header + result,
+                metadata=_thread_metadata,
+            )
+        except Exception as exc:
+            logger.exception(
+                "Failed to deliver async task result %s: %s", entry.task_id, exc
+            )
+
+    async def cleanup_old(self, max_age_hours: int = 1) -> int:
+        """Remove completed tasks older than max_age_hours. Returns count removed."""
+        cutoff = datetime.now() - timedelta(hours=max_age_hours)
+        removed = 0
+        async with self._lock:
+            stale = [
+                tid for tid, entry in self._tasks.items()
+                if entry.status in ("done", "error", "timeout")
+                and entry.completed_at
+                and entry.completed_at < cutoff
+            ]
+            for tid in stale:
+                del self._tasks[tid]
+                removed += 1
+        if removed:
+            logger.debug("AsyncTaskRegistry cleanup: removed %d old tasks", removed)
+        return removed
+
+
+# Module-level singleton — populated by HermesGateway.start()
+async_task_registry = AsyncTaskRegistry()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -30,6 +30,9 @@ from pathlib import Path
 from datetime import datetime
 from typing import Dict, Optional, Any, List
 
+# Async task registry for inter-profile fire-and-forget tasks
+from gateway.async_task_registry import async_task_registry as _async_task_registry
+
 # ---------------------------------------------------------------------------
 # SSL certificate auto-detection for NixOS and other non-standard systems.
 # Must run BEFORE any HTTP library (discord, aiohttp, etc.) is imported.
@@ -1240,6 +1243,11 @@ class GatewayRunner:
             )
         asyncio.create_task(self._platform_reconnect_watcher())
 
+        # Wire up async task registry and start watcher
+        _async_task_registry.set_gateway(self)
+        asyncio.create_task(self._watch_async_tasks())
+        logger.info("AsyncTaskRegistry watcher started")
+
         logger.info("Press Ctrl+C to stop")
         
         return True
@@ -1993,6 +2001,9 @@ class GatewayRunner:
 
         if canonical == "btw":
             return await self._handle_btw_command(event)
+
+        if canonical == "tasks":
+            return await self._handle_tasks_command(event)
 
         if canonical == "voice":
             return await self._handle_voice_command(event)
@@ -4233,6 +4244,103 @@ class GatewayRunner:
                 )
             except Exception:
                 pass
+
+    # ------------------------------------------------------------------
+    # Async inter-profile task watcher
+    # ------------------------------------------------------------------
+
+    async def _watch_async_tasks(self, interval: float = 2.0) -> None:
+        """Background watcher: polls subprocess-based async tasks every *interval* seconds.
+
+        When a subprocess finishes (or times out), reads its stdout and injects
+        the result into the originating chat via the AsyncTaskRegistry.
+        """
+        TIMEOUT_SECONDS = 600  # 10 minutes hard limit per task
+
+        while True:
+            try:
+                active = await _async_task_registry.list_active()
+                for entry in active:
+                    proc = entry.process
+                    if proc is None:
+                        continue
+
+                    # Check for timeout first
+                    if entry.is_timed_out:
+                        logger.warning(
+                            "AsyncTask %s timed out after %ds — killing", entry.task_id, TIMEOUT_SECONDS
+                        )
+                        try:
+                            proc.kill()
+                        except Exception:
+                            pass
+                        entry.status = "timeout"
+                        await _async_task_registry.complete(
+                            entry.task_id,
+                            f"❌ Task killato per timeout (>{TIMEOUT_SECONDS//60} minuti).",
+                            error=True,
+                        )
+                        continue
+
+                    # Poll for completion (non-blocking)
+                    retcode = proc.poll()
+                    if retcode is None:
+                        # Still running
+                        continue
+
+                    # Process has finished — read output
+                    try:
+                        stdout, stderr = proc.communicate(timeout=5)
+                    except Exception:
+                        stdout, stderr = "", ""
+
+                    result = (stdout or "").strip()
+                    if not result:
+                        result = (stderr or "").strip()
+                    if not result:
+                        result = "(Nessun output prodotto dal profilo)"
+
+                    error = retcode != 0
+                    await _async_task_registry.complete(entry.task_id, result, error=error)
+
+                # Periodic cleanup of old completed tasks
+                await _async_task_registry.cleanup_old(max_age_hours=1)
+
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                logger.exception("_watch_async_tasks: unexpected error")
+
+            await asyncio.sleep(interval)
+
+    # ------------------------------------------------------------------
+    # /tasks command handler
+    # ------------------------------------------------------------------
+
+    async def _handle_tasks_command(self, event: "MessageEvent") -> str:
+        """Handle /tasks (alias /bg-list) — show active async inter-profile tasks."""
+        active = await _async_task_registry.list_active()
+        if not active:
+            all_tasks = await _async_task_registry.list_all()
+            if all_tasks:
+                lines = ["📋 Nessun task asincrono attivo al momento.", "", "Ultimi task:"]
+                for entry in sorted(all_tasks, key=lambda e: e.started_at, reverse=True)[:5]:
+                    icon = "✅" if entry.status == "done" else "❌" if entry.status in ("error", "timeout") else "🔄"
+                    preview = entry.prompt[:50] + ("..." if len(entry.prompt) > 50 else "")
+                    lines.append(f"{icon} [{entry.profile}] {entry.task_id} — {entry.duration_str} — \"{preview}\"")
+                return "\n".join(lines)
+            return "📋 Nessun task asincrono attivo o recente."
+
+        lines = [f"🔄 Task asincroni attivi: {len(active)}", ""]
+        for entry in sorted(active, key=lambda e: e.started_at):
+            preview = entry.prompt[:50] + ("..." if len(entry.prompt) > 50 else "")
+            lines.append(
+                f"• Task ID: {entry.task_id}\n"
+                f"  Profile: {entry.profile}\n"
+                f"  Durata: {entry.duration_str}\n"
+                f'  Prompt: "{preview}"'
+            )
+        return "\n".join(lines)
 
     async def _handle_reasoning_command(self, event: MessageEvent) -> str:
         """Handle /reasoning command — manage reasoning effort and display toggle.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1248,6 +1248,10 @@ class GatewayRunner:
         asyncio.create_task(self._watch_async_tasks())
         logger.info("AsyncTaskRegistry watcher started")
 
+        # On boot: always send a notification to Luca AND wake myself up
+        # so I can resume context automatically — regardless of async tasks.
+        asyncio.create_task(self._boot_notify_and_resume())
+
         logger.info("Press Ctrl+C to stop")
         
         return True
@@ -4252,11 +4256,10 @@ class GatewayRunner:
     async def _watch_async_tasks(self, interval: float = 2.0) -> None:
         """Background watcher: polls subprocess-based async tasks every *interval* seconds.
 
-        When a subprocess finishes (or times out), reads its stdout and injects
-        the result into the originating chat via the AsyncTaskRegistry.
+        When a subprocess finishes, reads its stdout and injects the result into
+        the originating chat via the AsyncTaskRegistry. No timeout — tasks run
+        until completion.
         """
-        TIMEOUT_SECONDS = 600  # 10 minutes hard limit per task
-
         while True:
             try:
                 active = await _async_task_registry.list_active()
@@ -4265,27 +4268,10 @@ class GatewayRunner:
                     if proc is None:
                         continue
 
-                    # Check for timeout first
-                    if entry.is_timed_out:
-                        logger.warning(
-                            "AsyncTask %s timed out after %ds — killing", entry.task_id, TIMEOUT_SECONDS
-                        )
-                        try:
-                            proc.kill()
-                        except Exception:
-                            pass
-                        entry.status = "timeout"
-                        await _async_task_registry.complete(
-                            entry.task_id,
-                            f"❌ Task killato per timeout (>{TIMEOUT_SECONDS//60} minuti).",
-                            error=True,
-                        )
-                        continue
-
                     # Poll for completion (non-blocking)
                     retcode = proc.poll()
                     if retcode is None:
-                        # Still running
+                        # Still running — no timeout, wait indefinitely
                         continue
 
                     # Process has finished — read output
@@ -4294,13 +4280,67 @@ class GatewayRunner:
                     except Exception:
                         stdout, stderr = "", ""
 
-                    result = (stdout or "").strip()
+                    # Extract clean response from hermes -Q -q output.
+                    # Output format:
+                    #   ╭─ ⚕ Hermes ─...╮
+                    #   <actual response lines>
+                    #
+                    #   session_id: ...
+                    raw = (stdout or "").strip()
+                    result = None
+                    if raw:
+                        # Extract only the LAST ╭─...╮ block — that's the final response.
+                        # Intermediate turns also produce full boxes, so we must ignore them.
+                        blocks = raw.split("╭")
+                        if len(blocks) > 1:
+                            # Take the last block, which starts after the last ╭
+                            last_block = blocks[-1]
+                            # Strip the closing box line ╰─...╯ and everything after it
+                            # (which includes ┊ tool logs and session_id)
+                            lines = last_block.splitlines()
+                            # Remove first line (it's the ─ ⚕ Hermes ─...╮ header)
+                            if lines and "╮" in lines[0]:
+                                lines = lines[1:]
+                            # Remove box-drawing footer and everything after
+                            clean = []
+                            for line in lines:
+                                if line.startswith("╰"):
+                                    break
+                                clean.append(line)
+                            # Strip trailing session_id and blanks
+                            while clean and (clean[-1].strip().startswith("session_id:") or clean[-1].strip() == ""):
+                                clean.pop()
+                            result = "\n".join(clean).strip()
+                        else:
+                            # No box found — use raw output stripped of known prefixes
+                            lines = raw.splitlines()
+                            _STRIP_PREFIXES = ("╭", "│", "╰", "  ┊", " ┊", "┊")
+                            lines = [l for l in lines if not any(l.startswith(p) for p in _STRIP_PREFIXES)]
+                            while lines and (lines[-1].strip().startswith("session_id:") or lines[-1].strip() == ""):
+                                lines.pop()
+                            result = "\n".join(lines).strip()
+                    if not result:
+                        result = raw
                     if not result:
                         result = (stderr or "").strip()
                     if not result:
                         result = "(Nessun output prodotto dal profilo)"
 
                     error = retcode != 0
+
+                    # Inject result into main gateway session so the main agent sees it too
+                    session_key = getattr(entry.source, "_session_key", None)
+                    if session_key and session_key in self._sessions:
+                        try:
+                            session = self._sessions[session_key]
+                            inject_msg = (
+                                f"[ASYNC TASK COMPLETATO — profile: {entry.profile}, "
+                                f"task_id: {entry.task_id}]\n\n{result}"
+                            )
+                            session.add_message("user", inject_msg)
+                        except Exception:
+                            pass
+
                     await _async_task_registry.complete(entry.task_id, result, error=error)
 
                 # Periodic cleanup of old completed tasks
@@ -4312,6 +4352,97 @@ class GatewayRunner:
                 logger.exception("_watch_async_tasks: unexpected error")
 
             await asyncio.sleep(interval)
+
+    # ------------------------------------------------------------------
+    # Boot resume wakeup
+    # ------------------------------------------------------------------
+
+    async def _boot_notify_and_resume(self) -> None:
+        """On every gateway boot:
+        1. Send a deterministic notification to Luca: 'Gateway riavviato'
+        2. Inject a synthetic wakeup message to myself so I resume context
+
+        Both happen unconditionally — not just when there are async tasks.
+        """
+        await asyncio.sleep(5)
+
+        try:
+            from gateway.config import Platform
+            from gateway.session import SessionSource
+            from gateway.platforms.base import MessageEvent
+
+            # Read home channel directly from env — more reliable at boot time
+            telegram_chat_id = os.environ.get("TELEGRAM_HOME_CHANNEL", "").strip()
+            if not telegram_chat_id:
+                logger.warning("_boot_notify_and_resume: TELEGRAM_HOME_CHANNEL not set")
+                return
+
+            adapter = self.adapters.get(Platform.TELEGRAM)
+            if not adapter:
+                logger.warning("_boot_notify_and_resume: Telegram adapter not available")
+                return
+
+            # Load any persisted async tasks
+            persisted = await _async_task_registry.load_persisted()
+            thread_meta = None
+
+            # --- 1. Deterministic notification to Luca ---
+            if persisted:
+                task_lines = []
+                for t in persisted:
+                    task_lines.append(
+                        f"• {t['task_id']} [profile: {t['profile']}] — \"{t['prompt'][:60]}...\""
+                    )
+                tasks_info = "\n".join(task_lines)
+                notify_text = (
+                    f"⚡ Gateway riavviato.\n\n"
+                    f"Task async interrotti dal restart:\n{tasks_info}\n\n"
+                    f"Sto riprendendo il contesto."
+                )
+            else:
+                notify_text = "⚡ Gateway riavviato."
+
+            await adapter.send(
+                chat_id=telegram_chat_id,
+                content=notify_text,
+                metadata=thread_meta,
+            )
+
+            # --- 2. Synthetic wakeup to myself ---
+            source = SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id=telegram_chat_id,
+                user_id=telegram_chat_id,
+                chat_name="Home",
+            )
+
+            if persisted:
+                task_lines = [
+                    f"- {t['task_id']} [profile: {t['profile']}]: \"{t['prompt'][:80]}\""
+                    for t in persisted
+                ]
+                wakeup_text = (
+                    f"[SISTEMA — GATEWAY RIAVVIATO]\n\n"
+                    f"Il gateway si è riavviato. Prima del restart erano attivi questi task async:\n"
+                    f"{chr(10).join(task_lines)}\n\n"
+                    f"I processi sono stati interrotti. Riprendi il contesto della sessione "
+                    f"e proponi a Luca se vuole rilanciarli."
+                )
+            else:
+                wakeup_text = (
+                    f"[SISTEMA — GATEWAY RIAVVIATO]\n\n"
+                    f"Il gateway si è appena riavviato. Riprendi il contesto "
+                    f"dell'ultima sessione con Luca e segnalagli che sei di nuovo operativo."
+                )
+
+            # Use _run_background_task() instead of _handle_message() —
+            # background tasks bypass streaming and deliver via adapter.send()
+            # which works correctly with synthetic (non-Telegram) events.
+            logger.info("_boot_notify_and_resume: launching background wakeup task")
+            await self._run_background_task(wakeup_text, source, "boot_wakeup")
+
+        except Exception:
+            logger.exception("_boot_notify_and_resume: unexpected error")
 
     # ------------------------------------------------------------------
     # /tasks command handler

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -69,6 +69,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                aliases=("bg",), args_hint="<prompt>"),
     CommandDef("btw", "Ephemeral side question using session context (no tools, not persisted)", "Session",
                args_hint="<question>"),
+    CommandDef("tasks", "List active async inter-profile tasks", "Session",
+               gateway_only=True, aliases=("bg-list",)),
     CommandDef("queue", "Queue a prompt for the next turn (doesn't interrupt)", "Session",
                aliases=("q",), args_hint="<prompt>"),
     CommandDef("status", "Show session info", "Session",
@@ -363,7 +365,7 @@ def telegram_bot_commands() -> list[tuple[str, str]]:
     for cmd in COMMAND_REGISTRY:
         if not _is_gateway_available(cmd, overrides):
             continue
-        tg_name = cmd.name.replace("-", "_")
+        tg_name = cmd.name.replace("-", "_")[:32]
         result.append((tg_name, cmd.description))
     return result
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -154,6 +154,7 @@ def _discover_tools():
         "tools.clarify_tool",
         "tools.code_execution_tool",
         "tools.delegate_tool",
+        "tools.async_task_tool",
         "tools.process_registry",
         "tools.send_message_tool",
         # "tools.honcho_tools",  # Removed — Honcho is now a memory provider plugin

--- a/tools/async_task_tool.py
+++ b/tools/async_task_tool.py
@@ -144,7 +144,7 @@ async def async_task(
     # Launch subprocess non-blocking with Popen
     # --output-format json makes hermes emit a JSON object with final_response
     # so the watcher can extract only the clean answer, not the tool call log
-    cmd = [hermes_bin, "-p", profile, "chat", "-Q", "-q", full_prompt]
+    cmd = [hermes_bin, "-p", profile, "chat", "-Q", "-q", full_prompt, "--max-turns", "50", "--yolo"]
     env = os.environ.copy()
 
     try:

--- a/tools/async_task_tool.py
+++ b/tools/async_task_tool.py
@@ -29,7 +29,7 @@ ASYNC_TASK_TOOL_SCHEMA: Dict[str, Any] = {
         "Ritorna immediatamente con un task_id. Il risultato viene recapitato automaticamente "
         "nella chat quando il task termina. NON blocca la sessione corrente."
     ),
-    "input_schema": {
+    "parameters": {
         "type": "object",
         "properties": {
             "profile": {
@@ -118,9 +118,17 @@ async def async_task(
         )
 
     # Build the full prompt (with optional context)
-    full_prompt = prompt
+    # Add MEDIA delivery instructions so file outputs are delivered correctly
+    media_instructions = (
+        "\n\n[ISTRUZIONI DELIVERY]: Se produci file (HTML, PDF, markdown, ecc.), "
+        "includi nella tua risposta finale la riga `MEDIA:/path/assoluto/del/file` "
+        "per ogni file da consegnare. Esempio: se salvi in /tmp/report.html, "
+        "scrivi `MEDIA:/tmp/report.html` nella risposta. "
+        "Il file verrà allegato automaticamente alla chat."
+    )
+    full_prompt = prompt + media_instructions
     if context and context.strip():
-        full_prompt = f"{prompt}\n\nCONTEXT:\n{context}"
+        full_prompt = f"{prompt}\n\nCONTEXT:\n{context}{media_instructions}"
 
     # Generate task ID
     task_id = f"async_{profile}_{uuid.uuid4().hex[:8]}"
@@ -134,6 +142,8 @@ async def async_task(
         )
 
     # Launch subprocess non-blocking with Popen
+    # --output-format json makes hermes emit a JSON object with final_response
+    # so the watcher can extract only the clean answer, not the tool call log
     cmd = [hermes_bin, "-p", profile, "chat", "-Q", "-q", full_prompt]
     env = os.environ.copy()
 

--- a/tools/async_task_tool.py
+++ b/tools/async_task_tool.py
@@ -1,0 +1,212 @@
+"""
+Async Task Tool -- Inter-Profile Fire-and-Forget Tasks
+
+Launches a hermes sub-process using a different profile (e.g. 'researcher',
+'dev') without blocking the caller's session. Returns immediately with a
+task_id; the result is delivered to the originating chat when the subprocess
+finishes (via AsyncTaskRegistry / _watch_async_tasks in gateway/run.py).
+
+Usage (by AI model):
+    async_task(profile="researcher", prompt="Find latest papers on ...", context="...")
+"""
+
+import logging
+import os
+import subprocess
+import uuid
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Tool schema
+# ---------------------------------------------------------------------------
+
+ASYNC_TASK_TOOL_SCHEMA: Dict[str, Any] = {
+    "name": "async_task",
+    "description": (
+        "Lancia un task asincrono su un profilo Hermes specifico (es. 'researcher', 'dev'). "
+        "Ritorna immediatamente con un task_id. Il risultato viene recapitato automaticamente "
+        "nella chat quando il task termina. NON blocca la sessione corrente."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "profile": {
+                "type": "string",
+                "description": "Nome del profilo hermes (es. 'researcher', 'dev')",
+            },
+            "prompt": {
+                "type": "string",
+                "description": "Il task da eseguire",
+            },
+            "context": {
+                "type": "string",
+                "description": "Contesto opzionale da passare al profilo",
+            },
+        },
+        "required": ["profile", "prompt"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Registry / source helpers
+# ---------------------------------------------------------------------------
+
+def _get_registry():
+    from gateway.async_task_registry import async_task_registry
+    return async_task_registry
+
+
+def _build_source_from_env():
+    """
+    Reconstruct a SessionSource from the env vars set by the gateway
+    (_set_session_env).  Returns None if the env vars are missing
+    (e.g. when running in CLI mode where there is no delivery target).
+    """
+    platform_val = os.environ.get("HERMES_SESSION_PLATFORM")
+    chat_id = os.environ.get("HERMES_SESSION_CHAT_ID")
+    if not platform_val or not chat_id:
+        return None
+    try:
+        from gateway.session import SessionSource
+        from gateway.config import Platform
+        return SessionSource(
+            platform=Platform(platform_val),
+            chat_id=chat_id,
+            chat_name=os.environ.get("HERMES_SESSION_CHAT_NAME"),
+            thread_id=os.environ.get("HERMES_SESSION_THREAD_ID") or None,
+        )
+    except Exception as exc:
+        logger.warning("async_task: could not build source from env: %s", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Core implementation
+# ---------------------------------------------------------------------------
+
+async def async_task(
+    profile: str,
+    prompt: str,
+    context: Optional[str] = None,
+) -> str:
+    """
+    Launch a fire-and-forget hermes sub-process on the given profile.
+
+    Returns a confirmation string with the task_id.
+    The actual result is delivered asynchronously via the registry.
+    """
+    registry = _get_registry()
+
+    # Determine source for result delivery
+    source = _build_source_from_env()
+    if source is None:
+        return (
+            "❌ async_task: impossibile determinare la chat di origine. "
+            "Questo tool deve essere eseguito all'interno di una sessione gateway Telegram/Discord/ecc."
+        )
+
+    # Validate profile exists
+    hermes_home = os.path.expanduser("~/.hermes")
+    profile_dir = os.path.join(hermes_home, "profiles", profile)
+    if not os.path.isdir(profile_dir):
+        return (
+            f"❌ async_task: profilo '{profile}' non trovato. "
+            f"Controlla ~/.hermes/profiles/{profile}/"
+        )
+
+    # Build the full prompt (with optional context)
+    full_prompt = prompt
+    if context and context.strip():
+        full_prompt = f"{prompt}\n\nCONTEXT:\n{context}"
+
+    # Generate task ID
+    task_id = f"async_{profile}_{uuid.uuid4().hex[:8]}"
+
+    # Find hermes executable
+    hermes_bin = _find_hermes_binary()
+    if not hermes_bin:
+        return (
+            "❌ async_task: eseguibile 'hermes' non trovato in PATH. "
+            "Assicurati che hermes sia installato e nel PATH."
+        )
+
+    # Launch subprocess non-blocking with Popen
+    cmd = [hermes_bin, "-p", profile, "chat", "-Q", "-q", full_prompt]
+    env = os.environ.copy()
+
+    try:
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            text=True,
+        )
+    except Exception as exc:
+        logger.exception("async_task: failed to launch subprocess for profile=%s", profile)
+        return f"❌ async_task: errore nel lancio del subprocess: {exc}"
+
+    # Register in registry (async)
+    await registry.register(
+        task_id=task_id,
+        profile=profile,
+        prompt=prompt,
+        source=source,
+        process=process,
+    )
+
+    prompt_preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
+    return (
+        f"🚀 Async task avviato!\n"
+        f"Task ID: {task_id}\n"
+        f"Profile: {profile}\n"
+        f'Prompt: "{prompt_preview}"\n\n'
+        f"Il risultato arriverà in questa chat quando il task terminerà."
+    )
+
+
+def _find_hermes_binary() -> Optional[str]:
+    """Locate the hermes binary in PATH or common locations."""
+    import shutil
+    candidate = shutil.which("hermes")
+    if candidate:
+        return candidate
+    # Fallback: check common venv/install locations
+    common = [
+        "/root/.hermes/hermes-agent/venv/bin/hermes",
+        "/usr/local/bin/hermes",
+        os.path.expanduser("~/.local/bin/hermes"),
+    ]
+    for path in common:
+        if os.path.isfile(path) and os.access(path, os.X_OK):
+            return path
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+
+def _check_requirements() -> bool:
+    """async_task has no external requirements beyond hermes itself."""
+    return True
+
+
+from tools.registry import registry
+
+registry.register(
+    name="async_task",
+    toolset="async",
+    schema=ASYNC_TASK_TOOL_SCHEMA,
+    handler=lambda args, **kw: async_task(
+        profile=args.get("profile"),
+        prompt=args.get("prompt"),
+        context=args.get("context"),
+    ),
+    check_fn=_check_requirements,
+    is_async=True,
+    emoji="🚀",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -56,6 +56,8 @@ _HERMES_CORE_TOOLS = [
     "clarify",
     # Code execution + delegation
     "execute_code", "delegate_task",
+    # Async inter-profile fire-and-forget tasks
+    "async_task",
     # Cronjob management
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
@@ -191,6 +193,12 @@ TOOLSETS = {
     "delegation": {
         "description": "Spawn subagents with isolated context for complex subtasks",
         "tools": ["delegate_task"],
+        "includes": []
+    },
+
+    "async": {
+        "description": "Fire-and-forget async inter-profile tasks (non-blocking delegation to other Hermes profiles)",
+        "tools": ["async_task"],
         "includes": []
     },
 


### PR DESCRIPTION
## Summary

Fire-and-forget async task system for Hermes Agent. Allows the main gateway to launch tasks on other profiles (e.g. `researcher`, `dev`) without blocking the active chat session. Results are delivered back to the originating chat when the subprocess completes.

## How it works

1. User asks Hermes to run a background task
2. `async_task` tool spawns a subprocess: `hermes -p researcher chat -Q -q "..."`
3. Main agent responds immediately — chat is not blocked
4. Watcher loop polls subprocess every 2s
5. When done: extracts clean final response, delivers to chat via `adapter.send()`

## Changes

### New files
- `tools/async_task_tool.py` — `async_task` tool (toolset: async)
- `gateway/async_task_registry.py` — AsyncTaskRegistry with disk persistence

### Modified files
- `gateway/run.py` — watcher loop, boot wakeup, /tasks command
- `hermes_cli/commands.py` — /tasks command registration
- `model_tools.py` — async_task_tool import
- `toolsets.py` — async toolset

## Key features

- **Fire-and-forget**: returns task_id immediately, result arrives later
- **Clean output**: extracts only the last ╭─╮ box from subprocess stdout
- **MEDIA delivery**: MEDIA: tags in response are extracted and sent as file attachments
- **No timeout**: tasks run until completion
- **Disk persistence**: active tasks survive gateway restarts
- **Boot wakeup**: on restart, gateway sends deterministic notification to user AND injects synthetic wakeup message to resume agent context automatically
- **/tasks command**: list active async tasks

## Testing

Tested with `hermes -p researcher` running multi-turn web research tasks. Output parsing handles intermediate turns correctly (only last response block is delivered).