### PR TITLE
fix(docker): upgrade Node.js from 20 to 22 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM debian:13.4
 
+# Install Node.js 22 LTS via NodeSource (Node 20 LTS reaches EOL April 2026)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl ca-certificates && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    rm -rf /var/lib/apt/lists/*
+
 # Install system dependencies in one layer, clear APT cache
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Problem

The Dockerfile installs `nodejs` from Debian 13.4 (trixie) apt repos, which provides **Node.js 20.x**. Node 20 LTS reaches **end-of-life in April 2026** and will stop receiving security patches.

## Fix

Add a [NodeSource](https://github.com/nodesource/distributions) setup step before the main `apt-get install` to pin the package source to **Node.js 22 LTS** (supported through April 2027):

```dockerfile
# Install Node.js 22 LTS via NodeSource (Node 20 LTS reaches EOL April 2026)
RUN apt-get update && \
    apt-get install -y --no-install-recommends curl ca-certificates && \
    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
    rm -rf /var/lib/apt/lists/*
```

The subsequent `apt-get install ... nodejs npm ...` layer then resolves to Node 22.x instead of the Debian default.

## Changes

- `Dockerfile`: add NodeSource 22.x setup layer before the main dependency install

## Notes

- No changes to `npm install` steps — Node 22 is a drop-in replacement
- `curl` and `ca-certificates` are added as minimal bootstrap deps for the NodeSource script (both are standard Debian packages)
- Follows the official [NodeSource install guide](https://github.com/nodesource/distributions#debian-and-ubuntu-based-distributions)

Closes #4876