### PR TITLE
fix(doctor): detect OPENAI_BASE_URL vs config.yaml base_url conflicts

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -319,6 +319,65 @@ def run_doctor(args):
             pass
 
     # =========================================================================
+    # Check: Provider endpoint configuration (OPENAI_BASE_URL conflicts)
+    # =========================================================================
+    print()
+    print(color("◆ Provider Endpoint Configuration", Colors.CYAN, Colors.BOLD))
+
+    # Check for OPENAI_BASE_URL vs config.yaml base_url conflict (#5161)
+    env_base_url = os.environ.get("OPENAI_BASE_URL", "").rstrip("/")
+    config_base_url = ""
+    try:
+        config_path = HERMES_HOME / "config.yaml"
+        if config_path.exists():
+            with open(config_path) as f:
+                raw_config = yaml.safe_load(f) or {}
+            config_base_url = (raw_config.get("model", {}).get("base_url") or "").rstrip("/")
+    except Exception:
+        pass
+
+    if env_base_url and config_base_url:
+        if env_base_url != config_base_url:
+            check_warn(
+                "OPENAI_BASE_URL conflicts with config.yaml base_url",
+                f"(env: {env_base_url[:40]}... vs config: {config_base_url[:40]}...)"
+            )
+            check_info("Auxiliary clients (compression, vision, subagents) may route to wrong endpoint")
+            check_info(f"Fix: comment out OPENAI_BASE_URL in {_DHH}/.env or align endpoints")
+            if should_fix:
+                # Comment out OPENAI_BASE_URL in .env
+                env_file = HERMES_HOME / ".env"
+                if env_file.exists():
+                    try:
+                        content = env_file.read_text()
+                        lines = content.splitlines()
+                        new_lines = []
+                        modified = False
+                        for line in lines:
+                            stripped = line.strip()
+                            if stripped.startswith("OPENAI_BASE_URL="):
+                                new_lines.append(f"# {line}  # commented by hermes doctor --fix")
+                                modified = True
+                            else:
+                                new_lines.append(line)
+                        if modified:
+                            env_file.write_text("\n".join(new_lines) + "\n")
+                            check_ok(f"Commented out OPENAI_BASE_URL in {_DHH}/.env")
+                            fixed_count += 1
+                    except Exception as e:
+                        check_warn(f"Could not fix .env: {e}")
+            else:
+                issues.append(f"OPENAI_BASE_URL in .env conflicts with base_url in config.yaml — run 'hermes doctor --fix'")
+        else:
+            check_ok("OPENAI_BASE_URL matches config.yaml base_url")
+    elif env_base_url and not config_base_url:
+        check_ok(f"OPENAI_BASE_URL set (custom endpoint: {env_base_url[:50]}...)")
+    elif config_base_url:
+        check_ok(f"base_url configured in config.yaml")
+    else:
+        check_ok("Using provider defaults (no custom endpoint)")
+
+    # =========================================================================
     # Check: Auth providers
     # =========================================================================
     print()

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -59,6 +59,36 @@ def _has_provider_env_config(content: str) -> bool:
     return any(key in content for key in _PROVIDER_ENV_HINTS)
 
 
+def _normalize_base_url(url: str) -> str:
+    """Normalize a base URL for comparison.
+
+    Handles:
+      - Trailing slashes
+      - Default ports (:443 for https, :80 for http)
+      - Case normalization for scheme/host
+
+    This prevents false-positive conflict warnings when URLs are semantically
+    identical but differ in representation (e.g., https://api.example.com:443/
+    vs https://api.example.com).
+    """
+    import re
+    if not url:
+        return ""
+    url = url.strip().rstrip("/")
+    # Normalize scheme and host to lowercase (path case is preserved)
+    if "://" in url:
+        scheme_host, _, path = url.partition("/")
+        if "/" in path:
+            # Has path after host
+            url = scheme_host.lower() + "/" + path
+        else:
+            url = url.lower()
+    # Remove default ports
+    url = re.sub(r"^(https://[^/:]+):443(/|$)", r"\1\2", url)
+    url = re.sub(r"^(http://[^/:]+):80(/|$)", r"\1\2", url)
+    return url
+
+
 def _honcho_is_configured_for_doctor() -> bool:
     """Return True when Honcho is configured, even if this process has no active session."""
     try:
@@ -325,22 +355,26 @@ def run_doctor(args):
     print(color("◆ Provider Endpoint Configuration", Colors.CYAN, Colors.BOLD))
 
     # Check for OPENAI_BASE_URL vs config.yaml base_url conflict (#5161)
-    env_base_url = os.environ.get("OPENAI_BASE_URL", "").rstrip("/")
+    env_base_url_raw = os.environ.get("OPENAI_BASE_URL", "")
+    env_base_url = _normalize_base_url(env_base_url_raw)
     config_base_url = ""
+    config_base_url_raw = ""
     try:
         config_path = HERMES_HOME / "config.yaml"
         if config_path.exists():
             with open(config_path) as f:
                 raw_config = yaml.safe_load(f) or {}
-            config_base_url = (raw_config.get("model", {}).get("base_url") or "").rstrip("/")
+            config_base_url_raw = raw_config.get("model", {}).get("base_url") or ""
+            config_base_url = _normalize_base_url(config_base_url_raw)
     except Exception:
         pass
 
     if env_base_url and config_base_url:
         if env_base_url != config_base_url:
+            # Show raw values in output so users can see what they configured
             check_warn(
                 "OPENAI_BASE_URL conflicts with config.yaml base_url",
-                f"(env: {env_base_url[:40]}... vs config: {config_base_url[:40]}...)"
+                f"(env: {env_base_url_raw[:40]}... vs config: {config_base_url_raw[:40]}...)"
             )
             check_info("Auxiliary clients (compression, vision, subagents) may route to wrong endpoint")
             check_info(f"Fix: comment out OPENAI_BASE_URL in {_DHH}/.env or align endpoints")


### PR DESCRIPTION
## Summary

Adds a new 'Provider Endpoint Configuration' check to `hermes doctor` that detects when `OPENAI_BASE_URL` in `.env` conflicts with `base_url` in `config.yaml`.

## Problem

When switching providers via `hermes model`, the `config.yaml` is updated with the new `base_url`, but any pre-existing `OPENAI_BASE_URL` in `.env` remains. This causes:

- **Main conversations**: Work correctly (use explicit `base_url` from `config.yaml`)
- **Auxiliary clients**: Route to wrong endpoint (fall back to `OPENAI_BASE_URL` from environment)
  - Context compression
  - Vision analysis
  - Subagent delegation via `delegate_task`
  - Memory extraction

The failure is hard to diagnose because it's asymmetric — main inference works, but auxiliary operations silently fail or produce degraded output.

## Solution

The new check in `hermes doctor`:

1. Reads `OPENAI_BASE_URL` from environment
2. Reads `base_url` from `config.yaml`
3. Compares them (normalizing trailing slashes)
4. Warns if both are set and differ
5. Explains which clients are affected
6. Offers `--fix` to comment out the conflicting env var

### Example output

```
◆ Provider Endpoint Configuration
  ⚠ OPENAI_BASE_URL conflicts with config.yaml base_url (env: https://integrate.api.nvidia.com/v... vs config: https://openrouter.ai/api/v...)
    → Auxiliary clients (compression, vision, subagents) may route to wrong endpoint
    → Fix: comment out OPENAI_BASE_URL in ~/.hermes/.env or align endpoints
```

## Testing

1. Set `OPENAI_BASE_URL=https://example.com/v1` in `.env`
2. Set `base_url: https://different.com/v1` in `config.yaml`
3. Run `hermes doctor` — should warn about conflict
4. Run `hermes doctor --fix` — should comment out the env var

Fixes #5161