### PR TITLE
fix(honcho): read peer cards from direct peer APIs

### DIFF
--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -618,35 +618,19 @@ class HonchoSessionManager:
         if not session:
             return {}
 
-        honcho_session = self._sessions_cache.get(session.honcho_session_id)
-        if not honcho_session:
-            return {}
-
         result: dict[str, str] = {}
         try:
-            ctx = honcho_session.context(
-                summary=False,
-                tokens=self._context_tokens,
-                peer_target=session.user_peer_id,
-                peer_perspective=session.assistant_peer_id,
-            )
-            card = ctx.peer_card or []
-            result["representation"] = ctx.peer_representation or ""
-            result["card"] = "\n".join(card) if isinstance(card, list) else str(card)
+            user_ctx = self._fetch_peer_context(session.user_peer_id)
+            result["representation"] = user_ctx["representation"]
+            result["card"] = "\n".join(user_ctx["card"])
         except Exception as e:
             logger.warning("Failed to fetch user context from Honcho: %s", e)
 
         # Also fetch AI peer's own representation so Hermes knows itself.
         try:
-            ai_ctx = honcho_session.context(
-                summary=False,
-                tokens=self._context_tokens,
-                peer_target=session.assistant_peer_id,
-                peer_perspective=session.user_peer_id,
-            )
-            ai_card = ai_ctx.peer_card or []
-            result["ai_representation"] = ai_ctx.peer_representation or ""
-            result["ai_card"] = "\n".join(ai_card) if isinstance(ai_card, list) else str(ai_card)
+            ai_ctx = self._fetch_peer_context(session.assistant_peer_id)
+            result["ai_representation"] = ai_ctx["representation"]
+            result["ai_card"] = "\n".join(ai_ctx["card"])
         except Exception as e:
             logger.debug("Failed to fetch AI peer context from Honcho: %s", e)
 
@@ -823,6 +807,64 @@ class HonchoSessionManager:
 
         return uploaded
 
+    @staticmethod
+    def _normalize_card(card: Any) -> list[str]:
+        """Normalize Honcho card payloads into a plain list of strings."""
+        if not card:
+            return []
+        if isinstance(card, list):
+            return [str(item) for item in card if item]
+        return [str(card)]
+
+    def _fetch_peer_card(self, peer_id: str) -> list[str]:
+        """Fetch a peer card directly from the peer object.
+
+        This avoids relying on session.context(), which can return an empty
+        peer_card for per-session messaging sessions even when the peer itself
+        has a populated card.
+        """
+        peer = self._get_or_create_peer(peer_id)
+        getter = getattr(peer, "get_card", None)
+        if callable(getter):
+            return self._normalize_card(getter())
+
+        legacy_getter = getattr(peer, "card", None)
+        if callable(legacy_getter):
+            return self._normalize_card(legacy_getter())
+
+        return []
+
+    def _fetch_peer_context(self, peer_id: str, search_query: str | None = None) -> dict[str, Any]:
+        """Fetch representation + peer card directly from a peer object."""
+        peer = self._get_or_create_peer(peer_id)
+        representation = ""
+        card: list[str] = []
+
+        try:
+            ctx = peer.context(search_query=search_query) if search_query else peer.context()
+            representation = (
+                getattr(ctx, "representation", None)
+                or getattr(ctx, "peer_representation", None)
+                or ""
+            )
+            card = self._normalize_card(getattr(ctx, "peer_card", None))
+        except Exception as e:
+            logger.debug("Direct peer.context() failed for '%s': %s", peer_id, e)
+
+        if not representation:
+            try:
+                representation = peer.representation() or ""
+            except Exception as e:
+                logger.debug("Direct peer.representation() failed for '%s': %s", peer_id, e)
+
+        if not card:
+            try:
+                card = self._fetch_peer_card(peer_id)
+            except Exception as e:
+                logger.debug("Direct peer card fetch failed for '%s': %s", peer_id, e)
+
+        return {"representation": representation, "card": card}
+
     def get_peer_card(self, session_key: str) -> list[str]:
         """
         Fetch the user peer's card — a curated list of key facts.
@@ -835,19 +877,8 @@ class HonchoSessionManager:
         if not session:
             return []
 
-        honcho_session = self._sessions_cache.get(session.honcho_session_id)
-        if not honcho_session:
-            return []
-
         try:
-            ctx = honcho_session.context(
-                summary=False,
-                tokens=200,
-                peer_target=session.user_peer_id,
-                peer_perspective=session.assistant_peer_id,
-            )
-            card = ctx.peer_card or []
-            return card if isinstance(card, list) else [str(card)]
+            return self._fetch_peer_card(session.user_peer_id)
         except Exception as e:
             logger.debug("Failed to fetch peer card from Honcho: %s", e)
             return []
@@ -872,25 +903,14 @@ class HonchoSessionManager:
         if not session:
             return ""
 
-        honcho_session = self._sessions_cache.get(session.honcho_session_id)
-        if not honcho_session:
-            return ""
-
         try:
-            ctx = honcho_session.context(
-                summary=False,
-                tokens=max_tokens,
-                peer_target=session.user_peer_id,
-                peer_perspective=session.assistant_peer_id,
-                search_query=query,
-            )
+            ctx = self._fetch_peer_context(session.user_peer_id, search_query=query)
             parts = []
-            if ctx.peer_representation:
-                parts.append(ctx.peer_representation)
-            card = ctx.peer_card or []
+            if ctx["representation"]:
+                parts.append(ctx["representation"])
+            card = ctx["card"] or []
             if card:
-                facts = card if isinstance(card, list) else [str(card)]
-                parts.append("\n".join(f"- {f}" for f in facts))
+                parts.append("\n".join(f"- {f}" for f in card))
             return "\n\n".join(parts)
         except Exception as e:
             logger.debug("Honcho search_context failed: %s", e)
@@ -994,21 +1014,11 @@ class HonchoSessionManager:
         if not session:
             return {"representation": "", "card": ""}
 
-        honcho_session = self._sessions_cache.get(session.honcho_session_id)
-        if not honcho_session:
-            return {"representation": "", "card": ""}
-
         try:
-            ctx = honcho_session.context(
-                summary=False,
-                tokens=self._context_tokens,
-                peer_target=session.assistant_peer_id,
-                peer_perspective=session.user_peer_id,
-            )
-            ai_card = ctx.peer_card or []
+            ctx = self._fetch_peer_context(session.assistant_peer_id)
             return {
-                "representation": ctx.peer_representation or "",
-                "card": "\n".join(ai_card) if isinstance(ai_card, list) else str(ai_card),
+                "representation": ctx["representation"] or "",
+                "card": "\n".join(ctx["card"]),
             }
         except Exception as e:
             logger.debug("Failed to fetch AI representation: %s", e)

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -1,6 +1,7 @@
 """Tests for plugins/memory/honcho/session.py — HonchoSession and helpers."""
 
 from datetime import datetime
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from plugins.memory.honcho.session import (
@@ -187,3 +188,82 @@ class TestManagerCacheOps:
         assert keys == {"k1", "k2"}
         s1_info = next(s for s in sessions if s["key"] == "k1")
         assert s1_info["message_count"] == 1
+
+
+class TestPeerLookupHelpers:
+    def _make_cached_manager(self):
+        mgr = HonchoSessionManager()
+        session = HonchoSession(
+            key="telegram:123",
+            user_peer_id="robert",
+            assistant_peer_id="hermes",
+            honcho_session_id="telegram-123",
+        )
+        mgr._cache[session.key] = session
+        return mgr, session
+
+    def test_get_peer_card_uses_direct_peer_lookup(self):
+        mgr, session = self._make_cached_manager()
+        user_peer = MagicMock()
+        user_peer.get_card.return_value = ["Name: Robert"]
+        mgr._get_or_create_peer = MagicMock(return_value=user_peer)
+
+        assert mgr.get_peer_card(session.key) == ["Name: Robert"]
+        user_peer.get_card.assert_called_once_with()
+
+    def test_search_context_uses_peer_context_response(self):
+        mgr, session = self._make_cached_manager()
+        user_peer = MagicMock()
+        user_peer.context.return_value = SimpleNamespace(
+            representation="Robert runs neuralancer",
+            peer_card=["Location: Melbourne"],
+        )
+        mgr._get_or_create_peer = MagicMock(return_value=user_peer)
+
+        result = mgr.search_context(session.key, "neuralancer")
+
+        assert "Robert runs neuralancer" in result
+        assert "- Location: Melbourne" in result
+        user_peer.context.assert_called_once_with(search_query="neuralancer")
+
+    def test_get_prefetch_context_fetches_user_and_ai_from_peer_api(self):
+        mgr, session = self._make_cached_manager()
+        user_peer = MagicMock()
+        user_peer.context.return_value = SimpleNamespace(
+            representation="User representation",
+            peer_card=["Name: Robert"],
+        )
+        ai_peer = MagicMock()
+        ai_peer.context.return_value = SimpleNamespace(
+            representation="AI representation",
+            peer_card=["Owner: Robert"],
+        )
+        mgr._get_or_create_peer = MagicMock(side_effect=[user_peer, ai_peer])
+
+        result = mgr.get_prefetch_context(session.key)
+
+        assert result == {
+            "representation": "User representation",
+            "card": "Name: Robert",
+            "ai_representation": "AI representation",
+            "ai_card": "Owner: Robert",
+        }
+        user_peer.context.assert_called_once_with()
+        ai_peer.context.assert_called_once_with()
+
+    def test_get_ai_representation_uses_peer_api(self):
+        mgr, session = self._make_cached_manager()
+        ai_peer = MagicMock()
+        ai_peer.context.return_value = SimpleNamespace(
+            representation="AI representation",
+            peer_card=["Owner: Robert"],
+        )
+        mgr._get_or_create_peer = MagicMock(return_value=ai_peer)
+
+        result = mgr.get_ai_representation(session.key)
+
+        assert result == {
+            "representation": "AI representation",
+            "card": "Owner: Robert",
+        }
+        ai_peer.context.assert_called_once_with()


### PR DESCRIPTION
## Bug Description

`honcho_profile` could return `No profile facts available yet.` even when `hermes honcho status` showed a populated peer card and `honcho_context` could synthesize stable facts.

## Root Cause

The Honcho plugin was reading peer-card data through `session.context(...)`. For per-session messaging flows, that session-scoped lookup could return an empty `peer_card` even when the underlying Honcho peer had a populated card.

## Fix

- fetch profile cards directly from the Honcho peer object via `get_card()` / `card()`
- use peer-level context / representation lookups for search and prefetch paths that were relying on the same empty session-scoped data
- normalize card payloads into a stable list-of-strings shape inside the session manager

## How to Verify

1. Configure Hermes with the Honcho memory provider and a populated Honcho peer card.
2. Call `honcho_profile` in a messaging or CLI session.
3. Confirm it returns the peer card facts instead of `No profile facts available yet.`

## Test Plan

- [x] Added regression test for this bug
- [x] Existing targeted tests pass (`pytest tests/honcho_plugin/test_session.py -q`)
- [x] Manual verification of `honcho_profile` returning a populated peer card after restart

## Risk Assessment

Low — the change only affects Honcho read paths for peer-card / representation retrieval, and it adds explicit regression coverage for the new behavior.
