### PR TITLE
fix(mem0): merge env vars with mem0.json instead of either/or (salvage #4836)

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -38,23 +38,31 @@ _BREAKER_COOLDOWN_SECS = 120
 # ---------------------------------------------------------------------------
 
 def _load_config() -> dict:
-    """Load config from $HERMES_HOME/mem0.json or env vars."""
+    """Load config from env vars, with $HERMES_HOME/mem0.json overrides.
+
+    Environment variables provide defaults; mem0.json (if present) overrides
+    individual keys.  This avoids a silent failure when the JSON file exists
+    but is missing fields like ``api_key`` that the user set in ``.env``.
+    """
     from hermes_constants import get_hermes_home
-    config_path = get_hermes_home() / "mem0.json"
 
-    if config_path.exists():
-        try:
-            return json.loads(config_path.read_text(encoding="utf-8"))
-        except Exception:
-            pass
-
-    return {
+    config = {
         "api_key": os.environ.get("MEM0_API_KEY", ""),
         "user_id": os.environ.get("MEM0_USER_ID", "hermes-user"),
         "agent_id": os.environ.get("MEM0_AGENT_ID", "hermes"),
         "rerank": True,
         "keyword_search": False,
     }
+
+    config_path = get_hermes_home() / "mem0.json"
+    if config_path.exists():
+        try:
+            file_cfg = json.loads(config_path.read_text(encoding="utf-8"))
+            config.update({k: v for k, v in file_cfg.items() if v})
+        except Exception:
+            pass
+
+    return config
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -58,7 +58,8 @@ def _load_config() -> dict:
     if config_path.exists():
         try:
             file_cfg = json.loads(config_path.read_text(encoding="utf-8"))
-            config.update({k: v for k, v in file_cfg.items() if v})
+            config.update({k: v for k, v in file_cfg.items()
+                           if v is not None and v != ""})
         except Exception:
             pass
 


### PR DESCRIPTION
## Summary

Salvage of PR #4836 by @ellenlivia-mem0 with a truthiness fix on top.

### The bug
`hermes memory status` shows mem0 as "not available" even when `MEM0_API_KEY` is set in `.env`. The cause: `_load_config()` treats `mem0.json` and env vars as mutually exclusive. If `mem0.json` exists (created by `hermes memory setup` with just `user_id`/`agent_id`), it returns that file and never checks env vars — so `api_key` is silently empty.

### The fix
Env vars provide defaults, `mem0.json` overrides individual keys on top. Both sources work together.

### Our follow-up
Changed the merge filter from `if v` (truthiness) to `if v is not None and v != ""`. The original would silently drop `False` and `0` from the JSON — so `"rerank": false` in `mem0.json` would be ignored, stuck on the default `True`.

### E2E verified (7 cases)
- Env vars only (no json) → works
- api_key in env + user/agent in json (the bug case) → both merge correctly
- JSON overrides env when both set
- Empty string in json doesn't clobber env default
- `False` in json preserved (the truthiness fix)
- Integer `0` in json preserved
- `null` in json doesn't clobber env default

Closes #4836