### PR TITLE
fix: use clean user_message for memory sync/prefetch (fixes #4889)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8644,10 +8644,11 @@ class AIAgent:
             self._iters_since_skill = 0
 
         # External memory provider: sync the completed turn + queue next prefetch
-        if self._memory_manager and final_response and user_message:
+        clean_msg = persist_user_message if persist_user_message is not None else user_message
+        if self._memory_manager and final_response and clean_msg:
             try:
-                self._memory_manager.sync_all(user_message, final_response)
-                self._memory_manager.queue_prefetch_all(user_message)
+                self._memory_manager.sync_all(clean_msg, final_response)
+                self._memory_manager.queue_prefetch_all(clean_msg)
             except Exception:
                 pass
 


### PR DESCRIPTION
## Problem

When a skill is triggered, `user_message` contains the full SKILL.md content injected by the skill system. This inflated message was being passed directly to the memory manager's `sync_all()` and `queue_prefetch_all()`, causing Honcho dialectic queries to fail because the query exceeds the 10K character limit.

## Root Cause

In `run_agent.py` (lines 8647-8650), the memory sync/prefetch code used the raw `user_message` parameter, which includes injected skill content when a skill is active. The codebase already has a pattern for getting the clean user message (`persist_user_message if persist_user_message is not None else user_message`) used at line 6493, but this pattern was not applied to the memory manager calls.

## Fix

Use `persist_user_message` (the clean, original user input) for memory sync and prefetch, falling back to `user_message` when `persist_user_message` is `None`. This follows the existing `original_user_message` pattern already established in the same method.

```python
# Before
if self._memory_manager and final_response and user_message:
    try:
        self._memory_manager.sync_all(user_message, final_response)
        self._memory_manager.queue_prefetch_all(user_message)

# After
clean_msg = persist_user_message if persist_user_message is not None else user_message
if self._memory_manager and final_response and clean_msg:
    try:
        self._memory_manager.sync_all(clean_msg, final_response)
        self._memory_manager.queue_prefetch_all(clean_msg)
```

## Testing

All existing tests pass (7700 passed, 9 pre-existing failures unrelated to this change).

Fixes #4889