### PR TITLE
feat(delegation): add named subagent capability profiles

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -681,7 +681,16 @@ code_execution:
 # Supports single tasks and batch mode (up to 3 parallel).
 delegation:
   max_iterations: 50                          # Max tool-calling turns per child (default: 50)
-  default_toolsets: ["terminal", "file", "web"]  # Default toolsets for subagents
+  default_toolsets: ["terminal", "file", "web"]  # Legacy fallback when no delegation profile is selected
+  # default_profile: "friendly"               # Built-in: restricted, friendly, privileged
+  # profiles:
+  #   docs:
+  #     toolsets: ["file", "web"]
+  #     memory: "read"                        # none | read | write
+  #     provider_tools: false
+  #     terminal:
+  #       backend: "docker"                   # docker | modal | local | ssh | singularity | daytona
+  #       docker_image: "nikolaik/python-nodejs:python3.11-nodejs20"
   # model: "google/gemini-3-flash-preview"    # Override model for subagents (empty = inherit parent)
   # provider: "openrouter"                    # Override provider for subagents (empty = inherit parent)
   #                                           # Resolves full credentials (base_url, api_key) automatically.

--- a/cli.py
+++ b/cli.py
@@ -237,6 +237,8 @@ def load_cli_config() -> Dict[str, Any]:
             "provider": "",    # Subagent provider override (empty = inherit parent provider)
             "base_url": "",    # Direct OpenAI-compatible endpoint for subagents
             "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
+            "default_profile": "",  # Named child capability profile (empty = legacy/default toolsets)
+            "profiles": {},    # Optional custom delegation profiles
         },
     }
     

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -444,6 +444,8 @@ DEFAULT_CONFIG = {
         "provider": "",    # e.g. "openrouter" (empty = inherit parent provider + credentials)
         "base_url": "",    # direct OpenAI-compatible endpoint for subagents
         "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
+        "default_profile": "",  # e.g. "friendly" for built-in or custom delegation profiles
+        "profiles": {},    # optional named child capability profiles (toolsets, memory, terminal)
         "max_iterations": 50,  # per-subagent iteration cap (each subagent gets its own budget,
                                # independent of the parent's max_iterations)
     },

--- a/run_agent.py
+++ b/run_agent.py
@@ -466,6 +466,9 @@ class AIAgent:
         platform: str = None,
         skip_context_files: bool = False,
         skip_memory: bool = False,
+        memory_write_enabled: bool = True,
+        provider_tool_access: bool = True,
+        agent_context: str = "primary",
         session_db=None,
         iteration_budget: "IterationBudget" = None,
         fallback_model: Dict[str, Any] = None,
@@ -534,6 +537,9 @@ class AIAgent:
         self._print_fn = None
         self.background_review_callback = None  # Optional sync callback for gateway delivery
         self.skip_context_files = skip_context_files
+        self._memory_write_enabled = bool(memory_write_enabled)
+        self._provider_tool_access = bool(provider_tool_access)
+        self._agent_context = str(agent_context or "primary")
         self.pass_session_id = pass_session_id
         self.persist_session = persist_session
         self._credential_pool = credential_pool
@@ -1070,7 +1076,7 @@ class AIAgent:
                             "session_id": self.session_id,
                             "platform": platform or "cli",
                             "hermes_home": str(_ghh()),
-                            "agent_context": "primary",
+                            "agent_context": self._agent_context,
                         }
                         # Profile identity for per-profile provider scoping
                         try:
@@ -1090,7 +1096,7 @@ class AIAgent:
                 self._memory_manager = None
 
         # Inject memory provider tool schemas into the tool surface
-        if self._memory_manager and self.tools is not None:
+        if self._memory_manager and self._provider_tool_access and self.tools is not None:
             for _schema in self._memory_manager.get_all_tool_schemas():
                 _wrapped = {"type": "function", "function": _schema}
                 self.tools.append(_wrapped)
@@ -5586,6 +5592,45 @@ class AIAgent:
         finally:
             self._executing_tools = False
 
+    def _handle_builtin_memory_tool(self, function_args: dict) -> str:
+        """Handle the built-in memory tool with optional write protection."""
+        if not self._memory_write_enabled:
+            return json.dumps({
+                "success": False,
+                "error": "Memory writes are disabled for this agent.",
+            })
+
+        target = function_args.get("target", "memory")
+        from tools.memory_tool import memory_tool as _memory_tool
+        result = _memory_tool(
+            action=function_args.get("action"),
+            target=target,
+            content=function_args.get("content"),
+            old_text=function_args.get("old_text"),
+            store=self._memory_store,
+        )
+
+        if self._memory_manager and function_args.get("action") in ("add", "replace"):
+            try:
+                self._memory_manager.on_memory_write(
+                    function_args.get("action", ""),
+                    target,
+                    function_args.get("content", ""),
+                )
+            except Exception:
+                pass
+
+        return result
+
+    def _handle_provider_memory_tool(self, function_name: str, function_args: dict) -> str:
+        """Handle external memory-provider tools with optional access control."""
+        if not self._provider_tool_access:
+            return json.dumps({
+                "success": False,
+                "error": "Memory provider tools are disabled for this agent.",
+            })
+        return self._memory_manager.handle_tool_call(function_name, function_args)
+
     def _invoke_tool(self, function_name: str, function_args: dict, effective_task_id: str) -> str:
         """Invoke a single tool and return the result string. No display logic.
 
@@ -5612,28 +5657,9 @@ class AIAgent:
                 current_session_id=self.session_id,
             )
         elif function_name == "memory":
-            target = function_args.get("target", "memory")
-            from tools.memory_tool import memory_tool as _memory_tool
-            result = _memory_tool(
-                action=function_args.get("action"),
-                target=target,
-                content=function_args.get("content"),
-                old_text=function_args.get("old_text"),
-                store=self._memory_store,
-            )
-            # Bridge: notify external memory provider of built-in memory writes
-            if self._memory_manager and function_args.get("action") in ("add", "replace"):
-                try:
-                    self._memory_manager.on_memory_write(
-                        function_args.get("action", ""),
-                        target,
-                        function_args.get("content", ""),
-                    )
-                except Exception:
-                    pass
-            return result
+            return self._handle_builtin_memory_tool(function_args)
         elif self._memory_manager and self._memory_manager.has_tool(function_name):
-            return self._memory_manager.handle_tool_call(function_name, function_args)
+            return self._handle_provider_memory_tool(function_name, function_args)
         elif function_name == "clarify":
             from tools.clarify_tool import clarify_tool as _clarify_tool
             return _clarify_tool(
@@ -5647,6 +5673,7 @@ class AIAgent:
                 goal=function_args.get("goal"),
                 context=function_args.get("context"),
                 toolsets=function_args.get("toolsets"),
+                profile=function_args.get("profile"),
                 tasks=function_args.get("tasks"),
                 max_iterations=function_args.get("max_iterations"),
                 parent_agent=self,
@@ -5969,15 +5996,7 @@ class AIAgent:
                 if self.quiet_mode:
                     self._vprint(f"  {_get_cute_tool_message_impl('session_search', function_args, tool_duration, result=function_result)}")
             elif function_name == "memory":
-                target = function_args.get("target", "memory")
-                from tools.memory_tool import memory_tool as _memory_tool
-                function_result = _memory_tool(
-                    action=function_args.get("action"),
-                    target=target,
-                    content=function_args.get("content"),
-                    old_text=function_args.get("old_text"),
-                    store=self._memory_store,
-                )
+                function_result = self._handle_builtin_memory_tool(function_args)
                 tool_duration = time.time() - tool_start_time
                 if self.quiet_mode:
                     self._vprint(f"  {_get_cute_tool_message_impl('memory', function_args, tool_duration, result=function_result)}")
@@ -6011,6 +6030,7 @@ class AIAgent:
                         goal=function_args.get("goal"),
                         context=function_args.get("context"),
                         toolsets=function_args.get("toolsets"),
+                        profile=function_args.get("profile"),
                         tasks=tasks_arg,
                         max_iterations=function_args.get("max_iterations"),
                         parent_agent=self,
@@ -6036,7 +6056,7 @@ class AIAgent:
                     spinner.start()
                 _mem_result = None
                 try:
-                    function_result = self._memory_manager.handle_tool_call(function_name, function_args)
+                    function_result = self._handle_provider_memory_tool(function_name, function_args)
                     _mem_result = function_result
                 except Exception as tool_error:
                     function_result = json.dumps({"error": f"Memory tool '{function_name}' failed: {tool_error}"})

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1300,6 +1300,50 @@ class TestConcurrentToolExecution:
             mock_todo.assert_called_once()
         assert "ok" in result
 
+    def test_invoke_tool_blocks_memory_writes_when_disabled(self, agent_with_memory_tool):
+        agent = agent_with_memory_tool
+        agent._memory_write_enabled = False
+        agent._memory_store = MagicMock()
+
+        result = json.loads(
+            agent._invoke_tool(
+                "memory",
+                {"action": "add", "target": "memory", "content": "blocked"},
+                "task-1",
+            )
+        )
+
+        assert result["success"] is False
+        assert "disabled" in result["error"].lower()
+
+    def test_invoke_tool_blocks_provider_memory_tools_when_disabled(self, agent):
+        manager = MagicMock()
+        manager.has_tool.return_value = True
+        agent._memory_manager = manager
+        agent._provider_tool_access = False
+
+        result = json.loads(
+            agent._invoke_tool("honcho_search", {"query": "test"}, "task-1")
+        )
+
+        assert result["success"] is False
+        assert "disabled" in result["error"].lower()
+        manager.handle_tool_call.assert_not_called()
+
+    def test_invoke_tool_routes_provider_memory_tools_when_enabled(self, agent):
+        manager = MagicMock()
+        manager.has_tool.return_value = True
+        manager.handle_tool_call.return_value = '{"ok": true}'
+        agent._memory_manager = manager
+        agent._provider_tool_access = True
+
+        result = agent._invoke_tool("honcho_search", {"query": "test"}, "task-1")
+
+        assert json.loads(result)["ok"] is True
+        manager.handle_tool_call.assert_called_once_with(
+            "honcho_search", {"query": "test"}
+        )
+
 
 class TestPathsOverlap:
     """Unit tests for the _paths_overlap helper."""

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -194,6 +194,60 @@ class TestDelegateTask(unittest.TestCase):
         call_args = mock_run.call_args
         self.assertEqual(call_args.kwargs.get("goal") or call_args[1].get("goal", call_args[0][1] if len(call_args[0]) > 1 else None), "Actual task")
 
+    @patch("tools.delegate_tool._load_config", return_value={"max_iterations": 45})
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._run_single_child")
+    def test_top_level_profile_reaches_child_builder(self, mock_run, mock_build, mock_creds, _mock_cfg):
+        mock_creds.return_value = {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+        mock_build.return_value = MagicMock()
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed",
+            "summary": "Done", "api_calls": 1, "duration_seconds": 1.0
+        }
+        parent = _make_mock_parent()
+
+        delegate_task(goal="Profile test", profile="friendly", parent_agent=parent)
+
+        profile_arg = mock_build.call_args.kwargs["profile"]
+        self.assertEqual(profile_arg["name"], "friendly")
+        self.assertEqual(profile_arg["memory"], "read")
+
+    @patch("tools.delegate_tool._load_config", return_value={"max_iterations": 45, "default_profile": "restricted"})
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._run_single_child")
+    def test_task_profile_overrides_top_level_or_default_profile(self, mock_run, mock_build, mock_creds, _mock_cfg):
+        mock_creds.return_value = {
+            "model": None,
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+        mock_build.return_value = MagicMock()
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed",
+            "summary": "Done", "api_calls": 1, "duration_seconds": 1.0
+        }
+        parent = _make_mock_parent()
+
+        delegate_task(
+            profile="friendly",
+            tasks=[{"goal": "Use privileged child", "profile": "privileged"}],
+            parent_agent=parent,
+        )
+
+        profile_arg = mock_build.call_args.kwargs["profile"]
+        self.assertEqual(profile_arg["name"], "privileged")
+        self.assertEqual(profile_arg["memory"], "write")
+
     @patch("tools.delegate_tool._run_single_child")
     def test_failed_child_included_in_results(self, mock_run):
         mock_run.return_value = {

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -25,6 +25,7 @@ from tools.delegate_tool import (
     delegate_task,
     _build_child_agent,
     _build_child_system_prompt,
+    _resolve_delegation_profile,
     _strip_blocked_tools,
     _resolve_delegation_credentials,
 )
@@ -61,6 +62,7 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("tasks", props)
         self.assertIn("context", props)
         self.assertIn("toolsets", props)
+        self.assertIn("profile", props)
         self.assertIn("max_iterations", props)
         self.assertEqual(props["tasks"]["maxItems"], 3)
 
@@ -118,6 +120,13 @@ class TestDelegateTask(unittest.TestCase):
         parent = _make_mock_parent()
         result = json.loads(delegate_task(goal="  ", parent_agent=parent))
         self.assertIn("error", result)
+
+    @patch("tools.delegate_tool._load_config", return_value={"max_iterations": 45, "default_profile": "missing"})
+    def test_unknown_profile_returns_json_error(self, _mock_cfg):
+        parent = _make_mock_parent()
+        result = json.loads(delegate_task(goal="test", parent_agent=parent))
+        self.assertIn("error", result)
+        self.assertIn("Unknown delegation profile", result["error"])
 
     def test_task_missing_goal(self):
         parent = _make_mock_parent()
@@ -309,6 +318,7 @@ class TestToolNamePreservation(unittest.TestCase):
                     goal="regression check",
                     context=None,
                     toolsets=None,
+                    profile=_resolve_delegation_profile({}, None),
                     model=None,
                     max_iterations=10,
                     parent_agent=parent,
@@ -333,8 +343,9 @@ class TestToolNamePreservation(unittest.TestCase):
         with patch("run_agent.AIAgent") as MockAgent:
             mock_child = MagicMock()
 
-            def capture_and_return(user_message):
+            def capture_and_return(user_message, task_id=None):
                 captured["saved"] = list(mock_child._delegate_saved_tool_names)
+                captured["task_id"] = task_id
                 return {"final_response": "ok", "completed": True, "api_calls": 1}
 
             mock_child.run_conversation.side_effect = capture_and_return
@@ -343,6 +354,57 @@ class TestToolNamePreservation(unittest.TestCase):
             delegate_task(goal="capture test", parent_agent=parent)
 
         self.assertEqual(captured["saved"], expected_tools)
+        self.assertTrue(captured["task_id"].startswith("delegate-"))
+
+    def test_friendly_profile_configures_read_only_memory(self):
+        parent = _make_mock_parent(depth=0)
+        profile = _resolve_delegation_profile({}, "friendly")
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="friendly child",
+                context=None,
+                toolsets=None,
+                profile=profile,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+            )
+
+            _, kwargs = MockAgent.call_args
+            self.assertFalse(kwargs["skip_memory"])
+            self.assertFalse(kwargs["memory_write_enabled"])
+            self.assertFalse(kwargs["provider_tool_access"])
+            self.assertEqual(kwargs["agent_context"], "subagent")
+
+    def test_privileged_profile_configures_writable_memory(self):
+        parent = _make_mock_parent(depth=0)
+        profile = _resolve_delegation_profile({}, "privileged")
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="privileged child",
+                context=None,
+                toolsets=None,
+                profile=profile,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+            )
+
+            _, kwargs = MockAgent.call_args
+            self.assertFalse(kwargs["skip_memory"])
+            self.assertTrue(kwargs["memory_write_enabled"])
+            self.assertTrue(kwargs["provider_tool_access"])
+            self.assertEqual(kwargs["agent_context"], "subagent")
 
 
 class TestDelegateObservability(unittest.TestCase):

--- a/tests/tools/test_delegate_toolset_scope.py
+++ b/tests/tools/test_delegate_toolset_scope.py
@@ -1,66 +1,68 @@
-"""Tests for delegate_tool toolset scoping.
+"""Tests for delegate_tool toolset scoping and delegation profiles."""
 
-Verifies that subagents cannot gain tools that the parent does not have.
-The LLM controls the `toolsets` parameter — without intersection with the
-parent's enabled_toolsets, it can escalate privileges by requesting
-arbitrary toolsets.
-"""
-
-from unittest.mock import MagicMock, patch
 from types import SimpleNamespace
 
-from tools.delegate_tool import _strip_blocked_tools
+from toolsets import TOOLSETS, resolve_toolset
+from tools.delegate_tool import (
+    _build_child_blocked_tools,
+    _build_child_enabled_toolsets,
+    _resolve_delegation_profile,
+    _strip_blocked_tools,
+)
 
 
 class TestToolsetIntersection:
-    """Subagent toolsets must be a subset of parent's enabled_toolsets."""
-
-    def test_requested_toolsets_intersected_with_parent(self):
-        """LLM requests toolsets parent doesn't have — extras are dropped."""
-        parent = SimpleNamespace(enabled_toolsets=["terminal", "file"])
-
-        # Simulate the intersection logic from _build_child_agent
-        parent_toolsets = set(parent.enabled_toolsets)
-        requested = ["terminal", "file", "web", "browser", "rl"]
-        scoped = [t for t in requested if t in parent_toolsets]
-
-        assert sorted(scoped) == ["file", "terminal"]
-        assert "web" not in scoped
-        assert "browser" not in scoped
-        assert "rl" not in scoped
-
-    def test_all_requested_toolsets_available_on_parent(self):
-        """LLM requests subset of parent tools — all pass through."""
-        parent = SimpleNamespace(enabled_toolsets=["terminal", "file", "web", "browser"])
-
-        parent_toolsets = set(parent.enabled_toolsets)
-        requested = ["terminal", "web"]
-        scoped = [t for t in requested if t in parent_toolsets]
-
-        assert sorted(scoped) == ["terminal", "web"]
-
-    def test_no_toolsets_requested_inherits_parent(self):
-        """When toolsets is None/empty, child inherits parent's set."""
-        parent_toolsets = ["terminal", "file", "web"]
-        child = _strip_blocked_tools(parent_toolsets)
-        assert "terminal" in child
-        assert "file" in child
-        assert "web" in child
+    """Subagent toolsets must stay within parent + profile scope."""
 
     def test_strip_blocked_removes_delegation(self):
-        """Blocked toolsets (delegation, clarify, etc.) are always removed."""
         child = _strip_blocked_tools(["terminal", "delegation", "clarify", "memory"])
         assert "delegation" not in child
         assert "clarify" not in child
         assert "memory" not in child
         assert "terminal" in child
 
-    def test_empty_intersection_yields_empty_toolsets(self):
-        """If parent has no overlap with requested, child gets nothing extra."""
-        parent = SimpleNamespace(enabled_toolsets=["terminal"])
+    def test_requested_toolsets_are_scoped_by_profile_and_blocklist(self):
+        parent = SimpleNamespace(enabled_toolsets=["hermes-cli"])
+        blocked = _build_child_blocked_tools("none")
+        child_toolsets, temp_toolset = _build_child_enabled_toolsets(
+            task_index=0,
+            requested_toolsets=["terminal", "web", "memory"],
+            parent_agent=parent,
+            profile_toolsets=["terminal", "web", "memory"],
+            blocked_tools=blocked,
+        )
+        try:
+            assert child_toolsets == [temp_toolset]
+            resolved = set(resolve_toolset(temp_toolset))
+            assert "terminal" in resolved
+            assert "web_search" in resolved
+            assert "memory" not in resolved
+            assert "delegate_task" not in resolved
+        finally:
+            TOOLSETS.pop(temp_toolset, None)
 
-        parent_toolsets = set(parent.enabled_toolsets)
-        requested = ["web", "browser"]
-        scoped = [t for t in requested if t in parent_toolsets]
+    def test_requested_toolset_outside_profile_is_dropped(self):
+        parent = SimpleNamespace(enabled_toolsets=["terminal", "file", "web"])
+        blocked = _build_child_blocked_tools("none")
+        _, temp_toolset = _build_child_enabled_toolsets(
+            task_index=1,
+            requested_toolsets=["web"],
+            parent_agent=parent,
+            profile_toolsets=["file"],
+            blocked_tools=blocked,
+        )
+        try:
+            assert resolve_toolset(temp_toolset) == []
+        finally:
+            TOOLSETS.pop(temp_toolset, None)
 
-        assert scoped == []
+    def test_legacy_default_toolsets_apply_without_profile(self):
+        profile = _resolve_delegation_profile({"default_toolsets": ["file", "web"]}, None)
+        assert profile["toolsets"] == ["file", "web"]
+        assert profile["memory"] == "none"
+
+    def test_privileged_profile_allows_memory_writes(self):
+        profile = _resolve_delegation_profile({}, "privileged")
+        blocked = _build_child_blocked_tools(profile["memory"])
+        assert profile["memory"] == "write"
+        assert "memory" not in blocked

--- a/tests/tools/test_parse_env_var.py
+++ b/tests/tools/test_parse_env_var.py
@@ -52,6 +52,20 @@ class TestParseEnvVar:
         assert result is fake_env
         assert mock_docker.call_args.kwargs["forward_env"] == ["GITHUB_TOKEN"]
 
+    def test_task_override_can_switch_backend_with_sandbox_default_cwd(self):
+        task_id = "delegate-friendly"
+        with patch.dict("os.environ", {"TERMINAL_ENV": "local"}, clear=False):
+            _tt_mod.register_task_env_overrides(task_id, {"env_type": "docker"})
+            try:
+                resolved = _tt_mod._resolve_task_environment_settings(task_id)
+            finally:
+                _tt_mod.clear_task_env_overrides(task_id)
+
+        assert resolved["env_type"] == "docker"
+        assert resolved["cwd"] == "/root"
+        assert resolved["host_cwd"] is None
+        assert resolved["container_config"] is not None
+
     def test_falls_back_to_default(self):
         with patch.dict("os.environ", {}, clear=False):
             # Remove the var if it exists, rely on default

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -39,6 +39,36 @@ MAX_DEPTH = 2  # parent (0) -> child (1) -> grandchild rejected (2)
 DEFAULT_MAX_ITERATIONS = 50
 DEFAULT_TOOLSETS = ["terminal", "file", "web"]
 
+BUILTIN_DELEGATION_PROFILES = {
+    "restricted": {
+        "description": "Minimal subagent profile with no memory access.",
+        "toolsets": ["terminal", "file"],
+        "memory": "none",
+        "provider_tools": False,
+        "terminal": {
+            "backend": "docker",
+        },
+    },
+    "friendly": {
+        "description": "Read-only memory profile for cooperative code and research tasks.",
+        "toolsets": ["terminal", "file", "web"],
+        "memory": "read",
+        "provider_tools": False,
+        "terminal": {
+            "backend": "docker",
+        },
+    },
+    "privileged": {
+        "description": "Write-capable memory profile for trusted subagents.",
+        "toolsets": ["terminal", "file", "web", "memory"],
+        "memory": "write",
+        "provider_tools": True,
+        "terminal": {
+            "backend": "docker",
+        },
+    },
+}
+
 
 def check_delegate_requirements() -> bool:
     """Delegation has no external requirements -- always available."""
@@ -73,6 +103,203 @@ def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
         "delegation", "clarify", "memory", "code_execution",
     }
     return [t for t in toolsets if t not in blocked_toolset_names]
+
+
+def _resolve_toolset_tools(toolsets: List[str]) -> set[str]:
+    """Resolve a list of toolset names into concrete tool names."""
+    from toolsets import resolve_toolset, validate_toolset
+
+    resolved: set[str] = set()
+    for toolset_name in toolsets or []:
+        if validate_toolset(toolset_name):
+            resolved.update(resolve_toolset(toolset_name))
+    return resolved
+
+
+def _normalize_memory_access(value: object) -> str:
+    """Normalize a delegation profile memory mode."""
+    normalized = str(value or "none").strip().lower()
+    if normalized not in {"none", "read", "write"}:
+        raise ValueError(
+            f"Invalid delegation memory mode '{value}'. "
+            "Expected one of: none, read, write."
+        )
+    return normalized
+
+
+def _parse_boolish(value: object, default: bool = False) -> bool:
+    """Parse profile bool-like config values safely."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes", "on"}:
+            return True
+        if lowered in {"false", "0", "no", "off"}:
+            return False
+    return default
+
+
+def _get_delegation_profiles(cfg: dict) -> dict:
+    """Return built-in profiles plus any user-defined overrides."""
+    profiles = {
+        name: {
+            "description": spec.get("description", ""),
+            "toolsets": list(spec.get("toolsets") or []),
+            "memory": spec.get("memory", "none"),
+            "provider_tools": spec.get("provider_tools", False),
+            "terminal": dict(spec.get("terminal") or {}),
+        }
+        for name, spec in BUILTIN_DELEGATION_PROFILES.items()
+    }
+
+    custom = cfg.get("profiles") or {}
+    if not isinstance(custom, dict):
+        return profiles
+
+    for name, spec in custom.items():
+        if not isinstance(spec, dict):
+            continue
+        existing = profiles.get(name, {})
+        merged = {
+            "description": spec.get("description", existing.get("description", "")),
+            "toolsets": list(spec.get("toolsets") or existing.get("toolsets") or []),
+            "memory": spec.get("memory", existing.get("memory", "none")),
+            "provider_tools": spec.get("provider_tools", existing.get("provider_tools", False)),
+            "terminal": {
+                **dict(existing.get("terminal") or {}),
+                **dict(spec.get("terminal") or {}),
+            },
+        }
+        profiles[name] = merged
+
+    return profiles
+
+
+def _resolve_delegation_profile(cfg: dict, requested_profile: Optional[str]) -> dict:
+    """Resolve a delegation capability profile."""
+    profile_name = (requested_profile or cfg.get("default_profile") or "").strip()
+    if not profile_name:
+        legacy_toolsets = cfg.get("default_toolsets")
+        if not isinstance(legacy_toolsets, list):
+            legacy_toolsets = []
+        return {
+            "name": "",
+            "toolsets": list(legacy_toolsets),
+            "memory": "none",
+            "provider_tools": False,
+            "terminal": {},
+        }
+
+    profiles = _get_delegation_profiles(cfg)
+    spec = profiles.get(profile_name)
+    if not isinstance(spec, dict):
+        raise ValueError(
+            f"Unknown delegation profile '{profile_name}'. "
+            f"Available: {', '.join(sorted(profiles))}"
+        )
+
+    return {
+        "name": profile_name,
+        "toolsets": list(spec.get("toolsets") or []),
+        "memory": _normalize_memory_access(spec.get("memory")),
+        "provider_tools": _parse_boolish(spec.get("provider_tools"), default=False),
+        "terminal": dict(spec.get("terminal") or {}),
+    }
+
+
+def _build_child_blocked_tools(memory_access: str) -> set[str]:
+    """Return the blocked tool names for a child profile."""
+    blocked = set(DELEGATE_BLOCKED_TOOLS)
+    if memory_access == "write":
+        blocked.discard("memory")
+    return blocked
+
+
+def _build_child_enabled_toolsets(
+    task_index: int,
+    requested_toolsets: Optional[List[str]],
+    parent_agent,
+    profile_toolsets: Optional[List[str]],
+    blocked_tools: set[str],
+) -> tuple[List[str], str]:
+    """Create an exact child toolset derived from parent + profile constraints."""
+    from toolsets import create_custom_toolset, resolve_toolset, validate_toolset
+
+    parent_toolsets = list(getattr(parent_agent, "enabled_toolsets", None) or DEFAULT_TOOLSETS)
+    parent_allowed_tools = _resolve_toolset_tools(parent_toolsets) - blocked_tools
+
+    profile_allowed_tools = set(parent_allowed_tools)
+    if profile_toolsets:
+        profile_allowed_tools = set()
+        for toolset_name in profile_toolsets:
+            if not validate_toolset(toolset_name):
+                logger.debug("Ignoring unknown toolset in delegation profile: %s", toolset_name)
+                continue
+            profile_allowed_tools.update(resolve_toolset(toolset_name))
+        profile_allowed_tools &= parent_allowed_tools
+
+    child_tools = set(profile_allowed_tools)
+    if requested_toolsets:
+        child_tools = set()
+        for toolset_name in requested_toolsets:
+            if not validate_toolset(toolset_name):
+                logger.debug("Dropping unknown delegated toolset request: %s", toolset_name)
+                continue
+
+            requested_tools = set(resolve_toolset(toolset_name)) - blocked_tools
+            if not requested_tools:
+                logger.debug(
+                    "Dropping delegated toolset '%s': contains no child-safe tools",
+                    toolset_name,
+                )
+                continue
+
+            if not requested_tools.issubset(profile_allowed_tools):
+                logger.debug(
+                    "Dropping delegated toolset '%s': requests tools outside parent/profile scope",
+                    toolset_name,
+                )
+                continue
+
+            child_tools.update(requested_tools)
+
+    toolset_name = f"_delegate_child_{os.getpid()}_{task_index}_{time.time_ns()}"
+    create_custom_toolset(
+        name=toolset_name,
+        description="Exact tool subset for delegated child agent",
+        tools=sorted(child_tools),
+    )
+    return [toolset_name], toolset_name
+
+
+def _build_terminal_overrides(profile: dict) -> Dict[str, Any]:
+    """Translate a delegation profile terminal block into per-task overrides."""
+    terminal = profile.get("terminal") or {}
+    if not isinstance(terminal, dict):
+        return {}
+
+    overrides: Dict[str, Any] = {}
+    backend = str(terminal.get("backend") or "").strip()
+    if backend:
+        overrides["env_type"] = backend
+
+    for key in (
+        "cwd",
+        "docker_image",
+        "modal_image",
+        "daytona_image",
+        "singularity_image",
+        "docker_mount_cwd_to_workspace",
+        "docker_forward_env",
+        "docker_volumes",
+    ):
+        if key in terminal:
+            overrides[key] = terminal[key]
+
+    return overrides
 
 
 def _build_child_progress_callback(task_index: int, parent_agent, task_count: int = 1) -> Optional[callable]:
@@ -152,6 +379,7 @@ def _build_child_agent(
     goal: str,
     context: Optional[str],
     toolsets: Optional[List[str]],
+    profile: dict,
     model: Optional[str],
     max_iterations: int,
     parent_agent,
@@ -172,16 +400,14 @@ def _build_child_agent(
     """
     from run_agent import AIAgent
 
-    # When no explicit toolsets given, inherit from parent's enabled toolsets
-    # so disabled tools (e.g. web) don't leak to subagents.
-    parent_toolsets = set(getattr(parent_agent, "enabled_toolsets", None) or DEFAULT_TOOLSETS)
-    if toolsets:
-        # Intersect with parent — subagent must not gain tools the parent lacks
-        child_toolsets = _strip_blocked_tools([t for t in toolsets if t in parent_toolsets])
-    elif parent_agent and getattr(parent_agent, "enabled_toolsets", None):
-        child_toolsets = _strip_blocked_tools(parent_agent.enabled_toolsets)
-    else:
-        child_toolsets = _strip_blocked_tools(DEFAULT_TOOLSETS)
+    blocked_tools = _build_child_blocked_tools(profile.get("memory", "none"))
+    child_toolsets, delegate_toolset_name = _build_child_enabled_toolsets(
+        task_index=task_index,
+        requested_toolsets=toolsets,
+        parent_agent=parent_agent,
+        profile_toolsets=profile.get("toolsets"),
+        blocked_tools=blocked_tools,
+    )
 
     child_prompt = _build_child_system_prompt(goal, context)
     # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
@@ -224,7 +450,10 @@ def _build_child_agent(
         log_prefix=f"[subagent-{task_index}]",
         platform=parent_agent.platform,
         skip_context_files=True,
-        skip_memory=True,
+        skip_memory=profile.get("memory", "none") == "none",
+        memory_write_enabled=profile.get("memory", "none") == "write",
+        provider_tool_access=bool(profile.get("provider_tools", False)),
+        agent_context="subagent",
         clarify_callback=None,
         session_db=getattr(parent_agent, '_session_db', None),
         providers_allowed=parent_agent.providers_allowed,
@@ -236,6 +465,9 @@ def _build_child_agent(
     )
     # Set delegation depth so children can't spawn grandchildren
     child._delegate_depth = getattr(parent_agent, '_delegate_depth', 0) + 1
+    child._delegate_temp_toolset = delegate_toolset_name
+    child._delegate_terminal_overrides = _build_terminal_overrides(profile)
+    child._delegate_task_id = f"delegate-{task_index}-{time.time_ns()}"
 
     # Register child for interrupt propagation
     if hasattr(parent_agent, '_active_children'):
@@ -269,9 +501,15 @@ def _run_single_child(
     import model_tools
     _saved_tool_names = getattr(child, "_delegate_saved_tool_names",
                                 list(model_tools._last_resolved_tool_names))
+    child_task_id = getattr(child, "_delegate_task_id", f"delegate-{task_index}-{time.time_ns()}")
+    terminal_overrides = getattr(child, "_delegate_terminal_overrides", None) or {}
 
     try:
-        result = child.run_conversation(user_message=goal)
+        if terminal_overrides:
+            from tools.terminal_tool import register_task_env_overrides
+            register_task_env_overrides(child_task_id, terminal_overrides)
+
+        result = child.run_conversation(user_message=goal, task_id=child_task_id)
 
         # Flush any remaining batched progress to gateway
         if child_progress_cb and hasattr(child_progress_cb, '_flush'):
@@ -383,10 +621,18 @@ def _run_single_child(
         # Restore the parent's tool names so the process-global is correct
         # for any subsequent execute_code calls or other consumers.
         import model_tools
+        from toolsets import TOOLSETS
+        from tools.terminal_tool import clear_task_env_overrides
 
         saved_tool_names = getattr(child, "_delegate_saved_tool_names", None)
         if isinstance(saved_tool_names, list):
             model_tools._last_resolved_tool_names = list(saved_tool_names)
+
+        temp_toolset = getattr(child, "_delegate_temp_toolset", None)
+        if temp_toolset:
+            TOOLSETS.pop(temp_toolset, None)
+
+        clear_task_env_overrides(child_task_id)
 
         # Unregister child from interrupt propagation
         if hasattr(parent_agent, '_active_children'):
@@ -404,6 +650,7 @@ def delegate_task(
     goal: Optional[str] = None,
     context: Optional[str] = None,
     toolsets: Optional[List[str]] = None,
+    profile: Optional[str] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
     parent_agent=None,
@@ -449,7 +696,7 @@ def delegate_task(
     if tasks and isinstance(tasks, list):
         task_list = tasks[:MAX_CONCURRENT_CHILDREN]
     elif goal and isinstance(goal, str) and goal.strip():
-        task_list = [{"goal": goal, "context": context, "toolsets": toolsets}]
+        task_list = [{"goal": goal, "context": context, "toolsets": toolsets, "profile": profile}]
     else:
         return json.dumps({"error": "Provide either 'goal' (single task) or 'tasks' (batch)."})
 
@@ -480,8 +727,13 @@ def delegate_task(
     children = []
     try:
         for i, t in enumerate(task_list):
+            try:
+                resolved_profile = _resolve_delegation_profile(cfg, t.get("profile") or profile)
+            except ValueError as exc:
+                return json.dumps({"error": str(exc)})
             child = _build_child_agent(
                 task_index=i, goal=t["goal"], context=t.get("context"),
+                profile=resolved_profile,
                 toolsets=t.get("toolsets") or toolsets, model=creds["model"],
                 max_iterations=effective_max_iter, parent_agent=parent_agent,
                 override_provider=creds["provider"], override_base_url=creds["base_url"],
@@ -716,10 +968,12 @@ DELEGATE_TASK_SCHEMA = {
         "- Single tool call -> just call the tool directly\n"
         "- Tasks needing user interaction -> subagents cannot use clarify\n\n"
         "IMPORTANT:\n"
-        "- Subagents have NO memory of your conversation. Pass all relevant "
+        "- Subagents do not automatically know your conversation history. Pass all relevant "
         "info (file paths, error messages, constraints) via the 'context' field.\n"
-        "- Subagents CANNOT call: delegate_task, clarify, memory, send_message, "
-        "execute_code.\n"
+        "- Profiles can change child capabilities, including memory access and "
+        "terminal backend selection.\n"
+        "- Subagents CANNOT call: delegate_task, clarify, send_message, "
+        "execute_code. Memory access depends on the selected profile.\n"
         "- Each subagent gets its own terminal session (separate working directory and state).\n"
         "- Results are always returned as an array, one entry per task."
     ),
@@ -747,10 +1001,18 @@ DELEGATE_TASK_SCHEMA = {
                 "items": {"type": "string"},
                 "description": (
                     "Toolsets to enable for this subagent. "
-                    "Default: inherits your enabled toolsets. "
+                    "Default: inherits the selected profile's child-safe tools. "
                     "Common patterns: ['terminal', 'file'] for code work, "
                     "['web'] for research, ['terminal', 'file', 'web'] for "
                     "full-stack tasks."
+                ),
+            },
+            "profile": {
+                "type": "string",
+                "description": (
+                    "Optional delegation capability profile. Built-ins: "
+                    "'restricted', 'friendly', 'privileged'. Profiles can set "
+                    "default toolsets, memory access, and terminal backend overrides."
                 ),
             },
             "tasks": {
@@ -760,6 +1022,10 @@ DELEGATE_TASK_SCHEMA = {
                     "properties": {
                         "goal": {"type": "string", "description": "Task goal"},
                         "context": {"type": "string", "description": "Task-specific context"},
+                        "profile": {
+                            "type": "string",
+                            "description": "Delegation profile for this specific task",
+                        },
                         "toolsets": {
                             "type": "array",
                             "items": {"type": "string"},
@@ -799,6 +1065,7 @@ registry.register(
         goal=args.get("goal"),
         context=args.get("context"),
         toolsets=args.get("toolsets"),
+        profile=args.get("profile"),
         tasks=args.get("tasks"),
         max_iterations=args.get("max_iterations"),
         parent_agent=kw.get("parent_agent")),

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -158,7 +158,8 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
     """
     from tools.terminal_tool import (
         _active_environments, _env_lock, _create_environment,
-        _get_env_config, _last_activity, _start_cleanup_thread,
+        _get_env_config, _last_activity, _resolve_task_environment_settings,
+        _start_cleanup_thread,
         _creation_locks,
         _creation_locks_lock,
     )
@@ -195,62 +196,23 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                 terminal_env = None
 
         if terminal_env is None:
-            from tools.terminal_tool import _task_env_overrides
-
             config = _get_env_config()
-            env_type = config["env_type"]
-            overrides = _task_env_overrides.get(task_id, {})
-
-            if env_type == "docker":
-                image = overrides.get("docker_image") or config["docker_image"]
-            elif env_type == "singularity":
-                image = overrides.get("singularity_image") or config["singularity_image"]
-            elif env_type == "modal":
-                image = overrides.get("modal_image") or config["modal_image"]
-            elif env_type == "daytona":
-                image = overrides.get("daytona_image") or config["daytona_image"]
-            else:
-                image = ""
-
-            cwd = overrides.get("cwd") or config["cwd"]
+            resolved_env = _resolve_task_environment_settings(task_id, config)
+            env_type = resolved_env["env_type"]
+            image = resolved_env["image"]
+            cwd = resolved_env["cwd"]
             logger.info("Creating new %s environment for task %s...", env_type, task_id[:8])
-
-            container_config = None
-            if env_type in ("docker", "singularity", "modal", "daytona"):
-                container_config = {
-                    "container_cpu": config.get("container_cpu", 1),
-                    "container_memory": config.get("container_memory", 5120),
-                    "container_disk": config.get("container_disk", 51200),
-                    "container_persistent": config.get("container_persistent", True),
-                    "docker_volumes": config.get("docker_volumes", []),
-                }
-
-            ssh_config = None
-            if env_type == "ssh":
-                ssh_config = {
-                    "host": config.get("ssh_host", ""),
-                    "user": config.get("ssh_user", ""),
-                    "port": config.get("ssh_port", 22),
-                    "key": config.get("ssh_key", ""),
-                    "persistent": config.get("ssh_persistent", False),
-                }
-
-            local_config = None
-            if env_type == "local":
-                local_config = {
-                    "persistent": config.get("local_persistent", False),
-                }
 
             terminal_env = _create_environment(
                 env_type=env_type,
                 image=image,
                 cwd=cwd,
-                timeout=config["timeout"],
-                ssh_config=ssh_config,
-                container_config=container_config,
-                local_config=local_config,
+                timeout=resolved_env["timeout"],
+                ssh_config=resolved_env["ssh_config"],
+                container_config=resolved_env["container_config"],
+                local_config=resolved_env["local_config"],
                 task_id=task_id,
-                host_cwd=config.get("host_cwd"),
+                host_cwd=resolved_env.get("host_cwd"),
             )
 
             with _env_lock:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -422,6 +422,15 @@ _cleanup_running = False
 _task_env_overrides: Dict[str, Dict[str, Any]] = {}
 
 
+def _default_cwd_for_env_type(env_type: str) -> str:
+    """Return the backend-appropriate default working directory."""
+    if env_type == "local":
+        return os.getcwd()
+    if env_type == "ssh":
+        return "~"
+    return "/root"
+
+
 def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
     """
     Register environment overrides for a specific task/rollout.
@@ -430,9 +439,15 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
     per-task sandbox settings (e.g., a custom Dockerfile for the Modal image).
 
     Supported override keys:
+        - env_type: str -- Backend override ("docker", "modal", etc.)
         - modal_image: str -- Path to Dockerfile or Docker Hub image name
         - docker_image: str -- Docker image name
+        - singularity_image: str -- Singularity image reference
+        - daytona_image: str -- Daytona image name
         - cwd: str -- Working directory inside the sandbox
+        - docker_forward_env: list[str] -- Env vars to forward into Docker
+        - docker_volumes: list[str] -- Additional Docker bind mounts
+        - docker_mount_cwd_to_workspace: bool -- Opt-in host cwd bind mount
 
     Args:
         task_id: The rollout's unique task identifier
@@ -475,15 +490,7 @@ def _get_env_config() -> Dict[str, Any]:
     
     mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in ("true", "1", "yes")
 
-    # Default cwd: local uses the host's current directory, everything
-    # else starts in the user's home (~ resolves to whatever account
-    # is running inside the container/remote).
-    if env_type == "local":
-        default_cwd = os.getcwd()
-    elif env_type == "ssh":
-        default_cwd = "~"
-    else:
-        default_cwd = "/root"
+    default_cwd = _default_cwd_for_env_type(env_type)
 
     # Read TERMINAL_CWD but sanity-check it for container backends.
     # If Docker cwd passthrough is explicitly enabled, remap the host path to
@@ -543,6 +550,80 @@ def _get_env_config() -> Dict[str, Any]:
         "container_disk": _parse_env_var("TERMINAL_CONTAINER_DISK", "51200"),        # MB (default 50GB)
         "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in ("true", "1", "yes"),
         "docker_volumes": _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON"),
+    }
+
+
+def _resolve_task_environment_settings(task_id: str, config: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    """Resolve per-task environment settings after applying registered overrides."""
+    config = dict(config or _get_env_config())
+    overrides = dict(_task_env_overrides.get(task_id, {}) or {})
+
+    env_type = str(overrides.get("env_type") or config["env_type"])
+    base_env_type = str(config["env_type"])
+
+    if env_type == "docker":
+        image = overrides.get("docker_image") or config["docker_image"]
+    elif env_type == "singularity":
+        image = overrides.get("singularity_image") or config["singularity_image"]
+    elif env_type == "modal":
+        image = overrides.get("modal_image") or config["modal_image"]
+    elif env_type == "daytona":
+        image = overrides.get("daytona_image") or config["daytona_image"]
+    else:
+        image = ""
+
+    cwd = overrides.get("cwd")
+    if not cwd:
+        cwd = config["cwd"] if env_type == base_env_type else _default_cwd_for_env_type(env_type)
+
+    host_cwd = overrides.get("host_cwd")
+    if host_cwd is None:
+        host_cwd = config.get("host_cwd") if env_type == base_env_type else None
+
+    container_config = None
+    if env_type in ("docker", "singularity", "modal", "daytona"):
+        container_config = {
+            "container_cpu": config.get("container_cpu", 1),
+            "container_memory": config.get("container_memory", 5120),
+            "container_disk": config.get("container_disk", 51200),
+            "container_persistent": config.get("container_persistent", True),
+            "modal_mode": config.get("modal_mode", "auto"),
+            "docker_volumes": overrides.get("docker_volumes", config.get("docker_volumes", [])),
+            "docker_mount_cwd_to_workspace": overrides.get(
+                "docker_mount_cwd_to_workspace",
+                config.get("docker_mount_cwd_to_workspace", False),
+            ),
+            "docker_forward_env": overrides.get(
+                "docker_forward_env",
+                config.get("docker_forward_env", []),
+            ),
+        }
+
+    ssh_config = None
+    if env_type == "ssh":
+        ssh_config = {
+            "host": config.get("ssh_host", ""),
+            "user": config.get("ssh_user", ""),
+            "port": config.get("ssh_port", 22),
+            "key": config.get("ssh_key", ""),
+            "persistent": config.get("ssh_persistent", False),
+        }
+
+    local_config = None
+    if env_type == "local":
+        local_config = {
+            "persistent": config.get("local_persistent", False),
+        }
+
+    return {
+        "env_type": env_type,
+        "image": image,
+        "cwd": cwd,
+        "host_cwd": host_cwd,
+        "container_config": container_config,
+        "ssh_config": ssh_config,
+        "local_config": local_config,
+        "timeout": config["timeout"],
     }
 
 
@@ -941,29 +1022,13 @@ def terminal_tool(
     try:
         # Get configuration
         config = _get_env_config()
-        env_type = config["env_type"]
-
         # Use task_id for environment isolation
         effective_task_id = task_id or "default"
-
-        # Check per-task overrides (set by environments like TerminalBench2Env)
-        # before falling back to global env var config
-        overrides = _task_env_overrides.get(effective_task_id, {})
-        
-        # Select image based on env type, with per-task override support
-        if env_type == "docker":
-            image = overrides.get("docker_image") or config["docker_image"]
-        elif env_type == "singularity":
-            image = overrides.get("singularity_image") or config["singularity_image"]
-        elif env_type == "modal":
-            image = overrides.get("modal_image") or config["modal_image"]
-        elif env_type == "daytona":
-            image = overrides.get("daytona_image") or config["daytona_image"]
-        else:
-            image = ""
-
-        cwd = overrides.get("cwd") or config["cwd"]
-        default_timeout = config["timeout"]
+        resolved_env = _resolve_task_environment_settings(effective_task_id, config)
+        env_type = resolved_env["env_type"]
+        image = resolved_env["image"]
+        cwd = resolved_env["cwd"]
+        default_timeout = resolved_env["timeout"]
         effective_timeout = timeout or default_timeout
 
         # Start cleanup thread
@@ -1002,32 +1067,9 @@ def terminal_tool(
                     logger.info("Creating new %s environment for task %s...", env_type, effective_task_id[:8])
                     try:
                         ssh_config = None
-                        if env_type == "ssh":
-                            ssh_config = {
-                                "host": config.get("ssh_host", ""),
-                                "user": config.get("ssh_user", ""),
-                                "port": config.get("ssh_port", 22),
-                                "key": config.get("ssh_key", ""),
-                                "persistent": config.get("ssh_persistent", False),
-                            }
-
-                        container_config = None
-                        if env_type in ("docker", "singularity", "modal", "daytona"):
-                            container_config = {
-                                "container_cpu": config.get("container_cpu", 1),
-                                "container_memory": config.get("container_memory", 5120),
-                                "container_disk": config.get("container_disk", 51200),
-                                "container_persistent": config.get("container_persistent", True),
-                                "modal_mode": config.get("modal_mode", "auto"),
-                                "docker_volumes": config.get("docker_volumes", []),
-                                "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
-                            }
-
-                        local_config = None
-                        if env_type == "local":
-                            local_config = {
-                                "persistent": config.get("local_persistent", False),
-                            }
+                        ssh_config = resolved_env["ssh_config"]
+                        container_config = resolved_env["container_config"]
+                        local_config = resolved_env["local_config"]
 
                         new_env = _create_environment(
                             env_type=env_type,
@@ -1038,7 +1080,7 @@ def terminal_tool(
                             container_config=container_config,
                             local_config=local_config,
                             task_id=effective_task_id,
-                            host_cwd=config.get("host_cwd"),
+                            host_cwd=resolved_env.get("host_cwd"),
                         )
                     except ImportError as e:
                         return json.dumps({

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -206,9 +206,19 @@ Delegation has a **depth limit of 2** — a parent (depth 0) can spawn children 
 # In ~/.hermes/config.yaml
 delegation:
   max_iterations: 50                        # Max turns per child (default: 50)
-  default_toolsets: ["terminal", "file", "web"]  # Default toolsets
+  default_toolsets: ["terminal", "file", "web"]  # Legacy fallback when no profile is selected
+  default_profile: "friendly"                     # Built-in: restricted, friendly, privileged
   model: "google/gemini-3-flash-preview"             # Optional provider/model override
   provider: "openrouter"                             # Optional built-in provider
+
+  # Optional custom child capability profiles
+  profiles:
+    docs:
+      toolsets: ["file", "web"]
+      memory: "read"
+      provider_tools: false
+      terminal:
+        backend: "docker"
 
 # Or use a direct custom endpoint instead of provider:
 delegation:


### PR DESCRIPTION
## What does this PR do?

Adds named delegation capability profiles for `delegate_task`.

This lets subagents inherit a policy bundle instead of only a raw toolset list. A profile can define child-safe toolsets, memory access mode, memory-provider tool exposure, and terminal backend overrides.

It also hardens child tool scoping to work on resolved tools instead of exact toolset-name intersection, which fixes dynamic/alias-style toolsets like MCP servers and avoids leaking blocked tools through umbrella toolsets.

## Related Issue

Fixes #4928

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- add built-in delegation profiles: `restricted`, `friendly`, `privileged`
- add `delegation.default_profile` and `delegation.profiles` config keys
- add `delegate_task(profile=...)` and per-task `profile` support in the schema
- scope child tools by resolved tools, not exact toolset-name intersection
- add child memory policy controls: `none`, `read`, `write`
- allow profile-driven terminal overrides, including backend selection
- reuse per-task terminal overrides in file sandbox creation too
- update docs and `cli-config.yaml.example`
- add focused tests for profile resolution, child agent construction, tool scoping, and backend override behavior

## How to Test

1. Set `delegation.default_profile: friendly` in `~/.hermes/config.yaml`.
2. Run a task that delegates and confirm the child gets terminal/file/web plus read-only memory context.
3. Run `python -m pytest tests/tools/test_delegate.py tests/tools/test_delegate_toolset_scope.py tests/tools/test_parse_env_var.py -q`.

Validation on this branch:
- targeted profile/delegation slice: `68 passed`
- full suite: `7883 passed, 172 skipped, 1 xfailed, 7 failed`
- the 7 failures were outside the touched files in this PR

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
