### PR TITLE
Honcho optional skill + setup wizard alignment

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4748,11 +4748,8 @@ For more help on a command:
     def cmd_honcho(args):
         sub = getattr(args, "honcho_command", None)
         if sub == "setup":
-            # Redirect to the generic memory setup
-            print("\n  Honcho is now configured via the memory provider system.")
-            print("  Running 'hermes memory setup'...\n")
-            from hermes_cli.memory_setup import memory_command
-            memory_command(args)
+            from hermes_cli.memory_setup import cmd_setup_provider
+            cmd_setup_provider("honcho")
             return
         from plugins.memory.honcho.cli import honcho_command
         honcho_command(args)

--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -219,15 +219,19 @@ def _get_available_providers() -> list:
                 continue
         except Exception:
             continue
-        # Override description with setup hint
+
         schema = provider.get_config_schema() if hasattr(provider, "get_config_schema") else []
         has_secrets = any(f.get("secret") for f in schema)
-        if has_secrets:
+        has_non_secrets = any(not f.get("secret") for f in schema)
+        if has_secrets and has_non_secrets:
+            setup_hint = "API key / local"
+        elif has_secrets:
             setup_hint = "requires API key"
         elif not schema:
             setup_hint = "no setup needed"
         else:
             setup_hint = "local"
+
         results.append((name, setup_hint, provider))
     return results
 
@@ -235,6 +239,42 @@ def _get_available_providers() -> list:
 # ---------------------------------------------------------------------------
 # Setup wizard
 # ---------------------------------------------------------------------------
+
+def cmd_setup_provider(provider_name: str) -> None:
+    """Run memory setup for a specific provider, skipping the picker."""
+    from hermes_cli.config import load_config, save_config
+
+    providers = _get_available_providers()
+    match = None
+    for name, desc, provider in providers:
+        if name == provider_name:
+            match = (name, desc, provider)
+            break
+
+    if not match:
+        print(f"\n  Memory provider '{provider_name}' not found.")
+        print("  Run 'hermes memory setup' to see available providers.\n")
+        return
+
+    name, _, provider = match
+
+    _install_dependencies(name)
+
+    config = load_config()
+    if not isinstance(config.get("memory"), dict):
+        config["memory"] = {}
+
+    if hasattr(provider, "post_setup"):
+        hermes_home = str(Path(os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes"))))
+        provider.post_setup(hermes_home, config)
+        return
+
+    # Fallback: generic schema-based setup (same as cmd_setup)
+    config["memory"]["provider"] = name
+    save_config(config)
+    print(f"\n  Memory provider: {name}")
+    print(f"  Activation saved to config.yaml\n")
+
 
 def cmd_setup(args) -> None:
     """Interactive memory provider setup wizard."""
@@ -272,6 +312,13 @@ def cmd_setup(args) -> None:
 
     # Install pip dependencies if declared in plugin.yaml
     _install_dependencies(name)
+
+    # If the provider has a post_setup hook, delegate entirely to it.
+    # The hook handles its own config, connection test, and activation.
+    if hasattr(provider, "post_setup"):
+        hermes_home = str(Path(os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes"))))
+        provider.post_setup(hermes_home, config)
+        return
 
     schema = provider.get_config_schema() if hasattr(provider, "get_config_schema") else []
 
@@ -335,18 +382,18 @@ def cmd_setup(args) -> None:
         try:
             provider.save_config(provider_config, hermes_home)
         except Exception as e:
-            print(f"  ⚠ Failed to write provider config: {e}")
+            print(f"  Failed to write provider config: {e}")
 
     # Write secrets to .env
     if env_writes:
         _write_env_vars(env_path, env_writes)
 
-    print(f"\n  ✓ Memory provider: {name}")
-    print(f"  ✓ Activation saved to config.yaml")
+    print(f"\n  Memory provider: {name}")
+    print(f"  Activation saved to config.yaml")
     if provider_config:
-        print(f"  ✓ Provider config saved")
+        print(f"  Provider config saved")
     if env_writes:
-        print(f"  ✓ API keys saved to .env")
+        print(f"  API keys saved to .env")
     print(f"\n  Start a new session to activate.\n")
 
 

--- a/optional-skills/autonomous-ai-agents/honcho/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/honcho/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: honcho
+description: Configure and use Honcho memory with Hermes -- cross-session user modeling, multi-profile peer isolation, observation config, and dialectic reasoning. Use when setting up Honcho, troubleshooting memory, managing profiles with Honcho peers, or tuning observation and recall settings.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [Honcho, Memory, Profiles, Observation, Dialectic, User-Modeling]
+    homepage: https://docs.honcho.dev
+    related_skills: [hermes-agent]
+prerequisites:
+  pip: [honcho-ai]
+---
+
+# Honcho Memory for Hermes
+
+Honcho provides AI-native cross-session user modeling. It learns who the user is across conversations and gives every Hermes profile its own peer identity while sharing a unified view of the user.
+
+## When to Use
+
+- Setting up Honcho (cloud or self-hosted)
+- Troubleshooting memory not working / peers not syncing
+- Creating multi-profile setups where each agent has its own Honcho peer
+- Tuning observation, recall, or write frequency settings
+- Understanding what the 4 Honcho tools do and when to use them
+
+## Setup
+
+### Cloud (app.honcho.dev)
+
+```bash
+hermes honcho setup
+# select "cloud", paste API key from https://app.honcho.dev
+```
+
+### Self-hosted
+
+```bash
+hermes honcho setup
+# select "local", enter base URL (e.g. http://localhost:8000)
+```
+
+See: https://docs.honcho.dev/v3/guides/integrations/hermes#running-honcho-locally-with-hermes
+
+### Verify
+
+```bash
+hermes honcho status    # shows resolved config, connection test, peer info
+```
+
+## Architecture
+
+### Peers
+
+Honcho models conversations as interactions between **peers**. Hermes creates two peers per session:
+
+- **User peer** (`peerName`): represents the human. Honcho builds a user representation from observed messages.
+- **AI peer** (`aiPeer`): represents this Hermes instance. Each profile gets its own AI peer so agents develop independent views.
+
+### Observation
+
+Each peer has two observation toggles that control what Honcho learns from:
+
+| Toggle | What it does |
+|--------|-------------|
+| `observeMe` | Peer's own messages are observed (builds self-representation) |
+| `observeOthers` | Other peers' messages are observed (builds cross-peer understanding) |
+
+Default: all four toggles **on** (full bidirectional observation).
+
+Configure per-peer in `honcho.json`:
+
+```json
+{
+  "observation": {
+    "user": { "observeMe": true, "observeOthers": true },
+    "ai":   { "observeMe": true, "observeOthers": true }
+  }
+}
+```
+
+Or use the shorthand presets:
+
+| Preset | User | AI | Use case |
+|--------|------|----|----------|
+| `"directional"` (default) | me:on, others:on | me:on, others:on | Multi-agent, full memory |
+| `"unified"` | me:on, others:off | me:off, others:on | Single agent, user-only modeling |
+
+Settings changed in the [Honcho dashboard](https://app.honcho.dev) are synced back on session init -- server-side config wins over local defaults.
+
+### Sessions
+
+Honcho sessions scope where messages and observations land. Strategy options:
+
+| Strategy | Behavior |
+|----------|----------|
+| `per-directory` (default) | One session per working directory |
+| `per-repo` | One session per git repository root |
+| `per-session` | New Honcho session each Hermes run |
+| `global` | Single session across all directories |
+
+Manual override: `hermes honcho map my-project-name`
+
+### Recall Modes
+
+How the agent accesses Honcho memory:
+
+| Mode | Auto-inject context? | Tools available? | Use case |
+|------|---------------------|-----------------|----------|
+| `hybrid` (default) | Yes | Yes | Agent decides when to use tools vs auto context |
+| `context` | Yes | No (hidden) | Minimal token cost, no tool calls |
+| `tools` | No | Yes | Agent controls all memory access explicitly |
+
+## Multi-Profile Setup
+
+Each Hermes profile gets its own Honcho AI peer while sharing the same workspace (user context). This means:
+
+- All profiles see the same user representation
+- Each profile builds its own AI identity and observations
+- Conclusions written by one profile are visible to others via the shared workspace
+
+### Create a profile with Honcho peer
+
+```bash
+hermes profile create coder --clone
+# creates host block hermes.coder, AI peer "coder", inherits config from default
+```
+
+What `--clone` does for Honcho:
+1. Creates a `hermes.coder` host block in `honcho.json`
+2. Sets `aiPeer: "coder"` (the profile name)
+3. Inherits `workspace`, `peerName`, `writeFrequency`, `recallMode`, etc. from default
+4. Eagerly creates the peer in Honcho so it exists before first message
+
+### Backfill existing profiles
+
+```bash
+hermes honcho sync    # creates host blocks for all profiles that don't have one yet
+```
+
+### Per-profile config
+
+Override any setting in the host block:
+
+```json
+{
+  "hosts": {
+    "hermes.coder": {
+      "aiPeer": "coder",
+      "recallMode": "tools",
+      "observation": {
+        "user": { "observeMe": true, "observeOthers": false },
+        "ai": { "observeMe": true, "observeOthers": true }
+      }
+    }
+  }
+}
+```
+
+## Tools
+
+The agent has 4 Honcho tools (hidden in `context` recall mode):
+
+### `honcho_profile`
+Quick factual snapshot of the user -- name, role, preferences, patterns. No LLM call, minimal cost. Use at conversation start or for fast lookups.
+
+### `honcho_search`
+Semantic search over stored context. Returns raw excerpts ranked by relevance, no LLM synthesis. Default 800 tokens, max 2000. Use when you want specific past facts to reason over yourself.
+
+### `honcho_context`
+Natural language question answered by Honcho's dialectic reasoning (LLM call on Honcho's backend). Higher cost, higher quality. Can query about user (default) or the AI peer.
+
+### `honcho_conclude`
+Write a persistent fact about the user. Conclusions build the user's profile over time. Use when the user states a preference, corrects you, or shares something to remember.
+
+## Config Reference
+
+Config file: `$HERMES_HOME/honcho.json` (profile-local) or `~/.honcho/config.json` (global).
+
+### Key settings
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `apiKey` | -- | API key ([get one](https://app.honcho.dev)) |
+| `baseUrl` | -- | Base URL for self-hosted Honcho |
+| `peerName` | -- | User peer identity |
+| `aiPeer` | host key | AI peer identity |
+| `workspace` | host key | Shared workspace ID |
+| `recallMode` | `hybrid` | `hybrid`, `context`, or `tools` |
+| `observation` | all on | Per-peer `observeMe`/`observeOthers` booleans |
+| `writeFrequency` | `async` | `async`, `turn`, `session`, or integer N |
+| `sessionStrategy` | `per-directory` | `per-directory`, `per-repo`, `per-session`, `global` |
+| `dialecticReasoningLevel` | `low` | `minimal`, `low`, `medium`, `high`, `max` |
+| `messageMaxChars` | `25000` | Max chars per message (chunked if exceeded) |
+| `dialecticMaxInputChars` | `10000` | Max chars for dialectic query input |
+
+### Cost-awareness (advanced, root config only)
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `injectionFrequency` | `every-turn` | `every-turn` or `first-turn` |
+| `contextCadence` | `1` | Min turns between context API calls |
+| `dialecticCadence` | `1` | Min turns between dialectic API calls |
+
+## Troubleshooting
+
+### "Honcho not configured"
+Run `hermes honcho setup`. Ensure `memory.provider: honcho` is in `~/.hermes/config.yaml`.
+
+### Memory not persisting across sessions
+Check `hermes honcho status` -- verify `saveMessages: true` and `writeFrequency` isn't `session` (which only writes on exit).
+
+### Profile not getting its own peer
+Use `--clone` when creating: `hermes profile create <name> --clone`. For existing profiles: `hermes honcho sync`.
+
+### Observation changes in dashboard not reflected
+Observation config is synced from the server on each session init. Start a new session after changing settings in the Honcho UI.
+
+### Messages truncated
+Messages over `messageMaxChars` (default 25k) are automatically chunked with `[continued]` markers. If you're hitting this often, check if tool results or skill content is inflating message size.
+
+## CLI Commands
+
+```
+hermes honcho setup          # full interactive wizard
+hermes honcho status         # show resolved config
+hermes honcho enable/disable # toggle for active profile
+hermes honcho peer           # update peer names
+hermes honcho tokens         # tune context/dialectic budgets
+hermes honcho map <name>     # map cwd to session name
+hermes honcho sync           # create host blocks for all profiles
+hermes honcho mode           # change recall/observation mode
+```

--- a/plugins/memory/honcho/README.md
+++ b/plugins/memory/honcho/README.md
@@ -2,15 +2,18 @@
 
 AI-native cross-session user modeling with dialectic Q&A, semantic search, peer cards, and persistent conclusions.
 
+> **Honcho docs:** <https://docs.honcho.dev/v3/guides/integrations/hermes>
+
 ## Requirements
 
 - `pip install honcho-ai`
-- Honcho API key from [app.honcho.dev](https://app.honcho.dev)
+- Honcho API key from [app.honcho.dev](https://app.honcho.dev), or a self-hosted instance
 
 ## Setup
 
 ```bash
-hermes memory setup    # select "honcho"
+hermes honcho setup    # full interactive wizard (cloud or local)
+hermes memory setup    # generic picker, also works
 ```
 
 Or manually:
@@ -19,17 +22,186 @@ hermes config set memory.provider honcho
 echo "HONCHO_API_KEY=your-key" >> ~/.hermes/.env
 ```
 
-## Config
+## Config Resolution
 
-Config file: `$HERMES_HOME/honcho.json` (or `~/.honcho/config.json` legacy)
+Config is read from the first file that exists:
 
-Existing Honcho users: your config and data are preserved. Just set `memory.provider: honcho`.
+| Priority | Path | Scope |
+|----------|------|-------|
+| 1 | `$HERMES_HOME/honcho.json` | Profile-local (isolated Hermes instances) |
+| 2 | `~/.hermes/honcho.json` | Default profile (shared host blocks) |
+| 3 | `~/.honcho/config.json` | Global (cross-app interop) |
+
+Host key is derived from the active Hermes profile: `hermes` (default) or `hermes.<profile>`.
 
 ## Tools
 
-| Tool | Description |
-|------|-------------|
-| `honcho_profile` | User's peer card — key facts, no LLM |
-| `honcho_search` | Semantic search over stored context |
-| `honcho_context` | LLM-synthesized answer from memory |
-| `honcho_conclude` | Write a fact about the user to memory |
+| Tool | LLM call? | Description |
+|------|-----------|-------------|
+| `honcho_profile` | No | User's peer card -- key facts snapshot |
+| `honcho_search` | No | Semantic search over stored context (800 tok default, 2000 max) |
+| `honcho_context` | Yes | LLM-synthesized answer via dialectic reasoning |
+| `honcho_conclude` | No | Write a persistent fact about the user |
+
+Tool availability depends on `recallMode`: hidden in `context` mode, always present in `tools` and `hybrid`.
+
+## Full Configuration Reference
+
+### Identity & Connection
+
+| Key | Type | Default | Scope | Description |
+|-----|------|---------|-------|-------------|
+| `apiKey` | string | -- | root / host | API key. Falls back to `HONCHO_API_KEY` env var |
+| `baseUrl` | string | -- | root | Base URL for self-hosted Honcho. Local URLs (`localhost`, `127.0.0.1`, `::1`) auto-skip API key auth |
+| `environment` | string | `"production"` | root / host | SDK environment mapping |
+| `enabled` | bool | auto | root / host | Master toggle. Auto-enables when `apiKey` or `baseUrl` present |
+| `workspace` | string | host key | root / host | Honcho workspace ID |
+| `peerName` | string | -- | root / host | User peer identity |
+| `aiPeer` | string | host key | root / host | AI peer identity |
+| `linkedHosts` | array | `[]` | host only | Host keys to link for cross-workspace observation |
+
+### Memory & Recall
+
+| Key | Type | Default | Scope | Description |
+|-----|------|---------|-------|-------------|
+| `memoryMode` | string or object | `"hybrid"` | root / host | `"hybrid"` (Honcho + built-in) or per-peer object: `{"default": "hybrid", "hermes": "honcho"}` |
+| `recallMode` | string | `"hybrid"` | root / host | `"hybrid"` (auto-inject + tools), `"context"` (auto-inject only, tools hidden), `"tools"` (tools only, no injection). Legacy `"auto"` normalizes to `"hybrid"` |
+| `observationMode` | string | `"directional"` | root / host | Shorthand preset: `"directional"` (all on) or `"unified"` (shared pool). Use `observation` object for granular control |
+| `observation` | object | -- | root / host | Per-peer observation config (see below) |
+
+#### Observation (granular)
+
+Maps 1:1 to Honcho's per-peer `SessionPeerConfig`. When present, overrides `observationMode` preset.
+
+```json
+"observation": {
+  "user": { "observeMe": true, "observeOthers": true },
+  "ai":   { "observeMe": true, "observeOthers": true }
+}
+```
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `user.observeMe` | `true` | User peer self-observation (Honcho builds user representation) |
+| `user.observeOthers` | `true` | User peer observes AI messages |
+| `ai.observeMe` | `true` | AI peer self-observation (Honcho builds AI representation) |
+| `ai.observeOthers` | `true` | AI peer observes user messages (enables cross-peer dialectic) |
+
+Presets for `observationMode`:
+- `"directional"` (default): all four booleans `true`
+- `"unified"`: user `observeMe=true`, AI `observeOthers=true`, rest `false`
+
+### Write Behavior
+
+| Key | Type | Default | Scope | Description |
+|-----|------|---------|-------|-------------|
+| `writeFrequency` | string or int | `"async"` | root / host | `"async"` (background thread), `"turn"` (sync per turn), `"session"` (batch on end), or integer N (every N turns) |
+| `saveMessages` | bool | `true` | root / host | Whether to persist messages to Honcho API |
+
+### Session Resolution
+
+| Key | Type | Default | Scope | Description |
+|-----|------|---------|-------|-------------|
+| `sessionStrategy` | string | `"per-directory"` | root / host | `"per-directory"`, `"per-session"` (new each run), `"per-repo"` (git root name), `"global"` (single session) |
+| `sessionPeerPrefix` | bool | `false` | root / host | Prepend peer name to session keys |
+| `sessions` | object | `{}` | root | Manual directory-to-session-name mappings: `{"/path/to/project": "my-session"}` |
+
+### Token Budgets & Dialectic
+
+| Key | Type | Default | Scope | Description |
+|-----|------|---------|-------|-------------|
+| `contextTokens` | int | SDK default | root / host | Token budget for `context()` API calls. Also gates prefetch truncation (tokens x 4 chars) |
+| `dialecticReasoningLevel` | string | `"low"` | root / host | Default reasoning level for `peer.chat()`: `"minimal"`, `"low"`, `"medium"`, `"high"`, `"max"`. Auto-bumped for longer queries (120+ chars: +1 level, 400+ chars: +2 levels, capped at `"high"`) |
+| `dialecticMaxChars` | int | `600` | root / host | Max chars of dialectic result injected into system prompt |
+| `dialecticMaxInputChars` | int | `10000` | root / host | Max chars for dialectic query input to `peer.chat()`. Honcho cloud limit: 10k |
+| `messageMaxChars` | int | `25000` | root / host | Max chars per message sent via `add_messages()`. Messages exceeding this are chunked with `[continued]` markers. Honcho cloud limit: 25k |
+
+### Cost Awareness (Advanced)
+
+These are read from the root config object, not the host block. Must be set manually in `honcho.json`.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `injectionFrequency` | string | `"every-turn"` | `"every-turn"` or `"first-turn"` (inject context only on turn 0) |
+| `contextCadence` | int | `1` | Minimum turns between `context()` API calls |
+| `dialecticCadence` | int | `1` | Minimum turns between `peer.chat()` API calls |
+| `reasoningLevelCap` | string | -- | Hard cap on auto-bumped reasoning: `"minimal"`, `"low"`, `"mid"`, `"high"` |
+
+### Hardcoded Limits (Not Configurable)
+
+| Limit | Value | Location |
+|-------|-------|----------|
+| Search tool max tokens | 2000 (hard cap), 800 (default) | `__init__.py` handle_tool_call |
+| Peer card fetch tokens | 200 | `session.py` get_peer_card |
+
+## Config Precedence
+
+For every key, resolution order is: **host block > root > env var > default**.
+
+Host key derivation: `HERMES_HONCHO_HOST` env > active profile (`hermes.<profile>`) > `"hermes"`.
+
+## Environment Variables
+
+| Variable | Fallback for |
+|----------|-------------|
+| `HONCHO_API_KEY` | `apiKey` |
+| `HONCHO_BASE_URL` | `baseUrl` |
+| `HONCHO_ENVIRONMENT` | `environment` |
+| `HERMES_HONCHO_HOST` | Host key override |
+
+## CLI Commands
+
+| Command | Description |
+|---------|-------------|
+| `hermes honcho setup` | Full interactive setup wizard |
+| `hermes honcho status` | Show resolved config for active profile |
+| `hermes honcho enable` / `disable` | Toggle Honcho for active profile |
+| `hermes honcho mode <mode>` | Change recall or observation mode |
+| `hermes honcho peer --user <name>` | Update user peer name |
+| `hermes honcho peer --ai <name>` | Update AI peer name |
+| `hermes honcho tokens --context <N>` | Set context token budget |
+| `hermes honcho tokens --dialectic <N>` | Set dialectic max chars |
+| `hermes honcho map <name>` | Map current directory to a session name |
+| `hermes honcho sync` | Create host blocks for all Hermes profiles |
+
+## Example Config
+
+```json
+{
+  "apiKey": "your-key",
+  "workspace": "hermes",
+  "peerName": "eri",
+  "hosts": {
+    "hermes": {
+      "enabled": true,
+      "aiPeer": "hermes",
+      "workspace": "hermes",
+      "peerName": "eri",
+      "memoryMode": "hybrid",
+      "recallMode": "hybrid",
+      "observation": {
+        "user": { "observeMe": true, "observeOthers": true },
+        "ai": { "observeMe": true, "observeOthers": true }
+      },
+      "writeFrequency": "async",
+      "sessionStrategy": "per-directory",
+      "dialecticReasoningLevel": "low",
+      "dialecticMaxChars": 600,
+      "saveMessages": true
+    },
+    "hermes.coder": {
+      "enabled": true,
+      "aiPeer": "coder",
+      "workspace": "hermes",
+      "peerName": "eri",
+      "observation": {
+        "user": { "observeMe": true, "observeOthers": false },
+        "ai": { "observeMe": true, "observeOthers": true }
+      }
+    }
+  },
+  "sessions": {
+    "/home/user/myproject": "myproject-main"
+  }
+}
+```

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -187,8 +187,14 @@ class HonchoMemoryProvider(MemoryProvider):
     def get_config_schema(self):
         return [
             {"key": "api_key", "description": "Honcho API key", "secret": True, "env_var": "HONCHO_API_KEY", "url": "https://app.honcho.dev"},
-            {"key": "base_url", "description": "Honcho base URL", "default": "https://api.honcho.dev"},
+            {"key": "baseUrl", "description": "Honcho base URL (for self-hosted)"},
         ]
+
+    def post_setup(self, hermes_home: str, config: dict) -> None:
+        """Run the full Honcho setup wizard after provider selection."""
+        import types
+        from plugins.memory.honcho.cli import cmd_setup
+        cmd_setup(types.SimpleNamespace())
 
     def initialize(self, session_id: str, **kwargs) -> None:
         """Initialize Honcho session manager.
@@ -233,36 +239,10 @@ class HonchoMemoryProvider(MemoryProvider):
             except Exception as e:
                 logger.debug("Honcho cost-awareness config parse error: %s", e)
 
-            # ----- Port #1969: aiPeer sync from SOUL.md -----
-            try:
-                hermes_home = kwargs.get("hermes_home", "")
-                if hermes_home and not cfg.raw.get("aiPeer"):
-                    soul_path = Path(hermes_home) / "SOUL.md"
-                    if soul_path.exists():
-                        soul_text = soul_path.read_text(encoding="utf-8").strip()
-                        if soul_text:
-                            # Try YAML frontmatter: "name: Foo"
-                            first_line = soul_text.split("\n")[0].strip()
-                            if first_line.startswith("---"):
-                                # Look for name: in frontmatter
-                                for line in soul_text.split("\n")[1:]:
-                                    line = line.strip()
-                                    if line == "---":
-                                        break
-                                    if line.lower().startswith("name:"):
-                                        name_val = line.split(":", 1)[1].strip().strip("\"'")
-                                        if name_val:
-                                            cfg.ai_peer = name_val
-                                            logger.debug("Honcho ai_peer set from SOUL.md: %s", name_val)
-                                        break
-                            elif first_line.startswith("# "):
-                                # Markdown heading: "# AgentName"
-                                name_val = first_line[2:].strip()
-                                if name_val:
-                                    cfg.ai_peer = name_val
-                                    logger.debug("Honcho ai_peer set from SOUL.md heading: %s", name_val)
-            except Exception as e:
-                logger.debug("Honcho SOUL.md ai_peer sync failed: %s", e)
+            # ----- Port #1969: aiPeer sync from SOUL.md — REMOVED -----
+            # SOUL.md is persona content, not identity config. aiPeer should
+            # only come from honcho.json (host block or root) or the default.
+            # See scratch/memory-plugin-ux-specs.md #10 for rationale.
 
             # ----- B2: peer_memory_mode gating (stub) -----
             try:
@@ -547,19 +527,72 @@ class HonchoMemoryProvider(MemoryProvider):
         """Track turn count for cadence and injection_frequency logic."""
         self._turn_count = turn_number
 
+    @staticmethod
+    def _chunk_message(content: str, limit: int) -> list[str]:
+        """Split content into chunks that fit within the Honcho message limit.
+
+        Splits at paragraph boundaries when possible, falling back to
+        sentence boundaries, then word boundaries. Each continuation
+        chunk is prefixed with "[continued] " so Honcho's representation
+        engine can reconstruct the full message.
+        """
+        if len(content) <= limit:
+            return [content]
+
+        prefix = "[continued] "
+        prefix_len = len(prefix)
+        chunks = []
+        remaining = content
+        first = True
+        while remaining:
+            budget = limit if first else limit - prefix_len
+            if len(remaining) <= budget:
+                chunks.append(remaining if first else prefix + remaining)
+                break
+
+            effective_limit = limit if first else limit - prefix_len
+            segment = remaining[:effective_limit]
+
+            # Try paragraph break, then sentence, then word
+            cut = segment.rfind("\n\n")
+            if cut < effective_limit * 0.3:
+                cut = segment.rfind(". ")
+                if cut >= 0:
+                    cut += 2  # include the period and space
+            if cut < effective_limit * 0.3:
+                cut = segment.rfind(" ")
+            if cut < effective_limit * 0.3:
+                cut = effective_limit  # hard cut
+
+            chunk = remaining[:cut].rstrip()
+            remaining = remaining[cut:].lstrip()
+            if not first:
+                chunk = prefix + chunk
+            chunks.append(chunk)
+            first = False
+
+        return chunks
+
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
-        """Record the conversation turn in Honcho (non-blocking)."""
+        """Record the conversation turn in Honcho (non-blocking).
+
+        Messages exceeding the Honcho API limit (default 25k chars) are
+        split into multiple messages with continuation markers.
+        """
         if self._cron_skipped:
             return
         if not self._manager or not self._session_key:
             return
 
+        msg_limit = self._config.message_max_chars if self._config else 25000
+
         def _sync():
             try:
                 session = self._manager.get_or_create(self._session_key)
-                session.add_message("user", user_content[:4000])
-                session.add_message("assistant", assistant_content[:4000])
-                # Flush to Honcho API
+                for chunk in self._chunk_message(user_content, msg_limit):
+                    session.add_message("user", chunk)
+                for chunk in self._chunk_message(assistant_content, msg_limit):
+                    session.add_message("assistant", chunk)
                 self._manager._flush_session(session)
             except Exception as e:
                 logger.debug("Honcho sync_turn failed: %s", e)

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -337,91 +337,137 @@ def cmd_setup(args) -> None:
     if not _ensure_sdk_installed():
         return
 
-    # All writes go to the active host block — root keys are managed by
-    # the user or the honcho CLI only.
     hosts = cfg.setdefault("hosts", {})
     hermes_host = hosts.setdefault(_host_key(), {})
 
-    # API key — shared credential, lives at root so all hosts can read it
-    current_key = cfg.get("apiKey", "")
-    masked = f"...{current_key[-8:]}" if len(current_key) > 8 else ("set" if current_key else "not set")
-    print(f"  Current API key: {masked}")
-    new_key = _prompt("Honcho API key (leave blank to keep current)", secret=True)
-    if new_key:
-        cfg["apiKey"] = new_key
+    # --- 1. Cloud or local? ---
+    print("  Deployment:")
+    print("    cloud -- Honcho cloud (api.honcho.dev)")
+    print("    local -- self-hosted Honcho server")
+    current_deploy = "local" if any(
+        h in (cfg.get("baseUrl") or cfg.get("base_url") or "")
+        for h in ("localhost", "127.0.0.1", "::1")
+    ) else "cloud"
+    deploy = _prompt("Cloud or local?", default=current_deploy)
+    is_local = deploy.lower() in ("local", "l")
 
-    effective_key = cfg.get("apiKey", "")
-    if not effective_key:
-        print("\n  No API key configured. Get your API key at https://app.honcho.dev")
-        print("  Run 'hermes honcho setup' again once you have a key.\n")
-        return
+    # Clean up legacy snake_case key
+    cfg.pop("base_url", None)
 
-    # Peer name
+    if is_local:
+        # --- Local: ask for base URL, skip or clear API key ---
+        current_url = cfg.get("baseUrl") or ""
+        new_url = _prompt("Base URL", default=current_url or "http://localhost:8000")
+        if new_url:
+            cfg["baseUrl"] = new_url
+
+        # For local no-auth, the SDK must not send an API key.
+        # We keep the key in config (for cloud switching later) but
+        # the client should skip auth when baseUrl is local.
+        current_key = cfg.get("apiKey", "")
+        if current_key:
+            print(f"\n  API key present in config (kept for cloud/hybrid use).")
+            print("  Local connections will skip auth automatically.")
+        else:
+            print("\n  No API key set. Local no-auth ready.")
+    else:
+        # --- Cloud: set default base URL, require API key ---
+        cfg.pop("baseUrl", None)  # cloud uses SDK default
+
+        current_key = cfg.get("apiKey", "")
+        masked = f"...{current_key[-8:]}" if len(current_key) > 8 else ("set" if current_key else "not set")
+        print(f"\n  Current API key: {masked}")
+        new_key = _prompt("Honcho API key (leave blank to keep current)", secret=True)
+        if new_key:
+            cfg["apiKey"] = new_key
+
+        if not cfg.get("apiKey"):
+            print("\n  No API key configured. Get yours at https://app.honcho.dev")
+            print("  Run 'hermes honcho setup' again once you have a key.\n")
+            return
+
+    # --- 3. Identity ---
     current_peer = hermes_host.get("peerName") or cfg.get("peerName", "")
     new_peer = _prompt("Your name (user peer)", default=current_peer or os.getenv("USER", "user"))
     if new_peer:
         hermes_host["peerName"] = new_peer
+
+    current_ai = hermes_host.get("aiPeer") or cfg.get("aiPeer", "hermes")
+    new_ai = _prompt("AI peer name", default=current_ai)
+    if new_ai:
+        hermes_host["aiPeer"] = new_ai
 
     current_workspace = hermes_host.get("workspace") or cfg.get("workspace", "hermes")
     new_workspace = _prompt("Workspace ID", default=current_workspace)
     if new_workspace:
         hermes_host["workspace"] = new_workspace
 
-    hermes_host.setdefault("aiPeer", _host_key())
-
-    # Memory mode
-    current_mode = hermes_host.get("memoryMode") or cfg.get("memoryMode", "hybrid")
-    print("\n  Memory mode options:")
-    print("    hybrid  — write to both Honcho and local MEMORY.md (default)")
-    print("    honcho  — Honcho only, skip MEMORY.md writes")
-    new_mode = _prompt("Memory mode", default=current_mode)
-    if new_mode in ("hybrid", "honcho"):
-        hermes_host["memoryMode"] = new_mode
+    # --- 4. Observation mode ---
+    current_obs = hermes_host.get("observationMode") or cfg.get("observationMode", "directional")
+    print("\n  Observation mode:")
+    print("    directional  -- all observations on, each AI peer builds its own view (default)")
+    print("    unified      -- shared pool, user observes self, AI observes others only")
+    new_obs = _prompt("Observation mode", default=current_obs)
+    if new_obs in ("unified", "directional"):
+        hermes_host["observationMode"] = new_obs
     else:
-        hermes_host["memoryMode"] = "hybrid"
+        hermes_host["observationMode"] = "directional"
 
-    # Write frequency
+    # --- 5. Write frequency ---
     current_wf = str(hermes_host.get("writeFrequency") or cfg.get("writeFrequency", "async"))
-    print("\n  Write frequency options:")
-    print("    async   — background thread, no token cost (recommended)")
-    print("    turn    — sync write after every turn")
-    print("    session — batch write at session end only")
-    print("    N       — write every N turns (e.g. 5)")
+    print("\n  Write frequency:")
+    print("    async   -- background thread, no token cost (recommended)")
+    print("    turn    -- sync write after every turn")
+    print("    session -- batch write at session end only")
+    print("    N       -- write every N turns (e.g. 5)")
     new_wf = _prompt("Write frequency", default=current_wf)
     try:
         hermes_host["writeFrequency"] = int(new_wf)
     except (ValueError, TypeError):
         hermes_host["writeFrequency"] = new_wf if new_wf in ("async", "turn", "session") else "async"
 
-    # Recall mode
+    # --- 6. Recall mode ---
     _raw_recall = hermes_host.get("recallMode") or cfg.get("recallMode", "hybrid")
     current_recall = "hybrid" if _raw_recall not in ("hybrid", "context", "tools") else _raw_recall
-    print("\n  Recall mode options:")
-    print("    hybrid  — auto-injected context + Honcho tools available (default)")
-    print("    context — auto-injected context only, Honcho tools hidden")
-    print("    tools   — Honcho tools only, no auto-injected context")
+    print("\n  Recall mode:")
+    print("    hybrid  -- auto-injected context + Honcho tools available (default)")
+    print("    context -- auto-injected context only, Honcho tools hidden")
+    print("    tools   -- Honcho tools only, no auto-injected context")
     new_recall = _prompt("Recall mode", default=current_recall)
     if new_recall in ("hybrid", "context", "tools"):
         hermes_host["recallMode"] = new_recall
 
-    # Session strategy
+    # --- 7. Session strategy ---
     current_strat = hermes_host.get("sessionStrategy") or cfg.get("sessionStrategy", "per-directory")
-    print("\n  Session strategy options:")
-    print("    per-directory — one session per working directory (default)")
-    print("    per-session   — new Honcho session each run, named by Hermes session ID")
-    print("    per-repo      — one session per git repository (uses repo root name)")
-    print("    global        — single session across all directories")
+    print("\n  Session strategy:")
+    print("    per-directory -- one session per working directory (default)")
+    print("    per-session   -- new Honcho session each run")
+    print("    per-repo      -- one session per git repository")
+    print("    global        -- single session across all directories")
     new_strat = _prompt("Session strategy", default=current_strat)
     if new_strat in ("per-session", "per-repo", "per-directory", "global"):
         hermes_host["sessionStrategy"] = new_strat
 
-    hermes_host.setdefault("enabled", True)
+    # Memory mode is always hybrid (built-in + Honcho run together)
+    hermes_host["memoryMode"] = "hybrid"
+    hermes_host["enabled"] = True
     hermes_host.setdefault("saveMessages", True)
 
     _write_config(cfg)
     print(f"\n  Config written to {write_path}")
 
-    # Test connection
+    # --- Auto-enable Honcho as memory provider in config.yaml ---
+    try:
+        from hermes_cli.config import load_config, save_config
+        hermes_config = load_config()
+        hermes_config.setdefault("memory", {})["provider"] = "honcho"
+        save_config(hermes_config)
+        print("  Memory provider set to 'honcho' in config.yaml")
+    except Exception as e:
+        print(f"  Could not auto-enable in config.yaml: {e}")
+        print("  Run: hermes config set memory.provider honcho")
+
+    # --- Test connection ---
     print("  Testing connection... ", end="", flush=True)
     try:
         from plugins.memory.honcho.client import HonchoClientConfig, get_honcho_client, reset_honcho_client
@@ -436,24 +482,23 @@ def cmd_setup(args) -> None:
     print("\n  Honcho is ready.")
     print(f"  Session:   {hcfg.resolve_session_name()}")
     print(f"  Workspace: {hcfg.workspace_id}")
-    print(f"  Peer:      {hcfg.peer_name}")
-    _mode_str = hcfg.memory_mode
-    if hcfg.peer_memory_modes:
-        overrides = ", ".join(f"{k}={v}" for k, v in hcfg.peer_memory_modes.items())
-        _mode_str = f"{hcfg.memory_mode}  (peers: {overrides})"
-    print(f"  Mode:      {_mode_str}")
+    print(f"  User:      {hcfg.peer_name}")
+    print(f"  AI peer:   {hcfg.ai_peer}")
+    print(f"  Observe:   {hcfg.observation_mode}")
     print(f"  Frequency: {hcfg.write_frequency}")
+    print(f"  Recall:    {hcfg.recall_mode}")
+    print(f"  Sessions:  {hcfg.session_strategy}")
     print("\n  Honcho tools available in chat:")
-    print("    honcho_context  — ask Honcho a question about you (LLM-synthesized)")
-    print("    honcho_search       — semantic search over your history (no LLM)")
-    print("    honcho_profile      — your peer card, key facts (no LLM)")
-    print("    honcho_conclude     — persist a user fact to Honcho memory (no LLM)")
+    print("    honcho_context   -- ask Honcho about the user (LLM-synthesized)")
+    print("    honcho_search    -- semantic search over history (no LLM)")
+    print("    honcho_profile   -- peer card, key facts (no LLM)")
+    print("    honcho_conclude  -- persist a user fact to memory (no LLM)")
     print("\n  Other commands:")
-    print("    hermes honcho status     — show full config")
-    print("    hermes honcho mode       — show or change memory mode")
-    print("    hermes honcho tokens     — show or set token budgets")
-    print("    hermes honcho identity   — seed or show AI peer identity")
-    print("    hermes honcho map <name> — map this directory to a session name\n")
+    print("    hermes honcho status     -- show full config")
+    print("    hermes honcho mode       -- change recall/observation mode")
+    print("    hermes honcho tokens     -- tune context and dialectic budgets")
+    print("    hermes honcho peer       -- update peer names")
+    print("    hermes honcho map <name> -- map this directory to a session name\n")
 
 
 def _active_profile_name() -> str:

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -92,7 +92,49 @@ _OBSERVATION_MODE_ALIASES = {"shared": "unified", "separate": "directional", "cr
 def _normalize_observation_mode(val: str) -> str:
     """Normalize observation mode values."""
     val = _OBSERVATION_MODE_ALIASES.get(val, val)
-    return val if val in _VALID_OBSERVATION_MODES else "unified"
+    return val if val in _VALID_OBSERVATION_MODES else "directional"
+
+
+# Observation presets — granular booleans derived from legacy string mode.
+# Explicit per-peer config always wins over presets.
+_OBSERVATION_PRESETS = {
+    "directional": {
+        "user_observe_me": True, "user_observe_others": True,
+        "ai_observe_me": True, "ai_observe_others": True,
+    },
+    "unified": {
+        "user_observe_me": True, "user_observe_others": False,
+        "ai_observe_me": False, "ai_observe_others": True,
+    },
+}
+
+
+def _resolve_observation(
+    mode: str,
+    observation_obj: dict | None,
+) -> dict:
+    """Resolve per-peer observation booleans.
+
+    Config forms:
+      String shorthand:  ``"observationMode": "directional"``
+      Granular object:   ``"observation": {"user": {"observeMe": true, "observeOthers": true},
+                                           "ai": {"observeMe": true, "observeOthers": false}}``
+
+    Granular fields override preset defaults.
+    """
+    preset = _OBSERVATION_PRESETS.get(mode, _OBSERVATION_PRESETS["directional"])
+    if not observation_obj or not isinstance(observation_obj, dict):
+        return dict(preset)
+
+    user_block = observation_obj.get("user") or {}
+    ai_block = observation_obj.get("ai") or {}
+
+    return {
+        "user_observe_me": user_block.get("observeMe", preset["user_observe_me"]),
+        "user_observe_others": user_block.get("observeOthers", preset["user_observe_others"]),
+        "ai_observe_me": ai_block.get("observeMe", preset["ai_observe_me"]),
+        "ai_observe_others": ai_block.get("observeOthers", preset["ai_observe_others"]),
+    }
 
 
 def _resolve_memory_mode(
@@ -159,15 +201,25 @@ class HonchoClientConfig:
     dialectic_reasoning_level: str = "low"
     # Max chars of dialectic result to inject into Hermes system prompt
     dialectic_max_chars: int = 600
+    # Honcho API limits — configurable for self-hosted instances
+    # Max chars per message sent via add_messages() (Honcho cloud: 25000)
+    message_max_chars: int = 25000
+    # Max chars for dialectic query input to peer.chat() (Honcho cloud: 10000)
+    dialectic_max_input_chars: int = 10000
     # Recall mode: how memory retrieval works when Honcho is active.
     # "hybrid"  — auto-injected context + Honcho tools available (model decides)
     # "context" — auto-injected context only, Honcho tools removed
     # "tools"   — Honcho tools only, no auto-injected context
     recall_mode: str = "hybrid"
-    # Observation mode: how Honcho peers observe each other.
-    # "unified"      — user peer observes self; all agents share one observation pool
-    # "directional"  — AI peer observes user; each agent keeps its own view
-    observation_mode: str = "unified"
+    # Observation mode: legacy string shorthand ("directional" or "unified").
+    # Kept for backward compat; granular per-peer booleans below are preferred.
+    observation_mode: str = "directional"
+    # Per-peer observation booleans — maps 1:1 to Honcho's SessionPeerConfig.
+    # Resolved from "observation" object in config, falling back to observation_mode preset.
+    user_observe_me: bool = True
+    user_observe_others: bool = True
+    ai_observe_me: bool = True
+    ai_observe_others: bool = True
     # Session resolution
     session_strategy: str = "per-directory"
     session_peer_prefix: bool = False
@@ -253,6 +305,7 @@ class HonchoClientConfig:
 
         base_url = (
             raw.get("baseUrl")
+            or raw.get("base_url")
             or os.environ.get("HONCHO_BASE_URL", "").strip()
             or None
         )
@@ -322,6 +375,16 @@ class HonchoClientConfig:
                 or raw.get("dialecticMaxChars")
                 or 600
             ),
+            message_max_chars=int(
+                host_block.get("messageMaxChars")
+                or raw.get("messageMaxChars")
+                or 25000
+            ),
+            dialectic_max_input_chars=int(
+                host_block.get("dialecticMaxInputChars")
+                or raw.get("dialecticMaxInputChars")
+                or 10000
+            ),
             recall_mode=_normalize_recall_mode(
                 host_block.get("recallMode")
                 or raw.get("recallMode")
@@ -330,7 +393,15 @@ class HonchoClientConfig:
             observation_mode=_normalize_observation_mode(
                 host_block.get("observationMode")
                 or raw.get("observationMode")
-                or "unified"
+                or "directional"
+            ),
+            **_resolve_observation(
+                _normalize_observation_mode(
+                    host_block.get("observationMode")
+                    or raw.get("observationMode")
+                    or "directional"
+                ),
+                host_block.get("observation") or raw.get("observation"),
             ),
             session_strategy=session_strategy,
             session_peer_prefix=session_peer_prefix,
@@ -478,12 +549,22 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
 
     # Local Honcho instances don't require an API key, but the SDK
     # expects a non-empty string.  Use a placeholder for local URLs.
+    # For local: only use config.api_key if the host block explicitly
+    # sets apiKey (meaning the user wants local auth). Otherwise skip
+    # the stored key -- it's likely a cloud key that would break local.
     _is_local = resolved_base_url and (
         "localhost" in resolved_base_url
         or "127.0.0.1" in resolved_base_url
         or "::1" in resolved_base_url
     )
-    effective_api_key = config.api_key or ("local" if _is_local else None)
+    if _is_local:
+        # Check if the host block has its own apiKey (explicit local auth)
+        _raw = config.raw or {}
+        _host_block = (_raw.get("hosts") or {}).get(config.host, {})
+        _host_has_key = bool(_host_block.get("apiKey"))
+        effective_api_key = config.api_key if _host_has_key else "local"
+    else:
+        effective_api_key = config.api_key
 
     kwargs: dict = {
         "workspace_id": config.workspace_id,

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -111,7 +111,18 @@ class HonchoSessionManager:
             config.dialectic_max_chars if config else 600
         )
         self._observation_mode: str = (
-            config.observation_mode if config else "unified"
+            config.observation_mode if config else "directional"
+        )
+        # Per-peer observation booleans (granular, from config)
+        self._user_observe_me: bool = config.user_observe_me if config else True
+        self._user_observe_others: bool = config.user_observe_others if config else True
+        self._ai_observe_me: bool = config.ai_observe_me if config else True
+        self._ai_observe_others: bool = config.ai_observe_others if config else True
+        self._message_max_chars: int = (
+            config.message_max_chars if config else 25000
+        )
+        self._dialectic_max_input_chars: int = (
+            config.dialectic_max_input_chars if config else 10000
         )
 
         # Async write queue — started lazily on first enqueue
@@ -162,20 +173,41 @@ class HonchoSessionManager:
 
         session = self.honcho.session(session_id)
 
-        # Configure peer observation settings based on observation_mode.
-        # Unified: user peer observes self, AI peer passive — all agents share
-        #          one observation pool via user self-observations.
-        # Directional: AI peer observes user — each agent keeps its own view.
+        # Configure per-peer observation from granular booleans.
+        # These map 1:1 to Honcho's SessionPeerConfig toggles.
         try:
             from honcho.session import SessionPeerConfig
-            if self._observation_mode == "directional":
-                user_config = SessionPeerConfig(observe_me=True, observe_others=False)
-                ai_config = SessionPeerConfig(observe_me=False, observe_others=True)
-            else:  # unified (default)
-                user_config = SessionPeerConfig(observe_me=True, observe_others=False)
-                ai_config = SessionPeerConfig(observe_me=False, observe_others=False)
+            user_config = SessionPeerConfig(
+                observe_me=self._user_observe_me,
+                observe_others=self._user_observe_others,
+            )
+            ai_config = SessionPeerConfig(
+                observe_me=self._ai_observe_me,
+                observe_others=self._ai_observe_others,
+            )
 
             session.add_peers([(user_peer, user_config), (assistant_peer, ai_config)])
+
+            # Sync back: server-side config (set via Honcho UI) wins over
+            # local defaults. Read the effective config after add_peers.
+            try:
+                server_user = session.get_peer_configuration(user_peer)
+                server_ai = session.get_peer_configuration(assistant_peer)
+                if server_user.observe_me is not None:
+                    self._user_observe_me = server_user.observe_me
+                if server_user.observe_others is not None:
+                    self._user_observe_others = server_user.observe_others
+                if server_ai.observe_me is not None:
+                    self._ai_observe_me = server_ai.observe_me
+                if server_ai.observe_others is not None:
+                    self._ai_observe_others = server_ai.observe_others
+                logger.debug(
+                    "Honcho observation synced from server: user(me=%s,others=%s) ai(me=%s,others=%s)",
+                    self._user_observe_me, self._user_observe_others,
+                    self._ai_observe_me, self._ai_observe_others,
+                )
+            except Exception as e:
+                logger.debug("Honcho get_peer_configuration failed (using local config): %s", e)
         except Exception as e:
             logger.warning(
                 "Honcho session '%s' add_peers failed (non-fatal): %s",
@@ -501,11 +533,15 @@ class HonchoSessionManager:
         if not session:
             return ""
 
+        # Guard: truncate query to Honcho's dialectic input limit
+        if len(query) > self._dialectic_max_input_chars:
+            query = query[:self._dialectic_max_input_chars].rsplit(" ", 1)[0]
+
         level = reasoning_level or self._dynamic_reasoning_level(query)
 
         try:
-            if self._observation_mode == "directional":
-                # AI peer queries about the user (cross-observation)
+            if self._ai_observe_others:
+                # AI peer can observe user — use cross-observation routing
                 if peer == "ai":
                     ai_peer_obj = self._get_or_create_peer(session.assistant_peer_id)
                     result = ai_peer_obj.chat(query, reasoning_level=level) or ""
@@ -517,7 +553,7 @@ class HonchoSessionManager:
                         reasoning_level=level,
                     ) or ""
             else:
-                # Unified: user peer queries self, or AI peer queries self
+                # AI can't observe others — each peer queries self
                 peer_id = session.assistant_peer_id if peer == "ai" else session.user_peer_id
                 target_peer = self._get_or_create_peer(peer_id)
                 result = target_peer.chat(query, reasoning_level=level) or ""
@@ -919,12 +955,12 @@ class HonchoSessionManager:
             return False
 
         try:
-            if self._observation_mode == "directional":
+            if self._ai_observe_others:
                 # AI peer creates conclusion about user (cross-observation)
                 assistant_peer = self._get_or_create_peer(session.assistant_peer_id)
                 conclusions_scope = assistant_peer.conclusions_of(session.user_peer_id)
             else:
-                # Unified: user peer creates self-conclusion
+                # AI can't observe others — user peer creates self-conclusion
                 user_peer = self._get_or_create_peer(session.user_peer_id)
                 conclusions_scope = user_peer.conclusions_of(session.user_peer_id)
 

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -346,14 +346,22 @@ class TestResolveConfigPath:
     def test_falls_back_to_global_when_no_local(self, tmp_path):
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir()
-        # No honcho.json in HERMES_HOME
+        # No honcho.json in HERMES_HOME — also isolate ~/.hermes so
+        # the default-profile fallback doesn't hit the real filesystem.
+        fake_home = tmp_path / "fakehome"
+        fake_home.mkdir()
 
-        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}), \
+             patch.object(Path, "home", return_value=fake_home):
             result = resolve_config_path()
         assert result == GLOBAL_CONFIG_PATH
 
-    def test_falls_back_to_global_without_hermes_home_env(self):
-        with patch.dict(os.environ, {}, clear=False):
+    def test_falls_back_to_global_without_hermes_home_env(self, tmp_path):
+        fake_home = tmp_path / "fakehome"
+        fake_home.mkdir()
+
+        with patch.dict(os.environ, {}, clear=False), \
+             patch.object(Path, "home", return_value=fake_home):
             os.environ.pop("HERMES_HOME", None)
             result = resolve_config_path()
         assert result == GLOBAL_CONFIG_PATH

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -7,6 +7,7 @@ from plugins.memory.honcho.session import (
     HonchoSession,
     HonchoSessionManager,
 )
+from plugins.memory.honcho import HonchoMemoryProvider
 
 
 # ---------------------------------------------------------------------------
@@ -187,3 +188,96 @@ class TestManagerCacheOps:
         assert keys == {"k1", "k2"}
         s1_info = next(s for s in sessions if s["key"] == "k1")
         assert s1_info["message_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Message chunking
+# ---------------------------------------------------------------------------
+
+
+class TestChunkMessage:
+    def test_short_message_single_chunk(self):
+        result = HonchoMemoryProvider._chunk_message("hello world", 100)
+        assert result == ["hello world"]
+
+    def test_exact_limit_single_chunk(self):
+        msg = "x" * 100
+        result = HonchoMemoryProvider._chunk_message(msg, 100)
+        assert result == [msg]
+
+    def test_splits_at_paragraph_boundary(self):
+        msg = "first paragraph.\n\nsecond paragraph."
+        # limit=30: total is 35, forces split; second chunk with prefix is 29, fits
+        result = HonchoMemoryProvider._chunk_message(msg, 30)
+        assert len(result) == 2
+        assert result[0] == "first paragraph."
+        assert result[1] == "[continued] second paragraph."
+
+    def test_splits_at_sentence_boundary(self):
+        msg = "First sentence. Second sentence. Third sentence is here."
+        result = HonchoMemoryProvider._chunk_message(msg, 35)
+        assert len(result) >= 2
+        # First chunk should end at a sentence boundary (rstripped)
+        assert result[0].rstrip().endswith(".")
+
+    def test_splits_at_word_boundary(self):
+        msg = "word " * 20  # 100 chars
+        result = HonchoMemoryProvider._chunk_message(msg, 30)
+        assert len(result) >= 2
+        # No words should be split mid-word
+        for chunk in result:
+            clean = chunk.replace("[continued] ", "")
+            assert not clean.startswith(" ")
+
+    def test_continuation_prefix(self):
+        msg = "a" * 200
+        result = HonchoMemoryProvider._chunk_message(msg, 50)
+        assert len(result) >= 2
+        assert not result[0].startswith("[continued]")
+        for chunk in result[1:]:
+            assert chunk.startswith("[continued] ")
+
+    def test_empty_message(self):
+        result = HonchoMemoryProvider._chunk_message("", 100)
+        assert result == [""]
+
+    def test_large_message_many_chunks(self):
+        msg = "word " * 10000  # 50k chars
+        result = HonchoMemoryProvider._chunk_message(msg, 25000)
+        assert len(result) >= 2
+        for chunk in result:
+            assert len(chunk) <= 25000
+
+
+# ---------------------------------------------------------------------------
+# Dialectic input guard
+# ---------------------------------------------------------------------------
+
+
+class TestDialecticInputGuard:
+    def test_long_query_truncated(self):
+        """Queries exceeding dialectic_max_input_chars are truncated."""
+        from plugins.memory.honcho.client import HonchoClientConfig
+
+        cfg = HonchoClientConfig(dialectic_max_input_chars=100)
+        mgr = HonchoSessionManager(config=cfg)
+        mgr._dialectic_max_input_chars = 100
+
+        # Create a cached session so dialectic_query doesn't bail early
+        session = HonchoSession(
+            key="test", user_peer_id="u", assistant_peer_id="a",
+            honcho_session_id="s",
+        )
+        mgr._cache["test"] = session
+
+        # Mock the peer to capture the query
+        mock_peer = MagicMock()
+        mock_peer.chat.return_value = "answer"
+        mgr._get_or_create_peer = MagicMock(return_value=mock_peer)
+
+        long_query = "word " * 100  # 500 chars, exceeds 100 limit
+        mgr.dialectic_query("test", long_query)
+
+        # The query passed to chat() should be truncated
+        actual_query = mock_peer.chat.call_args[0][0]
+        assert len(actual_query) <= 100

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -44,26 +44,38 @@ AI-native cross-session user modeling with dialectic Q&A, semantic search, and p
 
 | | |
 |---|---|
-| **Best for** | Teams using Honcho's user modeling platform |
-| **Requires** | `pip install honcho-ai` + API key |
-| **Data storage** | Honcho Cloud |
-| **Cost** | Honcho pricing |
+| **Best for** | Multi-agent systems with cross-session context, user-agent alignment |
+| **Requires** | `pip install honcho-ai` + [API key](https://app.honcho.dev) or self-hosted instance |
+| **Data storage** | Honcho Cloud or self-hosted |
+| **Cost** | Honcho pricing (cloud) / free (self-hosted) |
 
 **Tools:** `honcho_profile` (peer card), `honcho_search` (semantic search), `honcho_context` (LLM-synthesized), `honcho_conclude` (store facts)
 
-**Setup:**
+**Setup Wizard:**
 ```bash
-hermes memory setup    # select "honcho"
-# Or manually:
-hermes config set memory.provider honcho
-echo "HONCHO_API_KEY=your-key" >> ~/.hermes/.env
+hermes honcho setup        # (legacy command) 
+# or
+hermes memory setup        # select "honcho"
 ```
 
-**Config:** `$HERMES_HOME/honcho.json` — existing Honcho users' configuration and data are fully preserved.
+**Config:** `$HERMES_HOME/honcho.json` — see the [config reference](https://github.com/hermes-ai/hermes-agent/blob/main/plugins/memory/honcho/README.md) and the [Honcho integration guide](https://docs.honcho.dev/v3/guides/integrations/hermes).
 
 :::tip Migrating from `hermes honcho`
-If you previously used `hermes honcho setup`, your config and all server-side data are intact. Just set `memory.provider: honcho` to reactivate via the new system.
+If you previously used `hermes honcho setup`, your config and all server-side data are intact. Just re-enable through the setup wizard again or manually set `memory.provider: honcho` to reactivate via the new system.
 :::
+
+**Multi-agent / Profiles:**
+
+Each Hermes profile gets its own Honcho peer identity while sharing the same workspace (user context, sessions, project history). When creating a profile with `--clone`, Honcho config is auto-cloned:
+
+```bash
+hermes profile create coder --clone   # creates honcho peer "coder", inherits config
+hermes honcho sync                    # backfill host blocks for all existing profiles
+```
+
+See [Honcho integration guide](https://docs.honcho.dev/v3/guides/integrations/hermes) for the full config reference.
+
+
 
 ---
 


### PR DESCRIPTION
## Summary

Full Honcho memory plugin overhaul -- resolves the spec issues from `scratch/memory-plugin-ux-specs.md` and adds missing infrastructure for production-quality Honcho integration.

### Spec issues resolved

- **C1 (critical)**: setup wizard now hardcodes `memoryMode: hybrid`, removed honcho-only mode option (was dead code -- MemoryManager ignores suppress flags)
- **C2 (critical)**: removed SOUL.md aiPeer sync (persona content != identity config), cleaned up orphaned `_sanitize_peer_name`
- **H1 (high)**: `base_url`/`baseUrl` mismatch fixed -- client reads both, schema declares `baseUrl`, CLI cleans up legacy snake_case key on setup
- **H2 (high)**: setup command conflation resolved via `post_setup()` hook -- both `hermes honcho setup` and `hermes memory setup` converge to the same full wizard
- **M2 (medium)**: picker now shows "API key / local" instead of "requires API key"
- **L1 (low)**: memory-providers.md updated with self-hosted info, API key link, multi-profile section

### New features

- **Message chunking**: messages exceeding Honcho API limit (default 25k) are split at paragraph/sentence/word boundaries with `[continued]` markers. Configurable via `messageMaxChars`
- **Dialectic input guard**: queries exceeding 10k are truncated at word boundary before `peer.chat()`. Configurable via `dialecticMaxInputChars`
- **Granular per-peer observation**: replaces the `observationMode` string preset with per-peer `observeMe`/`observeOthers` booleans that map 1:1 to Honcho's `SessionPeerConfig`. Legacy presets still work as shorthands
- **Server-side observation sync**: `get_peer_configuration()` called after `add_peers` on session init -- settings changed in Honcho dashboard are synced back automatically
- **Setup wizard rewrite**: cloud/local deployment picker, explicit AI peer prompt, observation mode config, auto-enables honcho as memory provider in config.yaml
- **Local auth fix**: cloud API keys no longer leak to local Honcho instances -- only sends key if host block explicitly sets `apiKey`

### Docs + skill

- Comprehensive `plugins/memory/honcho/README.md` with full config reference (27+ keys, all defaults, scope, precedence rules)
- New optional skill `autonomous-ai-agents/honcho` -- covers setup, architecture, multi-profile, observation, tools, troubleshooting
- `memory-providers.md` Honcho section rewritten: self-hosted support, API key link, multi-profile with `--clone`, link to config reference

### Tests

- Fixed 2 pre-existing `TestResolveConfigPath` failures (tests not isolating from real `~/.hermes/honcho.json`)
- 9 new tests: message chunking (paragraph/sentence/word splits, continuation prefix, large messages) + dialectic input guard

### Changed files

| File | What |
|------|------|
| `plugins/memory/honcho/__init__.py` | message chunking, post_setup hook, removed SOUL.md sync + dead code |
| `plugins/memory/honcho/client.py` | granular observation config, messageMaxChars/dialecticMaxInputChars, baseUrl compat |
| `plugins/memory/honcho/session.py` | per-peer observation booleans, dialectic input guard, server-side config sync |
| `plugins/memory/honcho/cli.py` | setup wizard rewrite (cloud/local, observation, auto-activate) |
| `plugins/memory/honcho/README.md` | full config reference |
| `hermes_cli/main.py` | `hermes honcho setup` -> `cmd_setup_provider` |
| `hermes_cli/memory_setup.py` | `cmd_setup_provider`, post_setup hook, "API key / local" hints |
| `tests/honcho_plugin/test_client.py` | fix resolve_config_path isolation |
| `tests/honcho_plugin/test_session.py` | chunking + dialectic guard tests |
| `website/docs/user-guide/features/memory-providers.md` | honcho section rewrite |
| `optional-skills/autonomous-ai-agents/honcho/SKILL.md` | new skill |

### Not addressed (separate PRs)

- H4: Container pip install (Dockerfile change)
- M3: Dialectic log pollution / prompt bleed
- L2: Recommended badge in picker
- TUI session label restoration