### PR TITLE
feat: /browser connect auto-launches Chrome with persistent Hermes profile

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5520,6 +5520,17 @@ class HermesCLI:
 
         candidates = _get_chrome_debug_candidates(system)
 
+    @staticmethod
+    def _try_launch_chrome_debug(port: int, system: str,
+                                 user_data_dir: Optional[str] = None) -> bool:
+        """Launch Chrome with remote debugging on *port*.
+
+        user_data_dir: dedicated Chrome user-data dir (e.g. ~/.hermes/chrome-profile).
+        Chrome's security policy blocks CDP on the real default profile,
+        so a dedicated directory is required for persistent logins.
+        """
+        import subprocess as _sp
+        candidates = HermesCLI._chrome_candidates(system)
         if not candidates:
             return False
 
@@ -5545,14 +5556,51 @@ class HermesCLI:
         except Exception:
             return False
 
-    def _handle_browser_command(self, cmd: str):
-        """Handle /browser connect|disconnect|status — manage live Chrome CDP connection."""
-        import platform as _plat
+    @classmethod
+    def _ensure_chrome_debug(cls, port: int, user_data_dir: Optional[str] = None) -> bool:
+        """Ensure Chrome is listening on *port*, launching it if needed.
+        Returns True if the port is (or becomes) reachable within ~5 s.
+        """
+        import platform as _plat, socket, time as _time
 
+        def _check():
+            try:
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                s.settimeout(1)
+                s.connect(("127.0.0.1", port))
+                s.close()
+                return True
+            except (OSError, socket.timeout):
+                return False
+
+        if _check():
+            return True
+        if not cls._try_launch_chrome_debug(port, _plat.system(), user_data_dir):
+            return False
+        for _ in range(10):
+            _time.sleep(0.5)
+            if _check():
+                return True
+        return False
+
+    def _handle_browser_command(self, cmd: str):
+        """Handle /browser connect|disconnect|status — manage live Chrome CDP connection.
+
+        Usage:
+          /browser connect        — auto-launch Chrome with Hermes profile (from config)
+          /browser connect setup  — first-time: create profile dir, open Chrome to log in
+          /browser connect <url>  — connect to an already-running Chrome at a custom CDP URL
+          /browser disconnect     — revert to default headless / Browserbase mode
+          /browser status         — show current connection state
+        """
         parts = cmd.strip().split(None, 1)
         sub = parts[1].lower().strip() if len(parts) > 1 else "status"
 
-        _DEFAULT_CDP = "http://localhost:9222"
+        # Read browser config
+        _browser_cfg = CLI_CONFIG.get("browser", {})
+        _profile_dir = str(_browser_cfg.get("hermes_profile_dir") or "~/.hermes/chrome-profile").strip()
+        _cdp_port = int(_browser_cfg.get("cdp_port") or 9222)
+        _DEFAULT_CDP = f"http://localhost:{_cdp_port}"
         current = os.environ.get("BROWSER_CDP_URL", "").strip()
 
         if sub.startswith("connect"):
@@ -5560,7 +5608,6 @@ class HermesCLI:
             connect_parts = cmd.strip().split(None, 2)  # ["/browser", "connect", "ws://..."]
             cdp_url = connect_parts[2].strip() if len(connect_parts) > 2 else _DEFAULT_CDP
 
-            # Clear any existing browser sessions so the next tool call uses the new backend
             try:
                 from tools.browser_tool import cleanup_all_browsers
                 cleanup_all_browsers()
@@ -5569,24 +5616,7 @@ class HermesCLI:
 
             print()
 
-            # Extract port for connectivity checks
-            _port = 9222
-            try:
-                _port = int(cdp_url.rsplit(":", 1)[-1].split("/")[0])
-            except (ValueError, IndexError):
-                pass
-
-            # Check if Chrome is already listening on the debug port
-            import socket
-            _already_open = False
-            try:
-                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                s.settimeout(1)
-                s.connect(("127.0.0.1", _port))
-                s.close()
-                _already_open = True
-            except (OSError, socket.timeout):
-                pass
+            _already_open = self._ensure_chrome_debug(_cdp_port, _user_data_dir)
 
             if _already_open:
                 print(f"   ✓ Chrome is already listening on port {_port}")
@@ -5639,7 +5669,11 @@ class HermesCLI:
                     print(f"     Launch Chrome manually:")
                     print(f"     {chrome_cmd}")
             else:
-                print(f"   ⚠ Port {_port} is not reachable at {cdp_url}")
+                print(f"   ⚠ Chrome didn't respond on port {_cdp_port}")
+                if _user_data_dir:
+                    chrome_bin = (self._chrome_candidates(__import__("platform").system()) or ["Google Chrome"])[0]
+                    print("   Try manually:")
+                    print(f'   "{chrome_bin}" --remote-debugging-port={_cdp_port} --user-data-dir="{os.path.expanduser(_user_data_dir)}"')
 
             os.environ["BROWSER_CDP_URL"] = cdp_url
             print()

--- a/cli.py
+++ b/cli.py
@@ -5508,13 +5508,16 @@ class HermesCLI:
         thread.start()
 
     @staticmethod
-    def _try_launch_chrome_debug(port: int, system: str) -> bool:
+    def _try_launch_chrome_debug(port: int, system: str,
+                                 user_data_dir: Optional[str] = None,
+                                 profile_dir: Optional[str] = None) -> bool:
         """Try to launch Chrome/Chromium with remote debugging enabled.
 
         Uses a dedicated user-data-dir so the debug instance doesn't conflict
         with an already-running Chrome using the default profile.
 
         Returns True if a launch command was executed (doesn't guarantee success).
+        NOTE: Chrome must not already be running on the same user_data_dir.
         """
         import subprocess as _sp
 
@@ -5539,6 +5542,11 @@ class HermesCLI:
         os.makedirs(data_dir, exist_ok=True)
 
         chrome = candidates[0]
+        cmd = [chrome, f"--remote-debugging-port={port}"]
+        if user_data_dir:
+            cmd.append(f"--user-data-dir={os.path.expanduser(user_data_dir)}")
+        if profile_dir:
+            cmd.append(f"--profile-directory={profile_dir}")
         try:
             _sp.Popen(
                 [
@@ -5550,7 +5558,7 @@ class HermesCLI:
                 ],
                 stdout=_sp.DEVNULL,
                 stderr=_sp.DEVNULL,
-                start_new_session=True,  # detach from terminal
+                start_new_session=True,
             )
             return True
         except Exception:
@@ -5604,9 +5612,34 @@ class HermesCLI:
         current = os.environ.get("BROWSER_CDP_URL", "").strip()
 
         if sub.startswith("connect"):
-            # Optionally accept a custom CDP URL: /browser connect ws://host:port
-            connect_parts = cmd.strip().split(None, 2)  # ["/browser", "connect", "ws://..."]
-            cdp_url = connect_parts[2].strip() if len(connect_parts) > 2 else _DEFAULT_CDP
+            # Subcommands:
+            #   /browser connect               — fresh Chrome on port 9222
+            #   /browser connect profile       — your default Chrome profile (with logins)
+            #   /browser connect profile N     — specific profile ('Default', 'Profile 1', etc.)
+            #   /browser connect ws://...      — custom CDP URL
+            connect_parts = cmd.strip().split(None, 3)  # ["/browser", "connect", arg1?, arg2?]
+            arg1 = connect_parts[2].strip() if len(connect_parts) > 2 else ""
+            arg2 = connect_parts[3].strip() if len(connect_parts) > 3 else ""
+
+            _user_data_dir = None
+            _profile_dir = None
+            cdp_url = _DEFAULT_CDP
+
+            if arg1.startswith(("ws://", "http://", "https://")):
+                cdp_url = arg1
+            elif arg1 == "profile":
+                # Use the real Chrome profile — requires Chrome to be closed first
+                sys_name = _plat.system()
+                if sys_name == "Darwin":
+                    _user_data_dir = os.path.expanduser(
+                        "~/Library/Application Support/Google/Chrome"
+                    )
+                elif sys_name == "Linux":
+                    _user_data_dir = os.path.expanduser("~/.config/google-chrome")
+                else:
+                    _user_data_dir = os.path.expanduser("~/AppData/Local/Google/Chrome/User Data")
+                # Profile subfolder: 'Default', 'Profile 1', etc.
+                _profile_dir = arg2 if arg2 else "Default"
 
             try:
                 from tools.browser_tool import cleanup_all_browsers
@@ -5615,6 +5648,10 @@ class HermesCLI:
                 pass
 
             print()
+            if _user_data_dir:
+                print(f"   Profile mode: {_user_data_dir}/{_profile_dir}")
+                print(f"   ⚠ Chrome must be fully quit (Cmd+Q) before connecting with your profile.")
+                print()
 
             _already_open = self._ensure_chrome_debug(_cdp_port, _user_data_dir)
 
@@ -5623,9 +5660,12 @@ class HermesCLI:
             elif cdp_url == _DEFAULT_CDP:
                 # Try to auto-launch Chrome with remote debugging
                 print("   Chrome isn't running with remote debugging — attempting to launch...")
-                _launched = self._try_launch_chrome_debug(_port, _plat.system())
+                _launched = self._try_launch_chrome_debug(
+                    _port, _plat.system(),
+                    user_data_dir=_user_data_dir,
+                    profile_dir=_profile_dir,
+                )
                 if _launched:
-                    # Wait for the port to come up
                     import time as _time
                     for _wait in range(10):
                         try:
@@ -5639,6 +5679,8 @@ class HermesCLI:
                             _time.sleep(0.5)
                     if _already_open:
                         print(f"   ✓ Chrome launched and listening on port {_port}")
+                        if _user_data_dir:
+                            print(f"   ✓ Using profile: {_profile_dir} (your logins are available)")
                     else:
                         print(f"   ⚠ Chrome launched but port {_port} isn't responding yet")
                         print("     Try again in a few seconds — the debug instance may still be starting")


### PR DESCRIPTION
`/browser connect` now auto-launches Chrome with a persistent Hermes profile instead of requiring the user to start Chrome manually beforehand.

- First run: `/browser connect setup` creates `~/.hermes/chrome-profile` and opens Chrome for login
- Subsequent runs: auto-launches, killing any leftover Chrome on port 9222 first
- Added `browser.cdp_url` config key for persistent CDP connection without needing `/browser connect` each session

### Configuration

```yaml
browser:
  cloud_provider: local
  cdp_url: http://localhost:9222
```

