### PR TITLE
fix(openviking): send tenant-scoping headers for multi-tenant servers (salvage #4863)

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -10,6 +10,8 @@ lifecycle instead of read-only search endpoints.
 Config via environment variables (profile-scoped via each profile's .env):
   OPENVIKING_ENDPOINT  — Server URL (default: http://127.0.0.1:1933)
   OPENVIKING_API_KEY   — API key (required for authenticated servers)
+  OPENVIKING_ACCOUNT   — Tenant account (default: root)
+  OPENVIKING_USER      — Tenant user (default: default)
 
 Capabilities:
   - Automatic memory extraction on session commit (6 categories)
@@ -51,15 +53,22 @@ def _get_httpx():
 class _VikingClient:
     """Thin HTTP client for the OpenViking REST API."""
 
-    def __init__(self, endpoint: str, api_key: str = ""):
+    def __init__(self, endpoint: str, api_key: str = "",
+                 account: str = "", user: str = ""):
         self._endpoint = endpoint.rstrip("/")
         self._api_key = api_key
+        self._account = account or os.environ.get("OPENVIKING_ACCOUNT", "root")
+        self._user = user or os.environ.get("OPENVIKING_USER", "default")
         self._httpx = _get_httpx()
         if self._httpx is None:
             raise ImportError("httpx is required for OpenViking: pip install httpx")
 
     def _headers(self) -> dict:
-        h = {"Content-Type": "application/json"}
+        h = {
+            "Content-Type": "application/json",
+            "X-OpenViking-Account": self._account,
+            "X-OpenViking-User": self._user,
+        }
         if self._api_key:
             h["X-API-Key"] = self._api_key
         return h


### PR DESCRIPTION
Salvages #4863 by @Mibayy. Adds required `X-OpenViking-Account` and `X-OpenViking-User` headers to the OpenViking memory plugin client. Fixes #4825.