### PR TITLE
fix(security): prevent gateway '/approve' from unintentionally escalating to session-level trust

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -812,12 +812,17 @@ def check_all_command_guards(command: str, env_type: str,
 
             # User approved — persist based on scope (same logic as CLI)
             for key, _, is_tirith in warnings:
-                if choice in ("once", "session") or (choice == "always" and is_tirith):
+                if choice == "session" or (choice == "always" and is_tirith):
+                    # "session" or tirith+always: approve for this session only
                     approve_session(session_key, key)
                 elif choice == "always":
+                    # "always" for dangerous patterns: permanent
                     approve_session(session_key, key)
                     approve_permanent(key)
                     save_permanent_allowlist(_permanent_approved)
+                # "once": no approve_session() — approval is implicit in the
+                # return value below. The next command with the same pattern
+                # will prompt again, matching the CLI's one-time-only behavior.
 
             return {"approved": True, "message": None}
 


### PR DESCRIPTION
🐛 The Bug
During an autonomous security audit of the hermes-agent command approval system, a privilege escalation vulnerability was discovered in the gateway flow (tools/approval.py -> check_all_command_guards).

When a user interacts with the agent via a messaging gateway (e.g., Discord, Slack) or the async CLI, and the agent attempts a dangerous command, the process pauses and awaits user input. If the user explicitly approved the command with /approve (which translates to explicitly approving the command once), the backend logic was overly permissive:

# The flaw: "once" was grouped with "session"
if choice in ("once", "session") or (choice == "always" and is_tirith):
    approve_session(session_key, key)

This caused a one-time approval to unintentionally grant session-wide blanket approval for any subsequent commands matching that same dangerous pattern, bypassing future security prompts entirely.

🛠️ The Fix
Removed the "once" option from the approve_session escalation path in the gateway flow. The "once" choice now relies purely on the implicit True return value of the function without persisting the pattern to the session's allowlist.

This mirrors the interactive CLI behavior (prompt_dangerous_approval mapping) where one-time approvals are successfully scoped only to the immediate execution context.

🧪 Validation
Manual inspection and comparison against interactive CLI approval branching.
Verified that subsequent executions of the same dangerous command pattern correctly trigger a fresh approval prompt when previously approved with /approve (rather than /approve session).
Validated that pytest tests/gateway/test_approve_deny_commands.py flows still resolve correctly with targeted mock assertions.

📋 Checklist
[x] Bug fix (non-breaking change which fixes an issue)
[x] Security patch (fixes a privilege/trust scope vulnerability)
[x] Tested locally
[x] Code adheres to the "Hermes Agent Contribution Guide" strictly