### PR TITLE
fix(tools): serialize MCP OAuth client info as JSON

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -89,6 +89,34 @@ class TestHermesTokenStorage:
         assert data["client_id"] == "hermes-123"
         assert data["redirect_uri"] == "https://example.com/callback"
 
+    def test_serializes_real_oauth_client_info_urls(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("test-server")
+        import asyncio
+
+        try:
+            from mcp.shared.auth import OAuthClientInformationFull
+        except ImportError:
+            pytest.skip("MCP SDK auth not available")
+
+        asyncio.run(
+            storage.set_client_info(
+                OAuthClientInformationFull(
+                    client_id="hermes-123",
+                    client_secret="secret",
+                    redirect_uris=["https://example.com/callback"],
+                    grant_types=["authorization_code"],
+                    response_types=["code"],
+                )
+            )
+        )
+
+        client_path = tmp_path / "mcp-tokens" / "test-server.client.json"
+        data = json.loads(client_path.read_text())
+        assert data["client_id"] == "hermes-123"
+        assert data["client_secret"] == "secret"
+        assert data["redirect_uris"] == ["https://example.com/callback"]
+
     def test_remove_cleans_up(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         storage = HermesTokenStorage("test-server")

--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock, AsyncMock
 
 import pytest
+from pydantic import BaseModel, AnyUrl
 
 from tools.mcp_oauth import (
     HermesTokenStorage,
@@ -64,6 +65,29 @@ class TestHermesTokenStorage:
 
         client_path = tmp_path / "mcp-tokens" / "test-server.client.json"
         assert client_path.exists()
+
+    def test_serializes_anyurl_client_info(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("test-server")
+        import asyncio
+
+        class ClientInfo(BaseModel):
+            client_id: str
+            redirect_uri: AnyUrl
+
+        asyncio.run(
+            storage.set_client_info(
+                ClientInfo(
+                    client_id="hermes-123",
+                    redirect_uri="https://example.com/callback",
+                )
+            )
+        )
+
+        client_path = tmp_path / "mcp-tokens" / "test-server.client.json"
+        data = json.loads(client_path.read_text())
+        assert data["client_id"] == "hermes-123"
+        assert data["redirect_uri"] == "https://example.com/callback"
 
     def test_remove_cleans_up(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -86,7 +86,7 @@ class HermesTokenStorage:
             return None
 
     async def set_tokens(self, tokens) -> None:
-        self._write_json(self._tokens_path(), tokens.model_dump(exclude_none=True))
+        self._write_json(self._tokens_path(), tokens.model_dump(mode="json", exclude_none=True))
 
     async def get_client_info(self):
         data = self._read_json(self._client_path())
@@ -99,7 +99,7 @@ class HermesTokenStorage:
             return None
 
     async def set_client_info(self, client_info) -> None:
-        self._write_json(self._client_path(), client_info.model_dump(exclude_none=True))
+        self._write_json(self._client_path(), client_info.model_dump(mode="json", exclude_none=True))
 
     # -- helpers --
 


### PR DESCRIPTION
## Bug Description

MCP OAuth client metadata could fail to save when it contained URL-typed Pydantic fields such as `AnyUrl`.

## Root Cause

`tools/mcp_oauth.py` wrote client info with `model_dump(exclude_none=True)`, which uses Pydantic's default Python-mode serialization.

In Python mode, URL-typed fields can remain Pydantic objects instead of plain JSON-native strings. That means writing the result with `json.dumps(...)` can fail when client metadata includes fields such as `AnyUrl` or collections of URL-typed values.

## Why This Wasn't Caught Earlier

The previous test used a mock object and only verified that the file was created.

That exercised the write path, but it did not use a real Pydantic model with a URL-typed field, so it never verified that the dumped payload was actually JSON-serializable.

## Fix

- Serialize stored OAuth models with `model_dump(mode="json", exclude_none=True)` so URL-typed fields are converted to plain strings before writing
- Add regression coverage for `AnyUrl`
- Add regression coverage using the real MCP OAuth client info model path

## Verification

Focused verification:
- `uv run --frozen --extra all --extra dev python -m pytest tests/tools/test_mcp_oauth.py -q`
- Result: `25 passed`

Full-suite verification against current rebased baseline:
- `main`: `16 failed, 8217 passed, 27 skipped, 1 xpassed`
- this branch: no increase in failing-test count relative to baseline on fresh rerun

## Existing Baseline Issues

The current upstream baseline already includes unrelated failing tests, including:
- `tests/gateway/test_matrix_voice.py::TestMatrixSendVoiceMSC3245::test_send_voice_includes_msc3245_field`
- `tests/hermes_cli/test_tools_config.py::test_first_install_nous_auto_configures_managed_defaults`
- `tests/hermes_cli/test_update_gateway_restart.py::TestCmdUpdateLaunchdRestart::test_update_with_systemd_still_restarts_via_systemd`
- `tests/test_api_key_providers.py::TestHasAnyProviderConfigured::*`
- `tests/tools/test_browser_camofox_state.py::TestCamofoxConfigDefaults::test_config_version_unchanged`
- `tests/tools/test_skill_manager_tool.py::*`

## Risk Assessment

Low. This only changes how OAuth metadata is serialized before being written to disk.
