### PR TITLE
fix: DingTalk platform adapter has multiple bugs preventing message processing

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -132,7 +132,7 @@ class DingTalkAdapter(BasePlatformAdapter):
         while self._running:
             try:
                 logger.debug("[%s] Starting stream client...", self.name)
-                await asyncio.to_thread(self._stream_client.start)
+                await self._stream_client.start()
             except asyncio.CancelledError:
                 return
             except Exception as e:
@@ -172,9 +172,33 @@ class DingTalkAdapter(BasePlatformAdapter):
 
     # -- Inbound message processing -----------------------------------------
 
+    # Map snake_case attr names to camelCase data dict keys
+    _DATA_KEY_MAP = {
+        "message_id": "msgId",
+        "conversation_id": "conversationId",
+        "conversation_type": "conversationType",
+        "sender_id": "senderId",
+        "sender_nick": "senderNick",
+        "sender_staff_id": "senderStaffId",
+        "conversation_title": "conversationTitle",
+        "create_at": "createAt",
+        "session_webhook": "sessionWebhook",
+    }
+
+    def _get_field(self, message: Any, snake_name: str, default: Any = None) -> Any:
+        """Get a field from CallbackMessage (data dict) or ChatbotMessage (direct attr)."""
+        val = getattr(message, snake_name, None)
+        if val is not None:
+            return val
+        data = getattr(message, "data", None)
+        if isinstance(data, dict):
+            camel = self._DATA_KEY_MAP.get(snake_name, snake_name)
+            return data.get(camel, default)
+        return default
+
     async def _on_message(self, message: "ChatbotMessage") -> None:
         """Process an incoming DingTalk chatbot message."""
-        msg_id = getattr(message, "message_id", None) or uuid.uuid4().hex
+        msg_id = self._get_field(message, "message_id") or getattr(getattr(message, "headers", None), "message_id", None) or uuid.uuid4().hex
         if self._is_duplicate(msg_id):
             logger.debug("[%s] Duplicate message %s, skipping", self.name, msg_id)
             return
@@ -185,32 +209,36 @@ class DingTalkAdapter(BasePlatformAdapter):
             return
 
         # Chat context
-        conversation_id = getattr(message, "conversation_id", "") or ""
-        conversation_type = getattr(message, "conversation_type", "1")
+        conversation_id = self._get_field(message, "conversation_id", "") or ""
+        conversation_type = self._get_field(message, "conversation_type", "1")
         is_group = str(conversation_type) == "2"
-        sender_id = getattr(message, "sender_id", "") or ""
-        sender_nick = getattr(message, "sender_nick", "") or sender_id
-        sender_staff_id = getattr(message, "sender_staff_id", "") or ""
+        sender_id = self._get_field(message, "sender_id", "") or ""
+        sender_nick = self._get_field(message, "sender_nick", "") or sender_id
+        sender_staff_id = self._get_field(message, "sender_staff_id", "") or ""
+
+        # Use staff_id (numeric corp ID) for authorization — the encrypted
+        # open ID (sender_id) is unreadable and varies per app.
+        auth_user_id = sender_staff_id or sender_id
 
         chat_id = conversation_id or sender_id
         chat_type = "group" if is_group else "dm"
 
         # Store session webhook for reply routing
-        session_webhook = getattr(message, "session_webhook", None) or ""
+        session_webhook = self._get_field(message, "session_webhook", "") or ""
         if session_webhook and chat_id:
             self._session_webhooks[chat_id] = session_webhook
 
         source = self.build_source(
             chat_id=chat_id,
-            chat_name=getattr(message, "conversation_title", None),
+            chat_name=self._get_field(message, "conversation_title"),
             chat_type=chat_type,
-            user_id=sender_id,
+            user_id=auth_user_id,
             user_name=sender_nick,
-            user_id_alt=sender_staff_id if sender_staff_id else None,
+            user_id_alt=sender_id if sender_id != auth_user_id else None,
         )
 
         # Parse timestamp
-        create_at = getattr(message, "create_at", None)
+        create_at = self._get_field(message, "create_at")
         try:
             timestamp = datetime.fromtimestamp(int(create_at) / 1000, tz=timezone.utc) if create_at else datetime.now(tz=timezone.utc)
         except (ValueError, OSError, TypeError):
@@ -231,12 +259,28 @@ class DingTalkAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _extract_text(message: "ChatbotMessage") -> str:
-        """Extract plain text from a DingTalk chatbot message."""
-        text = getattr(message, "text", None) or ""
+        """Extract plain text from a DingTalk chatbot message.
+
+        Handles both ChatbotMessage (attrs) and CallbackMessage (data dict).
+        """
+        # Try direct attribute first (ChatbotMessage)
+        text = getattr(message, "text", None)
         if isinstance(text, dict):
             content = text.get("content", "").strip()
-        else:
+        elif text:
             content = str(text).strip()
+        else:
+            content = ""
+
+        # Fall back to data dict (CallbackMessage)
+        if not content:
+            data = getattr(message, "data", None)
+            if isinstance(data, dict):
+                raw = data.get("text")
+                if isinstance(raw, dict):
+                    content = raw.get("content", "").strip()
+                elif raw:
+                    content = str(raw).strip()
 
         # Fall back to rich text if present
         if not content:
@@ -321,10 +365,11 @@ class _IncomingHandler(ChatbotHandler if DINGTALK_STREAM_AVAILABLE else object):
         self._adapter = adapter
         self._loop = loop
 
-    def process(self, message: "ChatbotMessage"):
-        """Called by dingtalk-stream in its thread when a message arrives.
+    async def process(self, message: "ChatbotMessage"):
+        """Called by dingtalk-stream when a message arrives.
 
-        Schedules the async handler on the main event loop.
+        Schedules the async handler on the main event loop as a fire-and-forget task
+        and returns ACK immediately.
         """
         loop = self._loop
         if loop is None or loop.is_closed():
@@ -332,9 +377,12 @@ class _IncomingHandler(ChatbotHandler if DINGTALK_STREAM_AVAILABLE else object):
             return dingtalk_stream.AckMessage.STATUS_OK, "OK"
 
         future = asyncio.run_coroutine_threadsafe(self._adapter._on_message(message), loop)
-        try:
-            future.result(timeout=60)
-        except Exception:
-            logger.exception("[DingTalk] Error processing incoming message")
+
+        def _log_error(f):
+            exc = f.exception()
+            if exc:
+                logger.error("[DingTalk] Error processing message: %s", exc)
+
+        future.add_done_callback(_log_error)
 
         return dingtalk_stream.AckMessage.STATUS_OK, "OK"


### PR DESCRIPTION
## Description

The DingTalk platform adapter (`gateway/platforms/dingtalk.py`) has several critical bugs that prevent it from receiving and responding to messages. Found while debugging on HarmonyOS 4 (DingTalk mobile client).

## Bugs Found

### 1. `DingTalkStreamClient.start` wrapped incorrectly with `asyncio.to_thread`

**Line 135 (original):**
```python
await asyncio.to_thread(self._stream_client.start)
```

`DingTalkStreamClient.start()` is an async coroutine. `asyncio.to_thread()` is designed for synchronous (blocking) functions — wrapping an async function creates a coroutine object that never gets awaited. This causes repeated reconnection loops with no useful error.

**Fix:** Changed to `await self._stream_client.start()`

### 2. `process()` method signature mismatch with SDK base class

The `dingtalk_stream.ChatbotHandler.process()` is defined as `async def process(self, message: CallbackMessage)` in the SDK. The adapter overrides it as a regular `def process(self, message)` — when the SDK tries `await handler.process(message)`, it gets a plain tuple `(STATUS_OK, "OK")` and fails with:

```
ERROR dingtalk_stream.client: error processing message: object tuple can't be used in 'await' expression
```

**Fix:** Changed to `async def process(self, message)` and replaced blocking `future.result(timeout=60)` with fire-and-forget `future.add_done_callback()` for error logging.

### 3. `TimeoutError` from blocking `future.result(timeout=60)`

The `process()` method blocked the dingtalk-stream SDK thread waiting for agent processing to complete within 60 seconds. Agent responses typically take longer (tool calls, LLM inference), causing a `TimeoutError` and preventing the ACK from being returned to the SDK promptly.

```
ERROR gateway.platforms.dingtalk: [DingTalk] Error processing incoming message
TimeoutError
```

**Fix:** Return ACK immediately, dispatch agent work as fire-and-forget background task.

### 4. `_extract_text()` fails on `CallbackMessage` — messages silently dropped

The SDK sends messages as `CallbackMessage` with all fields inside `message.data` dict (e.g., `message.data['text'] = {'content': 'hello'}`). The adapter uses `getattr(message, "text", None)` which returns `None` since `CallbackMessage` has no `text` attribute — only `data`, `headers`, `spec_version`, `type`, `extensions`.

Result: text extraction returns empty string, message is silently skipped with DEBUG log `"Empty message, skipping"`.

**Fix:** Added fallback to `message.data['text']['content']` for `CallbackMessage` format.

### 5. `_on_message()` fails to extract any fields from `CallbackMessage`

Same issue as #4 but for ALL fields: `conversation_id`, `sender_id`, `sender_nick`, `sender_staff_id`, `session_webhook`, `create_at`, `conversation_title`. All use `getattr(message, "...", default)` which returns defaults since `CallbackMessage` stores everything in `data` dict with camelCase keys (`conversationId`, `senderId`, `sessionWebhook`, etc.).

Result: `session_webhook` is never captured, replies cannot be sent. User IDs are empty, authorization fails.

**Fix:** Added `_get_field()` helper with `_DATA_KEY_MAP` (snake_case to camelCase) that falls back to `message.data[key]`.

### 6. Authorization uses unreadable encrypted `senderId` instead of `senderStaffId`

DingTalk provides two user identifiers:
- `senderId`: encrypted open ID like `$:LWCP_v1:$qoM1+WxS0Q5F5iqeTKOz7Hge06B2HTXW` (unreadable, varies per app)
- `senderStaffId`: numeric corp employee ID like `22514138787330` (human-readable, stable)

The adapter used `senderId` as `user_id` for authorization, making it impractical to add users to allowlists.

**Fix:** Use `senderStaffId` as primary `user_id`, keep `senderId` as `user_id_alt`.

## Environment

- **OS:** HarmonyOS 4 (DingTalk mobile client sending messages)
- **Hermes:** Current `cli` branch
- **Python:** 3.11.15
- **dingtalk-stream SDK:** Latest from pip
- **Platform:** DingTalk Stream Mode (WebSocket)

## Reproduction

1. Configure DingTalk platform in `config.yaml`
2. Start gateway: `hermes gateway run`
3. Send message from DingTalk mobile client
4. Observe: messages arrive but are silently dropped or timeout

## Fixes Applied

All six bugs have been fixed locally. The changes ensure:
- Stream client starts correctly with `await`
- SDK thread is not blocked by long-running agent processing
- `CallbackMessage` fields are properly extracted via `data` dict
- Human-readable staff IDs are used for authorization

Happy to submit a PR if the fixes look good.
