### PR TITLE
feat(skills): add autoresearch — autonomous git-based experiment loop

### DIFF
--- a/skills/research/autoresearch/SKILL.md
+++ b/skills/research/autoresearch/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: autoresearch
+description: >
+  Autonomous research skill. When user asks to research something, ask clarifying
+  questions then offer regular research (normal chat flow) or autoresearch (autonomous
+  background loop with git-based keep/revert). No custom Python package - uses Hermes
+  native tools only.
+tags: [research, autonomous, background, ml, market, idea, sales]
+---
+
+# Research Skill
+
+## When to Use
+- User asks to "research X", "investigate Y", "find out about Z"
+- User says "pause/stop/resume research"
+- User asks "research status" or "how's my research going"
+
+## Flow
+
+### Step 1 - Scope (Inference, Not Interrogation)
+If you can infer scope/domain from the user's request, proceed directly to Step 2.
+Ask ONE clarifying question ONLY if the request is genuinely ambiguous (e.g., "AAPL" could mean stock analysis or Apple Inc tech products).
+Otherwise use the user's request text as-is for scope and domain.
+
+### Step 2 - Ask Research Mode
+After clarifying, ask:
+- **Regular research**: I research it right here in chat. Normal Hermes flow - web search, browse, read, synthesize, give you results. Good for quick questions and when you want to steer interactively.
+- **Autoresearch**: Autonomous background loop. I launch a background agent that iterates independently - plans experiments, executes them, self-evaluates, keeps good results, reverts bad ones. Runs without blocking you. Good for deep/long research where you don't want to babysit.
+
+If user picks regular -> just do the research normally in chat. No special tooling needed.
+If user picks autoresearch -> ask depth tier, then follow the Autoresearch section below.
+
+### Step 3 - Set Depth Tier (autoresearch only)
+Ask: "How thorough?"
+- **Quick** (~30min, ~$2): Fast scan, 10 experiments. Good for simple questions.
+- **Deep** (~3hrs, ~$10): Thorough analysis, 25 experiments. Good for important decisions.
+- **Unlimited** (runs until done, no budget cap): No time/token/cost limits. Stops when all experiments are complete. Still has experiment hard cap and stall protection.
+- **Custom**: User sets their own limits.
+
+Budget defaults per tier:
+
+| Tier | max_duration | max_tokens | max_experiments | hard_cap |
+|------|-------------|------------|-----------------|----------|
+| Quick | 30 min | 500K | 10 | 15 |
+| Deep | 180 min | 2M | 25 | 38 |
+| Unlimited | 0 (none) | 0 (none) | 30 | 45 |
+| Custom | user sets | user sets | user sets | 1.5x |
+
+For Quick/Deep, confirm: "This will run up to X minutes, max Y tokens, max Z experiments. OK?"
+For Unlimited, confirm: "This will run until all experiments are done. No time or token cap, but max 45 experiments. Watchdog will alert you on progress. OK?"
+
+0 means no limit in config. The check-budget script treats 0 as "skip this check".
+Cost is NOT budgeted - it varies by model/provider. Show real consumed tokens via usage.py after the run.
+
+---
+
+## Autoresearch (Background Autonomous Loop)
+
+### How It Works
+Uses Hermes native tools (terminal, write_file, web, browser, delegate_task, execute_code) plus helper scripts for state management, planning, evaluation, and reporting. No external dependencies - stdlib Python only.
+
+### Helper Scripts (scripts/ directory)
+- **state.py** - Atomic JSON I/O for status, config, control, checkpoint. Research ID generation. Budget checks.
+- **plan.py** - Experiment plan CRUD. Types: investigate, deepen, verify, synthesize. Mid-run replanning.
+- **evaluate.py** - Scoring rubric (5 criteria, 1-5 each, threshold logic). Results logging. Stats.
+- **workspace.py** - Git branch naming, merge/revert command generation. Safe branch names from descriptions.
+- **report.py** - Full markdown report, compact summary, Telegram summary from state files.
+- **registry.py** - Multi-user run tracking. Register, list, filter by user/platform, find by job ID.
+- **usage.py** - Token consumption and cost tracking. Queries Hermes SessionDB for actual usage, falls back to local tracking.
+
+### Two Modes
+
+**Mode 1 - Iterative Experiment** (ML, code optimization, prompt engineering):
+- Target file: train.py / optimize.py / prompt.txt
+- Evaluation: run script, check real metric (val_bpb, accuracy, latency)
+- Each experiment modifies code, runs it, measures result
+
+**Mode 2 - Knowledge Research** (market, competitive, idea, sales, academic):
+- Target file: research.md (structured document with sections)
+- Evaluation: agent self-evaluates its own diff - "Is the document BETTER than before this experiment?"
+- Same iterative refinement as Mode 1. Agent revisits sections, deepens them, corrects them, improves them across multiple passes. NOT linear gap-filling.
+- The document gets better each pass, not just longer. Quality converges like a metric.
+
+### Prompt Templates
+All in templates/ directory. Load with skill_view:
+
+- **templates/cron_prompt.md** - Main research agent prompt
+- **templates/watchdog_prompt.md** - Watchdog monitor prompt
+- **templates/resume_prompt.md** - Resume from checkpoint prompt
+
+### Multi-User & Session Management
+
+Registry at `$HERMES_HOME/autoresearch/registry.json` (defaults to `~/.hermes`) tracks user_id, platform, chat_id, goal, cron job IDs.
+
+### User Control
+
+ID auto-resolves when user has 1 active run. Supports: pause, stop, stop all, resume, status, cost, adjust, list.
+
+### Launching
+
+**Important**: Cron jobs require a persistent Hermes Gateway process. They will NOT fire from ephemeral sandbox containers (e.g., Docker containers with `sleep` as PID 1). Launch from an environment where the Hermes Agent runs persistently (your Mac, a server).
+
+From your main Hermes Agent session:
+1. Load the skill: `skill_view("autoresearch")`
+2. Set depth tier (or default to Quick)
+3. The chat agent fills in the cron_prompt.md template with your parameters and creates a cron job via `mcp_cronjob(action="create", prompt=<filled_template>, schedule="1m", skills=["autoresearch"], deliver="origin")`
+
+`schedule="1m"` is used instead of `"now"` — the scheduler doesn't reliably fire `"now"` jobs.
+
+### Monitoring (Two Layers + On-Demand)
+Cron jobs have messaging toolset DISABLED. Research agent CANNOT send mid-run updates.
+
+1. **Watchdog cron**: Every 15min, reads status + results. Uses [SILENT] when nothing to report.
+2. **On-demand**: User asks, chat agent reads status.json.
+3. **Final delivery**: Research agent's final response auto-delivered by cron system.
+
+### Safety Gates
+- Deterministic budget limits (time/tokens/cost/experiments)
+- Watchdog enforcement (backup layer)
+- Stall detection (30min alert, 60min force stop)
+- 3 consecutive failures = auto-pause
+- Experiment hard cap prevents infinite replanning growth

--- a/skills/research/autoresearch/scripts/_util.py
+++ b/skills/research/autoresearch/scripts/_util.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Shared utilities for autoresearch helper scripts."""
+import json, os, tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def now_iso():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def hermes_home():
+    """Return the active Hermes home directory, respecting HERMES_HOME."""
+    return os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes"))
+
+
+def atomic_write(path, data):
+    """Write JSON data atomically via tempfile + os.replace."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+            f.write("\n")
+        os.replace(tmp, str(path))
+    except Exception:
+        os.unlink(tmp)
+        raise
+
+
+def read_json(path):
+    """Read a JSON file, returning {} on missing/corrupt files."""
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}

--- a/skills/research/autoresearch/scripts/evaluate.py
+++ b/skills/research/autoresearch/scripts/evaluate.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Autoresearch experiment evaluation - scoring rubric and decision logic.
+
+Usage:
+    python evaluate.py score <evidence> <accuracy> <depth> <relevance> <net_improvement>
+    python evaluate.py log-result <run_dir> <exp_id> <description> <type> <target> <decision> <reason> [--scores E,A,D,R,N]
+    python evaluate.py log-result-ml <run_dir> <exp_id> <description> <metric_name> <metric_value> <prev_best> <decision> <reason>
+    python evaluate.py read-results <run_dir> [--last N]
+    python evaluate.py stats <run_dir>
+"""
+import json, os, sys
+from _util import now_iso
+
+def score_knowledge(evidence, accuracy, depth, relevance, net_improvement):
+    total = evidence + accuracy + depth + relevance + net_improvement
+    scores = {"evidence": evidence, "accuracy": accuracy, "depth": depth,
+              "relevance": relevance, "net_improvement": net_improvement, "total": total, "max": 25}
+    if evidence == 1: return {"scores": scores, "decision": "REVERT", "reason": "Evidence=1: no unsourced claims"}
+    if net_improvement == 1: return {"scores": scores, "decision": "REVERT", "reason": "NetImprovement=1: made doc worse"}
+    if total >= 18: return {"scores": scores, "decision": "MERGE", "reason": f"Strong (total={total}/25)"}
+    elif total >= 13:
+        if evidence >= 3 and relevance >= 3:
+            return {"scores": scores, "decision": "MERGE", "reason": f"Acceptable (total={total}/25)"}
+        return {"scores": scores, "decision": "REVERT", "reason": "Borderline weak evidence/relevance"}
+    return {"scores": scores, "decision": "REVERT", "reason": f"Below threshold (total={total}/25)"}
+
+def score_ml(metric_value, prev_best, lower_is_better=True):
+    improved = metric_value < prev_best if lower_is_better else metric_value > prev_best
+    delta = (prev_best - metric_value) if lower_is_better else (metric_value - prev_best)
+    decision = "MERGE" if improved else "REVERT"
+    return {"decision": decision, "metric_value": metric_value, "prev_best": prev_best,
+            "delta": delta, "reason": f"Metric {'improved' if improved else 'not improved'} by {delta:.6f}"}
+
+def log_result(run_dir, exp_id, description, exp_type, target, decision, reason, scores=None):
+    entry = f"\n## Experiment {exp_id}: {description}\nTime: {now_iso()}\nType: {exp_type}\nTarget: {target}\n"
+    if scores: entry += f"Scores: {scores}\n"
+    entry += f"Decision: {decision}\nReason: {reason}\n---\n"
+    with open(os.path.join(run_dir, "results.log"), "a") as f: f.write(entry)
+    print(json.dumps({"status": "logged", "experiment_id": exp_id, "decision": decision}))
+
+def log_result_ml(run_dir, exp_id, description, metric_name, metric_value, prev_best, decision, reason):
+    entry = f"\n## Experiment {exp_id}: {description}\nTime: {now_iso()}\nMetric: {metric_name}={metric_value} (previous best: {prev_best})\nDecision: {decision}\nReason: {reason}\n---\n"
+    with open(os.path.join(run_dir, "results.log"), "a") as f: f.write(entry)
+    print(json.dumps({"status": "logged", "experiment_id": exp_id, "decision": decision}))
+
+def read_results(run_dir, last_n=None):
+    try:
+        with open(os.path.join(run_dir, "results.log")) as f: content = f.read()
+    except FileNotFoundError: print("No results yet."); return
+    if last_n:
+        entries = [e.strip() for e in content.split("---\n") if e.strip()]
+        print("\n---\n".join(entries[-last_n:]))
+    else: print(content)
+
+def stats(run_dir):
+    try:
+        with open(os.path.join(run_dir, "results.log")) as f: content = f.read()
+    except FileNotFoundError: print(json.dumps({"total": 0})); return
+    entries = [e.strip() for e in content.split("---\n") if e.strip()]
+    merged = sum(1 for e in entries if "Decision: MERGE" in e)
+    reverted = sum(1 for e in entries if "Decision: REVERT" in e)
+    types = {}
+    for e in entries:
+        for line in e.split("\n"):
+            if line.startswith("Type: "): t = line[6:].strip(); types[t] = types.get(t, 0) + 1
+    print(json.dumps({"total": len(entries), "merged": merged, "reverted": reverted,
+                       "merge_rate": f"{merged/len(entries)*100:.0f}%" if entries else "0%", "by_type": types}, indent=2))
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    if not args: print(__doc__); sys.exit(1)
+    cmd = args[0]
+    if cmd == "score": print(json.dumps(score_knowledge(int(args[1]),int(args[2]),int(args[3]),int(args[4]),int(args[5])), indent=2))
+    elif cmd == "log-result":
+        scores_str = None
+        if "--scores" in args: idx = args.index("--scores"); scores_str = args[idx+1]; args = args[:idx]+args[idx+2:]
+        log_result(args[1], int(args[2]), args[3], args[4], args[5], args[6], args[7], scores_str)
+    elif cmd == "log-result-ml": log_result_ml(args[1], int(args[2]), args[3], args[4], float(args[5]), float(args[6]), args[7], args[8])
+    elif cmd == "read-results":
+        last_n = int(args[args.index("--last")+1]) if "--last" in args else None
+        read_results(args[1], last_n)
+    elif cmd == "stats": stats(args[1])
+    else: print(f"Unknown: {cmd}"); sys.exit(1)

--- a/skills/research/autoresearch/scripts/plan.py
+++ b/skills/research/autoresearch/scripts/plan.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Autoresearch experiment planning and tracking.
+
+Usage:
+    python plan.py write <run_dir> <experiments_json>
+    python plan.py read <run_dir>
+    python plan.py update-experiment <run_dir> <exp_id> <status> [--reason TEXT]
+    python plan.py add-experiment <run_dir> <type> <hypothesis> <target_section>
+    python plan.py next-pending <run_dir>
+    python plan.py summary <run_dir>
+
+Experiment types: investigate, deepen, verify, synthesize
+Statuses: pending, in_progress, merged, reverted, failed
+"""
+import json, os, sys
+from _util import now_iso, atomic_write, read_json
+
+def _plan_path(run_dir): return os.path.join(run_dir, "plan.json")
+
+def write_plan(run_dir, experiments_json):
+    experiments = json.loads(experiments_json)
+    valid_types = {"investigate", "deepen", "verify", "synthesize"}
+    for exp in experiments:
+        if "id" not in exp: raise ValueError(f"Experiment missing 'id': {exp}")
+        if exp.get("type", "investigate") not in valid_types:
+            raise ValueError(f"Invalid type '{exp.get('type')}'")
+        exp.setdefault("status", "pending"); exp.setdefault("type", "investigate")
+        exp.setdefault("target_section", ""); exp.setdefault("hypothesis", "")
+    atomic_write(_plan_path(run_dir), {"experiments": experiments, "created": now_iso(), "last_updated": now_iso()})
+    print(json.dumps({"status": "plan_written", "count": len(experiments)}))
+
+def read_plan(run_dir):
+    print(json.dumps(read_json(_plan_path(run_dir)), indent=2))
+
+def update_experiment(run_dir, exp_id, status, reason=None):
+    valid = {"pending", "in_progress", "merged", "reverted", "failed"}
+    if status not in valid: print(json.dumps({"error": "Invalid status"})); sys.exit(1)
+    data = read_json(_plan_path(run_dir)); found = False
+    for exp in data.get("experiments", []):
+        if exp["id"] == exp_id:
+            exp["status"] = status; exp["updated"] = now_iso()
+            if reason: exp["reason"] = reason
+            found = True; break
+    if not found: print(json.dumps({"error": f"Experiment {exp_id} not found"})); sys.exit(1)
+    data["last_updated"] = now_iso(); atomic_write(_plan_path(run_dir), data)
+    print(json.dumps({"status": "updated", "experiment_id": exp_id, "new_status": status}))
+
+def add_experiment(run_dir, exp_type, hypothesis, target_section):
+    data = read_json(_plan_path(run_dir)); experiments = data.get("experiments", [])
+    max_id = max((e["id"] for e in experiments), default=0)
+    new_exp = {"id": max_id+1, "type": exp_type, "hypothesis": hypothesis,
+               "target_section": target_section, "status": "pending", "added_during_run": True}
+    experiments.append(new_exp); data["experiments"] = experiments; data["last_updated"] = now_iso()
+    atomic_write(_plan_path(run_dir), data)
+    print(json.dumps({"status": "added", "experiment": new_exp}))
+
+def next_pending(run_dir):
+    for exp in read_json(_plan_path(run_dir)).get("experiments", []):
+        if exp["status"] == "pending": print(json.dumps(exp)); return
+    print(json.dumps({"status": "all_done"}))
+
+def summary(run_dir):
+    exps = read_json(_plan_path(run_dir)).get("experiments", [])
+    counts = {}; types = {}
+    for e in exps:
+        s = e.get("status", "unknown"); counts[s] = counts.get(s, 0) + 1
+        t = e.get("type", "unknown"); types[t] = types.get(t, 0) + 1
+    print(json.dumps({"total": len(exps), "by_status": counts, "by_type": types}, indent=2))
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    if not args: print(__doc__); sys.exit(1)
+    cmd = args[0]
+    if cmd == "write": write_plan(args[1], args[2])
+    elif cmd == "read": read_plan(args[1])
+    elif cmd == "update-experiment":
+        reason = args[args.index("--reason")+1] if "--reason" in args else None
+        update_experiment(args[1], int(args[2]), args[3], reason)
+    elif cmd == "add-experiment": add_experiment(args[1], args[2], args[3], args[4] if len(args)>4 else "")
+    elif cmd == "next-pending": next_pending(args[1])
+    elif cmd == "summary": summary(args[1])
+    else: print(f"Unknown: {cmd}"); sys.exit(1)

--- a/skills/research/autoresearch/scripts/registry.py
+++ b/skills/research/autoresearch/scripts/registry.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Autoresearch run registry - multi-user tracking.
+Usage:
+    python registry.py register <rid> <user_id> <platform> <chat_id> <goal> <cron_job_id> [--watchdog-job-id ID]
+    python registry.py list [--user-id U] [--platform P] [--active-only]
+    python registry.py get <rid>
+    python registry.py update <rid> [--phase P] [--cron-job-id ID]
+    python registry.py remove <rid>
+    python registry.py find-by-job <cron_job_id>
+"""
+import json, os, sys
+from _util import now_iso, atomic_write, read_json, hermes_home
+
+
+def _registry_path():
+    return os.path.join(hermes_home(), "autoresearch", "registry.json")
+
+
+def _read_registry():
+    try:
+        with open(_registry_path()) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {"runs": {}}
+
+
+def register(rid, uid, plat, cid, goal, jid, wid=None):
+    reg = _read_registry()
+    run_dir = os.path.join(hermes_home(), "autoresearch", rid)
+    reg["runs"][rid] = {
+        "research_id": rid, "user_id": uid, "platform": plat,
+        "chat_id": cid, "goal": goal, "cron_job_id": jid,
+        "watchdog_job_id": wid, "run_dir": run_dir,
+        "created": now_iso(), "phase": "starting",
+    }
+    atomic_write(_registry_path(), reg)
+    print(json.dumps({"status": "registered", "research_id": rid}))
+
+
+def list_runs(uid=None, plat=None, active_only=False):
+    runs = list(_read_registry().get("runs", {}).values())
+    if uid:
+        runs = [r for r in runs if r.get("user_id") == uid]
+    if plat:
+        runs = [r for r in runs if r.get("platform") == plat]
+    for run in runs:
+        try:
+            with open(os.path.join(run["run_dir"], "status.json")) as f:
+                status = json.load(f)
+            run["phase"] = status.get("phase", "?")
+            run["experiments_done"] = status.get("experiments_done", 0)
+            run["experiments_total"] = status.get("experiments_total", 0)
+        except Exception:
+            pass
+    if active_only:
+        runs = [r for r in runs if r.get("phase") in ("planning", "executing", "starting")]
+    print(json.dumps({"count": len(runs), "runs": runs}, indent=2))
+
+
+def get_run(rid):
+    run = _read_registry().get("runs", {}).get(rid)
+    if not run:
+        print(json.dumps({"error": f"Not found: {rid}"}))
+        sys.exit(1)
+    try:
+        with open(os.path.join(run["run_dir"], "status.json")) as f:
+            run["status"] = json.load(f)
+    except Exception:
+        run["status"] = None
+    print(json.dumps(run, indent=2))
+
+
+def update_run(rid, **kw):
+    reg = _read_registry()
+    if rid not in reg.get("runs", {}):
+        print(json.dumps({"error": "Not found"}))
+        sys.exit(1)
+    for k, v in kw.items():
+        if v is not None:
+            reg["runs"][rid][k] = v
+    atomic_write(_registry_path(), reg)
+    print(json.dumps({"status": "updated"}))
+
+
+def remove_run(rid):
+    reg = _read_registry()
+    if rid in reg.get("runs", {}):
+        del reg["runs"][rid]
+        atomic_write(_registry_path(), reg)
+        print(json.dumps({"status": "removed"}))
+    else:
+        print(json.dumps({"error": "Not found"}))
+
+
+def find_by_job(jid):
+    for run in _read_registry().get("runs", {}).values():
+        if run.get("cron_job_id") == jid or run.get("watchdog_job_id") == jid:
+            print(json.dumps(run, indent=2))
+            return
+    print(json.dumps({"error": f"No run for job {jid}"}))
+
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    if not args:
+        print(__doc__)
+        sys.exit(1)
+    cmd = args[0]
+    if cmd == "register":
+        wid = args[args.index("--watchdog-job-id") + 1] if "--watchdog-job-id" in args else None
+        register(args[1], args[2], args[3], args[4], args[5], args[6], wid)
+    elif cmd == "list":
+        uid = args[args.index("--user-id") + 1] if "--user-id" in args else None
+        plat = args[args.index("--platform") + 1] if "--platform" in args else None
+        list_runs(uid, plat, "--active-only" in args)
+    elif cmd == "get":
+        get_run(args[1])
+    elif cmd == "update":
+        kw = {}
+        i = 2
+        while i < len(args):
+            if args[i].startswith("--"):
+                kw[args[i][2:].replace("-", "_")] = args[i + 1]
+                i += 2
+            else:
+                i += 1
+        update_run(args[1], **kw)
+    elif cmd == "remove":
+        remove_run(args[1])
+    elif cmd == "find-by-job":
+        find_by_job(args[1])
+    else:
+        print(f"Unknown: {cmd}")
+        sys.exit(1)

--- a/skills/research/autoresearch/scripts/report.py
+++ b/skills/research/autoresearch/scripts/report.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Autoresearch report generation from state files.
+
+Usage:
+    python report.py generate <run_dir>
+    python report.py summary <run_dir>
+"""
+import json, os, sys
+from pathlib import Path
+from _util import read_json
+
+
+def _read_text(path):
+    try:
+        return Path(path).read_text()
+    except FileNotFoundError:
+        return ""
+
+
+def _results_entries(run_dir):
+    content = _read_text(os.path.join(run_dir, "results.log"))
+    if not content.strip():
+        return []
+    return [e.strip() for e in content.split("---\n") if e.strip()]
+
+
+def generate_report(run_dir):
+    config = read_json(os.path.join(run_dir, "config.json"))
+    status = read_json(os.path.join(run_dir, "status.json"))
+    plan = read_json(os.path.join(run_dir, "plan.json"))
+    usage = read_json(os.path.join(run_dir, "usage.json"))
+    entries = _results_entries(run_dir)
+
+    merged = [e for e in entries if "Decision: MERGE" in e]
+    reverted = [e for e in entries if "Decision: REVERT" in e]
+
+    lines = []
+    lines.append(f"# Research Report: {config.get('goal', 'Unknown')}")
+    lines.append("")
+    lines.append(f"- **Domain**: {config.get('domain', 'N/A')}")
+    lines.append(f"- **Scope**: {config.get('scope', 'N/A')}")
+    lines.append(f"- **Depth**: {config.get('depth', 'N/A')}")
+    lines.append(
+        f"- **Experiments**: {status.get('experiments_done', 0)}"
+        f" ({status.get('experiments_merged', 0)} merged,"
+        f" {status.get('experiments_reverted', 0)} reverted,"
+        f" {status.get('experiments_failed', 0)} failed)"
+    )
+
+    if usage:
+        lines.append(
+            f"- **Tokens**: {usage.get('total_tokens', 0):,}"
+            f" (input: {usage.get('total_input_tokens', 0):,},"
+            f" output: {usage.get('total_output_tokens', 0):,})"
+        )
+        if usage.get("estimated_cost_usd"):
+            lines.append(
+                f"- **Estimated cost**: ${usage['estimated_cost_usd']:.4f}"
+            )
+
+    lines.append("")
+
+    if entries:
+        merge_rate = len(merged) / len(entries) * 100 if entries else 0
+        lines.append("## Summary")
+        lines.append("")
+        lines.append(f"Merge rate: {merge_rate:.0f}% ({len(merged)}/{len(entries)})")
+        lines.append("")
+
+    # Experiment log
+    if merged:
+        lines.append("## Merged Experiments")
+        lines.append("")
+        for e in merged:
+            for line in e.split("\n"):
+                if line.startswith("## "):
+                    lines.append(f"\n### {line[3:]}")
+                elif line.startswith("Reason:"):
+                    lines.append(f"  {line}")
+
+    if reverted:
+        lines.append("")
+        lines.append("## Reverted Experiments")
+        lines.append("")
+        for e in reverted:
+            for line in e.split("\n"):
+                if line.startswith("## "):
+                    lines.append(f"\n### {line[3:]}")
+                elif line.startswith("Reason:"):
+                    lines.append(f"  {line}")
+
+    report = "\n".join(lines)
+    report_path = os.path.join(run_dir, "report.md")
+    Path(report_path).write_text(report)
+    print(json.dumps({"status": "generated", "path": report_path}))
+
+
+def summary(run_dir):
+    config = read_json(os.path.join(run_dir, "config.json"))
+    status = read_json(os.path.join(run_dir, "status.json"))
+    entries = _results_entries(run_dir)
+
+    merged = sum(1 for e in entries if "Decision: MERGE" in e)
+    reverted = sum(1 for e in entries if "Decision: REVERT" in e)
+
+    lines = [
+        f"Research: {config.get('goal', 'Unknown')}",
+        f"Phase: {status.get('phase', 'unknown')}",
+        f"Experiments: {status.get('experiments_done', 0)}/{status.get('experiments_total', 0)}"
+        f" | Merged: {merged} | Reverted: {reverted} | Failed: {status.get('experiments_failed', 0)}",
+    ]
+
+    if entries and merged > 0:
+        top_merges = [
+            e.split("\n")[0]
+            for e in entries
+            if "Decision: MERGE" in e
+        ][:3]
+        for tm in top_merges:
+            lines.append(f"  + {tm}")
+
+    print(json.dumps({"summary": "\n".join(lines)}))
+
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    if not args:
+        print(__doc__)
+        sys.exit(1)
+    cmd = args[0]
+    if cmd == "generate":
+        generate_report(args[1])
+    elif cmd == "summary":
+        summary(args[1])
+    else:
+        print(f"Unknown: {cmd}")
+        sys.exit(1)

--- a/skills/research/autoresearch/scripts/state.py
+++ b/skills/research/autoresearch/scripts/state.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Autoresearch state management - atomic JSON I/O, research ID generation, budget checks.
+
+Usage:
+    python state.py init <run_dir> <goal> <domain> <scope> <depth> <max_experiments>
+    python state.py status <run_dir>
+    python state.py update-status <run_dir> <phase> [--experiments-done N] [--merged N] [--reverted N]
+    python state.py control <run_dir> [--action ACTION] [--addendum TEXT]
+    python state.py read-control <run_dir>
+    python state.py checkpoint <run_dir> <last_completed> <next>
+    python state.py read-checkpoint <run_dir>
+    python state.py check-budget <run_dir> [--tokens N]
+    python state.py gen-id <domain>
+"""
+import json, os, sys, hashlib
+from datetime import datetime, timezone
+from pathlib import Path
+from _util import now_iso, atomic_write, read_json
+
+def gen_id(domain):
+    h = hashlib.sha256(f"{domain}{now_iso()}{os.getpid()}".encode()).hexdigest()[:6]
+    return f"{domain}_{h}_{datetime.now(timezone.utc).strftime('%Y%m%d')}"
+
+def init(run_dir, goal, domain, scope, depth, max_exp, max_duration=180, max_tokens=2000000):
+    rd = Path(run_dir); (rd/"workspace").mkdir(parents=True, exist_ok=True)
+    atomic_write(str(rd/"config.json"), {"goal":goal,"domain":domain,"scope":scope,"depth":depth,
+        "max_experiments":max_exp,"max_experiments_hard_cap":int(max_exp*1.5),
+        "max_duration_minutes":max_duration,"max_tokens":max_tokens,"created":now_iso()})
+    atomic_write(str(rd/"status.json"), {"phase":"planning","experiments_done":0,"experiments_total":0,
+        "experiments_merged":0,"experiments_reverted":0,"experiments_failed":0,
+        "current_experiment":None,"last_updated":now_iso()})
+    atomic_write(str(rd/"control.json"), {"action":"none"})
+    atomic_write(str(rd/"plan.json"), {"experiments":[]})
+    (rd/"results.log").touch()
+    print(json.dumps({"status":"initialized","run_dir":str(rd),"workspace":str(rd/"workspace")}, indent=2))
+
+def status(run_dir):
+    d = read_json(os.path.join(run_dir, "status.json"))
+    if not d: print(json.dumps({"error":"status.json not found"})); sys.exit(1)
+    print(json.dumps(d, indent=2))
+
+def update_status(run_dir, phase, **kw):
+    p = os.path.join(run_dir, "status.json"); d = read_json(p)
+    d["phase"] = phase; d["last_updated"] = now_iso()
+    for k, v in kw.items():
+        if v is not None:
+            # Normalize --merged/--reverted to experiments_merged/experiments_reverted
+            if k == "merged": k = "experiments_merged"
+            elif k == "reverted": k = "experiments_reverted"
+            d[k] = v
+    atomic_write(p, d); print(json.dumps(d, indent=2))
+
+def write_control(run_dir, action="none", addendum=None):
+    d = {"action": action, "timestamp": now_iso()}
+    if addendum: d["addendum"] = addendum
+    atomic_write(os.path.join(run_dir, "control.json"), d); print(json.dumps(d, indent=2))
+
+def read_control(run_dir):
+    print(json.dumps(read_json(os.path.join(run_dir, "control.json")), indent=2))
+
+def checkpoint(run_dir, last, nxt):
+    d = {"last_completed": last, "next": nxt, "timestamp": now_iso()}
+    atomic_write(os.path.join(run_dir, "checkpoint.json"), d); print(json.dumps(d, indent=2))
+
+def read_checkpoint(run_dir):
+    d = read_json(os.path.join(run_dir, "checkpoint.json"))
+    print(json.dumps(d if d else {"error": "no checkpoint"}, indent=2))
+
+def check_budget(run_dir, tokens=None):
+    cfg = read_json(os.path.join(run_dir, "config.json"))
+    st = read_json(os.path.join(run_dir, "status.json"))
+    md, mt = cfg.get("max_duration_minutes",180), cfg.get("max_tokens",2000000)
+    cap = cfg.get("max_experiments_hard_cap",30); done = st.get("experiments_done",0)
+    # Auto-read token usage from usage.json when not explicitly provided
+    if tokens is None:
+        usage = read_json(os.path.join(run_dir, "usage.json"))
+        tokens = usage.get("total_tokens", 0)
+    v = []
+    if md and cfg.get("created"):
+        try:
+            elapsed = (datetime.now(timezone.utc) - datetime.fromisoformat(cfg["created"])).total_seconds()/60
+            if elapsed > md: v.append(f"time_exceeded: {elapsed:.0f}min > {md}min")
+        except Exception: pass
+    if mt and tokens > mt: v.append(f"tokens_exceeded: {tokens} > {mt}")
+    if done >= cap: v.append(f"experiments_exceeded: {done} >= {cap}")
+    print(json.dumps({"exceeded":len(v)>0,"violations":v,
+        "budget":{"max_duration_minutes":md,"max_tokens":mt,"max_experiments_hard_cap":cap},
+        "current":{"experiments_done":done,"tokens_used":tokens}}, indent=2))
+
+if __name__ == "__main__":
+    a = sys.argv[1:]
+    if not a: print(__doc__); sys.exit(1)
+    c = a[0]
+    if c == "gen-id": print(gen_id(a[1] if len(a)>1 else "general"))
+    elif c == "init":
+        mx_dur,mx_tok=180,2000000; i=7
+        while i<len(a):
+            if a[i]=="--max-duration": mx_dur=int(a[i+1]); i+=2
+            elif a[i]=="--max-tokens": mx_tok=int(a[i+1]); i+=2
+            else: i+=1
+        init(a[1],a[2],a[3],a[4],a[5],int(a[6]),mx_dur,mx_tok)
+    elif c == "status": status(a[1])
+    elif c == "update-status":
+        kw={}; i=3
+        while i<len(a):
+            if a[i].startswith("--"): k=a[i][2:].replace("-","_"); v=a[i+1]
+            else: i+=1; continue
+            try: v=int(v)
+            except ValueError: pass
+            kw[k]=v; i+=2
+        update_status(a[1],a[2],**kw)
+    elif c == "control":
+        act,add="none",None; i=2
+        while i<len(a):
+            if a[i]=="--action": act=a[i+1]; i+=2
+            elif a[i]=="--addendum": add=a[i+1]; i+=2
+            else: i+=1
+        write_control(a[1],act,add)
+    elif c == "read-control": read_control(a[1])
+    elif c == "checkpoint": checkpoint(a[1],int(a[2]),int(a[3]))
+    elif c == "read-checkpoint": read_checkpoint(a[1])
+    elif c == "check-budget":
+        t = int(a[a.index("--tokens")+1]) if "--tokens" in a else None
+        check_budget(a[1],t)
+    else: print(f"Unknown: {c}"); sys.exit(1)

--- a/skills/research/autoresearch/scripts/usage.py
+++ b/skills/research/autoresearch/scripts/usage.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Autoresearch token usage and cost tracking.
+Usage:
+    python usage.py session-cost <session_id>
+    python usage.py job-cost <cron_job_id>
+    python usage.py research-cost <run_dir>
+    python usage.py track <run_dir> <exp_id> <input_tokens> <output_tokens> [--cost USD]
+    python usage.py summary <run_dir>
+"""
+import json, os, sys, sqlite3
+from _util import now_iso, atomic_write, read_json, hermes_home
+
+
+def _sessions_db():
+    return os.path.join(hermes_home(), "sessions.db")
+
+
+def _registry_path():
+    return os.path.join(hermes_home(), "autoresearch", "registry.json")
+
+
+def session_cost(sid):
+    db = _sessions_db()
+    if not os.path.exists(db):
+        print(json.dumps({"error": "No SessionDB"}))
+        return
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    r = conn.execute(
+        "SELECT id,model,input_tokens,output_tokens,cache_read_tokens,"
+        "cache_write_tokens,reasoning_tokens,estimated_cost_usd "
+        "FROM sessions WHERE id=?", (sid,)
+    ).fetchone()
+    conn.close()
+    if not r:
+        print(json.dumps({"error": f"Session {sid} not found"}))
+        return
+    print(json.dumps({
+        "session_id": r["id"], "model": r["model"],
+        "input_tokens": r["input_tokens"] or 0,
+        "output_tokens": r["output_tokens"] or 0,
+        "total_tokens": (r["input_tokens"] or 0) + (r["output_tokens"] or 0),
+        "estimated_cost_usd": r["estimated_cost_usd"],
+    }, indent=2))
+
+
+def job_cost(jid):
+    db = _sessions_db()
+    if not os.path.exists(db):
+        print(json.dumps({"error": "No SessionDB"}))
+        return
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT input_tokens,output_tokens,estimated_cost_usd "
+        "FROM sessions WHERE id LIKE ? ORDER BY started_at",
+        (f"cron_{jid}_%",)
+    ).fetchall()
+    conn.close()
+    if not rows:
+        print(json.dumps({"error": f"No sessions for job {jid}"}))
+        return
+    ti = sum(r["input_tokens"] or 0 for r in rows)
+    to = sum(r["output_tokens"] or 0 for r in rows)
+    tc = sum(r["estimated_cost_usd"] or 0 for r in rows)
+    print(json.dumps({
+        "cron_job_id": jid, "sessions": len(rows),
+        "input_tokens": ti, "output_tokens": to,
+        "total_tokens": ti + to,
+        "estimated_cost_usd": round(tc, 4) if tc else None,
+    }, indent=2))
+
+
+def track(run_dir, exp_id, inp, out, cost=None):
+    up = os.path.join(run_dir, "usage.json")
+    u = read_json(up)
+    if "experiments" not in u:
+        u = {"total_input_tokens": 0, "total_output_tokens": 0,
+             "total_tokens": 0, "estimated_cost_usd": 0.0, "experiments": {}}
+    u["experiments"][str(exp_id)] = {
+        "input_tokens": inp, "output_tokens": out,
+        "cost_usd": cost, "timestamp": now_iso(),
+    }
+    u["total_input_tokens"] = sum(e["input_tokens"] for e in u["experiments"].values())
+    u["total_output_tokens"] = sum(e["output_tokens"] for e in u["experiments"].values())
+    u["total_tokens"] = u["total_input_tokens"] + u["total_output_tokens"]
+    costs = [e["cost_usd"] for e in u["experiments"].values() if e["cost_usd"] is not None]
+    u["estimated_cost_usd"] = round(sum(costs), 4) if costs else 0.0
+    atomic_write(up, u)
+    print(json.dumps({
+        "status": "tracked",
+        "cumulative_tokens": u["total_tokens"],
+        "estimated_cost_usd": u["estimated_cost_usd"],
+    }))
+
+
+def usage_summary(run_dir):
+    rid = os.path.basename(run_dir.rstrip("/"))
+    reg = read_json(_registry_path())
+    run = reg.get("runs", {}).get(rid, {})
+    result = {"research_id": rid, "source": "local"}
+    u = read_json(os.path.join(run_dir, "usage.json"))
+    if u:
+        result["local_tracking"] = {
+            "total_tokens": u.get("total_tokens", 0),
+            "estimated_cost_usd": u.get("estimated_cost_usd"),
+        }
+    db = _sessions_db()
+    cid = run.get("cron_job_id")
+    if cid and os.path.exists(db):
+        try:
+            conn = sqlite3.connect(db)
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                "SELECT input_tokens,output_tokens,estimated_cost_usd "
+                "FROM sessions WHERE id LIKE ?", (f"cron_{cid}_%",)
+            ).fetchall()
+            conn.close()
+            if rows:
+                result["source"] = "session_db"
+                result["session_db_tracking"] = {
+                    "total_tokens": sum((r["input_tokens"] or 0) + (r["output_tokens"] or 0) for r in rows),
+                    "estimated_cost_usd": round(sum(r["estimated_cost_usd"] or 0 for r in rows), 4),
+                }
+        except Exception:
+            pass
+    wid = run.get("watchdog_job_id")
+    if wid and os.path.exists(db):
+        try:
+            conn = sqlite3.connect(db)
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                "SELECT input_tokens,output_tokens,estimated_cost_usd "
+                "FROM sessions WHERE id LIKE ?", (f"cron_{wid}_%",)
+            ).fetchall()
+            conn.close()
+            if rows:
+                result["watchdog_cost"] = {
+                    "total_tokens": sum((r["input_tokens"] or 0) + (r["output_tokens"] or 0) for r in rows),
+                    "estimated_cost_usd": round(sum(r["estimated_cost_usd"] or 0 for r in rows), 4),
+                }
+        except Exception:
+            pass
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    a = sys.argv[1:]
+    if not a:
+        print(__doc__)
+        sys.exit(1)
+    c = a[0]
+    if c == "session-cost": session_cost(a[1])
+    elif c == "job-cost": job_cost(a[1])
+    elif c == "research-cost": usage_summary(a[1])
+    elif c == "track":
+        cost = float(a[a.index("--cost") + 1]) if "--cost" in a else None
+        track(a[1], int(a[2]), int(a[3]), int(a[4]), cost)
+    elif c == "summary": usage_summary(a[1])
+    else: print(f"Unknown: {c}"); sys.exit(1)

--- a/skills/research/autoresearch/scripts/workspace.py
+++ b/skills/research/autoresearch/scripts/workspace.py
@@ -28,6 +28,7 @@ def init(d):
         f"cd {qd} && git init --initial-branch=main 2>/dev/null || (cd {qd} && git init && cd {qd} && git checkout -b main)",
         f"cd {qd} && git config user.email 'autoresearch@hermes'",
         f"cd {qd} && git config user.name 'autoresearch'",
+        f"cd {qd} && git commit --allow-empty -m 'init autoresearch workspace'",
     ])
 
 def branch(d, eid, desc):

--- a/skills/research/autoresearch/scripts/workspace.py
+++ b/skills/research/autoresearch/scripts/workspace.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Autoresearch git workspace management. Outputs commands for agent to execute.
+
+Usage:
+    python workspace.py init <workspace_dir>
+    python workspace.py branch <workspace_dir> <exp_id> <short_description>
+    python workspace.py branch-name <exp_id> <description>
+    python workspace.py diff <workspace_dir>
+    python workspace.py merge <workspace_dir> <exp_id> <short_description> <commit_message>
+    python workspace.py revert <workspace_dir> <exp_id> <short_description>
+    python workspace.py log <workspace_dir> [--oneline]
+    python workspace.py current-branch <workspace_dir>
+"""
+import json, os, re, shlex, sys
+
+def _safe_branch_name(exp_id, desc):
+    safe = re.sub(r'[^a-zA-Z0-9_-]', '_', desc.lower())
+    safe = re.sub(r'_+', '_', safe)[:40].rstrip('_')
+    return f"exp_{exp_id}_{safe}"
+
+def _cmds(workspace_dir, commands):
+    print(json.dumps({"workspace": workspace_dir, "commands": commands}, indent=2))
+
+def init(d):
+    qd = shlex.quote(d)
+    os.makedirs(d, exist_ok=True)
+    _cmds(d, [
+        f"cd {qd} && git init --initial-branch=main 2>/dev/null || (cd {qd} && git init && cd {qd} && git checkout -b main)",
+        f"cd {qd} && git config user.email 'autoresearch@hermes'",
+        f"cd {qd} && git config user.name 'autoresearch'",
+    ])
+
+def branch(d, eid, desc):
+    qd = shlex.quote(d)
+    b = _safe_branch_name(eid, desc)
+    _cmds(d, [f"cd {qd} && git checkout main", f"cd {qd} && git checkout -b {b}"])
+
+def diff(d):
+    qd = shlex.quote(d)
+    _cmds(d, [f"cd {qd} && git diff main"])
+
+def merge(d, eid, desc, msg):
+    qd = shlex.quote(d)
+    b = _safe_branch_name(eid, desc)
+    qmsg = shlex.quote(msg)
+    _cmds(d, [
+        f"cd {qd} && git add -A",
+        f"cd {qd} && git commit -m {qmsg}",
+        f"cd {qd} && git checkout main",
+        f"cd {qd} && git merge {b} --no-edit",
+        f"cd {qd} && git branch -d {b}",
+    ])
+
+def revert(d, eid, desc):
+    qd = shlex.quote(d)
+    b = _safe_branch_name(eid, desc)
+    _cmds(d, [f"cd {qd} && git checkout -f main", f"cd {qd} && git branch -D {b}"])
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    if not args: print(__doc__); sys.exit(1)
+    cmd = args[0]
+    if cmd == "init": init(args[1])
+    elif cmd == "branch": branch(args[1], int(args[2]), args[3])
+    elif cmd == "branch-name": print(_safe_branch_name(int(args[1]), args[2]))
+    elif cmd == "diff": diff(args[1])
+    elif cmd == "merge": merge(args[1], int(args[2]), args[3], args[4])
+    elif cmd == "revert": revert(args[1], int(args[2]), args[3])
+    elif cmd == "log":
+        qd = shlex.quote(args[1])
+        _cmds(args[1], [f"cd {qd} && git log{' --oneline' if '--oneline' in args else ''} -20"])
+    elif cmd == "current-branch":
+        qd = shlex.quote(args[1])
+        _cmds(args[1], [f"cd {qd} && git branch --show-current"])
+    else: print(f"Unknown: {cmd}"); sys.exit(1)

--- a/skills/research/autoresearch/templates/cron_prompt.md
+++ b/skills/research/autoresearch/templates/cron_prompt.md
@@ -1,0 +1,195 @@
+# Autonomous Research Agent
+
+You are an autonomous research agent running as a background cron job. You have access to terminal, file, web, browser, execute_code, delegate_task, vision, and skills tools. You CANNOT send messages mid-run (messaging disabled for cron). Your FINAL response is auto-delivered to the user.
+
+## YOUR TASK
+- **GOAL**: {{goal}}
+- **DOMAIN**: {{domain}}
+- **SCOPE**: {{scope}}
+- **DEPTH**: {{depth}}
+- **RESEARCH ID**: {{research_id}}
+- **RUN DIR**: {{run_dir}}
+- **WORKSPACE**: {{run_dir}}/workspace/
+- **MAX EXPERIMENTS**: {{max_experiments}}
+- **MAX DURATION**: {{max_duration_minutes}} minutes
+- **MAX TOKENS**: {{max_tokens}}
+- **SCRIPTS DIR**: {{scripts_dir}}
+
+## HELPER SCRIPTS
+Use these via terminal instead of hand-rolling JSON:
+
+**state.py** - Run state management:
+```bash
+python {{scripts_dir}}/state.py init {{run_dir}} "{{goal}}" "{{domain}}" "{{scope}}" "{{depth}}" {{max_experiments}} --max-duration {{max_duration_minutes}} --max-tokens {{max_tokens}}
+python {{scripts_dir}}/state.py update-status {{run_dir}} executing --experiments-done 5 --experiments-total 15 --merged 3 --reverted 2
+python {{scripts_dir}}/state.py read-control {{run_dir}}
+python {{scripts_dir}}/state.py check-budget {{run_dir}}
+python {{scripts_dir}}/state.py checkpoint {{run_dir}} 5 6
+```
+
+**plan.py** - Experiment planning:
+```bash
+python {{scripts_dir}}/plan.py write {{run_dir}} '[{"id":1,"type":"investigate","hypothesis":"...","target_section":"Section 1"}]'
+python {{scripts_dir}}/plan.py next-pending {{run_dir}}
+python {{scripts_dir}}/plan.py update-experiment {{run_dir}} 1 merged --reason "Found specific pricing data"
+python {{scripts_dir}}/plan.py add-experiment {{run_dir}} deepen "Revisit section with better sources" "Section 2"
+python {{scripts_dir}}/plan.py summary {{run_dir}}
+```
+
+**evaluate.py** - Scoring and result logging:
+```bash
+python {{scripts_dir}}/evaluate.py score 4 3 4 5 4
+python {{scripts_dir}}/evaluate.py log-result {{run_dir}} 1 "Found OpenAI pricing" investigate "Section 1" MERGE "Specific data" --scores "E=4,A=3,D=4,R=5,N=4 Total=20/25"
+python {{scripts_dir}}/evaluate.py read-results {{run_dir}} --last 5
+python {{scripts_dir}}/evaluate.py stats {{run_dir}}
+```
+
+**workspace.py** - Git operations (outputs commands for you to run):
+```bash
+python {{scripts_dir}}/workspace.py init {{run_dir}}/workspace
+python {{scripts_dir}}/workspace.py branch {{run_dir}}/workspace 1 "openai-pricing"
+python {{scripts_dir}}/workspace.py merge {{run_dir}}/workspace 1 "openai-pricing" "exp 1: found pricing"
+python {{scripts_dir}}/workspace.py revert {{run_dir}}/workspace 1 "openai-pricing"
+```
+
+**report.py** - Report generation:
+```bash
+python {{scripts_dir}}/report.py generate {{run_dir}}
+python {{scripts_dir}}/report.py summary {{run_dir}}
+```
+
+---
+
+## PHASE 1: SETUP
+
+1. Initialize state:
+```bash
+python {{scripts_dir}}/state.py init {{run_dir}} "{{goal}}" "{{domain}}" "{{scope}}" "{{depth}}" {{max_experiments}} --max-duration {{max_duration_minutes}} --max-tokens {{max_tokens}}
+```
+
+2. Initialize git workspace:
+```bash
+python {{scripts_dir}}/workspace.py init {{run_dir}}/workspace
+# Execute the outputted commands via terminal
+```
+
+3. Create initial target file:
+   - **Knowledge research**: Create `research.md` with structured sections based on goal.
+   - **ML/code**: Create baseline code file.
+
+4. Initial commit:
+```bash
+cd {{run_dir}}/workspace && git add -A && git commit -m "initial skeleton"
+```
+
+---
+
+## PHASE 2: PLANNING
+
+Break goal into experiments. Mix types:
+- **investigate**: First pass, gather raw data
+- **deepen**: Revisit thin sections with better sources
+- **verify**: Cross-reference claims across sources
+- **synthesize**: Compare, contrast, build tables, draw conclusions
+
+Include experiments that REVISIT earlier sections. Plan for iteration, not linear coverage.
+
+```bash
+python {{scripts_dir}}/plan.py write {{run_dir}} '<JSON array>'
+python {{scripts_dir}}/state.py update-status {{run_dir}} executing --experiments-total N
+```
+
+---
+
+## PHASE 3: THE LOOP
+
+### A. Check Control AND Budget (MANDATORY before every experiment)
+```bash
+python {{scripts_dir}}/state.py read-control {{run_dir}}
+python {{scripts_dir}}/state.py check-budget {{run_dir}}
+```
+
+Control: pause -> checkpoint + EXIT. stop -> PHASE 4. adjust -> add experiments. none -> continue.
+
+Budget exceeded -> Jump to PHASE 4. **NON-NEGOTIABLE.**
+
+### B. Read History
+```bash
+python {{scripts_dir}}/evaluate.py read-results {{run_dir}} --last 5
+```
+
+### C. Branch
+```bash
+python {{scripts_dir}}/workspace.py branch {{run_dir}}/workspace <exp_id> "<description>"
+python {{scripts_dir}}/plan.py update-experiment {{run_dir}} <exp_id> in_progress
+```
+
+### D. Do the Work
+investigate: web search, browser, extract specific data. deepen: read current section, find better sources. verify: cross-check claims. synthesize: build tables, connect findings.
+
+Use **delegate_task** for parallel searches. Use **execute_code** for data processing.
+
+### E. Evaluate
+```bash
+cd {{run_dir}}/workspace && git diff main
+python {{scripts_dir}}/evaluate.py score <evidence> <accuracy> <depth> <relevance> <net_improvement>
+```
+
+For ML: compare metric. Better = MERGE.
+
+### F. Merge or Revert
+MERGE:
+```bash
+python {{scripts_dir}}/workspace.py merge {{run_dir}}/workspace <id> "<desc>" "exp <id>: <what>"
+python {{scripts_dir}}/plan.py update-experiment {{run_dir}} <id> merged --reason "<reason>"
+python {{scripts_dir}}/evaluate.py log-result {{run_dir}} <id> "<desc>" <type> "<target>" MERGE "<reason>"
+```
+
+REVERT:
+```bash
+python {{scripts_dir}}/workspace.py revert {{run_dir}}/workspace <id> "<desc>"
+python {{scripts_dir}}/plan.py update-experiment {{run_dir}} <id> reverted --reason "<reason>"
+python {{scripts_dir}}/evaluate.py log-result {{run_dir}} <id> "<desc>" <type> "<target>" REVERT "<reason>"
+```
+
+### G. Update State
+```bash
+python {{scripts_dir}}/state.py update-status {{run_dir}} executing --experiments-done N --merged X --reverted Y
+python {{scripts_dir}}/state.py checkpoint {{run_dir}} <last> <next>
+```
+
+### H. Mid-Run Replan (every 5 experiments)
+```bash
+python {{scripts_dir}}/evaluate.py stats {{run_dir}}
+python {{scripts_dir}}/plan.py summary {{run_dir}}
+```
+Add experiments IF below hard cap. NEVER exceed it.
+
+### I. Failure Handling
+3 consecutive failures:
+```bash
+python {{scripts_dir}}/state.py update-status {{run_dir}} paused_error
+python {{scripts_dir}}/state.py checkpoint {{run_dir}} <last> <next>
+```
+
+---
+
+## PHASE 4: SYNTHESIS
+
+```bash
+python {{scripts_dir}}/report.py generate {{run_dir}}
+python {{scripts_dir}}/report.py summary {{run_dir}}
+python {{scripts_dir}}/state.py update-status {{run_dir}} completed
+```
+
+Your FINAL RESPONSE = summary + top 3-5 key findings.
+
+---
+
+## RULES
+- CANNOT send messages mid-run. Final response = delivery.
+- NEVER ask questions. Fully autonomous.
+- ALWAYS read results.log before each experiment.
+- Always branch from main. Main = proven best.
+- Honest evaluation. Reverting IS progress.
+- Depth over breadth.

--- a/skills/research/autoresearch/templates/resume_prompt.md
+++ b/skills/research/autoresearch/templates/resume_prompt.md
@@ -1,0 +1,41 @@
+# Autonomous Research Agent - RESUME RUN
+
+You are resuming a previously paused research run. Fully autonomous, no messaging, final response is auto-delivered.
+
+## YOUR TASK
+- **GOAL**: {{goal}}
+- **DOMAIN**: {{domain}}
+- **RESEARCH ID**: {{research_id}}
+- **RUN DIR**: {{run_dir}}
+- **WORKSPACE**: {{run_dir}}/workspace/
+- **SCRIPTS DIR**: {{scripts_dir}}
+
+## RESUME PROCEDURE
+
+1. Read existing state:
+```bash
+python {{scripts_dir}}/state.py status {{run_dir}}
+python {{scripts_dir}}/state.py read-checkpoint {{run_dir}}
+python {{scripts_dir}}/plan.py read {{run_dir}}
+python {{scripts_dir}}/plan.py summary {{run_dir}}
+python {{scripts_dir}}/evaluate.py read-results {{run_dir}}
+python {{scripts_dir}}/evaluate.py stats {{run_dir}}
+```
+
+2. Check workspace: `cd {{run_dir}}/workspace && git log --oneline -20`
+
+3. Reset control:
+```bash
+python {{scripts_dir}}/state.py control {{run_dir}} --action none
+python {{scripts_dir}}/state.py update-status {{run_dir}} executing
+```
+
+4. Continue from checkpoint.next. Skip completed experiments. Same loop as fresh run.
+
+5. Complete synthesis and delivery as normal.
+
+## RULES
+- Cannot send messages. Final response = delivery.
+- Never ask questions. Fully autonomous.
+- Always branch from main. Honest self-evaluation.
+- 3 consecutive failures = auto-pause + checkpoint.

--- a/skills/research/autoresearch/templates/watchdog_prompt.md
+++ b/skills/research/autoresearch/templates/watchdog_prompt.md
@@ -1,0 +1,69 @@
+# Autoresearch Watchdog - {{research_id}}
+
+You are a monitoring agent for research run {{research_id}}. Check status, enforce safety limits, report progress.
+
+## SCRIPTS
+```bash
+python {{scripts_dir}}/state.py status {{run_dir}}
+python {{scripts_dir}}/state.py check-budget {{run_dir}}
+python {{scripts_dir}}/state.py control {{run_dir}} --action stop
+python {{scripts_dir}}/evaluate.py read-results {{run_dir}} --last 3
+python {{scripts_dir}}/evaluate.py stats {{run_dir}}
+python {{scripts_dir}}/usage.py summary {{run_dir}}
+```
+
+## Steps
+
+### 1. Read status
+```bash
+python {{scripts_dir}}/state.py status {{run_dir}}
+```
+
+### 2. If completed or paused
+```
+[SILENT]
+Research {{research_id}} is <completed|paused>.
+```
+
+### 3. If paused_error
+```
+⚠️ Research {{research_id}} paused due to errors.
+Experiments: <done>/<total> | Merged: <X> | Reverted: <Y>
+Say "resume research {{research_id}}" to retry.
+```
+
+### 4. If executing - CHECK SAFETY LIMITS FIRST
+```bash
+python {{scripts_dir}}/state.py check-budget {{run_dir}}
+```
+
+If ANY budget exceeded:
+```bash
+python {{scripts_dir}}/state.py control {{run_dir}} --action stop
+```
+Report the forced stop.
+
+If stalled >30min: alert. If stalled >60min: force stop.
+
+If running normally:
+```bash
+python {{scripts_dir}}/evaluate.py read-results {{run_dir}} --last 3
+python {{scripts_dir}}/usage.py summary {{run_dir}}
+```
+```
+🔬 Research {{research_id}} progress:
+Experiments: <done>/<total> | Merged: <X> | Reverted: <Y>
+Tokens: ~<total> | Est. cost: $<cost>
+Recent: <last 2-3 experiments>
+```
+
+### 5. If status.json missing
+```
+⚠️ Research {{research_id}} - cannot read status. May have crashed.
+```
+
+## RULES
+- [SILENT] ONLY for completed/paused.
+- Budget enforcement is NON-NEGOTIABLE.
+- Stall >60min = force stop.
+- Keep responses SHORT.

--- a/skills/research/autoresearch/test_e2e.py
+++ b/skills/research/autoresearch/test_e2e.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""End-to-end test for autoresearch helper scripts.
+
+Tests Mode 2 (Knowledge Research) flow:
+  init -> plan -> branch -> work(echo) -> evaluate -> merge -> branch -> evaluate(revert) -> report
+
+Returns JSON with pass/fail per step.
+"""
+import json, os, sys, shutil, subprocess, tempfile
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).parent / "scripts"
+PASS, FAIL = [], []
+
+def run(cmd, cwd=None, input_json=None):
+    """Run a python script command, return parsed JSON output."""
+    env = {**os.environ, "PYTHONPATH": str(SCRIPTS_DIR)}
+    r = subprocess.run(cmd, capture_output=True, text=True, cwd=cwd, env=env)
+    if r.returncode != 0:
+        raise RuntimeError(f"Command failed ({r.returncode}): {' '.join(cmd)}\nstderr: {r.stderr}")
+    out = r.stdout.strip()
+    # Collect all lines from first { to last } for multi-line JSON
+    first, last = out.find("{"), out.rfind("}")
+    if first == -1 or last == -1:
+        raise RuntimeError(f"No JSON output from: {' '.join(cmd)}\nstdout: {out}")
+    json_str = out[first:last+1]
+    return json.loads(json_str)
+
+def check(name, condition, detail=""):
+    if condition:
+        PASS.append(name)
+        print(f"  PASS: {name}")
+    else:
+        FAIL.append(name)
+        print(f"  FAIL: {name} -- {detail}")
+
+def main():
+    workdir = Path(tempfile.mkdtemp(prefix="autoresearch_test_"))
+    run_dir = str(workdir / "research")
+    ws_dir = run_dir + "/workspace"
+
+    print(f"Test dir: {workdir}")
+    print(f"Scripts:  {SCRIPTS_DIR}")
+    print()
+
+    # --- STEP 1: state.py init ---
+    print("=== 1. state.py init ===")
+    r = run(["python3", str(SCRIPTS_DIR/"state.py"), "init", run_dir,
+             "Test AI market", "market", "AI infrastructure", "Quick", "5"])
+    check("init status", r.get("status") == "initialized")
+    check("workspace dir", Path(r["workspace"]).exists(), "workspace not created")
+
+    # --- STEP 2: workspace.py init ---
+    print("\n=== 2. workspace.py init ===")
+    r = run(["python3", str(SCRIPTS_DIR/"workspace.py"), "init", ws_dir])
+    check("init outputs commands", "commands" in r and len(r["commands"]) >= 2)
+    # Execute the commands
+    for cmd in r["commands"]:
+        subprocess.run(cmd, shell=True, capture_output=True)
+    check("workspace is git repo", Path(ws_dir + "/.git").exists())
+    # Create initial doc
+    (Path(ws_dir) / "research.md").write_text("# AI Infrastructure Market\n\n## Overview\n\n## Players\n\n## Pricing\n\n## Trends\n")
+    subprocess.run(f"cd {ws_dir} && git add -A && git commit -m 'initial skeleton'", shell=True, capture_output=True)
+    check("initial commit", True)
+
+    # --- STEP 3: plan.py write ---
+    print("\n=== 3. plan.py write + read ---")
+    experiments = json.dumps([
+        {"id": 1, "type": "investigate", "hypothesis": "Find top AI infra providers", "target_section": "Players"},
+        {"id": 2, "type": "investigate", "hypothesis": "Compare pricing models", "target_section": "Pricing"},
+        {"id": 3, "type": "deepen", "hypothesis": "Deep dive on trending tools", "target_section": "Trends"},
+    ])
+    r = run(["python3", str(SCRIPTS_DIR/"plan.py"), "write", run_dir, experiments])
+    check("plan written", r.get("status") == "plan_written", f"got {r}")
+    check("3 experiments", r.get("count") == 3, f"count={r.get('count')}")
+
+    r = run(["python3", str(SCRIPTS_DIR/"plan.py"), "read", run_dir])
+    check("plan readable", len(r.get("experiments", [])) == 3)
+
+    # --- STEP 4: next-pending ---
+    print("\n=== 4. plan.py next-pending ===")
+    r = run(["python3", str(SCRIPTS_DIR/"plan.py"), "next-pending", run_dir])
+    check("first pending is id=1", r.get("id") == 1, f"got id={r.get('id')}")
+
+    # --- STEP 5: workspace.py branch + merge (happy path) ---
+    print("\n=== 5. workspace.py branch -> merge ===")
+    # Branch
+    r = run(["python3", str(SCRIPTS_DIR/"workspace.py"), "branch", ws_dir, "1", "ai-providers"])
+    check("branch commands generated", "commands" in r)
+    for cmd in r["commands"]:
+        subprocess.run(cmd, shell=True, capture_output=True)
+
+    # Simulate work: edit the file
+    content = Path(ws_dir + "/research.md").read_text()
+    content = content.replace("## Players\n", "## Players\n\nMajor providers: AWS, GCP, Azure, Modal, Replicate, Lambda Labs.\n")
+    Path(ws_dir + "/research.md").write_text(content)
+
+    # Evaluate
+    r = run(["python3", str(SCRIPTS_DIR/"evaluate.py"), "score", "4", "5", "3", "5", "4"])
+    check("merge decision", r.get("decision") == "MERGE", f"decision={r.get('decision')} scores: {r.get('scores')}")
+
+    # Merge
+    r = run(["python3", str(SCRIPTS_DIR/"workspace.py"), "merge", ws_dir, "1", "ai-providers", "exp 1: added providers"])
+    check("merge commands generated", "commands" in r)
+    for cmd in r["commands"]:
+        subprocess.run(cmd, shell=True, capture_output=True)
+
+    # Update plan
+    run(["python3", str(SCRIPTS_DIR/"plan.py"), "update-experiment", run_dir, "1", "merged", "--reason", "data found"])
+
+    # Log result
+    r = run(["python3", str(SCRIPTS_DIR/"evaluate.py"), "log-result", run_dir, "1",
+             "Found providers", "investigate", "Players", "MERGE", "Specific data found",
+             "--scores", "E=4,A=5,D=3,R=5,N=4"])
+    check("result logged", True)
+
+    # --- STEP 6: Branch -> REVERT path ---
+    print("\n=== 6. workspace.py branch -> revert (bad experiment) ===")
+    r = run(["python3", str(SCRIPTS_DIR/"workspace.py"), "branch", ws_dir, "2", "bad-pricing"])
+    for cmd in r["commands"]:
+        subprocess.run(cmd, shell=True, capture_output=True)
+    run(["python3", str(SCRIPTS_DIR/"plan.py"), "update-experiment", run_dir, "2", "in_progress"])
+
+    # Simulate bad work: nonsense section
+    content = Path(ws_dir + "/research.md").read_text()
+    content += "\n\n## Pricing\n\nThis section was vandalized with nonsense.\n"
+    Path(ws_dir + "/research.md").write_text(content)
+
+    # Evaluate
+    r = run(["python3", str(SCRIPTS_DIR/"evaluate.py"), "score", "1", "1", "1", "1", "1"])
+    check("revert decision (all 1s)", r.get("decision") == "REVERT", f"decision={r.get('decision')}")
+
+    # Revert
+    r = run(["python3", str(SCRIPTS_DIR/"workspace.py"), "revert", ws_dir, "2", "bad-pricing"])
+    check("revert commands generated", "commands" in r)
+    for cmd in r["commands"]:
+        subprocess.run(cmd, shell=True, capture_output=True)
+
+    run(["python3", str(SCRIPTS_DIR/"plan.py"), "update-experiment", run_dir, "2", "reverted", "--reason", "nonsense"])
+    run(["python3", str(SCRIPTS_DIR/"evaluate.py"), "log-result", run_dir, "2",
+             "Bad pricing edit", "investigate", "Pricing", "REVERT", "Low quality",
+             "--scores", "E=1,A=1,D=1,R=1,N=1"])
+
+    # --- STEP 7: state updates ---
+    print("\n=== 7. state.py update-status + checkpoint ===")
+    r = run(["python3", str(SCRIPTS_DIR/"state.py"), "update-status", run_dir, "executing",
+             "--experiments-done", "2", "--experiments-total", "3", "--experiments-merged", "1", "--experiments-reverted", "1"])
+    check("status updated", r.get("phase") == "executing", f"phase={r.get('phase')}")
+
+    r = run(["python3", str(SCRIPTS_DIR/"state.py"), "checkpoint", run_dir, "1", "3"])
+    check("checkpoint written", r.get("last_completed") == 1)
+
+    # --- STEP 8: evaluate stats ---
+    print("\n=== 8. evaluate.py stats + read-results ===")
+    r = run(["python3", str(SCRIPTS_DIR/"evaluate.py"), "stats", run_dir])
+    check("stats merged=1", r.get("merged") == 1, f"merged={r.get('merged')}")
+    check("stats reverted=1", r.get("reverted") == 1, f"reverted={r.get('reverted')}")
+
+    # read-results outputs plain text, not JSON
+    env = {**os.environ, "PYTHONPATH": str(SCRIPTS_DIR)}
+    r = subprocess.run(["python3", str(SCRIPTS_DIR/"evaluate.py"), "read-results", run_dir, "--last", "5"],
+                       capture_output=True, text=True, env=env)
+    check("results readable", r.returncode == 0 and "Experiment" in r.stdout)
+
+    # --- STEP 9: budget check ---
+    print("\n=== 9. state.py check-budget ===")
+    r = run(["python3", str(SCRIPTS_DIR/"state.py"), "check-budget", run_dir, "--tokens", "100"])
+    check("budget not exceeded", not r.get("exceeded"), f"violations={r.get('violations')}")
+
+    # --- STEP 10: workspace log ---
+    print("\n=== 10. workspace.py log + status ===")
+    r = run(["python3", str(SCRIPTS_DIR/"workspace.py"), "log", ws_dir, "--oneline"])
+    check("log works", "commands" in r)
+
+    r = run(["python3", str(SCRIPTS_DIR/"state.py"), "status", run_dir])
+    check("status readable", r.get("phase") == "executing")
+
+    # --- STEP 11: report.py ---
+    print("\n=== 11. report.py generate + summary ===")
+    r = run(["python3", str(SCRIPTS_DIR/"report.py"), "generate", run_dir])
+    check("report generated", r.get("status") == "generated", f"got {r}")
+    check("report file exists", Path(r["path"]).exists())
+
+    report = Path(r["path"]).read_text()
+    check("report has title", "# Research Report:" in report)
+    check("report has experiments", "Merged Experiments" in report)
+    check("report has reverted", "Reverted Experiments" in report)
+
+    r = run(["python3", str(SCRIPTS_DIR/"report.py"), "summary", run_dir])
+    check("summary generated", "summary" in r)
+
+    # --- STEP 12: usage.py track ---
+    print("\n=== 12. usage.py track + summary ===")
+    r = run(["python3", str(SCRIPTS_DIR/"usage.py"), "track", run_dir, "1", "5000", "3000"])
+    check("usage tracked", r.get("status") == "tracked")
+
+    r = run(["python3", str(SCRIPTS_DIR/"usage.py"), "summary", run_dir])
+    check("usage summary works", True)
+
+    # --- STEP 13: state.py control ---
+    print("\n=== 13. state.py control + read-control ===")
+    run(["python3", str(SCRIPTS_DIR/"state.py"), "control", run_dir, "--action", "pause"])
+    r = run(["python3", str(SCRIPTS_DIR/"state.py"), "read-control", run_dir])
+    check("control shows pause", r.get("action") == "pause", f"action={r.get('action')}")
+
+    # Reset
+    run(["python3", str(SCRIPTS_DIR/"state.py"), "control", run_dir, "--action", "none"])
+
+    # --- SUMMARY ---
+    print(f"\n{'='*50}")
+    print(f"Results: {len(PASS)} passed, {len(FAIL)} failed out of {len(PASS)+len(FAIL)}")
+    if FAIL:
+        print(f"FAILED: {', '.join(FAIL)}")
+        sys.exit(1)
+    else:
+        print("ALL TESTS PASSED")
+
+    # Cleanup
+    shutil.rmtree(workdir, ignore_errors=True)
+
+if __name__ == "__main__":
+    main()

--- a/skills/research/autoresearch/test_integration.py
+++ b/skills/research/autoresearch/test_integration.py
@@ -1,0 +1,567 @@
+#!/usr/bin/env python3
+"""Integration tests for autoresearch helper scripts and templates.
+
+Tests:
+1. state.py - init, status, update, checkpoint, control, budget
+2. plan.py - write, read, update, add experiment
+3. evaluate.py - score, log-result, stats, results reading
+4. workspace.py - init, branch, merge, revert, git operations
+5. report.py - generate, summary
+6. registry.py - register, list, get
+7. usage.py - track, summary
+8. Template rendering - cron_prompt.md variable substitution
+9. SKILL.md - validates references to all scripts and templates
+10. Full end-to-end loop (knowledge research mode)
+
+Run: pip install pytest && pytest test_integration.py -v
+Or:  python test_integration.py
+"""
+import json, os, sys, subprocess, tempfile, shutil, unittest
+from pathlib import Path
+
+BASE_DIR = Path(__file__).parent
+SCRIPTS_DIR = BASE_DIR / "scripts"
+TEMPLATES_DIR = BASE_DIR / "templates"
+
+class AutoresearchTestBase(unittest.TestCase):
+    """Creates a temporary run directory for each test."""
+    
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="autoresearch_test_")
+        self.run_dir = os.path.join(self.tmp, "research")
+        self.ws_dir = os.path.join(self.run_dir, "workspace")
+        os.makedirs(self.run_dir)
+    
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+    
+    def run_helper(self, script, *args):
+        """Run a helper script and return parsed JSON output."""
+        cmd = ["python3", str(SCRIPTS_DIR / f"{script}.py")] + [str(a) for a in args]
+        env = {**os.environ, "PYTHONPATH": str(SCRIPTS_DIR)}
+        r = subprocess.run(cmd, capture_output=True, text=True, env=env)
+        self.assertEqual(r.returncode, 0, f"Script {script} failed: {r.stderr}")
+        out = r.stdout.strip()
+        first, last = out.find('{'), out.rfind('}')
+        if first == -1 or last == -1:
+            return {"_raw": out}
+        return json.loads(out[first:last+1])
+    
+    def workspace_init(self):
+        """Initialize the git workspace and return True."""
+        os.makedirs(self.ws_dir, exist_ok=True)
+        cmds_result = self.run_helper("workspace", "init", self.ws_dir)
+        self.assertIn("commands", cmds_result)
+        for cmd in cmds_result["commands"]:
+            subprocess.run(cmd, shell=True, capture_output=True, text=True, cwd=self.ws_dir)
+        # Verify git repo
+        git_dir = os.path.join(self.ws_dir, ".git")
+        self.assertTrue(os.path.exists(git_dir))
+        # Ensure default branch is main
+        r = subprocess.run("git branch --show-current", shell=True, capture_output=True, text=True, cwd=self.ws_dir)
+        self.assertEqual(r.stdout.strip(), "main")
+        return True
+
+
+class TestState(AutoresearchTestBase):
+    """Test state.py operations."""
+    
+    def test_init_creates_files(self):
+        result = self.run_helper("state", "init", self.run_dir, "Test goal", "test", "scope", "quick", "5")
+        self.assertEqual(result["status"], "initialized")
+        for fname in ["config.json", "status.json", "control.json", "plan.json"]:
+            self.assertTrue(os.path.exists(os.path.join(self.run_dir, fname)), f"{fname} not created")
+        self.assertTrue(os.path.exists(os.path.join(self.run_dir, "results.log")), "results.log not created")
+    
+    def test_status_readable(self):
+        self.run_helper("state", "init", self.run_dir, "Test", "test", "scope", "quick", "3")
+        result = self.run_helper("state", "status", self.run_dir)
+        self.assertIn("phase", result)
+        self.assertEqual(result["phase"], "planning")
+        self.assertEqual(result["experiments_total"], 0)
+    
+    def test_update_status(self):
+        self.run_helper("state", "init", self.run_dir, "Test", "test", "scope", "quick", "5")
+        result = self.run_helper("state", "update-status", self.run_dir, "executing", "--experiments-done", "3", "--merged", "2")
+        self.assertEqual(result["phase"], "executing")
+        self.assertEqual(result["experiments_done"], 3)
+        self.assertEqual(result["experiments_merged"], 2)
+    
+    def test_control_write_and_read(self):
+        self.run_helper("state", "init", self.run_dir, "Test", "test", "scope", "quick", "3")
+        self.run_helper("state", "control", self.run_dir, "--action", "pause", "--addendum", "testing")
+        result = self.run_helper("state", "read-control", self.run_dir)
+        self.assertEqual(result["action"], "pause")
+        self.assertIn("addendum", result)
+    
+    def test_checkpoint(self):
+        self.run_helper("state", "init", self.run_dir, "Test", "test", "scope", "quick", "3")
+        result = self.run_helper("state", "checkpoint", self.run_dir, "5", "6")
+        self.assertEqual(result["last_completed"], 5)
+        self.assertEqual(result["next"], 6)
+        read = self.run_helper("state", "read-checkpoint", self.run_dir)
+        self.assertEqual(read["last_completed"], 5)
+    
+    def test_budget_not_exceeded(self):
+        self.run_helper("state", "init", self.run_dir, "Test", "test", "scope", "quick", "10")
+        result = self.run_helper("state", "check-budget", self.run_dir, "--tokens", "100000")
+        self.assertFalse(result["exceeded"])
+        self.assertEqual(result["violations"], [])
+    
+    def test_budget_time_exceeded(self):
+        # Manipulate config to have a 1-minute max duration set in the past
+        self.run_helper("state", "init", self.run_dir, "Test", "test", "scope", "quick", "3")
+        config_path = os.path.join(self.run_dir, "config.json")
+        with open(config_path) as f:
+            config = json.load(f)
+        config["max_duration_minutes"] = 1
+        # Set created to 10 minutes ago
+        from datetime import datetime, timezone, timedelta
+        config["created"] = (datetime.now(timezone.utc) - timedelta(minutes=10)).isoformat()
+        with open(config_path, "w") as f:
+            json.dump(config, f)
+        
+        result = self.run_helper("state", "check-budget", self.run_dir, "--tokens", "100000")
+        self.assertTrue(result["exceeded"])
+        self.assertIn("time_exceeded", result["violations"][0])
+    
+    def test_budget_hard_cap_exceeded(self):
+        self.run_helper("state", "init", self.run_dir, "Test", "test", "scope", "quick", "3")
+        # Set experiments_done to exceed hard cap
+        status_path = os.path.join(self.run_dir, "status.json")
+        self.run_helper("state", "update-status", self.run_dir, "executing", "--experiments-done", "10")
+        
+        result = self.run_helper("state", "check-budget", self.run_dir, "--tokens", "100000")
+        self.assertTrue(result["exceeded"])
+
+
+class TestPlan(AutoresearchTestBase):
+    """Test plan.py operations."""
+    
+    def test_write_and_read(self):
+        experiments = json.dumps([
+            {"id": 1, "type": "investigate", "hypothesis": "test1", "target_section": "Section1"},
+            {"id": 2, "type": "deepen", "hypothesis": "test2", "target_section": "Section2"},
+        ])
+        result = self.run_helper("plan", "write", self.run_dir, experiments)
+        self.assertEqual(result["status"], "plan_written")
+        self.assertEqual(result["count"], 2)
+        
+        read = self.run_helper("plan", "read", self.run_dir)
+        self.assertEqual(len(read["experiments"]), 2)
+    
+    def test_next_pending(self):
+        exps = json.dumps([{"id":1,"type":"investigate","hypothesis":"h1","target_section":"s1"}])
+        self.run_helper("plan", "write", self.run_dir, exps)
+        result = self.run_helper("plan", "next-pending", self.run_dir)
+        self.assertEqual(result["id"], 1)
+        self.assertEqual(result["status"], "pending")
+    
+    def test_update_experiment(self):
+        exps = json.dumps([{"id":1,"type":"investigate","hypothesis":"h1","target_section":"s1"}])
+        self.run_helper("plan", "write", self.run_dir, exps)
+        self.run_helper("plan", "update-experiment", self.run_dir, 1, "merged", "--reason", "tested")
+        result = self.run_helper("plan", "next-pending", self.run_dir)
+        self.assertEqual(result["status"], "all_done")
+    
+    def test_add_experiment(self):
+        exps = json.dumps([{"id":1,"type":"investigate","hypothesis":"h1","target_section":"s1"}])
+        self.run_helper("plan", "write", self.run_dir, exps)
+        self.run_helper("plan", "add-experiment", self.run_dir, "deepen", "new hypothesis", "Section1")
+        read = self.run_helper("plan", "read", self.run_dir)
+        self.assertEqual(len(read["experiments"]), 2)
+        self.assertEqual(read["experiments"][1]["type"], "deepen")
+    
+    def test_summary(self):
+        exps = json.dumps([
+            {"id":1,"type":"investigate","hypothesis":"h1","target_section":"s1","status":"merged"},
+            {"id":2,"type":"deepen","hypothesis":"h2","target_section":"s2","status":"reverted"},
+            {"id":3,"type":"investigate","hypothesis":"h3","target_section":"s3","status":"pending"},
+        ])
+        self.run_helper("plan", "write", self.run_dir, exps)
+        result = self.run_helper("plan", "summary", self.run_dir)
+        self.assertEqual(result["by_status"]["merged"], 1)
+        self.assertEqual(result["by_status"]["reverted"], 1)
+        self.assertEqual(result["by_status"]["pending"], 1)
+
+
+class TestEvaluate(AutoresearchTestBase):
+    """Test evaluate.py scoring and result tracking."""
+    
+    def test_knowledge_scoring_merge(self):
+        result = self.run_helper("evaluate", "score", "4", "5", "4", "4", "4")
+        self.assertGreaterEqual(result["scores"]["total"], 13)
+        self.assertEqual(result["decision"], "MERGE")
+    
+    def test_knowledge_scoring_revert_low_total(self):
+        result = self.run_helper("evaluate", "score", "2", "2", "2", "2", "2")
+        self.assertEqual(result["decision"], "REVERT")
+    
+    def test_knowledge_scoring_revert_no_evidence(self):
+        result = self.run_helper("evaluate", "score", "1", "5", "5", "5", "5")
+        self.assertEqual(result["decision"], "REVERT")  # Evidence=1 -> auto reject
+    
+    def test_knowledge_scoring_revert_no_improvement(self):
+        result = self.run_helper("evaluate", "score", "4", "5", "4", "5", "1")
+        self.assertEqual(result["decision"], "REVERT")  # Net improvement=1
+    
+    def test_borderline_reject_weak_evidence(self):
+        result = self.run_helper("evaluate", "score", "2", "4", "4", "2", "4")
+        self.assertEqual(result["decision"], "REVERT")  # Total 16 but weak evidence/relevance
+    
+    def test_log_and_read_results(self):
+        self.run_helper("evaluate", "log-result", self.run_dir, 1, "Test result", "investigate", "Section1", "MERGE", "Good findings")
+        result = self.run_helper("evaluate", "read-results", self.run_dir)
+        self.assertIn("Experiment 1", result.get("_raw", ""))
+    
+    def test_stats_after_logging(self):
+        self.run_helper("evaluate", "log-result", self.run_dir, 1, "merged", "investigate", "S1", "MERGE", "good")
+        self.run_helper("evaluate", "log-result", self.run_dir, 2, "reverted", "investigate", "S2", "REVERT", "bad")
+        stats = self.run_helper("evaluate", "stats", self.run_dir)
+        self.assertEqual(stats["merged"], 1)
+        self.assertEqual(stats["reverted"], 1)
+        self.assertEqual(stats["merge_rate"], "50%")
+    
+    def test_ml_scoring_improve(self):
+        result = self.run_helper("evaluate", "score", "4", "5", "4", "4", "5")
+        self.assertEqual(result["decision"], "MERGE")
+    
+    def test_ml_scoring_worse(self):
+        result = self.run_helper("evaluate", "score", "2", "1", "2", "2", "1")
+        self.assertLess(result["scores"]["total"], 13)
+
+
+class TestWorkspace(AutoresearchTestBase):
+    """Test workspace.py git operations."""
+    
+    def test_init_creates_git_repo(self):
+        self.workspace_init()
+        self.assertTrue(os.path.exists(os.path.join(self.ws_dir, ".git")))
+    
+    def test_branch_and_merge(self):
+        self.workspace_init()
+        # Initial commit
+        with open(os.path.join(self.ws_dir, "research.md"), "w") as f:
+            f.write("# Research\n\n## Section 1\n\n")
+        subprocess.run("git add -A && git commit -m 'init'", shell=True, capture_output=True, cwd=self.ws_dir)
+        
+        # Branch
+        result = self.run_helper("workspace", "branch", self.ws_dir, 1, "test-branch")
+        self.assertIn("commands", result)
+        for cmd in result["commands"]:
+            subprocess.run(cmd, shell=True, capture_output=True, text=True, cwd=self.ws_dir)
+        
+        # Verify on new branch
+        r = subprocess.run("git branch --show-current", shell=True, capture_output=True, text=True, cwd=self.ws_dir)
+        self.assertIn("exp_1", r.stdout.strip())
+        
+        # Merge
+        merge_result = self.run_helper("workspace", "merge", self.ws_dir, 1, "test-branch", "exp 1: test")
+        self.assertIn("commands", merge_result)
+        for cmd in merge_result["commands"]:
+            subprocess.run(cmd, shell=True, capture_output=True, text=True, cwd=self.ws_dir)
+        
+        # Back on main
+        r = subprocess.run("git branch --show-current", shell=True, capture_output=True, text=True, cwd=self.ws_dir)
+        self.assertEqual(r.stdout.strip(), "main")
+    
+    def test_revert_deletes_branch(self):
+        self.workspace_init()
+        with open(os.path.join(self.ws_dir, "research.md"), "w") as f:
+            f.write("# Research\n")
+        subprocess.run("git add -A && git commit -m 'init'", shell=True, capture_output=True, cwd=self.ws_dir)
+        
+        self.run_helper("workspace", "branch", self.ws_dir, 1, "bad-exp")
+        # Execute branch commands
+        result = self.run_helper("workspace", "branch", self.ws_dir, 1, "bad-exp")
+        for cmd in result["commands"]:
+            subprocess.run(cmd, shell=True, capture_output=True, cwd=self.ws_dir)
+        
+        # Revert
+        revert_result = self.run_helper("workspace", "revert", self.ws_dir, 1, "bad-exp")
+        for cmd in revert_result["commands"]:
+            subprocess.run(cmd, shell=True, capture_output=True, cwd=self.ws_dir)
+        
+        # Branch should be deleted
+        r = subprocess.run("git branch", shell=True, capture_output=True, text=True, cwd=self.ws_dir)
+        branches = r.stdout.strip().split("\n")
+        self.assertNotIn("exp_1_bad_exp", [b.strip() for b in branches])
+    
+    def test_branch_name_sanitization(self):
+        result = self.run_helper("workspace", "branch-name", 1, "Some Complex/Topic Here!")
+        self.assertTrue(result["_raw"].startswith("exp_1_"))
+        self.assertNotIn("/", result["_raw"])
+        self.assertNotIn(" ", result["_raw"])
+
+
+class TestReport(AutoresearchTestBase):
+    """Test report.py generation."""
+    
+    def setUp(self):
+        super().setUp()
+        # Create a minimal state for report generation
+        self.run_helper("state", "init", self.run_dir, "Test Report", "test", "scope", "quick", "3")
+        self.run_helper("plan", "write", self.run_dir, json.dumps([
+            {"id":1,"type":"investigate","hypothesis":"h1","target_section":"s1"}
+        ]))
+        # Log some results
+        self.run_helper("evaluate", "log-result", self.run_dir, 1, "Merged exp", "investigate", "s1", "MERGE", "good")
+    
+    def test_generate_report(self):
+        result = self.run_helper("report", "generate", self.run_dir)
+        self.assertEqual(result["status"], "generated")
+        report_path = Path(result["path"])
+        self.assertTrue(report_path.exists())
+        content = report_path.read_text()
+        self.assertIn("Test Report", content)
+        self.assertIn("Merged Experiments", content)
+    
+    def test_summary(self):
+        result = self.run_helper("report", "summary", self.run_dir)
+        self.assertIn("summary", result)
+
+
+class TestRegistry(AutoresearchTestBase):
+    """Test registry.py multi-user tracking using HERMES_HOME pointed at temp dir."""
+
+    def run_registry(self, *args):
+        """Run registry.py with HERMES_HOME pointed at the temp directory."""
+        cmd = ["python3", str(SCRIPTS_DIR / "registry.py")] + [str(a) for a in args]
+        env = {**os.environ, "PYTHONPATH": str(SCRIPTS_DIR), "HERMES_HOME": self.tmp}
+        r = subprocess.run(cmd, capture_output=True, text=True, env=env)
+        self.assertEqual(r.returncode, 0, f"registry.py failed: {r.stderr}")
+        out = r.stdout.strip()
+        first, last = out.find('{'), out.rfind('}')
+        if first == -1 or last == -1:
+            return {"_raw": out}
+        return json.loads(out[first:last+1])
+
+    def test_register_and_get(self):
+        result = self.run_registry("register", "test_001", "user1", "telegram", "chat1", "Test goal", "cron_123")
+        self.assertEqual(result["status"], "registered")
+
+        result = self.run_registry("get", "test_001")
+        self.assertEqual(result["research_id"], "test_001")
+        self.assertEqual(result["user_id"], "user1")
+        self.assertIn(self.tmp, result["run_dir"])
+
+    def test_list_runs(self):
+        self.run_registry("register", "run_a", "user1", "telegram", "c1", "Goal A", "cron_a")
+        self.run_registry("register", "run_b", "user2", "slack", "c2", "Goal B", "cron_b")
+
+        result = self.run_registry("list")
+        self.assertEqual(result["count"], 2)
+
+        result = self.run_registry("list", "--user-id", "user1")
+        self.assertEqual(result["count"], 1)
+
+    def test_remove_run(self):
+        self.run_registry("register", "rm_test", "u1", "tg", "c1", "Goal", "cron_x")
+        result = self.run_registry("remove", "rm_test")
+        self.assertEqual(result["status"], "removed")
+
+        result = self.run_registry("list")
+        self.assertEqual(result["count"], 0)
+
+    def test_find_by_job(self):
+        self.run_registry("register", "find_test", "u1", "tg", "c1", "Goal", "cron_42", "--watchdog-job-id", "watch_42")
+
+        result = self.run_registry("find-by-job", "cron_42")
+        self.assertEqual(result["research_id"], "find_test")
+
+        result = self.run_registry("find-by-job", "watch_42")
+        self.assertEqual(result["research_id"], "find_test")
+
+    def test_hermes_home_respected(self):
+        """Verify registry writes to HERMES_HOME, not ~/.hermes."""
+        self.run_registry("register", "home_test", "u1", "tg", "c1", "Goal", "cron_99")
+        reg_path = os.path.join(self.tmp, "autoresearch", "registry.json")
+        self.assertTrue(os.path.exists(reg_path), "Registry not written under HERMES_HOME")
+
+
+class TestTemplates(unittest.TestCase):
+    """Test that templates reference correct script names and contain all phases."""
+    
+    def test_cron_prompt_references_all_scripts(self):
+        template_path = TEMPLATES_DIR / "cron_prompt.md"
+        self.assertTrue(template_path.exists(), "cron_prompt.md not found")
+        content = open(template_path).read()
+        for script in ["state.py", "plan.py", "evaluate.py", "workspace.py", "report.py"]:
+            self.assertIn(script, content, f"cron_prompt.md missing reference to {script}")
+    
+    def test_cron_prompt_has_all_phases(self):
+        content = open(TEMPLATES_DIR / "cron_prompt.md").read()
+        for phase in ["PHASE 1", "PHASE 2", "PHASE 3", "PHASE 4"]:
+            self.assertIn(phase, content, f"cron_prompt.md missing {phase}")
+    
+    def test_watchdog_prompt_references_scripts(self):
+        content = open(TEMPLATES_DIR / "watchdog_prompt.md").read()
+        for script in ["state.py", "evaluate.py", "usage.py"]:
+            self.assertIn(script, content, f"watchdog_prompt.md missing {script}")
+    
+    def test_resume_prompt_references_scripts(self):
+        content = open(TEMPLATES_DIR / "resume_prompt.md").read()
+        for script in ["state.py", "plan.py", "evaluate.py"]:
+            self.assertIn(script, content, f"resume_prompt.md missing {script}")
+    
+    def test_no_syntax_errors_in_state_py(self):
+        env = {**os.environ, "PYTHONPATH": str(SCRIPTS_DIR)}
+        result = subprocess.run(f"python3 -m py_compile {SCRIPTS_DIR}/state.py", shell=True, capture_output=True, text=True, env=env)
+        self.assertEqual(result.returncode, 0, f"state.py syntax error: {result.stderr}")
+
+    def test_all_scripts_compile(self):
+        env = {**os.environ, "PYTHONPATH": str(SCRIPTS_DIR)}
+        for script in ["_util.py", "state.py", "plan.py", "evaluate.py", "workspace.py", "report.py", "registry.py", "usage.py"]:
+            result = subprocess.run(f"python3 -m py_compile {SCRIPTS_DIR}/{script}", shell=True, capture_output=True, text=True, env=env)
+            self.assertEqual(result.returncode, 0, f"{script} syntax error: {result.stderr}")
+
+
+class TestSkillDoc(AutoresearchTestBase):
+    """Test SKILL.md consistency with actual files."""
+    
+    def test_skill_references_existing_scripts(self):
+        skill_path = BASE_DIR / "SKILL.md"
+        content = open(skill_path).read()
+        for script in ["state.py", "plan.py", "evaluate.py", "workspace.py", "report.py", "registry.py", "usage.py"]:
+            self.assertIn(script, content, f"SKILL.md missing reference to {script}")
+    
+    def test_skill_references_existing_templates(self):
+        content = open(BASE_DIR / "SKILL.md").read()
+        for template in ["cron_prompt", "watchdog_prompt", "resume_prompt"]:
+            self.assertIn(template, content, f"SKILL.md missing reference to {template}")
+    
+    def test_all_referred_scripts_exist(self):
+        content = open(BASE_DIR / "SKILL.md").read()
+        for script in ["state.py", "plan.py", "evaluate.py", "workspace.py", "report.py", "registry.py", "usage.py"]:
+            script_path = SCRIPTS_DIR / script
+            self.assertTrue(script_path.exists(), f"SKILL.md references {script} but file doesn't exist")
+
+
+class TestFullE2E(AutoresearchTestBase):
+    """End-to-end test: full knowledge research loop with 3 experiments."""
+    
+    def test_full_knowledge_research_loop(self):
+        # Initialize
+        self.run_helper("state", "init", self.run_dir, "E2E Test", "test", "scope", "quick", "3")
+        
+        # Init workspace
+        self.workspace_init()
+        
+        # Create initial document and commit
+        with open(os.path.join(self.ws_dir, "research.md"), "w") as f:
+            f.write("# E2E Test Research\n\n## Section 1\n\n## Section 2\n\n## Section 3\n")
+        subprocess.run("git add -A && git commit -m 'initial skeleton'", shell=True, capture_output=True, cwd=self.ws_dir)
+        
+        # Write plan
+        exps = json.dumps([
+            {"id":1,"type":"investigate","hypothesis":"Fill section 1 with real data","target_section":"Section 1"},
+            {"id":2,"type":"investigate","hypothesis":"Fill section 2 with real data","target_section":"Section 2"},
+            {"id":3,"type":"synthesize","hypothesis":"Synthesize findings","target_section":"Section 3"},
+        ])
+        self.run_helper("plan", "write", self.run_dir, exps)
+        self.run_helper("state", "update-status", self.run_dir, "executing", "--experiments-total", "3")
+        
+        # Experiment loop
+        merged_total = 0
+        reverted_total = 0
+        for exp_id in [1, 2, 3]:
+            # Branch
+            result = self.run_helper("workspace", "branch", self.ws_dir, exp_id, f"exp{exp_id}")
+            for cmd in result["commands"]:
+                subprocess.run(cmd, shell=True, capture_output=True, cwd=self.ws_dir)
+            
+            self.run_helper("plan", "update-experiment", self.run_dir, exp_id, "in_progress")
+            
+            # Simulate work: add content to research.md
+            current_content = Path(os.path.join(self.ws_dir, "research.md")).read_text()
+            new_content = current_content.replace(f"## Section {exp_id}\n", f"## Section {exp_id}\n\nThis section has been filled with researched data and evidence for experiment {exp_id}.\n")
+            Path(os.path.join(self.ws_dir, "research.md")).write_text(new_content)
+            
+            # Commit the change
+            subprocess.run(f"git add -A && git commit -m 'exp {exp_id}'", shell=True, capture_output=True, cwd=self.ws_dir)
+            
+            # Score (all good experiments)
+            score_result = self.run_helper("evaluate", "score", "4", "4", "4", "4", "4")
+            self.assertEqual(score_result["decision"], "MERGE")
+            
+            # Merge
+            merge_result = self.run_helper("workspace", "merge", self.ws_dir, exp_id, f"exp{exp_id}", f"Completed experiment {exp_id}")
+            for cmd in merge_result["commands"]:
+                subprocess.run(cmd, shell=True, capture_output=True, cwd=self.ws_dir)
+            
+            self.run_helper("plan", "update-experiment", self.run_dir, exp_id, "merged", "--reason", f"Experiment {exp_id} completed")
+            self.run_helper("evaluate", "log-result", self.run_dir, exp_id, f"Experiment {exp_id}", "investigate", f"Section {exp_id}", "MERGE", "Good data", "--scores", "E=4,A=4,D=4,R=4,N=4")
+            merged_total += 1
+            
+            # Update status
+            self.run_helper("state", "update-status", self.run_dir, "executing",
+                           "--experiments-done", str(exp_id),
+                           "--experiments-merged", str(merged_total))
+        
+        # Also test a revert path
+        result = self.run_helper("workspace", "branch", self.ws_dir, 99, "bad-exp")
+        for cmd in result["commands"]:
+            subprocess.run(cmd, shell=True, capture_output=True, cwd=self.ws_dir)
+        
+        # Simulate bad work
+        current_content = Path(os.path.join(self.ws_dir, "research.md")).read_text()
+        Path(os.path.join(self.ws_dir, "research.md")).write_text(current_content + "\n\n# VANDALISM\n\nThis is bad content.\n")
+        subprocess.run("git add -A && git commit -m 'bad'", shell=True, capture_output=True, cwd=self.ws_dir)
+        
+        # Score - should be bad
+        score_result = self.run_helper("evaluate", "score", "1", "1", "1", "1", "1")
+        self.assertEqual(score_result["decision"], "REVERT")
+        
+        # Revert
+        revert_result = self.run_helper("workspace", "revert", self.ws_dir, 99, "bad-exp")
+        for cmd in revert_result["commands"]:
+            subprocess.run(cmd, shell=True, capture_output=True, cwd=self.ws_dir)
+        
+        # Verify we're back on main and vandalism is gone
+        current_content = Path(os.path.join(self.ws_dir, "research.md")).read_text()
+        self.assertNotIn("VANDALISM", current_content)
+        reverted_total = 1
+        
+        # Final state update
+        self.run_helper("state", "update-status", self.run_dir, "complete", "--experiments-done", "4", "--merged", "3", "--reverted", "1")
+        
+        # Generate report
+        report_result = self.run_helper("report", "generate", self.run_dir)
+        self.assertEqual(report_result["status"], "generated")
+        
+        report_content = Path(report_result["path"]).read_text()
+        self.assertIn("E2E Test", report_content)
+        self.assertIn("Merged Experiments", report_content)
+        
+        # Verify final status
+        final_status = self.run_helper("state", "status", self.run_dir)
+        self.assertEqual(final_status["phase"], "complete")
+        self.assertEqual(final_status["experiments_merged"], 3)
+        self.assertEqual(final_status["experiments_reverted"], 1)
+        
+        # Verify git log has all merges
+        log_result = self.run_helper("workspace", "log", self.ws_dir)
+        self.assertIn("commands", log_result)
+    
+    def test_budget_enforcement(self):
+        """Test that budget check correctly blocks after max experiments."""
+        self.run_helper("state", "init", self.run_dir, "Budget Test", "test", "scope", "quick", "3")
+        
+        # Set experiments_done above hard cap
+        self.run_helper("state", "update-status", self.run_dir, "executing", "--experiments-done", "20")
+        
+        result = self.run_helper("state", "check-budget", self.run_dir, "--tokens", "100000")
+        self.assertTrue(result["exceeded"])
+        
+        # Find the experiments_exceeded violation
+        violations = result["violations"]
+        found = False
+        for v in violations:
+            if "experiments_exceeded" in v:
+                found = True
+                break
+        self.assertTrue(found, f"Expected experiments_exceeded in violations: {violations}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Adds the [autoresearch](https://github.com/karpathy/autoresearch) pattern as a native Hermes skill: autonomous background research using a **branch → experiment → evaluate → merge/revert** git loop. Zero external dependencies.

## What It Does

1. **Initialize** — Creates run directory with state files (config, status, plan, control, checkpoint)
2. **Plan** — Breaks research goal into experiments (investigate, deepen, verify, synthesize)
3. **Loop** — For each experiment:
   - `git checkout -b exp_N` from main
   - Do the work (modify code, gather data, train ML)
   - Evaluate: deterministic metric (ML) or self-eval rubric (knowledge)
   - **Merge** if improved / **Revert** if worse
4. **Report** — Markdown report with findings, experiment log, token usage

## Supported Flows

**Flow 1 — ML/Code Optimization**: Iterate on train.py, try different models/hyperparameters, keep only what beats baseline. Evaluation is deterministic: metric comparison (val_bpb, accuracy, latency). Example: "Optimize this random forest classifier on the wine dataset."

**Flow 2 — Knowledge Research**: Build research.md via web research. Self-eval rubric: evidence (1-5), accuracy (1-5), depth (1-5), relevance (1-5), net improvement (1-5). Total >= 13 with evidence >= 3 and relevance >= 3 → merge. Example: "Research the AI coding agents market — pricing, features, market share."

**Flow 3 — Code Analysis/Security Audit**: Analyze a codebase for issues using static analysis. Experiments add findings with file paths, line numbers, and code snippets. Only merges with concrete evidence. Example: "Audit this repo for OWASP top 10 vulnerabilities."

**Flow 4 — Recurring Competitive Intelligence**: Weekly cron that checks for competitor changes, merges only genuinely new findings. Same knowledge rubric but experiments focus on delta from last run. Example: "Track weekly changes in competitor pricing pages."

**Flow 5 — Product Requirements / Spec Refinement**: Start with a rough PRD, iteratively refine via research on feasibility, competitors, and market gaps. Each experiment deepens a section. Example: "Refine this PRD for a developer tools product."

## Architecture

```
skills/research/autoresearch/
├── SKILL.md                    # Skill definition and trigger conditions
├── scripts/                    # 8 helper scripts (stdlib Python only)
│   ├── _util.py                # Shared atomic write, JSON I/O, HERMES_HOME
│   ├── state.py                # Atomic JSON I/O, budget enforcement
│   ├── plan.py                 # Experiment CRUD (investigate/deepen/verify/synthesize)
│   ├── evaluate.py             # Scoring rubric + ML metric comparison
│   ├── workspace.py            # Git branch/merge/revert operations
│   ├── report.py               # Markdown report generation from results.log
│   ├── registry.py             # Multi-user run tracking
│   └── usage.py                # Token/cost tracking via SessionDB
├── templates/
│   ├── cron_prompt.md          # Main loop (4 phases: setup, planning, loop, synthesis)
│   ├── watchdog_prompt.md      # Progress monitor (every 15 min)
│   └── resume_prompt.md        # Resume from checkpoint
├── test_e2e.py                 # 32 assertions
└── test_integration.py         # 44 tests, 10 classes
```

## Testing
- **test_integration.py**: 44 tests, 10 classes — ALL PASSING
- **test_e2e.py**: 32 assertions — ALL PASSING
- **Full loop simulation**: 83 assertions (init → plan → 6 experiments → pause/resume → budget enforcement → report) — ALL PASSING
- **P1 fix tests**: 17 assertions (token auto-read from usage.json, tier param enforcement) — ALL PASSING
- Mode 1 (ML): Wine dataset RF baseline 100%, 6 experiments all correctly evaluated
- Mode 2 (Knowledge): AI coding agents analysis, 6 experiments merged, 450-line report

**What's tested**: All helper scripts, the full Phase 1→4 loop (init, plan, branch, evaluate, merge/revert, pause/resume, budget enforcement, report generation, registry, usage tracking), template variable references, git history integrity.

**What needs live validation**: The actual cron scheduling + gateway delivery path — i.e. launching via `cronjob()`, watchdog firing every 15min, and final report auto-delivery. This requires a persistent Hermes gateway with cron enabled. The skill uses the existing cron system as-is (no modifications to it), so the integration risk is low.

## How to Use

Launch from any Hermes Agent session:
```
cronjob(action="create", name="research-<id>", schedule="1m",
        skills=["autoresearch"], prompt=<filled_template>, deliver="origin")
```

## Key Implementation Details

- **state.py**: tempfile.mkstemp + os.replace for atomic writes. Budget checks auto-read usage.json for token enforcement. control.json read before every loop iteration.
- **workspace.py**: git init with initial empty commit so main branch exists immediately. shlex.quote() on all shell-interpolated values. Outputs commands for agent to execute.
- **evaluate.py**: Two scoring paths - score_knowledge(evidence, accuracy, depth, relevance, net_improvement) for knowledge, score_ml(metric_value, prev_best) for ML.
- **report.py**: Parses results.log for merge/revert decisions, reads usage.json for token counts. Summary shows top findings when merged > 0.
- **registry.py / usage.py**: Respect HERMES_HOME env var for non-default profiles and test environments.
- **cron_prompt.md**: Passes --max-duration and --max-tokens to state.py init so Quick/Deep/Unlimited tiers get correct budget limits.
- **Zero dependencies**: All stdlib Python. No changes to core Hermes.

## Related
- Issue: #5114
- Supersedes: #5112
- Inspired by: [karpathy/autoresearch](https://github.com/karpathy/autoresearch)
- Related: #492, #404, #375

## Contribution
- [x] I have read the contributing guidelines
- [x] I have tested my changes locally
- [x] My changes do not introduce any new warnings or errors
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally with my changes

Closes #5114 
