### PR TITLE
fix(gateway): stabilize cron handlers and OAuth serialization

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -999,7 +999,7 @@ class APIServerAdapter(BasePlatformAdapter):
             return cron_err
         try:
             include_disabled = request.query.get("include_disabled", "").lower() in ("true", "1")
-            jobs = self._cron_list(include_disabled=include_disabled)
+            jobs = type(self)._cron_list(include_disabled=include_disabled)
             return web.json_response({"jobs": jobs})
         except Exception as e:
             return web.json_response({"error": str(e)}, status=500)
@@ -1047,7 +1047,7 @@ class APIServerAdapter(BasePlatformAdapter):
             if repeat is not None:
                 kwargs["repeat"] = repeat
 
-            job = self._cron_create(**kwargs)
+            job = type(self)._cron_create(**kwargs)
             return web.json_response({"job": job})
         except Exception as e:
             return web.json_response({"error": str(e)}, status=500)
@@ -1064,7 +1064,7 @@ class APIServerAdapter(BasePlatformAdapter):
         if id_err:
             return id_err
         try:
-            job = self._cron_get(job_id)
+            job = type(self)._cron_get(job_id)
             if not job:
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})
@@ -1097,7 +1097,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response(
                     {"error": f"Prompt must be ≤ {self._MAX_PROMPT_LENGTH} characters"}, status=400,
                 )
-            job = self._cron_update(job_id, sanitized)
+            job = type(self)._cron_update(job_id, sanitized)
             if not job:
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})
@@ -1116,7 +1116,7 @@ class APIServerAdapter(BasePlatformAdapter):
         if id_err:
             return id_err
         try:
-            success = self._cron_remove(job_id)
+            success = type(self)._cron_remove(job_id)
             if not success:
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"ok": True})
@@ -1135,7 +1135,7 @@ class APIServerAdapter(BasePlatformAdapter):
         if id_err:
             return id_err
         try:
-            job = self._cron_pause(job_id)
+            job = type(self)._cron_pause(job_id)
             if not job:
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})
@@ -1154,7 +1154,7 @@ class APIServerAdapter(BasePlatformAdapter):
         if id_err:
             return id_err
         try:
-            job = self._cron_resume(job_id)
+            job = type(self)._cron_resume(job_id)
             if not job:
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})
@@ -1173,7 +1173,7 @@ class APIServerAdapter(BasePlatformAdapter):
         if id_err:
             return id_err
         try:
-            job = self._cron_trigger(job_id)
+            job = type(self)._cron_trigger(job_id)
             if not job:
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -86,7 +86,7 @@ class HermesTokenStorage:
             return None
 
     async def set_tokens(self, tokens) -> None:
-        self._write_json(self._tokens_path(), tokens.model_dump(exclude_none=True))
+        self._write_json(self._tokens_path(), tokens.model_dump(mode="json", exclude_none=True))
 
     async def get_client_info(self):
         data = self._read_json(self._client_path())
@@ -99,7 +99,7 @@ class HermesTokenStorage:
             return None
 
     async def set_client_info(self, client_info) -> None:
-        self._write_json(self._client_path(), client_info.model_dump(exclude_none=True))
+        self._write_json(self._client_path(), client_info.model_dump(mode="json", exclude_none=True))
 
     # -- helpers --
 


### PR DESCRIPTION
## Bug Description

`hermes update` was flagging local changes because two upstream code paths were still broken in the current checkout:
- API server cron handlers were calling cron helpers through the instance, which breaks class-level monkeypatching in tests.
- MCP OAuth client metadata could not be serialized because `AnyUrl` was being dumped as raw Pydantic objects.

## Root Cause

- `gateway/platforms/api_server.py` used `self._cron_*` for cron operations.
- `tools/mcp_oauth.py` used a plain `model_dump(...)` path that left `AnyUrl` values non-JSON-serializable.

## Fix

- Route cron helper calls through `type(self)._cron_*` so the adapter behaves correctly under class-level patching.
- Serialize MCP OAuth client info with `model_dump(mode="json", ...)` so `AnyUrl` values are written as JSON-safe strings.
- Revert unrelated `package-lock.json` churn to keep the PR focused.

## How to Verify

1. Run `source venv/bin/activate && pytest tests/gateway/test_api_server_jobs.py -q`
2. Run `source venv/bin/activate && pytest tests/gateway/test_api_server_toolset.py -q`
3. Run `source venv/bin/activate && pytest tests/tools/test_mcp_oauth.py -q`

## Test Plan

- Focused cron API tests passed.
- API server toolset tests passed.
- MCP OAuth serialization test passed.
- Full suite was also attempted with `pytest tests/ -v`, but it hit unrelated existing timeout/resource issues in other areas of the repo.

## Risk Assessment

Low. The changes are narrow and only affect cron API dispatch and MCP OAuth client-info persistence.
