### PR TITLE
fix: exclude infrastructure dirs from --clone-all when cloning default profile

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -66,6 +66,19 @@ _CLONE_ALL_STRIP = [
     "processes.json",
 ]
 
+# Root-level entries to exclude during --clone-all when the source is the
+# default (~/.hermes) profile.  The default profile contains infrastructure
+# (repo checkout, virtualenv, git worktrees, installed binaries) that named
+# profiles never have.  Everything else (state.db, sessions, logs, caches)
+# IS profile data — clone-all means "complete snapshot".
+_CLONE_ALL_DEFAULT_EXCLUDE = frozenset({
+    "hermes-agent",         # repo checkout + venv + node_modules (~2 GB)
+    ".worktrees",           # git worktrees
+    "profiles",             # other profiles — never recursive-clone
+    "bin",                  # installed binaries (tirith, etc.)
+    "node_modules",         # npm packages (if any at root level)
+})
+
 # Directories/files to exclude when exporting the default (~/.hermes) profile.
 # The default profile contains infrastructure (repo checkout, worktrees, DBs,
 # caches, binaries) that named profiles don't have.  We exclude those so the
@@ -418,9 +431,23 @@ def create_profile(
             )
 
     if clone_all and source_dir:
-        # Full copy of source profile
-        shutil.copytree(source_dir, profile_dir)
-        # Strip runtime files
+        # Full copy of source profile data.  When the source is the default
+        # profile (~/.hermes) we exclude infrastructure directories that are
+        # NOT profile data (hermes-agent/ alone is 2+ GB).  For named
+        # profiles no root-level exclusions are needed.
+        is_default = (source_dir == _get_default_hermes_home())
+
+        def _ignore(directory: str, contents: list) -> set:
+            ignored: set = set()
+            for c in contents:
+                if c == "__pycache__" or c.endswith((".sock", ".tmp")):
+                    ignored.add(c)
+            if is_default and Path(directory) == source_dir:
+                ignored.update(c for c in contents if c in _CLONE_ALL_DEFAULT_EXCLUDE)
+            return ignored
+
+        shutil.copytree(source_dir, profile_dir, ignore=_ignore)
+        # Strip any remaining runtime files
         for stale in _CLONE_ALL_STRIP:
             (profile_dir / stale).unlink(missing_ok=True)
     else:

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -171,6 +171,42 @@ class TestCreateProfile:
         assert not (profile_dir / "gateway_state.json").exists()
         assert not (profile_dir / "processes.json").exists()
 
+    def test_clone_all_excludes_default_infrastructure(self, profile_env):
+        """clone-all from default profile excludes hermes-agent/, profiles/, etc."""
+        tmp_path = profile_env
+        default_home = tmp_path / ".hermes"
+        # Simulate infrastructure dirs that only the default profile has
+        (default_home / "hermes-agent" / ".git").mkdir(parents=True)
+        (default_home / "hermes-agent" / "venv" / "bin").mkdir(parents=True)
+        (default_home / "hermes-agent" / "README.md").write_text("repo")
+        (default_home / "profiles" / "other").mkdir(parents=True)
+        (default_home / "profiles" / "other" / "config.yaml").write_text("x")
+        (default_home / "bin").mkdir(exist_ok=True)
+        (default_home / "bin" / "tool").write_text("binary")
+        # Profile data that SHOULD be copied (including state)
+        (default_home / "skills" / "my-skill").mkdir(parents=True)
+        (default_home / "skills" / "my-skill" / "SKILL.md").write_text("skill")
+        (default_home / "config.yaml").write_text("model: gpt-4")
+        (default_home / ".env").write_text("KEY=val")
+        (default_home / "state.db").write_text("sessions-data")
+        (default_home / "sessions").mkdir(exist_ok=True)
+        (default_home / "logs").mkdir(exist_ok=True)
+        (default_home / "logs" / "gateway.log").write_text("log")
+
+        profile_dir = create_profile("cloned", clone_all=True, no_alias=True)
+
+        # Infrastructure must be excluded
+        assert not (profile_dir / "hermes-agent").exists()
+        assert not (profile_dir / "profiles").exists()
+        assert not (profile_dir / "bin").exists()
+        # All profile data must be present — clone-all means "complete snapshot"
+        assert (profile_dir / "skills" / "my-skill" / "SKILL.md").read_text() == "skill"
+        assert (profile_dir / "config.yaml").read_text() == "model: gpt-4"
+        assert (profile_dir / ".env").read_text() == "KEY=val"
+        assert (profile_dir / "state.db").read_text() == "sessions-data"
+        assert (profile_dir / "sessions").exists()
+        assert (profile_dir / "logs" / "gateway.log").read_text() == "log"
+
     def test_clone_config_missing_files_skipped(self, profile_env):
         """Clone config gracefully skips files that don't exist in source."""
         profile_dir = create_profile("coder", clone_config=True, no_alias=True)


### PR DESCRIPTION
## Summary

When `--clone-all` clones from the default profile (`~/.hermes`), `shutil.copytree()` copied the **entire** directory with no exclusions — including `hermes-agent/` (2+ GB repo checkout with venv, node_modules, .git), `profiles/` (other profiles), and `bin/` (installed binaries). Only ~40 MB is actual profile data.

Profiles are isolated data directories, not independent installations. They all share the same `hermes-agent/` code via `HERMES_HOME`. Copying infrastructure into a profile wastes disk and is never used.

## Changes

- Add `_CLONE_ALL_DEFAULT_EXCLUDE` frozenset with 5 infrastructure entries (`hermes-agent`, `.worktrees`, `profiles`, `bin`, `node_modules`)
- Pass an `ignore` function to `shutil.copytree()` in the clone-all codepath that skips these at root level **only when the source is the default profile**
- Also excludes `__pycache__/`, `*.sock`, `*.tmp` at any depth
- All profile state is still copied: `state.db`, sessions, skills, memories, logs, caches, `.env`, `auth.json` — clone-all means "complete snapshot"
- Named profile sources are unaffected (no root-level exclusions needed)
- New test: `test_clone_all_excludes_default_infrastructure`

## Before / After

| | Before | After |
|---|---|---|
| Copy size (default profile) | ~2.3 GB | ~40 MB |
| Time | minutes | <1 second |
| Profile data preserved | ✅ | ✅ |
| Infrastructure excluded | ❌ | ✅ |

## Context

The export codepath already has this fix (`_DEFAULT_EXPORT_EXCLUDE_ROOT` + `_default_export_ignore()`, added in 68fc4aec). This applies the same principle to clone-all.

Fixes #5022