### PR TITLE
fix: normalize base_url to str before rstrip in anthropic adapter

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -172,7 +172,7 @@ def _is_third_party_anthropic_endpoint(base_url: str | None) -> bool:
     """
     if not base_url:
         return False  # No base_url = direct Anthropic API
-    normalized = base_url.rstrip("/").lower()
+    normalized = str(base_url).rstrip("/").lower()
     if "anthropic.com" in normalized:
         return False  # Direct Anthropic API — OAuth applies
     return True  # Any other endpoint is a third-party proxy
@@ -187,7 +187,7 @@ def _requires_bearer_auth(base_url: str | None) -> bool:
     """
     if not base_url:
         return False
-    normalized = base_url.rstrip("/").lower()
+    normalized = str(base_url).rstrip("/").lower()
     return normalized.startswith("https://api.minimax.io/anthropic") or normalized.startswith(
         "https://api.minimaxi.com/anthropic"
     )


### PR DESCRIPTION
## Summary
- Fixes #4944
- `_is_third_party_anthropic_endpoint()` and `_requires_bearer_auth()` called `.rstrip()` on `base_url` assuming it's always a string
- When a provider client exposes `base_url` as an `httpx.URL` object (e.g. MiniMax fallback), this crashes with `AttributeError: 'URL' object has no attribute 'rstrip'`
- Wrapping in `str()` handles both `str` and `httpx.URL` inputs

## Test plan
- [ ] `_requires_bearer_auth(httpx.URL("https://api.minimax.io/anthropic"))` returns `True` without crashing
- [ ] `_is_third_party_anthropic_endpoint(httpx.URL("https://example.com"))` returns `True` without crashing
- [ ] String inputs continue to work as before