### PR TITLE
feat: add telegram message reaction feedback for processing start and completion

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1283,6 +1283,41 @@ class TelegramAdapter(BasePlatformAdapter):
                     e,
                     exc_info=True,
                 )
+
+    async def on_processing_start(self, event) -> None:
+        """React with 👀 emoji to acknowledge message receipt instantly."""
+        if not self._bot or not event.message_id:
+            return
+        try:
+            from telegram import ReactionTypeEmoji
+            await self._bot.set_message_reaction(
+                chat_id=int(event.source.chat_id),
+                message_id=int(event.message_id),
+                reaction=[ReactionTypeEmoji("👀")],
+            )
+        except Exception as e:
+            logger.debug(
+                "[%s] Failed to set acknowledgment reaction: %s",
+                self.name, e,
+            )
+
+    async def on_processing_complete(self, event, success: bool) -> None:
+        """Swap reaction to ✅ on success or ❌ on failure."""
+        if not self._bot or not event.message_id:
+            return
+        try:
+            from telegram import ReactionTypeEmoji
+            emoji = "✅" if success else "❌"
+            await self._bot.set_message_reaction(
+                chat_id=int(event.source.chat_id),
+                message_id=int(event.message_id),
+                reaction=[ReactionTypeEmoji(emoji)],
+            )
+        except Exception as e:
+            logger.debug(
+                "[%s] Failed to set completion reaction: %s",
+                self.name, e,
+            )
     
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Get information about a Telegram chat."""


### PR DESCRIPTION
## What does this PR do?

Adds message reaction hooks to the Telegram gateway adapter, providing instant visual feedback when the bot receives and processes a user message.

- 👀 reaction is added immediately when a message is received (`on_processing_start`)
- ✅ reaction replaces it on successful processing (`on_processing_complete`)
- ❌ reaction is shown if processing fails

This improves user experience by giving visual confirmation that the bot has acknowledged the message, similar to how read receipts work in messaging apps.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] �� Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/telegram.py`: Added `on_processing_start()` — overrides the base adapter hook to set a 👀 reaction on the user's message via `set_message_reaction()` Telegram Bot API
- `gateway/platforms/telegram.py`: Added `on_processing_complete()` — overrides the base adapter hook to swap the reaction to ✅ (success) or ❌ (failure)
- Both methods use `ReactionTypeEmoji` from the `python-telegram-bot` library
- Errors are caught and logged at `debug` level to ensure reaction failures never block message processing

## How to Test

1. Configure a Telegram bot with the gateway
2. Send any text message to the bot
3. Observe 👀 reaction appears immediately on your message
4. After the bot finishes processing and responds, reaction changes to ✅
5. To test failure: trigger an error scenario and verify ❌ reaction appears

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Reactions flow: User sends message → 👀 appears instantly → Bot processes → ✅ replaces 👀 (or ❌ on error)