### PR TITLE
feat(agent): add in-session user progress messages

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -142,6 +142,7 @@ class HermesACPAgent(acp.Agent):
                 enabled_toolsets=enabled_toolsets,
                 disabled_toolsets=disabled_toolsets,
                 quiet_mode=True,
+                platform="acp",
             )
             state.agent.valid_tool_names = {
                 tool["function"]["name"] for tool in state.agent.tools or []
@@ -495,7 +496,7 @@ class HermesACPAgent(acp.Agent):
         try:
             from model_tools import get_tool_definitions
             toolsets = getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"]
-            tools = get_tool_definitions(enabled_toolsets=toolsets, quiet_mode=True)
+            tools = get_tool_definitions(enabled_toolsets=toolsets, quiet_mode=True, platform="acp")
             if not tools:
                 return "No tools available."
             lines = [f"Available tools ({len(tools)}):"]

--- a/cli.py
+++ b/cli.py
@@ -2313,7 +2313,7 @@ class HermesCLI:
             self._show_status()
         else:
             # Get tools for display
-            tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
+            tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True, platform="cli")
             
             # Get terminal working directory (where commands will execute)
             cwd = os.getenv("TERMINAL_CWD", os.getcwd())
@@ -2818,7 +2818,7 @@ class HermesCLI:
     def _show_status(self):
         """Show current status bar."""
         # Get tool count
-        tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
+        tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True, platform="cli")
         tool_count = len(tools) if tools else 0
         
         # Format model name (shorten if needed)
@@ -2882,7 +2882,7 @@ class HermesCLI:
     
     def show_tools(self):
         """Display available tools with kawaii ASCII art."""
-        tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
+        tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True, platform="cli")
         
         if not tools:
             print("(;_;) No tools available")
@@ -4061,7 +4061,7 @@ class HermesCLI:
                 if self.compact or term_w < 80:
                     cc.print(_build_compact_banner())
                 else:
-                    tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True)
+                    tools = get_tool_definitions(enabled_toolsets=self.enabled_toolsets, quiet_mode=True, platform="cli")
                     cwd = os.getenv("TERMINAL_CWD", os.getcwd())
                     ctx_len = None
                     if hasattr(self, 'agent') and self.agent and hasattr(self.agent, 'context_compressor'):
@@ -5216,6 +5216,7 @@ class HermesCLI:
                     enabled_toolsets=self.agent.enabled_toolsets
                     if hasattr(self.agent, "enabled_toolsets") else None,
                     quiet_mode=True,
+                    platform="cli",
                 )
                 self.agent.valid_tool_names = {
                     tool["function"]["name"] for tool in self.agent.tools

--- a/cli.py
+++ b/cli.py
@@ -2258,6 +2258,7 @@ class HermesCLI:
                 checkpoints_enabled=self.checkpoints_enabled,
                 checkpoint_max_snapshots=self.checkpoint_max_snapshots,
                 pass_session_id=self.pass_session_id,
+                message_callback=self._on_agent_message,
                 tool_progress_callback=self._on_tool_progress,
                 tool_start_callback=self._on_tool_start if self._inline_diffs_enabled else None,
                 tool_complete_callback=self._on_tool_complete if self._inline_diffs_enabled else None,
@@ -5272,6 +5273,16 @@ class HermesCLI:
         from agent.display import get_tool_emoji
         emoji = get_tool_emoji(tool_name, default="⚡")
         _cprint(f"  ┊ {emoji} preparing {tool_name}…")
+
+    def _on_agent_message(self, text: str) -> None:
+        """Render an in-session user-facing update from the agent."""
+        if not text:
+            return
+        if getattr(self, "_stream_box_opened", False):
+            self._flush_stream()
+            self._stream_box_opened = False
+        self._close_reasoning_box()
+        _cprint(f"  ┊ 💬 {text}")
 
     # ====================================================================
     # Tool progress callback (audio cues for voice mode)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5735,6 +5735,21 @@ class GatewayRunner:
             except Exception as _e:
                 logger.debug("status_callback error (%s): %s", event_type, _e)
 
+        def _message_callback_sync(message: str) -> None:
+            if not _status_adapter or not message:
+                return
+            try:
+                asyncio.run_coroutine_threadsafe(
+                    _status_adapter.send(
+                        _status_chat_id,
+                        message,
+                        metadata=_status_thread_metadata,
+                    ),
+                    _loop_for_step,
+                )
+            except Exception as _e:
+                logger.debug("message_callback error: %s", _e)
+
         def run_sync():
             # Pass session_key to process registry via env var so background
             # processes can be mapped back to this gateway session
@@ -5859,6 +5874,7 @@ class GatewayRunner:
             agent.tool_progress_callback = progress_callback if tool_progress_enabled else None
             agent.step_callback = _step_callback_sync if _hooks_ref.loaded_hooks else None
             agent.stream_delta_callback = _stream_delta_cb
+            agent.message_callback = _message_callback_sync
             agent.status_callback = _status_callback_sync
             agent.reasoning_config = reasoning_config
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -97,6 +97,7 @@ CONFIGURABLE_TOOLSETS = [
     ("memory",          "💾 Memory",                    "persistent memory across sessions"),
     ("session_search",  "🔎 Session Search",            "search past conversations"),
     ("clarify",         "❓ Clarifying Questions",      "clarify"),
+    ("user_updates",    "💬 User Updates",              "send_user_message"),
     ("delegation",      "👥 Task Delegation",           "delegate_task"),
     ("cronjob",         "⏰ Cron Jobs",                 "create/list/update/pause/resume/run, with optional attached skills"),
     ("rl",              "🧪 RL Training",               "Tinker-Atropos training tools"),

--- a/model_tools.py
+++ b/model_tools.py
@@ -152,6 +152,7 @@ def _discover_tools():
         "tools.memory_tool",
         "tools.session_search_tool",
         "tools.clarify_tool",
+        "tools.send_user_message_tool",
         "tools.code_execution_tool",
         "tools.delegate_tool",
         "tools.process_registry",
@@ -361,7 +362,7 @@ def get_tool_definitions(
 # because they need agent-level state (TodoStore, MemoryStore, etc.).
 # The registry still holds their schemas; dispatch just returns a stub error
 # so if something slips through, the LLM sees a sensible message.
-_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task"}
+_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task", "send_user_message"}
 _READ_SEARCH_TOOLS = {"read_file", "search_files"}
 
 

--- a/model_tools.py
+++ b/model_tools.py
@@ -236,6 +236,7 @@ def get_tool_definitions(
     enabled_toolsets: List[str] = None,
     disabled_toolsets: List[str] = None,
     quiet_mode: bool = False,
+    platform: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """
     Get tool definitions for model API calls with toolset-based filtering.
@@ -246,6 +247,7 @@ def get_tool_definitions(
         enabled_toolsets: Only include tools from these toolsets.
         disabled_toolsets: Exclude tools from these toolsets (if enabled_toolsets is None).
         quiet_mode: Suppress status prints.
+        platform: Runtime platform hint used for context-sensitive tool filtering.
 
     Returns:
         Filtered list of OpenAI-format tool definitions.
@@ -301,6 +303,32 @@ def get_tool_definitions(
 
     # Ask the registry for schemas (only returns tools whose check_fn passes)
     filtered_tools = registry.get_definitions(tools_to_include, quiet=quiet_mode)
+
+    # Interactive in-session messaging is only meaningful when Hermes has a
+    # live session surface that can route updates back to the current user.
+    # Keep it out of non-interactive/default contexts so the model does not
+    # waste turns on a tool that will deterministically fail at runtime.
+    interactive_message_platforms = {
+        "acp",
+        "cli",
+        "discord",
+        "dingtalk",
+        "email",
+        "feishu",
+        "homeassistant",
+        "matrix",
+        "mattermost",
+        "signal",
+        "slack",
+        "telegram",
+        "wecom",
+        "whatsapp",
+    }
+    if platform not in interactive_message_platforms:
+        filtered_tools = [
+            td for td in filtered_tools
+            if td.get("function", {}).get("name") != "send_user_message"
+        ]
 
     # The set of tool names that actually passed check_fn filtering.
     # Use this (not tools_to_include) for any downstream schema that references

--- a/run_agent.py
+++ b/run_agent.py
@@ -895,6 +895,7 @@ class AIAgent:
             enabled_toolsets=enabled_toolsets,
             disabled_toolsets=disabled_toolsets,
             quiet_mode=self.quiet_mode,
+            platform=self.platform,
         )
         
         # Show tool configuration and store valid tool names for validation
@@ -5799,7 +5800,7 @@ class AIAgent:
                     print(f"  📞 Tool {i}: {name}({list(args.keys())}) - {args_preview}")
 
         for tc, name, args in parsed_calls:
-            if self.tool_progress_callback:
+            if self.tool_progress_callback and name != "send_user_message":
                 try:
                     preview = _build_tool_preview(name, args)
                     self.tool_progress_callback(name, preview, args)
@@ -5970,7 +5971,7 @@ class AIAgent:
                     args_preview = args_str[:self.log_prefix_chars] + "..." if len(args_str) > self.log_prefix_chars else args_str
                     print(f"  📞 Tool {i}: {function_name}({list(function_args.keys())}) - {args_preview}")
 
-            if self.tool_progress_callback:
+            if self.tool_progress_callback and function_name != "send_user_message":
                 try:
                     preview = _build_tool_preview(function_name, function_args)
                     self.tool_progress_callback(function_name, preview, function_args)

--- a/run_agent.py
+++ b/run_agent.py
@@ -208,7 +208,7 @@ class IterationBudget:
 
 # Tools that must never run concurrently (interactive / user-facing).
 # When any of these appear in a batch, we fall back to sequential execution.
-_NEVER_PARALLEL_TOOLS = frozenset({"clarify"})
+_NEVER_PARALLEL_TOOLS = frozenset({"clarify", "send_user_message"})
 
 # Read-only tools with no shared mutable session state.
 _PARALLEL_SAFE_TOOLS = frozenset({
@@ -459,6 +459,7 @@ class AIAgent:
         step_callback: callable = None,
         stream_delta_callback: callable = None,
         tool_gen_callback: callable = None,
+        message_callback: callable = None,
         status_callback: callable = None,
         max_tokens: int = None,
         reasoning_config: Dict[str, Any] = None,
@@ -502,6 +503,8 @@ class AIAgent:
             tool_progress_callback (callable): Callback function(tool_name, args_preview) for progress notifications
             clarify_callback (callable): Callback function(question, choices) -> str for interactive user questions.
                 Provided by the platform layer (CLI or gateway). If None, the clarify tool returns an error.
+            message_callback (callable): Callback function(message_text) -> None for sending
+                a natural-language update to the current user without ending the turn.
             max_tokens (int): Maximum tokens for model responses (optional, uses model default if not set)
             reasoning_config (Dict): OpenRouter reasoning configuration override (e.g. {"effort": "none"} to disable thinking).
                 If None, defaults to {"enabled": True, "effort": "medium"} for OpenRouter. Set to disable/customize reasoning.
@@ -587,6 +590,7 @@ class AIAgent:
         self.clarify_callback = clarify_callback
         self.step_callback = step_callback
         self.stream_delta_callback = stream_delta_callback
+        self.message_callback = message_callback
         self.status_callback = status_callback
         self.tool_gen_callback = tool_gen_callback
         self._last_reported_tool = None  # Track for "new tool" mode
@@ -1325,6 +1329,43 @@ class AIAgent:
                 self.status_callback("lifecycle", message)
             except Exception:
                 logger.debug("status_callback error in _emit_status", exc_info=True)
+
+    def _emit_user_message(self, message: str) -> str:
+        """Send a natural-language update to the current user.
+
+        Prefers the dedicated ``message_callback`` so platforms can render
+        user-facing status naturally inside the current session. Falls back to
+        ``status_callback("agent_message", ...)`` for older embeddings that do
+        not wire the dedicated callback yet.
+        """
+        text = str(message or "").strip()
+        if not text:
+            return json.dumps({"error": "Message text is required."}, ensure_ascii=False)
+
+        if self.message_callback:
+            try:
+                self.message_callback(text)
+                return json.dumps({"sent": True, "message": text}, ensure_ascii=False)
+            except Exception as exc:
+                return json.dumps(
+                    {"error": f"Failed to send user message: {exc}"},
+                    ensure_ascii=False,
+                )
+
+        if self.status_callback:
+            try:
+                self.status_callback("agent_message", text)
+                return json.dumps({"sent": True, "message": text}, ensure_ascii=False)
+            except Exception as exc:
+                return json.dumps(
+                    {"error": f"Failed to send user message: {exc}"},
+                    ensure_ascii=False,
+                )
+
+        return json.dumps(
+            {"error": "send_user_message is not available in this execution context."},
+            ensure_ascii=False,
+        )
 
     def _is_direct_openai_url(self, base_url: str = None) -> bool:
         """Return True when a base URL targets OpenAI's native API."""
@@ -5664,6 +5705,8 @@ class AIAgent:
                 choices=function_args.get("choices"),
                 callback=self.clarify_callback,
             )
+        elif function_name == "send_user_message":
+            return self._emit_user_message(function_args.get("message", ""))
         elif function_name == "delegate_task":
             from tools.delegate_tool import delegate_task as _delegate_task
             return _delegate_task(
@@ -6014,6 +6057,11 @@ class AIAgent:
                 tool_duration = time.time() - tool_start_time
                 if self.quiet_mode:
                     self._vprint(f"  {_get_cute_tool_message_impl('clarify', function_args, tool_duration, result=function_result)}")
+            elif function_name == "send_user_message":
+                function_result = self._emit_user_message(function_args.get("message", ""))
+                tool_duration = time.time() - tool_start_time
+                if self.quiet_mode:
+                    self._vprint(f"  {_get_cute_tool_message_impl('send_user_message', function_args, tool_duration, result=function_result)}")
             elif function_name == "delegate_task":
                 from tools.delegate_tool import delegate_task as _delegate_task
                 tasks_arg = function_args.get("tasks")

--- a/tests/gateway/test_api_server_toolset.py
+++ b/tests/gateway/test_api_server_toolset.py
@@ -55,6 +55,10 @@ class TestHermesApiServerToolset:
         tools = resolve_toolset("hermes-api-server")
         assert "send_message" not in tools
 
+    def test_toolset_excludes_send_user_message(self):
+        tools = resolve_toolset("hermes-api-server")
+        assert "send_user_message" not in tools
+
     def test_toolset_excludes_text_to_speech(self):
         tools = resolve_toolset("hermes-api-server")
         assert "text_to_speech" not in tools

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 from hermes_cli.tools_config import (
+    CONFIGURABLE_TOOLSETS,
     _configure_provider,
     _get_platform_tools,
     _platform_toolset_summary,
@@ -28,6 +29,11 @@ def test_get_platform_tools_preserves_explicit_empty_selection():
     enabled = _get_platform_tools(config, "cli")
 
     assert enabled == set()
+
+
+def test_configurable_toolsets_include_user_updates():
+    keys = [ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS]
+    assert "user_updates" in keys
 
 
 def test_platform_toolset_summary_uses_explicit_platform_list():

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -49,6 +49,7 @@ class TestAgentLoopTools:
         assert "memory" in _AGENT_LOOP_TOOLS
         assert "session_search" in _AGENT_LOOP_TOOLS
         assert "delegate_task" in _AGENT_LOOP_TOOLS
+        assert "send_user_message" in _AGENT_LOOP_TOOLS
 
     def test_no_regular_tools_in_set(self):
         assert "web_search" not in _AGENT_LOOP_TOOLS

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -6,6 +6,7 @@ import pytest
 from model_tools import (
     handle_function_call,
     get_all_tool_names,
+    get_tool_definitions,
     get_toolset_for_tool,
     _AGENT_LOOP_TOOLS,
     _LEGACY_TOOLSET_MAP,
@@ -54,6 +55,26 @@ class TestAgentLoopTools:
     def test_no_regular_tools_in_set(self):
         assert "web_search" not in _AGENT_LOOP_TOOLS
         assert "terminal" not in _AGENT_LOOP_TOOLS
+
+    def test_send_user_message_only_exposed_on_interactive_platforms(self):
+        cli_tools = get_tool_definitions(
+            enabled_toolsets=["user_updates"],
+            quiet_mode=True,
+            platform="cli",
+        )
+        api_tools = get_tool_definitions(
+            enabled_toolsets=["user_updates"],
+            quiet_mode=True,
+            platform="api_server",
+        )
+        default_tools = get_tool_definitions(
+            enabled_toolsets=["user_updates"],
+            quiet_mode=True,
+        )
+
+        assert [t["function"]["name"] for t in cli_tools] == ["send_user_message"]
+        assert api_tools == []
+        assert default_tools == []
 
 
 # =========================================================================

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1040,6 +1040,22 @@ class TestConcurrentToolExecution:
                 mock_seq.assert_called_once()
                 mock_con.assert_not_called()
 
+    def test_send_user_message_forces_sequential(self, agent):
+        """Batches containing user-facing updates should stay sequential."""
+        tc1 = _mock_tool_call(name="web_search", arguments='{}', call_id="c1")
+        tc2 = _mock_tool_call(
+            name="send_user_message",
+            arguments='{"message":"I found the right file."}',
+            call_id="c2",
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
+        messages = []
+        with patch.object(agent, "_execute_tool_calls_sequential") as mock_seq:
+            with patch.object(agent, "_execute_tool_calls_concurrent") as mock_con:
+                agent._execute_tool_calls(mock_msg, messages, "task-1")
+                mock_seq.assert_called_once()
+                mock_con.assert_not_called()
+
     def test_multiple_tools_uses_concurrent_path(self, agent):
         """Multiple read-only tools should use concurrent path."""
         tc1 = _mock_tool_call(name="web_search", arguments='{}', call_id="c1")
@@ -1299,6 +1315,53 @@ class TestConcurrentToolExecution:
             result = agent._invoke_tool("todo", {"todos": []}, "task-1")
             mock_todo.assert_called_once()
         assert "ok" in result
+
+    def test_invoke_tool_send_user_message_uses_callback(self, agent):
+        cb = MagicMock()
+        agent.message_callback = cb
+
+        result = json.loads(
+            agent._invoke_tool(
+                "send_user_message",
+                {"message": "I found the relevant files."},
+                "task-1",
+            )
+        )
+
+        cb.assert_called_once_with("I found the relevant files.")
+        assert result["sent"] is True
+        assert result["message"] == "I found the relevant files."
+
+    def test_invoke_tool_send_user_message_falls_back_to_status_callback(self, agent):
+        cb = MagicMock()
+        agent.message_callback = None
+        agent.status_callback = cb
+
+        result = json.loads(
+            agent._invoke_tool(
+                "send_user_message",
+                {"message": "Still working through the patch."},
+                "task-1",
+            )
+        )
+
+        cb.assert_called_once_with("agent_message", "Still working through the patch.")
+        assert result["sent"] is True
+
+    def test_invoke_tool_send_user_message_errors_without_callback(self, agent):
+        agent.message_callback = None
+        agent.status_callback = None
+
+        result = json.loads(
+            agent._invoke_tool(
+                "send_user_message",
+                {"message": "No route available."},
+                "task-1",
+            )
+        )
+
+        assert "error" in result
+        assert "not available" in result["error"].lower()
 
 
 class TestPathsOverlap:

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1363,6 +1363,27 @@ class TestConcurrentToolExecution:
         assert "error" in result
         assert "not available" in result["error"].lower()
 
+    def test_send_user_message_skips_generic_tool_progress_callback(self, agent):
+        tc = _mock_tool_call(
+            name="send_user_message",
+            arguments='{"message":"I am updating the config now."}',
+            call_id="c1",
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+        progress_cb = MagicMock()
+        message_cb = MagicMock()
+        agent.tool_progress_callback = progress_cb
+        agent.message_callback = message_cb
+
+        agent._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+
+        progress_cb.assert_not_called()
+        message_cb.assert_called_once_with("I am updating the config now.")
+        assert len(messages) == 1
+        payload = json.loads(messages[0]["content"])
+        assert payload["sent"] is True
+
 
 class TestPathsOverlap:
     """Unit tests for the _paths_overlap helper."""

--- a/tools/send_user_message_tool.py
+++ b/tools/send_user_message_tool.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""In-session user messaging tool.
+
+Lets the agent send a natural-language status update to the current user
+without ending its turn. Unlike ``send_message``, this stays inside the
+current session/thread and is handled by the agent loop via a platform
+callback.
+"""
+
+import json
+
+from tools.registry import registry
+
+
+SEND_USER_MESSAGE_SCHEMA = {
+    "name": "send_user_message",
+    "description": (
+        "Send a natural-language message to the current user in the current "
+        "session without ending your turn. Use this for concise progress "
+        "updates before or between tool calls, such as briefly stating your "
+        "plan, reporting what you are doing, or flagging an important status "
+        "change while you continue working. Keep messages short and useful."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "message": {
+                "type": "string",
+                "description": (
+                    "The message to send to the current user in natural "
+                    "language. Example: 'I found the relevant files and I am "
+                    "patching the config path next.'"
+                ),
+            }
+        },
+        "required": ["message"],
+    },
+}
+
+
+def check_send_user_message_requirements() -> bool:
+    """Tool is schema-available on interactive platforms."""
+    return True
+
+
+def send_user_message_tool(args, **kwargs):
+    """Stub dispatcher for the registry.
+
+    Real handling happens in run_agent.py because it needs the live platform
+    callback for the current session.
+    """
+    return json.dumps(
+        {"error": "send_user_message must be handled by the agent loop"},
+        ensure_ascii=False,
+    )
+
+
+registry.register(
+    name="send_user_message",
+    toolset="user_updates",
+    schema=SEND_USER_MESSAGE_SCHEMA,
+    handler=send_user_message_tool,
+    check_fn=check_send_user_message_requirements,
+    description="Send a short in-session progress update to the current user.",
+    emoji="💬",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -54,6 +54,8 @@ _HERMES_CORE_TOOLS = [
     "session_search",
     # Clarifying questions
     "clarify",
+    # Natural-language progress updates to the current user
+    "send_user_message",
     # Code execution + delegation
     "execute_code", "delegate_task",
     # Cronjob management
@@ -181,6 +183,12 @@ TOOLSETS = {
         "tools": ["clarify"],
         "includes": []
     },
+
+    "user_updates": {
+        "description": "Send short natural-language progress updates to the current user without ending the turn",
+        "tools": ["send_user_message"],
+        "includes": []
+    },
     
     "code_execution": {
         "description": "Run Python scripts that call tools programmatically (reduces LLM round trips)",
@@ -239,13 +247,14 @@ TOOLSETS = {
             "browser_vision", "browser_console",
             "todo", "memory",
             "session_search",
+            "send_user_message",
             "execute_code", "delegate_task",
         ],
         "includes": []
     },
 
     "hermes-api-server": {
-        "description": "OpenAI-compatible API server — full agent tools accessible via HTTP (no interactive UI tools like clarify or send_message)",
+        "description": "OpenAI-compatible API server — full agent tools accessible via HTTP (no interactive UI tools like clarify, send_user_message, or send_message)",
         "tools": [
             # Web
             "web_search", "web_extract",


### PR DESCRIPTION
## Summary
- add `send_user_message` as a dedicated in-session tool for natural-language progress updates to the current user
- wire delivery through CLI, gateway, and ACP session callbacks without ending the turn
- scope the tool to interactive runtimes, exclude it from the API-server surface, and suppress generic tool-progress noise for this tool

## Why
`tool_progress` is useful for auditability, but it often exposes raw tool-call details rather than a concise user-facing update. Hermes also has `send_message`, but that is for cross-channel delivery to an explicit target, not "message the current user in the current session and keep working".

This adds the missing primitive for natural mid-turn progress updates.

Closes #5016

## Testing
- `source venv/bin/activate && python -m pytest tests/test_model_tools.py tests/test_run_agent.py tests/gateway/test_api_server_toolset.py tests/hermes_cli/test_tools_config.py -q`
- `271 passed`
