### PR TITLE
fix(approval): plain /approve grants one-time approval, not session-wide

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -812,7 +812,9 @@ def check_all_command_guards(command: str, env_type: str,
 
             # User approved — persist based on scope (same logic as CLI)
             for key, _, is_tirith in warnings:
-                if choice in ("once", "session") or (choice == "always" and is_tirith):
+                if choice == "session" or (choice == "always" and is_tirith):
+                    # "once" is intentionally excluded — it grants a single
+                    # execution without persisting session-wide approval.
                     approve_session(session_key, key)
                 elif choice == "always":
                     approve_session(session_key, key)


### PR DESCRIPTION
## Summary
- Fixes #4697
- The gateway blocking approval path treated `choice == "once"` the same as `"session"`, calling `approve_session()` for both
- Removed `"once"` from the session-persist branch so `/approve` grants a single execution only, matching documented and CLI semantics

## Test plan
- [ ] `/approve` a dangerous command, then trigger the same command again — should prompt again
- [ ] `/approve session` — should auto-approve for the rest of the session
- [ ] `/approve always` — should persist across restarts