### PR TITLE
Emit single-query thinking/tool progress to stdout

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1693,10 +1693,21 @@ class HermesCLI:
         return changed
 
     def _on_thinking(self, text: str) -> None:
-        """Called by agent when thinking starts/stops. Updates TUI spinner."""
+        """Called by agent when thinking starts/stops.
+
+        Interactive mode routes this into the TUI spinner widget. Single-query
+        mode has no prompt_toolkit app, so emit a plain stdout progress line that
+        adapters can parse instead of silently dropping the thinking state.
+        """
         if not text:
             self._flush_reasoning_preview(force=True)
         self._spinner_text = text or ""
+
+        if not getattr(self, "_app", None):
+            if text and self.tool_progress_mode != "off" and not self.verbose:
+                _cprint(f"  ┊ 💭 {text}")
+            return
+
         self._invalidate()
 
     # ── Streaming display ────────────────────────────────────────────────
@@ -5280,9 +5291,10 @@ class HermesCLI:
     def _on_tool_progress(self, function_name: str, preview: str, function_args: dict):
         """Called when a tool starts executing.
 
-        Updates the TUI spinner widget so the user can see what the agent
-        is doing during tool execution (fills the gap between thinking
-        spinner and next response).  Also plays audio cue in voice mode.
+        Updates the TUI spinner widget in interactive mode. In single-query
+        mode there is no prompt_toolkit app, so emit a `[tool]` line that
+        adapters can parse into an incremental tool_call event. Also plays
+        audio cue in voice mode.
         """
         if not function_name.startswith("_"):
             from agent.display import get_tool_emoji
@@ -5293,7 +5305,11 @@ class HermesCLI:
             if _pl > 0 and len(label) > _pl:
                 label = label[:_pl - 3] + "..."
             self._spinner_text = f"{emoji} {label}"
-            self._invalidate()
+
+            if getattr(self, "_app", None):
+                self._invalidate()
+            elif self.tool_progress_mode != "off" and not self.verbose:
+                _cprint(f"  [tool] {emoji} {label}")
 
         if not self._voice_mode:
             return


### PR DESCRIPTION
## Summary

- emit plain stdout `┊ 💭 ...` thinking lines when no prompt_toolkit app is active
- emit plain stdout `[tool] ...` tool-start lines in single-query mode
- keep the existing interactive TUI spinner path unchanged

This gives non-TTY adapters like Paperclip enough incremental progress output to render thinking and tool-start states instead of only final completion lines.

## Validation

- python3 -m py_compile cli.py
