### PR TITLE
fix(api-server): prune stale conversation pointers in response store

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -108,6 +108,16 @@ class ResponseStore:
         self._conn.commit()
         return json.loads(row[0])
 
+    def _delete_conversation_refs(self, response_ids: List[str]) -> None:
+        """Remove conversation mappings that point at deleted response IDs."""
+        if not response_ids:
+            return
+        placeholders = ",".join("?" for _ in response_ids)
+        self._conn.execute(
+            f"DELETE FROM conversations WHERE response_id IN ({placeholders})",
+            tuple(response_ids),
+        )
+
     def put(self, response_id: str, data: Dict[str, Any]) -> None:
         """Store a response, evicting the oldest if at capacity."""
         import time
@@ -118,11 +128,18 @@ class ResponseStore:
         # Evict oldest entries beyond max_size
         count = self._conn.execute("SELECT COUNT(*) FROM responses").fetchone()[0]
         if count > self._max_size:
-            self._conn.execute(
-                "DELETE FROM responses WHERE response_id IN "
-                "(SELECT response_id FROM responses ORDER BY accessed_at ASC LIMIT ?)",
+            rows = self._conn.execute(
+                "SELECT response_id FROM responses ORDER BY accessed_at ASC LIMIT ?",
                 (count - self._max_size,),
-            )
+            ).fetchall()
+            evicted_ids = [row[0] for row in rows]
+            if evicted_ids:
+                placeholders = ",".join("?" for _ in evicted_ids)
+                self._conn.execute(
+                    f"DELETE FROM responses WHERE response_id IN ({placeholders})",
+                    tuple(evicted_ids),
+                )
+                self._delete_conversation_refs(evicted_ids)
         self._conn.commit()
 
     def delete(self, response_id: str) -> bool:
@@ -130,6 +147,8 @@ class ResponseStore:
         cursor = self._conn.execute(
             "DELETE FROM responses WHERE response_id = ?", (response_id,)
         )
+        if cursor.rowcount > 0:
+            self._delete_conversation_refs([response_id])
         self._conn.commit()
         return cursor.rowcount > 0
 
@@ -138,7 +157,23 @@ class ResponseStore:
         row = self._conn.execute(
             "SELECT response_id FROM conversations WHERE name = ?", (name,)
         ).fetchone()
-        return row[0] if row else None
+        if row is None:
+            return None
+
+        response_id = row[0]
+        target = self._conn.execute(
+            "SELECT 1 FROM responses WHERE response_id = ?",
+            (response_id,),
+        ).fetchone()
+        if target is not None:
+            return response_id
+
+        self._conn.execute(
+            "DELETE FROM conversations WHERE name = ? AND response_id = ?",
+            (name, response_id),
+        )
+        self._conn.commit()
+        return None
 
     def set_conversation(self, name: str, response_id: str) -> None:
         """Map a conversation name to its latest response_id."""

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1577,6 +1577,57 @@ class TestConversationParameter:
                 # Conversation mapping should NOT be set since store=false
                 assert adapter._response_store.get_conversation("ephemeral-chat") is None
 
+    @pytest.mark.asyncio
+    async def test_delete_latest_response_resets_named_conversation(self, adapter):
+        """Deleting the latest response should not permanently brick the conversation name."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "First response", "messages": [], "api_calls": 1},
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+                resp1 = await cli.post("/v1/responses", json={
+                    "input": "hello",
+                    "conversation": "resettable-conv",
+                })
+                assert resp1.status == 200
+                response_id = (await resp1.json())["id"]
+
+                delete_resp = await cli.delete(f"/v1/responses/{response_id}")
+                assert delete_resp.status == 200
+                assert adapter._response_store.get_conversation("resettable-conv") is None
+
+                mock_run.return_value = (
+                    {"final_response": "Fresh response", "messages": [], "api_calls": 1},
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+                resp2 = await cli.post("/v1/responses", json={
+                    "input": "start over",
+                    "conversation": "resettable-conv",
+                })
+                assert resp2.status == 200
+
+                second_call_kwargs = mock_run.call_args_list[1]
+                history = second_call_kwargs.kwargs.get(
+                    "conversation_history",
+                    second_call_kwargs[1].get("conversation_history", []) if len(second_call_kwargs) > 1 else [],
+                )
+                assert history == []
+
+
+class TestResponseStoreCleanup:
+    def test_eviction_prunes_stale_conversation_mapping(self, tmp_path):
+        """LRU eviction should clear conversation pointers to evicted responses."""
+        store = ResponseStore(max_size=1, db_path=str(tmp_path / "responses.db"))
+        store.put("resp_old", {"response": {"id": "resp_old"}, "conversation_history": []})
+        store.set_conversation("evicted-conv", "resp_old")
+
+        store.put("resp_new", {"response": {"id": "resp_new"}, "conversation_history": []})
+
+        assert store.get("resp_old") is None
+        assert store.get_conversation("evicted-conv") is None
+
 
 # ---------------------------------------------------------------------------
 # X-Hermes-Session-Id header (session continuity)


### PR DESCRIPTION
## Summary
Fixes stale named-conversation pointers in the Responses API store.

When a stored response was deleted or evicted, the named conversation mapping could still point to a missing response ID. That left the conversation name in a broken state and caused later requests to fail with `Previous response not found`.

## What changed
- prune conversation mappings when a response is deleted
- prune conversation mappings when responses are evicted from the LRU store
- self-heal dangling mappings in `get_conversation()` by removing stale pointers and returning `None`

## Why this matters
A named conversation should either continue from a valid stored response or start cleanly if the old state is gone.

Before this change, deleting or evicting the mapped response could permanently brick the conversation name until the database was manually cleaned up.

## Tests
- `python -m pytest tests/gateway/test_api_server.py -q -k "delete_latest_response_resets_named_conversation or eviction_prunes_stale_conversation_mapping"`
- `python -m pytest tests/gateway/test_api_server.py -q`

Passed:
- focused tests: `2 passed`
- full related file: `96 passed`