### PR TITLE
feat(image): add Gemini Nano Banana image generation provider

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   "firecrawl-py>=4.16.0,<5",
   "parallel-web>=0.4.2,<1",
   "fal-client>=0.13.1,<1",
+  "gemimg>=0.5,<1",
   # Text-to-speech (Edge TTS is free, no API key needed)
   "edge-tts>=7.2.7,<8",
   # Skills Hub (GitHub App JWT auth — optional, only needed for bot identity)

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -41,6 +41,13 @@ from tools.debug_helpers import DebugSession
 from tools.managed_tool_gateway import resolve_managed_tool_gateway
 from tools.tool_backend_helpers import managed_nous_tools_enabled
 
+# Gemini image generation via gemimg
+try:
+    from gemimg import GemImg
+    _GEMIMG_AVAILABLE = True
+except ImportError:
+    _GEMIMG_AVAILABLE = False
+
 logger = logging.getLogger(__name__)
 
 # Configuration for image generation
@@ -650,6 +657,61 @@ if __name__ == "__main__":
 
 
 # ---------------------------------------------------------------------------
+# Gemini / Nano Banana image generation
+# ---------------------------------------------------------------------------
+
+GEMINI_DEFAULT_MODEL = "gemini-2.5-flash-image"
+GEMINI_PRO_MODEL = "gemini-3-pro-image-preview"
+
+GEMINI_ASPECT_RATIO_MAP = {
+    "landscape": "16:9",
+    "square": "1:1",
+    "portrait": "9:16",
+}
+
+
+def check_gemini_image_requirements() -> bool:
+    """Check if gemimg is available and a Gemini API key is set."""
+    return _GEMIMG_AVAILABLE and bool(os.getenv("GEMINI_API_KEY"))
+
+
+def image_generate_gemini(
+    prompt: str,
+    aspect_ratio: str = "landscape",
+    model: str = GEMINI_DEFAULT_MODEL,
+) -> str:
+    """
+    Generate an image using Google's Gemini (Nano Banana) via gemimg.
+
+    Returns JSON: {"success": bool, "image": str | None, "error": str | None}
+    Image is a local file path saved to ~/.hermes/image_cache/.
+    """
+    if not _GEMIMG_AVAILABLE:
+        return json.dumps({"success": False, "image": None, "error": "gemimg not installed"})
+
+    api_key = os.getenv("GEMINI_API_KEY")
+    if not api_key:
+        return json.dumps({"success": False, "image": None, "error": "GEMINI_API_KEY not set"})
+
+    ar = GEMINI_ASPECT_RATIO_MAP.get(aspect_ratio.lower().strip(), "16:9")
+    save_dir = os.path.expanduser("~/.hermes/image_cache")
+    os.makedirs(save_dir, exist_ok=True)
+
+    try:
+        g = GemImg(api_key=api_key, model=model)
+        result = g.generate(prompt, aspect_ratio=ar, save_dir=save_dir)
+        if result is None or not result.image_paths:
+            return json.dumps({"success": False, "image": None, "error": "Gemini returned no image"})
+        # image_paths are full paths when save_dir is set
+        img_path = str(result.image_paths[0])
+        if not os.path.isabs(img_path):
+            img_path = os.path.join(save_dir, img_path)
+        return json.dumps({"success": True, "image": img_path, "error": None})
+    except Exception as e:
+        return json.dumps({"success": False, "image": None, "error": str(e)})
+
+
+# ---------------------------------------------------------------------------
 # Registry
 # ---------------------------------------------------------------------------
 from tools.registry import registry
@@ -699,5 +761,56 @@ registry.register(
     check_fn=check_image_generation_requirements,
     requires_env=[],
     is_async=False,  # Switched to sync fal_client API to fix "Event loop is closed" in gateway
+    emoji="🎨",
+)
+
+
+GEMINI_IMAGE_GENERATE_SCHEMA = {
+    "name": "gemini_image_generate",
+    "description": "Generate high-quality images from text prompts using Google's Gemini Nano Banana (Gemini 2.5 Flash Image). Excellent at following detailed, markdown-formatted prompts. Supports text-guided editing and nuanced composition. Returns a local file path to the generated PNG. Display it using MEDIA:<path>.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": "The text prompt describing the desired image. Supports markdown lists and detailed descriptions for high accuracy."
+            },
+            "aspect_ratio": {
+                "type": "string",
+                "enum": ["landscape", "square", "portrait"],
+                "description": "Image aspect ratio: 'landscape' (16:9), 'portrait' (9:16), 'square' (1:1).",
+                "default": "landscape"
+            },
+            "model": {
+                "type": "string",
+                "enum": ["gemini-2.5-flash-image", "gemini-3-pro-image-preview"],
+                "description": "Model to use. Default is Nano Banana (Flash). Use Pro for higher quality.",
+                "default": "gemini-2.0-flash-preview-image-generation"
+            }
+        },
+        "required": ["prompt"]
+    }
+}
+
+
+def _handle_gemini_image_generate(args, **kw):
+    prompt = args.get("prompt", "")
+    if not prompt:
+        return json.dumps({"error": "prompt is required"})
+    return image_generate_gemini(
+        prompt=prompt,
+        aspect_ratio=args.get("aspect_ratio", "landscape"),
+        model=args.get("model", GEMINI_DEFAULT_MODEL),
+    )
+
+
+registry.register(
+    name="gemini_image_generate",
+    toolset="image_gen",
+    schema=GEMINI_IMAGE_GENERATE_SCHEMA,
+    handler=_handle_gemini_image_generate,
+    check_fn=check_gemini_image_requirements,
+    requires_env=["GEMINI_API_KEY"],
+    is_async=False,
     emoji="🎨",
 )


### PR DESCRIPTION
## Summary

Adds Google Gemini ([Nano Banana](https://deepmind.google/models/gemini/image/) / `gemini-2.5-flash-image`) as a second image generation provider alongside the existing fal.ai FLUX 2 Pro.

## Changes

- **`tools/image_generation_tool.py`**: New `image_generate_gemini()` function + `gemini_image_generate` tool registration
- **`pyproject.toml`**: Add `gemimg>=0.5,<1` dependency

## Details

- Uses [gemimg](https://github.com/minimaxir/gemimg) — a lightweight wrapper around the Gemini API with no Google SDK dependency
- Optional import: gracefully skipped if `gemimg` is not installed
- Tool is disabled if `GEMINI_API_KEY` is not set in the environment
- Supports `landscape` / `portrait` / `square` aspect ratios
- Supports both Flash (`gemini-2.5-flash-image`) and Pro (`gemini-3-pro-image-preview`) model variants
- Saves generated images locally to `~/.hermes/image_cache/` as PNG files
- Registered in the `image_gen` toolset alongside `image_generate`

## Why Gemini?

Nano Banana has notably strong prompt-following fidelity, especially for detailed compositional requirements. Provides a free-tier alternative to fal.ai for users who have a Gemini API key.