### PR TITLE
fix: reject plugin names that resolve to the plugins root

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -41,6 +41,11 @@ def _sanitize_plugin_name(name: str, plugins_dir: Path) -> Path:
     if not name:
         raise ValueError("Plugin name must not be empty.")
 
+    if name in (".", ".."):
+        raise ValueError(
+            f"Invalid plugin name '{name}': must not reference the plugins directory itself."
+        )
+
     # Reject obvious traversal characters
     for bad in ("/", "\\", ".."):
         if bad in name:
@@ -49,10 +54,14 @@ def _sanitize_plugin_name(name: str, plugins_dir: Path) -> Path:
     target = (plugins_dir / name).resolve()
     plugins_resolved = plugins_dir.resolve()
 
-    if (
-        not str(target).startswith(str(plugins_resolved) + os.sep)
-        and target != plugins_resolved
-    ):
+    if target == plugins_resolved:
+        raise ValueError(
+            f"Invalid plugin name '{name}': resolves to the plugins directory itself."
+        )
+
+    try:
+        target.relative_to(plugins_resolved)
+    except ValueError:
         raise ValueError(
             f"Invalid plugin name '{name}': resolves outside the plugins directory."
         )

--- a/tests/test_plugins_cmd.py
+++ b/tests/test_plugins_cmd.py
@@ -40,8 +40,12 @@ class TestSanitizePluginName:
             _sanitize_plugin_name("../../etc/passwd", tmp_path)
 
     def test_rejects_single_dot_dot(self, tmp_path):
-        with pytest.raises(ValueError, match="must not contain"):
+        with pytest.raises(ValueError, match="must not reference the plugins directory itself"):
             _sanitize_plugin_name("..", tmp_path)
+
+    def test_rejects_single_dot(self, tmp_path):
+        with pytest.raises(ValueError, match="must not reference the plugins directory itself"):
+            _sanitize_plugin_name(".", tmp_path)
 
     def test_rejects_forward_slash(self, tmp_path):
         with pytest.raises(ValueError, match="must not contain"):
@@ -227,6 +231,38 @@ class TestCmdInstall:
         with pytest.raises(SystemExit) as exc_info:
             cmd_install("invalid")
         assert exc_info.value.code == 1
+
+    @patch("hermes_cli.plugins_cmd._display_after_install")
+    @patch("hermes_cli.plugins_cmd.shutil.move")
+    @patch("hermes_cli.plugins_cmd.shutil.rmtree")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    @patch("hermes_cli.plugins_cmd._read_manifest")
+    @patch("hermes_cli.plugins_cmd.subprocess.run")
+    def test_install_rejects_manifest_name_pointing_at_plugins_root(
+        self,
+        mock_run,
+        mock_read_manifest,
+        mock_plugins_dir,
+        mock_rmtree,
+        mock_move,
+        mock_display_after_install,
+        tmp_path,
+    ):
+        from hermes_cli.plugins_cmd import cmd_install
+
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        mock_plugins_dir.return_value = plugins_dir
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        mock_read_manifest.return_value = {"name": "."}
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_install("owner/repo", force=True)
+
+        assert exc_info.value.code == 1
+        assert plugins_dir not in [call.args[0] for call in mock_rmtree.call_args_list]
+        mock_move.assert_not_called()
+        mock_display_after_install.assert_not_called()
 
 
 # ── cmd_update tests ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Fix plugin manifests that resolve to the plugins root

This PR closes a validation gap in plugin name handling.

Right now, plugin names containing `/`, `\`, or `..` are rejected, but the exact self-reference name `.` was still accepted. That creates a bad edge case: a plugin manifest can declare `name: "."`, which resolves to the plugins root directory instead of a single plugin directory.

In flows like force install, that means an operation intended for one plugin can end up targeting the entire plugins tree.

### Changes in this PR

- reject `.` and `..` as invalid plugin names
- reject any target that resolves to the plugins root itself
- switch the final boundary check from string-prefix logic to `Path.relative_to()`
- add regression tests for both:
  - direct sanitizer behavior
  - install flow protection when a manifest uses `name: "."`

### Why this matters

This is not just a validation cleanup. It prevents a real destructive case where a malformed or malicious plugin manifest can cause install/remove logic to operate on the whole plugins directory.

### Validation

Tested with:

- `python -m pytest tests/test_plugins_cmd.py -q`

Result:

- `44 passed`