### PR TITLE
fix(cli): guard fallback_model list format in save_config_value

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1623,7 +1623,7 @@ def save_config(config: Dict[str, Any]):
     if not sec or sec.get("redact_secrets") is None:
         parts.append(_SECURITY_COMMENT)
     fb = normalized.get("fallback_model", {})
-    if not fb or not (fb.get("provider") and fb.get("model")):
+    if not fb or not isinstance(fb, dict) or not (fb.get("provider") and fb.get("model")):
         parts.append(_FALLBACK_COMMENT)
 
     atomic_yaml_write(


### PR DESCRIPTION
## What changed and why

`save_config_value()` in `hermes_cli/config.py` crashes with `AttributeError: 'list' object has no attribute 'get'` when `fallback_model` is configured as a YAML list instead of a dict.

```python
fb = normalized.get("fallback_model", {})
if not fb or not (fb.get("provider") and fb.get("model")):  # crashes if fb is a list
```

This hits on any config-changing operation (model switch, plugin toggle, allowlist save) if the user has manually edited `config.yaml` with a list format.

## How to test

**Reproduce the crash:**
```yaml
# ~/.hermes/config.yaml — add this
fallback_model:
  - provider: openrouter
    model: anthropic/claude-sonnet-4
```
```bash
hermes config set model.default openrouter/gpt-4o  # crashes before fix, works after
```

**Unit tests:**
```bash
pytest tests/test_config*.py -v  # 13 passed
```

## Platform tested

Linux (Ubuntu 24.04, x86_64), Python 3.11.14

## Related issues

Fixes #4091

---

**AI-assisted disclosure:** Fix identified and implemented with Claude Sonnet 4.6. Verified manually on Linux. Marking as AI-assisted per CONTRIBUTING.md.