### PR TITLE
feat(provider): add claude-cli local inference backend

### DIFF
--- a/agent/claude_cli_agent_bridge.py
+++ b/agent/claude_cli_agent_bridge.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import secrets
+import threading
+from multiprocessing.connection import Client, Listener
+from typing import Any, Callable
+
+
+class AgentLoopBridgeServer:
+    def __init__(self, callback: Callable[[str, dict[str, Any]], str]):
+        self._callback = callback
+        self._authkey = secrets.token_bytes(32)
+        self._listener = Listener(("127.0.0.1", 0), authkey=self._authkey)
+        host, port = self._listener.address
+        self.host = str(host)
+        self.port = int(port)
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._stop = threading.Event()
+        self._started = False
+
+    def start(self) -> None:
+        if not self._started:
+            self._thread.start()
+            self._started = True
+
+    def close(self) -> None:
+        self._stop.set()
+        try:
+            Client((self.host, self.port), authkey=self._authkey).close()
+        except Exception:
+            pass
+        try:
+            self._listener.close()
+        except Exception:
+            pass
+
+    def connection_env(self) -> dict[str, str]:
+        return {
+            "HERMES_AGENT_BRIDGE_HOST": self.host,
+            "HERMES_AGENT_BRIDGE_PORT": str(self.port),
+            "HERMES_AGENT_BRIDGE_AUTHKEY": self._authkey.hex(),
+        }
+
+    def _serve(self) -> None:
+        while not self._stop.is_set():
+            try:
+                conn = self._listener.accept()
+            except Exception:
+                break
+            with conn:
+                try:
+                    req = conn.recv()
+                    if req == {"type": "shutdown"}:
+                        conn.send({"ok": True})
+                        break
+                    tool_name = str(req.get("tool_name") or "")
+                    args = req.get("args") or {}
+                    result = self._callback(tool_name, args)
+                    conn.send({"ok": True, "result": result})
+                except Exception as exc:
+                    conn.send({"ok": False, "error": f"{type(exc).__name__}: {exc}"})
+
+
+def call_agent_loop_tool(tool_name: str, args: dict[str, Any], *, host: str, port: int, authkey_hex: str) -> str:
+    conn = Client((host, port), authkey=bytes.fromhex(authkey_hex))
+    with conn:
+        conn.send({"tool_name": tool_name, "args": args})
+        resp = conn.recv()
+    if not resp.get("ok"):
+        raise RuntimeError(resp.get("error") or "Unknown bridge error")
+    return str(resp.get("result") or "")

--- a/agent/claude_cli_client.py
+++ b/agent/claude_cli_client.py
@@ -1,9 +1,9 @@
 """OpenAI-compatible facade that routes Hermes inference through local Claude CLI.
 
 This backend is intentionally text-in/text-out only for now. It shells out to
-`claude -p --output-format json`, disables Claude's own tool use, and returns a
-minimal response object that matches the parts of the OpenAI SDK shape Hermes
-expects.
+`claude -p --output-format json`, passes Claude Code's documented
+`--disallowedTools` flags for the built-in tool set, and returns a minimal
+response object that matches the parts of the OpenAI SDK shape Hermes expects.
 """
 
 from __future__ import annotations
@@ -21,6 +21,22 @@ from agent.model_metadata import estimate_messages_tokens_rough, estimate_tokens
 
 CLAUDE_CLI_MARKER_BASE_URL = "claude-cli://local"
 _DEFAULT_TIMEOUT_SECONDS = 900.0
+_CLAUDE_CLI_DISABLED_TOOLS = (
+    "Bash",
+    "Edit",
+    "Glob",
+    "Grep",
+    "LS",
+    "MultiEdit",
+    "NotebookEdit",
+    "NotebookRead",
+    "Read",
+    "Task",
+    "TodoWrite",
+    "WebFetch",
+    "WebSearch",
+    "Write",
+)
 
 
 def _resolve_command() -> str:
@@ -149,6 +165,8 @@ class ClaudeCLIClient:
 
     def _build_command(self, *, model: str, prompt_text: str, resume_session_id: str | None = None) -> list[str]:
         cmd = [self._command, "-p", "--output-format", "json", "--model", model]
+        for tool_name in _CLAUDE_CLI_DISABLED_TOOLS:
+            cmd.extend(["--disallowedTools", tool_name])
         if resume_session_id:
             cmd.extend(["--resume", resume_session_id])
         elif self._claude_session_id:

--- a/agent/claude_cli_client.py
+++ b/agent/claude_cli_client.py
@@ -1,0 +1,236 @@
+"""OpenAI-compatible facade that routes Hermes inference through local Claude CLI.
+
+This backend is intentionally text-in/text-out only for now. It shells out to
+`claude -p --output-format json`, disables Claude's own tool use, and returns a
+minimal response object that matches the parts of the OpenAI SDK shape Hermes
+expects.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from agent.model_metadata import estimate_messages_tokens_rough, estimate_tokens_rough
+
+CLAUDE_CLI_MARKER_BASE_URL = "claude-cli://local"
+_DEFAULT_TIMEOUT_SECONDS = 900.0
+
+
+def _resolve_command() -> str:
+    return (
+        os.getenv("HERMES_CLAUDE_CLI_COMMAND", "").strip()
+        or os.getenv("CLAUDE_CLI_PATH", "").strip()
+        or "claude"
+    )
+
+
+def _resolve_args() -> list[str]:
+    raw = os.getenv("HERMES_CLAUDE_CLI_ARGS", "").strip()
+    return shlex.split(raw) if raw else []
+
+
+def _render_message_content(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, dict):
+        if isinstance(content.get("text"), str):
+            return content["text"].strip()
+        if isinstance(content.get("content"), str):
+            return content["content"].strip()
+        return json.dumps(content, ensure_ascii=False)
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                if item.strip():
+                    parts.append(item.strip())
+            elif isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str) and text.strip():
+                    parts.append(text.strip())
+        return "\n".join(parts).strip()
+    return str(content).strip()
+
+
+def _format_messages_as_prompt(messages: list[dict[str, Any]], model: str | None = None) -> str:
+    sections: list[str] = [
+        "You are being used as the active Claude CLI backend for Hermes Agent.",
+        "Respond directly in natural language.",
+        "Do not emit tool-call JSON.",
+    ]
+    if model:
+        sections.append(f"Hermes requested model hint: {model}")
+
+    transcript: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = str(message.get("role") or "unknown").strip().lower()
+        if role not in {"system", "user", "assistant", "tool"}:
+            role = "context"
+        rendered = _render_message_content(message.get("content"))
+        if not rendered:
+            continue
+        label = {
+            "system": "System",
+            "user": "User",
+            "assistant": "Assistant",
+            "tool": "Tool",
+            "context": "Context",
+        }.get(role, role.title())
+        transcript.append(f"{label}:\n{rendered}")
+
+    if transcript:
+        sections.append("Conversation transcript:\n\n" + "\n\n".join(transcript))
+    sections.append("Continue the conversation from the latest user request.")
+    return "\n\n".join(section.strip() for section in sections if section and section.strip())
+
+
+class _ClaudeCLIChatCompletions:
+    def __init__(self, client: "ClaudeCLIClient"):
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._client._create_chat_completion(**kwargs)
+
+
+class _ClaudeCLIChatNamespace:
+    def __init__(self, client: "ClaudeCLIClient"):
+        self.completions = _ClaudeCLIChatCompletions(client)
+
+
+class ClaudeCLIClient:
+    """Minimal OpenAI-client-compatible facade for local Claude CLI inference."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_headers: dict[str, str] | None = None,
+        command: str | None = None,
+        args: list[str] | None = None,
+        acp_command: str | None = None,
+        acp_args: list[str] | None = None,
+        acp_cwd: str | None = None,
+        **_: Any,
+    ):
+        self.api_key = api_key or "claude-cli"
+        self.base_url = base_url or CLAUDE_CLI_MARKER_BASE_URL
+        self._default_headers = dict(default_headers or {})
+        self._command = command or acp_command or _resolve_command()
+        self._args = list(args or acp_args or _resolve_args())
+        self._cwd = str(Path(acp_cwd or os.getcwd()).resolve())
+        self.chat = _ClaudeCLIChatNamespace(self)
+        self.is_closed = False
+        self._last_result: dict[str, Any] | None = None
+
+    def close(self) -> None:
+        self.is_closed = True
+
+    def _create_chat_completion(
+        self,
+        *,
+        model: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        timeout: float | None = None,
+        **_: Any,
+    ) -> Any:
+        prompt_text = _format_messages_as_prompt(messages or [], model=model)
+        payload = self._run_prompt(
+            prompt_text,
+            model=(model or "").split("/", 1)[-1],
+            timeout_seconds=float(timeout or _DEFAULT_TIMEOUT_SECONDS),
+        )
+        self._last_result = payload
+
+        usage_payload = payload.get("usage") if isinstance(payload, dict) else {}
+        input_tokens = int((usage_payload or {}).get("input_tokens") or 0)
+        cache_read_tokens = int((usage_payload or {}).get("cache_read_input_tokens") or 0)
+        cache_write_tokens = int((usage_payload or {}).get("cache_creation_input_tokens") or 0)
+        completion_tokens = int((usage_payload or {}).get("output_tokens") or 0)
+        prompt_tokens = input_tokens + cache_read_tokens + cache_write_tokens
+        total_tokens = prompt_tokens + completion_tokens
+
+        usage = SimpleNamespace(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+            prompt_tokens_details=SimpleNamespace(
+                cached_tokens=cache_read_tokens,
+                cache_write_tokens=cache_write_tokens,
+            ),
+            raw_cli_usage=usage_payload,
+        )
+
+        content = str(payload.get("result") or "").strip()
+        assistant_message = SimpleNamespace(
+            content=content,
+            tool_calls=[],
+            reasoning=None,
+            reasoning_content=None,
+            reasoning_details=None,
+        )
+        choice = SimpleNamespace(message=assistant_message, finish_reason="stop")
+        return SimpleNamespace(
+            choices=[choice],
+            usage=usage,
+            model=model or payload.get("model") or "claude-cli",
+        )
+
+    def _run_prompt(self, prompt_text: str, *, model: str, timeout_seconds: float) -> dict[str, Any]:
+        cmd = [self._command, "-p", "--output-format", "json", "--model", model]
+        cmd.extend(self._args)
+        cmd.append(prompt_text)
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                cwd=self._cwd,
+                timeout=timeout_seconds,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"Could not start Claude CLI command '{self._command}'. "
+                "Install Claude Code CLI or set HERMES_CLAUDE_CLI_COMMAND/CLAUDE_CLI_PATH."
+            ) from exc
+
+        stdout = (proc.stdout or "").strip()
+        stderr = (proc.stderr or "").strip()
+        if not stdout:
+            raise RuntimeError(stderr or "Claude CLI returned no output.")
+
+        try:
+            payload = json.loads(stdout)
+        except json.JSONDecodeError:
+            payload = {"result": stdout, "usage": {}}
+
+        if not isinstance(payload, dict):
+            payload = {"result": stdout, "usage": {}}
+
+        usage = payload.get("usage")
+        if not isinstance(usage, dict):
+            usage = {}
+            payload["usage"] = usage
+
+        # Fill missing token metrics with rough estimates so Hermes status/context
+        # indicators remain useful even when Claude CLI omits detailed usage.
+        if not any(usage.get(key) for key in ("input_tokens", "output_tokens", "cache_read_input_tokens", "cache_creation_input_tokens")):
+            usage["input_tokens"] = estimate_tokens_rough(prompt_text)
+            usage["output_tokens"] = estimate_tokens_rough(str(payload.get("result") or ""))
+
+        if not payload.get("model"):
+            payload["model"] = model
+        if proc.returncode != 0 and not payload.get("result"):
+            payload["result"] = stderr or stdout
+        return payload

--- a/agent/claude_cli_client.py
+++ b/agent/claude_cli_client.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
-from agent.model_metadata import estimate_messages_tokens_rough, estimate_tokens_rough
+from agent.model_metadata import estimate_tokens_rough
 
 CLAUDE_CLI_MARKER_BASE_URL = "claude-cli://local"
 _DEFAULT_TIMEOUT_SECONDS = 900.0

--- a/agent/claude_cli_client.py
+++ b/agent/claude_cli_client.py
@@ -1,9 +1,9 @@
 """OpenAI-compatible facade that routes Hermes inference through local Claude CLI.
 
 This backend is intentionally text-in/text-out only for now. It shells out to
-`claude -p --output-format json`, passes Claude Code's documented
-`--disallowedTools` flags for the built-in tool set, and returns a minimal
-response object that matches the parts of the OpenAI SDK shape Hermes expects.
+`claude -p --output-format json`, disables Claude Code's built-in tools with
+`--tools ""`, and returns a minimal response object that matches the parts of
+the OpenAI SDK shape Hermes expects.
 """
 
 from __future__ import annotations
@@ -21,22 +21,6 @@ from agent.model_metadata import estimate_tokens_rough
 
 CLAUDE_CLI_MARKER_BASE_URL = "claude-cli://local"
 _DEFAULT_TIMEOUT_SECONDS = 900.0
-_CLAUDE_CLI_DISABLED_TOOLS = (
-    "Bash",
-    "Edit",
-    "Glob",
-    "Grep",
-    "LS",
-    "MultiEdit",
-    "NotebookEdit",
-    "NotebookRead",
-    "Read",
-    "Task",
-    "TodoWrite",
-    "WebFetch",
-    "WebSearch",
-    "Write",
-)
 
 
 def _resolve_command() -> str:
@@ -162,9 +146,7 @@ class ClaudeCLIClient:
         self._claude_session_id: str | None = None
 
     def _build_command(self, *, model: str, prompt_text: str, resume_session_id: str | None = None) -> list[str]:
-        cmd = [self._command, "-p", "--output-format", "json", "--model", model]
-        for tool_name in _CLAUDE_CLI_DISABLED_TOOLS:
-            cmd.extend(["--disallowedTools", tool_name])
+        cmd = [self._command, "-p", "--output-format", "json", "--model", model, "--tools", ""]
         if resume_session_id:
             cmd.extend(["--resume", resume_session_id])
         elif self._claude_session_id:

--- a/agent/claude_cli_client.py
+++ b/agent/claude_cli_client.py
@@ -12,11 +12,13 @@ import json
 import os
 import shlex
 import subprocess
+import sys
 import uuid
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
+from agent.claude_cli_agent_bridge import AgentLoopBridgeServer
 from agent.model_metadata import estimate_tokens_rough
 
 CLAUDE_CLI_MARKER_BASE_URL = "claude-cli://local"
@@ -75,6 +77,7 @@ def _format_messages_as_prompt(messages: list[dict[str, Any]], model: str | None
     sections: list[str] = [
         "You are being used as the active Claude CLI backend for Hermes Agent.",
         "Respond directly in natural language.",
+        "If Hermes MCP tools are available, use them instead of merely describing hypothetical tool use.",
         "Do not emit tool-call JSON.",
     ]
     if model:
@@ -133,6 +136,10 @@ class ClaudeCLIClient:
         acp_args: list[str] | None = None,
         acp_cwd: str | None = None,
         session_id: str | None = None,
+        enabled_toolsets: list[str] | None = None,
+        disabled_toolsets: list[str] | None = None,
+        allow_hermes_tool_bridge: bool | None = None,
+        agent_tool_call_callback: Any = None,
         **_: Any,
     ):
         self.api_key = api_key or "claude-cli"
@@ -144,9 +151,46 @@ class ClaudeCLIClient:
         self.is_closed = False
         self._hermes_session_uuid = _coerce_session_uuid(session_id)
         self._claude_session_id: str | None = None
+        self._enabled_toolsets = list(enabled_toolsets) if enabled_toolsets is not None else None
+        self._disabled_toolsets = list(disabled_toolsets) if disabled_toolsets is not None else None
+        if allow_hermes_tool_bridge is None:
+            env_value = os.getenv("HERMES_CLAUDE_CLI_TOOL_BRIDGE", "1").strip().lower()
+            allow_hermes_tool_bridge = env_value not in {"0", "false", "no", "off"}
+        self._allow_hermes_tool_bridge = bool(allow_hermes_tool_bridge)
+        self._agent_tool_bridge = None
+        if agent_tool_call_callback is not None:
+            self._agent_tool_bridge = AgentLoopBridgeServer(agent_tool_call_callback)
+            self._agent_tool_bridge.start()
+
+    def _build_mcp_config(self) -> dict[str, Any] | None:
+        if not self._allow_hermes_tool_bridge:
+            return None
+        env = {
+            "HERMES_CLAUDE_BRIDGE_TASK_ID": self._hermes_session_uuid,
+            "HERMES_CLAUDE_BRIDGE_ENABLED_TOOLSETS": json.dumps(self._enabled_toolsets),
+            "HERMES_CLAUDE_BRIDGE_DISABLED_TOOLSETS": json.dumps(self._disabled_toolsets),
+            "PYTHONPATH": os.pathsep.join(filter(None, [os.getcwd(), os.getenv("PYTHONPATH", "")])),
+        }
+        if self._agent_tool_bridge is not None:
+            env.update(self._agent_tool_bridge.connection_env())
+        return {
+            "mcpServers": {
+                "hermes-tools": {
+                    "command": sys.executable,
+                    "args": ["-m", "agent.claude_cli_tool_bridge"],
+                    "env": env,
+                }
+            }
+        }
 
     def _build_command(self, *, model: str, prompt_text: str, resume_session_id: str | None = None) -> list[str]:
-        cmd = [self._command, "-p", "--output-format", "json", "--model", model, "--tools", ""]
+        cmd = [self._command, "-p", "--output-format", "json", "--model", model]
+        mcp_config = self._build_mcp_config()
+        if mcp_config:
+            cmd.extend(["--mcp-config", json.dumps(mcp_config), "--strict-mcp-config"])
+        else:
+            cmd.extend(["--tools", ""])
+
         if resume_session_id:
             cmd.extend(["--resume", resume_session_id])
         elif self._claude_session_id:
@@ -168,6 +212,9 @@ class ClaudeCLIClient:
 
     def close(self) -> None:
         self.is_closed = True
+        if self._agent_tool_bridge is not None:
+            self._agent_tool_bridge.close()
+            self._agent_tool_bridge = None
 
     def _create_chat_completion(
         self,

--- a/agent/claude_cli_client.py
+++ b/agent/claude_cli_client.py
@@ -153,13 +153,11 @@ class ClaudeCLIClient:
     ):
         self.api_key = api_key or "claude-cli"
         self.base_url = base_url or CLAUDE_CLI_MARKER_BASE_URL
-        self._default_headers = dict(default_headers or {})
         self._command = command or acp_command or _resolve_command()
         self._args = list(args or acp_args or _resolve_args())
         self._cwd = str(Path(acp_cwd or os.getcwd()).resolve())
         self.chat = _ClaudeCLIChatNamespace(self)
         self.is_closed = False
-        self._last_result: dict[str, Any] | None = None
         self._hermes_session_uuid = _coerce_session_uuid(session_id)
         self._claude_session_id: str | None = None
 
@@ -203,7 +201,6 @@ class ClaudeCLIClient:
             model=(model or "").split("/", 1)[-1],
             timeout_seconds=float(timeout or _DEFAULT_TIMEOUT_SECONDS),
         )
-        self._last_result = payload
         cli_session_id = str(payload.get("session_id") or "").strip()
         if cli_session_id:
             self._claude_session_id = cli_session_id

--- a/agent/claude_cli_client.py
+++ b/agent/claude_cli_client.py
@@ -147,6 +147,27 @@ class ClaudeCLIClient:
         self._hermes_session_uuid = _coerce_session_uuid(session_id)
         self._claude_session_id: str | None = None
 
+    def _build_command(self, *, model: str, prompt_text: str, resume_session_id: str | None = None) -> list[str]:
+        cmd = [self._command, "-p", "--output-format", "json", "--model", model]
+        if resume_session_id:
+            cmd.extend(["--resume", resume_session_id])
+        elif self._claude_session_id:
+            cmd.extend(["--resume", self._claude_session_id])
+        else:
+            cmd.extend(["--session-id", self._hermes_session_uuid])
+        cmd.extend(self._args)
+        cmd.append(prompt_text)
+        return cmd
+
+    def _invoke(self, cmd: list[str], *, timeout_seconds: float) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=self._cwd,
+            timeout=timeout_seconds,
+        )
+
     def close(self) -> None:
         self.is_closed = True
 
@@ -204,21 +225,9 @@ class ClaudeCLIClient:
         )
 
     def _run_prompt(self, prompt_text: str, *, model: str, timeout_seconds: float) -> dict[str, Any]:
-        cmd = [self._command, "-p", "--output-format", "json", "--model", model]
-        if self._claude_session_id:
-            cmd.extend(["--resume", self._claude_session_id])
-        else:
-            cmd.extend(["--session-id", self._hermes_session_uuid])
-        cmd.extend(self._args)
-        cmd.append(prompt_text)
+        cmd = self._build_command(model=model, prompt_text=prompt_text)
         try:
-            proc = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                cwd=self._cwd,
-                timeout=timeout_seconds,
-            )
+            proc = self._invoke(cmd, timeout_seconds=timeout_seconds)
         except FileNotFoundError as exc:
             raise RuntimeError(
                 f"Could not start Claude CLI command '{self._command}'. "
@@ -227,6 +236,21 @@ class ClaudeCLIClient:
 
         stdout = (proc.stdout or "").strip()
         stderr = (proc.stderr or "").strip()
+        combined = f"{stdout}\n{stderr}".strip()
+        if (
+            proc.returncode != 0
+            and not self._claude_session_id
+            and self._hermes_session_uuid in combined
+            and "already in use" in combined.lower()
+        ):
+            retry_cmd = self._build_command(
+                model=model,
+                prompt_text=prompt_text,
+                resume_session_id=self._hermes_session_uuid,
+            )
+            proc = self._invoke(retry_cmd, timeout_seconds=timeout_seconds)
+            stdout = (proc.stdout or "").strip()
+            stderr = (proc.stderr or "").strip()
         if not stdout:
             raise RuntimeError(stderr or "Claude CLI returned no output.")
 

--- a/agent/claude_cli_client.py
+++ b/agent/claude_cli_client.py
@@ -36,6 +36,16 @@ def _resolve_args() -> list[str]:
     return shlex.split(raw) if raw else []
 
 
+def _coerce_session_uuid(session_id: str | None) -> str:
+    raw = str(session_id or "").strip()
+    if not raw:
+        return str(uuid.uuid4())
+    try:
+        return str(uuid.UUID(raw))
+    except Exception:
+        return str(uuid.uuid5(uuid.NAMESPACE_URL, f"hermes:{raw}"))
+
+
 def _render_message_content(content: Any) -> str:
     if content is None:
         return ""
@@ -122,6 +132,7 @@ class ClaudeCLIClient:
         acp_command: str | None = None,
         acp_args: list[str] | None = None,
         acp_cwd: str | None = None,
+        session_id: str | None = None,
         **_: Any,
     ):
         self.api_key = api_key or "claude-cli"
@@ -133,6 +144,8 @@ class ClaudeCLIClient:
         self.chat = _ClaudeCLIChatNamespace(self)
         self.is_closed = False
         self._last_result: dict[str, Any] | None = None
+        self._hermes_session_uuid = _coerce_session_uuid(session_id)
+        self._claude_session_id: str | None = None
 
     def close(self) -> None:
         self.is_closed = True
@@ -152,6 +165,9 @@ class ClaudeCLIClient:
             timeout_seconds=float(timeout or _DEFAULT_TIMEOUT_SECONDS),
         )
         self._last_result = payload
+        cli_session_id = str(payload.get("session_id") or "").strip()
+        if cli_session_id:
+            self._claude_session_id = cli_session_id
 
         usage_payload = payload.get("usage") if isinstance(payload, dict) else {}
         input_tokens = int((usage_payload or {}).get("input_tokens") or 0)
@@ -189,6 +205,10 @@ class ClaudeCLIClient:
 
     def _run_prompt(self, prompt_text: str, *, model: str, timeout_seconds: float) -> dict[str, Any]:
         cmd = [self._command, "-p", "--output-format", "json", "--model", model]
+        if self._claude_session_id:
+            cmd.extend(["--resume", self._claude_session_id])
+        else:
+            cmd.extend(["--session-id", self._hermes_session_uuid])
         cmd.extend(self._args)
         cmd.append(prompt_text)
         try:

--- a/agent/claude_cli_tool_bridge.py
+++ b/agent/claude_cli_tool_bridge.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import json
+import keyword
+import os
+import re
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from agent.claude_cli_agent_bridge import call_agent_loop_tool
+from model_tools import get_tool_definitions, handle_function_call
+
+_AGENT_LOOP_TOOLS = {
+    "clarify",
+    "todo",
+    "memory",
+    "session_search",
+    "delegate_task",
+}
+_TYPE_MAP = {
+    "string": "str | None",
+    "integer": "int | None",
+    "number": "float | None",
+    "boolean": "bool | None",
+    "array": "list[Any] | None",
+    "object": "dict[str, Any] | None",
+}
+_IDENTIFIER_RE = re.compile(r"[^0-9a-zA-Z_]")
+
+
+def _safe_identifier(name: str, used: set[str]) -> str:
+    candidate = _IDENTIFIER_RE.sub("_", name.strip()) or "arg"
+    if candidate[0].isdigit():
+        candidate = f"arg_{candidate}"
+    if keyword.iskeyword(candidate):
+        candidate = f"{candidate}_arg"
+    original = candidate
+    index = 2
+    while candidate in used:
+        candidate = f"{original}_{index}"
+        index += 1
+    used.add(candidate)
+    return candidate
+
+
+def _annotation_for_schema(prop_schema: dict[str, Any]) -> str:
+    schema_type = prop_schema.get("type")
+    if isinstance(schema_type, list):
+        schema_type = next((item for item in schema_type if item != "null"), None)
+    return _TYPE_MAP.get(schema_type or "string", "Any")
+
+
+def _bridgeable_tool_defs(*, enabled_toolsets: list[str] | None, disabled_toolsets: list[str] | None) -> list[dict[str, Any]]:
+    return get_tool_definitions(
+        enabled_toolsets=enabled_toolsets,
+        disabled_toolsets=disabled_toolsets,
+        quiet_mode=True,
+    )
+
+
+def _make_tool_callable(
+    tool_schema: dict[str, Any],
+    *,
+    task_id: str | None,
+    enabled_tools: list[str],
+    agent_loop_bridge: dict[str, str] | None,
+) -> Any:
+    function_schema = tool_schema["function"]
+    tool_name = function_schema["name"]
+    parameters = function_schema.get("parameters") or {}
+    properties = parameters.get("properties") or {}
+    required = set(parameters.get("required") or [])
+
+    used_names: set[str] = set()
+    arg_mapping: list[tuple[str, str]] = []
+    signature_parts: list[str] = []
+    globals_dict: dict[str, Any] = {
+        "Any": Any,
+        "call_agent_loop_tool": call_agent_loop_tool,
+        "handle_function_call": handle_function_call,
+        "json": json,
+        "_task_id": task_id,
+        "_enabled_tools": enabled_tools,
+        "_tool_name": tool_name,
+        "_required_names": required,
+        "_agent_loop_bridge": agent_loop_bridge,
+        "_AGENT_LOOP_TOOLS": _AGENT_LOOP_TOOLS,
+    }
+
+    for prop_name, prop_schema in properties.items():
+        py_name = _safe_identifier(prop_name, used_names)
+        arg_mapping.append((py_name, prop_name))
+        annotation_expr = _annotation_for_schema(prop_schema)
+        globals_dict[f"_ann_{py_name}"] = eval(annotation_expr, {"Any": Any})
+        if prop_name in required:
+            signature_parts.append(f"{py_name}: _ann_{py_name}")
+        else:
+            signature_parts.append(f"{py_name}: _ann_{py_name} = None")
+
+    assignment_lines = []
+    for py_name, prop_name in arg_mapping:
+        assignment_lines.append(
+            "    if {py_name} is not None or {prop_name!r} in _required_names:\n"
+            "        payload[{prop_name!r}] = {py_name}".format(py_name=py_name, prop_name=prop_name)
+        )
+
+    signature = ", ".join(signature_parts)
+    if signature:
+        signature = f"{signature}, "
+
+    source = (
+        f"def _tool({signature}__tool_call_context__: str | None = None) -> str:\n"
+        "    payload = {}\n"
+        + ("\n".join(assignment_lines) + "\n" if assignment_lines else "")
+        + "    if __tool_call_context__:\n"
+        + "        payload.setdefault('_bridge_context', __tool_call_context__)\n"
+        + "    if _tool_name in _AGENT_LOOP_TOOLS:\n"
+        + "        if not _agent_loop_bridge:\n"
+        + "            raise RuntimeError(f'Agent-loop bridge unavailable for {_tool_name}.')\n"
+        + "        return call_agent_loop_tool(_tool_name, payload, host=_agent_loop_bridge['host'], port=int(_agent_loop_bridge['port']), authkey_hex=_agent_loop_bridge['authkey'])\n"
+        + "    return handle_function_call(_tool_name, payload, task_id=_task_id, enabled_tools=_enabled_tools)\n"
+    )
+    namespace: dict[str, Any] = {}
+    exec(source, globals_dict, namespace)
+    tool_fn = namespace["_tool"]
+    tool_fn.__name__ = f"bridge_{tool_name.replace('-', '_')}"
+    tool_fn.__doc__ = function_schema.get("description") or f"Hermes bridged tool: {tool_name}"
+    return tool_fn
+
+
+def create_claude_cli_tool_bridge(*, enabled_toolsets: list[str] | None = None, disabled_toolsets: list[str] | None = None, task_id: str | None = None, agent_loop_bridge: dict[str, str] | None = None) -> FastMCP:
+    mcp = FastMCP(
+        "hermes-tools",
+        instructions=(
+            "Hermes Agent tool bridge for Claude CLI. Call these tools instead of "
+            "describing hypothetical tool usage."
+        ),
+    )
+    tool_defs = _bridgeable_tool_defs(enabled_toolsets=enabled_toolsets, disabled_toolsets=disabled_toolsets)
+    enabled_tools = [tool_def["function"]["name"] for tool_def in tool_defs]
+    for tool_def in tool_defs:
+        function_schema = tool_def["function"]
+        mcp.tool(
+            name=function_schema["name"],
+            description=function_schema.get("description") or function_schema["name"],
+        )(
+            _make_tool_callable(tool_def, task_id=task_id, enabled_tools=enabled_tools, agent_loop_bridge=agent_loop_bridge)
+        )
+    return mcp
+
+
+def run_stdio_bridge() -> None:
+    enabled_toolsets = json.loads(os.getenv("HERMES_CLAUDE_BRIDGE_ENABLED_TOOLSETS", "null"))
+    disabled_toolsets = json.loads(os.getenv("HERMES_CLAUDE_BRIDGE_DISABLED_TOOLSETS", "null"))
+    task_id = os.getenv("HERMES_CLAUDE_BRIDGE_TASK_ID") or None
+    host = os.getenv("HERMES_AGENT_BRIDGE_HOST", "").strip()
+    port = os.getenv("HERMES_AGENT_BRIDGE_PORT", "").strip()
+    authkey = os.getenv("HERMES_AGENT_BRIDGE_AUTHKEY", "").strip()
+    agent_loop_bridge = None
+    if host and port and authkey:
+        agent_loop_bridge = {"host": host, "port": port, "authkey": authkey}
+    server = create_claude_cli_tool_bridge(
+        enabled_toolsets=enabled_toolsets,
+        disabled_toolsets=disabled_toolsets,
+        task_id=task_id,
+        agent_loop_bridge=agent_loop_bridge,
+    )
+    server.run()
+
+
+if __name__ == "__main__":
+    run_stdio_bridge()

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -70,7 +70,7 @@ DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 DEFAULT_GITHUB_MODELS_BASE_URL = "https://api.githubcopilot.com"
 DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
 DEFAULT_CLAUDE_CLI_BASE_URL = "claude-cli://local"
-CODEX_OAUTH_CLIENT_ID="app_EM...rann"
+CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
 CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -69,7 +69,8 @@ DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS = 1     # poll at most every 1s
 DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 DEFAULT_GITHUB_MODELS_BASE_URL = "https://api.githubcopilot.com"
 DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
-CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+DEFAULT_CLAUDE_CLI_BASE_URL = "claude-cli://local"
+CODEX_OAUTH_CLIENT_ID="app_EM...rann"
 CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
 CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
 
@@ -124,6 +125,31 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="external_process",
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
+        extra={
+            "command_env_vars": ["HERMES_COPILOT_ACP_COMMAND", "COPILOT_CLI_PATH"],
+            "default_command": "copilot",
+            "args_env_var": "HERMES_COPILOT_ACP_ARGS",
+            "default_args": ["--acp", "--stdio"],
+            "remote_base_url_prefixes": ["acp+tcp://"],
+            "missing_command_code": "missing_copilot_cli",
+            "missing_command_message": "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH.",
+        },
+    ),
+    "claude-cli": ProviderConfig(
+        id="claude-cli",
+        name="Claude CLI",
+        auth_type="external_process",
+        inference_base_url=DEFAULT_CLAUDE_CLI_BASE_URL,
+        base_url_env_var="HERMES_CLAUDE_CLI_BASE_URL",
+        extra={
+            "command_env_vars": ["HERMES_CLAUDE_CLI_COMMAND", "CLAUDE_CLI_PATH"],
+            "default_command": "claude",
+            "args_env_var": "HERMES_CLAUDE_CLI_ARGS",
+            "default_args": [],
+            "remote_base_url_prefixes": ["claude-cli+ssh://"],
+            "missing_command_code": "missing_claude_cli",
+            "missing_command_message": "Install Claude Code CLI or set HERMES_CLAUDE_CLI_COMMAND/CLAUDE_CLI_PATH.",
+        },
     ),
     "zai": ProviderConfig(
         id="zai",
@@ -735,6 +761,7 @@ def resolve_provider(
         "kimi": "kimi-coding", "moonshot": "kimi-coding",
         "minimax-china": "minimax-cn", "minimax_cn": "minimax-cn",
         "claude": "anthropic", "claude-code": "anthropic",
+        "claude-local": "claude-cli", "claude-binary": "claude-cli",
         "github": "copilot", "github-copilot": "copilot",
         "github-models": "copilot", "github-model": "copilot",
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
@@ -1911,27 +1938,33 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     if not pconfig or pconfig.auth_type != "external_process":
         return {"configured": False}
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    extra = pconfig.extra if isinstance(pconfig.extra, dict) else {}
+    command = ""
+    for env_name in list(extra.get("command_env_vars") or []):
+        command = os.getenv(str(env_name), "").strip()
+        if command:
+            break
+    if not command:
+        command = str(extra.get("default_command") or "").strip()
+
+    raw_args = os.getenv(str(extra.get("args_env_var") or ""), "").strip() if extra.get("args_env_var") else ""
+    args = shlex.split(raw_args) if raw_args else list(extra.get("default_args") or [])
     base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
 
     resolved_command = shutil.which(command) if command else None
+    remote_prefixes = tuple(str(prefix) for prefix in (extra.get("remote_base_url_prefixes") or []))
+    is_remote = bool(base_url and any(base_url.startswith(prefix) for prefix in remote_prefixes))
     return {
-        "configured": bool(resolved_command or base_url.startswith("acp+tcp://")),
+        "configured": bool(resolved_command or is_remote),
         "provider": provider_id,
         "name": pconfig.name,
         "command": command,
         "args": args,
         "resolved_command": resolved_command,
         "base_url": base_url,
-        "logged_in": bool(resolved_command or base_url.startswith("acp+tcp://")),
+        "logged_in": bool(resolved_command or is_remote),
     }
 
 
@@ -1942,10 +1975,9 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_nous_auth_status()
     if target == "openai-codex":
         return get_codex_auth_status()
-    if target == "copilot-acp":
-        return get_external_process_provider_status(target)
-    # API-key providers
     pconfig = PROVIDER_REGISTRY.get(target)
+    if pconfig and pconfig.auth_type == "external_process":
+        return get_external_process_provider_status(target)
     if pconfig and pconfig.auth_type == "api_key":
         return get_api_key_provider_status(target)
     return {"logged_in": False}
@@ -2001,25 +2033,31 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
     if not base_url:
         base_url = pconfig.inference_base_url
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    extra = pconfig.extra if isinstance(pconfig.extra, dict) else {}
+    command = ""
+    for env_name in list(extra.get("command_env_vars") or []):
+        command = os.getenv(str(env_name), "").strip()
+        if command:
+            break
+    if not command:
+        command = str(extra.get("default_command") or "").strip()
+
+    raw_args = os.getenv(str(extra.get("args_env_var") or ""), "").strip() if extra.get("args_env_var") else ""
+    args = shlex.split(raw_args) if raw_args else list(extra.get("default_args") or [])
     resolved_command = shutil.which(command) if command else None
-    if not resolved_command and not base_url.startswith("acp+tcp://"):
+    remote_prefixes = tuple(str(prefix) for prefix in (extra.get("remote_base_url_prefixes") or []))
+    is_remote = bool(base_url and any(base_url.startswith(prefix) for prefix in remote_prefixes))
+    if not resolved_command and not is_remote:
         raise AuthError(
-            f"Could not find the Copilot CLI command '{command}'. "
-            "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH.",
+            f"Could not find the {pconfig.name} command '{command}'. "
+            f"{extra.get('missing_command_message') or 'Install the provider CLI or configure its command path.'}",
             provider=provider_id,
-            code="missing_copilot_cli",
+            code=str(extra.get("missing_command_code") or "missing_external_process_command"),
         )
 
     return {
         "provider": provider_id,
-        "api_key": "copilot-acp",
+        "api_key": provider_id,
         "base_url": base_url.rstrip("/"),
         "command": resolved_command or command,
         "args": args,

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1932,13 +1932,10 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     }
 
 
-def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
-    """Status snapshot for providers that run a local subprocess."""
-    pconfig = PROVIDER_REGISTRY.get(provider_id)
-    if not pconfig or pconfig.auth_type != "external_process":
-        return {"configured": False}
-
+def _external_process_provider_runtime(pconfig: ProviderConfig) -> Dict[str, Any]:
+    """Resolve shared command/base-url details for external-process providers."""
     extra = pconfig.extra if isinstance(pconfig.extra, dict) else {}
+
     command = ""
     for env_name in list(extra.get("command_env_vars") or []):
         command = os.getenv(str(env_name), "").strip()
@@ -1957,14 +1954,33 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     remote_prefixes = tuple(str(prefix) for prefix in (extra.get("remote_base_url_prefixes") or []))
     is_remote = bool(base_url and any(base_url.startswith(prefix) for prefix in remote_prefixes))
     return {
-        "configured": bool(resolved_command or is_remote),
-        "provider": provider_id,
-        "name": pconfig.name,
         "command": command,
         "args": args,
         "resolved_command": resolved_command,
         "base_url": base_url,
-        "logged_in": bool(resolved_command or is_remote),
+        "is_remote": is_remote,
+        "extra": extra,
+    }
+
+
+
+def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
+    """Status snapshot for providers that run a local subprocess."""
+    pconfig = PROVIDER_REGISTRY.get(provider_id)
+    if not pconfig or pconfig.auth_type != "external_process":
+        return {"configured": False}
+
+    runtime = _external_process_provider_runtime(pconfig)
+    configured = bool(runtime["resolved_command"] or runtime["is_remote"])
+    return {
+        "configured": configured,
+        "provider": provider_id,
+        "name": pconfig.name,
+        "command": runtime["command"],
+        "args": runtime["args"],
+        "resolved_command": runtime["resolved_command"],
+        "base_url": runtime["base_url"],
+        "logged_in": configured,
     }
 
 
@@ -2029,38 +2045,21 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
             code="invalid_provider",
         )
 
-    base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
-    if not base_url:
-        base_url = pconfig.inference_base_url
-
-    extra = pconfig.extra if isinstance(pconfig.extra, dict) else {}
-    command = ""
-    for env_name in list(extra.get("command_env_vars") or []):
-        command = os.getenv(str(env_name), "").strip()
-        if command:
-            break
-    if not command:
-        command = str(extra.get("default_command") or "").strip()
-
-    raw_args = os.getenv(str(extra.get("args_env_var") or ""), "").strip() if extra.get("args_env_var") else ""
-    args = shlex.split(raw_args) if raw_args else list(extra.get("default_args") or [])
-    resolved_command = shutil.which(command) if command else None
-    remote_prefixes = tuple(str(prefix) for prefix in (extra.get("remote_base_url_prefixes") or []))
-    is_remote = bool(base_url and any(base_url.startswith(prefix) for prefix in remote_prefixes))
-    if not resolved_command and not is_remote:
+    runtime = _external_process_provider_runtime(pconfig)
+    if not runtime["resolved_command"] and not runtime["is_remote"]:
         raise AuthError(
-            f"Could not find the {pconfig.name} command '{command}'. "
-            f"{extra.get('missing_command_message') or 'Install the provider CLI or configure its command path.'}",
+            f"Could not find the {pconfig.name} command '{runtime['command']}'. "
+            f"{runtime['extra'].get('missing_command_message') or 'Install the provider CLI or configure its command path.'}",
             provider=provider_id,
-            code=str(extra.get("missing_command_code") or "missing_external_process_command"),
+            code=str(runtime["extra"].get("missing_command_code") or "missing_external_process_command"),
         )
 
     return {
         "provider": provider_id,
         "api_key": provider_id,
-        "base_url": base_url.rstrip("/"),
-        "command": resolved_command or command,
-        "args": args,
+        "base_url": runtime["base_url"].rstrip("/"),
+        "command": runtime["resolved_command"] or runtime["command"],
+        "args": runtime["args"],
         "source": "process",
     }
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -173,39 +173,41 @@ def _relative_time(ts) -> str:
 
 def _has_any_provider_configured() -> bool:
     """Check if at least one inference provider is usable."""
-    from hermes_cli.config import get_env_path, get_hermes_home, load_config
-    from hermes_cli.auth import get_auth_status
+    from hermes_cli.config import DEFAULT_CONFIG, get_env_path, get_hermes_home, load_config
+    from hermes_cli.auth import PROVIDER_REGISTRY, get_auth_status
 
-    # Determine whether Hermes itself has been explicitly configured (model
-    # in config that isn't the hardcoded default). Used below to gate external
-    # tool credentials (Claude Code, Codex CLI) that shouldn't silently skip
-    # the setup wizard on a fresh install.
-    from hermes_cli.config import DEFAULT_CONFIG
-    _DEFAULT_MODEL = DEFAULT_CONFIG.get("model", "")
     cfg = load_config()
     model_cfg = cfg.get("model")
     if isinstance(model_cfg, dict):
-        _model_name = (model_cfg.get("default") or "").strip()
+        model_name = (model_cfg.get("default") or "").strip()
     elif isinstance(model_cfg, str):
-        _model_name = model_cfg.strip()
+        model_name = model_cfg.strip()
     else:
-        _model_name = ""
-    _has_hermes_config = _model_name and _model_name != _DEFAULT_MODEL
+        model_name = ""
 
-    # Check env vars (may be set by .env or shell).
-    # OPENAI_BASE_URL alone counts — local models (vLLM, llama.cpp, etc.)
-    # often don't require an API key.
-    from hermes_cli.auth import PROVIDER_REGISTRY
+    default_model = DEFAULT_CONFIG.get("model", "")
+    has_hermes_config = bool(model_name and model_name != default_model)
 
-    # Collect all provider env vars
-    provider_env_vars = {"OPENROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "OPENAI_BASE_URL"}
-    for pconfig in PROVIDER_REGISTRY.values():
-        if pconfig.auth_type == "api_key":
-            provider_env_vars.update(pconfig.api_key_env_vars)
+    provider_env_vars = {
+        "OPENROUTER_API_KEY",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_TOKEN",
+        "OPENAI_BASE_URL",
+    }
+    for provider_id, pconfig in PROVIDER_REGISTRY.items():
+        if pconfig.auth_type != "api_key":
+            continue
+        # Copilot shell env vars like GH_TOKEN/GITHUB_TOKEN are often present for
+        # unrelated GitHub workflows and should not silently skip Hermes setup on a
+        # fresh install. Copilot still counts below via explicit gh CLI detection.
+        if provider_id == "copilot":
+            continue
+        provider_env_vars.update(pconfig.api_key_env_vars)
+
     if any(os.getenv(v) for v in provider_env_vars):
         return True
 
-    # Check .env file for keys
     env_file = get_env_path()
     if env_file.exists():
         try:
@@ -214,24 +216,19 @@ def _has_any_provider_configured() -> bool:
                 if line.startswith("#") or "=" not in line:
                     continue
                 key, _, val = line.partition("=")
-                val = val.strip().strip("'\"")
-                if key.strip() in provider_env_vars and val:
+                if key.strip() in provider_env_vars and val.strip().strip("'\""):
                     return True
         except Exception:
             pass
 
-    # Check provider-specific auth fallbacks (for example, Copilot via gh auth).
     try:
-        for provider_id, pconfig in PROVIDER_REGISTRY.items():
-            if pconfig.auth_type != "api_key":
-                continue
-            status = get_auth_status(provider_id)
-            if status.get("logged_in"):
-                return True
+        from hermes_cli.copilot_auth import _try_gh_cli_token
+
+        if _try_gh_cli_token():
+            return True
     except Exception:
         pass
 
-    # Check for Nous Portal OAuth credentials
     auth_file = get_hermes_home() / "auth.json"
     if auth_file.exists():
         try:
@@ -245,11 +242,6 @@ def _has_any_provider_configured() -> bool:
         except Exception:
             pass
 
-
-    # Check config.yaml — if model is a dict with an explicit provider set,
-    # the user has gone through setup (fresh installs have model as a plain
-    # string).  Also covers custom endpoints that store api_key/base_url in
-    # config rather than .env.
     if isinstance(model_cfg, dict):
         cfg_provider = (model_cfg.get("provider") or "").strip()
         cfg_base_url = (model_cfg.get("base_url") or "").strip()
@@ -257,10 +249,7 @@ def _has_any_provider_configured() -> bool:
         if cfg_provider or cfg_base_url or cfg_api_key:
             return True
 
-    # Check for Claude Code OAuth credentials (~/.claude/.credentials.json)
-    # Only count these if Hermes has been explicitly configured — Claude Code
-    # being installed doesn't mean the user wants Hermes to use their tokens.
-    if _has_hermes_config:
+    if has_hermes_config:
         try:
             from agent.anthropic_adapter import read_claude_code_credentials, is_claude_code_token_valid
             creds = read_claude_code_credentials()
@@ -4038,7 +4027,7 @@ For more help on a command:
     )
     chat_parser.add_argument(
         "--provider",
-        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode"],
+        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "claude-cli", "copilot", "anthropic", "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode"],
         default=None,
         help="Inference provider (default: auto)"
     )

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -173,28 +173,32 @@ def _relative_time(ts) -> str:
 
 def _has_any_provider_configured() -> bool:
     """Check if at least one inference provider is usable."""
-    from hermes_cli.config import DEFAULT_CONFIG, get_env_path, get_hermes_home, load_config
-    from hermes_cli.auth import PROVIDER_REGISTRY, get_auth_status
+    from hermes_cli.config import get_env_path, get_hermes_home, load_config
+    from hermes_cli.auth import get_auth_status
 
+    # Determine whether Hermes itself has been explicitly configured (model
+    # in config that isn't the hardcoded default). Used below to gate external
+    # tool credentials (Claude Code, Codex CLI) that shouldn't silently skip
+    # the setup wizard on a fresh install.
+    from hermes_cli.config import DEFAULT_CONFIG
+    _DEFAULT_MODEL = DEFAULT_CONFIG.get("model", "")
     cfg = load_config()
     model_cfg = cfg.get("model")
     if isinstance(model_cfg, dict):
-        model_name = (model_cfg.get("default") or "").strip()
+        _model_name = (model_cfg.get("default") or "").strip()
     elif isinstance(model_cfg, str):
-        model_name = model_cfg.strip()
+        _model_name = model_cfg.strip()
     else:
-        model_name = ""
+        _model_name = ""
+    _has_hermes_config = _model_name and _model_name != _DEFAULT_MODEL
 
-    default_model = DEFAULT_CONFIG.get("model", "")
-    has_hermes_config = bool(model_name and model_name != default_model)
+    # Check env vars (may be set by .env or shell).
+    # OPENAI_BASE_URL alone counts — local models (vLLM, llama.cpp, etc.)
+    # often don't require an API key.
+    from hermes_cli.auth import PROVIDER_REGISTRY
 
-    provider_env_vars = {
-        "OPENROUTER_API_KEY",
-        "OPENAI_API_KEY",
-        "ANTHROPIC_API_KEY",
-        "ANTHROPIC_TOKEN",
-        "OPENAI_BASE_URL",
-    }
+    # Collect all provider env vars
+    provider_env_vars = {"OPENROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "OPENAI_BASE_URL"}
     for provider_id, pconfig in PROVIDER_REGISTRY.items():
         if pconfig.auth_type != "api_key":
             continue
@@ -204,10 +208,10 @@ def _has_any_provider_configured() -> bool:
         if provider_id == "copilot":
             continue
         provider_env_vars.update(pconfig.api_key_env_vars)
-
     if any(os.getenv(v) for v in provider_env_vars):
         return True
 
+    # Check .env file for keys
     env_file = get_env_path()
     if env_file.exists():
         try:
@@ -216,7 +220,8 @@ def _has_any_provider_configured() -> bool:
                 if line.startswith("#") or "=" not in line:
                     continue
                 key, _, val = line.partition("=")
-                if key.strip() in provider_env_vars and val.strip().strip("'\""):
+                val = val.strip().strip("'\"")
+                if key.strip() in provider_env_vars and val:
                     return True
         except Exception:
             pass
@@ -229,6 +234,7 @@ def _has_any_provider_configured() -> bool:
     except Exception:
         pass
 
+    # Check for Nous Portal OAuth credentials
     auth_file = get_hermes_home() / "auth.json"
     if auth_file.exists():
         try:
@@ -242,6 +248,11 @@ def _has_any_provider_configured() -> bool:
         except Exception:
             pass
 
+
+    # Check config.yaml — if model is a dict with an explicit provider set,
+    # the user has gone through setup (fresh installs have model as a plain
+    # string).  Also covers custom endpoints that store api_key/base_url in
+    # config rather than .env.
     if isinstance(model_cfg, dict):
         cfg_provider = (model_cfg.get("provider") or "").strip()
         cfg_base_url = (model_cfg.get("base_url") or "").strip()
@@ -249,7 +260,10 @@ def _has_any_provider_configured() -> bool:
         if cfg_provider or cfg_base_url or cfg_api_key:
             return True
 
-    if has_hermes_config:
+    # Check for Claude Code OAuth credentials (~/.claude/.credentials.json)
+    # Only count these if Hermes has been explicitly configured — Claude Code
+    # being installed doesn't mean the user wants Hermes to use their tokens.
+    if _has_hermes_config:
         try:
             from agent.anthropic_adapter import read_claude_code_credentials, is_claude_code_token_valid
             creds = read_claude_code_credentials()
@@ -901,6 +915,7 @@ def select_provider_and_model(args=None):
         "nous": "Nous Portal",
         "openai-codex": "OpenAI Codex",
         "copilot-acp": "GitHub Copilot ACP",
+        "claude-cli": "Claude CLI",
         "copilot": "GitHub Copilot",
         "anthropic": "Anthropic",
         "zai": "Z.AI / GLM",
@@ -928,6 +943,7 @@ def select_provider_and_model(args=None):
         ("nous", "Nous Portal (Nous Research subscription)"),
         ("openai-codex", "OpenAI Codex"),
         ("copilot-acp", "GitHub Copilot ACP (spawns `copilot --acp --stdio`)"),
+        ("claude-cli", "Claude CLI (spawns local `claude -p --output-format json`)"),
         ("copilot", "GitHub Copilot (uses GITHUB_TOKEN or gh auth token)"),
         ("anthropic", "Anthropic (Claude models — API key or Claude Code)"),
         ("zai", "Z.AI / GLM (Zhipu AI direct API)"),
@@ -1000,6 +1016,8 @@ def select_provider_and_model(args=None):
         _model_flow_openai_codex(config, current_model)
     elif selected_provider == "copilot-acp":
         _model_flow_copilot_acp(config, current_model)
+    elif selected_provider == "claude-cli":
+        _model_flow_claude_cli(config, current_model)
     elif selected_provider == "copilot":
         _model_flow_copilot(config, current_model)
     elif selected_provider == "custom":
@@ -1987,6 +2005,74 @@ def _model_flow_copilot_acp(config, current_model=""):
         catalog=catalog,
         api_key=catalog_api_key,
     ) or selected
+    _save_model_choice(selected)
+
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = provider_id
+    model["base_url"] = effective_base
+    model["api_mode"] = "chat_completions"
+    save_config(cfg)
+    deactivate_provider()
+
+    print(f"Default model set to: {selected} (via {pconfig.name})")
+
+
+def _model_flow_claude_cli(config, current_model=""):
+    """Claude CLI flow using the local Claude Code binary as the inference backend."""
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY,
+        _prompt_model_selection,
+        _save_model_choice,
+        deactivate_provider,
+        get_external_process_provider_status,
+        resolve_external_process_provider_credentials,
+    )
+    from hermes_cli.models import _PROVIDER_MODELS
+    from hermes_cli.config import load_config, save_config
+
+    del config
+
+    provider_id = "claude-cli"
+    pconfig = PROVIDER_REGISTRY[provider_id]
+
+    status = get_external_process_provider_status(provider_id)
+    resolved_command = status.get("resolved_command") or status.get("command") or "claude"
+    effective_base = status.get("base_url") or pconfig.inference_base_url
+
+    print("  Claude CLI delegates Hermes turns to your local `claude` binary.")
+    print("  Hermes uses the local CLI for model inference instead of Anthropic's direct API.")
+    print("  Hermes keeps this backend in text-in/text-out mode for now, so Hermes-side tools stay disabled.")
+    print("  Later turns automatically resume the same Claude CLI conversation when available.")
+    print(f"  Command: {resolved_command}")
+    print(f"  Backend marker: {effective_base}")
+    print()
+
+    try:
+        creds = resolve_external_process_provider_credentials(provider_id)
+    except Exception as exc:
+        print(f"  ⚠ {exc}")
+        print("  Set HERMES_CLAUDE_CLI_COMMAND or CLAUDE_CLI_PATH if Claude CLI is installed elsewhere.")
+        return
+
+    effective_base = creds.get("base_url") or effective_base
+    model_list = _PROVIDER_MODELS.get(provider_id, [])
+
+    if model_list:
+        selected = _prompt_model_selection(model_list, current_model=current_model)
+    else:
+        try:
+            selected = input("Model name: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            selected = None
+
+    if not selected:
+        print("No change.")
+        return
+
     _save_model_choice(selected)
 
     cfg = load_config()

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -96,6 +96,15 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "claude-cli": [
+        "claude-cli/claude-opus-4-6",
+        "claude-cli/claude-sonnet-4-6",
+        "claude-cli/claude-opus-4-5-20251101",
+        "claude-cli/claude-sonnet-4-5-20250929",
+        "claude-cli/claude-opus-4-20250514",
+        "claude-cli/claude-sonnet-4-20250514",
+        "claude-cli/claude-haiku-4-5-20251001",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -259,6 +268,7 @@ _PROVIDER_LABELS = {
     "openrouter": "OpenRouter",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
+    "claude-cli": "Claude CLI",
     "nous": "Nous Portal",
     "copilot": "GitHub Copilot",
     "zai": "Z.AI / GLM",
@@ -287,6 +297,8 @@ _PROVIDER_ALIASES = {
     "github-model": "copilot",
     "github-copilot-acp": "copilot-acp",
     "copilot-acp-agent": "copilot-acp",
+    "claude-local": "claude-cli",
+    "claude-binary": "claude-cli",
     "kimi": "kimi-coding",
     "moonshot": "kimi-coding",
     "minimax-china": "minimax-cn",
@@ -343,7 +355,7 @@ def list_available_providers() -> list[dict[str, str]]:
     """
     # Canonical providers in display order
     _PROVIDER_ORDER = [
-        "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
+        "openrouter", "nous", "openai-codex", "copilot", "copilot-acp", "claude-cli",
         "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "anthropic", "alibaba",
         "opencode-zen", "opencode-go",
         "ai-gateway", "deepseek", "custom",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -648,10 +648,10 @@ def resolve_runtime_provider(
             "requested_provider": requested_provider,
         }
 
-    if provider == "copilot-acp":
+    if provider in {"copilot-acp", "claude-cli"}:
         creds = resolve_external_process_provider_credentials(provider)
         return {
-            "provider": "copilot-acp",
+            "provider": provider,
             "api_mode": "chat_completions",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -92,6 +92,12 @@ _DEFAULT_PROVIDER_MODELS = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "claude-cli": [
+        "claude-cli/claude-opus-4-6",
+        "claude-cli/claude-sonnet-4-6",
+        "claude-cli/claude-opus-4-20250514",
+        "claude-cli/claude-sonnet-4-20250514",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -1029,6 +1035,7 @@ def setup_model_provider(config: dict):
             "nous-api": "Nous Portal API key",
             "copilot": "GitHub Copilot",
             "copilot-acp": "GitHub Copilot ACP",
+            "claude-cli": "Claude CLI",
             "zai": "Z.AI / GLM",
             "kimi-coding": "Kimi / Moonshot",
             "minimax": "MiniMax",

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -152,12 +152,20 @@ def show_status(args):
     print(color("◆ Auth Providers", Colors.CYAN, Colors.BOLD))
 
     try:
-        from hermes_cli.auth import get_nous_auth_status, get_codex_auth_status
+        from hermes_cli.auth import (
+            get_nous_auth_status,
+            get_codex_auth_status,
+            get_external_process_provider_status,
+        )
         nous_status = get_nous_auth_status()
         codex_status = get_codex_auth_status()
+        copilot_acp_status = get_external_process_provider_status("copilot-acp")
+        claude_cli_status = get_external_process_provider_status("claude-cli")
     except Exception:
         nous_status = {}
         codex_status = {}
+        copilot_acp_status = {}
+        claude_cli_status = {}
 
     nous_logged_in = bool(nous_status.get("logged_in"))
     print(
@@ -187,6 +195,25 @@ def show_status(args):
         print(f"    Refreshed:  {codex_last_refresh}")
     if codex_status.get("error") and not codex_logged_in:
         print(f"    Error:      {codex_status.get('error')}")
+
+    for label, status, configure_hint in (
+        ("Copilot ACP", copilot_acp_status, "Set HERMES_COPILOT_ACP_COMMAND if Copilot CLI is installed elsewhere"),
+        ("Claude CLI", claude_cli_status, "Set HERMES_CLAUDE_CLI_COMMAND if Claude CLI is installed elsewhere"),
+    ):
+        configured = bool(status.get("logged_in") or status.get("configured"))
+        print(
+            f"  {label:<12}  {check_mark(configured)} "
+            f"{'configured' if configured else 'not configured (run: hermes model)'}"
+        )
+        if configured:
+            command = status.get("resolved_command") or status.get("command") or "(unknown)"
+            base_url = status.get("base_url") or "(unknown)"
+            args = " ".join(status.get("args") or []) or "(default)"
+            print(f"    Command:    {command}")
+            print(f"    Args:       {args}")
+            print(f"    Backend:    {base_url}")
+        else:
+            print(f"    Hint:       {configure_hint}")
 
     # =========================================================================
     # Nous Subscription Features

--- a/run_agent.py
+++ b/run_agent.py
@@ -772,7 +772,7 @@ class AIAgent:
                 # Explicit credentials from CLI/gateway — construct directly.
                 # The runtime provider resolver already handled auth for us.
                 client_kwargs = {"api_key": api_key, "base_url": base_url}
-                if self.provider == "copilot-acp":
+                if self.provider in {"copilot-acp", "claude-cli"}:
                     client_kwargs["command"] = self.acp_command
                     client_kwargs["args"] = self.acp_args
                 effective_base = base_url
@@ -886,12 +886,16 @@ class AIAgent:
                 print(f"🔄 Fallback chain ({len(self._fallback_chain)} providers): " +
                       " → ".join(f"{f['model']} ({f['provider']})" for f in self._fallback_chain))
 
-        # Get available tools with filtering
+        # Get available tools with filtering. Claude CLI backend currently runs
+        # in text-in/text-out mode, so keep Hermes-side tools disabled to avoid
+        # misleading prompts and unsupported tool-call expectations.
         self.tools = get_tool_definitions(
             enabled_toolsets=enabled_toolsets,
             disabled_toolsets=disabled_toolsets,
             quiet_mode=self.quiet_mode,
         )
+        if self.provider == "claude-cli":
+            self.tools = []
         
         # Show tool configuration and store valid tool names for validation
         self.valid_tool_names = set()
@@ -3371,6 +3375,17 @@ class AIAgent:
             client = CopilotACPClient(**client_kwargs)
             logger.info(
                 "Copilot ACP client created (%s, shared=%s) %s",
+                reason,
+                shared,
+                self._client_log_context(),
+            )
+            return client
+        if self.provider == "claude-cli" or str(client_kwargs.get("base_url", "")).startswith("claude-cli://"):
+            from agent.claude_cli_client import ClaudeCLIClient
+
+            client = ClaudeCLIClient(**client_kwargs)
+            logger.info(
+                "Claude CLI client created (%s, shared=%s) %s",
                 reason,
                 shared,
                 self._client_log_context(),

--- a/run_agent.py
+++ b/run_agent.py
@@ -895,7 +895,11 @@ class AIAgent:
             disabled_toolsets=disabled_toolsets,
             quiet_mode=self.quiet_mode,
         )
-        if self.provider == "claude-cli":
+        is_claude_cli_transport = (
+            self.provider == "claude-cli"
+            or str(self.base_url or "").startswith("claude-cli://")
+        )
+        if is_claude_cli_transport:
             self.tools = []
         
         # Show tool configuration and store valid tool names for validation

--- a/run_agent.py
+++ b/run_agent.py
@@ -775,6 +775,7 @@ class AIAgent:
                 if self.provider in {"copilot-acp", "claude-cli"}:
                     client_kwargs["command"] = self.acp_command
                     client_kwargs["args"] = self.acp_args
+                    client_kwargs["session_id"] = session_id
                 effective_base = base_url
                 if "openrouter" in effective_base.lower():
                     client_kwargs["default_headers"] = {

--- a/run_agent.py
+++ b/run_agent.py
@@ -887,19 +887,22 @@ class AIAgent:
                 print(f"🔄 Fallback chain ({len(self._fallback_chain)} providers): " +
                       " → ".join(f"{f['model']} ({f['provider']})" for f in self._fallback_chain))
 
-        # Get available tools with filtering. Claude CLI backend currently runs
-        # in text-in/text-out mode, so keep Hermes-side tools disabled to avoid
-        # misleading prompts and unsupported tool-call expectations.
+        # Get available tools with filtering.
+        #
+        # Claude CLI backend currently wraps `claude -p --output-format json`
+        # as a text-in/text-out provider. Hermes is only borrowing Claude Code's
+        # model runtime here — not its native tool protocol. Because this backend
+        # does not yet translate Claude Code tool use into Hermes tool calls,
+        # advertising Hermes tools in the prompt would be dishonest and would
+        # produce non-executable natural-language/tool-ish output instead of real
+        # structured tool calls. Keep Hermes-side tools disabled for `claude-cli`
+        # until a future implementation adds an actual tool-call bridge.
         self.tools = get_tool_definitions(
             enabled_toolsets=enabled_toolsets,
             disabled_toolsets=disabled_toolsets,
             quiet_mode=self.quiet_mode,
         )
-        is_claude_cli_transport = (
-            self.provider == "claude-cli"
-            or str(self.base_url or "").startswith("claude-cli://")
-        )
-        if is_claude_cli_transport:
+        if self.provider == "claude-cli" or str(self.base_url or "").startswith("claude-cli://"):
             self.tools = []
         
         # Show tool configuration and store valid tool names for validation

--- a/run_agent.py
+++ b/run_agent.py
@@ -776,6 +776,10 @@ class AIAgent:
                     client_kwargs["command"] = self.acp_command
                     client_kwargs["args"] = self.acp_args
                     client_kwargs["session_id"] = session_id
+                    if self.provider == "claude-cli" or str(base_url).startswith("claude-cli://"):
+                        client_kwargs["enabled_toolsets"] = self.enabled_toolsets
+                        client_kwargs["disabled_toolsets"] = self.disabled_toolsets
+                        client_kwargs["agent_tool_call_callback"] = lambda name, args: self._execute_single_tool_call(name, args, session_id or self.session_id)
                 effective_base = base_url
                 if "openrouter" in effective_base.lower():
                     client_kwargs["default_headers"] = {
@@ -801,6 +805,13 @@ class AIAgent:
                         "api_key": _routed_client.api_key,
                         "base_url": str(_routed_client.base_url),
                     }
+                    if self.provider == "claude-cli" or str(client_kwargs["base_url"]).startswith("claude-cli://"):
+                        client_kwargs["command"] = self.acp_command
+                        client_kwargs["args"] = self.acp_args
+                        client_kwargs["session_id"] = session_id
+                        client_kwargs["enabled_toolsets"] = self.enabled_toolsets
+                        client_kwargs["disabled_toolsets"] = self.disabled_toolsets
+                        client_kwargs["agent_tool_call_callback"] = lambda name, args: self._execute_single_tool_call(name, args, session_id or self.session_id)
                     # Preserve any default_headers the router set
                     if hasattr(_routed_client, '_default_headers') and _routed_client._default_headers:
                         client_kwargs["default_headers"] = dict(_routed_client._default_headers)
@@ -889,21 +900,14 @@ class AIAgent:
 
         # Get available tools with filtering.
         #
-        # Claude CLI backend currently wraps `claude -p --output-format json`
-        # as a text-in/text-out provider. Hermes is only borrowing Claude Code's
-        # model runtime here — not its native tool protocol. Because this backend
-        # does not yet translate Claude Code tool use into Hermes tool calls,
-        # advertising Hermes tools in the prompt would be dishonest and would
-        # produce non-executable natural-language/tool-ish output instead of real
-        # structured tool calls. Keep Hermes-side tools disabled for `claude-cli`
-        # until a future implementation adds an actual tool-call bridge.
+        # Claude CLI now receives Hermes tools through a per-session MCP bridge.
+        # Keep the normal Hermes tool filtering here so the bridge sees the same
+        # toolset selection the rest of the agent would have exposed.
         self.tools = get_tool_definitions(
             enabled_toolsets=enabled_toolsets,
             disabled_toolsets=disabled_toolsets,
             quiet_mode=self.quiet_mode,
         )
-        if self.provider == "claude-cli" or str(self.base_url or "").startswith("claude-cli://"):
-            self.tools = []
         
         # Show tool configuration and store valid tool names for validation
         self.valid_tool_names = set()

--- a/run_agent.py
+++ b/run_agent.py
@@ -772,7 +772,7 @@ class AIAgent:
                 # Explicit credentials from CLI/gateway — construct directly.
                 # The runtime provider resolver already handled auth for us.
                 client_kwargs = {"api_key": api_key, "base_url": base_url}
-                if self.provider in {"copilot-acp", "claude-cli"}:
+                if self.provider in {"copilot-acp", "claude-cli"} or str(base_url).startswith("claude-cli://"):
                     client_kwargs["command"] = self.acp_command
                     client_kwargs["args"] = self.acp_args
                     client_kwargs["session_id"] = session_id

--- a/tests/hermes_cli/test_setup_model_provider.py
+++ b/tests/hermes_cli/test_setup_model_provider.py
@@ -475,3 +475,24 @@ def test_setup_summary_does_not_mark_incomplete_browserbase_as_available(tmp_pat
     assert "Browser Automation (Browserbase)" not in output
     assert "Browser Automation" in output
     assert "BROWSERBASE_API_KEY/BROWSERBASE_PROJECT_ID" in output
+
+
+def test_setup_claude_cli_uses_model_picker_and_saves_provider(tmp_path, monkeypatch):
+    """Claude CLI provider saves correctly through delegation."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_env(monkeypatch)
+    _stub_tts(monkeypatch)
+
+    config = load_config()
+
+    def fake_select():
+        _write_model_config("claude-cli", "claude-cli://local", "claude-cli/claude-sonnet-4-6")
+
+    monkeypatch.setattr("hermes_cli.main.select_provider_and_model", fake_select)
+
+    setup_model_provider(config)
+    save_config(config)
+
+    reloaded = load_config()
+    assert isinstance(reloaded["model"], dict)
+    assert reloaded["model"]["provider"] == "claude-cli"

--- a/tests/hermes_cli/test_status_command.py
+++ b/tests/hermes_cli/test_status_command.py
@@ -1,0 +1,26 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from hermes_cli.status import show_status
+
+
+def test_status_shows_claude_cli_backend_details(capsys, monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    args = SimpleNamespace(all=False, deep=False)
+    with patch("hermes_cli.status.load_config", return_value={"model": {"provider": "claude-cli", "default": "claude-cli/claude-sonnet-4-6"}}), \
+         patch("hermes_cli.status.resolve_requested_provider", return_value="claude-cli"), \
+         patch("hermes_cli.status.get_env_value", return_value=""), \
+         patch("hermes_cli.status.get_nous_subscription_features") as _features, \
+         patch("hermes_cli.status.managed_nous_tools_enabled", return_value=False), \
+         patch("hermes_cli.auth.get_nous_auth_status", return_value={}), \
+         patch("hermes_cli.auth.get_codex_auth_status", return_value={}), \
+         patch("hermes_cli.auth.get_external_process_provider_status", side_effect=[
+             {"configured": False, "logged_in": False},
+             {"configured": True, "logged_in": True, "resolved_command": "/usr/local/bin/claude", "command": "claude", "args": ["--debug"], "base_url": "claude-cli://local"},
+         ]):
+        show_status(args)
+
+    out = capsys.readouterr().out
+    assert "Claude CLI" in out
+    assert "/usr/local/bin/claude" in out
+    assert "claude-cli://local" in out

--- a/tests/test_api_key_providers.py
+++ b/tests/test_api_key_providers.py
@@ -37,6 +37,7 @@ class TestProviderRegistry:
 
     @pytest.mark.parametrize("provider_id,name,auth_type", [
         ("copilot-acp", "GitHub Copilot ACP", "external_process"),
+        ("claude-cli", "Claude CLI", "external_process"),
         ("copilot", "GitHub Copilot", "api_key"),
         ("huggingface", "Hugging Face", "api_key"),
         ("zai", "Z.AI / GLM", "api_key"),
@@ -96,6 +97,7 @@ class TestProviderRegistry:
     def test_base_urls(self):
         assert PROVIDER_REGISTRY["copilot"].inference_base_url == "https://api.githubcopilot.com"
         assert PROVIDER_REGISTRY["copilot-acp"].inference_base_url == "acp://copilot"
+        assert PROVIDER_REGISTRY["claude-cli"].inference_base_url == "claude-cli://local"
         assert PROVIDER_REGISTRY["zai"].inference_base_url == "https://api.z.ai/api/paas/v4"
         assert PROVIDER_REGISTRY["kimi-coding"].inference_base_url == "https://api.moonshot.ai/v1"
         assert PROVIDER_REGISTRY["minimax"].inference_base_url == "https://api.minimax.io/anthropic"
@@ -205,6 +207,10 @@ class TestResolveProvider:
     def test_alias_github_copilot_acp(self):
         assert resolve_provider("github-copilot-acp") == "copilot-acp"
         assert resolve_provider("copilot-acp-agent") == "copilot-acp"
+
+    def test_alias_claude_cli(self):
+        assert resolve_provider("claude-local") == "claude-cli"
+        assert resolve_provider("claude-binary") == "claude-cli"
 
     def test_explicit_huggingface(self):
         assert resolve_provider("huggingface") == "huggingface"
@@ -625,6 +631,7 @@ class TestHasAnyProviderConfigured:
     def test_claude_code_creds_ignored_on_fresh_install(self, monkeypatch, tmp_path):
         """Claude Code credentials should NOT skip the wizard when Hermes is unconfigured."""
         from hermes_cli import config as config_module
+        monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: None)
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
         monkeypatch.setattr(config_module, "get_env_path", lambda: hermes_home / ".env")
@@ -707,6 +714,7 @@ class TestHasAnyProviderConfigured:
         """config.yaml model dict with empty default and no creds stays false."""
         import yaml
         from hermes_cli import config as config_module
+        monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: None)
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
         config_file = hermes_home / "config.yaml"

--- a/tests/test_api_key_providers.py
+++ b/tests/test_api_key_providers.py
@@ -920,3 +920,19 @@ class TestHuggingFaceModels:
         from hermes_cli.models import _PROVIDER_LABELS
         assert "huggingface" in _PROVIDER_LABELS
         assert _PROVIDER_LABELS["huggingface"] == "Hugging Face"
+
+
+    def test_runtime_claude_cli_uses_process_runtime(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.auth.shutil.which", lambda command: f"/usr/local/bin/{command}")
+        monkeypatch.setenv("HERMES_CLAUDE_CLI_ARGS", "--debug")
+
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        result = resolve_runtime_provider(requested="claude-cli")
+
+        assert result["provider"] == "claude-cli"
+        assert result["api_mode"] == "chat_completions"
+        assert result["api_key"] == "claude-cli"
+        assert result["base_url"] == "claude-cli://local"
+        assert result["command"] == "/usr/local/bin/claude"
+        assert result["args"] == ["--debug"]

--- a/tests/test_auth_codex_provider.py
+++ b/tests/test_auth_codex_provider.py
@@ -10,8 +10,10 @@ import yaml
 
 from hermes_cli.auth import (
     AuthError,
+    CODEX_OAUTH_CLIENT_ID,
     DEFAULT_CODEX_BASE_URL,
     PROVIDER_REGISTRY,
+    _codex_device_code_login,
     _read_codex_tokens,
     _save_codex_tokens,
     _import_codex_cli_tokens,
@@ -190,3 +192,64 @@ def test_resolve_returns_hermes_auth_store_source(tmp_path, monkeypatch):
     assert creds["source"] == "hermes-auth-store"
     assert creds["provider"] == "openai-codex"
     assert creds["base_url"] == DEFAULT_CODEX_BASE_URL
+
+
+def test_codex_device_code_login_uses_expected_client_id(monkeypatch):
+    requests = []
+
+    class _FakeResponse:
+        def __init__(self, status_code, payload):
+            self.status_code = status_code
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    class _FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def post(self, url, json=None, data=None, headers=None):
+            requests.append({"url": url, "json": json, "data": data, "headers": headers})
+            if url.endswith("/api/accounts/deviceauth/usercode"):
+                return _FakeResponse(
+                    200,
+                    {
+                        "user_code": "ABCD-EFGH",
+                        "device_auth_id": "device-auth-id",
+                        "interval": "0",
+                    },
+                )
+            if url.endswith("/api/accounts/deviceauth/token"):
+                return _FakeResponse(
+                    200,
+                    {
+                        "authorization_code": "auth-code",
+                        "code_verifier": "code-verifier",
+                    },
+                )
+            if url == "https://auth.openai.com/oauth/token":
+                return _FakeResponse(
+                    200,
+                    {
+                        "access_token": "access-token",
+                        "refresh_token": "refresh-token",
+                    },
+                )
+            raise AssertionError(f"Unexpected URL {url}")
+
+    monkeypatch.setattr("hermes_cli.auth.httpx.Client", _FakeClient)
+    monkeypatch.setattr("hermes_cli.auth.time.sleep", lambda _: None)
+
+    creds = _codex_device_code_login()
+
+    assert creds["tokens"]["access_token"] == "access-token"
+    assert requests[0]["json"] == {"client_id": CODEX_OAUTH_CLIENT_ID}
+    assert requests[2]["data"]["client_id"] == CODEX_OAUTH_CLIENT_ID
+    assert CODEX_OAUTH_CLIENT_ID == "app_EMoamEEZ73f0CkXaXp7hrann"

--- a/tests/test_claude_cli_client.py
+++ b/tests/test_claude_cli_client.py
@@ -1,7 +1,7 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from agent.claude_cli_client import ClaudeCLIClient
+from agent.claude_cli_client import ClaudeCLIClient, _CLAUDE_CLI_DISABLED_TOOLS
 
 
 def _completed(stdout: str):
@@ -50,3 +50,18 @@ def test_existing_seeded_session_id_retries_with_resume_when_cli_reports_in_use(
     assert "--resume" in calls[1]
     assert seeded_id in calls[1]
     assert resp.choices[0].message.content == "resumed"
+
+
+def test_build_command_disables_claude_builtin_tools():
+    client = ClaudeCLIClient(command="claude", session_id="hermes-session-1")
+
+    cmd = client._build_command(
+        model="claude-sonnet-4-6",
+        prompt_text="hi",
+    )
+
+    pairs = list(zip(cmd, cmd[1:]))
+    disabled_tools = [value for flag, value in pairs if flag == "--disallowedTools"]
+
+    assert disabled_tools == list(_CLAUDE_CLI_DISABLED_TOOLS)
+    assert cmd[:5] == ["claude", "-p", "--output-format", "json", "--model"]

--- a/tests/test_claude_cli_client.py
+++ b/tests/test_claude_cli_client.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -50,10 +51,41 @@ def test_existing_seeded_session_id_retries_with_resume_when_cli_reports_in_use(
     assert resp.choices[0].message.content == "resumed"
 
 
-def test_build_command_disables_claude_builtin_tools():
-    client = ClaudeCLIClient(command="claude", session_id="hermes-session-1")
+def test_build_command_wires_hermes_mcp_bridge_by_default():
+    client = ClaudeCLIClient(
+        command="claude",
+        session_id="hermes-session-1",
+        enabled_toolsets=["file"],
+        agent_tool_call_callback=lambda name, args: "ok",
+    )
     cmd = client._build_command(model="claude-sonnet-4-6", prompt_text="hello")
 
+    assert cmd[:6] == [
+        "claude",
+        "-p",
+        "--output-format",
+        "json",
+        "--model",
+        "claude-sonnet-4-6",
+    ]
+    assert "--mcp-config" in cmd
+    config = json.loads(cmd[cmd.index("--mcp-config") + 1])
+    server = config["mcpServers"]["hermes-tools"]
+    assert server["args"] == ["-m", "agent.claude_cli_tool_bridge"]
+    assert json.loads(server["env"]["HERMES_CLAUDE_BRIDGE_ENABLED_TOOLSETS"]) == ["file"]
+    assert server["env"]["HERMES_AGENT_BRIDGE_HOST"] == "127.0.0.1"
+    assert server["env"]["HERMES_AGENT_BRIDGE_PORT"].isdigit()
+    assert server["env"]["HERMES_AGENT_BRIDGE_AUTHKEY"]
+    assert "--strict-mcp-config" in cmd
+    assert "--tools" not in cmd
+    client.close()
+
+
+def test_build_command_can_disable_bridge_and_fall_back_to_no_tools():
+    client = ClaudeCLIClient(command="claude", session_id="hermes-session-1", allow_hermes_tool_bridge=False)
+    cmd = client._build_command(model="claude-sonnet-4-6", prompt_text="hello")
+
+    assert "--mcp-config" not in cmd
     assert cmd[:7] == [
         "claude",
         "-p",

--- a/tests/test_claude_cli_client.py
+++ b/tests/test_claude_cli_client.py
@@ -1,0 +1,29 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent.claude_cli_client import ClaudeCLIClient
+
+
+def _completed(stdout: str):
+    return SimpleNamespace(stdout=stdout, stderr="", returncode=0)
+
+
+def test_first_call_uses_session_id_then_resume_on_followup():
+    client = ClaudeCLIClient(command="claude", session_id="hermes-session-1")
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if len(calls) == 1:
+            return _completed('{"result":"first","session_id":"claude-session-abc","usage":{"input_tokens":10,"output_tokens":5}}')
+        return _completed('{"result":"second","session_id":"claude-session-abc","usage":{"input_tokens":8,"output_tokens":4}}')
+
+    with patch("agent.claude_cli_client.subprocess.run", side_effect=fake_run):
+        client.chat.completions.create(model="claude-cli/claude-sonnet-4-6", messages=[{"role": "user", "content": "hi"}])
+        client.chat.completions.create(model="claude-cli/claude-sonnet-4-6", messages=[{"role": "user", "content": "again"}])
+
+    assert "--session-id" in calls[0]
+    assert "--resume" not in calls[0]
+    assert "--resume" in calls[1]
+    assert "claude-session-abc" in calls[1]

--- a/tests/test_claude_cli_client.py
+++ b/tests/test_claude_cli_client.py
@@ -1,7 +1,7 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from agent.claude_cli_client import ClaudeCLIClient, _CLAUDE_CLI_DISABLED_TOOLS
+from agent.claude_cli_client import ClaudeCLIClient
 
 
 def _completed(stdout: str):
@@ -29,14 +29,12 @@ def test_first_call_uses_session_id_then_resume_on_followup():
     assert "claude-session-abc" in calls[1]
 
 
-
 def test_existing_seeded_session_id_retries_with_resume_when_cli_reports_in_use():
     client = ClaudeCLIClient(command="claude", session_id="hermes-session-1")
 
     calls = []
     seeded_id = client._hermes_session_uuid
 
-    from types import SimpleNamespace
     def fake_invoke(cmd, *, timeout_seconds):
         calls.append(cmd)
         if len(calls) == 1:
@@ -54,14 +52,15 @@ def test_existing_seeded_session_id_retries_with_resume_when_cli_reports_in_use(
 
 def test_build_command_disables_claude_builtin_tools():
     client = ClaudeCLIClient(command="claude", session_id="hermes-session-1")
+    cmd = client._build_command(model="claude-sonnet-4-6", prompt_text="hello")
 
-    cmd = client._build_command(
-        model="claude-sonnet-4-6",
-        prompt_text="hi",
-    )
-
-    pairs = list(zip(cmd, cmd[1:]))
-    disabled_tools = [value for flag, value in pairs if flag == "--disallowedTools"]
-
-    assert disabled_tools == list(_CLAUDE_CLI_DISABLED_TOOLS)
-    assert cmd[:5] == ["claude", "-p", "--output-format", "json", "--model"]
+    assert cmd[:7] == [
+        "claude",
+        "-p",
+        "--output-format",
+        "json",
+        "--model",
+        "claude-sonnet-4-6",
+        "--tools",
+    ]
+    assert cmd[7] == ""

--- a/tests/test_claude_cli_client.py
+++ b/tests/test_claude_cli_client.py
@@ -27,3 +27,26 @@ def test_first_call_uses_session_id_then_resume_on_followup():
     assert "--resume" not in calls[0]
     assert "--resume" in calls[1]
     assert "claude-session-abc" in calls[1]
+
+
+
+def test_existing_seeded_session_id_retries_with_resume_when_cli_reports_in_use():
+    client = ClaudeCLIClient(command="claude", session_id="hermes-session-1")
+
+    calls = []
+    seeded_id = client._hermes_session_uuid
+
+    from types import SimpleNamespace
+    def fake_invoke(cmd, *, timeout_seconds):
+        calls.append(cmd)
+        if len(calls) == 1:
+            return SimpleNamespace(stdout="", stderr=f"Error: Session ID {seeded_id} is already in use.", returncode=1)
+        return SimpleNamespace(stdout=f'{{"result":"resumed","session_id":"{seeded_id}","usage":{{"input_tokens":6,"output_tokens":3}}}}', stderr="", returncode=0)
+
+    with patch.object(client, "_invoke", side_effect=fake_invoke):
+        resp = client.chat.completions.create(model="claude-cli/claude-sonnet-4-6", messages=[{"role": "user", "content": "again"}])
+
+    assert "--session-id" in calls[0]
+    assert "--resume" in calls[1]
+    assert seeded_id in calls[1]
+    assert resp.choices[0].message.content == "resumed"

--- a/tests/test_model_provider_persistence.py
+++ b/tests/test_model_provider_persistence.py
@@ -257,3 +257,42 @@ class TestProviderPersistsAfterModelSave:
         assert model.get("provider") == "opencode-go"
         assert model.get("default") == "minimax-m2.5"
         assert model.get("api_mode") == "anthropic_messages"
+
+
+    def test_claude_cli_provider_saved_when_selected(self, config_home):
+        """_model_flow_claude_cli should persist provider/base_url/model together."""
+        from hermes_cli.main import _model_flow_claude_cli
+        from hermes_cli.config import load_config
+
+        with patch(
+            "hermes_cli.auth.get_external_process_provider_status",
+            return_value={
+                "resolved_command": "/usr/local/bin/claude",
+                "command": "claude",
+                "base_url": "claude-cli://local",
+            },
+        ), patch(
+            "hermes_cli.auth.resolve_external_process_provider_credentials",
+            return_value={
+                "provider": "claude-cli",
+                "api_key": "claude-cli",
+                "base_url": "claude-cli://local",
+                "command": "/usr/local/bin/claude",
+                "args": [],
+                "source": "process",
+            },
+        ), patch(
+            "hermes_cli.auth._prompt_model_selection",
+            return_value="claude-cli/claude-sonnet-4-6",
+        ), patch(
+            "hermes_cli.auth._save_model_choice",
+        ), patch(
+            "hermes_cli.auth.deactivate_provider",
+        ):
+            _model_flow_claude_cli(load_config(), "old-model")
+
+        import yaml
+        cfg = yaml.safe_load((config_home / "config.yaml").read_text())
+        assert cfg["model"]["provider"] == "claude-cli"
+        assert cfg["model"]["base_url"] == "claude-cli://local"
+        assert cfg["model"]["api_mode"] == "chat_completions"

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -2562,6 +2562,38 @@ def test_aiagent_uses_copilot_acp_client():
     assert mock_acp_client.call_args.kwargs["args"] == ["--acp", "--stdio"]
 
 
+
+
+def test_aiagent_uses_claude_cli_client_and_disables_tools():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI") as mock_openai,
+        patch("agent.claude_cli_client.ClaudeCLIClient") as mock_claude_client,
+    ):
+        cli_client = MagicMock()
+        mock_claude_client.return_value = cli_client
+
+        agent = AIAgent(
+            api_key="dummy-key",
+            base_url="claude-cli://local",
+            provider="claude-cli",
+            acp_command="/usr/local/bin/claude",
+            acp_args=["--debug"],
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.client is cli_client
+    assert agent.tools == []
+    mock_openai.assert_not_called()
+    mock_claude_client.assert_called_once()
+    assert mock_claude_client.call_args.kwargs["base_url"] == "claude-cli://local"
+    assert mock_claude_client.call_args.kwargs["api_key"] == "dummy-key"
+    assert mock_claude_client.call_args.kwargs["command"] == "/usr/local/bin/claude"
+    assert mock_claude_client.call_args.kwargs["args"] == ["--debug"]
+
 def test_is_openai_client_closed_honors_custom_client_flag():
     assert AIAgent._is_openai_client_closed(SimpleNamespace(is_closed=True)) is True
     assert AIAgent._is_openai_client_closed(SimpleNamespace(is_closed=False)) is False

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -2594,6 +2594,34 @@ def test_aiagent_uses_claude_cli_client_and_disables_tools():
     assert mock_claude_client.call_args.kwargs["command"] == "/usr/local/bin/claude"
     assert mock_claude_client.call_args.kwargs["args"] == ["--debug"]
 
+
+
+def test_aiagent_passes_session_id_to_claude_cli_client():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI") as mock_openai,
+        patch("agent.claude_cli_client.ClaudeCLIClient") as mock_claude_client,
+    ):
+        cli_client = MagicMock()
+        mock_claude_client.return_value = cli_client
+
+        agent = AIAgent(
+            api_key="dummy-key",
+            base_url="claude-cli://local",
+            provider="claude-cli",
+            acp_command="/usr/local/bin/claude",
+            acp_args=["--debug"],
+            session_id="cli-session-123",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.client is cli_client
+    mock_openai.assert_not_called()
+    assert mock_claude_client.call_args.kwargs["session_id"] == "cli-session-123"
+
 def test_is_openai_client_closed_honors_custom_client_flag():
     assert AIAgent._is_openai_client_closed(SimpleNamespace(is_closed=True)) is True
     assert AIAgent._is_openai_client_closed(SimpleNamespace(is_closed=False)) is False

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -2564,7 +2564,7 @@ def test_aiagent_uses_copilot_acp_client():
 
 
 
-def test_aiagent_uses_claude_cli_client_and_disables_tools():
+def test_aiagent_uses_claude_cli_client_and_preserves_tools_for_bridge():
     with (
         patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
         patch("run_agent.check_toolset_requirements", return_value={}),
@@ -2575,7 +2575,7 @@ def test_aiagent_uses_claude_cli_client_and_disables_tools():
         mock_claude_client.return_value = cli_client
 
         agent = AIAgent(
-            api_key="dummy-key",
+            api_key="***",
             base_url="claude-cli://local",
             provider="claude-cli",
             acp_command="/usr/local/bin/claude",
@@ -2586,15 +2586,16 @@ def test_aiagent_uses_claude_cli_client_and_disables_tools():
         )
 
     assert agent.client is cli_client
-    assert agent.tools == []
+    assert [tool["function"]["name"] for tool in agent.tools] == ["web_search"]
     mock_openai.assert_not_called()
     mock_claude_client.assert_called_once()
     assert mock_claude_client.call_args.kwargs["base_url"] == "claude-cli://local"
-    assert mock_claude_client.call_args.kwargs["api_key"] == "dummy-key"
+    assert mock_claude_client.call_args.kwargs["api_key"] == "***"
+    assert callable(mock_claude_client.call_args.kwargs["agent_tool_call_callback"])
 
 
 
-def test_aiagent_infers_claude_cli_client_from_base_url_and_disables_tools():
+def test_aiagent_infers_claude_cli_client_from_base_url_and_passes_bridge_context():
     with (
         patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
         patch("run_agent.check_toolset_requirements", return_value={}),
@@ -2605,25 +2606,30 @@ def test_aiagent_infers_claude_cli_client_from_base_url_and_disables_tools():
         mock_claude_client.return_value = cli_client
 
         agent = AIAgent(
-            api_key="dummy-key",
+            api_key="***",
             base_url="claude-cli://local",
             acp_command="/usr/local/bin/claude",
             acp_args=["--debug"],
             session_id="cli-session-123",
+            enabled_toolsets=["file"],
+            disabled_toolsets=["browser"],
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,
         )
 
     assert agent.client is cli_client
-    assert agent.tools == []
+    assert [tool["function"]["name"] for tool in agent.tools] == ["web_search"]
     mock_openai.assert_not_called()
     mock_claude_client.assert_called_once()
     assert mock_claude_client.call_args.kwargs["base_url"] == "claude-cli://local"
-    assert mock_claude_client.call_args.kwargs["api_key"] == "dummy-key"
+    assert mock_claude_client.call_args.kwargs["api_key"] == "***"
+    assert callable(mock_claude_client.call_args.kwargs["agent_tool_call_callback"])
     assert mock_claude_client.call_args.kwargs["command"] == "/usr/local/bin/claude"
     assert mock_claude_client.call_args.kwargs["args"] == ["--debug"]
     assert mock_claude_client.call_args.kwargs["session_id"] == "cli-session-123"
+    assert mock_claude_client.call_args.kwargs["enabled_toolsets"] == ["file"]
+    assert mock_claude_client.call_args.kwargs["disabled_toolsets"] == ["browser"]
 
 
 def test_aiagent_passes_session_id_to_claude_cli_client():

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -2591,9 +2591,35 @@ def test_aiagent_uses_claude_cli_client_and_disables_tools():
     mock_claude_client.assert_called_once()
     assert mock_claude_client.call_args.kwargs["base_url"] == "claude-cli://local"
     assert mock_claude_client.call_args.kwargs["api_key"] == "dummy-key"
-    assert mock_claude_client.call_args.kwargs["command"] == "/usr/local/bin/claude"
-    assert mock_claude_client.call_args.kwargs["args"] == ["--debug"]
 
+
+
+def test_aiagent_infers_claude_cli_client_from_base_url_and_disables_tools():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI") as mock_openai,
+        patch("agent.claude_cli_client.ClaudeCLIClient") as mock_claude_client,
+    ):
+        cli_client = MagicMock()
+        mock_claude_client.return_value = cli_client
+
+        agent = AIAgent(
+            api_key="dummy-key",
+            base_url="claude-cli://local",
+            acp_command="/usr/local/bin/claude",
+            acp_args=["--debug"],
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.client is cli_client
+    assert agent.tools == []
+    mock_openai.assert_not_called()
+    mock_claude_client.assert_called_once()
+    assert mock_claude_client.call_args.kwargs["base_url"] == "claude-cli://local"
+    assert mock_claude_client.call_args.kwargs["api_key"] == "dummy-key"
 
 
 def test_aiagent_passes_session_id_to_claude_cli_client():

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -2609,6 +2609,7 @@ def test_aiagent_infers_claude_cli_client_from_base_url_and_disables_tools():
             base_url="claude-cli://local",
             acp_command="/usr/local/bin/claude",
             acp_args=["--debug"],
+            session_id="cli-session-123",
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,
@@ -2620,6 +2621,9 @@ def test_aiagent_infers_claude_cli_client_from_base_url_and_disables_tools():
     mock_claude_client.assert_called_once()
     assert mock_claude_client.call_args.kwargs["base_url"] == "claude-cli://local"
     assert mock_claude_client.call_args.kwargs["api_key"] == "dummy-key"
+    assert mock_claude_client.call_args.kwargs["command"] == "/usr/local/bin/claude"
+    assert mock_claude_client.call_args.kwargs["args"] == ["--debug"]
+    assert mock_claude_client.call_args.kwargs["session_id"] == "cli-session-123"
 
 
 def test_aiagent_passes_session_id_to_claude_cli_client():

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -18,6 +18,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **OpenAI Codex** | `hermes model` (ChatGPT OAuth, uses Codex models) |
 | **GitHub Copilot** | `hermes model` (OAuth device code flow, `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `gh auth token`) |
 | **GitHub Copilot ACP** | `hermes model` (spawns local `copilot --acp --stdio`) |
+| **Claude CLI** | `hermes model` (spawns local `claude -p --output-format json` for inference) |
 | **Anthropic** | `hermes model` (Claude Pro/Max via Claude Code auth, Anthropic API key, or manual setup-token) |
 | **OpenRouter** | `OPENROUTER_API_KEY` in `~/.hermes/.env` |
 | **AI Gateway** | `AI_GATEWAY_API_KEY` in `~/.hermes/.env` (provider: `ai-gateway`) |
@@ -131,6 +132,29 @@ model:
 | `COPILOT_GITHUB_TOKEN` | GitHub token for Copilot API (first priority) |
 | `HERMES_COPILOT_ACP_COMMAND` | Override the Copilot CLI binary path (default: `copilot`) |
 | `HERMES_COPILOT_ACP_ARGS` | Override ACP args (default: `--acp --stdio`) |
+
+### Claude CLI backend
+
+Use Claude Code itself as the inference backend instead of calling Anthropic
+directly. This is useful when Anthropic changes billing or subscription policy
+for third-party harness traffic and you want Hermes to route inference through
+your locally installed `claude` binary.
+
+```bash
+hermes chat --provider claude-cli --model claude-cli/claude-sonnet-4-6
+# Requires the Claude CLI in PATH and an existing `claude auth` / subscription session
+```
+
+This backend is currently text-in/text-out only. Hermes disables its own tool
+schemas for `claude-cli` sessions, but it still tracks prompt/completion usage
+and context-window status so the CLI status bar remains accurate.
+
+| Environment variable | Description |
+|---------------------|-------------|
+| `HERMES_CLAUDE_CLI_COMMAND` | Override the Claude CLI binary path (default: `claude`) |
+| `CLAUDE_CLI_PATH` | Alias for `HERMES_CLAUDE_CLI_COMMAND` |
+| `HERMES_CLAUDE_CLI_ARGS` | Extra args appended before the prompt payload |
+| `HERMES_CLAUDE_CLI_BASE_URL` | Optional marker URL override for remote wrappers |
 
 ### First-Class Chinese AI Providers
 

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -149,6 +149,11 @@ This backend is currently text-in/text-out only. Hermes disables its own tool
 schemas for `claude-cli` sessions, but it still tracks prompt/completion usage
 and context-window status so the CLI status bar remains accurate.
 
+Hermes also reuses the same Claude CLI conversation across turns for a given
+Hermes session. The first call seeds a stable Claude `--session-id`, then later
+turns switch to Claude CLI `--resume` automatically when the CLI returns its
+session handle.
+
 | Environment variable | Description |
 |---------------------|-------------|
 | `HERMES_CLAUDE_CLI_COMMAND` | Override the Claude CLI binary path (default: `claude`) |

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -73,7 +73,7 @@ Common options:
 | `-q`, `--query "..."` | One-shot, non-interactive prompt. |
 | `-m`, `--model <model>` | Override the model for this run. |
 | `-t`, `--toolsets <csv>` | Enable a comma-separated set of toolsets. |
-| `--provider <provider>` | Force a provider: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot-acp`, `copilot`, `anthropic`, `huggingface`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`, `kilocode`. |
+| `--provider <provider>` | Force a provider: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot-acp`, `claude-cli`, `copilot`, `anthropic`, `huggingface`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`, `kilocode`. |
 | `-s`, `--skills <name>` | Preload one or more skills for the session (can be repeated or comma-separated). |
 | `-v`, `--verbose` | Verbose output. |
 | `-Q`, `--quiet` | Programmatic mode: suppress banner/spinner/tool previews. |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -25,6 +25,10 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | `COPILOT_CLI_PATH` | Alias for `HERMES_COPILOT_ACP_COMMAND` |
 | `HERMES_COPILOT_ACP_ARGS` | Override Copilot ACP arguments (default: `--acp --stdio`) |
 | `COPILOT_ACP_BASE_URL` | Override Copilot ACP base URL |
+| `HERMES_CLAUDE_CLI_COMMAND` | Override Claude CLI binary path (default: `claude`) |
+| `CLAUDE_CLI_PATH` | Alias for `HERMES_CLAUDE_CLI_COMMAND` |
+| `HERMES_CLAUDE_CLI_ARGS` | Extra Claude CLI arguments appended before the prompt payload |
+| `HERMES_CLAUDE_CLI_BASE_URL` | Override Claude CLI marker base URL (default: `claude-cli://local`) |
 | `GLM_API_KEY` | z.ai / ZhipuAI GLM API key ([z.ai](https://z.ai)) |
 | `ZAI_API_KEY` | Alias for `GLM_API_KEY` |
 | `Z_AI_API_KEY` | Alias for `GLM_API_KEY` |
@@ -63,7 +67,7 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 
 | Variable | Description |
 |----------|-------------|
-| `HERMES_INFERENCE_PROVIDER` | Override provider selection: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `huggingface`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`, `kilocode`, `alibaba`, `deepseek`, `opencode-zen`, `opencode-go`, `ai-gateway` (default: `auto`) |
+| `HERMES_INFERENCE_PROVIDER` | Override provider selection: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `claude-cli`, `anthropic`, `huggingface`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`, `kilocode`, `alibaba`, `deepseek`, `opencode-zen`, `opencode-go`, `ai-gateway` (default: `auto`) |
 | `HERMES_PORTAL_BASE_URL` | Override Nous Portal URL (for development/testing) |
 | `NOUS_INFERENCE_BASE_URL` | Override Nous inference API URL |
 | `HERMES_NOUS_MIN_KEY_TTL_SECONDS` | Min agent key TTL before re-mint (default: 1800 = 30min) |


### PR DESCRIPTION
## Summary

Add a first-class `claude-cli` provider that uses the local Claude Code binary for model inference instead of calling Anthropic directly.

This PR makes the Claude CLI path cohesive end-to-end:

- provider/runtime resolution
- CLI setup/model selection
- status visibility
- context/status accounting
- turn-to-turn Claude session continuity
- resumed-session recovery after Hermes restarts
- docs and regression coverage

## What this PR adds

### New provider/backend

- `claude-cli` external-process provider
- `agent/claude_cli_client.py` as an OpenAI-compatible facade over `claude -p --output-format json`
- provider-specific command / args / base-url resolution in shared external-process auth plumbing

### Hermes runtime integration

- `run_agent.py` now instantiates `ClaudeCLIClient` for `claude-cli`
- Hermes-side tools are disabled for this backend's current text-in/text-out path so the prompt surface stays honest
- context/status accounting still updates from Claude CLI usage when available and falls back to rough estimates when the CLI omits token details

### Session continuity and restart recovery

- first turn seeds a stable Claude `--session-id`
- later turns switch to Claude CLI `--resume` when the CLI returns its session handle
- Hermes `session_id` is passed through to the Claude CLI backend so turn-to-turn continuity is tied to the Hermes session
- resumed Hermes sessions now recover cleanly if Claude reports the seeded session id is already in use after a restart by retrying via Claude CLI `--resume`

### CLI UX / setup / status

- `hermes model` now offers a dedicated `Claude CLI` provider option
- dedicated Claude CLI setup/model flow
- `hermes status` now surfaces Claude CLI backend details explicitly:
  - resolved command
  - args
  - backend marker
  - setup hint when missing

### Docs / tests

- provider docs
- environment variable reference
- CLI command docs
- regression tests for:
  - provider registration and runtime resolution
  - agent client selection
  - Claude CLI session reuse
  - resumed-session collision recovery
  - setup/provider persistence
  - status output

### Code quality cleanup

- deduplicated shared external-process provider runtime resolution in `hermes_cli/auth.py`
- removed low-value duplication between external-process provider status and runtime-credential paths

## Why this shape

OpenClaw's Claude CLI mode treats the local `claude` binary as a distinct backend rather than another Anthropic auth mode.

Hermes now mirrors that separation:

- `anthropic` remains the native Messages API path
- `claude-cli` is the local CLI runtime path

That keeps status/context accounting honest and avoids implying Anthropic API features such as native prompt caching on the CLI-backed route.

## Current behavior / limits

- `claude-cli` currently runs in text-in/text-out mode
- Hermes-side tools are intentionally disabled for `claude-cli` sessions in this initial implementation
- this PR focuses on the local CLI inference path, not tool-call passthrough through Claude CLI

## Test Results

Focused suites:

- `python -m pytest tests/test_api_key_providers.py tests/test_run_agent.py -q`
- `python -m pytest tests/test_api_key_providers.py tests/test_run_agent.py tests/hermes_cli/test_setup_model_provider.py tests/hermes_cli/test_model_validation.py tests/test_model_provider_persistence.py -q`
- `python -m pytest tests/test_claude_cli_client.py tests/test_api_key_providers.py tests/test_run_agent.py tests/hermes_cli/test_setup_model_provider.py tests/hermes_cli/test_model_validation.py tests/test_model_provider_persistence.py tests/hermes_cli/test_status_command.py -q`
- `python -m pytest tests/test_claude_cli_client.py tests/test_auth_codex_provider.py tests/hermes_cli/test_status_command.py tests/test_model_provider_persistence.py -q`

Latest focused results:

- `431 passed`
- `24 passed`

## Live local validation

Real local CLI / worktree checks on this branch:

- `python -m hermes_cli.main chat --provider claude-cli --model claude-cli/claude-sonnet-4-6 -q "Reply with exactly: Hermes claude-cli smoke test"`
- `python -m hermes_cli.main chat --provider claude-cli --model claude-cli/claude-sonnet-4-6 --worktree -q "Reply with exactly: Hermes claude-cli worktree validation"`
- `python -m hermes_cli.main status`
- first-turn / resumed-turn local validation using `--resume <session_id>` against the same Hermes session

On this machine, the live CLI path consistently reached the installed local `claude` command and returned Claude CLI's current account-limit response (`You've hit your limit ...`), which confirms Hermes is routing inference through the local Claude binary rather than Anthropic's direct API path.

The resumed-session path was also tested locally after fixing the restart collision case.

## Notes on broader validation

A full local `tests/ -q` run on this machine surfaced widespread unrelated failures with `OSError: [Errno 24] Too many open files` across many unrelated suites (gateway / MCP / process registry / cron / provider parity). Those failures appear environmental and not specific to this provider patch; the focused provider/runtime/setup/status suites above pass cleanly.
