### PR TITLE
fix(gateway): log dispositions for interrupt and auth edge cases

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -271,6 +271,35 @@ def _expand_whatsapp_auth_aliases(identifier: str) -> set:
 
 logger = logging.getLogger(__name__)
 
+
+def _log_gateway_disposition(
+    disposition: str,
+    *,
+    source: Optional[SessionSource] = None,
+    session_key: Optional[str] = None,
+    event: Optional[MessageEvent] = None,
+    reason: Optional[str] = None,
+) -> None:
+    parts = ["gateway_disposition", f"disposition={disposition}"]
+    if source is not None:
+        if getattr(source, "platform", None):
+            parts.append(f"platform={source.platform.value}")
+        if getattr(source, "chat_id", None):
+            parts.append(f"chat_id={source.chat_id}")
+        if getattr(source, "user_id", None):
+            parts.append(f"user_id={source.user_id}")
+    if session_key:
+        parts.append(f"session_key={session_key}")
+    if event is not None and getattr(event, "message_id", None):
+        parts.append(f"message_id={event.message_id}")
+    if event is not None:
+        cmd = event.get_command() if hasattr(event, "get_command") else None
+        if cmd:
+            parts.append(f"command={cmd}")
+    if reason:
+        parts.append(f"reason={reason}")
+    logger.info(" ".join(parts))
+
 # Sentinel placed into _running_agents immediately when a session starts
 # processing, *before* any await.  Prevents a second message for the same
 # session from bypassing the "already running" guard during the async gap
@@ -1711,6 +1740,12 @@ class GatewayRunner:
                 # prevent spamming the user with repeated messages when
                 # multiple DMs arrive in quick succession.
                 if self.pairing_store._is_rate_limited(platform_name, source.user_id):
+                    _log_gateway_disposition(
+                        "unauthorized_rate_limited",
+                        source=source,
+                        event=event,
+                        reason="pairing_rate_limited",
+                    )
                     return None
                 code = self.pairing_store.generate_code(
                     platform_name, source.user_id, source.user_name or ""
@@ -1855,6 +1890,13 @@ class GatewayRunner:
                             adapter._pending_messages[_quick_key] = event
                     else:
                         adapter._pending_messages[_quick_key] = event
+                _log_gateway_disposition(
+                    "queued_without_interrupt",
+                    source=source,
+                    session_key=_quick_key,
+                    event=event,
+                    reason="photo_follow_up_active_run",
+                )
                 return None
 
             running_agent = self._running_agents.get(_quick_key)
@@ -1878,6 +1920,13 @@ class GatewayRunner:
                 self._pending_messages[_quick_key] += "\n" + event.text
             else:
                 self._pending_messages[_quick_key] = event.text
+            _log_gateway_disposition(
+                "interrupt_requested",
+                source=source,
+                session_key=_quick_key,
+                event=event,
+                reason="active_run_interrupted_by_new_input",
+            )
             return None
 
         # Check for commands

--- a/tests/gateway/test_gateway_run_dispositions.py
+++ b/tests/gateway/test_gateway_run_dispositions.py
@@ -1,0 +1,143 @@
+import logging
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str, message_type=MessageType.TEXT) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=message_type,
+        source=_make_source(),
+        message_id="m1",
+    )
+
+
+def _make_runner(session_entry: SessionEntry):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    adapter._pending_messages = {}
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner._send_voice_reply = AsyncMock()
+    runner._capture_gateway_honcho_if_configured = lambda *args, **kwargs: None
+    runner._emit_gateway_run_progress = AsyncMock()
+    runner._MAX_INTERRUPT_DEPTH = 3
+    runner.pairing_store = MagicMock()
+    runner.pairing_store._is_rate_limited = MagicMock(return_value=False)
+    runner.pairing_store.generate_code = MagicMock(return_value="ABC123")
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_logs_disposition_when_runner_queues_photo_during_active_run(caplog):
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    runner._running_agents[build_session_key(_make_source())] = MagicMock()
+
+    with caplog.at_level(logging.INFO, logger="gateway.run"):
+        result = await runner._handle_message(_make_event("photo", message_type=MessageType.PHOTO))
+
+    assert result is None
+    assert any(
+        "gateway_disposition" in r.message and "queued_without_interrupt" in r.message
+        for r in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_logs_disposition_when_runner_interrupts_active_run(caplog):
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    running_agent = MagicMock()
+    runner._running_agents[build_session_key(_make_source())] = running_agent
+
+    with caplog.at_level(logging.INFO, logger="gateway.run"):
+        result = await runner._handle_message(_make_event("new message"))
+
+    assert result is None
+    running_agent.interrupt.assert_called_once_with("new message")
+    assert any(
+        "gateway_disposition" in r.message and "interrupt_requested" in r.message
+        for r in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_logs_disposition_when_unauthorized_dm_is_rate_limited(caplog):
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    runner._is_user_authorized = lambda _source: False
+    runner.pairing_store._is_rate_limited.return_value = True
+
+    with caplog.at_level(logging.INFO, logger="gateway.run"):
+        result = await runner._handle_message(_make_event("hello"))
+
+    assert result is None
+    assert any(
+        "gateway_disposition" in r.message and "unauthorized_rate_limited" in r.message
+        for r in caplog.records
+    )


### PR DESCRIPTION
## Summary
- add structured `gateway_disposition` logs in `gateway/run.py` for key swallowed-message-adjacent branches
- cover unauthorized rate-limited DMs, photo queueing during active runs, and active-run interrupt requests
- add targeted regression tests for those paths

## Why
PR #5031 adds base-adapter disposition logging, but important queue/interrupt/auth branches also live in `gateway/run.py`. This follow-up makes those runtime decisions visible too.

## Test Plan
- `python3 -m py_compile gateway/run.py tests/gateway/test_gateway_run_dispositions.py`
- `./venv/bin/pytest -q tests/gateway/test_gateway_run_dispositions.py -q`
