### PR TITLE
fix(cli): resolve launchctl path to handle UV's minimal PATH

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -11,6 +11,7 @@ import signal
 import subprocess
 import sys
 from pathlib import Path
+from functools import lru_cache
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 
@@ -22,6 +23,29 @@ from hermes_cli.setup import (
     prompt, prompt_choice, prompt_yes_no,
 )
 from hermes_cli.colors import Colors, color
+
+
+# =============================================================================
+# launchctl Path Resolution
+# =============================================================================
+
+@lru_cache(maxsize=1)
+def get_launchctl_path() -> str:
+    """Resolve the absolute path to launchctl.
+
+    UV's bundled Python can ship with a minimal PATH that doesn't include /bin,
+    causing FileNotFoundError when running launchctl directly. This resolves the
+    absolute path and caches it for the process lifetime.
+    """
+    found = shutil.which("launchctl")
+    if found:
+        return found
+    # Fallback to known macOS locations
+    for path in ("/bin/launchctl", "/usr/bin/launchctl"):
+        if os.path.isfile(path) and os.access(path, os.X_OK):
+            return path
+    # Last resort — let subprocess find it (may fail)
+    return "launchctl"
 
 
 # =============================================================================
@@ -973,8 +997,8 @@ def refresh_launchd_plist_if_needed() -> bool:
 
     plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
     # Unload/reload so launchd picks up the new definition
-    subprocess.run(["launchctl", "unload", str(plist_path)], check=False)
-    subprocess.run(["launchctl", "load", str(plist_path)], check=False)
+    subprocess.run([get_launchctl_path(), "unload", str(plist_path)], check=False)
+    subprocess.run([get_launchctl_path(), "load", str(plist_path)], check=False)
     print("↻ Updated gateway launchd service definition to match the current Hermes install")
     return True
 
@@ -996,7 +1020,7 @@ def launchd_install(force: bool = False):
     print(f"Installing launchd service to: {plist_path}")
     plist_path.write_text(generate_launchd_plist())
     
-    subprocess.run(["launchctl", "load", str(plist_path)], check=True)
+    subprocess.run([get_launchctl_path(), "load", str(plist_path)], check=True)
     
     print()
     print("✓ Service installed and loaded!")
@@ -1008,7 +1032,7 @@ def launchd_install(force: bool = False):
 
 def launchd_uninstall():
     plist_path = get_launchd_plist_path()
-    subprocess.run(["launchctl", "unload", str(plist_path)], check=False)
+    subprocess.run([get_launchctl_path(), "unload", str(plist_path)], check=False)
     
     if plist_path.exists():
         plist_path.unlink()
@@ -1025,25 +1049,25 @@ def launchd_start():
         print("↻ launchd plist missing; regenerating service definition")
         plist_path.parent.mkdir(parents=True, exist_ok=True)
         plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
-        subprocess.run(["launchctl", "load", str(plist_path)], check=True)
-        subprocess.run(["launchctl", "start", label], check=True)
+        subprocess.run([get_launchctl_path(), "load", str(plist_path)], check=True)
+        subprocess.run([get_launchctl_path(), "start", label], check=True)
         print("✓ Service started")
         return
 
     refresh_launchd_plist_if_needed()
     try:
-        subprocess.run(["launchctl", "start", label], check=True)
+        subprocess.run([get_launchctl_path(), "start", label], check=True)
     except subprocess.CalledProcessError as e:
         if e.returncode != 3:
             raise
         print("↻ launchd job was unloaded; reloading service definition")
-        subprocess.run(["launchctl", "load", str(plist_path)], check=True)
-        subprocess.run(["launchctl", "start", label], check=True)
+        subprocess.run([get_launchctl_path(), "load", str(plist_path)], check=True)
+        subprocess.run([get_launchctl_path(), "start", label], check=True)
     print("✓ Service started")
 
 def launchd_stop():
     label = get_launchd_label()
-    subprocess.run(["launchctl", "stop", label], check=True)
+    subprocess.run([get_launchctl_path(), "stop", label], check=True)
     print("✓ Service stopped")
 
 def _wait_for_gateway_exit(timeout: float = 10.0, force_after: float = 5.0):
@@ -1100,7 +1124,7 @@ def launchd_status(deep: bool = False):
     plist_path = get_launchd_plist_path()
     label = get_launchd_label()
     result = subprocess.run(
-        ["launchctl", "list", label],
+        [get_launchctl_path(), "list", label],
         capture_output=True,
         text=True
     )
@@ -1660,7 +1684,7 @@ def _is_service_running() -> bool:
         return False
     elif is_macos() and get_launchd_plist_path().exists():
         result = subprocess.run(
-            ["launchctl", "list", get_launchd_label()],
+            [get_launchctl_path(), "list", get_launchd_label()],
             capture_output=True, text=True
         )
         return result.returncode == 0

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3571,11 +3571,11 @@ def cmd_update(args):
             # --- Launchd services (macOS) ---
             if is_macos():
                 try:
-                    from hermes_cli.gateway import launchd_restart, get_launchd_label, get_launchd_plist_path
+                    from hermes_cli.gateway import launchd_restart, get_launchd_label, get_launchd_plist_path, get_launchctl_path
                     plist_path = get_launchd_plist_path()
                     if plist_path.exists():
                         check = subprocess.run(
-                            ["launchctl", "list", get_launchd_label()],
+                            [get_launchctl_path(), "list", get_launchd_label()],
                             capture_output=True, text=True, timeout=5,
                         )
                         if check.returncode == 0:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -582,7 +582,7 @@ def _cleanup_gateway_service(name: str, profile_dir: Path) -> None:
     old_home = os.environ.get("HERMES_HOME")
     try:
         os.environ["HERMES_HOME"] = str(profile_dir)
-        from hermes_cli.gateway import get_service_name, get_launchd_plist_path
+        from hermes_cli.gateway import get_service_name, get_launchd_plist_path, get_launchctl_path
 
         if _platform.system() == "Linux":
             svc_name = get_service_name()
@@ -607,7 +607,7 @@ def _cleanup_gateway_service(name: str, profile_dir: Path) -> None:
             plist_path = get_launchd_plist_path()
             if plist_path.exists():
                 subprocess.run(
-                    ["launchctl", "unload", str(plist_path)],
+                    [get_launchctl_path(), "unload", str(plist_path)],
                     capture_output=True, check=False, timeout=10,
                 )
                 plist_path.unlink(missing_ok=True)

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -326,10 +326,10 @@ def show_status(args):
         print("  Manager:      systemd (user)")
         
     elif sys.platform == 'darwin':
-        from hermes_cli.gateway import get_launchd_label
+        from hermes_cli.gateway import get_launchd_label, get_launchctl_path
         try:
             result = subprocess.run(
-                ["launchctl", "list", get_launchd_label()],
+                [get_launchctl_path(), "list", get_launchd_label()],
                 capture_output=True,
                 text=True,
                 timeout=5

--- a/tests/hermes_cli/test_launchctl_path.py
+++ b/tests/hermes_cli/test_launchctl_path.py
@@ -1,0 +1,56 @@
+"""Tests for launchctl path resolution."""
+
+import os
+import sys
+import pytest
+from unittest.mock import patch
+
+# Skip on non-macOS
+pytestmark = pytest.mark.skipif(sys.platform != "darwin", reason="macOS only")
+
+
+def test_get_launchctl_path_uses_which_first():
+    """Should use shutil.which() result when available."""
+    from hermes_cli.gateway import get_launchctl_path
+    
+    # Clear the cache
+    get_launchctl_path.cache_clear()
+    
+    with patch("shutil.which", return_value="/opt/custom/bin/launchctl"):
+        result = get_launchctl_path()
+        assert result == "/opt/custom/bin/launchctl"
+    
+    get_launchctl_path.cache_clear()
+
+
+def test_get_launchctl_path_fallback_to_bin():
+    """Should fall back to /bin/launchctl when which() fails."""
+    from hermes_cli.gateway import get_launchctl_path
+    
+    get_launchctl_path.cache_clear()
+    
+    with patch("shutil.which", return_value=None), \
+         patch("os.path.isfile", return_value=True), \
+         patch("os.access", return_value=True):
+        result = get_launchctl_path()
+        assert result in ("/bin/launchctl", "/usr/bin/launchctl")
+    
+    get_launchctl_path.cache_clear()
+
+
+def test_get_launchctl_path_caches_result():
+    """Should cache the result and not call which() repeatedly."""
+    from hermes_cli.gateway import get_launchctl_path
+    
+    get_launchctl_path.cache_clear()
+    
+    with patch("shutil.which", return_value="/test/launchctl") as mock_which:
+        # Call twice
+        result1 = get_launchctl_path()
+        result2 = get_launchctl_path()
+        
+        # Should only call which once due to caching
+        assert mock_which.call_count == 1
+        assert result1 == result2 == "/test/launchctl"
+    
+    get_launchctl_path.cache_clear()


### PR DESCRIPTION
## Summary
UV's bundled Python can ship with a minimal PATH that doesn't include `/bin`, causing `FileNotFoundError` when running launchctl commands during gateway operations (install, start, stop, restart, status).

## Changes
- Added `get_launchctl_path()` helper in `gateway.py` that:
  1. Uses `shutil.which()` to find launchctl in PATH
  2. Falls back to known macOS locations (`/bin/launchctl`, `/usr/bin/launchctl`)
  3. Caches the result for the process lifetime (via `@lru_cache`)
- Updated all launchctl subprocess calls across:
  - `hermes_cli/gateway.py`
  - `hermes_cli/main.py`
  - `hermes_cli/profiles.py`
  - `hermes_cli/status.py`
- Added test coverage for path resolution

## Testing
- All new tests pass: `pytest tests/hermes_cli/test_launchctl_path.py -v`
- Tested manually on macOS with UV-installed hermes

Fixes #3849

Supersedes #3905 (which had merge conflicts with recent main changes)