### PR TITLE
fix: link subagent sessions to parent and hide from session list

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -787,6 +787,7 @@ class SessionDB:
         exclude_sources: List[str] = None,
         limit: int = 20,
         offset: int = 0,
+        include_children: bool = False,
     ) -> List[Dict[str, Any]]:
         """List sessions with preview (first user message) and last active timestamp.
 
@@ -795,9 +796,15 @@ class SessionDB:
         last_active (timestamp of last message).
 
         Uses a single query with correlated subqueries instead of N+2 queries.
+
+        By default, child sessions (subagent runs, compression continuations)
+        are excluded.  Pass ``include_children=True`` to include them.
         """
         where_clauses = []
         params = []
+
+        if not include_children:
+            where_clauses.append("s.parent_session_id IS NULL")
 
         if source:
             where_clauses.append("s.source = ?")
@@ -1229,22 +1236,38 @@ class SessionDB:
         self._execute_write(_do)
 
     def delete_session(self, session_id: str) -> bool:
-        """Delete a session and all its messages. Returns True if found."""
+        """Delete a session, its child sessions, and all their messages.
+
+        Child sessions (subagent runs, compression continuations) are deleted
+        first to satisfy the ``parent_session_id`` foreign key constraint.
+        Returns True if the session was found and deleted.
+        """
         def _do(conn):
             cursor = conn.execute(
                 "SELECT COUNT(*) FROM sessions WHERE id = ?", (session_id,)
             )
             if cursor.fetchone()[0] == 0:
                 return False
+            # Delete child sessions first (FK constraint)
+            child_ids = [r[0] for r in conn.execute(
+                "SELECT id FROM sessions WHERE parent_session_id = ?",
+                (session_id,),
+            ).fetchall()]
+            for cid in child_ids:
+                conn.execute("DELETE FROM messages WHERE session_id = ?", (cid,))
+                conn.execute("DELETE FROM sessions WHERE id = ?", (cid,))
+            # Delete the session itself
             conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
             conn.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
             return True
         return self._execute_write(_do)
 
     def prune_sessions(self, older_than_days: int = 90, source: str = None) -> int:
-        """
-        Delete sessions older than N days. Returns count of deleted sessions.
-        Only prunes ended sessions (not active ones).
+        """Delete sessions older than N days. Returns count of deleted sessions.
+
+        Only prunes ended sessions (not active ones).  Child sessions whose
+        parents are being pruned are deleted first to satisfy the
+        ``parent_session_id`` foreign key constraint.
         """
         cutoff = time.time() - (older_than_days * 86400)
 
@@ -1260,7 +1283,19 @@ class SessionDB:
                     "SELECT id FROM sessions WHERE started_at < ? AND ended_at IS NOT NULL",
                     (cutoff,),
                 )
-            session_ids = [row["id"] for row in cursor.fetchall()]
+            session_ids = set(row["id"] for row in cursor.fetchall())
+
+            # Delete children first whose parents are in the prune set
+            # (avoids FK constraint errors)
+            for sid in list(session_ids):
+                child_ids = [r[0] for r in conn.execute(
+                    "SELECT id FROM sessions WHERE parent_session_id = ?",
+                    (sid,),
+                ).fetchall()]
+                for cid in child_ids:
+                    conn.execute("DELETE FROM messages WHERE session_id = ?", (cid,))
+                    conn.execute("DELETE FROM sessions WHERE id = ?", (cid,))
+                    session_ids.discard(cid)  # don't double-delete
 
             for sid in session_ids:
                 conn.execute("DELETE FROM messages WHERE session_id = ?", (sid,))

--- a/run_agent.py
+++ b/run_agent.py
@@ -467,6 +467,7 @@ class AIAgent:
         skip_context_files: bool = False,
         skip_memory: bool = False,
         session_db=None,
+        parent_session_id: str = None,
         iteration_budget: "IterationBudget" = None,
         fallback_model: Dict[str, Any] = None,
         credential_pool=None,
@@ -962,6 +963,7 @@ class AIAgent:
         
         # SQLite session store (optional -- provided by CLI or gateway)
         self._session_db = session_db
+        self._parent_session_id = parent_session_id
         self._last_flushed_db_idx = 0  # tracks DB-write cursor to prevent duplicate writes
         if self._session_db:
             try:
@@ -975,6 +977,7 @@ class AIAgent:
                         "max_tokens": max_tokens,
                     },
                     user_id=None,
+                    parent_session_id=self._parent_session_id,
                 )
             except Exception as e:
                 # Transient SQLite lock contention (e.g. CLI and gateway writing

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -227,6 +227,7 @@ def _build_child_agent(
         skip_memory=True,
         clarify_callback=None,
         session_db=getattr(parent_agent, '_session_db', None),
+        parent_session_id=getattr(parent_agent, 'session_id', None),
         providers_allowed=parent_agent.providers_allowed,
         providers_ignored=parent_agent.providers_ignored,
         providers_order=parent_agent.providers_order,


### PR DESCRIPTION
## Summary

`delegate_task` subagent sessions appear in `hermes sessions list` and `/resume` as untitled orphan entries, polluting the user-facing session list.

## Root Cause

`delegate_tool.py` passes `session_db` to child agents but not `parent_session_id`. Each subagent creates a top-level session with `source=cli` and `parent_session_id=NULL` — indistinguishable from user sessions.

The DB schema already has `parent_session_id` (FK column), and `session_search` already handles it correctly. It was just never wired up for subagents.

## Changes

**`tools/delegate_tool.py`** (+1 line)
- Pass `parent_session_id=parent_agent.session_id` to child agent

**`run_agent.py`** (+3 lines)
- Accept `parent_session_id` parameter in `__init__`
- Store as `self._parent_session_id`
- Pass to `create_session()` call

**`hermes_state.py`** (+39 lines)
- `list_sessions_rich()`: add `include_children=False` param, filter `parent_session_id IS NULL` by default
- `delete_session()`: delete child sessions and their messages before parent (FK constraint)
- `prune_sessions()`: delete children before parents to avoid FK violation

## Why `parent_session_id` instead of changing `source`

- Preserves the parent↔child relationship (useful for debugging, insights)
- Works with existing `session_search` logic (already filters/resolves by parent)
- The `source` field should reflect platform (cli, telegram, discord), not agent hierarchy
- No new source type to maintain

## Impact

| Code path | Effect |
|-----------|--------|
| `hermes sessions list` | **FIXED** — subagent sessions hidden |
| `/resume` picker | **FIXED** — subagent sessions hidden |
| `session_search` recent | Already works (filters `parent_session_id`) |
| `session_search` FTS | Already works (resolves children to parent) |
| `hermes sessions delete` | **FIXED** — cascades to children |
| `hermes sessions prune` | **FIXED** — handles FK ordering |
| `hermes insights` | Neutral (counts all sessions) |
| Compression session chains | Neutral (already uses `parent_session_id`) |

All 572 session-related tests pass. 80 profile tests pass.

Fixes #5122