### PR TITLE
fix(ssh): quote remote workdir and path operands in one-shot execution

### DIFF
--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import shlex
 import subprocess
 from unittest.mock import MagicMock
 
@@ -65,6 +66,81 @@ class TestBuildSSHCommand:
     def test_user_host_suffix(self):
         env = SSHEnvironment(host="h", user="u")
         assert env._build_ssh_command()[-1] == "u@h"
+
+
+class TestSSHCommandQuoting:
+    @pytest.fixture(autouse=True)
+    def _mock_connection(self, monkeypatch):
+        monkeypatch.setattr(ssh_env, "_ensure_ssh_available", lambda: None)
+        monkeypatch.setattr(ssh_env.SSHEnvironment, "_establish_connection", lambda self: None)
+        monkeypatch.setattr(ssh_env.SSHEnvironment, "_detect_remote_home", lambda self: "/home/tester")
+        monkeypatch.setattr(ssh_env.SSHEnvironment, "_sync_skills_and_credentials", lambda self: None)
+        monkeypatch.setattr(ssh_env.time, "sleep", lambda _: None)
+
+    def test_execute_oneshot_quotes_injection_like_workdir(self, monkeypatch):
+        captured = {}
+
+        class _DummyProc:
+            def __init__(self, cmd):
+                captured["cmd"] = cmd
+                self.stdout = iter([])
+                self.stdin = MagicMock()
+                self.returncode = 0
+
+            def poll(self):
+                return 0
+
+        monkeypatch.setattr(ssh_env.subprocess, "Popen", lambda *a, **k: _DummyProc(a[0]))
+
+        env = SSHEnvironment(host="h", user="u", persistent=False)
+        result = env._execute_oneshot("printf ok", cwd="/tmp/a; touch /tmp/pwned #")
+
+        assert result["returncode"] == 0
+        assert captured["cmd"][-1] == "cd '/tmp/a; touch /tmp/pwned #' && printf ok"
+
+    def test_execute_oneshot_quotes_space_containing_workdir(self, monkeypatch):
+        captured = {}
+
+        class _DummyProc:
+            def __init__(self, cmd):
+                captured["cmd"] = cmd
+                self.stdout = iter([])
+                self.stdin = MagicMock()
+                self.returncode = 0
+
+            def poll(self):
+                return 0
+
+        monkeypatch.setattr(ssh_env.subprocess, "Popen", lambda *a, **k: _DummyProc(a[0]))
+
+        env = SSHEnvironment(host="h", user="u", persistent=False)
+        result = env._execute_oneshot("pwd", cwd="/tmp/release artifacts")
+
+        assert result["returncode"] == 0
+        assert captured["cmd"][-1] == "cd '/tmp/release artifacts' && pwd"
+
+    def test_read_temp_files_and_cleanup_quote_remote_paths(self, monkeypatch):
+        calls = []
+
+        def _fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(ssh_env.subprocess, "run", _fake_run)
+
+        env = SSHEnvironment(host="h", user="u", persistent=False)
+        env._session_id = "abc123"
+
+        env._read_temp_files("/tmp/file name; touch /tmp/pwned #")
+        env._read_temp_files("/tmp/one path", "/tmp/two;rm -rf /")
+        env._cleanup_temp_files()
+
+        assert calls[0][-1] == f"cat {shlex.quote('/tmp/file name; touch /tmp/pwned #')} 2>/dev/null"
+        assert calls[1][-1] == (
+            f"cat {shlex.quote('/tmp/one path')} 2>/dev/null; echo '__HERMES_SEP_abc123__'; "
+            f"cat {shlex.quote('/tmp/two;rm -rf /')} 2>/dev/null; echo '__HERMES_SEP_abc123__'"
+        )
+        assert calls[2][-1] == "rm -f -- /tmp/hermes-ssh-abc123-*"
 
 
 class TestTerminalToolConfig:

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -1,6 +1,7 @@
 """SSH remote execution environment with ControlMaster connection persistence."""
 
 import logging
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -126,7 +127,7 @@ class SSHEnvironment(PersistentShellMixin, BaseEnvironment):
                 remote_path = mount_entry["container_path"].replace("/root/.hermes", container_base, 1)
                 parent_dir = str(Path(remote_path).parent)
                 mkdir_cmd = self._build_ssh_command()
-                mkdir_cmd.append(f"mkdir -p {parent_dir}")
+                mkdir_cmd.append(f"mkdir -p {shlex.quote(parent_dir)}")
                 subprocess.run(mkdir_cmd, capture_output=True, text=True, timeout=10)
                 cmd = rsync_base + [mount_entry["host_path"], f"{dest_prefix}:{remote_path}"]
                 result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
@@ -139,7 +140,7 @@ class SSHEnvironment(PersistentShellMixin, BaseEnvironment):
             for skills_mount in get_skills_directory_mount(container_base=container_base):
                 remote_path = skills_mount["container_path"]
                 mkdir_cmd = self._build_ssh_command()
-                mkdir_cmd.append(f"mkdir -p {remote_path}")
+                mkdir_cmd.append(f"mkdir -p {shlex.quote(remote_path)}")
                 subprocess.run(mkdir_cmd, capture_output=True, text=True, timeout=10)
                 cmd = rsync_base + [
                     skills_mount["host_path"].rstrip("/") + "/",
@@ -181,7 +182,7 @@ class SSHEnvironment(PersistentShellMixin, BaseEnvironment):
     def _read_temp_files(self, *paths: str) -> list[str]:
         if len(paths) == 1:
             cmd = self._build_ssh_command()
-            cmd.append(f"cat {paths[0]} 2>/dev/null")
+            cmd.append(f"cat {shlex.quote(paths[0])} 2>/dev/null")
             try:
                 result = subprocess.run(
                     cmd, capture_output=True, text=True, timeout=10,
@@ -192,7 +193,7 @@ class SSHEnvironment(PersistentShellMixin, BaseEnvironment):
 
         delim = f"__HERMES_SEP_{self._session_id}__"
         script = "; ".join(
-            f"cat {p} 2>/dev/null; echo '{delim}'" for p in paths
+            f"cat {shlex.quote(p)} 2>/dev/null; echo '{delim}'" for p in paths
         )
         cmd = self._build_ssh_command()
         cmd.append(script)
@@ -217,7 +218,7 @@ class SSHEnvironment(PersistentShellMixin, BaseEnvironment):
 
     def _cleanup_temp_files(self):
         cmd = self._build_ssh_command()
-        cmd.append(f"rm -f {self._temp_prefix}-*")
+        cmd.append(f"rm -f -- {shlex.quote(self._temp_prefix)}-*")
         try:
             subprocess.run(cmd, capture_output=True, timeout=5)
         except (subprocess.TimeoutExpired, OSError):
@@ -228,7 +229,7 @@ class SSHEnvironment(PersistentShellMixin, BaseEnvironment):
                          stdin_data: str | None = None) -> dict:
         work_dir = cwd or self.cwd
         exec_command, sudo_stdin = self._prepare_command(command)
-        wrapped = f'cd {work_dir} && {exec_command}'
+        wrapped = f"cd {shlex.quote(work_dir)} && {exec_command}"
         effective_timeout = timeout or self.timeout
 
         if sudo_stdin is not None and stdin_data is not None:


### PR DESCRIPTION
## What changed
Quoted remote path operands embedded in SSH shell commands with `shlex.quote()` in `tools/environments/ssh.py`.

This includes:
- one-shot execution workdir handling
- `mkdir -p` path operands
- temporary file reads via `cat`
- temp cleanup via `rm -f`

Also added regression tests covering:
- injection-like workdir input
- legitimate workdirs containing spaces
- quoted temp-path helper behavior

## Why
The one-shot SSH execution path embedded `workdir` directly into the remote shell command without quoting. This could lead to command injection and also broke valid directory paths containing spaces.

Quoting these operands ensures they are treated as data by the remote shell and makes behavior consistent with the persistent shell path.

## How to test
- Run with `TERMINAL_ENV=ssh` and `TERMINAL_SSH_PERSISTENT=false` using:
  - `workdir="/tmp/a; touch /tmp/pwned #"`
  - before the fix, an unintended extra command may run
  - after the fix, it must not
- Run with:
  - `workdir="/tmp/release artifacts"`
  - confirm the command executes in the correct directory
- Verify sudo-based SSH commands also run in the intended directory

## Validation
- `pytest tests/tools/test_ssh_environment.py -q` → `14 passed, 11 skipped`
- `python -m compileall tools/environments/ssh.py tests/tools/test_ssh_environment.py` → successful