### PR TITLE
fix(gateway): queue pending interrupt messages FIFO (#4947)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -422,10 +422,13 @@ class BasePlatformAdapter(ABC):
         self._fatal_error_retryable = True
         self._fatal_error_handler: Optional[Callable[["BasePlatformAdapter"], Awaitable[None] | None]] = None
         
-        # Track active message handlers per session for interrupt support
-        # Key: session_key (e.g., chat_id), Value: (event, asyncio.Event for interrupt)
+        # Track active message handlers per session for interrupt support.
+        # Key: session_key (e.g., chat_id), Value: asyncio.Event interrupt signal.
         self._active_sessions: Dict[str, asyncio.Event] = {}
-        self._pending_messages: Dict[str, MessageEvent] = {}
+        # Per-session FIFO queues of pending MessageEvent objects that arrived while
+        # a run was active. Keep Dict[str, Any] for backwards compatibility with
+        # older tests/helpers that may still assign a single MessageEvent directly.
+        self._pending_messages: Dict[str, Any] = {}
         # Background message-processing tasks spawned by handle_message().
         # Gateway shutdown cancels these so an old gateway instance doesn't keep
         # working on a task after --replace or manual restarts.
@@ -1004,6 +1007,76 @@ class BasePlatformAdapter(ABC):
             logger.error("[%s] Fallback send also failed: %s", self.name, fallback_result.error)
         return fallback_result
 
+    def _get_pending_queue(self, session_key: str, *, create: bool = False) -> List[MessageEvent]:
+        """Return the mutable pending-message queue for a session.
+
+        Backwards compatibility: older tests/helpers may still store a single
+        MessageEvent at ``_pending_messages[session_key]``. Normalize to a list.
+        """
+        raw = self._pending_messages.get(session_key)
+        if isinstance(raw, list):
+            return raw
+        if raw is None:
+            if create:
+                queue: List[MessageEvent] = []
+                self._pending_messages[session_key] = queue
+                return queue
+            return []
+        if isinstance(raw, MessageEvent):
+            queue = [raw]
+            self._pending_messages[session_key] = queue
+            return queue
+        # Unexpected type: reset to empty queue to avoid crashes.
+        if create:
+            queue = []
+            self._pending_messages[session_key] = queue
+            return queue
+        return []
+
+    def enqueue_pending_message(
+        self,
+        session_key: str,
+        event: MessageEvent,
+        *,
+        merge_photo_bursts: bool = False,
+    ) -> None:
+        """Queue a pending event in FIFO order for later replay."""
+        queue = self._get_pending_queue(session_key, create=True)
+
+        if (
+            merge_photo_bursts
+            and event.message_type == MessageType.PHOTO
+            and queue
+            and queue[-1].message_type == MessageType.PHOTO
+        ):
+            existing = queue[-1]
+            existing.media_urls.extend(event.media_urls)
+            existing.media_types.extend(event.media_types)
+            if event.text:
+                if not existing.text:
+                    existing.text = event.text
+                elif event.text not in existing.text:
+                    existing.text = f"{existing.text}\n\n{event.text}".strip()
+            return
+
+        queue.append(event)
+
+    def peek_pending_message(self, session_key: str) -> Optional[MessageEvent]:
+        """Return the next pending message without consuming it."""
+        queue = self._get_pending_queue(session_key)
+        return queue[0] if queue else None
+
+    def clear_pending_messages(self, session_key: str) -> None:
+        """Drop all queued messages for a session."""
+        self._pending_messages.pop(session_key, None)
+
+    def queue_message(self, session_key: str, text: str) -> None:
+        """Queue a plain-text message (used by gateway recursion safeguards)."""
+        self.enqueue_pending_message(
+            session_key,
+            MessageEvent(text=text, message_type=MessageType.TEXT),
+        )
+
     async def handle_message(self, event: MessageEvent) -> None:
         """
         Process an incoming message.
@@ -1053,22 +1126,12 @@ class BasePlatformAdapter(ABC):
             # then process them immediately after the current task finishes.
             if event.message_type == MessageType.PHOTO:
                 logger.debug("[%s] Queuing photo follow-up for session %s without interrupt", self.name, session_key)
-                existing = self._pending_messages.get(session_key)
-                if existing and existing.message_type == MessageType.PHOTO:
-                    existing.media_urls.extend(event.media_urls)
-                    existing.media_types.extend(event.media_types)
-                    if event.text:
-                        if not existing.text:
-                            existing.text = event.text
-                        elif event.text not in existing.text:
-                            existing.text = f"{existing.text}\n\n{event.text}".strip()
-                else:
-                    self._pending_messages[session_key] = event
+                self.enqueue_pending_message(session_key, event, merge_photo_bursts=True)
                 return  # Don't interrupt now - will run after current task completes
 
             # Default behavior for non-photo follow-ups: interrupt the running agent
             logger.debug("[%s] New message while session %s is active — triggering interrupt", self.name, session_key)
-            self._pending_messages[session_key] = event
+            self.enqueue_pending_message(session_key, event)
             # Signal the interrupt (the processing task checks this)
             self._active_sessions[session_key].set()
             return  # Don't process now - will be handled after current task finishes
@@ -1315,9 +1378,9 @@ class BasePlatformAdapter(ABC):
             processing_ok = delivery_succeeded if delivery_attempted else not bool(response)
             await self._run_processing_hook("on_processing_complete", event, processing_ok)
 
-            # Check if there's a pending message that was queued during our processing
-            if session_key in self._pending_messages:
-                pending_event = self._pending_messages.pop(session_key)
+            # Check if there's a pending message that was queued during processing.
+            pending_event = self.get_pending_message(session_key)
+            if pending_event is not None:
                 logger.debug("[%s] Processing queued message from interrupt", self.name)
                 # Clean up current session before processing pending
                 if session_key in self._active_sessions:
@@ -1391,8 +1454,17 @@ class BasePlatformAdapter(ABC):
         return session_key in self._active_sessions and self._active_sessions[session_key].is_set()
     
     def get_pending_message(self, session_key: str) -> Optional[MessageEvent]:
-        """Get and clear any pending message for a session."""
-        return self._pending_messages.pop(session_key, None)
+        """Consume and return the next pending message for a session (FIFO)."""
+        queue = self._get_pending_queue(session_key)
+        if not queue:
+            self._pending_messages.pop(session_key, None)
+            return None
+        event = queue.pop(0)
+        if not queue:
+            self._pending_messages.pop(session_key, None)
+        else:
+            self._pending_messages[session_key] = queue
+        return event
     
     def build_source(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1779,8 +1779,13 @@ class GatewayRunner:
                     running_agent.interrupt("Stop requested")
                 # Force-clean: remove the session lock regardless of agent state
                 adapter = self.adapters.get(source.platform)
-                if adapter and hasattr(adapter, 'get_pending_message'):
-                    adapter.get_pending_message(_quick_key)  # consume and discard
+                if adapter:
+                    if hasattr(adapter, 'clear_pending_messages'):
+                        adapter.clear_pending_messages(_quick_key)
+                    elif hasattr(adapter, '_pending_messages'):
+                        adapter._pending_messages.pop(_quick_key, None)
+                    elif hasattr(adapter, 'get_pending_message'):
+                        adapter.get_pending_message(_quick_key)
                 self._pending_messages.pop(_quick_key, None)
                 if _quick_key in self._running_agents:
                     del self._running_agents[_quick_key]
@@ -1800,8 +1805,13 @@ class GatewayRunner:
                     running_agent.interrupt("Session reset requested")
                 # Clear any pending messages so the old text doesn't replay
                 adapter = self.adapters.get(source.platform)
-                if adapter and hasattr(adapter, 'get_pending_message'):
-                    adapter.get_pending_message(_quick_key)  # consume and discard
+                if adapter:
+                    if hasattr(adapter, 'clear_pending_messages'):
+                        adapter.clear_pending_messages(_quick_key)
+                    elif hasattr(adapter, '_pending_messages'):
+                        adapter._pending_messages.pop(_quick_key, None)
+                    elif hasattr(adapter, 'get_pending_message'):
+                        adapter.get_pending_message(_quick_key)
                 self._pending_messages.pop(_quick_key, None)
                 # Clean up the running agent entry so the reset handler
                 # doesn't think an agent is still active.
@@ -1823,7 +1833,10 @@ class GatewayRunner:
                         source=event.source,
                         message_id=event.message_id,
                     )
-                    adapter._pending_messages[_quick_key] = queued_event
+                    if hasattr(adapter, 'enqueue_pending_message'):
+                        adapter.enqueue_pending_message(_quick_key, queued_event)
+                    else:
+                        adapter._pending_messages[_quick_key] = queued_event
                 return "Queued for the next turn."
 
             # /approve and /deny must bypass the running-agent interrupt path.
@@ -1839,19 +1852,8 @@ class GatewayRunner:
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key[:20])
                 adapter = self.adapters.get(source.platform)
                 if adapter:
-                    # Reuse adapter queue semantics so photo bursts merge cleanly.
-                    if _quick_key in adapter._pending_messages:
-                        existing = adapter._pending_messages[_quick_key]
-                        if getattr(existing, "message_type", None) == MessageType.PHOTO:
-                            existing.media_urls.extend(event.media_urls)
-                            existing.media_types.extend(event.media_types)
-                            if event.text:
-                                if not existing.text:
-                                    existing.text = event.text
-                                elif event.text not in existing.text:
-                                    existing.text = f"{existing.text}\n\n{event.text}".strip()
-                        else:
-                            adapter._pending_messages[_quick_key] = event
+                    if hasattr(adapter, 'enqueue_pending_message'):
+                        adapter.enqueue_pending_message(_quick_key, event, merge_photo_bursts=True)
                     else:
                         adapter._pending_messages[_quick_key] = event
                 return None
@@ -1869,9 +1871,18 @@ class GatewayRunner:
                 # agent starts.
                 adapter = self.adapters.get(source.platform)
                 if adapter:
-                    adapter._pending_messages[_quick_key] = event
+                    if hasattr(adapter, 'enqueue_pending_message'):
+                        adapter.enqueue_pending_message(_quick_key, event)
+                    else:
+                        adapter._pending_messages[_quick_key] = event
                 return None
             logger.debug("PRIORITY interrupt for session %s", _quick_key[:20])
+            adapter = self.adapters.get(source.platform)
+            if adapter:
+                if hasattr(adapter, 'enqueue_pending_message'):
+                    adapter.enqueue_pending_message(_quick_key, event)
+                else:
+                    adapter._pending_messages[_quick_key] = event
             running_agent.interrupt(event.text)
             if _quick_key in self._pending_messages:
                 self._pending_messages[_quick_key] += "\n" + event.text
@@ -6098,7 +6109,13 @@ class GatewayRunner:
                 if hasattr(adapter, 'has_pending_interrupt') and adapter.has_pending_interrupt(session_key):
                     agent = agent_holder[0]
                     if agent:
-                        pending_event = adapter.get_pending_message(session_key)
+                        # Peek (don't consume) so replay can process the same
+                        # message after the interrupted run returns.
+                        pending_event = (
+                            adapter.peek_pending_message(session_key)
+                            if hasattr(adapter, 'peek_pending_message')
+                            else adapter.get_pending_message(session_key)
+                        )
                         pending_text = pending_event.text if pending_event else None
                         logger.debug("Interrupt detected from adapter, signaling agent...")
                         agent.interrupt(pending_text)

--- a/tests/gateway/test_interrupt_key_match.py
+++ b/tests/gateway/test_interrupt_key_match.py
@@ -144,7 +144,7 @@ class TestInterruptKeyConsistency:
         )
         await adapter.handle_message(event)
 
-        queued = adapter._pending_messages[session_key]
+        queued = adapter.get_pending_message(session_key)
         assert queued is event
         assert queued.media_urls == ["/tmp/photo-a.jpg"]
         assert interrupt_event.is_set() is False

--- a/tests/gateway/test_interrupt_queue_ordering.py
+++ b/tests/gateway/test_interrupt_queue_ordering.py
@@ -1,0 +1,86 @@
+import pytest
+from unittest.mock import MagicMock
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner, _dequeue_pending_text
+from gateway.session import SessionSource, build_session_key
+
+
+class _QueueAdapter:
+    def __init__(self):
+        self._pending_messages = {}
+
+    def enqueue_pending_message(self, session_key, event, merge_photo_bursts=False):
+        queue = self._pending_messages.setdefault(session_key, [])
+        queue.append(event)
+
+    def peek_pending_message(self, session_key):
+        queue = self._pending_messages.get(session_key) or []
+        return queue[0] if queue else None
+
+    def get_pending_message(self, session_key):
+        queue = self._pending_messages.get(session_key) or []
+        if not queue:
+            self._pending_messages.pop(session_key, None)
+            return None
+        event = queue.pop(0)
+        if not queue:
+            self._pending_messages.pop(session_key, None)
+        return event
+
+
+def _make_runner():
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")})
+    runner.adapters = {Platform.TELEGRAM: _QueueAdapter()}
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._voice_mode = {}
+    runner._is_user_authorized = lambda _source: True
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_running_agent_interrupt_path_queues_multiple_messages_fifo():
+    runner = _make_runner()
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm")
+    session_key = build_session_key(source)
+
+    running_agent = MagicMock()
+    runner._running_agents[session_key] = running_agent
+
+    e1 = MessageEvent(text="first follow-up", message_type=MessageType.TEXT, source=source, message_id="m1")
+    e2 = MessageEvent(text="second follow-up", message_type=MessageType.TEXT, source=source, message_id="m2")
+
+    result1 = await runner._handle_message(e1)
+    result2 = await runner._handle_message(e2)
+
+    assert result1 is None
+    assert result2 is None
+    assert running_agent.interrupt.call_count == 2
+
+    adapter = runner.adapters[Platform.TELEGRAM]
+    first = adapter.get_pending_message(session_key)
+    second = adapter.get_pending_message(session_key)
+    assert first and first.text == "first follow-up"
+    assert second and second.text == "second follow-up"
+
+
+def test_dequeue_pending_text_returns_messages_in_fifo_order():
+    adapter = _QueueAdapter()
+    session_key = "agent:main:telegram:dm:12345"
+
+    adapter.enqueue_pending_message(
+        session_key,
+        MessageEvent(text="first", message_type=MessageType.TEXT),
+    )
+    adapter.enqueue_pending_message(
+        session_key,
+        MessageEvent(text="second", message_type=MessageType.TEXT),
+    )
+
+    assert _dequeue_pending_text(adapter, session_key) == "first"
+    assert _dequeue_pending_text(adapter, session_key) == "second"
+    assert _dequeue_pending_text(adapter, session_key) is None

--- a/tests/gateway/test_queue_consumption.py
+++ b/tests/gateway/test_queue_consumption.py
@@ -147,8 +147,8 @@ class TestQueueConsumptionAfterCompletion:
         assert retrieved is not None
         assert retrieved.text == "process this after"
 
-    def test_multiple_queues_last_one_wins(self):
-        """If user /queue's multiple times, last message overwrites."""
+    def test_multiple_queues_are_fifo(self):
+        """Queued messages should preserve arrival order (no overwrite)."""
         adapter = _StubAdapter()
         session_key = "telegram:user:123"
 
@@ -159,7 +159,14 @@ class TestQueueConsumptionAfterCompletion:
                 source=MagicMock(),
                 message_id=f"q-{text}",
             )
-            adapter._pending_messages[session_key] = event
+            adapter.enqueue_pending_message(session_key, event)
 
-        retrieved = adapter.get_pending_message(session_key)
-        assert retrieved.text == "third"
+        first = adapter.get_pending_message(session_key)
+        second = adapter.get_pending_message(session_key)
+        third = adapter.get_pending_message(session_key)
+        none_left = adapter.get_pending_message(session_key)
+
+        assert first and first.text == "first"
+        assert second and second.text == "second"
+        assert third and third.text == "third"
+        assert none_left is None

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -297,7 +297,6 @@ async def test_stop_clears_pending_messages():
     # Queue a pending message in the adapter too
     adapter = runner.adapters[Platform.TELEGRAM]
     adapter._pending_messages[session_key] = _make_event(text="queued")
-    adapter.get_pending_message = MagicMock(return_value=_make_event(text="queued"))
     adapter.has_pending_interrupt = MagicMock(return_value=False)
 
     stop_event = _make_event(text="/stop")
@@ -305,7 +304,7 @@ async def test_stop_clears_pending_messages():
 
     # Pending messages must be cleared
     assert session_key not in runner._pending_messages
-    adapter.get_pending_message.assert_called_once_with(session_key)
+    assert session_key not in adapter._pending_messages
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes #4947 by replacing single-slot pending-message storage with FIFO queue semantics and by preventing early interrupt-monitor consumption of the first queued message.

## Root cause diagnosis
There were two independent loss vectors:

1) Single-slot overwrite in adapter and gateway fast path
- `BasePlatformAdapter` stored one `MessageEvent` per session key (`_pending_messages[session_key] = event`).
- `GatewayRunner._handle_message` running-agent fast path also assigned directly into `adapter._pending_messages[_quick_key]`.
- Multiple arrivals while a run was active overwrote earlier events silently.

2) First queued interrupt message consumed too early
- In `_run_agent.monitor_for_interrupt()`, interrupt detection called `adapter.get_pending_message(session_key)` (pop) just to fetch text for `agent.interrupt(...)`.
- Later replay logic called `_dequeue_pending_text(...)` again to determine next prompt.
- If more than one message arrived, the first was consumed by monitor and the second became the replay prompt; first message could be skipped.

## What changed
### `gateway/platforms/base.py`
- Added queue helpers:
  - `_get_pending_queue(...)`
  - `enqueue_pending_message(...)`
  - `peek_pending_message(...)`
  - `clear_pending_messages(...)`
  - `queue_message(...)`
- Updated active-session handling to enqueue messages instead of overwriting.
- Preserved photo-burst merge behavior using `merge_photo_bursts=True` on queue tail.
- Updated `get_pending_message(...)` to FIFO dequeue semantics.
- Updated background follow-up replay to consume via FIFO dequeue.

### `gateway/run.py`
- In running-agent intercept paths (`/queue`, photo follow-up, pending sentinel, normal text interrupt), switched to `adapter.enqueue_pending_message(...)` when available.
- In interrupt monitor, switched from dequeue to `peek_pending_message(...)` so replay still processes the same first message.
- In `/stop` and `/new` force-clean paths, clear full adapter pending queue via `clear_pending_messages(...)` (or safe fallback) instead of consuming only one message.

## Regression tests
Added/updated tests to cover FIFO and replay behavior:
- `tests/gateway/test_interrupt_queue_ordering.py` (new)
  - running-agent path queues multiple follow-ups in FIFO order
  - `_dequeue_pending_text` dequeues FIFO
- `tests/gateway/test_queue_consumption.py`
  - updated expectation from "last one wins" to FIFO ordering
- `tests/gateway/test_interrupt_key_match.py`
  - adjusted photo queue assertion to consume via `get_pending_message(...)`
- `tests/gateway/test_session_race_guard.py`
  - adjusted `/stop` pending-clear assertion for new clear-path behavior

## Validation
- `python -m py_compile gateway/platforms/base.py gateway/run.py tests/gateway/test_queue_consumption.py tests/gateway/test_interrupt_key_match.py tests/gateway/test_interrupt_queue_ordering.py tests/gateway/test_session_race_guard.py`
- In isolated venv: `python -m pytest -q -o addopts='' tests/gateway/test_queue_consumption.py tests/gateway/test_interrupt_key_match.py tests/gateway/test_telegram_photo_interrupts.py tests/gateway/test_interrupt_queue_ordering.py tests/gateway/test_session_race_guard.py`
  - Result: `24 passed`
