### PR TITLE
fix(cli): preserve image interrupts when re-queueing

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -898,6 +898,94 @@ def _detect_file_drop(user_input: str) -> "dict | None":
     }
 
 
+# ---------------------------------------------------------------------------
+# Interrupt/pending payload helpers — extracted as pure functions so the
+# queue reassembly path can safely handle multimodal image payloads.
+# ---------------------------------------------------------------------------
+
+
+def _split_input_payload(payload: Any) -> tuple[str, list[Path]]:
+    """Normalize a queued CLI input payload into ``(text, images)``.
+
+    Interactive input is queued as either:
+      - ``str`` for text-only turns
+      - ``(text, [Path, ...])`` when clipboard/dragged images are attached
+
+    The interrupt requeue path may have to merge multiple queued payloads, so
+    this helper defensively tolerates tuples, lists, strings, ``None``, and
+    path-like values without crashing the CLI.
+    """
+    if payload is None:
+        return "", []
+
+    if isinstance(payload, str):
+        return payload, []
+
+    if isinstance(payload, tuple) and len(payload) == 2:
+        text, images = payload
+        text_value = text if isinstance(text, str) else ("" if text is None else str(text))
+        if images is None:
+            return text_value, []
+        if isinstance(images, (list, tuple)):
+            coerced = [
+                img if isinstance(img, Path) else Path(img)
+                for img in images
+                if img is not None
+            ]
+            return text_value, coerced
+        return text_value, [images if isinstance(images, Path) else Path(images)]
+
+    return str(payload), []
+
+
+def _merge_input_payloads(payloads: list[Any]) -> str | tuple[str, list[Path]] | None:
+    """Merge queued CLI inputs while preserving attached image payloads.
+
+    Text payloads are joined with newlines in arrival order. Any attached image
+    paths are concatenated in the same order. Returns:
+      - ``str`` when only text is present
+      - ``(text, [Path, ...])`` when one or more images are present
+      - ``None`` when every payload is empty
+    """
+    text_parts: list[str] = []
+    image_paths: list[Path] = []
+
+    for payload in payloads:
+        text, images = _split_input_payload(payload)
+        if text:
+            text_parts.append(text)
+        if images:
+            image_paths.extend(images)
+
+    if image_paths:
+        return ("\n".join(text_parts), image_paths)
+    if text_parts:
+        return "\n".join(text_parts)
+    return None
+
+
+def _preview_input_payload(payload: Any, max_chars: int = 50) -> str:
+    """Return a human-readable preview for queued/interrupted CLI payloads."""
+    text, images = _split_input_payload(payload)
+    text = text.strip()
+    image_label = (
+        f"[{len(images)} image{'s' if len(images) != 1 else ''} attached]"
+        if images
+        else ""
+    )
+
+    if text and image_label:
+        preview = f"{text} {image_label}"
+    elif text:
+        preview = text
+    else:
+        preview = image_label
+
+    if len(preview) > max_chars:
+        return preview[:max_chars] + "..."
+    return preview
+
+
 class ChatConsole:
     """Rich Console adapter for prompt_toolkit's patch_stdout context.
 
@@ -6578,14 +6666,15 @@ class HermesCLI:
                             all_parts.append(extra)
                     except queue.Empty:
                         break
-                combined = "\n".join(all_parts)
-                n = len(all_parts)
-                preview = combined[:50] + ("..." if len(combined) > 50 else "")
-                if n > 1:
-                    print(f"\n⚡ Sending {n} messages after interrupt: '{preview}'")
-                else:
-                    print(f"\n⚡ Sending after interrupt: '{preview}'")
-                self._pending_input.put(combined)
+                combined = _merge_input_payloads(all_parts)
+                if combined:
+                    n = len(all_parts)
+                    preview = _preview_input_payload(combined)
+                    if n > 1:
+                        print(f"\n⚡ Sending {n} messages after interrupt: '{preview}'")
+                    else:
+                        print(f"\n⚡ Sending after interrupt: '{preview}'")
+                    self._pending_input.put(combined)
             
             return response
             
@@ -8012,13 +8101,9 @@ class HermesCLI:
                             self._check_config_mcp_changes()
                         continue
                     
-                    if not user_input:
+                    user_input, submit_images = _split_input_payload(user_input)
+                    if not user_input and not submit_images:
                         continue
-
-                    # Unpack image payload: (text, [Path, ...]) or plain str
-                    submit_images = []
-                    if isinstance(user_input, tuple):
-                        user_input, submit_images = user_input
                     
                     # Check for commands — but detect dragged/pasted file paths first.
                     # See _detect_file_drop() for details.
@@ -8077,19 +8162,22 @@ class HermesCLI:
                         user_input = expanded
                     else:
                         _user_bar = f"[{_accent_hex()}]{'─' * 40}[/]"
-                        if '\n' in user_input:
+                        print()
+                        ChatConsole().print(_user_bar)
+                        if user_input and '\n' in user_input:
                             first_line = user_input.split('\n')[0]
                             line_count = user_input.count('\n') + 1
-                            print()
-                            ChatConsole().print(_user_bar)
                             ChatConsole().print(
                                 f"[bold {_accent_hex()}]●[/] [bold]{_escape(first_line)}[/] "
                                 f"[dim](+{line_count - 1} lines)[/]"
                             )
-                        else:
-                            print()
-                            ChatConsole().print(_user_bar)
+                        elif user_input:
                             ChatConsole().print(f"[bold {_accent_hex()}]●[/] [bold]{_escape(user_input)}[/]")
+                        else:
+                            image_summary = f"[Attached {len(submit_images)} image{'s' if len(submit_images) != 1 else ''}]"
+                            ChatConsole().print(
+                                f"[bold {_accent_hex()}]●[/] [bold]{_escape(image_summary)}[/]"
+                            )
                     
                     # Show image attachment count
                     if submit_images:

--- a/tests/test_cli_interrupt_payloads.py
+++ b/tests/test_cli_interrupt_payloads.py
@@ -1,0 +1,81 @@
+"""Tests for CLI interrupt payload merging with attached images."""
+
+from pathlib import Path
+
+from cli import _merge_input_payloads, _preview_input_payload, _split_input_payload
+
+
+class TestSplitInputPayload:
+    def test_text_payload(self):
+        text, images = _split_input_payload("retry")
+        assert text == "retry"
+        assert images == []
+
+    def test_tuple_payload_preserves_images(self, tmp_path):
+        img = tmp_path / "clip.png"
+        img.write_bytes(b"png")
+
+        text, images = _split_input_payload(("what do you see?", [img]))
+
+        assert text == "what do you see?"
+        assert images == [img]
+
+    def test_non_path_images_are_coerced(self, tmp_path):
+        img = tmp_path / "clip.png"
+        img.write_bytes(b"png")
+
+        text, images = _split_input_payload(("", [str(img)]))
+
+        assert text == ""
+        assert images == [img]
+
+
+class TestMergeInputPayloads:
+    def test_text_only_payloads_join_with_newlines(self):
+        merged = _merge_input_payloads(["stop", "show me the plan instead"])
+
+        assert merged == "stop\nshow me the plan instead"
+
+    def test_image_interrupts_preserve_paths_instead_of_crashing(self, tmp_path):
+        img1 = tmp_path / "clip_1.png"
+        img2 = tmp_path / "clip_2.png"
+        img1.write_bytes(b"png")
+        img2.write_bytes(b"png")
+
+        merged = _merge_input_payloads([
+            ("", [img1]),
+            "retry",
+            ("describe this one too", [img2]),
+        ])
+
+        assert isinstance(merged, tuple)
+        text, images = merged
+        assert text == "retry\ndescribe this one too"
+        assert images == [img1, img2]
+
+    def test_image_only_payloads_stay_multimodal(self, tmp_path):
+        img = tmp_path / "clip.png"
+        img.write_bytes(b"png")
+
+        merged = _merge_input_payloads([("", [img])])
+
+        assert merged == ("", [img])
+
+    def test_all_empty_payloads_return_none(self):
+        assert _merge_input_payloads(["", None, ("", [])]) is None
+
+
+class TestPreviewInputPayload:
+    def test_preview_mentions_images_when_text_is_empty(self, tmp_path):
+        img1 = tmp_path / "clip_1.png"
+        img2 = tmp_path / "clip_2.png"
+        img1.write_bytes(b"png")
+        img2.write_bytes(b"png")
+
+        preview = _preview_input_payload(("", [img1, img2]))
+
+        assert preview == "[2 images attached]"
+
+    def test_preview_truncates_long_text(self):
+        preview = _preview_input_payload("x" * 60, max_chars=10)
+        assert preview == "xxxxxxxxxx..."


### PR DESCRIPTION
## Summary
- preserve multimodal `(text, [Path, ...])` CLI payloads when merging interrupted input back into `_pending_input`
- avoid `"\n".join(...)` on tuple payloads, which crashed when a running turn was interrupted with attached clipboard images
- add regression coverage for tuple/image payload splitting, merging, and preview formatting

## Reproduction (before fix)
Interactive CLI repro:
1. Start `hermes` in interactive mode.
2. Ask it to do something long-running so the agent stays busy for a bit.
3. While it is still running, paste or attach an image from the clipboard so the input is queued as an image payload.
4. Hit Enter to interrupt the current turn.
5. Let Hermes re-queue the interrupted input for the next turn.

Before this patch, the re-queue path treated every queued item as a string and attempted `"\n".join(all_parts)`. If one of those items was the image payload tuple, Hermes crashed with:

`TypeError: sequence item 0: expected str instance, tuple found`

The exact failing payload shape looked like:

`("", [PosixPath("/Users/.../.hermes/images/clip_*.png")])`

Minimal code-level repro:
```py
all_parts = [('', [Path('/tmp/clip.png')]), 'retry']
'\n'.join(all_parts)
```

## Root cause
The interactive CLI queues image attachments as `(text, images)` tuples. When a turn was interrupted, the requeue path treated every pending item as a string and did `"\n".join(all_parts)`, which raised the TypeError above.

## Validation
- `~/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts='' tests/test_cli_interrupt_payloads.py tests/test_cli_file_drop.py tests/tools/test_interrupt.py -q`
- `~/.hermes/hermes-agent/venv/bin/python -m py_compile cli.py tests/test_cli_interrupt_payloads.py`
- `git diff --check`
