### PR TITLE
Fix Anthropic OAuth stale token shadowing

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -451,25 +451,49 @@ def _resolve_claude_code_token_from_credentials(creds: Optional[Dict[str, Any]] 
     return None
 
 
-def _prefer_refreshable_claude_code_token(env_token: str, creds: Optional[Dict[str, Any]]) -> Optional[str]:
-    """Prefer Claude Code creds when a persisted env OAuth token would shadow refresh.
+def _resolve_hermes_oauth_token_from_credentials(creds: Optional[Dict[str, Any]] = None) -> Optional[str]:
+    """Resolve a token from Hermes-managed OAuth credentials, refreshing if needed."""
+    creds = creds or read_hermes_oauth_credentials()
+    if creds and is_claude_code_token_valid(creds):
+        logger.debug("Using Hermes-managed Anthropic OAuth credentials")
+        return creds["accessToken"]
+    if creds:
+        logger.debug("Hermes-managed Anthropic OAuth credentials expired — attempting refresh")
+        refreshed = refresh_hermes_oauth_token()
+        if refreshed:
+            return refreshed
+        logger.debug("Hermes OAuth refresh failed — re-run 'hermes auth add anthropic' or 'hermes model'")
+    return None
+
+
+def _prefer_refreshable_file_backed_token(
+    env_token: str,
+    claude_creds: Optional[Dict[str, Any]],
+    hermes_creds: Optional[Dict[str, Any]],
+) -> Optional[str]:
+    """Prefer refreshable file-backed OAuth creds over a static env token.
 
     Hermes historically persisted setup tokens into ANTHROPIC_TOKEN. That makes
     later refresh impossible because the static env token wins before we ever
-    inspect Claude Code's refreshable credential file. If we have a refreshable
-    Claude Code credential record, prefer it over the static env OAuth token.
+    inspect refreshable credential stores. If we have a refreshable Hermes PKCE
+    or Claude Code credential record, prefer it over the static env OAuth token.
     """
-    if not env_token or not _is_oauth_token(env_token) or not isinstance(creds, dict):
-        return None
-    if not creds.get("refreshToken"):
+    if not env_token or not _is_oauth_token(env_token):
         return None
 
-    resolved = _resolve_claude_code_token_from_credentials(creds)
-    if resolved and resolved != env_token:
-        logger.debug(
-            "Preferring Claude Code credential file over static env OAuth token so refresh can proceed"
-        )
-        return resolved
+    for label, creds, resolver in (
+        ("Hermes OAuth", hermes_creds, _resolve_hermes_oauth_token_from_credentials),
+        ("Claude Code", claude_creds, _resolve_claude_code_token_from_credentials),
+    ):
+        if not isinstance(creds, dict) or not creds.get("refreshToken"):
+            continue
+        resolved = resolver(creds)
+        if resolved and resolved != env_token:
+            logger.debug(
+                "Preferring %s credential file over static env OAuth token so refresh can proceed",
+                label,
+            )
+            return resolved
     return None
 
 
@@ -486,6 +510,10 @@ def get_anthropic_token_source(token: Optional[str] = None) -> str:
     cc_env_token = os.getenv("CLAUDE_CODE_OAUTH_TOKEN", "").strip()
     if cc_env_token and cc_env_token == token:
         return "claude_code_oauth_token_env"
+
+    hermes_creds = read_hermes_oauth_credentials()
+    if hermes_creds and hermes_creds.get("accessToken") == token:
+        return "hermes_oauth_credentials"
 
     creds = read_claude_code_credentials()
     if creds and creds.get("accessToken") == token:
@@ -506,38 +534,48 @@ def resolve_anthropic_token() -> Optional[str]:
     """Resolve an Anthropic token from all available sources.
 
     Priority:
-      1. ANTHROPIC_TOKEN env var (OAuth/setup token saved by Hermes)
+      1. ANTHROPIC_TOKEN env var (legacy/static setup token)
+         — but prefer refreshable Hermes/Claude credential stores when available
       2. CLAUDE_CODE_OAUTH_TOKEN env var
-      3. Claude Code credentials (~/.claude.json or ~/.claude/.credentials.json)
+         — but prefer refreshable Hermes/Claude credential stores when available
+      3. Hermes-managed OAuth credentials (~/.hermes/.anthropic_oauth.json)
          — with automatic refresh if expired and a refresh token is available
-      4. ANTHROPIC_API_KEY env var (regular API key, or legacy fallback)
+      4. Claude Code credentials (~/.claude/.credentials.json)
+         — with automatic refresh if expired and a refresh token is available
+      5. ANTHROPIC_API_KEY env var (regular API key, or legacy fallback)
 
     Returns the token string or None.
     """
-    creds = read_claude_code_credentials()
+    claude_creds = read_claude_code_credentials()
+    hermes_creds = read_hermes_oauth_credentials()
 
-    # 1. Hermes-managed OAuth/setup token env var
+    # 1. Legacy/static OAuth token in env — allow refreshable stores to override.
     token = os.getenv("ANTHROPIC_TOKEN", "").strip()
     if token:
-        preferred = _prefer_refreshable_claude_code_token(token, creds)
+        preferred = _prefer_refreshable_file_backed_token(token, claude_creds, hermes_creds)
         if preferred:
             return preferred
         return token
 
-    # 2. CLAUDE_CODE_OAUTH_TOKEN (used by Claude Code for setup-tokens)
+    # 2. Claude Code setup-token env — allow refreshable stores to override.
     cc_token = os.getenv("CLAUDE_CODE_OAUTH_TOKEN", "").strip()
     if cc_token:
-        preferred = _prefer_refreshable_claude_code_token(cc_token, creds)
+        preferred = _prefer_refreshable_file_backed_token(cc_token, claude_creds, hermes_creds)
         if preferred:
             return preferred
         return cc_token
 
-    # 3. Claude Code credential file
-    resolved_claude_token = _resolve_claude_code_token_from_credentials(creds)
+    # 3. Hermes-native PKCE credentials.
+    resolved_hermes_token = _resolve_hermes_oauth_token_from_credentials(hermes_creds)
+    if resolved_hermes_token:
+        return resolved_hermes_token
+
+    # 4. Claude Code credential file.
+    resolved_claude_token = _resolve_claude_code_token_from_credentials(claude_creds)
     if resolved_claude_token:
         return resolved_claude_token
 
-    # 4. Regular API key, or a legacy OAuth token saved in ANTHROPIC_API_KEY.
+    # 5. Regular API key, or a legacy OAuth token saved in ANTHROPIC_API_KEY.
     # This remains as a compatibility fallback for pre-migration Hermes configs.
     api_key = os.getenv("ANTHROPIC_API_KEY", "").strip()
     if api_key:

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -674,10 +674,12 @@ def _normalize_pool_priorities(provider: str, entries: List[PooledCredential]) -
         return False
 
     source_rank = {
-        "env:ANTHROPIC_TOKEN": 0,
-        "env:CLAUDE_CODE_OAUTH_TOKEN": 1,
-        "hermes_pkce": 2,
-        "claude_code": 3,
+        # Prefer refreshable file-backed OAuth over static env setup-tokens so
+        # Anthropic reauth/refresh can actually take effect.
+        "hermes_pkce": 0,
+        "claude_code": 1,
+        "env:ANTHROPIC_TOKEN": 2,
+        "env:CLAUDE_CODE_OAUTH_TOKEN": 3,
         "env:ANTHROPIC_API_KEY": 4,
     }
     manual_entries = sorted(

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -176,6 +176,20 @@ def auth_add_command(args) -> None:
         creds = anthropic_mod.run_hermes_oauth_login_pure()
         if not creds:
             raise SystemExit("Anthropic OAuth login did not return credentials.")
+
+        # Persist the same refreshable OAuth credentials to Hermes/Claude files so
+        # status, doctor, and non-pool Anthropic paths stay in sync with auth add.
+        anthropic_mod._save_hermes_oauth_credentials(
+            creds["access_token"],
+            creds.get("refresh_token", ""),
+            creds.get("expires_at_ms", 0),
+        )
+        anthropic_mod._write_claude_code_credentials(
+            creds["access_token"],
+            creds.get("refresh_token", ""),
+            creds.get("expires_at_ms", 0),
+        )
+
         label = (getattr(args, "label", None) or "").strip() or label_from_token(
             creds["access_token"],
             _oauth_default_label(provider, len(pool.entries()) + 1),

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -623,7 +623,12 @@ def run_doctor(args):
     else:
         check_warn("OpenRouter API", "(not configured)")
     
-    anthropic_key = os.getenv("ANTHROPIC_TOKEN") or os.getenv("ANTHROPIC_API_KEY")
+    anthropic_key = None
+    try:
+        from agent.anthropic_adapter import resolve_anthropic_token
+        anthropic_key = resolve_anthropic_token()
+    except Exception:
+        anthropic_key = os.getenv("ANTHROPIC_TOKEN") or os.getenv("ANTHROPIC_API_KEY")
     if anthropic_key:
         print("  Checking Anthropic API...", end="", flush=True)
         try:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -4,6 +4,7 @@ Doctor command for hermes CLI.
 Diagnoses issues with Hermes Agent setup.
 """
 
+import logging
 import os
 import sys
 import subprocess
@@ -29,6 +30,8 @@ load_dotenv(PROJECT_ROOT / ".env", override=False, encoding="utf-8")
 
 from hermes_cli.colors import Colors, color
 from hermes_constants import OPENROUTER_MODELS_URL
+
+logger = logging.getLogger(__name__)
 
 
 _PROVIDER_ENV_HINTS = (
@@ -130,6 +133,22 @@ def _check_gateway_service_linger(issues: list[str]) -> None:
         issues.append("Enable linger for the gateway user service: sudo loginctl enable-linger $USER")
     else:
         check_warn("Could not verify systemd linger", f"({linger_detail})")
+
+
+def _resolve_anthropic_key_for_doctor():
+    """Resolve Anthropic credentials for doctor, warning on resolver failures."""
+    try:
+        from agent.anthropic_adapter import resolve_anthropic_token
+
+        return resolve_anthropic_token()
+    except Exception as exc:
+        logger.warning(
+            "Failed to resolve Anthropic credentials in doctor; "
+            "falling back to environment variables: %s",
+            exc,
+            exc_info=True,
+        )
+        return os.getenv("ANTHROPIC_TOKEN") or os.getenv("ANTHROPIC_API_KEY")
 
 
 def run_doctor(args):
@@ -623,12 +642,7 @@ def run_doctor(args):
     else:
         check_warn("OpenRouter API", "(not configured)")
     
-    anthropic_key = None
-    try:
-        from agent.anthropic_adapter import resolve_anthropic_token
-        anthropic_key = resolve_anthropic_token()
-    except Exception:
-        anthropic_key = os.getenv("ANTHROPIC_TOKEN") or os.getenv("ANTHROPIC_API_KEY")
+    anthropic_key = _resolve_anthropic_key_for_doctor()
     if anthropic_key:
         print("  Checking Anthropic API...", end="", flush=True)
         try:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -73,6 +73,25 @@ def _honcho_is_configured_for_doctor() -> bool:
         return False
 
 
+def _honcho_memory_mode_label(cfg) -> str:
+    """Return a display-safe Honcho memory mode for mixed-version installs."""
+    mode = getattr(cfg, "memory_mode", None)
+    if isinstance(mode, str) and mode:
+        return mode
+
+    raw = getattr(cfg, "raw", None)
+    if isinstance(raw, dict):
+        raw_mode = raw.get("memoryMode")
+        if isinstance(raw_mode, dict):
+            default_mode = raw_mode.get("default")
+            if isinstance(default_mode, str) and default_mode:
+                return default_mode
+        elif isinstance(raw_mode, str) and raw_mode:
+            return raw_mode
+
+    return "default"
+
+
 def _apply_doctor_tool_availability_overrides(available: list[str], unavailable: list[dict]) -> tuple[list[str], list[dict]]:
     """Adjust runtime-gated tool availability for doctor diagnostics."""
     if not _honcho_is_configured_for_doctor():
@@ -836,7 +855,7 @@ def run_doctor(args):
                 get_honcho_client(hcfg)
                 check_ok(
                     "Honcho connected",
-                    f"workspace={hcfg.workspace_id} mode={hcfg.memory_mode} freq={hcfg.write_frequency}",
+                    f"workspace={hcfg.workspace_id} mode={_honcho_memory_mode_label(hcfg)} freq={hcfg.write_frequency}",
                 )
             except Exception as _e:
                 check_fail("Honcho connection failed", str(_e))

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2227,8 +2227,10 @@ def _model_flow_api_key_provider(config, provider_id, current_model=""):
 
 
 def _run_anthropic_oauth_flow(save_env_value):
-    """Run the Claude OAuth setup-token flow. Returns True if credentials were saved."""
+    """Run Anthropic OAuth login, preferring Hermes-native PKCE over static setup-tokens."""
     from agent.anthropic_adapter import (
+        run_hermes_oauth_login,
+        read_hermes_oauth_credentials,
         run_oauth_setup_token,
         read_claude_code_credentials,
         is_claude_code_token_valid,
@@ -2238,15 +2240,29 @@ def _run_anthropic_oauth_flow(save_env_value):
         use_anthropic_claude_code_credentials,
     )
 
-    def _activate_claude_code_credentials_if_available() -> bool:
-        try:
-            creds = read_claude_code_credentials()
-        except Exception:
-            creds = None
-        if creds and (
+    def _is_refreshable(creds) -> bool:
+        return bool(creds) and (
             is_claude_code_token_valid(creds)
             or bool(creds.get("refreshToken"))
-        ):
+        )
+
+    def _activate_file_backed_credentials_if_available() -> bool:
+        try:
+            hermes_creds = read_hermes_oauth_credentials()
+        except Exception:
+            hermes_creds = None
+        if _is_refreshable(hermes_creds):
+            use_anthropic_claude_code_credentials(save_fn=save_env_value)
+            print("  ✓ Hermes OAuth credentials linked.")
+            from hermes_constants import display_hermes_home as _dhh_fn
+            print(f"    Hermes will use its refreshable credential store directly instead of copying a setup-token into {_dhh_fn()}/.env.")
+            return True
+
+        try:
+            claude_creds = read_claude_code_credentials()
+        except Exception:
+            claude_creds = None
+        if _is_refreshable(claude_creds):
             use_anthropic_claude_code_credentials(save_fn=save_env_value)
             print("  ✓ Claude Code credentials linked.")
             from hermes_constants import display_hermes_home as _dhh_fn
@@ -2254,14 +2270,28 @@ def _run_anthropic_oauth_flow(save_env_value):
             return True
         return False
 
+    print()
+    print("  Starting Hermes-native Anthropic OAuth login.")
+    print("  A browser window will open for you to authorize access.")
+    print()
+    token = run_hermes_oauth_login()
+    if token:
+        if _activate_file_backed_credentials_if_available():
+            return True
+        save_anthropic_oauth_token(token, save_fn=save_env_value)
+        print("  ✓ OAuth credentials saved.")
+        return True
+
+    print("  Hermes-native OAuth login did not complete.")
+    print()
+
     try:
-        print()
-        print("  Running 'claude setup-token' — follow the prompts below.")
+        print("  Falling back to 'claude setup-token' — follow the prompts below.")
         print("  A browser window will open for you to authorize access.")
         print()
         token = run_oauth_setup_token()
         if token:
-            if _activate_claude_code_credentials_if_available():
+            if _activate_file_backed_credentials_if_available():
                 return True
             save_anthropic_oauth_token(token, save_fn=save_env_value)
             print("  ✓ OAuth credentials saved.")
@@ -2287,9 +2317,10 @@ def _run_anthropic_oauth_flow(save_env_value):
     except FileNotFoundError:
         # Claude CLI not installed — guide user through manual setup
         print()
-        print("  The 'claude' CLI is required for OAuth login.")
+        print("  Claude Code is not installed, so Hermes could not fall back to 'claude setup-token'.")
         print()
-        print("  To install and authenticate:")
+        print("  You can still authenticate with Hermes-native OAuth by re-running this flow,")
+        print("  or install Claude Code for the setup-token fallback:")
         print()
         print("    1. Install Claude Code:  npm install -g @anthropic-ai/claude-code")
         print("    2. Run:                  claude setup-token")

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -137,11 +137,16 @@ def show_status(args):
         display = redact_key(value) if not show_all else value
         print(f"  {name:<12}  {check_mark(has_key)} {display}")
 
-    anthropic_value = (
-        get_env_value("ANTHROPIC_TOKEN")
-        or get_env_value("ANTHROPIC_API_KEY")
-        or ""
-    )
+    anthropic_value = ""
+    try:
+        from agent.anthropic_adapter import resolve_anthropic_token
+        anthropic_value = resolve_anthropic_token() or ""
+    except Exception:
+        anthropic_value = (
+            get_env_value("ANTHROPIC_TOKEN")
+            or get_env_value("ANTHROPIC_API_KEY")
+            or ""
+        )
     anthropic_display = redact_key(anthropic_value) if not show_all else anthropic_value
     print(f"  {'Anthropic':<12}  {check_mark(bool(anthropic_value))} {anthropic_display}")
 

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -4,6 +4,7 @@ Status command for hermes CLI.
 Shows the status of all Hermes Agent components.
 """
 
+import logging
 import os
 import sys
 import subprocess
@@ -19,6 +20,9 @@ from hermes_cli.nous_subscription import get_nous_subscription_features
 from hermes_cli.runtime_provider import resolve_requested_provider
 from hermes_constants import OPENROUTER_MODELS_URL
 from tools.tool_backend_helpers import managed_nous_tools_enabled
+
+logger = logging.getLogger(__name__)
+
 
 def check_mark(ok: bool) -> str:
     if ok:
@@ -79,6 +83,26 @@ def _effective_provider_label() -> str:
     return provider_label(effective)
 
 
+def _resolve_anthropic_key_for_status() -> str:
+    """Resolve Anthropic credentials for status, warning on resolver failures."""
+    try:
+        from agent.anthropic_adapter import resolve_anthropic_token
+
+        return resolve_anthropic_token() or ""
+    except Exception as exc:
+        logger.warning(
+            "Failed to resolve Anthropic credentials in status; "
+            "falling back to environment variables: %s",
+            exc,
+            exc_info=True,
+        )
+        return (
+            get_env_value("ANTHROPIC_TOKEN")
+            or get_env_value("ANTHROPIC_API_KEY")
+            or ""
+        )
+
+
 def show_status(args):
     """Show status of all Hermes Agent components."""
     show_all = getattr(args, 'all', False)
@@ -137,16 +161,7 @@ def show_status(args):
         display = redact_key(value) if not show_all else value
         print(f"  {name:<12}  {check_mark(has_key)} {display}")
 
-    anthropic_value = ""
-    try:
-        from agent.anthropic_adapter import resolve_anthropic_token
-        anthropic_value = resolve_anthropic_token() or ""
-    except Exception:
-        anthropic_value = (
-            get_env_value("ANTHROPIC_TOKEN")
-            or get_env_value("ANTHROPIC_API_KEY")
-            or ""
-        )
+    anthropic_value = _resolve_anthropic_key_for_status()
     anthropic_display = redact_key(anthropic_value) if not show_all else anthropic_value
     print(f"  {'Anthropic':<12}  {check_mark(bool(anthropic_value))} {anthropic_display}")
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -5,6 +5,7 @@ import sys
 import types
 from argparse import Namespace
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -136,3 +137,21 @@ def test_check_gateway_service_linger_skips_when_service_not_installed(monkeypat
     out = capsys.readouterr().out
     assert out == ""
     assert issues == []
+
+
+def test_resolve_anthropic_key_for_doctor_logs_warning_and_falls_back(monkeypatch):
+    warning = MagicMock()
+    monkeypatch.setattr(doctor_mod.logger, "warning", warning)
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.resolve_anthropic_token",
+        lambda: (_ for _ in ()).throw(RuntimeError("bad creds")),
+    )
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-fallback")
+    monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+
+    resolved = doctor_mod._resolve_anthropic_key_for_doctor()
+
+    assert resolved == "sk-ant-api03-fallback"
+    warning.assert_called_once()
+    assert "Failed to resolve Anthropic credentials in doctor" in warning.call_args.args[0]
+    assert warning.call_args.kwargs["exc_info"] is True

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -76,6 +76,28 @@ class TestHonchoDoctorConfigDetection:
         assert not doctor._honcho_is_configured_for_doctor()
 
 
+class TestHonchoDoctorMemoryModeLabel:
+    def test_uses_memory_mode_when_available(self):
+        fake_config = SimpleNamespace(memory_mode="honcho")
+
+        assert doctor._honcho_memory_mode_label(fake_config) == "honcho"
+
+    def test_falls_back_to_raw_string_memory_mode(self):
+        fake_config = SimpleNamespace(raw={"memoryMode": "hybrid"})
+
+        assert doctor._honcho_memory_mode_label(fake_config) == "hybrid"
+
+    def test_falls_back_to_raw_object_default_memory_mode(self):
+        fake_config = SimpleNamespace(raw={"memoryMode": {"default": "context"}})
+
+        assert doctor._honcho_memory_mode_label(fake_config) == "context"
+
+    def test_returns_default_for_legacy_configs(self):
+        fake_config = SimpleNamespace(raw={})
+
+        assert doctor._honcho_memory_mode_label(fake_config) == "default"
+
+
 def test_run_doctor_sets_interactive_env_for_tool_checks(monkeypatch, tmp_path):
     """Doctor should present CLI-gated tools as available in CLI context."""
     project_root = tmp_path / "project"

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -1,5 +1,7 @@
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
+from hermes_cli import status as status_mod
 from hermes_cli.status import show_status
 
 
@@ -12,3 +14,25 @@ def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
     output = capsys.readouterr().out
     assert "Tavily" in output
     assert "tvly...cdef" in output
+
+
+def test_resolve_anthropic_key_for_status_logs_warning_and_falls_back(monkeypatch):
+    warning = MagicMock()
+    monkeypatch.setattr(status_mod.logger, "warning", warning)
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.resolve_anthropic_token",
+        lambda: (_ for _ in ()).throw(RuntimeError("bad creds")),
+    )
+    monkeypatch.setattr(
+        status_mod,
+        "get_env_value",
+        lambda name: "sk-ant-api03-fallback" if name == "ANTHROPIC_API_KEY" else "",
+        raising=False,
+    )
+
+    resolved = status_mod._resolve_anthropic_key_for_status()
+
+    assert resolved == "sk-ant-api03-fallback"
+    warning.assert_called_once()
+    assert "Failed to resolve Anthropic credentials in status" in warning.call_args.args[0]
+    assert warning.call_args.kwargs["exc_info"] is True

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -165,6 +165,22 @@ class TestResolveAnthropicToken:
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
         assert resolve_anthropic_token() == "sk-ant-oat01-mytoken"
 
+    def test_reports_hermes_oauth_source(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.read_hermes_oauth_credentials",
+            lambda: {
+                "accessToken": "hermes-oauth-token",
+                "refreshToken": "refresh-token",
+                "expiresAt": int(time.time() * 1000) + 3600_000,
+            },
+        )
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+
+        assert get_anthropic_token_source("hermes-oauth-token") == "hermes_oauth_credentials"
+
     def test_reports_claude_json_primary_key_source(self, monkeypatch, tmp_path):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
@@ -211,6 +227,22 @@ class TestResolveAnthropicToken:
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
         assert resolve_anthropic_token() == "sk-ant-oat01-test-token"
 
+    def test_falls_back_to_hermes_oauth_credentials(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.read_hermes_oauth_credentials",
+            lambda: {
+                "accessToken": "hermes-auto-token",
+                "refreshToken": "refresh",
+                "expiresAt": int(time.time() * 1000) + 3600_000,
+            },
+        )
+        monkeypatch.setattr("agent.anthropic_adapter.read_claude_code_credentials", lambda: None)
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        assert resolve_anthropic_token() == "hermes-auto-token"
+
     def test_falls_back_to_claude_code_credentials(self, monkeypatch, tmp_path):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
@@ -224,8 +256,26 @@ class TestResolveAnthropicToken:
                 "expiresAt": int(time.time() * 1000) + 3600_000,
             }
         }))
+        monkeypatch.setattr("agent.anthropic_adapter.read_hermes_oauth_credentials", lambda: None)
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
         assert resolve_anthropic_token() == "cc-auto-token"
+
+    def test_prefers_refreshable_hermes_oauth_credentials_over_static_anthropic_token(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_TOKEN", "sk-ant-oat01-static-token")
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.read_hermes_oauth_credentials",
+            lambda: {
+                "accessToken": "hermes-auto-token",
+                "refreshToken": "refresh-token",
+                "expiresAt": int(time.time() * 1000) + 3600_000,
+            },
+        )
+        monkeypatch.setattr("agent.anthropic_adapter.read_claude_code_credentials", lambda: None)
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+
+        assert resolve_anthropic_token() == "hermes-auto-token"
 
     def test_prefers_refreshable_claude_code_credentials_over_static_anthropic_token(self, monkeypatch, tmp_path):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
@@ -240,6 +290,7 @@ class TestResolveAnthropicToken:
                 "expiresAt": int(time.time() * 1000) + 3600_000,
             }
         }))
+        monkeypatch.setattr("agent.anthropic_adapter.read_hermes_oauth_credentials", lambda: None)
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
 
         assert resolve_anthropic_token() == "cc-auto-token"

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -424,6 +424,32 @@ class TestResolveWithRefresh:
 
         assert result == "refreshed-token"
 
+    def test_falls_back_to_api_key_when_both_refreshable_stores_are_expired_and_refresh_fails(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-fallback-key")
+        monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+        monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+
+        expired_hermes_creds = {
+            "accessToken": "expired-hermes-token",
+            "refreshToken": "hermes-refresh-token",
+            "expiresAt": int(time.time() * 1000) - 3600_000,
+        }
+        expired_claude_creds = {
+            "accessToken": "expired-claude-token",
+            "refreshToken": "claude-refresh-token",
+            "expiresAt": int(time.time() * 1000) - 3600_000,
+        }
+
+        with patch("agent.anthropic_adapter.read_hermes_oauth_credentials", return_value=expired_hermes_creds), \
+             patch("agent.anthropic_adapter.read_claude_code_credentials", return_value=expired_claude_creds), \
+             patch("agent.anthropic_adapter.refresh_hermes_oauth_token", return_value=None) as hermes_refresh, \
+             patch("agent.anthropic_adapter._refresh_oauth_token", return_value=None) as claude_refresh:
+            result = resolve_anthropic_token()
+
+        assert result == "sk-ant-api03-fallback-key"
+        hermes_refresh.assert_called_once()
+        claude_refresh.assert_called_once()
+
 
 class TestRunOauthSetupToken:
     def test_raises_when_claude_not_installed(self, monkeypatch):

--- a/tests/test_anthropic_oauth_flow.py
+++ b/tests/test_anthropic_oauth_flow.py
@@ -3,11 +3,55 @@
 from hermes_cli.config import load_env, save_env_value
 
 
-def test_run_anthropic_oauth_flow_prefers_claude_code_credentials(tmp_path, monkeypatch, capsys):
+def test_run_anthropic_oauth_flow_prefers_hermes_pkce_credentials(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.run_hermes_oauth_login",
+        lambda: "sk-ant-oat01-from-hermes-pkce",
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.read_hermes_oauth_credentials",
+        lambda: {
+            "accessToken": "hermes-access-token",
+            "refreshToken": "hermes-refresh-token",
+            "expiresAt": 9999999999999,
+        },
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.run_oauth_setup_token",
+        lambda: (_ for _ in ()).throw(AssertionError("should not fall back to claude setup-token")),
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.read_claude_code_credentials",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.is_claude_code_token_valid",
+        lambda creds: True,
+    )
+
+    from hermes_cli.main import _run_anthropic_oauth_flow
+
+    save_env_value("ANTHROPIC_TOKEN", "stale-env-token")
+    assert _run_anthropic_oauth_flow(save_env_value) is True
+
+    env_vars = load_env()
+    assert env_vars["ANTHROPIC_TOKEN"] == ""
+    assert env_vars["ANTHROPIC_API_KEY"] == ""
+    output = capsys.readouterr().out
+    assert "Hermes OAuth credentials linked" in output
+
+
+def test_run_anthropic_oauth_flow_prefers_claude_code_credentials_on_fallback(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("agent.anthropic_adapter.run_hermes_oauth_login", lambda: None)
     monkeypatch.setattr(
         "agent.anthropic_adapter.run_oauth_setup_token",
         lambda: "sk-ant-oat01-from-claude-setup",
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.read_hermes_oauth_credentials",
+        lambda: None,
     )
     monkeypatch.setattr(
         "agent.anthropic_adapter.read_claude_code_credentials",
@@ -34,9 +78,12 @@ def test_run_anthropic_oauth_flow_prefers_claude_code_credentials(tmp_path, monk
     assert "Claude Code credentials linked" in output
 
 
+
 def test_run_anthropic_oauth_flow_manual_token_still_persists(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr("agent.anthropic_adapter.run_hermes_oauth_login", lambda: None)
     monkeypatch.setattr("agent.anthropic_adapter.run_oauth_setup_token", lambda: None)
+    monkeypatch.setattr("agent.anthropic_adapter.read_hermes_oauth_credentials", lambda: None)
     monkeypatch.setattr("agent.anthropic_adapter.read_claude_code_credentials", lambda: None)
     monkeypatch.setattr("agent.anthropic_adapter.is_claude_code_token_valid", lambda creds: False)
     monkeypatch.setattr("builtins.input", lambda _prompt="": "sk-ant-oat01-manual-token")

--- a/tests/test_auth_commands.py
+++ b/tests/test_auth_commands.py
@@ -64,6 +64,11 @@ def test_auth_add_anthropic_oauth_persists_pool_entry(tmp_path, monkeypatch):
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
     monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "agent.anthropic_adapter._HERMES_OAUTH_FILE",
+        tmp_path / "hermes" / ".anthropic_oauth.json",
+    )
     _write_auth_store(tmp_path, {"version": 1, "providers": {}})
     token = _jwt_with_email("claude@example.com")
     monkeypatch.setattr(
@@ -92,6 +97,14 @@ def test_auth_add_anthropic_oauth_persists_pool_entry(tmp_path, monkeypatch):
     assert entry["source"] == "manual:hermes_pkce"
     assert entry["refresh_token"] == "refresh-token"
     assert entry["expires_at_ms"] == 1711234567000
+
+    hermes_oauth = json.loads((tmp_path / "hermes" / ".anthropic_oauth.json").read_text())
+    assert hermes_oauth["accessToken"] == token
+    assert hermes_oauth["refreshToken"] == "refresh-token"
+
+    claude_creds = json.loads((tmp_path / ".claude" / ".credentials.json").read_text())
+    assert claude_creds["claudeAiOauth"]["accessToken"] == token
+    assert claude_creds["claudeAiOauth"]["refreshToken"] == "refresh-token"
 
 
 def test_auth_add_nous_oauth_persists_pool_entry(tmp_path, monkeypatch):

--- a/tests/test_credential_pool.py
+++ b/tests/test_credential_pool.py
@@ -541,7 +541,7 @@ def test_singleton_seed_does_not_clobber_manual_oauth_entry(tmp_path, monkeypatc
     assert {entry.source for entry in entries} == {"manual:hermes_pkce", "hermes_pkce"}
 
 
-def test_load_pool_prefers_anthropic_env_token_over_file_backed_oauth(tmp_path, monkeypatch):
+def test_load_pool_prefers_file_backed_anthropic_oauth_over_env_token(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.setenv("ANTHROPIC_TOKEN", "env-override-token")
@@ -567,8 +567,34 @@ def test_load_pool_prefers_anthropic_env_token_over_file_backed_oauth(tmp_path, 
     entry = pool.select()
 
     assert entry is not None
+    assert entry.source == "hermes_pkce"
+    assert entry.access_token == "file-backed-token"
+
+
+def test_load_pool_uses_anthropic_env_token_when_no_file_backed_oauth_exists(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("ANTHROPIC_TOKEN", "env-only-token")
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.read_hermes_oauth_credentials",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.read_claude_code_credentials",
+        lambda: None,
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("anthropic")
+    entry = pool.select()
+
+    assert entry is not None
     assert entry.source == "env:ANTHROPIC_TOKEN"
-    assert entry.access_token == "env-override-token"
+    assert entry.access_token == "env-only-token"
 
 
 def test_least_used_strategy_selects_lowest_count(tmp_path, monkeypatch):


### PR DESCRIPTION
Fixes #6346

## Summary
Fix Anthropic OAuth flows getting stuck behind stale `ANTHROPIC_TOKEN` values.

## Changes
- prefer Hermes-native PKCE in `hermes model` Anthropic OAuth flow
- prefer refreshable Hermes/Claude file-backed creds over static env setup tokens
- persist Hermes Anthropic OAuth creds when using `hermes auth add anthropic`
- route status/doctor Anthropic checks through token resolution logic
- add regression coverage for stale-token shadowing

## Reproduction (before fix)
1. Put a stale or invalid Anthropic OAuth token in your environment, for example in `~/.hermes/.env`:
   ```bash
   ANTHROPIC_TOKEN=stale-env-token
   ```
   or export it in your shell:
   ```bash
   export ANTHROPIC_TOKEN=stale-env-token
   ```
2. Re-auth Anthropic successfully through a refreshable OAuth flow so Hermes now has valid file-backed credentials.
   For example:
   ```bash
   hermes auth add anthropic
   ```
   or use the Anthropic login flow in `hermes model`.
3. Run a command that should use the newly refreshed Anthropic credentials, such as:
   ```bash
   hermes status
   hermes doctor
   ```
   or start Hermes on an Anthropic model.
4. Before this fix, the stale `ANTHROPIC_TOKEN` could still win during credential resolution and shadow the fresh OAuth credentials.

Observed pre-fix behavior:
- Anthropic requests still fail with 401/unauthorized-style auth errors even after reauth
- status/doctor can report Anthropic as broken even though valid refreshable creds exist
- `hermes auth add anthropic` did not consistently persist the right credential source for later use

## Why
Users could end up with an invalid or stale `ANTHROPIC_TOKEN` in `.env`, causing Anthropic 401s even after reauth. The refreshable credential stores were not consistently preferred or persisted across flows.

## Validation
```bash
pytest -q -o addopts='' tests/test_anthropic_oauth_flow.py tests/test_anthropic_adapter.py tests/test_credential_pool.py tests/test_auth_commands.py tests/test_anthropic_provider_persistence.py
python3 -m compileall agent/anthropic_adapter.py hermes_cli/main.py hermes_cli/auth_commands.py hermes_cli/status.py hermes_cli/doctor.py
```

Result: `148 passed`
