### PR TITLE
fix(local-env): restore Windows persistent-shell timeout cleanup

### DIFF
--- a/tests/tools/test_local_persistent.py
+++ b/tests/tools/test_local_persistent.py
@@ -1,9 +1,11 @@
 """Tests for the local persistent shell backend."""
 
 import glob as glob_mod
+import subprocess
 
 import pytest
 
+import tools.environments.local as local_mod
 from tools.environments.local import LocalEnvironment
 from tools.environments.persistent_shell import PersistentShellMixin
 
@@ -162,3 +164,28 @@ class TestLocalPersistent:
     def test_multiple_commands_semicolon(self, env):
         r = env.execute("X=42; echo $X")
         assert r["output"].strip() == "42"
+
+    def test_windows_kill_shell_children_falls_back_to_taskkill(self, monkeypatch):
+        env = LocalEnvironment.__new__(LocalEnvironment)
+        env._shell_pid = 4242
+        env._shell_alive = True
+        calls = []
+
+        def fake_run(cmd, capture_output=True, timeout=5, **kwargs):
+            calls.append(cmd)
+            if cmd[:2] == [r"C:\Program Files\Git\bin\bash.exe", "-lc"]:
+                return subprocess.CompletedProcess(cmd, 127)
+            if cmd[0] == "taskkill":
+                return subprocess.CompletedProcess(cmd, 0)
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        monkeypatch.setattr(local_mod, "_find_bash", lambda: r"C:\Program Files\Git\bin\bash.exe")
+        monkeypatch.setattr(local_mod.subprocess, "run", fake_run)
+
+        LocalEnvironment._kill_shell_children(env)
+
+        assert calls[0][:2] == [r"C:\Program Files\Git\bin\bash.exe", "-lc"]
+        assert "pkill -P 4242" in calls[0][2]
+        assert calls[1] == ["taskkill", "/PID", "4242", "/T", "/F"]
+        assert env._shell_alive is False

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -6,6 +6,7 @@ import platform
 import shutil
 import signal
 import subprocess
+import tempfile
 import threading
 import time
 
@@ -335,6 +336,11 @@ class LocalEnvironment(PersistentShellMixin, BaseEnvironment):
 
     @property
     def _temp_prefix(self) -> str:
+        if _IS_WINDOWS:
+            # Git Bash can write to forward-slash Windows paths like
+            # C:/Users/... and native Python can read them unchanged.
+            tmpdir = tempfile.gettempdir().rstrip("\\/").replace("\\", "/")
+            return f"{tmpdir}/hermes-local-{self._session_id}"
         return f"/tmp/hermes-local-{self._session_id}"
 
     def _spawn_shell_process(self) -> subprocess.Popen:
@@ -361,15 +367,51 @@ class LocalEnvironment(PersistentShellMixin, BaseEnvironment):
         return results
 
     def _kill_shell_children(self):
-        if self._shell_pid is None:
+        shell_pid = self._shell_pid
+        if shell_pid is None and _IS_WINDOWS:
+            shell_proc = getattr(self, "_shell_proc", None)
+            shell_pid = getattr(shell_proc, "pid", None)
+
+        if shell_pid is None:
             return
-        try:
+
+        def _kill_shell_tree_windows():
             subprocess.run(
-                ["pkill", "-P", str(self._shell_pid)],
+                ["taskkill", "/PID", str(shell_pid), "/T", "/F"],
+                capture_output=True, timeout=5,
+            )
+            # The persistent shell itself is gone; let the next execute() restart it.
+            self._shell_alive = False
+
+        try:
+            if _IS_WINDOWS:
+                bash = _find_bash()
+                result = subprocess.run(
+                    [
+                        bash,
+                        "-lc",
+                        (
+                            "command -v pkill >/dev/null 2>&1 "
+                            f"&& pkill -P {shell_pid} 2>/dev/null"
+                        ),
+                    ],
+                    capture_output=True,
+                    timeout=5,
+                )
+                if result.returncode != 0:
+                    _kill_shell_tree_windows()
+                return
+
+            subprocess.run(
+                ["pkill", "-P", str(shell_pid)],
                 capture_output=True, timeout=5,
             )
         except (subprocess.TimeoutExpired, FileNotFoundError):
-            pass
+            if _IS_WINDOWS:
+                try:
+                    _kill_shell_tree_windows()
+                except (subprocess.TimeoutExpired, FileNotFoundError):
+                    pass
 
     def _cleanup_temp_files(self):
         for f in glob.glob(f"{self._temp_prefix}-*"):


### PR DESCRIPTION
## What this PR fixes
This fixes a Windows persistent-shell cleanup bug where timed-out commands could continue running after the command was already reported as interrupted.

## Main changes
- fixed Windows temp-path handling used by the persistent shell
- added a PID fallback when the shell PID file is missing
- improved Windows child-process cleanup by trying Git Bash `pkill` first and `taskkill` as a fallback
- added regression coverage for the fallback path

## Why it matters
Timeouts should be real. If the agent reports that a command stopped, the process tree should not still be running in the background on the host.

## Testing
- `python -m pytest tests/tools/test_local_persistent.py -q -k windows_kill_shell_children_falls_back_to_taskkill`
- `python -m pytest tests/tools/test_local_persistent.py -q -k timeout_then_recovery`
- `python -m pytest tests/tools/test_local_persistent.py -q`

All passed.