### PR TITLE
fix(hindsight): correct client constructor args and add configurable api_url

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -141,6 +141,7 @@ def _load_config() -> dict:
     return {
         "mode": os.environ.get("HINDSIGHT_MODE", "cloud"),
         "apiKey": os.environ.get("HINDSIGHT_API_KEY", ""),
+        "apiUrl": os.environ.get("HINDSIGHT_API_URL", ""),
         "banks": {
             "hermes": {
                 "bankId": os.environ.get("HINDSIGHT_BANK_ID", "hermes"),
@@ -205,6 +206,7 @@ class HindsightMemoryProvider(MemoryProvider):
         return [
             {"key": "mode", "description": "Cloud API or local embedded mode", "default": "cloud", "choices": ["cloud", "local"]},
             {"key": "api_key", "description": "Hindsight Cloud API key", "secret": True, "env_var": "HINDSIGHT_API_KEY", "url": "https://app.hindsight.vectorize.io"},
+            {"key": "api_url", "description": "API endpoint for self-hosted Hindsight (env: HINDSIGHT_API_URL)", "default": _DEFAULT_API_URL},
             {"key": "bank_id", "description": "Memory bank identifier", "default": "hermes"},
             {"key": "budget", "description": "Recall thoroughness", "default": "mid", "choices": ["low", "mid", "high"]},
             {"key": "llm_provider", "description": "LLM provider for local mode", "default": "anthropic", "choices": ["anthropic", "openai", "groq", "ollama"]},
@@ -224,7 +226,13 @@ class HindsightMemoryProvider(MemoryProvider):
                 llm_model=embed.get("llmModel", ""),
             )
         from hindsight_client import Hindsight
-        return Hindsight(api_key=self._api_key, timeout=30.0)
+        # Resolve base_url: config -> env -> default
+        base_url = (
+            self._config.get("apiUrl")
+            or os.environ.get("HINDSIGHT_API_URL")
+            or _DEFAULT_API_URL
+        )
+        return Hindsight(base_url=base_url, api_key=self._api_key, timeout=120.0)
 
     def initialize(self, session_id: str, **kwargs) -> None:
         self._config = _load_config()


### PR DESCRIPTION
## Summary

Fixes the Hindsight cloud client constructor and adds support for self-hosted instances.

### Bug: broken constructor arguments

`_make_client()` passed `api_key` as the first positional argument to `Hindsight()`, but the constructor signature is `Hindsight(base_url, api_key=None, timeout=300.0)`. Cloud mode never worked.

```python
# Before (broken) — api_key lands in base_url parameter
return Hindsight(api_key=self._api_key, timeout=30.0)

# After (fixed) — named parameters, correct order
return Hindsight(base_url=base_url, api_key=self._api_key, timeout=120.0)
```

### Feature: configurable api_url for self-hosted instances

Adds `api_url` configuration field so users running Hindsight via self-hosted Docker can point to their local instance instead of the default cloud endpoint.

Resolution order: `config.json` → `HINDSIGHT_API_URL` env var → default (`https://api.hindsight.vectorize.io`)

## Changes

**`plugins/memory/hindsight/__init__.py`** (9 insertions, 1 deletion):
- `_load_config()`: add `apiUrl` from `HINDSIGHT_API_URL` env var
- `get_config_schema()`: add `api_url` field with env var hint and default
- `_make_client()`: resolve `base_url` from config → env → default; pass as named arg; timeout 120s

## Context

Related to PR #4762 (closed by maintainer). The sequential dispatch fix from that PR was already merged separately as PR #4803. This PR covers the remaining fix: the constructor argument order and self-hosted URL support.

## Testing

- ✅ 124 memory-related tests pass (0 failures)
- ✅ File compiles without errors
- ✅ Tested locally with self-hosted Docker Hindsight (localhost:8888) — retain/recall/reflect all functional