### PR TITLE
fix(auth): restore Codex OAuth client id in claude-cli follow-up

### DIFF
--- a/agent/claude_cli_client.py
+++ b/agent/claude_cli_client.py
@@ -1,0 +1,236 @@
+"""OpenAI-compatible facade that routes Hermes inference through local Claude CLI.
+
+This backend is intentionally text-in/text-out only for now. It shells out to
+`claude -p --output-format json`, disables Claude's own tool use, and returns a
+minimal response object that matches the parts of the OpenAI SDK shape Hermes
+expects.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from agent.model_metadata import estimate_messages_tokens_rough, estimate_tokens_rough
+
+CLAUDE_CLI_MARKER_BASE_URL = "claude-cli://local"
+_DEFAULT_TIMEOUT_SECONDS = 900.0
+
+
+def _resolve_command() -> str:
+    return (
+        os.getenv("HERMES_CLAUDE_CLI_COMMAND", "").strip()
+        or os.getenv("CLAUDE_CLI_PATH", "").strip()
+        or "claude"
+    )
+
+
+def _resolve_args() -> list[str]:
+    raw = os.getenv("HERMES_CLAUDE_CLI_ARGS", "").strip()
+    return shlex.split(raw) if raw else []
+
+
+def _render_message_content(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, dict):
+        if isinstance(content.get("text"), str):
+            return content["text"].strip()
+        if isinstance(content.get("content"), str):
+            return content["content"].strip()
+        return json.dumps(content, ensure_ascii=False)
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                if item.strip():
+                    parts.append(item.strip())
+            elif isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str) and text.strip():
+                    parts.append(text.strip())
+        return "\n".join(parts).strip()
+    return str(content).strip()
+
+
+def _format_messages_as_prompt(messages: list[dict[str, Any]], model: str | None = None) -> str:
+    sections: list[str] = [
+        "You are being used as the active Claude CLI backend for Hermes Agent.",
+        "Respond directly in natural language.",
+        "Do not emit tool-call JSON.",
+    ]
+    if model:
+        sections.append(f"Hermes requested model hint: {model}")
+
+    transcript: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = str(message.get("role") or "unknown").strip().lower()
+        if role not in {"system", "user", "assistant", "tool"}:
+            role = "context"
+        rendered = _render_message_content(message.get("content"))
+        if not rendered:
+            continue
+        label = {
+            "system": "System",
+            "user": "User",
+            "assistant": "Assistant",
+            "tool": "Tool",
+            "context": "Context",
+        }.get(role, role.title())
+        transcript.append(f"{label}:\n{rendered}")
+
+    if transcript:
+        sections.append("Conversation transcript:\n\n" + "\n\n".join(transcript))
+    sections.append("Continue the conversation from the latest user request.")
+    return "\n\n".join(section.strip() for section in sections if section and section.strip())
+
+
+class _ClaudeCLIChatCompletions:
+    def __init__(self, client: "ClaudeCLIClient"):
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._client._create_chat_completion(**kwargs)
+
+
+class _ClaudeCLIChatNamespace:
+    def __init__(self, client: "ClaudeCLIClient"):
+        self.completions = _ClaudeCLIChatCompletions(client)
+
+
+class ClaudeCLIClient:
+    """Minimal OpenAI-client-compatible facade for local Claude CLI inference."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_headers: dict[str, str] | None = None,
+        command: str | None = None,
+        args: list[str] | None = None,
+        acp_command: str | None = None,
+        acp_args: list[str] | None = None,
+        acp_cwd: str | None = None,
+        **_: Any,
+    ):
+        self.api_key = api_key or "claude-cli"
+        self.base_url = base_url or CLAUDE_CLI_MARKER_BASE_URL
+        self._default_headers = dict(default_headers or {})
+        self._command = command or acp_command or _resolve_command()
+        self._args = list(args or acp_args or _resolve_args())
+        self._cwd = str(Path(acp_cwd or os.getcwd()).resolve())
+        self.chat = _ClaudeCLIChatNamespace(self)
+        self.is_closed = False
+        self._last_result: dict[str, Any] | None = None
+
+    def close(self) -> None:
+        self.is_closed = True
+
+    def _create_chat_completion(
+        self,
+        *,
+        model: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        timeout: float | None = None,
+        **_: Any,
+    ) -> Any:
+        prompt_text = _format_messages_as_prompt(messages or [], model=model)
+        payload = self._run_prompt(
+            prompt_text,
+            model=(model or "").split("/", 1)[-1],
+            timeout_seconds=float(timeout or _DEFAULT_TIMEOUT_SECONDS),
+        )
+        self._last_result = payload
+
+        usage_payload = payload.get("usage") if isinstance(payload, dict) else {}
+        input_tokens = int((usage_payload or {}).get("input_tokens") or 0)
+        cache_read_tokens = int((usage_payload or {}).get("cache_read_input_tokens") or 0)
+        cache_write_tokens = int((usage_payload or {}).get("cache_creation_input_tokens") or 0)
+        completion_tokens = int((usage_payload or {}).get("output_tokens") or 0)
+        prompt_tokens = input_tokens + cache_read_tokens + cache_write_tokens
+        total_tokens = prompt_tokens + completion_tokens
+
+        usage = SimpleNamespace(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=total_tokens,
+            prompt_tokens_details=SimpleNamespace(
+                cached_tokens=cache_read_tokens,
+                cache_write_tokens=cache_write_tokens,
+            ),
+            raw_cli_usage=usage_payload,
+        )
+
+        content = str(payload.get("result") or "").strip()
+        assistant_message = SimpleNamespace(
+            content=content,
+            tool_calls=[],
+            reasoning=None,
+            reasoning_content=None,
+            reasoning_details=None,
+        )
+        choice = SimpleNamespace(message=assistant_message, finish_reason="stop")
+        return SimpleNamespace(
+            choices=[choice],
+            usage=usage,
+            model=model or payload.get("model") or "claude-cli",
+        )
+
+    def _run_prompt(self, prompt_text: str, *, model: str, timeout_seconds: float) -> dict[str, Any]:
+        cmd = [self._command, "-p", "--output-format", "json", "--model", model]
+        cmd.extend(self._args)
+        cmd.append(prompt_text)
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                cwd=self._cwd,
+                timeout=timeout_seconds,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"Could not start Claude CLI command '{self._command}'. "
+                "Install Claude Code CLI or set HERMES_CLAUDE_CLI_COMMAND/CLAUDE_CLI_PATH."
+            ) from exc
+
+        stdout = (proc.stdout or "").strip()
+        stderr = (proc.stderr or "").strip()
+        if not stdout:
+            raise RuntimeError(stderr or "Claude CLI returned no output.")
+
+        try:
+            payload = json.loads(stdout)
+        except json.JSONDecodeError:
+            payload = {"result": stdout, "usage": {}}
+
+        if not isinstance(payload, dict):
+            payload = {"result": stdout, "usage": {}}
+
+        usage = payload.get("usage")
+        if not isinstance(usage, dict):
+            usage = {}
+            payload["usage"] = usage
+
+        # Fill missing token metrics with rough estimates so Hermes status/context
+        # indicators remain useful even when Claude CLI omits detailed usage.
+        if not any(usage.get(key) for key in ("input_tokens", "output_tokens", "cache_read_input_tokens", "cache_creation_input_tokens")):
+            usage["input_tokens"] = estimate_tokens_rough(prompt_text)
+            usage["output_tokens"] = estimate_tokens_rough(str(payload.get("result") or ""))
+
+        if not payload.get("model"):
+            payload["model"] = model
+        if proc.returncode != 0 and not payload.get("result"):
+            payload["result"] = stderr or stdout
+        return payload

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -70,7 +70,7 @@ DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 DEFAULT_GITHUB_MODELS_BASE_URL = "https://api.githubcopilot.com"
 DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
 DEFAULT_CLAUDE_CLI_BASE_URL = "claude-cli://local"
-CODEX_OAUTH_CLIENT_ID="app_EM...rann"
+CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
 CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -69,7 +69,8 @@ DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS = 1     # poll at most every 1s
 DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 DEFAULT_GITHUB_MODELS_BASE_URL = "https://api.githubcopilot.com"
 DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
-CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+DEFAULT_CLAUDE_CLI_BASE_URL = "claude-cli://local"
+CODEX_OAUTH_CLIENT_ID="app_EM...rann"
 CODEX_OAUTH_TOKEN_URL = "https://auth.openai.com/oauth/token"
 CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120
 
@@ -124,6 +125,31 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="external_process",
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
+        extra={
+            "command_env_vars": ["HERMES_COPILOT_ACP_COMMAND", "COPILOT_CLI_PATH"],
+            "default_command": "copilot",
+            "args_env_var": "HERMES_COPILOT_ACP_ARGS",
+            "default_args": ["--acp", "--stdio"],
+            "remote_base_url_prefixes": ["acp+tcp://"],
+            "missing_command_code": "missing_copilot_cli",
+            "missing_command_message": "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH.",
+        },
+    ),
+    "claude-cli": ProviderConfig(
+        id="claude-cli",
+        name="Claude CLI",
+        auth_type="external_process",
+        inference_base_url=DEFAULT_CLAUDE_CLI_BASE_URL,
+        base_url_env_var="HERMES_CLAUDE_CLI_BASE_URL",
+        extra={
+            "command_env_vars": ["HERMES_CLAUDE_CLI_COMMAND", "CLAUDE_CLI_PATH"],
+            "default_command": "claude",
+            "args_env_var": "HERMES_CLAUDE_CLI_ARGS",
+            "default_args": [],
+            "remote_base_url_prefixes": ["claude-cli+ssh://"],
+            "missing_command_code": "missing_claude_cli",
+            "missing_command_message": "Install Claude Code CLI or set HERMES_CLAUDE_CLI_COMMAND/CLAUDE_CLI_PATH.",
+        },
     ),
     "zai": ProviderConfig(
         id="zai",
@@ -735,6 +761,7 @@ def resolve_provider(
         "kimi": "kimi-coding", "moonshot": "kimi-coding",
         "minimax-china": "minimax-cn", "minimax_cn": "minimax-cn",
         "claude": "anthropic", "claude-code": "anthropic",
+        "claude-local": "claude-cli", "claude-binary": "claude-cli",
         "github": "copilot", "github-copilot": "copilot",
         "github-models": "copilot", "github-model": "copilot",
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
@@ -1911,27 +1938,33 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     if not pconfig or pconfig.auth_type != "external_process":
         return {"configured": False}
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    extra = pconfig.extra if isinstance(pconfig.extra, dict) else {}
+    command = ""
+    for env_name in list(extra.get("command_env_vars") or []):
+        command = os.getenv(str(env_name), "").strip()
+        if command:
+            break
+    if not command:
+        command = str(extra.get("default_command") or "").strip()
+
+    raw_args = os.getenv(str(extra.get("args_env_var") or ""), "").strip() if extra.get("args_env_var") else ""
+    args = shlex.split(raw_args) if raw_args else list(extra.get("default_args") or [])
     base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
 
     resolved_command = shutil.which(command) if command else None
+    remote_prefixes = tuple(str(prefix) for prefix in (extra.get("remote_base_url_prefixes") or []))
+    is_remote = bool(base_url and any(base_url.startswith(prefix) for prefix in remote_prefixes))
     return {
-        "configured": bool(resolved_command or base_url.startswith("acp+tcp://")),
+        "configured": bool(resolved_command or is_remote),
         "provider": provider_id,
         "name": pconfig.name,
         "command": command,
         "args": args,
         "resolved_command": resolved_command,
         "base_url": base_url,
-        "logged_in": bool(resolved_command or base_url.startswith("acp+tcp://")),
+        "logged_in": bool(resolved_command or is_remote),
     }
 
 
@@ -1942,10 +1975,9 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_nous_auth_status()
     if target == "openai-codex":
         return get_codex_auth_status()
-    if target == "copilot-acp":
-        return get_external_process_provider_status(target)
-    # API-key providers
     pconfig = PROVIDER_REGISTRY.get(target)
+    if pconfig and pconfig.auth_type == "external_process":
+        return get_external_process_provider_status(target)
     if pconfig and pconfig.auth_type == "api_key":
         return get_api_key_provider_status(target)
     return {"logged_in": False}
@@ -2001,25 +2033,31 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
     if not base_url:
         base_url = pconfig.inference_base_url
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    extra = pconfig.extra if isinstance(pconfig.extra, dict) else {}
+    command = ""
+    for env_name in list(extra.get("command_env_vars") or []):
+        command = os.getenv(str(env_name), "").strip()
+        if command:
+            break
+    if not command:
+        command = str(extra.get("default_command") or "").strip()
+
+    raw_args = os.getenv(str(extra.get("args_env_var") or ""), "").strip() if extra.get("args_env_var") else ""
+    args = shlex.split(raw_args) if raw_args else list(extra.get("default_args") or [])
     resolved_command = shutil.which(command) if command else None
-    if not resolved_command and not base_url.startswith("acp+tcp://"):
+    remote_prefixes = tuple(str(prefix) for prefix in (extra.get("remote_base_url_prefixes") or []))
+    is_remote = bool(base_url and any(base_url.startswith(prefix) for prefix in remote_prefixes))
+    if not resolved_command and not is_remote:
         raise AuthError(
-            f"Could not find the Copilot CLI command '{command}'. "
-            "Install GitHub Copilot CLI or set HERMES_COPILOT_ACP_COMMAND/COPILOT_CLI_PATH.",
+            f"Could not find the {pconfig.name} command '{command}'. "
+            f"{extra.get('missing_command_message') or 'Install the provider CLI or configure its command path.'}",
             provider=provider_id,
-            code="missing_copilot_cli",
+            code=str(extra.get("missing_command_code") or "missing_external_process_command"),
         )
 
     return {
         "provider": provider_id,
-        "api_key": "copilot-acp",
+        "api_key": provider_id,
         "base_url": base_url.rstrip("/"),
         "command": resolved_command or command,
         "args": args,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -173,39 +173,41 @@ def _relative_time(ts) -> str:
 
 def _has_any_provider_configured() -> bool:
     """Check if at least one inference provider is usable."""
-    from hermes_cli.config import get_env_path, get_hermes_home, load_config
-    from hermes_cli.auth import get_auth_status
+    from hermes_cli.config import DEFAULT_CONFIG, get_env_path, get_hermes_home, load_config
+    from hermes_cli.auth import PROVIDER_REGISTRY, get_auth_status
 
-    # Determine whether Hermes itself has been explicitly configured (model
-    # in config that isn't the hardcoded default). Used below to gate external
-    # tool credentials (Claude Code, Codex CLI) that shouldn't silently skip
-    # the setup wizard on a fresh install.
-    from hermes_cli.config import DEFAULT_CONFIG
-    _DEFAULT_MODEL = DEFAULT_CONFIG.get("model", "")
     cfg = load_config()
     model_cfg = cfg.get("model")
     if isinstance(model_cfg, dict):
-        _model_name = (model_cfg.get("default") or "").strip()
+        model_name = (model_cfg.get("default") or "").strip()
     elif isinstance(model_cfg, str):
-        _model_name = model_cfg.strip()
+        model_name = model_cfg.strip()
     else:
-        _model_name = ""
-    _has_hermes_config = _model_name and _model_name != _DEFAULT_MODEL
+        model_name = ""
 
-    # Check env vars (may be set by .env or shell).
-    # OPENAI_BASE_URL alone counts — local models (vLLM, llama.cpp, etc.)
-    # often don't require an API key.
-    from hermes_cli.auth import PROVIDER_REGISTRY
+    default_model = DEFAULT_CONFIG.get("model", "")
+    has_hermes_config = bool(model_name and model_name != default_model)
 
-    # Collect all provider env vars
-    provider_env_vars = {"OPENROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "OPENAI_BASE_URL"}
-    for pconfig in PROVIDER_REGISTRY.values():
-        if pconfig.auth_type == "api_key":
-            provider_env_vars.update(pconfig.api_key_env_vars)
+    provider_env_vars = {
+        "OPENROUTER_API_KEY",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_TOKEN",
+        "OPENAI_BASE_URL",
+    }
+    for provider_id, pconfig in PROVIDER_REGISTRY.items():
+        if pconfig.auth_type != "api_key":
+            continue
+        # Copilot shell env vars like GH_TOKEN/GITHUB_TOKEN are often present for
+        # unrelated GitHub workflows and should not silently skip Hermes setup on a
+        # fresh install. Copilot still counts below via explicit gh CLI detection.
+        if provider_id == "copilot":
+            continue
+        provider_env_vars.update(pconfig.api_key_env_vars)
+
     if any(os.getenv(v) for v in provider_env_vars):
         return True
 
-    # Check .env file for keys
     env_file = get_env_path()
     if env_file.exists():
         try:
@@ -214,24 +216,19 @@ def _has_any_provider_configured() -> bool:
                 if line.startswith("#") or "=" not in line:
                     continue
                 key, _, val = line.partition("=")
-                val = val.strip().strip("'\"")
-                if key.strip() in provider_env_vars and val:
+                if key.strip() in provider_env_vars and val.strip().strip("'\""):
                     return True
         except Exception:
             pass
 
-    # Check provider-specific auth fallbacks (for example, Copilot via gh auth).
     try:
-        for provider_id, pconfig in PROVIDER_REGISTRY.items():
-            if pconfig.auth_type != "api_key":
-                continue
-            status = get_auth_status(provider_id)
-            if status.get("logged_in"):
-                return True
+        from hermes_cli.copilot_auth import _try_gh_cli_token
+
+        if _try_gh_cli_token():
+            return True
     except Exception:
         pass
 
-    # Check for Nous Portal OAuth credentials
     auth_file = get_hermes_home() / "auth.json"
     if auth_file.exists():
         try:
@@ -245,11 +242,6 @@ def _has_any_provider_configured() -> bool:
         except Exception:
             pass
 
-
-    # Check config.yaml — if model is a dict with an explicit provider set,
-    # the user has gone through setup (fresh installs have model as a plain
-    # string).  Also covers custom endpoints that store api_key/base_url in
-    # config rather than .env.
     if isinstance(model_cfg, dict):
         cfg_provider = (model_cfg.get("provider") or "").strip()
         cfg_base_url = (model_cfg.get("base_url") or "").strip()
@@ -257,10 +249,7 @@ def _has_any_provider_configured() -> bool:
         if cfg_provider or cfg_base_url or cfg_api_key:
             return True
 
-    # Check for Claude Code OAuth credentials (~/.claude/.credentials.json)
-    # Only count these if Hermes has been explicitly configured — Claude Code
-    # being installed doesn't mean the user wants Hermes to use their tokens.
-    if _has_hermes_config:
+    if has_hermes_config:
         try:
             from agent.anthropic_adapter import read_claude_code_credentials, is_claude_code_token_valid
             creds = read_claude_code_credentials()
@@ -4038,7 +4027,7 @@ For more help on a command:
     )
     chat_parser.add_argument(
         "--provider",
-        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "copilot", "anthropic", "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode"],
+        choices=["auto", "openrouter", "nous", "openai-codex", "copilot-acp", "claude-cli", "copilot", "anthropic", "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode"],
         default=None,
         help="Inference provider (default: auto)"
     )

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -96,6 +96,15 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "claude-cli": [
+        "claude-cli/claude-opus-4-6",
+        "claude-cli/claude-sonnet-4-6",
+        "claude-cli/claude-opus-4-5-20251101",
+        "claude-cli/claude-sonnet-4-5-20250929",
+        "claude-cli/claude-opus-4-20250514",
+        "claude-cli/claude-sonnet-4-20250514",
+        "claude-cli/claude-haiku-4-5-20251001",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -259,6 +268,7 @@ _PROVIDER_LABELS = {
     "openrouter": "OpenRouter",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
+    "claude-cli": "Claude CLI",
     "nous": "Nous Portal",
     "copilot": "GitHub Copilot",
     "zai": "Z.AI / GLM",
@@ -287,6 +297,8 @@ _PROVIDER_ALIASES = {
     "github-model": "copilot",
     "github-copilot-acp": "copilot-acp",
     "copilot-acp-agent": "copilot-acp",
+    "claude-local": "claude-cli",
+    "claude-binary": "claude-cli",
     "kimi": "kimi-coding",
     "moonshot": "kimi-coding",
     "minimax-china": "minimax-cn",
@@ -343,7 +355,7 @@ def list_available_providers() -> list[dict[str, str]]:
     """
     # Canonical providers in display order
     _PROVIDER_ORDER = [
-        "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
+        "openrouter", "nous", "openai-codex", "copilot", "copilot-acp", "claude-cli",
         "huggingface", "zai", "kimi-coding", "minimax", "minimax-cn", "kilocode", "anthropic", "alibaba",
         "opencode-zen", "opencode-go",
         "ai-gateway", "deepseek", "custom",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -648,10 +648,10 @@ def resolve_runtime_provider(
             "requested_provider": requested_provider,
         }
 
-    if provider == "copilot-acp":
+    if provider in {"copilot-acp", "claude-cli"}:
         creds = resolve_external_process_provider_credentials(provider)
         return {
-            "provider": "copilot-acp",
+            "provider": provider,
             "api_mode": "chat_completions",
             "base_url": creds.get("base_url", "").rstrip("/"),
             "api_key": creds.get("api_key", ""),

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -92,6 +92,12 @@ _DEFAULT_PROVIDER_MODELS = {
     "copilot-acp": [
         "copilot-acp",
     ],
+    "claude-cli": [
+        "claude-cli/claude-opus-4-6",
+        "claude-cli/claude-sonnet-4-6",
+        "claude-cli/claude-opus-4-20250514",
+        "claude-cli/claude-sonnet-4-20250514",
+    ],
     "copilot": [
         "gpt-5.4",
         "gpt-5.4-mini",
@@ -1029,6 +1035,7 @@ def setup_model_provider(config: dict):
             "nous-api": "Nous Portal API key",
             "copilot": "GitHub Copilot",
             "copilot-acp": "GitHub Copilot ACP",
+            "claude-cli": "Claude CLI",
             "zai": "Z.AI / GLM",
             "kimi-coding": "Kimi / Moonshot",
             "minimax": "MiniMax",

--- a/run_agent.py
+++ b/run_agent.py
@@ -772,7 +772,7 @@ class AIAgent:
                 # Explicit credentials from CLI/gateway — construct directly.
                 # The runtime provider resolver already handled auth for us.
                 client_kwargs = {"api_key": api_key, "base_url": base_url}
-                if self.provider == "copilot-acp":
+                if self.provider in {"copilot-acp", "claude-cli"}:
                     client_kwargs["command"] = self.acp_command
                     client_kwargs["args"] = self.acp_args
                 effective_base = base_url
@@ -886,12 +886,16 @@ class AIAgent:
                 print(f"🔄 Fallback chain ({len(self._fallback_chain)} providers): " +
                       " → ".join(f"{f['model']} ({f['provider']})" for f in self._fallback_chain))
 
-        # Get available tools with filtering
+        # Get available tools with filtering. Claude CLI backend currently runs
+        # in text-in/text-out mode, so keep Hermes-side tools disabled to avoid
+        # misleading prompts and unsupported tool-call expectations.
         self.tools = get_tool_definitions(
             enabled_toolsets=enabled_toolsets,
             disabled_toolsets=disabled_toolsets,
             quiet_mode=self.quiet_mode,
         )
+        if self.provider == "claude-cli":
+            self.tools = []
         
         # Show tool configuration and store valid tool names for validation
         self.valid_tool_names = set()
@@ -3371,6 +3375,17 @@ class AIAgent:
             client = CopilotACPClient(**client_kwargs)
             logger.info(
                 "Copilot ACP client created (%s, shared=%s) %s",
+                reason,
+                shared,
+                self._client_log_context(),
+            )
+            return client
+        if self.provider == "claude-cli" or str(client_kwargs.get("base_url", "")).startswith("claude-cli://"):
+            from agent.claude_cli_client import ClaudeCLIClient
+
+            client = ClaudeCLIClient(**client_kwargs)
+            logger.info(
+                "Claude CLI client created (%s, shared=%s) %s",
                 reason,
                 shared,
                 self._client_log_context(),

--- a/tests/test_api_key_providers.py
+++ b/tests/test_api_key_providers.py
@@ -37,6 +37,7 @@ class TestProviderRegistry:
 
     @pytest.mark.parametrize("provider_id,name,auth_type", [
         ("copilot-acp", "GitHub Copilot ACP", "external_process"),
+        ("claude-cli", "Claude CLI", "external_process"),
         ("copilot", "GitHub Copilot", "api_key"),
         ("huggingface", "Hugging Face", "api_key"),
         ("zai", "Z.AI / GLM", "api_key"),
@@ -96,6 +97,7 @@ class TestProviderRegistry:
     def test_base_urls(self):
         assert PROVIDER_REGISTRY["copilot"].inference_base_url == "https://api.githubcopilot.com"
         assert PROVIDER_REGISTRY["copilot-acp"].inference_base_url == "acp://copilot"
+        assert PROVIDER_REGISTRY["claude-cli"].inference_base_url == "claude-cli://local"
         assert PROVIDER_REGISTRY["zai"].inference_base_url == "https://api.z.ai/api/paas/v4"
         assert PROVIDER_REGISTRY["kimi-coding"].inference_base_url == "https://api.moonshot.ai/v1"
         assert PROVIDER_REGISTRY["minimax"].inference_base_url == "https://api.minimax.io/anthropic"
@@ -205,6 +207,10 @@ class TestResolveProvider:
     def test_alias_github_copilot_acp(self):
         assert resolve_provider("github-copilot-acp") == "copilot-acp"
         assert resolve_provider("copilot-acp-agent") == "copilot-acp"
+
+    def test_alias_claude_cli(self):
+        assert resolve_provider("claude-local") == "claude-cli"
+        assert resolve_provider("claude-binary") == "claude-cli"
 
     def test_explicit_huggingface(self):
         assert resolve_provider("huggingface") == "huggingface"
@@ -625,6 +631,7 @@ class TestHasAnyProviderConfigured:
     def test_claude_code_creds_ignored_on_fresh_install(self, monkeypatch, tmp_path):
         """Claude Code credentials should NOT skip the wizard when Hermes is unconfigured."""
         from hermes_cli import config as config_module
+        monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: None)
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
         monkeypatch.setattr(config_module, "get_env_path", lambda: hermes_home / ".env")
@@ -707,6 +714,7 @@ class TestHasAnyProviderConfigured:
         """config.yaml model dict with empty default and no creds stays false."""
         import yaml
         from hermes_cli import config as config_module
+        monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: None)
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
         config_file = hermes_home / "config.yaml"

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -2562,6 +2562,38 @@ def test_aiagent_uses_copilot_acp_client():
     assert mock_acp_client.call_args.kwargs["args"] == ["--acp", "--stdio"]
 
 
+
+
+def test_aiagent_uses_claude_cli_client_and_disables_tools():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI") as mock_openai,
+        patch("agent.claude_cli_client.ClaudeCLIClient") as mock_claude_client,
+    ):
+        cli_client = MagicMock()
+        mock_claude_client.return_value = cli_client
+
+        agent = AIAgent(
+            api_key="dummy-key",
+            base_url="claude-cli://local",
+            provider="claude-cli",
+            acp_command="/usr/local/bin/claude",
+            acp_args=["--debug"],
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.client is cli_client
+    assert agent.tools == []
+    mock_openai.assert_not_called()
+    mock_claude_client.assert_called_once()
+    assert mock_claude_client.call_args.kwargs["base_url"] == "claude-cli://local"
+    assert mock_claude_client.call_args.kwargs["api_key"] == "dummy-key"
+    assert mock_claude_client.call_args.kwargs["command"] == "/usr/local/bin/claude"
+    assert mock_claude_client.call_args.kwargs["args"] == ["--debug"]
+
 def test_is_openai_client_closed_honors_custom_client_flag():
     assert AIAgent._is_openai_client_closed(SimpleNamespace(is_closed=True)) is True
     assert AIAgent._is_openai_client_closed(SimpleNamespace(is_closed=False)) is False

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -18,6 +18,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **OpenAI Codex** | `hermes model` (ChatGPT OAuth, uses Codex models) |
 | **GitHub Copilot** | `hermes model` (OAuth device code flow, `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `gh auth token`) |
 | **GitHub Copilot ACP** | `hermes model` (spawns local `copilot --acp --stdio`) |
+| **Claude CLI** | `hermes model` (spawns local `claude -p --output-format json` for inference) |
 | **Anthropic** | `hermes model` (Claude Pro/Max via Claude Code auth, Anthropic API key, or manual setup-token) |
 | **OpenRouter** | `OPENROUTER_API_KEY` in `~/.hermes/.env` |
 | **AI Gateway** | `AI_GATEWAY_API_KEY` in `~/.hermes/.env` (provider: `ai-gateway`) |
@@ -131,6 +132,29 @@ model:
 | `COPILOT_GITHUB_TOKEN` | GitHub token for Copilot API (first priority) |
 | `HERMES_COPILOT_ACP_COMMAND` | Override the Copilot CLI binary path (default: `copilot`) |
 | `HERMES_COPILOT_ACP_ARGS` | Override ACP args (default: `--acp --stdio`) |
+
+### Claude CLI backend
+
+Use Claude Code itself as the inference backend instead of calling Anthropic
+directly. This is useful when Anthropic changes billing or subscription policy
+for third-party harness traffic and you want Hermes to route inference through
+your locally installed `claude` binary.
+
+```bash
+hermes chat --provider claude-cli --model claude-cli/claude-sonnet-4-6
+# Requires the Claude CLI in PATH and an existing `claude auth` / subscription session
+```
+
+This backend is currently text-in/text-out only. Hermes disables its own tool
+schemas for `claude-cli` sessions, but it still tracks prompt/completion usage
+and context-window status so the CLI status bar remains accurate.
+
+| Environment variable | Description |
+|---------------------|-------------|
+| `HERMES_CLAUDE_CLI_COMMAND` | Override the Claude CLI binary path (default: `claude`) |
+| `CLAUDE_CLI_PATH` | Alias for `HERMES_CLAUDE_CLI_COMMAND` |
+| `HERMES_CLAUDE_CLI_ARGS` | Extra args appended before the prompt payload |
+| `HERMES_CLAUDE_CLI_BASE_URL` | Optional marker URL override for remote wrappers |
 
 ### First-Class Chinese AI Providers
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -73,7 +73,7 @@ Common options:
 | `-q`, `--query "..."` | One-shot, non-interactive prompt. |
 | `-m`, `--model <model>` | Override the model for this run. |
 | `-t`, `--toolsets <csv>` | Enable a comma-separated set of toolsets. |
-| `--provider <provider>` | Force a provider: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot-acp`, `copilot`, `anthropic`, `huggingface`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`, `kilocode`. |
+| `--provider <provider>` | Force a provider: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot-acp`, `claude-cli`, `copilot`, `anthropic`, `huggingface`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`, `kilocode`. |
 | `-s`, `--skills <name>` | Preload one or more skills for the session (can be repeated or comma-separated). |
 | `-v`, `--verbose` | Verbose output. |
 | `-Q`, `--quiet` | Programmatic mode: suppress banner/spinner/tool previews. |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -25,6 +25,10 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 | `COPILOT_CLI_PATH` | Alias for `HERMES_COPILOT_ACP_COMMAND` |
 | `HERMES_COPILOT_ACP_ARGS` | Override Copilot ACP arguments (default: `--acp --stdio`) |
 | `COPILOT_ACP_BASE_URL` | Override Copilot ACP base URL |
+| `HERMES_CLAUDE_CLI_COMMAND` | Override Claude CLI binary path (default: `claude`) |
+| `CLAUDE_CLI_PATH` | Alias for `HERMES_CLAUDE_CLI_COMMAND` |
+| `HERMES_CLAUDE_CLI_ARGS` | Extra Claude CLI arguments appended before the prompt payload |
+| `HERMES_CLAUDE_CLI_BASE_URL` | Override Claude CLI marker base URL (default: `claude-cli://local`) |
 | `GLM_API_KEY` | z.ai / ZhipuAI GLM API key ([z.ai](https://z.ai)) |
 | `ZAI_API_KEY` | Alias for `GLM_API_KEY` |
 | `Z_AI_API_KEY` | Alias for `GLM_API_KEY` |
@@ -63,7 +67,7 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 
 | Variable | Description |
 |----------|-------------|
-| `HERMES_INFERENCE_PROVIDER` | Override provider selection: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `huggingface`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`, `kilocode`, `alibaba`, `deepseek`, `opencode-zen`, `opencode-go`, `ai-gateway` (default: `auto`) |
+| `HERMES_INFERENCE_PROVIDER` | Override provider selection: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `claude-cli`, `anthropic`, `huggingface`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`, `kilocode`, `alibaba`, `deepseek`, `opencode-zen`, `opencode-go`, `ai-gateway` (default: `auto`) |
 | `HERMES_PORTAL_BASE_URL` | Override Nous Portal URL (for development/testing) |
 | `NOUS_INFERENCE_BASE_URL` | Override Nous inference API URL |
 | `HERMES_NOUS_MIN_KEY_TTL_SECONDS` | Min agent key TTL before re-mint (default: 1800 = 30min) |


### PR DESCRIPTION
## Summary
This is a follow-up to PR #4957.

The claude-cli provider work inadvertently replaced `CODEX_OAUTH_CLIENT_ID` in `hermes_cli/auth.py` with a redacted placeholder. That breaks `openai-codex` OAuth login because Hermes sends an invalid `client_id` to OpenAI before tokens can be issued.

This PR restores the real Codex OAuth client id and leaves the rest of the claude-cli backend changes untouched.

## Scope
- restore `CODEX_OAUTH_CLIENT_ID` in `hermes_cli/auth.py`
- no behavioral changes outside the Codex auth constant

## Why this is separate
`upstream/main` does not contain the regression. The bad constant is introduced by the branch behind PR #4957, so this branch is that change plus a minimal one-line fix.

## Verification
- `/Users/kshitij/Projects/hermes-agent/.venv/bin/python -m py_compile hermes_cli/auth.py`
- `/Users/kshitij/Projects/hermes-agent/.venv/bin/python -m pytest tests/test_auth_commands.py -q -k codex`
- Result: `1 passed`

## Reviewer context
Addresses the P1 review finding on PR #4957:
- restore the real Codex OAuth client id in `hermes_cli/auth.py`

Without this fix, `hermes model` / Codex auth flows fail immediately for `openai-codex` users.
