### PR TITLE
fix: add missing shutil import for Matrix E2EE setup

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -14,6 +14,7 @@ Config files are stored in ~/.hermes/ for easy access.
 import importlib.util
 import logging
 import os
+import shutil
 import sys
 from pathlib import Path
 from typing import Optional, Dict, Any

--- a/tests/hermes_cli/test_setup_matrix_e2ee.py
+++ b/tests/hermes_cli/test_setup_matrix_e2ee.py
@@ -1,0 +1,31 @@
+"""Test that setup.py has shutil available for Matrix E2EE auto-install."""
+import ast
+
+import pytest
+
+
+def _parse_setup_imports():
+    """Parse setup.py and return top-level import names."""
+    with open("hermes_cli/setup.py") as f:
+        tree = ast.parse(f.read())
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                names.add(alias.name)
+    return names
+
+
+class TestSetupShutilImport:
+    def test_shutil_imported_at_module_level(self):
+        """shutil must be imported at module level so setup_gateway can use it
+        for the matrix-nio auto-install path (line ~2126)."""
+        names = _parse_setup_imports()
+        assert "shutil" in names, (
+            "shutil is not imported at the top of hermes_cli/setup.py. "
+            "This causes a NameError when the Matrix E2EE auto-install "
+            "tries to call shutil.which('uv')."
+        )


### PR DESCRIPTION
Fixes #5134

The Matrix E2EE setup path in setup_gateway() calls shutil.which("uv") but
shutil was never imported at module level. This crashes the setup wizard with
NameError when trying to auto-install matrix-nio[e2e].

Added shutil to the top-level imports. Added a test that verifies the import
exists so this doesn't regress.