### PR TITLE
fix(whatsapp): clarify allowlist number format in setup prompts

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -737,9 +737,9 @@ def cmd_whatsapp(args):
             response = "n"
         if response.lower() in ("y", "yes"):
             if wa_mode == "bot":
-                phone = input("  Phone numbers that can message the bot (comma-separated): ").strip()
+                phone = input("  Phone numbers that can message the bot (comma-separated, with country code, no +): ").strip()
             else:
-                phone = input("  Your phone number (e.g. 15551234567): ").strip()
+                phone = input("  Your phone number (with country code, no +, e.g. 15551234567): ").strip()
             if phone:
                 save_env_value("WHATSAPP_ALLOWED_USERS", phone.replace(" ", ""))
                 print(f"  ✓ Updated to: {phone}")
@@ -747,9 +747,9 @@ def cmd_whatsapp(args):
         print()
         if wa_mode == "bot":
             print("  Who should be allowed to message the bot?")
-            phone = input("  Phone numbers (comma-separated, or * for anyone): ").strip()
+            phone = input("  Phone numbers (comma-separated, with country code, no +, or * for anyone): ").strip()
         else:
-            phone = input("  Your phone number (e.g. 15551234567): ").strip()
+            phone = input("  Your phone number (with country code, no +, e.g. 15551234567): ").strip()
         if phone:
             save_env_value("WHATSAPP_ALLOWED_USERS", phone.replace(" ", ""))
             print(f"  ✓ Allowed users set: {phone}")


### PR DESCRIPTION
## Summary
- clarify WhatsApp setup prompts to explicitly ask for phone numbers with country code and no plus sign
- keep the change scoped to prompt text only

## Why
The current prompts are easy to misread, which makes it too easy to enter local-format numbers like  instead of the documented country-code format.

## Test plan
- not run (prompt-text only change)

Related to the general WhatsApp allowlist UX/docs issues around number formatting.