### PR TITLE
fix(gateway): write update-pending state atomically to prevent corruption

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4872,7 +4872,9 @@ class GatewayRunner:
             "user_id": event.source.user_id,
             "timestamp": datetime.now().isoformat(),
         }
-        pending_path.write_text(json.dumps(pending))
+        _tmp_pending = pending_path.with_suffix(".tmp")
+        _tmp_pending.write_text(json.dumps(pending))
+        _tmp_pending.replace(pending_path)
         exit_code_path.unlink(missing_ok=True)
 
         # Spawn `hermes update` detached so it survives gateway restart.


### PR DESCRIPTION
Cherry-pick of PR #4852 by @memosr onto current main.

Replaces `pending_path.write_text()` with write-to-tmp + `Path.replace()` (atomic on POSIX). Prevents corrupt update-pending state if the gateway is killed mid-write, which would silently drop the scheduled `hermes update` command.

Consistent with existing atomic write patterns in `cron/jobs.py`, `utils.py`, and `gateway/status.py`.

Credit: @memosr (original PR #4852)