### PR TITLE
fix(deps): include Telegram webhook extras in messaging installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
 modal = ["modal>=1.0.0,<2"]
 daytona = ["daytona>=0.148.0,<1"]
 dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "mcp>=1.2.0,<2"]
-messaging = ["python-telegram-bot>=22.6,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]
+messaging = ["python-telegram-bot[webhooks]>=22.6,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]
 cron = ["croniter>=6.0.0,<7"]
 slack = ["slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]
 matrix = ["matrix-nio[e2e]>=0.24.0,<1"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,6 @@ edge-tts
 croniter
 
 # Optional: For messaging platform integrations (gateway)
-python-telegram-bot>=20.0
+python-telegram-bot[webhooks]>=22.6
 discord.py>=2.0
 aiohttp>=3.9.0

--- a/uv.lock
+++ b/uv.lock
@@ -1689,7 +1689,7 @@ all = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-xdist" },
-    { name = "python-telegram-bot" },
+    { name = "python-telegram-bot", extra = ["webhooks"] },
     { name = "pywinpty", marker = "sys_platform == 'win32'" },
     { name = "simple-term-menu" },
     { name = "slack-bolt" },
@@ -1733,7 +1733,7 @@ mcp = [
 messaging = [
     { name = "aiohttp" },
     { name = "discord-py", extra = ["voice"] },
-    { name = "python-telegram-bot" },
+    { name = "python-telegram-bot", extra = ["webhooks"] },
     { name = "slack-bolt" },
     { name = "slack-sdk" },
 ]
@@ -1827,7 +1827,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0,<2" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.0,<4" },
     { name = "python-dotenv", specifier = ">=1.2.1,<2" },
-    { name = "python-telegram-bot", marker = "extra == 'messaging'", specifier = ">=22.6,<23" },
+    { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'messaging'", specifier = ">=22.6,<23" },
     { name = "pywinpty", marker = "sys_platform == 'win32' and extra == 'pty'", specifier = ">=2.0.0,<3" },
     { name = "pyyaml", specifier = ">=6.0.2,<7" },
     { name = "requests", specifier = ">=2.33.0,<3" },
@@ -3962,6 +3962,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cd/9b/8df90c85404166a6631e857027866263adb27440d8af1dbeffbdc4f0166c/python_telegram_bot-22.6.tar.gz", hash = "sha256:50ae8cc10f8dff01445628687951020721f37956966b92a91df4c1bf2d113742", size = 1503761, upload-time = "2026-01-24T13:57:00.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/97/7298f0e1afe3a1ae52ff4c5af5087ed4de319ea73eb3b5c8c4dd4e76e708/python_telegram_bot-22.6-py3-none-any.whl", hash = "sha256:e598fe171c3dde2dfd0f001619ee9110eece66761a677b34719fb18934935ce0", size = 737267, upload-time = "2026-01-24T13:56:58.06Z" },
+]
+
+[package.optional-dependencies]
+webhooks = [
+    { name = "tornado" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Fix Docker/all-install Telegram webhook startup failure by including python-telegram-bot webhook extras in messaging dependencies.

## Root cause
The Docker image installs Hermes with:

- `pip install -e ".[all]"`

`[all]` includes the `messaging` extra from `pyproject.toml`, which previously depended on:

- `python-telegram-bot>=22.6,<23`

That installs PTB without optional webhook dependencies. When Hermes uses Telegram webhook mode, PTB raises:

`RuntimeError: To use start_webhook, PTB must be installed via pip install "python-telegram-bot[webhooks]".`

## Changes
- `pyproject.toml`
  - `messaging`: `python-telegram-bot` -> `python-telegram-bot[webhooks]` (same version range)
- `requirements.txt` (convenience file aligned with canonical deps)
  - `python-telegram-bot>=20.0` -> `python-telegram-bot[webhooks]>=22.6`
- `uv.lock`
  - refreshed to capture the webhook extra dependency graph (includes tornado).

## Repro / verification
In an isolated venv:
1) With `python-telegram-bot` (no extras), `Updater.start_webhook(...)` raises the exact missing-webhooks RuntimeError.
2) After installing `python-telegram-bot[webhooks]`, that specific RuntimeError is gone.

Closes #4915
