### PR TITLE
fix: wire model.max_tokens from config to Agent

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -41,6 +41,12 @@ model:
   # api_key: "your-key-here"  # Uncomment to set here instead of .env
   base_url: "https://openrouter.ai/api/v1"
 
+  # Output token limit for LLM responses.  When omitted the server picks
+  # its own default, which may be too low for thinking models that spend
+  # tokens on internal reasoning before the visible reply.
+  # Recommended for local models (vLLM, Atlas Spark, llama.cpp).
+  # max_tokens: 65536
+
 # =============================================================================
 # OpenRouter Provider Routing (only applies when using OpenRouter)
 # =============================================================================

--- a/cli.py
+++ b/cli.py
@@ -1213,6 +1213,9 @@ class HermesCLI:
             not _config_model or _config_model == _DEFAULT_CONFIG_MODEL
         )
 
+        # Read model.max_tokens from config (output token limit for the LLM).
+        self.max_tokens = (_model_config.get("max_tokens") if isinstance(_model_config, dict) else None)
+
         self._explicit_api_key = api_key
         self._explicit_base_url = base_url
 
@@ -2263,6 +2266,7 @@ class HermesCLI:
                 tool_complete_callback=self._on_tool_complete if self._inline_diffs_enabled else None,
                 stream_delta_callback=self._stream_delta if self.streaming_enabled else None,
                 tool_gen_callback=self._on_tool_gen_start if self.streaming_enabled else None,
+                max_tokens=self.max_tokens,
             )
             # Store reference for atexit memory provider shutdown
             global _active_agent_ref
@@ -4579,6 +4583,7 @@ class HermesCLI:
                     provider_require_parameters=self._provider_require_params,
                     provider_data_collection=self._provider_data_collection,
                     fallback_model=self._fallback_model,
+                    max_tokens=self.max_tokens,
                 )
                 # Silence raw spinner; route thinking through TUI widget when no foreground agent is active.
                 bg_agent._print_fn = lambda *_a, **_kw: None
@@ -4718,6 +4723,7 @@ class HermesCLI:
                     skip_memory=True,
                     skip_context_files=True,
                     persist_session=False,
+                    max_tokens=self.max_tokens,
                 )
 
                 btw_prompt = (


### PR DESCRIPTION
## What does this PR do?

`model.max_tokens` in `config.yaml` has no effect. The CLI config key is documented and `run_agent.py` accepts the parameter, but `cli.py` never reads the value or passes it to the `AIAgent` constructor.

This causes local/self-hosted models (e.g. Qwen3.5-35B on Atlas Spark, Kimi K2.5 on NIM) to exhaust all output tokens on `<think>` reasoning blocks with nothing left for the actual response — producing `finish_reason: length` with 1 visible token.

## Related Issue

Fixes #4404

Related (closed, not merged):
- #788 — same bug, different approach (threaded `HERMES_MAX_TOKENS` env var through runtime provider resolution). This PR takes a simpler approach: read `model.max_tokens` in CLI, pass to Agent.
- #782 — the original feature request that spawned #788

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `cli.py`: Read `model.max_tokens` from config in `HermesCLI.__init__`, pass to all `AIAgent()` instantiations (main agent, background agent, btw agent)
- `cli-config.yaml.example`: Document the `max_tokens` config key under the `model:` section with usage notes

> **Note:** `run_agent.py` already supports the `max_tokens` constructor parameter, `_build_api_kwargs()` inclusion, and the `_max_tokens_param()` provider-aware helper. The missing piece was the CLI reading the config value and passing it through.

## v2 changes

Removed `frequency_penalty` support that was in v1. `frequency_penalty` is counter-productive for agentic use cases — it penalises repeated tokens proportionally to prior frequency, which actively fights against correct JSON tool-call generation, code output, and structured multi-file edits. The v1 PR also had an `elif` chain bug where setting `frequency_penalty` would silently skip the OpenRouter `max_tokens` fallback.

## How to Test

1. Set up a custom/self-hosted provider in `~/.hermes/config.yaml` (e.g. Atlas Spark, Ollama, vLLM)
2. Add `max_tokens: 16384` under `model:` in config
3. Run `hermes chat -q "Hello"` — verify the response completes with `finish_reason: stop` instead of `length`

**Bug reproduction (before fix):**
```
# config.yaml
model:
  max_tokens: 65536  # This was silently ignored
```
Agent sends requests with no `max_tokens` -> server applies low default -> model exhausts tokens on `<think>` -> `finish_reason: length` with 1 token of visible output.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've tested on my platform: Ubuntu 24.04 (DGX Spark / NVIDIA GB10, Atlas Spark inference server)

### Documentation & Housekeeping

- [x] I've updated `cli-config.yaml.example` with the new config key

## Screenshots / Logs

**Before fix** (Atlas Spark logs):
```
Session 0x9d2f...: 15126 prompt tokens, remaining=4095
Done: 1 tokens (length), time=0.16s
```

**After fix** (with `max_tokens: 65536` in config):
```
Session 0x9aeb...: 10470 prompt tokens, remaining=65535
Done: 92 tokens (stop), time=3.4s
```