### PR TITLE
fix(setup): add missing shutil import in matrix-nio auto-install block

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1960,6 +1960,7 @@ def setup_gateway(config: dict):
             except ImportError:
                 print_info(f"Installing {matrix_pkg}...")
                 import subprocess
+                import shutil
 
                 uv_bin = shutil.which("uv")
                 if uv_bin:


### PR DESCRIPTION
Fixes #4912

## Problem
Setup wizard crashed with "NameError: name 'shutil' is not defined" when trying to auto-install matrix-nio. The shutil module was used but never imported in that block.

## Fix
Added `import shutil` inside the matrix-nio auto-install except block, consistent with how other install blocks in setup.py handle their imports.
