### PR TITLE
feat: Rich Markdown rendering for CLI responses

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -277,8 +277,10 @@ PLATFORM_HINTS = {
         "destination — put the primary content directly in your response."
     ),
     "cli": (
-        "You are a CLI AI Agent. Try not to use markdown but simple text "
-        "renderable inside a terminal."
+        "You are a CLI AI Agent. Your terminal supports full markdown "
+        "rendering. Use markdown freely for headings, bold, code blocks, "
+        "tables, lists, and other formatting to make responses clear and "
+        "well-structured."
     ),
     "sms": (
         "You are communicating via SMS. Keep responses concise and use plain text "

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -278,9 +278,9 @@ PLATFORM_HINTS = {
     ),
     "cli": (
         "You are a CLI AI Agent. Your terminal supports full markdown "
-        "rendering. Use markdown freely for headings, bold, code blocks, "
-        "tables, lists, and other formatting to make responses clear and "
-        "well-structured."
+        "rendering. Use markdown freely for headings, bold, italic, "
+        "code blocks, tables, lists, blockquotes, and links to make "
+        "responses clear and well-structured."
     ),
     "sms": (
         "You are communicating via SMS. Keep responses concise and use plain text "

--- a/cli.py
+++ b/cli.py
@@ -834,20 +834,43 @@ def _rich_text_from_ansi(text: str) -> _RichText:
     return _RichText.from_ansi(text or "")
 
 
+# Matches common markdown characters: #heading, *bold*, `code`, |table|,
+# >blockquote, [link], ~strikethrough, double-newline (block break),
+# and numbered lists (1. item).  Checked against the first 500 chars only
+# to avoid scanning multi-KB responses — if markdown is present it almost
+# always appears early (headers, opening paragraph, first code fence).
 _MD_SYNTAX_RE = re.compile(r'[#*`|>\[~]|\n\n|^\d+\.\s|\n\d+\.\s', re.MULTILINE)
 
 
 def _has_markdown_syntax(text: str) -> bool:
-    """Fast check for markdown syntax in first 500 chars (avoids parser overhead)."""
+    """Fast-path check: skip Rich Markdown parser when text is plain.
+
+    Avoids the overhead of markdown lexing for responses that contain no
+    markdown syntax at all (common for short answers and tool output).
+    Inspired by claude-code's hasMarkdownSyntax() optimisation.
+    """
     return bool(_MD_SYNTAX_RE.search(text[:500] if len(text) > 500 else text))
 
 
-def _render_response(text: str, as_markdown: bool = True):
-    """Render assistant response as Rich Markdown or plain ANSI text."""
+def _render_response(text: str, as_markdown: bool = True,
+                     code_theme: str = "monokai",
+                     text_color: str = ""):
+    """Render assistant response as Rich Markdown or plain ANSI text.
+
+    When *as_markdown* is True the text is parsed through Rich's Markdown
+    renderer with Pygments syntax-highlighted code blocks.  *code_theme*
+    selects the Pygments colour scheme (defaults to monokai); *text_color*
+    sets the base paragraph colour so plain prose matches the active skin
+    while headings, bold, and code keep their own element-specific styles
+    (Rich Markdown's ``style`` parameter layers underneath element styles,
+    unlike Panel's ``style`` which overrides everything).
+    """
     if not as_markdown or not text or not _has_markdown_syntax(text):
         return _rich_text_from_ansi(text)
     try:
-        return _RichMarkdown(text, code_theme="monokai")
+        # Use skin text colour as base style; "none" means default terminal colour
+        md_style = text_color if text_color else "none"
+        return _RichMarkdown(text, code_theme=code_theme, style=md_style)
     except Exception:
         return _rich_text_from_ansi(text)
 
@@ -2021,6 +2044,8 @@ class HermesCLI:
         # Close reasoning box if still open (in case no content tokens arrived)
         self._close_reasoning_box()
 
+        # Render any trailing incomplete markdown block that was held in
+        # buffer waiting for more tokens (e.g. unclosed paragraph at EOT).
         if self.markdown_enabled and self._stream_md_buf:
             remaining = self._stream_md_buf[self._stream_md_rendered:]
             if remaining.strip():
@@ -2042,8 +2067,14 @@ class HermesCLI:
     def _find_block_boundary(self, buf: str, start: int) -> int:
         """Find the last safe markdown block split point.
 
-        Tracks code fence state (``` open/close) and only splits at
-        double-newline boundaries outside fences.
+        Scans *buf* from *start* looking for double-newline paragraph
+        breaks (``\\n\\n``) that are **not** inside a fenced code block
+        (backtick or tilde).  Returns the char offset just after the last
+        safe boundary found, or *start* if no safe split exists yet.
+
+        This prevents the streaming renderer from chopping a code block
+        in half — the block is held in buffer until the closing fence
+        arrives, then rendered in one piece with syntax highlighting.
         """
         in_fence = self._stream_md_fence_open
         last_boundary = start
@@ -2063,9 +2094,17 @@ class HermesCLI:
         return last_boundary
 
     def _render_markdown_chunk(self, chunk: str) -> None:
-        """Render a markdown fragment to terminal via _cprint."""
+        """Render a complete markdown block to the terminal.
+
+        Uses a lazily-created Rich Console + StringIO buffer (reused
+        across calls to avoid per-chunk allocation).  Output is routed
+        through ``_cprint`` so it renders correctly inside prompt_toolkit's
+        ``patch_stdout`` context.  Falls back to plain-text printing if
+        the Markdown parser raises for any reason.
+        """
         if not chunk.strip():
             return
+        # Lazy-init: create Console + buffer once per streaming session
         if self._stream_md_console is None:
             from io import StringIO
             self._stream_md_iobuf = StringIO()
@@ -2081,14 +2120,31 @@ class HermesCLI:
         buf.truncate()
         self._stream_md_console.width = shutil.get_terminal_size((80, 24)).columns
         try:
-            self._stream_md_console.print(_RichMarkdown(chunk, code_theme="monokai"))
+            # Use skin-aware code theme and text colour for streamed blocks
+            _theme = getattr(self, "_stream_md_code_theme", "monokai")
+            _color = getattr(self, "_stream_md_text_color", "")
+            _md_style = _color if _color else "none"
+            self._stream_md_console.print(
+                _RichMarkdown(chunk, code_theme=_theme, style=_md_style)
+            )
         except Exception:
             self._stream_md_console.print(chunk)
         for line in buf.getvalue().rstrip("\n").split("\n"):
             _cprint(line)
 
     def _emit_stream_markdown(self, text: str) -> None:
-        """Accumulate streamed tokens and render complete markdown blocks."""
+        """Accumulate streamed tokens and render complete markdown blocks.
+
+        Tokens are appended to ``_stream_md_buf``.  On each call we scan
+        for the last double-newline boundary outside a code fence (via
+        ``_find_block_boundary``).  Everything before that boundary is a
+        complete markdown block — we render it through Rich Markdown once
+        and trim it from the buffer.  The trailing incomplete block stays
+        buffered until more tokens arrive or ``_flush_stream`` renders it.
+
+        This is O(unstable-block-size) per token, not O(full-text),
+        inspired by claude-code's StreamingMarkdown component.
+        """
         if not text:
             return
 
@@ -2106,6 +2162,9 @@ class HermesCLI:
                 from hermes_cli.skin_engine import get_active_skin
                 _skin = get_active_skin()
                 label = _skin.get_branding("response_label", "⚕ Hermes")
+                # Capture skin settings for markdown chunk rendering
+                self._stream_md_code_theme = _skin.get_color("code_theme", "monokai")
+                self._stream_md_text_color = _skin.get_color("banner_text", "#FFF8DC")
             except Exception:
                 label = "⚕ Hermes"
             w = shutil.get_terminal_size().columns
@@ -2133,12 +2192,15 @@ class HermesCLI:
         self._reasoning_box_opened = False
         self._reasoning_buf = ""
         self._reasoning_preview_buf = ""
-        # Markdown streaming state
-        self._stream_md_buf = ""
-        self._stream_md_rendered = 0
-        self._stream_md_fence_open = False
-        self._stream_md_console = None
-        self._stream_md_iobuf = None
+        # Markdown streaming state — block-by-block rendering inspired by
+        # claude-code's monotonic stable-prefix boundary approach.
+        self._stream_md_buf = ""           # accumulated text awaiting render
+        self._stream_md_rendered = 0       # char offset of already-rendered content
+        self._stream_md_fence_open = False # True when inside a ``` or ~~~ code fence
+        self._stream_md_console = None     # lazily-created Console for chunk rendering
+        self._stream_md_iobuf = None       # StringIO backing the streaming Console
+        self._stream_md_code_theme = "monokai"  # Pygments theme from active skin
+        self._stream_md_text_color = ""         # base text colour from active skin
 
     def _slow_command_status(self, command: str) -> str:
         """Return a user-facing status message for slower slash commands."""
@@ -4591,7 +4653,12 @@ class HermesCLI:
                         _resp_text = "#FFF8DC"
 
                     _chat_console = ChatConsole()
-                    _renderable = _render_response(response, self.markdown_enabled)
+                    # Skin-aware markdown rendering for background task output
+                    _code_theme = _skin.get_color("code_theme", "monokai")
+                    _renderable = _render_response(
+                        response, self.markdown_enabled,
+                        code_theme=_code_theme, text_color=_resp_text,
+                    )
                     _panel_kw = dict(
                         title=f"[{_resp_color} bold]{label} (background #{task_num})[/]",
                         title_align="left",
@@ -4716,8 +4783,14 @@ class HermesCLI:
                     except Exception:
                         _resp_color = "#4F6D4A"
 
+                    # Skin-aware markdown rendering for /btw output
+                    _code_theme = _skin.get_color("code_theme", "monokai")
+                    _btw_text = _skin.get_color("banner_text", "#FFF8DC")
                     ChatConsole().print(Panel(
-                        _render_response(response, self.markdown_enabled),
+                        _render_response(
+                            response, self.markdown_enabled,
+                            code_theme=_code_theme, text_color=_btw_text,
+                        ),
                         title=f"[{_resp_color} bold]⚕ /btw[/]",
                         title_align="left",
                         border_style=_resp_color,
@@ -4948,7 +5021,11 @@ class HermesCLI:
             print()
 
     def _handle_markdown_command(self, cmd: str):
-        """Handle /markdown [on|off] — toggle markdown rendering."""
+        """Handle /markdown [on|off] — toggle Rich Markdown rendering.
+
+        With no argument, shows current state.  Persists the preference
+        to ``display.markdown`` in the user's config.yaml.
+        """
         parts = cmd.strip().split(maxsplit=1)
 
         if len(parts) < 2 or not parts[1].strip():
@@ -6526,7 +6603,13 @@ class HermesCLI:
                     pass
                 else:
                     _chat_console = ChatConsole()
-                    _renderable = _render_response(response, self.markdown_enabled)
+                    # Skin-aware markdown: code_theme from skin (or monokai),
+                    # banner_text as base paragraph colour.
+                    _code_theme = _skin.get_color("code_theme", "monokai") if hasattr(_skin, "get_color") else "monokai"
+                    _renderable = _render_response(
+                        response, self.markdown_enabled,
+                        code_theme=_code_theme, text_color=_resp_text,
+                    )
                     _panel_kw = dict(
                         title=f"[{_resp_color} bold]{label}[/]",
                         title_align="left",
@@ -6534,6 +6617,9 @@ class HermesCLI:
                         box=rich_box.HORIZONTALS,
                         padding=(1, 2),
                     )
+                    # Omit Panel style= when markdown is on — Panel's style
+                    # overrides ALL child styles, washing out heading/code colours.
+                    # Markdown's own style= parameter layers underneath instead.
                     if not self.markdown_enabled:
                         _panel_kw["style"] = _resp_text
                     _chat_console.print(Panel(_renderable, **_panel_kw))

--- a/cli.py
+++ b/cli.py
@@ -15,6 +15,7 @@ Usage:
 
 import logging
 import os
+import re
 import shutil
 import sys
 import json
@@ -208,6 +209,7 @@ def load_cli_config() -> Dict[str, Any]:
             "busy_input_mode": "interrupt",
 
             "skin": "default",
+            "markdown": True,
         },
         "clarify": {
             "timeout": 120,  # Seconds to wait for a clarify answer before auto-proceeding
@@ -483,6 +485,7 @@ from rich import box as rich_box
 from rich.console import Console
 from rich.markup import escape as _escape
 from rich.panel import Panel
+from rich.markdown import Markdown as _RichMarkdown
 from rich.text import Text as _RichText
 
 import fire
@@ -831,6 +834,24 @@ def _rich_text_from_ansi(text: str) -> _RichText:
     return _RichText.from_ansi(text or "")
 
 
+_MD_SYNTAX_RE = re.compile(r'[#*`|>\[~]|\n\n|^\d+\.\s|\n\d+\.\s', re.MULTILINE)
+
+
+def _has_markdown_syntax(text: str) -> bool:
+    """Fast check for markdown syntax in first 500 chars (avoids parser overhead)."""
+    return bool(_MD_SYNTAX_RE.search(text[:500] if len(text) > 500 else text))
+
+
+def _render_response(text: str, as_markdown: bool = True):
+    """Render assistant response as Rich Markdown or plain ANSI text."""
+    if not as_markdown or not text or not _has_markdown_syntax(text):
+        return _rich_text_from_ansi(text)
+    try:
+        return _RichMarkdown(text, code_theme="monokai")
+    except Exception:
+        return _rich_text_from_ansi(text)
+
+
 def _cprint(text: str):
     """Print ANSI-colored text through prompt_toolkit's native renderer.
 
@@ -1174,6 +1195,9 @@ class HermesCLI:
         
         # streaming: stream tokens to the terminal as they arrive (display.streaming in config.yaml)
         self.streaming_enabled = CLI_CONFIG["display"].get("streaming", False)
+
+        # Markdown rendering for assistant responses (display.markdown in config.yaml)
+        self.markdown_enabled = CLI_CONFIG["display"].get("markdown", True)
 
         # Inline diff previews for write actions (display.inline_diffs in config.yaml)
         self._inline_diffs_enabled = CLI_CONFIG["display"].get("inline_diffs", True)
@@ -1890,7 +1914,10 @@ class HermesCLI:
                     # Emit everything before the tag
                     before = self._stream_prefilt[:idx]
                     if before:
-                        self._emit_stream_text(before)
+                        if self.markdown_enabled:
+                            self._emit_stream_markdown(before)
+                        else:
+                            self._emit_stream_text(before)
                     self._in_reasoning_block = True
                     self._stream_prefilt = self._stream_prefilt[idx + len(tag):]
                     break
@@ -1905,7 +1932,10 @@ class HermesCLI:
                             safe = self._stream_prefilt[:-i]
                             break
                 if safe:
-                    self._emit_stream_text(safe)
+                    if self.markdown_enabled:
+                        self._emit_stream_markdown(safe)
+                    else:
+                        self._emit_stream_text(safe)
                     self._stream_prefilt = self._stream_prefilt[len(safe):]
                 return
 
@@ -1991,7 +2021,13 @@ class HermesCLI:
         # Close reasoning box if still open (in case no content tokens arrived)
         self._close_reasoning_box()
 
-        if self._stream_buf:
+        if self.markdown_enabled and self._stream_md_buf:
+            remaining = self._stream_md_buf[self._stream_md_rendered:]
+            if remaining.strip():
+                self._render_markdown_chunk(remaining)
+            self._stream_md_buf = ""
+            self._stream_md_rendered = 0
+        elif self._stream_buf:
             _tc = getattr(self, "_stream_text_ansi", "")
             _cprint(f"{_tc}{self._stream_buf}{_RST}" if _tc else self._stream_buf)
             self._stream_buf = ""
@@ -2000,6 +2036,90 @@ class HermesCLI:
         if self._stream_box_opened:
             w = shutil.get_terminal_size().columns
             _cprint(f"{_GOLD}╰{'─' * (w - 2)}╯{_RST}")
+
+    # -- Streaming markdown helpers ------------------------------------------
+
+    def _find_block_boundary(self, buf: str, start: int) -> int:
+        """Find the last safe markdown block split point.
+
+        Tracks code fence state (``` open/close) and only splits at
+        double-newline boundaries outside fences.
+        """
+        in_fence = self._stream_md_fence_open
+        last_boundary = start
+        i = start
+        while i < len(buf):
+            if buf[i:i + 3] in ('```', '~~~'):
+                in_fence = not in_fence
+                eol = buf.find('\n', i)
+                i = (eol + 1) if eol != -1 else len(buf)
+                continue
+            if not in_fence and buf[i:i + 2] == '\n\n':
+                last_boundary = i + 2
+                i += 2
+                continue
+            i += 1
+        self._stream_md_fence_open = in_fence
+        return last_boundary
+
+    def _render_markdown_chunk(self, chunk: str) -> None:
+        """Render a markdown fragment to terminal via _cprint."""
+        if not chunk.strip():
+            return
+        if self._stream_md_console is None:
+            from io import StringIO
+            self._stream_md_iobuf = StringIO()
+            self._stream_md_console = Console(
+                file=self._stream_md_iobuf,
+                force_terminal=True,
+                color_system="truecolor",
+                highlight=False,
+                width=shutil.get_terminal_size((80, 24)).columns,
+            )
+        buf = self._stream_md_iobuf
+        buf.seek(0)
+        buf.truncate()
+        self._stream_md_console.width = shutil.get_terminal_size((80, 24)).columns
+        try:
+            self._stream_md_console.print(_RichMarkdown(chunk, code_theme="monokai"))
+        except Exception:
+            self._stream_md_console.print(chunk)
+        for line in buf.getvalue().rstrip("\n").split("\n"):
+            _cprint(line)
+
+    def _emit_stream_markdown(self, text: str) -> None:
+        """Accumulate streamed tokens and render complete markdown blocks."""
+        if not text:
+            return
+
+        self._close_reasoning_box()
+        self._stream_md_buf += text
+
+        # Open box header on first visible text
+        if not self._stream_box_opened:
+            stripped = self._stream_md_buf.lstrip("\n")
+            if not stripped:
+                return
+            self._stream_md_buf = stripped
+            self._stream_box_opened = True
+            try:
+                from hermes_cli.skin_engine import get_active_skin
+                _skin = get_active_skin()
+                label = _skin.get_branding("response_label", "⚕ Hermes")
+            except Exception:
+                label = "⚕ Hermes"
+            w = shutil.get_terminal_size().columns
+            fill = w - 2 - len(label)
+            _cprint(f"\n{_GOLD}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}")
+
+        # Find the safe render boundary
+        boundary = self._find_block_boundary(self._stream_md_buf, self._stream_md_rendered)
+
+        if boundary > self._stream_md_rendered:
+            self._render_markdown_chunk(self._stream_md_buf[self._stream_md_rendered:boundary])
+            # Trim rendered prefix to avoid unbounded buffer growth
+            self._stream_md_buf = self._stream_md_buf[boundary:]
+            self._stream_md_rendered = 0
 
     def _reset_stream_state(self) -> None:
         """Reset streaming state before each agent invocation."""
@@ -2013,6 +2133,12 @@ class HermesCLI:
         self._reasoning_box_opened = False
         self._reasoning_buf = ""
         self._reasoning_preview_buf = ""
+        # Markdown streaming state
+        self._stream_md_buf = ""
+        self._stream_md_rendered = 0
+        self._stream_md_fence_open = False
+        self._stream_md_console = None
+        self._stream_md_iobuf = None
 
     def _slow_command_status(self, command: str) -> str:
         """Return a user-facing status message for slower slash commands."""
@@ -4228,6 +4354,8 @@ class HermesCLI:
                     _cprint(f"  Queued: {payload[:80]}{'...' if len(payload) > 80 else ''}")
         elif canonical == "skin":
             self._handle_skin_command(cmd_original)
+        elif canonical == "markdown":
+            self._handle_markdown_command(cmd_original)
         elif canonical == "voice":
             self._handle_voice_command(cmd_original)
         else:
@@ -4463,15 +4591,17 @@ class HermesCLI:
                         _resp_text = "#FFF8DC"
 
                     _chat_console = ChatConsole()
-                    _chat_console.print(Panel(
-                        _rich_text_from_ansi(response),
+                    _renderable = _render_response(response, self.markdown_enabled)
+                    _panel_kw = dict(
                         title=f"[{_resp_color} bold]{label} (background #{task_num})[/]",
                         title_align="left",
                         border_style=_resp_color,
-                        style=_resp_text,
                         box=rich_box.HORIZONTALS,
                         padding=(1, 2),
-                    ))
+                    )
+                    if not self.markdown_enabled:
+                        _panel_kw["style"] = _resp_text
+                    _chat_console.print(Panel(_renderable, **_panel_kw))
                 else:
                     _cprint("  (No response generated)")
 
@@ -4587,7 +4717,7 @@ class HermesCLI:
                         _resp_color = "#4F6D4A"
 
                     ChatConsole().print(Panel(
-                        _rich_text_from_ansi(response),
+                        _render_response(response, self.markdown_enabled),
                         title=f"[{_resp_color} bold]⚕ /btw[/]",
                         title_align="left",
                         border_style=_resp_color,
@@ -4816,6 +4946,28 @@ class HermesCLI:
             print("   disconnect   Revert to default browser backend")
             print("   status       Show current browser mode")
             print()
+
+    def _handle_markdown_command(self, cmd: str):
+        """Handle /markdown [on|off] — toggle markdown rendering."""
+        parts = cmd.strip().split(maxsplit=1)
+
+        if len(parts) < 2 or not parts[1].strip():
+            state = "on" if self.markdown_enabled else "off"
+            _cprint(f"  {_GOLD}Markdown rendering: {state}{_RST}")
+            _cprint(f"  {_DIM}Usage: /markdown on|off{_RST}")
+            return
+
+        arg = parts[1].strip().lower()
+        if arg in ("on", "true", "1"):
+            self.markdown_enabled = True
+            save_config_value("display.markdown", True)
+            _cprint(f"  {_GOLD}Markdown rendering: ON (saved){_RST}")
+        elif arg in ("off", "false", "0"):
+            self.markdown_enabled = False
+            save_config_value("display.markdown", False)
+            _cprint(f"  {_GOLD}Markdown rendering: OFF (saved){_RST}")
+        else:
+            _cprint(f"  {_DIM}Unknown argument: {arg}. Use on or off.{_RST}")
 
     def _handle_skin_command(self, cmd: str):
         """Handle /skin [name] — show or change the display skin."""
@@ -6374,15 +6526,17 @@ class HermesCLI:
                     pass
                 else:
                     _chat_console = ChatConsole()
-                    _chat_console.print(Panel(
-                        _rich_text_from_ansi(response),
+                    _renderable = _render_response(response, self.markdown_enabled)
+                    _panel_kw = dict(
                         title=f"[{_resp_color} bold]{label}[/]",
                         title_align="left",
                         border_style=_resp_color,
-                        style=_resp_text,
                         box=rich_box.HORIZONTALS,
                         padding=(1, 2),
-                    ))
+                    )
+                    if not self.markdown_enabled:
+                        _panel_kw["style"] = _resp_text
+                    _chat_console.print(Panel(_renderable, **_panel_kw))
 
 
             # Play terminal bell when agent finishes (if enabled).

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -102,6 +102,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
                subcommands=("none", "low", "minimal", "medium", "high", "xhigh", "show", "hide", "on", "off")),
     CommandDef("skin", "Show or change the display skin/theme", "Configuration",
                cli_only=True, args_hint="[name]"),
+    CommandDef("markdown", "Toggle markdown rendering for responses", "Configuration",
+               cli_only=True, aliases=("md",), args_hint="[on|off]",
+               subcommands=("on", "off")),
     CommandDef("voice", "Toggle voice mode", "Configuration",
                args_hint="[on|off|tts|status]", subcommands=("on", "off", "tts", "status")),
 


### PR DESCRIPTION
## Summary

Closes #3621, closes #4236, partially addresses #684.

- **Full markdown rendering** for assistant responses using Rich's built-in `Markdown` class with Pygments syntax highlighting — headings, bold, italic, code blocks, tables, lists, blockquotes, and links all render beautifully in the terminal
- **Skin-aware**: paragraph text colour and code theme automatically adapt to the active skin's palette via existing `get_color()` fallbacks — zero changes to skin definitions or `SkinConfig`
- **Block-based streaming**: when `display.streaming: true`, tokens accumulate and complete markdown blocks render progressively (code fences tracked to avoid splitting mid-block), inspired by claude-code's monotonic stable-prefix boundary approach
- **`/markdown` command** (`/md` alias): toggle on/off with config persistence
- **Fast-path detection**: regex check on first 500 chars skips the Markdown parser for plain text responses
- **Graceful fallback**: if Markdown parsing fails, silently falls back to the existing `_rich_text_from_ansi()` renderer
- **Platform hint update**: CLI hint now encourages the LLM to use markdown formatting

## Files changed

| File | What |
|------|------|
| `cli.py` | Markdown renderer, streaming engine, skin integration, `/markdown` command (+259 lines) |
| `hermes_cli/commands.py` | Register `/markdown` command (+3 lines) |
| `agent/prompt_builder.py` | CLI platform hint encourages markdown |

## Test plan

- [ ] `display.streaming: false`, `display.markdown: true` — ask for headings, bold, code blocks, table, list, blockquote
- [ ] Verify code blocks are syntax-highlighted (monokai), tables have borders, headings are styled
- [ ] `/markdown off` → raw markdown text; `/markdown on` → rendering resumes
- [ ] `display.streaming: true` → verify progressive block-by-block rendering
- [ ] Long code block in streaming → buffers until fence closes, then renders highlighted
- [ ] `/btw` and `/bg` commands render markdown
- [ ] Different skins (`/skin ares`, `/skin mono`, `/skin poseidon`) tint paragraph text correctly
- [ ] Plain text response looks identical to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)