### PR TITLE
fix: include docker_forward_env in terminal_tool container_config

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1020,6 +1020,7 @@ def terminal_tool(
                                 "container_persistent": config.get("container_persistent", True),
                                 "modal_mode": config.get("modal_mode", "auto"),
                                 "docker_volumes": config.get("docker_volumes", []),
+                                "docker_forward_env": config.get("docker_forward_env", []),
                                 "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
                             }
 


### PR DESCRIPTION
## Summary
- Fixes #4916
- `terminal_tool()` parsed `docker_forward_env` in `_get_env_config()` and `_create_environment()` accepted it, but the `container_config` dict built in the main code path omitted the key
- Added `docker_forward_env` to the dict so env vars are properly forwarded into docker sandboxes

## Test plan
- [ ] Set `terminal.docker_forward_env: ["MY_VAR"]` in config
- [ ] Run terminal_tool with docker backend
- [ ] Verify `MY_VAR` is forwarded into the container