### PR TITLE
fix(gateway): log media and timeout dispositions

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -271,6 +271,35 @@ def _expand_whatsapp_auth_aliases(identifier: str) -> set:
 
 logger = logging.getLogger(__name__)
 
+
+def _log_gateway_disposition(
+    disposition: str,
+    *,
+    source: Optional[SessionSource] = None,
+    session_key: Optional[str] = None,
+    event: Optional[MessageEvent] = None,
+    reason: Optional[str] = None,
+) -> None:
+    parts = ["gateway_disposition", f"disposition={disposition}"]
+    if source is not None:
+        if getattr(source, "platform", None):
+            parts.append(f"platform={source.platform.value}")
+        if getattr(source, "chat_id", None):
+            parts.append(f"chat_id={source.chat_id}")
+        if getattr(source, "user_id", None):
+            parts.append(f"user_id={source.user_id}")
+    if session_key:
+        parts.append(f"session_key={session_key}")
+    if event is not None and getattr(event, "message_id", None):
+        parts.append(f"message_id={event.message_id}")
+    if event is not None:
+        cmd = event.get_command() if hasattr(event, "get_command") else None
+        if cmd:
+            parts.append(f"command={cmd}")
+    if reason:
+        parts.append(f"reason={reason}")
+    logger.info(" ".join(parts))
+
 # Sentinel placed into _running_agents immediately when a session starts
 # processing, *before* any await.  Prevents a second message for the same
 # session from bypassing the "already running" guard during the async gap
@@ -2873,6 +2902,13 @@ class GatewayRunner:
             # when already_sent is True, so media files would never be
             # delivered without this.
             if agent_result.get("already_sent"):
+                _log_gateway_disposition(
+                    "streamed_already_sent",
+                    source=source,
+                    session_key=session_key,
+                    event=event,
+                    reason="stream_consumer_delivered_response",
+                )
                 if response:
                     _media_adapter = self.adapters.get(source.platform)
                     if _media_adapter:
@@ -3809,6 +3845,7 @@ class GatewayRunner:
             local_files, _ = adapter.extract_local_files(cleaned)
 
             _thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+            _partial_failure = False
 
             _AUDIO_EXTS = {'.ogg', '.opus', '.mp3', '.wav', '.m4a'}
             _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
@@ -3818,52 +3855,88 @@ class GatewayRunner:
                 try:
                     ext = Path(media_path).suffix.lower()
                     if ext in _AUDIO_EXTS:
-                        await adapter.send_voice(
+                        result = await adapter.send_voice(
                             chat_id=event.source.chat_id,
                             audio_path=media_path,
                             metadata=_thread_meta,
                         )
                     elif ext in _VIDEO_EXTS:
-                        await adapter.send_video(
+                        result = await adapter.send_video(
                             chat_id=event.source.chat_id,
                             video_path=media_path,
                             metadata=_thread_meta,
                         )
                     elif ext in _IMAGE_EXTS:
-                        await adapter.send_image_file(
+                        result = await adapter.send_image_file(
                             chat_id=event.source.chat_id,
                             image_path=media_path,
                             metadata=_thread_meta,
                         )
                     else:
-                        await adapter.send_document(
+                        result = await adapter.send_document(
                             chat_id=event.source.chat_id,
                             file_path=media_path,
                             metadata=_thread_meta,
                         )
+                    if result is not None and not getattr(result, 'success', False):
+                        _partial_failure = True
+                        _log_gateway_disposition(
+                            'post_stream_media_partial_failure',
+                            source=event.source,
+                            event=event,
+                            reason=f'media_send_failed:{ext}',
+                        )
                 except Exception as e:
+                    _partial_failure = True
                     logger.warning("[%s] Post-stream media delivery failed: %s", adapter.name, e)
+                    _log_gateway_disposition(
+                        'post_stream_media_partial_failure',
+                        source=event.source,
+                        event=event,
+                        reason='media_send_exception',
+                    )
 
             for file_path in local_files:
                 try:
                     ext = Path(file_path).suffix.lower()
                     if ext in _IMAGE_EXTS:
-                        await adapter.send_image_file(
+                        result = await adapter.send_image_file(
                             chat_id=event.source.chat_id,
                             image_path=file_path,
                             metadata=_thread_meta,
                         )
                     else:
-                        await adapter.send_document(
+                        result = await adapter.send_document(
                             chat_id=event.source.chat_id,
                             file_path=file_path,
                             metadata=_thread_meta,
                         )
+                    if result is not None and not getattr(result, 'success', False):
+                        _partial_failure = True
+                        _log_gateway_disposition(
+                            'post_stream_media_partial_failure',
+                            source=event.source,
+                            event=event,
+                            reason=f'local_file_send_failed:{ext}',
+                        )
                 except Exception as e:
-                    logger.warning("[%s] Post-stream file delivery failed: %s", adapter.name, e)
-
+                    _partial_failure = True
+                    logger.warning("[%s] Post-stream local-file delivery failed: %s", adapter.name, e)
+                    _log_gateway_disposition(
+                        'post_stream_media_partial_failure',
+                        source=event.source,
+                        event=event,
+                        reason='local_file_send_exception',
+                    )
         except Exception as e:
-            logger.warning("Post-stream media extraction failed: %s", e)
+            logger.warning("[%s] Post-stream media extraction failed: %s", adapter.name, e)
+            _log_gateway_disposition(
+                'post_stream_media_partial_failure',
+                source=event.source,
+                event=event,
+                reason='media_extraction_exception',
+            )
+
 
     async def _handle_rollback_command(self, event: MessageEvent) -> str:
         """Handle /rollback command — list or restore filesystem checkpoints."""
@@ -6240,6 +6313,12 @@ class GatewayRunner:
                 logger.error(
                     "Agent execution timed out after %.0fs for session %s",
                     _agent_timeout, session_key,
+                )
+                _log_gateway_disposition(
+                    "timeout",
+                    source=source,
+                    session_key=session_key,
+                    reason=f"agent_timeout:{int(_agent_timeout or 0)}s",
                 )
                 # Interrupt the agent if it's still running so the thread
                 # pool worker is freed.

--- a/tests/gateway/test_gateway_poststream_media.py
+++ b/tests/gateway/test_gateway_poststream_media.py
@@ -1,0 +1,60 @@
+import asyncio
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, SessionSource, SendResult
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    return runner
+
+
+def _make_event():
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="c1",
+        user_id="u1",
+        user_name="tester",
+        chat_type="dm",
+    )
+    return MessageEvent(source=source, text="test", message_id="m1")
+
+
+class _Adapter:
+    name = "Telegram"
+
+    def __init__(self):
+        self.send_image_file = AsyncMock(return_value=SendResult(success=False, error="boom"))
+        self.send_document = AsyncMock(return_value=SendResult(success=True, message_id="d1"))
+        self.send_voice = AsyncMock(return_value=SendResult(success=True, message_id="v1"))
+        self.send_video = AsyncMock(return_value=SendResult(success=True, message_id="vid1"))
+
+    def extract_media(self, response):
+        return [], response
+
+    def extract_images(self, response):
+        return [], response
+
+    def extract_local_files(self, response):
+        return ["/tmp/test.png"], response
+
+
+@pytest.mark.asyncio
+async def test_logs_post_stream_media_partial_failure(caplog):
+    runner = _make_runner()
+    adapter = _Adapter()
+
+    with caplog.at_level(logging.INFO, logger="gateway.run"):
+        await runner._deliver_media_from_response("hello", _make_event(), adapter)
+
+    assert any(
+        "gateway_disposition" in r.message and "post_stream_media_partial_failure" in r.message
+        for r in caplog.records
+    )

--- a/tests/gateway/test_gateway_timeout_stream_dispositions.py
+++ b/tests/gateway/test_gateway_timeout_stream_dispositions.py
@@ -1,0 +1,41 @@
+import logging
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, SessionSource
+from gateway.run import _log_gateway_disposition
+
+
+def _make_source():
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="c1",
+        user_id="u1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def test_logs_timeout_disposition(caplog):
+    source = _make_source()
+    with caplog.at_level(logging.INFO, logger="gateway.run"):
+        _log_gateway_disposition(
+            "timeout",
+            source=source,
+            session_key="agent:main:telegram:dm:c1",
+            reason="agent_timeout:300s",
+        )
+    assert any("gateway_disposition" in r.message and "disposition=timeout" in r.message for r in caplog.records)
+
+
+def test_logs_streamed_already_sent_disposition(caplog):
+    source = _make_source()
+    event = MessageEvent(source=source, text="hello", message_id="m1")
+    with caplog.at_level(logging.INFO, logger="gateway.run"):
+        _log_gateway_disposition(
+            "streamed_already_sent",
+            source=source,
+            session_key="agent:main:telegram:dm:c1",
+            event=event,
+            reason="stream_consumer_delivered_response",
+        )
+    assert any("gateway_disposition" in r.message and "disposition=streamed_already_sent" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- log explicit gateway dispositions for post-stream media partial failures
- log explicit gateway dispositions for timeouts and streamed-already-sent responses
- add targeted regression tests for those logging paths

## Why
This continues the swallowed-message debugging work from #5031 and #5032. Media-only partial failures and timeout/streaming suppression paths are especially hard to reason about when the gateway appears to "do nothing". These logs make those outcomes visible.

## Test Plan
- `python3 -m py_compile gateway/run.py tests/gateway/test_gateway_poststream_media.py tests/gateway/test_gateway_timeout_stream_dispositions.py`
- `./venv/bin/pytest -q tests/gateway/test_gateway_poststream_media.py tests/gateway/test_gateway_timeout_stream_dispositions.py -q`
