### PR TITLE
feat(display): inline read_file content preview in CLI transcript

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -1082,3 +1082,67 @@ def format_context_pressure_gateway(
         hint = "Auto-compaction is disabled — context may be truncated."
 
     return f"{icon} Context: {bar} {pct_int}% to compaction\n{hint}"
+
+
+# =========================================================================
+# Inline read_file preview (show file content in CLI transcript)
+# =========================================================================
+
+_ANSI_LINE_NUM = "\033[38;2;100;100;120m"
+_MAX_INLINE_READ_LINES = 60
+
+
+def render_read_file_inline(
+    function_result: str,
+    *,
+    print_fn=None,
+    max_lines: int = _MAX_INLINE_READ_LINES,
+) -> bool:
+    """Render read_file content inline in the CLI transcript.
+
+    Parses the JSON tool result from read_file and emits the file content
+    with dimmed line numbers, similar to how inline diffs are rendered for
+    write_file/patch.  Returns True if content was emitted.
+
+    When the file exceeds *max_lines*, the first portion is shown with a
+    trailing summary of how many lines were omitted.
+    """
+    if print_fn is None or not function_result:
+        return False
+    try:
+        data = json.loads(function_result)
+    except (json.JSONDecodeError, TypeError):
+        return False
+    if not isinstance(data, dict):
+        return False
+    content = data.get("content")
+    if not content or not isinstance(content, str):
+        return False
+
+    # Skip rendering for binary/image files
+    if data.get("is_binary") or data.get("is_image"):
+        return False
+
+    lines = content.splitlines()
+    total = len(lines)
+    show = lines[:max_lines]
+
+    try:
+        skin_prefix = get_skin_tool_prefix()
+        for line in show:
+            # Lines from read_file are already formatted as "NUM|CONTENT"
+            parts = line.split("|", 1)
+            if len(parts) == 2 and parts[0].strip().isdigit():
+                num = parts[0]
+                text = parts[1]
+                print_fn(f"  {skin_prefix} {_ANSI_LINE_NUM}{num}{_ANSI_RESET}|{_ANSI_DIM}{text}{_ANSI_RESET}")
+            else:
+                print_fn(f"  {skin_prefix} {_ANSI_DIM}{line}{_ANSI_RESET}")
+
+        if total > max_lines:
+            omitted = total - max_lines
+            print_fn(f"  {skin_prefix} {_ANSI_HUNK}… {omitted} more line(s) (of {total} total){_ANSI_RESET}")
+
+        return True
+    except Exception:
+        return False

--- a/cli.py
+++ b/cli.py
@@ -5201,6 +5201,15 @@ class HermesCLI:
         except Exception:
             logger.debug("Edit diff preview failed for %s", function_name, exc_info=True)
 
+        # Inline file content preview for read_file
+        if function_name == "read_file":
+            try:
+                from agent.display import render_read_file_inline
+
+                render_read_file_inline(function_result, print_fn=_cprint)
+            except Exception:
+                logger.debug("Read file inline preview failed", exc_info=True)
+
     # ====================================================================
     # Voice mode methods
     # ====================================================================

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,5 +1,6 @@
-"""Tests for agent/display.py — build_tool_preview() and inline diff previews."""
+"""Tests for agent/display.py — build_tool_preview(), inline diff previews, and read_file inline rendering."""
 
+import json
 import os
 import pytest
 from unittest.mock import MagicMock, patch
@@ -11,6 +12,7 @@ from agent.display import (
     _render_inline_unified_diff,
     _summarize_rendered_diff_sections,
     render_edit_diff_with_delta,
+    render_read_file_inline,
 )
 
 
@@ -200,3 +202,101 @@ class TestEditDiffPreview:
         assert any("a/file2.py" in line for line in rendered)
         assert not any("a/file7.py" in line for line in rendered)
         assert "additional file" in rendered[-1]
+
+
+class TestReadFileInlinePreview:
+    """Tests for render_read_file_inline — inline file content rendering."""
+
+    def _make_result(self, content="     1|hello\n     2|world", **overrides):
+        """Build a fake read_file JSON result."""
+        data = {
+            "content": content,
+            "total_lines": content.count("\n") + 1 if content else 0,
+            "file_size": len(content) if content else 0,
+            "truncated": False,
+            "is_binary": False,
+            "is_image": False,
+        }
+        data.update(overrides)
+        return json.dumps(data)
+
+    def test_renders_basic_content(self):
+        """Normal file content should be emitted with line numbers."""
+        lines = []
+        result = self._make_result()
+        ok = render_read_file_inline(result, print_fn=lines.append)
+        assert ok is True
+        assert len(lines) == 2
+        # Line numbers should be present
+        assert "1" in lines[0]
+        assert "2" in lines[1]
+
+    def test_returns_false_without_print_fn(self):
+        result = self._make_result()
+        assert render_read_file_inline(result, print_fn=None) is False
+
+    def test_returns_false_for_empty_result(self):
+        lines = []
+        assert render_read_file_inline("", print_fn=lines.append) is False
+        assert render_read_file_inline(None, print_fn=lines.append) is False
+
+    def test_returns_false_for_binary_file(self):
+        lines = []
+        result = self._make_result(is_binary=True)
+        assert render_read_file_inline(result, print_fn=lines.append) is False
+        assert len(lines) == 0
+
+    def test_returns_false_for_image_file(self):
+        lines = []
+        result = self._make_result(is_image=True)
+        assert render_read_file_inline(result, print_fn=lines.append) is False
+        assert len(lines) == 0
+
+    def test_returns_false_for_error_result(self):
+        lines = []
+        result = json.dumps({"error": "file not found"})
+        assert render_read_file_inline(result, print_fn=lines.append) is False
+
+    def test_returns_false_for_empty_content(self):
+        lines = []
+        result = self._make_result(content="")
+        assert render_read_file_inline(result, print_fn=lines.append) is False
+
+    def test_truncation_at_max_lines(self):
+        """Files exceeding max_lines should show truncation summary."""
+        content = "\n".join(f"     {i}|line {i}" for i in range(1, 101))
+        result = self._make_result(content=content)
+        lines = []
+        ok = render_read_file_inline(result, print_fn=lines.append, max_lines=10)
+        assert ok is True
+        # 10 content lines + 1 truncation summary
+        assert len(lines) == 11
+        assert "90 more line" in lines[-1]
+        assert "100 total" in lines[-1]
+
+    def test_no_truncation_when_within_limit(self):
+        """Files within max_lines should not show truncation summary."""
+        content = "\n".join(f"     {i}|line {i}" for i in range(1, 6))
+        result = self._make_result(content=content)
+        lines = []
+        ok = render_read_file_inline(result, print_fn=lines.append, max_lines=10)
+        assert ok is True
+        assert len(lines) == 5
+        # No truncation line
+        assert not any("more line" in l for l in lines)
+
+    def test_invalid_json_returns_false(self):
+        lines = []
+        assert render_read_file_inline("not json {{{", print_fn=lines.append) is False
+
+    def test_non_dict_json_returns_false(self):
+        lines = []
+        assert render_read_file_inline('"just a string"', print_fn=lines.append) is False
+
+    def test_handles_lines_without_pipe_format(self):
+        """Lines not in NUM|CONTENT format should still render."""
+        result = self._make_result(content="plain text line\nanother line")
+        lines = []
+        ok = render_read_file_inline(result, print_fn=lines.append)
+        assert ok is True
+        assert len(lines) == 2


### PR DESCRIPTION
## What does this PR do?

When `read_file` completes in the CLI, the tool result line only shows a one-line summary:

```
┊ 📖 read      ~/.hermes/skills/my-skill/SKILL.md  1.1s
```

The actual file content is sent to the AI model but **never rendered in the CLI transcript**. Users have to rely on the AI echoing file content in its response, which is unreliable — the model often summarises instead.

This PR adds inline content rendering for `read_file` results, matching the existing inline diff rendering for `write_file`/`patch`. After the tool completes, file content is displayed directly in the transcript with dimmed line numbers:

```
┊ 📖 read      config.yaml  0.3s
  ┊      1|server:
  ┊      2|  host: 0.0.0.0
  ┊      3|  port: 8080
```

Large files are capped at 60 lines with a truncation summary. Binary and image files are skipped.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/display.py`: Added `render_read_file_inline()` function — parses read_file JSON result, emits content with ANSI-dimmed line numbers, caps at 60 lines with truncation summary, skips binary/image files, uses skin-aware prefix character
- `cli.py`: Hooked `render_read_file_inline` into `_on_tool_complete` callback alongside existing diff rendering
- `tests/test_display.py`: Added `TestReadFileInlinePreview` class with 12 tests covering normal rendering, edge cases (binary, image, empty, error, invalid JSON), truncation behaviour, and non-standard line formats

## How to Test

1. Start a CLI session: `hermes`
2. Ask the AI to read a file (e.g. "show me ~/.hermes/config.yaml")
3. Observe the file content rendered inline below the `┊ 📖 read` tool line
4. Verify large files (>60 lines) show truncation summary
5. Verify binary files are not rendered inline

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (12 new tests)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] N/A — no documentation, config, architecture, or schema changes needed

## Design Notes

- Follows the same pattern as the existing inline diff rendering (`render_edit_diff_with_delta` / `_emit_inline_diff`)
- Uses existing ANSI colour constants (`_ANSI_DIM`, `_ANSI_HUNK`, `_ANSI_RESET`) for visual consistency
- Respects skin engine tool prefix via `get_skin_tool_prefix()`
- All exceptions are caught and logged at debug level — rendering failures never block tool execution
- The `max_lines` cap (default 60) prevents the transcript from being flooded by large files while still showing enough content to be useful