### PR TITLE
fix(environments): write snapshot stores atomically to prevent corruption

### DIFF
--- a/tools/environments/modal.py
+++ b/tools/environments/modal.py
@@ -39,7 +39,9 @@ def _load_snapshots() -> Dict[str, str]:
 def _save_snapshots(data: Dict[str, str]) -> None:
     """Persist snapshot ID mapping to disk."""
     _SNAPSHOT_STORE.parent.mkdir(parents=True, exist_ok=True)
-    _SNAPSHOT_STORE.write_text(json.dumps(data, indent=2))
+    _tmp = _SNAPSHOT_STORE.with_suffix(".tmp")
+    _tmp.write_text(json.dumps(data, indent=2))
+    _tmp.replace(_SNAPSHOT_STORE)
 
 
 def _direct_snapshot_key(task_id: str) -> str:

--- a/tools/environments/modal.py
+++ b/tools/environments/modal.py
@@ -40,8 +40,17 @@ def _save_snapshots(data: Dict[str, str]) -> None:
     """Persist snapshot ID mapping to disk."""
     _SNAPSHOT_STORE.parent.mkdir(parents=True, exist_ok=True)
     _tmp = _SNAPSHOT_STORE.with_suffix(".tmp")
-    _tmp.write_text(json.dumps(data, indent=2))
-    _tmp.replace(_SNAPSHOT_STORE)
+    with open(_tmp, "w") as f:
+        f.write(json.dumps(data, indent=2))
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(str(_tmp), str(_SNAPSHOT_STORE))
+    try:
+        dir_fd = os.open(str(_SNAPSHOT_STORE.parent), os.O_RDONLY)
+        os.fsync(dir_fd)
+        os.close(dir_fd)
+    except OSError:
+        pass
 
 
 def _direct_snapshot_key(task_id: str) -> str:

--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -88,8 +88,17 @@ def _load_snapshots() -> Dict[str, str]:
 def _save_snapshots(data: Dict[str, str]) -> None:
     _SNAPSHOT_STORE.parent.mkdir(parents=True, exist_ok=True)
     _tmp = _SNAPSHOT_STORE.with_suffix(".tmp")
-    _tmp.write_text(json.dumps(data, indent=2))
-    _tmp.replace(_SNAPSHOT_STORE)
+    with open(_tmp, "w") as f:
+        f.write(json.dumps(data, indent=2))
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(str(_tmp), str(_SNAPSHOT_STORE))
+    try:
+        dir_fd = os.open(str(_SNAPSHOT_STORE.parent), os.O_RDONLY)
+        os.fsync(dir_fd)
+        os.close(dir_fd)
+    except OSError:
+        pass
 
 
 # -------------------------------------------------------------------------

--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -87,7 +87,9 @@ def _load_snapshots() -> Dict[str, str]:
 
 def _save_snapshots(data: Dict[str, str]) -> None:
     _SNAPSHOT_STORE.parent.mkdir(parents=True, exist_ok=True)
-    _SNAPSHOT_STORE.write_text(json.dumps(data, indent=2))
+    _tmp = _SNAPSHOT_STORE.with_suffix(".tmp")
+    _tmp.write_text(json.dumps(data, indent=2))
+    _tmp.replace(_SNAPSHOT_STORE)
 
 
 # -------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Both `tools/environments/modal.py` and `tools/environments/singularity.py`
persist their snapshot ID mappings using `write_text()` directly — a
non-atomic operation. If the process is killed mid-write (crash, OOM,
SIGKILL), the snapshot store file is left partially written and corrupt.

On the next run, `json.loads()` fails to parse the corrupt file — all
tracked sandbox snapshot IDs are lost. This means Modal/Singularity
environments can no longer resume from their snapshots and must rebuild
from scratch, wasting significant time and compute.

## Fix

Write to a `.tmp` sibling file first, then use `Path.replace()` which
is atomic on POSIX systems (rename syscall). Applied to both files.
```python
# Before (non-atomic)
_SNAPSHOT_STORE.write_text(json.dumps(data, indent=2))

# After (atomic)
_tmp = _SNAPSHOT_STORE.with_suffix(".tmp")
_tmp.write_text(json.dumps(data, indent=2))
_tmp.replace(_SNAPSHOT_STORE)
```

This is consistent with the atomic write pattern already used in
`hermes_cli/auth.py`, `gateway/run.py`, and `tools/skill_manager_tool.py`.

## Files Changed

- `tools/environments/modal.py` — `modal_snapshots.json`
- `tools/environments/singularity.py` — `singularity_snapshots.json`

## Type of Change

- [x] 🐛 Bug fix (reliability)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Consistent with existing atomic write pattern in Hermes
- [x] No behavior change under normal operation
- [x] Prevents snapshot state loss after process crash