### PR TITLE
fix credential files preserve sanitized temp dirs for multiple skills roots

### DIFF
--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -173,6 +173,46 @@ class TestSkillsDirectoryMount:
 
         assert mounts[0]["host_path"] == str(skills_dir)
 
+    def test_multiple_symlinked_skill_roots_keep_distinct_live_temp_dirs(self, tmp_path):
+        """Sanitizing one skills root must not delete another root's temp copy."""
+        hermes_home = tmp_path / ".hermes"
+        local_skills = hermes_home / "skills"
+        external_skills = tmp_path / "external-skills"
+        local_skills.mkdir(parents=True)
+        external_skills.mkdir(parents=True)
+        (local_skills / "local.md").write_text("local")
+        (external_skills / "external.md").write_text("external")
+        (local_skills / "local-link").write_text("placeholder")
+        (external_skills / "external-link").write_text("placeholder")
+
+        real_is_symlink = Path.is_symlink
+
+        def fake_is_symlink(path):
+            if path.name in {"local-link", "external-link"}:
+                return True
+            return real_is_symlink(path)
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}), \
+             patch("agent.skill_utils.get_external_skills_dirs", return_value=[external_skills]), \
+             patch("pathlib.Path.is_symlink", new=fake_is_symlink), \
+             patch("os.readlink", return_value="mock-target"):
+            mounts = get_skills_directory_mount()
+
+        assert len(mounts) == 2
+        local_mount, external_mount = mounts
+        local_safe_path = Path(local_mount["host_path"])
+        external_safe_path = Path(external_mount["host_path"])
+
+        assert local_safe_path.exists()
+        assert external_safe_path.exists()
+        assert local_safe_path != external_safe_path
+        assert local_safe_path != local_skills
+        assert external_safe_path != external_skills
+        assert (local_safe_path / "local.md").exists()
+        assert (external_safe_path / "external.md").exists()
+        assert not (local_safe_path / "local-link").exists()
+        assert not (external_safe_path / "external-link").exists()
+
 
 class TestIterSkillsFiles:
     def test_returns_files_skipping_symlinks(self, tmp_path):

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -236,12 +236,14 @@ def get_skills_directory_mount(
     return mounts
 
 
-_safe_skills_tempdir: Path | None = None
+_safe_skills_tempdirs: Dict[Path, Path] = {}
 
 
 def _safe_skills_path(skills_dir: Path) -> str:
     """Return *skills_dir* if symlink-free, else a sanitized temp copy."""
-    global _safe_skills_tempdir
+    global _safe_skills_tempdirs
+
+    skills_dir = skills_dir.resolve()
 
     symlinks = [p for p in skills_dir.rglob("*") if p.is_symlink()]
     if not symlinks:
@@ -255,12 +257,13 @@ def _safe_skills_path(skills_dir: Path) -> str:
     import shutil
     import tempfile
 
-    # Reuse the same temp dir across calls to avoid accumulation.
-    if _safe_skills_tempdir and _safe_skills_tempdir.is_dir():
-        shutil.rmtree(_safe_skills_tempdir, ignore_errors=True)
+    # Reuse only the sanitized copy for this specific skills root.
+    old_safe_dir = _safe_skills_tempdirs.get(skills_dir)
+    if old_safe_dir and old_safe_dir.is_dir():
+        shutil.rmtree(old_safe_dir, ignore_errors=True)
 
     safe_dir = Path(tempfile.mkdtemp(prefix="hermes-skills-safe-"))
-    _safe_skills_tempdir = safe_dir
+    _safe_skills_tempdirs[skills_dir] = safe_dir
 
     for item in skills_dir.rglob("*"):
         if item.is_symlink():
@@ -276,6 +279,8 @@ def _safe_skills_path(skills_dir: Path) -> str:
     def _cleanup():
         if safe_dir.is_dir():
             shutil.rmtree(safe_dir, ignore_errors=True)
+        if _safe_skills_tempdirs.get(skills_dir) == safe_dir:
+            _safe_skills_tempdirs.pop(skills_dir, None)
 
     atexit.register(_cleanup)
     logger.info("credential_files: created symlink-safe skills copy at %s", safe_dir)


### PR DESCRIPTION
## Summary
Fixes a bug in skill directory sanitization where multiple symlinked skill roots could invalidate each other’s temporary sanitized copies.

## What was happening
`get_skills_directory_mount()` can sanitize more than one skills root in a single call, including the local skills tree and configured external skill directories.

The previous implementation used a single global sanitized temp directory. When a second symlinked skills root was sanitized, it deleted the temp copy already returned for the first root. That left the mount list holding a stale path.

## What changed
- replaced the single global sanitized temp dir with a per-source-dir cache
- refresh only the sanitized copy for the specific skills root being processed
- keep cleanup scoped to the matching source root
- added regression coverage for multiple symlinked skill roots in one mount computation

## Why this matters
Backends that consume the returned mount list can otherwise receive dead host paths, which can lead to missing skills, empty mounts, or sync/startup failures.

## Test coverage
Added a targeted regression test covering:
- local skills + external skills
- both roots containing symlinked entries
- both returned sanitized directories remaining distinct and live

## Validation
Ran:
- `python -m pytest tests/tools/test_credential_files.py -q -k multiple_symlinked_skill_roots_keep_distinct_live_temp_dirs`
- `python -m pytest tests/tools/test_credential_files.py -q`

Results:
- targeted regression test: `1 passed`
- full related file still shows 4 pre-existing failures on both patched and clean main
- no new failure was introduced by this change