### PR TITLE
fix(gateway): restore short preview truncation for all/new tool progress modes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4359,9 +4359,9 @@ class GatewayRunner:
         cycle = ["off", "new", "all", "verbose"]
         descriptions = {
             "off": "⚙️ Tool progress: **OFF** — no tool activity shown.",
-            "new": "⚙️ Tool progress: **NEW** — shown when tool changes.",
-            "all": "⚙️ Tool progress: **ALL** — every tool call shown.",
-            "verbose": "⚙️ Tool progress: **VERBOSE** — full args and results.",
+            "new": "⚙️ Tool progress: **NEW** — shown when tool changes (short previews).",
+            "all": "⚙️ Tool progress: **ALL** — every tool call shown (short previews).",
+            "verbose": "⚙️ Tool progress: **VERBOSE** — every tool call with full arguments.",
         }
 
         raw_progress = user_config.get("display", {}).get("tool_progress", "all")
@@ -5419,22 +5419,28 @@ class GatewayRunner:
             from agent.display import get_tool_emoji
             emoji = get_tool_emoji(tool_name, default="⚙️")
             
-            # Verbose mode: show detailed arguments
-            if progress_mode == "verbose" and args:
-                import json as _json
-                args_str = _json.dumps(args, ensure_ascii=False, default=str)
-                if len(args_str) > 200:
-                    args_str = args_str[:197] + "..."
-                msg = f"{emoji} {tool_name}({list(args.keys())})\n{args_str}"
+            # Verbose mode: show detailed arguments, respects tool_preview_length
+            if progress_mode == "verbose":
+                if args:
+                    from agent.display import get_tool_preview_max_len
+                    _pl = get_tool_preview_max_len()
+                    import json as _json
+                    args_str = _json.dumps(args, ensure_ascii=False, default=str)
+                    _cap = _pl if _pl > 0 else 200
+                    if len(args_str) > _cap:
+                        args_str = args_str[:_cap - 3] + "..."
+                    msg = f"{emoji} {tool_name}({list(args.keys())})\n{args_str}"
+                elif preview:
+                    msg = f"{emoji} {tool_name}: \"{preview}\""
+                else:
+                    msg = f"{emoji} {tool_name}..."
                 progress_queue.put(msg)
                 return
             
+            # "all" / "new" modes: short preview, always truncated (40 chars)
             if preview:
-                # Truncate preview unless config says unlimited
-                from agent.display import get_tool_preview_max_len
-                _pl = get_tool_preview_max_len()
-                if _pl > 0 and len(preview) > _pl:
-                    preview = preview[:_pl - 3] + "..."
+                if len(preview) > 40:
+                    preview = preview[:37] + "..."
                 msg = f"{emoji} {tool_name}: \"{preview}\""
             else:
                 msg = f"{emoji} {tool_name}..."


### PR DESCRIPTION
## Summary

Fixes tool progress messages on Telegram showing full untruncated terminal commands, code blocks, and file paths instead of short previews.

## Root cause

Commit e314833c made `tool_preview_length: 0` (unlimited) the default so CLI users could see full file paths in spinners. But the same setting flows into the gateway progress callback, removing truncation from Telegram progress messages too. Since these messages are permanent (never deleted), users see walls of tool output alongside the actual response.

## Fix

- **all/new modes**: Always truncate previews to 40 chars (the pre-e314833c behavior). These are the modes most users run.
- **verbose mode**: Respects `tool_preview_length` config for JSON args cap. This is the opt-in detailed mode.
- Updated `/verbose` command descriptions to clarify the difference.

## Before/After (all mode)

**Before:** `terminal: "cd /home/teknium/.hermes/hermes-agent/.worktrees/hermes-cc1cea2c && source .venv/bin/activate && python -m pytest tests/gateway/test_dm_topics.py -n0 -q 2>&1 | cat"`

**After:** `terminal: "cd /home/teknium/.hermes/hermes-agent/.w..."`

Reported by Paulclgro and socialsurfer on Discord.