### PR TITLE
Add podcast-intel skill to media optional-skills

### DIFF
--- a/optional-skills/creative/photo-alchemy/SKILL.md
+++ b/optional-skills/creative/photo-alchemy/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: photo-alchemy
+description: Transform any photo into surrealist AI art. Uses Claude to write a story about your photo, then Gemini generates a reimagined version in one of 35+ visual styles. Deep Apple Photos integration — pick from albums, save back, schedule as an Apple TV screensaver.
+version: 1.0.0
+author: hbmartin
+license: Apache-2.0
+metadata:
+  hermes:
+    tags: [AI, Images, Claude, Gemini, Apple-Photos, Creative, macOS]
+    homepage: https://github.com/hbmartin/imagemine
+---
+
+# photo-alchemy
+
+Transform any photo into surrealist AI art via a two-step pipeline:
+1. Claude writes a surrealist story + image prompt about your photo
+2. Gemini generates a brand-new image from that description in a random visual style
+
+Built by Harold Martin. Installable via uvx — no setup required beyond API keys.
+
+## Prerequisites
+
+- Python 3.14+
+- Anthropic API key (`ANTHROPIC_API_KEY`)
+- Google Gemini API key (`GEMINI_API_KEY`)
+
+## Installation
+
+### One-off (no install)
+```bash
+uvx imagemine path/to/photo.jpg
+```
+
+### Permanent install
+```bash
+curl -LsSf uvx.sh/imagemine/install.sh | sh
+```
+
+## API Key Setup
+
+Keys are resolved in order: SQLite DB → env vars → interactive prompt (saved to DB on first entry).
+
+```bash
+# Via environment
+export ANTHROPIC_API_KEY=***
+export GEMINI_API_KEY=***
+
+# Or via interactive config wizard (saves to ~/.imagemine.db)
+imagemine --config
+```
+
+## Basic Usage
+
+```bash
+# Transform a single photo
+imagemine photo.jpg
+
+# Pick a random photo from a macOS Photos album
+imagemine --input-album "Camera Roll"
+
+# Save output to a specific directory
+imagemine photo.jpg --output-dir ~/Desktop/output
+
+# Use a specific visual style instead of random
+imagemine photo.jpg --style "Ukiyo-e woodblock print, bold outlines, flat color"
+
+# Tune creativity (default 1.0 for both)
+imagemine photo.jpg --desc-temp 1.5 --img-temp 0.8
+
+# Pick style interactively from a numbered table
+imagemine photo.jpg --choose-style
+
+# Blend multiple styles (enter comma-separated numbers)
+imagemine photo.jpg --choose-style  # then enter: 1,5,12
+
+# JSON output (for scripting)
+imagemine photo.jpg --json
+
+# Show recent run history with timing sparklines
+imagemine --history
+```
+
+## Visual Styles
+
+35+ built-in styles including: Watercolor, 8-Bit Pixel Art, Ukiyo-e Woodblock, Neon Noir,
+Tarot Card, Vaporwave, Glitch Art, Renaissance Painting, and more.
+
+```bash
+imagemine --list-styles          # show all styles with usage count
+imagemine --add-style            # add a custom style interactively
+imagemine --remove-style         # remove styles interactively
+```
+
+## Apple Photos Integration
+
+imagemine reads face-detection names from Photos albums and uses them in prompts.
+Use character mappings to rename people before they reach the AI (e.g. "John" → "Captain America").
+
+```bash
+# Pick input from album, save generated image back to another album
+imagemine --input-album "Camera Roll" --destination-album "AI Art"
+
+# Manage character name mappings
+imagemine --add-character-mapping
+imagemine --list-character-mappings
+imagemine --remove-character-mapping
+```
+
+## Apple TV Screensaver (killer feature)
+
+Run photo-alchemy on a schedule to continuously generate new art into a shared Photos album,
+then set that album as your Apple TV screensaver for a living, ever-changing art display.
+
+### Setup
+
+1. Create two macOS Photos albums: one for source photos, one for output (make output a Shared Album so Apple TV can see it)
+2. Configure albums:
+```bash
+imagemine --config
+# Set INPUT_ALBUM and DESTINATION_ALBUM
+```
+
+3. Schedule via launchd (runs every N minutes):
+```bash
+imagemine --launchd 30
+# Writes ~/Library/LaunchAgents/imagemine.plist and prints the launchctl command
+launchctl load ~/Library/LaunchAgents/imagemine.plist
+```
+
+4. On Apple TV: Photos app → Shared Albums → select your output album → Set as Screen Saver
+
+### Apple TV Pitfalls
+- Output album must be a **Shared Album** for Apple TV to see it
+- New images appear in the screensaver automatically once added to the shared album
+- Use `--config-path` if you want a non-default DB location with launchd
+
+## Configuration Reference
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `ANTHROPIC_API_KEY` | — | Claude API key |
+| `GEMINI_API_KEY` | — | Gemini API key |
+| `CLAUDE_MODEL` | `claude-sonnet-4-6` | Claude model for story/prompt generation |
+| `GEMINI_MODEL` | `gemini-3-pro-image-preview` | Gemini model for image generation |
+| `DEFAULT_DESC_TEMP` | `1.0` | Claude sampling temperature |
+| `DEFAULT_IMG_TEMP` | `1.0` | Gemini sampling temperature |
+| `INPUT_ALBUM` | — | macOS Photos album to pick input from |
+| `DESTINATION_ALBUM` | — | macOS Photos album to save output to |
+| `ASPECT_RATIO` | `4:3` | Output image aspect ratio (1:1, 3:4, 4:3, 9:16, 16:9) |
+
+## Pipeline Steps (what happens under the hood)
+
+1. Resize input to max 1024px (preserving aspect ratio), save to disk
+2. Send resized image to Claude via Files API → generates surrealist story + image prompt
+3. Pick a random visual style from the style library (or use `--style`)
+4. Pass story + style + resized image to Gemini → generates the new image
+5. Save run metadata to `~/.imagemine.db` (SQLite)
+6. Optionally import generated image into a macOS Photos album
+
+## Run History & Database
+
+Every run is recorded in `~/.imagemine.db` with input path, generated story, style used,
+model names, per-step timing (ms), and output path.
+
+```bash
+imagemine --history              # show recent runs with timing sparklines
+imagemine --config-path ~/custom.db  # use a different DB location
+```
+
+## Notes
+
+- A new Claude description is generated on every run — no caching of stories
+- `--fresh` picks from least-used styles (good for variety over time)
+- `--session-svg` saves a styled SVG of the terminal session alongside the output image
+- macOS only for Photos/launchd features; core image generation works on any platform

--- a/optional-skills/media/podcast-intel/SKILL.md
+++ b/optional-skills/media/podcast-intel/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: podcast-intel
+description: Turn your Overcast listening history into actionable intelligence. Syncs episodes, transcripts, and chapters to SQLite, then uses LLM analysis to surface insights from what you've listened to and connect them to your current projects and interests. Depth of analysis is caller-configured.
+version: 1.0.0
+author: hbmartin
+license: Apache-2.0
+metadata:
+  hermes:
+    tags: [Podcasts, Overcast, SQLite, Transcripts, Intelligence, RSS]
+    homepage: https://github.com/hbmartin/overcast-to-sqlite
+prerequisites:
+  commands: [uvx, uv]
+---
+
+# podcast-intel
+
+Turns your Overcast listening history into a structured knowledge base, then surfaces insights
+from recent episodes and connects them to your current work and interests.
+
+Built on three tools by Harold Martin:
+- overcast-to-sqlite  — https://github.com/hbmartin/overcast-to-sqlite
+- podcast-transcript-convert — https://github.com/hbmartin/podcast-transcript-convert
+- podcast-chapter-tools — https://github.com/hbmartin/podcast-chapter-tools
+
+---
+
+## One-Time Setup
+
+### 1. Install the tools
+
+```bash
+uv tool install overcast-to-sqlite
+uv tool install podcast-transcript-convert
+```
+
+### 2. Authenticate with Overcast
+
+```bash
+overcast-to-sqlite auth
+# Logs into Overcast and saves an auth cookie to ./auth.json
+# Your password is NOT saved — only the session cookie
+```
+
+Store auth.json somewhere stable, e.g. ~/.overcast/auth.json:
+```bash
+mkdir -p ~/.overcast
+mv auth.json ~/.overcast/auth.json
+```
+
+### 3. Run the first full sync (takes a while the first time)
+
+```bash
+overcast-to-sqlite all -a ~/.overcast/auth.json ~/.overcast/overcast.db -v
+```
+
+This runs save → extend → transcripts → chapters sequentially.
+First run downloads XML for every subscribed feed — may take several minutes.
+Transcripts are saved to ~/.overcast/archive/transcripts/ by default.
+
+---
+
+## Daily Sync
+
+Run this to pull in the latest listening activity:
+
+```bash
+overcast-to-sqlite all -a ~/.overcast/auth.json ~/.overcast/overcast.db
+```
+
+Or for a faster update (skips feed XML re-download):
+```bash
+overcast-to-sqlite save -a ~/.overcast/auth.json ~/.overcast/overcast.db
+overcast-to-sqlite transcripts -a ~/.overcast/auth.json ~/.overcast/overcast.db
+```
+
+To fetch transcripts for starred episodes only:
+```bash
+overcast-to-sqlite transcripts -s -a ~/.overcast/auth.json ~/.overcast/overcast.db
+```
+
+> Suggested cron schedule: run `overcast-to-sqlite all` once daily, e.g. at 4am before
+> any morning digest jobs that depend on it. Use launchd on macOS or cron on Linux.
+
+---
+
+## Querying Recent Listening
+
+Use these SQL queries against ~/.overcast/overcast.db:
+
+### Episodes played or significantly progressed in the last 24 hours
+```sql
+SELECT
+  e.title,
+  f.title AS podcast,
+  e.overcastUrl,
+  e.userRecommendedDate,
+  e.transcriptDownloadPath,
+  e.progress,
+  e.played
+FROM episodes e
+JOIN feeds f ON e.feedId = f.overcastId
+WHERE (e.played = 1 OR e.progress > 300)
+  AND e.userUpdatedDate >= datetime('now', '-1 day')
+ORDER BY
+  e.userRecommendedDate DESC,
+  e.userUpdatedDate DESC;
+```
+
+### Starred episodes with transcripts available
+```sql
+SELECT
+  e.title,
+  f.title AS podcast,
+  e.overcastUrl,
+  e.userRecommendedDate,
+  e.transcriptDownloadPath
+FROM episodes_starred e
+JOIN feeds f ON e.feedId = f.overcastId
+WHERE e.transcriptDownloadPath IS NOT NULL
+ORDER BY e.userRecommendedDate DESC
+LIMIT 20;
+```
+
+### Full-text search across chapter content
+```sql
+SELECT c.content, e.title, f.title AS podcast, c.time
+FROM chapters_fts
+JOIN chapters c ON chapters_fts.rowid = c.rowid
+JOIN episodes e ON c.enclosureUrl = e.enclosureUrl
+JOIN feeds f ON e.feedId = f.overcastId
+WHERE chapters_fts MATCH 'your search term'
+ORDER BY rank;
+```
+
+---
+
+## Processing Transcripts
+
+Transcripts are stored in mixed formats (SRT, WebVTT, HTML, JSON).
+Use podcast-transcript-convert to normalize them to PodcastIndex JSON:
+
+```bash
+transcript2json ~/.overcast/archive/transcripts/ ~/.overcast/archive/transcripts-json/
+```
+
+To read a transcript as plain text for LLM analysis, parse the JSON:
+
+```bash
+python3 -c "
+import json, sys
+data = json.load(open(sys.argv[1]))
+for seg in data.get('segments', []):
+    print(seg.get('speaker', ''), seg.get('body', ''))
+" ~/.overcast/archive/transcripts-json/episode.json
+```
+
+---
+
+## LLM Analysis Workflow
+
+When asked to analyze recent listening, follow this process:
+
+### Step 1 — Query the DB for recent episodes
+Run the last-24h query above using the terminal tool against ~/.overcast/overcast.db.
+
+### Step 2 — Separate starred from non-starred
+Episodes with a non-null userRecommendedDate are starred. Give these deeper treatment.
+
+### Step 3 — Load and analyze transcripts
+For each episode with a transcriptDownloadPath:
+1. Read the transcript file (convert if needed using transcript2json)
+2. Extract key concepts, claims, techniques, and names mentioned
+3. Note timestamps/chapters where important ideas appear
+
+For episodes without transcripts, use the episode description from episodes_extended.description.
+
+### Step 4 — Cross-reference with user interests
+Ask the user what they are currently working on and interested in, or read from context.
+For each episode, identify:
+- Direct connections to current projects or problems the user is solving
+- Techniques or frameworks mentioned that could be applied
+- People, papers, or tools referenced worth following up on
+- Contrarian or surprising takes worth sitting with
+
+### Step 5 — Format the output
+Depth is determined by the user when invoking the skill. Default structure:
+
+**[Starred] Episode Title — Podcast Name**
+Summary: 2-3 sentence overview of what was covered
+Key insight: The most actionable or interesting idea
+Connections: How this relates to what the user is working on
+Follow-up: Papers, people, tools, or questions worth pursuing
+
+**[Played] Episode Title — Podcast Name**
+One-line summary + any standout idea worth surfacing
+
+---
+
+## Listening Stats
+
+```bash
+overcast-to-sqlite stats ~/.overcast/overcast.db
+```
+
+Shows: total episodes played, total listening time, starred count, top podcasts by time.
+
+---
+
+## Searching Your History
+
+```bash
+overcast-to-sqlite search "reinforcement learning" ~/.overcast/overcast.db
+overcast-to-sqlite search "agentic" ~/.overcast/overcast.db -l 5
+```
+
+Searches across episode titles, feed descriptions, and chapter content (FTS5).
+
+---
+
+## Database Location
+
+Default: ~/.overcast/overcast.db
+Default transcript archive: ~/.overcast/archive/transcripts/
+Default auth: ~/.overcast/auth.json
+
+Override any path via CLI flags. See overcast-to-sqlite --help for full options.
+
+---
+
+## Notes
+
+- Transcripts are only available for episodes where the podcast publisher provides them
+  via the podcast:transcript RSS tag. Not all episodes have transcripts.
+- The extend command adds ~2MB per feed to the DB — expect a large file with many subscriptions
+- auth.json contains only a session cookie, not your password. Rotate it via overcast-to-sqlite auth
+- For starred-only transcript downloads use the -s flag on the transcripts command
+- Chapter FTS5 search is a powerful way to find where a specific topic was discussed across
+  your entire listening history without reading full transcripts


### PR DESCRIPTION
## podcast-intel

Turns Overcast podcast listening history into a structured knowledge base with LLM-powered insight extraction.

**What it does:**
- Full setup guide for overcast-to-sqlite (auth, first sync, daily sync)
- SQL queries for last-24h played episodes and starred episodes
- Transcript processing via podcast-transcript-convert (normalizes SRT/WebVTT/HTML → JSON)
- LLM analysis workflow: extract insights → cross-reference user interests → configurable depth
- FTS5 chapter search across entire listening history
- Cron-ready — suggests scheduling but leaves implementation to the user

**Source tools:** https://github.com/hbmartin/overcast-to-sqlite  
**Author:** Harold Martin (@hbmartin)  
**Already published:** clawhub.ai/skills/hbmartin-podcast-intel