### PR TITLE
fix(security): validate cron deliver platform name to prevent env var enumeration

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -13,6 +13,12 @@ import concurrent.futures
 import json
 import logging
 import os
+_KNOWN_DELIVERY_PLATFORMS = frozenset({
+    "telegram", "discord", "slack", "whatsapp", "signal",
+    "matrix", "mattermost", "dingtalk", "feishu", "wecom",
+    "sms", "email", "webhook",
+})
+import subprocess
 import subprocess
 import sys
 import traceback
@@ -119,14 +125,10 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
             "thread_id": origin.get("thread_id"),
         }
 
-    _KNOWN_PLATFORMS = {
-            "telegram", "discord", "slack", "whatsapp", "signal",
-            "matrix", "mattermost", "dingtalk", "feishu", "wecom",
-            "sms", "email", "webhook",
-        }
-        if platform_name.lower() not in _KNOWN_PLATFORMS:
-            return None
-        chat_id = os.getenv(f"{platform_name.upper()}_HOME_CHANNEL", "")
+    
+    if platform_name.lower() not in _KNOWN_DELIVERY_PLATFORMS:
+        return None
+    chat_id = os.getenv(f"{platform_name.upper()}_HOME_CHANNEL", "")
     if not chat_id:
         return None
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -119,7 +119,14 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
             "thread_id": origin.get("thread_id"),
         }
 
-    chat_id = os.getenv(f"{platform_name.upper()}_HOME_CHANNEL", "")
+    _KNOWN_PLATFORMS = {
+            "telegram", "discord", "slack", "whatsapp", "signal",
+            "matrix", "mattermost", "dingtalk", "feishu", "wecom",
+            "sms", "email", "webhook",
+        }
+        if platform_name.lower() not in _KNOWN_PLATFORMS:
+            return None
+        chat_id = os.getenv(f"{platform_name.upper()}_HOME_CHANNEL", "")
     if not chat_id:
         return None
 


### PR DESCRIPTION
## What does this PR do?

The cron job delivery resolver reads a home channel from environment
variables using the job's `deliver` field as the platform name:
```python
# Before (vulnerable)
chat_id = os.getenv(f"{platform_name.upper()}_HOME_CHANNEL", "")
```

The `platform_name` value comes directly from the job config without
validation. An attacker who can create or modify a cron job could set:
```yaml
deliver: "AWS_SECRET_ACCESS_KEY"
```

This would read `AWS_SECRET_ACCESS_KEY_HOME_CHANNEL` — which likely
doesn't exist, but with a crafted env var name like `SOME_SECRET` it
could leak sensitive environment variable values as the delivery
target chat ID, which then gets logged or sent to a platform.

## Fix

Added an allowlist of known platform names. If `platform_name` is not
in the allowlist, the function returns `None` immediately — no env var
is read.
```python
_KNOWN_PLATFORMS = {
    "telegram", "discord", "slack", "whatsapp", "signal",
    "matrix", "mattermost", "dingtalk", "feishu", "wecom",
    "sms", "email", "webhook",
}
if platform_name.lower() not in _KNOWN_PLATFORMS:
    return None
```

## Type of Change

- [x] 🔒 Security fix (env var enumeration)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Allowlist covers all platforms in `gateway/platforms/`
- [x] No behavior change for legitimate platform names