### PR TITLE
fix: add missing shutil import in setup.py (fixes #5060)

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -14,6 +14,7 @@ Config files are stored in ~/.hermes/ for easy access.
 import importlib.util
 import logging
 import os
+import shutil
 import sys
 from pathlib import Path
 from typing import Optional, Dict, Any


### PR DESCRIPTION
## Problem
When running `hermes setup` with E2EE enabled, the setup wizard crashes at 
line 2126 of `setup.py` with `NameError: name 'shutil' is not defined`.

This happens because:
1. `matrix-nio[e2e]` fails to import (`ModuleNotFoundError`)
2. The except handler tries to locate `uv` via `shutil.which("uv")`
3. But `shutil` was never imported at the module level — only locally 
   inside other functions (lines 951, 1397, 1513)

## Fix
Add `import shutil` at the top of `hermes_cli/setup.py` alongside the 
other standard library imports.

Fixes #5060