### PR TITLE
feat(tools): add delegation model pool with per-call model/provider override

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -686,6 +686,18 @@ delegation:
   # provider: "openrouter"                    # Override provider for subagents (empty = inherit parent)
   #                                           # Resolves full credentials (base_url, api_key) automatically.
   #                                           # Supported: openrouter, nous, zai, kimi-coding, minimax
+  #
+  # Delegation model pool — opt models into subagent routing.
+  # The LLM sees this pool and picks the best model for each task.
+  # Models not in the pool cannot be selected (cost control).
+  # Per-entry 'provider' is optional — inherits delegation.provider.
+  # pool:
+  #   - model: "glm-5.1"
+  #     strengths: "coding, debugging, implementation"
+  #   - model: "glm-5"
+  #     strengths: "research, analysis, reasoning"
+  #   - model: "glm-5-turbo"
+  #     strengths: "general-purpose, writing, quick tasks"
 
 # =============================================================================
 # Honcho Integration (Cross-Session User Modeling)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -454,6 +454,15 @@ DEFAULT_CONFIG = {
         "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
         "max_iterations": 50,  # per-subagent iteration cap (each subagent gets its own budget,
                                # independent of the parent's max_iterations)
+        # Delegation model pool — opt specific models into subagent routing.
+        # Each entry declares a model the LLM can choose for delegation tasks.
+        # The pool is injected into delegate_task's tool description so the
+        # LLM sees available models and their strengths, then picks the best
+        # fit via the existing 'model' param. Models NOT in the pool cannot
+        # be selected (prevents surprise costs from expensive models).
+        # Per-entry 'provider' is optional — inherits delegation.provider.
+        # Resolution: per-call model > pool match > delegation.model > parent model
+        "pool": [],  # e.g. [{"model": "glm-5.1", "strengths": "coding, debugging"}, ...]
     },
 
     # Ephemeral prefill messages file — JSON list of {role, content} dicts

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -225,7 +225,8 @@ class TestDelegateTask(unittest.TestCase):
             delegate_task(goal="Test tracking", parent_agent=parent)
             self.assertEqual(len(parent._active_children), 0)
 
-    def test_child_inherits_runtime_credentials(self):
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_child_inherits_runtime_credentials(self, mock_cfg):
         parent = _make_mock_parent(depth=0)
         parent.base_url = "https://chatgpt.com/backend-api/codex"
         parent.api_key = "codex-token"

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -406,6 +406,8 @@ def delegate_task(
     toolsets: Optional[List[str]] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -432,8 +434,18 @@ def delegate_task(
 
     # Load config
     cfg = _load_config()
+    # Per-call provider override (from tool params) takes precedence
+    if provider:
+        cfg["provider"] = provider
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
     effective_max_iter = max_iterations or default_max_iter
+
+    # Load pool from config for model validation
+    pool_entries = cfg.get("pool") or []
+    pool_model_names = set()
+    for entry in pool_entries:
+        if isinstance(entry, dict) and entry.get("model"):
+            pool_model_names.add(str(entry["model"]).strip())
 
     # Resolve delegation credentials (provider:model pair).
     # When delegation.provider is configured, this resolves the full credential
@@ -444,6 +456,27 @@ def delegate_task(
         creds = _resolve_delegation_credentials(cfg, parent_agent)
     except ValueError as exc:
         return json.dumps({"error": str(exc)})
+
+    # --- Helper: resolve the effective model for a single task ---
+    def _resolve_model_for_task(task):
+        """Resolve model: per-call model > per-task model, then validate against pool."""
+        # 1. Per-call model override (top-level param, applies to all tasks)
+        resolved = model
+        # 2. Per-task model override (batch mode only)
+        if not resolved:
+            task_model = str(task.get("model") or "").strip()
+            if task_model:
+                resolved = task_model
+        # 3. Validate against pool (if pool is configured)
+        if resolved and pool_model_names and resolved not in pool_model_names:
+            logger.warning(
+                "delegate_task: model '%s' not in delegation pool %s; "
+                "falling back to default",
+                resolved, pool_model_names,
+            )
+            resolved = None
+        # 4. delegation.model from config (already in creds["model"])
+        return resolved  # None signals "use creds model"
 
     # Normalize to task list
     if tasks and isinstance(tasks, list):
@@ -480,9 +513,13 @@ def delegate_task(
     children = []
     try:
         for i, t in enumerate(task_list):
+            # Resolve model for this specific task
+            task_model = _resolve_model_for_task(t)
+            effective_model = task_model or creds["model"]
+
             child = _build_child_agent(
                 task_index=i, goal=t["goal"], context=t.get("context"),
-                toolsets=t.get("toolsets") or toolsets, model=creds["model"],
+                toolsets=t.get("toolsets") or toolsets, model=effective_model,
                 max_iterations=effective_max_iter, parent_agent=parent_agent,
                 override_provider=creds["provider"], override_base_url=creds["base_url"],
                 override_api_key=creds["api_key"],
@@ -696,96 +733,168 @@ def _load_config() -> dict:
 # OpenAI Function-Calling Schema
 # ---------------------------------------------------------------------------
 
-DELEGATE_TASK_SCHEMA = {
-    "name": "delegate_task",
-    "description": (
-        "Spawn one or more subagents to work on tasks in isolated contexts. "
-        "Each subagent gets its own conversation, terminal session, and toolset. "
-        "Only the final summary is returned -- intermediate tool results "
-        "never enter your context window.\n\n"
-        "TWO MODES (one of 'goal' or 'tasks' is required):\n"
-        "1. Single task: provide 'goal' (+ optional context, toolsets)\n"
-        "2. Batch (parallel): provide 'tasks' array with up to 3 items. "
-        "All run concurrently and results are returned together.\n\n"
-        "WHEN TO USE delegate_task:\n"
-        "- Reasoning-heavy subtasks (debugging, code review, research synthesis)\n"
-        "- Tasks that would flood your context with intermediate data\n"
-        "- Parallel independent workstreams (research A and B simultaneously)\n\n"
-        "WHEN NOT TO USE (use these instead):\n"
-        "- Mechanical multi-step work with no reasoning needed -> use execute_code\n"
-        "- Single tool call -> just call the tool directly\n"
-        "- Tasks needing user interaction -> subagents cannot use clarify\n\n"
-        "IMPORTANT:\n"
-        "- Subagents have NO memory of your conversation. Pass all relevant "
-        "info (file paths, error messages, constraints) via the 'context' field.\n"
-        "- Subagents CANNOT call: delegate_task, clarify, memory, send_message, "
-        "execute_code.\n"
-        "- Each subagent gets its own terminal session (separate working directory and state).\n"
-        "- Results are always returned as an array, one entry per task."
-    ),
-    "parameters": {
-        "type": "object",
-        "properties": {
-            "goal": {
-                "type": "string",
-                "description": (
-                    "What the subagent should accomplish. Be specific and "
-                    "self-contained -- the subagent knows nothing about your "
-                    "conversation history."
-                ),
-            },
-            "context": {
-                "type": "string",
-                "description": (
-                    "Background information the subagent needs: file paths, "
-                    "error messages, project structure, constraints. The more "
-                    "specific you are, the better the subagent performs."
-                ),
-            },
-            "toolsets": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": (
-                    "Toolsets to enable for this subagent. "
-                    "Default: inherits your enabled toolsets. "
-                    "Common patterns: ['terminal', 'file'] for code work, "
-                    "['web'] for research, ['terminal', 'file', 'web'] for "
-                    "full-stack tasks."
-                ),
-            },
-            "tasks": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "goal": {"type": "string", "description": "Task goal"},
-                        "context": {"type": "string", "description": "Task-specific context"},
-                        "toolsets": {
-                            "type": "array",
-                            "items": {"type": "string"},
-                            "description": "Toolsets for this specific task",
-                        },
-                    },
-                    "required": ["goal"],
+def _build_pool_description(pool):
+    """Build a human-readable pool description for injection into the tool schema."""
+    if not pool:
+        return ""
+    lines = ["AVAILABLE MODELS (pick from these via the 'model' param):"]
+    for entry in pool:
+        if isinstance(entry, dict):
+            name = entry.get("model", "unknown")
+            strengths = entry.get("strengths", "")
+            provider_note = entry.get("provider", "")
+            desc = f"  - {name}"
+            if strengths:
+                desc += f": {strengths}"
+            if provider_note:
+                desc += f" (provider: {provider_note})"
+            lines.append(desc)
+    return "\n".join(lines)
+
+
+def _build_delegate_schema():
+    """Build the delegate_task schema with pool info injected into description."""
+    # Load pool from config
+    _pool = []
+    try:
+        from cli import CLI_CONFIG
+        _cfg = CLI_CONFIG.get("delegation", {})
+        if _cfg:
+            _pool = _cfg.get("pool") or []
+    except Exception:
+        pass
+    if not _pool:
+        try:
+            from hermes_cli.config import load_config
+            _full = load_config()
+            _pool = (_full.get("delegation", {}) or {}).get("pool") or []
+        except Exception:
+            pass
+
+    pool_desc = _build_pool_description(_pool)
+    if pool_desc:
+        pool_section = f"\n\n{pool_desc}\n\n"
+    else:
+        pool_section = ""
+
+    return {
+        "name": "delegate_task",
+        "description": (
+            "Spawn one or more subagents to work on tasks in isolated contexts. "
+            "Each subagent gets its own conversation, terminal session, and toolset. "
+            "Only the final summary is returned -- intermediate tool results "
+            "never enter your context window.\n\n"
+            f"{pool_section}"
+            "TWO MODES (one of 'goal' or 'tasks' is required):\n"
+            "1. Single task: provide 'goal' (+ optional context, toolsets)\n"
+            "2. Batch (parallel): provide 'tasks' array with up to 3 items. "
+            "All run concurrently and results are returned together.\n\n"
+            "WHEN TO USE delegate_task:\n"
+            "- Reasoning-heavy subtasks (debugging, code review, research synthesis)\n"
+            "- Tasks that would flood your context with intermediate data\n"
+            "- Parallel independent workstreams (research A and B simultaneously)\n\n"
+            "WHEN NOT TO USE (use these instead):\n"
+            "- Mechanical multi-step work with no reasoning needed -> use execute_code\n"
+            "- Single tool call -> just call the tool directly\n"
+            "- Tasks needing user interaction -> subagents cannot use clarify\n\n"
+            "IMPORTANT:\n"
+            "- Subagents have NO memory of your conversation. Pass all relevant "
+            "info (file paths, error messages, constraints) via the 'context' field.\n"
+            "- Subagents CANNOT call: delegate_task, clarify, memory, send_message, "
+            "execute_code.\n"
+            "- Each subagent gets its own terminal session (separate working directory and state).\n"
+            "- Results are always returned as an array, one entry per task."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "goal": {
+                    "type": "string",
+                    "description": (
+                        "What the subagent should accomplish. Be specific and "
+                        "self-contained -- the subagent knows nothing about your "
+                        "conversation history."
+                    ),
                 },
-                "maxItems": 3,
-                "description": (
-                    "Batch mode: up to 3 tasks to run in parallel. Each gets "
-                    "its own subagent with isolated context and terminal session. "
-                    "When provided, top-level goal/context/toolsets are ignored."
-                ),
+                "context": {
+                    "type": "string",
+                    "description": (
+                        "Background information the subagent needs: file paths, "
+                        "error messages, project structure, constraints. The more "
+                        "specific you are, the better the subagent performs."
+                    ),
+                },
+                "toolsets": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Toolsets to enable for this subagent. "
+                        "Default: inherits your enabled toolsets. "
+                        "Common patterns: ['terminal', 'file'] for code work, "
+                        "['web'] for research, ['terminal', 'file', 'web'] for "
+                        "full-stack tasks."
+                    ),
+                },
+                "tasks": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "goal": {"type": "string", "description": "Task goal"},
+                            "context": {"type": "string", "description": "Task-specific context"},
+                            "toolsets": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": "Toolsets for this specific task",
+                            },
+                            "model": {
+                                "type": "string",
+                                "description": (
+                                    "Override model for this specific task only. "
+                                    "Pick from the AVAILABLE MODELS listed in the "
+                                    "description above."
+                                ),
+                            },
+                        },
+                        "required": ["goal"],
+                    },
+                    "maxItems": 3,
+                    "description": (
+                        "Batch mode: up to 3 tasks to run in parallel. Each gets "
+                        "its own subagent with isolated context and terminal session. "
+                        "When provided, top-level goal/context/toolsets are ignored."
+                    ),
+                },
+                "max_iterations": {
+                    "type": "integer",
+                    "description": (
+                        "Max tool-calling turns per subagent (default: 50). "
+                        "Only set lower for simple tasks."
+                    ),
+                },
+                "model": {
+                    "type": "string",
+                    "description": (
+                        "Override model for ALL tasks in this delegation. "
+                        "Takes highest precedence — if not set, the LLM should "
+                        "pick the best model from the pool via per-task 'model' field."
+                    ),
+                },
+                "provider": {
+                    "type": "string",
+                    "description": (
+                        "Override provider for this delegation. "
+                        "Takes precedence over delegation.provider in config. "
+                        "Resolves full credentials (base_url, api_key) automatically."
+                    ),
+                },
             },
-            "max_iterations": {
-                "type": "integer",
-                "description": (
-                    "Max tool-calling turns per subagent (default: 50). "
-                    "Only set lower for simple tasks."
-                ),
-            },
+            "required": [],
         },
-        "required": [],
-    },
-}
+    }
+
+
+DELEGATE_TASK_SCHEMA = _build_delegate_schema()
 
 
 # --- Registry ---
@@ -801,6 +910,8 @@ registry.register(
         toolsets=args.get("toolsets"),
         tasks=args.get("tasks"),
         max_iterations=args.get("max_iterations"),
+        model=args.get("model"),
+        provider=args.get("provider"),
         parent_agent=kw.get("parent_agent")),
     check_fn=check_delegate_requirements,
     emoji="🔀",

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1151,6 +1151,43 @@ The delegation provider uses the same credential resolution as CLI/gateway start
 
 **Precedence:** `delegation.base_url` in config → `delegation.provider` in config → parent provider (inherited). `delegation.model` in config → parent model (inherited). Setting just `model` without `provider` changes only the model name while keeping the parent's credentials (useful for switching models within the same provider like OpenRouter).
 
+### Delegation Model Pool
+
+Opt specific models into subagent routing with a pool configuration. Each entry declares a model with its strengths. The pool is injected into the `delegate_task` tool description, so the LLM sees available models and picks the best fit automatically.
+
+```yaml
+delegation:
+  provider: zai
+  model: glm-5-turbo           # Fallback when no model is picked
+  pool:
+    - model: glm-5.1
+      strengths: coding, debugging, implementation
+    - model: glm-5
+      strengths: research, analysis, reasoning, math
+    - model: glm-5-turbo
+      strengths: general-purpose, writing, quick tasks
+    # Cross-provider example:
+    # - model: deepseek-r1
+    #   provider: openrouter
+    #   strengths: math, formal proofs
+```
+
+The LLM reads the pool and selects the best model for each task via the `model` param. No manual task-type mapping needed.
+
+**Model resolution (highest to lowest precedence):**
+
+1. Per-call `model` param — explicit override
+2. Per-task `model` field (batch mode) — override for that task
+3. Pool validation — if model was set but not in pool, falls back to default with a warning
+4. `delegation.model` — fallback default from config
+5. Parent agent's model — inherited when nothing is configured
+
+**Key points:**
+- Models NOT in the pool cannot be selected — this prevents surprise costs from expensive models.
+- `pool` only selects the model name. Provider is always `delegation.provider` (unless overridden per-entry or per-call).
+- Any model name is valid — the pool is user-defined, not a fixed taxonomy.
+- If no pool is configured, all models are allowed (backward compatible).
+
 ## Clarify
 
 Configure the clarification prompt behavior:


### PR DESCRIPTION
## Summary

Add intelligent model routing for subagent delegation via a configurable model pool and per-call overrides.

**Problem:** Users with access to multiple models/providers (e.g. via OpenRouter or Z.AI) had no way to control which model a subagent uses at call time.

**Solution:**

1. **Delegation model pool** (`delegation.pool`): Users define a list of models with strengths. The pool is injected into the `delegate_task` tool description, so the LLM sees available models and picks the best fit automatically.

2. **Per-call overrides**: `model` and `provider` params on `delegate_task` for explicit routing. Per-task `model` field in batch mode.

3. **Pool validation**: If a model is set but not in the pool, falls back to default with a warning.

## Changes
- `tools/delegate_tool.py`: Dynamic schema builder, pool validation, per-task model support
- `hermes_cli/config.py`: Add `pool` to DEFAULT_CONFIG
- `cli-config.yaml.example`: Document pool configuration
- `website/docs/user-guide/configuration.md`: Add Delegation Model Pool section

## Model resolution (highest to lowest)
1. Per-call `model` param
2. Per-task `model` field (batch mode)
3. Pool validation (falls back with warning if not in pool)
4. `delegation.model` from config
5. Parent agent's model (inherited)

## Test plan
- [ ] Pool models appear in delegate_task tool description
- [ ] Subagent spawns with pool-selected model
- [ ] Per-call model/provider override takes precedence
- [ ] Per-task model in batch mode
- [ ] Pool validation warning for unknown models
- [ ] Backward compatible when pool is empty/unset