### PR TITLE
fix(setup): Add more actionable Discord setup link

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1912,7 +1912,7 @@ def setup_gateway(config: dict):
             existing_discord = None
 
     if not existing_discord and prompt_yes_no("Set up Discord bot?", False):
-        print_info("Create a bot at https://discord.com/developers/applications")
+        print_info("Create a bot by following https://hermes-agent.nousresearch.com/docs/user-guide/messaging/discord#step-1-create-a-discord-application")
         token = prompt("Discord bot token", password=True)
         if token:
             save_env_value("DISCORD_BOT_TOKEN", token)


### PR DESCRIPTION
## What does this PR do?

* In the current state the Discord setup instructs the user to create a bot at https://discord.com/developers/applications which misses key configuraiton options discussed at https://hermes-agent.nousresearch.com/docs/user-guide/messaging/discord#step-1-create-a-discord-application

* This commit changes that by using the latter link at setup.

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)


### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)