### PR TITLE
fix(security): validate HONCHO_BASE_URL against SSRF before requests

### DIFF
--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -189,6 +189,18 @@ class HonchoClientConfig:
         resolved_host = host or resolve_active_host()
         api_key = os.environ.get("HONCHO_API_KEY")
         base_url = os.environ.get("HONCHO_BASE_URL", "").strip() or None
+      if base_url:
+            try:
+                from tools.url_safety import is_safe_url
+                if not is_safe_url(base_url):
+                    logger.warning(
+                        "HONCHO_BASE_URL '%s' resolves to a private/internal address "
+                        "and has been ignored.",
+                        base_url,
+                    )
+                    base_url = None
+            except ImportError:
+                pass
         return cls(
             host=resolved_host,
             workspace_id=workspace_id,


### PR DESCRIPTION
## What does this PR do?

The Honcho memory plugin reads `HONCHO_BASE_URL` from an environment
variable and passes it directly to the Honcho client without validation.

If `HONCHO_BASE_URL` is set to an internal address (e.g.
`http://169.254.169.254` on AWS, `http://metadata.google.internal` on GCP,
or any private network service), every memory read and write would silently
make requests to that internal address — a classic SSRF attack vector.

## Fix

Added an `is_safe_url()` check after reading `HONCHO_BASE_URL`. If the
URL resolves to a private/internal address, it is ignored with a warning
log and the plugin falls back to API-key-only mode.

This is consistent with the SSRF protection already applied in:
- `tools/homeassistant_tool.py` (HASS_URL)
- `plugins/memory/retaindb/__init__.py` (RETAINDB_BASE_URL)
- `tools/web_tools.py`

## Type of Change

- [x] 🔒 Security fix (SSRF)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Consistent with existing SSRF protection pattern in Hermes
- [x] No behavior change for legitimate Honcho endpoints
- [x] ImportError handled gracefully