### PR TITLE
Security Fix: Resolve Cross-Platform Path Guard Bypass (OS Path Mismatch)

### DIFF
--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -97,17 +97,27 @@ _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
 
 def _check_sensitive_path(filepath: str) -> str | None:
     """Return an error message if the path targets a sensitive system location."""
+    import posixpath
+
+    # Cross-platform posix-safe check for container environments
+    # This prevents bypasses where Windows paths (C:\etc) mask target Unix paths (/etc)
+    try:
+        posix_resolved = posixpath.normpath(filepath)
+    except Exception:
+        posix_resolved = filepath
+
     try:
         resolved = os.path.realpath(os.path.expanduser(filepath))
     except (OSError, ValueError):
         resolved = filepath
+
     for prefix in _SENSITIVE_PATH_PREFIXES:
-        if resolved.startswith(prefix):
+        if resolved.startswith(prefix) or posix_resolved.startswith(prefix):
             return (
                 f"Refusing to write to sensitive system path: {filepath}\n"
                 "Use the terminal tool with sudo if you need to modify system files."
             )
-    if resolved in _SENSITIVE_EXACT_PATHS:
+    if resolved in _SENSITIVE_EXACT_PATHS or posix_resolved in _SENSITIVE_EXACT_PATHS:
         return (
             f"Refusing to write to sensitive system path: {filepath}\n"
             "Use the terminal tool with sudo if you need to modify system files."


### PR DESCRIPTION
Type: Bug Fix (Security) Components: tools, file_tools Platform: Multi-platform environments (Windows Host → Linux Sandbox)

Overview
This pull request addresses a silent security bypass inside tools/file_tools.py. The _check_sensitive_path guard was implemented to prevent writes to Unix sensitive files such as /etc/shadow and /usr/lib/systemd/ by prefix-matching the input path. However, the path was being parsed by the host's os.path.realpath, leading to an OS path mismatch vulnerability.

When a user runs the Hermes Agent on a Windows machine but executes tasks within a Docker or Linux-based Container Sandbox, sending a malicious path like /etc/shadow would be parsed by Python Windows os.path.realpath as C:\etc\shadow (inheriting the drive letter). The resulting validation resolved.startswith("/etc/") immediately fails, giving a false sense of security while successfully dispatching cat << 'EOF' > /etc/shadow directly to the Linux ShellFileOperations backend.

Details & Root Cause
By using os.path.realpath(...), the tools/file_tools.py bound the safety check entirely to the host OS traversal standards instead of the destination container's filesystem.

# Before
try:
    resolved = os.path.realpath(os.path.expanduser(filepath))
except (OSError, ValueError):
    resolved = filepath

for prefix in _SENSITIVE_PATH_PREFIXES:
    if resolved.startswith(prefix):
        # ...
        
        This bypass permitted unchecked programmatic control to container environments where Unix configurations are actively manipulated via write_file_tool and patch_tool.

Remediation
I introduced a dual-resolution safety check. We now employ posixpath.normpath exclusively alongside the conventional host os check. This isolates the traversal safety constraints across boundaries, ensuring that paths evaluated within Linux backends are safely stopped.

# After
import posixpath

try:
    posix_resolved = posixpath.normpath(filepath)
except Exception:
    posix_resolved = filepath

# ... (host os.path check kept intact for local envs)

for prefix in _SENSITIVE_PATH_PREFIXES:
    if resolved.startswith(prefix) or posix_resolved.startswith(prefix):
        # Successfully blocked across both environments!

Testing
Verified posixpath.normpath('/etc/shadow') correctly retains /etc/shadow on Windows without prepending C:\.
Verified the Agent now fully rejects attempts to deploy malicious modifications into Docker/Containers when hosted by a native Windows system.
