### PR TITLE
fix: use launchctl kickstart for atomic gateway restart on macOS

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1087,6 +1087,26 @@ def _wait_for_gateway_exit(timeout: float = 10.0, force_after: float = 5.0):
 
 
 def launchd_restart():
+    label = get_launchd_label()
+    plist_path = get_launchd_plist_path()
+
+    # Refresh plist if code changed (e.g. after hermes update)
+    refresh_launchd_plist_if_needed()
+
+    # Try atomic kill+restart via kickstart -k (macOS 10.10+).
+    # This avoids the race where KeepAlive respawns the process
+    # between stop and start, causing _wait_for_gateway_exit to hang.
+    try:
+        subprocess.run(
+            ["launchctl", "kickstart", "-kp", f"gui/{os.getuid()}/{label}"],
+            check=True, capture_output=True, text=True,
+        )
+        print("✓ Service restarted")
+        return
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+
+    # Fallback: stop → wait → start
     try:
         launchd_stop()
     except subprocess.CalledProcessError as e:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1088,7 +1088,6 @@ def _wait_for_gateway_exit(timeout: float = 10.0, force_after: float = 5.0):
 
 def launchd_restart():
     label = get_launchd_label()
-    plist_path = get_launchd_plist_path()
 
     # Refresh plist if code changed (e.g. after hermes update)
     refresh_launchd_plist_if_needed()

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -311,6 +311,58 @@ class TestGatewaySystemServiceRouting:
         assert run_calls == []
 
 
+class TestLaunchdRestartKickstart:
+    """Tests for launchd_restart() kickstart behavior."""
+
+    def test_kickstart_success_skips_stop_wait_start(self, monkeypatch):
+        """When kickstart succeeds, stop/wait/start should not be called."""
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+        monkeypatch.setattr(gateway_cli, "refresh_launchd_plist_if_needed", lambda: None)
+
+        kickstart_calls = []
+        stop_calls = []
+
+        import subprocess as _subprocess
+
+        def fake_run(cmd, **kwargs):
+            if "kickstart" in cmd:
+                kickstart_calls.append(cmd)
+                return _subprocess.CompletedProcess(cmd, 0)
+            raise AssertionError(f"Unexpected subprocess.run call: {cmd}")
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        monkeypatch.setattr(gateway_cli, "launchd_stop", lambda: stop_calls.append(1))
+
+        gateway_cli.launchd_restart()
+
+        assert len(kickstart_calls) == 1
+        assert "kickstart" in kickstart_calls[0]
+        assert f"gui/{os.getuid()}/ai.hermes.gateway" in kickstart_calls[0][-1]
+        assert stop_calls == []
+
+    def test_kickstart_failure_falls_back_to_stop_wait_start(self, monkeypatch):
+        """When kickstart fails, fall back to stop → wait → start."""
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+        monkeypatch.setattr(gateway_cli, "refresh_launchd_plist_if_needed", lambda: None)
+
+        import subprocess as _subprocess
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            if "kickstart" in cmd:
+                raise _subprocess.CalledProcessError(1, cmd)
+            return _subprocess.CompletedProcess(cmd, 0)
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        monkeypatch.setattr(gateway_cli, "launchd_stop", lambda: calls.append("stop"))
+        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda: calls.append("wait"))
+        monkeypatch.setattr(gateway_cli, "launchd_start", lambda: calls.append("start"))
+
+        gateway_cli.launchd_restart()
+
+        assert calls == ["stop", "wait", "start"]
+
+
 class TestDetectVenvDir:
     """Tests for _detect_venv_dir() virtualenv detection."""
 


### PR DESCRIPTION
Fixes #5126

## Problem
`hermes gateway restart` hangs indefinitely on macOS when the gateway is managed by launchd with `KeepAlive/SuccessfulExit = false`. The old `stop → wait → start` sequence races with KeepAlive which respawns the process immediately after stop.

## Fix
Use `launchctl kickstart -kp gui/<uid>/<label>` for atomic kill+restart. Falls back to the old stop/wait/start sequence if kickstart fails (e.g., on older macOS).

## Testing
Tested on macOS Sequoia, M4 Max. `hermes gateway restart` now completes instantly instead of hanging.