### PR TITLE
fix(gateway): don't clobber resolved TERMINAL_CWD with raw config

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -131,6 +131,10 @@ if _config_path.exists():
             }
             for _cfg_key, _env_var in _terminal_env_map.items():
                 if _cfg_key in _terminal_cfg:
+                    # Don't clobber TERMINAL_CWD if cli.py already resolved
+                    # a relative path (like ".") to an absolute path.
+                    if _env_var == "TERMINAL_CWD" and os.path.isabs(os.environ.get("TERMINAL_CWD", "")):
+                        continue
                     _val = _terminal_cfg[_cfg_key]
                     if isinstance(_val, list):
                         os.environ[_env_var] = json.dumps(_val)


### PR DESCRIPTION
## Summary
- Fixes #4672
- `cli.py` resolves `cwd: "."` to an absolute path and sets `TERMINAL_CWD`
- `gateway/run.py` then re-reads the raw config value `"."` and overwrites it, causing the terminal to fall back to `$HOME`
- Skip the `cwd` bridge when `TERMINAL_CWD` already holds an absolute path

## Test plan
- [ ] Set `terminal.cwd: "."` in config.yaml
- [ ] `cd /some/project && hermes chat -q "pwd"` — should print `/some/project`, not `$HOME`