### PR TITLE
fix: remove Gemma from tool-use enforcement defaults

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -187,7 +187,7 @@ TOOL_USE_ENFORCEMENT_GUIDANCE = (
 
 # Model name substrings that trigger tool-use enforcement guidance.
 # Add new patterns here when a model family needs explicit steering.
-TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex", "gemini", "gemma")
+TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex", "gemini")
 
 # Gemini/Gemma-specific operational guidance, adapted from OpenCode's gemini.txt.
 # Injected alongside TOOL_USE_ENFORCEMENT_GUIDANCE when the model is Gemini or Gemma.

--- a/run_agent.py
+++ b/run_agent.py
@@ -2483,11 +2483,12 @@ class AIAgent:
                 _inject = any(p in model_lower for p in TOOL_USE_ENFORCEMENT_MODELS)
             if _inject:
                 prompt_parts.append(TOOL_USE_ENFORCEMENT_GUIDANCE)
-                # Google model operational guidance (conciseness, absolute
-                # paths, parallel tool calls, verify-before-edit, etc.)
-                _model_lower = (self.model or "").lower()
-                if "gemini" in _model_lower or "gemma" in _model_lower:
-                    prompt_parts.append(GOOGLE_MODEL_OPERATIONAL_GUIDANCE)
+            # Google model operational guidance (conciseness, absolute
+            # paths, parallel tool calls, verify-before-edit, etc.)
+            # Injected independently of tool-use enforcement.
+            _model_lower = (self.model or "").lower()
+            if "gemini" in _model_lower or "gemma" in _model_lower:
+                prompt_parts.append(GOOGLE_MODEL_OPERATIONAL_GUIDANCE)
 
         # so it can refer the user to them rather than reinventing answers.
 


### PR DESCRIPTION
## Summary

- Remove `"gemma"` from `TOOL_USE_ENFORCEMENT_MODELS` — Gemma 4 models have native tool-calling support and the enforcement prompt causes them to get stuck
- Move `GOOGLE_MODEL_OPERATIONAL_GUIDANCE` injection outside the enforcement gate so it still applies to Gemma/Gemini models independently

## Problem

When using Gemma 4 (e.g. `gemma-4-26B-A4B-it`) via llama.cpp server, the model frequently produces **5-9 token responses** and stops. It starts describing investigation steps ("here's what I'll do: step 1…") then emits EOS immediately.

The `TOOL_USE_ENFORCEMENT_GUIDANCE` added in 831e8ba (2026-03-28) includes:

> "Never end your turn with a promise of future action — execute it now."
> "Responses that only describe intentions without acting are not acceptable."

This conflicts with Gemma 4's natural planning-then-acting behavior. The model begins listing steps, the enforcement guidance triggers an internal conflict, and the model emits EOS instead of continuing to the actual tool calls.

### Server-side evidence (llama.cpp logs)

Completed requests producing only 5-9 generation tokens — the server returns 200 OK with no errors, confirming the model is deliberately stopping:

```
task 23795 | prompt eval: 35,436 tokens → eval: 5 tokens (80ms)
task 29553 | prompt eval: 18,541 tokens → eval: 5 tokens (77ms)
task 36625 | prompt eval: 50,728 tokens → eval: 9 tokens (62ms)
task 11002 | prompt eval: 45,208 tokens → eval: 9 tokens (55ms)
```

For comparison, normal responses from the same model generate 100-1000+ tokens.

### Why Gemma 4 doesn't need this

- Gemma 4 has **native tool-calling support** via the `peg-gemma4` chat format in llama.cpp
- It uses function-calling tokens baked into the model's vocabulary and chat template
- The enforcement guidance was added 2026-03-28, likely tested primarily with GPT/Codex, and `"gemma"` was included as a catch-all without Gemma 4 testing

### Side effect fixed

`GOOGLE_MODEL_OPERATIONAL_GUIDANCE` (absolute paths, verify-before-edit, dependency checks, etc.) was nested inside `if _inject:`, meaning it was only applied when tool-use enforcement was active. This is now injected independently for all Gemma/Gemini models, since it's useful regardless of enforcement settings.

### Opt-in preserved

Users who still want enforcement for Gemma models can enable it via config:

```yaml
agent:
  tool_use_enforcement: ["gemma"]
```

## Test plan

- [ ] Verify existing tests pass (no test asserts `"gemma" in TOOL_USE_ENFORCEMENT_MODELS`)
- [ ] Test Gemma 4 model in agentic loop — should no longer produce truncated 5-9 token responses
- [ ] Verify Gemma models still receive `GOOGLE_MODEL_OPERATIONAL_GUIDANCE` when enforcement is off
- [ ] Verify `tool_use_enforcement: ["gemma"]` config override still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)