### PR TITLE
fix(gateway): session metadata race and cached agent session_id staleness

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5856,6 +5856,7 @@ class GatewayRunner:
 
             # Per-message state — callbacks and reasoning config change every
             # turn and must not be baked into the cached agent constructor.
+            agent.session_id = session_id  # sync with current gateway session (may have auto-reset)
             agent.tool_progress_callback = progress_callback if tool_progress_enabled else None
             agent.step_callback = _step_callback_sync if _hooks_ref.loaded_hooks else None
             agent.stream_delta_callback = _stream_delta_cb

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -363,12 +363,26 @@ class SessionDB:
         user_id: str = None,
         parent_session_id: str = None,
     ) -> str:
-        """Create a new session record. Returns the session_id."""
+        """Create or enrich a session record. Returns the session_id.
+
+        Uses INSERT ... ON CONFLICT to handle the gateway/agent race:
+        the gateway creates a bare row (source + user_id only) before
+        the agent exists, then the agent calls this with richer metadata
+        (model, model_config, system_prompt).  The ON CONFLICT clause
+        backfills NULL fields without overwriting data already present.
+        """
         def _do(conn):
             conn.execute(
-                """INSERT OR IGNORE INTO sessions (id, source, user_id, model, model_config,
+                """INSERT INTO sessions (id, source, user_id, model, model_config,
                    system_prompt, parent_session_id, started_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(id) DO UPDATE SET
+                       model = COALESCE(sessions.model, excluded.model),
+                       model_config = COALESCE(sessions.model_config, excluded.model_config),
+                       system_prompt = COALESCE(sessions.system_prompt, excluded.system_prompt),
+                       user_id = COALESCE(sessions.user_id, excluded.user_id),
+                       parent_session_id = COALESCE(sessions.parent_session_id, excluded.parent_session_id)
+                """,
                 (
                     session_id,
                     source,


### PR DESCRIPTION
## What does this PR do?

Fixes gateway sessions (telegram, discord, etc.) having NULL model, NULL billing_provider, and missing token counts in the sessions DB. Two root causes identified and fixed.

## Related Issue

No existing issue — discovered during a token usage audit that revealed all 331 telegram sessions and 35 discord sessions had billing_provider=NULL and most had 0 token counts despite active conversations.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`hermes_state.py`** (`create_session`): Changed `INSERT OR IGNORE` to `INSERT ... ON CONFLICT(id) DO UPDATE SET` with `COALESCE`. The gateway's `get_or_create_session()` creates a bare session row (source + user_id only) *before* the agent exists. When the agent later calls `create_session()` with model, model_config, and system_prompt, `INSERT OR IGNORE` silently skipped because the row already existed. The upsert backfills NULL fields without overwriting data already present.

- **`gateway/run.py`** (per-message state block): Added `agent.session_id = session_id` alongside the existing callback and reasoning_config updates. When the gateway's session auto-reset policy creates a new session_id, the cached `AIAgent` (reused for prompt cache efficiency) still held the old session_id from construction. Token writes via `update_token_counts()` targeted the old session — the new session row stayed at 0 tokens indefinitely.

## How to Test

1. Session creation upsert:
```python
from pathlib import Path
from hermes_state import SessionDB

db = SessionDB(Path('/tmp/test.db'))

# Gateway creates bare row
db.create_session('s1', source='telegram', user_id='user123')
# Agent enriches — model should be written
db.create_session('s1', source='telegram', model='claude-opus-4-6',
                  model_config={'max_iterations': 90})

# Verify via sqlite3:
# SELECT model, user_id, model_config FROM sessions WHERE id='s1'
# → claude-opus-4-6, user123, {"max_iterations": 90}
```

2. Cached agent session sync: send messages to the gateway with >session reset interval between them, verify token counts appear on the *current* session (not the old one).

3. Full test suite: `python -m pytest tests/ -k "session or state or token" -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes — the upsert behavior is verified by the reproduction script above; 871 existing session/state/token tests pass unchanged
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal DB logic, no user-facing docs)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure Python + SQLite, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
