### PR TITLE
fix(signal): implement send_image_file for MEDIA: tag delivery

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -748,6 +748,50 @@ class SignalAdapter(BasePlatformAdapter):
             return SendResult(success=True)
         return SendResult(success=False, error="RPC send document failed")
 
+    async def send_image_file(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send a local image file natively via Signal.
+
+        This method is called by the gateway's media delivery flow when
+        MEDIA:/path/to/image.png tags are extracted from agent responses.
+
+        Unlike send_image() which takes a URL, this takes a local file path
+        and sends it directly via signal-cli RPC.
+        """
+        await self._stop_typing_indicator(chat_id)
+
+        if not Path(image_path).exists():
+            return SendResult(success=False, error=f"Image file not found: {image_path}")
+
+        # Validate size
+        file_size = Path(image_path).stat().st_size
+        if file_size > SIGNAL_MAX_ATTACHMENT_SIZE:
+            return SendResult(success=False, error=f"Image too large ({file_size} bytes)")
+
+        params: Dict[str, Any] = {
+            "account": self.account,
+            "message": caption or "",
+            "attachments": [image_path],
+        }
+
+        if chat_id.startswith("group:"):
+            params["groupId"] = chat_id[6:]
+        else:
+            params["recipient"] = [chat_id]
+
+        result = await self._rpc("send", params)
+        if result is not None:
+            self._track_sent_timestamp(result)
+            return SendResult(success=True)
+        return SendResult(success=False, error="RPC send image file failed")
+
     # ------------------------------------------------------------------
     # Typing Indicators
     # ------------------------------------------------------------------

--- a/signal_fix.patch
+++ b/signal_fix.patch
@@ -1,0 +1,55 @@
+diff --git a/gateway/platforms/signal.py b/gateway/platforms/signal.py
+index 1234567..abcdefg 100644
+--- a/gateway/platforms/signal.py
++++ b/gateway/platforms/signal.py
+@@ -749,6 +749,45 @@ class SignalAdapter(BasePlatformAdapter):
+             return SendResult(success=True)
+         return SendResult(success=False, error="RPC send document failed")
+ 
++    async def send_image_file(
++        self,
++        chat_id: str,
++        image_path: str,
++        caption: Optional[str] = None,
++        reply_to: Optional[str] = None,
++        metadata: Optional[Dict[str, Any]] = None,
++        **kwargs,
++    ) -> SendResult:
++        """Send a local image file natively via Signal.
++
++        This method is called by the gateway's media delivery flow when
++        MEDIA:/path/to/image.png tags are extracted from agent responses.
++        
++        Unlike send_image() which takes a URL, this takes a local file path
++        and sends it directly via signal-cli RPC.
++        """
++        await self._stop_typing_indicator(chat_id)
++
++        if not Path(image_path).exists():
++            return SendResult(success=False, error=f"Image file not found: {image_path}")
++
++        # Validate size
++        file_size = Path(image_path).stat().st_size
++        if file_size > SIGNAL_MAX_ATTACHMENT_SIZE:
++            return SendResult(success=False, error=f"Image too large ({file_size} bytes)")
++
++        params: Dict[str, Any] = {
++            "account": self.account,
++            "message": caption or "",
++            "attachments": [image_path],
++        }
++
++        if chat_id.startswith("group:"):
++            params["groupId"] = chat_id[6:]
++        else:
++            params["recipient"] = [chat_id]
++
++        result = await self._rpc("send", params)
++        if result is not None:
++            self._track_sent_timestamp(result)
++            return SendResult(success=True)
++        return SendResult(success=False, error="RPC send image file failed")
++
+     # ------------------------------------------------------------------
+     # Typing Indicators
+     # ------------------------------------------------------------------

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -368,3 +368,101 @@ class TestSignalSendMessage:
         # Just verify the import works and Signal is a valid platform
         from gateway.config import Platform
         assert Platform.SIGNAL.value == "signal"
+
+
+# ---------------------------------------------------------------------------
+# send_image_file method
+# ---------------------------------------------------------------------------
+
+class TestSignalSendImageFile:
+    @pytest.mark.asyncio
+    async def test_send_image_file_sends_via_rpc(self, monkeypatch, tmp_path):
+        """send_image_file should send image via signal-cli RPC."""
+        adapter = _make_signal_adapter(monkeypatch)
+        mock_rpc, captured = _stub_rpc({"timestamp": 1234567890})
+        adapter._rpc = mock_rpc
+        adapter._stop_typing_indicator = AsyncMock()
+
+        # Create test image
+        img_path = tmp_path / "test.png"
+        img_path.write_bytes(b"PNG fake image data")
+
+        result = await adapter.send_image_file(chat_id="+155****4567", image_path=str(img_path))
+
+        assert result.success is True
+        assert len(captured) == 1
+        assert captured[0]["method"] == "send"
+        assert captured[0]["params"]["recipient"] == ["+155****4567"]
+        assert captured[0]["params"]["attachments"] == [str(img_path)]
+
+    @pytest.mark.asyncio
+    async def test_send_image_file_to_group(self, monkeypatch, tmp_path):
+        """send_image_file should handle group chats."""
+        adapter = _make_signal_adapter(monkeypatch)
+        mock_rpc, captured = _stub_rpc({"timestamp": 1234567890})
+        adapter._rpc = mock_rpc
+        adapter._stop_typing_indicator = AsyncMock()
+
+        # Create test image
+        img_path = tmp_path / "test.png"
+        img_path.write_bytes(b"PNG fake image data")
+
+        result = await adapter.send_image_file(
+            chat_id="group:xyz123==", image_path=str(img_path), caption="Test caption"
+        )
+
+        assert result.success is True
+        assert captured[0]["params"]["groupId"] == "xyz123=="
+        assert captured[0]["params"]["message"] == "Test caption"
+
+    @pytest.mark.asyncio
+    async def test_send_image_file_missing_file(self, monkeypatch):
+        """send_image_file should return error for nonexistent file."""
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._stop_typing_indicator = AsyncMock()
+
+        result = await adapter.send_image_file(chat_id="+155****4567", image_path="/nonexistent.png")
+
+        assert result.success is False
+        assert "not found" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_send_image_file_size_limit(self, monkeypatch, tmp_path):
+        """send_image_file should reject oversized files."""
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._stop_typing_indicator = AsyncMock()
+
+        # Create a file that reports large size via mock
+        img_path = tmp_path / "huge.png"
+        img_path.write_bytes(b"small")
+
+        # Mock stat to return huge size
+        import stat
+        original_stat = Path.stat
+
+        def mock_stat(self):
+            class FakeStat:
+                st_size = 200 * 1024 * 1024  # 200 MB > 100 MB limit
+            return FakeStat()
+
+        with patch.object(Path, "stat", mock_stat):
+            result = await adapter.send_image_file(chat_id="+155****4567", image_path=str(img_path))
+
+        assert result.success is False
+        assert "too large" in result.error.lower()
+
+    @pytest.mark.asyncio
+    async def test_send_image_file_rpc_failure(self, monkeypatch, tmp_path):
+        """send_image_file should return error when RPC fails."""
+        adapter = _make_signal_adapter(monkeypatch)
+        mock_rpc, captured = _stub_rpc(None)  # RPC returns None on failure
+        adapter._rpc = mock_rpc
+        adapter._stop_typing_indicator = AsyncMock()
+
+        img_path = tmp_path / "test.png"
+        img_path.write_bytes(b"PNG fake image data")
+
+        result = await adapter.send_image_file(chat_id="+155****4567", image_path=str(img_path))
+
+        assert result.success is False
+        assert "failed" in result.error.lower()


### PR DESCRIPTION
## Summary

Implements the `send_image_file` method on `SignalAdapter` to enable proper delivery of `MEDIA:/path/to/file` attachments from agent responses.

## Problem

The Signal gateway was not delivering file attachments specified via `MEDIA:` tags. While the base `BasePlatformAdapter.extract_media()` method correctly extracts these tags from responses, and the gateway calls `adapter.send_image_file()` to deliver them, the Signal adapter was inheriting the base implementation which only sent the file path as text rather than actually attaching the file.

## Solution

Added a proper `send_image_file()` implementation to `SignalAdapter` that:
1. Validates the file exists
2. Checks file size against the 100MB Signal limit
3. Sends the file via signal-cli RPC with proper attachment handling
4. Handles both DM and group chat routing

## Changes

- **gateway/platforms/signal.py**: Added `send_image_file()` method
- **tests/gateway/test_signal.py**: Added comprehensive unit tests for the new method

## Testing

Added 5 new test cases covering:
- Successful image delivery via RPC
- Group chat image delivery
- Nonexistent file error handling
- Oversized file rejection
- RPC failure handling

## Fixes

Fixes #5105