### PR TITLE
fix(gateway): log structured dispositions for non-response paths

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -506,6 +506,35 @@ class BasePlatformAdapter(ABC):
     def is_connected(self) -> bool:
         """Check if adapter is currently connected."""
         return self._running
+
+    def _log_disposition(
+        self,
+        disposition: str,
+        *,
+        event: Optional[MessageEvent] = None,
+        session_key: Optional[str] = None,
+        reason: Optional[str] = None,
+    ) -> None:
+        """Emit a structured gateway disposition log for non-happy-path outcomes."""
+        parts = [
+            "gateway_disposition",
+            f"platform={self.platform.value}",
+            f"adapter={self.name}",
+            f"disposition={disposition}",
+        ]
+        if session_key:
+            parts.append(f"session_key={session_key}")
+        if event is not None:
+            if getattr(event, "message_id", None):
+                parts.append(f"message_id={event.message_id}")
+            if getattr(event.source, "chat_id", None):
+                parts.append(f"chat_id={event.source.chat_id}")
+            cmd = event.get_command() if hasattr(event, "get_command") else None
+            if cmd:
+                parts.append(f"command={cmd}")
+        if reason:
+            parts.append(f"reason={reason}")
+        logger.info(" ".join(parts))
     
     def set_message_handler(self, handler: MessageHandler) -> None:
         """
@@ -982,6 +1011,11 @@ class BasePlatformAdapter(ABC):
             else:
                 # All retries exhausted (loop completed without break) — notify user
                 logger.error("[%s] Failed to deliver response after %d retries: %s", self.name, max_retries, error_str)
+                self._log_disposition(
+                    "delivery_failed_retries_exhausted",
+                    session_key=chat_id,
+                    reason=error_str[:160] if error_str else "retry_exhausted",
+                )
                 notice = (
                     "\u26a0\ufe0f Message delivery failed after multiple attempts. "
                     "Please try again \u2014 your request was processed but the response could not be sent."
@@ -1064,6 +1098,12 @@ class BasePlatformAdapter(ABC):
                             existing.text = f"{existing.text}\n\n{event.text}".strip()
                 else:
                     self._pending_messages[session_key] = event
+                self._log_disposition(
+                    "queued_without_interrupt",
+                    event=event,
+                    session_key=session_key,
+                    reason="photo_follow_up",
+                )
                 return  # Don't interrupt now - will run after current task completes
 
             # Default behavior for non-photo follow-ups: interrupt the running agent
@@ -1148,6 +1188,12 @@ class BasePlatformAdapter(ABC):
             # DEBUG to avoid noisy warnings for expected behavior.
             if not response:
                 logger.debug("[%s] Handler returned empty/None response for %s", self.name, event.source.chat_id)
+                self._log_disposition(
+                    "handler_empty_response",
+                    event=event,
+                    session_key=session_key,
+                    reason="empty_or_already_streamed",
+                )
             if response:
                 # Extract MEDIA:<path> tags (from TTS tool) before other processing
                 media_files, response = self.extract_media(response)

--- a/tests/gateway/test_gateway_dispositions.py
+++ b/tests/gateway/test_gateway_dispositions.py
@@ -1,0 +1,95 @@
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.session import SessionSource, build_session_key
+
+
+class _StubAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.TELEGRAM)
+        self._send_results = []
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        self._mark_disconnected()
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        if self._send_results:
+            return self._send_results.pop(0)
+        return SendResult(success=True, message_id="msg-1")
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id, "type": "dm"}
+
+
+def _make_source(chat_id="chat-1", user_id="user-1"):
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=chat_id,
+        user_id=user_id,
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text="hello", message_type=MessageType.TEXT):
+    return MessageEvent(
+        text=text,
+        message_type=message_type,
+        source=_make_source(),
+        message_id="m1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_logs_disposition_when_photo_is_queued_without_interrupt(caplog):
+    adapter = _StubAdapter()
+    adapter.set_message_handler(AsyncMock(return_value="ok"))
+    session_key = build_session_key(_make_source())
+    adapter._active_sessions[session_key] = asyncio.Event()
+
+    with caplog.at_level(logging.INFO, logger="gateway.platforms.base"):
+        await adapter.handle_message(_make_event(message_type=MessageType.PHOTO))
+
+    assert any(
+        "gateway_disposition" in r.message and "queued_without_interrupt" in r.message
+        for r in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_logs_disposition_when_handler_returns_empty(caplog):
+    adapter = _StubAdapter()
+    adapter.set_message_handler(AsyncMock(return_value=None))
+
+    with caplog.at_level(logging.INFO, logger="gateway.platforms.base"):
+        await adapter.handle_message(_make_event())
+        await asyncio.sleep(0.3)
+
+    assert any(
+        "gateway_disposition" in r.message and "handler_empty_response" in r.message
+        for r in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_logs_disposition_when_delivery_retries_exhausted(caplog):
+    adapter = _StubAdapter()
+    network_err = SendResult(success=False, error="httpx.ConnectError: host unreachable")
+    adapter._send_results = [network_err, network_err, network_err, SendResult(success=True)]
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        with caplog.at_level(logging.INFO, logger="gateway.platforms.base"):
+            await adapter._send_with_retry("chat1", "hello", max_retries=2, base_delay=0)
+
+    assert any(
+        "gateway_disposition" in r.message and "delivery_failed_retries_exhausted" in r.message
+        for r in caplog.records
+    )


### PR DESCRIPTION
## Summary
- add structured `gateway_disposition` logs in the base adapter for key non-happy-path outcomes
- log when photo follow-ups are queued without interrupt, when handlers return empty/None, and when delivery retries are exhausted
- add regression tests covering those disposition logs

## Why
Gateway reliability currently feels worse than terminal partly because too many meaningful outcomes collapse into ambiguous `None` / queue / retry paths. This PR does not solve the whole lifecycle problem, but it makes swallowed-message debugging much more legible immediately.

## Test Plan
- `python3 -m py_compile gateway/platforms/base.py tests/gateway/test_gateway_dispositions.py`
- `./venv/bin/pytest -q tests/gateway/test_gateway_dispositions.py -q`
- `./venv/bin/pytest -q tests/gateway/test_send_retry.py tests/gateway/test_queue_consumption.py tests/gateway/test_gateway_dispositions.py -q`
