### PR TITLE
fix(security): wrap cron script output in XML tags to prevent prompt injection

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -297,7 +297,7 @@ def _build_job_prompt(job: dict) -> str:
                     "## Script Output\n"
                     "The following data was collected by a pre-run script. "
                     "Use it as context for your analysis.\n\n"
-                    f"<data>\n{script_output}\n</data>\n\n"
+                    f"<data>\n{script_output.replace('</data>', '<\\/data>')}\n</data>\n\n"
                     f"{prompt}"
                 )
             else:
@@ -309,7 +309,7 @@ def _build_job_prompt(job: dict) -> str:
             prompt = (
                 "## Script Error\n"
                 "The data-collection script failed. Report this to the user.\n\n"
-                f"<data>\n{script_output}\n</data>\n\n"
+                f"<data>\n{script_output.replace('</data>', '<\\/data>')}\n</data>\n\n"
                 f"{prompt}"
             )
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -297,7 +297,7 @@ def _build_job_prompt(job: dict) -> str:
                     "## Script Output\n"
                     "The following data was collected by a pre-run script. "
                     "Use it as context for your analysis.\n\n"
-                    f"```\n{script_output}\n```\n\n"
+                    f"<data>\n{script_output}\n</data>\n\n"
                     f"{prompt}"
                 )
             else:
@@ -309,7 +309,7 @@ def _build_job_prompt(job: dict) -> str:
             prompt = (
                 "## Script Error\n"
                 "The data-collection script failed. Report this to the user.\n\n"
-                f"```\n{script_output}\n```\n\n"
+                f"<data>\n{script_output}\n</data>\n\n"
                 f"{prompt}"
             )
 


### PR DESCRIPTION
Inside a markdown code block, LLMs can still interpret such content
as instructions — especially when the code block contains natural
language text rather than code.

## Fix

Wrap script output in XML `<data>` tags instead of markdown code
blocks. XML tags signal to the LLM that the content is structured
data to be processed, not instructions to be followed — a standard
prompt injection mitigation.
```python
# After (safe)
f"<data>\n{script_output}\n</data>\n\n"
```

Applied to both the success path (line 300) and the error path
(line 312).

## Type of Change

- [x] 🔒 Security fix (prompt injection)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Standard prompt injection mitigation technique
- [x] No behavior change for legitimate script output