### PR TITLE
fix: use clean user message for all memory provider operations

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6689,10 +6689,12 @@ class AIAgent:
         # External memory provider: prefetch once before the tool loop.
         # Reuse the cached result on every iteration to avoid re-calling
         # prefetch_all() on each tool call (10 tool calls = 10x latency + cost).
+        # Use original_user_message (clean input) — user_message may contain
+        # injected skill content that bloats / breaks provider queries.
         _ext_prefetch_cache = ""
         if self._memory_manager:
             try:
-                _query = user_message if isinstance(user_message, str) else ""
+                _query = original_user_message if isinstance(original_user_message, str) else ""
                 _ext_prefetch_cache = self._memory_manager.prefetch_all(_query) or ""
             except Exception:
                 pass
@@ -8666,11 +8668,13 @@ class AIAgent:
             _should_review_skills = True
             self._iters_since_skill = 0
 
-        # External memory provider: sync the completed turn + queue next prefetch
-        if self._memory_manager and final_response and user_message:
+        # External memory provider: sync the completed turn + queue next prefetch.
+        # Use original_user_message (clean input) — user_message may contain
+        # injected skill content that bloats / breaks provider queries.
+        if self._memory_manager and final_response and original_user_message:
             try:
-                self._memory_manager.sync_all(user_message, final_response)
-                self._memory_manager.queue_prefetch_all(user_message)
+                self._memory_manager.sync_all(original_user_message, final_response)
+                self._memory_manager.queue_prefetch_all(original_user_message)
             except Exception:
                 pass
 


### PR DESCRIPTION
## Problem

When a skill is active, `user_message` contains the full SKILL.md content injected by the skill system. This bloated string (often 10K+ chars) was being passed to memory provider operations, causing providers with query size limits (e.g. Honcho's 10K char limit) to fail.

Relates to #4889 and #4902.

## Fix

Both memory provider call sites now use `original_user_message` (the clean user input, already defined earlier in `run_conversation()`) instead of the skill-inflated `user_message`:

- **Pre-turn prefetch** (line ~6695): `prefetch_all()` query used for context recall before the LLM call
- **Post-turn sync** (line ~8672): `sync_all()` for turn persistence + `queue_prefetch_all()` for next-turn recall

`original_user_message` is derived from `persist_user_message` (the clean original) with fallback to `user_message` when no override exists — this pattern was already established at line 6516 for plugin hooks.

## Why not just the post-turn fix?

PR #4902 only fixed the post-turn sync/prefetch. The pre-turn `prefetch_all()` had the same issue — it ran the skill-inflated message as the recall query, returning irrelevant context and potentially exceeding provider limits.

## Test plan
- 269 memory/agent tests pass
- Single file change, +9/-5 lines