### PR TITLE
fix(setup): import shutil for Matrix auto-install path

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -14,6 +14,7 @@ Config files are stored in ~/.hermes/ for easy access.
 import importlib.util
 import logging
 import os
+import shutil
 import sys
 from pathlib import Path
 from typing import Optional, Dict, Any


### PR DESCRIPTION
## Summary
Fixes a NameError in the Matrix setup wizard path.

When Matrix is configured and nio is not already installed, setup_gateway() enters the auto-install branch and calls shutil.which("uv"). shutil was not imported at module scope, causing:

NameError: name 'shutil' is not defined

This patch adds the missing top-level import shutil in hermes_cli/setup.py.

## Repro (before)
- Configure Matrix in setup wizard (password or token flow)
- Choose E2EE yes/no
- Ensure nio is not installed so auto-install path executes
- Wizard crashes with NameError at shutil.which("uv")

## Validation
- python -m py_compile hermes_cli/setup.py
- Verified module now exposes shutil and the failing lookup no longer raises NameError

Closes #4912
