### PR TITLE
fix(security): remove full traceback from cron error output to prevent info leakage

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -588,8 +588,6 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 
 ```
 {error_msg}
-
-{traceback.format_exc()}
 ```
 """
         return False, output, "", error_msg

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -15,7 +15,6 @@ import logging
 import os
 import subprocess
 import sys
-import traceback
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
@@ -572,7 +571,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         
     except Exception as e:
         error_msg = f"{type(e).__name__}: {str(e)}"
-        logger.error("Job '%s' failed: %s", job_name, error_msg)
+        logger.exception("Job '%s' failed: %s", job_name, error_msg)
         
         output = f"""# Cron Job: {job_name} (FAILED)
 


### PR DESCRIPTION
## What does this PR do?

When a cron job fails, the error output sent to the delivery platform
includes the full Python traceback:
```python
# Before (leaks internal info)
## Error
```
{error_msg}

{traceback.format_exc()}

A full traceback exposes:
- Internal file paths (e.g. `/home/user/.hermes/...`)
- Python library versions
- System architecture details
- Internal function call stack

This information is delivered to the configured platform (Telegram,
Discord, Slack, etc.) and could be seen by unintended recipients or
used by an attacker to fingerprint the system.

## Fix

Removed `traceback.format_exc()` from the delivered output. The
`error_msg` (the exception message itself) is still included — it
provides enough context for the user to understand what went wrong
without leaking internal system details.
```python
# After (safe)
## Error
```
{error_msg}

## Type of Change

- [x] 🔒 Security fix (information leakage)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Error message still delivered for user debugging
- [x] Full traceback still available in local logs for developers