### PR TITLE
fix(agent): filter malformed tool calls before persistence and replay

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1810,9 +1810,16 @@ class AIAgent:
                     tool_calls_data = [
                         {"name": tc.function.name, "arguments": tc.function.arguments}
                         for tc in msg.tool_calls
+                        if tc.function.name and tc.function.arguments
                     ]
                 elif isinstance(msg.get("tool_calls"), list):
-                    tool_calls_data = msg["tool_calls"]
+                    tool_calls_data = [
+                        tc for tc in msg["tool_calls"]
+                        if isinstance(tc, dict)
+                        and tc.get("name") and tc.get("arguments")
+                    ]
+                if tool_calls_data is not None and not tool_calls_data:
+                    tool_calls_data = None
                 self._session_db.append_message(
                     session_id=self.session_id,
                     role=role,
@@ -2607,6 +2614,28 @@ class AIAgent:
                 continue
             filtered.append(msg)
         messages = filtered
+
+        # --- Strip malformed tool calls from assistant messages -----------
+        # Malformed entries (empty name, empty/non-JSON arguments) can be
+        # persisted by older versions or edge-case provider responses and
+        # cause 400 errors when replayed to strict providers.
+        for msg in messages:
+            if msg.get("role") == "assistant" and msg.get("tool_calls"):
+                valid = []
+                for tc in msg["tool_calls"]:
+                    name = tc.get("name") or (tc.get("function") or {}).get("name")
+                    args = tc.get("arguments") or (tc.get("function") or {}).get("arguments")
+                    if name and args:
+                        valid.append(tc)
+                    else:
+                        logger.debug(
+                            "Pre-call sanitizer: dropping malformed tool call (name=%r)",
+                            name,
+                        )
+                if valid:
+                    msg["tool_calls"] = valid
+                else:
+                    msg.pop("tool_calls", None)
 
         surviving_call_ids: set = set()
         for msg in messages:


### PR DESCRIPTION
## What changed and why

Hermes could persist malformed assistant tool calls (empty \unction.name\, empty \unction.arguments\) into the SQLite session database. Once persisted, these invalid entries were replayed on every subsequent request in that session, causing repeated HTTP 400 errors from strict OpenAI-compatible providers:

\\\
HTTP 400: InternalError.Algo.InvalidParameter: The function.arguments parameter of the code model must be in JSON format.
\\\

## Fix

Added validation in two places:

1. **\_flush_messages_to_session_db\**: Skip tool calls with falsy \
ame\ or \rguments\ before writing to the database. Handles both the \	ool_calls\ attribute path (raw API response objects) and the dict path (pre-normalized messages). If all tool calls in a message are invalid, \	ool_calls_data\ is set to \None\ so the row is written cleanly.

2. **\_sanitize_api_messages\**: Strip malformed tool calls from assistant messages before every API call. This protects sessions that were already poisoned by older versions. Handles both flat dict format (\
ame\/\rguments\ at top level) and nested format (\unction.name\/\unction.arguments\).

## How to test

1. Resume a session that has a malformed tool call stored in its history (empty name or empty arguments)
2. Send a new message
3. Verify the request succeeds without HTTP 400 errors - the malformed entries are silently dropped

## Platform tested

Windows 11

## Related issue

Closes #4662