### PR TITLE
fix(gateway): rewrite transcripts atomically

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1002,11 +1002,28 @@ class SessionStore:
             except Exception as e:
                 logger.debug("Failed to rewrite transcript in DB: %s", e)
         
-        # JSONL: overwrite the file
+        # JSONL: write to a temp file first so crashes never leave partial output
         transcript_path = self.get_transcript_path(session_id)
-        with open(transcript_path, "w", encoding="utf-8") as f:
-            for msg in messages:
-                f.write(json.dumps(msg, ensure_ascii=False) + "\n")
+        transcript_path.parent.mkdir(parents=True, exist_ok=True)
+
+        import tempfile
+
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(transcript_path.parent), suffix=".tmp", prefix=".transcript_"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                for msg in messages:
+                    f.write(json.dumps(msg, ensure_ascii=False) + "\n")
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, transcript_path)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError as e:
+                logger.debug("Could not remove temp file %s: %s", tmp_path, e)
+            raise
 
     def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
         """Load all messages from a session's transcript."""

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -420,6 +420,40 @@ class TestSessionStoreRewriteTranscript:
         reloaded = store.load_transcript(session_id)
         assert reloaded == []
 
+    def test_rewrite_failure_leaves_existing_jsonl_intact(self, store, monkeypatch):
+        session_id = "test_session_atomic_failure"
+        original_messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        replacement_messages = [
+            {"role": "user", "content": "rewrite me"},
+            {"role": "assistant", "content": "this should not land"},
+        ]
+
+        for msg in original_messages:
+            store.append_to_transcript(session_id, msg)
+
+        transcript_path = store.get_transcript_path(session_id)
+        original_contents = transcript_path.read_text(encoding="utf-8")
+        real_dumps = json.dumps
+        call_count = 0
+
+        def fail_mid_rewrite(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise RuntimeError("boom during rewrite")
+            return real_dumps(*args, **kwargs)
+
+        monkeypatch.setattr("gateway.session.json.dumps", fail_mid_rewrite)
+
+        with pytest.raises(RuntimeError, match="boom during rewrite"):
+            store.rewrite_transcript(session_id, replacement_messages)
+
+        assert transcript_path.read_text(encoding="utf-8") == original_contents
+        assert store.load_transcript(session_id) == original_messages
+
 
 class TestLoadTranscriptCorruptLines:
     """Regression: corrupt JSONL lines (e.g. from mid-write crash) must be


### PR DESCRIPTION
`rewrite_transcript()` still overwrites the legacy JSONL transcript with a bare
`open(path, "w")`. If the gateway dies mid-write during `/retry`, `/undo`, or
`/compress`, the transcript file can be left empty or partially rewritten.

This refresh trims the PR down to the still-reproducible bug on current `main`.
`channel_directory` already uses `atomic_json_write()`, so it is no longer part
of the fix.

## Changes Made

- Rewrite transcripts through a temp file in the same directory
- `fsync()` the temp file before replacing the original transcript
- Remove the temp file on failure so aborted rewrites do not leave garbage behind
- Add a regression test proving a mid-rewrite failure leaves the old transcript intact

## How to Test

```bash
python3 -m pytest tests/gateway/test_session.py -k rewrite -v
python3 -m pytest tests/gateway/test_session.py -v
```

## Checklist

- [x] Tests added
- [x] Existing session test file passes
- [x] Tested on Linux (Ubuntu 22.04)