### PR TITLE
fix(environments): stop shell-interpolating Hermes SWE verifier tests

### DIFF
--- a/environments/hermes_swe_env/hermes_swe_env.py
+++ b/environments/hermes_swe_env/hermes_swe_env.py
@@ -29,6 +29,7 @@ Usage:
         --env.terminal_backend modal
 """
 
+import json
 import logging
 import sys
 import time
@@ -157,6 +158,33 @@ class HermesSweEnv(HermesAgentBaseEnv):
 
         return prompt
 
+    @staticmethod
+    def _write_verifier_file(
+        ctx: ToolContext,
+        path: str,
+        content: str,
+    ) -> Dict[str, Any]:
+        """Persist verifier code without embedding it into a shell command."""
+        write_fn = getattr(ctx, "write_file", None)
+        if callable(write_fn):
+            return write_fn(path, content)
+
+        call_tool = getattr(ctx, "call_tool", None)
+        if callable(call_tool):
+            raw_result = call_tool("write_file", {"path": path, "content": content})
+            if isinstance(raw_result, dict):
+                return raw_result
+            if isinstance(raw_result, str):
+                try:
+                    parsed = json.loads(raw_result)
+                except json.JSONDecodeError:
+                    return {"error": raw_result}
+                if isinstance(parsed, dict):
+                    return parsed
+                return {"error": str(parsed)}
+
+        return {"error": "No safe file-write API available for verifier execution"}
+
     async def compute_reward(
         self, item: Dict[str, Any], result: AgentResult, ctx: ToolContext
     ) -> float:
@@ -174,10 +202,29 @@ class HermesSweEnv(HermesAgentBaseEnv):
         test_code = item.get("test", item.get("test_code", item.get("tests", "")))
 
         if test_code:
-            # Run the test in the model's sandbox
-            test_result = ctx.terminal(
-                f'cd /workspace && python3 -c "{test_code}"', timeout=60
-            )
+            verifier_path = "/workspace/.hermes_reward_test.py"
+            write_result = self._write_verifier_file(ctx, verifier_path, test_code)
+
+            if write_result.get("error"):
+                logger.warning(
+                    "Failed to write verifier script: %s",
+                    write_result["error"],
+                )
+                test_result = {
+                    "exit_code": 1,
+                    "output": write_result["error"],
+                }
+            else:
+                try:
+                    test_result = ctx.terminal(
+                        "cd /workspace && python3 .hermes_reward_test.py",
+                        timeout=60,
+                    )
+                finally:
+                    ctx.terminal(
+                        f"rm -f {verifier_path}",
+                        timeout=10,
+                    )
 
             if test_result["exit_code"] == 0:
                 self.reward_buffer.append(1.0)

--- a/tests/test_hermes_swe_env.py
+++ b/tests/test_hermes_swe_env.py
@@ -1,0 +1,159 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _load_hermes_swe_module():
+    module_path = (
+        Path(__file__).resolve().parent.parent
+        / "environments"
+        / "hermes_swe_env"
+        / "hermes_swe_env.py"
+    )
+
+    datasets_mod = types.ModuleType("datasets")
+    datasets_mod.load_dataset = lambda *args, **kwargs: []
+
+    atropos_mod = types.ModuleType("atroposlib")
+    atropos_envs_mod = types.ModuleType("atroposlib.envs")
+    atropos_envs_base_mod = types.ModuleType("atroposlib.envs.base")
+    atropos_server_mod = types.ModuleType("atroposlib.envs.server_handling")
+    atropos_server_manager_mod = types.ModuleType(
+        "atroposlib.envs.server_handling.server_manager"
+    )
+    atropos_types_mod = types.ModuleType("atroposlib.type_definitions")
+
+    class ScoredDataGroup:
+        pass
+
+    class APIServerConfig:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    atropos_envs_base_mod.ScoredDataGroup = ScoredDataGroup
+    atropos_server_manager_mod.APIServerConfig = APIServerConfig
+    atropos_types_mod.Item = dict
+
+    agent_loop_mod = types.ModuleType("environments.agent_loop")
+    agent_loop_mod.AgentResult = object
+
+    hermes_base_env_mod = types.ModuleType("environments.hermes_base_env")
+
+    class HermesAgentBaseEnv:
+        pass
+
+    class HermesAgentEnvConfig:
+        pass
+
+    hermes_base_env_mod.HermesAgentBaseEnv = HermesAgentBaseEnv
+    hermes_base_env_mod.HermesAgentEnvConfig = HermesAgentEnvConfig
+
+    tool_context_mod = types.ModuleType("environments.tool_context")
+    tool_context_mod.ToolContext = object
+
+    stubbed_modules = {
+        "datasets": datasets_mod,
+        "atroposlib": atropos_mod,
+        "atroposlib.envs": atropos_envs_mod,
+        "atroposlib.envs.base": atropos_envs_base_mod,
+        "atroposlib.envs.server_handling": atropos_server_mod,
+        "atroposlib.envs.server_handling.server_manager": atropos_server_manager_mod,
+        "atroposlib.type_definitions": atropos_types_mod,
+        "environments.agent_loop": agent_loop_mod,
+        "environments.hermes_base_env": hermes_base_env_mod,
+        "environments.tool_context": tool_context_mod,
+    }
+
+    spec = importlib.util.spec_from_file_location("test_hermes_swe_env_target", module_path)
+    module = importlib.util.module_from_spec(spec)
+    with patch.dict(sys.modules, stubbed_modules):
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+    return module
+
+
+class RecordingCtx:
+    def __init__(self, terminal_results):
+        self.writes = []
+        self.terminal_calls = []
+        self._terminal_results = list(terminal_results)
+
+    def write_file(self, path, content):
+        self.writes.append((path, content))
+        return {}
+
+    def terminal(self, command, timeout=180):
+        self.terminal_calls.append((command, timeout))
+        if self._terminal_results:
+            return self._terminal_results.pop(0)
+        return {"exit_code": 0, "output": ""}
+
+
+@pytest.mark.asyncio
+async def test_compute_reward_writes_verifier_file_for_code_with_quotes():
+    module = _load_hermes_swe_module()
+    env = module.HermesSweEnv.__new__(module.HermesSweEnv)
+    env.reward_buffer = []
+
+    test_code = 'assert candidate("x") == "x"'
+    ctx = RecordingCtx(
+        [
+            {"exit_code": 0, "output": "ok"},
+            {"exit_code": 0, "output": ""},
+        ]
+    )
+
+    reward = await module.HermesSweEnv.compute_reward(
+        env,
+        {"test_code": test_code},
+        result=object(),
+        ctx=ctx,
+    )
+
+    assert reward == 1.0
+    assert env.reward_buffer == [1.0]
+    assert ctx.writes == [("/workspace/.hermes_reward_test.py", test_code)]
+    assert ctx.terminal_calls == [
+        ("cd /workspace && python3 .hermes_reward_test.py", 60),
+        ("rm -f /workspace/.hermes_reward_test.py", 10),
+    ]
+    assert all("python3 -c" not in command for command, _ in ctx.terminal_calls)
+    assert all(test_code not in command for command, _ in ctx.terminal_calls)
+
+
+@pytest.mark.asyncio
+async def test_compute_reward_does_not_shell_interpolate_injection_like_verifier():
+    module = _load_hermes_swe_module()
+    env = module.HermesSweEnv.__new__(module.HermesSweEnv)
+    env.reward_buffer = []
+
+    verifier = '"; touch /workspace/pwned #'
+    ctx = RecordingCtx(
+        [
+            {"exit_code": 1, "output": "SyntaxError"},
+            {"exit_code": 0, "output": ""},
+            {"exit_code": 0, "output": "/workspace/solution.py\n"},
+        ]
+    )
+
+    reward = await module.HermesSweEnv.compute_reward(
+        env,
+        {"test_code": verifier},
+        result=object(),
+        ctx=ctx,
+    )
+
+    assert reward == 0.1
+    assert env.reward_buffer == [0.1]
+    assert ctx.writes == [("/workspace/.hermes_reward_test.py", verifier)]
+    assert ctx.terminal_calls == [
+        ("cd /workspace && python3 .hermes_reward_test.py", 60),
+        ("rm -f /workspace/.hermes_reward_test.py", 10),
+        ("find /workspace -name '*.py' -newer /tmp/.start_marker 2>/dev/null | head -5", 180),
+    ]
+    assert all("python3 -c" not in command for command, _ in ctx.terminal_calls)
+    assert all(verifier not in command for command, _ in ctx.terminal_calls)


### PR DESCRIPTION
## What changed
Stopped shell-interpolating dataset-provided verifier code in `HermesSweEnv.compute_reward()`.

The verifier content is now written to `/workspace/.hermes_reward_test.py` using the existing safe file-write API, then executed via `python3 .hermes_reward_test.py`, and cleaned up afterward.

Also added regression tests covering:
- valid verifier code containing quotes
- injection-like verifier content

## Why
Previously, dataset-provided verifier text was embedded directly into `python3 -c "..."`, which allowed shell-breaking behavior and could lead to command injection through malicious verifier content.

Treating the verifier as file content instead of shell syntax prevents quotes, semicolons, command substitutions, and newlines from escaping into the shell.

## How to test
- Run `pytest tests/test_hermes_swe_env.py -q`
- Verify quoted verifier code like `assert candidate("x") == "x"` executes correctly
- Verify injection-like content such as `"; touch /workspace/pwned #` is not shell-interpolated

## Validation
- `python -m pytest tests/test_hermes_swe_env.py -q` → `2 passed`