### PR TITLE
fix(gateway): bypass active-session guard for /approve and /deny commands

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1022,6 +1022,32 @@ class BasePlatformAdapter(ABC):
         
         # Check if there's already an active handler for this session
         if session_key in self._active_sessions:
+            # /approve and /deny must bypass the active-session guard.
+            # The agent thread is blocked on threading.Event.wait() inside
+            # tools/approval.py — queuing these commands creates a deadlock:
+            # the agent waits for approval, approval waits for agent to finish.
+            # Dispatch directly to the message handler without touching session
+            # lifecycle (no competing background task, no session guard removal).
+            cmd = event.get_command()
+            if cmd in ("approve", "deny"):
+                logger.debug(
+                    "[%s] Approval command '/%s' bypassing active-session guard for %s",
+                    self.name, cmd, session_key,
+                )
+                try:
+                    _thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+                    response = await self._message_handler(event)
+                    if response:
+                        await self._send_with_retry(
+                            chat_id=event.source.chat_id,
+                            content=response,
+                            reply_to=event.message_id,
+                            metadata=_thread_meta,
+                        )
+                except Exception as e:
+                    logger.error("[%s] Approval dispatch failed: %s", self.name, e, exc_info=True)
+                return
+
             # Special case: photo bursts/albums frequently arrive as multiple near-
             # simultaneous messages. Queue them without interrupting the active run,
             # then process them immediately after the current task finishes.


### PR DESCRIPTION
## Summary

Fixes a deadlock where `/approve` and `/deny` commands on Telegram (and all gateway platforms) are silently queued while the agent is waiting for approval, creating a circular dependency that times out.

Based on the diagnosis from PR #4904 by @mechovation (excellent root cause analysis in issue #4898). Reimplemented with a cleaner dispatch approach.

### The deadlock

1. Agent hits dangerous command → blocks on `threading.Event.wait()` in `tools/approval.py`
2. User sends `/approve` via Telegram  
3. Base adapter sees `session_key in self._active_sessions` → queues in `_pending_messages`, returns
4. Queued message waits for agent to finish → agent waits for approval → deadlock

### The fix

`/approve` and `/deny` now bypass the active-session guard and dispatch directly to `self._message_handler(event)`. This reaches `gateway/run.py`'s `_handle_approve_command()` which calls `resolve_gateway_approval()` and unblocks the agent thread.

Key design choice: dispatches directly via `await self._message_handler(event)` instead of spawning a second `_process_message_background` task. The original PR (#4904) used `_process_message_background` which would create a competing background task that manages session lifecycle — its `finally` block removes the session guard, opening a race window where new messages could spawn duplicate agent tasks.

### E2E verified
- `/approve` dispatched to handler while session active, response sent, guard intact
- `/deny` dispatched, guard intact
- Normal text still queued (not bypassed)
- `/approve@botname` suffix stripped correctly
- Handler errors caught gracefully, guard survives
- `/stop` and other commands still queued (only approve/deny bypass)

### Test results  
- 1,866 gateway tests passed (5 pre-existing failures in signal/DAVE)

Fixes #4898, closes #4904