### PR TITLE
test(redact): add regression tests for lowercase variable redaction (#4367)

### DIFF
--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -82,6 +82,38 @@ class TestEnvAssignments:
         result = redact_sensitive_text(text)
         assert result == text
 
+    def test_lowercase_python_variable_token_unchanged(self):
+        # Regression: #4367 — lowercase 'token' assignment must not be redacted
+        text = "before_tokens = response.usage.prompt_tokens"
+        result = redact_sensitive_text(text)
+        assert result == text
+
+    def test_lowercase_python_variable_api_key_unchanged(self):
+        # Regression: #4367 — lowercase 'api_key' must not be redacted
+        text = "api_key = config.get('api_key')"
+        result = redact_sensitive_text(text)
+        assert result == text
+
+    def test_typescript_await_token_unchanged(self):
+        # Regression: #4367 — 'await' keyword must not be redacted as a secret value
+        text = "const token = await getToken();"
+        result = redact_sensitive_text(text)
+        assert result == text
+
+    def test_typescript_await_secret_unchanged(self):
+        # Regression: #4367 — similar pattern with 'secret' variable
+        text = "const secret = await fetchSecret();"
+        result = redact_sensitive_text(text)
+        assert result == text
+
+    def test_export_whitespace_preserved(self):
+        # Regression: #4367 — whitespace before uppercase env var must be preserved
+        text = "export SECRET_TOKEN=mypassword"
+        result = redact_sensitive_text(text)
+        assert result.startswith("export ")
+        assert "SECRET_TOKEN=" in result
+        assert "mypassword" not in result
+
 
 class TestJsonFields:
     def test_json_api_key(self):


### PR DESCRIPTION
## Summary

Adds 5 regression tests for the IGNORECASE bug in `_ENV_ASSIGN_RE` (issue #4367). The core fix already landed in commit 6367e1c4 — these tests prevent re-introduction.

Tests salvaged from PR #4476 by @gnanam1990 (most comprehensive of the three submitted PRs).

**Tests added:**
- Lowercase Python variable with 'token' in name (`before_tokens = ...`)
- Lowercase Python variable with 'api_key' in name
- TypeScript `await` not treated as secret value
- TypeScript `secret` variable assignment
- `export` prefix preserved for uppercase env vars

Closes #4367

Co-authored-by: gnanam1990 <gnanam1990@users.noreply.github.com>