### PR TITLE
fix(terminal): pass docker_forward_env through terminal tool

### DIFF
--- a/tests/tools/test_parse_env_var.py
+++ b/tests/tools/test_parse_env_var.py
@@ -52,6 +52,48 @@ class TestParseEnvVar:
         assert result is fake_env
         assert mock_docker.call_args.kwargs["forward_env"] == ["GITHUB_TOKEN"]
 
+    def test_terminal_tool_passes_docker_forward_env_into_container_config(self):
+        fake_env = type(
+            "FakeEnv",
+            (),
+            {"execute": lambda self, *args, **kwargs: {"output": "ok", "exit_code": 0, "error": ""}},
+        )()
+        config = {
+            "env_type": "docker",
+            "docker_image": "python:3.11",
+            "cwd": "/root",
+            "timeout": 180,
+            "container_cpu": 1,
+            "container_memory": 5120,
+            "container_disk": 51200,
+            "container_persistent": True,
+            "modal_mode": "auto",
+            "docker_volumes": [],
+            "docker_mount_cwd_to_workspace": False,
+            "docker_forward_env": ["GITHUB_TOKEN", "NPM_TOKEN"],
+            "host_cwd": None,
+        }
+        task_id = "docker-forward-env-test"
+        _tt_mod._active_environments.clear()
+        _tt_mod._last_activity.clear()
+        _tt_mod._task_env_overrides.clear()
+
+        try:
+            with patch.object(_tt_mod, "_get_env_config", return_value=config), \
+                 patch.object(_tt_mod, "_create_environment", return_value=fake_env) as mock_create, \
+                 patch.object(_tt_mod, "_start_cleanup_thread"), \
+                 patch.object(_tt_mod, "_check_all_guards", return_value={"approved": True}):
+                result = json.loads(_tt_mod.terminal_tool("echo ok", task_id=task_id))
+
+            assert result["exit_code"] == 0
+            assert mock_create.call_args.kwargs["container_config"]["docker_forward_env"] == [
+                "GITHUB_TOKEN",
+                "NPM_TOKEN",
+            ]
+        finally:
+            _tt_mod._active_environments.clear()
+            _tt_mod._last_activity.clear()
+
     def test_falls_back_to_default(self):
         with patch.dict("os.environ", {}, clear=False):
             # Remove the var if it exists, rely on default

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1021,6 +1021,7 @@ def terminal_tool(
                                 "modal_mode": config.get("modal_mode", "auto"),
                                 "docker_volumes": config.get("docker_volumes", []),
                                 "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
+                                "docker_forward_env": config.get("docker_forward_env", []),
                             }
 
                         local_config = None


### PR DESCRIPTION
## What does this PR do?

Passes `docker_forward_env` through the main `terminal_tool()` environment-creation path so requested env vars are not dropped when new docker sandboxes are created.

## Related Issue

Fixes #4916

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- add `docker_forward_env` to the `container_config` assembled inside `tools/terminal_tool.py`
- add a regression test in `tests/tools/test_parse_env_var.py` that exercises the main `terminal_tool()` path

## How to Test

1. `source venv/bin/activate`
2. `python -m pytest tests/tools/test_parse_env_var.py -q`
3. Verify the `container_config` passed to `_create_environment()` includes `docker_forward_env`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1, Python 3.12.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A