### PR TITLE
fix(claw): copy openclaw.json to Hermes home after migration (fixes #5190)

### DIFF
--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -197,6 +197,22 @@ def _cmd_migrate(args):
         logger.debug("OpenClaw migration error", exc_info=True)
         return
 
+
+    # Warn about openclaw.json not being copied
+    if not dry_run:
+        source_config = source_dir / "openclaw.json"
+        if source_config.exists():
+            import shutil
+            hermes_home = get_hermes_home()
+            dest_config = hermes_home / "openclaw.json"
+            if not dest_config.exists():
+                shutil.copy2(source_config, dest_config)
+                print()
+                print_success(f"Copied openclaw.json to {dest_config}")
+            else:
+                print()
+                print_warning("openclaw.json already exists in Hermes home, skipping copy.")
+
     # Print results
     _print_migration_report(report, dry_run)
 


### PR DESCRIPTION
## Problem
`hermes claw migrate` silently leaves `openclaw.json` behind after migration.
The gateway then starts with no config — no auth token, no model credentials,
no channel configuration — causing cryptic errors:

- `ENOENT: no such file or directory, chdir '~/.openclaw.pre-migration-.../workspace'`
- `unauthorized: gateway token missing`
- `openclaw status` reports gateway unreachable

## Fix
After a successful (non-dry-run) migration, `_cmd_migrate` now:
1. Checks if `openclaw.json` exists in the source directory
2. Copies it to `~/.hermes/openclaw.json` if not already present
3. Prints a clear success or skip message so the user knows what happened

Fixes #5190