### PR TITLE
feat: add Claude Code CLI delegation tool and /claude slash command

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4364,27 +4364,45 @@ class HermesCLI:
             self.console.print("[bold red]Plan mode unavailable: input queue not initialized[/]")
     
     def _handle_claude_command(self, cmd: str):
-        """Handle /claude <prompt> -- send a task directly to Claude Code CLI."""
+        """Handle /claude <prompt> -- send a task directly to Claude Code CLI with streaming."""
         parts = cmd.strip().split(maxsplit=1)
         if len(parts) < 2 or not parts[1].strip():
             _cprint("  Usage: /claude <prompt>")
             _cprint("  Example: /claude analyze src/main.py and suggest improvements")
             _cprint("  Sends the prompt to Claude Code CLI using your subscription.")
+            _cprint("  Session is preserved -- Claude remembers previous /claude calls.")
             return
 
         prompt = parts[1].strip()
         preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
         _cprint(f'  Claude Code: "{preview}"')
 
-        from tools.claude_code_tool import claude_code
-        result = claude_code(prompt=prompt, timeout=300)
+        from tools.claude_code_tool import claude_code_streaming
+
+        session_key = getattr(self, "session_id", None) or "cli_default"
+
+        def on_text(chunk: str):
+            self.console.print(chunk, end="")
+
+        result = claude_code_streaming(
+            prompt=prompt,
+            on_text=on_text,
+            timeout=300,
+            session_key=session_key,
+        )
+
+        self.console.print()  # newline after streaming
 
         if result.get("success"):
-            output = result.get("output", "").strip()
-            if output:
-                self.console.print(output)
-            else:
-                _cprint("  Claude Code returned an empty response.")
+            cost = result.get("cost_usd")
+            duration = result.get("duration_ms")
+            meta_parts = []
+            if cost is not None:
+                meta_parts.append(f"${cost:.4f}")
+            if duration is not None:
+                meta_parts.append(f"{duration/1000:.1f}s")
+            if meta_parts:
+                _cprint(f"  [{' | '.join(meta_parts)}]")
         else:
             error = result.get("error", "Unknown error")
             _cprint(f"  Claude Code failed: {error}")

--- a/cli.py
+++ b/cli.py
@@ -4210,6 +4210,8 @@ class HermesCLI:
             self._handle_rollback_command(cmd_original)
         elif canonical == "stop":
             self._handle_stop_command()
+        elif canonical == "claude":
+            self._handle_claude_command(cmd_original)
         elif canonical == "background":
             self._handle_background_command(cmd_original)
         elif canonical == "btw":
@@ -4361,6 +4363,32 @@ class HermesCLI:
         else:
             self.console.print("[bold red]Plan mode unavailable: input queue not initialized[/]")
     
+    def _handle_claude_command(self, cmd: str):
+        """Handle /claude <prompt> -- send a task directly to Claude Code CLI."""
+        parts = cmd.strip().split(maxsplit=1)
+        if len(parts) < 2 or not parts[1].strip():
+            _cprint("  Usage: /claude <prompt>")
+            _cprint("  Example: /claude analyze src/main.py and suggest improvements")
+            _cprint("  Sends the prompt to Claude Code CLI using your subscription.")
+            return
+
+        prompt = parts[1].strip()
+        preview = prompt[:60] + ("..." if len(prompt) > 60 else "")
+        _cprint(f'  Claude Code: "{preview}"')
+
+        from tools.claude_code_tool import claude_code
+        result = claude_code(prompt=prompt, timeout=300)
+
+        if result.get("success"):
+            output = result.get("output", "").strip()
+            if output:
+                self.console.print(output)
+            else:
+                _cprint("  Claude Code returned an empty response.")
+        else:
+            error = result.get("error", "Unknown error")
+            _cprint(f"  Claude Code failed: {error}")
+
     def _handle_background_command(self, cmd: str):
         """Handle /background <prompt> — run a prompt in a separate background session.
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3931,22 +3931,22 @@ class GatewayRunner:
         """Handle /claude <prompt> -- delegate a task to Claude Code CLI.
 
         Runs ``claude -p "<prompt>"`` using the user's existing Claude
-        subscription (no API key or extra usage credits).  The result is
-        returned directly without going through the agent loop.
+        subscription (no API key or extra usage credits).  Sessions are
+        preserved per chat so Claude remembers context across calls.
         """
         prompt = event.get_command_args().strip()
         if not prompt:
             return (
                 "Usage: /claude <prompt>\n"
                 "Example: /claude analyze the code in src/main.py and suggest improvements\n\n"
-                "Sends the prompt directly to Claude Code CLI using your subscription."
+                "Sends the prompt directly to Claude Code CLI using your subscription.\n"
+                "Session is preserved -- Claude remembers previous /claude calls."
             )
 
         source = event.source
         adapter = self.adapters.get(source.platform)
         _thread_metadata = {"thread_id": source.thread_id} if source.thread_id else None
 
-        # Notify user that Claude is working
         if adapter:
             try:
                 await adapter.send(
@@ -3957,14 +3957,15 @@ class GatewayRunner:
             except Exception:
                 pass
 
-        # Run claude -p in a thread to avoid blocking the event loop
         import asyncio
         from tools.claude_code_tool import claude_code
+
+        session_key = self._session_key_for_source(source)
 
         try:
             result = await asyncio.get_event_loop().run_in_executor(
                 None,
-                lambda: claude_code(prompt=prompt, timeout=300),
+                lambda: claude_code(prompt=prompt, timeout=300, session_key=session_key),
             )
         except Exception as e:
             return f"Claude Code error: {e}"
@@ -3973,6 +3974,9 @@ class GatewayRunner:
             output = result.get("output", "").strip()
             if not output:
                 return "Claude Code returned an empty response."
+            cost = result.get("cost_usd")
+            if cost is not None:
+                output += f"\n\n[${cost:.4f}]"
             return output
         else:
             error = result.get("error", "Unknown error")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2005,6 +2005,9 @@ class GatewayRunner:
         if canonical == "voice":
             return await self._handle_voice_command(event)
 
+        if canonical == "claude":
+            return await self._handle_claude_command(event)
+
         # User-defined quick commands (bypass agent loop, no LLM call)
         if command:
             if isinstance(self.config, dict):
@@ -3923,6 +3926,57 @@ class GatewayRunner:
                 f"A pre-rollback snapshot was saved automatically."
             )
         return f"❌ {result['error']}"
+
+    async def _handle_claude_command(self, event: MessageEvent) -> str:
+        """Handle /claude <prompt> -- delegate a task to Claude Code CLI.
+
+        Runs ``claude -p "<prompt>"`` using the user's existing Claude
+        subscription (no API key or extra usage credits).  The result is
+        returned directly without going through the agent loop.
+        """
+        prompt = event.get_command_args().strip()
+        if not prompt:
+            return (
+                "Usage: /claude <prompt>\n"
+                "Example: /claude analyze the code in src/main.py and suggest improvements\n\n"
+                "Sends the prompt directly to Claude Code CLI using your subscription."
+            )
+
+        source = event.source
+        adapter = self.adapters.get(source.platform)
+        _thread_metadata = {"thread_id": source.thread_id} if source.thread_id else None
+
+        # Notify user that Claude is working
+        if adapter:
+            try:
+                await adapter.send(
+                    source.chat_id,
+                    "Claude Code is working on your task...",
+                    metadata=_thread_metadata,
+                )
+            except Exception:
+                pass
+
+        # Run claude -p in a thread to avoid blocking the event loop
+        import asyncio
+        from tools.claude_code_tool import claude_code
+
+        try:
+            result = await asyncio.get_event_loop().run_in_executor(
+                None,
+                lambda: claude_code(prompt=prompt, timeout=300),
+            )
+        except Exception as e:
+            return f"Claude Code error: {e}"
+
+        if result.get("success"):
+            output = result.get("output", "").strip()
+            if not output:
+                return "Claude Code returned an empty response."
+            return output
+        else:
+            error = result.get("error", "Unknown error")
+            return f"Claude Code failed: {error}"
 
     async def _handle_background_command(self, event: MessageEvent) -> str:
         """Handle /background <prompt> — run a prompt in a separate background session.

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -116,6 +116,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("cron", "Manage scheduled tasks", "Tools & Skills",
                cli_only=True, args_hint="[subcommand]",
                subcommands=("list", "add", "create", "edit", "pause", "resume", "run", "remove")),
+    CommandDef("claude", "Send a task directly to Claude Code CLI (uses your subscription)",
+               "Tools & Skills", args_hint="<prompt>"),
     CommandDef("reload-mcp", "Reload MCP servers from config", "Tools & Skills",
                aliases=("reload_mcp",)),
     CommandDef("browser", "Connect browser tools to your live Chrome via CDP", "Tools & Skills",

--- a/model_tools.py
+++ b/model_tools.py
@@ -154,6 +154,7 @@ def _discover_tools():
         "tools.clarify_tool",
         "tools.code_execution_tool",
         "tools.delegate_tool",
+        "tools.claude_code_tool",
         "tools.process_registry",
         "tools.send_message_tool",
         # "tools.honcho_tools",  # Removed — Honcho is now a memory provider plugin

--- a/tests/tools/test_claude_code_tool.py
+++ b/tests/tools/test_claude_code_tool.py
@@ -1,0 +1,157 @@
+"""Tests for the Claude Code CLI delegation tool."""
+
+import json
+import subprocess
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from tools.claude_code_tool import (
+    claude_code,
+    handle_claude_code,
+    check_claude_code_available,
+    _build_claude_command,
+    DEFAULT_TIMEOUT,
+    MAX_PROMPT_LENGTH,
+)
+
+
+class TestCheckAvailability:
+    def test_available_when_claude_on_path(self):
+        with patch("shutil.which", return_value="/usr/local/bin/claude"):
+            assert check_claude_code_available() is True
+
+    def test_unavailable_when_not_on_path(self):
+        with patch("shutil.which", return_value=None):
+            assert check_claude_code_available() is False
+
+
+class TestBuildCommand:
+    def test_basic_command(self):
+        cmd = _build_claude_command("hello")
+        assert cmd == ["claude", "-p", "hello"]
+
+    def test_with_model(self):
+        cmd = _build_claude_command("hello", model="sonnet")
+        assert cmd == ["claude", "-p", "--model", "sonnet", "hello"]
+
+    def test_with_max_turns(self):
+        cmd = _build_claude_command("hello", max_turns=5)
+        assert cmd == ["claude", "-p", "--max-turns", "5", "hello"]
+
+    def test_with_all_options(self):
+        cmd = _build_claude_command("hello", model="opus", max_turns=3)
+        assert cmd == ["claude", "-p", "--model", "opus", "--max-turns", "3", "hello"]
+
+    def test_zero_max_turns_ignored(self):
+        cmd = _build_claude_command("hello", max_turns=0)
+        assert cmd == ["claude", "-p", "hello"]
+
+
+class TestClaudeCode:
+    def test_empty_prompt(self):
+        result = claude_code(prompt="")
+        assert result["success"] is False
+        assert "empty" in result["error"].lower()
+
+    def test_prompt_too_long(self):
+        result = claude_code(prompt="x" * (MAX_PROMPT_LENGTH + 1))
+        assert result["success"] is False
+        assert "too long" in result["error"].lower()
+
+    def test_cli_not_found(self):
+        with patch("tools.claude_code_tool.check_claude_code_available", return_value=False):
+            result = claude_code(prompt="hello")
+            assert result["success"] is False
+            assert "not found" in result["error"].lower()
+
+    def test_successful_execution(self):
+        mock_result = MagicMock()
+        mock_result.stdout = "Hello world"
+        mock_result.stderr = ""
+        mock_result.returncode = 0
+
+        with patch("tools.claude_code_tool.check_claude_code_available", return_value=True), \
+             patch("subprocess.run", return_value=mock_result):
+            result = claude_code(prompt="say hello")
+            assert result["success"] is True
+            assert result["output"] == "Hello world"
+
+    def test_nonzero_exit_code(self):
+        mock_result = MagicMock()
+        mock_result.stdout = ""
+        mock_result.stderr = "Authentication failed"
+        mock_result.returncode = 1
+
+        with patch("tools.claude_code_tool.check_claude_code_available", return_value=True), \
+             patch("subprocess.run", return_value=mock_result):
+            result = claude_code(prompt="do something")
+            assert result["success"] is False
+            assert "Authentication failed" in result["error"]
+
+    def test_timeout(self):
+        with patch("tools.claude_code_tool.check_claude_code_available", return_value=True), \
+             patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="claude", timeout=10)):
+            result = claude_code(prompt="long task", timeout=10)
+            assert result["success"] is False
+            assert "timed out" in result["error"].lower()
+
+    def test_output_truncation(self):
+        long_output = "x" * 60_000
+        mock_result = MagicMock()
+        mock_result.stdout = long_output
+        mock_result.stderr = ""
+        mock_result.returncode = 0
+
+        with patch("tools.claude_code_tool.check_claude_code_available", return_value=True), \
+             patch("subprocess.run", return_value=mock_result):
+            result = claude_code(prompt="generate long output")
+            assert result["success"] is True
+            assert "[Output truncated]" in result["output"]
+
+    def test_timeout_capped_at_600(self):
+        mock_result = MagicMock()
+        mock_result.stdout = "ok"
+        mock_result.stderr = ""
+        mock_result.returncode = 0
+
+        with patch("tools.claude_code_tool.check_claude_code_available", return_value=True), \
+             patch("subprocess.run", return_value=mock_result) as mock_run:
+            claude_code(prompt="test", timeout=9999)
+            call_kwargs = mock_run.call_args
+            assert call_kwargs.kwargs["timeout"] == 600
+
+    def test_custom_cwd(self):
+        mock_result = MagicMock()
+        mock_result.stdout = "ok"
+        mock_result.stderr = ""
+        mock_result.returncode = 0
+
+        with patch("tools.claude_code_tool.check_claude_code_available", return_value=True), \
+             patch("subprocess.run", return_value=mock_result) as mock_run:
+            claude_code(prompt="test", cwd="/tmp")
+            call_kwargs = mock_run.call_args
+            assert call_kwargs.kwargs["cwd"] == "/tmp"
+
+
+class TestHandleClaudeCode:
+    def test_handler_returns_json(self):
+        mock_result = MagicMock()
+        mock_result.stdout = "result"
+        mock_result.stderr = ""
+        mock_result.returncode = 0
+
+        with patch("tools.claude_code_tool.check_claude_code_available", return_value=True), \
+             patch("subprocess.run", return_value=mock_result):
+            output = handle_claude_code(prompt="test")
+            parsed = json.loads(output)
+            assert parsed["success"] is True
+            assert parsed["output"] == "result"
+
+    def test_handler_empty_model_becomes_none(self):
+        with patch("tools.claude_code_tool.check_claude_code_available", return_value=True), \
+             patch("tools.claude_code_tool.claude_code", return_value={"success": True, "output": "ok"}) as mock_cc:
+            handle_claude_code(prompt="test", model="", max_turns=0, cwd="", timeout=0)
+            mock_cc.assert_called_once_with(
+                prompt="test", model=None, max_turns=None, cwd=None, timeout=None,
+            )

--- a/tests/tools/test_claude_code_tool.py
+++ b/tests/tools/test_claude_code_tool.py
@@ -8,9 +8,14 @@ import pytest
 
 from tools.claude_code_tool import (
     claude_code,
+    claude_code_streaming,
     _handle_claude_code_dispatch,
     check_claude_code_available,
     _build_claude_command,
+    _parse_json_output,
+    get_claude_session,
+    set_claude_session,
+    clear_claude_session,
     DEFAULT_TIMEOUT,
     MAX_PROMPT_LENGTH,
 )
@@ -29,23 +34,81 @@ class TestCheckAvailability:
 class TestBuildCommand:
     def test_basic_command(self):
         cmd = _build_claude_command("hello")
-        assert cmd == ["claude", "-p", "hello"]
+        assert cmd == ["claude", "-p", "--output-format", "json", "hello"]
 
     def test_with_model(self):
         cmd = _build_claude_command("hello", model="sonnet")
-        assert cmd == ["claude", "-p", "--model", "sonnet", "hello"]
+        assert "--model" in cmd
+        assert "sonnet" in cmd
 
     def test_with_max_turns(self):
         cmd = _build_claude_command("hello", max_turns=5)
-        assert cmd == ["claude", "-p", "--max-turns", "5", "hello"]
+        assert "--max-turns" in cmd
+        assert "5" in cmd
 
-    def test_with_all_options(self):
-        cmd = _build_claude_command("hello", model="opus", max_turns=3)
-        assert cmd == ["claude", "-p", "--model", "opus", "--max-turns", "3", "hello"]
+    def test_with_session_resume(self):
+        cmd = _build_claude_command("hello", session_id="abc-123")
+        assert "--resume" in cmd
+        assert "abc-123" in cmd
 
     def test_zero_max_turns_ignored(self):
         cmd = _build_claude_command("hello", max_turns=0)
-        assert cmd == ["claude", "-p", "hello"]
+        assert "--max-turns" not in cmd
+
+    def test_stream_format(self):
+        cmd = _build_claude_command("hello", output_format="stream-json")
+        assert "--output-format" in cmd
+        assert "stream-json" in cmd
+
+
+class TestSessionStore:
+    def test_set_and_get(self):
+        set_claude_session("test-key", "session-123")
+        assert get_claude_session("test-key") == "session-123"
+        clear_claude_session("test-key")
+
+    def test_get_nonexistent(self):
+        assert get_claude_session("nonexistent") is None
+
+    def test_clear(self):
+        set_claude_session("test-clear", "session-456")
+        clear_claude_session("test-clear")
+        assert get_claude_session("test-clear") is None
+
+    def test_overwrite(self):
+        set_claude_session("test-overwrite", "old")
+        set_claude_session("test-overwrite", "new")
+        assert get_claude_session("test-overwrite") == "new"
+        clear_claude_session("test-overwrite")
+
+
+class TestParseJsonOutput:
+    def test_parse_full_json_output(self):
+        data = json.dumps([
+            {"type": "system", "subtype": "init", "session_id": "sess-abc"},
+            {"type": "assistant", "message": {"content": [{"type": "text", "text": "Hello world"}]}},
+            {"type": "result", "result": "Hello world", "session_id": "sess-abc",
+             "total_cost_usd": 0.01, "duration_ms": 1500},
+        ])
+        parsed = _parse_json_output(data)
+        assert parsed["result_text"] == "Hello world"
+        assert parsed["session_id"] == "sess-abc"
+        assert parsed["cost_usd"] == 0.01
+        assert parsed["duration_ms"] == 1500
+
+    def test_parse_plain_text_fallback(self):
+        parsed = _parse_json_output("just plain text")
+        assert parsed["result_text"] == "just plain text"
+        assert parsed["session_id"] is None
+
+    def test_parse_empty_content(self):
+        data = json.dumps([
+            {"type": "system", "subtype": "init", "session_id": "sess-empty"},
+            {"type": "result", "result": "", "session_id": "sess-empty"},
+        ])
+        parsed = _parse_json_output(data)
+        assert parsed["result_text"] == ""
+        assert parsed["session_id"] == "sess-empty"
 
 
 class TestClaudeCode:
@@ -65,17 +128,59 @@ class TestClaudeCode:
             assert result["success"] is False
             assert "not found" in result["error"].lower()
 
-    def test_successful_execution(self):
+    def test_successful_execution_with_json(self):
+        json_output = json.dumps([
+            {"type": "system", "subtype": "init", "session_id": "sess-ok"},
+            {"type": "result", "result": "Done!", "session_id": "sess-ok",
+             "total_cost_usd": 0.005, "duration_ms": 800},
+        ])
         mock_result = MagicMock()
-        mock_result.stdout = "Hello world"
+        mock_result.stdout = json_output
         mock_result.stderr = ""
         mock_result.returncode = 0
 
         with patch("tools.claude_code_tool.check_claude_code_available", return_value=True), \
              patch("subprocess.run", return_value=mock_result):
-            result = claude_code(prompt="say hello")
+            result = claude_code(prompt="do something")
             assert result["success"] is True
-            assert result["output"] == "Hello world"
+            assert result["output"] == "Done!"
+            assert result["session_id"] == "sess-ok"
+            assert result["cost_usd"] == 0.005
+
+    def test_session_persistence(self):
+        json_output = json.dumps([
+            {"type": "system", "subtype": "init", "session_id": "sess-persist"},
+            {"type": "result", "result": "ok", "session_id": "sess-persist"},
+        ])
+        mock_result = MagicMock()
+        mock_result.stdout = json_output
+        mock_result.stderr = ""
+        mock_result.returncode = 0
+
+        with patch("tools.claude_code_tool.check_claude_code_available", return_value=True), \
+             patch("subprocess.run", return_value=mock_result):
+            claude_code(prompt="first call", session_key="hermes-test")
+            assert get_claude_session("hermes-test") == "sess-persist"
+            clear_claude_session("hermes-test")
+
+    def test_session_resume_in_command(self):
+        set_claude_session("hermes-resume", "old-session-id")
+        json_output = json.dumps([
+            {"type": "system", "subtype": "init", "session_id": "old-session-id"},
+            {"type": "result", "result": "resumed", "session_id": "old-session-id"},
+        ])
+        mock_result = MagicMock()
+        mock_result.stdout = json_output
+        mock_result.stderr = ""
+        mock_result.returncode = 0
+
+        with patch("tools.claude_code_tool.check_claude_code_available", return_value=True), \
+             patch("subprocess.run", return_value=mock_result) as mock_run:
+            claude_code(prompt="continue", session_key="hermes-resume")
+            cmd = mock_run.call_args[0][0]
+            assert "--resume" in cmd
+            assert "old-session-id" in cmd
+            clear_claude_session("hermes-resume")
 
     def test_nonzero_exit_code(self):
         mock_result = MagicMock()
@@ -96,22 +201,16 @@ class TestClaudeCode:
             assert result["success"] is False
             assert "timed out" in result["error"].lower()
 
-    def test_output_truncation(self):
-        long_output = "x" * 60_000
-        mock_result = MagicMock()
-        mock_result.stdout = long_output
-        mock_result.stderr = ""
-        mock_result.returncode = 0
-
-        with patch("tools.claude_code_tool.check_claude_code_available", return_value=True), \
-             patch("subprocess.run", return_value=mock_result):
-            result = claude_code(prompt="generate long output")
-            assert result["success"] is True
-            assert "[Output truncated]" in result["output"]
+    def test_invalid_cwd(self):
+        with patch("tools.claude_code_tool.check_claude_code_available", return_value=True):
+            result = claude_code(prompt="test", cwd="/nonexistent/path/xyz")
+            assert result["success"] is False
+            assert "does not exist" in result["error"]
 
     def test_timeout_capped_at_600(self):
+        json_output = json.dumps([{"type": "result", "result": "ok"}])
         mock_result = MagicMock()
-        mock_result.stdout = "ok"
+        mock_result.stdout = json_output
         mock_result.stderr = ""
         mock_result.returncode = 0
 
@@ -121,31 +220,14 @@ class TestClaudeCode:
             call_kwargs = mock_run.call_args
             assert call_kwargs.kwargs["timeout"] == 600
 
-    def test_custom_cwd(self):
-        import os
-        mock_result = MagicMock()
-        mock_result.stdout = "ok"
-        mock_result.stderr = ""
-        mock_result.returncode = 0
-
-        with patch("tools.claude_code_tool.check_claude_code_available", return_value=True), \
-             patch("subprocess.run", return_value=mock_result) as mock_run:
-            claude_code(prompt="test", cwd="/tmp")
-            call_kwargs = mock_run.call_args
-            assert call_kwargs.kwargs["cwd"] == os.path.realpath("/tmp")
-
-
-    def test_invalid_cwd(self):
-        with patch("tools.claude_code_tool.check_claude_code_available", return_value=True):
-            result = claude_code(prompt="test", cwd="/nonexistent/path/xyz")
-            assert result["success"] is False
-            assert "does not exist" in result["error"]
-
 
 class TestDispatchHandler:
     def test_handler_returns_json(self):
+        json_output = json.dumps([
+            {"type": "result", "result": "dispatch result", "session_id": "sess-d"},
+        ])
         mock_result = MagicMock()
-        mock_result.stdout = "result"
+        mock_result.stdout = json_output
         mock_result.stderr = ""
         mock_result.returncode = 0
 
@@ -154,12 +236,12 @@ class TestDispatchHandler:
             output = _handle_claude_code_dispatch({"prompt": "test"})
             parsed = json.loads(output)
             assert parsed["success"] is True
-            assert parsed["output"] == "result"
+            assert parsed["output"] == "dispatch result"
 
     def test_handler_receives_args_dict(self):
         with patch("tools.claude_code_tool.check_claude_code_available", return_value=True), \
              patch("tools.claude_code_tool.claude_code", return_value={"success": True, "output": "ok"}) as mock_cc:
             _handle_claude_code_dispatch({"prompt": "test", "model": "", "max_turns": 0, "cwd": "", "timeout": 0})
             mock_cc.assert_called_once_with(
-                prompt="test", model=None, max_turns=None, cwd=None, timeout=None,
+                prompt="test", model=None, max_turns=None, cwd=None, timeout=None, session_key=None,
             )

--- a/tests/tools/test_claude_code_tool.py
+++ b/tests/tools/test_claude_code_tool.py
@@ -8,7 +8,7 @@ import pytest
 
 from tools.claude_code_tool import (
     claude_code,
-    handle_claude_code,
+    _handle_claude_code_dispatch,
     check_claude_code_available,
     _build_claude_command,
     DEFAULT_TIMEOUT,
@@ -122,6 +122,7 @@ class TestClaudeCode:
             assert call_kwargs.kwargs["timeout"] == 600
 
     def test_custom_cwd(self):
+        import os
         mock_result = MagicMock()
         mock_result.stdout = "ok"
         mock_result.stderr = ""
@@ -131,10 +132,17 @@ class TestClaudeCode:
              patch("subprocess.run", return_value=mock_result) as mock_run:
             claude_code(prompt="test", cwd="/tmp")
             call_kwargs = mock_run.call_args
-            assert call_kwargs.kwargs["cwd"] == "/tmp"
+            assert call_kwargs.kwargs["cwd"] == os.path.realpath("/tmp")
 
 
-class TestHandleClaudeCode:
+    def test_invalid_cwd(self):
+        with patch("tools.claude_code_tool.check_claude_code_available", return_value=True):
+            result = claude_code(prompt="test", cwd="/nonexistent/path/xyz")
+            assert result["success"] is False
+            assert "does not exist" in result["error"]
+
+
+class TestDispatchHandler:
     def test_handler_returns_json(self):
         mock_result = MagicMock()
         mock_result.stdout = "result"
@@ -143,15 +151,15 @@ class TestHandleClaudeCode:
 
         with patch("tools.claude_code_tool.check_claude_code_available", return_value=True), \
              patch("subprocess.run", return_value=mock_result):
-            output = handle_claude_code(prompt="test")
+            output = _handle_claude_code_dispatch({"prompt": "test"})
             parsed = json.loads(output)
             assert parsed["success"] is True
             assert parsed["output"] == "result"
 
-    def test_handler_empty_model_becomes_none(self):
+    def test_handler_receives_args_dict(self):
         with patch("tools.claude_code_tool.check_claude_code_available", return_value=True), \
              patch("tools.claude_code_tool.claude_code", return_value={"success": True, "output": "ok"}) as mock_cc:
-            handle_claude_code(prompt="test", model="", max_turns=0, cwd="", timeout=0)
+            _handle_claude_code_dispatch({"prompt": "test", "model": "", "max_turns": 0, "cwd": "", "timeout": 0})
             mock_cc.assert_called_once_with(
                 prompt="test", model=None, max_turns=None, cwd=None, timeout=None,
             )

--- a/tools/claude_code_tool.py
+++ b/tools/claude_code_tool.py
@@ -390,12 +390,13 @@ def claude_code_streaming(
 # ---------------------------------------------------------------------------
 
 def _handle_claude_code_dispatch(args: dict, **kwargs) -> str:
-    """Tool handler entry point (called by registry dispatch with args dict)."""
-    # Try to get hermes session key from parent agent context
-    session_key = None
-    parent_agent = kwargs.get("parent_agent") or kwargs.get("agent")
-    if parent_agent:
-        session_key = getattr(parent_agent, "session_id", None) or getattr(parent_agent, "task_id", None)
+    """Tool handler entry point (called by registry dispatch with args dict).
+
+    Registry passes ``task_id`` and ``user_task`` as kwargs (see model_tools.py).
+    We use ``task_id`` as the session key so Claude sessions are scoped to
+    the Hermes session/task.
+    """
+    session_key = kwargs.get("task_id")
 
     result = claude_code(
         prompt=args.get("prompt", ""),
@@ -415,12 +416,15 @@ def _handle_claude_code_dispatch(args: dict, **kwargs) -> str:
 CLAUDE_CODE_SCHEMA = {
     "name": TOOL_NAME,
     "description": (
-        "Delegate a complex task to Claude Code (Anthropic's coding agent). "
-        "Use this for tasks that require deep code analysis, multi-file refactoring, "
-        "architecture review, debugging complex issues, or writing substantial code. "
-        "Claude runs locally using the user's existing subscription -- no API key needed. "
-        "Sessions are preserved: Claude remembers context from previous calls in this session. "
-        "Provide a clear, detailed prompt describing the task."
+        "Delegate a task to Claude Code (Anthropic's coding agent). "
+        "ONLY use this tool when the user explicitly asks to use Claude, "
+        "or when a task clearly requires capabilities you lack (e.g. multi-file "
+        "refactoring across 5+ files, complex architecture redesign, or debugging "
+        "issues you failed to solve after 2+ attempts). "
+        "Do NOT use this for simple questions, single-file edits, or tasks you can handle. "
+        "Claude runs locally using the user's existing subscription. "
+        "Sessions are preserved across calls. "
+        "Provide a clear, detailed prompt with file paths and context."
     ),
     "parameters": {
         "type": "object",

--- a/tools/claude_code_tool.py
+++ b/tools/claude_code_tool.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""
+Claude Code Tool -- Delegate tasks to Claude Code CLI.
+
+Allows Hermes to offload complex tasks (deep code analysis, refactoring,
+multi-file edits, architecture review) to Claude Code via its print mode
+(``claude -p``).  This uses the user's existing Claude subscription --
+no API key or extra usage credits required.
+
+The tool runs ``claude -p "<prompt>"`` as a subprocess and returns the
+output.  The calling LLM (e.g. Qwen) decides when a task is too complex
+for itself and delegates to Claude.
+
+Requirements:
+  - Claude Code CLI installed and authenticated (``claude`` on PATH)
+"""
+
+import logging
+import os
+import shutil
+import subprocess
+from typing import Dict, Any, Optional
+
+from tools.registry import registry
+
+logger = logging.getLogger(__name__)
+
+TOOL_NAME = "claude_code"
+TOOLSET = "claude_code"
+
+DEFAULT_TIMEOUT = 300  # 5 minutes max
+MAX_PROMPT_LENGTH = 100_000
+MAX_OUTPUT_LENGTH = 50_000
+
+
+def check_claude_code_available() -> bool:
+    """Return True when the ``claude`` CLI binary is on PATH."""
+    return shutil.which("claude") is not None
+
+
+def _build_claude_command(
+    prompt: str,
+    model: Optional[str] = None,
+    max_turns: Optional[int] = None,
+) -> list:
+    """Build the claude CLI command list."""
+    cmd = ["claude", "-p"]
+
+    if model:
+        cmd.extend(["--model", model])
+
+    if max_turns and max_turns > 0:
+        cmd.extend(["--max-turns", str(max_turns)])
+
+    cmd.append(prompt)
+    return cmd
+
+
+def claude_code(
+    prompt: str,
+    model: Optional[str] = None,
+    max_turns: Optional[int] = None,
+    cwd: Optional[str] = None,
+    timeout: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Run a task via Claude Code CLI in print mode.
+
+    Args:
+        prompt:     The task description / prompt for Claude.
+        model:      Optional model override (e.g. "sonnet", "opus").
+        max_turns:  Max agentic turns Claude can take (default: 1 for simple queries).
+        cwd:        Working directory for Claude (defaults to current dir).
+        timeout:    Max seconds to wait (default: 300).
+
+    Returns:
+        Dict with "success", "output", and optional "error" keys.
+    """
+    if not prompt or not prompt.strip():
+        return {"success": False, "output": "", "error": "Prompt cannot be empty."}
+
+    if len(prompt) > MAX_PROMPT_LENGTH:
+        return {
+            "success": False,
+            "output": "",
+            "error": f"Prompt too long ({len(prompt)} chars, max {MAX_PROMPT_LENGTH}).",
+        }
+
+    if not check_claude_code_available():
+        return {
+            "success": False,
+            "output": "",
+            "error": "Claude Code CLI not found. Install it: npm install -g @anthropic-ai/claude-code",
+        }
+
+    effective_timeout = min(timeout or DEFAULT_TIMEOUT, 600)
+    work_dir = cwd or os.getcwd()
+
+    cmd = _build_claude_command(prompt, model=model, max_turns=max_turns)
+
+    logger.info("Running Claude Code: cwd=%s, model=%s, timeout=%ds", work_dir, model or "default", effective_timeout)
+
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=effective_timeout,
+            cwd=work_dir,
+            env={**os.environ, "CLAUDE_CODE_DISABLE_NONINTERACTIVE_HINT": "1"},
+        )
+
+        output = result.stdout.strip()
+        stderr = result.stderr.strip()
+
+        if len(output) > MAX_OUTPUT_LENGTH:
+            output = output[:MAX_OUTPUT_LENGTH] + "\n\n[Output truncated]"
+
+        if result.returncode != 0:
+            error_detail = stderr or f"Exit code {result.returncode}"
+            logger.warning("Claude Code returned non-zero: %s", error_detail)
+            return {
+                "success": False,
+                "output": output,
+                "error": f"Claude Code failed: {error_detail}",
+            }
+
+        logger.info("Claude Code completed: %d chars output", len(output))
+        return {"success": True, "output": output}
+
+    except subprocess.TimeoutExpired:
+        logger.error("Claude Code timed out after %ds", effective_timeout)
+        return {
+            "success": False,
+            "output": "",
+            "error": f"Claude Code timed out after {effective_timeout} seconds.",
+        }
+    except Exception as e:
+        logger.error("Claude Code execution error: %s", e, exc_info=True)
+        return {"success": False, "output": "", "error": f"Execution error: {e}"}
+
+
+# ---------------------------------------------------------------------------
+# Tool handler (called by model_tools dispatch)
+# ---------------------------------------------------------------------------
+
+def handle_claude_code(
+    prompt: str,
+    model: str = "",
+    max_turns: int = 0,
+    cwd: str = "",
+    timeout: int = 0,
+    **kwargs,
+) -> str:
+    """Tool handler entry point."""
+    import json
+    result = claude_code(
+        prompt=prompt,
+        model=model or None,
+        max_turns=max_turns or None,
+        cwd=cwd or None,
+        timeout=timeout or None,
+    )
+    return json.dumps(result, ensure_ascii=False)
+
+
+# ---------------------------------------------------------------------------
+# Schema + Registration
+# ---------------------------------------------------------------------------
+
+CLAUDE_CODE_SCHEMA = {
+    "name": TOOL_NAME,
+    "description": (
+        "Delegate a complex task to Claude Code (Anthropic's coding agent). "
+        "Use this for tasks that require deep code analysis, multi-file refactoring, "
+        "architecture review, debugging complex issues, or writing substantial code. "
+        "Claude runs locally using the user's existing subscription -- no API key needed. "
+        "Provide a clear, detailed prompt describing the task."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": (
+                    "Detailed task description for Claude. Include relevant context: "
+                    "file paths, code snippets, expected behavior, and specific instructions."
+                ),
+            },
+            "model": {
+                "type": "string",
+                "description": "Optional model override: 'sonnet', 'opus', or 'haiku'. Leave empty for default.",
+                "default": "",
+            },
+            "max_turns": {
+                "type": "integer",
+                "description": "Max agentic turns (0 = default). Set higher for complex multi-step tasks.",
+                "default": 0,
+            },
+            "cwd": {
+                "type": "string",
+                "description": "Working directory for Claude. Leave empty for current directory.",
+                "default": "",
+            },
+            "timeout": {
+                "type": "integer",
+                "description": "Max seconds to wait (default 300, max 600).",
+                "default": 0,
+            },
+        },
+        "required": ["prompt"],
+    },
+}
+
+registry.register(
+    name=TOOL_NAME,
+    toolset=TOOLSET,
+    schema=CLAUDE_CODE_SCHEMA,
+    handler=handle_claude_code,
+    check_fn=check_claude_code_available,
+    requires_env=[],
+    description="Delegate complex tasks to Claude Code CLI",
+    emoji="",
+)

--- a/tools/claude_code_tool.py
+++ b/tools/claude_code_tool.py
@@ -7,19 +7,23 @@ multi-file edits, architecture review) to Claude Code via its print mode
 (``claude -p``).  This uses the user's existing Claude subscription --
 no API key or extra usage credits required.
 
-The tool runs ``claude -p "<prompt>"`` as a subprocess and returns the
-output.  The calling LLM (e.g. Qwen) decides when a task is too complex
-for itself and delegates to Claude.
+Features:
+  - Session persistence: each Hermes session gets a Claude session that
+    can be resumed across calls (``--resume <session_id>``).
+  - JSON output: structured results with session_id, cost, duration.
+  - Streaming support: real-time output via ``--output-format stream-json``.
 
 Requirements:
   - Claude Code CLI installed and authenticated (``claude`` on PATH)
 """
 
+import json
 import logging
 import os
 import shutil
 import subprocess
-from typing import Dict, Any, Optional
+import threading
+from typing import Dict, Any, Optional, Callable
 
 from tools.registry import registry
 
@@ -32,16 +36,40 @@ DEFAULT_TIMEOUT = 300  # 5 minutes max
 MAX_PROMPT_LENGTH = 100_000
 MAX_OUTPUT_LENGTH = 50_000
 
+# Session store: maps hermes session key -> claude session_id
+_session_store: Dict[str, str] = {}
+_session_lock = threading.Lock()
+
 
 def check_claude_code_available() -> bool:
     """Return True when the ``claude`` CLI binary is on PATH."""
     return shutil.which("claude") is not None
 
 
+def get_claude_session(hermes_session_key: str) -> Optional[str]:
+    """Get the Claude session ID for a Hermes session."""
+    with _session_lock:
+        return _session_store.get(hermes_session_key)
+
+
+def set_claude_session(hermes_session_key: str, claude_session_id: str) -> None:
+    """Store the Claude session ID for a Hermes session."""
+    with _session_lock:
+        _session_store[hermes_session_key] = claude_session_id
+
+
+def clear_claude_session(hermes_session_key: str) -> None:
+    """Clear the Claude session for a Hermes session."""
+    with _session_lock:
+        _session_store.pop(hermes_session_key, None)
+
+
 def _build_claude_command(
     prompt: str,
     model: Optional[str] = None,
     max_turns: Optional[int] = None,
+    session_id: Optional[str] = None,
+    output_format: str = "json",
 ) -> list:
     """Build the claude CLI command list."""
     cmd = ["claude", "-p"]
@@ -52,8 +80,55 @@ def _build_claude_command(
     if max_turns and max_turns > 0:
         cmd.extend(["--max-turns", str(max_turns)])
 
+    if session_id:
+        cmd.extend(["--resume", session_id])
+
+    cmd.extend(["--output-format", output_format])
+
     cmd.append(prompt)
     return cmd
+
+
+def _parse_json_output(raw_output: str) -> Dict[str, Any]:
+    """Parse Claude CLI JSON output and extract result + session_id."""
+    try:
+        data = json.loads(raw_output)
+    except json.JSONDecodeError:
+        return {"result_text": raw_output.strip(), "session_id": None, "cost_usd": None}
+
+    # JSON output is a list of events
+    if isinstance(data, list):
+        result_text = ""
+        session_id = None
+        cost_usd = None
+        duration_ms = None
+
+        for event in data:
+            event_type = event.get("type", "")
+
+            if event_type == "system" and event.get("subtype") == "init":
+                session_id = event.get("session_id")
+
+            elif event_type == "assistant":
+                msg = event.get("message", {})
+                for content in msg.get("content", []):
+                    if content.get("type") == "text":
+                        result_text += content.get("text", "")
+
+            elif event_type == "result":
+                result_text = event.get("result", result_text)
+                session_id = session_id or event.get("session_id")
+                cost_usd = event.get("total_cost_usd")
+                duration_ms = event.get("duration_ms")
+
+        return {
+            "result_text": result_text.strip(),
+            "session_id": session_id,
+            "cost_usd": cost_usd,
+            "duration_ms": duration_ms,
+        }
+
+    return {"result_text": str(data), "session_id": None, "cost_usd": None}
 
 
 def claude_code(
@@ -62,18 +137,20 @@ def claude_code(
     max_turns: Optional[int] = None,
     cwd: Optional[str] = None,
     timeout: Optional[int] = None,
+    session_key: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Run a task via Claude Code CLI in print mode.
 
     Args:
-        prompt:     The task description / prompt for Claude.
-        model:      Optional model override (e.g. "sonnet", "opus").
-        max_turns:  Max agentic turns Claude can take (default: 1 for simple queries).
-        cwd:        Working directory for Claude (defaults to current dir).
-        timeout:    Max seconds to wait (default: 300).
+        prompt:      The task description / prompt for Claude.
+        model:       Optional model override (e.g. "sonnet", "opus").
+        max_turns:   Max agentic turns Claude can take.
+        cwd:         Working directory for Claude (defaults to current dir).
+        timeout:     Max seconds to wait (default: 300).
+        session_key: Hermes session key for session persistence.
 
     Returns:
-        Dict with "success", "output", and optional "error" keys.
+        Dict with "success", "output", "session_id", "cost_usd", and optional "error" keys.
     """
     if not prompt or not prompt.strip():
         return {"success": False, "output": "", "error": "Prompt cannot be empty."}
@@ -102,9 +179,21 @@ def claude_code(
             "error": f"Working directory does not exist: {work_dir}",
         }
 
-    cmd = _build_claude_command(prompt, model=model, max_turns=max_turns)
+    # Resume existing Claude session if available
+    resume_session_id = get_claude_session(session_key) if session_key else None
 
-    logger.info("Running Claude Code: cwd=%s, model=%s, timeout=%ds", work_dir, model or "default", effective_timeout)
+    cmd = _build_claude_command(
+        prompt,
+        model=model,
+        max_turns=max_turns,
+        session_id=resume_session_id,
+        output_format="json",
+    )
+
+    logger.info(
+        "Running Claude Code: cwd=%s, model=%s, resume=%s, timeout=%ds",
+        work_dir, model or "default", resume_session_id or "new", effective_timeout,
+    )
 
     try:
         result = subprocess.run(
@@ -116,23 +205,41 @@ def claude_code(
             env={**os.environ, "CLAUDE_CODE_DISABLE_NONINTERACTIVE_HINT": "1"},
         )
 
-        output = result.stdout.strip()
         stderr = result.stderr.strip()
-
-        if len(output) > MAX_OUTPUT_LENGTH:
-            output = output[:MAX_OUTPUT_LENGTH] + "\n\n[Output truncated]"
 
         if result.returncode != 0:
             error_detail = stderr or f"Exit code {result.returncode}"
             logger.warning("Claude Code returned non-zero: %s", error_detail)
             return {
                 "success": False,
-                "output": output,
+                "output": "",
                 "error": f"Claude Code failed: {error_detail}",
             }
 
-        logger.info("Claude Code completed: %d chars output", len(output))
-        return {"success": True, "output": output}
+        parsed = _parse_json_output(result.stdout)
+        output = parsed["result_text"]
+
+        if len(output) > MAX_OUTPUT_LENGTH:
+            output = output[:MAX_OUTPUT_LENGTH] + "\n\n[Output truncated]"
+
+        # Persist session for future calls
+        if session_key and parsed.get("session_id"):
+            set_claude_session(session_key, parsed["session_id"])
+
+        logger.info(
+            "Claude Code completed: %d chars, session=%s, cost=$%.4f",
+            len(output),
+            parsed.get("session_id", "?"),
+            parsed.get("cost_usd") or 0,
+        )
+
+        return {
+            "success": True,
+            "output": output,
+            "session_id": parsed.get("session_id"),
+            "cost_usd": parsed.get("cost_usd"),
+            "duration_ms": parsed.get("duration_ms"),
+        }
 
     except subprocess.TimeoutExpired:
         logger.error("Claude Code timed out after %ds", effective_timeout)
@@ -146,19 +253,157 @@ def claude_code(
         return {"success": False, "output": "", "error": f"Execution error: {e}"}
 
 
+def claude_code_streaming(
+    prompt: str,
+    on_text: Callable[[str], None],
+    model: Optional[str] = None,
+    max_turns: Optional[int] = None,
+    cwd: Optional[str] = None,
+    timeout: Optional[int] = None,
+    session_key: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Run Claude Code with streaming output.
+
+    Streams partial results via the ``on_text`` callback as they arrive.
+
+    Args:
+        prompt:      The task description for Claude.
+        on_text:     Callback invoked with each text chunk.
+        model:       Optional model override.
+        max_turns:   Max agentic turns.
+        cwd:         Working directory.
+        timeout:     Max seconds to wait.
+        session_key: Hermes session key for session persistence.
+
+    Returns:
+        Dict with "success", "output", "session_id", "cost_usd", and optional "error" keys.
+    """
+    if not prompt or not prompt.strip():
+        return {"success": False, "output": "", "error": "Prompt cannot be empty."}
+
+    if not check_claude_code_available():
+        return {
+            "success": False,
+            "output": "",
+            "error": "Claude Code CLI not found.",
+        }
+
+    effective_timeout = min(timeout or DEFAULT_TIMEOUT, 600)
+    work_dir = os.path.realpath(cwd) if cwd else os.getcwd()
+
+    if not os.path.isdir(work_dir):
+        return {"success": False, "output": "", "error": f"Directory not found: {work_dir}"}
+
+    resume_session_id = get_claude_session(session_key) if session_key else None
+
+    cmd = _build_claude_command(
+        prompt,
+        model=model,
+        max_turns=max_turns,
+        session_id=resume_session_id,
+        output_format="stream-json",
+    )
+    cmd.insert(2, "--include-partial-messages")
+
+    logger.info("Running Claude Code (streaming): cwd=%s, resume=%s", work_dir, resume_session_id or "new")
+
+    collected_text = []
+    session_id = None
+    cost_usd = None
+    duration_ms = None
+
+    try:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=work_dir,
+            env={**os.environ, "CLAUDE_CODE_DISABLE_NONINTERACTIVE_HINT": "1"},
+        )
+
+        try:
+            for line in proc.stdout:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                event_type = event.get("type", "")
+
+                if event_type == "system" and event.get("subtype") == "init":
+                    session_id = event.get("session_id")
+
+                elif event_type == "assistant":
+                    msg = event.get("message", {})
+                    for content in msg.get("content", []):
+                        if content.get("type") == "text":
+                            text = content.get("text", "")
+                            if text:
+                                collected_text.append(text)
+                                on_text(text)
+
+                elif event_type == "result":
+                    session_id = session_id or event.get("session_id")
+                    cost_usd = event.get("total_cost_usd")
+                    duration_ms = event.get("duration_ms")
+                    final_result = event.get("result", "")
+                    if final_result and not collected_text:
+                        collected_text.append(final_result)
+
+            proc.wait(timeout=effective_timeout)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            return {"success": False, "output": "", "error": f"Timed out after {effective_timeout}s."}
+
+        if session_key and session_id:
+            set_claude_session(session_key, session_id)
+
+        full_output = "".join(collected_text).strip()
+
+        if proc.returncode != 0:
+            stderr = proc.stderr.read().strip() if proc.stderr else ""
+            return {
+                "success": False,
+                "output": full_output,
+                "error": f"Exit code {proc.returncode}: {stderr}",
+            }
+
+        return {
+            "success": True,
+            "output": full_output,
+            "session_id": session_id,
+            "cost_usd": cost_usd,
+            "duration_ms": duration_ms,
+        }
+
+    except Exception as e:
+        logger.error("Claude Code streaming error: %s", e, exc_info=True)
+        return {"success": False, "output": "", "error": f"Execution error: {e}"}
+
+
 # ---------------------------------------------------------------------------
 # Tool handler (called by model_tools dispatch)
 # ---------------------------------------------------------------------------
 
 def _handle_claude_code_dispatch(args: dict, **kwargs) -> str:
     """Tool handler entry point (called by registry dispatch with args dict)."""
-    import json
+    # Try to get hermes session key from parent agent context
+    session_key = None
+    parent_agent = kwargs.get("parent_agent") or kwargs.get("agent")
+    if parent_agent:
+        session_key = getattr(parent_agent, "session_id", None) or getattr(parent_agent, "task_id", None)
+
     result = claude_code(
         prompt=args.get("prompt", ""),
         model=args.get("model", "") or None,
         max_turns=args.get("max_turns", 0) or None,
         cwd=args.get("cwd", "") or None,
         timeout=args.get("timeout", 0) or None,
+        session_key=session_key,
     )
     return json.dumps(result, ensure_ascii=False)
 
@@ -174,6 +419,7 @@ CLAUDE_CODE_SCHEMA = {
         "Use this for tasks that require deep code analysis, multi-file refactoring, "
         "architecture review, debugging complex issues, or writing substantial code. "
         "Claude runs locally using the user's existing subscription -- no API key needed. "
+        "Sessions are preserved: Claude remembers context from previous calls in this session. "
         "Provide a clear, detailed prompt describing the task."
     ),
     "parameters": {

--- a/tools/claude_code_tool.py
+++ b/tools/claude_code_tool.py
@@ -93,7 +93,14 @@ def claude_code(
         }
 
     effective_timeout = min(timeout or DEFAULT_TIMEOUT, 600)
-    work_dir = cwd or os.getcwd()
+    work_dir = os.path.realpath(cwd) if cwd else os.getcwd()
+
+    if not os.path.isdir(work_dir):
+        return {
+            "success": False,
+            "output": "",
+            "error": f"Working directory does not exist: {work_dir}",
+        }
 
     cmd = _build_claude_command(prompt, model=model, max_turns=max_turns)
 
@@ -143,22 +150,15 @@ def claude_code(
 # Tool handler (called by model_tools dispatch)
 # ---------------------------------------------------------------------------
 
-def handle_claude_code(
-    prompt: str,
-    model: str = "",
-    max_turns: int = 0,
-    cwd: str = "",
-    timeout: int = 0,
-    **kwargs,
-) -> str:
-    """Tool handler entry point."""
+def _handle_claude_code_dispatch(args: dict, **kwargs) -> str:
+    """Tool handler entry point (called by registry dispatch with args dict)."""
     import json
     result = claude_code(
-        prompt=prompt,
-        model=model or None,
-        max_turns=max_turns or None,
-        cwd=cwd or None,
-        timeout=timeout or None,
+        prompt=args.get("prompt", ""),
+        model=args.get("model", "") or None,
+        max_turns=args.get("max_turns", 0) or None,
+        cwd=args.get("cwd", "") or None,
+        timeout=args.get("timeout", 0) or None,
     )
     return json.dumps(result, ensure_ascii=False)
 
@@ -176,7 +176,7 @@ CLAUDE_CODE_SCHEMA = {
         "Claude runs locally using the user's existing subscription -- no API key needed. "
         "Provide a clear, detailed prompt describing the task."
     ),
-    "input_schema": {
+    "parameters": {
         "type": "object",
         "properties": {
             "prompt": {
@@ -215,7 +215,7 @@ registry.register(
     name=TOOL_NAME,
     toolset=TOOLSET,
     schema=CLAUDE_CODE_SCHEMA,
-    handler=handle_claude_code,
+    handler=_handle_claude_code_dispatch,
     check_fn=check_claude_code_available,
     requires_env=[],
     description="Delegate complex tasks to Claude Code CLI",

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -28,6 +28,7 @@ from typing import Any, Dict, List, Optional
 # Tools that children must never have access to
 DELEGATE_BLOCKED_TOOLS = frozenset([
     "delegate_task",   # no recursive delegation
+    "claude_code",     # no nested agentic calls from subagents
     "clarify",         # no user interaction
     "memory",          # no writes to shared MEMORY.md
     "send_message",    # no cross-platform side effects

--- a/toolsets.py
+++ b/toolsets.py
@@ -56,6 +56,8 @@ _HERMES_CORE_TOOLS = [
     "clarify",
     # Code execution + delegation
     "execute_code", "delegate_task",
+    # Claude Code CLI delegation
+    "claude_code",
     # Cronjob management
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
@@ -191,6 +193,12 @@ TOOLSETS = {
     "delegation": {
         "description": "Spawn subagents with isolated context for complex subtasks",
         "tools": ["delegate_task"],
+        "includes": []
+    },
+
+    "claude_code": {
+        "description": "Delegate complex tasks to Claude Code CLI (uses existing subscription)",
+        "tools": ["claude_code"],
         "includes": []
     },
 


### PR DESCRIPTION
## Summary

- Adds `claude_code` tool that delegates tasks to Claude Code CLI via `claude -p` (print mode)
- Adds `/claude <prompt>` slash command for direct Claude Code delegation from CLI and messaging platforms (Telegram, Discord, etc.)
- Uses the user's existing Claude subscription -- no API key or extra usage credits needed

## Why both tool and slash command?

| | `claude_code` tool | `/claude` command |
|---|---|---|
| **Who decides** | Agent auto-delegates | User explicitly triggers |
| **Use case** | Agent offloads complex tasks it can't handle | User wants Claude directly |
| **Platforms** | All (CLI, gateway, messaging) | All (CLI, gateway, messaging) |

This complements the existing `claude-code` skill (which uses terminal+PTY for interactive sessions). The tool works on **all platforms including messaging gateways** where PTY/terminal is not available.

## Features

- **Session persistence**: Claude remembers context across calls within a Hermes session (`--resume <session_id>`)
- **Streaming output**: CLI streams text as it arrives via `subprocess.Popen`
- **JSON output parsing**: extracts session_id, cost, duration from Claude CLI
- **Cost display**: shows cost after each call
- **Safety**: blocked from subagent delegation (`DELEGATE_BLOCKED_TOOLS`), cwd path validation
- **Tool description**: explicit guidance on when to use/not use (prevents over-delegation by cheap models)

## Files changed

- `tools/claude_code_tool.py` -- new tool implementation
- `tests/tools/test_claude_code_tool.py` -- 27 tests
- `toolsets.py` -- toolset registration
- `model_tools.py` -- tool discovery
- `hermes_cli/commands.py` -- `/claude` command registration
- `cli.py` -- CLI handler (streaming)
- `gateway/run.py` -- gateway handler (session-aware)
- `tools/delegate_tool.py` -- block claude_code from subagents

