### PR TITLE
Avoid double-starting the macOS gateway after launchd plist refresh

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -974,9 +974,9 @@ def refresh_launchd_plist_if_needed() -> bool:
     plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
     # Unload/reload so launchd picks up the new definition
     subprocess.run(["launchctl", "unload", str(plist_path)], check=False)
-    subprocess.run(["launchctl", "load", str(plist_path)], check=False)
+    result = subprocess.run(["launchctl", "load", str(plist_path)], check=False)
     print("↻ Updated gateway launchd service definition to match the current Hermes install")
-    return True
+    return result.returncode == 0
 
 
 def launchd_install(force: bool = False):

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1030,7 +1030,14 @@ def launchd_start():
         print("✓ Service started")
         return
 
-    refresh_launchd_plist_if_needed()
+    refreshed = refresh_launchd_plist_if_needed()
+    if refreshed:
+        # refresh_launchd_plist_if_needed() unloads + loads the plist, and the
+        # service is configured with RunAtLoad. Issuing an immediate explicit
+        # `launchctl start` after that can race a second gateway instance into
+        # existence before the first one finishes booting.
+        print("✓ Service started")
+        return
     try:
         subprocess.run(["launchctl", "start", label], check=True)
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
## Summary
- avoid issuing a second `launchctl start` after a plist refresh already performed `unload` + `load`
- prevent duplicate local gateway instances during macOS launchd refresh flows

## Why
The Hermes launchd plist uses `RunAtLoad`. Reloading the plist already starts the gateway again, so an immediate extra `launchctl start` can race a second local gateway process into existence and trigger token/session lock conflicts.

Fixes #5109

## Verification
- `python -m py_compile hermes_cli/gateway.py`
- manual macOS stop/start lifecycle verification

## Not run
- no automated launchd regression test in CI yet
