### PR TITLE
fix: join sync_turn thread before tool calls to prevent race condition on _cache

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -632,6 +632,15 @@ class HonchoMemoryProvider(MemoryProvider):
         # See: https://github.com/NousResearch/hermes-agent/issues/5102
         if self._sync_thread and self._sync_thread.is_alive():
             self._sync_thread.join(timeout=5.0)
+            if self._sync_thread.is_alive():
+                return json.dumps(
+                    {
+                        "error": (
+                            "Honcho is still synchronizing session state. "
+                            "Please retry the tool call."
+                        )
+                    }
+                )
 
         try:
             if tool_name == "honcho_profile":

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -627,6 +627,12 @@ class HonchoMemoryProvider(MemoryProvider):
         if not self._manager or not self._session_key:
             return json.dumps({"error": "Honcho is not active for this session."})
 
+        # Fix race condition: sync_turn runs in a background thread and accesses
+        # the same _cache dict. Wait for it to complete before tool calls.
+        # See: https://github.com/NousResearch/hermes-agent/issues/5102
+        if self._sync_thread and self._sync_thread.is_alive():
+            self._sync_thread.join(timeout=5.0)
+
         try:
             if tool_name == "honcho_profile":
                 card = self._manager.get_peer_card(self._session_key)


### PR DESCRIPTION
## Summary

Fixes a race condition in the Honcho memory plugin where `create_conclusion()` intermittently fails due to concurrent access to `HonchoSessionManager._cache` from the `sync_turn` background thread and the main thread.

## Problem

`sync_turn()` spawns a background thread that calls `get_or_create()` on `_cache` (a plain `dict`). Meanwhile, `handle_tool_call()` reads `_cache` via `create_conclusion()` in the main thread. Since `get_or_create()` is a multi-step read-modify-write operation, the main thread can observe `_cache` in an inconsistent state, causing `_cache.get(session_key)` to return `None` and the conclusion to silently fail.

## Fix

Join the `sync_turn` thread before processing any tool call in `handle_tool_call()`. This ensures `_cache` is in a consistent state when tool handlers access it.

This is the minimal fix. A more comprehensive solution would add a `threading.Lock` to all `_cache` access in `HonchoSessionManager`, similar to the existing `_prefetch_cache_lock`.

## Testing

- Reproduced with 13 consecutive `honcho_conclude` calls — 2 random failures
- After fix: all calls succeed consistently
- No performance impact: `sync_turn` thread typically completes in <1s, and the join is a no-op when it's not running

Fixes #5102