### PR TITLE
feat(web): add MiniMax Token Plan MCP as a native web_search backend

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -245,6 +245,15 @@ TOOL_CATEGORIES = {
                 ],
             },
             {
+                "name": "MiniMax Token Plan MCP",
+                "tag": "MiniMax subscription — MCP-backed web search (search only)",
+                "web_backend": "minimax",
+                "env_vars": [
+                    {"key": "MINIMAX_API_KEY", "prompt": "MiniMax API key", "url": "https://platform.minimax.io/subscribe/token-plan"},
+                ],
+                "post_setup": "minimax_mcp_web",
+            },
+            {
                 "name": "Firecrawl Self-Hosted",
                 "tag": "Free - run your own instance",
                 "web_backend": "firecrawl",
@@ -369,7 +378,7 @@ TOOLSET_ENV_REQUIREMENTS = {
 
 # ─── Post-Setup Hooks ─────────────────────────────────────────────────────────
 
-def _run_post_setup(post_setup_key: str):
+def _run_post_setup(post_setup_key: str, config: dict | None = None):
     """Run post-setup hooks for tools that need extra installation steps."""
     import shutil
     if post_setup_key == "browserbase":
@@ -439,6 +448,52 @@ def _run_post_setup(post_setup_key: str):
                 _print_warning("    tinker-atropos submodule not found - run:")
                 _print_info("      git submodule update --init --recursive")
                 _print_info('      uv pip install -e "./tinker-atropos"')
+
+    elif post_setup_key == "minimax_mcp_web":
+        if config is None:
+            _print_warning("    Could not update config for MiniMax MCP: config object missing")
+            return
+
+        uvx_path = shutil.which("uvx") or "uvx"
+        config.setdefault("web", {})["backend"] = "minimax"
+
+        mcp_servers = config.setdefault("mcp_servers", {})
+        minimax_cfg = mcp_servers.setdefault("minimax", {})
+        minimax_cfg["command"] = minimax_cfg.get("command") or uvx_path
+        minimax_cfg["args"] = ["minimax-coding-plan-mcp", "-y"]
+        minimax_cfg["connect_timeout"] = minimax_cfg.get("connect_timeout", 120)
+        minimax_cfg["timeout"] = minimax_cfg.get("timeout", 120)
+
+        env_cfg = minimax_cfg.setdefault("env", {})
+        env_cfg["MINIMAX_API_KEY"] = "${MINIMAX_API_KEY}"
+        env_cfg["MINIMAX_API_HOST"] = env_cfg.get("MINIMAX_API_HOST") or "https://api.minimax.io"
+
+        tools_cfg = minimax_cfg.setdefault("tools", {})
+        include = tools_cfg.get("include")
+        if not isinstance(include, list):
+            include = []
+        if "web_search" not in include:
+            include.append("web_search")
+        tools_cfg["include"] = include
+
+        _print_success(f"    MiniMax MCP server configured with command: {minimax_cfg['command']}")
+        if uvx_path == "uvx":
+            _print_info("    If Hermes later reports 'spawn uvx ENOENT', replace the command with your absolute uvx path in ~/.hermes/config.yaml")
+        _print_info("    Restart Hermes or reload MCP servers to pick up the MiniMax MCP tools")
+
+
+def _invoke_post_setup(post_setup_key: str, config: dict):
+    """Call the post-setup hook while remaining compatible with older 1-arg stubs."""
+    import inspect
+
+    try:
+        params = inspect.signature(_run_post_setup).parameters
+    except (TypeError, ValueError):
+        params = {}
+
+    if len(params) >= 2:
+        return _run_post_setup(post_setup_key, config)
+    return _run_post_setup(post_setup_key)
 
 
 # ─── Platform / Toolset Helpers ───────────────────────────────────────────────
@@ -1035,7 +1090,7 @@ def _configure_provider(provider: dict, config: dict):
 
     if not env_vars:
         if provider.get("post_setup"):
-            _run_post_setup(provider["post_setup"])
+            _invoke_post_setup(provider["post_setup"], config)
         _print_success(f"  {provider['name']} - no configuration needed!")
         if managed_feature:
             _print_info("  Requests for this tool will be billed to your Nous subscription.")
@@ -1074,7 +1129,7 @@ def _configure_provider(provider: dict, config: dict):
 
     # Run post-setup hooks if needed
     if provider.get("post_setup") and all_configured:
-        _run_post_setup(provider["post_setup"])
+        _invoke_post_setup(provider["post_setup"], config)
 
     if all_configured:
         _print_success(f"  {provider['name']} configured!")
@@ -1244,7 +1299,7 @@ def _reconfigure_provider(provider: dict, config: dict):
 
     if not env_vars:
         if provider.get("post_setup"):
-            _run_post_setup(provider["post_setup"])
+            _invoke_post_setup(provider["post_setup"], config)
         _print_success(f"  {provider['name']} - no configuration needed!")
         if managed_feature:
             _print_info("  Requests for this tool will be billed to your Nous subscription.")

--- a/tests/hermes_cli/test_tools_config_minimax.py
+++ b/tests/hermes_cli/test_tools_config_minimax.py
@@ -1,0 +1,46 @@
+from unittest.mock import patch
+
+from hermes_cli.tools_config import _run_post_setup
+
+
+class TestMiniMaxWebPostSetup:
+    def test_post_setup_configures_minimax_mcp_server(self):
+        config = {}
+
+        with patch("shutil.which", return_value="/usr/bin/uvx"):
+            _run_post_setup("minimax_mcp_web", config)
+
+        assert config["web"]["backend"] == "minimax"
+        assert config["mcp_servers"]["minimax"] == {
+            "command": "/usr/bin/uvx",
+            "args": ["minimax-coding-plan-mcp", "-y"],
+            "connect_timeout": 120,
+            "timeout": 120,
+            "env": {
+                "MINIMAX_API_KEY": "${MINIMAX_API_KEY}",
+                "MINIMAX_API_HOST": "https://api.minimax.io",
+            },
+            "tools": {
+                "include": ["web_search"],
+            },
+        }
+
+    def test_post_setup_preserves_existing_command_and_include_entries(self):
+        config = {
+            "mcp_servers": {
+                "minimax": {
+                    "command": "/custom/uvx",
+                    "tools": {"include": ["understand_image"]},
+                    "env": {"MINIMAX_API_HOST": "https://custom.minimax.local"},
+                }
+            }
+        }
+
+        with patch("shutil.which", return_value="/usr/bin/uvx"):
+            _run_post_setup("minimax_mcp_web", config)
+
+        server = config["mcp_servers"]["minimax"]
+        assert server["command"] == "/custom/uvx"
+        assert server["tools"]["include"] == ["understand_image", "web_search"]
+        assert server["env"]["MINIMAX_API_HOST"] == "https://custom.minimax.local"
+        assert server["env"]["MINIMAX_API_KEY"] == "${MINIMAX_API_KEY}"

--- a/tests/tools/test_web_tools_minimax.py
+++ b/tests/tools/test_web_tools_minimax.py
@@ -1,0 +1,64 @@
+import json
+from unittest.mock import patch
+
+from tools import web_tools
+
+
+class TestMiniMaxWebBackend:
+    @patch("tools.web_tools._load_web_config", return_value={"backend": "minimax"})
+    def test_explicit_minimax_backend_selected(self, _cfg):
+        assert web_tools._get_backend() == "minimax"
+
+    @patch("tools.web_tools._load_web_config", return_value={"backend": "minimax"})
+    @patch("tools.web_tools._is_minimax_mcp_backend_ready", return_value=True)
+    def test_check_web_api_key_uses_minimax_mcp(self, _ready, _cfg):
+        assert web_tools.check_web_api_key() is True
+
+    @patch("tools.web_tools._load_web_config", return_value={"backend": "minimax"})
+    @patch("tools.web_tools._is_minimax_mcp_backend_ready", return_value=True)
+    def test_extract_hidden_for_minimax_search_only_backend(self, _ready, _cfg):
+        assert web_tools.check_web_extract_backend() is False
+
+    @patch("tools.interrupt.is_interrupted", return_value=False)
+    @patch("tools.web_tools._load_web_config", return_value={"backend": "minimax"})
+    @patch("tools.web_tools.registry.dispatch")
+    def test_web_search_tool_normalizes_minimax_mcp_results(self, mock_dispatch, _cfg, _interrupt):
+        mock_dispatch.return_value = json.dumps(
+            {
+                "result": json.dumps(
+                    {
+                        "organic": [
+                            {
+                                "title": "MiniMax result",
+                                "link": "https://example.com/minimax",
+                                "snippet": "MiniMax search result",
+                                "date": "2026-04-03",
+                            }
+                        ],
+                        "related_searches": [{"query": "MiniMax Hermes MCP"}],
+                        "base_resp": {"status_code": 0, "status_msg": "success"},
+                    }
+                )
+            }
+        )
+
+        result = json.loads(web_tools.web_search_tool("MiniMax Hermes", limit=3))
+
+        assert result["success"] is True
+        assert result["data"]["web"] == [
+            {
+                "title": "MiniMax result",
+                "url": "https://example.com/minimax",
+                "description": "MiniMax search result (2026-04-03)",
+                "position": 1,
+            }
+        ]
+        assert result["data"]["related_searches"] == ["MiniMax Hermes MCP"]
+        assert result["meta"]["provider"] == "minimax-mcp"
+
+    @patch("tools.interrupt.is_interrupted", return_value=False)
+    @patch("tools.web_tools._load_web_config", return_value={"backend": "minimax"})
+    @patch("tools.web_tools.registry.dispatch", return_value=json.dumps({"error": "MCP unavailable"}))
+    def test_web_search_tool_surfaces_minimax_mcp_errors(self, _dispatch, _cfg, _interrupt):
+        result = json.loads(web_tools.web_search_tool("MiniMax Hermes", limit=3))
+        assert result["error"] == "Error searching web: MCP unavailable"

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -17,6 +17,7 @@ Backend compatibility:
 - Firecrawl: https://docs.firecrawl.dev/introduction (search, extract, crawl; direct or derived firecrawl-gateway.<domain> for Nous Subscribers)
 - Parallel: https://docs.parallel.ai (search, extract)
 - Tavily: https://tavily.com (search, extract, crawl)
+- MiniMax Token Plan MCP: https://platform.minimax.io/docs/guides/token-plan-mcp-guide (search only via MCP)
 
 LLM Processing:
 - Uses OpenRouter API with Gemini 3 Flash Preview for intelligent content extraction
@@ -65,6 +66,8 @@ from tools.website_policy import check_website_access
 
 logger = logging.getLogger(__name__)
 
+_MINIMAX_MCP_SEARCH_TOOL = "mcp_minimax_web_search"
+
 
 # ─── Backend Selection ────────────────────────────────────────────────────────
 
@@ -80,6 +83,90 @@ def _load_web_config() -> dict:
     except (ImportError, Exception):
         return {}
 
+
+def _is_minimax_mcp_backend_ready() -> bool:
+    """Return True when the MiniMax MCP web_search tool is registered and connected."""
+    try:
+        toolset = registry.get_toolset_for_tool(_MINIMAX_MCP_SEARCH_TOOL)
+        if toolset != "mcp-minimax" or not registry.is_toolset_available("mcp-minimax"):
+            from tools.mcp_tool import discover_mcp_tools
+
+            discover_mcp_tools()
+            toolset = registry.get_toolset_for_tool(_MINIMAX_MCP_SEARCH_TOOL)
+        return toolset == "mcp-minimax" and registry.is_toolset_available("mcp-minimax")
+    except Exception:
+        return False
+
+
+def _normalize_minimax_search_results(response: dict, limit: int) -> dict:
+    """Normalize MiniMax MCP search results into Hermes's built-in web schema."""
+    organic = response.get("organic") or []
+    web_results = []
+    for idx, item in enumerate(organic[: max(limit, 0)]):
+        snippet = (item.get("snippet") or item.get("description") or "").strip()
+        date = (item.get("date") or "").strip()
+        description = snippet if not date else f"{snippet} ({date})" if snippet else date
+        web_results.append(
+            {
+                "title": (item.get("title") or "").strip(),
+                "url": (item.get("link") or item.get("url") or "").strip(),
+                "description": description,
+                "position": idx + 1,
+            }
+        )
+
+    normalized = {
+        "success": True,
+        "data": {
+            "web": web_results,
+        },
+    }
+
+    related_queries = [
+        item.get("query", "").strip()
+        for item in (response.get("related_searches") or [])
+        if (item.get("query") or "").strip()
+    ]
+    if related_queries:
+        normalized["data"]["related_searches"] = related_queries
+
+    base_resp = response.get("base_resp") or {}
+    if base_resp:
+        normalized["meta"] = {
+            "provider": "minimax-mcp",
+            "status_code": base_resp.get("status_code"),
+            "status_msg": base_resp.get("status_msg"),
+        }
+
+    return normalized
+
+
+def _minimax_mcp_search(query: str, limit: int = 5) -> dict:
+    """Search the web via the MiniMax Token Plan MCP server."""
+    raw_response = registry.dispatch(_MINIMAX_MCP_SEARCH_TOOL, {"query": query})
+    try:
+        outer = json.loads(raw_response)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"MiniMax MCP returned invalid JSON envelope: {exc}") from exc
+
+    if outer.get("error"):
+        raise ValueError(str(outer["error"]))
+
+    result_payload = outer.get("result") or "{}"
+    try:
+        response = json.loads(result_payload)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"MiniMax MCP returned non-JSON search results: {exc}") from exc
+
+    base_resp = response.get("base_resp") or {}
+    status_code = base_resp.get("status_code")
+    if status_code not in (None, 0, "0"):
+        status_msg = base_resp.get("status_msg") or "MiniMax MCP search failed"
+        raise ValueError(f"MiniMax MCP search failed ({status_code}): {status_msg}")
+
+    return _normalize_minimax_search_results(response, limit)
+
+
 def _get_backend() -> str:
     """Determine which web backend to use.
 
@@ -88,7 +175,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in ("parallel", "firecrawl", "tavily", "exa"):
+    if configured in ("parallel", "firecrawl", "tavily", "exa", "minimax"):
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -99,6 +186,7 @@ def _get_backend() -> str:
         ("parallel", _has_env("PARALLEL_API_KEY")),
         ("tavily", _has_env("TAVILY_API_KEY")),
         ("exa", _has_env("EXA_API_KEY")),
+        ("minimax", _is_minimax_mcp_backend_ready()),
     )
     for backend, available in backend_candidates:
         if available:
@@ -117,7 +205,14 @@ def _is_backend_available(backend: str) -> bool:
         return check_firecrawl_api_key()
     if backend == "tavily":
         return _has_env("TAVILY_API_KEY")
+    if backend == "minimax":
+        return _is_minimax_mcp_backend_ready()
     return False
+
+
+def _backend_supports_extract(backend: str) -> bool:
+    """Return whether the named backend supports content extraction."""
+    return backend in {"exa", "parallel", "firecrawl", "tavily"}
 
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
 
@@ -189,6 +284,7 @@ def _web_requires_env() -> list[str]:
         "TAVILY_API_KEY",
         "FIRECRAWL_API_KEY",
         "FIRECRAWL_API_URL",
+        "MINIMAX_API_KEY",
     ]
     if managed_nous_tools_enabled():
         requires.extend(
@@ -1016,7 +1112,7 @@ def web_search_tool(query: str, limit: int = 5) -> str:
     Search the web for information using available search API backend.
 
     This function provides a generic interface for web search that can work
-    with multiple backends (Parallel or Firecrawl).
+    with multiple backends (Parallel, Firecrawl, Tavily, Exa, or MiniMax MCP).
 
     Note: This function returns search result metadata only (URLs, titles, descriptions).
     Use web_extract_tool to get full content from specific URLs.
@@ -1090,6 +1186,16 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                 "include_images": False,
             })
             response_data = _normalize_tavily_search_results(raw)
+            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
+            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+            debug_call_data["final_response_size"] = len(result_json)
+            _debug.log_call("web_search_tool", debug_call_data)
+            _debug.save()
+            return result_json
+
+        if backend == "minimax":
+            logger.info("MiniMax MCP search: '%s' (limit: %d)", query, limit)
+            response_data = _minimax_mcp_search(query, limit)
             debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
             result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
             debug_call_data["final_response_size"] = len(result_json)
@@ -1229,6 +1335,19 @@ async def web_extract_tool(
                     "include_images": False,
                 })
                 results = _normalize_tavily_documents(raw, fallback_url=safe_urls[0] if safe_urls else "")
+            elif backend == "minimax":
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": (
+                            "web_extract is not available when web.backend=minimax. "
+                            "MiniMax Token Plan MCP currently exposes web_search only. "
+                            "Switch web.backend to firecrawl, parallel, exa, or tavily for extraction, "
+                            "or use the browser tool for page access."
+                        ),
+                    },
+                    ensure_ascii=False,
+                )
             else:
                 # ── Firecrawl extraction ──
                 # Determine requested formats for Firecrawl v2
@@ -1884,9 +2003,17 @@ def check_firecrawl_api_key() -> bool:
 
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
-    configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in ("exa", "parallel", "firecrawl", "tavily"):
+    configured = (_load_web_config().get("backend") or "").lower().strip()
+    if configured in ("exa", "parallel", "firecrawl", "tavily", "minimax"):
         return _is_backend_available(configured)
+    return any(_is_backend_available(backend) for backend in ("exa", "parallel", "firecrawl", "tavily", "minimax"))
+
+
+def check_web_extract_backend() -> bool:
+    """Check whether the configured web backend supports extraction."""
+    configured = (_load_web_config().get("backend") or "").lower().strip()
+    if configured in ("exa", "parallel", "firecrawl", "tavily", "minimax"):
+        return _backend_supports_extract(configured) and _is_backend_available(configured)
     return any(_is_backend_available(backend) for backend in ("exa", "parallel", "firecrawl", "tavily"))
 
 
@@ -1925,6 +2052,8 @@ if __name__ == "__main__":
             print("   Using Parallel API (https://parallel.ai)")
         elif backend == "tavily":
             print("   Using Tavily API (https://tavily.com)")
+        elif backend == "minimax":
+            print("   Using MiniMax Token Plan MCP (search-only backend)")
         else:
             if firecrawl_url_available:
                 print(f"   Using self-hosted Firecrawl: {os.getenv('FIRECRAWL_API_URL').strip().rstrip('/')}")
@@ -2058,7 +2187,7 @@ registry.register(
     schema=WEB_EXTRACT_SCHEMA,
     handler=lambda args, **kw: web_extract_tool(
         args.get("urls", [])[:5] if isinstance(args.get("urls"), list) else [], "markdown"),
-    check_fn=check_web_api_key,
+    check_fn=check_web_extract_backend,
     requires_env=_web_requires_env(),
     is_async=True,
     emoji="📄",


### PR DESCRIPTION
## Summary
- add MiniMax Token Plan MCP as a native Hermes `web_search` backend
- add `hermes tools` setup support for MiniMax MCP-backed web search
- normalize MiniMax MCP search results into the Hermes web result schema
- make MiniMax explicitly search-only for native web tooling

## Scope
This PR intentionally supports only native `web_search`.

Not included in this PR:
- `web_extract`
- crawl support

Reason: the current MiniMax Token Plan MCP exposes `web_search` and `understand_image`, but not extract/crawl-style web tools.

## Behavior
When `web.backend: minimax` is configured:
- Hermes routes native `web_search` through `mcp_minimax_web_search`
- search results are normalized into the standard Hermes web schema
- `web_extract` is hidden as unavailable for this backend
- manual extract attempts return a clear search-only error

## Implementation
- `tools/web_tools.py`
  - add MiniMax backend detection and readiness checks
  - trigger MCP discovery on first use when needed
  - add MiniMax MCP search dispatch + normalization
  - gate extract support separately from search support
- `hermes_cli/tools_config.py`
  - add `MiniMax Token Plan MCP` to web provider setup
  - configure `web.backend: minimax`
  - configure `mcp_servers.minimax` post-setup
  - keep post-setup invocation backward-compatible for older 1-arg test stubs

## Test Plan
Passed locally:
- `./venv/bin/python -m pytest tests/tools/test_web_tools_minimax.py tests/hermes_cli/test_tools_config_minimax.py tests/tools/test_config_null_guard.py tests/tools/test_web_tools_tavily.py tests/tools/test_website_policy.py tests/tools/test_browser_secret_exfil.py tests/hermes_cli/test_tools_config.py -q`
- `./venv/bin/python -m compileall tools/web_tools.py hermes_cli/tools_config.py`
- `./venv/bin/python -m hermes_cli.main doctor`

## Notes for Reviewers
- this is a search-only MiniMax integration, not a drop-in replacement for Firecrawl/Tavily/Exa/Parallel extraction or crawl workflows
- setup only auto-whitelists `web_search` for this PR scope
- MiniMax MCP must be available/reloaded after setup for the native backend to work
