### PR TITLE
fix(approval): load permanent command allowlist on module import

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -357,6 +357,12 @@ def save_permanent_allowlist(patterns: set):
         logger.warning("Could not save allowlist: %s", e)
 
 
+# Load permanent allowlist entries from config on module import so that
+# patterns saved via '/approve always' in previous sessions are available
+# immediately when is_approved() is first called.
+load_permanent_allowlist()
+
+
 # =========================================================================
 # Approval prompting + orchestration
 # =========================================================================


### PR DESCRIPTION
## What changed and why

\load_permanent_allowlist()\ in \	ools/approval.py\ was defined (line 313) but never called anywhere in the codebase. When a user approved a dangerous command with \/approve always\, the pattern was saved to \config.yaml\ under \command_allowlist\ - but on process restart, these patterns were never loaded back into the in-memory \_permanent_approved\ set.

This meant all 'permanent' approvals were silently lost after every gateway or CLI restart, and users were re-prompted for the same commands they had already permanently approved.

## Fix

Added a module-level call to \load_permanent_allowlist()\ at the end of the config persistence section in \	ools/approval.py\. The function already has a try/except that returns an empty set on any error, so calling it at import time is safe and consistent with the self-registering pattern used by other tool modules.

## How to test

1. Run hermes with \pprovals.mode: manual\
2. Trigger a dangerous command (e.g., \python3 -c 'print(1)'\)
3. Approve with \/approve always\
4. Verify the pattern is saved in \config.yaml\ under \command_allowlist\
5. Restart hermes
6. Trigger the same command - it should now be auto-approved without prompting

## Platform tested

Windows 11

## Related issue

Closes #4739