### PR TITLE
feat(browser): make snapshot threshold configurable via config.yaml

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -365,6 +365,11 @@ browser:
   # after this period of no activity between agent loops (default: 120 = 2 minutes)
   inactivity_timeout: 120
 
+  # Maximum characters of snapshot content before summarization/truncation.
+  # Increase for long pages (for example, documentation or financial reports),
+  # or decrease to reduce context usage. Minimum: 1000; default: 8000.
+  # snapshot_threshold: 8000
+
 # =============================================================================
 # Tool Loop Guardrails
 # =============================================================================

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1267,6 +1267,7 @@ DEFAULT_CONFIG = {
     "browser": {
         "inactivity_timeout": 120,
         "command_timeout": 30,  # Timeout for browser commands in seconds (screenshot, navigate, etc.)
+        "snapshot_threshold": 8000,  # Max chars before snapshot summarization/truncation
         "record_sessions": False,  # Auto-record browser sessions as WebM videos
         "allow_private_urls": False,  # Allow navigating to private/internal IPs (localhost, 192.168.x.x, etc.)
         # Browser engine for local mode.  Passed as ``--engine <value>`` to

--- a/tests/tools/test_browser_snapshot_threshold.py
+++ b/tests/tools/test_browser_snapshot_threshold.py
@@ -1,0 +1,219 @@
+"""Behavior tests for config-driven browser snapshot thresholds."""
+
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from hermes_cli.config import DEFAULT_CONFIG
+from tools import browser_camofox, browser_tool
+
+
+@pytest.fixture(autouse=True)
+def isolated_snapshot_threshold(tmp_path, monkeypatch):
+    """Use a real, isolated config file and reset module-level caches."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    original_cached = browser_tool._cached_snapshot_threshold
+    original_resolved = browser_tool._snapshot_threshold_resolved
+    browser_tool._cached_snapshot_threshold = None
+    browser_tool._snapshot_threshold_resolved = False
+    yield tmp_path
+    browser_tool._cached_snapshot_threshold = original_cached
+    browser_tool._snapshot_threshold_resolved = original_resolved
+
+
+def _write_threshold(hermes_home, value):
+    (hermes_home / "config.yaml").write_text(
+        f"browser:\n  snapshot_threshold: {value}\n",
+        encoding="utf-8",
+    )
+
+
+def _long_snapshot(chars: int) -> str:
+    line = "button [ref=e1] example content\n"
+    return line * ((chars // len(line)) + 2)
+
+
+def test_default_matches_browser_config(isolated_snapshot_threshold):
+    assert browser_tool.get_browser_snapshot_threshold() == (
+        DEFAULT_CONFIG["browser"]["snapshot_threshold"]
+    )
+
+
+def test_reads_profile_config_override(isolated_snapshot_threshold):
+    _write_threshold(isolated_snapshot_threshold, 30000)
+
+    assert browser_tool.get_browser_snapshot_threshold() == 30000
+
+
+def test_clamps_small_values_to_safe_floor(isolated_snapshot_threshold):
+    _write_threshold(isolated_snapshot_threshold, 10)
+
+    assert browser_tool.get_browser_snapshot_threshold() == (
+        browser_tool.MIN_SNAPSHOT_THRESHOLD
+    )
+
+
+def test_invalid_values_fall_back_to_default(isolated_snapshot_threshold):
+    _write_threshold(isolated_snapshot_threshold, "not-a-number")
+
+    assert browser_tool.get_browser_snapshot_threshold() == (
+        browser_tool.DEFAULT_SNAPSHOT_THRESHOLD
+    )
+
+
+def test_cleanup_reloads_updated_profile_config(isolated_snapshot_threshold):
+    _write_threshold(isolated_snapshot_threshold, 12000)
+    assert browser_tool.get_browser_snapshot_threshold() == 12000
+
+    _write_threshold(isolated_snapshot_threshold, 15001)
+    assert browser_tool.get_browser_snapshot_threshold() == 12000
+
+    browser_tool.cleanup_all_browsers()
+    assert browser_tool.get_browser_snapshot_threshold() == 15001
+
+
+def test_browser_snapshot_applies_profile_threshold(
+    isolated_snapshot_threshold,
+    monkeypatch,
+):
+    _write_threshold(isolated_snapshot_threshold, 1000)
+    snapshot = _long_snapshot(1500)
+
+    monkeypatch.setattr(browser_tool, "_is_camofox_mode", lambda: False)
+    monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: True)
+    monkeypatch.setattr(browser_tool, "_last_session_key", lambda task_id: task_id)
+    monkeypatch.setattr(
+        browser_tool,
+        "_run_browser_command",
+        lambda *args, **kwargs: {
+            "success": True,
+            "data": {"snapshot": snapshot, "refs": {"e1": {}}},
+        },
+    )
+
+    result = json.loads(browser_tool.browser_snapshot(task_id="threshold-test"))
+
+    assert result["success"] is True
+    assert len(result["snapshot"]) < len(snapshot)
+    assert "more lines truncated" in result["snapshot"]
+
+
+def test_browser_navigation_applies_profile_threshold(
+    isolated_snapshot_threshold,
+    monkeypatch,
+):
+    _write_threshold(isolated_snapshot_threshold, 1000)
+    snapshot = _long_snapshot(1500)
+    task_id = "threshold-navigate-test"
+
+    monkeypatch.setattr(browser_tool, "_is_local_backend", lambda: True)
+    monkeypatch.setattr(browser_tool, "_get_cloud_provider", lambda: None)
+    monkeypatch.setattr(
+        browser_tool,
+        "_get_session_info",
+        lambda session_key: {
+            "session_name": "threshold-test",
+            "_first_nav": False,
+            "features": {"local": True, "proxies": True},
+        },
+    )
+    monkeypatch.setattr(
+        browser_tool,
+        "_run_browser_command",
+        Mock(
+            side_effect=[
+                {
+                    "success": True,
+                    "data": {
+                        "title": "Example",
+                        "url": "https://example.com/",
+                    },
+                },
+                {
+                    "success": True,
+                    "data": {"snapshot": snapshot, "refs": {"e1": {}}},
+                },
+            ]
+        ),
+    )
+
+    result = json.loads(
+        browser_tool.browser_navigate(
+            "https://example.com",
+            task_id=task_id,
+        )
+    )
+    browser_tool._last_active_session_key.pop(task_id, None)
+
+    assert result["success"] is True
+    assert len(result["snapshot"]) < len(snapshot)
+    assert "more lines truncated" in result["snapshot"]
+
+
+def test_camofox_navigation_applies_same_profile_threshold(
+    isolated_snapshot_threshold,
+    monkeypatch,
+):
+    _write_threshold(isolated_snapshot_threshold, 1000)
+    snapshot = _long_snapshot(1500)
+    session = {"tab_id": "tab-1", "user_id": "user-1"}
+
+    monkeypatch.setattr(
+        browser_camofox,
+        "_rewrite_loopback_url_for_camofox",
+        lambda url: (url, None),
+    )
+    monkeypatch.setattr(browser_camofox, "_get_session", lambda task_id: session)
+    monkeypatch.setattr(
+        browser_camofox,
+        "_post",
+        lambda *args, **kwargs: {"url": "https://example.com", "title": "Example"},
+    )
+    monkeypatch.setattr(
+        browser_camofox,
+        "_get",
+        lambda *args, **kwargs: {"snapshot": snapshot, "refsCount": 1},
+    )
+    monkeypatch.setattr(browser_camofox, "get_vnc_url", lambda: None)
+
+    result = json.loads(
+        browser_camofox.camofox_navigate(
+            "https://example.com",
+            task_id="threshold-test",
+        )
+    )
+
+    assert result["success"] is True
+    assert len(result["snapshot"]) < len(snapshot)
+    assert "more lines truncated" in result["snapshot"]
+
+
+def test_camofox_snapshot_applies_same_profile_threshold(
+    isolated_snapshot_threshold,
+    monkeypatch,
+):
+    _write_threshold(isolated_snapshot_threshold, 1000)
+    snapshot = _long_snapshot(1500)
+    session = {"tab_id": "tab-1", "user_id": "user-1"}
+
+    monkeypatch.setattr(browser_camofox, "_get_session", lambda task_id: session)
+    monkeypatch.setattr(
+        browser_camofox,
+        "_camofox_private_page_block",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        browser_camofox,
+        "_get",
+        lambda *args, **kwargs: {"snapshot": snapshot, "refsCount": 1},
+    )
+
+    result = json.loads(
+        browser_camofox.camofox_snapshot(task_id="threshold-snapshot-test")
+    )
+
+    assert result["success"] is True
+    assert len(result["snapshot"]) < len(snapshot)
+    assert "more lines truncated" in result["snapshot"]

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -546,11 +546,12 @@ def camofox_navigate(url: str, task_id: Optional[str] = None) -> str:
             )
             snapshot_text = snap_data.get("snapshot", "")
             from tools.browser_tool import (
-                SNAPSHOT_SUMMARIZE_THRESHOLD,
+                get_browser_snapshot_threshold,
                 _truncate_snapshot,
             )
-            if len(snapshot_text) > SNAPSHOT_SUMMARIZE_THRESHOLD:
-                snapshot_text = _truncate_snapshot(snapshot_text)
+            threshold = get_browser_snapshot_threshold()
+            if len(snapshot_text) > threshold:
+                snapshot_text = _truncate_snapshot(snapshot_text, max_chars=threshold)
             result["snapshot"] = snapshot_text
             result["element_count"] = snap_data.get("refsCount", 0)
         except Exception:
@@ -626,16 +627,21 @@ def camofox_snapshot(full: bool = False, task_id: Optional[str] = None,
 
         # Apply same summarization logic as the main browser tool
         from tools.browser_tool import (
-            SNAPSHOT_SUMMARIZE_THRESHOLD,
+            get_browser_snapshot_threshold,
             _extract_relevant_content,
             _truncate_snapshot,
         )
 
-        if len(snapshot) > SNAPSHOT_SUMMARIZE_THRESHOLD:
+        threshold = get_browser_snapshot_threshold()
+        if len(snapshot) > threshold:
             if user_task:
-                snapshot = _extract_relevant_content(snapshot, user_task)
+                snapshot = _extract_relevant_content(
+                    snapshot,
+                    user_task,
+                    max_chars=threshold,
+                )
             else:
-                snapshot = _truncate_snapshot(snapshot)
+                snapshot = _truncate_snapshot(snapshot, max_chars=threshold)
 
         return json.dumps({
             "success": True,
@@ -944,6 +950,5 @@ def camofox_console(clear: bool = False, task_id: Optional[str] = None) -> str:
         "note": "Console log capture is not available with the Camofox backend. "
                 "Use browser_snapshot or browser_vision to inspect page state.",
     })
-
 
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -229,14 +229,22 @@ DEFAULT_COMMAND_TIMEOUT = 30
 MIN_OPEN_TIMEOUT = 60
 MIN_FIRST_OPEN_TIMEOUT = 120
 
-# Max tokens for snapshot content before summarization
-SNAPSHOT_SUMMARIZE_THRESHOLD = 8000
+# Default max characters for snapshot content before summarization/truncation.
+# Configurable via ``browser.snapshot_threshold`` in config.yaml.
+DEFAULT_SNAPSHOT_THRESHOLD = 8000
+MIN_SNAPSHOT_THRESHOLD = 1000
+
+# Backwards-compatible import surface. Runtime call sites use
+# ``get_browser_snapshot_threshold()`` so config overrides take effect.
+SNAPSHOT_SUMMARIZE_THRESHOLD = DEFAULT_SNAPSHOT_THRESHOLD
 
 # Commands that legitimately return empty stdout (e.g. close, record).
 _EMPTY_OK_COMMANDS: frozenset = frozenset({"close", "record"})
 
 _cached_command_timeout: Optional[int] = None
 _command_timeout_resolved = False
+_cached_snapshot_threshold: Optional[int] = None
+_snapshot_threshold_resolved = False
 
 
 def _sanitize_url_for_logs(value: object) -> str:
@@ -289,6 +297,33 @@ def _safe_command_timeout() -> int:
     """
     val = _get_command_timeout()
     return val if val is not None else DEFAULT_COMMAND_TIMEOUT
+
+
+def get_browser_snapshot_threshold() -> int:
+    """Return the configured maximum browser snapshot size in characters.
+
+    Reads the raw profile-aware config so tool JSON output is not affected by
+    config-loader warnings. The value is cached for the browser lifecycle and
+    reset by :func:`cleanup_all_browsers`.
+    """
+    global _cached_snapshot_threshold, _snapshot_threshold_resolved
+    if _snapshot_threshold_resolved and _cached_snapshot_threshold is not None:
+        return _cached_snapshot_threshold
+
+    result = DEFAULT_SNAPSHOT_THRESHOLD
+    try:
+        from hermes_cli.config import read_raw_config
+        cfg = read_raw_config()
+        val = cfg_get(cfg, "browser", "snapshot_threshold")
+        if val is not None:
+            result = max(int(val), MIN_SNAPSHOT_THRESHOLD)
+    except Exception as exc:
+        logger.debug("Could not read browser.snapshot_threshold: %s", exc)
+
+    # Preserve the same race-safety invariant as the command-timeout cache.
+    _cached_snapshot_threshold = result
+    _snapshot_threshold_resolved = True
+    return result
 
 
 def _get_open_command_timeout(*, first_open: bool = False) -> int:
@@ -2581,12 +2616,17 @@ def _run_browser_command(
 
 def _extract_relevant_content(
     snapshot_text: str,
-    user_task: Optional[str] = None
+    user_task: Optional[str] = None,
+    max_chars: Optional[int] = None,
 ) -> str:
     """Use LLM to extract relevant content from a snapshot based on the user's task.
 
     Falls back to simple truncation when no auxiliary text model is configured.
     """
+    fallback_max_chars = (
+        max_chars if max_chars is not None else DEFAULT_SNAPSHOT_THRESHOLD
+    )
+
     if user_task:
         extraction_prompt = (
             f"You are a content extractor for a browser automation agent.\n\n"
@@ -2628,14 +2668,23 @@ def _extract_relevant_content(
         if model:
             call_kwargs["model"] = model
         response = call_llm(**call_kwargs)
-        extracted = (response.choices[0].message.content or "").strip() or _truncate_snapshot(snapshot_text)
+        extracted = (response.choices[0].message.content or "").strip() or _truncate_snapshot(
+            snapshot_text,
+            max_chars=fallback_max_chars,
+        )
         # Redact any secrets the auxiliary LLM may have echoed back.
         return redact_sensitive_text(extracted)
     except Exception:
-        return _truncate_snapshot(snapshot_text)
+        return _truncate_snapshot(
+            snapshot_text,
+            max_chars=fallback_max_chars,
+        )
 
 
-def _truncate_snapshot(snapshot_text: str, max_chars: int = 8000) -> str:
+def _truncate_snapshot(
+    snapshot_text: str,
+    max_chars: int = DEFAULT_SNAPSHOT_THRESHOLD,
+) -> str:
     """Structure-aware truncation for snapshots.
 
     Cuts at line boundaries so that accessibility tree elements are never
@@ -2900,8 +2949,9 @@ def browser_navigate(url: str, task_id: Optional[str] = None) -> str:
                 snap_data = snap_result.get("data", {})
                 snapshot_text = snap_data.get("snapshot", "")
                 refs = snap_data.get("refs", {})
-                if len(snapshot_text) > SNAPSHOT_SUMMARIZE_THRESHOLD:
-                    snapshot_text = _truncate_snapshot(snapshot_text)
+                threshold = get_browser_snapshot_threshold()
+                if len(snapshot_text) > threshold:
+                    snapshot_text = _truncate_snapshot(snapshot_text, max_chars=threshold)
                 response["snapshot"] = _redact_browser_output(snapshot_text)
                 response["element_count"] = len(refs) if refs else 0
                 if snap_result.get("fallback_warning") and not response.get("fallback_warning"):
@@ -2983,10 +3033,15 @@ def browser_snapshot(
                 logger.debug("browser_snapshot: URL safety check failed (%s)", _url_exc)
 
         # Check if snapshot needs summarization
-        if len(snapshot_text) > SNAPSHOT_SUMMARIZE_THRESHOLD and user_task:
-            snapshot_text = _extract_relevant_content(snapshot_text, user_task)
-        elif len(snapshot_text) > SNAPSHOT_SUMMARIZE_THRESHOLD:
-            snapshot_text = _truncate_snapshot(snapshot_text)
+        threshold = get_browser_snapshot_threshold()
+        if len(snapshot_text) > threshold and user_task:
+            snapshot_text = _extract_relevant_content(
+                snapshot_text,
+                user_task,
+                max_chars=threshold,
+            )
+        elif len(snapshot_text) > threshold:
+            snapshot_text = _truncate_snapshot(snapshot_text, max_chars=threshold)
 
         response = {
             "success": True,
@@ -4380,6 +4435,7 @@ def cleanup_all_browsers() -> None:
     # Reset cached lookups so they are re-evaluated on next use.
     global _cached_agent_browser, _agent_browser_resolved
     global _cached_command_timeout, _command_timeout_resolved
+    global _cached_snapshot_threshold, _snapshot_threshold_resolved
     global _cached_chromium_installed
     global _cached_browser_engine, _browser_engine_resolved
     _cached_agent_browser = None
@@ -4389,6 +4445,8 @@ def cleanup_all_browsers() -> None:
     # reader never sees ``resolved=True`` with ``cache=None`` (#14331).
     _command_timeout_resolved = False
     _cached_command_timeout = None
+    _snapshot_threshold_resolved = False
+    _cached_snapshot_threshold = None
     _cached_chromium_installed = None
     global _chromium_autoinstall_attempted
     _chromium_autoinstall_attempted = False

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -443,7 +443,20 @@ Get a text-based snapshot of the current page's accessibility tree. Returns inte
 - **`full=false`** (default): Compact view showing only interactive elements
 - **`full=true`**: Complete page content
 
-Snapshots over 8000 characters are automatically summarized by an LLM.
+Snapshots larger than `browser.snapshot_threshold` are automatically summarized
+or truncated. The default remains 8000 characters. Increase it for long pages
+where more source content should reach the agent:
+
+```yaml
+# ~/.hermes/config.yaml
+browser:
+  snapshot_threshold: 30000
+```
+
+You can also run `hermes config set browser.snapshot_threshold 30000`. The
+setting applies to both explicit `browser_snapshot` calls and the automatic
+snapshot returned after navigation, including the Camofox backend. Restart the
+current Hermes session after changing it so the browser config cache reloads.
 
 ### `browser_click`
 
@@ -655,7 +668,7 @@ If paid features aren't available on your plan, Hermes automatically falls back 
 ## Limitations
 
 - **Text-based interaction** — relies on accessibility tree, not pixel coordinates
-- **Snapshot size** — large pages may be truncated or LLM-summarized at 8000 characters
+- **Snapshot size** — large pages may be truncated or LLM-summarized at `browser.snapshot_threshold` (default: 8000 characters)
 - **Session timeout** — cloud sessions expire based on your provider's plan settings
 - **Cost** — cloud sessions consume provider credits; sessions are automatically cleaned up when the conversation ends or after inactivity. Use `/browser connect` for free local browsing.
 - **No file downloads** — cannot download files from the browser


### PR DESCRIPTION
## Summary

Makes the browser snapshot threshold configurable through `browser.snapshot_threshold` in `config.yaml`.

- Preserves the existing 8,000-character default contract.
- Applies one profile-aware threshold accessor to explicit and automatic post-navigation snapshots.
- Keeps the main browser and Camofox backends in sync.
- Uses the lightweight cached `read_raw_config()` path and resets the threshold cache with browser cleanup.
- Documents the key and tests default, override, invalid, floor, cache reload, and all four snapshot paths.

The earlier #4586 approach was not rejected; that PR was closed because it accumulated unrelated commits. This PR is the focused resubmission and has now been rebuilt on current `main`.

## Usage

```yaml
browser:
  snapshot_threshold: 30000
```

Or: `hermes config set browser.snapshot_threshold 30000`

## Validation

- Related suite: 225 passed.
- Focused post-rebase threshold suite: 9 passed.
- Ruff checks passed on changed Python files.
- Live local config probe resolved the effective threshold to 30000.

Closes #4585