### PR TITLE
fix(honcho): respect nested host aiPeer config in SOUL.md sync

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -234,9 +234,15 @@ class HonchoMemoryProvider(MemoryProvider):
                 logger.debug("Honcho cost-awareness config parse error: %s", e)
 
             # ----- Port #1969: aiPeer sync from SOUL.md -----
+            # Only sync if aiPeer wasn't explicitly configured at root OR in host block.
+            # cfg.ai_peer default is "hermes" — if it differs, user customized it.
             try:
                 hermes_home = kwargs.get("hermes_home", "")
-                if hermes_home and not cfg.raw.get("aiPeer"):
+                already_configured = (
+                    cfg.raw.get("aiPeer") is not None
+                    or (cfg.ai_peer and cfg.ai_peer != "hermes")
+                )
+                if hermes_home and not already_configured:
                     soul_path = Path(hermes_home) / "SOUL.md"
                     if soul_path.exists():
                         soul_text = soul_path.read_text(encoding="utf-8").strip()


### PR DESCRIPTION
## Bug

The SOUL.md `aiPeer` sync (added in #1969, landed via commit 9e0fc626) checks `cfg.raw.get("aiPeer")` which only reads the **root-level** `aiPeer` key from the raw config dict. But the Hermes setup wizard writes `aiPeer` under `hosts.<host>.aiPeer` (see `cli.py` line 736) — the canonical nested format documented in `client.py`.

For any user who ran `hermes honcho setup` AND has a `SOUL.md` whose first heading doesn't exactly match their configured `aiPeer`, the sync silently overrides the configured value with a sanitized version of the SOUL.md heading.

### Concrete repro
Config (standard wizard output):
```json
{
  "hosts": {
    "hermes": { "peerName": "Tiger", "aiPeer": "clawd" }
  }
}
```

SOUL.md:
```markdown
# SOUL.md — Who I Am

I am Clawd. [...]
```

**Expected:** assistant peer id = `clawd`  
**Actual:** assistant peer id = `SOUL-md---Who-I-Am` (sanitized first heading)

Result: `honcho_profile`, `honcho_search`, and auto-injected context all return empty because the session's assistant peer has no data — the user's actual conclusions/observations were written under `clawd`.

## Fix

Also skip the sync when `cfg.ai_peer` was already customized from its default (`"hermes"`). The resolved `cfg.ai_peer` is set correctly from the host block at config load time in `HonchoClientConfig.from_global_config()` — the sync check just looked at the wrong level.

```python
already_configured = (
    cfg.raw.get("aiPeer") is not None
    or (cfg.ai_peer and cfg.ai_peer != "hermes")
)
if hermes_home and not already_configured:
    # ... SOUL.md sync logic
```

## Testing

- Verified locally: with nested `hosts.hermes.aiPeer: "clawd"` config + SOUL.md with `# SOUL.md — Who I Am` heading, the sync is now correctly skipped and `honcho_profile` returns the 40-item peer card for `clawd`.
- SOUL.md sync still runs when `cfg.ai_peer == "hermes"` (default), so existing behavior for users who never configured `aiPeer` is preserved.
- No change to root-level `aiPeer` check — backward compatible with flat configs.

## Users affected

Anyone who ran `hermes honcho setup` (always writes nested) with a SOUL.md whose heading doesn't match their configured `aiPeer`.