### PR TITLE
fix: sanitize tool_calls for all strict APIs (Fireworks, Mistral, etc.)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6810,10 +6810,10 @@ class AIAgent:
                 if "finish_reason" in api_msg:
                     api_msg.pop("finish_reason")
                 # Strip Codex Responses API fields (call_id, response_item_id) for
-                # strict providers like Mistral that reject unknown fields with 422.
+                # strict providers like Mistral, Fireworks, etc. that reject unknown fields.
                 # Uses new dicts so the internal messages list retains the fields
                 # for Codex Responses compatibility.
-                if "api.mistral.ai" in self._base_url_lower:
+                if self._should_sanitize_tool_calls():
                     self._sanitize_tool_calls_for_strict_api(api_msg)
                 # Keep 'reasoning_details' - OpenRouter uses this for multi-turn reasoning context
                 # The signature field helps maintain reasoning continuity

--- a/run_agent.py
+++ b/run_agent.py
@@ -6282,13 +6282,13 @@ class AIAgent:
         try:
             # Build API messages, stripping internal-only fields
             # (finish_reason, reasoning) that strict APIs like Mistral reject with 422
-            _is_strict_api = "api.mistral.ai" in self._base_url_lower
+            _needs_sanitize = self._should_sanitize_tool_calls()
             api_messages = []
             for msg in messages:
                 api_msg = msg.copy()
                 for internal_field in ("reasoning", "finish_reason"):
                     api_msg.pop(internal_field, None)
-                if _is_strict_api:
+                if _needs_sanitize:
                     self._sanitize_tool_calls_for_strict_api(api_msg)
                 api_messages.append(api_msg)
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -5396,7 +5396,7 @@ class AIAgent:
 
         try:
             # Build API messages for the flush call
-            _is_strict_api = "api.mistral.ai" in self._base_url_lower
+            _needs_sanitize = self._should_sanitize_tool_calls()
             api_messages = []
             for msg in messages:
                 api_msg = msg.copy()
@@ -5407,7 +5407,7 @@ class AIAgent:
                 api_msg.pop("reasoning", None)
                 api_msg.pop("finish_reason", None)
                 api_msg.pop("_flush_sentinel", None)
-                if _is_strict_api:
+                if _needs_sanitize:
                     self._sanitize_tool_calls_for_strict_api(api_msg)
                 api_messages.append(api_msg)
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -5345,6 +5345,19 @@ class AIAgent:
         ]
         return api_msg
 
+    def _should_sanitize_tool_calls(self) -> bool:
+        """Determine if tool_calls need sanitization for strict APIs.
+
+        Codex Responses API uses fields like call_id and response_item_id
+        that are not part of the standard Chat Completions schema. These
+        fields must be stripped when calling any other API to avoid
+        validation errors (400 Bad Request).
+
+        Returns:
+            bool: True if sanitization is needed (non-Codex API), False otherwise.
+        """
+        return self.api_mode != "codex_responses"
+
     def flush_memories(self, messages: list = None, min_turns: int = None):
         """Give the model one turn to persist memories before context is lost.
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -5324,15 +5324,18 @@ class AIAgent:
     def _sanitize_tool_calls_for_strict_api(api_msg: dict) -> dict:
         """Strip Codex Responses API fields from tool_calls for strict providers.
 
-        Providers like Mistral strictly validate the Chat Completions schema
-        and reject unknown fields (call_id, response_item_id) with 422.
-        These fields are preserved in the internal message history — this
-        method only modifies the outgoing API copy.
+        Providers like Mistral, Fireworks, and other strict OpenAI-compatible APIs
+        validate the Chat Completions schema and reject unknown fields (call_id,
+        response_item_id) with 400 or 422 errors. These fields are preserved in
+        the internal message history — this method only modifies the outgoing
+        API copy.
 
         Creates new tool_call dicts rather than mutating in-place, so the
         original messages list retains call_id/response_item_id for Codex
         Responses API compatibility (e.g. if the session falls back to a
         Codex provider later).
+
+        Fields stripped: call_id, response_item_id
         """
         tool_calls = api_msg.get("tool_calls")
         if not isinstance(tool_calls, list):

--- a/tests/test_provider_parity.py
+++ b/tests/test_provider_parity.py
@@ -137,6 +137,23 @@ class TestBuildApiKwargsOpenRouter:
         assert messages[1]["tool_calls"][0]["response_item_id"] == "fc_123"
         assert "codex_reasoning_items" in messages[1]
 
+    def test_should_sanitize_tool_calls_codex_vs_chat(self, monkeypatch):
+        """Codex API should NOT sanitize, all other APIs should sanitize."""
+        # Codex mode should NOT need sanitization
+        codex_agent = _make_agent(monkeypatch, "openrouter")
+        codex_agent.api_mode = "codex_responses"
+        assert codex_agent._should_sanitize_tool_calls() is False
+
+        # Chat completions mode should need sanitization
+        chat_agent = _make_agent(monkeypatch, "openrouter")
+        chat_agent.api_mode = "chat_completions"
+        assert chat_agent._should_sanitize_tool_calls() is True
+
+        # Anthropic mode should need sanitization
+        anthropic_agent = _make_agent(monkeypatch, "openrouter")
+        anthropic_agent.api_mode = "anthropic_messages"
+        assert anthropic_agent._should_sanitize_tool_calls() is True
+
 
 class TestDeveloperRoleSwap:
     """GPT-5 and Codex models should get 'developer' instead of 'system' role."""

--- a/tests/test_strict_api_validation.py
+++ b/tests/test_strict_api_validation.py
@@ -1,0 +1,144 @@
+"""Test validation error prevention for strict APIs (Fireworks, etc.)"""
+
+import sys
+import types
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+from run_agent import AIAgent
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _tool_defs(*names):
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": n,
+                "description": f"{n} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for n in names
+    ]
+
+
+class _FakeOpenAI:
+    def __init__(self, **kw):
+        self.api_key = kw.get("api_key", "test")
+        self.base_url = kw.get("base_url", "http://test")
+
+    def close(self):
+        pass
+
+
+def _make_agent(monkeypatch, provider, api_mode="chat_completions", base_url="https://openrouter.ai/api/v1"):
+    monkeypatch.setattr("run_agent.get_tool_definitions", lambda **kw: _tool_defs("web_search", "terminal"))
+    monkeypatch.setattr("run_agent.check_toolset_requirements", lambda: {})
+    monkeypatch.setattr("run_agent.OpenAI", _FakeOpenAI)
+    return AIAgent(
+        api_key="test",
+        base_url=base_url,
+        provider=provider,
+        api_mode=api_mode,
+        max_iterations=4,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+
+class TestStrictApiValidation:
+    """Verify tool_call field sanitization prevents 400 errors on strict APIs."""
+
+    def test_fireworks_compatible_messages_after_sanitization(self, monkeypatch):
+        """Messages should be Fireworks-compatible after sanitization."""
+        agent = _make_agent(monkeypatch, "openrouter")
+        agent.api_mode = "chat_completions"  # Fireworks uses chat completions
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "Checking now.",
+                "tool_calls": [
+                    {
+                        "id": "call_123",
+                        "call_id": "call_123",  # Codex-only field
+                        "response_item_id": "fc_123",  # Codex-only field
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": '{"command":"pwd"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_123", "content": "/tmp"},
+        ]
+
+        # After _build_api_kwargs, Codex fields should be stripped
+        kwargs = agent._build_api_kwargs(messages)
+
+        assistant_msg = kwargs["messages"][1]
+        tool_call = assistant_msg["tool_calls"][0]
+
+        # Fireworks rejects these fields
+        assert "call_id" not in tool_call
+        assert "response_item_id" not in tool_call
+        # Standard fields should remain
+        assert tool_call["id"] == "call_123"
+        assert tool_call["function"]["name"] == "terminal"
+
+    def test_codex_preserves_fields_for_replay(self, monkeypatch):
+        """Codex mode should preserve fields for Responses API replay."""
+        agent = _make_agent(monkeypatch, "openrouter")
+        agent.api_mode = "codex_responses"
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "Checking now.",
+                "tool_calls": [
+                    {
+                        "id": "call_123",
+                        "call_id": "call_123",
+                        "response_item_id": "fc_123",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": '{"command":"pwd"}'},
+                    }
+                ],
+            },
+        ]
+
+        # In Codex mode, original messages should NOT be mutated
+        assert messages[1]["tool_calls"][0]["call_id"] == "call_123"
+        assert messages[1]["tool_calls"][0]["response_item_id"] == "fc_123"
+
+    def test_sanitize_method_with_fireworks_provider(self, monkeypatch):
+        """Simulating Fireworks provider should trigger sanitization."""
+        agent = _make_agent(
+            monkeypatch,
+            "fireworks",
+            api_mode="chat_completions",
+            base_url="https://api.fireworks.ai/inference/v1"
+        )
+
+        # Should sanitize for Fireworks (chat_completions mode)
+        assert agent._should_sanitize_tool_calls() is True
+
+    def test_no_sanitize_for_codex_responses(self, monkeypatch):
+        """Codex responses mode should NOT sanitize."""
+        agent = _make_agent(
+            monkeypatch,
+            "openai",
+            api_mode="codex_responses",
+            base_url="https://api.openai.com/v1"
+        )
+
+        # Should NOT sanitize for Codex
+        assert agent._should_sanitize_tool_calls() is False


### PR DESCRIPTION
# Fix: Tool Call Sanitization for Strict APIs

## Problem
Codex-only fields (call_id, response_item_id) were being sent to strict APIs
like Fireworks, causing 400 errors:
"Extra inputs are not permitted, field: 'messages[X].tool_calls[Y].call_id'"

## Root Cause
Sanitization was only applied for api.mistral.ai, not for other strict APIs.

## Solution
Created `_should_sanitize_tool_calls()` method that returns True for all APIs
except codex_responses. Updated 3 locations in run_agent.py:

1. flush_memories() - line ~5397
2. _handle_max_iterations() - line ~6285  
3. run_conversation() - line ~6816

## Tests Added
- test_should_sanitize_tool_calls_codex_vs_chat
- test_fireworks_compatible_messages_after_sanitization
- test_codex_preserves_fields_for_replay
- test_sanitize_method_with_fireworks_provider
- test_no_sanitize_for_codex_responses

All existing tests pass:
- 221 tests in test_run_agent.py ✓
- 71 tests in test_provider_parity.py ✓

## Commits
1. feat: add _should_sanitize_tool_calls() method
2. refactor: use _should_sanitize_tool_calls in flush_memories()
3. refactor: use _should_sanitize_tool_calls in _handle_max_iterations()
4. refactor: use _should_sanitize_tool_calls in run_conversation()
5. test: add test for _should_sanitize_tool_calls()
6. test: add strict API validation tests for Fireworks compatibility
7. docs: update docstring to mention Fireworks strict validation
