### PR TITLE
fix(gateway): cap memory flush retries at 3 to prevent infinite loop

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1266,6 +1266,8 @@ class GatewayRunner:
         next message, so there's no blocking delay.
         """
         await asyncio.sleep(60)  # initial delay — let the gateway fully start
+        _flush_failures: dict[str, int] = {}  # session_id -> consecutive failure count
+        _MAX_FLUSH_RETRIES = 3
         while self._running:
             try:
                 self.session_store._ensure_loaded()
@@ -1298,8 +1300,25 @@ class GatewayRunner:
                             "Pre-reset memory flush completed for session %s",
                             entry.session_id,
                         )
+                        _flush_failures.pop(entry.session_id, None)
                     except Exception as e:
-                        logger.debug("Proactive memory flush failed for %s: %s", entry.session_id, e)
+                        failures = _flush_failures.get(entry.session_id, 0) + 1
+                        _flush_failures[entry.session_id] = failures
+                        if failures >= _MAX_FLUSH_RETRIES:
+                            logger.warning(
+                                "Proactive memory flush gave up after %d attempts for %s: %s. "
+                                "Marking as flushed to prevent infinite retry loop.",
+                                failures, entry.session_id, e,
+                            )
+                            with self.session_store._lock:
+                                entry.memory_flushed = True
+                                self.session_store._save()
+                            _flush_failures.pop(entry.session_id, None)
+                        else:
+                            logger.debug(
+                                "Proactive memory flush failed (%d/%d) for %s: %s",
+                                failures, _MAX_FLUSH_RETRIES, entry.session_id, e,
+                            )
             except Exception as e:
                 logger.debug("Session expiry watcher error: %s", e)
             # Sleep in small increments so we can stop quickly


### PR DESCRIPTION
## Problem

The `_session_expiry_watcher` in `gateway/run.py` retries failed memory flushes forever. When `_async_flush_memories` throws (rate limit, network error), the exception is caught at `debug` level without setting `memory_flushed = True`, so the same expired session retries every 5 minutes indefinitely.

This burns API quota and triggers 429 rate limit cascades that block all gateway message processing (Telegram, Discord, etc.), making the bot appear unresponsive.

**Observed case:** A March 19 session retried 28+ times over ~17 days, causing repeated 429 errors that made Telegram completely unresponsive.

## Fix

Add a per-session failure counter (`_flush_failures`) in the watcher loop. After 3 consecutive failures for the same session:
1. Log a warning explaining the give-up
2. Set `memory_flushed = True` and persist to disk
3. Remove from failure tracker

This breaks the infinite retry loop while still allowing transient failures to recover (up to 3 attempts at 5-min intervals = ~15 min grace period).

## Testing

- All 9 existing flush tests pass (`test_flush_memory_stale_guard.py`)
- All 19 session hygiene tests pass (`test_session_hygiene.py`)
- Patch is scoped to the watcher loop only, no dataclass changes needed