### PR TITLE
feat(tools): add Patchright as browser provider

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -234,6 +234,10 @@ terminal:
 # Browser Tool Configuration
 # =============================================================================
 browser:
+  # Browser provider: "local", "browserbase", "browser-use", "camofox", or "patchright"
+  # Set via: hermes setup tools -> Browser Automation -> choose provider
+  # cloud_provider: local
+
   # Inactivity timeout in seconds - browser sessions are automatically closed
   # after this period of no activity between agent loops (default: 120 = 2 minutes)
   inactivity_timeout: 120

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -132,6 +132,7 @@ def _browser_label(current_provider: str) -> str:
         "browserbase": "Browserbase",
         "browser-use": "Browser Use",
         "camofox": "Camofox",
+        "patchright": "Patchright",
         "local": "Local browser",
     }
     return mapping.get(current_provider or "local", current_provider or "Local browser")
@@ -180,6 +181,8 @@ def _resolve_browser_feature_state(
             active = bool(browser_tool_enabled and available)
             return current_provider, available, active, False
         if current_provider == "camofox":
+            return current_provider, False, False, False
+        if current_provider == "patchright":
             return current_provider, False, False, False
 
         current_provider = "local"

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -325,6 +325,13 @@ TOOL_CATEGORIES = {
                 "browser_provider": "camofox",
                 "post_setup": "camofox",
             },
+            {
+                "name": "Patchright",
+                "tag": "Local anti-detection browser (Chromium/Patchright)",
+                "env_vars": [],
+                "browser_provider": "patchright",
+                "post_setup": "patchright",
+            },
         ],
     },
     "homeassistant": {
@@ -410,6 +417,30 @@ def _run_post_setup(post_setup_key: str):
         elif not shutil.which("npm"):
             _print_warning("    Node.js not found. Install Camofox via Docker:")
             _print_info("      docker run -p 9377:9377 -e CAMOFOX_PORT=9377 jo-inc/camofox-browser")
+
+    elif post_setup_key == "patchright":
+        patchright_dir = PROJECT_ROOT / "node_modules" / "patchright"
+        pw_core_dir = PROJECT_ROOT / "node_modules" / "playwright-core"
+        if not patchright_dir.exists() and shutil.which("npm"):
+            _print_info("    Installing Patchright...")
+            import subprocess
+            result = subprocess.run(
+                ["npm", "install", "--save", "patchright"],
+                capture_output=True, text=True, cwd=str(PROJECT_ROOT)
+            )
+            if result.returncode == 0:
+                # Create symlink: playwright-core -> patchright
+                if pw_core_dir.exists() and not pw_core_dir.is_symlink():
+                    shutil.rmtree(str(pw_core_dir))
+                if not pw_core_dir.exists():
+                    pw_core_dir.symlink_to(patchright_dir)
+                _print_success("    Patchright installed and playwright-core symlinked")
+            else:
+                _print_warning("    npm install failed - run manually: npm install patchright")
+        elif not shutil.which("npm"):
+            _print_warning("    Node.js not found. Install Node.js first, then re-run setup.")
+        if pw_core_dir.is_symlink() and patchright_dir.exists():
+            _print_success("    Patchright is active (playwright-core -> patchright)")
 
     elif post_setup_key == "rl_training":
         try:

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -89,6 +89,36 @@ try:
 except ImportError:
     _is_camofox_mode = lambda: False  # noqa: E731
 
+# Patchright local anti-detection browser backend (optional).
+# When cloud_provider is set to "patchright" in config, the browser
+# uses the Patchright (patched Playwright) instead of the standard
+# agent-browser CLI.
+try:
+    from tools.tool_backend_helpers import normalize_browser_cloud_provider
+    _PATCHRIGHT_PROVIDER = "patchright"
+
+    def _is_patchright_mode() -> bool:
+        if not _is_local_mode():
+            return False
+        try:
+            hermes_home = get_hermes_home()
+            config_path = hermes_home / "config.yaml"
+            if config_path.exists():
+                import yaml
+                with open(config_path) as f:
+                    cfg = yaml.safe_load(f) or {}
+                browser_cfg = cfg.get("browser", {})
+                if isinstance(browser_cfg, dict) and "cloud_provider" in browser_cfg:
+                    provider_key = normalize_browser_cloud_provider(
+                        browser_cfg.get("cloud_provider")
+                    )
+                    return provider_key == _PATCHRIGHT_PROVIDER
+        except Exception:
+            pass
+        return False
+except ImportError:
+    _is_patchright_mode = lambda: False  # noqa: E731
+
 logger = logging.getLogger(__name__)
 
 # Standard PATH entries for environments with minimal PATH (e.g. systemd services).
@@ -307,12 +337,12 @@ def _is_local_backend() -> bool:
 
     SSRF protection is only meaningful for cloud backends (Browserbase,
     BrowserUse) where the agent could reach internal resources on a remote
-    machine.  For local backends — Camofox, or the built-in headless
-    Chromium without a cloud provider — the user already has full terminal
-    and network access on the same machine, so the check adds no security
-    value.
+    machine.  For local backends — Camofox, Patchright, or the built-in
+    headless Chromium without a cloud provider — the user already has full
+    terminal and network access on the same machine, so the check adds no
+    security value.
     """
-    return _is_camofox_mode() or _get_cloud_provider() is None
+    return _is_camofox_mode() or _is_patchright_mode() or _get_cloud_provider() is None
 
 
 def _allow_private_urls() -> bool:
@@ -922,6 +952,9 @@ def _run_browser_command(
 
         browser_env["PATH"] = ":".join(path_parts)
         browser_env["AGENT_BROWSER_SOCKET_DIR"] = task_socket_dir
+
+        if _is_patchright_mode():
+            browser_env["AGENT_BROWSER_HEADED"] = "1"
         
         # Use temp files for stdout/stderr instead of pipes.
         # agent-browser starts a background daemon that inherits file


### PR DESCRIPTION
## Summary

Add [Patchright](https://github.com/AhmadHassanWagih1/patchright) — a patched fork of Playwright that bypasses bot detection (Cloudflare, Datadome, etc.) — as a first-class browser provider option, following the same integration pattern as Camofox.

## How it works

- Users select Patchright via **`hermes setup tools` → Browser Automation → Patchright**
- The post-setup hook runs `npm install patchright` and symlinks `playwright-core → patchright` in `node_modules`
- At runtime, `AGENT_BROWSER_HEADED=1` is injected so agent-browser uses the full Chromium binary (not headless-shell) — required for Patchright to work correctly
- No API key needed, fully local, MIT/Apache 2.0 licensed

## Changes

| File | Change |
|------|--------|
| `hermes_cli/tools_config.py` | Provider entry in `TOOL_CATEGORIES["browser"]["providers"]` + `post_setup` hook for npm install + symlink |
| `hermes_cli/nous_subscription.py` | `"patchright"` in `_browser_label()` mapping + `_resolve_browser_feature_state()` handling |
| `tools/browser_tool.py` | `_is_patchright_mode()` detection function + `AGENT_BROWSER_HEADED=1` env var injection + local backend classification |
| `cli-config.yaml.example` | Documented `cloud_provider` option with Patchright listed |

## Testing

- ✅ Python syntax check (`ast.parse`) passes on all 3 modified `.py` files
- ✅ `pytest tests/tools/` — 1278 passed, 2 pre-existing failures (unrelated: `test_create_duplicate_blocked`, `test_openai_tts_uses_managed_audio_gateway_when_direct_key_absent`)
- ✅ Zero behavior change for existing users — Patchright is opt-in only
- ✅ Follows the exact same pattern as Camofox integration

## Contributing compliance

- [x] Minimal, focused changes (76 insertions, 5 deletions across 4 files)
- [x] Conventional commit message (`feat(tools): ...`)
- [x] Branch naming: `feat/patchright-browser-provider`
- [x] Cross-platform safe (no platform-specific code)
- [x] No new dependencies required (npm install only when user opts in)
- [x] Code style matches existing patterns