### PR TITLE
feat: add SerpAPI as a native web search backend

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -733,6 +733,14 @@ OPTIONAL_ENV_VARS = {
     },
 
     # ── Tool API keys ──
+    "SERPAPI_API_KEY": {
+        "description": "SerpAPI key for Google Search",
+        "prompt": "SerpAPI API key",
+        "url": "https://serpapi.com/",
+        "tools": ["web_search", "web_extract"],
+        "password": True,
+        "category": "tool",
+    },
     "EXA_API_KEY": {
         "description": "Exa API key for AI-native web search and contents",
         "prompt": "Exa API key",

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -308,6 +308,7 @@ class TestBackendSelection:
         "TOOL_GATEWAY_SCHEME",
         "TOOL_GATEWAY_USER_TOKEN",
         "TAVILY_API_KEY",
+        "SERPAPI_API_KEY",
     )
 
     def setup_method(self):
@@ -321,6 +322,19 @@ class TestBackendSelection:
             os.environ.pop(key, None)
 
     # ── Config-based selection (web.backend in config.yaml) ───────────
+
+    def test_config_serpapi(self):
+        """web.backend=serpapi in config → 'serpapi' regardless of other keys."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "serpapi"}):
+            assert _get_backend() == "serpapi"
+
+    def test_config_serpapi_overrides_env_keys(self):
+        """web.backend=serpapi in config → 'serpapi' even if Firecrawl key set."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "serpapi"}), \
+             patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test"}):
+            assert _get_backend() == "serpapi"
 
     def test_config_parallel(self):
         """web.backend=parallel in config → 'parallel' regardless of keys."""
@@ -425,6 +439,20 @@ class TestBackendSelection:
         with patch("tools.web_tools._load_web_config", return_value={}), \
              patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test"}):
             assert _get_backend() == "firecrawl"
+
+    def test_fallback_serpapi_only_key(self):
+        """Only SERPAPI_API_KEY set → 'serpapi'."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch.dict(os.environ, {"SERPAPI_API_KEY": "serp-test"}):
+            assert _get_backend() == "serpapi"
+
+    def test_fallback_serpapi_with_firecrawl_prefers_serpapi(self):
+        """SerpAPI has highest fallback priority when its key is set."""
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch.dict(os.environ, {"SERPAPI_API_KEY": "serp-test", "FIRECRAWL_API_KEY": "fc-test"}):
+            assert _get_backend() == "serpapi"
 
     def test_fallback_no_keys_defaults_to_firecrawl(self):
         """No keys, no config → 'firecrawl' (will fail at client init)."""
@@ -533,6 +561,7 @@ class TestCheckWebApiKey:
         "TOOL_GATEWAY_SCHEME",
         "TOOL_GATEWAY_USER_TOKEN",
         "TAVILY_API_KEY",
+        "SERPAPI_API_KEY",
     )
 
     def setup_method(self):
@@ -567,6 +596,11 @@ class TestCheckWebApiKey:
 
     def test_tavily_key_only(self):
         with patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test"}):
+            from tools.web_tools import check_web_api_key
+            assert check_web_api_key() is True
+
+    def test_serpapi_key_only(self):
+        with patch.dict(os.environ, {"SERPAPI_API_KEY": "serp-test"}):
             from tools.web_tools import check_web_api_key
             assert check_web_api_key() is True
 
@@ -615,3 +649,9 @@ def test_web_requires_env_includes_exa_key():
     from tools.web_tools import _web_requires_env
 
     assert "EXA_API_KEY" in _web_requires_env()
+
+
+def test_web_requires_env_includes_serpapi_key():
+    from tools.web_tools import _web_requires_env
+
+    assert "SERPAPI_API_KEY" in _web_requires_env()

--- a/tests/tools/test_web_tools_serpapi.py
+++ b/tests/tools/test_web_tools_serpapi.py
@@ -1,0 +1,219 @@
+"""Tests for SerpAPI web backend integration.
+
+Coverage:
+  _serpapi_search() — API key handling, endpoint construction, error propagation,
+                      result normalization (organic_results → standard web format).
+  web_search_tool  — SerpAPI dispatch path.
+"""
+
+import json
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+# ─── _serpapi_search ─────────────────────────────────────────────────────────
+
+class TestSerpApiSearch:
+    """Test suite for the _serpapi_search helper."""
+
+    def test_raises_without_api_key(self):
+        """No SERPAPI_API_KEY → ValueError with guidance."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SERPAPI_API_KEY", None)
+            from tools.web_tools import _serpapi_search
+            with pytest.raises(ValueError, match="SERPAPI_API_KEY"):
+                _serpapi_search("test query")
+
+    def test_sends_correct_params(self):
+        """API key, engine, query, and num are sent as GET params."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"organic_results": []}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = mock_response
+
+        with patch.dict(os.environ, {"SERPAPI_API_KEY": "serp-test-key"}), \
+             patch("tools.web_tools.httpx.Client", return_value=mock_client), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            from tools.web_tools import _serpapi_search
+            result = _serpapi_search("hello world", limit=5)
+
+            mock_client.get.assert_called_once()
+            call_args = mock_client.get.call_args
+            params = call_args.kwargs.get("params") or call_args[1].get("params")
+            assert params["api_key"] == "serp-test-key"
+            assert params["engine"] == "google"
+            assert params["q"] == "hello world"
+            assert params["num"] == 5
+
+    def test_limit_capped_at_20(self):
+        """num param is capped at 20 even if limit is higher."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"organic_results": []}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = mock_response
+
+        with patch.dict(os.environ, {"SERPAPI_API_KEY": "serp-test-key"}), \
+             patch("tools.web_tools.httpx.Client", return_value=mock_client), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            from tools.web_tools import _serpapi_search
+            _serpapi_search("query", limit=50)
+
+            call_args = mock_client.get.call_args
+            params = call_args.kwargs.get("params") or call_args[1].get("params")
+            assert params["num"] == 20
+
+    def test_raises_on_http_error(self):
+        """Non-2xx responses propagate as httpx.HTTPStatusError."""
+        import httpx as _httpx
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = _httpx.HTTPStatusError(
+            "401 Unauthorized", request=MagicMock(), response=mock_response
+        )
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = mock_response
+
+        with patch.dict(os.environ, {"SERPAPI_API_KEY": "serp-bad-key"}), \
+             patch("tools.web_tools.httpx.Client", return_value=mock_client), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            from tools.web_tools import _serpapi_search
+            with pytest.raises(_httpx.HTTPStatusError):
+                _serpapi_search("test")
+
+    def test_returns_early_when_interrupted(self):
+        """If interrupted before HTTP call, returns error dict immediately."""
+        with patch.dict(os.environ, {"SERPAPI_API_KEY": "serp-test-key"}), \
+             patch("tools.interrupt.is_interrupted", return_value=True):
+            from tools.web_tools import _serpapi_search
+            result = _serpapi_search("test")
+            assert result["success"] is False
+            assert "error" in result
+
+
+# ─── Result normalization ────────────────────────────────────────────────────
+
+class TestSerpApiNormalization:
+    """Test that organic_results are normalized to the standard web format."""
+
+    def _search_with_response(self, api_response: dict) -> dict:
+        """Helper: run _serpapi_search with a mocked API response."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = api_response
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = mock_response
+
+        with patch.dict(os.environ, {"SERPAPI_API_KEY": "serp-test-key"}), \
+             patch("tools.web_tools.httpx.Client", return_value=mock_client), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            from tools.web_tools import _serpapi_search
+            return _serpapi_search("test")
+
+    def test_basic_normalization(self):
+        """organic_results fields map to standard title/url/description/position."""
+        raw = {
+            "organic_results": [
+                {"title": "Python Docs", "link": "https://docs.python.org", "snippet": "Official docs"},
+                {"title": "Tutorial", "link": "https://example.com", "snippet": "A tutorial"},
+            ]
+        }
+        result = self._search_with_response(raw)
+        assert result["success"] is True
+        web = result["data"]["web"]
+        assert len(web) == 2
+        assert web[0]["title"] == "Python Docs"
+        assert web[0]["url"] == "https://docs.python.org"
+        assert web[0]["description"] == "Official docs"
+        assert web[0]["position"] == 1
+        assert web[1]["position"] == 2
+
+    def test_empty_results(self):
+        """No organic_results → empty web list, still success."""
+        result = self._search_with_response({"organic_results": []})
+        assert result["success"] is True
+        assert result["data"]["web"] == []
+
+    def test_missing_organic_results_key(self):
+        """Response without organic_results key → empty web list."""
+        result = self._search_with_response({"search_metadata": {}})
+        assert result["success"] is True
+        assert result["data"]["web"] == []
+
+    def test_missing_fields_default_to_empty_string(self):
+        """Result entries with missing link/title/snippet → empty strings."""
+        result = self._search_with_response({"organic_results": [{}]})
+        web = result["data"]["web"]
+        assert web[0]["title"] == ""
+        assert web[0]["url"] == ""
+        assert web[0]["description"] == ""
+        assert web[0]["position"] == 1
+
+    def test_results_capped_by_limit(self):
+        """Only `limit` results are returned even if API gives more."""
+        raw = {
+            "organic_results": [
+                {"title": f"Result {i}", "link": f"https://r{i}.com", "snippet": f"Desc {i}"}
+                for i in range(10)
+            ]
+        }
+        mock_response = MagicMock()
+        mock_response.json.return_value = raw
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = mock_response
+
+        with patch.dict(os.environ, {"SERPAPI_API_KEY": "serp-test-key"}), \
+             patch("tools.web_tools.httpx.Client", return_value=mock_client), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            from tools.web_tools import _serpapi_search
+            result = _serpapi_search("test", limit=3)
+            assert len(result["data"]["web"]) == 3
+            assert result["data"]["web"][2]["position"] == 3
+
+
+# ─── web_search_tool (SerpAPI dispatch) ──────────────────────────────────────
+
+class TestWebSearchSerpApi:
+    """Test web_search_tool dispatch to SerpAPI."""
+
+    def test_search_dispatches_to_serpapi(self):
+        """web_search_tool with serpapi backend → calls _serpapi_search."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "organic_results": [
+                {"title": "Result", "link": "https://r.com", "snippet": "desc"}
+            ]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = mock_response
+
+        with patch("tools.web_tools._get_backend", return_value="serpapi"), \
+             patch.dict(os.environ, {"SERPAPI_API_KEY": "serp-test"}), \
+             patch("tools.web_tools.httpx.Client", return_value=mock_client), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            from tools.web_tools import web_search_tool
+            result = json.loads(web_search_tool("test query", limit=3))
+            assert result["success"] is True
+            assert len(result["data"]["web"]) == 1
+            assert result["data"]["web"][0]["title"] == "Result"

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1947,9 +1947,9 @@ def check_firecrawl_api_key() -> bool:
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
     configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in ("exa", "parallel", "firecrawl", "tavily"):
+    if configured in ("exa", "parallel", "firecrawl", "tavily", "serpapi"):
         return _is_backend_available(configured)
-    return any(_is_backend_available(backend) for backend in ("exa", "parallel", "firecrawl", "tavily"))
+    return any(_is_backend_available(backend) for backend in ("exa", "parallel", "firecrawl", "tavily", "serpapi"))
 
 
 def check_auxiliary_model() -> bool:

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -88,13 +88,14 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in ("parallel", "firecrawl", "tavily", "exa"):
+    if configured in ("parallel", "firecrawl", "tavily", "exa", "serpapi"):
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
     # available backend. Firecrawl also counts as available when the managed
     # tool gateway is configured for Nous subscribers.
     backend_candidates = (
+        ("serpapi", _has_env("SERPAPI_API_KEY")),
         ("firecrawl", _has_env("FIRECRAWL_API_KEY") or _has_env("FIRECRAWL_API_URL") or _is_tool_gateway_ready()),
         ("parallel", _has_env("PARALLEL_API_KEY")),
         ("tavily", _has_env("TAVILY_API_KEY")),
@@ -109,6 +110,8 @@ def _get_backend() -> str:
 
 def _is_backend_available(backend: str) -> bool:
     """Return True when the selected backend is currently usable."""
+    if backend == "serpapi":
+        return _has_env("SERPAPI_API_KEY")
     if backend == "exa":
         return _has_env("EXA_API_KEY")
     if backend == "parallel":
@@ -184,6 +187,7 @@ def _firecrawl_backend_help_suffix() -> str:
 def _web_requires_env() -> list[str]:
     """Return tool metadata env vars for the currently enabled web backends."""
     requires = [
+        "SERPAPI_API_KEY",
         "EXA_API_KEY",
         "PARALLEL_API_KEY",
         "TAVILY_API_KEY",
@@ -873,6 +877,52 @@ def _get_exa_client():
     return _exa_client
 
 
+
+_SERPAPI_SEARCH_URL = "https://serpapi.com/search.json"
+
+
+def _serpapi_search(query: str, limit: int = 10) -> dict:
+    from tools.interrupt import is_interrupted
+
+    if is_interrupted():
+        return {"error": "Interrupted", "success": False}
+
+    api_key = os.getenv("SERPAPI_API_KEY", "").strip()
+    if not api_key:
+        raise ValueError(
+            "SERPAPI_API_KEY environment variable not set. "
+            "Get your API key at https://serpapi.com"
+        )
+
+    params = {
+        "engine": "google",
+        "q": query,
+        "api_key": api_key,
+        "num": min(limit, 20),
+    }
+
+    logger.info("SerpAPI search: '%s' (limit=%d)", query, limit)
+
+    with httpx.Client(timeout=30) as client:
+        response = client.get(_SERPAPI_SEARCH_URL, params=params)
+        response.raise_for_status()
+        data = response.json()
+
+    organic_results = data.get("organic_results", [])
+    web_results = []
+    for i, result in enumerate(organic_results[:limit]):
+        web_results.append(
+            {
+                "url": result.get("link", ""),
+                "title": result.get("title", ""),
+                "description": result.get("snippet", ""),
+                "position": i + 1,
+            }
+        )
+
+    return {"success": True, "data": {"web": web_results}}
+
+
 # ─── Exa Search & Extract Helpers ─────────────────────────────────────────────
 
 def _exa_search(query: str, limit: int = 10) -> dict:
@@ -1075,6 +1125,18 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         if backend == "exa":
             response_data = _exa_search(query, limit)
             debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
+            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+            debug_call_data["final_response_size"] = len(result_json)
+            _debug.log_call("web_search_tool", debug_call_data)
+            _debug.save()
+            return result_json
+
+
+        if backend == "serpapi":
+            response_data = _serpapi_search(query, limit)
+            debug_call_data["results_count"] = len(
+                response_data.get("data", {}).get("web", [])
+            )
             result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
             debug_call_data["final_response_size"] = len(result_json)
             _debug.log_call("web_search_tool", debug_call_data)


### PR DESCRIPTION
## Summary

- Add **SerpAPI (Google Search)** as a first-class search backend alongside Exa, Firecrawl, Parallel, and Tavily
- When `SERPAPI_API_KEY` is set, SerpAPI takes **priority** as the default search provider
- Users can also explicitly configure `web.backend: serpapi` in `config.yaml`

## Changes

### `tools/web_tools.py`
- Add `_serpapi_search()` function — calls SerpAPI's Google Search engine and returns results in the same format as other backends
- Add `"serpapi"` to `_get_backend()` configured backends and fallback candidates
- Add SerpAPI check to `_is_backend_available()`
- Add `SERPAPI_API_KEY` to `_web_requires_env()` metadata
- Add SerpAPI dispatch branch in `web_search_tool()`

### `hermes_cli/config.py`
- Register `SERPAPI_API_KEY` in `OPTIONAL_ENV_VARS` with metadata for `hermes setup` / `hermes doctor`

## Usage

```bash
# In ~/.hermes/.env
SERPAPI_API_KEY=your-key-here
```

Or explicitly set in `~/.hermes/config.yaml`:
```yaml
web:
  backend: serpapi
```

## Testing

- Backend resolves to `serpapi` when `SERPAPI_API_KEY` is present
- `_is_backend_available("serpapi")` returns `True` when key is set
- Search results match the existing format: `{"success": true, "data": {"web": [{"url", "title", "description", "position"}]}}`