### PR TITLE
fix: Honcho base_url host-block resolution + OpenViking is_available + doctor check

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -738,6 +738,74 @@ def run_doctor(args):
         check_warn("Honcho check failed", str(_e))
 
     # =========================================================================
+    # OpenViking knowledge base
+    # =========================================================================
+    print()
+    print(color("◆ OpenViking Knowledge Base", Colors.CYAN, Colors.BOLD))
+
+    try:
+        from plugins.memory.openviking import OpenVikingMemoryProvider, _get_httpx
+        _ov_provider = OpenVikingMemoryProvider()
+        if not _ov_provider.is_available():
+            check_warn("OpenViking not configured", "(set OPENVIKING_ENDPOINT in .env)")
+        else:
+            _ov_endpoint = os.environ.get("OPENVIKING_ENDPOINT", "")
+            if not _ov_endpoint:
+                # Read from .env directly
+                try:
+                    _ov_env = get_env_path()
+                    if _ov_env.exists():
+                        for _line in _ov_env.read_text().splitlines():
+                            if _line.strip().startswith("OPENVIKING_ENDPOINT="):
+                                _ov_endpoint = _line.strip().split("=", 1)[1].strip()
+                                break
+                except Exception:
+                    pass
+
+            _httpx = _get_httpx()
+            if _httpx is None:
+                check_warn("OpenViking configured but httpx not installed", "(pip install httpx)")
+            elif not _ov_endpoint:
+                check_warn("OpenViking endpoint could not be resolved")
+            else:
+                print(f"  Checking OpenViking at {_ov_endpoint}...", end="", flush=True)
+                try:
+                    _ov_resp = _httpx.get(f"{_ov_endpoint.rstrip('/')}/health", timeout=3.0)
+                    if _ov_resp.status_code == 200:
+                        # Also check what's in the knowledge base
+                        try:
+                            _ov_headers = {
+                                "Content-Type": "application/json",
+                                "X-OpenViking-Account": os.environ.get("OPENVIKING_ACCOUNT", "default"),
+                                "X-OpenViking-User": os.environ.get("OPENVIKING_USER", "default"),
+                            }
+                            _ov_ls = _httpx.get(
+                                f"{_ov_endpoint.rstrip('/')}/api/v1/fs/ls",
+                                params={"uri": "viking://"},
+                                headers=_ov_headers,
+                                timeout=5.0,
+                            )
+                            _ov_items = _ov_ls.json().get("result", []) if _ov_ls.status_code == 200 else []
+                            _ov_count = len(_ov_items) if isinstance(_ov_items, list) else 0
+                            print(f"\r  {color('✓', Colors.GREEN)} OpenViking connected"
+                                  f" {color(f'({_ov_endpoint}, {_ov_count} top-level entries)', Colors.DIM)}       ")
+                        except Exception:
+                            print(f"\r  {color('✓', Colors.GREEN)} OpenViking connected"
+                                  f" {color(f'({_ov_endpoint})', Colors.DIM)}                    ")
+                    else:
+                        print(f"\r  {color('✗', Colors.RED)} OpenViking unhealthy"
+                              f" {color(f'(HTTP {_ov_resp.status_code})', Colors.DIM)}                    ")
+                        issues.append(f"OpenViking server at {_ov_endpoint} returned HTTP {_ov_resp.status_code}")
+                except Exception as _ov_e:
+                    print(f"\r  {color('✗', Colors.RED)} OpenViking unreachable"
+                          f" {color(f'({_ov_e})', Colors.DIM)}                    ")
+                    issues.append(f"OpenViking unreachable at {_ov_endpoint}: {_ov_e}")
+    except ImportError:
+        check_warn("OpenViking plugin not found")
+    except Exception as _ov_e:
+        check_warn("OpenViking check failed", str(_ov_e))
+
+    # =========================================================================
     # Profiles
     # =========================================================================
     try:

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -252,7 +252,9 @@ class HonchoClientConfig:
         )
 
         base_url = (
-            raw.get("baseUrl")
+            host_block.get("baseUrl")
+            or raw.get("baseUrl")
+            or raw.get("base_url")
             or os.environ.get("HONCHO_BASE_URL", "").strip()
             or None
         )

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -242,8 +242,26 @@ class OpenVikingMemoryProvider(MemoryProvider):
         return "openviking"
 
     def is_available(self) -> bool:
-        """Check if OpenViking endpoint is configured. No network calls."""
-        return bool(os.environ.get("OPENVIKING_ENDPOINT"))
+        """Check if OpenViking endpoint is configured. No network calls.
+
+        Checks env vars first, then falls back to reading the .env file
+        directly (needed when called outside the CLI runtime, e.g. during
+        'hermes memory setup' or 'hermes doctor').
+        """
+        if os.environ.get("OPENVIKING_ENDPOINT"):
+            return True
+        # Fallback: read .env file directly for out-of-process checks
+        try:
+            from hermes_cli.config import get_env_path
+            env_path = get_env_path()
+            if env_path.exists():
+                for line in env_path.read_text().splitlines():
+                    line = line.strip()
+                    if line.startswith("OPENVIKING_ENDPOINT=") and line.split("=", 1)[1].strip():
+                        return True
+        except Exception:
+            pass
+        return False
 
     def get_config_schema(self):
         return [


### PR DESCRIPTION
## What does this PR do?

Three fixes for self-hosted Honcho and OpenViking users. All are in the config/discovery layer — no runtime behavior changes.

1. **Honcho `base_url` resolution**: `from_global_config()` only checked `raw.get("baseUrl")` at root level, but `honcho.json` commonly stores it as `base_url` (snake_case) at root or `baseUrl` (camelCase) in host blocks. Self-hosted users get `is_available() = False` and "not configured" in `hermes memory status` / `hermes doctor`.

2. **OpenViking `is_available()` fallback**: Only checks `os.environ.get("OPENVIKING_ENDPOINT")`, but `.env` isn't loaded when called during `hermes memory setup`, `hermes memory status`, or `hermes doctor`. Shows "not available" even when properly configured.

3. **Doctor OpenViking section**: `hermes doctor` has no OpenViking health check. Users can't diagnose connectivity issues with self-hosted instances.

## Related Issue

Fixes #2613
Fixes #4296

Related PRs:
- #2645 (open, @erosika) — local baseUrl-only configuration. Complementary: #2645 fixes `hermes honcho setup` and `hermes honcho identity` accepting baseUrl-only configs; this PR fixes the `from_global_config()` resolution that feeds into `is_available()`, `hermes memory setup`, and `hermes doctor`.
- #4606 (closed as dup of #2645) — host-scoped baseUrl config. Same root cause, smaller fix.
- #3276 — Honcho PR map (tracking issue for all Honcho integration work)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `plugins/memory/honcho/client.py`: In `from_global_config()`, check `host_block.get("baseUrl")` first, then `raw.get("baseUrl")`, then `raw.get("base_url")`, then `HONCHO_BASE_URL` env var. Three lines added.
- `plugins/memory/openviking/__init__.py`: In `is_available()`, fall back to reading `OPENVIKING_ENDPOINT` directly from the `.env` file on disk when the env var isn't set in `os.environ`.
- `hermes_cli/doctor.py`: Add "OpenViking Knowledge Base" section that checks endpoint health, reports status, and shows top-level entry count. Matches the style of the existing Honcho section.

## How to Test

**Fix 1 — Honcho base_url:**
1. Set up a self-hosted Honcho instance at `http://localhost:8000`
2. Configure `honcho.json` with `base_url` at root level (snake_case)
3. Run `hermes memory status` — should show Honcho as "available"
4. Run `hermes doctor` — Honcho section should show the correct base URL

**Fix 2 — OpenViking is_available:**
1. Set `OPENVIKING_ENDPOINT=http://localhost:1933` in `~/.hermes/.env`
2. Do NOT export it to the shell environment
3. Run `hermes memory setup` — should show OpenViking as "available"

**Fix 3 — Doctor OpenViking:**
1. Run `hermes doctor` — should show a new "OpenViking Knowledge Base" section
2. If OpenViking is running: shows endpoint, health status, entry count
3. If not running: shows "not reachable" with the configured endpoint

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (DGX Spark / NVIDIA GB10, self-hosted Honcho + OpenViking)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

**Before fix** — `hermes memory status` / provider discovery:
```python
>>> HonchoClientConfig.from_global_config()
base_url: None  # honcho.json has base_url but from_global_config misses it
is_available: False

>>> OpenVikingMemoryProvider().is_available()
False  # .env has OPENVIKING_ENDPOINT but os.environ doesn't
```

**After fix:**
```python
>>> HonchoClientConfig.from_global_config()
base_url: 'http://localhost:8000'  # resolved from host block
is_available: True

>>> OpenVikingMemoryProvider().is_available()
True  # falls back to reading .env file from disk
```
