### PR TITLE
fix: normalize fallback anthropic base URLs

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -163,6 +163,17 @@ def _is_oauth_token(key: str) -> bool:
     return True
 
 
+def _normalize_base_url_text(base_url: Any) -> str:
+    """Normalize SDK/base transport URL values to a plain string for inspection.
+
+    Some client objects expose ``base_url`` as an ``httpx.URL`` instead of a raw
+    string. Provider/auth detection should accept either shape.
+    """
+    if not base_url:
+        return ""
+    return str(base_url).strip()
+
+
 def _is_third_party_anthropic_endpoint(base_url: str | None) -> bool:
     """Return True for non-Anthropic endpoints using the Anthropic Messages API.
 
@@ -170,9 +181,10 @@ def _is_third_party_anthropic_endpoint(base_url: str | None) -> bool:
     with their own API keys via x-api-key, not Anthropic OAuth tokens. OAuth
     detection should be skipped for these endpoints.
     """
-    if not base_url:
+    normalized = _normalize_base_url_text(base_url)
+    if not normalized:
         return False  # No base_url = direct Anthropic API
-    normalized = base_url.rstrip("/").lower()
+    normalized = normalized.rstrip("/").lower()
     if "anthropic.com" in normalized:
         return False  # Direct Anthropic API — OAuth applies
     return True  # Any other endpoint is a third-party proxy
@@ -182,12 +194,13 @@ def _requires_bearer_auth(base_url: str | None) -> bool:
     """Return True for Anthropic-compatible providers that require Bearer auth.
 
     Some third-party /anthropic endpoints implement Anthropic's Messages API but
-    require Authorization: Bearer instead of Anthropic's native x-api-key header.
+    require Authorization: Bearer *** of Anthropic's native x-api-key header.
     MiniMax's global and China Anthropic-compatible endpoints follow this pattern.
     """
-    if not base_url:
+    normalized = _normalize_base_url_text(base_url)
+    if not normalized:
         return False
-    normalized = base_url.rstrip("/").lower()
+    normalized = normalized.rstrip("/").lower()
     return normalized.startswith("https://api.minimax.io/anthropic") or normalized.startswith(
         "https://api.minimaxi.com/anthropic"
     )
@@ -205,13 +218,14 @@ def build_anthropic_client(api_key: str, base_url: str = None):
         )
     from httpx import Timeout
 
+    normalized_base_url = _normalize_base_url_text(base_url)
     kwargs = {
         "timeout": Timeout(timeout=900.0, connect=10.0),
     }
-    if base_url:
-        kwargs["base_url"] = base_url
+    if normalized_base_url:
+        kwargs["base_url"] = normalized_base_url
 
-    if _requires_bearer_auth(base_url):
+    if _requires_bearer_auth(normalized_base_url):
         # Some Anthropic-compatible providers (e.g. MiniMax) expect the API key in
         # Authorization: Bearer even for regular API keys. Route those endpoints
         # through auth_token so the SDK sends Bearer auth instead of x-api-key.

--- a/run_agent.py
+++ b/run_agent.py
@@ -4574,7 +4574,7 @@ class AIAgent:
                 effective_key = (fb_client.api_key or resolve_anthropic_token() or "") if fb_provider == "anthropic" else (fb_client.api_key or "")
                 self.api_key = effective_key
                 self._anthropic_api_key = effective_key
-                self._anthropic_base_url = getattr(fb_client, "base_url", None)
+                self._anthropic_base_url = fb_base_url
                 self._anthropic_client = build_anthropic_client(effective_key, self._anthropic_base_url)
                 self._is_anthropic_oauth = _is_oauth_token(effective_key)
                 self.client = None

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -5,6 +5,7 @@ import time
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
+from httpx import URL
 import pytest
 
 from agent.prompt_caching import apply_anthropic_cache_control
@@ -94,6 +95,17 @@ class TestBuildAnthropicClient:
             assert kwargs["default_headers"] == {
                 "anthropic-beta": "interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14"
             }
+
+    def test_httpx_url_base_url_is_normalized_before_auth_detection(self):
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client(
+                "minimax-secret-123",
+                base_url=URL("https://api.minimax.io/anthropic"),
+            )
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["base_url"] == "https://api.minimax.io/anthropic"
+            assert kwargs["auth_token"] == "minimax-secret-123"
+            assert "api_key" not in kwargs
 
 
 class TestReadClaudeCodeCredentials:

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -12,7 +12,9 @@ import uuid
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch, mock_open
+
+from httpx import URL
 
 import pytest
 
@@ -2513,6 +2515,29 @@ class TestFallbackAnthropicProvider:
             agent._try_activate_fallback()
 
         assert agent._use_prompt_caching is True
+
+    def test_fallback_to_minimax_anthropic_accepts_httpx_url_base_url(self, agent):
+        agent._fallback_activated = False
+        agent._fallback_model = {"provider": "minimax", "model": "MiniMax-M2.7"}
+        agent._fallback_chain = [agent._fallback_model]
+        agent._fallback_index = 0
+
+        mock_client = MagicMock()
+        mock_client.base_url = URL("https://api.minimax.io/anthropic")
+        mock_client.api_key = "minimax-secret-123"
+
+        with (
+            patch("agent.auxiliary_client.resolve_provider_client", return_value=(mock_client, None)),
+            patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()) as mock_build,
+            patch("agent.anthropic_adapter.resolve_anthropic_token", return_value=None),
+        ):
+            result = agent._try_activate_fallback()
+
+        assert result is True
+        assert agent.api_mode == "anthropic_messages"
+        assert agent.base_url == "https://api.minimax.io/anthropic"
+        assert agent._anthropic_base_url == "https://api.minimax.io/anthropic"
+        assert mock_build.call_args[0][1] == "https://api.minimax.io/anthropic"
 
     def test_fallback_to_openrouter_uses_openai_client(self, agent):
         agent._fallback_activated = False


### PR DESCRIPTION
## Summary
- normalize Anthropic-compatible base URLs before auth/provider inspection so `httpx.URL` values do not crash fallback activation
- keep fallback Anthropic runtime state string-normalized in `run_agent.py`
- add regressions for both the adapter helper path and MiniMax fallback activation path

## Root cause
I reproduced this on current main: `_try_activate_fallback()` can reach the Anthropic-compatible MiniMax path with a routed client whose `base_url` is an `httpx.URL` object, not a plain string. `agent/anthropic_adapter.py` then calls `rstrip()` on that object inside helper paths like `_requires_bearer_auth()` / `_is_third_party_anthropic_endpoint()`, causing:

- `AttributeError: 'URL' object has no attribute 'rstrip'`

This is similar in shape to #1071: a hot runtime path assumes a more specific type than some compatible backends/providers actually return.

Fixes #4944.

## Test plan
- `source /Users/kshitij/.hermes/hermes-agent/venv/bin/activate && python -m pytest tests/test_anthropic_adapter.py tests/test_run_agent.py -q`
- `source /Users/kshitij/.hermes/hermes-agent/venv/bin/activate && python -m pytest tests/ -q` *(hits unrelated current-main failures on my machine)*
- `source /Users/kshitij/.hermes/hermes-agent/venv/bin/activate && python -m pytest tests/gateway/test_api_server_jobs.py tests/tools/test_file_read_guards.py -q` *(reproduces unrelated current-main failures in a fresh detached `origin/main` worktree too)*

## Notes on unrelated failures
The broader failures I saw during full-suite validation are not introduced by this PR. I reproduced representative failures on a fresh detached `origin/main` worktree (`tests/tools/test_file_read_guards.py`, plus the same full-suite resource-exhaustion pattern), so I kept this PR tightly scoped to the MiniMax/Anthropic fallback type bug.
