### PR TITLE
fix(security): guard cron script against path traversal and redact output

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -248,7 +248,13 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
     path = Path(script_path).expanduser()
     if not path.is_absolute():
         # Resolve relative paths against HERMES_HOME/scripts/
-        path = get_hermes_home() / "scripts" / path
+        scripts_dir = get_hermes_home() / "scripts"
+        path = (scripts_dir / path).resolve()
+        # Guard against path traversal (e.g. "../../etc/passwd")
+        try:
+            path.relative_to(scripts_dir.resolve())
+        except ValueError:
+            return False, f"Script path escapes the scripts directory: {script_path!r}"
 
     if not path.exists():
         return False, f"Script not found: {path}"
@@ -274,6 +280,13 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
                 parts.append(f"stdout:\n{stdout}")
             return False, "\n".join(parts)
 
+        # Redact any secrets that may appear in script output before
+        # they are injected into the LLM prompt context.
+        try:
+            from agent.redact import redact_sensitive_text
+            stdout = redact_sensitive_text(stdout)
+        except Exception:
+            pass
         return True, stdout
 
     except subprocess.TimeoutExpired:


### PR DESCRIPTION
## Summary

Salvage of PR #5093 by memosr (fixes 1 and 3; absolute path restriction dropped).

### 1. Path Traversal Guard (relative paths)

Relative script paths resolved against `HERMES_HOME/scripts/` were not validated to stay within that directory. `../../etc/passwd` would resolve outside and be executed as Python.

**Fix:** After resolving, verify the path stays within `scripts_dir` using `Path.relative_to()`. Paths that escape are rejected.

### 2. Secret Redaction

Script stdout was injected raw into the LLM prompt. If a script outputs env vars or API keys, they flow unmasked into context.

**Fix:** Apply `redact_sensitive_text()` to stdout before injection — same pattern as execute_code sandbox output.

### What was dropped

The absolute path restriction to HERMES_HOME was dropped — it's too restrictive for the feature's design intent. Users may legitimately want to point cron scripts at paths outside `~/.hermes/`. The agent already has full terminal access, so this doesn't close a meaningful security boundary.

## Test plan

- All 111 cron tests pass
- E2E verified: legit scripts work, traversal blocked, absolute paths still allowed, secrets redacted

Credit: memosr (original PR #5093)