### PR TITLE
fix(nix): exclude voice extra on aarch64-darwin to avoid onnxruntime wheel failure

### DIFF
--- a/nix/python.nix
+++ b/nix/python.nix
@@ -22,7 +22,17 @@ let
         pyproject-build-systems.overlays.default
         overlay
       ]);
+  # onnxruntime (pulled in by the "voice" extra) does not publish aarch64-darwin
+  # wheels, causing nix profile install to fail on Apple Silicon.
+  # Exclude the voice extra on macOS aarch64; all other extras remain available.
+  hermesExtras =
+    if (lib.systems.elaborate { system = builtins.currentSystem; }).isAarch64 &&
+       (lib.systems.elaborate { system = builtins.currentSystem; }).isDarwin
+    then
+      builtins.filter (e: e != "voice") (lib.attrNames (lib.importTOML ../pyproject.toml).project.optional-dependencies)
+    else
+      [ "all" ];
 in
 pythonSet.mkVirtualEnv "hermes-agent-env" {
-  hermes-agent = [ "all" ];
+  hermes-agent = hermesExtras;
 }


### PR DESCRIPTION
Fixes #4934

## Problem
nix profile install fails on macOS aarch64 with:
"No compatible wheel, nor sdist found for package 'onnxruntime' 1.24.4"

onnxruntime is pulled in by the voice optional dependency group and does not publish aarch64-darwin wheels.

## Fix
In nix/python.nix, detect aarch64-darwin at build time and exclude the voice extra. All other extras remain available. Linux and macOS Intel are unaffected.
