### PR TITLE
fix: fall back to LITELLM_KEY for /models metadata auth

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -439,6 +439,8 @@ def fetch_endpoint_model_metadata(
     if alternate and alternate not in candidates:
         candidates.append(alternate)
 
+    if not api_key:
+        api_key = os.environ.get("LITELLM_KEY", "") or os.environ.get("OPENAI_API_KEY", "")
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
     last_error: Optional[Exception] = None
 


### PR DESCRIPTION
## Summary
- Fixes #4913
- `fetch_endpoint_model_metadata()` sent unauthenticated `/models` requests when `api_key` was empty at the call site
- Now falls back to `LITELLM_KEY` or `OPENAI_API_KEY` from the environment, so custom endpoints requiring auth on `/models` get a proper `Authorization` header

## Test plan
- [ ] Configure a custom endpoint with auth-required `/models` route
- [ ] Set `LITELLM_KEY` in environment
- [ ] Trigger metadata/pricing lookup — should succeed with 200, not 401