### PR TITLE
Fix install command for interactive prompts in setup wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Use any model you want — [Nous Portal](https://portal.nousresearch.com), [Open
 ## Quick Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh)"
 ```
 
 Works on Linux, macOS, and WSL2. The installer handles everything — Python, Node.js, dependencies, and the `hermes` command. No prerequisites except git.


### PR DESCRIPTION
## Description
This PR updates the Quick Install command in the README to evaluate the script via `bash -c` instead of piping directly to `bash`.

### Why?
When running `curl | bash`, standard input (stdin) is tied to the pipe. This causes the interactive prompts inside the installation script (like asking for `Y/n` confirmations during system package installs or the setup wizard) to break or hang on some systems. 

By wrapping the fetch inside `bash -c "$(curl -fsSL ...)"`, stdin remains attached to the user's terminal. This allows the interactive `read` prompts to work perfectly across all environments while preserving the convenience of the one-liner.
