### PR TITLE
fix(agent): sanitize surrogate characters from API responses and before API calls

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5239,9 +5239,16 @@ class AIAgent:
                 except Exception:
                     pass
 
+        # Sanitize surrogates from API response — some models (e.g. Kimi/GLM via Ollama)
+        # can return invalid surrogate code points that crash json.dumps() on persist.
+        _raw_content = assistant_message.content or ""
+        _san_content = _sanitize_surrogates(_raw_content)
+        if reasoning_text:
+            reasoning_text = _sanitize_surrogates(reasoning_text)
+
         msg = {
             "role": "assistant",
-            "content": assistant_message.content or "",
+            "content": _san_content,
             "reasoning": reasoning_text,
             "finish_reason": finish_reason,
         }
@@ -6822,6 +6829,12 @@ class AIAgent:
             # manual message manipulation are always caught.
             api_messages = self._sanitize_api_messages(api_messages)
 
+            # Proactively strip any surrogate characters before the API call.
+            # Models served via Ollama (Kimi K2.5, GLM-5, Qwen) can return
+            # lone surrogates (U+D800-U+DFFF) that crash json.dumps() inside
+            # the OpenAI SDK. Sanitizing here prevents the 3-retry cycle.
+            _sanitize_messages_surrogates(api_messages)
+
             # Calculate approximate request size for logging
             total_chars = sum(len(str(msg)) for msg in api_messages)
             approx_tokens = total_chars // 4  # Rough estimate: 4 chars per token
@@ -7333,7 +7346,7 @@ class AIAgent:
                     # -----------------------------------------------------------
                     if isinstance(api_error, UnicodeEncodeError) and not getattr(self, '_surrogate_sanitized', False):
                         self._surrogate_sanitized = True
-                        if _sanitize_messages_surrogates(messages):
+                        if _sanitize_messages_surrogates(api_messages):
                             self._vprint(
                                 f"{self.log_prefix}⚠️  Stripped invalid surrogate characters from messages. Retrying...",
                                 force=True,


### PR DESCRIPTION
Fixes surrogate character crashes from Ollama models (Kimi K2.5, GLM-5, Qwen).

## Fix — 3 call sites
1. Proactive sanitization before API call
2. Sanitize assistant response before storing
3. Fixed retry path to use api_messages

_sanitize_surrogates() already existed — this wires it to missing call sites.