### PR TITLE
fix(auth): write Anthropic OAuth token files atomically to prevent corruption

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -429,7 +429,9 @@ def _write_claude_code_credentials(
         existing["claudeAiOauth"] = oauth_data
 
         cred_path.parent.mkdir(parents=True, exist_ok=True)
-        cred_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+        _tmp_cred = cred_path.with_suffix(".tmp")
+        _tmp_cred.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+        _tmp_cred.replace(cred_path)
         # Restrict permissions (credentials file)
         cred_path.chmod(0o600)
     except (OSError, IOError) as e:
@@ -740,7 +742,9 @@ def _save_hermes_oauth_credentials(access_token: str, refresh_token: str, expire
     }
     try:
         _HERMES_OAUTH_FILE.parent.mkdir(parents=True, exist_ok=True)
-        _HERMES_OAUTH_FILE.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        _tmp = _HERMES_OAUTH_FILE.with_suffix(".tmp")
+        _tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        _tmp.replace(_HERMES_OAUTH_FILE)
         _HERMES_OAUTH_FILE.chmod(0o600)
     except (OSError, IOError) as e:
         logger.debug("Failed to save Hermes OAuth credentials: %s", e)


### PR DESCRIPTION
## What does this PR do?

`agent/anthropic_adapter.py` writes Anthropic OAuth token files using
`write_text()` directly — a non-atomic operation. If the process is
killed mid-write (crash, OOM, SIGKILL), the file is left partially
written and corrupt.

On the next startup, `json.loads()` fails to parse the corrupt token
file — the user's Anthropic OAuth session is permanently broken and
they must re-authenticate manually.

Two write sites are affected:
- `_HERMES_OAUTH_FILE` — the main Hermes OAuth token store
- `cred_path` — per-credential token files

## Fix

Write to a `.tmp` sibling file first, then use `Path.replace()` which
is atomic on POSIX systems (rename syscall).
```python
# Before (non-atomic)
_HERMES_OAUTH_FILE.write_text(json.dumps(data, indent=2), encoding="utf-8")

# After (atomic)
_tmp = _HERMES_OAUTH_FILE.with_suffix(".tmp")
_tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
_tmp.replace(_HERMES_OAUTH_FILE)
```

This is consistent with the atomic write pattern already used in
`hermes_cli/auth.py` (`_save_auth_store`), `gateway/run.py`, and
`tools/skill_manager_tool.py`.

## Type of Change

- [x] 🐛 Bug fix (reliability)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Consistent with existing atomic write pattern in Hermes
- [x] No behavior change under normal operation
- [x] Prevents OAuth token loss after process crash