### PR TITLE
fix(cli): catch KeyboardInterrupt during slash commands to prevent session exit

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7876,11 +7876,17 @@ class HermesCLI:
 
                     if not _file_drop and isinstance(user_input, str) and _looks_like_slash_command(user_input):
                         _cprint(f"\n⚙️  {user_input}")
-                        if not self.process_command(user_input):
-                            self._should_exit = True
-                            # Schedule app exit
-                            if app.is_running:
-                                app.exit()
+                        try:
+                            if not self.process_command(user_input):
+                                self._should_exit = True
+                                # Schedule app exit
+                                if app.is_running:
+                                    app.exit()
+                        except KeyboardInterrupt:
+                            # Ctrl+C during a slow slash command (e.g. /skills browse)
+                            # should interrupt the command and return to the prompt,
+                            # not exit the session.
+                            _cprint("\n[dim]Command interrupted.[/dim]")
                         continue
                     
                     # Expand paste references back to full content


### PR DESCRIPTION
Fixes #5142

Ctrl+C during slow slash commands (e.g. /skills browse) now interrupts the command and returns to the prompt instead of exiting the session.

Wraps process_command() in try/except KeyboardInterrupt. Shows "Command interrupted." message and continues the input loop.