### PR TITLE
fix(api-server): pass fallback_model to AIAgent in _create_agent()

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -410,7 +410,7 @@ class APIServerAdapter(BasePlatformAdapter):
         gateway platforms), falling back to the hermes-api-server default.
         """
         from run_agent import AIAgent
-        from gateway.run import _resolve_runtime_agent_kwargs, _resolve_gateway_model, _load_gateway_config
+        from gateway.run import _resolve_runtime_agent_kwargs, _resolve_gateway_model, _load_gateway_config, _load_fallback_model
         from hermes_cli.tools_config import _get_platform_tools
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()
@@ -418,6 +418,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
+        fallback_model = _load_fallback_model()
 
         max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
 
@@ -434,6 +435,7 @@ class APIServerAdapter(BasePlatformAdapter):
             stream_delta_callback=stream_delta_callback,
             tool_progress_callback=tool_progress_callback,
             session_db=self._ensure_session_db(),
+            fallback_model=fallback_model,
         )
         return agent
 


### PR DESCRIPTION
## Problem

The API server platform (`gateway/platforms/api_server.py`) was constructing `AIAgent` without the `fallback_model` argument. This meant the fallback chain was always empty when requests came through the OpenAI-compatible endpoint (`/v1/chat/completions`). When the primary provider was rate-limited or unavailable, `_try_activate_fallback()` returned `False` immediately because `_fallback_chain` was never populated — silently failing instead of falling back.

All other platforms (Telegram, Discord, Slack, etc.) correctly pass `fallback_model` via `self._fallback_model` in `gateway/run.py` (lines 3969, 4143, 5658).

## Root Cause

In `_create_agent()` (~line 413), the `AIAgent` constructor was called without `fallback_model`:

```python
# Before — fallback_model missing
agent = AIAgent(
    model=model,
    **runtime_kwargs,
    ...
    session_db=self._ensure_session_db(),
    # fallback_model never passed → _fallback_chain stays empty
)
```

## Fix

Import `_load_fallback_model()` from `gateway.run` (the same static helper already used by `GatewayApp`) and pass its return value to the `AIAgent` constructor:

```python
from gateway.run import _resolve_runtime_agent_kwargs, _resolve_gateway_model, _load_gateway_config, _load_fallback_model

fallback_model = _load_fallback_model()

agent = AIAgent(
    ...
    session_db=self._ensure_session_db(),
    fallback_model=fallback_model,  # ← added
)
```

## Changes

- `gateway/platforms/api_server.py`: 3-line change — add `_load_fallback_model` to the import, call it, and pass the result to `AIAgent`.

## Testing

1. Configure `fallback_providers` in `~/.hermes/config.yaml`
2. Connect an OpenAI-compatible client to `localhost:8642/v1`
3. Send a request while the primary provider is unavailable
4. The agent now falls back to the configured fallback chain instead of failing silently

Fixes #4954