### PR TITLE
feat(gateway): emit structured gateway state hook events

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -8,6 +8,7 @@ Hooks are discovered from ~/.hermes/hooks/ directories, each containing:
 
 Events:
   - gateway:startup     -- Gateway process starts
+  - gateway:state       -- Structured runtime state/disposition event for queueing, timeouts, approvals, delivery issues
   - session:start       -- New session created (first message of a new session)
   - session:end         -- Session ends (user ran /new or /reset)
   - session:reset       -- Session reset completed (new session entry created)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2852,6 +2852,13 @@ class GatewayRunner:
 
             # Surface error details when the agent failed silently (final_response=None)
             if not response and agent_result.get("failed"):
+                await self._update_gateway_run_state(
+                    "failed",
+                    source=source,
+                    session_key=session_key,
+                    event=event,
+                    reason=str(agent_result.get("error", "unknown error"))[:160],
+                )
                 error_detail = agent_result.get("error", "unknown error")
                 error_str = str(error_detail).lower()
 
@@ -3021,6 +3028,13 @@ class GatewayRunner:
             # when already_sent is True, so media files would never be
             # delivered without this.
             if agent_result.get("already_sent"):
+                await self._update_gateway_run_state(
+                    "streamed_already_sent",
+                    source=source,
+                    session_key=session_key,
+                    event=event,
+                    reason="stream_consumer_delivered_response",
+                )
                 if response:
                     _media_adapter = self.adapters.get(source.platform)
                     if _media_adapter:
@@ -3957,6 +3971,7 @@ class GatewayRunner:
             local_files, _ = adapter.extract_local_files(cleaned)
 
             _thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+            _partial_failure = False
 
             _AUDIO_EXTS = {'.ogg', '.opus', '.mp3', '.wav', '.m4a'}
             _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
@@ -3966,52 +3981,72 @@ class GatewayRunner:
                 try:
                     ext = Path(media_path).suffix.lower()
                     if ext in _AUDIO_EXTS:
-                        await adapter.send_voice(
+                        result = await adapter.send_voice(
                             chat_id=event.source.chat_id,
                             audio_path=media_path,
                             metadata=_thread_meta,
                         )
                     elif ext in _VIDEO_EXTS:
-                        await adapter.send_video(
+                        result = await adapter.send_video(
                             chat_id=event.source.chat_id,
                             video_path=media_path,
                             metadata=_thread_meta,
                         )
                     elif ext in _IMAGE_EXTS:
-                        await adapter.send_image_file(
+                        result = await adapter.send_image_file(
                             chat_id=event.source.chat_id,
                             image_path=media_path,
                             metadata=_thread_meta,
                         )
                     else:
-                        await adapter.send_document(
+                        result = await adapter.send_document(
                             chat_id=event.source.chat_id,
                             file_path=media_path,
                             metadata=_thread_meta,
                         )
+                    if result is not None and not getattr(result, 'success', False):
+                        _partial_failure = True
                 except Exception as e:
+                    _partial_failure = True
                     logger.warning("[%s] Post-stream media delivery failed: %s", adapter.name, e)
 
             for file_path in local_files:
                 try:
                     ext = Path(file_path).suffix.lower()
                     if ext in _IMAGE_EXTS:
-                        await adapter.send_image_file(
+                        result = await adapter.send_image_file(
                             chat_id=event.source.chat_id,
                             image_path=file_path,
                             metadata=_thread_meta,
                         )
                     else:
-                        await adapter.send_document(
+                        result = await adapter.send_document(
                             chat_id=event.source.chat_id,
                             file_path=file_path,
                             metadata=_thread_meta,
                         )
+                    if result is not None and not getattr(result, 'success', False):
+                        _partial_failure = True
                 except Exception as e:
+                    _partial_failure = True
                     logger.warning("[%s] Post-stream file delivery failed: %s", adapter.name, e)
+
+            if _partial_failure:
+                await self._update_gateway_run_state(
+                    'partial_failure',
+                    source=event.source,
+                    event=event,
+                    reason='post_stream_media_partial_failure',
+                )
 
         except Exception as e:
             logger.warning("Post-stream media extraction failed: %s", e)
+            await self._update_gateway_run_state(
+                'partial_failure',
+                source=event.source,
+                event=event,
+                reason='post_stream_media_extraction_failed',
+            )
 
     async def _handle_rollback_command(self, event: MessageEvent) -> str:
         """Handle /rollback command — list or restore filesystem checkpoints."""
@@ -6149,6 +6184,18 @@ class GatewayRunner:
                 """
                 cmd = approval_data.get("command", "")
                 desc = approval_data.get("description", "dangerous command")
+                try:
+                    asyncio.run_coroutine_threadsafe(
+                        self._update_gateway_run_state(
+                            "awaiting_approval",
+                            source=source,
+                            session_key=session_key,
+                            reason="dangerous_command_requires_approval",
+                        ),
+                        _loop_for_step,
+                    ).result(timeout=15)
+                except Exception:
+                    pass
 
                 # Prefer button-based approval when the adapter supports it.
                 # Check the *class* for the method, not the instance — avoids
@@ -6417,6 +6464,12 @@ class GatewayRunner:
                 logger.error(
                     "Agent execution timed out after %.0fs for session %s",
                     _agent_timeout, session_key,
+                )
+                await self._update_gateway_run_state(
+                    "timed_out",
+                    source=source,
+                    session_key=session_key,
+                    reason=f"agent_timeout:{int(_agent_timeout or 0)}s",
                 )
                 # Interrupt the agent if it's still running so the thread
                 # pool worker is freed.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -334,6 +334,25 @@ def _log_gateway_disposition(
     logger.info(" ".join(parts))
     return context
 
+
+def _build_run_state_context(
+    state: str,
+    *,
+    source: Optional[SessionSource] = None,
+    session_key: Optional[str] = None,
+    event: Optional[MessageEvent] = None,
+    reason: Optional[str] = None,
+) -> dict[str, Any]:
+    context = _build_gateway_disposition_context(
+        state,
+        source=source,
+        session_key=session_key,
+        event=event,
+        reason=reason,
+    )
+    context["state"] = state
+    return context
+
 # Sentinel placed into _running_agents immediately when a session starts
 # processing, *before* any await.  Prevents a second message for the same
 # session from bypassing the "already running" guard during the async gap
@@ -556,6 +575,7 @@ class GatewayRunner:
         self._running_agents: Dict[str, Any] = {}
         self._running_agents_ts: Dict[str, float] = {}  # start timestamp per session
         self._pending_messages: Dict[str, str] = {}  # Queued messages during interrupt
+        self._gateway_run_states: Dict[str, Dict[str, Any]] = {}
 
         # Cache AIAgent instances per session to preserve prompt caching.
         # Without this, a new AIAgent is created per message, rebuilding the
@@ -1764,6 +1784,12 @@ class GatewayRunner:
         """
         source = event.source
         run_id = _ensure_gateway_run_id(event)
+        await self._update_gateway_run_state(
+            "received",
+            source=source,
+            event=event,
+            reason="message_received",
+        )
 
         # Check if user is authorized
         if not self._is_user_authorized(source):
@@ -1775,13 +1801,18 @@ class GatewayRunner:
                 # prevent spamming the user with repeated messages when
                 # multiple DMs arrive in quick succession.
                 if self.pairing_store._is_rate_limited(platform_name, source.user_id):
-                    ctx = _log_gateway_disposition(
+                    _log_gateway_disposition(
                         "unauthorized_rate_limited",
                         source=source,
                         event=event,
                         reason="pairing_rate_limited",
                     )
-                    await self.hooks.emit("gateway:state", ctx)
+                    await self._update_gateway_run_state(
+                        "unauthorized_rate_limited",
+                        source=source,
+                        event=event,
+                        reason="pairing_rate_limited",
+                    )
                     return None
                 code = self.pairing_store.generate_code(
                     platform_name, source.user_id, source.user_name or ""
@@ -1926,14 +1957,20 @@ class GatewayRunner:
                             adapter._pending_messages[_quick_key] = event
                     else:
                         adapter._pending_messages[_quick_key] = event
-                ctx = _log_gateway_disposition(
+                _log_gateway_disposition(
                     "queued_without_interrupt",
                     source=source,
                     session_key=_quick_key,
                     event=event,
                     reason="photo_follow_up_active_run",
                 )
-                await self.hooks.emit("gateway:state", ctx)
+                await self._update_gateway_run_state(
+                    "queued",
+                    source=source,
+                    session_key=_quick_key,
+                    event=event,
+                    reason="photo_follow_up_active_run",
+                )
                 return None
 
             running_agent = self._running_agents.get(_quick_key)
@@ -1957,14 +1994,20 @@ class GatewayRunner:
                 self._pending_messages[_quick_key] += "\n" + event.text
             else:
                 self._pending_messages[_quick_key] = event.text
-            ctx = _log_gateway_disposition(
+            _log_gateway_disposition(
                 "interrupt_requested",
                 source=source,
                 session_key=_quick_key,
                 event=event,
                 reason="active_run_interrupted_by_new_input",
             )
-            await self.hooks.emit("gateway:state", ctx)
+            await self._update_gateway_run_state(
+                "interrupted",
+                source=source,
+                session_key=_quick_key,
+                event=event,
+                reason="active_run_interrupted_by_new_input",
+            )
             return None
 
         # Check for commands
@@ -2214,6 +2257,13 @@ class GatewayRunner:
         """Inner handler that runs under the _running_agents sentinel guard."""
 
         run_id = _ensure_gateway_run_id(event)
+
+        await self._update_gateway_run_state(
+            "running",
+            source=source,
+            event=event,
+            reason="agent_handler_entered",
+        )
 
         # Get or create session
         session_entry = self.session_store.get_or_create_session(source)
@@ -2851,6 +2901,13 @@ class GatewayRunner:
                 **hook_ctx,
                 "response": (response or "")[:500],
             })
+            await self._update_gateway_run_state(
+                "completed",
+                source=source,
+                session_key=session_key,
+                event=event,
+                reason="agent_completed",
+            )
             
             # Check for pending process watchers (check_interval on background processes)
             try:
@@ -5530,6 +5587,35 @@ class GatewayRunner:
         if _lock:
             with _lock:
                 self._agent_cache.pop(session_key, None)
+
+    async def _update_gateway_run_state(
+        self,
+        state: str,
+        *,
+        source: Optional[SessionSource] = None,
+        session_key: Optional[str] = None,
+        event: Optional[MessageEvent] = None,
+        reason: Optional[str] = None,
+    ) -> dict[str, Any]:
+        context = _build_run_state_context(
+            state,
+            source=source,
+            session_key=session_key,
+            event=event,
+            reason=reason,
+        )
+        run_id = context.get("run_id")
+        store = getattr(self, "_gateway_run_states", None)
+        if store is None:
+            store = {}
+            self._gateway_run_states = store
+        if run_id:
+            current = store.get(run_id, {}).copy()
+            current.update(context)
+            current["updated_at"] = datetime.now().isoformat()
+            store[run_id] = current
+        await self.hooks.emit("gateway:state", context)
+        return context
 
     async def _run_agent(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -272,6 +272,17 @@ def _expand_whatsapp_auth_aliases(identifier: str) -> set:
 logger = logging.getLogger(__name__)
 
 
+def _ensure_gateway_run_id(event: Optional[MessageEvent]) -> Optional[str]:
+    if event is None:
+        return None
+    existing = getattr(event, "run_id", None)
+    if existing:
+        return existing
+    run_id = f"gw_{uuid.uuid4().hex[:12]}"
+    setattr(event, "run_id", run_id)
+    return run_id
+
+
 def _build_gateway_disposition_context(
     disposition: str,
     *,
@@ -292,6 +303,9 @@ def _build_gateway_disposition_context(
         context["session_key"] = session_key
     if event is not None and getattr(event, "message_id", None):
         context["message_id"] = event.message_id
+    run_id = _ensure_gateway_run_id(event)
+    if run_id:
+        context["run_id"] = run_id
     if event is not None:
         cmd = event.get_command() if hasattr(event, "get_command") else None
         if cmd:
@@ -1749,6 +1763,7 @@ class GatewayRunner:
         7. Return response
         """
         source = event.source
+        run_id = _ensure_gateway_run_id(event)
 
         # Check if user is authorized
         if not self._is_user_authorized(source):
@@ -2198,6 +2213,8 @@ class GatewayRunner:
     async def _handle_message_with_agent(self, event, source, _quick_key: str):
         """Inner handler that runs under the _running_agents sentinel guard."""
 
+        run_id = _ensure_gateway_run_id(event)
+
         # Get or create session
         session_entry = self.session_store.get_or_create_session(source)
         session_key = session_entry.session_key
@@ -2213,8 +2230,9 @@ class GatewayRunner:
                 "user_id": source.user_id,
                 "session_id": session_entry.session_id,
                 "session_key": session_key,
+                "run_id": run_id,
             })
-        
+
         # Build session context
         context = build_session_context(source, self.config, session_entry)
         
@@ -2731,6 +2749,7 @@ class GatewayRunner:
                 "platform": source.platform.value if source.platform else "",
                 "user_id": source.user_id,
                 "session_id": session_entry.session_id,
+                "run_id": run_id,
                 "message": message_text[:500],
             }
             await self.hooks.emit("agent:start", hook_ctx)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -271,6 +271,55 @@ def _expand_whatsapp_auth_aliases(identifier: str) -> set:
 
 logger = logging.getLogger(__name__)
 
+
+def _build_gateway_disposition_context(
+    disposition: str,
+    *,
+    source: Optional[SessionSource] = None,
+    session_key: Optional[str] = None,
+    event: Optional[MessageEvent] = None,
+    reason: Optional[str] = None,
+) -> dict[str, Any]:
+    context: dict[str, Any] = {"disposition": disposition}
+    if source is not None:
+        if getattr(source, "platform", None):
+            context["platform"] = source.platform.value
+        if getattr(source, "chat_id", None):
+            context["chat_id"] = source.chat_id
+        if getattr(source, "user_id", None):
+            context["user_id"] = source.user_id
+    if session_key:
+        context["session_key"] = session_key
+    if event is not None and getattr(event, "message_id", None):
+        context["message_id"] = event.message_id
+    if event is not None:
+        cmd = event.get_command() if hasattr(event, "get_command") else None
+        if cmd:
+            context["command"] = cmd
+    if reason:
+        context["reason"] = reason
+    return context
+
+
+def _log_gateway_disposition(
+    disposition: str,
+    *,
+    source: Optional[SessionSource] = None,
+    session_key: Optional[str] = None,
+    event: Optional[MessageEvent] = None,
+    reason: Optional[str] = None,
+) -> dict[str, Any]:
+    context = _build_gateway_disposition_context(
+        disposition,
+        source=source,
+        session_key=session_key,
+        event=event,
+        reason=reason,
+    )
+    parts = ["gateway_disposition"] + [f"{k}={v}" for k, v in context.items()]
+    logger.info(" ".join(parts))
+    return context
+
 # Sentinel placed into _running_agents immediately when a session starts
 # processing, *before* any await.  Prevents a second message for the same
 # session from bypassing the "already running" guard during the async gap
@@ -1711,6 +1760,13 @@ class GatewayRunner:
                 # prevent spamming the user with repeated messages when
                 # multiple DMs arrive in quick succession.
                 if self.pairing_store._is_rate_limited(platform_name, source.user_id):
+                    ctx = _log_gateway_disposition(
+                        "unauthorized_rate_limited",
+                        source=source,
+                        event=event,
+                        reason="pairing_rate_limited",
+                    )
+                    await self.hooks.emit("gateway:state", ctx)
                     return None
                 code = self.pairing_store.generate_code(
                     platform_name, source.user_id, source.user_name or ""
@@ -1855,6 +1911,14 @@ class GatewayRunner:
                             adapter._pending_messages[_quick_key] = event
                     else:
                         adapter._pending_messages[_quick_key] = event
+                ctx = _log_gateway_disposition(
+                    "queued_without_interrupt",
+                    source=source,
+                    session_key=_quick_key,
+                    event=event,
+                    reason="photo_follow_up_active_run",
+                )
+                await self.hooks.emit("gateway:state", ctx)
                 return None
 
             running_agent = self._running_agents.get(_quick_key)
@@ -1878,6 +1942,14 @@ class GatewayRunner:
                 self._pending_messages[_quick_key] += "\n" + event.text
             else:
                 self._pending_messages[_quick_key] = event.text
+            ctx = _log_gateway_disposition(
+                "interrupt_requested",
+                source=source,
+                session_key=_quick_key,
+                event=event,
+                reason="active_run_interrupted_by_new_input",
+            )
+            await self.hooks.emit("gateway:state", ctx)
             return None
 
         # Check for commands

--- a/tests/gateway/test_gateway_advanced_run_states.py
+++ b/tests/gateway/test_gateway_advanced_run_states.py
@@ -1,0 +1,189 @@
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, SessionSource, SendResult
+from gateway.session import SessionEntry, build_session_key
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, message_type=MessageType.TEXT, source=_make_source(), message_id="m1")
+
+
+def _make_runner(session_entry: SessionEntry):
+    from gateway.run import GatewayRunner
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")})
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    adapter._pending_messages = {}
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._gateway_run_states = {}
+    runner._session_db = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner._send_voice_reply = AsyncMock()
+    runner._capture_gateway_honcho_if_configured = lambda *args, **kwargs: None
+    runner._emit_gateway_run_progress = AsyncMock()
+    runner._MAX_INTERRUPT_DEPTH = 3
+    runner.pairing_store = MagicMock()
+    runner.pairing_store._is_rate_limited = MagicMock(return_value=False)
+    runner.pairing_store.generate_code = MagicMock(return_value="ABC123")
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_update_gateway_run_state_tracks_timeout_state():
+    now = datetime.now()
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=now,
+        updated_at=now,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    event = _make_event("hello")
+
+    await runner._update_gateway_run_state(
+        "timed_out",
+        source=event.source,
+        session_key=build_session_key(event.source),
+        event=event,
+        reason="agent_timeout:300s",
+    )
+
+    state = runner._gateway_run_states[event.run_id]
+    assert state["state"] == "timed_out"
+    assert state["reason"] == "agent_timeout:300s"
+
+
+@pytest.mark.asyncio
+async def test_update_gateway_run_state_tracks_partial_failure_state():
+    now = datetime.now()
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=now,
+        updated_at=now,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    event = _make_event("hello")
+
+    await runner._update_gateway_run_state(
+        "partial_failure",
+        source=event.source,
+        session_key=build_session_key(event.source),
+        event=event,
+        reason="post_stream_media_partial_failure",
+    )
+
+    state = runner._gateway_run_states[event.run_id]
+    assert state["state"] == "partial_failure"
+    assert state["reason"] == "post_stream_media_partial_failure"
+
+
+@pytest.mark.asyncio
+async def test_update_gateway_run_state_tracks_awaiting_approval_state():
+    now = datetime.now()
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=now,
+        updated_at=now,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    event = _make_event("hello")
+
+    await runner._update_gateway_run_state(
+        "awaiting_approval",
+        source=event.source,
+        session_key=build_session_key(event.source),
+        event=event,
+        reason="dangerous_command_requires_approval",
+    )
+
+    state = runner._gateway_run_states[event.run_id]
+    assert state["state"] == "awaiting_approval"
+    assert state["reason"] == "dangerous_command_requires_approval"
+
+
+@pytest.mark.asyncio
+async def test_deliver_media_from_response_tracks_partial_failure_state():
+    now = datetime.now()
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=now,
+        updated_at=now,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    event = _make_event("hello")
+
+    class _Adapter:
+        name = "Telegram"
+
+        def extract_media(self, response):
+            return [], response
+
+        def extract_images(self, response):
+            return [], response
+
+        def extract_local_files(self, response):
+            return ["/tmp/test.png"], response
+
+        async def send_image_file(self, **kwargs):
+            return SendResult(success=False, error="boom")
+
+        async def send_document(self, **kwargs):
+            return SendResult(success=True, message_id="d1")
+
+        async def send_voice(self, **kwargs):
+            return SendResult(success=True, message_id="v1")
+
+        async def send_video(self, **kwargs):
+            return SendResult(success=True, message_id="vid1")
+
+    await runner._deliver_media_from_response("hello", event, _Adapter())
+
+    state = runner._gateway_run_states[event.run_id]
+    assert state["state"] == "partial_failure"
+    assert state["reason"] == "post_stream_media_partial_failure"

--- a/tests/gateway/test_gateway_run_ids.py
+++ b/tests/gateway/test_gateway_run_ids.py
@@ -1,4 +1,3 @@
-import logging
 from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -6,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
-from gateway.platforms.base import MessageEvent, MessageType
+from gateway.platforms.base import MessageEvent
 from gateway.session import SessionEntry, SessionSource, build_session_key
 
 
@@ -20,8 +19,8 @@ def _make_source() -> SessionSource:
     )
 
 
-def _make_event(text: str, message_type=MessageType.TEXT) -> MessageEvent:
-    return MessageEvent(text=text, message_type=message_type, source=_make_source(), message_id="m1")
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
 
 
 def _make_runner(session_entry: SessionEntry):
@@ -30,7 +29,6 @@ def _make_runner(session_entry: SessionEntry):
     runner.config = GatewayConfig(platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")})
     adapter = MagicMock()
     adapter.send = AsyncMock()
-    adapter._pending_messages = {}
     runner.adapters = {Platform.TELEGRAM: adapter}
     runner._voice_mode = {}
     runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
@@ -58,56 +56,32 @@ def _make_runner(session_entry: SessionEntry):
     runner._emit_gateway_run_progress = AsyncMock()
     runner._MAX_INTERRUPT_DEPTH = 3
     runner.pairing_store = MagicMock()
-    runner.pairing_store._is_rate_limited = MagicMock(return_value=False)
-    runner.pairing_store.generate_code = MagicMock(return_value="ABC123")
+    runner._run_agent = AsyncMock(return_value={"final_response": "ok", "messages": [], "tools": [], "history_offset": 0})
     return runner
 
 
 @pytest.mark.asyncio
-async def test_emits_gateway_state_for_interrupt_requested():
+async def test_session_and_agent_hooks_share_same_run_id():
+    now = datetime.now()
     session_entry = SessionEntry(
         session_key=build_session_key(_make_source()),
         session_id="sess-1",
-        created_at=datetime.now(),
-        updated_at=datetime.now(),
+        created_at=now,
+        updated_at=now,
         platform=Platform.TELEGRAM,
         chat_type="dm",
     )
     runner = _make_runner(session_entry)
-    running_agent = MagicMock()
-    runner._running_agents[build_session_key(_make_source())] = running_agent
-
-    event = _make_event("new message")
-    await runner._handle_message(event)
-
-    assert any(
-        call.args[0] == "gateway:state"
-        and call.args[1].get("disposition") == "interrupt_requested"
-        and call.args[1].get("run_id") == event.run_id
-        for call in runner.hooks.emit.await_args_list
-    )
-
-
-@pytest.mark.asyncio
-async def test_emits_gateway_state_for_unauthorized_rate_limited_dm():
-    session_entry = SessionEntry(
-        session_key=build_session_key(_make_source()),
-        session_id="sess-1",
-        created_at=datetime.now(),
-        updated_at=datetime.now(),
-        platform=Platform.TELEGRAM,
-        chat_type="dm",
-    )
-    runner = _make_runner(session_entry)
-    runner._is_user_authorized = lambda _source: False
-    runner.pairing_store._is_rate_limited.return_value = True
-
     event = _make_event("hello")
+
     await runner._handle_message(event)
 
-    assert any(
-        call.args[0] == "gateway:state"
-        and call.args[1].get("disposition") == "unauthorized_rate_limited"
-        and call.args[1].get("run_id") == event.run_id
-        for call in runner.hooks.emit.await_args_list
-    )
+    emits = runner.hooks.emit.await_args_list
+    session_start = next(call.args[1] for call in emits if call.args[0] == "session:start")
+    agent_start = next(call.args[1] for call in emits if call.args[0] == "agent:start")
+    agent_end = next(call.args[1] for call in emits if call.args[0] == "agent:end")
+
+    assert event.run_id.startswith("gw_")
+    assert session_start["run_id"] == event.run_id
+    assert agent_start["run_id"] == event.run_id
+    assert agent_end["run_id"] == event.run_id

--- a/tests/gateway/test_gateway_run_state_registry.py
+++ b/tests/gateway/test_gateway_run_state_registry.py
@@ -1,4 +1,3 @@
-import logging
 from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -6,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
-from gateway.platforms.base import MessageEvent, MessageType
+from gateway.platforms.base import MessageEvent
 from gateway.session import SessionEntry, SessionSource, build_session_key
 
 
@@ -20,8 +19,8 @@ def _make_source() -> SessionSource:
     )
 
 
-def _make_event(text: str, message_type=MessageType.TEXT) -> MessageEvent:
-    return MessageEvent(text=text, message_type=message_type, source=_make_source(), message_id="m1")
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
 
 
 def _make_runner(session_entry: SessionEntry):
@@ -30,7 +29,6 @@ def _make_runner(session_entry: SessionEntry):
     runner.config = GatewayConfig(platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")})
     adapter = MagicMock()
     adapter.send = AsyncMock()
-    adapter._pending_messages = {}
     runner.adapters = {Platform.TELEGRAM: adapter}
     runner._voice_mode = {}
     runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
@@ -45,6 +43,7 @@ def _make_runner(session_entry: SessionEntry):
     runner._running_agents_ts = {}
     runner._pending_messages = {}
     runner._pending_approvals = {}
+    runner._gateway_run_states = {}
     runner._session_db = None
     runner._reasoning_config = None
     runner._provider_routing = {}
@@ -58,56 +57,51 @@ def _make_runner(session_entry: SessionEntry):
     runner._emit_gateway_run_progress = AsyncMock()
     runner._MAX_INTERRUPT_DEPTH = 3
     runner.pairing_store = MagicMock()
-    runner.pairing_store._is_rate_limited = MagicMock(return_value=False)
-    runner.pairing_store.generate_code = MagicMock(return_value="ABC123")
+    runner._run_agent = AsyncMock(return_value={"final_response": "ok", "messages": [], "tools": [], "history_offset": 0})
     return runner
 
 
 @pytest.mark.asyncio
-async def test_emits_gateway_state_for_interrupt_requested():
+async def test_run_registry_tracks_latest_state_for_completed_run():
+    now = datetime.now()
     session_entry = SessionEntry(
         session_key=build_session_key(_make_source()),
         session_id="sess-1",
-        created_at=datetime.now(),
-        updated_at=datetime.now(),
+        created_at=now,
+        updated_at=now,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    event = _make_event("hello")
+
+    await runner._handle_message(event)
+
+    state = runner._gateway_run_states[event.run_id]
+    assert state["run_id"] == event.run_id
+    assert state["state"] == "completed"
+    assert state["session_key"] == build_session_key(_make_source())
+    assert state["chat_id"] == "c1"
+
+
+@pytest.mark.asyncio
+async def test_run_registry_tracks_interrupted_state():
+    now = datetime.now()
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=now,
+        updated_at=now,
         platform=Platform.TELEGRAM,
         chat_type="dm",
     )
     runner = _make_runner(session_entry)
     running_agent = MagicMock()
     runner._running_agents[build_session_key(_make_source())] = running_agent
-
     event = _make_event("new message")
+
     await runner._handle_message(event)
 
-    assert any(
-        call.args[0] == "gateway:state"
-        and call.args[1].get("state") == "interrupted"
-        and call.args[1].get("run_id") == event.run_id
-        for call in runner.hooks.emit.await_args_list
-    )
-
-
-@pytest.mark.asyncio
-async def test_emits_gateway_state_for_unauthorized_rate_limited_dm():
-    session_entry = SessionEntry(
-        session_key=build_session_key(_make_source()),
-        session_id="sess-1",
-        created_at=datetime.now(),
-        updated_at=datetime.now(),
-        platform=Platform.TELEGRAM,
-        chat_type="dm",
-    )
-    runner = _make_runner(session_entry)
-    runner._is_user_authorized = lambda _source: False
-    runner.pairing_store._is_rate_limited.return_value = True
-
-    event = _make_event("hello")
-    await runner._handle_message(event)
-
-    assert any(
-        call.args[0] == "gateway:state"
-        and call.args[1].get("state") == "unauthorized_rate_limited"
-        and call.args[1].get("run_id") == event.run_id
-        for call in runner.hooks.emit.await_args_list
-    )
+    state = runner._gateway_run_states[event.run_id]
+    assert state["state"] == "interrupted"
+    assert state["reason"] == "active_run_interrupted_by_new_input"

--- a/tests/gateway/test_gateway_state_events.py
+++ b/tests/gateway/test_gateway_state_events.py
@@ -1,0 +1,107 @@
+import logging
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str, message_type=MessageType.TEXT) -> MessageEvent:
+    return MessageEvent(text=text, message_type=message_type, source=_make_source(), message_id="m1")
+
+
+def _make_runner(session_entry: SessionEntry):
+    from gateway.run import GatewayRunner
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")})
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    adapter._pending_messages = {}
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner._send_voice_reply = AsyncMock()
+    runner._capture_gateway_honcho_if_configured = lambda *args, **kwargs: None
+    runner._emit_gateway_run_progress = AsyncMock()
+    runner._MAX_INTERRUPT_DEPTH = 3
+    runner.pairing_store = MagicMock()
+    runner.pairing_store._is_rate_limited = MagicMock(return_value=False)
+    runner.pairing_store.generate_code = MagicMock(return_value="ABC123")
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_emits_gateway_state_for_interrupt_requested():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    running_agent = MagicMock()
+    runner._running_agents[build_session_key(_make_source())] = running_agent
+
+    await runner._handle_message(_make_event("new message"))
+
+    assert any(
+        call.args[0] == "gateway:state" and call.args[1].get("disposition") == "interrupt_requested"
+        for call in runner.hooks.emit.await_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_emits_gateway_state_for_unauthorized_rate_limited_dm():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    runner._is_user_authorized = lambda _source: False
+    runner.pairing_store._is_rate_limited.return_value = True
+
+    await runner._handle_message(_make_event("hello"))
+
+    assert any(
+        call.args[0] == "gateway:state" and call.args[1].get("disposition") == "unauthorized_rate_limited"
+        for call in runner.hooks.emit.await_args_list
+    )


### PR DESCRIPTION
## Summary
- add a generic `gateway:state` hook event for structured runtime state/disposition emissions
- emit those events for key queue/auth/interrupt branches in `gateway/run.py`
- add regression tests verifying hook emission

## Why
The recent disposition logging PRs improve observability in logs, but a one-app client or community hook system needs structured runtime events, not just text logs. This adds a generic state-event surface other integrations can consume without being tied to Charlie's use case.

## Test Plan
- `python3 -m py_compile gateway/run.py gateway/hooks.py tests/gateway/test_gateway_state_events.py`
- `./venv/bin/pytest -q tests/gateway/test_gateway_state_events.py -q`
