### PR TITLE
perf: fix O(n²) catastrophic backtracking in redact regex (salvage #4779)

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -53,7 +53,7 @@ _PREFIX_PATTERNS = [
 # ENV assignment patterns: KEY=value where KEY contains a secret-like name
 _SECRET_ENV_NAMES = r"(?:API_?KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIAL|AUTH)"
 _ENV_ASSIGN_RE = re.compile(
-    rf"([A-Z_]*{_SECRET_ENV_NAMES}[A-Z_]*)\s*=\s*(['\"]?)(\S+)\2",
+    rf"([A-Z_]{{0,50}}{_SECRET_ENV_NAMES}[A-Z_]{{0,50}})\s*=\s*(['\"]?)(\S+)\2",
     re.IGNORECASE,
 )
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -345,8 +345,6 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         # ── Perform the read ──────────────────────────────────────────
         file_ops = _get_file_ops(task_id)
         result = file_ops.read_file(path, offset, limit)
-        if result.content:
-            result.content = redact_sensitive_text(result.content)
         result_dict = result.to_dict()
 
         # ── Character-count guard ─────────────────────────────────────
@@ -355,6 +353,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         # amount of content, reject it and tell the model to narrow down.
         # Note: we check the formatted content (with line-number prefixes),
         # not the raw file size, because that's what actually enters context.
+        # Check BEFORE redaction to avoid expensive regex on huge content.
         content_len = len(result.content or "")
         file_size = result_dict.get("file_size", 0)
         max_chars = _get_max_read_chars()
@@ -371,6 +370,11 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 "total_lines": total_lines,
                 "file_size": file_size,
             }, ensure_ascii=False)
+
+        # ── Redact secrets (after guard check to skip oversized content) ──
+        if result.content:
+            result.content = redact_sensitive_text(result.content)
+            result_dict["content"] = result.content
 
         # Large-file hint: if the file is big and the caller didn't ask
         # for a narrow window, nudge toward targeted reads.


### PR DESCRIPTION
Salvage of PR #4779 by @acsezen. Cherry-picked with authorship preserved.

### Fixes
1. **Regex bound** (`agent/redact.py`): `[A-Z_]*` → `[A-Z_]{0,50}` in `_ENV_ASSIGN_RE`. Eliminates O(n²) catastrophic backtracking on large uniform strings. Benefits all callers (file_tools, terminal_tool, browser_tool, code_execution_tool).

2. **Guard reorder** (`tools/file_tools.py`): Character-count guard now runs before `redact_sensitive_text()`. Oversized content rejected immediately without touching the regex.

### Results
- 81 redact + file_tools tests pass in 0.20s (3 previously timed out at 30s+)
- No behavioral change for real-world input (env var names are never 50+ chars)

Closes #4779