### PR TITLE
fix(signal): restore read receipts for direct messages

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -544,6 +544,12 @@ class SignalAdapter(BasePlatformAdapter):
         logger.debug("Signal: message from %s in %s: %s",
                       _redact_phone(sender), chat_id[:20], (text or "")[:50])
 
+        # Send read receipt for direct messages so Signal shows the message as read.
+        # Groups are skipped because group receipt semantics are noisier and this
+        # behavior was requested specifically for 1:1 chats.
+        if ts_ms and sender and not is_group:
+            asyncio.create_task(self._send_read_receipt(sender, ts_ms))
+
         await self.handle_message(event)
 
     # ------------------------------------------------------------------
@@ -618,6 +624,23 @@ class SignalAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.warning("Signal RPC %s failed: %s", method, e)
             return None
+
+    # ------------------------------------------------------------------
+    # Read Receipts
+    # ------------------------------------------------------------------
+
+    async def _send_read_receipt(self, sender: str, timestamp: int) -> None:
+        """Send a read receipt for an incoming direct message."""
+        try:
+            await self._rpc("sendReceipt", {
+                "account": self.account,
+                "recipient": sender,
+                "type": "read",
+                "targetTimestamp": [timestamp],
+            }, rpc_id="receipt")
+            logger.debug("Signal: sent read receipt to %s", _redact_phone(sender))
+        except Exception as e:
+            logger.debug("Signal: failed to send read receipt: %s", e)
 
     # ------------------------------------------------------------------
     # Sending

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -1,4 +1,5 @@
 """Tests for Signal messenger platform adapter."""
+import asyncio
 import base64
 import json
 import pytest
@@ -259,6 +260,49 @@ class TestSignalAttachmentFetch:
 
         assert path == "/tmp/test.pdf"
         assert ext == ".pdf"
+
+
+# ---------------------------------------------------------------------------
+# Read Receipts
+# ---------------------------------------------------------------------------
+
+class TestSignalReadReceipts:
+    @pytest.mark.asyncio
+    async def test_send_read_receipt_uses_signal_rpc(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._rpc, captured = _stub_rpc({"timestamp": 123})
+
+        await adapter._send_read_receipt("+155****9999", 1712100000123)
+
+        call = captured[0]
+        assert call["method"] == "sendReceipt"
+        assert call["params"]["account"] == adapter.account
+        assert call["params"]["recipient"] == "+155****9999"
+        assert call["params"]["type"] == "read"
+        assert call["params"]["targetTimestamp"] == [1712100000123]
+
+    @pytest.mark.asyncio
+    async def test_handle_envelope_sends_read_receipt_for_dm(self, monkeypatch):
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter.handle_message = AsyncMock()
+        adapter._send_read_receipt = AsyncMock()
+
+        envelope = {
+            "envelope": {
+                "sourceNumber": "+155****9999",
+                "sourceName": "Charlie",
+                "timestamp": 1712100000123,
+                "dataMessage": {
+                    "message": "hey",
+                },
+            }
+        }
+
+        await adapter._handle_envelope(envelope)
+        await asyncio.sleep(0)
+
+        adapter._send_read_receipt.assert_awaited_once_with("+155****9999", 1712100000123)
+        adapter.handle_message.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- restore Signal direct-message read receipts in the adapter
- send `sendReceipt` with `type=read` and the inbound message timestamp
- add Signal regression coverage so this does not disappear again on branch churn

## Why
Read receipts had been added locally before, but they were no longer present in the current checkout. This reintroduces the behavior as a clean focused fix.

## Test Plan
- `python3 -m py_compile gateway/platforms/signal.py tests/gateway/test_signal.py`
- `./venv/bin/pytest -q tests/gateway/test_signal.py::TestSignalReadReceipts -q`
- `./venv/bin/pytest -q tests/gateway/test_signal.py -q`
