### PR TITLE
fix(model-metadata): fall back to LITELLM_KEY for endpoint metadata

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1245,6 +1245,8 @@ def fetch_endpoint_model_metadata(
     if alternate and alternate not in candidates:
         candidates.append(alternate)
 
+    if not api_key:
+        api_key = os.getenv("LITELLM_KEY", "")
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
     last_error: Optional[Exception] = None
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -23,6 +23,7 @@ from agent.model_metadata import (
     _strip_provider_prefix,
     estimate_tokens_rough,
     estimate_messages_tokens_rough,
+    fetch_endpoint_model_metadata,
     get_model_context_length,
     get_next_probe_tier,
     get_cached_context_length,
@@ -561,6 +562,32 @@ class TestFetchEndpointModelMetadata:
         not_found.close.assert_called_once()
         success.close.assert_called_once()
 
+    @patch("agent.model_metadata.requests.get")
+    def test_uses_litellm_key_fallback_when_api_key_missing(self, mock_get):
+        """When api_key is empty, fall back to LITELLM_KEY env var so the
+        /models request is authenticated via LiteLLM proxy credentials."""
+        import os
+        import agent.model_metadata as mm
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "data": [{"id": "test/model", "context_length": 32768, "name": "Test Model"}]
+        }
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        with patch.dict(os.environ, {"LITELLM_KEY": "litellm-secret"}, clear=False):
+            result = mm.fetch_endpoint_model_metadata(
+                "https://example.test/v1",
+                api_key="",
+                force_refresh=True,
+            )
+
+        assert "test/model" in result
+        assert mock_get.call_count == 1
+        assert mock_get.call_args.args[0] == "https://example.test/v1/models"
+        assert mock_get.call_args.kwargs["headers"]["Authorization"] == "Bearer litellm-secret"
+
 
 # =========================================================================
 # Nous Portal context-window resolution (provider="nous")
@@ -1003,10 +1030,6 @@ class TestFetchModelMetadata:
         assert "anthropic/claude-3.5-sonnet:beta" in result
         assert "anthropic/claude-3.5-sonnet" in result
         assert result["anthropic/claude-3.5-sonnet"]["context_length"] == 200000
-
-
-
-
 
 # =========================================================================
 # Context probe tiers


### PR DESCRIPTION
## What does this PR do?

Falls back to `LITELLM_KEY` in `fetch_endpoint_model_metadata()` when no explicit `api_key` is passed. This fixes custom endpoint metadata and pricing lookups that currently send unauthenticated `/models` requests and fail with 401s.

## Related Issue

Fixes #4913

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- use `LITELLM_KEY` as a fallback in `agent/model_metadata.py` when `api_key` is empty
- add a regression test in `tests/agent/test_model_metadata.py` that verifies the `Authorization` header is sent

## How to Test

1. `source venv/bin/activate`
2. `python -m pytest tests/agent/test_model_metadata.py tests/test_model_metadata_local_ctx.py -q`
3. Verify `fetch_endpoint_model_metadata(..., api_key="")` sends `Authorization: Bearer <LITELLM_KEY>` when `LITELLM_KEY` is set

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1, Python 3.12.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A