### PR TITLE
fix(config): handle locked config writes safely

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1052,6 +1052,18 @@ def _parse_skills_argument(skills: str | list[str] | tuple[str, ...] | None) -> 
     return parsed
 
 
+def save_config_value_result(key_path: str, value: any):
+    """Save a config key and return a structured result."""
+    from hermes_cli.config import save_config_key_result
+
+    # Use the same precedence as load_cli_config: user config first, then project config
+    user_config_path = _hermes_home / 'config.yaml'
+    project_config_path = Path(__file__).parent / 'cli-config.yaml'
+    config_path = user_config_path if user_config_path.exists() else project_config_path
+
+    return save_config_key_result(key_path, value, config_path=config_path)
+
+
 def save_config_value(key_path: str, value: any) -> bool:
     """
     Save a value to the active config file at the specified key path.
@@ -1067,46 +1079,27 @@ def save_config_value(key_path: str, value: any) -> bool:
     Returns:
         True if successful, False otherwise
     """
-    # Use the same precedence as load_cli_config: user config first, then project config
-    user_config_path = _hermes_home / 'config.yaml'
-    project_config_path = Path(__file__).parent / 'cli-config.yaml'
-    config_path = user_config_path if user_config_path.exists() else project_config_path
-    
     try:
-        # Ensure parent directory exists (for ~/.hermes/config.yaml on first use)
-        config_path.parent.mkdir(parents=True, exist_ok=True)
-        
-        # Load existing config
-        if config_path.exists():
-            with open(config_path, 'r') as f:
-                config = yaml.safe_load(f) or {}
-        else:
-            config = {}
-        
-        # Navigate to the key and set value
-        keys = key_path.split('.')
-        current = config
-        for key in keys[:-1]:
-            if key not in current or not isinstance(current[key], dict):
-                current[key] = {}
-            current = current[key]
-        current[keys[-1]] = value
-        
-        # Save back atomically — write to temp file + fsync + os.replace
-        # so an interrupt never leaves config.yaml truncated or empty.
-        from utils import atomic_yaml_write
-        atomic_yaml_write(config_path, config)
-        
-        # Enforce owner-only permissions on config files (contain API keys)
-        try:
-            os.chmod(config_path, 0o600)
-        except (OSError, NotImplementedError):
-            pass
-        
-        return True
+        result = save_config_value_result(key_path, value)
+        if result:
+            # Enforce owner-only permissions on config files (contain API keys)
+            try:
+                os.chmod(result.path, 0o600)
+            except (OSError, NotImplementedError):
+                pass
+        return bool(result)
     except Exception as e:
         logger.error("Failed to save config: %s", e)
         return False
+
+
+def _print_config_write_failure(action: str, result) -> None:
+    """Render a readable config write failure in the interactive CLI."""
+    from hermes_cli.config import describe_config_write_failure
+
+    print(f"  (! ) {action} could not be persisted.")
+    print()
+    print(describe_config_write_failure(result, action=action))
 
 
 
@@ -3757,17 +3750,21 @@ class HermesCLI:
             if new_prompt.lower() == "clear":
                 self.system_prompt = ""
                 self.agent = None  # Force re-init
-                if save_config_value("agent.system_prompt", ""):
+                result = save_config_value_result("agent.system_prompt", "")
+                if result:
                     print("(^_^)b System prompt cleared (saved to config)")
                 else:
                     print("(^_^) System prompt cleared (session only)")
+                    _print_config_write_failure("clear the system prompt", result)
             else:
                 self.system_prompt = new_prompt
                 self.agent = None  # Force re-init
-                if save_config_value("agent.system_prompt", new_prompt):
+                result = save_config_value_result("agent.system_prompt", new_prompt)
+                if result:
                     print("(^_^)b System prompt set (saved to config)")
                 else:
                     print("(^_^) System prompt set (session only)")
+                    _print_config_write_failure("save the system prompt", result)
                 print(f"  \"{new_prompt[:60]}{'...' if len(new_prompt) > 60 else ''}\"")
         else:
             # Show current prompt
@@ -3827,7 +3824,9 @@ class HermesCLI:
                 if save_config_value("agent.system_prompt", ""):
                     print("(^_^)b Personality cleared (saved to config)")
                 else:
+                    result = save_config_value_result("agent.system_prompt", "")
                     print("(^_^) Personality cleared (session only)")
+                    _print_config_write_failure("clear the personality overlay", result)
                 print("  No personality overlay — using base agent behavior.")
             elif personality_name in self.personalities:
                 self.system_prompt = self._resolve_personality_prompt(self.personalities[personality_name])
@@ -3835,7 +3834,9 @@ class HermesCLI:
                 if save_config_value("agent.system_prompt", self.system_prompt):
                     print(f"(^_^)b Personality set to '{personality_name}' (saved to config)")
                 else:
+                    result = save_config_value_result("agent.system_prompt", self.system_prompt)
                     print(f"(^_^) Personality set to '{personality_name}' (session only)")
+                    _print_config_write_failure("save the personality overlay", result)
                 print(f"  \"{self.system_prompt[:60]}{'...' if len(self.system_prompt) > 60 else ''}\"")
             else:
                 print(f"(._.) Unknown personality: {personality_name}")
@@ -5011,10 +5012,12 @@ class HermesCLI:
             return
 
         set_active_skin(new_skin)
-        if save_config_value("display.skin", new_skin):
+        result = save_config_value_result("display.skin", new_skin)
+        if result:
             print(f"  Skin set to: {new_skin} (saved)")
         else:
-            print(f"  Skin set to: {new_skin}")
+            print(f"  Skin set to: {new_skin} (session only)")
+            _print_config_write_failure("save the active skin", result)
         print("  Note: banner colors will update on next session start.")
         if self._apply_tui_skin_style():
             print("  Prompt + TUI colors updated.")
@@ -5091,16 +5094,24 @@ class HermesCLI:
             self.show_reasoning = True
             if self.agent:
                 self.agent.reasoning_callback = self._current_reasoning_callback()
-            save_config_value("display.show_reasoning", True)
-            _cprint(f"  {_GOLD}✓ Reasoning display: ON (saved){_RST}")
+            result = save_config_value_result("display.show_reasoning", True)
+            if result:
+                _cprint(f"  {_GOLD}✓ Reasoning display: ON (saved){_RST}")
+            else:
+                _cprint(f"  {_GOLD}✓ Reasoning display: ON (session only){_RST}")
+                _print_config_write_failure("save reasoning display settings", result)
             _cprint(f"  {_DIM}  Model thinking will be shown during and after each response.{_RST}")
             return
         if arg in ("hide", "off"):
             self.show_reasoning = False
             if self.agent:
                 self.agent.reasoning_callback = self._current_reasoning_callback()
-            save_config_value("display.show_reasoning", False)
-            _cprint(f"  {_GOLD}✓ Reasoning display: OFF (saved){_RST}")
+            result = save_config_value_result("display.show_reasoning", False)
+            if result:
+                _cprint(f"  {_GOLD}✓ Reasoning display: OFF (saved){_RST}")
+            else:
+                _cprint(f"  {_GOLD}✓ Reasoning display: OFF (session only){_RST}")
+                _print_config_write_failure("save reasoning display settings", result)
             return
 
         # Effort level change
@@ -5114,10 +5125,12 @@ class HermesCLI:
         self.reasoning_config = parsed
         self.agent = None  # Force agent re-init with new reasoning config
 
-        if save_config_value("agent.reasoning_effort", arg):
+        result = save_config_value_result("agent.reasoning_effort", arg)
+        if result:
             _cprint(f"  {_GOLD}✓ Reasoning effort set to '{arg}' (saved to config){_RST}")
         else:
             _cprint(f"  {_GOLD}✓ Reasoning effort set to '{arg}' (session only){_RST}")
+            _print_config_write_failure("save reasoning effort", result)
 
     def _on_reasoning(self, reasoning_text: str):
         """Callback for intermediate reasoning display during tool-call loops."""

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -353,14 +353,28 @@ class TelegramAdapter(BasePlatformAdapter):
         """Save a newly created thread_id back into config.yaml so it persists across restarts."""
         try:
             from hermes_constants import get_hermes_home
+            from hermes_cli.config import (
+                describe_config_write_failure,
+                load_raw_config_mapping_result,
+                save_yaml_config_result,
+            )
             config_path = get_hermes_home() / "config.yaml"
             if not config_path.exists():
                 logger.warning("[%s] Config file not found at %s, cannot persist thread_id", self.name, config_path)
                 return
 
-            import yaml as _yaml
-            with open(config_path, "r") as f:
-                config = _yaml.safe_load(f) or {}
+            config, load_error = load_raw_config_mapping_result(
+                config_path,
+                action="persist Telegram DM topic thread IDs",
+            )
+            if load_error is not None:
+                logger.warning(
+                    "[%s] %s",
+                    self.name,
+                    describe_config_write_failure(load_error, action="persist Telegram DM topic thread IDs"),
+                )
+                return
+            assert config is not None
 
             # Navigate to platforms.telegram.extra.dm_topics
             dm_topics = (
@@ -383,8 +397,14 @@ class TelegramAdapter(BasePlatformAdapter):
                         break
 
             if changed:
-                with open(config_path, "w") as f:
-                    _yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+                result = save_yaml_config_result(config_path, config, sort_keys=False)
+                if not result:
+                    logger.warning(
+                        "[%s] %s",
+                        self.name,
+                        describe_config_write_failure(result, action="persist Telegram DM topic thread IDs"),
+                    )
+                    return
                 logger.info(
                     "[%s] Persisted thread_id=%s for topic '%s' in config.yaml",
                     self.name, thread_id, topic_name,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3526,22 +3526,19 @@ class GatewayRunner:
     
     async def _handle_personality_command(self, event: MessageEvent) -> str:
         """Handle /personality command - list or set a personality."""
-        import yaml
-
         args = event.get_command_args().strip().lower()
         config_path = _hermes_home / 'config.yaml'
 
-        try:
-            if config_path.exists():
-                with open(config_path, 'r', encoding="utf-8") as f:
-                    config = yaml.safe_load(f) or {}
-                personalities = config.get("agent", {}).get("personalities", {})
-            else:
-                config = {}
-                personalities = {}
-        except Exception:
-            config = {}
-            personalities = {}
+        from hermes_cli.config import load_raw_config_mapping_result
+
+        config, error_result = load_raw_config_mapping_result(
+            config_path,
+            action="read personality settings",
+        )
+        if error_result is not None:
+            return f"⚠️ {error_result.error}"
+        assert config is not None
+        personalities = config.get("agent", {}).get("personalities", {})
 
         if not personalities:
             return "No personalities configured in `~/.hermes/config.yaml`"
@@ -3570,10 +3567,14 @@ class GatewayRunner:
 
         if args in ("none", "default", "neutral"):
             try:
+                from hermes_cli.config import describe_config_write_failure, save_yaml_config_result
+
                 if "agent" not in config or not isinstance(config.get("agent"), dict):
                     config["agent"] = {}
                 config["agent"]["system_prompt"] = ""
-                atomic_yaml_write(config_path, config)
+                result = save_yaml_config_result(config_path, config)
+                if not result:
+                    return f"⚠️ Personality cleared for this session only.\n\n{describe_config_write_failure(result, action='save the personality change')}"
             except Exception as e:
                 return f"⚠️ Failed to save personality change: {e}"
             self._ephemeral_system_prompt = ""
@@ -3583,10 +3584,18 @@ class GatewayRunner:
 
             # Write to config.yaml, same pattern as CLI save_config_value.
             try:
+                from hermes_cli.config import describe_config_write_failure, save_yaml_config_result
+
                 if "agent" not in config or not isinstance(config.get("agent"), dict):
                     config["agent"] = {}
                 config["agent"]["system_prompt"] = new_prompt
-                atomic_yaml_write(config_path, config)
+                result = save_yaml_config_result(config_path, config)
+                if not result:
+                    self._ephemeral_system_prompt = new_prompt
+                    return (
+                        f"🎭 Personality set to **{args}**\n_(session only — config is locked)_\n\n"
+                        f"{describe_config_write_failure(result, action='save the personality change')}"
+                    )
             except Exception as e:
                 return f"⚠️ Failed to save personality change: {e}"
 
@@ -3666,19 +3675,31 @@ class GatewayRunner:
         chat_name = source.chat_name or chat_id
         
         env_key = f"{platform_name.upper()}_HOME_CHANNEL"
+        try:
+            from gateway.config import HomeChannel
+
+            if getattr(self, "config", None) and source.platform in self.config.platforms:
+                self.config.platforms[source.platform].home_channel = HomeChannel(
+                    platform=source.platform,
+                    chat_id=str(chat_id),
+                    name=str(chat_name),
+                )
+        except Exception:
+            logger.debug("Failed to update in-memory home channel", exc_info=True)
         
         # Save to config.yaml
         try:
-            import yaml
-            config_path = _hermes_home / 'config.yaml'
-            user_config = {}
-            if config_path.exists():
-                with open(config_path, encoding="utf-8") as f:
-                    user_config = yaml.safe_load(f) or {}
-            user_config[env_key] = chat_id
-            atomic_yaml_write(config_path, user_config)
+            from hermes_cli.config import describe_config_write_failure, save_config_key_result
+
+            result = save_config_key_result(env_key, chat_id, config_path=_hermes_home / "config.yaml")
             # Also set in the current environment so it takes effect immediately
             os.environ[env_key] = str(chat_id)
+            if not result:
+                return (
+                    f"✅ Home channel set to **{chat_name}** (ID: {chat_id}) for this running gateway only.\n"
+                    f"_(could not persist to config)_\n\n"
+                    f"{describe_config_write_failure(result, action='save the home channel')}"
+                )
         except Exception as e:
             return f"Failed to save home channel: {e}"
         
@@ -4493,22 +4514,17 @@ class GatewayRunner:
         def _save_config_key(key_path: str, value):
             """Save a dot-separated key to config.yaml."""
             try:
-                user_config = {}
-                if config_path.exists():
-                    with open(config_path, encoding="utf-8") as f:
-                        user_config = yaml.safe_load(f) or {}
-                keys = key_path.split(".")
-                current = user_config
-                for k in keys[:-1]:
-                    if k not in current or not isinstance(current[k], dict):
-                        current[k] = {}
-                    current = current[k]
-                current[keys[-1]] = value
-                atomic_yaml_write(config_path, user_config)
-                return True
+                from hermes_cli.config import ConfigWriteResult, save_config_key_result
+
+                return save_config_key_result(key_path, value, config_path=config_path)
             except Exception as e:
                 logger.error("Failed to save config key %s: %s", key_path, e)
-                return False
+                return ConfigWriteResult(
+                    success=False,
+                    path=config_path,
+                    error=e,
+                    blocked=False,
+                )
 
         if not args:
             # Show current state
@@ -4530,13 +4546,25 @@ class GatewayRunner:
         # Display toggle
         if args in ("show", "on"):
             self._show_reasoning = True
-            _save_config_key("display.show_reasoning", True)
-            return "🧠 ✓ Reasoning display: **ON**\nModel thinking will be shown before each response."
+            result = _save_config_key("display.show_reasoning", True)
+            if result:
+                return "🧠 ✓ Reasoning display: **ON**\nModel thinking will be shown before each response."
+            from hermes_cli.config import describe_config_write_failure
+            return (
+                "🧠 ✓ Reasoning display: **ON**\n_(session only — config is locked)_\n\n"
+                f"{describe_config_write_failure(result, action='save reasoning display settings')}"
+            )
 
         if args in ("hide", "off"):
             self._show_reasoning = False
-            _save_config_key("display.show_reasoning", False)
-            return "🧠 ✓ Reasoning display: **OFF**"
+            result = _save_config_key("display.show_reasoning", False)
+            if result:
+                return "🧠 ✓ Reasoning display: **OFF**"
+            from hermes_cli.config import describe_config_write_failure
+            return (
+                "🧠 ✓ Reasoning display: **OFF**\n_(session only — config is locked)_\n\n"
+                f"{describe_config_write_failure(result, action='save reasoning display settings')}"
+            )
 
         # Effort level change
         effort = args.strip()
@@ -4552,10 +4580,14 @@ class GatewayRunner:
             )
 
         self._reasoning_config = parsed
-        if _save_config_key("agent.reasoning_effort", effort):
+        result = _save_config_key("agent.reasoning_effort", effort)
+        if result:
             return f"🧠 ✓ Reasoning effort set to `{effort}` (saved to config)\n_(takes effect on next message)_"
-        else:
-            return f"🧠 ✓ Reasoning effort set to `{effort}` (this session only)"
+        from hermes_cli.config import describe_config_write_failure
+        return (
+            f"🧠 ✓ Reasoning effort set to `{effort}` (this session only)\n\n"
+            f"{describe_config_write_failure(result, action='save reasoning effort')}"
+        )
 
     async def _handle_yolo_command(self, event: MessageEvent) -> str:
         """Handle /yolo — toggle dangerous command approval bypass."""
@@ -4574,19 +4606,19 @@ class GatewayRunner:
         When enabled, cycles the tool progress mode through off → new → all →
         verbose → off, same as the CLI.
         """
-        import yaml
-
         config_path = _hermes_home / "config.yaml"
 
         # --- check config gate ------------------------------------------------
-        try:
-            user_config = {}
-            if config_path.exists():
-                with open(config_path, encoding="utf-8") as f:
-                    user_config = yaml.safe_load(f) or {}
-            gate_enabled = user_config.get("display", {}).get("tool_progress_command", False)
-        except Exception:
-            gate_enabled = False
+        from hermes_cli.config import load_raw_config_mapping_result
+
+        user_config, error_result = load_raw_config_mapping_result(
+            config_path,
+            action="read `/verbose` settings",
+        )
+        if error_result is not None:
+            return f"⚠️ {error_result.error}"
+        assert user_config is not None
+        gate_enabled = user_config.get("display", {}).get("tool_progress_command", False)
 
         if not gate_enabled:
             return (
@@ -4619,11 +4651,18 @@ class GatewayRunner:
 
         # Save to config.yaml
         try:
+            from hermes_cli.config import describe_config_write_failure, save_yaml_config_result
+
             if "display" not in user_config or not isinstance(user_config.get("display"), dict):
                 user_config["display"] = {}
             user_config["display"]["tool_progress"] = new_mode
-            atomic_yaml_write(config_path, user_config)
-            return f"{descriptions[new_mode]}\n_(saved to config — takes effect on next message)_"
+            result = save_yaml_config_result(config_path, user_config)
+            if result:
+                return f"{descriptions[new_mode]}\n_(saved to config — takes effect on next message)_"
+            return (
+                f"{descriptions[new_mode]}\n_(session only — config is locked)_\n\n"
+                f"{describe_config_write_failure(result, action='save tool progress mode')}"
+            )
         except Exception as e:
             logger.warning("Failed to save tool_progress mode: %s", e)
             return f"{descriptions[new_mode]}\n_(could not save to config: {e})_"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3687,21 +3687,19 @@ class GatewayRunner:
         except Exception:
             logger.debug("Failed to update in-memory home channel", exc_info=True)
         
-        # Save to config.yaml
+        # Save to .env
         try:
-            from hermes_cli.config import describe_config_write_failure, save_config_key_result
+            from hermes_cli.config import save_env_value
 
-            result = save_config_key_result(env_key, chat_id, config_path=_hermes_home / "config.yaml")
+            save_env_value(env_key, str(chat_id))
             # Also set in the current environment so it takes effect immediately
             os.environ[env_key] = str(chat_id)
-            if not result:
-                return (
-                    f"✅ Home channel set to **{chat_name}** (ID: {chat_id}) for this running gateway only.\n"
-                    f"_(could not persist to config)_\n\n"
-                    f"{describe_config_write_failure(result, action='save the home channel')}"
-                )
         except Exception as e:
-            return f"Failed to save home channel: {e}"
+            os.environ[env_key] = str(chat_id)
+            return (
+                f"✅ Home channel set to **{chat_name}** (ID: {chat_id}) for this running gateway only.\n"
+                f"_(could not persist to .env: {e})_"
+            )
         
         return (
             f"✅ Home channel set to **{chat_name}** (ID: {chat_id}).\n"

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2082,14 +2082,22 @@ def _update_config_for_provider(
     config_path = get_config_path()
     config_path.parent.mkdir(parents=True, exist_ok=True)
 
-    config: Dict[str, Any] = {}
-    if config_path.exists():
-        try:
-            loaded = yaml.safe_load(config_path.read_text()) or {}
-            if isinstance(loaded, dict):
-                config = loaded
-        except Exception:
-            config = {}
+    from hermes_cli.config import (
+        ConfigWriteError,
+        load_raw_config_mapping_result,
+        save_yaml_config_result,
+    )
+
+    config, load_error = load_raw_config_mapping_result(config_path, action="save provider settings")
+    if load_error is not None:
+        raise ConfigWriteError(
+            path=config_path,
+            action="save provider settings",
+            error=load_error.error or OSError("invalid existing config"),
+            blocked=load_error.blocked,
+            diff=load_error.diff,
+        )
+    assert config is not None
 
     current_model = config.get("model")
     if isinstance(current_model, dict):
@@ -2116,7 +2124,15 @@ def _update_config_for_provider(
 
     config["model"] = model_cfg
 
-    config_path.write_text(yaml.safe_dump(config, sort_keys=False))
+    result = save_yaml_config_result(config_path, config, sort_keys=False)
+    if not result:
+        raise ConfigWriteError(
+            path=config_path,
+            action="save provider settings",
+            error=result.error or OSError("unknown config write failure"),
+            blocked=result.blocked,
+            diff=result.diff,
+        )
     return config_path
 
 
@@ -2126,20 +2142,38 @@ def _reset_config_provider() -> Path:
     if not config_path.exists():
         return config_path
 
-    try:
-        config = yaml.safe_load(config_path.read_text()) or {}
-    except Exception:
-        return config_path
+    from hermes_cli.config import (
+        ConfigWriteError,
+        load_raw_config_mapping_result,
+        save_yaml_config_result,
+    )
 
-    if not isinstance(config, dict):
-        return config_path
+    config, load_error = load_raw_config_mapping_result(config_path, action="reset provider settings")
+    if load_error is not None:
+        raise ConfigWriteError(
+            path=config_path,
+            action="reset provider settings",
+            error=load_error.error or OSError("invalid existing config"),
+            blocked=load_error.blocked,
+            diff=load_error.diff,
+        )
+    assert config is not None
 
     model = config.get("model")
     if isinstance(model, dict):
         model["provider"] = "auto"
         if "base_url" in model:
             model["base_url"] = OPENROUTER_BASE_URL
-    config_path.write_text(yaml.safe_dump(config, sort_keys=False))
+
+    result = save_yaml_config_result(config_path, config, sort_keys=False)
+    if not result:
+        raise ConfigWriteError(
+            path=config_path,
+            action="reset provider settings",
+            error=result.error or OSError("unknown config write failure"),
+            blocked=result.blocked,
+            diff=result.diff,
+        )
     return config_path
 
 

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -29,6 +29,7 @@ from agent.credential_pool import (
 )
 import hermes_cli.auth as auth_mod
 from hermes_cli.auth import PROVIDER_REGISTRY
+from hermes_cli.config import guard_config_command
 from hermes_constants import OPENROUTER_BASE_URL
 
 
@@ -465,6 +466,7 @@ def _interactive_strategy() -> None:
     print(f"Set {provider} strategy to: {strategy}")
 
 
+@guard_config_command
 def auth_command(args) -> None:
     action = getattr(args, "auth_action", "")
     if action == "add":

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -19,8 +19,13 @@ import stat
 import subprocess
 import sys
 import tempfile
+import difflib
+import errno
+import shutil
 from pathlib import Path
 from typing import Dict, Any, Optional, List, Tuple
+from dataclasses import dataclass
+from functools import wraps
 
 from tools.tool_backend_helpers import managed_nous_tools_enabled as _managed_nous_tools_enabled
 
@@ -62,6 +67,65 @@ _MANAGED_SYSTEM_NAMES = {
     "nixos": "NixOS",
 }
 
+_LOCKED_CONFIG_ERRNOS = {errno.EACCES, errno.EPERM, errno.EROFS, errno.EBUSY}
+
+
+@dataclass
+class ConfigWriteResult:
+    """Structured outcome for config.yaml write attempts."""
+
+    success: bool
+    path: Path
+    error: Optional[BaseException] = None
+    blocked: bool = False
+    diff: str = ""
+
+    def __bool__(self) -> bool:
+        return self.success
+
+
+class ConfigWriteError(OSError):
+    """Raised when Hermes cannot persist config.yaml changes."""
+
+    def __init__(
+        self,
+        *,
+        path: Path,
+        action: str,
+        error: BaseException,
+        blocked: bool,
+        diff: str = "",
+    ) -> None:
+        self.path = Path(path)
+        self.action = action
+        self.original_error = error
+        self.blocked = blocked
+        self.diff = diff
+        super().__init__(describe_config_write_failure(
+            ConfigWriteResult(
+                success=False,
+                path=self.path,
+                error=error,
+                blocked=blocked,
+                diff=diff,
+            ),
+            action=action,
+        ))
+
+
+def guard_config_command(func):
+    """Catch ConfigWriteError for user-facing CLI command entry points."""
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except ConfigWriteError as exc:
+            print(str(exc))
+            return None
+
+    return wrapper
+
 
 def get_managed_system() -> Optional[str]:
     """Return the package manager owning this install, if any."""
@@ -101,6 +165,245 @@ def get_managed_update_command() -> Optional[str]:
 def recommended_update_command() -> str:
     """Return the best update command for the current installation."""
     return get_managed_update_command() or "hermes update"
+
+
+def _render_yaml_text(
+    data: Any,
+    *,
+    default_flow_style: bool = False,
+    sort_keys: bool = False,
+    extra_content: Optional[str] = None,
+) -> str:
+    text = yaml.dump(data, default_flow_style=default_flow_style, sort_keys=sort_keys)
+    if extra_content:
+        text += extra_content
+    return text
+
+
+def _build_config_diff(path: Path, before: str, after: str) -> str:
+    diff_lines = list(
+        difflib.unified_diff(
+            before.splitlines(),
+            after.splitlines(),
+            fromfile=str(path),
+            tofile=f"{path} (proposed)",
+            lineterm="",
+        )
+    )
+    return "\n".join(diff_lines)
+
+
+def _looks_like_locked_config_error(path: Path, exc: BaseException) -> bool:
+    if isinstance(exc, OSError) and exc.errno in _LOCKED_CONFIG_ERRNOS:
+        return True
+
+    text = str(exc).lower()
+    if any(
+        token in text
+        for token in (
+            "read-only",
+            "resource busy",
+            "operation not permitted",
+            "permission denied",
+            "device or resource busy",
+        )
+    ):
+        return True
+
+    try:
+        if path.exists() and not os.access(path, os.W_OK):
+            return True
+    except OSError:
+        pass
+
+    try:
+        if not os.access(path.parent, os.W_OK):
+            return True
+    except OSError:
+        pass
+
+    return False
+
+
+def describe_config_write_failure(result: ConfigWriteResult, *, action: str = "save configuration") -> str:
+    """Format a user-facing config write failure with a manual patch when possible."""
+    path = Path(result.path)
+    reason = str(result.error) if result.error else "unknown error"
+    if result.blocked:
+        header = (
+            f"Hermes could not {action} because `{path}` is read-only or otherwise locked."
+        )
+    else:
+        header = f"Hermes could not {action}: {reason}"
+
+    lines = [header]
+    if result.blocked:
+        lines.append(f"Reason: {reason}")
+
+    if result.diff:
+        lines.extend(
+            [
+                "",
+                "Apply this patch manually:",
+                "```diff",
+                result.diff,
+                "```",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def save_text_config_result(path: Path, text: str) -> ConfigWriteResult:
+    """Attempt to atomically replace a config file with already-rendered text."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    before = ""
+    if path.exists():
+        try:
+            before = path.read_text(encoding="utf-8")
+        except Exception:
+            before = ""
+
+    fd, tmp_path = tempfile.mkstemp(
+        dir=str(path.parent),
+        prefix=f".{path.stem}_",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, path)
+        return ConfigWriteResult(success=True, path=path)
+    except Exception as exc:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        return ConfigWriteResult(
+            success=False,
+            path=path,
+            error=exc,
+            blocked=_looks_like_locked_config_error(path, exc),
+            diff=_build_config_diff(path, before, text),
+        )
+
+
+def load_raw_config_mapping_result(
+    path: Path,
+    *,
+    action: str,
+) -> tuple[Optional[Dict[str, Any]], Optional[ConfigWriteResult]]:
+    """Load the raw user config as a mapping or return a structured failure."""
+    path = Path(path)
+    if not path.exists():
+        return {}, None
+
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except Exception as exc:
+        return None, ConfigWriteResult(success=False, path=path, error=exc, blocked=False)
+
+    try:
+        parsed = yaml.safe_load(raw_text) if raw_text.strip() else {}
+    except yaml.YAMLError as exc:
+        return None, ConfigWriteResult(
+            success=False,
+            path=path,
+            error=ValueError(
+                f"`{path}` contains invalid YAML. Fix it before Hermes can {action}."
+            ),
+            blocked=False,
+        )
+
+    if parsed is None:
+        return {}, None
+    if not isinstance(parsed, dict):
+        return None, ConfigWriteResult(
+            success=False,
+            path=path,
+            error=ValueError(
+                f"`{path}` must contain a top-level mapping/object. Fix it before Hermes can {action}."
+            ),
+            blocked=False,
+        )
+
+    return parsed, None
+
+
+def save_yaml_config_result(
+    path: Path,
+    data: Dict[str, Any],
+    *,
+    default_flow_style: bool = False,
+    sort_keys: bool = False,
+    extra_content: Optional[str] = None,
+) -> ConfigWriteResult:
+    """Attempt to persist a YAML config file and capture fallback context on failure."""
+    from utils import atomic_yaml_write
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    before = ""
+    if path.exists():
+        try:
+            before = path.read_text(encoding="utf-8")
+        except Exception:
+            before = ""
+
+    after = _render_yaml_text(
+        data,
+        default_flow_style=default_flow_style,
+        sort_keys=sort_keys,
+        extra_content=extra_content,
+    )
+
+    try:
+        atomic_yaml_write(
+            path,
+            data,
+            default_flow_style=default_flow_style,
+            sort_keys=sort_keys,
+            extra_content=extra_content,
+        )
+        return ConfigWriteResult(success=True, path=path)
+    except Exception as exc:
+        return ConfigWriteResult(
+            success=False,
+            path=path,
+            error=exc,
+            blocked=_looks_like_locked_config_error(path, exc),
+            diff=_build_config_diff(path, before, after),
+        )
+
+
+def save_config_key_result(
+    key_path: str,
+    value: Any,
+    *,
+    config_path: Optional[Path] = None,
+) -> ConfigWriteResult:
+    """Update a dot-separated key in a YAML config and return a structured result."""
+    path = Path(config_path) if config_path is not None else get_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    config, error_result = load_raw_config_mapping_result(path, action=f"update `{key_path}`")
+    if error_result is not None:
+        return error_result
+    assert config is not None
+
+    keys = key_path.split(".")
+    current = config
+    for key in keys[:-1]:
+        if key not in current or not isinstance(current[key], dict):
+            current[key] = {}
+        current = current[key]
+    current[keys[-1]] = value
+
+    return save_yaml_config_result(path, config)
 
 
 def format_managed_message(action: str = "modify this Hermes installation") -> str:
@@ -1699,11 +2002,19 @@ def save_config(config: Dict[str, Any]):
     if is_managed():
         managed_error("save configuration")
         return
-    from utils import atomic_yaml_write
 
     ensure_hermes_home()
     config_path = get_config_path()
     normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
+    _, load_error = load_raw_config_mapping_result(config_path, action="save configuration")
+    if load_error is not None:
+        raise ConfigWriteError(
+            path=config_path,
+            action="save configuration",
+            error=load_error.error or OSError("invalid existing config"),
+            blocked=load_error.blocked,
+            diff=load_error.diff,
+        )
 
     # Build optional commented-out sections for features that are off by
     # default or only relevant when explicitly configured.
@@ -1715,11 +2026,19 @@ def save_config(config: Dict[str, Any]):
     if not fb or not (fb.get("provider") and fb.get("model")):
         parts.append(_FALLBACK_COMMENT)
 
-    atomic_yaml_write(
+    result = save_yaml_config_result(
         config_path,
         normalized,
         extra_content="".join(parts) if parts else None,
     )
+    if not result:
+        raise ConfigWriteError(
+            path=config_path,
+            action="save configuration",
+            error=result.error or OSError("unknown config write failure"),
+            blocked=result.blocked,
+            diff=result.diff,
+        )
     _secure_file(config_path)
 
 
@@ -2107,8 +2426,12 @@ def edit_config():
     
     # Ensure config exists
     if not config_path.exists():
-        save_config(DEFAULT_CONFIG)
-        print(f"Created {config_path}")
+        try:
+            save_config(DEFAULT_CONFIG)
+            print(f"Created {config_path}")
+        except ConfigWriteError as exc:
+            print(str(exc))
+            return
     
     # Find editor
     editor = os.getenv('EDITOR') or os.getenv('VISUAL')
@@ -2116,7 +2439,6 @@ def edit_config():
     if not editor:
         # Try common editors
         for cmd in ['nano', 'vim', 'vi', 'code', 'notepad']:
-            import shutil
             if shutil.which(cmd):
                 editor = cmd
                 break
@@ -2126,8 +2448,54 @@ def edit_config():
         print(f"  {config_path}")
         return
     
-    print(f"Opening {config_path} in {editor}...")
-    subprocess.run([editor, str(config_path)])
+    original_text = config_path.read_text(encoding="utf-8") if config_path.exists() else ""
+    fd, temp_path_raw = tempfile.mkstemp(prefix="hermes-config-", suffix=".yaml")
+    temp_path = Path(temp_path_raw)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as tmp:
+            tmp.write(original_text)
+
+        while True:
+            print(f"Opening temporary copy in {editor}...")
+            completed = subprocess.run([editor, str(temp_path)])
+            if completed.returncode != 0:
+                print(f"Editor exited with status {completed.returncode}; config not changed.")
+                return
+
+            edited_text = temp_path.read_text(encoding="utf-8")
+            try:
+                parsed = yaml.safe_load(edited_text) if edited_text.strip() else {}
+            except yaml.YAMLError as exc:
+                print("Config not saved: YAML syntax is invalid.")
+                print(f"  {exc}")
+                retry = input("Re-open the editor to fix it? [Y/n]: ").strip().lower()
+                if retry in ("", "y", "yes"):
+                    continue
+                print("Aborted without changing config.yaml.")
+                return
+
+            if parsed is None:
+                parsed = {}
+            if not isinstance(parsed, dict):
+                print("Config not saved: top-level YAML must be a mapping/object.")
+                retry = input("Re-open the editor to fix it? [Y/n]: ").strip().lower()
+                if retry in ("", "y", "yes"):
+                    continue
+                print("Aborted without changing config.yaml.")
+                return
+
+            result = save_text_config_result(config_path, edited_text)
+            if result:
+                _secure_file(config_path)
+                print(f"Saved {config_path}")
+            else:
+                print(describe_config_write_failure(result, action="save configuration"))
+            return
+    finally:
+        try:
+            temp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
 
 
 def set_config_value(key: str, value: str):
@@ -2154,27 +2522,6 @@ def set_config_value(key: str, value: str):
         print(f"✓ Set {key} in {get_env_path()}")
         return
     
-    # Otherwise it goes to config.yaml
-    # Read the raw user config (not merged with defaults) to avoid
-    # dumping all default values back to the file
-    config_path = get_config_path()
-    user_config = {}
-    if config_path.exists():
-        try:
-            with open(config_path, encoding="utf-8") as f:
-                user_config = yaml.safe_load(f) or {}
-        except Exception:
-            user_config = {}
-    
-    # Handle nested keys (e.g., "tts.provider")
-    parts = key.split('.')
-    current = user_config
-    
-    for part in parts[:-1]:
-        if part not in current or not isinstance(current.get(part), dict):
-            current[part] = {}
-        current = current[part]
-    
     # Convert value to appropriate type
     if value.lower() in ('true', 'yes', 'on'):
         value = True
@@ -2185,12 +2532,11 @@ def set_config_value(key: str, value: str):
     elif value.replace('.', '', 1).isdigit():
         value = float(value)
     
-    current[parts[-1]] = value
-    
-    # Write only user config back (not the full merged defaults)
-    ensure_hermes_home()
-    with open(config_path, 'w', encoding="utf-8") as f:
-        yaml.dump(user_config, f, default_flow_style=False, sort_keys=False)
+    config_path = get_config_path()
+    result = save_config_key_result(key, value, config_path=config_path)
+    if not result:
+        print(describe_config_write_failure(result, action=f"update `{key}`"))
+        return
     
     # Keep .env in sync for keys that terminal_tool reads directly from env vars.
     # config.yaml is authoritative, but terminal_tool only reads TERMINAL_ENV etc.

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -858,7 +858,15 @@ def cmd_setup(args):
 def cmd_model(args):
     """Select default model — starts with provider selection, then model picker."""
     _require_tty("model")
-    select_provider_and_model(args=args)
+    try:
+        select_provider_and_model(args=args)
+    except Exception as exc:
+        from hermes_cli.config import ConfigWriteError
+
+        if isinstance(exc, ConfigWriteError):
+            print(str(exc))
+            return
+        raise
 
 
 def select_provider_and_model(args=None):
@@ -1374,14 +1382,14 @@ def _model_flow_custom(config):
             context_length = None
 
     if model_name:
-        _save_model_choice(model_name)
-
-        # Update config and deactivate any OAuth provider
+        # Update config and deactivate any OAuth provider with a single save so
+        # locked/read-only config fallbacks can show the full intended patch.
         cfg = load_config()
         model = cfg.get("model")
         if not isinstance(model, dict):
             model = {"default": model} if model else {}
             cfg["model"] = model
+        model["default"] = model_name
         model["provider"] = "custom"
         model["base_url"] = effective_url
         if effective_key:

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -17,6 +17,7 @@ import time
 from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_cli.config import (
+    guard_config_command,
     load_config,
     save_config,
     get_env_value,
@@ -608,6 +609,7 @@ def cmd_mcp_configure(args):
 
 # ─── Dispatcher ───────────────────────────────────────────────────────────────
 
+@guard_config_command
 def mcp_command(args):
     """Main dispatcher for ``hermes mcp`` subcommands."""
     action = getattr(args, "mcp_action", None)

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -16,6 +16,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from hermes_cli.config import guard_config_command
+
 logger = logging.getLogger(__name__)
 
 # Minimum manifest version this installer understands.
@@ -573,6 +575,7 @@ def cmd_toggle() -> None:
         console.print("\n[dim]No changes.[/dim]")
 
 
+@guard_config_command
 def plugins_command(args) -> None:
     """Dispatch hermes plugins subcommands."""
     action = getattr(args, "plugins_action", None)

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -334,6 +334,7 @@ from hermes_cli.config import (
     get_hermes_home,
     get_config_path,
     get_env_path,
+    guard_config_command,
     load_config,
     save_config,
     save_env_value,
@@ -2664,6 +2665,7 @@ RETURNING_USER_MENU_SECTION_KEYS = [
 ]
 
 
+@guard_config_command
 def run_setup_wizard(args):
     """Run the interactive setup wizard.
 

--- a/hermes_cli/skills_config.py
+++ b/hermes_cli/skills_config.py
@@ -13,7 +13,7 @@ Config stored in ~/.hermes/config.yaml under:
 """
 from typing import List, Optional, Set
 
-from hermes_cli.config import load_config, save_config
+from hermes_cli.config import guard_config_command, load_config, save_config
 from hermes_cli.colors import Colors, color
 
 PLATFORMS = {
@@ -133,6 +133,7 @@ def _toggle_by_category(skills: List[dict], disabled: Set[str]) -> Set[str]:
 
 # ─── Entry Point ──────────────────────────────────────────────────────────────
 
+@guard_config_command
 def skills_command(args=None):
     """Entry point for `hermes skills`."""
     from hermes_cli.curses_ui import curses_checklist

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -17,7 +17,11 @@ from typing import Dict, List, Optional, Set
 
 
 from hermes_cli.config import (
-    load_config, save_config, get_env_value, save_env_value,
+    guard_config_command,
+    load_config,
+    save_config,
+    get_env_value,
+    save_env_value,
 )
 from hermes_cli.colors import Colors, color
 from hermes_cli.nous_subscription import (
@@ -1297,6 +1301,7 @@ def _reconfigure_simple_requirements(ts_key: str):
 
 # ─── Main Entry Point ─────────────────────────────────────────────────────────
 
+@guard_config_command
 def tools_command(args=None, first_install: bool = False, config: dict = None):
     """Entry point for `hermes tools` and `hermes setup tools`.
 
@@ -1740,6 +1745,7 @@ def _print_tools_list(enabled_toolsets: set, mcp_servers: dict, platform: str = 
                 _print_info(f"{srv_name}  {color('all tools enabled', Colors.DIM)}")
 
 
+@guard_config_command
 def tools_disable_enable_command(args):
     """Enable, disable, or list tools for a platform.
 

--- a/tests/gateway/test_config_command_errors.py
+++ b/tests/gateway/test_config_command_errors.py
@@ -1,0 +1,62 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_event(text, platform=Platform.TELEGRAM, user_id="12345", chat_id="67890"):
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._show_reasoning = False
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.hooks.loaded_hooks = []
+    runner._session_db = None
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_verbose_reports_invalid_yaml(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text("display: [\n", encoding="utf-8")
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+    runner = _make_runner()
+    result = await runner._handle_verbose_command(_make_event("/verbose"))
+
+    assert "invalid YAML" in result
+
+
+@pytest.mark.asyncio
+async def test_personality_reports_invalid_yaml(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text("agent: [\n", encoding="utf-8")
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+    runner = _make_runner()
+    result = await runner._handle_personality_command(_make_event("/personality"))
+
+    assert "invalid YAML" in result

--- a/tests/gateway/test_dm_topics.py
+++ b/tests/gateway/test_dm_topics.py
@@ -280,6 +280,22 @@ def test_persist_dm_topic_thread_id_skips_if_already_set(tmp_path):
     assert topics[0]["thread_id"] == 500  # unchanged
 
 
+def test_persist_dm_topic_thread_id_does_not_overwrite_invalid_yaml(tmp_path, caplog):
+    config_file = tmp_path / ".hermes" / "config.yaml"
+    config_file.parent.mkdir(parents=True)
+    original = "platforms: [broken\n"
+    config_file.write_text(original, encoding="utf-8")
+
+    adapter = _make_adapter()
+
+    with patch.object(Path, "home", return_value=tmp_path), \
+         patch.dict(os.environ, {"HERMES_HOME": str(tmp_path / ".hermes")}):
+        adapter._persist_dm_topic_thread_id(111, "General", 999)
+
+    assert config_file.read_text(encoding="utf-8") == original
+    assert "contains invalid YAML" in caplog.text
+
+
 # ── _get_dm_topic_info ──
 
 

--- a/tests/gateway/test_sethome_command.py
+++ b/tests/gateway/test_sethome_command.py
@@ -1,0 +1,61 @@
+"""Tests for gateway /sethome config persistence fallback."""
+
+import errno
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_event(text="/sethome", platform=Platform.TELEGRAM, user_id="12345", chat_id="67890"):
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+        chat_name="Ops",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._show_reasoning = False
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.hooks.loaded_hooks = []
+    runner._session_db = None
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_sethome_reports_session_only_when_config_is_locked(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text("", encoding="utf-8")
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+    def locked_write(*args, **kwargs):
+        raise OSError(errno.EBUSY, "Device or resource busy")
+
+    monkeypatch.setattr("utils.atomic_yaml_write", locked_write)
+
+    runner = _make_runner()
+    result = await runner._handle_set_home_command(_make_event())
+
+    assert "for this running gateway only" in result
+    assert "read-only or otherwise locked" in result
+    assert "Apply this patch manually" in result
+    assert "TELEGRAM_HOME_CHANNEL" in result

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1,12 +1,15 @@
 """Tests for hermes_cli configuration management."""
 
+import errno
 import os
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
+import pytest
 import yaml
 
 from hermes_cli.config import (
+    ConfigWriteError,
     DEFAULT_CONFIG,
     get_hermes_home,
     ensure_hermes_home,
@@ -206,6 +209,96 @@ class TestSaveConfigAtomicity:
                 raw = yaml.safe_load(f)
             assert raw["model"] == "test/atomic-model"
             assert raw["agent"]["max_turns"] == 77
+
+    def test_save_config_raises_readable_error_for_locked_file(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config = load_config()
+            config["model"] = "test/locked-model"
+
+            with patch("utils.atomic_yaml_write", side_effect=OSError(errno.EROFS, "Read-only file system")):
+                with pytest.raises(ConfigWriteError) as exc_info:
+                    save_config(config)
+
+            assert "read-only or otherwise locked" in str(exc_info.value)
+            assert "Apply this patch manually" in str(exc_info.value)
+
+    def test_save_config_refuses_to_overwrite_invalid_existing_yaml(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config_path = tmp_path / "config.yaml"
+            config_path.write_text("model: [broken\n", encoding="utf-8")
+
+            config = load_config()
+            config["model"] = "test-fixed-model"
+
+            with pytest.raises(ConfigWriteError) as exc_info:
+                save_config(config)
+
+            assert "contains invalid YAML" in str(exc_info.value)
+            assert config_path.read_text(encoding="utf-8") == "model: [broken\n"
+
+
+class TestEditConfig:
+    def test_edit_config_retries_until_yaml_is_valid(self, tmp_path, monkeypatch, capsys):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("model: original\n", encoding="utf-8")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("EDITOR", "fake-editor")
+
+        calls = {"count": 0}
+
+        def fake_run(args):
+            edited_path = Path(args[1])
+            calls["count"] += 1
+            if calls["count"] == 1:
+                edited_path.write_text("model: [broken\n", encoding="utf-8")
+            else:
+                edited_path.write_text("model: fixed\n", encoding="utf-8")
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr("hermes_cli.config.subprocess.run", fake_run)
+        monkeypatch.setattr("builtins.input", lambda prompt="": "y")
+
+        from hermes_cli.config import edit_config
+
+        edit_config()
+
+        assert yaml.safe_load(config_path.read_text(encoding="utf-8")) == {"model": "fixed"}
+        assert calls["count"] == 2
+        output = capsys.readouterr().out
+        assert "YAML syntax is invalid" in output
+        assert f"Saved {config_path}" in output
+
+    def test_edit_config_reports_manual_patch_when_target_is_locked(self, tmp_path, monkeypatch, capsys):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("model: original\n", encoding="utf-8")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("EDITOR", "fake-editor")
+
+        def fake_run(args):
+            edited_path = Path(args[1])
+            edited_path.write_text("model: updated\n", encoding="utf-8")
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr("hermes_cli.config.subprocess.run", fake_run)
+        monkeypatch.setattr(
+            "hermes_cli.config.os.replace",
+            lambda src, dst: (_ for _ in ()).throw(OSError(errno.EBUSY, "Device or resource busy")),
+        )
+
+        from hermes_cli.config import edit_config
+
+        edit_config()
+
+        output = capsys.readouterr().out
+        assert "read-only or otherwise locked" in output
+        assert "Apply this patch manually" in output
+        assert "model: updated" in output
 
 
 class TestSanitizeEnvLines:

--- a/tests/hermes_cli/test_config_write_guard_commands.py
+++ b/tests/hermes_cli/test_config_write_guard_commands.py
@@ -1,0 +1,99 @@
+from argparse import Namespace
+from pathlib import Path
+
+from hermes_cli.config import ConfigWriteError
+
+
+def _config_write_error(tmp_path: Path) -> ConfigWriteError:
+    return ConfigWriteError(
+        path=tmp_path / "config.yaml",
+        action="save configuration",
+        error=OSError(16, "Device or resource busy"),
+        blocked=True,
+        diff="--- before\n+++ after",
+    )
+
+
+def test_setup_wizard_catches_config_write_error(tmp_path, monkeypatch, capsys):
+    from hermes_cli import setup as setup_mod
+
+    monkeypatch.setattr("hermes_cli.config.is_managed", lambda: False)
+    monkeypatch.setattr(setup_mod, "ensure_hermes_home", lambda: None)
+    monkeypatch.setattr(setup_mod, "load_config", lambda: {})
+    monkeypatch.setattr(setup_mod, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(setup_mod, "is_interactive_stdin", lambda: True)
+    monkeypatch.setattr("hermes_cli.auth.get_active_provider", lambda: None)
+    monkeypatch.setattr(setup_mod, "SETUP_SECTIONS", [("model", "Model", lambda config: None)])
+    monkeypatch.setattr(setup_mod, "save_config", lambda config: (_ for _ in ()).throw(_config_write_error(tmp_path)))
+
+    args = Namespace(section="model", non_interactive=False, reset=False)
+    setup_mod.run_setup_wizard(args)
+
+    out = capsys.readouterr().out
+    assert "read-only or otherwise locked" in out
+    assert "Apply this patch manually" in out
+
+
+def test_tools_command_catches_config_write_error(tmp_path, monkeypatch, capsys):
+    from hermes_cli import tools_config as mod
+
+    monkeypatch.setattr(mod, "_get_enabled_platforms", lambda: ["cli"])
+    monkeypatch.setattr(mod, "_get_platform_tools", lambda *args, **kwargs: set())
+    monkeypatch.setattr(mod, "_prompt_toolset_checklist", lambda *args, **kwargs: {"web"})
+    monkeypatch.setattr(mod, "_configure_toolset", lambda *args, **kwargs: None)
+    monkeypatch.setattr(mod, "apply_nous_managed_defaults", lambda *args, **kwargs: set())
+    monkeypatch.setattr(mod, "_save_platform_tools", lambda *args, **kwargs: (_ for _ in ()).throw(_config_write_error(tmp_path)))
+
+    mod.tools_command(first_install=True, config={})
+
+    out = capsys.readouterr().out
+    assert "read-only or otherwise locked" in out
+
+
+def test_mcp_command_catches_config_write_error(tmp_path, monkeypatch, capsys):
+    from hermes_cli import mcp_config as mod
+
+    monkeypatch.setattr(mod, "cmd_mcp_configure", lambda args: (_ for _ in ()).throw(_config_write_error(tmp_path)))
+    mod.mcp_command(Namespace(mcp_action="configure", name="demo"))
+
+    out = capsys.readouterr().out
+    assert "read-only or otherwise locked" in out
+
+
+def test_skills_command_catches_config_write_error(tmp_path, monkeypatch, capsys):
+    from hermes_cli import skills_config as mod
+
+    monkeypatch.setattr(mod, "_list_all_skills", lambda: [{
+        "name": "demo",
+        "category": "general",
+        "description": "demo skill",
+    }])
+    monkeypatch.setattr(mod, "_select_platform", lambda: None)
+    monkeypatch.setattr("builtins.input", lambda *_args, **_kwargs: "1")
+    monkeypatch.setattr("hermes_cli.curses_ui.curses_checklist", lambda *args, **kwargs: set())
+    monkeypatch.setattr(mod, "save_disabled_skills", lambda *args, **kwargs: (_ for _ in ()).throw(_config_write_error(tmp_path)))
+
+    mod.skills_command()
+
+    out = capsys.readouterr().out
+    assert "read-only or otherwise locked" in out
+
+
+def test_auth_command_catches_config_write_error(tmp_path, monkeypatch, capsys):
+    from hermes_cli import auth_commands as mod
+
+    monkeypatch.setattr(mod, "auth_add_command", lambda args: (_ for _ in ()).throw(_config_write_error(tmp_path)))
+    mod.auth_command(Namespace(auth_action="add"))
+
+    out = capsys.readouterr().out
+    assert "read-only or otherwise locked" in out
+
+
+def test_plugins_command_catches_config_write_error(tmp_path, monkeypatch, capsys):
+    from hermes_cli import plugins_cmd as mod
+
+    monkeypatch.setattr(mod, "cmd_enable", lambda name: (_ for _ in ()).throw(_config_write_error(tmp_path)))
+    mod.plugins_command(Namespace(plugins_action="enable", name="demo"))
+
+    out = capsys.readouterr().out
+    assert "read-only or otherwise locked" in out

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -127,6 +127,18 @@ class TestConfigYamlRouting:
             or "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE=True" in env_content
         )
 
+    def test_invalid_existing_yaml_is_not_overwritten(self, _isolated_hermes_home, capsys):
+        config_path = _isolated_hermes_home / "config.yaml"
+        original = "model: [broken\n"
+        config_path.write_text(original, encoding="utf-8")
+
+        set_config_value("terminal.backend", "docker")
+
+        assert config_path.read_text(encoding="utf-8") == original
+        output = capsys.readouterr().out
+        assert "contains invalid YAML" in output
+        assert "Fix it before Hermes can update `terminal.backend`" in output
+
 
 # ---------------------------------------------------------------------------
 # Empty / falsy values — regression tests for #4277

--- a/tests/test_cli_provider_resolution.py
+++ b/tests/test_cli_provider_resolution.py
@@ -3,6 +3,7 @@ import sys
 import types
 from contextlib import nullcontext
 from types import SimpleNamespace
+from pathlib import Path
 
 import pytest
 
@@ -556,7 +557,6 @@ def test_model_flow_custom_saves_verified_v1_base_url(monkeypatch, capsys):
     )
     saved_env = {}
     monkeypatch.setattr("hermes_cli.config.save_env_value", lambda key, value: saved_env.__setitem__(key, value))
-    monkeypatch.setattr("hermes_cli.auth._save_model_choice", lambda model: saved_env.__setitem__("MODEL", model))
     monkeypatch.setattr("hermes_cli.auth.deactivate_provider", lambda: None)
     monkeypatch.setattr("hermes_cli.main._save_custom_provider", lambda *args, **kwargs: None)
     monkeypatch.setattr(
@@ -569,11 +569,12 @@ def test_model_flow_custom_saves_verified_v1_base_url(monkeypatch, capsys):
             "used_fallback": True,
         },
     )
+    saved_cfg = {}
     monkeypatch.setattr(
         "hermes_cli.config.load_config",
         lambda: {"model": {"default": "", "provider": "custom", "base_url": ""}},
     )
-    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: saved_cfg.update(cfg))
 
     # After the probe detects a single model ("llm"), the flow asks
     # "Use this model? [Y/n]:" — confirm with Enter, then context length.
@@ -587,7 +588,33 @@ def test_model_flow_custom_saves_verified_v1_base_url(monkeypatch, capsys):
     assert "Detected model: llm" in output
     # OPENAI_BASE_URL is no longer saved to .env — config.yaml is authoritative
     assert "OPENAI_BASE_URL" not in saved_env
-    assert saved_env["MODEL"] == "llm"
+    assert saved_cfg["model"]["default"] == "llm"
+    assert saved_cfg["model"]["provider"] == "custom"
+    assert saved_cfg["model"]["base_url"] == "http://localhost:8000/v1"
+    assert saved_cfg["model"]["api_key"] == "local-key"
+
+
+def test_cmd_model_prints_readable_config_error(monkeypatch, capsys):
+    from hermes_cli.config import ConfigWriteError
+
+    monkeypatch.setattr(hermes_main, "_require_tty", lambda *a: None)
+
+    def _boom(*args, **kwargs):
+        raise ConfigWriteError(
+            path=Path("/tmp/config.yaml"),
+            action="save configuration",
+            error=OSError(16, "Device or resource busy"),
+            blocked=True,
+            diff="--- /tmp/config.yaml\n+++ /tmp/config.yaml (proposed)",
+        )
+
+    monkeypatch.setattr(hermes_main, "select_provider_and_model", _boom)
+
+    hermes_main.cmd_model(SimpleNamespace())
+    output = capsys.readouterr().out
+
+    assert "read-only or otherwise locked" in output
+    assert "Apply this patch manually" in output
 
 
 def test_cmd_model_forwards_nous_login_tls_options(monkeypatch):

--- a/tests/test_cli_save_config_value.py
+++ b/tests/test_cli_save_config_value.py
@@ -1,5 +1,6 @@
 """Tests for save_config_value() in cli.py — atomic write behavior."""
 
+import errno
 import os
 import yaml
 from pathlib import Path
@@ -78,3 +79,29 @@ class TestSaveConfigValueAtomic:
 
         assert result is False
         assert config_env.read_text() == original_content
+
+    def test_returns_structured_result_for_locked_config(self, config_env, monkeypatch):
+        """Read-only config saves should return a patch the user can apply manually."""
+        def locked_write(*args, **kwargs):
+            raise OSError(errno.EROFS, "Read-only file system")
+
+        monkeypatch.setattr("utils.atomic_yaml_write", locked_write)
+
+        from cli import save_config_value_result
+
+        result = save_config_value_result("display.skin", "mono")
+
+        assert not result
+        assert result.blocked is True
+        assert "display:" in result.diff
+        assert "+  skin: mono" in result.diff or "+skin: mono" in result.diff
+
+    def test_rejects_invalid_existing_yaml(self, config_env):
+        config_env.write_text("display: [broken\n", encoding="utf-8")
+
+        from cli import save_config_value_result
+
+        result = save_config_value_result("display.skin", "mono")
+
+        assert not result
+        assert "contains invalid YAML" in str(result.error)

--- a/tests/tools/test_command_guards.py
+++ b/tests/tools/test_command_guards.py
@@ -267,6 +267,22 @@ class TestAlwaysVisibility:
         cb.assert_called_once()
         assert cb.call_args[1]["allow_permanent"] is True
 
+    @patch(_TIRITH_PATCH, return_value=_tirith_result("allow"))
+    def test_dangerous_only_reports_allowlist_persistence_failure(self, mock_tirith):
+        os.environ["HERMES_INTERACTIVE"] = "1"
+        cb = MagicMock(return_value="always")
+        with patch(
+            "tools.approval.save_permanent_allowlist",
+            return_value="Permanent approval was applied for this session only.",
+        ):
+            result = check_all_command_guards(
+                "rm -rf /tmp/test",
+                "local",
+                approval_callback=cb,
+            )
+        assert result["approved"] is True
+        assert "session only" in result["message"]
+
 
 # ---------------------------------------------------------------------------
 # tirith ImportError → treated as allow

--- a/tests/tools/test_terminal_tool_approval_feedback.py
+++ b/tests/tools/test_terminal_tool_approval_feedback.py
@@ -1,0 +1,40 @@
+import json
+
+
+def test_terminal_tool_surfaces_allowlist_persistence_warning(monkeypatch):
+    import tools.terminal_tool as mod
+
+    class FakeEnv:
+        def execute(self, command, **kwargs):
+            return {"output": "command output", "returncode": 0}
+
+    monkeypatch.setattr(
+        mod,
+        "_get_env_config",
+        lambda: {
+            "env_type": "local",
+            "cwd": ".",
+            "timeout": 30,
+            "docker_image": "",
+            "singularity_image": "",
+            "modal_image": "",
+            "daytona_image": "",
+        },
+    )
+    monkeypatch.setattr(mod, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        mod,
+        "_check_all_guards",
+        lambda command, env_type: {
+            "approved": True,
+            "message": "Permanent approval was applied for this session only.",
+        },
+    )
+    monkeypatch.setattr(mod, "_active_environments", {"default": FakeEnv()})
+    monkeypatch.setattr(mod, "_last_activity", {})
+
+    result = json.loads(mod.terminal_tool("echo hello"))
+
+    assert result["exit_code"] == 0
+    assert "Permanent approval was applied for this session only." in result["output"]
+    assert "command output" in result["output"]

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -346,15 +346,31 @@ def load_permanent_allowlist() -> set:
         return set()
 
 
-def save_permanent_allowlist(patterns: set):
-    """Save permanently allowed command patterns to config."""
+def save_permanent_allowlist(patterns: set) -> str | None:
+    """Save permanently allowed command patterns to config.
+
+    Returns a user-facing warning when the allowlist could not be persisted.
+    """
     try:
-        from hermes_cli.config import load_config, save_config
+        from hermes_cli.config import ConfigWriteError, load_config, save_config
         config = load_config()
         config["command_allowlist"] = list(patterns)
         save_config(config)
+        return None
+    except ConfigWriteError as exc:
+        warning = (
+            "Permanent approval was applied for this session only because Hermes "
+            "could not persist the command allowlist.\n\n"
+            f"{exc}"
+        )
+        logger.warning("Could not save allowlist: %s", exc)
+        return warning
     except Exception as e:
         logger.warning("Could not save allowlist: %s", e)
+        return (
+            "Permanent approval was applied for this session only because Hermes "
+            f"could not persist the command allowlist: {e}"
+        )
 
 
 # =========================================================================
@@ -811,6 +827,7 @@ def check_all_command_guards(command: str, env_type: str,
                     "description": combined_desc,
                 }
 
+            persistence_warning = None
             # User approved — persist based on scope (same logic as CLI)
             for key, _, is_tirith in warnings:
                 if choice in ("once", "session") or (choice == "always" and is_tirith):
@@ -818,10 +835,16 @@ def check_all_command_guards(command: str, env_type: str,
                 elif choice == "always":
                     approve_session(session_key, key)
                     approve_permanent(key)
-                    save_permanent_allowlist(_permanent_approved)
+                    warning = save_permanent_allowlist(_permanent_approved)
+                    if warning and persistence_warning is None:
+                        persistence_warning = warning
 
-            return {"approved": True, "message": None,
-                    "user_approved": True, "description": combined_desc}
+            return {
+                "approved": True,
+                "message": persistence_warning,
+                "user_approved": True,
+                "description": combined_desc,
+            }
 
         # Fallback: no gateway callback registered (e.g. cron, batch).
         # Return approval_required for backward compat.
@@ -856,6 +879,7 @@ def check_all_command_guards(command: str, env_type: str,
             "description": combined_desc,
         }
 
+    persistence_warning = None
     # Persist approval for each warning individually
     for key, _, is_tirith in warnings:
         if choice == "session" or (choice == "always" and is_tirith):
@@ -865,7 +889,13 @@ def check_all_command_guards(command: str, env_type: str,
             # dangerous patterns: permanent allowed
             approve_session(session_key, key)
             approve_permanent(key)
-            save_permanent_allowlist(_permanent_approved)
+            warning = save_permanent_allowlist(_permanent_approved)
+            if warning and persistence_warning is None:
+                persistence_warning = warning
 
-    return {"approved": True, "message": None,
-            "user_approved": True, "description": combined_desc}
+    return {
+        "approved": True,
+        "message": persistence_warning,
+        "user_approved": True,
+        "description": combined_desc,
+    }

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1017,6 +1017,7 @@ def terminal_tool(
         # Get configuration
         config = _get_env_config()
         env_type = config["env_type"]
+        pre_exec_notice = ""
 
         # Use task_id for environment isolation
         effective_task_id = task_id or "default"
@@ -1156,7 +1157,7 @@ def terminal_tool(
                     "output": "",
                     "exit_code": -1,
                     "error": approval.get("message", fallback_msg),
-                    "status": "blocked"
+                        "status": "blocked"
                 }, ensure_ascii=False)
             # Track whether approval was explicitly granted by the user
             if approval.get("user_approved"):
@@ -1165,6 +1166,7 @@ def terminal_tool(
             elif approval.get("smart_approved"):
                 desc = approval.get("description", "flagged as dangerous")
                 approval_note = f"Command was flagged ({desc}) and auto-approved by smart approval."
+            pre_exec_notice = (approval.get("message") or "").strip()
 
         # Prepare command for execution
         if background:
@@ -1195,8 +1197,11 @@ def terminal_tool(
                         session_key=session_key,
                     )
 
+                result_output = "Background process started"
+                if pre_exec_notice:
+                    result_output = f"{pre_exec_notice}\n\n{result_output}"
                 result_data = {
-                    "output": "Background process started",
+                    "output": result_output,
                     "session_id": proc_session.id,
                     "pid": proc_session.pid,
                     "exit_code": 0,
@@ -1293,6 +1298,8 @@ def terminal_tool(
             
             # Add helpful message for sudo failures in messaging context
             output = _handle_sudo_failure(output, env_type)
+            if pre_exec_notice:
+                output = f"{pre_exec_notice}\n\n{output}" if output else pre_exec_notice
             
             # Truncate output if too long, keeping both head and tail
             MAX_OUTPUT_CHARS = 50000


### PR DESCRIPTION
## Summary
- handle read-only or locked `config.yaml` writes with a clear manual diff fallback
- validate `hermes config edit` YAML before replacing the real file
- stop masking malformed config in command paths that mutate or read settings
- surface permanent approval persistence failures to the user

Closes #5214

## Testing
- `python -m pytest tests/hermes_cli/test_config_write_guard_commands.py tests/gateway/test_config_command_errors.py tests/gateway/test_verbose_command.py tests/tools/test_command_guards.py tests/tools/test_terminal_tool_approval_feedback.py tests/hermes_cli/test_config.py tests/hermes_cli/test_set_config_value.py tests/test_cli_save_config_value.py tests/gateway/test_dm_topics.py tests/gateway/test_sethome_command.py tests/test_cli_provider_resolution.py tests/test_personality_none.py tests/hermes_cli/test_tools_config.py tests/hermes_cli/test_mcp_config.py tests/hermes_cli/test_setup_noninteractive.py tests/test_plugins_cmd.py tests/tools/test_approval.py -q`
- `368 passed`