### PR TITLE
feat(skills): add manim-video skill for mathematical and technical animations

### DIFF
--- a/skills/creative/video-toolkit/README.md
+++ b/skills/creative/video-toolkit/README.md
@@ -1,0 +1,62 @@
+# Video Toolkit
+
+Production pipeline for programmatic video using [Remotion](https://remotion.dev) (React). Create announcement videos, explainers, product demos, social clips, data stories, and music-synced content entirely from code.
+
+## Quick Start
+
+```bash
+# Check prerequisites
+bash skills/creative/video-toolkit/scripts/setup.sh
+
+# Start from a template
+cp -r skills/creative/video-toolkit/templates/announcement ./my-video
+cd my-video
+npm install
+
+# Edit src/Root.tsx to customize content
+# Preview in browser
+npx remotion studio
+
+# Render to MP4
+npm run render
+```
+
+## Templates
+
+| Template | Duration | Description |
+|----------|----------|-------------|
+| `announcement` | 30s | Product/feature announcement — title, features, CTA |
+| `explainer` | 60s | Technical explainer — problem, solution, result |
+
+## Modes
+
+| Mode | Best for |
+|------|----------|
+| **Announcement** | Product launches, feature releases, version updates |
+| **Explainer** | Architecture overviews, how-it-works, protocol explanations |
+| **Demo** | Product demos, tool walkthroughs, onboarding |
+| **Data story** | Benchmarks, quarterly reports, before/after comparisons |
+| **Social clip** | Twitter/X, Instagram, Discord announcements (15-30s) |
+| **Music video** | Audio-reactive visuals, lyric videos, visualizers |
+
+## Stack
+
+- **Remotion 4.x** — React-based video framework
+- **Node.js 18+** — runtime
+- **ffmpeg** — post-processing (optional)
+- **ElevenLabs / Qwen3-TTS** — voiceover generation (optional)
+
+## References
+
+Detailed documentation in `references/`:
+
+- `remotion-core.md` — Compositions, hooks, layout, rendering pipeline
+- `animations.md` — interpolate, spring, easing, stagger patterns
+- `text-and-typography.md` — Kinetic typography, typewriter, font loading
+- `transitions.md` — Scene transitions, overlays, custom effects
+- `audio.md` — Audio visualization, voiceover/TTS, music sync
+- `visual-components.md` — Backgrounds, overlays, layout components
+- `data-visualization.md` — Charts, counters, stat comparisons
+- `recording-and-demos.md` — Browser recording, mockups, terminal demos
+- `rendering-and-output.md` — CLI rendering, quality presets, formats
+- `troubleshooting.md` — Common errors and fixes

--- a/skills/creative/video-toolkit/SKILL.md
+++ b/skills/creative/video-toolkit/SKILL.md
@@ -1,0 +1,349 @@
+---
+name: video-toolkit
+description: "Production pipeline for programmatic video using Remotion (React). Creates announcement videos, explainers, product demos, social clips, data stories, and music-synced content entirely from code. Covers: kinetic typography, motion graphics, audio visualization, voiceover/TTS integration, browser demo recording, chart animations, scene transitions, and headless rendering. Use when users request: making a video, announcement video, demo video, explainer video, product launch video, social media clip, animated presentation, motion graphics, kinetic text, or any video content that can be described and generated programmatically."
+---
+
+# Video Toolkit — Remotion Production Pipeline
+
+## Creative Standard
+
+This is video production. React is the medium; cinema is the standard.
+
+**Before writing a single component**, articulate the creative concept. What is the mood? What story does this video tell? What makes THIS video memorable? The user's prompt is a creative brief — interpret it with directorial ambition, not literal transcription.
+
+**First-render excellence is non-negotiable.** The output must look professional without revision rounds. If it looks like "AI-generated motion graphics" — generic gradients, default fonts, predictable timing — it is wrong. Rethink the creative concept before shipping.
+
+**Go beyond safe defaults.** The reference catalogs provide a vocabulary of techniques. For every project, combine, modify, and invent. Stock transitions and template typography are a starting point. The viewer should see something they haven't seen before.
+
+**Be proactively creative.** Include at least one visual moment the user didn't ask for but will appreciate — a transition effect, a data visualization, a typographic flourish that elevates the whole piece.
+
+**Timing is everything.** Video lives and dies by rhythm. Every cut, every text reveal, every transition should land on a beat or a breath. A technically perfect video with bad timing feels amateur.
+
+**Cohesive aesthetic.** All scenes must feel connected by a unifying visual language — shared color temperature, consistent typography, related motion vocabulary. A video where every scene uses a different font and color palette is an aesthetic failure.
+
+## Modes
+
+| Mode | Input | Output | Best for |
+|------|-------|--------|----------|
+| **Announcement** | Product/feature details | 30-60s launch/release video | Product launches, feature announcements, release videos |
+| **Explainer** | Technical concept | 60-120s walkthrough | Architecture overviews, how-it-works, protocol explanations |
+| **Demo** | App/tool to showcase | 30-90s screen recording + motion graphics | Product demos, tool walkthroughs, onboarding |
+| **Data story** | Metrics/stats | 30-60s animated data visualization | Quarterly reports, benchmarks, before/after comparisons |
+| **Social clip** | Key message | 15-30s vertical or square clip | Twitter/X, Instagram, Discord announcements |
+| **Music video** | Audio track + visual concept | Duration of track | Audio-reactive visuals, lyric videos, visualizers |
+
+## Stack
+
+React/TypeScript project per video. Renders to MP4 headlessly via CLI.
+
+| Layer | Tool | Purpose |
+|-------|------|---------|
+| Core | Remotion 4.x | React-based video framework — compositions, timeline, rendering |
+| Animation | `interpolate()`, `spring()` | Frame-driven animation (CSS animations are FORBIDDEN) |
+| Typography | Google Fonts, `@remotion/google-fonts` | Web font loading for kinetic text |
+| Transitions | `@remotion/transitions` | Scene-to-scene effects (fade, slide, wipe, custom) |
+| Audio | `@remotion/media-utils` | Audio visualization, waveform data, duration detection |
+| TTS | ElevenLabs API / Qwen3-TTS (local) | AI voiceover generation |
+| Recording | Playwright (via Hermes browser tool) | Browser demo capture as video assets |
+| Charts | D3.js / custom React | Animated data visualizations |
+| 3D | React Three Fiber (optional) | 3D scenes, product renders, globe visualizations |
+| Rendering | Remotion CLI | Headless MP4/WebM/GIF output |
+| Video I/O | ffmpeg | Post-processing, format conversion, audio muxing |
+
+## Pipeline
+
+Every mode follows the same 6-stage pipeline:
+
+```
+CONCEPT → STORYBOARD → SCENES → AUDIO → RENDER → REVIEW
+```
+
+1. **CONCEPT** — Creative vision: mood, story, color world, typography, what makes it unique
+2. **STORYBOARD** — Scene breakdown with timing, transitions, and content per scene
+3. **SCENES** — Write React components for each scene. Each scene is a self-contained composition
+4. **AUDIO** — Generate voiceover (TTS), source music, sync timing to audio beats/pauses
+5. **RENDER** — Preview frames (`npx remotion still`), then full render (`npx remotion render`)
+6. **REVIEW** — Watch output, check timing, verify creative vision, iterate if needed
+
+## Creative Direction
+
+### Typography Styles
+
+| Style | Technique | Best for | Reference |
+|-------|-----------|----------|-----------|
+| **Kinetic reveal** | Word-by-word or letter-by-letter with spring physics | Headlines, key messages | `references/text-and-typography.md` |
+| **Typewriter** | Character-by-character with blinking cursor | Code snippets, terminal output | `references/text-and-typography.md` |
+| **Slide-up stack** | Lines entering from bottom, stacking vertically | Feature lists, bullet points | `references/text-and-typography.md` |
+| **Scale burst** | Text scales from 0 to full size with overshoot | Single-word emphasis, titles | `references/animations.md` |
+| **Highlight sweep** | Colored highlight bar sweeps behind text | Key terms, callouts | `references/text-and-typography.md` |
+| **Split reveal** | Text splits from center or slides in from edges | Dramatic openings, transitions | `references/text-and-typography.md` |
+
+### Color Strategies
+
+| Strategy | Description | Best for |
+|----------|-------------|----------|
+| **Dark tech** | Dark background (#0a0a0f), bright accents (cyan, purple, electric blue) | Dev tools, technical products |
+| **Clean corporate** | White/light gray background, brand colors for accents | Enterprise, professional |
+| **Gradient wash** | Full-screen animated gradient as background | Social clips, modern feel |
+| **Monochrome + accent** | Grayscale with a single highlight color | Elegant, focused messaging |
+| **Neon on dark** | Black background with glowing neon colors | Gaming, creative tools |
+| **Earth + warmth** | Deep browns, amber, warm whites | Human-centric, community |
+
+### Motion Vocabulary
+
+| Motion | When to use | Physics |
+|--------|-------------|---------|
+| **Spring entrance** | Element appearing for the first time | `spring({ damping: 12, mass: 0.5 })` |
+| **Fade in** | Subtle appearance, backgrounds | `interpolate(frame, [0, 20], [0, 1])` |
+| **Slide from edge** | Panels, sidebars, secondary content | Spring + translateX/Y |
+| **Scale from zero** | Emphasis, dramatic reveals | Spring + scale transform |
+| **Stagger** | Lists, grids, multiple items | Delay each by N frames |
+| **Exit up/fade** | Leaving the scene | Reverse of entrance, faster |
+
+### Per-Scene Variation
+
+Never use identical styling across all scenes. For each scene:
+- **Different dominant color** (or shift the accent within the palette)
+- **Different text animation** (kinetic reveal for headlines, typewriter for code, slide for lists)
+- **Different layout** (centered, left-aligned, split-screen, full-bleed)
+- **Vary transition type** between scenes (don't use the same fade everywhere)
+- **Match energy to content** (fast cuts for features, slow reveals for emotional moments)
+
+### Project-Specific Invention
+
+For every project, create at least one of:
+- A custom color palette matching the brand/mood
+- A custom transition (combine built-in transitions with overlays)
+- A custom typographic treatment for the key message
+- A visual motif that repeats across scenes (a shape, a pattern, a color accent)
+- A moment of visual surprise the user didn't request
+
+## Workflow
+
+### Step 1: Creative Vision
+
+Before any code, articulate:
+
+- **Mood/atmosphere**: Professional? Energetic? Elegant? Technical? Playful?
+- **Visual story**: What's the arc? Build excitement → reveal → CTA? Problem → solution → result?
+- **Color world**: Brand colors? Dark tech? Warm gradients? What's the dominant hue?
+- **Typography**: Sans-serif modern? Monospace technical? Display dramatic?
+- **Timing**: Fast-paced (15fps cuts)? Measured (3s per scene)? Music-synced?
+- **What makes THIS different**: What's the one thing that makes this video memorable?
+
+### Step 2: Project Setup
+
+Start from a template or initialize fresh:
+
+```bash
+# From template (recommended)
+cp -r skills/creative/video-toolkit/templates/announcement ./my-video
+cd my-video && npm install
+
+# Or fresh init
+npx create-video@latest --template blank
+```
+
+Project structure:
+```
+my-video/
+├── src/
+│   ├── Root.tsx              # Register all compositions
+│   ├── scenes/               # One component per scene
+│   │   ├── TitleScene.tsx
+│   │   ├── FeatureScene.tsx
+│   │   └── CTAScene.tsx
+│   └── components/           # Shared visual components
+│       ├── AnimatedBg.tsx
+│       └── KineticText.tsx
+├── public/                   # Static assets (audio, images, fonts)
+├── remotion.config.ts        # Remotion configuration
+└── package.json
+```
+
+### Step 3: Build Scenes
+
+Each scene is a React component driven by `useCurrentFrame()`:
+
+```tsx
+import { useCurrentFrame, useVideoConfig, interpolate, spring } from "remotion";
+
+export const TitleScene: React.FC<{ title: string }> = ({ title }) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+
+  const scale = spring({ frame, fps, config: { damping: 12 } });
+  const opacity = interpolate(frame, [0, fps * 0.5], [0, 1], {
+    extrapolateRight: "clamp",
+  });
+
+  return (
+    <AbsoluteFill style={{
+      background: "linear-gradient(135deg, #0a0a1a, #1a0a2e)",
+      justifyContent: "center",
+      alignItems: "center",
+    }}>
+      <h1 style={{
+        color: "white",
+        fontSize: 80,
+        fontFamily: "Inter",
+        transform: `scale(${scale})`,
+        opacity,
+      }}>
+        {title}
+      </h1>
+    </AbsoluteFill>
+  );
+};
+```
+
+**Critical rules:**
+- ALL animation via `useCurrentFrame()` + `interpolate()`/`spring()` — CSS animations and Tailwind animation classes are **FORBIDDEN** (they don't render in Remotion's frame-by-frame pipeline)
+- Use `<AbsoluteFill>` as scene container (full-frame positioning)
+- Use `<Sequence>` for timed sub-elements within a scene
+- Time everything in frames, convert seconds via `fps`: `const frameAt2s = 2 * fps`
+
+### Step 4: Audio Integration
+
+For voiceover, generate TTS audio first, then size the composition to match:
+
+```tsx
+// In Root.tsx — use calculateMetadata prop on Composition to set dynamic duration
+const calculateMyMetadata: CalculateMetadataFunction<Props> = async ({ props }) => {
+  const duration = await getAudioDurationInSeconds(staticFile("voiceover.mp3"));
+  return { durationInFrames: Math.ceil(duration * 30) + 60 }; // +2s padding
+};
+
+<Composition
+  id="MainVideo"
+  component={MainVideo}
+  calculateMetadata={calculateMyMetadata}
+  fps={30}
+  width={1920}
+  height={1080}
+/>
+```
+
+For music sync, use `useWindowedAudioData()` to drive visuals. See `references/audio.md`.
+
+### Step 5: Preview and Render
+
+```bash
+# Preview a single frame at 3 seconds (frame 90 at 30fps)
+npx remotion still src/index.ts MainVideo --frame=90 --output=preview.png
+
+# Preview at multiple timestamps
+for f in 0 90 180 270; do
+  npx remotion still src/index.ts MainVideo --frame=$f --output=preview_$f.png
+done
+
+# Full render
+npx remotion render src/index.ts MainVideo --output=output.mp4
+
+# Draft quality (faster)
+npx remotion render src/index.ts MainVideo --output=draft.mp4 --quality=50 --scale=0.5
+
+# Production quality
+npx remotion render src/index.ts MainVideo --output=final.mp4 --codec=h264 --crf=18
+```
+
+### Step 6: Quality Verification
+
+- **Preview frames first**: always render stills at key timestamps before full render
+- **Timing check**: do cuts land where they should? Does text have time to be read?
+- **Readability**: can all text be read at playback speed? Minimum 2 seconds for short text, 4 for sentences
+- **Audio sync**: do visual transitions align with audio beats/pauses?
+- **Creative vision check**: does the output match the concept from Step 1? If it looks generic, go back
+- **Platform check**: correct aspect ratio and duration for the target platform
+
+## Critical Implementation Notes
+
+### CSS Animations Are Forbidden
+
+Remotion renders frame-by-frame. CSS transitions, `@keyframes`, and Tailwind animation classes (`animate-spin`, `animate-bounce`) produce blank or static output. ALL motion must be driven by `useCurrentFrame()` + `interpolate()` or `spring()`.
+
+### Font Loading
+
+Use `@remotion/google-fonts` for web fonts. Fonts must be loaded before the first frame renders:
+
+```tsx
+import { loadFont } from "@remotion/google-fonts/Inter";
+const { fontFamily } = loadFont();
+```
+
+Never use `@import url()` in CSS — it doesn't work in Remotion's rendering context.
+
+### Audio Must Be in public/
+
+Audio files referenced via `staticFile()` must be in the `public/` directory. Remotion resolves `staticFile("voiceover.mp3")` to `public/voiceover.mp3`.
+
+### Frame Rate and Duration
+
+Default: 30fps. Set in the Composition registration:
+
+```tsx
+<Composition id="MainVideo" component={Main}
+  durationInFrames={30 * 60} // 60 seconds
+  fps={30}
+  width={1920} height={1080}
+/>
+```
+
+Common durations: 15s social clip = 450 frames, 30s announcement = 900, 60s explainer = 1800.
+
+### Aspect Ratios
+
+| Platform | Ratio | Resolution |
+|----------|-------|------------|
+| YouTube/general | 16:9 | 1920x1080 |
+| Instagram Reels / TikTok | 9:16 | 1080x1920 |
+| Twitter/X | 16:9 or 1:1 | 1920x1080 or 1080x1080 |
+| Square (universal) | 1:1 | 1080x1080 |
+
+## Hermes Tool Usage
+
+The agent builds Remotion projects using Hermes's standard tools:
+
+| Tool | Usage |
+|------|-------|
+| **terminal** | `npm install`, `npx remotion render`, `npx remotion still`, ffmpeg post-processing |
+| **write_file** | Create/modify `.tsx` scene files, `Root.tsx`, `package.json` |
+| **read_file** | Inspect existing scenes before modification, read rendered preview images |
+| **patch** | Modify specific parts of scene components (preferred over full file rewrites) |
+| **browser_tool** | Record demos via Playwright, capture screenshots for video assets |
+
+**Workflow pattern:**
+1. Use `write_file` to create the project structure from template
+2. Use `terminal` to run `npm install`
+3. Use `write_file` / `patch` to create/modify scene components
+4. Use `terminal` to render preview stills: `npx remotion still ...`
+5. Use `read_file` to inspect the preview image
+6. Use `patch` to adjust scenes based on preview
+7. Use `terminal` to render full video: `npx remotion render ...`
+
+**Preview-first iteration:** Always render a still frame before a full render. Preview stills take 3-10 seconds; full renders take 2-10 minutes. Inspect the preview, adjust the code, re-preview. Only do a full render when previews look correct.
+
+## Performance Targets
+
+| Stage | Budget |
+|-------|--------|
+| Scene component render | 50-200ms/frame |
+| Audio data processing | 5-20ms/frame |
+| Full 30s video render | 2-5 minutes |
+| Full 60s video render | 4-10 minutes |
+| Preview still | 3-10 seconds |
+
+## References
+
+| File | Contents |
+|------|----------|
+| `references/remotion-core.md` | Composition registration, hooks (`useCurrentFrame`, `useVideoConfig`), `<Sequence>`, `<Series>`, `<AbsoluteFill>`, static files, the rendering pipeline |
+| `references/animations.md` | `interpolate()`, `spring()`, easing curves, stagger patterns, entrance/exit/emphasis animations, loop patterns |
+| `references/text-and-typography.md` | Kinetic typography (word reveal, typewriter, highlight sweep), Google Fonts loading, text measurement, responsive text, captions/subtitles |
+| `references/transitions.md` | `TransitionSeries`, built-in transitions (fade, slide, wipe, flip), custom transitions (glitch, RGB split, pixelate), timing functions, overlays |
+| `references/audio.md` | `useWindowedAudioData()`, audio visualization (spectrum, waveform, bass-reactive), audio import/trimming, voiceover generation (ElevenLabs + Qwen3-TTS), music sync patterns |
+| `references/visual-components.md` | Animated backgrounds (gradient, particle, noise), vignette, film grain, split screen, picture-in-picture, progress bars, animated shapes |
+| `references/data-visualization.md` | Animated counters, bar charts, pie charts, before/after comparisons, stat cards, D3.js integration |
+| `references/recording-and-demos.md` | Playwright browser recording via Hermes browser tool, screen capture as video assets, embedding recordings in compositions |
+| `references/rendering-and-output.md` | CLI rendering commands, quality presets (draft/preview/production), format options (MP4/WebM/GIF), `npx remotion still` for previews, Lambda/cloud rendering |
+| `references/troubleshooting.md` | Common errors (CSS animations, font loading, audio sync), ffmpeg post-processing, memory limits, debugging frame-by-frame |

--- a/skills/creative/video-toolkit/references/animations.md
+++ b/skills/creative/video-toolkit/references/animations.md
@@ -1,0 +1,172 @@
+# Animations
+
+**Critical rule:** ALL animation MUST be driven by `useCurrentFrame()`. CSS transitions, `@keyframes`, `transition:`, and Tailwind animation classes (`animate-spin`, `animate-bounce`, etc.) are **FORBIDDEN** — they produce blank or static frames in Remotion's renderer.
+
+## interpolate()
+
+Maps a frame number to any value range:
+
+```tsx
+import { interpolate, useCurrentFrame } from "remotion";
+
+const frame = useCurrentFrame();
+
+// Fade in over 20 frames
+const opacity = interpolate(frame, [0, 20], [0, 1], {
+  extrapolateRight: "clamp",
+});
+
+// Slide in from 100px left over 30 frames
+const translateX = interpolate(frame, [0, 30], [-100, 0], {
+  extrapolateRight: "clamp",
+});
+```
+
+Always use `extrapolateRight: "clamp"` to prevent values from exceeding the target range after the animation completes.
+
+### Easing
+
+```tsx
+import { Easing } from "remotion";
+
+const scale = interpolate(frame, [0, 30], [0.5, 1], {
+  extrapolateRight: "clamp",
+  easing: Easing.bezier(0.25, 0.1, 0.25, 1), // ease-out
+});
+```
+
+Common easings:
+- `Easing.ease` — standard ease
+- `Easing.bezier(0.33, 1, 0.68, 1)` — ease-out (most natural for entrances)
+- `Easing.bezier(0.65, 0, 0.35, 1)` — ease-in-out
+- `Easing.bezier(0.68, -0.6, 0.32, 1.6)` — overshoot bounce
+
+### Time in Seconds
+
+Always convert seconds to frames:
+
+```tsx
+const { fps } = useVideoConfig();
+const opacity = interpolate(frame, [0, 0.5 * fps], [0, 1], {
+  extrapolateRight: "clamp",
+});
+```
+
+## spring()
+
+Physics-based animation with overshoot and settle:
+
+```tsx
+import { spring, useCurrentFrame, useVideoConfig } from "remotion";
+
+const frame = useCurrentFrame();
+const { fps } = useVideoConfig();
+
+const scale = spring({
+  frame,
+  fps,
+  config: {
+    damping: 12,   // higher = less bounce (default 10)
+    mass: 0.5,     // lower = faster (default 1)
+    stiffness: 200, // higher = snappier (default 100)
+  },
+});
+// scale goes from 0 → ~1, with natural overshoot and settle
+```
+
+### Spring Presets
+
+| Preset | Config | Character |
+|--------|--------|-----------|
+| **Snappy** | `{ damping: 15, mass: 0.4, stiffness: 250 }` | Fast, minimal bounce |
+| **Bouncy** | `{ damping: 8, mass: 0.8, stiffness: 180 }` | Playful overshoot |
+| **Heavy** | `{ damping: 12, mass: 2, stiffness: 120 }` | Slow, weighty |
+| **Gentle** | `{ damping: 20, mass: 0.6, stiffness: 100 }` | Smooth, no overshoot |
+
+### Delayed Spring
+
+```tsx
+const scale = spring({
+  frame: frame - delayFrames, // negative frames produce 0
+  fps,
+  config: { damping: 12 },
+});
+```
+
+## Stagger Pattern
+
+Animate multiple items with sequential delays:
+
+```tsx
+const items = ["Feature A", "Feature B", "Feature C", "Feature D"];
+const staggerDelay = 8; // frames between each item
+
+{items.map((item, i) => {
+  const entrance = spring({
+    frame: frame - i * staggerDelay,
+    fps,
+    config: { damping: 12, mass: 0.5 },
+  });
+
+  return (
+    <div key={i} style={{
+      opacity: entrance,
+      transform: `translateY(${interpolate(entrance, [0, 1], [30, 0])}px)`,
+    }}>
+      {item}
+    </div>
+  );
+})}
+```
+
+## Common Animation Patterns
+
+### Entrance Animations
+
+```tsx
+// Fade in
+const opacity = interpolate(frame, [0, 20], [0, 1], { extrapolateRight: "clamp" });
+
+// Slide up + fade
+const y = interpolate(frame, [0, 25], [40, 0], { extrapolateRight: "clamp", easing: Easing.bezier(0.33, 1, 0.68, 1) });
+const opacity = interpolate(frame, [0, 15], [0, 1], { extrapolateRight: "clamp" });
+
+// Scale in with spring
+const scale = spring({ frame, fps, config: { damping: 12 } });
+
+// Slide from left
+const x = interpolate(frame, [0, 30], [-200, 0], { extrapolateRight: "clamp", easing: Easing.bezier(0.33, 1, 0.68, 1) });
+```
+
+### Exit Animations
+
+Exits should be faster than entrances (shorter duration, no overshoot):
+
+```tsx
+const exitStart = durationInFrames - 15; // start exit 15 frames before scene ends
+const exitOpacity = interpolate(frame, [exitStart, durationInFrames], [1, 0], {
+  extrapolateLeft: "clamp",
+  extrapolateRight: "clamp",
+});
+```
+
+### Emphasis (Pulse, Glow)
+
+```tsx
+// Gentle pulse (loop)
+const pulse = Math.sin(frame * 0.1) * 0.05 + 1; // oscillates 0.95 to 1.05
+<div style={{ transform: `scale(${pulse})` }}>Highlighted text</div>
+
+// Color glow cycle
+const hue = (frame * 2) % 360;
+<div style={{ textShadow: `0 0 20px hsl(${hue}, 80%, 60%)` }}>Glowing</div>
+```
+
+### Loop Pattern
+
+```tsx
+// Loop a 60-frame animation forever using modulo
+const loopDuration = 60;
+const loopedFrame = frame % loopDuration;
+const rotation = interpolate(loopedFrame, [0, loopDuration], [0, 360]);
+```

--- a/skills/creative/video-toolkit/references/audio.md
+++ b/skills/creative/video-toolkit/references/audio.md
@@ -1,0 +1,245 @@
+# Audio
+
+## Importing Audio
+
+```tsx
+import { Audio, staticFile } from "remotion";
+
+// Background music (full duration)
+<Audio src={staticFile("music.mp3")} volume={0.3} />
+
+// Voiceover (starts at frame 60)
+<Sequence from={60}>
+  <Audio src={staticFile("voiceover.mp3")} volume={1.0} />
+</Sequence>
+```
+
+Audio files MUST be in `public/` and referenced via `staticFile()`.
+
+### Volume Control
+
+```tsx
+// Static volume
+<Audio src={staticFile("music.mp3")} volume={0.4} />
+
+// Dynamic volume (duck music during voiceover)
+<Audio
+  src={staticFile("music.mp3")}
+  volume={(f) =>
+    interpolate(f, [voiceStart - 15, voiceStart, voiceEnd, voiceEnd + 15],
+      [0.4, 0.1, 0.1, 0.4], { extrapolateLeft: "clamp", extrapolateRight: "clamp" })
+  }
+/>
+```
+
+### Trimming Audio
+
+```tsx
+<Audio src={staticFile("song.mp3")} startFrom={90} endAt={900} />
+// Plays from frame 90 to frame 900 of the audio file (3s to 30s at 30fps)
+```
+
+## Audio Duration Detection
+
+```tsx
+import { getAudioDurationInSeconds } from "@remotion/media-utils";
+import { staticFile } from "remotion";
+
+// In calculateMetadata:
+const duration = await getAudioDurationInSeconds(staticFile("voiceover.mp3"));
+const durationInFrames = Math.ceil(duration * fps) + 90; // +3s padding
+```
+
+## Audio Visualization
+
+```bash
+npx remotion add @remotion/media-utils
+```
+
+### Windowed Audio Data
+
+Get frequency/amplitude data for the current frame:
+
+```tsx
+import { useWindowedAudioData } from "@remotion/media-utils";
+import { staticFile, useCurrentFrame, useVideoConfig } from "remotion";
+
+const frame = useCurrentFrame();
+const { fps } = useVideoConfig();
+
+const { audioData, dataOffsetInSeconds } = useWindowedAudioData({
+  src: staticFile("music.wav"),
+  frame,
+  fps,
+  numberOfSamples: 256,     // FFT resolution
+  windowInSeconds: 1 / fps, // one frame's worth of audio
+});
+```
+
+`audioData` contains frequency amplitude values (0-255) for each FFT bin.
+
+### Spectrum Bars
+
+```tsx
+const SpectrumBars: React.FC<{ audioSrc: string; barCount?: number }> = ({
+  audioSrc,
+  barCount = 32,
+}) => {
+  const frame = useCurrentFrame();
+  const { fps, height } = useVideoConfig();
+
+  const { audioData } = useWindowedAudioData({
+    src: staticFile(audioSrc),
+    frame,
+    fps,
+    numberOfSamples: 256,
+    windowInSeconds: 0.1,
+  });
+
+  if (!audioData) return null;
+
+  const barWidth = 100 / barCount;
+
+  return (
+    <AbsoluteFill style={{ alignItems: "flex-end" }}>
+      <div style={{ display: "flex", width: "80%", height: "60%", alignItems: "flex-end", gap: 4 }}>
+        {Array.from({ length: barCount }).map((_, i) => {
+          const binIndex = Math.floor((i / barCount) * (audioData.length / 2));
+          const amplitude = (audioData[binIndex] ?? 0) / 255;
+
+          return (
+            <div
+              key={i}
+              style={{
+                flex: 1,
+                height: `${amplitude * 100}%`,
+                backgroundColor: `hsl(${(i / barCount) * 200 + 200}, 80%, 60%)`,
+                borderRadius: 4,
+                transition: "none", // NEVER use CSS transition
+              }}
+            />
+          );
+        })}
+      </div>
+    </AbsoluteFill>
+  );
+};
+```
+
+### Bass-Reactive Scale
+
+Drive element scale by bass amplitude:
+
+```tsx
+const bassAmplitude = audioData
+  ? audioData.slice(0, 8).reduce((sum, v) => sum + v, 0) / (8 * 255)
+  : 0;
+
+const scale = 1 + bassAmplitude * 0.3; // 1.0 to 1.3 range
+<div style={{ transform: `scale(${scale})` }}>
+  <Logo />
+</div>
+```
+
+## Voiceover Generation
+
+### ElevenLabs (Primary — highest quality)
+
+Generate voiceover audio via the ElevenLabs API:
+
+```typescript
+// generate-voiceover.ts (run with: npx tsx generate-voiceover.ts)
+import fs from "fs";
+
+const ELEVENLABS_API_KEY = process.env.ELEVENLABS_API_KEY;
+const VOICE_ID = "21m00Tcm4TlvDq8ikWAM"; // "Rachel" — default female
+
+interface SceneScript {
+  id: string;
+  text: string;
+}
+
+const scenes: SceneScript[] = [
+  { id: "intro", text: "Introducing our latest feature..." },
+  { id: "feature", text: "Built from the ground up for performance." },
+  { id: "cta", text: "Try it today. Link in the description." },
+];
+
+async function generateVoiceover(scene: SceneScript) {
+  const response = await fetch(
+    `https://api.elevenlabs.io/v1/text-to-speech/${VOICE_ID}`,
+    {
+      method: "POST",
+      headers: {
+        "xi-api-key": ELEVENLABS_API_KEY!,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        text: scene.text,
+        model_id: "eleven_turbo_v2_5",
+        voice_settings: { stability: 0.5, similarity_boost: 0.75 },
+      }),
+    }
+  );
+
+  const buffer = await response.arrayBuffer();
+  fs.writeFileSync(`public/audio/${scene.id}.mp3`, Buffer.from(buffer));
+  console.log(`Generated: public/audio/${scene.id}.mp3`);
+}
+
+for (const scene of scenes) {
+  await generateVoiceover(scene);
+}
+```
+
+### Qwen3-TTS (Free / Local Alternative)
+
+For users without an ElevenLabs key, Qwen3-TTS runs locally:
+
+```bash
+# Install
+pip install transformers torch torchaudio
+
+# Generate via Python
+python3 -c "
+from transformers import AutoModelForCausalLM, AutoTokenizer
+import torchaudio, torch
+
+model = AutoModelForCausalLM.from_pretrained('Qwen/Qwen3-TTS', torch_dtype=torch.float16, device_map='auto')
+tokenizer = AutoTokenizer.from_pretrained('Qwen/Qwen3-TTS')
+
+text = 'Introducing our latest feature.'
+inputs = tokenizer(text, return_tensors='pt').to(model.device)
+audio = model.generate(**inputs, max_new_tokens=2048)
+torchaudio.save('public/audio/intro.wav', audio.cpu(), 24000)
+"
+```
+
+Quality is lower than ElevenLabs but serviceable and free.
+
+## Music Sync Patterns
+
+### Beat-Aligned Cuts
+
+If you know the BPM of the music track, calculate beat positions:
+
+```tsx
+const bpm = 120;
+const framesPerBeat = (60 / bpm) * fps; // 15 frames per beat at 120bpm/30fps
+
+// Scene durations as multiples of the beat
+const scene1Duration = framesPerBeat * 8;  // 2 bars
+const scene2Duration = framesPerBeat * 16; // 4 bars
+```
+
+### Manual Beat Markers
+
+For irregular rhythms, define beat timestamps manually:
+
+```tsx
+const beatFrames = [0, 15, 30, 52, 67, 90, 105, 120]; // frames where beats land
+
+// Flash or pulse on beats
+const isNearBeat = beatFrames.some((b) => Math.abs(frame - b) < 3);
+const beatPulse = isNearBeat ? 1.1 : 1.0;
+```

--- a/skills/creative/video-toolkit/references/data-visualization.md
+++ b/skills/creative/video-toolkit/references/data-visualization.md
@@ -1,0 +1,252 @@
+# Data Visualization
+
+Animated charts, counters, and stat comparisons for data-driven video content.
+
+## Animated Counter
+
+Numbers counting up from 0 to a target value:
+
+```tsx
+const AnimatedCounter: React.FC<{
+  target: number;
+  duration?: number; // seconds
+  prefix?: string;
+  suffix?: string;
+  decimals?: number;
+}> = ({ target, duration = 2, prefix = "", suffix = "", decimals = 0 }) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+
+  const value = interpolate(frame, [0, duration * fps], [0, target], {
+    extrapolateRight: "clamp",
+    easing: Easing.bezier(0.33, 1, 0.68, 1),
+  });
+
+  return (
+    <span style={{ fontVariantNumeric: "tabular-nums", fontFamily: "Inter", fontWeight: 700 }}>
+      {prefix}{value.toFixed(decimals)}{suffix}
+    </span>
+  );
+};
+
+// Usage:
+<AnimatedCounter target={99.7} suffix="%" decimals={1} />
+<AnimatedCounter target={50000} prefix="$" />
+<AnimatedCounter target={12} suffix="x faster" />
+```
+
+## Stat Card
+
+A single metric with label, animated entrance:
+
+```tsx
+const StatCard: React.FC<{
+  label: string;
+  value: number;
+  suffix?: string;
+  delay?: number;
+  color?: string;
+}> = ({ label, value, suffix = "", delay = 0, color = "#00d4ff" }) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+
+  const entrance = spring({
+    frame: frame - delay,
+    fps,
+    config: { damping: 14, mass: 0.5 },
+  });
+
+  const countValue = interpolate(
+    frame - delay,
+    [0, fps * 1.5],
+    [0, value],
+    { extrapolateLeft: "clamp", extrapolateRight: "clamp" }
+  );
+
+  return (
+    <div style={{
+      opacity: entrance,
+      transform: `translateY(${interpolate(entrance, [0, 1], [30, 0])}px) scale(${entrance})`,
+      textAlign: "center",
+      padding: 24,
+    }}>
+      <div style={{ fontSize: 72, fontWeight: 800, color, fontVariantNumeric: "tabular-nums" }}>
+        {Math.round(countValue)}{suffix}
+      </div>
+      <div style={{ fontSize: 24, color: "rgba(255,255,255,0.6)", marginTop: 8 }}>
+        {label}
+      </div>
+    </div>
+  );
+};
+```
+
+## Bar Chart
+
+Animated horizontal or vertical bars:
+
+```tsx
+const BarChart: React.FC<{
+  data: { label: string; value: number; color?: string }[];
+  maxValue?: number;
+  direction?: "horizontal" | "vertical";
+}> = ({ data, maxValue, direction = "horizontal" }) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const max = maxValue ?? Math.max(...data.map((d) => d.value));
+
+  return (
+    <div style={{
+      display: "flex",
+      flexDirection: direction === "horizontal" ? "column" : "row",
+      gap: 12,
+      alignItems: direction === "horizontal" ? "stretch" : "flex-end",
+      width: "100%",
+      height: direction === "vertical" ? "100%" : "auto",
+    }}>
+      {data.map((item, i) => {
+        const barProgress = interpolate(
+          frame - i * 8, // stagger
+          [0, fps * 0.8],
+          [0, item.value / max],
+          { extrapolateLeft: "clamp", extrapolateRight: "clamp", easing: Easing.bezier(0.33, 1, 0.68, 1) }
+        );
+        const barColor = item.color ?? `hsl(${(i / data.length) * 200 + 200}, 70%, 55%)`;
+
+        if (direction === "horizontal") {
+          return (
+            <div key={i} style={{ display: "flex", alignItems: "center", gap: 12 }}>
+              <div style={{ width: 100, fontSize: 14, color: "rgba(255,255,255,0.7)", textAlign: "right" }}>
+                {item.label}
+              </div>
+              <div style={{ flex: 1, height: 24, borderRadius: 4, overflow: "hidden", backgroundColor: "rgba(255,255,255,0.05)" }}>
+                <div style={{ width: `${barProgress * 100}%`, height: "100%", backgroundColor: barColor, borderRadius: 4 }} />
+              </div>
+              <div style={{ width: 60, fontSize: 14, color: "rgba(255,255,255,0.7)" }}>
+                {Math.round(barProgress * item.value)}
+              </div>
+            </div>
+          );
+        }
+
+        return (
+          <div key={i} style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "flex-end", gap: 8 }}>
+            <div style={{ width: "80%", height: `${barProgress * 100}%`, backgroundColor: barColor, borderRadius: "4px 4px 0 0" }} />
+            <div style={{ fontSize: 12, color: "rgba(255,255,255,0.6)" }}>{item.label}</div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+```
+
+## Before/After Comparison
+
+Two stat sets with a visual divider:
+
+```tsx
+const BeforeAfter: React.FC<{
+  before: { label: string; value: string }[];
+  after: { label: string; value: string }[];
+  beforeTitle?: string;
+  afterTitle?: string;
+}> = ({ before, after, beforeTitle = "Before", afterTitle = "After" }) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+
+  const dividerProgress = interpolate(frame, [fps * 0.5, fps * 1], [0, 1], {
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+  });
+
+  return (
+    <AbsoluteFill style={{ flexDirection: "row", padding: 80 }}>
+      {/* Before */}
+      <div style={{ flex: 1, opacity: 0.5 }}>
+        <h3 style={{ color: "rgba(255,255,255,0.4)", fontSize: 24 }}>{beforeTitle}</h3>
+        {before.map((item, i) => (
+          <div key={i} style={{ marginTop: 16 }}>
+            <div style={{ fontSize: 36, color: "rgba(255,255,255,0.5)" }}>{item.value}</div>
+            <div style={{ fontSize: 16, color: "rgba(255,255,255,0.3)" }}>{item.label}</div>
+          </div>
+        ))}
+      </div>
+
+      {/* Divider */}
+      <div style={{
+        width: 2,
+        backgroundColor: "rgba(255,255,255,0.2)",
+        margin: "0 40px",
+        transform: `scaleY(${dividerProgress})`,
+        transformOrigin: "top",
+      }} />
+
+      {/* After */}
+      <div style={{ flex: 1 }}>
+        <h3 style={{ color: "#00d4ff", fontSize: 24 }}>{afterTitle}</h3>
+        {after.map((item, i) => {
+          const entrance = spring({
+            frame: frame - fps * 1 - i * 10,
+            fps,
+            config: { damping: 12 },
+          });
+          return (
+            <div key={i} style={{ marginTop: 16, opacity: entrance, transform: `translateX(${interpolate(entrance, [0, 1], [20, 0])}px)` }}>
+              <div style={{ fontSize: 36, fontWeight: 700, color: "white" }}>{item.value}</div>
+              <div style={{ fontSize: 16, color: "rgba(255,255,255,0.6)" }}>{item.label}</div>
+            </div>
+          );
+        })}
+      </div>
+    </AbsoluteFill>
+  );
+};
+```
+
+## Percentage Circle
+
+Animated donut/ring showing a percentage:
+
+```tsx
+const PercentageCircle: React.FC<{
+  value: number; // 0-100
+  size?: number;
+  color?: string;
+  strokeWidth?: number;
+}> = ({ value, size = 200, color = "#00d4ff", strokeWidth = 12 }) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+
+  const progress = interpolate(frame, [0, fps * 1.5], [0, value / 100], {
+    extrapolateRight: "clamp",
+    easing: Easing.bezier(0.33, 1, 0.68, 1),
+  });
+
+  const r = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * r;
+  const offset = circumference * (1 - progress);
+
+  return (
+    <div style={{ width: size, height: size, position: "relative" }}>
+      <svg width={size} height={size} style={{ transform: "rotate(-90deg)" }}>
+        <circle cx={size / 2} cy={size / 2} r={r} fill="none" stroke="rgba(255,255,255,0.1)" strokeWidth={strokeWidth} />
+        <circle
+          cx={size / 2} cy={size / 2} r={r} fill="none"
+          stroke={color} strokeWidth={strokeWidth}
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+          strokeLinecap="round"
+        />
+      </svg>
+      <div style={{
+        position: "absolute", inset: 0,
+        display: "flex", justifyContent: "center", alignItems: "center",
+        fontSize: size * 0.25, fontWeight: 700, color: "white",
+      }}>
+        {Math.round(progress * value)}%
+      </div>
+    </div>
+  );
+};
+```

--- a/skills/creative/video-toolkit/references/recording-and-demos.md
+++ b/skills/creative/video-toolkit/references/recording-and-demos.md
@@ -1,0 +1,182 @@
+# Recording and Demos
+
+Capture browser interactions and screen recordings as video assets for Remotion compositions.
+
+## Browser Demo Recording via Playwright
+
+Hermes has a built-in browser tool. Use it to record browser interactions as video:
+
+### Record a Web App Demo
+
+```bash
+# Start a screen recording via Playwright
+# Hermes browser tool supports this natively
+```
+
+In a Hermes session, use the browser tool to:
+
+1. Navigate to the target URL
+2. Start video recording
+3. Perform the demo interactions (clicks, typing, navigation)
+4. Stop recording
+5. Save the video file to `public/demos/`
+
+### Convert Screen Recording to Remotion Asset
+
+Once you have a recorded video file:
+
+```tsx
+import { Video, staticFile, Sequence } from "remotion";
+
+// Embed the demo recording in a scene
+const DemoScene: React.FC = () => (
+  <AbsoluteFill style={{ backgroundColor: "#0a0a1a", padding: 40 }}>
+    {/* Browser chrome mockup */}
+    <div style={{
+      borderRadius: 12,
+      overflow: "hidden",
+      border: "1px solid rgba(255,255,255,0.1)",
+      boxShadow: "0 20px 60px rgba(0,0,0,0.5)",
+    }}>
+      {/* Title bar */}
+      <div style={{
+        height: 36,
+        backgroundColor: "#1e1e2e",
+        display: "flex",
+        alignItems: "center",
+        padding: "0 12px",
+        gap: 8,
+      }}>
+        <div style={{ width: 12, height: 12, borderRadius: "50%", backgroundColor: "#ff5f56" }} />
+        <div style={{ width: 12, height: 12, borderRadius: "50%", backgroundColor: "#ffbd2e" }} />
+        <div style={{ width: 12, height: 12, borderRadius: "50%", backgroundColor: "#27c93f" }} />
+        <div style={{
+          flex: 1, height: 24, borderRadius: 6,
+          backgroundColor: "rgba(255,255,255,0.05)",
+          marginLeft: 12, display: "flex", alignItems: "center",
+          padding: "0 12px", fontSize: 12, color: "rgba(255,255,255,0.3)",
+        }}>
+          https://your-app.com
+        </div>
+      </div>
+      {/* Video content */}
+      <Video src={staticFile("demos/app-demo.mp4")} style={{ width: "100%" }} />
+    </div>
+  </AbsoluteFill>
+);
+```
+
+### Zoom and Pan on Demo Video
+
+Highlight specific parts of a recording by zooming in:
+
+```tsx
+const ZoomedDemo: React.FC<{
+  src: string;
+  zoomRegion: { x: number; y: number; scale: number };
+  zoomAt: number; // frame to start zoom
+  zoomDuration?: number; // frames
+}> = ({ src, zoomRegion, zoomAt, zoomDuration = 30 }) => {
+  const frame = useCurrentFrame();
+
+  const zoomProgress = interpolate(frame, [zoomAt, zoomAt + zoomDuration], [0, 1], {
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+    easing: Easing.bezier(0.33, 1, 0.68, 1),
+  });
+
+  const scale = interpolate(zoomProgress, [0, 1], [1, zoomRegion.scale]);
+  const x = interpolate(zoomProgress, [0, 1], [0, -zoomRegion.x]);
+  const y = interpolate(zoomProgress, [0, 1], [0, -zoomRegion.y]);
+
+  return (
+    <div style={{ overflow: "hidden", width: "100%", height: "100%" }}>
+      <Video
+        src={staticFile(src)}
+        style={{
+          transform: `scale(${scale}) translate(${x}px, ${y}px)`,
+          transformOrigin: "top left",
+        }}
+      />
+    </div>
+  );
+};
+```
+
+## Screenshot Assets
+
+Use Hermes browser tool to capture screenshots, then embed as images:
+
+```tsx
+import { Img, staticFile } from "remotion";
+
+<Img src={staticFile("screenshots/feature-highlight.png")}
+  style={{ width: "80%", borderRadius: 12, boxShadow: "0 20px 60px rgba(0,0,0,0.5)" }}
+/>
+```
+
+## Phone / Device Mockups
+
+Wrap screenshots in device frames:
+
+```tsx
+const PhoneMockup: React.FC<{ screenshot: string }> = ({ screenshot }) => (
+  <div style={{
+    width: 300, height: 650,
+    borderRadius: 36,
+    border: "4px solid #333",
+    overflow: "hidden",
+    backgroundColor: "#000",
+    padding: 8,
+    boxShadow: "0 20px 60px rgba(0,0,0,0.5)",
+  }}>
+    <div style={{ borderRadius: 28, overflow: "hidden", width: "100%", height: "100%" }}>
+      <Img src={staticFile(screenshot)} style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+    </div>
+  </div>
+);
+```
+
+## Terminal / CLI Mockup
+
+For recording CLI tool demos, embed terminal-style output:
+
+```tsx
+const TerminalMockup: React.FC<{
+  lines: { text: string; delay: number }[];
+}> = ({ lines }) => {
+  const frame = useCurrentFrame();
+
+  return (
+    <div style={{
+      backgroundColor: "#1a1a2e",
+      borderRadius: 12,
+      padding: 24,
+      fontFamily: "JetBrains Mono",
+      fontSize: 16,
+      color: "#e0e0e0",
+      lineHeight: 1.6,
+      border: "1px solid rgba(255,255,255,0.1)",
+    }}>
+      {/* Terminal header */}
+      <div style={{ display: "flex", gap: 8, marginBottom: 16 }}>
+        <div style={{ width: 12, height: 12, borderRadius: "50%", backgroundColor: "#ff5f56" }} />
+        <div style={{ width: 12, height: 12, borderRadius: "50%", backgroundColor: "#ffbd2e" }} />
+        <div style={{ width: 12, height: 12, borderRadius: "50%", backgroundColor: "#27c93f" }} />
+      </div>
+      {/* Lines with typewriter effect */}
+      {lines.map((line, i) => {
+        const lineFrame = frame - line.delay;
+        if (lineFrame < 0) return null;
+        const charsShown = Math.min(Math.floor(lineFrame * 0.8), line.text.length);
+        return (
+          <div key={i}>
+            <span style={{ color: "#888" }}>$ </span>
+            {line.text.slice(0, charsShown)}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+```

--- a/skills/creative/video-toolkit/references/remotion-core.md
+++ b/skills/creative/video-toolkit/references/remotion-core.md
@@ -1,0 +1,192 @@
+# Remotion Core
+
+## Composition Registration
+
+Every video starts with a Composition registered in `Root.tsx`:
+
+```tsx
+import { Composition } from "remotion";
+import { MainVideo } from "./MainVideo";
+
+export const RemotionRoot: React.FC = () => (
+  <>
+    <Composition
+      id="MainVideo"
+      component={MainVideo}
+      durationInFrames={900}   // 30 seconds at 30fps
+      fps={30}
+      width={1920}
+      height={1080}
+      defaultProps={{
+        title: "My Video",
+      }}
+    />
+  </>
+);
+```
+
+Multiple compositions can be registered for different versions (social, widescreen, preview).
+
+## Core Hooks
+
+### useCurrentFrame()
+
+Returns the current frame number (0-indexed). This is the ONLY way to drive animation.
+
+```tsx
+const frame = useCurrentFrame(); // 0, 1, 2, ... durationInFrames-1
+```
+
+### useVideoConfig()
+
+Returns composition metadata:
+
+```tsx
+const { fps, durationInFrames, width, height } = useVideoConfig();
+const currentSecond = frame / fps;
+```
+
+## Layout Primitives
+
+### AbsoluteFill
+
+Full-frame container. Stack multiple for layered compositions:
+
+```tsx
+import { AbsoluteFill } from "remotion";
+
+// Background layer
+<AbsoluteFill style={{ backgroundColor: "#0a0a1a" }} />
+// Content layer
+<AbsoluteFill style={{ justifyContent: "center", alignItems: "center" }}>
+  <h1>Title</h1>
+</AbsoluteFill>
+// Overlay layer
+<AbsoluteFill style={{ background: "linear-gradient(transparent, rgba(0,0,0,0.5))" }} />
+```
+
+### Sequence
+
+Time-offset a subtree. Children only render during their sequence window:
+
+```tsx
+import { Sequence } from "remotion";
+
+// Title appears at 0s, subtitle at 1s, body at 2s
+<Sequence from={0} durationInFrames={fps * 4}>
+  <Title />
+</Sequence>
+<Sequence from={fps * 1} durationInFrames={fps * 3}>
+  <Subtitle />
+</Sequence>
+<Sequence from={fps * 2}>
+  <Body />
+</Sequence>
+```
+
+Inside a `<Sequence>`, `useCurrentFrame()` resets to 0 at the sequence start. This is critical — animations within a sequence always start from frame 0 regardless of their position in the timeline.
+
+### Series
+
+Sequential arrangement without manual frame math:
+
+```tsx
+import { Series } from "remotion";
+
+<Series>
+  <Series.Sequence durationInFrames={90}>
+    <SceneOne />
+  </Series.Sequence>
+  <Series.Sequence durationInFrames={120}>
+    <SceneTwo />
+  </Series.Sequence>
+  <Series.Sequence durationInFrames={90}>
+    <SceneThree />
+  </Series.Sequence>
+</Series>
+```
+
+## Static Files
+
+Place assets in `public/`. Reference via `staticFile()`:
+
+```tsx
+import { staticFile, Audio, Img, Video } from "remotion";
+
+<Audio src={staticFile("voiceover.mp3")} />
+<Img src={staticFile("logo.png")} />
+<Video src={staticFile("demo.mp4")} />
+```
+
+Never use relative imports for media files. Always `staticFile()`.
+
+## Dynamic Metadata
+
+Use `calculateMetadata` to set duration/dimensions dynamically (e.g., based on audio length):
+
+```tsx
+import { CalculateMetadataFunction } from "remotion";
+import { getAudioDurationInSeconds } from "@remotion/media-utils";
+
+export const calculateMyMetadata: CalculateMetadataFunction<Props> = async ({ props }) => {
+  const duration = await getAudioDurationInSeconds(staticFile(props.audioFile));
+  return {
+    durationInFrames: Math.ceil(duration * 30) + 90, // +3s padding
+    props,
+  };
+};
+
+// In Root.tsx:
+<Composition
+  id="MainVideo"
+  component={MainVideo}
+  calculateMetadata={calculateMyMetadata}
+  // durationInFrames is now dynamic
+  fps={30}
+  width={1920}
+  height={1080}
+/>
+```
+
+## Project Structure
+
+```
+my-video/
+├── src/
+│   ├── Root.tsx              # Composition registration
+│   ├── MainVideo.tsx         # Top-level component (arranges scenes)
+│   ├── scenes/               # One file per scene
+│   │   ├── TitleScene.tsx
+│   │   ├── FeatureScene.tsx
+│   │   └── CTAScene.tsx
+│   ├── components/           # Shared visual components
+│   │   ├── AnimatedBg.tsx
+│   │   └── KineticText.tsx
+│   └── index.ts              # Entry point
+├── public/                   # Static assets
+│   ├── audio/
+│   ├── images/
+│   └── fonts/
+├── remotion.config.ts
+├── tsconfig.json
+└── package.json
+```
+
+## Entry Point (index.ts)
+
+```tsx
+import { registerRoot } from "remotion";
+import { RemotionRoot } from "./Root";
+
+registerRoot(RemotionRoot);
+```
+
+## Remotion Config
+
+```ts
+// remotion.config.ts
+import { Config } from "@remotion/cli/config";
+
+Config.setVideoImageFormat("jpeg"); // faster preview than PNG
+Config.setOverwriteOutput(true);    // don't prompt on re-render
+```

--- a/skills/creative/video-toolkit/references/rendering-and-output.md
+++ b/skills/creative/video-toolkit/references/rendering-and-output.md
@@ -1,0 +1,198 @@
+# Rendering and Output
+
+## Preview Stills
+
+Always render preview frames before a full render. This saves minutes of wasted render time:
+
+```bash
+# Preview frame at 3 seconds (frame 90 at 30fps)
+npx remotion still src/index.ts MainVideo --frame=90 --output=preview.png
+
+# Preview multiple key moments
+for f in 0 45 90 180 360 720; do
+  npx remotion still src/index.ts MainVideo --frame=$f --output=preview_${f}.png
+done
+```
+
+Preview stills render in 3-10 seconds. A full 30-second video takes 2-5 minutes. Always preview first.
+
+## Full Render
+
+### Basic Render
+
+```bash
+# Default (H.264 MP4)
+npx remotion render src/index.ts MainVideo --output=output.mp4
+
+# Specify composition by ID
+npx remotion render src/index.ts MyCompositionId --output=output.mp4
+```
+
+### Quality Presets
+
+```bash
+# Draft — fast, low quality (for checking timing/structure)
+npx remotion render src/index.ts MainVideo \
+  --output=draft.mp4 \
+  --scale=0.5 \
+  --quality=50 \
+  --concurrency=100%
+
+# Preview — balanced (for client review)
+npx remotion render src/index.ts MainVideo \
+  --output=preview.mp4 \
+  --quality=80
+
+# Production — highest quality
+npx remotion render src/index.ts MainVideo \
+  --output=final.mp4 \
+  --codec=h264 \
+  --crf=18 \
+  --pixel-format=yuv420p
+```
+
+### CRF (Constant Rate Factor)
+
+Controls quality vs file size tradeoff:
+- `--crf=18` — near-lossless, large file (production)
+- `--crf=23` — default, good quality, reasonable size
+- `--crf=28` — smaller file, visible compression (drafts)
+
+Lower CRF = better quality = larger file.
+
+## Output Formats
+
+### Video Formats
+
+```bash
+# H.264 MP4 (universal compatibility)
+npx remotion render src/index.ts MainVideo --codec=h264 --output=video.mp4
+
+# H.265/HEVC (smaller files, less compatible)
+npx remotion render src/index.ts MainVideo --codec=h265 --output=video.mp4
+
+# VP8/WebM (web-optimized)
+npx remotion render src/index.ts MainVideo --codec=vp8 --output=video.webm
+
+# ProRes (editing, post-production)
+npx remotion render src/index.ts MainVideo --codec=prores --output=video.mov
+```
+
+### GIF
+
+```bash
+# Animated GIF (limited to 256 colors)
+npx remotion render src/index.ts MainVideo --codec=gif --output=output.gif
+
+# Better quality GIF: render to MP4 then convert with ffmpeg
+npx remotion render src/index.ts MainVideo --output=temp.mp4
+ffmpeg -i temp.mp4 -vf "fps=15,scale=640:-1:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse" output.gif
+```
+
+### PNG Sequence
+
+```bash
+# Individual frames as PNG files
+npx remotion render src/index.ts MainVideo --image-format=png --sequence --output-location=frames/
+```
+
+### Transparent Video
+
+For overlays and compositing:
+
+```tsx
+// In composition — use transparent background
+<Composition
+  id="Overlay"
+  component={OverlayComponent}
+  width={1920} height={1080} fps={30}
+  durationInFrames={150}
+/>
+```
+
+```bash
+# Render with alpha channel
+npx remotion render src/index.ts Overlay --codec=vp8 --output=overlay.webm
+# VP8/WebM supports transparency; H.264 does not
+```
+
+## Aspect Ratio Rendering
+
+```bash
+# Standard 16:9 (YouTube, general)
+# Set in Composition: width={1920} height={1080}
+
+# Vertical 9:16 (Instagram Reels, TikTok, YouTube Shorts)
+# Set in Composition: width={1080} height={1920}
+
+# Square 1:1 (Instagram feed, Twitter)
+# Set in Composition: width={1080} height={1080}
+```
+
+To render multiple aspect ratios, register multiple Compositions with different dimensions but the same content (adapt layout per ratio).
+
+## Rendering Performance
+
+### Concurrency
+
+```bash
+# Use all CPU cores (default)
+npx remotion render ... --concurrency=100%
+
+# Limit to 4 cores (if system is constrained)
+npx remotion render ... --concurrency=4
+```
+
+### Memory
+
+Long videos or complex scenes may hit memory limits:
+
+```bash
+# Increase Node.js memory
+NODE_OPTIONS="--max-old-space-size=8192" npx remotion render ...
+```
+
+### Performance Tips
+
+- Reduce `scale` for drafts (`--scale=0.5` renders at half resolution)
+- Use `jpeg` image format instead of `png` for previews (faster)
+- Pre-render complex scenes as video clips and embed them
+- Minimize DOM nodes per frame — React reconciliation is the bottleneck
+
+## Post-Processing with ffmpeg
+
+### Add Music to Rendered Video
+
+```bash
+# Replace audio track
+ffmpeg -i video.mp4 -i music.mp3 -c:v copy -c:a aac -shortest output.mp4
+
+# Mix background music with existing voiceover
+ffmpeg -i video.mp4 -i music.mp3 \
+  -filter_complex "[1:a]volume=0.3[bg];[0:a][bg]amix=inputs=2:duration=first" \
+  -c:v copy output.mp4
+```
+
+### Trim
+
+```bash
+# Cut from 5s to 25s
+ffmpeg -i input.mp4 -ss 5 -to 25 -c copy trimmed.mp4
+```
+
+### Resize
+
+```bash
+# Scale to 720p
+ffmpeg -i input.mp4 -vf scale=1280:720 -c:a copy output_720p.mp4
+```
+
+### Compress for Social Media
+
+```bash
+# Twitter/X (max 512MB, recommended <15MB for fast upload)
+ffmpeg -i input.mp4 -c:v libx264 -crf 26 -preset medium -c:a aac -b:a 128k twitter.mp4
+
+# Discord (max 25MB for free users)
+ffmpeg -i input.mp4 -c:v libx264 -crf 28 -preset medium -c:a aac -b:a 96k discord.mp4
+```

--- a/skills/creative/video-toolkit/references/text-and-typography.md
+++ b/skills/creative/video-toolkit/references/text-and-typography.md
@@ -1,0 +1,221 @@
+# Text and Typography
+
+## Font Loading
+
+Use `@remotion/google-fonts` for web fonts. Never use `@import url()` in CSS.
+
+```bash
+npx remotion add @remotion/google-fonts
+```
+
+```tsx
+import { loadFont } from "@remotion/google-fonts/Inter";
+const { fontFamily } = loadFont();
+
+// Use in components:
+<p style={{ fontFamily }}>Clean sans-serif text</p>
+```
+
+Common choices by mood:
+| Mood | Font | Weight |
+|------|------|--------|
+| Modern/tech | Inter, Space Grotesk | 400, 700 |
+| Editorial | Playfair Display, Fraunces | 400, 700 |
+| Monospace/code | JetBrains Mono, Fira Code | 400, 500 |
+| Bold display | Bebas Neue, Anton | 400 |
+| Friendly | Nunito, Poppins | 400, 600 |
+
+## Kinetic Typography — Word-by-Word Reveal
+
+The signature motion graphics technique. Reveal text one word at a time with spring physics:
+
+```tsx
+const KineticText: React.FC<{ text: string; startFrame?: number }> = ({
+  text,
+  startFrame = 0,
+}) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const words = text.split(" ");
+  const framesPerWord = Math.floor(fps * 0.12); // ~4 frames per word at 30fps
+
+  return (
+    <div style={{ display: "flex", flexWrap: "wrap", gap: 12, justifyContent: "center" }}>
+      {words.map((word, i) => {
+        const wordFrame = frame - startFrame - i * framesPerWord;
+        const entrance = spring({
+          frame: wordFrame,
+          fps,
+          config: { damping: 14, mass: 0.5, stiffness: 200 },
+        });
+
+        return (
+          <span
+            key={i}
+            style={{
+              opacity: entrance,
+              transform: `translateY(${interpolate(entrance, [0, 1], [20, 0])}px)`,
+              fontSize: 64,
+              fontWeight: 700,
+              color: "white",
+            }}
+          >
+            {word}
+          </span>
+        );
+      })}
+    </div>
+  );
+};
+```
+
+## Typewriter Effect
+
+Character-by-character reveal with blinking cursor. Use string slicing, never per-character opacity:
+
+```tsx
+const Typewriter: React.FC<{ text: string; charsPerFrame?: number }> = ({
+  text,
+  charsPerFrame = 0.5,
+}) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const charsShown = Math.min(Math.floor(frame * charsPerFrame), text.length);
+  const showCursor = frame % Math.floor(fps * 0.5) < Math.floor(fps * 0.25);
+  const isComplete = charsShown >= text.length;
+
+  return (
+    <span style={{ fontFamily: "JetBrains Mono", fontSize: 32, color: "#00ff88" }}>
+      {text.slice(0, charsShown)}
+      {(!isComplete || showCursor) && (
+        <span style={{ opacity: showCursor ? 1 : 0 }}>|</span>
+      )}
+    </span>
+  );
+};
+```
+
+## Word Highlight
+
+Animated highlighter pen sweeping behind a word:
+
+```tsx
+const HighlightWord: React.FC<{ children: string; color?: string; delay?: number }> = ({
+  children,
+  color = "#FFD700",
+  delay = 0,
+}) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+
+  const progress = interpolate(frame - delay, [0, fps * 0.3], [0, 100], {
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+    easing: Easing.bezier(0.33, 1, 0.68, 1),
+  });
+
+  return (
+    <span style={{ position: "relative", display: "inline-block" }}>
+      <span
+        style={{
+          position: "absolute",
+          bottom: 2,
+          left: -4,
+          height: "35%",
+          width: `${progress}%`,
+          backgroundColor: color,
+          opacity: 0.4,
+          borderRadius: 4,
+          zIndex: -1,
+        }}
+      />
+      {children}
+    </span>
+  );
+};
+```
+
+## Slide-Up Stack
+
+Lines entering from bottom, stacking vertically. Good for feature lists:
+
+```tsx
+const SlideUpStack: React.FC<{ lines: string[] }> = ({ lines }) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+  const staggerFrames = Math.floor(fps * 0.3);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+      {lines.map((line, i) => {
+        const lineFrame = frame - i * staggerFrames;
+        const y = interpolate(lineFrame, [0, 20], [40, 0], {
+          extrapolateLeft: "clamp",
+          extrapolateRight: "clamp",
+          easing: Easing.bezier(0.33, 1, 0.68, 1),
+        });
+        const opacity = interpolate(lineFrame, [0, 15], [0, 1], {
+          extrapolateLeft: "clamp",
+          extrapolateRight: "clamp",
+        });
+
+        return (
+          <div key={i} style={{ opacity, transform: `translateY(${y}px)`, fontSize: 36 }}>
+            {line}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+```
+
+## Text Measurement
+
+Measure text to fit within containers or create responsive layouts:
+
+```tsx
+import { measureText } from "@remotion/layout-utils";
+
+const { width, height } = measureText({
+  text: "Hello World",
+  fontFamily: "Inter",
+  fontSize: 64,
+  fontWeight: "700",
+});
+```
+
+For fitting text to a container width:
+
+```tsx
+import { fitText } from "@remotion/layout-utils";
+
+const { fontSize } = fitText({
+  text: "A very long title that needs to fit",
+  withinWidth: 1600,
+  fontFamily: "Inter",
+  fontWeight: "700",
+});
+```
+
+## Captions / Subtitles
+
+For voiceover-synced captions, use `@remotion/captions`:
+
+```bash
+npx remotion add @remotion/captions
+```
+
+Import SRT or generate from TTS timestamps. Render as animated text synced to audio. See `references/audio.md` for voiceover generation and timing extraction.
+
+## Readability Guidelines
+
+| Content type | Minimum display time |
+|-------------|---------------------|
+| Single word / title | 1.5 seconds |
+| Short phrase (3-5 words) | 2 seconds |
+| Full sentence | 3-4 seconds |
+| Paragraph / bullet list | 5-8 seconds |
+| Code snippet | 6-10 seconds |
+
+At 30fps: 1.5s = 45 frames, 2s = 60 frames, 4s = 120 frames.

--- a/skills/creative/video-toolkit/references/transitions.md
+++ b/skills/creative/video-toolkit/references/transitions.md
@@ -1,0 +1,165 @@
+# Transitions
+
+## TransitionSeries
+
+The primary scene arrangement component when transitions are needed between scenes:
+
+```bash
+npx remotion add @remotion/transitions
+```
+
+```tsx
+import { TransitionSeries, linearTiming } from "@remotion/transitions";
+import { fade } from "@remotion/transitions/fade";
+import { slide } from "@remotion/transitions/slide";
+
+<TransitionSeries>
+  <TransitionSeries.Sequence durationInFrames={90}>
+    <TitleScene />
+  </TransitionSeries.Sequence>
+
+  <TransitionSeries.Transition
+    presentation={fade()}
+    timing={linearTiming({ durationInFrames: 20 })}
+  />
+
+  <TransitionSeries.Sequence durationInFrames={120}>
+    <FeatureScene />
+  </TransitionSeries.Sequence>
+
+  <TransitionSeries.Transition
+    presentation={slide({ direction: "from-left" })}
+    timing={linearTiming({ durationInFrames: 25 })}
+  />
+
+  <TransitionSeries.Sequence durationInFrames={90}>
+    <CTAScene />
+  </TransitionSeries.Sequence>
+</TransitionSeries>
+```
+
+**Important:** TransitionSeries shortens the timeline — during a transition, both scenes play simultaneously. A 20-frame fade means the video is 20 frames shorter than the sum of all sequence durations.
+
+## Timing Functions
+
+```tsx
+import { linearTiming, springTiming } from "@remotion/transitions";
+
+// Linear (constant speed)
+timing={linearTiming({ durationInFrames: 20 })}
+
+// Spring (physics-based, natural feel — recommended)
+timing={springTiming({ config: { damping: 12 }, durationInFrames: 30 })}
+```
+
+Spring timing is almost always better than linear for scene transitions.
+
+## Built-in Transitions
+
+| Transition | Import | Options | Best for |
+|-----------|--------|---------|----------|
+| `fade()` | `@remotion/transitions/fade` | — | Universal, subtle |
+| `slide()` | `@remotion/transitions/slide` | `direction`: from-left/right/top/bottom | Panel reveals, directional flow |
+| `wipe()` | `@remotion/transitions/wipe` | `direction`, `angle` | Cinematic, energetic |
+| `flip()` | `@remotion/transitions/flip` | `direction` | Playful, card-like |
+| `clockWipe()` | `@remotion/transitions/clock-wipe` | — | Dramatic, radial |
+
+```tsx
+import { fade } from "@remotion/transitions/fade";
+import { slide } from "@remotion/transitions/slide";
+import { wipe } from "@remotion/transitions/wipe";
+
+// Slide from right
+slide({ direction: "from-right" })
+
+// Wipe at angle
+wipe({ direction: "from-left" })
+```
+
+## Overlays (Non-Shortening)
+
+Overlays render ON TOP of the cut point without shortening the timeline. Use for light leaks, flash effects, or decorative elements:
+
+```bash
+npx remotion add @remotion/light-leaks
+```
+
+```tsx
+import { TransitionSeries, linearTiming } from "@remotion/transitions";
+import { LightLeak } from "@remotion/light-leaks";
+
+<TransitionSeries>
+  <TransitionSeries.Sequence durationInFrames={90}>
+    <SceneOne />
+  </TransitionSeries.Sequence>
+
+  <TransitionSeries.Overlay timing={linearTiming({ durationInFrames: 30 })}>
+    <LightLeak seed={3} />
+  </TransitionSeries.Overlay>
+
+  <TransitionSeries.Sequence durationInFrames={120}>
+    <SceneTwo />
+  </TransitionSeries.Sequence>
+</TransitionSeries>
+```
+
+## Custom Transitions
+
+Build transitions as React components that receive `progress` (0 to 1):
+
+```tsx
+import { TransitionPresentation } from "@remotion/transitions";
+
+// Glitch transition
+const glitch = (): TransitionPresentation => {
+  return {
+    component: ({ progress, children }) => {
+      const glitchAmount = Math.sin(progress * Math.PI) * 20;
+      const rgbShift = Math.sin(progress * Math.PI) * 10;
+
+      return (
+        <AbsoluteFill>
+          <div style={{
+            width: "100%",
+            height: "100%",
+            filter: `hue-rotate(${glitchAmount * 5}deg)`,
+            transform: `translateX(${Math.random() > 0.9 ? glitchAmount : 0}px)`,
+          }}>
+            {children}
+          </div>
+        </AbsoluteFill>
+      );
+    },
+  };
+};
+```
+
+### Custom Transition Ideas
+
+| Transition | Description | Technique |
+|-----------|-------------|-----------|
+| **Glitch** | Digital distortion with RGB shift and horizontal tears | Random translateX + hue-rotate at peak progress |
+| **Pixelate** | Mosaic dissolution — pixels grow larger then resolve | CSS `image-rendering: pixelated` + scale |
+| **Blur zoom** | Scene blurs and zooms simultaneously | `filter: blur()` + `transform: scale()` |
+| **Curtain** | Vertical strips reveal the next scene left to right | Clip-path with animated percentage |
+| **Flash** | Bright white flash between scenes | White overlay with opacity peak at progress=0.5 |
+
+## Transition Selection Guide
+
+| Scenario | Recommended |
+|----------|-------------|
+| Default / safe | `fade()` with spring timing |
+| Directional flow (left→right narrative) | `slide({ direction: "from-right" })` |
+| Energy change (calm→intense) | `wipe()` or custom flash |
+| Same topic, new angle | `fade()` 15-frame duration |
+| Dramatic reveal | `clockWipe()` |
+| Playful / casual | `flip()` |
+| Technical / glitch aesthetic | Custom glitch transition |
+| Cinematic | Light leak overlay + fade |
+
+## Transition Timing Guidelines
+
+- **Subtle transitions** (same topic): 10-15 frames (0.3-0.5s)
+- **Standard scene change**: 20-25 frames (0.7-0.8s)
+- **Dramatic reveal**: 30-40 frames (1.0-1.3s)
+- **Music-synced**: align transition midpoint with the beat

--- a/skills/creative/video-toolkit/references/troubleshooting.md
+++ b/skills/creative/video-toolkit/references/troubleshooting.md
@@ -1,0 +1,164 @@
+# Troubleshooting
+
+## CSS Animations Don't Work
+
+**Symptom:** Elements are static despite having CSS `transition`, `animation`, or Tailwind animation classes.
+
+**Cause:** Remotion renders frame-by-frame. CSS animations run in real-time and don't advance between frames. They produce blank or frozen output.
+
+**Fix:** Replace ALL CSS animation with `useCurrentFrame()` + `interpolate()` or `spring()`.
+
+```tsx
+// WRONG — will not animate
+<div style={{ transition: "opacity 0.5s", opacity: isVisible ? 1 : 0 }}>
+
+// WRONG — will not animate
+<div className="animate-fadeIn">
+
+// CORRECT
+const opacity = interpolate(frame, [0, 15], [0, 1], { extrapolateRight: "clamp" });
+<div style={{ opacity }}>
+```
+
+This is the #1 most common error with Remotion.
+
+## Font Not Loading
+
+**Symptom:** Text renders in a default sans-serif instead of the specified font.
+
+**Cause:** `@import url()` in CSS doesn't work in Remotion. Google Fonts must be loaded via the Remotion package.
+
+**Fix:**
+```bash
+npx remotion add @remotion/google-fonts
+```
+
+```tsx
+// WRONG
+// @import url('https://fonts.googleapis.com/css2?family=Inter');
+
+// CORRECT
+import { loadFont } from "@remotion/google-fonts/Inter";
+const { fontFamily } = loadFont();
+```
+
+## Audio Out of Sync
+
+**Symptom:** Voiceover or music doesn't align with visual elements.
+
+**Cause:** Usually the composition duration doesn't match the audio duration, or Sequences have wrong `from` values.
+
+**Fix:** Use `calculateMetadata` to set duration from audio length:
+
+```tsx
+const duration = await getAudioDurationInSeconds(staticFile("voiceover.mp3"));
+return { durationInFrames: Math.ceil(duration * fps) + 60 }; // +2s padding
+```
+
+For manual sync, preview at specific frames and compare audio position with visual state.
+
+## Black / Blank Frames
+
+**Symptom:** Some or all frames render as black.
+
+**Causes and fixes:**
+
+1. **Component returns null** — A condition causes the component to return nothing for some frames. Check all conditional rendering.
+
+2. **Sequence timing off** — Content is inside a `<Sequence>` that hasn't started or has ended. Check `from` and `durationInFrames`.
+
+3. **Z-index stacking** — A background `<AbsoluteFill>` is rendering on top of content. Check layer order (later JSX elements render on top).
+
+4. **Opacity at 0** — An interpolation produces 0 opacity outside its range. Add `extrapolateRight: "clamp"` to prevent values going below 0.
+
+## "Cannot find module" Errors
+
+**Symptom:** Import errors when rendering.
+
+**Fix:** Ensure all dependencies are installed:
+
+```bash
+npm install
+npx remotion add @remotion/transitions    # if using transitions
+npx remotion add @remotion/media-utils    # if using audio
+npx remotion add @remotion/google-fonts   # if using fonts
+npx remotion add @remotion/light-leaks    # if using light leak overlays
+```
+
+## Rendering is Slow
+
+**Symptom:** Full render takes much longer than expected.
+
+**Causes:**
+1. **Complex DOM per frame** — Reduce the number of DOM nodes. Simplify particle systems, reduce data points in charts.
+2. **Unoptimized images** — Large PNG files slow down every frame. Compress images before adding to `public/`.
+3. **Re-renders** — Memoize expensive components with `React.memo()` and `useMemo()`.
+
+**Quick fixes:**
+```bash
+# Draft render at half resolution
+npx remotion render ... --scale=0.5 --quality=50
+
+# Check which frames are slow (shows per-frame timing)
+npx remotion render ... --log=verbose
+```
+
+## ffmpeg Issues
+
+### "ffmpeg not found"
+
+Install ffmpeg:
+```bash
+# macOS
+brew install ffmpeg
+
+# Ubuntu/Debian
+sudo apt install ffmpeg
+
+# Or download from https://ffmpeg.org/download.html
+```
+
+### Audio Not Included in Output
+
+Remotion includes audio by default. If audio is missing:
+1. Check the audio file exists in `public/`
+2. Check `<Audio src={staticFile("file.mp3")} />` is in the component tree
+3. Check the audio Sequence timing — it might start after the composition ends
+
+### Output File Too Large
+
+```bash
+# Re-encode with higher CRF (lower quality, smaller file)
+ffmpeg -i output.mp4 -c:v libx264 -crf 28 -c:a aac -b:a 128k smaller.mp4
+
+# Or render with higher CRF directly
+npx remotion render ... --crf=28
+```
+
+## TypeScript Errors
+
+### "Property does not exist on type"
+
+Remotion is strongly typed. Define props interfaces for all components:
+
+```tsx
+interface SceneProps {
+  title: string;
+  subtitle?: string;
+  accentColor?: string;
+}
+
+export const MyScene: React.FC<SceneProps> = ({ title, subtitle, accentColor = "#00d4ff" }) => {
+  // ...
+};
+```
+
+### "Module has no exported member"
+
+Some Remotion imports changed between versions. Check the version:
+
+```bash
+npx remotion --version
+```
+
+Use the correct import paths for your version. v4.x is the current stable.

--- a/skills/creative/video-toolkit/references/visual-components.md
+++ b/skills/creative/video-toolkit/references/visual-components.md
@@ -1,0 +1,266 @@
+# Visual Components
+
+Reusable visual building blocks for scene backgrounds, overlays, and effects.
+
+## Animated Backgrounds
+
+### Gradient Animation
+
+```tsx
+const AnimatedGradient: React.FC<{
+  colors?: [string, string, string];
+  speed?: number;
+}> = ({ colors = ["#0a0a2e", "#1a0a3e", "#0a1a3e"], speed = 0.5 }) => {
+  const frame = useCurrentFrame();
+  const angle = (frame * speed) % 360;
+
+  return (
+    <AbsoluteFill
+      style={{
+        background: `linear-gradient(${angle}deg, ${colors[0]}, ${colors[1]}, ${colors[2]})`,
+      }}
+    />
+  );
+};
+```
+
+### Floating Particles
+
+```tsx
+const Particles: React.FC<{ count?: number; color?: string }> = ({
+  count = 30,
+  color = "rgba(255,255,255,0.15)",
+}) => {
+  const frame = useCurrentFrame();
+  const { width, height } = useVideoConfig();
+
+  // Generate deterministic particles from seed (same every render)
+  const particles = useMemo(
+    () =>
+      Array.from({ length: count }).map((_, i) => ({
+        x: ((i * 7919) % 1000) / 1000, // pseudo-random but deterministic
+        y: ((i * 6271) % 1000) / 1000,
+        size: 2 + ((i * 3571) % 6),
+        speed: 0.3 + ((i * 4219) % 500) / 1000,
+      })),
+    [count]
+  );
+
+  return (
+    <AbsoluteFill>
+      {particles.map((p, i) => (
+        <div
+          key={i}
+          style={{
+            position: "absolute",
+            left: p.x * width,
+            top: ((p.y * height + frame * p.speed) % (height + 20)) - 10,
+            width: p.size,
+            height: p.size,
+            borderRadius: "50%",
+            backgroundColor: color,
+          }}
+        />
+      ))}
+    </AbsoluteFill>
+  );
+};
+```
+
+### Grid Pattern
+
+```tsx
+const GridBackground: React.FC<{
+  cellSize?: number;
+  color?: string;
+  animated?: boolean;
+}> = ({ cellSize = 40, color = "rgba(255,255,255,0.05)", animated = true }) => {
+  const frame = useCurrentFrame();
+  const offset = animated ? (frame * 0.5) % cellSize : 0;
+
+  return (
+    <AbsoluteFill
+      style={{
+        backgroundImage: `
+          linear-gradient(${color} 1px, transparent 1px),
+          linear-gradient(90deg, ${color} 1px, transparent 1px)
+        `,
+        backgroundSize: `${cellSize}px ${cellSize}px`,
+        backgroundPosition: `${offset}px ${offset}px`,
+      }}
+    />
+  );
+};
+```
+
+## Overlays
+
+### Vignette
+
+Darkened edges for cinematic feel:
+
+```tsx
+const Vignette: React.FC<{ intensity?: number }> = ({ intensity = 0.6 }) => (
+  <AbsoluteFill
+    style={{
+      background: `radial-gradient(ellipse at center, transparent 40%, rgba(0,0,0,${intensity}) 100%)`,
+      pointerEvents: "none",
+    }}
+  />
+);
+```
+
+### Film Grain
+
+Subtle noise overlay for texture:
+
+```tsx
+const FilmGrain: React.FC<{ opacity?: number }> = ({ opacity = 0.04 }) => {
+  const frame = useCurrentFrame();
+
+  return (
+    <AbsoluteFill
+      style={{
+        opacity,
+        pointerEvents: "none",
+        mixBlendMode: "overlay",
+        // SVG filter for noise
+        filter: `url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.8' seed='${frame}' numOctaves='4'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>#n")`,
+        width: "100%",
+        height: "100%",
+      }}
+    />
+  );
+};
+```
+
+### Progress Bar
+
+Animated progress indicator across the bottom:
+
+```tsx
+const ProgressBar: React.FC<{
+  color?: string;
+  height?: number;
+}> = ({ color = "#00d4ff", height = 4 }) => {
+  const frame = useCurrentFrame();
+  const { durationInFrames } = useVideoConfig();
+  const progress = (frame / durationInFrames) * 100;
+
+  return (
+    <AbsoluteFill style={{ justifyContent: "flex-end" }}>
+      <div
+        style={{
+          height,
+          width: `${progress}%`,
+          backgroundColor: color,
+          boxShadow: `0 0 8px ${color}`,
+        }}
+      />
+    </AbsoluteFill>
+  );
+};
+```
+
+## Layout Components
+
+### Split Screen
+
+Side-by-side comparison or content arrangement:
+
+```tsx
+const SplitScreen: React.FC<{
+  left: React.ReactNode;
+  right: React.ReactNode;
+  dividerColor?: string;
+}> = ({ left, right, dividerColor = "rgba(255,255,255,0.1)" }) => (
+  <AbsoluteFill style={{ flexDirection: "row" }}>
+    <div style={{ flex: 1, position: "relative", overflow: "hidden" }}>{left}</div>
+    <div style={{ width: 2, backgroundColor: dividerColor }} />
+    <div style={{ flex: 1, position: "relative", overflow: "hidden" }}>{right}</div>
+  </AbsoluteFill>
+);
+```
+
+### Centered Content Card
+
+Floating card with shadow for focused content:
+
+```tsx
+const ContentCard: React.FC<{
+  children: React.ReactNode;
+  width?: number;
+  bgColor?: string;
+}> = ({ children, width = 800, bgColor = "rgba(255,255,255,0.05)" }) => (
+  <AbsoluteFill style={{ justifyContent: "center", alignItems: "center" }}>
+    <div
+      style={{
+        width,
+        padding: 48,
+        backgroundColor: bgColor,
+        borderRadius: 16,
+        border: "1px solid rgba(255,255,255,0.1)",
+        backdropFilter: "blur(20px)",
+      }}
+    >
+      {children}
+    </div>
+  </AbsoluteFill>
+);
+```
+
+## Animated Shapes
+
+### Animated Circle
+
+```tsx
+const PulsingCircle: React.FC<{ color?: string; size?: number }> = ({
+  color = "#00d4ff",
+  size = 200,
+}) => {
+  const frame = useCurrentFrame();
+  const scale = 1 + Math.sin(frame * 0.05) * 0.1;
+
+  return (
+    <div
+      style={{
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        backgroundColor: color,
+        opacity: 0.3,
+        transform: `scale(${scale})`,
+        filter: `blur(${size * 0.3}px)`,
+      }}
+    />
+  );
+};
+```
+
+### Decorative Lines
+
+```tsx
+const AnimatedLine: React.FC<{ direction?: "horizontal" | "vertical" }> = ({
+  direction = "horizontal",
+}) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+
+  const length = interpolate(frame, [0, fps * 0.5], [0, 100], {
+    extrapolateRight: "clamp",
+    easing: Easing.bezier(0.33, 1, 0.68, 1),
+  });
+
+  const isH = direction === "horizontal";
+
+  return (
+    <div
+      style={{
+        [isH ? "width" : "height"]: `${length}%`,
+        [isH ? "height" : "width"]: 2,
+        background: "linear-gradient(90deg, transparent, rgba(255,255,255,0.3), transparent)",
+      }}
+    />
+  );
+};
+```

--- a/skills/creative/video-toolkit/scripts/render.sh
+++ b/skills/creative/video-toolkit/scripts/render.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Video Toolkit Render Helper
+# Usage: ./render.sh [draft|preview|production] [composition-id]
+set -e
+
+QUALITY=${1:-preview}
+COMP=${2:-MainVideo}
+
+case $QUALITY in
+  draft)
+    echo "Rendering DRAFT (half resolution, low quality)..."
+    npx remotion render src/index.ts "$COMP" \
+      --output="draft.mp4" \
+      --scale=0.5 \
+      --quality=50 \
+      --concurrency=100%
+    echo "Output: draft.mp4"
+    ;;
+  preview)
+    echo "Rendering PREVIEW (full resolution, standard quality)..."
+    npx remotion render src/index.ts "$COMP" \
+      --output="preview.mp4" \
+      --quality=80 \
+      --concurrency=100%
+    echo "Output: preview.mp4"
+    ;;
+  production)
+    echo "Rendering PRODUCTION (maximum quality)..."
+    npx remotion render src/index.ts "$COMP" \
+      --output="final.mp4" \
+      --codec=h264 \
+      --crf=18 \
+      --pixel-format=yuv420p \
+      --concurrency=100%
+    echo "Output: final.mp4"
+    ;;
+  *)
+    echo "Usage: ./render.sh [draft|preview|production] [composition-id]"
+    echo ""
+    echo "Quality presets:"
+    echo "  draft      — half resolution, low quality, fast"
+    echo "  preview    — full resolution, standard quality"
+    echo "  production — full resolution, maximum quality"
+    exit 1
+    ;;
+esac

--- a/skills/creative/video-toolkit/scripts/setup.sh
+++ b/skills/creative/video-toolkit/scripts/setup.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Video Toolkit Setup — verify prerequisites and install dependencies
+set -e
+
+echo "Video Toolkit Setup"
+echo "==================="
+echo ""
+
+# Check Node.js
+if ! command -v node &>/dev/null; then
+  echo "ERROR: Node.js is required but not installed."
+  echo "  Install: https://nodejs.org/ (v18+ required)"
+  exit 1
+fi
+
+NODE_VERSION=$(node -v | sed 's/v//' | cut -d. -f1)
+if [ "$NODE_VERSION" -lt 18 ]; then
+  echo "ERROR: Node.js 18+ required, found v$(node -v)"
+  exit 1
+fi
+echo "Node.js: $(node -v)"
+
+# Check npm
+if ! command -v npm &>/dev/null; then
+  echo "ERROR: npm not found"
+  exit 1
+fi
+echo "npm: $(npm -v)"
+
+# Check ffmpeg (optional but recommended)
+if command -v ffmpeg &>/dev/null; then
+  echo "ffmpeg: $(ffmpeg -version 2>&1 | head -1 | awk '{print $3}')"
+else
+  echo "ffmpeg: not found (optional — needed for post-processing and GIF conversion)"
+  echo "  Install: brew install ffmpeg (macOS) or apt install ffmpeg (Linux)"
+fi
+
+echo ""
+echo "Ready. To create a video project:"
+echo "  cp -r skills/creative/video-toolkit/templates/announcement ./my-video"
+echo "  cd my-video && npm install"
+echo "  npx remotion studio  # preview in browser"
+echo "  npm run render        # render to MP4"

--- a/skills/creative/video-toolkit/templates/announcement/package.json
+++ b/skills/creative/video-toolkit/templates/announcement/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "hermes-announcement-video",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "remotion studio",
+    "render": "remotion render src/index.ts MainVideo --output=output.mp4",
+    "preview": "remotion still src/index.ts MainVideo --frame=90 --output=preview.png",
+    "draft": "remotion render src/index.ts MainVideo --output=draft.mp4 --scale=0.5 --quality=50"
+  },
+  "dependencies": {
+    "@remotion/cli": "4.0.0",
+    "@remotion/google-fonts": "4.0.0",
+    "@remotion/transitions": "4.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "remotion": "4.0.0",
+    "@remotion/media-utils": "4.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/skills/creative/video-toolkit/templates/announcement/remotion.config.ts
+++ b/skills/creative/video-toolkit/templates/announcement/remotion.config.ts
@@ -1,0 +1,4 @@
+import { Config } from "@remotion/cli/config";
+
+Config.setVideoImageFormat("jpeg");
+Config.setOverwriteOutput(true);

--- a/skills/creative/video-toolkit/templates/announcement/src/MainVideo.tsx
+++ b/skills/creative/video-toolkit/templates/announcement/src/MainVideo.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { TransitionSeries, linearTiming } from "@remotion/transitions";
+import { fade } from "@remotion/transitions/fade";
+import { TitleScene } from "./scenes/TitleScene";
+import { FeatureScene } from "./scenes/FeatureScene";
+import { CTAScene } from "./scenes/CTAScene";
+
+interface VideoProps {
+  title: string;
+  subtitle: string;
+  features: string[];
+  ctaText: string;
+  ctaUrl: string;
+  accentColor: string;
+}
+
+export const MainVideo: React.FC<VideoProps> = (props) => (
+  <TransitionSeries>
+    <TransitionSeries.Sequence durationInFrames={270}>
+      <TitleScene
+        title={props.title}
+        subtitle={props.subtitle}
+        accentColor={props.accentColor}
+      />
+    </TransitionSeries.Sequence>
+
+    <TransitionSeries.Transition
+      presentation={fade()}
+      timing={linearTiming({ durationInFrames: 20 })}
+    />
+
+    <TransitionSeries.Sequence durationInFrames={360}>
+      <FeatureScene
+        features={props.features}
+        accentColor={props.accentColor}
+      />
+    </TransitionSeries.Sequence>
+
+    <TransitionSeries.Transition
+      presentation={fade()}
+      timing={linearTiming({ durationInFrames: 20 })}
+    />
+
+    <TransitionSeries.Sequence durationInFrames={270}>
+      <CTAScene
+        ctaText={props.ctaText}
+        ctaUrl={props.ctaUrl}
+        accentColor={props.accentColor}
+      />
+    </TransitionSeries.Sequence>
+  </TransitionSeries>
+);

--- a/skills/creative/video-toolkit/templates/announcement/src/Root.tsx
+++ b/skills/creative/video-toolkit/templates/announcement/src/Root.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { Composition } from "remotion";
+import { MainVideo } from "./MainVideo";
+
+// --- CUSTOMIZE THESE ---
+const VIDEO_CONFIG = {
+  title: "Your Product Name",
+  subtitle: "The tagline that sells it",
+  features: [
+    "Lightning fast performance",
+    "Built for developers",
+    "Open source",
+  ],
+  ctaText: "Try it today",
+  ctaUrl: "github.com/your/repo",
+  accentColor: "#00d4ff",
+};
+
+export const RemotionRoot: React.FC = () => (
+  <>
+    <Composition
+      id="MainVideo"
+      component={MainVideo}
+      durationInFrames={900} // 30 seconds at 30fps
+      fps={30}
+      width={1920}
+      height={1080}
+      defaultProps={VIDEO_CONFIG}
+    />
+    {/* Social variant */}
+    <Composition
+      id="Social"
+      component={MainVideo}
+      durationInFrames={450} // 15 seconds
+      fps={30}
+      width={1080}
+      height={1080}
+      defaultProps={VIDEO_CONFIG}
+    />
+  </>
+);

--- a/skills/creative/video-toolkit/templates/announcement/src/index.ts
+++ b/skills/creative/video-toolkit/templates/announcement/src/index.ts
@@ -1,0 +1,4 @@
+import { registerRoot } from "remotion";
+import { RemotionRoot } from "./Root";
+
+registerRoot(RemotionRoot);

--- a/skills/creative/video-toolkit/templates/announcement/src/scenes/CTAScene.tsx
+++ b/skills/creative/video-toolkit/templates/announcement/src/scenes/CTAScene.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import {
+  AbsoluteFill,
+  useCurrentFrame,
+  useVideoConfig,
+  interpolate,
+  spring,
+} from "remotion";
+import { loadFont } from "@remotion/google-fonts/Inter";
+
+const { fontFamily } = loadFont();
+
+interface CTASceneProps {
+  ctaText: string;
+  ctaUrl: string;
+  accentColor: string;
+}
+
+export const CTAScene: React.FC<CTASceneProps> = ({
+  ctaText,
+  ctaUrl,
+  accentColor,
+}) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+
+  // CTA text entrance
+  const ctaEntrance = spring({
+    frame,
+    fps,
+    config: { damping: 12, mass: 0.6 },
+  });
+
+  // URL entrance — delayed
+  const urlDelay = Math.floor(fps * 0.5);
+  const urlOpacity = interpolate(frame - urlDelay, [0, fps * 0.3], [0, 1], {
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+  });
+  const urlY = interpolate(frame - urlDelay, [0, fps * 0.3], [15, 0], {
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+  });
+
+  // Glow pulse on the accent elements
+  const glowIntensity = Math.sin(frame * 0.08) * 4 + 12;
+
+  return (
+    <>
+      {/* Background — warmer for CTA */}
+      <AbsoluteFill
+        style={{
+          background: `radial-gradient(ellipse at 50% 60%, #1a0a2e, #0a0a1a 70%)`,
+        }}
+      />
+
+      {/* Content */}
+      <AbsoluteFill
+        style={{
+          justifyContent: "center",
+          alignItems: "center",
+          fontFamily,
+          gap: 32,
+        }}
+      >
+        {/* CTA text */}
+        <h2
+          style={{
+            fontSize: 64,
+            fontWeight: 700,
+            color: "white",
+            margin: 0,
+            transform: `scale(${ctaEntrance})`,
+            letterSpacing: -1,
+          }}
+        >
+          {ctaText}
+        </h2>
+
+        {/* URL */}
+        <div
+          style={{
+            fontSize: 28,
+            color: accentColor,
+            opacity: urlOpacity,
+            transform: `translateY(${urlY}px)`,
+            fontWeight: 500,
+            textShadow: `0 0 ${glowIntensity}px ${accentColor}`,
+          }}
+        >
+          {ctaUrl}
+        </div>
+      </AbsoluteFill>
+
+      {/* Vignette */}
+      <AbsoluteFill
+        style={{
+          background:
+            "radial-gradient(ellipse at center, transparent 40%, rgba(0,0,0,0.7) 100%)",
+          pointerEvents: "none",
+        }}
+      />
+    </>
+  );
+};

--- a/skills/creative/video-toolkit/templates/announcement/src/scenes/FeatureScene.tsx
+++ b/skills/creative/video-toolkit/templates/announcement/src/scenes/FeatureScene.tsx
@@ -1,0 +1,148 @@
+import React from "react";
+import {
+  AbsoluteFill,
+  useCurrentFrame,
+  useVideoConfig,
+  interpolate,
+  spring,
+  Easing,
+} from "remotion";
+import { loadFont } from "@remotion/google-fonts/Inter";
+
+const { fontFamily } = loadFont();
+
+interface FeatureSceneProps {
+  features: string[];
+  accentColor: string;
+}
+
+export const FeatureScene: React.FC<FeatureSceneProps> = ({
+  features,
+  accentColor,
+}) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+
+  return (
+    <>
+      {/* Background — slightly different from title scene */}
+      <AbsoluteFill
+        style={{
+          background: `radial-gradient(ellipse at 70% 40%, #0a1a3e, #0a0a1a 70%)`,
+        }}
+      />
+
+      {/* Grid pattern overlay */}
+      <AbsoluteFill
+        style={{
+          backgroundImage: `
+            linear-gradient(rgba(255,255,255,0.02) 1px, transparent 1px),
+            linear-gradient(90deg, rgba(255,255,255,0.02) 1px, transparent 1px)
+          `,
+          backgroundSize: "60px 60px",
+        }}
+      />
+
+      {/* Features list */}
+      <AbsoluteFill
+        style={{
+          justifyContent: "center",
+          alignItems: "flex-start",
+          padding: "0 180px",
+          fontFamily,
+        }}
+      >
+        {features.map((feature, i) => {
+          const staggerDelay = Math.floor(fps * 0.8) * i;
+          const featureFrame = frame - staggerDelay;
+
+          // Entrance
+          const entrance = spring({
+            frame: featureFrame,
+            fps,
+            config: { damping: 14, mass: 0.5 },
+          });
+
+          // Accent dot
+          const dotScale = spring({
+            frame: featureFrame - 5,
+            fps,
+            config: { damping: 10, mass: 0.3, stiffness: 300 },
+          });
+
+          // Line underneath
+          const lineWidth = interpolate(
+            featureFrame,
+            [0, fps * 0.5],
+            [0, 100],
+            {
+              extrapolateLeft: "clamp",
+              extrapolateRight: "clamp",
+              easing: Easing.bezier(0.33, 1, 0.68, 1),
+            }
+          );
+
+          return (
+            <div
+              key={i}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 24,
+                marginBottom: 48,
+                opacity: entrance,
+                transform: `translateX(${interpolate(entrance, [0, 1], [40, 0])}px)`,
+              }}
+            >
+              {/* Accent dot */}
+              <div
+                style={{
+                  width: 12,
+                  height: 12,
+                  borderRadius: "50%",
+                  backgroundColor: accentColor,
+                  transform: `scale(${dotScale})`,
+                  boxShadow: `0 0 12px ${accentColor}`,
+                  flexShrink: 0,
+                }}
+              />
+
+              <div>
+                <div
+                  style={{
+                    fontSize: 40,
+                    fontWeight: 600,
+                    color: "white",
+                    letterSpacing: -0.5,
+                  }}
+                >
+                  {feature}
+                </div>
+                {/* Accent underline */}
+                <div
+                  style={{
+                    width: `${lineWidth}%`,
+                    height: 2,
+                    backgroundColor: accentColor,
+                    opacity: 0.3,
+                    marginTop: 8,
+                    borderRadius: 1,
+                  }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </AbsoluteFill>
+
+      {/* Vignette */}
+      <AbsoluteFill
+        style={{
+          background:
+            "radial-gradient(ellipse at center, transparent 50%, rgba(0,0,0,0.5) 100%)",
+          pointerEvents: "none",
+        }}
+      />
+    </>
+  );
+};

--- a/skills/creative/video-toolkit/templates/announcement/src/scenes/TitleScene.tsx
+++ b/skills/creative/video-toolkit/templates/announcement/src/scenes/TitleScene.tsx
@@ -1,0 +1,128 @@
+import React from "react";
+import {
+  AbsoluteFill,
+  useCurrentFrame,
+  useVideoConfig,
+  interpolate,
+  spring,
+} from "remotion";
+import { loadFont } from "@remotion/google-fonts/Inter";
+
+const { fontFamily } = loadFont();
+
+interface TitleSceneProps {
+  title: string;
+  subtitle: string;
+  accentColor: string;
+}
+
+export const TitleScene: React.FC<TitleSceneProps> = ({
+  title,
+  subtitle,
+  accentColor,
+}) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+
+  // Title entrance — spring scale from center
+  const titleScale = spring({
+    frame,
+    fps,
+    config: { damping: 14, mass: 0.6, stiffness: 200 },
+  });
+  const titleOpacity = interpolate(frame, [0, fps * 0.3], [0, 1], {
+    extrapolateRight: "clamp",
+  });
+
+  // Subtitle entrance — delayed fade + slide up
+  const subtitleDelay = Math.floor(fps * 0.6);
+  const subtitleOpacity = interpolate(
+    frame - subtitleDelay,
+    [0, fps * 0.4],
+    [0, 1],
+    { extrapolateLeft: "clamp", extrapolateRight: "clamp" }
+  );
+  const subtitleY = interpolate(
+    frame - subtitleDelay,
+    [0, fps * 0.4],
+    [20, 0],
+    { extrapolateLeft: "clamp", extrapolateRight: "clamp" }
+  );
+
+  // Accent line — grows from center
+  const lineWidth = interpolate(frame - Math.floor(fps * 0.4), [0, fps * 0.5], [0, 200], {
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+  });
+
+  return (
+    <>
+      {/* Background */}
+      <AbsoluteFill
+        style={{
+          background: `radial-gradient(ellipse at 30% 50%, #1a0a2e, #0a0a1a 70%)`,
+        }}
+      />
+
+      {/* Content */}
+      <AbsoluteFill
+        style={{
+          justifyContent: "center",
+          alignItems: "center",
+          fontFamily,
+        }}
+      >
+        {/* Title */}
+        <h1
+          style={{
+            fontSize: 80,
+            fontWeight: 800,
+            color: "white",
+            margin: 0,
+            transform: `scale(${titleScale})`,
+            opacity: titleOpacity,
+            letterSpacing: -2,
+          }}
+        >
+          {title}
+        </h1>
+
+        {/* Accent line */}
+        <div
+          style={{
+            width: lineWidth,
+            height: 3,
+            backgroundColor: accentColor,
+            marginTop: 24,
+            marginBottom: 24,
+            borderRadius: 2,
+            boxShadow: `0 0 12px ${accentColor}`,
+          }}
+        />
+
+        {/* Subtitle */}
+        <p
+          style={{
+            fontSize: 32,
+            color: "rgba(255,255,255,0.6)",
+            margin: 0,
+            opacity: subtitleOpacity,
+            transform: `translateY(${subtitleY}px)`,
+            fontWeight: 400,
+          }}
+        >
+          {subtitle}
+        </p>
+      </AbsoluteFill>
+
+      {/* Vignette */}
+      <AbsoluteFill
+        style={{
+          background:
+            "radial-gradient(ellipse at center, transparent 50%, rgba(0,0,0,0.6) 100%)",
+          pointerEvents: "none",
+        }}
+      />
+    </>
+  );
+};

--- a/skills/creative/video-toolkit/templates/announcement/tsconfig.json
+++ b/skills/creative/video-toolkit/templates/announcement/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/skills/creative/video-toolkit/templates/explainer/package.json
+++ b/skills/creative/video-toolkit/templates/explainer/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "hermes-announcement-video",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "remotion studio",
+    "render": "remotion render src/index.ts MainVideo --output=output.mp4",
+    "preview": "remotion still src/index.ts MainVideo --frame=90 --output=preview.png",
+    "draft": "remotion render src/index.ts MainVideo --output=draft.mp4 --scale=0.5 --quality=50"
+  },
+  "dependencies": {
+    "@remotion/cli": "4.0.0",
+    "@remotion/google-fonts": "4.0.0",
+    "@remotion/transitions": "4.0.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "remotion": "4.0.0",
+    "@remotion/media-utils": "4.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/skills/creative/video-toolkit/templates/explainer/remotion.config.ts
+++ b/skills/creative/video-toolkit/templates/explainer/remotion.config.ts
@@ -1,0 +1,4 @@
+import { Config } from "@remotion/cli/config";
+
+Config.setVideoImageFormat("jpeg");
+Config.setOverwriteOutput(true);

--- a/skills/creative/video-toolkit/templates/explainer/src/MainVideo.tsx
+++ b/skills/creative/video-toolkit/templates/explainer/src/MainVideo.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { TransitionSeries, linearTiming } from "@remotion/transitions";
+import { fade } from "@remotion/transitions/fade";
+import { slide } from "@remotion/transitions/slide";
+import { ProblemScene } from "./scenes/ProblemScene";
+import { SolutionScene } from "./scenes/SolutionScene";
+import { ResultScene } from "./scenes/ResultScene";
+
+interface VideoProps {
+  problem: string;
+  solution: string;
+  solutionPoints: string[];
+  result: string;
+  accentColor: string;
+}
+
+export const MainVideo: React.FC<VideoProps> = (props) => (
+  <TransitionSeries>
+    {/* Problem — establish the pain */}
+    <TransitionSeries.Sequence durationInFrames={540}>
+      <ProblemScene
+        problem={props.problem}
+        accentColor={props.accentColor}
+      />
+    </TransitionSeries.Sequence>
+
+    <TransitionSeries.Transition
+      presentation={slide({ direction: "from-right" })}
+      timing={linearTiming({ durationInFrames: 25 })}
+    />
+
+    {/* Solution — the reveal */}
+    <TransitionSeries.Sequence durationInFrames={720}>
+      <SolutionScene
+        solution={props.solution}
+        points={props.solutionPoints}
+        accentColor={props.accentColor}
+      />
+    </TransitionSeries.Sequence>
+
+    <TransitionSeries.Transition
+      presentation={fade()}
+      timing={linearTiming({ durationInFrames: 20 })}
+    />
+
+    {/* Result — the payoff */}
+    <TransitionSeries.Sequence durationInFrames={540}>
+      <ResultScene
+        result={props.result}
+        accentColor={props.accentColor}
+      />
+    </TransitionSeries.Sequence>
+  </TransitionSeries>
+);

--- a/skills/creative/video-toolkit/templates/explainer/src/Root.tsx
+++ b/skills/creative/video-toolkit/templates/explainer/src/Root.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { Composition } from "remotion";
+import { MainVideo } from "./MainVideo";
+
+// --- CUSTOMIZE THESE ---
+const VIDEO_CONFIG = {
+  problem: "Current solutions are slow, fragile, and hard to debug",
+  solution: "A new approach that solves all three",
+  solutionPoints: [
+    "10x faster processing",
+    "Self-healing architecture",
+    "Built-in observability",
+  ],
+  result: "Teams ship 3x faster with 90% fewer incidents",
+  accentColor: "#8b5cf6",
+};
+
+export const RemotionRoot: React.FC = () => (
+  <>
+    <Composition
+      id="MainVideo"
+      component={MainVideo}
+      durationInFrames={1800} // 60 seconds at 30fps
+      fps={30}
+      width={1920}
+      height={1080}
+      defaultProps={VIDEO_CONFIG}
+    />
+  </>
+);

--- a/skills/creative/video-toolkit/templates/explainer/src/index.ts
+++ b/skills/creative/video-toolkit/templates/explainer/src/index.ts
@@ -1,0 +1,4 @@
+import { registerRoot } from "remotion";
+import { RemotionRoot } from "./Root";
+
+registerRoot(RemotionRoot);

--- a/skills/creative/video-toolkit/templates/explainer/src/scenes/ProblemScene.tsx
+++ b/skills/creative/video-toolkit/templates/explainer/src/scenes/ProblemScene.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import {
+  AbsoluteFill,
+  useCurrentFrame,
+  useVideoConfig,
+  interpolate,
+  spring,
+} from "remotion";
+import { loadFont } from "@remotion/google-fonts/Inter";
+
+const { fontFamily } = loadFont();
+
+interface ProblemSceneProps {
+  problem: string;
+  accentColor: string;
+}
+
+export const ProblemScene: React.FC<ProblemSceneProps> = ({
+  problem,
+  accentColor,
+}) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+
+  // "The Problem" label
+  const labelOpacity = interpolate(frame, [0, fps * 0.3], [0, 1], {
+    extrapolateRight: "clamp",
+  });
+
+  // Problem text — word by word reveal
+  const words = problem.split(" ");
+  const framesPerWord = Math.floor(fps * 0.15);
+
+  return (
+    <>
+      <AbsoluteFill style={{ background: "#0a0a0f" }} />
+
+      {/* Subtle red gradient — problem = tension */}
+      <AbsoluteFill
+        style={{
+          background: "radial-gradient(ellipse at 50% 80%, rgba(220,40,40,0.08), transparent 60%)",
+        }}
+      />
+
+      <AbsoluteFill
+        style={{
+          justifyContent: "center",
+          alignItems: "center",
+          fontFamily,
+          padding: "0 200px",
+        }}
+      >
+        {/* Label */}
+        <div
+          style={{
+            fontSize: 18,
+            fontWeight: 600,
+            color: accentColor,
+            opacity: labelOpacity,
+            textTransform: "uppercase",
+            letterSpacing: 4,
+            marginBottom: 32,
+          }}
+        >
+          The Problem
+        </div>
+
+        {/* Problem statement — word by word */}
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 14,
+            justifyContent: "center",
+            maxWidth: 1200,
+          }}
+        >
+          {words.map((word, i) => {
+            const wordDelay = Math.floor(fps * 0.6) + i * framesPerWord;
+            const wordEntrance = spring({
+              frame: frame - wordDelay,
+              fps,
+              config: { damping: 14, mass: 0.5 },
+            });
+
+            return (
+              <span
+                key={i}
+                style={{
+                  fontSize: 56,
+                  fontWeight: 600,
+                  color: "white",
+                  opacity: wordEntrance,
+                  transform: `translateY(${interpolate(wordEntrance, [0, 1], [15, 0])}px)`,
+                }}
+              >
+                {word}
+              </span>
+            );
+          })}
+        </div>
+      </AbsoluteFill>
+    </>
+  );
+};

--- a/skills/creative/video-toolkit/templates/explainer/src/scenes/ResultScene.tsx
+++ b/skills/creative/video-toolkit/templates/explainer/src/scenes/ResultScene.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import {
+  AbsoluteFill,
+  useCurrentFrame,
+  useVideoConfig,
+  interpolate,
+  spring,
+} from "remotion";
+import { loadFont } from "@remotion/google-fonts/Inter";
+
+const { fontFamily } = loadFont();
+
+interface ResultSceneProps {
+  result: string;
+  accentColor: string;
+}
+
+export const ResultScene: React.FC<ResultSceneProps> = ({
+  result,
+  accentColor,
+}) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+
+  // Result text entrance — dramatic scale from center
+  const scale = spring({
+    frame: frame - Math.floor(fps * 0.3),
+    fps,
+    config: { damping: 10, mass: 0.8, stiffness: 150 },
+  });
+
+  const opacity = interpolate(frame, [Math.floor(fps * 0.2), Math.floor(fps * 0.5)], [0, 1], {
+    extrapolateLeft: "clamp",
+    extrapolateRight: "clamp",
+  });
+
+  // Glow pulse
+  const glowIntensity = 8 + Math.sin(frame * 0.06) * 4;
+
+  return (
+    <>
+      {/* Background — brightest scene, accent color presence */}
+      <AbsoluteFill
+        style={{
+          background: `radial-gradient(ellipse at 50% 50%, rgba(${parseInt(accentColor.slice(1, 3), 16)},${parseInt(accentColor.slice(3, 5), 16)},${parseInt(accentColor.slice(5, 7), 16)},0.1), #0a0a1a 60%)`,
+        }}
+      />
+
+      <AbsoluteFill
+        style={{
+          justifyContent: "center",
+          alignItems: "center",
+          fontFamily,
+          padding: "0 200px",
+          textAlign: "center",
+        }}
+      >
+        {/* Label */}
+        <div
+          style={{
+            fontSize: 18,
+            fontWeight: 600,
+            color: accentColor,
+            textTransform: "uppercase",
+            letterSpacing: 4,
+            marginBottom: 32,
+            opacity: interpolate(frame, [0, fps * 0.3], [0, 1], { extrapolateRight: "clamp" }),
+          }}
+        >
+          The Result
+        </div>
+
+        {/* Result statement */}
+        <h2
+          style={{
+            fontSize: 60,
+            fontWeight: 800,
+            color: "white",
+            margin: 0,
+            opacity,
+            transform: `scale(${scale})`,
+            letterSpacing: -1,
+            textShadow: `0 0 ${glowIntensity}px rgba(255,255,255,0.15)`,
+            maxWidth: 1000,
+          }}
+        >
+          {result}
+        </h2>
+      </AbsoluteFill>
+
+      {/* Vignette */}
+      <AbsoluteFill
+        style={{
+          background:
+            "radial-gradient(ellipse at center, transparent 40%, rgba(0,0,0,0.7) 100%)",
+          pointerEvents: "none",
+        }}
+      />
+    </>
+  );
+};

--- a/skills/creative/video-toolkit/templates/explainer/src/scenes/SolutionScene.tsx
+++ b/skills/creative/video-toolkit/templates/explainer/src/scenes/SolutionScene.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import {
+  AbsoluteFill,
+  useCurrentFrame,
+  useVideoConfig,
+  interpolate,
+  spring,
+  Easing,
+} from "remotion";
+import { loadFont } from "@remotion/google-fonts/Inter";
+
+const { fontFamily } = loadFont();
+
+interface SolutionSceneProps {
+  solution: string;
+  points: string[];
+  accentColor: string;
+}
+
+export const SolutionScene: React.FC<SolutionSceneProps> = ({
+  solution,
+  points,
+  accentColor,
+}) => {
+  const frame = useCurrentFrame();
+  const { fps } = useVideoConfig();
+
+  // Solution title entrance
+  const titleEntrance = spring({
+    frame,
+    fps,
+    config: { damping: 12, mass: 0.6 },
+  });
+
+  return (
+    <>
+      {/* Background — brighter, more hopeful */}
+      <AbsoluteFill
+        style={{
+          background: `radial-gradient(ellipse at 40% 40%, rgba(${parseInt(accentColor.slice(1, 3), 16)},${parseInt(accentColor.slice(3, 5), 16)},${parseInt(accentColor.slice(5, 7), 16)},0.06), #0a0a1a 60%)`,
+        }}
+      />
+
+      <AbsoluteFill
+        style={{
+          justifyContent: "center",
+          padding: "0 180px",
+          fontFamily,
+        }}
+      >
+        {/* Solution headline */}
+        <h2
+          style={{
+            fontSize: 52,
+            fontWeight: 700,
+            color: "white",
+            margin: 0,
+            marginBottom: 48,
+            opacity: titleEntrance,
+            transform: `scale(${titleEntrance})`,
+          }}
+        >
+          {solution}
+        </h2>
+
+        {/* Solution points */}
+        {points.map((point, i) => {
+          const pointDelay = Math.floor(fps * 1) + i * Math.floor(fps * 0.7);
+          const entrance = spring({
+            frame: frame - pointDelay,
+            fps,
+            config: { damping: 14, mass: 0.5 },
+          });
+
+          const lineProgress = interpolate(
+            frame - pointDelay,
+            [0, fps * 0.4],
+            [0, 100],
+            { extrapolateLeft: "clamp", extrapolateRight: "clamp", easing: Easing.bezier(0.33, 1, 0.68, 1) }
+          );
+
+          return (
+            <div
+              key={i}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 20,
+                marginBottom: 36,
+                opacity: entrance,
+                transform: `translateX(${interpolate(entrance, [0, 1], [30, 0])}px)`,
+              }}
+            >
+              <div
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: "50%",
+                  backgroundColor: accentColor,
+                  boxShadow: `0 0 10px ${accentColor}`,
+                  flexShrink: 0,
+                }}
+              />
+              <span style={{ fontSize: 36, color: "rgba(255,255,255,0.9)", fontWeight: 500 }}>
+                {point}
+              </span>
+            </div>
+          );
+        })}
+      </AbsoluteFill>
+    </>
+  );
+};

--- a/skills/creative/video-toolkit/templates/explainer/tsconfig.json
+++ b/skills/creative/video-toolkit/templates/explainer/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

Production pipeline skill for creating animated videos using Manim Community Edition. The agent handles the full workflow from creative planning through final render.

## What it produces

- **Concept explainers** — animated explanations with geometric intuition
- **Equation derivations** — step-by-step animated proofs with LaTeX
- **Algorithm visualizations** — data structures building up, sorting in action
- **Data stories** — animated charts, before/after comparisons, counters
- **Architecture diagrams** — components connecting progressively
- **3D visualizations** — rotating surfaces, parametric curves, spatial geometry

## Skill structure

```
skills/creative/manim-video/
  SKILL.md                          # Pipeline: Plan → Code → Render → Stitch → Audio → Review
  README.md
  references/
    animations.md                   # Core animations, rate functions, .animate syntax, timing patterns
    mobjects.md                     # Text, shapes, VGroup, positioning, styling, custom mobjects
    visual-design.md                # 12 design principles, opacity layering, 6 layout templates, palettes
    equations.md                    # LaTeX, TransformMatchingTex, derivation patterns
    graphs-and-data.md              # Axes, plotting, BarChart, animated data, algorithm viz
    camera-and-3d.md                # MovingCameraScene, ThreeDScene, 3D surfaces, camera control
    scene-planning.md               # 4 narrative arcs, scene transition patterns, planning template
    rendering.md                    # CLI reference, quality presets, ffmpeg stitching, voiceover workflow
    troubleshooting.md              # LaTeX errors, animation errors, common mistakes, debugging
  scripts/
    setup.sh                        # Prerequisite verification (Python, Manim, LaTeX, ffmpeg)
```

## Architecture

Follows the same pattern as the existing `ascii-video` skill:
- **SKILL.md** loaded into context when activated — creative standard, pipeline, workflow
- **references/*.md** loaded on demand by the agent when it needs specific patterns
- **Agent uses standard tools** (write_file, terminal, read_file) — no custom tool definitions
- **Single Python script per project** — one class per scene, independently renderable

## Verified against

All API references checked against `ManimCommunity/manim` source: `add_subcaption`, `ThreeDScene`, `MovingCameraScene`, `BarChart.change_bar_values`, `set_color_by_gradient`, `TransformMatchingTex`, camera background_color setter.

## Size

12 files, 2354 lines. Comparable to other creative skills (ascii-video is 7900 lines but encodes a custom framework; Manim has extensive official docs).