### PR TITLE
fix: add ChatGPT-Account-ID and User-Agent headers for openai-codex provider

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -779,7 +779,9 @@ def _try_codex() -> Tuple[Optional[Any], Optional[str]]:
             return None, None
         base_url = _CODEX_AUX_BASE_URL
     logger.debug("Auxiliary client: Codex OAuth (%s via Responses API)", _CODEX_AUX_MODEL)
-    real_client = OpenAI(api_key=codex_token, base_url=base_url)
+    from hermes_cli.auth import codex_default_headers
+    real_client = OpenAI(api_key=codex_token, base_url=base_url,
+                         default_headers=codex_default_headers())
     return CodexAuxiliaryClient(real_client, _CODEX_AUX_MODEL), _CODEX_AUX_MODEL
 
 
@@ -1052,7 +1054,9 @@ def resolve_provider_client(
                                "but no Codex OAuth token found (run: hermes model)")
                 return None, None
             final_model = model or _CODEX_AUX_MODEL
-            raw_client = OpenAI(api_key=codex_token, base_url=_CODEX_AUX_BASE_URL)
+            from hermes_cli.auth import codex_default_headers
+            raw_client = OpenAI(api_key=codex_token, base_url=_CODEX_AUX_BASE_URL,
+                                default_headers=codex_default_headers())
             return (raw_client, final_model)
         # Standard path: wrap in CodexAuxiliaryClient adapter
         client, default = _try_codex()

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1124,6 +1124,11 @@ def resolve_codex_runtime_credentials(
         or DEFAULT_CODEX_BASE_URL
     )
 
+    # Extract account_id for ChatGPT-Account-ID header (required by Codex backend)
+    account_id = ""
+    if isinstance(data.get("tokens"), dict):
+        account_id = str(data["tokens"].get("account_id", "") or "").strip()
+
     return {
         "provider": "openai-codex",
         "base_url": base_url,
@@ -1131,7 +1136,48 @@ def resolve_codex_runtime_credentials(
         "source": "hermes-auth-store",
         "last_refresh": data.get("last_refresh"),
         "auth_mode": "chatgpt",
+        "account_id": account_id,
     }
+
+
+# =============================================================================
+# Codex default headers (cached)
+# =============================================================================
+
+_codex_headers_cache: Optional[Dict[str, str]] = None
+
+
+def codex_default_headers(*, force_refresh: bool = False) -> Dict[str, str]:
+    """Return HTTP headers required by the ChatGPT Codex backend API.
+
+    The chatgpt.com/backend-api/codex endpoint requires a
+    ChatGPT-Account-ID header and a recognisable User-Agent.
+    Results are cached for the process lifetime; pass
+    *force_refresh=True* after a credential refresh.
+    """
+    global _codex_headers_cache
+    if _codex_headers_cache is not None and not force_refresh:
+        return _codex_headers_cache
+
+    import platform as _plat
+    from hermes_cli import __version__
+
+    headers: Dict[str, str] = {
+        "User-Agent": (
+            f"hermes-agent/{__version__}"
+            f" ({_plat.system()} {_plat.release()}; {_plat.machine()})"
+        ),
+    }
+    try:
+        creds = resolve_codex_runtime_credentials(refresh_if_expiring=False)
+        acct = creds.get("account_id", "")
+        if acct:
+            headers["ChatGPT-Account-ID"] = acct
+    except (AuthError, FileNotFoundError, KeyError):
+        logger.debug("Could not resolve Codex account_id for headers", exc_info=True)
+
+    _codex_headers_cache = headers
+    return headers
 
 
 # =============================================================================

--- a/run_agent.py
+++ b/run_agent.py
@@ -790,6 +790,9 @@ class AIAgent:
                     client_kwargs["default_headers"] = {
                         "User-Agent": "KimiCLI/1.3",
                     }
+                elif "chatgpt.com/backend-api/codex" in effective_base.lower():
+                    from hermes_cli.auth import codex_default_headers
+                    client_kwargs["default_headers"] = codex_default_headers()
             else:
                 # No explicit creds — use the centralized provider router
                 from agent.auxiliary_client import resolve_provider_client
@@ -3719,6 +3722,8 @@ class AIAgent:
         self.base_url = base_url.strip().rstrip("/")
         self._client_kwargs["api_key"] = self.api_key
         self._client_kwargs["base_url"] = self.base_url
+        from hermes_cli.auth import codex_default_headers
+        self._client_kwargs["default_headers"] = codex_default_headers(force_refresh=True)
 
         if not self._replace_primary_openai_client(reason="codex_credential_refresh"):
             return False
@@ -3811,6 +3816,9 @@ class AIAgent:
             self._client_kwargs["default_headers"] = copilot_default_headers()
         elif "api.kimi.com" in normalized:
             self._client_kwargs["default_headers"] = {"User-Agent": "KimiCLI/1.3"}
+        elif "chatgpt.com/backend-api/codex" in normalized:
+            from hermes_cli.auth import codex_default_headers
+            self._client_kwargs["default_headers"] = codex_default_headers()
         else:
             self._client_kwargs.pop("default_headers", None)
 


### PR DESCRIPTION
## Summary

Requests to `chatgpt.com/backend-api/codex` are silently blocked by Cloudflare's
managed challenge when `ChatGPT-Account-ID` and a recognisable `User-Agent` are
missing. The agent receives an HTML JS-challenge page instead of JSON, logged as
`Non-retryable client error: <html>…Enable JavaScript and cookies…`.

This PR adds both required headers to every OpenAI client targeting the Codex backend.

## Root cause

The Codex CLI (`codex_cli_rs`) sends `ChatGPT-Account-ID` and a versioned
`User-Agent` on every request. Hermes only sends `Authorization: Bearer` — no
account header, no identifiable user-agent. Cloudflare's bot-detection layer on
`chatgpt.com` then serves a JS challenge page that the OpenAI Python SDK cannot
handle.

This likely also explains:
- **#2176** — account bans after using Hermes with openai-codex (requests without
  `ChatGPT-Account-ID` may be classified as unauthorised API abuse)
- **#1167** — usage appearing as "Other" in the Codex dashboard (no client
  identification headers)

## Changes

| File | What |
|------|------|
| `hermes_cli/auth.py` | Extract `account_id` from auth store tokens; new cached `codex_default_headers()` function |
| `run_agent.py` | Inject headers at 3 code paths: agent init, credential refresh, credential swap |
| `agent/auxiliary_client.py` | Inject headers at 2 code paths: `_try_codex()`, `resolve_provider_client()` |

## Headers sent

```
User-Agent: hermes-agent/{version} ({os} {release}; {arch})
ChatGPT-Account-ID: {account_id from auth.json tokens}
```

The `account_id` is already stored in `~/.hermes/auth.json` under
`providers.openai-codex.tokens.account_id` (populated during OAuth login
and Codex CLI credential migration).

## Design decisions

- **Cached**: Headers are built once per process and reused. `force_refresh=True`
  is only called after credential rotation in `_try_refresh_codex_client_credentials`.
- **Placed in `hermes_cli/auth.py`**: Follows the pattern of `copilot_default_headers()`
  in `hermes_cli/models.py` — provider-specific header builders live near their
  auth logic.
- **Narrowed exceptions**: Only catches `AuthError`, `FileNotFoundError`, `KeyError`
  (not bare `Exception`), with `logger.debug` for visibility.
- **Uses `hermes_cli.__version__`**: Avoids hardcoded version strings.

## Test plan

- [x] Configure `model.provider: openai-codex` and send a message — response received
  (previously: Cloudflare HTML block → silent failure)
- [x] Verify headers: `python -c "from hermes_cli.auth import codex_default_headers; print(codex_default_headers())"`
- [x] Verify caching: second call returns same object
- [x] Verify `force_refresh=True` rebuilds headers
- [ ] Test without Codex credentials: should gracefully skip `ChatGPT-Account-ID`

🤖 Generated with [Claude Code](https://claude.com/claude-code)