### PR TITLE
fix(profiles): support Windows profile aliases

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3747,7 +3747,7 @@ def cmd_profile(args):
         list_profiles, create_profile, delete_profile, seed_profile_skills,
         get_active_profile, set_active_profile, get_active_profile_name,
         check_alias_collision, create_wrapper_script, remove_wrapper_script,
-        _is_wrapper_dir_in_path, _get_wrapper_dir,
+        _is_wrapper_dir_in_path, _get_wrapper_dir, _get_wrapper_path,
     )
     from hermes_constants import display_hermes_home
 
@@ -3902,7 +3902,7 @@ def cmd_profile(args):
         model, provider = _read_config_model(profile_dir)
         gw = _check_gateway_running(profile_dir)
         skills = _count_skills(profile_dir)
-        wrapper = _get_wrapper_dir() / name
+        wrapper = _get_wrapper_path(name)
 
         print(f"\nProfile: {name}")
         print(f"Path:    {profile_dir}")

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -137,6 +137,12 @@ def _get_wrapper_dir() -> Path:
     return Path.home() / ".local" / "bin"
 
 
+def _get_wrapper_path(name: str) -> Path:
+    """Return the platform-specific wrapper path for a profile alias."""
+    suffix = ".cmd" if os.name == "nt" else ""
+    return _get_wrapper_dir() / f"{name}{suffix}"
+
+
 # ---------------------------------------------------------------------------
 # Validation
 # ---------------------------------------------------------------------------
@@ -181,24 +187,22 @@ def check_alias_collision(name: str) -> Optional[str]:
         return f"'{name}' conflicts with a hermes subcommand"
 
     # Check existing commands in PATH
-    wrapper_dir = _get_wrapper_dir()
-    try:
-        result = subprocess.run(
-            ["which", name], capture_output=True, text=True, timeout=5,
-        )
-        if result.returncode == 0:
-            existing_path = result.stdout.strip()
-            # Allow overwriting our own wrappers
-            if existing_path == str(wrapper_dir / name):
-                try:
-                    content = (wrapper_dir / name).read_text()
-                    if "hermes -p" in content:
-                        return None  # it's our wrapper, safe to overwrite
-                except Exception:
-                    pass
-            return f"'{name}' conflicts with an existing command ({existing_path})"
-    except (FileNotFoundError, subprocess.TimeoutExpired):
-        pass
+    wrapper_path = _get_wrapper_path(name)
+    existing_path = shutil.which(name)
+    if existing_path:
+        existing = Path(existing_path)
+        try:
+            same_wrapper = existing.resolve() == wrapper_path.resolve()
+        except OSError:
+            same_wrapper = existing == wrapper_path
+        if same_wrapper:
+            try:
+                content = wrapper_path.read_text()
+                if "hermes -p" in content:
+                    return None  # it's our wrapper, safe to overwrite
+            except Exception:
+                pass
+        return f"'{name}' conflicts with an existing command ({existing_path})"
 
     return None  # safe
 
@@ -221,10 +225,13 @@ def create_wrapper_script(name: str) -> Optional[Path]:
         print(f"⚠ Could not create {wrapper_dir}: {e}")
         return None
 
-    wrapper_path = wrapper_dir / name
+    wrapper_path = _get_wrapper_path(name)
     try:
-        wrapper_path.write_text(f'#!/bin/sh\nexec hermes -p {name} "$@"\n')
-        wrapper_path.chmod(wrapper_path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        if os.name == "nt":
+            wrapper_path.write_text(f"@echo off\nhermes -p {name} %*\n")
+        else:
+            wrapper_path.write_text(f'#!/bin/sh\nexec hermes -p {name} "$@"\n')
+            wrapper_path.chmod(wrapper_path.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
         return wrapper_path
     except OSError as e:
         print(f"⚠ Could not create wrapper at {wrapper_path}: {e}")
@@ -233,7 +240,7 @@ def create_wrapper_script(name: str) -> Optional[Path]:
 
 def remove_wrapper_script(name: str) -> bool:
     """Remove the wrapper script for a profile. Returns True if removed."""
-    wrapper_path = _get_wrapper_dir() / name
+    wrapper_path = _get_wrapper_path(name)
     if wrapper_path.exists():
         try:
             # Verify it's our wrapper before removing
@@ -320,7 +327,6 @@ def _count_skills(profile_dir: Path) -> int:
 def list_profiles() -> List[ProfileInfo]:
     """Return info for all profiles, including the default."""
     profiles = []
-    wrapper_dir = _get_wrapper_dir()
 
     # Default profile
     default_home = _get_default_hermes_home()
@@ -347,7 +353,7 @@ def list_profiles() -> List[ProfileInfo]:
             if not _PROFILE_ID_RE.match(name):
                 continue
             model, provider = _read_config_model(entry)
-            alias_path = wrapper_dir / name
+            alias_path = _get_wrapper_path(name)
             profiles.append(ProfileInfo(
                 name=name,
                 path=entry,
@@ -518,7 +524,7 @@ def delete_profile(name: str, yes: bool = False) -> Path:
 
     # Check for service
     from hermes_cli.gateway import _profile_suffix, get_service_name
-    wrapper_path = _get_wrapper_dir() / name
+    wrapper_path = _get_wrapper_path(name)
     has_wrapper = wrapper_path.exists()
     if has_wrapper:
         items.append(f"Command alias ({wrapper_path})")

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -137,9 +137,14 @@ def _get_wrapper_dir() -> Path:
     return Path.home() / ".local" / "bin"
 
 
+def _is_windows() -> bool:
+    """Return True when wrapper behavior should follow Windows conventions."""
+    return os.name == "nt"
+
+
 def _get_wrapper_path(name: str) -> Path:
     """Return the platform-specific wrapper path for a profile alias."""
-    suffix = ".cmd" if os.name == "nt" else ""
+    suffix = ".cmd" if _is_windows() else ""
     return _get_wrapper_dir() / f"{name}{suffix}"
 
 
@@ -227,7 +232,7 @@ def create_wrapper_script(name: str) -> Optional[Path]:
 
     wrapper_path = _get_wrapper_path(name)
     try:
-        if os.name == "nt":
+        if _is_windows():
             wrapper_path.write_text(f"@echo off\nhermes -p {name} %*\n")
         else:
             wrapper_path.write_text(f'#!/bin/sh\nexec hermes -p {name} "$@"\n')

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -13,11 +13,13 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import pytest
+import hermes_cli.profiles as profiles_mod
 
 from hermes_cli.profiles import (
     validate_profile_name,
     get_profile_dir,
     create_profile,
+    create_wrapper_script,
     delete_profile,
     list_profiles,
     set_active_profile,
@@ -356,6 +358,35 @@ class TestAliasCollision:
         result = check_alias_collision("default")
         assert result is not None
         assert "reserved" in result.lower()
+
+
+class TestWindowsWrappers:
+    """Windows-specific alias wrapper behavior."""
+
+    def test_create_wrapper_script_uses_cmd_on_windows(self, profile_env, monkeypatch):
+        monkeypatch.setattr(profiles_mod.os, "name", "nt")
+
+        wrapper = create_wrapper_script("coder")
+
+        assert wrapper == profile_env / ".local" / "bin" / "coder.cmd"
+        assert wrapper.read_text() == "@echo off\nhermes -p coder %*\n"
+
+    def test_check_alias_collision_allows_existing_windows_wrapper(self, profile_env, monkeypatch):
+        monkeypatch.setattr(profiles_mod.os, "name", "nt")
+        wrapper = create_wrapper_script("coder")
+        monkeypatch.setattr(profiles_mod.shutil, "which", lambda _: str(wrapper))
+
+        assert check_alias_collision("coder") is None
+
+    def test_list_profiles_detects_windows_wrapper_alias(self, profile_env, monkeypatch):
+        monkeypatch.setattr(profiles_mod.os, "name", "nt")
+        create_profile("coder", no_alias=True)
+        wrapper = create_wrapper_script("coder")
+
+        profiles = list_profiles()
+        coder = next(p for p in profiles if p.name == "coder")
+
+        assert coder.alias_path == wrapper
 
 
 # ===================================================================

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -364,7 +364,7 @@ class TestWindowsWrappers:
     """Windows-specific alias wrapper behavior."""
 
     def test_create_wrapper_script_uses_cmd_on_windows(self, profile_env, monkeypatch):
-        monkeypatch.setattr(profiles_mod.os, "name", "nt")
+        monkeypatch.setattr(profiles_mod, "_is_windows", lambda: True)
 
         wrapper = create_wrapper_script("coder")
 
@@ -372,14 +372,14 @@ class TestWindowsWrappers:
         assert wrapper.read_text() == "@echo off\nhermes -p coder %*\n"
 
     def test_check_alias_collision_allows_existing_windows_wrapper(self, profile_env, monkeypatch):
-        monkeypatch.setattr(profiles_mod.os, "name", "nt")
+        monkeypatch.setattr(profiles_mod, "_is_windows", lambda: True)
         wrapper = create_wrapper_script("coder")
         monkeypatch.setattr(profiles_mod.shutil, "which", lambda _: str(wrapper))
 
         assert check_alias_collision("coder") is None
 
     def test_list_profiles_detects_windows_wrapper_alias(self, profile_env, monkeypatch):
-        monkeypatch.setattr(profiles_mod.os, "name", "nt")
+        monkeypatch.setattr(profiles_mod, "_is_windows", lambda: True)
         create_profile("coder", no_alias=True)
         wrapper = create_wrapper_script("coder")
 


### PR DESCRIPTION
## Overview

This PR fixes the profile alias workflow on Windows.

The existing alias implementation assumed a POSIX-style environment: collision checks relied on `which`, wrapper creation produced an extensionless `#!/bin/sh` script, and the related show/list/delete flows looked for that same POSIX-style wrapper path.

That works on Unix-like systems, but it breaks on Windows, where the alias wrapper is neither resolved nor executed the way the CLI suggests.

---

## What was happening

After running:

```bash
hermes profile create coder