### PR TITLE
feat(tts): add shared provider registry seam

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1174,16 +1174,14 @@ class BasePlatformAdapter(ABC):
                         and not media_files
                         and event.source.chat_id not in self._auto_tts_disabled_chats):
                     try:
-                        from tools.tts_tool import text_to_speech_tool, check_tts_requirements
-                        if check_tts_requirements():
-                            import json as _json
-                            speech_text = re.sub(r'[*_`#\[\]()]', '', text_content)[:4000].strip()
+                        from tools.tts_tool import generate_tts_result, resolve_tts_provider, _strip_markdown_for_tts
+                        if resolve_tts_provider().available:
+                            speech_text = _strip_markdown_for_tts(text_content[:4000]).strip()
                             if not speech_text:
                                 raise ValueError("Empty text after markdown cleanup")
-                            tts_result_str = await asyncio.to_thread(
-                                text_to_speech_tool, text=speech_text
+                            tts_data = await asyncio.to_thread(
+                                generate_tts_result, text=speech_text
                             )
-                            tts_data = _json.loads(tts_result_str)
                             _tts_path = tts_data.get("file_path")
                     except Exception as tts_err:
                         logger.warning("[%s] Auto-TTS failed: %s", self.name, tts_err)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3737,24 +3737,23 @@ class GatewayRunner:
         audio_path = None
         actual_path = None
         try:
-            from tools.tts_tool import text_to_speech_tool, _strip_markdown_for_tts
+            from tools.tts_tool import generate_tts_result, _strip_markdown_for_tts
 
             tts_text = _strip_markdown_for_tts(text[:4000])
             if not tts_text:
                 return
 
             # Use .mp3 extension so edge-tts conversion to opus works correctly.
-            # The TTS tool may convert to .ogg — use file_path from result.
+            # The shared TTS seam may convert to .ogg — use file_path from result.
             audio_path = os.path.join(
                 tempfile.gettempdir(), "hermes_voice",
                 f"tts_reply_{_uuid.uuid4().hex[:12]}.mp3",
             )
             os.makedirs(os.path.dirname(audio_path), exist_ok=True)
 
-            result_json = await asyncio.to_thread(
-                text_to_speech_tool, text=tts_text, output_path=audio_path
+            result = await asyncio.to_thread(
+                generate_tts_result, text=tts_text, output_path=audio_path
             )
-            result = json.loads(result_json)
 
             # Use the actual file path from result (may differ after opus conversion)
             actual_path = result.get("file_path", audio_path)

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -7,6 +7,7 @@ import queue
 import sys
 import threading
 import time
+from pathlib import Path
 import pytest
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -352,9 +353,9 @@ class TestSendVoiceReply:
         event = _make_event()
         runner.adapters[event.source.platform] = mock_adapter
 
-        tts_result = json.dumps({"success": True, "file_path": "/tmp/test.ogg"})
+        tts_result = {"success": True, "file_path": "/tmp/test.ogg"}
 
-        with patch("tools.tts_tool.text_to_speech_tool", return_value=tts_result), \
+        with patch("tools.tts_tool.generate_tts_result", return_value=tts_result), \
              patch("tools.tts_tool._strip_markdown_for_tts", side_effect=lambda t: t), \
              patch("os.path.isfile", return_value=True), \
              patch("os.unlink"), \
@@ -366,10 +367,39 @@ class TestSendVoiceReply:
         assert call_args.kwargs.get("chat_id") == "123"
 
     @pytest.mark.asyncio
+    async def test_uses_shared_generate_tts_result_and_cleans_requested_and_actual_paths(self, runner, tmp_path):
+        mock_adapter = AsyncMock()
+        mock_adapter.send_voice = AsyncMock()
+        event = _make_event()
+        runner.adapters[event.source.platform] = mock_adapter
+
+        actual_path = tmp_path / "hermes_voice" / "actual.ogg"
+        actual_path.parent.mkdir(parents=True, exist_ok=True)
+        actual_path.write_bytes(b"voice")
+
+        with patch("tools.tts_tool.generate_tts_result", return_value={
+            "success": True,
+            "file_path": str(actual_path),
+        }) as mock_generate, \
+             patch("tools.tts_tool._strip_markdown_for_tts", side_effect=lambda t: t), \
+             patch("tempfile.gettempdir", return_value=str(tmp_path)), \
+             patch("os.path.isfile", return_value=True), \
+             patch("os.makedirs"):
+            await runner._send_voice_reply(event, "Hello world")
+
+        mock_generate.assert_called_once()
+        requested_path = Path(mock_generate.call_args.kwargs["output_path"])
+        assert requested_path.parent == tmp_path / "hermes_voice"
+        assert requested_path.suffix == ".mp3"
+        mock_adapter.send_voice.assert_called_once()
+        assert mock_adapter.send_voice.call_args.kwargs["audio_path"] == str(actual_path)
+        assert not actual_path.exists()
+
+    @pytest.mark.asyncio
     async def test_empty_text_after_strip_skips(self, runner):
         event = _make_event()
 
-        with patch("tools.tts_tool.text_to_speech_tool") as mock_tts, \
+        with patch("tools.tts_tool.generate_tts_result") as mock_tts, \
              patch("tools.tts_tool._strip_markdown_for_tts", return_value=""):
             await runner._send_voice_reply(event, "```code only```")
 
@@ -380,9 +410,9 @@ class TestSendVoiceReply:
         event = _make_event()
         mock_adapter = AsyncMock()
         runner.adapters[event.source.platform] = mock_adapter
-        tts_result = json.dumps({"success": False, "error": "API error"})
+        tts_result = {"success": False, "error": "API error"}
 
-        with patch("tools.tts_tool.text_to_speech_tool", return_value=tts_result), \
+        with patch("tools.tts_tool.generate_tts_result", return_value=tts_result), \
              patch("tools.tts_tool._strip_markdown_for_tts", side_effect=lambda t: t), \
              patch("os.path.isfile", return_value=False), \
              patch("os.makedirs"):
@@ -393,7 +423,7 @@ class TestSendVoiceReply:
     @pytest.mark.asyncio
     async def test_exception_caught(self, runner):
         event = _make_event()
-        with patch("tools.tts_tool.text_to_speech_tool", side_effect=RuntimeError("boom")), \
+        with patch("tools.tts_tool.generate_tts_result", side_effect=RuntimeError("boom")), \
              patch("tools.tts_tool._strip_markdown_for_tts", side_effect=lambda t: t), \
              patch("os.makedirs"):
             # Should not raise
@@ -1884,10 +1914,10 @@ class TestSendVoiceReplyCleanup:
         audio_file = fake_audio / "test.mp3"
         audio_file.write_bytes(b"fake audio")
 
-        tts_result = json.dumps({
+        tts_result = {
             "success": True,
             "file_path": str(audio_file),
-        })
+        }
 
         with patch("gateway.run.asyncio.to_thread", new_callable=AsyncMock, return_value=tts_result), \
              patch("tools.tts_tool._strip_markdown_for_tts", return_value="hello"), \

--- a/tests/tools/test_tts_registry.py
+++ b/tests/tools/test_tts_registry.py
@@ -1,0 +1,112 @@
+"""Tests for the shared TTS provider registry / provider-resolution seam."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+
+def test_resolve_tts_provider_uses_configured_provider_when_available():
+    from tools.tts_tool import resolve_tts_provider
+
+    with patch("tools.tts_tool._load_tts_config", return_value={"provider": "openai"}), \
+         patch("tools.tts_tool._import_openai_client", return_value=object()), \
+         patch("tools.tts_tool._resolve_openai_audio_client_config", return_value=("key", "https://api.openai.com/v1")):
+        resolved = resolve_tts_provider()
+
+    assert resolved.requested_provider == "openai"
+    assert resolved.provider == "openai"
+    assert resolved.available is True
+    assert resolved.supports_native_opus is True
+
+
+def test_resolve_tts_provider_falls_back_from_edge_to_neutts_when_needed():
+    from tools.tts_tool import resolve_tts_provider
+
+    with patch("tools.tts_tool._load_tts_config", return_value={"provider": "edge"}), \
+         patch("tools.tts_tool._import_edge_tts", side_effect=ImportError), \
+         patch("tools.tts_tool._check_neutts_available", return_value=True):
+        resolved = resolve_tts_provider()
+
+    assert resolved.requested_provider == "edge"
+    assert resolved.provider == "neutts"
+    assert resolved.available is True
+
+
+def test_generate_tts_result_uses_registered_provider_and_returns_actual_path(tmp_path):
+    from tools.tts_tool import generate_tts_result
+
+    requested_path = tmp_path / "requested.mp3"
+    actual_path = tmp_path / "generated.ogg"
+
+    def _fake_generate(text: str, output_path: str, tts_config: dict) -> str:
+        Path(actual_path).write_bytes(b"audio")
+        return str(actual_path)
+
+    with patch("tools.tts_tool._load_tts_config", return_value={"provider": "openai"}), \
+         patch("tools.tts_tool.resolve_tts_provider") as mock_resolve:
+        from tools.tts_tool import ResolvedTTSProvider
+        from tools.tts_registry import RegisteredTTSProvider
+
+        mock_resolve.return_value = ResolvedTTSProvider(
+            requested_provider="openai",
+            provider="openai",
+            provider_entry=RegisteredTTSProvider(
+                synthesize=_fake_generate,
+                is_available=lambda _cfg: True,
+                supports_native_opus=True,
+            ),
+            available=True,
+            error=None,
+            supports_native_opus=True,
+            tts_config={"provider": "openai"},
+        )
+
+        result = generate_tts_result("Hello world", output_path=str(requested_path))
+
+    assert result["success"] is True
+    assert result["provider"] == "openai"
+    assert result["file_path"] == str(actual_path)
+    assert result["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{actual_path}"
+    assert result["voice_compatible"] is True
+
+
+def test_check_tts_requirements_uses_registry_availability_checks():
+    from tools.tts_tool import check_tts_requirements
+
+    with patch("tools.tts_tool._load_tts_config", return_value={"provider": "edge"}), \
+         patch("tools.tts_tool.iter_tts_providers") as mock_iter:
+        from tools.tts_registry import RegisteredTTSProvider
+
+        mock_iter.return_value = iter([
+            ("edge", RegisteredTTSProvider(synthesize=lambda *_args, **_kwargs: "", is_available=lambda _cfg: False)),
+            ("openai", RegisteredTTSProvider(synthesize=lambda *_args, **_kwargs: "", is_available=lambda _cfg: True, supports_native_opus=True)),
+        ])
+
+        assert check_tts_requirements() is True
+
+
+def test_custom_provider_override_survives_resolution(monkeypatch, tmp_path):
+    import tools.tts_registry as tts_registry
+    import tools.tts_tool as tts_tool
+
+    monkeypatch.setattr(tts_registry, "_TTS_PROVIDERS", {})
+    monkeypatch.setattr(tts_tool, "_BUILTIN_TTS_PROVIDERS_REGISTERED", False)
+
+    def _custom_edge(text: str, output_path: str, tts_config: dict) -> str:
+        Path(output_path).write_bytes(b"edge")
+        return output_path
+
+    tts_registry.register_tts_provider(
+        "edge",
+        _custom_edge,
+        is_available=lambda _cfg: True,
+        override=True,
+    )
+
+    resolved = tts_tool.resolve_tts_provider({"provider": "edge"})
+    assert resolved.provider_entry is not None
+    assert resolved.provider_entry.synthesize is _custom_edge
+
+    result = tts_tool.generate_tts_result("hello", output_path=str(tmp_path / "out.mp3"), tts_config={"provider": "edge"})
+    assert result["success"] is True
+    assert os.path.exists(result["file_path"])

--- a/tools/tts_registry.py
+++ b/tools/tts_registry.py
@@ -1,0 +1,47 @@
+"""Shared TTS provider registry used by tool and gateway voice paths."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterator, Tuple
+
+SynthesizeFn = Callable[[str, str, Dict[str, Any]], str]
+AvailabilityFn = Callable[[Dict[str, Any]], bool]
+
+
+@dataclass(frozen=True)
+class RegisteredTTSProvider:
+    synthesize: SynthesizeFn
+    is_available: AvailabilityFn
+    supports_native_opus: bool = False
+
+
+_TTS_PROVIDERS: Dict[str, RegisteredTTSProvider] = {}
+
+
+def register_tts_provider(
+    name: str,
+    synthesize: SynthesizeFn,
+    *,
+    is_available: AvailabilityFn,
+    supports_native_opus: bool = False,
+    override: bool = False,
+) -> None:
+    key = (name or "").strip().lower()
+    if not key:
+        raise ValueError("TTS provider name is required")
+    if key in _TTS_PROVIDERS and not override:
+        raise ValueError(f"TTS provider already registered: {key}")
+    _TTS_PROVIDERS[key] = RegisteredTTSProvider(
+        synthesize=synthesize,
+        is_available=is_available,
+        supports_native_opus=supports_native_opus,
+    )
+
+
+def get_tts_provider(name: str) -> RegisteredTTSProvider | None:
+    return _TTS_PROVIDERS.get((name or "").strip().lower())
+
+
+def iter_tts_providers() -> Iterator[Tuple[str, RegisteredTTSProvider]]:
+    return iter(_TTS_PROVIDERS.items())

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -34,6 +34,7 @@ import subprocess
 import tempfile
 import threading
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Dict, Any, Optional
 from urllib.parse import urljoin
@@ -41,6 +42,7 @@ from urllib.parse import urljoin
 logger = logging.getLogger(__name__)
 from tools.managed_tool_gateway import resolve_managed_tool_gateway
 from tools.tool_backend_helpers import managed_nous_tools_enabled, resolve_openai_audio_api_key
+from tools.tts_registry import RegisteredTTSProvider, get_tts_provider, iter_tts_providers, register_tts_provider
 
 # ---------------------------------------------------------------------------
 # Lazy imports -- providers are imported only when actually used to avoid
@@ -116,6 +118,17 @@ def _load_tts_config() -> Dict[str, Any]:
 def _get_provider(tts_config: Dict[str, Any]) -> str:
     """Get the configured TTS provider name."""
     return (tts_config.get("provider") or DEFAULT_PROVIDER).lower().strip()
+
+
+@dataclass(frozen=True)
+class ResolvedTTSProvider:
+    requested_provider: str
+    provider: str
+    provider_entry: Optional[RegisteredTTSProvider]
+    available: bool
+    error: Optional[str]
+    supports_native_opus: bool
+    tts_config: Dict[str, Any]
 
 
 # ===========================================================================
@@ -441,6 +454,232 @@ def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) ->
     return output_path
 
 
+def _generate_edge_tts_sync(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    logger.info("Generating speech with Edge TTS...")
+    try:
+        asyncio.get_running_loop()
+        import concurrent.futures
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            pool.submit(
+                lambda: asyncio.run(_generate_edge_tts(text, output_path, tts_config))
+            ).result(timeout=60)
+    except RuntimeError:
+        asyncio.run(_generate_edge_tts(text, output_path, tts_config))
+    return output_path
+
+
+def _is_edge_available(_tts_config: Dict[str, Any]) -> bool:
+    try:
+        _import_edge_tts()
+        return True
+    except ImportError:
+        return False
+
+
+def _is_elevenlabs_available(_tts_config: Dict[str, Any]) -> bool:
+    try:
+        _import_elevenlabs()
+        return bool(os.getenv("ELEVENLABS_API_KEY"))
+    except ImportError:
+        return False
+
+
+def _is_openai_available(_tts_config: Dict[str, Any]) -> bool:
+    try:
+        _import_openai_client()
+        _resolve_openai_audio_client_config()
+        return True
+    except Exception:
+        return False
+
+
+def _is_minimax_available(_tts_config: Dict[str, Any]) -> bool:
+    return bool(os.getenv("MINIMAX_API_KEY"))
+
+
+def _is_neutts_available(_tts_config: Dict[str, Any]) -> bool:
+    return _check_neutts_available()
+
+
+_BUILTIN_TTS_PROVIDERS_REGISTERED = False
+
+
+def _register_builtin_tts_providers() -> None:
+    global _BUILTIN_TTS_PROVIDERS_REGISTERED
+    if _BUILTIN_TTS_PROVIDERS_REGISTERED:
+        return
+
+    builtin_providers = {
+        "edge": (_generate_edge_tts_sync, _is_edge_available, False),
+        "elevenlabs": (_generate_elevenlabs, _is_elevenlabs_available, True),
+        "openai": (_generate_openai_tts, _is_openai_available, True),
+        "minimax": (_generate_minimax_tts, _is_minimax_available, False),
+        "neutts": (_generate_neutts, _is_neutts_available, False),
+    }
+    for name, (synthesize, is_available, supports_native_opus) in builtin_providers.items():
+        if get_tts_provider(name) is None:
+            register_tts_provider(
+                name,
+                synthesize,
+                is_available=is_available,
+                supports_native_opus=supports_native_opus,
+            )
+
+    _BUILTIN_TTS_PROVIDERS_REGISTERED = True
+
+
+def resolve_tts_provider(tts_config: Optional[Dict[str, Any]] = None) -> ResolvedTTSProvider:
+    _register_builtin_tts_providers()
+    config = _load_tts_config() if tts_config is None else tts_config
+    requested_provider = _get_provider(config)
+    provider_entry = get_tts_provider(requested_provider)
+
+    if provider_entry is not None:
+        try:
+            if provider_entry.is_available(config):
+                return ResolvedTTSProvider(
+                    requested_provider=requested_provider,
+                    provider=requested_provider,
+                    provider_entry=provider_entry,
+                    available=True,
+                    error=None,
+                    supports_native_opus=provider_entry.supports_native_opus,
+                    tts_config=config,
+                )
+        except Exception as exc:
+            return ResolvedTTSProvider(
+                requested_provider=requested_provider,
+                provider=requested_provider,
+                provider_entry=provider_entry,
+                available=False,
+                error=str(exc),
+                supports_native_opus=provider_entry.supports_native_opus,
+                tts_config=config,
+            )
+
+    if requested_provider == "edge":
+        neutts_entry = get_tts_provider("neutts")
+        if neutts_entry is not None and neutts_entry.is_available(config):
+            return ResolvedTTSProvider(
+                requested_provider=requested_provider,
+                provider="neutts",
+                provider_entry=neutts_entry,
+                available=True,
+                error=None,
+                supports_native_opus=neutts_entry.supports_native_opus,
+                tts_config=config,
+            )
+
+    if provider_entry is None:
+        error = f"Unknown TTS provider: {requested_provider}"
+    elif requested_provider == "edge":
+        error = "No TTS provider available. Install edge-tts (pip install edge-tts) or set up NeuTTS for local synthesis."
+    elif requested_provider == "elevenlabs":
+        error = "ElevenLabs provider selected but 'elevenlabs' package or ELEVENLABS_API_KEY is missing."
+    elif requested_provider == "openai":
+        error = "OpenAI provider selected but the OpenAI audio backend is not available."
+    elif requested_provider == "minimax":
+        error = "MiniMax provider selected but MINIMAX_API_KEY is missing."
+    elif requested_provider == "neutts":
+        error = "NeuTTS provider selected but neutts is not installed. Run hermes setup and choose NeuTTS, or install espeak-ng and run python -m pip install -U neutts[all]."
+    else:
+        error = f"TTS provider unavailable: {requested_provider}"
+
+    return ResolvedTTSProvider(
+        requested_provider=requested_provider,
+        provider=requested_provider,
+        provider_entry=provider_entry,
+        available=False,
+        error=error,
+        supports_native_opus=bool(provider_entry and provider_entry.supports_native_opus),
+        tts_config=config,
+    )
+
+
+def generate_tts_result(
+    text: str,
+    output_path: Optional[str] = None,
+    tts_config: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Generate TTS audio through the shared provider-resolution seam."""
+    if not text or not text.strip():
+        return {"success": False, "error": "Text is required"}
+
+    if len(text) > MAX_TEXT_LENGTH:
+        logger.warning("TTS text too long (%d chars), truncating to %d", len(text), MAX_TEXT_LENGTH)
+        text = text[:MAX_TEXT_LENGTH]
+
+    resolved = resolve_tts_provider(tts_config)
+    provider = resolved.provider
+    if not resolved.available or resolved.provider_entry is None:
+        error_msg = f"TTS configuration error ({provider}): {resolved.error or 'provider unavailable'}"
+        logger.error("%s", error_msg)
+        return {"success": False, "error": error_msg}
+
+    platform = os.getenv("HERMES_SESSION_PLATFORM", "").lower()
+    want_opus = (platform == "telegram")
+
+    if output_path:
+        file_path = Path(output_path).expanduser()
+    else:
+        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        out_dir = Path(DEFAULT_OUTPUT_DIR)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        suffix = ".ogg" if want_opus and resolved.supports_native_opus else ".mp3"
+        file_path = out_dir / f"tts_{timestamp}{suffix}"
+
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_str = str(file_path)
+
+    try:
+        generated_path = resolved.provider_entry.synthesize(text, file_str, resolved.tts_config)
+        if generated_path:
+            file_str = generated_path
+
+        if not os.path.exists(file_str) or os.path.getsize(file_str) == 0:
+            return {
+                "success": False,
+                "error": f"TTS generation produced no output (provider: {provider})",
+            }
+
+        voice_compatible = False
+        if not resolved.supports_native_opus and not file_str.endswith(".ogg"):
+            opus_path = _convert_to_opus(file_str)
+            if opus_path:
+                file_str = opus_path
+                voice_compatible = True
+        else:
+            voice_compatible = file_str.endswith(".ogg")
+
+        file_size = os.path.getsize(file_str)
+        logger.info("TTS audio saved: %s (%s bytes, provider: %s)", file_str, f"{file_size:,}", provider)
+
+        media_tag = f"MEDIA:{file_str}"
+        if voice_compatible:
+            media_tag = f"[[audio_as_voice]]\n{media_tag}"
+
+        return {
+            "success": True,
+            "file_path": file_str,
+            "media_tag": media_tag,
+            "provider": provider,
+            "voice_compatible": voice_compatible,
+        }
+
+    except ValueError as e:
+        error_msg = f"TTS configuration error ({provider}): {e}"
+        logger.error("%s", error_msg)
+        return {"success": False, "error": error_msg}
+    except FileNotFoundError as e:
+        error_msg = f"TTS dependency missing ({provider}): {e}"
+        logger.error("%s", error_msg, exc_info=True)
+        return {"success": False, "error": error_msg}
+    except Exception as e:
+        error_msg = f"TTS generation failed ({provider}): {e}"
+        logger.error("%s", error_msg, exc_info=True)
+        return {"success": False, "error": error_msg}
+
+
 # ===========================================================================
 # Main tool function
 # ===========================================================================
@@ -465,160 +704,7 @@ def text_to_speech_tool(
     Returns:
         str: JSON result with success, file_path, and optionally MEDIA tag.
     """
-    if not text or not text.strip():
-        return json.dumps({"success": False, "error": "Text is required"}, ensure_ascii=False)
-
-    # Truncate very long text with a warning
-    if len(text) > MAX_TEXT_LENGTH:
-        logger.warning("TTS text too long (%d chars), truncating to %d", len(text), MAX_TEXT_LENGTH)
-        text = text[:MAX_TEXT_LENGTH]
-
-    tts_config = _load_tts_config()
-    provider = _get_provider(tts_config)
-
-    # Detect platform from gateway env var to choose the best output format.
-    # Telegram voice bubbles require Opus (.ogg); OpenAI and ElevenLabs can
-    # produce Opus natively (no ffmpeg needed).  Edge TTS always outputs MP3
-    # and needs ffmpeg for conversion.
-    platform = os.getenv("HERMES_SESSION_PLATFORM", "").lower()
-    want_opus = (platform == "telegram")
-
-    # Determine output path
-    if output_path:
-        file_path = Path(output_path).expanduser()
-    else:
-        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-        out_dir = Path(DEFAULT_OUTPUT_DIR)
-        out_dir.mkdir(parents=True, exist_ok=True)
-        # Use .ogg for Telegram with providers that support native Opus output,
-        # otherwise fall back to .mp3 (Edge TTS will attempt ffmpeg conversion later).
-        if want_opus and provider in ("openai", "elevenlabs"):
-            file_path = out_dir / f"tts_{timestamp}.ogg"
-        else:
-            file_path = out_dir / f"tts_{timestamp}.mp3"
-
-    # Ensure parent directory exists
-    file_path.parent.mkdir(parents=True, exist_ok=True)
-    file_str = str(file_path)
-
-    try:
-        # Generate audio with the configured provider
-        if provider == "elevenlabs":
-            try:
-                _import_elevenlabs()
-            except ImportError:
-                return json.dumps({
-                    "success": False,
-                    "error": "ElevenLabs provider selected but 'elevenlabs' package not installed. Run: pip install elevenlabs"
-                }, ensure_ascii=False)
-            logger.info("Generating speech with ElevenLabs...")
-            _generate_elevenlabs(text, file_str, tts_config)
-
-        elif provider == "openai":
-            try:
-                _import_openai_client()
-            except ImportError:
-                return json.dumps({
-                    "success": False,
-                    "error": "OpenAI provider selected but 'openai' package not installed."
-                }, ensure_ascii=False)
-            logger.info("Generating speech with OpenAI TTS...")
-            _generate_openai_tts(text, file_str, tts_config)
-
-        elif provider == "minimax":
-            logger.info("Generating speech with MiniMax TTS...")
-            _generate_minimax_tts(text, file_str, tts_config)
-
-        elif provider == "neutts":
-            if not _check_neutts_available():
-                return json.dumps({
-                    "success": False,
-                    "error": "NeuTTS provider selected but neutts is not installed. "
-                             "Run hermes setup and choose NeuTTS, or install espeak-ng and run python -m pip install -U neutts[all]."
-                }, ensure_ascii=False)
-            logger.info("Generating speech with NeuTTS (local)...")
-            _generate_neutts(text, file_str, tts_config)
-
-        else:
-            # Default: Edge TTS (free), with NeuTTS as local fallback
-            edge_available = True
-            try:
-                _import_edge_tts()
-            except ImportError:
-                edge_available = False
-
-            if edge_available:
-                logger.info("Generating speech with Edge TTS...")
-                try:
-                    loop = asyncio.get_running_loop()
-                    import concurrent.futures
-                    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                        pool.submit(
-                            lambda: asyncio.run(_generate_edge_tts(text, file_str, tts_config))
-                        ).result(timeout=60)
-                except RuntimeError:
-                    asyncio.run(_generate_edge_tts(text, file_str, tts_config))
-            elif _check_neutts_available():
-                logger.info("Edge TTS not available, falling back to NeuTTS (local)...")
-                provider = "neutts"
-                _generate_neutts(text, file_str, tts_config)
-            else:
-                return json.dumps({
-                    "success": False,
-                    "error": "No TTS provider available. Install edge-tts (pip install edge-tts) "
-                             "or set up NeuTTS for local synthesis."
-                }, ensure_ascii=False)
-
-        # Check the file was actually created
-        if not os.path.exists(file_str) or os.path.getsize(file_str) == 0:
-            return json.dumps({
-                "success": False,
-                "error": f"TTS generation produced no output (provider: {provider})"
-            }, ensure_ascii=False)
-
-        # Try Opus conversion for Telegram compatibility
-        # Edge TTS outputs MP3, NeuTTS outputs WAV — both need ffmpeg conversion
-        voice_compatible = False
-        if provider in ("edge", "neutts", "minimax") and not file_str.endswith(".ogg"):
-            opus_path = _convert_to_opus(file_str)
-            if opus_path:
-                file_str = opus_path
-                voice_compatible = True
-        elif provider in ("elevenlabs", "openai"):
-            # These providers can output Opus natively if the path ends in .ogg
-            voice_compatible = file_str.endswith(".ogg")
-
-        file_size = os.path.getsize(file_str)
-        logger.info("TTS audio saved: %s (%s bytes, provider: %s)", file_str, f"{file_size:,}", provider)
-
-        # Build response with MEDIA tag for platform delivery
-        media_tag = f"MEDIA:{file_str}"
-        if voice_compatible:
-            media_tag = f"[[audio_as_voice]]\n{media_tag}"
-
-        return json.dumps({
-            "success": True,
-            "file_path": file_str,
-            "media_tag": media_tag,
-            "provider": provider,
-            "voice_compatible": voice_compatible,
-        }, ensure_ascii=False)
-
-    except ValueError as e:
-        # Configuration errors (missing API keys, etc.)
-        error_msg = f"TTS configuration error ({provider}): {e}"
-        logger.error("%s", error_msg)
-        return json.dumps({"success": False, "error": error_msg}, ensure_ascii=False)
-    except FileNotFoundError as e:
-        # Missing dependencies or files
-        error_msg = f"TTS dependency missing ({provider}): {e}"
-        logger.error("%s", error_msg, exc_info=True)
-        return json.dumps({"success": False, "error": error_msg}, ensure_ascii=False)
-    except Exception as e:
-        # Unexpected errors
-        error_msg = f"TTS generation failed ({provider}): {e}"
-        logger.error("%s", error_msg, exc_info=True)
-        return json.dumps({"success": False, "error": error_msg}, ensure_ascii=False)
+    return json.dumps(generate_tts_result(text=text, output_path=output_path), ensure_ascii=False)
 
 
 # ===========================================================================
@@ -626,35 +712,19 @@ def text_to_speech_tool(
 # ===========================================================================
 def check_tts_requirements() -> bool:
     """
-    Check if at least one TTS provider is available.
-
-    Edge TTS needs no API key and is the default, so if the package
-    is installed, TTS is available.
+    Check if at least one registered TTS provider is available.
 
     Returns:
         bool: True if at least one provider can work.
     """
-    try:
-        _import_edge_tts()
-        return True
-    except ImportError:
-        pass
-    try:
-        _import_elevenlabs()
-        if os.getenv("ELEVENLABS_API_KEY"):
-            return True
-    except ImportError:
-        pass
-    try:
-        _import_openai_client()
-        if _has_openai_audio_backend():
-            return True
-    except ImportError:
-        pass
-    if os.getenv("MINIMAX_API_KEY"):
-        return True
-    if _check_neutts_available():
-        return True
+    _register_builtin_tts_providers()
+    config = _load_tts_config()
+    for _name, provider in iter_tts_providers():
+        try:
+            if provider.is_available(config):
+                return True
+        except Exception:
+            continue
     return False
 
 


### PR DESCRIPTION
## Summary
- add a tiny shared TTS provider registry in `tools/tts_registry.py`
- route `text_to_speech_tool()` through a shared `generate_tts_result()` / `resolve_tts_provider()` seam
- route gateway voice reply generation through the same shared seam instead of provider-specific branching
- add focused tests for registry-backed provider resolution and gateway voice reply usage of the shared seam

## Why
Hermes currently hard-codes provider selection in `tools/tts_tool.py`, while gateway voice reply paths call into the TTS tool wrapper and inherit provider logic indirectly. This works for today's built-ins, but it makes future provider-specific behaviors (for example websocket/live-streaming backends) harder to add cleanly without repeating provider-specific branching in multiple places.

This PR introduces a small shared seam so both the TTS tool and gateway voice replies resolve and invoke providers through one path.

Adding this to facilitate a low latency websocket implementation for Minimax subscription TTS.  See PR [4758](https://github.com/NousResearch/hermes-agent/pull/4758) for a PR addressing the HTML side of Minimax TTS.

## Scope
In scope:
- tiny TTS provider registry
- shared provider resolution + generation seam in `tools/tts_tool.py`
- gateway voice reply paths updated to use the shared seam
- focused regression tests

Out of scope:
- new TTS providers
- websocket/live-streaming implementation
- plugin registration hooks
- CLI voice-mode streaming changes

## Testing
```bash
python3 -m py_compile tools/tts_tool.py tools/tts_registry.py gateway/run.py gateway/platforms/base.py tests/tools/test_tts_registry.py tests/gateway/test_voice_command.py tests/tools/test_config_null_guard.py
uv run --with pytest-asyncio pytest -o addopts='' tests/tools/test_tts_registry.py tests/tools/test_config_null_guard.py tests/gateway/test_voice_command.py -q
```
