### PR TITLE
fix(security): extend secret redaction to Groq and Matrix tokens

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -48,6 +48,8 @@ _PREFIX_PATTERNS = [
     r"sk_[A-Za-z0-9_]{10,}",            # ElevenLabs TTS key (sk_ underscore, not sk- dash)
     r"tvly-[A-Za-z0-9]{10,}",           # Tavily search API key
     r"exa_[A-Za-z0-9]{10,}",            # Exa search API key
+    r"gsk_[A-Za-z0-9]{20,}",           # Groq API key
+    r"syt_[A-Za-z0-9_-]{10,}",         # Matrix access token
 ]
 
 # ENV assignment patterns: KEY=value where KEY contains a secret-like name


### PR DESCRIPTION
## What does this PR do?

Two API tokens actively used in Hermes were not covered by
`_PREFIX_PATTERNS` in `agent/redact.py`, allowing them to leak
in plaintext through logs or LLM context:

| Token prefix | Service | Environment variable |
|---|---|---|
| `gsk_` | Groq Cloud API | `GROQ_API_KEY` |
| `syt_` | Matrix access token | `MATRIX_ACCESS_TOKEN` |

Both services are first-class integrations in Hermes:
- **Groq** is a supported STT/transcription provider (`config.stt.provider: groq`)
- **Matrix** is a full gateway adapter with E2EE support

## Fix

Added two new patterns to `_PREFIX_PATTERNS`:
```python
r"gsk_[A-Za-z0-9]{20,}",           # Groq API key
r"syt_[A-Za-z0-9_-]{10,}",         # Matrix access token
```

This follows the same pattern as previous redaction expansions:
- ElevenLabs, Tavily, Exa (#3920)
- Slack xapp, GitLab, Deepgram, Linear (#4541)
- RetainDB, Hindsight, Mem0, ByteRover (#5058)

## Type of Change

- [x] 🔒 Security fix

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Consistent with existing `_PREFIX_PATTERNS` format
- [x] No behavior change for non-secret strings