### PR TITLE
fix(mcp): normalize schemas with missing type

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1464,6 +1464,10 @@ def _normalize_mcp_input_schema(schema: dict | None) -> dict:
     if not schema:
         return {"type": "object", "properties": {}}
 
+    # Fix missing or invalid type (e.g. type: None from some MCP servers)
+    if not schema.get("type"):
+        schema = {**schema, "type": "object"}
+
     if schema.get("type") == "object" and "properties" not in schema:
         return {**schema, "properties": {}}
 


### PR DESCRIPTION
## Summary
- normalize MCP tool input schemas that arrive with a missing or null `type`
- default those schemas to `{"type": "object"}` before the existing properties normalization runs

## Why
- some MCP servers emit invalid schemas with `type: null` or no `type` at all
- this keeps Hermes tool registration resilient instead of passing broken schemas through to provider validation
