### PR TITLE
fix(whatsapp): add send_voice() override to send native audio messages

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -741,8 +741,77 @@ class WhatsAppAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         **kwargs,
     ) -> SendResult:
-        """Send an audio file as a native WhatsApp voice message via bridge."""
-        return await self._send_media_to_bridge(chat_id, audio_path, "audio", caption)
+        """Send an audio file as a native WhatsApp voice message via bridge.
+
+        WhatsApp bridge sets ptt=true (voice bubble) only for .ogg/.opus files.
+        If the file is not already ogg/opus, attempt ffmpeg conversion so it
+        lands as a playable voice note rather than a file attachment.
+        """
+        import shutil
+        import tempfile
+        import asyncio
+
+        ext = os.path.splitext(audio_path)[1].lower()
+        final_path = audio_path
+
+        # WhatsApp bridge only renders as voice bubble for ogg/opus
+        if ext not in (".ogg", ".opus"):
+            ffmpeg_bin = shutil.which("ffmpeg")
+            if ffmpeg_bin:
+                try:
+                    # Create temp file for converted audio
+                    fd, converted_path = tempfile.mkstemp(suffix=".ogg")
+                    os.close(fd)
+
+                    # Convert to opus in ogg container (WhatsApp-compatible voice format)
+                    proc = await asyncio.create_subprocess_exec(
+                        ffmpeg_bin,
+                        "-y",  # Overwrite output
+                        "-i", audio_path,
+                        "-c:a", "libopus",
+                        "-b:a", "32k",  # Low bitrate for voice
+                        "-ar", "48000",  # Opus standard sample rate
+                        "-ac", "1",  # Mono for voice
+                        "-application", "voip",  # Optimize for speech
+                        converted_path,
+                        stdout=asyncio.subprocess.DEVNULL,
+                        stderr=asyncio.subprocess.DEVNULL,
+                    )
+                    await asyncio.wait_for(proc.wait(), timeout=30.0)
+
+                    if proc.returncode == 0 and os.path.exists(converted_path):
+                        final_path = converted_path
+                        logger.debug(
+                            "Converted %s to opus for WhatsApp voice bubble",
+                            audio_path,
+                        )
+                    else:
+                        # Conversion failed, clean up and use original
+                        if os.path.exists(converted_path):
+                            os.unlink(converted_path)
+                        logger.debug(
+                            "ffmpeg conversion failed for %s, sending as-is",
+                            audio_path,
+                        )
+                except asyncio.TimeoutError:
+                    logger.warning("ffmpeg conversion timed out for %s", audio_path)
+                except Exception as e:
+                    logger.debug("ffmpeg conversion error for %s: %s", audio_path, e)
+            else:
+                logger.debug(
+                    "ffmpeg not available, sending %s as-is (may not render as voice bubble)",
+                    audio_path,
+                )
+
+        try:
+            return await self._send_media_to_bridge(chat_id, final_path, "audio", caption)
+        finally:
+            # Clean up converted file if we created one
+            if final_path != audio_path and os.path.exists(final_path):
+                try:
+                    os.unlink(final_path)
+                except Exception:
+                    pass
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Send typing indicator via bridge."""

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -800,6 +800,8 @@ class WhatsAppAdapter(BasePlatformAdapter):
                         os.unlink(converted_path)
                     logger.warning("ffmpeg conversion timed out for %s", audio_path)
                 except Exception as e:
+                    if os.path.exists(converted_path):
+                        os.unlink(converted_path)
                     logger.debug("ffmpeg conversion error for %s: %s", audio_path, e)
             else:
                 logger.debug(

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -733,6 +733,17 @@ class WhatsAppAdapter(BasePlatformAdapter):
             file_name or os.path.basename(file_path),
         )
 
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send an audio file as a native WhatsApp voice message via bridge."""
+        return await self._send_media_to_bridge(chat_id, audio_path, "audio", caption)
+
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Send typing indicator via bridge."""
         if not self._running or not self._http_session:

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -794,6 +794,10 @@ class WhatsAppAdapter(BasePlatformAdapter):
                             audio_path,
                         )
                 except asyncio.TimeoutError:
+                    proc.kill()
+                    await proc.wait()
+                    if os.path.exists(converted_path):
+                        os.unlink(converted_path)
                     logger.warning("ffmpeg conversion timed out for %s", audio_path)
                 except Exception as e:
                     logger.debug("ffmpeg conversion error for %s: %s", audio_path, e)

--- a/tests/gateway/test_whatsapp_send_voice.py
+++ b/tests/gateway/test_whatsapp_send_voice.py
@@ -252,6 +252,43 @@ def test_send_voice_ffmpeg_timeout_kills_process():
     asyncio.run(run())
 
 
+def test_send_voice_ffmpeg_os_error_cleans_temp_file():
+    """When ffmpeg raises a non-timeout exception, the temp file should still be cleaned up."""
+    async def run():
+        import shutil
+
+        adapter = _make_adapter()
+        expected_result = SendResult(success=True, message_id="voice-oserror")
+        adapter._send_media_to_bridge = AsyncMock(return_value=expected_result)
+
+        fd, ogg_path = tempfile.mkstemp(suffix=".ogg")
+
+        try:
+            with patch.object(shutil, "which", return_value="/usr/bin/ffmpeg"), \
+                 patch("tempfile.mkstemp", return_value=(fd, ogg_path)), \
+                 patch("asyncio.create_subprocess_exec", side_effect=OSError("Permission denied")):
+                result = await adapter.send_voice(
+                    chat_id="123456789@c.us",
+                    audio_path="/tmp/test-voice.mp3",
+                )
+
+            # Should fall back to original path
+            adapter._send_media_to_bridge.assert_called_once_with(
+                "123456789@c.us",
+                "/tmp/test-voice.mp3",
+                "audio",
+                None,
+            )
+            assert result.success is True
+            # Temp file should have been cleaned up
+            assert not os.path.exists(ogg_path)
+        finally:
+            if os.path.exists(ogg_path):
+                os.unlink(ogg_path)
+
+    asyncio.run(run())
+
+
 def test_send_voice_method_exists():
     """WhatsAppAdapter should have its own send_voice implementation."""
     from gateway.platforms.whatsapp import WhatsAppAdapter

--- a/tests/gateway/test_whatsapp_send_voice.py
+++ b/tests/gateway/test_whatsapp_send_voice.py
@@ -1,0 +1,104 @@
+"""Test for WhatsApp send_voice() override.
+
+Regression test for #4979: WhatsApp adapter was missing send_voice() override,
+causing voice messages to be sent as text instead of native audio.
+"""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import SendResult
+
+
+def _make_adapter():
+    """Create a WhatsAppAdapter with test attributes (bypass __init__)."""
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+    adapter.config = MagicMock()
+    adapter._bridge_port = 19876
+    adapter._bridge_script = "/tmp/test-bridge.js"
+    adapter._session_path = Path("/tmp/test-wa-session")
+    adapter._bridge_log_fh = None
+    adapter._bridge_log = None
+    adapter._bridge_process = None
+    adapter._reply_prefix = None
+    adapter._running = True
+    adapter._message_handler = None
+    adapter._fatal_error_code = None
+    adapter._fatal_error_message = None
+    adapter._fatal_error_retryable = True
+    adapter._fatal_error_handler = None
+    adapter._active_sessions = {}
+    adapter._pending_messages = {}
+    adapter._background_tasks = set()
+    adapter._auto_tts_disabled_chats = set()
+    adapter._message_queue = asyncio.Queue()
+    adapter._http_session = MagicMock()
+    return adapter
+
+
+def test_send_voice_calls_send_media_to_bridge():
+    """send_voice() should route audio through _send_media_to_bridge()."""
+    async def run():
+        adapter = _make_adapter()
+        
+        # Mock _send_media_to_bridge to verify it's called
+        expected_result = SendResult(success=True, message_id="voice-123")
+        adapter._send_media_to_bridge = AsyncMock(return_value=expected_result)
+        
+        result = await adapter.send_voice(
+            chat_id="123456789@c.us",
+            audio_path="/tmp/test-voice.ogg",
+            caption="Test caption",
+        )
+        
+        # Verify _send_media_to_bridge was called with correct args
+        adapter._send_media_to_bridge.assert_called_once_with(
+            "123456789@c.us",
+            "/tmp/test-voice.ogg",
+            "audio",
+            "Test caption",
+        )
+        assert result == expected_result
+    
+    asyncio.get_event_loop().run_until_complete(run())
+
+
+def test_send_voice_without_caption():
+    """send_voice() should work without a caption."""
+    async def run():
+        adapter = _make_adapter()
+        
+        expected_result = SendResult(success=True, message_id="voice-456")
+        adapter._send_media_to_bridge = AsyncMock(return_value=expected_result)
+        
+        result = await adapter.send_voice(
+            chat_id="123456789@c.us",
+            audio_path="/tmp/test-voice.ogg",
+        )
+        
+        adapter._send_media_to_bridge.assert_called_once_with(
+            "123456789@c.us",
+            "/tmp/test-voice.ogg",
+            "audio",
+            None,  # No caption
+        )
+        assert result.success is True
+    
+    asyncio.get_event_loop().run_until_complete(run())
+
+
+def test_send_voice_method_exists():
+    """WhatsAppAdapter should have its own send_voice implementation."""
+    from gateway.platforms.whatsapp import WhatsAppAdapter
+    from gateway.platforms.base import BasePlatformAdapter
+    
+    # Verify WhatsAppAdapter has its own send_voice (not inherited from base)
+    assert hasattr(WhatsAppAdapter, 'send_voice')
+    assert WhatsAppAdapter.send_voice is not BasePlatformAdapter.send_voice

--- a/tests/gateway/test_whatsapp_send_voice.py
+++ b/tests/gateway/test_whatsapp_send_voice.py
@@ -5,6 +5,8 @@ causing voice messages to be sent as text instead of native audio.
 """
 
 import asyncio
+import os
+import tempfile
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -67,7 +69,7 @@ def test_send_voice_calls_send_media_to_bridge():
         )
         assert result == expected_result
     
-    asyncio.get_event_loop().run_until_complete(run())
+    asyncio.run(run())
 
 
 def test_send_voice_without_caption():
@@ -91,7 +93,163 @@ def test_send_voice_without_caption():
         )
         assert result.success is True
     
-    asyncio.get_event_loop().run_until_complete(run())
+    asyncio.run(run())
+
+
+def test_send_voice_mp3_triggers_ffmpeg_conversion():
+    """Non-ogg/opus files should be converted via ffmpeg before sending."""
+    async def run():
+        import shutil
+
+        adapter = _make_adapter()
+        expected_result = SendResult(success=True, message_id="voice-conv-1")
+        adapter._send_media_to_bridge = AsyncMock(return_value=expected_result)
+
+        # Create a real temp file — keep fd OPEN so the method's os.close(fd) succeeds
+        fd, ogg_path = tempfile.mkstemp(suffix=".ogg")
+
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 0
+        mock_proc.wait = AsyncMock(return_value=0)
+
+        mock_subprocess = AsyncMock(return_value=mock_proc)
+
+        try:
+            with patch.object(shutil, "which", return_value="/usr/bin/ffmpeg"), \
+                 patch("tempfile.mkstemp", return_value=(fd, ogg_path)), \
+                 patch("asyncio.create_subprocess_exec", mock_subprocess):
+                result = await adapter.send_voice(
+                    chat_id="123456789@c.us",
+                    audio_path="/tmp/test-voice.mp3",
+                )
+
+            # ffmpeg should have been invoked
+            mock_subprocess.assert_called_once()
+            call_args = mock_subprocess.call_args[0]
+            assert call_args[0] == "/usr/bin/ffmpeg"
+            assert "-c:a" in call_args
+            assert "libopus" in call_args
+
+            # The converted ogg path should have been sent
+            sent_path = adapter._send_media_to_bridge.call_args[0][1]
+            assert sent_path.endswith(".ogg")
+            assert result.success is True
+        finally:
+            if os.path.exists(ogg_path):
+                os.unlink(ogg_path)
+
+    asyncio.run(run())
+
+
+def test_send_voice_ffmpeg_not_available_sends_original():
+    """When ffmpeg is not installed, send the original file as-is."""
+    async def run():
+        import shutil
+
+        adapter = _make_adapter()
+        expected_result = SendResult(success=True, message_id="voice-noffmpeg")
+        adapter._send_media_to_bridge = AsyncMock(return_value=expected_result)
+
+        with patch.object(shutil, "which", return_value=None):
+            result = await adapter.send_voice(
+                chat_id="123456789@c.us",
+                audio_path="/tmp/test-voice.mp3",
+            )
+
+        # Original path should be used
+        adapter._send_media_to_bridge.assert_called_once_with(
+            "123456789@c.us",
+            "/tmp/test-voice.mp3",
+            "audio",
+            None,
+        )
+        assert result.success is True
+
+    asyncio.run(run())
+
+
+def test_send_voice_ffmpeg_failure_sends_original():
+    """When ffmpeg returns non-zero, fall back to the original file."""
+    async def run():
+        import shutil
+
+        adapter = _make_adapter()
+        expected_result = SendResult(success=True, message_id="voice-fail")
+        adapter._send_media_to_bridge = AsyncMock(return_value=expected_result)
+
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 1
+        mock_proc.wait = AsyncMock(return_value=1)
+
+        fd, ogg_path = tempfile.mkstemp(suffix=".ogg")
+        # Keep fd open so the method's os.close(fd) succeeds
+
+        try:
+            with patch.object(shutil, "which", return_value="/usr/bin/ffmpeg"), \
+                 patch("tempfile.mkstemp", return_value=(fd, ogg_path)), \
+                 patch("asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)):
+                result = await adapter.send_voice(
+                    chat_id="123456789@c.us",
+                    audio_path="/tmp/test-voice.wav",
+                )
+
+            # Should fall back to original path
+            adapter._send_media_to_bridge.assert_called_once_with(
+                "123456789@c.us",
+                "/tmp/test-voice.wav",
+                "audio",
+                None,
+            )
+            assert result.success is True
+        finally:
+            if os.path.exists(ogg_path):
+                os.unlink(ogg_path)
+
+    asyncio.run(run())
+
+
+def test_send_voice_ffmpeg_timeout_kills_process():
+    """When ffmpeg times out, the process should be killed and temp file cleaned up."""
+    async def run():
+        import shutil
+
+        adapter = _make_adapter()
+        expected_result = SendResult(success=True, message_id="voice-timeout")
+        adapter._send_media_to_bridge = AsyncMock(return_value=expected_result)
+
+        mock_proc = AsyncMock()
+        mock_proc.kill = MagicMock()
+        mock_proc.wait = AsyncMock(return_value=-9)
+
+        fd, ogg_path = tempfile.mkstemp(suffix=".ogg")
+        # Keep fd open so the method's os.close(fd) succeeds
+
+        try:
+            with patch.object(shutil, "which", return_value="/usr/bin/ffmpeg"), \
+                 patch("tempfile.mkstemp", return_value=(fd, ogg_path)), \
+                 patch("asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)), \
+                 patch("asyncio.wait_for", side_effect=asyncio.TimeoutError):
+                result = await adapter.send_voice(
+                    chat_id="123456789@c.us",
+                    audio_path="/tmp/test-voice.mp3",
+                )
+
+            # Process should have been killed
+            mock_proc.kill.assert_called_once()
+
+            # Should fall back to original path
+            adapter._send_media_to_bridge.assert_called_once_with(
+                "123456789@c.us",
+                "/tmp/test-voice.mp3",
+                "audio",
+                None,
+            )
+            assert result.success is True
+        finally:
+            if os.path.exists(ogg_path):
+                os.unlink(ogg_path)
+
+    asyncio.run(run())
 
 
 def test_send_voice_method_exists():


### PR DESCRIPTION
## Summary
The WhatsApp adapter was missing a `send_voice()` override, causing the base class fallback to send audio file paths as plain text (e.g. `🔊 Audio: /path/to/file.ogg`) instead of native voice messages.

## Changes
- Added `send_voice()` to `WhatsAppAdapter` which routes audio through `_send_media_to_bridge()` with `type='audio'`
- Consistent with existing `send_image`, `send_video`, and `send_document` implementations
- Added test coverage verifying the fix

## Testing
```bash
pytest tests/gateway/test_whatsapp_send_voice.py -v
```

Fixes #4979