### PR TITLE
fix(security): validate RETAINDB_BASE_URL against SSRF before requests

### DIFF
--- a/plugins/memory/retaindb/__init__.py
+++ b/plugins/memory/retaindb/__init__.py
@@ -146,6 +146,17 @@ class RetainDBMemoryProvider(MemoryProvider):
     def initialize(self, session_id: str, **kwargs) -> None:
         self._api_key = os.environ.get("RETAINDB_API_KEY", "")
         self._base_url = os.environ.get("RETAINDB_BASE_URL", _DEFAULT_BASE_URL)
+      try:
+            from tools.url_safety import is_safe_url
+            if not is_safe_url(self._base_url):
+                logger.warning(
+                    "RETAINDB_BASE_URL '%s' resolves to a private/internal address "
+                    "and has been reset to the default endpoint.",
+                    self._base_url,
+                )
+                self._base_url = _DEFAULT_BASE_URL
+        except ImportError:
+            pass
         self._user_id = kwargs.get("user_id", "default")
         self._session_id = session_id
 


### PR DESCRIPTION
## What does this PR do?

The RetainDB memory plugin reads `RETAINDB_BASE_URL` from an environment
variable and uses it directly in HTTP requests without any validation.

If `RETAINDB_BASE_URL` is set to an internal address (e.g.
`http://169.254.169.254` on AWS, `http://metadata.google.internal` on GCP,
or any private network service), every memory read and write would silently
make requests to that internal address — a classic SSRF attack vector.

## Fix

Added an `is_safe_url()` check in `initialize()` after reading
`RETAINDB_BASE_URL`. If the URL resolves to a private/internal address,
it is reset to the safe default endpoint with a warning log.

This is consistent with the SSRF protection already applied in:
- `tools/homeassistant_tool.py` (HASS_URL)
- `tools/web_tools.py`
- `tools/vision_tools.py`
- `gateway/platforms/wecom.py`

## Type of Change

- [x] 🔒 Security fix (SSRF)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Consistent with existing SSRF protection pattern in Hermes
- [x] No behavior change for legitimate RetainDB endpoints
- [x] ImportError handled gracefully