### PR TITLE
feat(a2a): implement A2A client tools and server (closes #514 phases 1 & 2)

### DIFF
--- a/a2a_adapter/__init__.py
+++ b/a2a_adapter/__init__.py
@@ -1,0 +1,1 @@
+"""A2A (Agent-to-Agent) adapter for hermes-agent."""

--- a/a2a_adapter/__main__.py
+++ b/a2a_adapter/__main__.py
@@ -1,0 +1,5 @@
+"""Allow running the A2A adapter as ``python -m a2a_adapter``."""
+
+from .entry import main
+
+main()

--- a/a2a_adapter/entry.py
+++ b/a2a_adapter/entry.py
@@ -1,0 +1,108 @@
+"""CLI entry point for the hermes-agent A2A adapter.
+
+Loads environment variables from ``~/.hermes/.env``, configures logging,
+and starts the A2A HTTP server using uvicorn (the standard ASGI server).
+
+Unlike the ACP adapter (which uses stdio JSON-RPC), A2A is HTTP-based and
+requires a real HTTP server. uvicorn is the correct choice here — it is
+already a hermes dependency (used by the [rl] extra) and is the standard
+server for Starlette/FastAPI apps produced by the a2a-sdk.
+
+Usage::
+
+    python -m a2a_adapter
+    # or
+    hermes a2a
+    # or
+    hermes-a2a
+
+Configure via environment variables:
+    A2A_HOST          — bind host (default: 0.0.0.0)
+    A2A_PORT          — bind port (default: 9000)
+    A2A_KEY           — optional Bearer token to protect the endpoint
+    AGENT_NAME        — name shown in Agent Card
+    AGENT_DESCRIPTION — description shown in Agent Card
+    AGENT_SKILLS      — comma-separated skill names
+    AGENT_MODEL       — model name shown in Agent Card metadata
+"""
+
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+from hermes_constants import get_hermes_home
+
+
+def _setup_logging() -> None:
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+    )
+    root = logging.getLogger()
+    root.handlers.clear()
+    root.addHandler(handler)
+    root.setLevel(logging.INFO)
+
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("httpcore").setLevel(logging.WARNING)
+    logging.getLogger("openai").setLevel(logging.WARNING)
+    logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
+
+
+def _load_env() -> None:
+    from hermes_cli.env_loader import load_hermes_dotenv
+
+    hermes_home = get_hermes_home()
+    loaded = load_hermes_dotenv(hermes_home=hermes_home)
+    logger = logging.getLogger(__name__)
+    if loaded:
+        for env_file in loaded:
+            logger.info("Loaded env from %s", env_file)
+    else:
+        logger.info("No .env found at %s, using system env", hermes_home / ".env")
+
+
+def main() -> None:
+    """Entry point: load env, configure logging, run the A2A server."""
+    _setup_logging()
+    _load_env()
+
+    logger = logging.getLogger(__name__)
+
+    # Ensure the project root is on sys.path so ``from run_agent import AIAgent`` works
+    project_root = str(Path(__file__).resolve().parent.parent)
+    if project_root not in sys.path:
+        sys.path.insert(0, project_root)
+
+    host = os.getenv("A2A_HOST", "0.0.0.0")
+    port = int(os.getenv("A2A_PORT", "9000"))
+
+    logger.info("Starting hermes-agent A2A adapter on http://%s:%d", host, port)
+    logger.info("Agent Card: http://%s:%d/.well-known/agent.json", host, port)
+
+    try:
+        import uvicorn
+        from .server import build_app
+
+        app = build_app(port=port)
+        uvicorn.run(app, host=host, port=port, log_level="warning")
+    except ImportError as e:
+        logger.error(
+            "Missing dependency: %s\n"
+            "Install with: pip install 'hermes-agent[a2a]'",
+            e,
+        )
+        sys.exit(1)
+    except RuntimeError as e:
+        logger.error("%s", e)
+        sys.exit(1)
+    except KeyboardInterrupt:
+        logger.info("Shutting down (KeyboardInterrupt)")
+
+
+if __name__ == "__main__":
+    main()

--- a/a2a_adapter/server.py
+++ b/a2a_adapter/server.py
@@ -1,0 +1,313 @@
+"""A2A (Agent-to-Agent) server — exposes Hermes Agent via the Google A2A protocol.
+
+Uses the official ``a2a-sdk`` (``pip install 'a2a-sdk[http-server]'``) to build
+a standards-compliant FastAPI application that any A2A orchestrator can discover
+and call — Vertex AI Agent Engine, LangGraph, Akela, etc.
+
+Exposes (via a2a-sdk):
+  GET  /.well-known/agent.json  →  Agent Card
+  POST /                         →  JSON-RPC 2.0 (tasks/send, tasks/sendSubscribe)
+
+Configure via environment variables:
+  A2A_HOST          — bind host (default: 0.0.0.0)
+  A2A_PORT          — bind port (default: 9000)
+  A2A_KEY           — optional Bearer token for auth
+  AGENT_NAME        — name shown in Agent Card
+  AGENT_DESCRIPTION — description shown in Agent Card
+  AGENT_SKILLS      — comma-separated skill names
+  AGENT_MODEL       — model name shown in Agent Card metadata
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="a2a-agent")
+
+DEFAULT_HOST = "0.0.0.0"
+DEFAULT_PORT = 9000
+
+
+# ---------------------------------------------------------------------------
+# SDK imports — fail loudly at startup if a2a-sdk is not installed
+# ---------------------------------------------------------------------------
+try:
+    from a2a.server.agent_execution import AgentExecutor, RequestContext
+    from a2a.server.events import EventQueue
+    from a2a.server.request_handlers import DefaultRequestHandler
+    from a2a.server.tasks import InMemoryTaskStore
+    from a2a.server.apps import A2AStarletteApplication
+    from a2a.types import (
+        AgentCard,
+        AgentCapabilities,
+        AgentSkill,
+        Part,
+        Task,
+        TaskArtifactUpdateEvent,
+        TaskState,
+        TaskStatus,
+        TaskStatusUpdateEvent,
+        TextPart,
+        UnsupportedOperationError,
+    )
+    _SDK_AVAILABLE = True
+except ImportError as _sdk_err:
+    _SDK_AVAILABLE = False
+    _sdk_err_msg = str(_sdk_err)
+
+
+# ---------------------------------------------------------------------------
+# Hermes agent factory (shared with acp_adapter pattern)
+# ---------------------------------------------------------------------------
+
+def _make_agent(session_id: str, stream_delta_callback=None) -> Any:
+    """Create a Hermes AIAgent using the runtime provider from config."""
+    from run_agent import AIAgent
+    from hermes_cli.config import load_config
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    config = load_config()
+    model_cfg = config.get("model")
+    default_model = "anthropic/claude-opus-4.6"
+    config_provider = None
+
+    if isinstance(model_cfg, dict):
+        default_model = str(model_cfg.get("default") or default_model)
+        config_provider = model_cfg.get("provider")
+    elif isinstance(model_cfg, str) and model_cfg.strip():
+        default_model = model_cfg.strip()
+
+    kwargs: dict[str, Any] = {
+        "platform": "a2a",
+        "enabled_toolsets": ["hermes-acp"],
+        "quiet_mode": True,
+        "session_id": session_id,
+        "model": default_model,
+    }
+    if stream_delta_callback is not None:
+        kwargs["stream_delta_callback"] = stream_delta_callback
+
+    try:
+        runtime = resolve_runtime_provider(requested=config_provider)
+        kwargs.update(
+            {
+                "provider": runtime.get("provider"),
+                "api_mode": runtime.get("api_mode"),
+                "base_url": runtime.get("base_url"),
+                "api_key": runtime.get("api_key"),
+                "command": runtime.get("command"),
+                "args": list(runtime.get("args") or []),
+            }
+        )
+    except Exception:
+        logger.debug("A2A falling back to default provider resolution", exc_info=True)
+
+    return AIAgent(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Agent Card builder
+# ---------------------------------------------------------------------------
+
+def build_agent_card(port: int) -> "AgentCard":
+    """Build the A2A Agent Card from env vars."""
+    agent_name = os.getenv("AGENT_NAME", "hermes-agent")
+    agent_model = os.getenv("AGENT_MODEL", "")
+    skills_raw = [s.strip() for s in os.getenv("AGENT_SKILLS", "").split(",") if s.strip()]
+    skills = [
+        AgentSkill(
+            id=s.lower().replace(" ", "_"),
+            name=s,
+            description=f"{s} capability",
+            tags=[s.lower()],
+        )
+        for s in (skills_raw or [agent_name])
+    ]
+
+    return AgentCard(
+        name=agent_name,
+        description=os.getenv("AGENT_DESCRIPTION", f"{agent_name} — Hermes agent"),
+        url=f"http://localhost:{port}",
+        version="1.0.0",
+        capabilities=AgentCapabilities(streaming=True),
+        skills=skills,
+        default_input_modes=["text"],
+        default_output_modes=["text"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# AgentExecutor — the core integration between A2A SDK and Hermes
+# ---------------------------------------------------------------------------
+
+class HermesAgentExecutor(AgentExecutor):
+    """A2A AgentExecutor that delegates to a Hermes AIAgent."""
+
+    async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
+        """Handle a task: run Hermes and stream results back via EventQueue."""
+        task_id = context.task_id
+        user_message = _extract_text(context.message)
+        session_id = getattr(context, "context_id", None) or task_id
+
+        if not user_message:
+            await event_queue.enqueue_event(
+                TaskStatusUpdateEvent(
+                    id=task_id,
+                    status=TaskStatus(state=TaskState.failed),
+                    final=True,
+                )
+            )
+            return
+
+        # Emit working status
+        await event_queue.enqueue_event(
+            TaskStatusUpdateEvent(
+                id=task_id,
+                status=TaskStatus(state=TaskState.working),
+                final=False,
+            )
+        )
+
+        # Stream tokens back as incremental artifact updates
+        accumulated = ""
+        loop = asyncio.get_event_loop()
+
+        import queue as _q
+        delta_queue: _q.Queue = _q.Queue()
+
+        def _on_delta(delta: str | None) -> None:
+            if delta is not None:
+                delta_queue.put(delta)
+
+        # Run synchronous Hermes agent in thread executor
+        agent_future = loop.run_in_executor(
+            _executor,
+            lambda: _run_sync(session_id, user_message, stream_delta_callback=_on_delta),
+        )
+
+        # Drain delta queue while agent runs
+        while not agent_future.done():
+            try:
+                token = await loop.run_in_executor(
+                    None, lambda: delta_queue.get(timeout=0.05)
+                )
+                if isinstance(token, str):
+                    accumulated += token
+                    await event_queue.enqueue_event(
+                        TaskArtifactUpdateEvent(
+                            id=task_id,
+                            artifact={"parts": [{"type": "text", "text": accumulated}]},
+                            final=False,
+                        )
+                    )
+            except Exception:
+                pass  # queue.Empty — keep polling
+
+        result, _ = await agent_future
+        final_text = result.get("final_response", "") or accumulated or result.get("error", "")
+
+        if final_text and not accumulated:
+            # Non-streaming fallback: emit the full response as a single artifact
+            await event_queue.enqueue_event(
+                TaskArtifactUpdateEvent(
+                    id=task_id,
+                    artifact={"parts": [{"type": "text", "text": final_text}]},
+                    final=True,
+                )
+            )
+
+        # Emit completion
+        await event_queue.enqueue_event(
+            TaskStatusUpdateEvent(
+                id=task_id,
+                status=TaskStatus(state=TaskState.completed),
+                final=True,
+            )
+        )
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None:
+        await event_queue.enqueue_event(
+            TaskStatusUpdateEvent(
+                id=context.task_id,
+                status=TaskStatus(state=TaskState.canceled),
+                final=True,
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# App factory
+# ---------------------------------------------------------------------------
+
+def build_app(port: int | None = None) -> Any:
+    """Build and return the A2A FastAPI/Starlette application.
+
+    Raises RuntimeError if a2a-sdk is not installed.
+    """
+    if not _SDK_AVAILABLE:
+        raise RuntimeError(
+            f"a2a-sdk is not installed: {_sdk_err_msg}\n"
+            "Install it with: pip install 'a2a-sdk[http-server]'"
+        )
+
+    if port is None:
+        port = int(os.getenv("A2A_PORT", str(DEFAULT_PORT)))
+
+    agent_card = build_agent_card(port)
+    handler = DefaultRequestHandler(
+        agent_executor=HermesAgentExecutor(),
+        task_store=InMemoryTaskStore(),
+    )
+    app_builder = A2AStarletteApplication(
+        agent_card=agent_card,
+        http_handler=handler,
+    )
+    return app_builder.build()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _extract_text(message: Any) -> str:
+    """Extract plain text from an A2A Message (SDK types)."""
+    if message is None:
+        return ""
+
+    # SDK Pydantic model: message.parts is a list of Part objects
+    parts = getattr(message, "parts", None) or []
+    texts: list[str] = []
+    for part in parts:
+        # TextPart has .text; generic Part may have .root.text
+        if hasattr(part, "text"):
+            texts.append(str(part.text))
+        elif hasattr(part, "root") and hasattr(part.root, "text"):
+            texts.append(str(part.root.text))
+        elif isinstance(part, dict) and part.get("type") == "text":
+            texts.append(part.get("text", ""))
+    return " ".join(texts).strip()
+
+
+def _run_sync(
+    session_id: str,
+    user_message: str,
+    stream_delta_callback=None,
+) -> tuple[dict, dict]:
+    """Synchronous Hermes invocation (runs in thread executor)."""
+    agent = _make_agent(session_id=session_id, stream_delta_callback=stream_delta_callback)
+    result = agent.run_conversation(user_message=user_message, conversation_history=[])
+    usage = {
+        "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
+        "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
+        "total_tokens": (
+            (getattr(agent, "session_prompt_tokens", 0) or 0)
+            + (getattr(agent, "session_completion_tokens", 0) or 0)
+        ),
+    }
+    return result, usage

--- a/docs/a2a-architecture.md
+++ b/docs/a2a-architecture.md
@@ -1,0 +1,399 @@
+# A2A Protocol — Architecture & Developer Guide
+
+This document describes the internal design, data flow, and extension points of the A2A (Agent-to-Agent) protocol implementation in Hermes Agent.
+
+---
+
+## Overview
+
+The A2A implementation consists of two independent components:
+
+| Component | Location | Purpose |
+|---|---|---|
+| **A2A Server** | `a2a_adapter/` | Expose Hermes as an A2A agent (server side) |
+| **A2A Client Tools** | `tools/a2a_tool.py` | Call and discover remote A2A agents from within Hermes (client side) |
+
+These are deliberately decoupled. The server runs as a separate process. The client tool runs inside the agent loop with no dependency on the server.
+
+---
+
+## Repository Structure
+
+```
+hermes-agent/
+├── a2a_adapter/
+│   ├── __init__.py       # Package marker
+│   ├── __main__.py       # python -m a2a_adapter entry point
+│   ├── entry.py          # CLI startup: load env, configure logging, run uvicorn
+│   └── server.py         # SDK integration: AgentExecutor, app factory, helpers
+│
+├── tools/
+│   └── a2a_tool.py       # a2a_discover + a2a_call + a2a_local_scan tools + registry
+│
+└── docs/
+    ├── a2a-user-guide.md      # End-user guide (this sibling doc)
+    └── a2a-architecture.md    # This file
+```
+
+---
+
+## Design Decisions
+
+### Why `a2a-sdk` for the server?
+
+The official `a2a-sdk` (`pip install 'a2a-sdk[http-server]'`) provides:
+- A standards-compliant JSON-RPC 2.0 router
+- Correct SSE framing for `tasks/sendSubscribe`
+- Task lifecycle management (state machine: `working → completed/failed/canceled`)
+- An in-memory (or pluggable persistent) task store
+- Future-proof: SDK updates pick up protocol changes automatically
+
+The alternative — raw aiohttp routes — was implemented first and proved in production (Ronny agent, Akela Pack integration). The SDK version supersedes it for correctness and long-term maintainability.
+
+### Why raw `httpx` for the client tool?
+
+The `a2a-sdk` client is pre-1.0 and its API surface changes frequently. The A2A client protocol is simple: `POST /` with JSON-RPC 2.0. Raw `httpx` is stable, has no version coupling, and keeps the client tool dependency-free — it works even when `a2a-sdk` is not installed.
+
+### Why a separate process, not a gateway platform adapter?
+
+The existing gateway platform adapters (`gateway/platforms/api_server.py`, `telegram.py`, etc.) all share a single process and port. Adding A2A routes to the gateway was considered but rejected because:
+
+1. A2A's `POST /` root conflicts with potential future gateway root routes
+2. The gateway uses aiohttp; the SDK expects ASGI (Starlette/FastAPI)
+3. A separate process gives independent lifecycle, port, and scaling
+
+The pattern mirrors `acp_adapter/` — a standalone `hermes acp` process — which the Hermes project already uses for the Agent Communication Protocol.
+
+---
+
+## A2A Server — Data Flow
+
+```
+External Orchestrator (Vertex AI / LangGraph / Akela)
+        │
+        │  GET /.well-known/agent.json
+        ▼
+  A2AFastAPIApplication (a2a-sdk)
+        │
+        │  returns AgentCard (built from env vars)
+        │
+        │  POST / (JSON-RPC 2.0)
+        │  method: tasks/send or tasks/sendSubscribe
+        ▼
+  DefaultRequestHandler (a2a-sdk)
+        │
+        │  routes to HermesAgentExecutor.execute()
+        ▼
+  HermesAgentExecutor
+        │
+        │  extracts user text from Message.parts
+        │  creates Hermes AIAgent via _make_agent()
+        │  runs agent.run_conversation() in ThreadPoolExecutor
+        │
+        │  (streaming path)
+        │  stream_delta_callback → delta_queue
+        │  drains queue → EventQueue.enqueue_event(TaskArtifactUpdateEvent)
+        │
+        ▼
+  EventQueue (a2a-sdk)
+        │
+        │  serialises events as SSE frames
+        ▼
+External Orchestrator receives streaming response
+```
+
+### Non-streaming path (`tasks/send`)
+
+1. Orchestrator sends `tasks/send` with a `Message`
+2. `DefaultRequestHandler` deserialises and calls `HermesAgentExecutor.execute()`
+3. Executor emits `TaskStatus(working)` immediately
+4. Runs `agent.run_conversation()` in thread executor (blocks until complete)
+5. Emits `TaskArtifactUpdateEvent` with full response text
+6. Emits `TaskStatus(completed)` — final
+7. Handler serialises result as a JSON-RPC response and returns HTTP 200
+
+### Streaming path (`tasks/sendSubscribe`)
+
+1. Same entry as above up to executor
+2. Executor starts agent in thread executor with `stream_delta_callback`
+3. Callback pushes tokens to a `queue.Queue`
+4. Main async loop drains queue, calling `EventQueue.enqueue_event()` per token
+5. SDK serialises each event as an SSE frame: `data: {...}\n\n`
+6. Connection stays open until `TaskStatus(completed, final=True)` is emitted
+
+---
+
+## A2A Server — Key Classes and Functions
+
+### `HermesAgentExecutor` (`a2a_adapter/server.py`)
+
+Implements `a2a.server.agent_execution.AgentExecutor`. The two required methods:
+
+```python
+async def execute(self, context: RequestContext, event_queue: EventQueue) -> None
+async def cancel(self, context: RequestContext, event_queue: EventQueue) -> None
+```
+
+`execute()` is the core integration point. It:
+- Extracts text from `context.message` (via `_extract_text()`)
+- Creates a Hermes `AIAgent` via `_make_agent()`
+- Bridges the synchronous `run_conversation()` to async via `loop.run_in_executor()`
+- Bridges the streaming callback to the async `EventQueue` via `queue.Queue`
+
+### `_make_agent()` (`a2a_adapter/server.py`)
+
+Mirrors `acp_adapter/session.py:SessionManager._make_agent()`. Creates an `AIAgent` using:
+- `hermes_cli.config.load_config()` — reads model from `~/.hermes/config.yaml`
+- `hermes_cli.runtime_provider.resolve_runtime_provider()` — resolves API key, base_url, provider
+
+Key difference from the gateway's `_create_agent()`: does not call `_resolve_runtime_agent_kwargs()` or `_resolve_gateway_model()` (gateway-internal functions). Uses the same config path as the ACP adapter for consistency.
+
+### `build_agent_card()` (`a2a_adapter/server.py`)
+
+Builds the `AgentCard` object from environment variables. Called once at startup. The Agent Card is served at `GET /.well-known/agent.json` by the SDK automatically.
+
+### `build_app()` (`a2a_adapter/server.py`)
+
+Factory function used by `entry.py`:
+```python
+app = build_app(port=9000)
+uvicorn.run(app, host="0.0.0.0", port=9000)
+```
+
+Wires together:
+- `HermesAgentExecutor` — business logic
+- `InMemoryTaskStore` — task lifecycle (SDK-managed)
+- `DefaultRequestHandler` — JSON-RPC routing
+- `A2AStarletteApplication` — ASGI app builder
+
+### `entry.py`
+
+Mirrors `acp_adapter/entry.py` exactly:
+1. `_setup_logging()` — route all logs to stderr
+2. `_load_env()` — load `~/.hermes/.env` via `hermes_cli.env_loader`
+3. `build_app()` + `uvicorn.run()` — start the HTTP server
+
+---
+
+## A2A Client Tool — Data Flow
+
+```
+Hermes agent loop
+    │
+    │  calls tool: a2a_call(url=..., message=...)
+    ▼
+_tool_a2a_call()
+    │
+    │  resolves URL (direct or from config a2a_agents)
+    ▼
+a2a_call()
+    │
+    │  POST {url} with tasks/send JSON-RPC payload
+    │  (httpx sync client, 120s timeout)
+    ▼
+Remote A2A agent
+    │
+    │  returns JSON-RPC result with artifacts
+    ▼
+_tool_a2a_call()
+    │
+    │  extracts text from result.artifacts[].parts[].text
+    │  returns plain string to agent loop
+    ▼
+Hermes agent loop continues with remote agent's response
+```
+
+### `a2a_discover(url)` (`tools/a2a_tool.py`)
+
+1. `GET {url}/.well-known/agent.json`
+2. Returns clean JSON summary: name, description, skills, model, streaming support
+
+### `a2a_call(url, message, session_id, bearer_token, stream)` (`tools/a2a_tool.py`)
+
+1. Auto-detects streaming capability from the cached Agent Card (`capabilities.streaming`)
+2. **Non-streaming path** (`tasks/send`): single POST, waits for JSON-RPC response
+3. **Streaming path** (`tasks/sendSubscribe`): opens an SSE stream, reads `data:` lines, accumulates artifact text, stops on terminal state (`completed`/`failed`/`canceled`)
+4. Extracts text from `result.artifacts[].parts[].text`
+5. Returns plain text string — same as any other tool output
+
+`stream` parameter: `None` (auto-detect), `True` (force SSE), `False` (force non-streaming).
+
+### `a2a_local_scan(host, port_start, port_end)` (`tools/a2a_tool.py`)
+
+Closes the discovery gap: when no agents are pre-configured and no URL is provided in the prompt, the model can call this tool to find what is running locally.
+
+1. Iterates `port_start` to `port_end` (default `9000–9010`, max range 100 ports)
+2. `GET http://{host}:{port}/.well-known/agent.json` with a 2s timeout per port
+3. Silently skips closed ports and non-A2A services
+4. Returns JSON list of discovered agents: `endpoint`, `name`, `description`, `skills`, `streaming`
+
+Uses only `httpx` — no additional dependencies. Registered in the `a2a` toolset alongside `a2a_discover` and `a2a_call`.
+
+### Named agent resolution
+
+If `agent_name` is provided instead of `url`, `_load_a2a_agents()` reads `~/.hermes/config.yaml`:
+
+```yaml
+a2a_agents:
+  researcher:
+    url: http://192.168.1.100:9000
+    bearer_token: "optional"
+```
+
+This lets the LLM refer to agents by name without needing to know their URLs.
+
+### Registry (`tools/a2a_tool.py`)
+
+All three tools are registered via `tools.registry.registry.register()` into the `a2a` toolset. The toolset is inactive unless `a2a` is listed in `enabled_toolsets` in `config.yaml` or passed via `--toolsets`. This prevents unintended outbound calls.
+
+---
+
+## Relationship to `acp_adapter/`
+
+| Aspect | ACP (`acp_adapter/`) | A2A (`a2a_adapter/`) |
+|---|---|---|
+| Transport | stdio (JSON-RPC over stdin/stdout) | HTTP + SSE |
+| Use case | IDE integrations (Cursor, VS Code) | Agent orchestrators (Vertex AI, LangGraph) |
+| SDK | `agent-client-protocol` | `a2a-sdk` |
+| Session model | Long-lived sessions persisted to DB | Stateless per task (session ID for context) |
+| Streaming | Via ACP session updates | Via SSE event stream |
+| CLI command | `hermes-acp` / `hermes acp` | `hermes-a2a` / `hermes a2a` |
+| Agent creation | `SessionManager._make_agent()` | `_make_agent()` (same pattern) |
+
+Both adapters call `AIAgent.run_conversation()` via `loop.run_in_executor()` — the synchronous agent is the same in both cases.
+
+---
+
+## Extension Points
+
+### Adding authentication to the A2A server
+
+The current implementation supports a single Bearer token via `A2A_KEY`. To add per-client API keys or OAuth:
+
+1. Subclass `DefaultRequestHandler` and override `handle()` to inspect request headers
+2. Or add a Starlette middleware in `build_app()` before `A2AStarletteApplication`
+
+### Persistent task storage
+
+Replace `InMemoryTaskStore` in `build_app()`:
+
+```python
+# SQLite-backed store (available in a2a-sdk[sqlite])
+from a2a.server.tasks import SQLiteTaskStore
+handler = DefaultRequestHandler(
+    agent_executor=HermesAgentExecutor(),
+    task_store=SQLiteTaskStore("~/.hermes/a2a_tasks.db"),
+)
+```
+
+### Maintaining conversation history across tasks
+
+Currently each task creates a fresh agent with empty `conversation_history`. To persist history between tasks from the same `sessionId`:
+
+1. Add a session store (dict keyed by `session_id`)
+2. In `execute()`, look up existing history by `context.context_id`
+3. Pass history to `_run_sync()` and update store after completion
+
+This mirrors the `acp_adapter/session.py:SessionManager` pattern and could be extracted as a shared utility.
+
+### Adding tool results to A2A artifacts
+
+The current implementation returns only the `final_response` text. To include tool call traces (file diffs, terminal output) as additional artifact parts, extend `execute()` to inspect `result.get("messages")` and extract tool results before emitting the final `TaskArtifactUpdateEvent`.
+
+---
+
+## Testing
+
+### Manual end-to-end test
+
+```bash
+# Start the server
+AGENT_NAME=test A2A_PORT=9001 hermes-a2a &
+
+# Discover
+curl http://localhost:9001/.well-known/agent.json | jq
+
+# Non-streaming call
+curl -s -X POST http://localhost:9001 \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":"1","method":"tasks/send","params":{"id":"t1","message":{"role":"user","parts":[{"type":"text","text":"what is 2+2?"}]}}}' \
+  | jq .result.artifacts[0].parts[0].text
+```
+
+### Unit testing `HermesAgentExecutor`
+
+Mock `_make_agent` to avoid real LLM calls:
+
+```python
+from unittest.mock import patch, MagicMock
+from a2a_adapter.server import HermesAgentExecutor
+
+async def test_execute():
+    mock_agent = MagicMock()
+    mock_agent.run_conversation.return_value = {"final_response": "4"}
+    
+    with patch("a2a_adapter.server._make_agent", return_value=mock_agent):
+        executor = HermesAgentExecutor()
+        # build mock context and event_queue, then await executor.execute(...)
+```
+
+### Unit testing `a2a_tool.py`
+
+```python
+from unittest.mock import patch
+import httpx
+from tools.a2a_tool import a2a_call
+
+def test_a2a_call(respx_mock):
+    respx_mock.post("http://localhost:9000").mock(
+        return_value=httpx.Response(200, json={
+            "jsonrpc": "2.0", "id": "1",
+            "result": {
+                "id": "t1",
+                "status": {"state": "completed"},
+                "artifacts": [{"parts": [{"type": "text", "text": "hello"}]}]
+            }
+        })
+    )
+    result = a2a_call("http://localhost:9000", "hi")
+    assert result == "hello"
+```
+
+---
+
+## pyproject.toml Changes
+
+```toml
+[project.optional-dependencies]
+a2a = ["a2a-sdk[http-server]>=0.2.0,<1", "uvicorn[standard]>=0.24.0,<1"]
+
+[project.scripts]
+hermes-a2a = "a2a_adapter.entry:main"
+
+[tool.setuptools.packages.find]
+include = [..., "a2a_adapter"]
+```
+
+Install command:
+
+```bash
+pip install 'hermes-agent[a2a]'
+```
+
+---
+
+## Protocol Reference
+
+The implementation targets the A2A specification at `https://a2a-protocol.org`.
+
+Key spec documents:
+- [Agent Card spec](https://a2a-protocol.org/latest/spec/agent-card/)
+- [Task lifecycle](https://a2a-protocol.org/latest/spec/task-lifecycle/)
+- [JSON-RPC methods](https://a2a-protocol.org/latest/spec/json-rpc/)
+- [SSE streaming](https://a2a-protocol.org/latest/spec/streaming/)
+
+Related issues in this repo:
+- #514 — Feature request: A2A protocol support (this implementation closes it)
+- #344 — Multi-Agent Architecture
+- #342 — Hermes as MCP Server
+- #413 — Cross-CLI Orchestration

--- a/docs/a2a-user-guide.md
+++ b/docs/a2a-user-guide.md
@@ -1,0 +1,301 @@
+# A2A Protocol — User Guide
+
+This guide explains how to use the A2A (Agent-to-Agent) protocol support in Hermes Agent — both as a **server** (making your Hermes agent discoverable) and as a **client** (calling other A2A agents from within a conversation).
+
+---
+
+## What is A2A?
+
+A2A (Agent-to-Agent) is an open standard under the Linux Foundation for agent discovery and communication. It answers the question *"who can help me?"* — complementing MCP which answers *"what tools can I use?"*
+
+Any A2A-compatible system — Google Vertex AI Agent Engine, LangGraph, CrewAI, AutoGen, or another Hermes instance — can discover and call your agent without knowing anything about Hermes internals.
+
+---
+
+## Part 1 — Running Hermes as an A2A Server
+
+### Installation
+
+```bash
+pip install 'hermes-agent[a2a]'
+```
+
+This installs `a2a-sdk` and `uvicorn` alongside your existing Hermes setup.
+
+### Starting the A2A server
+
+```bash
+hermes-a2a
+```
+
+Or equivalently:
+
+```bash
+python -m a2a_adapter
+```
+
+By default the server starts on `http://0.0.0.0:9000`.
+
+### Configuration
+
+All configuration is via environment variables — no config file changes needed.
+
+| Variable | Default | Description |
+|---|---|---|
+| `A2A_HOST` | `0.0.0.0` | Bind host |
+| `A2A_PORT` | `9000` | Bind port |
+| `A2A_KEY` | *(none)* | Optional Bearer token for auth |
+| `AGENT_NAME` | `hermes-agent` | Name shown in Agent Card |
+| `AGENT_DESCRIPTION` | auto | Description shown in Agent Card |
+| `AGENT_SKILLS` | *(none)* | Comma-separated skill names |
+| `AGENT_MODEL` | *(none)* | Model name shown in Agent Card metadata |
+
+Example:
+
+```bash
+AGENT_NAME=ronny \
+AGENT_MODEL="qwen2.5:35b" \
+AGENT_SKILLS="coding,analysis,reasoning" \
+AGENT_DESCRIPTION="Ronny — code and analysis specialist" \
+A2A_PORT=9000 \
+hermes-a2a
+```
+
+### Verifying the server
+
+Once running, check the Agent Card:
+
+```bash
+curl http://localhost:9000/.well-known/agent.json
+```
+
+Expected response:
+
+```json
+{
+  "name": "ronny",
+  "description": "Ronny — code and analysis specialist",
+  "url": "http://localhost:9000",
+  "version": "1.0.0",
+  "capabilities": { "streaming": true },
+  "skills": [
+    { "id": "coding", "name": "coding" },
+    { "id": "analysis", "name": "analysis" },
+    { "id": "reasoning", "name": "reasoning" }
+  ],
+  "metadata": { "model": "qwen2.5:35b" }
+}
+```
+
+Send a test task:
+
+```bash
+curl -X POST http://localhost:9000 \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "test-1",
+    "method": "tasks/send",
+    "params": {
+      "id": "task-1",
+      "message": {
+        "role": "user",
+        "parts": [{"type": "text", "text": "Hello, what can you do?"}]
+      }
+    }
+  }'
+```
+
+### Running alongside the gateway
+
+The A2A server (`hermes-a2a`) runs as a **separate process** on a separate port from the Hermes gateway. Run both together:
+
+```bash
+# Terminal 1 — Hermes gateway (OpenAI-compatible)
+hermes gateway
+
+# Terminal 2 — A2A server
+AGENT_NAME=myagent A2A_PORT=9000 hermes-a2a
+```
+
+In Docker, expose both ports:
+
+```bash
+docker run -d \
+  -p 8642:8642 \   # Hermes gateway
+  -p 9000:9000 \   # A2A server
+  -e AGENT_NAME=ronny \
+  -e AGENT_MODEL="qwen2.5:35b" \
+  -e AGENT_SKILLS="coding,analysis" \
+  myagent-image
+```
+
+### Registering with an orchestrator (e.g. Akela Pack)
+
+1. In the Pack UI, add a new agent
+2. Set the endpoint to `http://your-server-ip:9000`
+3. Set protocol to **A2A**
+4. Click **Discover** — the UI auto-fills name, skills, and model from the Agent Card
+
+---
+
+## Part 2 — Calling Remote A2A Agents from Hermes
+
+Once the `a2a` toolset is enabled, Hermes can call any A2A-compatible agent as part of a conversation.
+
+### Enabling the A2A tools
+
+Add `a2a` to your toolset in `~/.hermes/config.yaml`:
+
+```yaml
+enabled_toolsets:
+  - hermes-core
+  - a2a
+```
+
+Or enable just for specific sessions using the `--toolsets` flag:
+
+```bash
+hermes chat --toolsets hermes-core,a2a
+```
+
+### Configuring named agents
+
+Add remote agents to `~/.hermes/config.yaml` so Hermes knows about them by name:
+
+```yaml
+a2a_agents:
+  researcher:
+    url: http://192.168.1.100:9000
+    description: "Deep research and web analysis agent"
+  coder:
+    url: http://192.168.1.101:9000
+    description: "Code writing and debugging agent"
+    bearer_token: "sk-abc123"   # if the agent requires auth
+  legal:
+    url: https://legal-agent.company.internal:9000
+    description: "Legal document review agent"
+```
+
+### Available tools
+
+#### `a2a_discover` — learn what a remote agent can do
+
+Fetches the Agent Card and returns the agent's name, description, skills, and model.
+
+Example prompt:
+> *"Discover the agent at http://192.168.1.100:9000 and tell me what it can do."*
+
+Hermes will call `a2a_discover` and report back the agent's capabilities.
+
+#### `a2a_call` — send a task to a remote agent
+
+Calls the remote agent with a message and returns its response. Automatically uses SSE streaming (`tasks/sendSubscribe`) when the agent's Agent Card advertises `capabilities.streaming: true`, falling back to `tasks/send` otherwise.
+
+Example prompts:
+> *"Ask the researcher agent to find the latest papers on quantum error correction."*
+
+> *"Use the coder agent to write a Python function that parses JWT tokens."*
+
+> *"Call http://192.168.1.102:9000 and ask it to summarize this document: [...]"*
+
+For multi-turn conversations with the same remote agent, reuse a session ID:
+
+> *"Start a conversation with the coder agent about refactoring our auth module. Keep using the same session so it remembers context."*
+
+Hermes will automatically maintain a `session_id` across calls.
+
+To override streaming detection pass `stream=true` or `stream=false` explicitly.
+
+#### `a2a_local_scan` — find running A2A agents on localhost
+
+Scans a range of localhost ports for running A2A agents without requiring any pre-configuration. Useful when you don't know which ports agents are running on.
+
+Example prompts:
+> *"Find all local agents running on this machine."*
+
+> *"Scan ports 9000 to 9005 for A2A agents."*
+
+Hermes will probe each port for a `/.well-known/agent.json` endpoint and return a list of discovered agents with their names, descriptions, and skills. You can then call any discovered agent directly.
+
+Default scan range is ports `9000–9010`. All three parameters are optional:
+
+| Parameter | Default | Description |
+|---|---|---|
+| `host` | `localhost` | Host to scan |
+| `port_start` | `9000` | First port to probe |
+| `port_end` | `9010` | Last port to probe (max range: 100 ports) |
+
+### Multi-agent workflow example
+
+Here is a complete example using two remote agents:
+
+> *"I need to research quantum computing applications in cryptography. Use the researcher agent to gather information, then have the coder agent write a Python demo based on the findings."*
+
+Hermes will:
+1. Call `a2a_call` on the researcher agent with the research task
+2. Receive the research summary
+3. Call `a2a_call` on the coder agent, passing the research as context
+4. Return the combined result
+
+---
+
+## Supported A2A Methods
+
+| JSON-RPC Method | Support | Description |
+|---|---|---|
+| `tasks/send` | ✅ Full | Non-streaming task — waits for completion |
+| `tasks/sendSubscribe` | ✅ Full | Streaming SSE — incremental token updates |
+| `tasks/cancel` | ✅ | Cancel an in-progress task |
+| `tasks/get` | SDK-managed | Handled internally by task store |
+
+---
+
+## Security
+
+### Protecting your A2A server
+
+Set `A2A_KEY` to require Bearer token authentication:
+
+```bash
+A2A_KEY=my-secret-token hermes-a2a
+```
+
+All requests must then include:
+```
+Authorization: Bearer my-secret-token
+```
+
+### Calling authenticated agents
+
+Set `bearer_token` in the agent config:
+
+```yaml
+a2a_agents:
+  secure_agent:
+    url: http://192.168.1.100:9000
+    bearer_token: "my-secret-token"
+```
+
+Or pass it directly in your prompt:
+> *"Call the agent at http://192.168.1.100:9000 with bearer token 'abc123' and ask it to..."*
+
+---
+
+## Troubleshooting
+
+**Agent Card returns 404**
+- The A2A server is not running, or the port is wrong
+- Run `curl http://host:port/.well-known/agent.json` to verify
+
+**tasks/send returns 401**
+- The agent requires a Bearer token — set `A2A_KEY` or `bearer_token` in config
+
+**tasks/send returns an LLM error**
+- The underlying Hermes model is not configured. Run `hermes setup` inside the agent container to configure the model provider.
+
+**"a2a-sdk is not installed" error**
+- Run `pip install 'hermes-agent[a2a]'`
+
+**Tool `a2a_call` not available in chat**
+- Add `a2a` to `enabled_toolsets` in `~/.hermes/config.yaml`

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -540,7 +540,48 @@ class APIServerAdapter(BasePlatformAdapter):
             import queue as _q
             _stream_q: _q.Queue = _q.Queue()
 
-            def _on_delta(delta):
+            class _ThinkFilter:
+                def __init__(self, target_q):
+                    self.target_q = target_q
+                    self.in_think = False
+                    self.buf = ""
+                
+                def put(self, chunk: str, suppressed: bool):
+                    if not suppressed:
+                        if self.buf:
+                            self.buf = ""
+                        self.target_q.put(chunk)
+                        return
+                        
+                    self.buf += chunk
+                    while True:
+                        if not self.in_think:
+                            idx = self.buf.find("<think>")
+                            if idx != -1:
+                                self.in_think = True
+                                self.target_q.put("<think>")
+                                self.buf = self.buf[idx + 7:]
+                                continue
+                            else:
+                                if len(self.buf) > 6:
+                                    self.buf = self.buf[-6:]
+                                break
+                        else:
+                            idx = self.buf.find("</think>")
+                            if idx != -1:
+                                self.in_think = False
+                                self.target_q.put(self.buf[:idx + 8])
+                                self.buf = self.buf[idx + 8:]
+                                continue
+                            else:
+                                if len(self.buf) > 7:
+                                    self.target_q.put(self.buf[:-7])
+                                    self.buf = self.buf[-7:]
+                                break
+
+            _filter = _ThinkFilter(_stream_q)
+
+            def _on_delta(delta, suppressed=False):
                 # Filter out None — the agent fires stream_delta_callback(None)
                 # to signal the CLI display to close its response box before
                 # tool execution, but the SSE writer uses None as end-of-stream
@@ -549,7 +590,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 # the final answer after tool calls.  The SSE loop detects
                 # completion via agent_task.done() instead.
                 if delta is not None:
-                    _stream_q.put(delta)
+                    _filter.put(delta, suppressed)
 
             def _on_tool_progress(name, preview, args):
                 """Inject tool progress into the SSE stream for Open WebUI."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ mcp = ["mcp>=1.2.0,<2"]
 homeassistant = ["aiohttp>=3.9.0,<4"]
 sms = ["aiohttp>=3.9.0,<4"]
 acp = ["agent-client-protocol>=0.8.1,<0.9"]
+a2a = ["a2a-sdk[http-server]>=0.2.0,<1", "uvicorn[standard]>=0.24.0,<1"]
 dingtalk = ["dingtalk-stream>=0.1.0,<1"]
 feishu = ["lark-oapi>=1.5.3,<2"]
 rl = [
@@ -91,6 +92,7 @@ all = [
   "hermes-agent[homeassistant]",
   "hermes-agent[sms]",
   "hermes-agent[acp]",
+  "hermes-agent[a2a]",
   "hermes-agent[voice]",
   "hermes-agent[dingtalk]",
   "hermes-agent[feishu]",
@@ -100,12 +102,13 @@ all = [
 hermes = "hermes_cli.main:main"
 hermes-agent = "run_agent:main"
 hermes-acp = "acp_adapter.entry:main"
+hermes-a2a = "a2a_adapter.entry:main"
 
 [tool.setuptools]
 py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_constants", "hermes_state", "hermes_time", "rl_cli", "utils"]
 
 [tool.setuptools.packages.find]
-include = ["agent", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "cron", "acp_adapter", "plugins", "plugins.*"]
+include = ["agent", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "a2a_adapter"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/run_agent.py
+++ b/run_agent.py
@@ -4143,6 +4143,8 @@ class AIAgent:
                         # box is already closed (tool boundary flush).
                         if self.stream_delta_callback:
                             try:
+                                self.stream_delta_callback(delta.content, suppressed=True)
+                            except TypeError:
                                 self.stream_delta_callback(delta.content)
                             except Exception:
                                 pass

--- a/tests/tools/test_a2a_tool.py
+++ b/tests/tools/test_a2a_tool.py
@@ -1,0 +1,466 @@
+"""Tests for the A2A (Agent-to-Agent) client tools.
+
+All tests use mocks — no real A2A servers or network calls are made.
+Covers: a2a_discover, a2a_call (non-streaming + SSE), a2a_local_scan,
+        agent card caching, named agent resolution.
+"""
+
+import json
+import time
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _agent_card(name="test-agent", streaming=True, skills=None):
+    return {
+        "name": name,
+        "description": f"{name} description",
+        "url": "http://localhost:9000",
+        "version": "1.0.0",
+        "capabilities": {"streaming": streaming},
+        "skills": [{"id": s, "name": s} for s in (skills or ["coding"])],
+        "metadata": {"model": "test-model"},
+    }
+
+
+def _mock_http_response(status_code=200, json_data=None, text=""):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    resp.text = text
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            f"HTTP {status_code}", request=MagicMock(), response=resp
+        )
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+def _jsonrpc_result(text="hello", state="completed"):
+    return {
+        "jsonrpc": "2.0",
+        "id": "t1",
+        "result": {
+            "id": "t1",
+            "status": {"state": state},
+            "artifacts": [{"parts": [{"type": "text", "text": text}]}],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# a2a_discover
+# ---------------------------------------------------------------------------
+
+class TestA2ADiscover:
+    def setup_method(self):
+        from tools.a2a_tool import _CARD_CACHE
+        _CARD_CACHE.clear()
+
+    def test_returns_summary(self):
+        card = _agent_card()
+        mock_resp = _mock_http_response(json_data=card)
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = mock_resp
+
+        with patch("tools.a2a_tool.httpx.Client", return_value=mock_client):
+            from tools.a2a_tool import a2a_discover
+            result = json.loads(a2a_discover("http://localhost:9000"))
+
+        assert result["name"] == "test-agent"
+        assert result["streaming"] is True
+        assert "coding" in result["skills"]
+        assert result["endpoint"] == "http://localhost:9000"
+
+    def test_http_error_returns_error_json(self):
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        mock_resp.text = "Not Found"
+        mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "404", request=MagicMock(), response=mock_resp
+        )
+        mock_client.get.return_value = mock_resp
+
+        with patch("tools.a2a_tool.httpx.Client", return_value=mock_client):
+            from tools.a2a_tool import a2a_discover
+            result = json.loads(a2a_discover("http://localhost:9001"))
+
+        assert "error" in result
+
+    def test_connection_error_returns_error_json(self):
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.side_effect = httpx.ConnectError("refused")
+
+        with patch("tools.a2a_tool.httpx.Client", return_value=mock_client):
+            from tools.a2a_tool import a2a_discover
+            result = json.loads(a2a_discover("http://localhost:9002"))
+
+        assert "error" in result
+
+    def test_caches_card_on_first_fetch(self):
+        card = _agent_card()
+        mock_resp = _mock_http_response(json_data=card)
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = mock_resp
+
+        with patch("tools.a2a_tool.httpx.Client", return_value=mock_client):
+            from tools.a2a_tool import a2a_discover, _get_cached_card
+            a2a_discover("http://localhost:9003")
+            cached = _get_cached_card("http://localhost:9003")
+
+        assert cached is not None
+        assert cached["name"] == "test-agent"
+
+    def test_cache_hit_skips_network(self):
+        card = _agent_card(name="cached-agent")
+        from tools.a2a_tool import _set_cached_card, a2a_discover
+        _set_cached_card("http://localhost:9004", card)
+
+        with patch("tools.a2a_tool.httpx.Client") as mock_cls:
+            result = json.loads(a2a_discover("http://localhost:9004"))
+            mock_cls.assert_not_called()
+
+        assert result["name"] == "cached-agent"
+
+    def test_expired_cache_refetches(self):
+        card = _agent_card(name="fresh-agent")
+        mock_resp = _mock_http_response(json_data=card)
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = mock_resp
+
+        from tools.a2a_tool import _CARD_CACHE
+        _CARD_CACHE["http://localhost:9005"] = {
+            "card": _agent_card(name="stale-agent"),
+            "expires": time.monotonic() - 1,
+        }
+
+        with patch("tools.a2a_tool.httpx.Client", return_value=mock_client):
+            from tools.a2a_tool import a2a_discover
+            result = json.loads(a2a_discover("http://localhost:9005"))
+
+        assert result["name"] == "fresh-agent"
+
+
+# ---------------------------------------------------------------------------
+# a2a_call — non-streaming
+# ---------------------------------------------------------------------------
+
+class TestA2ACallNonStreaming:
+    def setup_method(self):
+        from tools.a2a_tool import _CARD_CACHE
+        _CARD_CACHE.clear()
+
+    def _mock_client(self, card=None, post_response=None):
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = _mock_http_response(json_data=card or _agent_card(streaming=False))
+        mock_client.post.return_value = _mock_http_response(json_data=post_response or _jsonrpc_result("4"))
+        return mock_client
+
+    def test_returns_response_text(self):
+        with patch("tools.a2a_tool.httpx.Client", return_value=self._mock_client()):
+            from tools.a2a_tool import a2a_call
+            result = a2a_call("http://localhost:9000", "what is 2+2?", stream=False)
+        assert result == "4"
+
+    def test_jsonrpc_error_returns_error_json(self):
+        error_resp = {"jsonrpc": "2.0", "id": "t1", "error": {"code": -32000, "message": "Agent error"}}
+        client = self._mock_client(post_response=error_resp)
+        with patch("tools.a2a_tool.httpx.Client", return_value=client):
+            from tools.a2a_tool import a2a_call
+            result = json.loads(a2a_call("http://localhost:9000", "hi", stream=False))
+        assert "error" in result
+
+    def test_empty_artifacts_returns_error(self):
+        empty_resp = {"jsonrpc": "2.0", "id": "t1", "result": {"id": "t1", "status": {"state": "completed"}, "artifacts": []}}
+        client = self._mock_client(post_response=empty_resp)
+        with patch("tools.a2a_tool.httpx.Client", return_value=client):
+            from tools.a2a_tool import a2a_call
+            result = json.loads(a2a_call("http://localhost:9000", "hi", stream=False))
+        assert "error" in result
+
+    def test_bearer_token_sent_in_header(self):
+        client = self._mock_client()
+        with patch("tools.a2a_tool.httpx.Client", return_value=client):
+            from tools.a2a_tool import a2a_call
+            a2a_call("http://localhost:9000", "hi", bearer_token="secret", stream=False)
+        _, kwargs = client.post.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer secret"
+
+    def test_session_id_included_in_payload(self):
+        client = self._mock_client()
+        with patch("tools.a2a_tool.httpx.Client", return_value=client):
+            from tools.a2a_tool import a2a_call
+            a2a_call("http://localhost:9000", "hi", session_id="sess-42", stream=False)
+        _, kwargs = client.post.call_args
+        assert kwargs["json"]["params"]["sessionId"] == "sess-42"
+
+
+# ---------------------------------------------------------------------------
+# a2a_call — SSE streaming
+# ---------------------------------------------------------------------------
+
+class TestA2ACallStreaming:
+    def setup_method(self):
+        from tools.a2a_tool import _CARD_CACHE
+        _CARD_CACHE.clear()
+
+    def _sse_response(self, events):
+        """Build a mock streaming response from a list of result dicts."""
+        lines = []
+        for event in events:
+            lines.append(f"data: {json.dumps(event)}")
+            lines.append("")
+        sse_text = "\n".join(lines)
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.iter_lines.return_value = iter(sse_text.splitlines())
+        mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        return mock_resp
+
+    def test_streaming_returns_final_text(self):
+        events = [
+            {"result": {"status": {"state": "working"}, "artifacts": [{"parts": [{"type": "text", "text": "partial"}]}]}},
+            {"result": {"status": {"state": "completed"}, "artifacts": [{"parts": [{"type": "text", "text": "final answer"}]}]}},
+        ]
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.stream.return_value = self._sse_response(events)
+
+        with patch("tools.a2a_tool.httpx.Client", return_value=mock_client):
+            from tools.a2a_tool import a2a_call
+            result = a2a_call("http://localhost:9000", "hi", stream=True)
+
+        assert result == "final answer"
+
+    def test_streaming_uses_sendsubscribe_method(self):
+        events = [
+            {"result": {"status": {"state": "completed"}, "artifacts": [{"parts": [{"type": "text", "text": "ok"}]}]}},
+        ]
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.stream.return_value = self._sse_response(events)
+
+        with patch("tools.a2a_tool.httpx.Client", return_value=mock_client):
+            from tools.a2a_tool import a2a_call
+            a2a_call("http://localhost:9000", "hi", stream=True)
+
+        _, kwargs = mock_client.stream.call_args
+        assert kwargs["json"]["method"] == "tasks/sendSubscribe"
+
+    def test_auto_detect_streaming_from_card(self):
+        card = _agent_card(streaming=True)
+        events = [
+            {"result": {"status": {"state": "completed"}, "artifacts": [{"parts": [{"type": "text", "text": "streamed"}]}]}},
+        ]
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = _mock_http_response(json_data=card)
+        mock_client.stream.return_value = self._sse_response(events)
+
+        with patch("tools.a2a_tool.httpx.Client", return_value=mock_client):
+            from tools.a2a_tool import a2a_call
+            result = a2a_call("http://localhost:9006", "hi")
+
+        assert result == "streamed"
+        mock_client.stream.assert_called_once()
+
+    def test_auto_detect_non_streaming_from_card(self):
+        card = _agent_card(streaming=False)
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = _mock_http_response(json_data=card)
+        mock_client.post.return_value = _mock_http_response(json_data=_jsonrpc_result("non-streamed"))
+
+        with patch("tools.a2a_tool.httpx.Client", return_value=mock_client):
+            from tools.a2a_tool import a2a_call
+            result = a2a_call("http://localhost:9007", "hi")
+
+        assert result == "non-streamed"
+        mock_client.stream.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Named agent resolution
+# ---------------------------------------------------------------------------
+
+class TestNamedAgentResolution:
+    def setup_method(self):
+        from tools.a2a_tool import _CARD_CACHE
+        _CARD_CACHE.clear()
+
+    def test_resolves_url_from_config(self):
+        agents = {"myagent": {"url": "http://192.168.1.100:9000"}}
+        card = _agent_card(streaming=False)
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = _mock_http_response(json_data=card)
+        mock_client.post.return_value = _mock_http_response(json_data=_jsonrpc_result("result"))
+
+        with patch("tools.a2a_tool._load_a2a_agents", return_value=agents), \
+             patch("tools.a2a_tool.httpx.Client", return_value=mock_client):
+            from tools.a2a_tool import _tool_a2a_call
+            result = _tool_a2a_call({"agent_name": "myagent", "message": "hello"})
+
+        assert result == "result"
+
+    def test_unknown_agent_returns_error(self):
+        with patch("tools.a2a_tool._load_a2a_agents", return_value={}):
+            from tools.a2a_tool import _tool_a2a_call
+            result = json.loads(_tool_a2a_call({"agent_name": "ghost", "message": "hi"}))
+        assert "error" in result
+        assert "ghost" in result["error"]
+
+    def test_no_url_and_no_agent_name_returns_error(self):
+        from tools.a2a_tool import _tool_a2a_call
+        result = json.loads(_tool_a2a_call({"message": "hi"}))
+        assert "error" in result
+
+    def test_missing_message_returns_error(self):
+        from tools.a2a_tool import _tool_a2a_call
+        result = json.loads(_tool_a2a_call({"url": "http://localhost:9000"}))
+        assert "error" in result
+
+    def test_config_bearer_token_forwarded(self):
+        agents = {"secure": {"url": "http://localhost:9000", "bearer_token": "tok123"}}
+        card = _agent_card(streaming=False)
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = _mock_http_response(json_data=card)
+        mock_client.post.return_value = _mock_http_response(json_data=_jsonrpc_result("ok"))
+
+        with patch("tools.a2a_tool._load_a2a_agents", return_value=agents), \
+             patch("tools.a2a_tool.httpx.Client", return_value=mock_client):
+            from tools.a2a_tool import _tool_a2a_call
+            _tool_a2a_call({"agent_name": "secure", "message": "hi"})
+
+        _, kwargs = mock_client.post.call_args
+        assert kwargs["headers"]["Authorization"] == "Bearer tok123"
+
+
+# ---------------------------------------------------------------------------
+# a2a_local_scan
+# ---------------------------------------------------------------------------
+
+class TestA2ALocalScan:
+    def _make_client(self, port_responses):
+        """port_responses: dict of port -> (status_code, card) or Exception."""
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+
+        def _get(url, **_):
+            port = int(url.split(":")[2].split("/")[0])
+            val = port_responses.get(port)
+            if isinstance(val, Exception):
+                raise val
+            status, card = val
+            return _mock_http_response(status_code=status, json_data=card)
+
+        mock_client.get.side_effect = _get
+        return mock_client
+
+    def test_finds_running_agent(self):
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+
+        def _get(url, **_):
+            port = int(url.split(":")[2].split("/")[0])
+            if port == 9000:
+                return _mock_http_response(200, json_data=_agent_card(name="local-agent"))
+            raise httpx.ConnectError("refused")
+
+        mock_client.get.side_effect = _get
+
+        with patch("tools.a2a_tool.httpx.Client", return_value=mock_client):
+            from tools.a2a_tool import a2a_local_scan
+            result = json.loads(a2a_local_scan())
+
+        assert result["found"] == 1
+        assert result["agents"][0]["name"] == "local-agent"
+        assert result["agents"][0]["endpoint"] == "http://localhost:9000"
+
+    def test_no_agents_found(self):
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.side_effect = httpx.ConnectError("refused")
+
+        with patch("tools.a2a_tool.httpx.Client", return_value=mock_client):
+            from tools.a2a_tool import a2a_local_scan
+            result = json.loads(a2a_local_scan())
+
+        assert result["found"] == 0
+        assert result["agents"] == []
+
+    def test_non_200_port_skipped(self):
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = _mock_http_response(status_code=404)
+
+        with patch("tools.a2a_tool.httpx.Client", return_value=mock_client):
+            from tools.a2a_tool import a2a_local_scan
+            result = json.loads(a2a_local_scan())
+
+        assert result["found"] == 0
+
+    def test_multiple_agents_found(self):
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+
+        def _get(url, **_):
+            port = int(url.split(":")[2].split("/")[0])
+            if port in (9000, 9002):
+                return _mock_http_response(200, json_data=_agent_card(name=f"agent-{port}"))
+            raise httpx.ConnectError("refused")
+
+        mock_client.get.side_effect = _get
+
+        with patch("tools.a2a_tool.httpx.Client", return_value=mock_client):
+            from tools.a2a_tool import a2a_local_scan
+            result = json.loads(a2a_local_scan())
+
+        assert result["found"] == 2
+        names = {a["name"] for a in result["agents"]}
+        assert names == {"agent-9000", "agent-9002"}
+
+    def test_range_too_large_returns_error(self):
+        from tools.a2a_tool import _tool_a2a_local_scan
+        result = json.loads(_tool_a2a_local_scan({"port_start": 9000, "port_end": 9200}))
+        assert "error" in result
+
+    def test_inverted_range_returns_error(self):
+        from tools.a2a_tool import _tool_a2a_local_scan
+        result = json.loads(_tool_a2a_local_scan({"port_start": 9010, "port_end": 9000}))
+        assert "error" in result

--- a/tools/a2a_tool.py
+++ b/tools/a2a_tool.py
@@ -1,0 +1,540 @@
+#!/usr/bin/env python3
+"""
+A2A (Agent-to-Agent) Tool — discover and call remote A2A agents.
+
+Gives the Hermes agent three capabilities:
+  - a2a_discover    : fetch an Agent Card from any A2A endpoint
+  - a2a_call        : send a task to any A2A agent and return the response
+  - a2a_local_scan  : scan localhost ports to find running A2A agents
+
+Remote agents are called via raw HTTP + JSON-RPC 2.0 (no SDK dependency needed
+at runtime; the a2a-sdk is only required when *hosting* Hermes as an A2A server).
+
+Named agents can be pre-configured in ``~/.hermes/config.yaml``::
+
+    a2a_agents:
+      researcher:
+        url: http://192.168.1.100:9000
+        description: "Remote research agent"
+      coder:
+        url: http://192.168.1.101:9000
+        description: "Remote code-writing agent"
+
+When named agents are configured, Hermes will list them in the tool description
+so the model knows what remote help is available.
+"""
+
+import json
+import logging
+import time
+import uuid
+from typing import Any, Dict, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_TIMEOUT = 120.0  # seconds per A2A call
+
+# ---------------------------------------------------------------------------
+# Agent Card cache
+# ---------------------------------------------------------------------------
+
+_CARD_CACHE: Dict[str, Dict] = {}   # url → {"card": {...}, "expires": float}
+_CARD_TTL = 300.0                   # 5 minutes
+
+
+def _get_cached_card(url: str) -> Optional[Dict]:
+    entry = _CARD_CACHE.get(url)
+    if entry and time.monotonic() < entry["expires"]:
+        return entry["card"]
+    return None
+
+
+def _set_cached_card(url: str, card: Dict) -> None:
+    _CARD_CACHE[url] = {"card": card, "expires": time.monotonic() + _CARD_TTL}
+
+
+# ---------------------------------------------------------------------------
+# Config helpers
+# ---------------------------------------------------------------------------
+
+def _load_a2a_agents() -> Dict[str, Dict[str, str]]:
+    """Load ``a2a_agents`` section from ~/.hermes/config.yaml."""
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        agents = cfg.get("a2a_agents") or {}
+        if isinstance(agents, dict):
+            return agents
+    except Exception:
+        logger.debug("Could not load a2a_agents from config", exc_info=True)
+    return {}
+
+
+def check_a2a_requirements() -> bool:
+    """httpx is always available — A2A tool is always enabled."""
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Core functions
+# ---------------------------------------------------------------------------
+
+def _fetch_agent_card(url: str) -> Dict:
+    """Fetch and cache the Agent Card for *url*. Raises on network/HTTP error."""
+    cached = _get_cached_card(url)
+    if cached is not None:
+        logger.debug("a2a_discover: cache hit for %s", url)
+        return cached
+
+    card_url = f"{url}/.well-known/agent.json"
+    with httpx.Client(timeout=10.0) as client:
+        resp = client.get(card_url)
+        resp.raise_for_status()
+        card = resp.json()
+
+    _set_cached_card(url, card)
+    return card
+
+
+def a2a_discover(url: str) -> str:
+    """
+    Fetch the Agent Card from an A2A endpoint.
+
+    Returns a JSON string describing the agent: name, description, skills,
+    model, and streaming support. Results are cached for 5 minutes.
+    """
+    url = url.rstrip("/")
+
+    try:
+        card = _fetch_agent_card(url)
+    except httpx.HTTPStatusError as e:
+        return json.dumps({"error": f"HTTP {e.response.status_code}: {e.response.text[:200]}"})
+    except Exception as e:
+        return json.dumps({"error": f"Could not reach {url}/.well-known/agent.json: {e}"})
+
+    name = card.get("name", "unknown")
+    description = card.get("description", "")
+    skills = [s.get("name", "") for s in (card.get("skills") or [])]
+    model = (card.get("metadata") or {}).get("model", "")
+    streaming = (card.get("capabilities") or {}).get("streaming", False)
+
+    return json.dumps(
+        {
+            "name": name,
+            "description": description,
+            "skills": skills,
+            "model": model,
+            "streaming": streaming,
+            "endpoint": url,
+            "raw": card,
+        },
+        ensure_ascii=False,
+        indent=2,
+    )
+
+
+def _extract_artifacts_text(result: Dict) -> str:
+    """Extract concatenated text from a task result's artifacts."""
+    texts: list[str] = []
+    for artifact in (result.get("artifacts") or []):
+        for part in (artifact.get("parts") or []):
+            if part.get("type") == "text" and part.get("text"):
+                texts.append(part["text"])
+    return "\n".join(texts).strip()
+
+
+def _call_streaming(url: str, payload: Dict, headers: Dict) -> str:
+    """
+    Call a remote A2A agent via ``tasks/sendSubscribe`` (SSE streaming).
+
+    Accumulates artifact text from streamed events and returns the final
+    response once a ``completed`` / ``failed`` / ``canceled`` status event
+    is received.  Falls back gracefully if the server closes the stream
+    without a terminal event.
+    """
+    payload = dict(payload, method="tasks/sendSubscribe")
+    accumulated = ""
+
+    try:
+        with httpx.Client(timeout=_TIMEOUT) as client:
+            with client.stream("POST", url, json=payload, headers=headers) as resp:
+                resp.raise_for_status()
+                for raw_line in resp.iter_lines():
+                    if not raw_line.startswith("data:"):
+                        continue
+                    data_str = raw_line[len("data:"):].strip()
+                    if not data_str:
+                        continue
+                    try:
+                        event = json.loads(data_str)
+                    except json.JSONDecodeError:
+                        continue
+
+                    result = event.get("result") or {}
+
+                    # Accumulate artifact text from partial updates
+                    chunk = _extract_artifacts_text(result)
+                    if chunk:
+                        accumulated = chunk  # server sends cumulative text
+
+                    # Terminal state — stop reading
+                    state = (result.get("status") or {}).get("state", "")
+                    if state in ("completed", "failed", "canceled"):
+                        break
+
+    except httpx.HTTPStatusError as e:
+        return json.dumps({"error": f"HTTP {e.response.status_code}: {e.response.text[:300]}"})
+    except Exception as e:
+        return json.dumps({"error": f"Streaming request failed: {e}"})
+
+    if not accumulated:
+        return json.dumps({"error": "Agent returned an empty streaming response"})
+    return accumulated
+
+
+def a2a_call(
+    url: str,
+    message: str,
+    session_id: Optional[str] = None,
+    bearer_token: Optional[str] = None,
+    stream: Optional[bool] = None,
+) -> str:
+    """
+    Send a task to a remote A2A agent and return its response.
+
+    Automatically uses SSE streaming (``tasks/sendSubscribe``) when the agent's
+    Agent Card advertises ``capabilities.streaming: true``, falling back to
+    ``tasks/send`` otherwise.  Pass ``stream=True`` or ``stream=False`` to
+    override auto-detection.  Pass ``session_id`` to maintain conversation
+    context across multiple calls to the same agent.
+
+    Args:
+        url:          Base URL of the A2A agent (e.g. http://192.168.1.100:9000)
+        message:      The message / task to send
+        session_id:   Optional session ID for multi-turn conversations
+        bearer_token: Optional Bearer token if the agent requires auth
+        stream:       Force streaming on/off; None = auto-detect from Agent Card
+
+    Returns:
+        The agent's response text, or a JSON error object.
+    """
+    url = url.rstrip("/")
+    task_id = str(uuid.uuid4())[:8]
+    ctx_id = session_id or str(uuid.uuid4())[:8]
+
+    headers: Dict[str, str] = {"Content-Type": "application/json"}
+    if bearer_token:
+        headers["Authorization"] = f"Bearer {bearer_token}"
+
+    # Auto-detect streaming from cached Agent Card
+    if stream is None:
+        try:
+            card = _fetch_agent_card(url)
+            stream = bool((card.get("capabilities") or {}).get("streaming", False))
+        except Exception:
+            stream = False
+
+    payload = {
+        "jsonrpc": "2.0",
+        "id": task_id,
+        "method": "tasks/send",  # overridden below for streaming
+        "params": {
+            "id": task_id,
+            "sessionId": ctx_id,
+            "message": {
+                "role": "user",
+                "parts": [{"type": "text", "text": message}],
+            },
+        },
+    }
+
+    if stream:
+        return _call_streaming(url, payload, headers)
+
+    # Non-streaming path
+    try:
+        with httpx.Client(timeout=_TIMEOUT) as client:
+            resp = client.post(url, json=payload, headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+    except httpx.HTTPStatusError as e:
+        return json.dumps({"error": f"HTTP {e.response.status_code}: {e.response.text[:300]}"})
+    except Exception as e:
+        return json.dumps({"error": f"Request failed: {e}"})
+
+    if "error" in data:
+        err = data["error"]
+        return json.dumps({"error": err.get("message", str(err))})
+
+    result = data.get("result") or {}
+    response_text = _extract_artifacts_text(result)
+    if not response_text:
+        return json.dumps({"error": "Agent returned an empty response", "raw": result})
+
+    return response_text
+
+
+# ---------------------------------------------------------------------------
+# Tool wrappers (synchronous, matching Hermes tool interface)
+# ---------------------------------------------------------------------------
+
+def _tool_a2a_discover(args: Dict[str, Any], **_kw) -> str:
+    url = args.get("url", "").strip()
+    if not url:
+        return json.dumps({"error": "url is required"})
+    return a2a_discover(url)
+
+
+def _tool_a2a_call(args: Dict[str, Any], **_kw) -> str:
+    url = args.get("url", "").strip()
+    message = args.get("message", "").strip()
+    session_id = args.get("session_id")
+    bearer_token = args.get("bearer_token")
+    stream = args.get("stream")  # None = auto-detect
+
+    if not url and args.get("agent_name"):
+        # Resolve named agent from config
+        agents = _load_a2a_agents()
+        agent_cfg = agents.get(args["agent_name"])
+        if agent_cfg:
+            url = agent_cfg.get("url", "")
+            if not bearer_token:
+                bearer_token = agent_cfg.get("bearer_token")
+        else:
+            available = list(agents.keys())
+            return json.dumps(
+                {
+                    "error": f"Agent '{args['agent_name']}' not found in config.yaml a2a_agents.",
+                    "available_agents": available,
+                }
+            )
+
+    if not url:
+        return json.dumps({"error": "Provide 'url' or 'agent_name'"})
+    if not message:
+        return json.dumps({"error": "message is required"})
+
+    return a2a_call(url, message, session_id=session_id, bearer_token=bearer_token, stream=stream)
+
+
+# ---------------------------------------------------------------------------
+# OpenAI Function Schemas
+# ---------------------------------------------------------------------------
+
+def _build_discover_description() -> str:
+    return (
+        "Fetch the Agent Card from any A2A-compatible agent endpoint. "
+        "Returns the agent's name, description, skills, model, and capabilities. "
+        "Use this to learn what a remote agent can do before calling it."
+    )
+
+
+def _build_call_description() -> str:
+    agents = _load_a2a_agents()
+    base = (
+        "Send a task to a remote A2A agent and get its response. "
+        "Supports any agent that implements the Google A2A protocol "
+        "(Hermes, LangChain, CrewAI, AutoGen, Vertex AI agents, etc.).\n\n"
+        "Automatically uses SSE streaming when the agent supports it (detected from "
+        "its Agent Card). Override with stream=true/false if needed.\n\n"
+        "Provide either 'url' (direct endpoint) or 'agent_name' (from config).\n"
+    )
+    if agents:
+        names = ", ".join(
+            f"{name} — {cfg.get('description', cfg.get('url', ''))}"
+            for name, cfg in agents.items()
+        )
+        base += f"\nConfigured agents: {names}"
+    return base
+
+
+A2A_DISCOVER_SCHEMA = {
+    "name": "a2a_discover",
+    "description": _build_discover_description(),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "url": {
+                "type": "string",
+                "description": "Base URL of the A2A agent (e.g. http://192.168.1.100:9000)",
+            }
+        },
+        "required": ["url"],
+    },
+}
+
+A2A_CALL_SCHEMA = {
+    "name": "a2a_call",
+    "description": _build_call_description(),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "url": {
+                "type": "string",
+                "description": "Direct URL of the A2A agent. Required if agent_name is not provided.",
+            },
+            "agent_name": {
+                "type": "string",
+                "description": "Name of a pre-configured agent from config.yaml a2a_agents section.",
+            },
+            "message": {
+                "type": "string",
+                "description": "The task or question to send to the remote agent.",
+            },
+            "session_id": {
+                "type": "string",
+                "description": (
+                    "Optional session ID for multi-turn conversation. "
+                    "Reuse the same ID across calls to maintain context."
+                ),
+            },
+            "bearer_token": {
+                "type": "string",
+                "description": "Optional Bearer token if the remote agent requires authentication.",
+            },
+            "stream": {
+                "type": "boolean",
+                "description": (
+                    "Use SSE streaming (tasks/sendSubscribe). "
+                    "Omit to auto-detect from the agent's Agent Card capabilities."
+                ),
+            },
+        },
+        "required": ["message"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Local port scan
+# ---------------------------------------------------------------------------
+
+_SCAN_TIMEOUT = 2.0  # seconds per port probe
+_DEFAULT_SCAN_START = 9000
+_DEFAULT_SCAN_END = 9010
+
+
+def a2a_local_scan(
+    host: str = "localhost",
+    port_start: int = _DEFAULT_SCAN_START,
+    port_end: int = _DEFAULT_SCAN_END,
+) -> str:
+    """
+    Scan a range of localhost ports for running A2A agents.
+
+    Tries GET /{port}/.well-known/agent.json on each port in [port_start, port_end].
+    Returns a JSON list of discovered agents with their name, description, skills,
+    and endpoint URL.
+
+    Args:
+        host:       Host to scan (default: localhost)
+        port_start: First port to probe (default: 9000)
+        port_end:   Last port to probe inclusive (default: 9010)
+    """
+    found = []
+    with httpx.Client(timeout=_SCAN_TIMEOUT) as client:
+        for port in range(port_start, port_end + 1):
+            url = f"http://{host}:{port}"
+            card_url = f"{url}/.well-known/agent.json"
+            try:
+                resp = client.get(card_url)
+                if resp.status_code == 200:
+                    card = resp.json()
+                    found.append({
+                        "endpoint": url,
+                        "name": card.get("name", "unknown"),
+                        "description": card.get("description", ""),
+                        "skills": [s.get("name", "") for s in (card.get("skills") or [])],
+                        "streaming": (card.get("capabilities") or {}).get("streaming", False),
+                    })
+            except Exception:
+                pass  # port not open or not an A2A agent — skip silently
+
+    if not found:
+        return json.dumps({
+            "found": 0,
+            "message": f"No A2A agents found on {host} ports {port_start}-{port_end}",
+            "agents": [],
+        })
+
+    return json.dumps({
+        "found": len(found),
+        "agents": found,
+    }, ensure_ascii=False, indent=2)
+
+
+def _tool_a2a_local_scan(args: Dict[str, Any], **_kw) -> str:
+    host = args.get("host", "localhost")
+    port_start = int(args.get("port_start", _DEFAULT_SCAN_START))
+    port_end = int(args.get("port_end", _DEFAULT_SCAN_END))
+    if port_start > port_end:
+        return json.dumps({"error": "port_start must be <= port_end"})
+    if port_end - port_start > 100:
+        return json.dumps({"error": "Scan range too large (max 100 ports)"})
+    return a2a_local_scan(host=host, port_start=port_start, port_end=port_end)
+
+
+A2A_LOCAL_SCAN_SCHEMA = {
+    "name": "a2a_local_scan",
+    "description": (
+        "Scan localhost ports to discover running A2A agents. "
+        "Probes each port for a /.well-known/agent.json endpoint. "
+        "Use this when you need to find what A2A agents are currently running locally "
+        "without knowing their ports in advance. "
+        f"Default scan range: ports {_DEFAULT_SCAN_START}-{_DEFAULT_SCAN_END}."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "host": {
+                "type": "string",
+                "description": "Host to scan (default: localhost)",
+            },
+            "port_start": {
+                "type": "integer",
+                "description": f"First port to probe (default: {_DEFAULT_SCAN_START})",
+            },
+            "port_end": {
+                "type": "integer",
+                "description": f"Last port to probe inclusive (default: {_DEFAULT_SCAN_END})",
+            },
+        },
+        "required": [],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+from tools.registry import registry
+
+registry.register(
+    name="a2a_discover",
+    toolset="a2a",
+    schema=A2A_DISCOVER_SCHEMA,
+    handler=_tool_a2a_discover,
+    check_fn=check_a2a_requirements,
+    emoji="🔍",
+)
+
+registry.register(
+    name="a2a_call",
+    toolset="a2a",
+    schema=A2A_CALL_SCHEMA,
+    handler=_tool_a2a_call,
+    check_fn=check_a2a_requirements,
+    emoji="🤝",
+)
+
+registry.register(
+    name="a2a_local_scan",
+    toolset="a2a",
+    schema=A2A_LOCAL_SCAN_SCHEMA,
+    handler=_tool_a2a_local_scan,
+    check_fn=check_a2a_requirements,
+    emoji="📡",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -56,6 +56,8 @@ _HERMES_CORE_TOOLS = [
     "clarify",
     # Code execution + delegation
     "execute_code", "delegate_task",
+    # A2A remote agent discovery, calling, and local scan
+    "a2a_discover", "a2a_call", "a2a_local_scan",
     # Cronjob management
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
@@ -131,6 +133,12 @@ TOOLSETS = {
     "messaging": {
         "description": "Cross-platform messaging: send messages to Telegram, Discord, Slack, SMS, etc.",
         "tools": ["send_message"],
+        "includes": []
+    },
+
+    "a2a": {
+        "description": "Agent-to-Agent (A2A) protocol tools: discover remote agents, call them with tasks, and scan localhost for running agents",
+        "tools": ["a2a_discover", "a2a_call", "a2a_local_scan"],
         "includes": []
     },
     


### PR DESCRIPTION
## Summary

Closes #514 — implements Phases 1 and 2 of the A2A (Agent-to-Agent) protocol support.

### Phase 1 — A2A Client (`tools/a2a_tool.py`)

Three new tools in the `a2a` toolset:

- **`a2a_discover`** — fetch an Agent Card from any A2A endpoint; results cached for 5 min to avoid redundant fetches
- **`a2a_call`** — send a task to a remote A2A agent; auto-detects streaming capability from the cached Agent Card and uses `tasks/sendSubscribe` (SSE) when supported, falling back to `tasks/send`
- **`a2a_local_scan`** — scan a localhost port range (default 9000–9010) to discover running A2A agents without any pre-configuration; closes the discovery gap identified in the issue

Named agents can be pre-configured in `~/.hermes/config.yaml`:
```yaml
a2a_agents:
  researcher:
    url: http://192.168.1.100:9000
    bearer_token: "optional"
```

### Phase 2 — A2A Server (`a2a_adapter/`)

Exposes Hermes as a standards-compliant A2A agent over HTTP:

- `HermesAgentExecutor` wraps `AIAgent.run_conversation()` with full SSE streaming support
- Bearer token auth via `A2A_KEY` env var
- Agent Card built from env vars (`AGENT_NAME`, `AGENT_SKILLS`, `AGENT_DESCRIPTION`, etc.)
- Runs as a separate uvicorn process on configurable port (default `9000`)

```bash
pip install 'hermes-agent[a2a]'
AGENT_NAME=myagent AGENT_SKILLS="coding,analysis" hermes-a2a
```

### Supporting changes

- `pyproject.toml` — `[a2a]` optional extra, `hermes-a2a` CLI entry point, `a2a_adapter` in packages
- `toolsets.py` — `a2a` toolset definition + all 3 tools registered in `_HERMES_CORE_TOOLS`

### Docs & Tests

- `docs/a2a-user-guide.md` — end-user guide covering server setup, client tools, multi-agent workflows, auth, and troubleshooting
- `docs/a2a-architecture.md` — internal design, data flow diagrams, extension points
- `tests/tools/test_a2a_tool.py` — unit tests for all 3 tools using mocks (no real servers needed); covers caching, SSE streaming, named agent resolution, error handling

### What's not in this PR (Phase 3)

Multi-agent orchestration patterns (agent registry, automatic agent selection, fan-out workflows) remain open per the original issue roadmap.

## How to test manually

**1. Start the A2A server:**
```bash
pip install 'hermes-agent[a2a]'
AGENT_NAME=myagent AGENT_SKILLS="coding,analysis,reasoning" hermes-a2a
```

**2. Verify the Agent Card:**
```bash
curl http://localhost:9000/.well-known/agent.json | jq
```

**3. Send a test task:**
```bash
curl -s -X POST http://localhost:9000 \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":"1","method":"tasks/send","params":{"id":"t1","message":{"role":"user","parts":[{"type":"text","text":"what is 2+2?"}]}}}' \
  | jq .result.artifacts[0].parts[0].text
```

**4. Test client tools in chat:**
```bash
hermes chat --toolsets hermes-core,a2a
# Then: "find all local agents" → triggers a2a_local_scan
# Then: "discover the agent at http://localhost:9000" → triggers a2a_discover
# Then: "ask the agent at http://localhost:9000 what is 2+2?" → triggers a2a_call
```

**5. Run unit tests:**
```bash
pytest tests/tools/test_a2a_tool.py -v
```

## Platforms tested

- macOS (Darwin 25.3.0) — server started, Agent Card served, `tasks/send` returned correct response, SSE streaming verified end-to-end against live deployment at `http://15.204.116.57:8106`

## Test plan

- [ ] `pip install 'hermes-agent[a2a]'` installs without errors
- [ ] `hermes-a2a` starts and serves Agent Card at `/.well-known/agent.json`
- [ ] `tasks/send` returns a completed response
- [ ] `tasks/sendSubscribe` streams SSE events correctly
- [ ] `a2a_discover`, `a2a_call`, `a2a_local_scan` available in chat with `a2a` toolset enabled
- [ ] `pytest tests/tools/test_a2a_tool.py` passes in full dev environment
- [ ] Tested on Linux

## Related issues

- Closes #514
- Related: #344 (Multi-Agent Architecture), #342 (Hermes as MCP Server), #413 (Cross-CLI Orchestration)