### PR TITLE
fix(model_metadata): add gpt-5.x context lengths + guard against poisoned cache

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -95,7 +95,15 @@ DEFAULT_CONTEXT_LENGTHS = {
     "claude-sonnet-4.6": 1000000,
     # Catch-all for older Claude models (must sort after specific entries)
     "claude": 200000,
-    # OpenAI
+    # OpenAI — specific gpt-5.x variants BEFORE the generic catch-all
+    "gpt-5.4": 1_050_000,
+    "gpt-5.4-mini": 1_050_000,
+    "gpt-5.4-pro": 1_050_000,
+    "gpt-5.4-nano": 1_050_000,
+    "gpt-5.3-codex": 1_048_576,
+    "gpt-5.2-codex": 1_048_576,
+    "gpt-5.1-codex-max": 1_048_576,
+    "gpt-5.1-codex-mini": 1_048_576,
     "gpt-4.1": 1047576,
     "gpt-5": 128000,
     "gpt-4": 128000,
@@ -532,6 +540,20 @@ def save_context_length(model: str, base_url: str, length: int) -> None:
     cache = _load_context_cache()
     if cache.get(key) == length:
         return  # already stored
+    # Sanity guard: reject suspiciously small values for models known to have
+    # large context windows. This prevents max_output_tokens (e.g. 32k for
+    # gpt-5.4 on the Codex endpoint) from being cached as context length.
+    _LARGE_CONTEXT_MODELS = ("gpt-5",)
+    _LARGE_CONTEXT_MIN = 128_001
+    for family in _LARGE_CONTEXT_MODELS:
+        if family in model.lower() and length < _LARGE_CONTEXT_MIN:
+            logger.warning(
+                "Rejecting suspiciously small context cache for %r: %s tokens "
+                "(expected >%s for %s family — may be max_output_tokens, not context length). "
+                "Set model.context_length in config.yaml to force a value.",
+                model, length, _LARGE_CONTEXT_MIN, family,
+            )
+            return
     cache[key] = length
     path = _get_context_cache_path()
     try:

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -633,3 +633,50 @@ class TestContextLengthCache:
         with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
             save_context_length(model, url, 200000)
             assert get_cached_context_length(model, url) == 200000
+
+
+# =========================================================================
+# GPT-5.x context lengths — issue #5173
+# =========================================================================
+
+class TestGpt5ContextLengths:
+    """gpt-5.4 and friends must return 1_050_000 from DEFAULT_CONTEXT_LENGTHS,
+    not fall through to the generic 'gpt-5': 128000 catch-all."""
+
+    @patch("agent.model_metadata.fetch_model_metadata", return_value={})
+    def test_gpt_5_4_returns_1050000(self, mock_fetch, tmp_path):
+        cache_file = tmp_path / "cache.yaml"
+        with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
+            result = get_model_context_length("gpt-5.4")
+        assert result == 1_050_000, f"Expected 1_050_000, got {result}"
+
+    @patch("agent.model_metadata.fetch_model_metadata", return_value={})
+    def test_gpt_5_4_mini_returns_1050000(self, mock_fetch, tmp_path):
+        cache_file = tmp_path / "cache.yaml"
+        with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
+            result = get_model_context_length("gpt-5.4-mini")
+        assert result == 1_050_000, f"Expected 1_050_000, got {result}"
+
+    def test_save_gpt54_small_value_is_rejected(self, tmp_path):
+        """save_context_length with 32k for gpt-5.4 must be silently dropped."""
+        cache_file = tmp_path / "cache.yaml"
+        url = "https://chatgpt.com/backend-api/codex"
+        with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
+            save_context_length("gpt-5.4", url, 32000)
+            assert get_cached_context_length("gpt-5.4", url) is None
+
+    def test_save_gpt54_large_value_is_cached(self, tmp_path):
+        """save_context_length with 1_050_000 for gpt-5.4 must succeed."""
+        cache_file = tmp_path / "cache.yaml"
+        url = "https://chatgpt.com/backend-api/codex"
+        with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
+            save_context_length("gpt-5.4", url, 1_050_000)
+            assert get_cached_context_length("gpt-5.4", url) == 1_050_000
+
+    def test_sanity_guard_does_not_apply_to_non_gpt5(self, tmp_path):
+        """Non-gpt-5 models (e.g. llama-3) can be cached at 32k without restriction."""
+        cache_file = tmp_path / "cache.yaml"
+        url = "http://localhost:11434"
+        with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
+            save_context_length("llama-3-8b", url, 32000)
+            assert get_cached_context_length("llama-3-8b", url) == 32000


### PR DESCRIPTION
Fixes #5173 — `gpt-5.4` shows 32k context in Hermes instead of 1,050,000

## Root Cause

Two independent bugs conspire to produce the wrong context window:

1. **Missing DEFAULT_CONTEXT_LENGTHS entries** — `gpt-5.4` (and other `gpt-5.x` variants) were absent from the fallback dict. Lookups fell through to the generic `"gpt-5": 128000` catch-all, returning 128k instead of 1,050,000.

2. **Cache poisoning** — When connecting via the Codex endpoint, Hermes probes the API and may receive `max_output_tokens` (32k) where it expects `context_length`. That value gets written to `context_length_cache.yaml`. Since the persistent cache is checked *first* in the resolution order, the bad 32k value overrides everything permanently.

## Fix (two-part)

### 1. Add specific gpt-5.x entries to `DEFAULT_CONTEXT_LENGTHS`

New entries added **before** the generic `"gpt-5": 128000` catch-all in `agent/model_metadata.py`:

| Model | Context Length |
|---|---|
| `gpt-5.4` | 1,050,000 |
| `gpt-5.4-mini` | 1,050,000 |
| `gpt-5.4-pro` | 1,050,000 |
| `gpt-5.4-nano` | 1,050,000 |
| `gpt-5.3-codex` | 1,048,576 |
| `gpt-5.2-codex` | 1,048,576 |
| `gpt-5.1-codex-max` | 1,048,576 |
| `gpt-5.1-codex-mini` | 1,048,576 |

The existing `sorted()` in `get_model_context_length` ensures longest-key-first matching, so specific variants correctly shadow the catch-all.

### 2. Sanity guard in `save_context_length()`

Added a pre-write check: if the model name contains `"gpt-5"` and the value being cached is <= 128,000, the write is rejected and a warning is logged. This stops `max_output_tokens` (32k) from ever being written into `context_length_cache.yaml` for gpt-5 family models.

The guard does **not** affect non-gpt-5 models — e.g. `llama-3` can still be cached at 32k normally.

Users who need to force a specific value can always set `model.context_length` in `config.yaml`, which is checked before the cache.

## Tests

Added `TestGpt5ContextLengths` in `tests/agent/test_model_metadata.py`:
- `gpt-5.4` -> 1,050,000 via DEFAULT_CONTEXT_LENGTHS
- `gpt-5.4-mini` -> 1,050,000 via DEFAULT_CONTEXT_LENGTHS
- `save_context_length("gpt-5.4", ..., 32000)` -> silently rejected
- `save_context_length("gpt-5.4", ..., 1_050_000)` -> cached successfully
- Sanity guard does NOT block `llama-3` at 32k

All 80 tests pass.