### PR TITLE
fix(approval): load permanent command allowlist on module import

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -866,3 +866,9 @@ def check_all_command_guards(command: str, env_type: str,
             save_permanent_allowlist(_permanent_approved)
 
     return {"approved": True, "message": None}
+
+
+# Load permanent allowlist from config on module import so that patterns
+# persisted via '/approve always' in a previous session take effect
+# immediately without requiring an explicit call at startup.
+load_permanent_allowlist()


### PR DESCRIPTION
## Summary
- Fixes #4739
- `load_permanent_allowlist()` was defined but never called anywhere, so patterns saved via `/approve always` were lost on every restart
- Added a module-level call so the persisted allowlist is loaded on import

## Test plan
- [ ] `/approve always` a dangerous command, verify it's in `config.yaml`
- [ ] Restart gateway/CLI
- [ ] Trigger same command — should be auto-approved without re-prompting