### PR TITLE
fix(gateway): honor custom provider context length

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -381,6 +381,64 @@ def _resolve_gateway_model(config: dict | None = None) -> str:
     return ""
 
 
+def _resolve_custom_provider_context_length(
+    config: dict,
+    *,
+    model: str,
+    provider: str | None = None,
+    base_url: str | None = None,
+) -> int | None:
+    """Return per-model context_length from a matching custom provider entry."""
+    custom_providers = config.get("custom_providers")
+    if not isinstance(custom_providers, list) or not model:
+        return None
+
+    normalized_provider = str(provider or "").strip()
+    normalized_base_url = str(base_url or "").strip().rstrip("/")
+
+    for entry in custom_providers:
+        if not isinstance(entry, dict):
+            continue
+
+        entry_name = str(entry.get("name") or "").strip()
+        entry_base_url = str(entry.get("base_url") or "").strip().rstrip("/")
+        if not (
+            (normalized_provider and entry_name == normalized_provider)
+            or (normalized_base_url and entry_base_url == normalized_base_url)
+        ):
+            continue
+
+        models = entry.get("models") or {}
+        if isinstance(models, dict):
+            model_cfg = models.get(model)
+            if not isinstance(model_cfg, dict):
+                return None
+            raw_ctx = model_cfg.get("context_length")
+            if raw_ctx is None:
+                return None
+            try:
+                return int(raw_ctx)
+            except (TypeError, ValueError):
+                return None
+
+        if isinstance(models, list):
+            for model_cfg in models:
+                if not isinstance(model_cfg, dict) or model_cfg.get("name") != model:
+                    continue
+                raw_ctx = model_cfg.get("context_length")
+                if raw_ctx is None:
+                    return None
+                try:
+                    return int(raw_ctx)
+                except (TypeError, ValueError):
+                    return None
+            return None
+
+        return None
+
+    return None
+
+
 def _resolve_hermes_bin() -> Optional[list[str]]:
     """Resolve the Hermes update command as argv parts.
 
@@ -2301,23 +2359,14 @@ class GatewayRunner:
                 # Check custom_providers per-model context_length
                 # (same fallback as run_agent.py lines 1171-1189).
                 # Must run after runtime resolution so _hyg_base_url is set.
-                if _hyg_config_context_length is None and _hyg_base_url:
+                if _hyg_config_context_length is None:
                     try:
-                        _hyg_custom_providers = _hyg_data.get("custom_providers")
-                        if isinstance(_hyg_custom_providers, list):
-                            for _cp in _hyg_custom_providers:
-                                if not isinstance(_cp, dict):
-                                    continue
-                                _cp_url = (_cp.get("base_url") or "").rstrip("/")
-                                if _cp_url and _cp_url == _hyg_base_url.rstrip("/"):
-                                    _cp_models = _cp.get("models", {})
-                                    if isinstance(_cp_models, dict):
-                                        _cp_model_cfg = _cp_models.get(_hyg_model, {})
-                                        if isinstance(_cp_model_cfg, dict):
-                                            _cp_ctx = _cp_model_cfg.get("context_length")
-                                            if _cp_ctx is not None:
-                                                _hyg_config_context_length = int(_cp_ctx)
-                                    break
+                        _hyg_config_context_length = _resolve_custom_provider_context_length(
+                            _hyg_data,
+                            model=_hyg_model,
+                            provider=_hyg_provider,
+                            base_url=_hyg_base_url,
+                        )
                     except (TypeError, ValueError):
                         pass
             except Exception:
@@ -2926,6 +2975,7 @@ class GatewayRunner:
         from agent.model_metadata import get_model_context_length, DEFAULT_FALLBACK_CONTEXT
 
         model = _resolve_gateway_model()
+        data = {}
         config_context_length = None
         provider = None
         base_url = None
@@ -2958,6 +3008,17 @@ class GatewayRunner:
             api_key = runtime.get("api_key")
         except Exception:
             pass
+
+        if config_context_length is None:
+            try:
+                config_context_length = _resolve_custom_provider_context_length(
+                    data,
+                    model=model,
+                    provider=provider,
+                    base_url=base_url,
+                )
+            except Exception:
+                pass
 
         context_length = get_model_context_length(
             model,

--- a/tests/gateway/test_session_info.py
+++ b/tests/gateway/test_session_info.py
@@ -61,6 +61,46 @@ class TestFormatSessionInfo:
         assert "128K" in info
         assert "model.context_length" in info
 
+    def test_custom_provider_list_context_length(self, runner, tmp_path):
+        p1, p2, p3 = _patch_info(
+            tmp_path,
+            "model:\n"
+            "  default: my-huge-model\n"
+            "  provider: my-custom\n"
+            "custom_providers:\n"
+            "  - name: my-custom\n"
+            "    base_url: https://my-gateway.io/v1\n"
+            "    models:\n"
+            "      - name: my-huge-model\n"
+            "        context_length: 1100000\n",
+            "my-huge-model",
+            {"provider": "my-custom", "base_url": "https://my-gateway.io/v1", "api_key": ""},
+        )
+        with p1, p2, p3:
+            info = runner._format_session_info()
+        assert "1.1M" in info
+        assert "config" in info
+
+    def test_custom_provider_dict_context_length(self, runner, tmp_path):
+        p1, p2, p3 = _patch_info(
+            tmp_path,
+            "model:\n"
+            "  default: my-huge-model\n"
+            "  provider: my-custom\n"
+            "custom_providers:\n"
+            "  - name: my-custom\n"
+            "    base_url: https://my-gateway.io/v1\n"
+            "    models:\n"
+            "      my-huge-model:\n"
+            "        context_length: 1100000\n",
+            "my-huge-model",
+            {"provider": "my-custom", "base_url": "https://my-gateway.io/v1", "api_key": ""},
+        )
+        with p1, p2, p3:
+            info = runner._format_session_info()
+        assert "1.1M" in info
+        assert "config" in info
+
     def test_local_endpoint_shown(self, runner, tmp_path):
         p1, p2, p3 = _patch_info(
             tmp_path,


### PR DESCRIPTION
Fixes: #5089

Summary:

  This fixes gateway context-length resolution for models configured under custom_providers. When model.context_length is not set at the top level, the gateway status banner was incorrectly falling back to the default 128K context window instead of using the per-model context_length defined on the matching custom provider.


  Related: #4085 fixed the gateway hygiene compression path for custom_providers context length resolution. This PR addresses the remaining gateway status/session info path and also makes the gateway-side lookup handle list-shaped custom_providers.models entries from the current repro.

 Root cause:

  _format_session_info() only read model.context_length from the top-level config and never resolved per-model context_length from custom_providers. The gateway hygiene path also assumed custom_providers[].models was always dict-shaped, so list-shaped model entries were skipped.
  
What changed:

  - Added a small resolver in gateway/run.py to read per-model context_length from the matching custom_providers entry.
  - Reused that resolver in both gateway status info formatting and gateway session hygiene context resolution.
  - Supported both config shapes for custom_providers[].models:
      - dict-based model mappings
      - list-based model entries
  - Added regression tests covering both shapes in tests/gateway/ test_session_info.py.

  Testing:

  - pytest tests/gateway/test_session_info.py

