### PR TITLE
fix(security): extend secret redaction to memory plugin API keys

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -48,6 +48,10 @@ _PREFIX_PATTERNS = [
     r"sk_[A-Za-z0-9_]{10,}",            # ElevenLabs TTS key (sk_ underscore, not sk- dash)
     r"tvly-[A-Za-z0-9]{10,}",           # Tavily search API key
     r"exa_[A-Za-z0-9]{10,}",            # Exa search API key
+    r"retaindb_[A-Za-z0-9_-]{10,}",      # RetainDB API key
+    r"hsk-[A-Za-z0-9_-]{10,}",           # Hindsight API key
+    r"mem0_[A-Za-z0-9_-]{10,}",          # Mem0 API key
+    r"brv_[A-Za-z0-9_-]{10,}",           # ByteRover API key
 ]
 
 # ENV assignment patterns: KEY=value where KEY contains a secret-like name


### PR DESCRIPTION
## What does this PR do?

Four memory provider plugins introduced in v0.7.0 use API keys that
were not covered by `_PREFIX_PATTERNS` in `agent/redact.py`. These
keys could leak in plaintext through logs or LLM context:

| Token prefix | Service | Environment variable |
|---|---|---|
| `retaindb_` | RetainDB cloud memory | `RETAINDB_API_KEY` |
| `hsk-` | Hindsight memory | `HINDSIGHT_API_KEY` |
| `mem0_` | Mem0 Platform memory | `MEM0_API_KEY` |
| `brv_` | ByteRover memory CLI | `BRV_API_KEY` |

All four plugins are shipped with v0.7.0 and their keys are actively
used in memory read/write operations, making them highly likely to
appear in user environments.

This follows the same pattern as the previous redaction expansions:
- ElevenLabs, Tavily, Exa (#3920)
- Slack xapp, GitLab, Deepgram, Linear (#4541)

## Type of Change

- [x] 🔒 Security fix

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Consistent with existing `_PREFIX_PATTERNS` format
- [x] No behavior change for non-secret strings