### PR TITLE
feat(cli): add /resume interactive picker and numeric selection (#4988)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3090,7 +3090,7 @@ class HermesCLI:
             return []
         return [s for s in sessions if s.get("id") != self.session_id]
 
-    def _show_recent_sessions(self, *, reason: str = "history", limit: int = 10) -> bool:
+    def _show_recent_sessions(self, *, reason: str = "history", limit: int = 10, numbered: bool = False) -> bool:
         """Render recent sessions inline from the active chat TUI.
 
         Returns True when something was shown, False if no session list was available.
@@ -3107,15 +3107,22 @@ class HermesCLI:
         else:
             print("  Recent sessions:")
         print()
-        print(f"  {'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
-        print(f"  {'─' * 32} {'─' * 40} {'─' * 13} {'─' * 24}")
-        for session in sessions:
+        num_col = "# " if numbered else ""
+        num_rule = "── " if numbered else ""
+        print(f"  {num_col}{'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
+        print(f"  {num_rule}{'─' * 32} {'─' * 40} {'─' * 13} {'─' * 24}")
+        for i, session in enumerate(sessions, start=1):
             title = (session.get("title") or "—")[:30]
             preview = (session.get("preview") or "")[:38]
             last_active = _relative_time(session.get("last_active"))
-            print(f"  {title:<32} {preview:<40} {last_active:<13} {session['id']}")
+            prefix = f"{i:<2}" if numbered else ""
+            spacer = " " if numbered else ""
+            print(f"  {prefix}{spacer}{title:<32} {preview:<40} {last_active:<13} {session['id']}")
         print()
-        print("  Use /resume <session id or title> to continue where you left off.")
+        if numbered:
+            print("  Use /resume <number|session id|title> to continue where you left off.")
+        else:
+            print("  Use /resume <session id or title> to continue where you left off.")
         print()
         return True
 
@@ -3241,26 +3248,69 @@ class HermesCLI:
         if not silent:
             print("(^_^)v New session started!")
 
+    def _resume_picker_enabled(self) -> bool:
+        """Return True when an interactive picker can run in this terminal."""
+        try:
+            return bool(sys.stdin.isatty() and sys.stdout.isatty())
+        except Exception:
+            return False
+
+    def _pick_recent_session_id(self, sessions: list[dict[str, Any]]) -> str | None:
+        """Open interactive session picker and return selected session ID."""
+        if not sessions or not self._resume_picker_enabled():
+            return None
+
+        try:
+            from hermes_cli.main import _session_browse_picker
+            selected = _session_browse_picker(sessions)
+            return selected or None
+        except Exception:
+            return None
+
+    def _resolve_numeric_resume_target(self, target: str, *, limit: int = 20) -> str | None:
+        """Resolve '/resume <number>' against recent session list."""
+        if not target.isdigit():
+            return None
+        idx = int(target)
+        if idx < 1:
+            return None
+        sessions = self._list_recent_sessions(limit=limit)
+        if idx > len(sessions):
+            return None
+        return sessions[idx - 1].get("id")
+
     def _handle_resume_command(self, cmd_original: str) -> None:
         """Handle /resume <session_id_or_title> — switch to a previous session mid-conversation."""
         parts = cmd_original.split(None, 1)
         target = parts[1].strip() if len(parts) > 1 else ""
 
         if not target:
-            _cprint("  Usage: /resume <session_id_or_title>")
-            if self._show_recent_sessions(reason="resume"):
+            sessions = self._list_recent_sessions(limit=20)
+            if sessions and self._resume_picker_enabled():
+                selected = self._pick_recent_session_id(sessions)
+                if not selected:
+                    _cprint("  Resume cancelled.")
+                    return
+                target = selected
+            else:
+                _cprint("  Usage: /resume <session_id_or_title>")
+                if self._show_recent_sessions(reason="resume", limit=20, numbered=True):
+                    return
+                _cprint("  Tip:   Use /history or `hermes sessions list` to find sessions.")
                 return
-            _cprint("  Tip:   Use /history or `hermes sessions list` to find sessions.")
-            return
 
         if not self._session_db:
             _cprint("  Session database not available.")
             return
 
-        # Resolve title or ID
-        from hermes_cli.main import _resolve_session_by_name_or_id
-        resolved = _resolve_session_by_name_or_id(target)
-        target_id = resolved or target
+        # Resolve title, session ID, or numeric index from recent-session list.
+        numeric_target = self._resolve_numeric_resume_target(target, limit=20)
+        if numeric_target:
+            target_id = numeric_target
+        else:
+            from hermes_cli.main import _resolve_session_by_name_or_id
+            resolved = _resolve_session_by_name_or_id(target)
+            target_id = resolved or target
 
         session_meta = self._session_db.get_session(target_id)
         if not session_meta:

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -243,7 +243,67 @@ class TestHistoryDisplay:
 
         assert "Recent sessions" in output
         assert "Checking Running Hermes Agent" in output
-        assert "Use /resume <session id or title> to continue" in output
+        assert "Use /resume <number|session id|title> to continue" in output
+
+    def test_resume_without_target_uses_interactive_picker_when_tty(self):
+        cli = _make_cli()
+        cli.agent = None
+        cli.session_id = "current"
+        cli._session_db = MagicMock()
+        cli._session_db.list_sessions_rich.return_value = [
+            {
+                "id": "current",
+                "title": "Current",
+                "preview": "Current preview",
+                "last_active": 0,
+                "source": "cli",
+            },
+            {
+                "id": "picked_session",
+                "title": "Picked",
+                "preview": "picked preview",
+                "last_active": 0,
+                "source": "cli",
+            },
+        ]
+        cli._session_db.get_session.return_value = {"id": "picked_session", "title": "Picked"}
+        cli._session_db.get_messages_as_conversation.return_value = []
+
+        with patch("sys.stdin.isatty", return_value=True), \
+             patch("sys.stdout.isatty", return_value=True), \
+             patch("hermes_cli.main._session_browse_picker", return_value="picked_session"):
+            cli._handle_resume_command("/resume")
+
+        assert cli.session_id == "picked_session"
+        cli._session_db.end_session.assert_called_once()
+        cli._session_db.reopen_session.assert_called_once_with("picked_session")
+
+    def test_resume_numeric_index_resolves_to_recent_session(self):
+        cli = _make_cli()
+        cli.agent = None
+        cli.session_id = "current"
+        cli._session_db = MagicMock()
+        cli._session_db.list_sessions_rich.return_value = [
+            {
+                "id": "current",
+                "title": "Current",
+                "preview": "Current preview",
+                "last_active": 0,
+            },
+            {
+                "id": "target_session",
+                "title": "Target",
+                "preview": "target preview",
+                "last_active": 0,
+            },
+        ]
+        cli._session_db.get_session.return_value = {"id": "target_session", "title": "Target"}
+        cli._session_db.get_messages_as_conversation.return_value = []
+
+        cli._handle_resume_command("/resume 1")
+
+        assert cli.session_id == "target_session"
+        cli._session_db.get_session.assert_called_with("target_session")
 
 
 class TestRootLevelProviderOverride:


### PR DESCRIPTION
## Summary
Fixes #4988 by making `/resume` in the interactive CLI open an in-chat interactive session picker when called without arguments, with a robust fallback for non-interactive contexts.

## Understanding and diagnosis
Before changes, CLI `/resume` behavior in `cli.py` was:
- `/resume <session_id_or_title>`: works
- `/resume` with no arg: prints usage + static recent-session table

So the core discoverability issue was real: users inside an active session had no selection UX (only manual copy/paste of IDs/titles).

I also confirmed there was already a mature picker implementation in `hermes_cli.main._session_browse_picker(...)` used by `hermes sessions browse`, but it was not wired into in-chat `/resume`.

## What changed
### 1) Interactive picker path for `/resume` with no args
In `HermesCLI._handle_resume_command`:
- If no target and terminal is interactive (`stdin/stdout` are TTY), call picker with recent sessions.
- If a session is selected, continue resume flow using that selected `session_id`.
- If picker is cancelled, return with a friendly cancellation message.

### 2) Non-interactive fallback improvements
For non-interactive `/resume` with no args:
- Show a numbered recent-session list.
- Updated hint text to include number-based resume syntax.

### 3) Numeric index resolution
Added support for:
- `/resume 1`
- `/resume 2`
etc.

The number resolves against the recent-session list ordering shown in fallback output.

## New helper methods (cli.py)
- `_resume_picker_enabled()`
- `_pick_recent_session_id(sessions)`
- `_resolve_numeric_resume_target(target, limit=20)`

## Tests
Updated/added tests in `tests/test_cli_init.py`:
- Existing no-arg resume display test updated for new fallback hint text
- New test: no-arg `/resume` uses picker in TTY mode
- New test: numeric `/resume <n>` resolves to the corresponding recent session

## Validation
- `python -m py_compile cli.py tests/test_cli_init.py`
- `python -m pytest -q -o addopts='' tests/test_cli_init.py::TestHistoryDisplay`
  - Result: 5 passed

(Used isolated venv for test runtime dependencies.)
