### PR TITLE
fix: clear stale gateway runtime errors

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -23,6 +23,7 @@ from typing import Any, Optional
 _GATEWAY_KIND = "hermes-gateway"
 _RUNTIME_STATUS_FILE = "gateway_state.json"
 _LOCKS_DIRNAME = "gateway-locks"
+_RUNTIME_STATUS_UNSET = object()
 
 
 def _get_pid_path() -> Path:
@@ -186,14 +187,18 @@ def write_pid_file() -> None:
 
 def write_runtime_status(
     *,
-    gateway_state: Optional[str] = None,
-    exit_reason: Optional[str] = None,
+    gateway_state: Optional[str] | object = _RUNTIME_STATUS_UNSET,
+    exit_reason: Optional[str] | object = _RUNTIME_STATUS_UNSET,
     platform: Optional[str] = None,
-    platform_state: Optional[str] = None,
-    error_code: Optional[str] = None,
-    error_message: Optional[str] = None,
+    platform_state: Optional[str] | object = _RUNTIME_STATUS_UNSET,
+    error_code: Optional[str] | object = _RUNTIME_STATUS_UNSET,
+    error_message: Optional[str] | object = _RUNTIME_STATUS_UNSET,
 ) -> None:
-    """Persist gateway runtime health information for diagnostics/status."""
+    """Persist gateway runtime health information for diagnostics/status.
+
+    Pass ``None`` explicitly to clear a previously-recorded field. Omit an argument
+    to preserve the existing value.
+    """
     path = _get_runtime_status_path()
     payload = _read_json_file(path) or _build_runtime_status_record()
     payload.setdefault("platforms", {})
@@ -202,18 +207,18 @@ def write_runtime_status(
     payload["start_time"] = _get_process_start_time(os.getpid())
     payload["updated_at"] = _utc_now_iso()
 
-    if gateway_state is not None:
+    if gateway_state is not _RUNTIME_STATUS_UNSET:
         payload["gateway_state"] = gateway_state
-    if exit_reason is not None:
+    if exit_reason is not _RUNTIME_STATUS_UNSET:
         payload["exit_reason"] = exit_reason
 
     if platform is not None:
         platform_payload = payload["platforms"].get(platform, {})
-        if platform_state is not None:
+        if platform_state is not _RUNTIME_STATUS_UNSET:
             platform_payload["state"] = platform_state
-        if error_code is not None:
+        if error_code is not _RUNTIME_STATUS_UNSET:
             platform_payload["error_code"] = error_code
-        if error_message is not None:
+        if error_message is not _RUNTIME_STATUS_UNSET:
             platform_payload["error_message"] = error_message
         platform_payload["updated_at"] = _utc_now_iso()
         payload["platforms"][platform] = platform_payload

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -103,6 +103,55 @@ class TestGatewayRuntimeStatus:
         assert payload["platforms"]["telegram"]["error_code"] == "telegram_polling_conflict"
         assert payload["platforms"]["telegram"]["error_message"] == "another poller is active"
 
+    def test_write_runtime_status_can_clear_previous_errors(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        status.write_runtime_status(
+            gateway_state="startup_failed",
+            exit_reason="discord conflict",
+            platform="discord",
+            platform_state="fatal",
+            error_code="discord_token_lock",
+            error_message="Discord bot token already in use.",
+        )
+
+        status.write_runtime_status(
+            gateway_state="running",
+            exit_reason=None,
+            platform="discord",
+            platform_state="connected",
+            error_code=None,
+            error_message=None,
+        )
+
+        payload = status.read_runtime_status()
+        assert payload["gateway_state"] == "running"
+        assert payload["exit_reason"] is None
+        assert payload["platforms"]["discord"]["state"] == "connected"
+        assert payload["platforms"]["discord"]["error_code"] is None
+        assert payload["platforms"]["discord"]["error_message"] is None
+
+    def test_write_runtime_status_omitted_args_preserve_previous_values(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        status.write_runtime_status(
+            gateway_state="startup_failed",
+            exit_reason="discord conflict",
+            platform="discord",
+            platform_state="fatal",
+            error_code="discord_token_lock",
+            error_message="Discord bot token already in use.",
+        )
+
+        status.write_runtime_status(platform="discord", platform_state="connected")
+
+        payload = status.read_runtime_status()
+        assert payload["gateway_state"] == "startup_failed"
+        assert payload["exit_reason"] == "discord conflict"
+        assert payload["platforms"]["discord"]["state"] == "connected"
+        assert payload["platforms"]["discord"]["error_code"] == "discord_token_lock"
+        assert payload["platforms"]["discord"]["error_message"] == "Discord bot token already in use."
+
 
 class TestScopedLocks:
     def test_acquire_scoped_lock_rejects_live_other_process(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- fix `write_runtime_status()` so omitted args preserve existing values while explicit `None` clears stale fields
- clear stale gateway/platform runtime errors after a later successful startup or reconnect
- add regression coverage for both clearing old errors and preserving values when args are omitted

## Root cause
`write_runtime_status()` treated `None` as both:
- "leave this field alone"
- and "clear this field"

That let old `exit_reason`, `error_code`, and `error_message` values stick around in `gateway_state.json`, which produced misleading health output like a platform showing `connected` while still carrying an old fatal error.

## Test plan
- `python -m pytest tests/gateway/test_status.py -q`
- `python -m pytest tests/gateway/test_runner_startup_failures.py tests/hermes_cli/test_gateway_runtime_health.py -q`
- attempted full suite per AGENTS.md: `python -m pytest tests/ -q`
  - currently red in this environment/repo state due many unrelated pre-existing failures, including repeated `OSError: [Errno 24] Too many open files` and unrelated gateway/tooling test failures outside this change
