### PR TITLE
feat(cli): add busy_input_toggle_key to flip interrupt/queue mode at runtime

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -722,6 +722,13 @@ display:
   # Ctrl+C always interrupts regardless of this setting.
   busy_input_mode: interrupt
 
+  # Keybinding to toggle between interrupt and queue mode at runtime (CLI only).
+  # When pressed while Hermes is running, flips busy_input_mode between
+  # "interrupt" and "queue" without restarting the session.
+  # Accepts prompt_toolkit key names: "c-t" (Ctrl+T), "f2", "c-q", etc.
+  # Leave unset (or null) to disable the toggle hotkey entirely.
+  # busy_input_toggle_key: c-t
+
   # Background process notifications (gateway/messaging only).
   # Controls how chatty the process watcher is when you use
   # terminal(background=true, check_interval=...) from Telegram/Discord/etc.

--- a/cli.py
+++ b/cli.py
@@ -1147,6 +1147,9 @@ class HermesCLI:
         # busy_input_mode: "interrupt" (Enter interrupts current run) or "queue" (Enter queues for next turn)
         _bim = CLI_CONFIG["display"].get("busy_input_mode", "interrupt")
         self.busy_input_mode = "queue" if str(_bim).strip().lower() == "queue" else "interrupt"
+        # busy_input_toggle_key: optional keybinding (e.g. "c-t") to flip busy_input_mode at runtime
+        _toggle_key = CLI_CONFIG["display"].get("busy_input_toggle_key", None)
+        self.busy_input_toggle_key: Optional[str] = str(_toggle_key).strip() if _toggle_key else None
 
         self.verbose = verbose if verbose is not None else (self.tool_progress_mode == "verbose")
         
@@ -1533,10 +1536,14 @@ class HermesCLI:
                 width = shutil.get_terminal_size((80, 24)).columns
             duration_label = snapshot["duration"]
 
+            queue_mode = getattr(self, "busy_input_mode", "interrupt") == "queue"
+            queue_frags = [("class:status-bar-dim", " [Q]")] if queue_mode else []
+
             if width < 52:
                 frags = [
                     ("class:status-bar", " ⚕ "),
                     ("class:status-bar-strong", snapshot["model_short"]),
+                    *queue_frags,
                     ("class:status-bar-dim", " · "),
                     ("class:status-bar-dim", duration_label),
                     ("class:status-bar", " "),
@@ -1548,6 +1555,7 @@ class HermesCLI:
                     frags = [
                         ("class:status-bar", " ⚕ "),
                         ("class:status-bar-strong", snapshot["model_short"]),
+                        *queue_frags,
                         ("class:status-bar-dim", " · "),
                         (self._status_bar_context_style(percent), percent_label),
                         ("class:status-bar-dim", " · "),
@@ -1566,6 +1574,7 @@ class HermesCLI:
                     frags = [
                         ("class:status-bar", " ⚕ "),
                         ("class:status-bar-strong", snapshot["model_short"]),
+                        *queue_frags,
                         ("class:status-bar-dim", " │ "),
                         ("class:status-bar-dim", context_label),
                         ("class:status-bar-dim", " │ "),
@@ -7545,6 +7554,19 @@ class HermesCLI:
             ),
             filter=Condition(lambda: cli_ref._status_bar_visible),
         )
+
+        # --- busy_input_toggle_key: flip interrupt/queue mode at runtime ---
+        if cli_ref.busy_input_toggle_key:
+            @kb.add(cli_ref.busy_input_toggle_key)
+            def handle_busy_input_toggle(event):
+                """Toggle busy_input_mode between 'interrupt' and 'queue'."""
+                if cli_ref.busy_input_mode == "interrupt":
+                    cli_ref.busy_input_mode = "queue"
+                    _cprint(f"  {_DIM}Input mode: queue — Enter will queue messages for the next turn{_RST}")
+                else:
+                    cli_ref.busy_input_mode = "interrupt"
+                    _cprint(f"  {_DIM}Input mode: interrupt — Enter will interrupt the running agent{_RST}")
+                event.app.invalidate()
 
         # Allow wrapper CLIs to register extra keybindings.
         self._register_extra_tui_keybindings(kb, input_area=input_area)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -358,6 +358,7 @@ DEFAULT_CONFIG = {
         "personality": "kawaii",
         "resume_display": "full",
         "busy_input_mode": "interrupt",
+        "busy_input_toggle_key": None,  # e.g. "c-t" or "f2" — toggles interrupt/queue mode at runtime
         "bell_on_complete": False,
         "show_reasoning": False,
         "streaming": False,


### PR DESCRIPTION
## Summary

Adds `display.busy_input_toggle_key` — a configurable keybinding that toggles `busy_input_mode` between `interrupt` and `queue` at runtime, without restarting the session.

Motivated by the UX friction of having to choose one mode statically via config. Users often want `interrupt` as the default but occasionally want to queue a follow-up thought while the agent is mid-task — without prepending `/queue` every time.

## Changes

- **`hermes_cli/config.py`** — adds `busy_input_toggle_key: None` to `DEFAULT_CONFIG["display"]`. Default is `null` so no behavior change for existing users.
- **`cli.py`** — reads the key at startup; registers a `kb.add()` handler (only when a key is configured) that flips `self.busy_input_mode` and prints a brief inline status message; adds a dim `[Q]` indicator to all three status bar width variants when queue mode is active.
- **`cli-config.yaml.example`** — documents the new option alongside `busy_input_mode`.

## Usage

```yaml
# ~/.hermes/config.yaml
display:
  busy_input_toggle_key: c-t   # Ctrl+T toggles interrupt/queue
```

Pressing the key at any time prints:
```
  Input mode: queue — Enter will queue messages for the next turn
```
or
```
  Input mode: interrupt — Enter will interrupt the running agent
```

The status bar shows `[Q]` next to the model name whenever queue mode is active.

Accepts any prompt_toolkit key name: `c-t`, `f2`, `c-q`, etc.

## Notes

- Ctrl+C always interrupts regardless of this setting (unchanged)
- `/queue <message>` still works as a one-off escape hatch
- The toggle works both while the agent is running and while idle
- No tests added — behavior is a thin wrapper around the existing `busy_input_mode` branch in `handle_enter`