### PR TITLE
fix(gateway): stabilize cron handlers

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -999,7 +999,7 @@ class APIServerAdapter(BasePlatformAdapter):
             return cron_err
         try:
             include_disabled = request.query.get("include_disabled", "").lower() in ("true", "1")
-            jobs = self._cron_list(include_disabled=include_disabled)
+            jobs = type(self)._cron_list(include_disabled=include_disabled)
             return web.json_response({"jobs": jobs})
         except Exception as e:
             return web.json_response({"error": str(e)}, status=500)
@@ -1047,7 +1047,7 @@ class APIServerAdapter(BasePlatformAdapter):
             if repeat is not None:
                 kwargs["repeat"] = repeat
 
-            job = self._cron_create(**kwargs)
+            job = type(self)._cron_create(**kwargs)
             return web.json_response({"job": job})
         except Exception as e:
             return web.json_response({"error": str(e)}, status=500)
@@ -1064,7 +1064,7 @@ class APIServerAdapter(BasePlatformAdapter):
         if id_err:
             return id_err
         try:
-            job = self._cron_get(job_id)
+            job = type(self)._cron_get(job_id)
             if not job:
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})
@@ -1097,7 +1097,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response(
                     {"error": f"Prompt must be ≤ {self._MAX_PROMPT_LENGTH} characters"}, status=400,
                 )
-            job = self._cron_update(job_id, sanitized)
+            job = type(self)._cron_update(job_id, sanitized)
             if not job:
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})
@@ -1116,7 +1116,7 @@ class APIServerAdapter(BasePlatformAdapter):
         if id_err:
             return id_err
         try:
-            success = self._cron_remove(job_id)
+            success = type(self)._cron_remove(job_id)
             if not success:
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"ok": True})
@@ -1135,7 +1135,7 @@ class APIServerAdapter(BasePlatformAdapter):
         if id_err:
             return id_err
         try:
-            job = self._cron_pause(job_id)
+            job = type(self)._cron_pause(job_id)
             if not job:
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})
@@ -1154,7 +1154,7 @@ class APIServerAdapter(BasePlatformAdapter):
         if id_err:
             return id_err
         try:
-            job = self._cron_resume(job_id)
+            job = type(self)._cron_resume(job_id)
             if not job:
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})
@@ -1173,7 +1173,7 @@ class APIServerAdapter(BasePlatformAdapter):
         if id_err:
             return id_err
         try:
-            job = self._cron_trigger(job_id)
+            job = type(self)._cron_trigger(job_id)
             if not job:
                 return web.json_response({"error": "Job not found"}, status=404)
             return web.json_response({"job": job})

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -541,6 +541,26 @@ class TestCronUnavailable:
                 assert "not available" in data["error"].lower()
 
     @pytest.mark.asyncio
+    async def test_cron_handler_accepts_plain_function_patch(self, adapter):
+        """The adapter should call cron helpers without binding self into class-level patches."""
+        app = _create_app(adapter)
+        captured = {}
+
+        def _plain_pause(job_id):
+            captured["job_id"] = job_id
+            return SAMPLE_JOB
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(APIServerAdapter, "_CRON_AVAILABLE", True), patch.object(
+                APIServerAdapter, "_cron_pause", _plain_pause
+            ):
+                resp = await cli.post(f"/api/jobs/{VALID_JOB_ID}/pause")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["job"] == SAMPLE_JOB
+                assert captured["job_id"] == VALID_JOB_ID
+
+    @pytest.mark.asyncio
     async def test_cron_unavailable_create(self, adapter):
         """POST /api/jobs returns 501 when _CRON_AVAILABLE is False."""
         app = _create_app(adapter)

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -541,8 +541,8 @@ class TestCronUnavailable:
                 assert "not available" in data["error"].lower()
 
     @pytest.mark.asyncio
-    async def test_cron_handler_accepts_plain_function_patch(self, adapter):
-        """The adapter should call cron helpers without binding self into class-level patches."""
+    async def test_pause_handler_accepts_plain_function_patch(self, adapter):
+        """Pause should work when the cron helper is patched with a plain class-level function."""
         app = _create_app(adapter)
         captured = {}
 
@@ -559,6 +559,52 @@ class TestCronUnavailable:
                 data = await resp.json()
                 assert data["job"] == SAMPLE_JOB
                 assert captured["job_id"] == VALID_JOB_ID
+
+    @pytest.mark.asyncio
+    async def test_list_handler_accepts_plain_function_patch(self, adapter):
+        """List should preserve keyword arguments when the helper is a plain class-level function."""
+        app = _create_app(adapter)
+        captured = {}
+
+        def _plain_list(include_disabled=False):
+            captured["include_disabled"] = include_disabled
+            return [SAMPLE_JOB]
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(APIServerAdapter, "_CRON_AVAILABLE", True), patch.object(
+                APIServerAdapter, "_cron_list", _plain_list
+            ):
+                resp = await cli.get("/api/jobs?include_disabled=true")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["jobs"] == [SAMPLE_JOB]
+                assert captured["include_disabled"] is True
+
+    @pytest.mark.asyncio
+    async def test_update_handler_accepts_plain_function_patch(self, adapter):
+        """Update should pass positional arguments correctly to plain class-level patches."""
+        app = _create_app(adapter)
+        captured = {}
+        updated_job = {**SAMPLE_JOB, "name": "updated-name"}
+
+        def _plain_update(job_id, updates):
+            captured["job_id"] = job_id
+            captured["updates"] = updates
+            return updated_job
+
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(APIServerAdapter, "_CRON_AVAILABLE", True), patch.object(
+                APIServerAdapter, "_cron_update", _plain_update
+            ):
+                resp = await cli.patch(
+                    f"/api/jobs/{VALID_JOB_ID}",
+                    json={"name": "updated-name"},
+                )
+                assert resp.status == 200
+                data = await resp.json()
+                assert data["job"] == updated_job
+                assert captured["job_id"] == VALID_JOB_ID
+                assert captured["updates"] == {"name": "updated-name"}
 
     @pytest.mark.asyncio
     async def test_cron_unavailable_create(self, adapter):


### PR DESCRIPTION
## Bug Description

API server cron endpoints could call cron helpers incorrectly because the helpers are imported as class attributes but invoked through the instance.

Since those helpers are plain module functions rather than instance methods, accessing them as `self._cron_*` causes Python to bind `self` as the first argument. That can shift arguments and break route behavior at runtime.

## Root Cause

`gateway/platforms/api_server.py` imports the cron helpers into the class body and then calls them through `self._cron_*`.

Because the imported helpers are plain functions, instance lookup turns them into bound methods and injects `self` unexpectedly.

## Why This Wasn't Caught Earlier

The existing tests mostly patched these helpers with `MagicMock`.

That verified route behavior, but it did not reproduce the same descriptor-binding behavior as a plain function stored on the class. As a result, the tests did not exercise the actual failure mode.

## Fix

- Route cron helper calls through `type(self)._cron_*` so the helpers are called without binding `self`
- Add regression coverage for plain-function patching across multiple cron helper call patterns

## Verification

Focused verification:
- `uv run --frozen --extra all --extra dev python -m pytest tests/gateway/test_api_server_jobs.py -q`
- Result: `35 passed`

Full-suite verification against current rebased baseline:
- `main`: `16 failed, 8217 passed, 27 skipped, 1 xpassed`
- this branch: baseline-equivalent failure picture on reruns

## Existing Baseline Issues

The current upstream baseline already includes unrelated failing tests, including:
- `tests/gateway/test_matrix_voice.py::TestMatrixSendVoiceMSC3245::test_send_voice_includes_msc3245_field`
- `tests/hermes_cli/test_tools_config.py::test_first_install_nous_auto_configures_managed_defaults`
- `tests/hermes_cli/test_update_gateway_restart.py::TestCmdUpdateLaunchdRestart::test_update_with_systemd_still_restarts_via_systemd`
- `tests/test_api_key_providers.py::TestHasAnyProviderConfigured::*`
- `tests/tools/test_browser_camofox_state.py::TestCamofoxConfigDefaults::test_config_version_unchanged`
- `tests/tools/test_skill_manager_tool.py::*`

## Risk Assessment

Low. This only changes how the API server adapter dispatches cron helper calls.
