### PR TITLE
fix(api-server): pass fallback config into AIAgent

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -418,6 +418,9 @@ class APIServerAdapter(BasePlatformAdapter):
 
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+        fallback_model = None
+        if isinstance(user_config, dict):
+            fallback_model = user_config.get("fallback_providers") or user_config.get("fallback_model")
 
         max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
 
@@ -434,6 +437,7 @@ class APIServerAdapter(BasePlatformAdapter):
             stream_delta_callback=stream_delta_callback,
             tool_progress_callback=tool_progress_callback,
             session_db=self._ensure_session_db(),
+            fallback_model=fallback_model,
         )
         return agent
 


### PR DESCRIPTION
## Summary
Fix API server fallback wiring so requests coming through /v1/chat/completions can use configured fallback providers.

Root cause: `APIServerAdapter._create_agent()` did not pass `fallback_model` into `AIAgent(...)`, so `_fallback_chain` stayed empty for api_server sessions.

## Change
- In `gateway/platforms/api_server.py`, load fallback config from gateway config:
  - `fallback_providers` (preferred)
  - `fallback_model` (legacy)
- Pass the resolved value as `fallback_model=...` to `AIAgent(...)`.

## Repro / Verification
- Reproduced before fix with a patched `_create_agent()` harness: constructed `AIAgent` kwargs did not include `fallback_model`.
- After fix, same harness shows `fallback_model` is passed through correctly.
- `python -m py_compile gateway/platforms/api_server.py` passes.

Closes #4954
