### PR TITLE
fix(gateway): surface partial attachment delivery failures

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1262,6 +1262,8 @@ class BasePlatformAdapter(ABC):
                 # Human-like pacing delay between text and media
                 human_delay = self._get_human_delay()
 
+                media_failure_count = 0
+
                 # Send extracted images as native attachments
                 if images:
                     logger.info("[%s] Extracted %d image(s) to send as attachments", self.name, len(images))
@@ -1286,9 +1288,23 @@ class BasePlatformAdapter(ABC):
                                 metadata=_thread_metadata,
                             )
                         if not img_result.success:
+                            media_failure_count += 1
                             logger.error("[%s] Failed to send image: %s", self.name, img_result.error)
+                            self._log_disposition(
+                                "partial_delivery_failure",
+                                event=event,
+                                session_key=session_key,
+                                reason="image_send_failed",
+                            )
                     except Exception as img_err:
+                        media_failure_count += 1
                         logger.error("[%s] Error sending image: %s", self.name, img_err, exc_info=True)
+                        self._log_disposition(
+                            "partial_delivery_failure",
+                            event=event,
+                            session_key=session_key,
+                            reason="image_send_exception",
+                        )
 
                 # Send extracted media files — route by file type
                 _AUDIO_EXTS = {'.ogg', '.opus', '.mp3', '.wav', '.m4a'}
@@ -1326,9 +1342,23 @@ class BasePlatformAdapter(ABC):
                             )
 
                         if not media_result.success:
+                            media_failure_count += 1
                             logger.warning("[%s] Failed to send media (%s): %s", self.name, ext, media_result.error)
+                            self._log_disposition(
+                                "partial_delivery_failure",
+                                event=event,
+                                session_key=session_key,
+                                reason=f"media_send_failed:{ext}",
+                            )
                     except Exception as media_err:
+                        media_failure_count += 1
                         logger.warning("[%s] Error sending media: %s", self.name, media_err)
+                        self._log_disposition(
+                            "partial_delivery_failure",
+                            event=event,
+                            session_key=session_key,
+                            reason="media_send_exception",
+                        )
 
                 # Send auto-detected local files as native attachments
                 for file_path in local_files:
@@ -1337,25 +1367,53 @@ class BasePlatformAdapter(ABC):
                     try:
                         ext = Path(file_path).suffix.lower()
                         if ext in _IMAGE_EXTS:
-                            await self.send_image_file(
+                            file_result = await self.send_image_file(
                                 chat_id=event.source.chat_id,
                                 image_path=file_path,
                                 metadata=_thread_metadata,
                             )
                         elif ext in _VIDEO_EXTS:
-                            await self.send_video(
+                            file_result = await self.send_video(
                                 chat_id=event.source.chat_id,
                                 video_path=file_path,
                                 metadata=_thread_metadata,
                             )
                         else:
-                            await self.send_document(
+                            file_result = await self.send_document(
                                 chat_id=event.source.chat_id,
                                 file_path=file_path,
                                 metadata=_thread_metadata,
                             )
+                        if file_result is not None and not getattr(file_result, "success", False):
+                            media_failure_count += 1
+                            self._log_disposition(
+                                "partial_delivery_failure",
+                                event=event,
+                                session_key=session_key,
+                                reason=f"local_file_send_failed:{ext}",
+                            )
                     except Exception as file_err:
+                        media_failure_count += 1
                         logger.error("[%s] Error sending local file %s: %s", self.name, file_path, file_err)
+                        self._log_disposition(
+                            "partial_delivery_failure",
+                            event=event,
+                            session_key=session_key,
+                            reason="local_file_send_exception",
+                        )
+
+                if text_content and media_failure_count > 0:
+                    notice = (
+                        f"⚠️ I sent the text response, but {media_failure_count} attachment"
+                        f"{'s' if media_failure_count != 1 else ''} failed to deliver."
+                    )
+                    notice_result = await self._send_with_retry(
+                        chat_id=event.source.chat_id,
+                        content=notice,
+                        reply_to=event.message_id,
+                        metadata=_thread_metadata,
+                    )
+                    _record_delivery(notice_result)
 
             # Determine overall success for the processing hook
             processing_ok = delivery_succeeded if delivery_attempted else not bool(response)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -506,6 +506,35 @@ class BasePlatformAdapter(ABC):
     def is_connected(self) -> bool:
         """Check if adapter is currently connected."""
         return self._running
+
+    def _log_disposition(
+        self,
+        disposition: str,
+        *,
+        event: Optional[MessageEvent] = None,
+        session_key: Optional[str] = None,
+        reason: Optional[str] = None,
+    ) -> None:
+        """Emit a structured gateway disposition log for non-happy-path outcomes."""
+        parts = [
+            "gateway_disposition",
+            f"platform={self.platform.value}",
+            f"adapter={self.name}",
+            f"disposition={disposition}",
+        ]
+        if session_key:
+            parts.append(f"session_key={session_key}")
+        if event is not None:
+            if getattr(event, "message_id", None):
+                parts.append(f"message_id={event.message_id}")
+            if getattr(event.source, "chat_id", None):
+                parts.append(f"chat_id={event.source.chat_id}")
+            cmd = event.get_command() if hasattr(event, "get_command") else None
+            if cmd:
+                parts.append(f"command={cmd}")
+        if reason:
+            parts.append(f"reason={reason}")
+        logger.info(" ".join(parts))
     
     def set_message_handler(self, handler: MessageHandler) -> None:
         """
@@ -982,6 +1011,11 @@ class BasePlatformAdapter(ABC):
             else:
                 # All retries exhausted (loop completed without break) — notify user
                 logger.error("[%s] Failed to deliver response after %d retries: %s", self.name, max_retries, error_str)
+                self._log_disposition(
+                    "delivery_failed_retries_exhausted",
+                    session_key=chat_id,
+                    reason=error_str[:160] if error_str else "retry_exhausted",
+                )
                 notice = (
                     "\u26a0\ufe0f Message delivery failed after multiple attempts. "
                     "Please try again \u2014 your request was processed but the response could not be sent."
@@ -1064,6 +1098,12 @@ class BasePlatformAdapter(ABC):
                             existing.text = f"{existing.text}\n\n{event.text}".strip()
                 else:
                     self._pending_messages[session_key] = event
+                self._log_disposition(
+                    "queued_without_interrupt",
+                    event=event,
+                    session_key=session_key,
+                    reason="photo_follow_up",
+                )
                 return  # Don't interrupt now - will run after current task completes
 
             # Default behavior for non-photo follow-ups: interrupt the running agent
@@ -1148,6 +1188,12 @@ class BasePlatformAdapter(ABC):
             # DEBUG to avoid noisy warnings for expected behavior.
             if not response:
                 logger.debug("[%s] Handler returned empty/None response for %s", self.name, event.source.chat_id)
+                self._log_disposition(
+                    "handler_empty_response",
+                    event=event,
+                    session_key=session_key,
+                    reason="empty_or_already_streamed",
+                )
             if response:
                 # Extract MEDIA:<path> tags (from TTS tool) before other processing
                 media_files, response = self.extract_media(response)

--- a/tests/gateway/test_gateway_dispositions.py
+++ b/tests/gateway/test_gateway_dispositions.py
@@ -1,0 +1,95 @@
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.session import SessionSource, build_session_key
+
+
+class _StubAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.TELEGRAM)
+        self._send_results = []
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        self._mark_disconnected()
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        if self._send_results:
+            return self._send_results.pop(0)
+        return SendResult(success=True, message_id="msg-1")
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id, "type": "dm"}
+
+
+def _make_source(chat_id="chat-1", user_id="user-1"):
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=chat_id,
+        user_id=user_id,
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text="hello", message_type=MessageType.TEXT):
+    return MessageEvent(
+        text=text,
+        message_type=message_type,
+        source=_make_source(),
+        message_id="m1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_logs_disposition_when_photo_is_queued_without_interrupt(caplog):
+    adapter = _StubAdapter()
+    adapter.set_message_handler(AsyncMock(return_value="ok"))
+    session_key = build_session_key(_make_source())
+    adapter._active_sessions[session_key] = asyncio.Event()
+
+    with caplog.at_level(logging.INFO, logger="gateway.platforms.base"):
+        await adapter.handle_message(_make_event(message_type=MessageType.PHOTO))
+
+    assert any(
+        "gateway_disposition" in r.message and "queued_without_interrupt" in r.message
+        for r in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_logs_disposition_when_handler_returns_empty(caplog):
+    adapter = _StubAdapter()
+    adapter.set_message_handler(AsyncMock(return_value=None))
+
+    with caplog.at_level(logging.INFO, logger="gateway.platforms.base"):
+        await adapter.handle_message(_make_event())
+        await asyncio.sleep(0.3)
+
+    assert any(
+        "gateway_disposition" in r.message and "handler_empty_response" in r.message
+        for r in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_logs_disposition_when_delivery_retries_exhausted(caplog):
+    adapter = _StubAdapter()
+    network_err = SendResult(success=False, error="httpx.ConnectError: host unreachable")
+    adapter._send_results = [network_err, network_err, network_err, SendResult(success=True)]
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        with caplog.at_level(logging.INFO, logger="gateway.platforms.base"):
+            await adapter._send_with_retry("chat1", "hello", max_retries=2, base_delay=0)
+
+    assert any(
+        "gateway_disposition" in r.message and "delivery_failed_retries_exhausted" in r.message
+        for r in caplog.records
+    )

--- a/tests/gateway/test_gateway_partial_success.py
+++ b/tests/gateway/test_gateway_partial_success.py
@@ -1,0 +1,77 @@
+import asyncio
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, SendResult
+from gateway.session import SessionSource, build_session_key
+
+
+class DummyAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.TELEGRAM)
+        self.sent = []
+        self.image_results = []
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent.append({
+            "chat_id": chat_id,
+            "content": content,
+            "reply_to": reply_to,
+            "metadata": metadata,
+        })
+        return SendResult(success=True, message_id=str(len(self.sent)))
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        return None
+
+    async def send_image(self, chat_id: str, image_url: str, caption=None, metadata=None, **kwargs):
+        if self.image_results:
+            return self.image_results.pop(0)
+        return SendResult(success=True, message_id="img-1")
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+
+def _make_event() -> MessageEvent:
+    return MessageEvent(
+        text="hello",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="c1",
+            user_id="u1",
+            user_name="tester",
+            chat_type="dm",
+        ),
+        message_id="m1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_message_background_sends_partial_failure_notice_when_text_succeeds_but_image_fails():
+    adapter = DummyAdapter()
+    adapter.image_results = [SendResult(success=False, error="boom")]
+
+    async def handler(_event):
+        return "Here you go https://example.com/test.png"
+
+    async def hold_typing(_chat_id, interval=2.0, metadata=None):
+        await asyncio.Event().wait()
+
+    adapter.set_message_handler(handler)
+    adapter._keep_typing = hold_typing
+    adapter.extract_images = lambda response: ([('https://example.com/test.png', 'test image')], 'Here you go')
+
+    event = _make_event()
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    assert len(adapter.sent) == 2
+    assert adapter.sent[0]["content"] == "Here you go"
+    assert "attachment" in adapter.sent[1]["content"].lower() or "image" in adapter.sent[1]["content"].lower()


### PR DESCRIPTION
## Summary
- send a follow-up notice when text delivery succeeds but one or more attachments fail to deliver
- log `partial_delivery_failure` dispositions for failed image/media/local-file sends
- add regression coverage for the partial-success case

## Why
One of the worst gateway UX failures is when Hermes sends the text but silently drops attachments. This PR makes that outcome visible to the user instead of leaving them thinking the whole thing succeeded.

## Test Plan
- `python3 -m py_compile gateway/platforms/base.py tests/gateway/test_gateway_partial_success.py`
- `./venv/bin/pytest -q tests/gateway/test_gateway_partial_success.py -q`
- `./venv/bin/pytest -q tests/gateway/test_gateway_dispositions.py tests/gateway/test_gateway_partial_success.py tests/gateway/test_send_retry.py tests/gateway/test_queue_consumption.py -q`

Depends conceptually on the disposition logging work in #5031.
