### PR TITLE
fix(opencode-go): MiniMax models 404 — strip /v1 from Anthropic base URL

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -123,6 +123,8 @@ DEFAULT_CONTEXT_LENGTHS = {
     "moonshotai/Kimi-K2-Thinking": 262144,
     "MiniMaxAI/MiniMax-M2.5": 204800,
     "XiaomiMiMo/MiMo-V2-Flash": 32768,
+    "mimo-v2-pro": 1048576,
+    "mimo-v2-omni": 1048576,
     "zai-org/GLM-5": 202752,
 }
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -201,7 +201,10 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "opencode-go": [
         "glm-5",
         "kimi-k2.5",
+        "mimo-v2-pro",
+        "mimo-v2-omni",
         "minimax-m2.7",
+        "minimax-m2.5",
     ],
     "ai-gateway": [
         "anthropic/claude-opus-4.6",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 from typing import Any, Dict, Optional
 
 from hermes_cli import auth as auth_mod
@@ -167,6 +168,13 @@ def _resolve_runtime_from_pool_entry(
             api_mode = opencode_model_api_mode(provider, model_cfg.get("default", ""))
         elif base_url.rstrip("/").endswith("/anthropic"):
             api_mode = "anthropic_messages"
+
+    # OpenCode base URLs end with /v1 for OpenAI-compatible models, but the
+    # Anthropic SDK prepends its own /v1/messages to the base_url.  Strip the
+    # trailing /v1 so the SDK constructs the correct path (e.g.
+    # https://opencode.ai/zen/go/v1/messages instead of .../v1/v1/messages).
+    if api_mode == "anthropic_messages" and provider in ("opencode-zen", "opencode-go"):
+        base_url = re.sub(r"/v1/?$", "", base_url)
 
     return {
         "provider": provider,
@@ -700,6 +708,9 @@ def resolve_runtime_provider(
             # (e.g. https://api.minimax.io/anthropic, https://dashscope.../anthropic)
             elif base_url.rstrip("/").endswith("/anthropic"):
                 api_mode = "anthropic_messages"
+        # Strip trailing /v1 for OpenCode Anthropic models (see comment above).
+        if api_mode == "anthropic_messages" and provider in ("opencode-zen", "opencode-go"):
+            base_url = re.sub(r"/v1/?$", "", base_url)
         return {
             "provider": provider,
             "api_mode": api_mode,

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -115,7 +115,7 @@ _DEFAULT_PROVIDER_MODELS = {
     "ai-gateway": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5", "google/gemini-3-flash"],
     "kilocode": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5.4", "google/gemini-3-pro-preview", "google/gemini-3-flash-preview"],
     "opencode-zen": ["gpt-5.4", "gpt-5.3-codex", "claude-sonnet-4-6", "gemini-3-flash", "glm-5", "kimi-k2.5", "minimax-m2.7"],
-    "opencode-go": ["glm-5", "kimi-k2.5", "minimax-m2.5", "minimax-m2.7"],
+    "opencode-go": ["glm-5", "kimi-k2.5", "mimo-v2-pro", "mimo-v2-omni", "minimax-m2.5", "minimax-m2.7"],
     "huggingface": [
         "Qwen/Qwen3.5-397B-A17B", "Qwen/Qwen3-235B-A22B-Thinking-2507",
         "Qwen/Qwen3-Coder-480B-A35B-Instruct", "deepseek-ai/DeepSeek-R1-0528",

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -859,7 +859,9 @@ def test_opencode_zen_claude_defaults_to_messages(monkeypatch):
 
     assert resolved["provider"] == "opencode-zen"
     assert resolved["api_mode"] == "anthropic_messages"
-    assert resolved["base_url"] == "https://opencode.ai/zen/v1"
+    # Trailing /v1 stripped for anthropic_messages mode — the Anthropic SDK
+    # appends its own /v1/messages to the base_url.
+    assert resolved["base_url"] == "https://opencode.ai/zen"
 
 
 def test_opencode_go_minimax_defaults_to_messages(monkeypatch):
@@ -872,7 +874,8 @@ def test_opencode_go_minimax_defaults_to_messages(monkeypatch):
 
     assert resolved["provider"] == "opencode-go"
     assert resolved["api_mode"] == "anthropic_messages"
-    assert resolved["base_url"] == "https://opencode.ai/zen/go/v1"
+    # Trailing /v1 stripped — Anthropic SDK appends /v1/messages itself.
+    assert resolved["base_url"] == "https://opencode.ai/zen/go"
 
 
 def test_opencode_go_glm_defaults_to_chat_completions(monkeypatch):


### PR DESCRIPTION
## Summary

Fixes MiniMax models (M2.5, M2.7) returning HTTP 404 on OpenCode Go. Also adds newly available MiMo-V2-Pro and MiMo-V2-Omni models.

**Root cause:** OpenCode Go's base URL is `https://opencode.ai/zen/go/v1`. For MiniMax models, we route through the Anthropic Messages API (`anthropic_messages` mode). The Anthropic SDK appends `/v1/messages` to the base URL, producing `https://opencode.ai/zen/go/v1/v1/messages` — a double `/v1` that returns OpenCode's 404 page.

**Fix:** Strip the trailing `/v1` from the base URL when the resolved api_mode is `anthropic_messages` and the provider is opencode-zen or opencode-go. The Anthropic SDK then constructs the correct path: `https://opencode.ai/zen/go/v1/messages`.

OpenAI-compatible models (GLM, Kimi, MiMo) are unaffected — their `chat_completions` mode keeps the `/v1` base URL intact.

## Changes

- `hermes_cli/runtime_provider.py`: Strip trailing `/v1` from base URL when api_mode is `anthropic_messages` for OpenCode providers (both resolution paths)
- `hermes_cli/models.py`: Add `mimo-v2-pro`, `mimo-v2-omni`, `minimax-m2.5` to OpenCode Go model list
- `hermes_cli/setup.py`: Sync model list
- `agent/model_metadata.py`: Add context lengths for MiMo-V2-Pro/Omni (1M tokens)
- `tests/test_runtime_provider_resolution.py`: Update assertions for stripped base URL

## Test Results

- 171/171 runtime provider + API key provider tests pass
- E2E verified: MiniMax → correct `/v1/messages` URL, GLM → correct `/v1/chat/completions` URL, MiMo → correct `chat_completions` mode

Fixes #4890