### PR TITLE
fix(security): guard cron script against path traversal and redact output

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -248,7 +248,15 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
     path = Path(script_path).expanduser()
     if not path.is_absolute():
         # Resolve relative paths against HERMES_HOME/scripts/
-        path = get_hermes_home() / "scripts" / path
+        scripts_dir = get_hermes_home() / "scripts"
+        path = (scripts_dir / path).resolve()
+        # Guard against path traversal (e.g. "../../etc/passwd")
+        try:
+            path.relative_to(scripts_dir.resolve())
+        except ValueError:
+            return False, f"Script path escapes the scripts directory: {script_path!r}"
+    else:
+        path = path.resolve()
 
     if not path.exists():
         return False, f"Script not found: {path}"
@@ -274,6 +282,13 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
                 parts.append(f"stdout:\n{stdout}")
             return False, "\n".join(parts)
 
+        # Redact any secrets that may appear in script output before
+        # they are injected into the LLM prompt context.
+        try:
+            from agent.redact import redact_sensitive_text
+            stdout = redact_sensitive_text(stdout)
+        except Exception:
+            pass
         return True, stdout
 
     except subprocess.TimeoutExpired:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -257,6 +257,12 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             return False, f"Script path escapes the scripts directory: {script_path!r}"
     else:
         path = path.resolve()
+        # Restrict absolute paths to HERMES_HOME to prevent
+        # arbitrary file execution outside the user's data directory.
+        try:
+            path.relative_to(get_hermes_home().resolve())
+        except ValueError:
+            return False, f"Absolute script path must be inside HERMES_HOME: {script_path!r}"
 
     if not path.exists():
         return False, f"Script not found: {path}"


### PR DESCRIPTION
## What does this PR do?

The new `script` field added in #5082 lets cron jobs run a Python script
before each turn to collect context data. Two security issues were introduced:

### 1. Path Traversal

Relative script paths were resolved against `HERMES_HOME/scripts/` but
without checking that the resolved path stays inside that directory:
```python
# Before (vulnerable)
path = get_hermes_home() / "scripts" / path
```

A job with `script: "../../.hermes/auth.json"` would resolve to the auth
store and attempt to execute it as Python — leaking its path in the error
message, or worse if the file happened to be valid Python.

**Fix:** After resolving the path, verify it stays within `scripts_dir`
using `Path.relative_to()`. Paths that escape the directory are rejected
with a clear error message.
```python
# After (safe)
scripts_dir = get_hermes_home() / "scripts"
path = (scripts_dir / path).resolve()
try:
    path.relative_to(scripts_dir.resolve())
except ValueError:
    return False, f"Script path escapes the scripts directory: {script_path!r}"
```

### 2. Secret Leakage via Script Output

Script stdout is injected directly into the cron job's LLM prompt context
without redaction. If a script outputs environment variables, config values,
or any string matching a known secret pattern, those secrets flow into the
LLM context unmasked.

**Fix:** Apply `redact_sensitive_text()` to stdout before injecting it —
the same function already used for execute_code sandbox output and log
redaction.
```python
from agent.redact import redact_sensitive_text
stdout = redact_sensitive_text(stdout)
```

### 3. Absolute Path Restriction (follow-up commit)

The initial fix only guarded relative paths. Absolute paths like
`/tmp/evil.py` or `/etc/passwd` were still accepted.

**Fix:** Absolute paths are now also restricted — they must resolve
inside `HERMES_HOME`. Paths outside are rejected with a clear error.
```python
path.relative_to(get_hermes_home().resolve())
```

## Type of Change

- [x] 🔒 Security fix (path traversal)
- [x] 🔒 Security fix (secret leakage)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Consistent with existing path validation pattern (`Path.relative_to()`)
- [x] Consistent with existing redaction pattern (execute_code sandbox)
- [x] No behavior change for legitimate scripts in `HERMES_HOME/scripts/`