### PR TITLE
fix(approval): load permanent command allowlist on startup

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -871,3 +871,7 @@ def check_all_command_guards(command: str, env_type: str,
 
     return {"approved": True, "message": None,
             "user_approved": True, "description": combined_desc}
+
+
+# Load permanent allowlist from config on module import
+load_permanent_allowlist()


### PR DESCRIPTION
Salvage of #4741 by @catbusconductor (cherry-picked onto current main).

## Summary

`load_permanent_allowlist()` was fully implemented but never called — permanent approvals from `/approve always` were written to `config.yaml` but silently lost on restart. This adds the module-level call so they're loaded back on import.

## Changes

- `tools/approval.py`: Added `load_permanent_allowlist()` call at module level (+4 lines)

Closes #4739, closes #4741