### PR TITLE
fix(memory): discover user-installed memory providers (#4956)

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -125,12 +125,29 @@ def _prompt(label: str, default: str | None = None, secret: bool = False) -> str
 # Provider discovery
 # ---------------------------------------------------------------------------
 
+def _find_provider_dir(provider_name: str) -> Path | None:
+    """Locate memory provider dir, preferring bundled over user-installed plugins."""
+    bundled = Path(__file__).parent.parent / "plugins" / "memory" / provider_name
+    if bundled.is_dir():
+        return bundled
+
+    from hermes_constants import get_hermes_home
+
+    user_plugin = get_hermes_home() / "plugins" / provider_name
+    if user_plugin.is_dir():
+        return user_plugin
+
+    return None
+
+
 def _install_dependencies(provider_name: str) -> None:
     """Install pip dependencies declared in plugin.yaml."""
     import subprocess
-    from pathlib import Path as _Path
 
-    plugin_dir = _Path(__file__).parent.parent / "plugins" / "memory" / provider_name
+    plugin_dir = _find_provider_dir(provider_name)
+    if not plugin_dir:
+        return
+
     yaml_path = plugin_dir / "plugin.yaml"
     if not yaml_path.exists():
         return

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -4,9 +4,9 @@ Scans ``plugins/memory/<name>/`` directories for memory provider plugins.
 Each subdirectory must contain ``__init__.py`` with a class implementing
 the MemoryProvider ABC.
 
-Memory providers are separate from the general plugin system — they live
-in the repo and are always available without user installation. Only ONE
-can be active at a time, selected via ``memory.provider`` in config.yaml.
+Memory providers can be bundled in ``plugins/memory/`` or installed by users
+under ``{HERMES_HOME}/plugins/``. Only ONE external provider can be active at
+a time, selected via ``memory.provider`` in config.yaml.
 
 Usage:
     from plugins.memory import discover_memory_providers, load_memory_provider
@@ -22,11 +22,36 @@ import importlib.util
 import logging
 import sys
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
+
+from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
 
 _MEMORY_PLUGINS_DIR = Path(__file__).parent
+
+
+def _user_plugins_dir() -> Path:
+    """Return the user plugin install directory: {HERMES_HOME}/plugins."""
+    return get_hermes_home() / "plugins"
+
+
+def _resolve_provider_dirs() -> Dict[str, Path]:
+    """Resolve provider directories with bundled plugins taking precedence."""
+    provider_dirs: Dict[str, Path] = {}
+    for base_dir in (_MEMORY_PLUGINS_DIR, _user_plugins_dir()):
+        if not base_dir.is_dir():
+            continue
+
+        for child in sorted(base_dir.iterdir()):
+            if not child.is_dir() or child.name.startswith(("_", ".")):
+                continue
+            if not (child / "__init__.py").exists():
+                continue
+            # Keep first match so bundled plugins (scanned first) win.
+            provider_dirs.setdefault(child.name, child)
+
+    return provider_dirs
 
 
 def discover_memory_providers() -> List[Tuple[str, str, bool]]:
@@ -37,15 +62,11 @@ def discover_memory_providers() -> List[Tuple[str, str, bool]]:
     and does a lightweight availability check.
     """
     results = []
-    if not _MEMORY_PLUGINS_DIR.is_dir():
+    provider_dirs = _resolve_provider_dirs()
+    if not provider_dirs:
         return results
 
-    for child in sorted(_MEMORY_PLUGINS_DIR.iterdir()):
-        if not child.is_dir() or child.name.startswith(("_", ".")):
-            continue
-        init_file = child / "__init__.py"
-        if not init_file.exists():
-            continue
+    for provider_name, child in sorted(provider_dirs.items()):
 
         # Read description from plugin.yaml if available
         desc = ""
@@ -70,7 +91,7 @@ def discover_memory_providers() -> List[Tuple[str, str, bool]]:
         except Exception:
             available = False
 
-        results.append((child.name, desc, available))
+        results.append((provider_name, desc, available))
 
     return results
 
@@ -80,9 +101,15 @@ def load_memory_provider(name: str) -> Optional["MemoryProvider"]:
 
     Returns None if the provider is not found or fails to load.
     """
-    provider_dir = _MEMORY_PLUGINS_DIR / name
-    if not provider_dir.is_dir():
-        logger.debug("Memory provider '%s' not found in %s", name, _MEMORY_PLUGINS_DIR)
+    provider_dirs = _resolve_provider_dirs()
+    provider_dir = provider_dirs.get(name)
+    if not provider_dir:
+        logger.debug(
+            "Memory provider '%s' not found in bundled (%s) or user plugins (%s)",
+            name,
+            _MEMORY_PLUGINS_DIR,
+            _user_plugins_dir(),
+        )
         return None
 
     try:

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -1,6 +1,9 @@
 """Tests for the memory provider interface, manager, and builtin provider."""
 
 import json
+import os
+from pathlib import Path
+
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -528,12 +531,46 @@ class TestSingleProviderGating:
 class TestPluginMemoryDiscovery:
     """Memory providers are discovered from plugins/memory/ directory."""
 
+    @staticmethod
+    def _write_user_memory_plugin(name: str, *, description: str = "") -> None:
+        hermes_home = Path(os.environ["HERMES_HOME"])
+        plugin_dir = hermes_home / "plugins" / name
+        plugin_dir.mkdir(parents=True, exist_ok=True)
+        (plugin_dir / "__init__.py").write_text(
+            "\n".join(
+                [
+                    "from agent.memory_provider import MemoryProvider",
+                    "",
+                    "class UserMemoryProvider(MemoryProvider):",
+                    f"    @property\n    def name(self):\n        return {name!r}",
+                    "    def is_available(self):\n        return True",
+                    "    def initialize(self, session_id, **kwargs):\n        return None",
+                    "    def get_tool_schemas(self):\n        return []",
+                ]
+            )
+            + "\n"
+        )
+        if description:
+            (plugin_dir / "plugin.yaml").write_text(f"description: {description}\n")
+
     def test_discover_finds_providers(self):
         """discover_memory_providers returns available providers."""
         from plugins.memory import discover_memory_providers
         providers = discover_memory_providers()
         names = [name for name, _, _ in providers]
         assert "holographic" in names  # always available (no external deps)
+
+    def test_discover_includes_user_installed_provider(self):
+        from plugins.memory import discover_memory_providers
+
+        self._write_user_memory_plugin("usermem", description="user memory plugin")
+
+        providers = discover_memory_providers()
+        provider_map = {name: (desc, available) for name, desc, available in providers}
+
+        assert "usermem" in provider_map
+        assert provider_map["usermem"][0] == "user memory plugin"
+        assert provider_map["usermem"][1] is True
 
     def test_load_provider_by_name(self):
         """load_memory_provider returns a working provider instance."""
@@ -542,6 +579,28 @@ class TestPluginMemoryDiscovery:
         assert p is not None
         assert p.name == "holographic"
         assert p.is_available()
+
+    def test_load_user_installed_provider_by_name(self):
+        from plugins.memory import load_memory_provider
+
+        self._write_user_memory_plugin("usermem")
+
+        p = load_memory_provider("usermem")
+        assert p is not None
+        assert p.name == "usermem"
+        assert p.is_available()
+
+    def test_bundled_provider_takes_precedence_over_user_plugin(self):
+        from plugins.memory import load_memory_provider
+
+        hermes_home = Path(os.environ["HERMES_HOME"])
+        plugin_dir = hermes_home / "plugins" / "holographic"
+        plugin_dir.mkdir(parents=True, exist_ok=True)
+        (plugin_dir / "__init__.py").write_text("raise RuntimeError('user plugin should not be loaded')\n")
+
+        p = load_memory_provider("holographic")
+        assert p is not None
+        assert p.name == "holographic"
 
     def test_load_nonexistent_returns_none(self):
         """load_memory_provider returns None for unknown names."""

--- a/tests/hermes_cli/test_memory_setup.py
+++ b/tests/hermes_cli/test_memory_setup.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import builtins
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from hermes_cli import memory_setup
+
+
+def test_find_provider_dir_falls_back_to_user_plugin():
+    hermes_home = Path(os.environ["HERMES_HOME"])
+    user_provider = hermes_home / "plugins" / "usermem"
+    user_provider.mkdir(parents=True, exist_ok=True)
+
+    found = memory_setup._find_provider_dir("usermem")
+
+    assert found == user_provider
+
+
+def test_find_provider_dir_prefers_bundled_over_user_plugin():
+    hermes_home = Path(os.environ["HERMES_HOME"])
+    user_provider = hermes_home / "plugins" / "holographic"
+    user_provider.mkdir(parents=True, exist_ok=True)
+
+    found = memory_setup._find_provider_dir("holographic")
+
+    assert found is not None
+    assert found.name == "holographic"
+    assert "plugins/memory/holographic" in str(found)
+
+
+def test_install_dependencies_reads_user_plugin_manifest(monkeypatch):
+    hermes_home = Path(os.environ["HERMES_HOME"])
+    user_provider = hermes_home / "plugins" / "usermem"
+    user_provider.mkdir(parents=True, exist_ok=True)
+    (user_provider / "plugin.yaml").write_text("pip_dependencies:\n  - fake-user-dep\n")
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "fake_user_dep":
+            raise ImportError("missing")
+        return real_import(name, *args, **kwargs)
+
+    mock_run = MagicMock()
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    monkeypatch.setattr("subprocess.run", mock_run)
+
+    memory_setup._install_dependencies("usermem")
+
+    assert mock_run.called
+    cmd = mock_run.call_args.args[0]
+    assert "fake-user-dep" in cmd


### PR DESCRIPTION
## Summary
Fixes #4956 by making memory provider discovery/load and memory setup dependency resolution aware of user-installed plugins in `${HERMES_HOME}/plugins`.

### What changed
- `plugins/memory/__init__.py`
  - Discover memory providers from both:
    - bundled `plugins/memory/*`
    - user-installed `${HERMES_HOME}/plugins/*`
  - Keep bundled precedence when names collide.
  - `load_memory_provider(name)` now resolves from the same merged provider map.
- `hermes_cli/memory_setup.py`
  - Added `_find_provider_dir()` to resolve provider directory from bundled first, then user plugins.
  - `_install_dependencies()` now uses that resolver, so `plugin.yaml` dependency install works for user-installed memory plugins.
- Tests
  - Expanded `tests/agent/test_memory_provider.py` coverage for:
    - discovering user-installed provider
    - loading user-installed provider
    - bundled precedence over same-named user plugin
  - Added `tests/hermes_cli/test_memory_setup.py` for:
    - provider directory resolution behavior
    - dependency install path reading user plugin `plugin.yaml`

## Reproduction
Before:
- creating `${HERMES_HOME}/plugins/usermem/__init__.py` provider
- `discover_memory_providers()` did not list `usermem`
- `load_memory_provider("usermem")` returned `None`

After:
- `discover_memory_providers()` lists `usermem`
- `load_memory_provider("usermem")` loads successfully
- bundled plugins still win on name collision

## Validation
- Manual repro script (isolated temp HERMES_HOME): confirmed before/after behavior
- `pytest -q -o addopts='' tests/agent/test_memory_provider.py::TestPluginMemoryDiscovery tests/hermes_cli/test_memory_setup.py`
- `python -m py_compile plugins/memory/__init__.py hermes_cli/memory_setup.py tests/hermes_cli/test_memory_setup.py tests/agent/test_memory_provider.py`
