### PR TITLE
Separate pooled credential runtime state from persisted credentials

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -10,7 +10,7 @@ import uuid
 import os
 import re
 from dataclasses import dataclass, fields, replace
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from hermes_constants import OPENROUTER_BASE_URL
@@ -27,7 +27,9 @@ from hermes_cli.auth import (
     _load_auth_store,
     _load_provider_state,
     read_credential_pool,
+    read_credential_pool_runtime,
     write_credential_pool,
+    write_credential_pool_runtime,
 )
 
 logger = logging.getLogger(__name__)
@@ -133,18 +135,31 @@ class PooledCredential:
         data.setdefault("access_token", "")
         return cls(provider=provider, **data)
 
-    def to_dict(self) -> Dict[str, Any]:
-        _ALWAYS_EMIT = {
-            "last_status",
-            "last_status_at",
-            "last_error_code",
-            "last_error_reason",
-            "last_error_message",
-            "last_error_reset_at",
-        }
+    def to_dict(self, *, include_runtime: bool = True) -> Dict[str, Any]:
+        _ALWAYS_EMIT = (
+            {
+                "last_status",
+                "last_status_at",
+                "last_error_code",
+                "last_error_reason",
+                "last_error_message",
+                "last_error_reset_at",
+            }
+            if include_runtime
+            else set()
+        )
         result: Dict[str, Any] = {}
         for field_def in fields(self):
             if field_def.name in ("provider", "extra"):
+                continue
+            if not include_runtime and field_def.name in {
+                "last_status",
+                "last_status_at",
+                "last_error_code",
+                "last_error_reason",
+                "last_error_message",
+                "last_error_reset_at",
+            }:
                 continue
             value = getattr(self, field_def.name)
             if value is not None or field_def.name in _ALWAYS_EMIT:
@@ -165,6 +180,92 @@ class PooledCredential:
         if self.provider == "nous":
             return self.inference_base_url or self.base_url
         return self.base_url
+
+
+@dataclass
+class CredentialRuntimeState:
+    last_status: Optional[str] = None
+    last_status_at: Optional[float] = None
+    last_error_code: Optional[int] = None
+    last_error_reason: Optional[str] = None
+    last_error_message: Optional[str] = None
+    last_error_reset_at: Optional[float] = None
+    last_success_at: Optional[float] = None
+    last_used_at: Optional[float] = None
+
+    @classmethod
+    def from_sources(
+        cls,
+        payload: Optional[Dict[str, Any]] = None,
+        legacy_entry: Optional[PooledCredential] = None,
+    ) -> "CredentialRuntimeState":
+        data = payload or {}
+        return cls(
+            last_status=data.get("last_status", getattr(legacy_entry, "last_status", None)),
+            last_status_at=data.get("last_status_at", getattr(legacy_entry, "last_status_at", None)),
+            last_error_code=data.get("last_error_code", getattr(legacy_entry, "last_error_code", None)),
+            last_error_reason=data.get("last_error_reason", getattr(legacy_entry, "last_error_reason", None)),
+            last_error_message=data.get("last_error_message", getattr(legacy_entry, "last_error_message", None)),
+            last_error_reset_at=data.get("last_error_reset_at", getattr(legacy_entry, "last_error_reset_at", None)),
+            last_success_at=data.get("last_success_at"),
+            last_used_at=data.get("last_used_at"),
+        )
+
+    def has_status_state(self) -> bool:
+        return any(
+            value is not None
+            for value in (
+                self.last_status,
+                self.last_status_at,
+                self.last_error_code,
+                self.last_error_reason,
+                self.last_error_message,
+                self.last_error_reset_at,
+            )
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        result: Dict[str, Any] = {}
+        if self.last_status is not None and self.last_status != STATUS_OK:
+            result["last_status"] = self.last_status
+        for key, value in {
+            "last_status_at": self.last_status_at,
+            "last_error_code": self.last_error_code,
+            "last_error_reason": self.last_error_reason,
+            "last_error_message": self.last_error_message,
+            "last_error_reset_at": self.last_error_reset_at,
+        }.items():
+            if value is not None:
+                result[key] = value
+        return result
+
+    def blocked_until(self) -> Optional[float]:
+        if self.last_status != STATUS_EXHAUSTED:
+            return None
+        if self.last_error_reset_at is not None:
+            parsed = _parse_absolute_timestamp(self.last_error_reset_at)
+            if parsed is not None:
+                return parsed
+        if self.last_status_at is None:
+            return None
+        return self.last_status_at + _exhausted_ttl(self.last_error_code)
+
+    def is_blocked(self, now: Optional[float] = None) -> bool:
+        blocked_until = self.blocked_until()
+        if blocked_until is None:
+            return False
+        return blocked_until > (now if now is not None else time.time())
+
+    def cleared(self) -> "CredentialRuntimeState":
+        return replace(
+            self,
+            last_status=STATUS_OK,
+            last_status_at=None,
+            last_error_code=None,
+            last_error_reason=None,
+            last_error_message=None,
+            last_error_reset_at=None,
+        )
 
 
 def label_from_token(token: str, fallback: str) -> str:
@@ -193,11 +294,7 @@ def _exhausted_ttl(error_code: Optional[int]) -> int:
 
 
 def _parse_absolute_timestamp(value: Any) -> Optional[float]:
-    """Best-effort parse for provider reset timestamps.
-
-    Accepts epoch seconds, epoch milliseconds, and ISO-8601 strings.
-    Returns seconds since epoch.
-    """
+    """Parse provider-supplied retry/reset timestamps into epoch seconds."""
     if value is None or value == "":
         return None
     if isinstance(value, (int, float)):
@@ -245,30 +342,20 @@ def _normalize_error_context(error_context: Optional[Dict[str, Any]]) -> Dict[st
     message = error_context.get("message")
     if isinstance(message, str) and message.strip():
         normalized["message"] = message.strip()
-    reset_at = (
-        error_context.get("reset_at")
-        or error_context.get("resets_at")
-        or error_context.get("retry_until")
-    )
+    reset_at = error_context.get("reset_at") or error_context.get("resets_at") or error_context.get("retry_until")
     parsed_reset_at = _parse_absolute_timestamp(reset_at)
     if parsed_reset_at is None and isinstance(message, str):
-        retry_delay_seconds = _extract_retry_delay_seconds(message)
-        if retry_delay_seconds is not None:
-            parsed_reset_at = time.time() + retry_delay_seconds
+        retry_delay = _extract_retry_delay_seconds(message)
+        if retry_delay is not None:
+            parsed_reset_at = time.time() + retry_delay
     if parsed_reset_at is not None:
         normalized["reset_at"] = parsed_reset_at
     return normalized
 
 
 def _exhausted_until(entry: PooledCredential) -> Optional[float]:
-    if entry.last_status != STATUS_EXHAUSTED:
-        return None
-    reset_at = _parse_absolute_timestamp(getattr(entry, "last_error_reset_at", None))
-    if reset_at is not None:
-        return reset_at
-    if entry.last_status_at:
-        return entry.last_status_at + _exhausted_ttl(entry.last_error_code)
-    return None
+    runtime = CredentialRuntimeState.from_sources(legacy_entry=entry)
+    return runtime.blocked_until()
 
 
 def _normalize_custom_pool_name(name: str) -> str:
@@ -348,12 +435,18 @@ def get_pool_strategy(provider: str) -> str:
 
 
 class CredentialPool:
-    def __init__(self, provider: str, entries: List[PooledCredential]):
+    def __init__(
+        self,
+        provider: str,
+        entries: List[PooledCredential],
+        runtime_state: Optional[Dict[str, CredentialRuntimeState]] = None,
+    ):
         self.provider = provider
         self._entries = sorted(entries, key=lambda entry: entry.priority)
         self._current_id: Optional[str] = None
         self._strategy = get_pool_strategy(provider)
         self._lock = threading.Lock()
+        self._runtime_state: Dict[str, CredentialRuntimeState] = runtime_state or {}
 
     def has_credentials(self) -> bool:
         return bool(self._entries)
@@ -363,12 +456,36 @@ class CredentialPool:
         return bool(self._available_entries())
 
     def entries(self) -> List[PooledCredential]:
-        return list(self._entries)
+        return [self._materialize_entry(entry) for entry in self._entries]
 
     def current(self) -> Optional[PooledCredential]:
         if not self._current_id:
             return None
-        return next((entry for entry in self._entries if entry.id == self._current_id), None)
+        entry = next((entry for entry in self._entries if entry.id == self._current_id), None)
+        return self._materialize_entry(entry) if entry is not None else None
+
+    def _runtime_for(self, entry_id: str) -> CredentialRuntimeState:
+        return self._runtime_state.get(entry_id, CredentialRuntimeState())
+
+    def _set_runtime(self, entry_id: str, runtime: CredentialRuntimeState) -> None:
+        self._runtime_state[entry_id] = runtime
+
+    def _clear_runtime(self, entry_id: str) -> None:
+        self._runtime_state.pop(entry_id, None)
+
+    def _materialize_entry(self, entry: Optional[PooledCredential]) -> Optional[PooledCredential]:
+        if entry is None:
+            return None
+        runtime = self._runtime_for(entry.id)
+        return replace(
+            entry,
+            last_status=runtime.last_status,
+            last_status_at=runtime.last_status_at,
+            last_error_code=runtime.last_error_code,
+            last_error_reason=runtime.last_error_reason,
+            last_error_message=runtime.last_error_message,
+            last_error_reset_at=runtime.last_error_reset_at,
+        )
 
     def _replace_entry(self, old: PooledCredential, new: PooledCredential) -> None:
         """Swap an entry in-place by id, preserving sort order."""
@@ -380,7 +497,15 @@ class CredentialPool:
     def _persist(self) -> None:
         write_credential_pool(
             self.provider,
-            [entry.to_dict() for entry in self._entries],
+            [entry.to_dict(include_runtime=False) for entry in self._entries],
+        )
+        write_credential_pool_runtime(
+            self.provider,
+            {
+                entry_id: runtime.to_dict()
+                for entry_id, runtime in self._runtime_state.items()
+                if runtime.to_dict()
+            },
         )
 
     def _mark_exhausted(
@@ -390,8 +515,8 @@ class CredentialPool:
         error_context: Optional[Dict[str, Any]] = None,
     ) -> PooledCredential:
         normalized_error = _normalize_error_context(error_context)
-        updated = replace(
-            entry,
+        runtime = replace(
+            self._runtime_for(entry.id),
             last_status=STATUS_EXHAUSTED,
             last_status_at=time.time(),
             last_error_code=status_code,
@@ -399,9 +524,9 @@ class CredentialPool:
             last_error_message=normalized_error.get("message"),
             last_error_reset_at=normalized_error.get("reset_at"),
         )
-        self._replace_entry(entry, updated)
+        self._set_runtime(entry.id, runtime)
         self._persist()
-        return updated
+        return self._materialize_entry(entry)
 
     def _sync_anthropic_entry_from_credentials_file(self, entry: PooledCredential) -> PooledCredential:
         """Sync a claude_code pool entry from ~/.claude/.credentials.json if tokens differ.
@@ -429,11 +554,9 @@ class CredentialPool:
                     access_token=file_access,
                     refresh_token=file_refresh,
                     expires_at_ms=file_expires,
-                    last_status=None,
-                    last_status_at=None,
-                    last_error_code=None,
                 )
                 self._replace_entry(entry, updated)
+                self._clear_runtime(entry.id)
                 self._persist()
                 return updated
         except Exception as exc:
@@ -537,11 +660,9 @@ class CredentialPool:
                             access_token=refreshed["access_token"],
                             refresh_token=refreshed["refresh_token"],
                             expires_at_ms=refreshed["expires_at_ms"],
-                            last_status=STATUS_OK,
-                            last_status_at=None,
-                            last_error_code=None,
                         )
                         self._replace_entry(synced, updated)
+                        self._set_runtime(synced.id, replace(self._runtime_for(synced.id).cleared(), last_success_at=time.time()))
                         self._persist()
                         try:
                             from agent.anthropic_adapter import _write_claude_code_credentials
@@ -562,15 +683,7 @@ class CredentialPool:
             self._mark_exhausted(entry, None)
             return None
 
-        updated = replace(
-            updated,
-            last_status=STATUS_OK,
-            last_status_at=None,
-            last_error_code=None,
-            last_error_reason=None,
-            last_error_message=None,
-            last_error_reset_at=None,
-        )
+        self._set_runtime(updated.id, replace(self._runtime_for(updated.id).cleared(), last_success_at=time.time()))
         self._replace_entry(entry, updated)
         self._persist()
         return updated
@@ -603,6 +716,8 @@ class CredentialPool:
             for idx, entry in enumerate(self._entries):
                 if entry.id == target_id:
                     self._entries[idx] = replace(entry, request_count=entry.request_count + 1)
+                    runtime = replace(self._runtime_for(target_id), last_used_at=time.time())
+                    self._set_runtime(target_id, runtime)
                     return
 
     def select(self) -> Optional[PooledCredential]:
@@ -620,38 +735,30 @@ class CredentialPool:
         cleared_any = False
         available: List[PooledCredential] = []
         for entry in self._entries:
+            runtime = self._runtime_for(entry.id)
             # For anthropic claude_code entries, sync from the credentials file
             # before any status/refresh checks. This picks up tokens refreshed
             # by other processes (Claude Code CLI, other Hermes profiles).
             if (self.provider == "anthropic" and entry.source == "claude_code"
-                    and entry.last_status == STATUS_EXHAUSTED):
+                    and runtime.last_status == STATUS_EXHAUSTED):
                 synced = self._sync_anthropic_entry_from_credentials_file(entry)
                 if synced is not entry:
                     entry = synced
                     cleared_any = True
-            if entry.last_status == STATUS_EXHAUSTED:
-                exhausted_until = _exhausted_until(entry)
-                if exhausted_until is not None and now < exhausted_until:
+                    runtime = self._runtime_for(entry.id)
+            if runtime.last_status == STATUS_EXHAUSTED:
+                blocked_until = runtime.blocked_until()
+                if blocked_until is not None and blocked_until > now:
                     continue
                 if clear_expired:
-                    cleared = replace(
-                        entry,
-                        last_status=STATUS_OK,
-                        last_status_at=None,
-                        last_error_code=None,
-                        last_error_reason=None,
-                        last_error_message=None,
-                        last_error_reset_at=None,
-                    )
-                    self._replace_entry(entry, cleared)
-                    entry = cleared
+                    self._set_runtime(entry.id, runtime.cleared())
                     cleared_any = True
             if refresh and self._entry_needs_refresh(entry):
                 refreshed = self._refresh_entry(entry, force=False)
                 if refreshed is None:
                     continue
                 entry = refreshed
-            available.append(entry)
+            available.append(self._materialize_entry(entry))
         if cleared_any:
             self._persist()
         return available
@@ -721,25 +828,12 @@ class CredentialPool:
 
     def reset_statuses(self) -> int:
         count = 0
-        new_entries = []
         for entry in self._entries:
-            if entry.last_status or entry.last_status_at or entry.last_error_code:
-                new_entries.append(
-                    replace(
-                        entry,
-                        last_status=None,
-                        last_status_at=None,
-                        last_error_code=None,
-                        last_error_reason=None,
-                        last_error_message=None,
-                        last_error_reset_at=None,
-                    )
-                )
+            runtime = self._runtime_for(entry.id)
+            if runtime.has_status_state():
+                self._set_runtime(entry.id, runtime.cleared())
                 count += 1
-            else:
-                new_entries.append(entry)
         if count:
-            self._entries = new_entries
             self._persist()
         return count
 
@@ -747,6 +841,7 @@ class CredentialPool:
         if index < 1 or index > len(self._entries):
             return None
         removed = self._entries.pop(index - 1)
+        self._clear_runtime(removed.id)
         self._entries = [
             replace(entry, priority=new_priority)
             for new_priority, entry in enumerate(self._entries)
@@ -763,7 +858,7 @@ class CredentialPool:
 
         for idx, entry in enumerate(self._entries, start=1):
             if entry.id == raw:
-                return idx, entry, None
+                return idx, self._materialize_entry(entry), None
 
         label_matches = [
             (idx, entry)
@@ -771,13 +866,14 @@ class CredentialPool:
             if entry.label.strip().lower() == raw.lower()
         ]
         if len(label_matches) == 1:
-            return label_matches[0][0], label_matches[0][1], None
+            return label_matches[0][0], self._materialize_entry(label_matches[0][1]), None
         if len(label_matches) > 1:
             return None, None, f'Ambiguous credential label "{raw}". Use the numeric index or entry id instead.'
+
         if raw.isdigit():
             index = int(raw)
             if 1 <= index <= len(self._entries):
-                return index, self._entries[index - 1], None
+                return index, self._materialize_entry(self._entries[index - 1]), None
             return None, None, f"No credential #{index}."
         return None, None, f'No credential matching "{raw}".'
 
@@ -1077,11 +1173,39 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
 
     return changed, active_sources
 
-
 def load_pool(provider: str) -> CredentialPool:
     provider = (provider or "").strip().lower()
     raw_entries = read_credential_pool(provider)
     entries = [PooledCredential.from_dict(provider, payload) for payload in raw_entries]
+    raw_runtime = read_credential_pool_runtime(provider)
+    runtime_state: Dict[str, CredentialRuntimeState] = {}
+    runtime_changed = False
+
+    for idx, entry in enumerate(entries):
+        runtime_payload = raw_runtime.get(entry.id) if isinstance(raw_runtime, dict) else None
+        runtime = CredentialRuntimeState.from_sources(runtime_payload, legacy_entry=entry)
+        if runtime.to_dict():
+            runtime_state[entry.id] = runtime
+        if (
+            entry.last_status is not None
+            or entry.last_status_at is not None
+            or entry.last_error_code is not None
+            or entry.last_error_reason is not None
+            or entry.last_error_message is not None
+            or entry.last_error_reset_at is not None
+        ):
+            stripped = replace(
+                entry,
+                last_status=None,
+                last_status_at=None,
+                last_error_code=None,
+                last_error_reason=None,
+                last_error_message=None,
+                last_error_reset_at=None,
+            )
+            if stripped != entry:
+                runtime_changed = True
+                entries[idx] = stripped
 
     if provider.startswith(CUSTOM_POOL_PREFIX):
         # Custom endpoint pool — seed from custom_providers config and model config
@@ -1095,9 +1219,18 @@ def load_pool(provider: str) -> CredentialPool:
         changed |= _prune_stale_seeded_entries(entries, singleton_sources | env_sources)
         changed |= _normalize_pool_priorities(provider, entries)
 
-    if changed:
+    if changed or runtime_changed:
         write_credential_pool(
             provider,
-            [entry.to_dict() for entry in sorted(entries, key=lambda item: item.priority)],
+            [entry.to_dict(include_runtime=False) for entry in sorted(entries, key=lambda item: item.priority)],
         )
-    return CredentialPool(provider, entries)
+    if runtime_changed or raw_runtime:
+        write_credential_pool_runtime(
+            provider,
+            {
+                entry_id: runtime.to_dict()
+                for entry_id, runtime in runtime_state.items()
+                if runtime.to_dict()
+            },
+        )
+    return CredentialPool(provider, entries, runtime_state=runtime_state)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -645,6 +645,30 @@ def write_credential_pool(provider_id: str, entries: List[Dict[str, Any]]) -> Pa
         return _save_auth_store(auth_store)
 
 
+def read_credential_pool_runtime(provider_id: Optional[str] = None) -> Dict[str, Any]:
+    """Return persisted credential pool runtime state, or one provider slice."""
+    auth_store = _load_auth_store()
+    runtime = auth_store.get("credential_pool_runtime")
+    if not isinstance(runtime, dict):
+        runtime = {}
+    if provider_id is None:
+        return dict(runtime)
+    provider_runtime = runtime.get(provider_id)
+    return dict(provider_runtime) if isinstance(provider_runtime, dict) else {}
+
+
+def write_credential_pool_runtime(provider_id: str, runtime_entries: Dict[str, Dict[str, Any]]) -> Path:
+    """Persist runtime state for one provider's credential pool."""
+    with _auth_store_lock():
+        auth_store = _load_auth_store()
+        runtime = auth_store.get("credential_pool_runtime")
+        if not isinstance(runtime, dict):
+            runtime = {}
+            auth_store["credential_pool_runtime"] = runtime
+        runtime[provider_id] = dict(runtime_entries)
+        return _save_auth_store(auth_store)
+
+
 def get_provider_auth_state(provider_id: str) -> Optional[Dict[str, Any]]:
     """Return persisted auth state for a provider, or None."""
     auth_store = _load_auth_store()
@@ -678,6 +702,10 @@ def clear_provider_auth(provider_id: Optional[str] = None) -> bool:
         if not isinstance(pool, dict):
             pool = {}
             auth_store["credential_pool"] = pool
+        runtime = auth_store.get("credential_pool_runtime")
+        if not isinstance(runtime, dict):
+            runtime = {}
+            auth_store["credential_pool_runtime"] = runtime
 
         cleared = False
         if target in providers:
@@ -685,6 +713,9 @@ def clear_provider_auth(provider_id: Optional[str] = None) -> bool:
             cleared = True
         if target in pool:
             del pool[target]
+            cleared = True
+        if target in runtime:
+            del runtime[target]
             cleared = True
 
         if not cleared:

--- a/run_agent.py
+++ b/run_agent.py
@@ -2140,7 +2140,7 @@ class AIAgent:
 
     @staticmethod
     def _extract_api_error_context(error: Exception) -> Dict[str, Any]:
-        """Extract structured rate-limit details from provider errors."""
+        """Extract structured cooldown metadata from provider errors."""
         context: Dict[str, Any] = {}
 
         body = getattr(error, "body", None)
@@ -2187,16 +2187,18 @@ class AIAgent:
         if "reset_at" not in context:
             message = context.get("message") or ""
             if isinstance(message, str):
-                delay_match = re.search(r"quotaResetDelay[:\s\"]+(\\d+(?:\\.\\d+)?)(ms|s)", message, re.IGNORECASE)
+                import re as _re
+
+                delay_match = _re.search(r"quotaResetDelay[:\s\"]+(\d+(?:\.\d+)?)(ms|s)", message, _re.IGNORECASE)
                 if delay_match:
                     value = float(delay_match.group(1))
                     seconds = value / 1000.0 if delay_match.group(2).lower() == "ms" else value
                     context["reset_at"] = time.time() + seconds
                 else:
-                    sec_match = re.search(
+                    sec_match = _re.search(
                         r"retry\s+(?:after\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)",
                         message,
-                        re.IGNORECASE,
+                        _re.IGNORECASE,
                     )
                     if sec_match:
                         context["reset_at"] = time.time() + float(sec_match.group(1))
@@ -5390,18 +5392,15 @@ class AIAgent:
     def _sanitize_tool_calls_for_strict_api(api_msg: dict) -> dict:
         """Strip Codex Responses API fields from tool_calls for strict providers.
 
-        Providers like Mistral, Fireworks, and other strict OpenAI-compatible APIs
-        validate the Chat Completions schema and reject unknown fields (call_id,
-        response_item_id) with 400 or 422 errors. These fields are preserved in
-        the internal message history — this method only modifies the outgoing
-        API copy.
+        Providers like Mistral strictly validate the Chat Completions schema
+        and reject unknown fields (call_id, response_item_id) with 422.
+        These fields are preserved in the internal message history — this
+        method only modifies the outgoing API copy.
 
         Creates new tool_call dicts rather than mutating in-place, so the
         original messages list retains call_id/response_item_id for Codex
         Responses API compatibility (e.g. if the session falls back to a
         Codex provider later).
-
-        Fields stripped: call_id, response_item_id
         """
         tool_calls = api_msg.get("tool_calls")
         if not isinstance(tool_calls, list):
@@ -5413,19 +5412,6 @@ class AIAgent:
             for tc in tool_calls
         ]
         return api_msg
-
-    def _should_sanitize_tool_calls(self) -> bool:
-        """Determine if tool_calls need sanitization for strict APIs.
-
-        Codex Responses API uses fields like call_id and response_item_id
-        that are not part of the standard Chat Completions schema. These
-        fields must be stripped when calling any other API to avoid
-        validation errors (400 Bad Request).
-
-        Returns:
-            bool: True if sanitization is needed (non-Codex API), False otherwise.
-        """
-        return self.api_mode != "codex_responses"
 
     def flush_memories(self, messages: list = None, min_turns: int = None):
         """Give the model one turn to persist memories before context is lost.
@@ -5465,7 +5451,7 @@ class AIAgent:
 
         try:
             # Build API messages for the flush call
-            _needs_sanitize = self._should_sanitize_tool_calls()
+            _is_strict_api = "api.mistral.ai" in self._base_url_lower
             api_messages = []
             for msg in messages:
                 api_msg = msg.copy()
@@ -5476,7 +5462,7 @@ class AIAgent:
                 api_msg.pop("reasoning", None)
                 api_msg.pop("finish_reason", None)
                 api_msg.pop("_flush_sentinel", None)
-                if _needs_sanitize:
+                if _is_strict_api:
                     self._sanitize_tool_calls_for_strict_api(api_msg)
                 api_messages.append(api_msg)
 
@@ -6351,13 +6337,13 @@ class AIAgent:
         try:
             # Build API messages, stripping internal-only fields
             # (finish_reason, reasoning) that strict APIs like Mistral reject with 422
-            _needs_sanitize = self._should_sanitize_tool_calls()
+            _is_strict_api = "api.mistral.ai" in self._base_url_lower
             api_messages = []
             for msg in messages:
                 api_msg = msg.copy()
                 for internal_field in ("reasoning", "finish_reason"):
                     api_msg.pop(internal_field, None)
-                if _needs_sanitize:
+                if _is_strict_api:
                     self._sanitize_tool_calls_for_strict_api(api_msg)
                 api_messages.append(api_msg)
 
@@ -6879,10 +6865,10 @@ class AIAgent:
                 if "finish_reason" in api_msg:
                     api_msg.pop("finish_reason")
                 # Strip Codex Responses API fields (call_id, response_item_id) for
-                # strict providers like Mistral, Fireworks, etc. that reject unknown fields.
+                # strict providers like Mistral that reject unknown fields with 422.
                 # Uses new dicts so the internal messages list retains the fields
                 # for Codex Responses compatibility.
-                if self._should_sanitize_tool_calls():
+                if "api.mistral.ai" in self._base_url_lower:
                     self._sanitize_tool_calls_for_strict_api(api_msg)
                 # Keep 'reasoning_details' - OpenRouter uses this for multi-turn reasoning context
                 # The signature field helps maintain reasoning continuity

--- a/tests/test_auth_commands.py
+++ b/tests/test_auth_commands.py
@@ -236,6 +236,174 @@ def test_auth_remove_reindexes_priorities(tmp_path, monkeypatch):
     assert entries[0]["priority"] == 0
 
 
+def test_auth_reset_clears_provider_statuses(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "anthropic": [
+                    {
+                        "id": "cred-1",
+                        "label": "primary",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-ant-api-primary",
+                        "last_status": "exhausted",
+                        "last_status_at": 1711230000.0,
+                        "last_error_code": 402,
+                    }
+                ]
+            },
+        },
+    )
+
+    from hermes_cli.auth_commands import auth_reset_command
+
+    class _Args:
+        provider = "anthropic"
+
+    auth_reset_command(_Args())
+
+    out = capsys.readouterr().out
+    assert "Reset status" in out
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entry = payload["credential_pool"]["anthropic"][0]
+    assert entry.get("last_status") is None
+    assert entry.get("last_status_at") is None
+    assert entry.get("last_error_code") is None
+    runtime = payload["credential_pool_runtime"]["anthropic"]
+    assert runtime == {}
+
+
+def test_clear_provider_auth_removes_provider_pool_entries(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "active_provider": "anthropic",
+            "providers": {
+                "anthropic": {"access_token": "legacy-token"},
+            },
+            "credential_pool": {
+                "anthropic": [
+                    {
+                        "id": "cred-1",
+                        "label": "primary",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual:hermes_pkce",
+                        "access_token": "pool-token",
+                    }
+                ],
+                "openrouter": [
+                    {
+                        "id": "cred-2",
+                        "label": "other-provider",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-or-test",
+                    }
+                ],
+            },
+            "credential_pool_runtime": {
+                "anthropic": {
+                    "cred-1": {
+                        "last_status": "exhausted",
+                        "last_status_at": 1711230000.0,
+                        "last_error_code": 429,
+                    }
+                }
+            },
+        },
+    )
+
+    from hermes_cli.auth import clear_provider_auth
+
+    assert clear_provider_auth("anthropic") is True
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert payload["active_provider"] is None
+    assert "anthropic" not in payload.get("providers", {})
+    assert "anthropic" not in payload.get("credential_pool", {})
+    assert "anthropic" not in payload.get("credential_pool_runtime", {})
+    assert "openrouter" in payload.get("credential_pool", {})
+
+
+def test_auth_list_does_not_call_mutating_select(monkeypatch, capsys):
+    from hermes_cli.auth_commands import auth_list_command
+
+    class _Entry:
+        id = "cred-1"
+        label = "primary"
+        auth_type="***"
+        source = "manual"
+        last_status = None
+        last_error_code = None
+        last_status_at = None
+
+    class _Pool:
+        def entries(self):
+            return [_Entry()]
+
+        def peek(self):
+            return _Entry()
+
+        def select(self):
+            raise AssertionError("auth_list_command should not call select()")
+
+    monkeypatch.setattr(
+        "hermes_cli.auth_commands.load_pool",
+        lambda provider: _Pool() if provider == "openrouter" else type("_EmptyPool", (), {"entries": lambda self: []})(),
+    )
+
+    class _Args:
+        provider = "openrouter"
+
+    auth_list_command(_Args())
+
+    out = capsys.readouterr().out
+    assert "openrouter (1 credentials):" in out
+    assert "primary" in out
+
+
+def test_auth_list_shows_exhausted_cooldown(monkeypatch, capsys):
+    from hermes_cli.auth_commands import auth_list_command
+
+    class _Entry:
+        id = "cred-1"
+        label = "primary"
+        auth_type = "api_key"
+        source = "manual"
+        last_status = "exhausted"
+        last_error_code = 429
+        last_status_at = 1000.0
+
+    class _Pool:
+        def entries(self):
+            return [_Entry()]
+
+        def peek(self):
+            return None
+
+    monkeypatch.setattr("hermes_cli.auth_commands.load_pool", lambda provider: _Pool())
+    monkeypatch.setattr("hermes_cli.auth_commands.time.time", lambda: 1030.0)
+
+    class _Args:
+        provider = "openrouter"
+
+    auth_list_command(_Args())
+
+    out = capsys.readouterr().out
+    assert "exhausted (429)" in out
+    assert "59m 30s left" in out
+
+
 def test_auth_remove_accepts_label_target(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(
@@ -327,162 +495,6 @@ def test_auth_remove_prefers_exact_numeric_label_over_index(tmp_path, monkeypatc
     payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
     labels = [entry["label"] for entry in payload["credential_pool"]["openai-codex"]]
     assert labels == ["first", "third"]
-
-
-def test_auth_reset_clears_provider_statuses(tmp_path, monkeypatch, capsys):
-    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
-    _write_auth_store(
-        tmp_path,
-        {
-            "version": 1,
-            "credential_pool": {
-                "anthropic": [
-                    {
-                        "id": "cred-1",
-                        "label": "primary",
-                        "auth_type": "api_key",
-                        "priority": 0,
-                        "source": "manual",
-                        "access_token": "sk-ant-api-primary",
-                        "last_status": "exhausted",
-                        "last_status_at": 1711230000.0,
-                        "last_error_code": 402,
-                    }
-                ]
-            },
-        },
-    )
-
-    from hermes_cli.auth_commands import auth_reset_command
-
-    class _Args:
-        provider = "anthropic"
-
-    auth_reset_command(_Args())
-
-    out = capsys.readouterr().out
-    assert "Reset status" in out
-
-    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
-    entry = payload["credential_pool"]["anthropic"][0]
-    assert entry["last_status"] is None
-    assert entry["last_status_at"] is None
-    assert entry["last_error_code"] is None
-
-
-def test_clear_provider_auth_removes_provider_pool_entries(tmp_path, monkeypatch):
-    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
-    _write_auth_store(
-        tmp_path,
-        {
-            "version": 1,
-            "active_provider": "anthropic",
-            "providers": {
-                "anthropic": {"access_token": "legacy-token"},
-            },
-            "credential_pool": {
-                "anthropic": [
-                    {
-                        "id": "cred-1",
-                        "label": "primary",
-                        "auth_type": "oauth",
-                        "priority": 0,
-                        "source": "manual:hermes_pkce",
-                        "access_token": "pool-token",
-                    }
-                ],
-                "openrouter": [
-                    {
-                        "id": "cred-2",
-                        "label": "other-provider",
-                        "auth_type": "api_key",
-                        "priority": 0,
-                        "source": "manual",
-                        "access_token": "sk-or-test",
-                    }
-                ],
-            },
-        },
-    )
-
-    from hermes_cli.auth import clear_provider_auth
-
-    assert clear_provider_auth("anthropic") is True
-
-    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
-    assert payload["active_provider"] is None
-    assert "anthropic" not in payload.get("providers", {})
-    assert "anthropic" not in payload.get("credential_pool", {})
-    assert "openrouter" in payload.get("credential_pool", {})
-
-
-def test_auth_list_does_not_call_mutating_select(monkeypatch, capsys):
-    from hermes_cli.auth_commands import auth_list_command
-
-    class _Entry:
-        id = "cred-1"
-        label = "primary"
-        auth_type="***"
-        source = "manual"
-        last_status = None
-        last_error_code = None
-        last_status_at = None
-
-    class _Pool:
-        def entries(self):
-            return [_Entry()]
-
-        def peek(self):
-            return _Entry()
-
-        def select(self):
-            raise AssertionError("auth_list_command should not call select()")
-
-    monkeypatch.setattr(
-        "hermes_cli.auth_commands.load_pool",
-        lambda provider: _Pool() if provider == "openrouter" else type("_EmptyPool", (), {"entries": lambda self: []})(),
-    )
-
-    class _Args:
-        provider = "openrouter"
-
-    auth_list_command(_Args())
-
-    out = capsys.readouterr().out
-    assert "openrouter (1 credentials):" in out
-    assert "primary" in out
-
-
-def test_auth_list_shows_exhausted_cooldown(monkeypatch, capsys):
-    from hermes_cli.auth_commands import auth_list_command
-
-    class _Entry:
-        id = "cred-1"
-        label = "primary"
-        auth_type = "api_key"
-        source = "manual"
-        last_status = "exhausted"
-        last_error_code = 429
-        last_status_at = 1000.0
-
-    class _Pool:
-        def entries(self):
-            return [_Entry()]
-
-        def peek(self):
-            return None
-
-    monkeypatch.setattr("hermes_cli.auth_commands.load_pool", lambda provider: _Pool())
-    monkeypatch.setattr("hermes_cli.auth_commands.time.time", lambda: 1030.0)
-
-    class _Args:
-        provider = "openrouter"
-
-    auth_list_command(_Args())
-
-    out = capsys.readouterr().out
-    assert "exhausted (429)" in out
-    assert "59m 30s left" in out
 
 
 def test_auth_list_prefers_explicit_reset_time(monkeypatch, capsys):

--- a/tests/test_credential_pool.py
+++ b/tests/test_credential_pool.py
@@ -214,39 +214,6 @@ def test_exhausted_entry_resets_after_ttl(tmp_path, monkeypatch):
     assert entry.last_status == "ok"
 
 
-def test_explicit_reset_timestamp_overrides_default_429_ttl(tmp_path, monkeypatch):
-    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
-    _write_auth_store(
-        tmp_path,
-        {
-            "version": 1,
-            "credential_pool": {
-                "openai-codex": [
-                    {
-                        "id": "cred-1",
-                        "label": "weekly-reset",
-                        "auth_type": "oauth",
-                        "priority": 0,
-                        "source": "manual:device_code",
-                        "access_token": "tok-1",
-                        "last_status": "exhausted",
-                        "last_status_at": time.time() - 7200,
-                        "last_error_code": 429,
-                        "last_error_reason": "device_code_exhausted",
-                        "last_error_reset_at": time.time() + 7 * 24 * 60 * 60,
-                    }
-                ]
-            },
-        },
-    )
-
-    from agent.credential_pool import load_pool
-
-    pool = load_pool("openai-codex")
-    assert pool.has_available() is False
-    assert pool.select() is None
-
-
 def test_mark_exhausted_and_rotate_persists_status(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
     _write_auth_store(
@@ -288,8 +255,87 @@ def test_mark_exhausted_and_rotate_persists_status(tmp_path, monkeypatch):
 
     auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
     persisted = auth_payload["credential_pool"]["anthropic"][0]
-    assert persisted["last_status"] == "exhausted"
-    assert persisted["last_error_code"] == 402
+    assert "last_status" not in persisted
+    runtime = auth_payload["credential_pool_runtime"]["anthropic"]["cred-1"]
+    assert runtime["last_status"] == "exhausted"
+    assert runtime["last_error_code"] == 402
+
+
+def test_load_pool_migrates_legacy_inline_status_fields_to_runtime_store(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-1",
+                        "label": "legacy",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual:device_code",
+                        "access_token": "tok-1",
+                        "last_status": "exhausted",
+                        "last_status_at": 1711230000.0,
+                        "last_error_code": 429,
+                    }
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    entry = pool.entries()[0]
+    assert entry.last_status == "exhausted"
+
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    persisted_entry = auth_payload["credential_pool"]["openai-codex"][0]
+    assert "last_status" not in persisted_entry
+    runtime = auth_payload["credential_pool_runtime"]["openai-codex"]["cred-1"]
+    assert runtime["last_status"] == "exhausted"
+    assert runtime["last_error_code"] == 429
+
+
+def test_explicit_reset_timestamp_overrides_default_429_ttl(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-1",
+                        "label": "weekly-reset",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual:device_code",
+                        "access_token": "tok-1",
+                    }
+                ]
+            },
+            "credential_pool_runtime": {
+                "openai-codex": {
+                    "cred-1": {
+                        "last_status": "exhausted",
+                        "last_status_at": time.time() - 7200,
+                        "last_error_code": 429,
+                        "last_error_reason": "device_code_exhausted",
+                        "last_error_reset_at": time.time() + 7 * 24 * 60 * 60,
+                    }
+                }
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    assert pool.has_available() is False
+    assert pool.select() is None
 
 
 def test_try_refresh_current_updates_only_current_entry(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
This PR separates pooled credential runtime state from pooled credential definitions.

Hermes currently persists temporary execution state like cooldowns and recent exhaustion directly on the credential records themselves. This branch introduces a dedicated `credential_pool_runtime` store in `auth.json` so Hermes can treat those as transient operational facts instead of durable credential identity.

## What this does
- adds `credential_pool_runtime` as the home for pooled credential runtime state
- keeps `credential_pool` focused on durable credential definitions only
- migrates legacy inline cooldown/error fields from `credential_pool` entries into runtime state automatically on read
- stores provider cooldown metadata preserved by current `main` in the runtime layer instead of writing it back into the credential definition

## Why the runtime split matters
A pooled credential has two different kinds of data:

1. Durable definition
- label, id, source
- token and refresh data
- base URL and provider metadata

2. Transient runtime state
- exhausted or healthy
- last error
- retry/reset time
- recent usage state

Before this split, Hermes mixed those together. That makes temporary rate limits look like part of the saved credential itself.

This change makes Hermes distinguish between:
- what a credential **is**
- what happened to it **recently**

## Bugs this helps prevent
- stale exhaustion state persisting as if it were part of the real credential record
- recovery logic having to rewrite credential definitions just to clear temporary cooldowns
- valid credentials being treated as permanently dirty because temporary runtime state was stored inline
- fragile future scheduler/selector work caused by mixing identity/configuration with execution-time status
- manual auth-store cleanup for older inline cooldown fields

## Scope note
Current `upstream/main` already includes the earlier work for:
- preserving provider reset windows like `resets_at`
- safe id/label-based auth removal
- improved auth cooldown display

This branch was cleaned up and rebased so it now carries only the remaining runtime-state split.

## Verification
- `uv run python -m pytest tests/test_auth_commands.py tests/test_credential_pool.py tests/test_run_agent.py tests/test_credential_pool_routing.py -q`
- `uv run python -m py_compile agent/credential_pool.py hermes_cli/auth.py run_agent.py tests/test_auth_commands.py tests/test_credential_pool.py`
- `HERMES_HOME=<tmp> uv run hermes -w auth list openai-codex`
- `HERMES_HOME=<tmp> uv run hermes -w auth remove openai-codex personal-account`

## Notes
- Rebasing against latest `upstream/main` removed redundant code that had already merged upstream.
- Full repository pytest was not run in this pass.
