### PR TITLE
Fix gpt-5.4 context length resolution for Codex

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -544,6 +544,46 @@ def get_cached_context_length(model: str, base_url: str) -> Optional[int]:
     return cache.get(key)
 
 
+def _looks_like_suspicious_context_cache_value(
+    model: str,
+    base_url: str,
+    length: int,
+    provider: str = "",
+) -> bool:
+    """Return True when a cached value likely captured output tokens, not context.
+
+    This mainly protects direct OpenAI/Codex endpoints where a prior overflow
+    error can mention small output-token budgets (for example 32K) that should
+    never be persisted as the model's context window.
+    """
+    if not isinstance(length, int) or length <= 0:
+        return False
+
+    effective_provider = provider
+    if not effective_provider or effective_provider in ("openrouter", "custom"):
+        if base_url:
+            inferred = _infer_provider_from_url(base_url)
+            if inferred:
+                effective_provider = inferred
+
+    if effective_provider not in {"openai", "openai-codex"}:
+        return False
+
+    try:
+        from agent.models_dev import lookup_models_dev_context
+
+        reference_context = lookup_models_dev_context("openai", model)
+    except Exception:
+        reference_context = None
+
+    if not isinstance(reference_context, int) or reference_context <= 0:
+        return False
+
+    # If the authoritative provider-aware context is very large, cached values
+    # at or below common output-token limits are almost certainly wrong.
+    return reference_context >= 400_000 and length <= 131_072
+
+
 def get_next_probe_tier(current_length: int) -> Optional[int]:
     """Return the next lower probe tier, or None if already at minimum."""
     for tier in CONTEXT_PROBE_TIERS:
@@ -797,7 +837,13 @@ def get_model_context_length(
     if base_url:
         cached = get_cached_context_length(model, base_url)
         if cached is not None:
-            return cached
+            if _looks_like_suspicious_context_cache_value(model, base_url, cached, provider=provider):
+                logger.warning(
+                    "Ignoring suspicious cached context length for %s @ %s: %s tokens",
+                    model, base_url, cached,
+                )
+            else:
+                return cached
 
     # 2. Active endpoint metadata for truly custom/unknown endpoints.
     # Known providers (Copilot, OpenAI, Anthropic, etc.) skip this — their

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -30,6 +30,8 @@ _models_dev_cache_time: float = 0
 
 # Provider ID mapping: Hermes provider names → models.dev provider IDs
 PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
+    "openai": "openai",
+    "openai-codex": "openai",
     "openrouter": "openrouter",
     "anthropic": "anthropic",
     "zai": "zai",

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -22,6 +22,7 @@ from unittest.mock import patch, MagicMock
 from agent.model_metadata import (
     CONTEXT_PROBE_TIERS,
     DEFAULT_CONTEXT_LENGTHS,
+    _looks_like_suspicious_context_cache_value,
     _strip_provider_prefix,
     estimate_tokens_rough,
     estimate_messages_tokens_rough,
@@ -633,3 +634,34 @@ class TestContextLengthCache:
         with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
             save_context_length(model, url, 200000)
             assert get_cached_context_length(model, url) == 200000
+
+    @patch("agent.models_dev.lookup_models_dev_context", return_value=1050000)
+    def test_suspicious_openai_codex_cache_is_ignored(self, _mock_lookup, tmp_path):
+        cache_file = tmp_path / "cache.yaml"
+        with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
+            save_context_length("gpt-5.4", "https://chatgpt.com/backend-api/codex", 32000)
+            assert get_model_context_length(
+                "gpt-5.4",
+                base_url="https://chatgpt.com/backend-api/codex",
+                provider="openai-codex",
+            ) == 1050000
+
+
+class TestSuspiciousContextCacheValue:
+    @patch("agent.models_dev.lookup_models_dev_context", return_value=1050000)
+    def test_flags_small_cached_value_for_openai_codex(self, _mock_lookup):
+        assert _looks_like_suspicious_context_cache_value(
+            "gpt-5.4",
+            "https://chatgpt.com/backend-api/codex",
+            32000,
+            provider="openai-codex",
+        ) is True
+
+    @patch("agent.models_dev.lookup_models_dev_context", return_value=1050000)
+    def test_allows_large_cached_value_for_openai_codex(self, _mock_lookup):
+        assert _looks_like_suspicious_context_cache_value(
+            "gpt-5.4",
+            "https://chatgpt.com/backend-api/codex",
+            1050000,
+            provider="openai-codex",
+        ) is False

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -60,6 +60,16 @@ SAMPLE_REGISTRY = {
             },
         },
     },
+    "openai": {
+        "id": "openai",
+        "name": "OpenAI",
+        "models": {
+            "gpt-5.4": {
+                "id": "gpt-5.4",
+                "limit": {"context": 1050000, "output": 128000},
+            },
+        },
+    },
     "audio-only": {
         "id": "audio-only",
         "models": {
@@ -83,10 +93,11 @@ class TestProviderMapping:
         assert PROVIDER_TO_MODELS_DEV["copilot"] == "github-copilot"
         assert PROVIDER_TO_MODELS_DEV["kilocode"] == "kilo"
         assert PROVIDER_TO_MODELS_DEV["ai-gateway"] == "vercel"
+        assert PROVIDER_TO_MODELS_DEV["openai"] == "openai"
+        assert PROVIDER_TO_MODELS_DEV["openai-codex"] == "openai"
 
     def test_unmapped_provider_not_in_dict(self):
         assert "nous" not in PROVIDER_TO_MODELS_DEV
-        assert "openai-codex" not in PROVIDER_TO_MODELS_DEV
 
 
 class TestExtractContext:
@@ -138,6 +149,11 @@ class TestLookupModelsDevContext:
         assert lookup_models_dev_context("anthropic", "claude-opus-4-6") == 1000000
         # GitHub Copilot: only 128K for same model
         assert lookup_models_dev_context("copilot", "claude-opus-4.6") == 128000
+
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_openai_codex_maps_to_openai_registry(self, mock_fetch):
+        mock_fetch.return_value = SAMPLE_REGISTRY
+        assert lookup_models_dev_context("openai-codex", "gpt-5.4") == 1050000
 
     @patch("agent.models_dev.fetch_models_dev")
     def test_zero_context_filtered(self, mock_fetch):


### PR DESCRIPTION
## Summary
- map `openai-codex` and inferred OpenAI endpoints to the models.dev `openai` registry
- ignore suspicious small cached context values for OpenAI/Codex models when provider-aware metadata says the true context is much larger
- add regression tests for the stale `gpt-5.4@https://chatgpt.com/backend-api/codex = 32000` cache case

## Problem
Hermes can show `gpt-5.4` with a `32k` context window in Codex-backed setups.

I reproduced a bad persisted cache entry locally:
`gpt-5.4@https://chatgpt.com/backend-api/codex: 32000`

OpenAI's current model docs list `gpt-5.4` at `1,050,000` context and `128,000` max output tokens, so the cached `32000` value is incorrect.

## Testing
- `pytest -q -o addopts='' tests/agent/test_models_dev.py tests/agent/test_model_metadata.py`
