### PR TITLE
fix(honcho): schema key mismatch breaks self-hosted Honcho config

### DIFF
--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -187,7 +187,7 @@ class HonchoMemoryProvider(MemoryProvider):
     def get_config_schema(self):
         return [
             {"key": "api_key", "description": "Honcho API key", "secret": True, "env_var": "HONCHO_API_KEY", "url": "https://app.honcho.dev"},
-            {"key": "base_url", "description": "Honcho base URL", "default": "https://api.honcho.dev"},
+            {"key": "baseUrl", "description": "Honcho base URL", "default": "https://api.honcho.dev"},
         ]
 
     def initialize(self, session_id: str, **kwargs) -> None:


### PR DESCRIPTION
## Problem

The Honcho memory plugin's `get_config_schema()` returns a field with key `base_url` (snake_case). This is what `hermes memory setup` writes to `~/.hermes/honcho.json`.

However, `HonchoClientConfig.from_global_config()` in `plugins/memory/honcho/client.py` reads `baseUrl` (camelCase) from that same file:

```python
base_url = (
    raw.get("baseUrl")    # ← camelCase
    or os.environ.get("HONCHO_BASE_URL", "").strip()
    or None
)
```

## Impact

Users who run `hermes memory setup` to configure a **self-hosted Honcho instance** (e.g. `http://localhost:8000`) have their base URL silently ignored. The client falls back to the default `https://api.honcho.dev` cloud endpoint, then fails with `Invalid API key` because the user's API key was set for their self-hosted instance.

Symptoms:
- `hermes honcho status` shows `Connection... OK` (because connectivity check passes differently)
- But `Peer data unavailable: Invalid API key` appears
- Honcho SDK internally hits `https://api.honcho.dev` instead of the configured URL

## Fix

Align the schema key to `baseUrl` to match the reader. One-character change.

## Verification

Tested locally against self-hosted Honcho 3.0.5 at `http://localhost:8000`:

**Before fix** (with `base_url`):
```
Peer data unavailable: Invalid API key
```

**After fix** (with `baseUrl`):
```
Connection... OK
No peer data yet (accumulates after first conversation)
```

## Note

`save_config()` in the same file has the docstring *"Write config to $HERMES_HOME/honcho.json (Honcho SDK native format)"*. The Honcho Python SDK uses camelCase (`baseUrl`), so the reader already uses the correct native format. The schema key was the outlier.