### PR TITLE
feat(cli): add Ctrl+Y shortcut to copy last code block to clipboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ models-dev-upstream/
 hermes_cli/tui_dist/*
 hermes_cli/scripts/
 docs/superpowers/*
+config.yaml
+*.env
+.env

--- a/cli.py
+++ b/cli.py
@@ -4415,6 +4415,7 @@ class HermesCLI:
             _cprint(f"\n{_ACCENT}╭─{label}{'─' * max(fill - 1, 0)}╮{_RST}")
 
         self._stream_buf += text
+        self._last_response += text
 
         # Emit complete lines, keep partial remainder in buffer
         _tc = getattr(self, "_stream_text_ansi", "")
@@ -4514,6 +4515,16 @@ class HermesCLI:
             w = self._scrollback_box_width()
             _cprint(f"{_ACCENT}╰{'─' * (w - 2)}╯{_RST}")
 
+        # Show copy hint if response contains code blocks
+        if getattr(self, "_last_response", ""):
+            import re as _re
+            _blocks = _re.findall(r'```[\s\S]*?```', self._last_response)
+            if _blocks:
+                _cprint(f"  {_DIM}📋 Ctrl+Y  copy last code block{_RST}")
+                self._has_code_blocks = True
+            else:
+                self._has_code_blocks = False
+
     def _reset_stream_state(self) -> None:
         """Reset streaming state before each agent invocation."""
         self._stream_buf = ""
@@ -4529,6 +4540,7 @@ class HermesCLI:
         self._deferred_content = ""
         self._stream_table_buf = []
         self._in_stream_table = False
+        self._last_response = ""
 
     def _slow_command_status(self, command: str) -> str:
         """Return a user-facing status message for slower slash commands."""
@@ -13392,6 +13404,30 @@ class HermesCLI:
             """
             if self._try_attach_clipboard_image():
                 event.app.invalidate()
+
+
+        @kb.add('c-y')
+        def handle_ctrl_c_copy(event):
+            """Ctrl+Y — copy last code block to clipboard."""
+            import re as _re
+            from hermes_cli.clipboard import set_clipboard_text
+            last = getattr(self, '_last_response', '')
+            blocks = _re.findall(
+                r'(?:```|~~~)(?:[\w-]+)?\n([\s\S]*?)(?:```|~~~)',
+                last
+            )
+            if blocks:
+                code = blocks[-1].strip()
+                try:
+                    if set_clipboard_text(code):
+                        _cprint('  ✅ Code copied to clipboard!')
+                    else:
+                        _cprint('  ❌ Could not copy to clipboard.')
+                except Exception as e:
+                    _cprint(f'  ❌ Clipboard error: {e}')
+            else:
+                _cprint('  ❌ No code block found in last response.')
+            event.app.invalidate()
 
         @kb.add('escape', 'v')
         def handle_alt_v(event):

--- a/hermes_cli/clipboard.py
+++ b/hermes_cli/clipboard.py
@@ -492,3 +492,89 @@ def _xclip_save(dest: Path) -> bool:
         logger.debug("xclip image extraction failed: %s", e)
         dest.unlink(missing_ok=True)
     return False
+
+
+def set_clipboard_text(text: str) -> bool:
+    """Copy text to the system clipboard.
+
+    Supports WSL2 (powershell.exe), macOS (pbcopy),
+    Wayland (wl-copy), and X11 (xclip).
+    Returns True on success, False otherwise.
+    """
+    if sys.platform == "darwin":
+        return _macos_set_text(text)
+    return _linux_set_text(text)
+
+
+def _macos_set_text(text: str) -> bool:
+    """Use pbcopy to set clipboard text on macOS."""
+    try:
+        subprocess.run(
+            ["pbcopy"],
+            input=text, capture_output=True,
+            text=True, timeout=5,
+        )
+        return True
+    except Exception as e:
+        logger.debug("pbcopy failed: %s", e)
+    return False
+
+
+def _linux_set_text(text: str) -> bool:
+    """Try clipboard backends in priority order: WSL2 -> Wayland -> X11."""
+    if _is_wsl():
+        if _wsl_set_text(text):
+            return True
+    if os.environ.get("WAYLAND_DISPLAY"):
+        if _wayland_set_text(text):
+            return True
+    return _xclip_set_text(text)
+
+
+def _wsl_set_text(text: str) -> bool:
+    """Use powershell.exe Set-Clipboard via stdin (safe from injection)."""
+    try:
+        proc = subprocess.run(
+            ["powershell.exe", "-NoProfile", "-NonInteractive",
+             "-Command", "Set-Clipboard"],
+            input=text, capture_output=True,
+            text=True, timeout=5,
+        )
+        return proc.returncode == 0
+    except FileNotFoundError:
+        logger.debug("powershell.exe not found")
+    except Exception as e:
+        logger.debug("WSL clipboard set failed: %s", e)
+    return False
+
+
+def _wayland_set_text(text: str) -> bool:
+    """Use wl-copy to set clipboard text on Wayland."""
+    try:
+        proc = subprocess.run(
+            ["wl-copy"],
+            input=text, capture_output=True,
+            text=True, timeout=5,
+        )
+        return proc.returncode == 0
+    except FileNotFoundError:
+        logger.debug("wl-copy not installed")
+    except Exception as e:
+        logger.debug("wl-copy failed: %s", e)
+    return False
+
+
+def _xclip_set_text(text: str) -> bool:
+    """Use xclip to set clipboard text on X11."""
+    try:
+        proc = subprocess.run(
+            ["xclip", "-selection", "clipboard"],
+            input=text, capture_output=True,
+            text=True, timeout=5,
+        )
+        return proc.returncode == 0
+    except FileNotFoundError:
+        logger.debug("xclip not installed")
+    except Exception as e:
+        logger.debug("xclip failed: %s", e)
+    return False


### PR DESCRIPTION
## What does this PR do?

Adds a `Ctrl+Y` keyboard shortcut to copy the last code block from the agent response to the system clipboard.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes Made
- Added `_last_response` buffer to accumulate full agent response text
- Added `📋 Ctrl+Y  copy last code block` hint after responses containing code blocks
- Added `Ctrl+Y` key binding that extracts and copies the last code block via WSL2/Linux clipboard
- Uses existing `clipboard.py` infrastructure for cross-platform support

## How to Test
1. Start Hermes CLI
2. Ask for any code snippet
3. See `📋 Ctrl+Y  copy last code block` hint at the bottom
4. Press `Ctrl+Y` to copy the last code block to clipboard

## Checklist
- [x] Tested locally
- [x] No new dependencies added
- [x] Works on WSL2

Closes #4883