### PR TITLE
fix: clean up timed-out cron processes and stabilize tick tests

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -450,7 +450,17 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # run_conversation is synchronous.
         _cron_timeout = float(os.getenv("HERMES_CRON_TIMEOUT", 600))
         _cron_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-        _cron_future = _cron_pool.submit(agent.run_conversation, prompt)
+
+        def _run_cron_turn():
+            from tools.approval import set_current_session_key, reset_current_session_key
+
+            token = set_current_session_key(_cron_session_id)
+            try:
+                return agent.run_conversation(prompt)
+            finally:
+                reset_current_session_key(token)
+
+        _cron_future = _cron_pool.submit(_run_cron_turn)
         try:
             result = _cron_future.result(timeout=_cron_timeout)
         except concurrent.futures.TimeoutError:
@@ -460,6 +470,19 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             )
             if hasattr(agent, "interrupt"):
                 agent.interrupt("Cron job timed out")
+            try:
+                from tools.process_registry import process_registry
+
+                killed = process_registry.kill_all_for_session(_cron_session_id)
+                if killed:
+                    logger.warning(
+                        "Job '%s' timeout cleanup killed %d background process(es) for session %s",
+                        job_name,
+                        killed,
+                        _cron_session_id,
+                    )
+            except Exception:
+                logger.exception("Job '%s': failed background-process cleanup after timeout", job_name)
             _cron_pool.shutdown(wait=False, cancel_futures=True)
             raise TimeoutError(
                 f"Cron job '{job_name}' timed out after "

--- a/run_agent.py
+++ b/run_agent.py
@@ -1593,7 +1593,7 @@ class AIAgent:
         }
     
     def _cleanup_task_resources(self, task_id: str) -> None:
-        """Clean up VM and browser resources for a given task."""
+        """Clean up VM, browser, and background-process resources for a given task."""
         try:
             cleanup_vm(task_id)
         except Exception as e:
@@ -1604,6 +1604,12 @@ class AIAgent:
         except Exception as e:
             if self.verbose_logging:
                 logging.warning(f"Failed to cleanup browser for task {task_id}: {e}")
+        try:
+            from tools.process_registry import process_registry
+            process_registry.kill_all(task_id)
+        except Exception as e:
+            if self.verbose_logging:
+                logging.warning(f"Failed to cleanup background processes for task {task_id}: {e}")
 
     # ------------------------------------------------------------------
     # Background memory/skill review

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1,5 +1,6 @@
 """Tests for cron/scheduler.py — origin resolution, delivery routing, and error logging."""
 
+import concurrent.futures
 import json
 import logging
 import os
@@ -8,6 +9,16 @@ from unittest.mock import AsyncMock, patch, MagicMock
 import pytest
 
 from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, run_job, SILENT_MARKER, _build_job_prompt
+
+
+@pytest.fixture(autouse=True)
+def isolate_tick_lock(tmp_path, monkeypatch):
+    """Give each test its own tick lock so xdist workers don't fight over one global file."""
+    import cron.scheduler as scheduler
+
+    lock_dir = tmp_path / "cron-lock"
+    monkeypatch.setattr(scheduler, "_LOCK_DIR", lock_dir)
+    monkeypatch.setattr(scheduler, "_LOCK_FILE", lock_dir / ".tick.lock")
 
 
 class TestResolveOrigin:
@@ -368,6 +379,45 @@ class TestRunJobSessionPersistence:
         assert final_response == ""
         # But the output log should show the placeholder
         assert "(No response generated)" in output
+
+    def test_run_job_timeout_interrupts_agent_and_cleans_session_processes(self, tmp_path):
+        job = {
+            "id": "slow-job",
+            "name": "slow test",
+            "prompt": "hello",
+        }
+        fake_db = MagicMock()
+        pool = MagicMock()
+        future = MagicMock()
+        future.result.side_effect = concurrent.futures.TimeoutError()
+        pool.submit.return_value = future
+        mock_agent = MagicMock()
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent", return_value=mock_agent), \
+             patch("cron.scheduler.concurrent.futures.ThreadPoolExecutor", return_value=pool), \
+             patch("tools.process_registry.process_registry.kill_all_for_session", return_value=2) as kill_mock:
+            success, output, final_response, error = run_job(job)
+
+        assert success is False
+        assert final_response == ""
+        assert "timed out after 10 minutes" in error
+        mock_agent.interrupt.assert_called_once_with("Cron job timed out")
+        kill_mock.assert_called_once()
+        assert kill_mock.call_args.args[0].startswith("cron_slow-job_")
+        fake_db.close.assert_called_once()
 
     def test_run_job_sets_auto_delivery_env_from_dotenv_home_channel(self, tmp_path, monkeypatch):
         job = {

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -7,6 +7,7 @@ import pytest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from tools.interrupt import set_interrupt
 from tools.environments.local import _HERMES_PROVIDER_ENV_FORCE_PREFIX
 from tools.process_registry import (
     ProcessRegistry,
@@ -173,6 +174,42 @@ class TestActiveQueries:
         s = _make_session(task_id="t1", exited=True, exit_code=0)
         registry._finished[s.id] = s
         assert registry.has_active_processes("t1") is False
+
+    def test_kill_all_for_session(self, registry):
+        s1 = _make_session(sid="proc_1")
+        s1.session_key = "cron_1"
+        s2 = _make_session(sid="proc_2")
+        s2.session_key = "cron_1"
+        s3 = _make_session(sid="proc_3")
+        s3.session_key = "other"
+        registry._running[s1.id] = s1
+        registry._running[s2.id] = s2
+        registry._running[s3.id] = s3
+
+        with patch.object(registry, "kill_process", return_value={"status": "killed"}) as kill_mock:
+            killed = registry.kill_all_for_session("cron_1")
+
+        assert killed == 2
+        assert kill_mock.call_count == 2
+        kill_mock.assert_any_call("proc_1")
+        kill_mock.assert_any_call("proc_2")
+
+
+class TestWait:
+    def test_wait_interrupt_kills_process(self, registry):
+        s = _make_session(output="still running")
+        registry._running[s.id] = s
+
+        try:
+            set_interrupt(True)
+            with patch.object(registry, "kill_process", return_value={"status": "killed"}) as kill_mock:
+                result = registry.wait(s.id, timeout=1)
+        finally:
+            set_interrupt(False)
+
+        assert result["status"] == "interrupted"
+        assert "terminated" in result["note"]
+        kill_mock.assert_called_once_with(s.id)
 
 
 # =========================================================================

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -523,11 +523,14 @@ class ProcessRegistry:
                 return result
 
             if _interrupt_event.is_set():
+                kill_result = self.kill_process(session_id)
                 result = {
                     "status": "interrupted",
                     "output": strip_ansi(session.output_buffer[-1000:]),
-                    "note": "User sent a new message -- wait interrupted",
+                    "note": "Interrupt received — background process was terminated",
                 }
+                if kill_result.get("status") not in ("killed", "already_exited"):
+                    result["kill_status"] = kill_result
                 if timeout_note:
                     result["timeout_note"] = timeout_note
                 return result
@@ -660,6 +663,21 @@ class ProcessRegistry:
                 s.session_key == session_key and not s.exited
                 for s in self._running.values()
             )
+
+    def kill_all_for_session(self, session_key: str) -> int:
+        """Kill all running processes associated with a session key."""
+        with self._lock:
+            targets = [
+                s for s in self._running.values()
+                if s.session_key == session_key and not s.exited
+            ]
+
+        killed = 0
+        for session in targets:
+            result = self.kill_process(session.id)
+            if result.get("status") in ("killed", "already_exited"):
+                killed += 1
+        return killed
 
     def kill_all(self, task_id: str = None) -> int:
         """Kill all running processes, optionally filtered by task_id. Returns count killed."""


### PR DESCRIPTION
## Summary
- bind cron runs to a session key before executing the agent so background terminal processes are attributable to the cron job
- kill session-scoped background processes when a cron run times out, and kill waited-on background processes when an interrupt arrives
- isolate scheduler tick lock files per test so xdist workers stop racing on one global .tick.lock

## Validation
- venv/bin/python -m pytest -q tests/cron/test_scheduler.py
- venv/bin/python -m pytest -q tests/tools/test_process_registry.py
- venv/bin/python -m pytest -q tests/cron/test_scheduler.py -n 0
