### PR TITLE
fix(mcp): write OAuth token cache atomically to prevent corruption

### DIFF
--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -114,7 +114,9 @@ class HermesTokenStorage:
 
     @staticmethod
     def _write_json(path: Path, data: dict) -> None:
-        path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        _tmp = path.with_suffix(".tmp")
+        _tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        _tmp.replace(path)
         try:
             path.chmod(0o600)
         except OSError:


### PR DESCRIPTION
## What does this PR do?

`tools/mcp_oauth.py` saves MCP OAuth token cache using `write_text()`
directly — a non-atomic operation. If the process is killed mid-write
(crash, OOM, SIGKILL), the token cache file is left partially written
and corrupt.

On the next startup, the corrupted cache causes MCP OAuth
re-authentication to fail silently — MCP servers that require OAuth
become inaccessible until the file is manually deleted.

## Fix

Write to a `.tmp` sibling file first, then use `Path.replace()` which
is atomic on POSIX systems (rename syscall).
```python
# Before (non-atomic)
path.write_text(json.dumps(data, indent=2), encoding="utf-8")

# After (atomic)
_tmp = path.with_suffix(".tmp")
_tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
_tmp.replace(path)
```

This is consistent with the atomic write pattern already used in
`hermes_cli/auth.py`, `gateway/run.py`, and `tools/skill_manager_tool.py`.

## Type of Change

- [x] 🐛 Bug fix (reliability)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Consistent with existing atomic write pattern in Hermes
- [x] No behavior change under normal operation
- [x] Prevents MCP OAuth token loss after process crash