### PR TITLE
fix(security): validate cron job base_url against SSRF before use

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -479,7 +479,20 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 "requested": job.get("provider") or os.getenv("HERMES_INFERENCE_PROVIDER"),
             }
             if job.get("base_url"):
-                runtime_kwargs["explicit_base_url"] = job.get("base_url")
+                _job_base_url = job.get("base_url")
+                try:
+                    from tools.url_safety import is_safe_url
+                    if not is_safe_url(_job_base_url):
+                        logger.warning(
+                            "Cron job %s base_url resolves to a private/internal "
+                            "address — ignoring to prevent SSRF.",
+                            job.get("id", "?"),
+                        )
+                        _job_base_url = None
+                except ImportError:
+                    pass
+                if _job_base_url:
+                    runtime_kwargs["explicit_base_url"] = _job_base_url
             runtime = resolve_runtime_provider(**runtime_kwargs)
         except Exception as exc:
             message = format_runtime_provider_error(exc)


### PR DESCRIPTION
## What does this PR do?

Cron jobs support a per-job `base_url` override that is passed directly
to the AI agent's runtime provider without any validation:
```python
# Before (vulnerable)
if job.get("base_url"):
    runtime_kwargs["explicit_base_url"] = job.get("base_url")
```

If a cron job's `base_url` is set to an internal/private address
(e.g. `http://169.254.169.254` on AWS, `http://metadata.google.internal`
on GCP), all LLM API calls — including the Authorization header containing
the API key — are sent to that address instead of the real provider.

This allows an attacker who can create or modify cron jobs to:
1. **Steal API keys** by intercepting LLM API calls
2. **Probe internal network services** via SSRF

## Fix

Added an `is_safe_url()` check before accepting `base_url`. URLs
resolving to private/internal addresses are ignored with a warning log.
```python
from tools.url_safety import is_safe_url
if not is_safe_url(_job_base_url):
    logger.warning("Cron job %s base_url resolves to a private/internal address...", ...)
    _job_base_url = None
```

This is consistent with SSRF protection already applied in:
- `tools/homeassistant_tool.py` (HASS_URL)
- `tools/web_tools.py`
- `plugins/memory/retaindb/__init__.py`

## Type of Change

- [x] 🔒 Security fix (SSRF)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Consistent with existing SSRF protection pattern in Hermes
- [x] No behavior change for legitimate external provider URLs
- [x] ImportError handled gracefully