### PR TITLE
fix(agent): sanitize surrogate characters from Ollama model output

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5239,9 +5239,17 @@ class AIAgent:
                 except Exception:
                     pass
 
+        # Sanitize surrogates from API response content before storing.
+        # Ollama-hosted models (Kimi K2.5, GLM-5, Qwen) can return lone
+        # surrogates that crash json.dumps() when persisting or logging.
+        raw_content = assistant_message.content or ""
+        sanitized_content = _sanitize_surrogates(raw_content)
+        if reasoning_text:
+            reasoning_text = _sanitize_surrogates(reasoning_text)
+
         msg = {
             "role": "assistant",
-            "content": assistant_message.content or "",
+            "content": sanitized_content,
             "reasoning": reasoning_text,
             "finish_reason": finish_reason,
         }
@@ -6840,6 +6848,12 @@ class AIAgent:
             # manual message manipulation are always caught.
             api_messages = self._sanitize_api_messages(api_messages)
 
+            # Proactive surrogate sanitization: clean lone surrogates from tool
+            # results, session history, or prior model output before the API call.
+            # Prevents UnicodeEncodeError during json.dumps() serialization when
+            # Ollama-hosted models return invalid surrogate code points.
+            _sanitize_messages_surrogates(api_messages)
+
             # Calculate approximate request size for logging
             total_chars = sum(len(str(msg)) for msg in api_messages)
             approx_tokens = total_chars // 4  # Rough estimate: 4 chars per token
@@ -7351,7 +7365,12 @@ class AIAgent:
                     # -----------------------------------------------------------
                     if isinstance(api_error, UnicodeEncodeError) and not getattr(self, '_surrogate_sanitized', False):
                         self._surrogate_sanitized = True
-                        if _sanitize_messages_surrogates(messages):
+                        # Sanitize api_messages (the list sent to the API), not
+                        # the internal messages list.  Also sanitize messages so
+                        # surrogates don't persist in session history.
+                        found = _sanitize_messages_surrogates(api_messages)
+                        found = _sanitize_messages_surrogates(messages) or found
+                        if found:
                             self._vprint(
                                 f"{self.log_prefix}⚠️  Stripped invalid surrogate characters from messages. Retrying...",
                                 force=True,


### PR DESCRIPTION
## What does this PR do?

Fixes three gaps in the existing surrogate character sanitization that cause `UnicodeEncodeError` crashes when using Ollama-hosted models (Kimi K2.5, GLM-5, Qwen). These models can return invalid surrogate code points (U+D800-U+DFFF) that crash `json.dumps()` during UTF-8 serialization.

The existing `_sanitize_surrogates()` and `_sanitize_messages_surrogates()` functions work correctly, but they're not called in the right places:

1. **No proactive sanitization before the API call** (line 6848). Surrogates from prior model output or tool results survive in `api_messages` and crash on the next turn. Fixed by calling `_sanitize_messages_surrogates(api_messages)` after `_sanitize_api_messages()`.

2. **API responses stored without sanitization** (line 5242). Surrogates from model output persist in session history via `_build_assistant_message()`. Fixed by sanitizing `content` and `reasoning_text` before building the message dict.

3. **Retry path sanitized the wrong variable** (line 7368). The `UnicodeEncodeError` handler called `_sanitize_messages_surrogates(messages)` but the API call uses `api_messages` (a separate list). The retry would fail again with the same error. Fixed by sanitizing both `api_messages` and `messages`.

## Related Issue

Fixes #5059

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py:6848`: Added `_sanitize_messages_surrogates(api_messages)` call after `_sanitize_api_messages()` for proactive surrogate cleaning before the API call
- `run_agent.py:5242`: Sanitize `assistant_message.content` and `reasoning_text` with `_sanitize_surrogates()` before storing in message history
- `run_agent.py:7368`: Changed `_sanitize_messages_surrogates(messages)` to also sanitize `api_messages` so the retry actually cleans the list sent to the API

## How to Test

1. Set up Hermes with an Ollama-hosted model (GLM-5 or Kimi K2.5)
2. Ask the model to process a large file or have a long conversation that produces surrogate characters
3. Verify no `UnicodeEncodeError` crash occurs
4. Run `pytest tests/test_surrogate_sanitization.py` to verify existing tests still pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.3.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

This contribution was developed with AI assistance (Claude Code).

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)