### PR TITLE
fix(honcho): use self-observation for peer_card queries

### DIFF
--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -830,6 +830,12 @@ class HonchoSessionManager:
         Fast, no LLM reasoning. Returns raw structured facts Honcho has
         inferred about the user (name, role, preferences, patterns).
         Empty list if unavailable.
+
+        Uses self-observation (peer_perspective=user_peer_id) rather than
+        cross-peer observation, because peer_card data is written by the
+        deriver at the self-observation level (user → user). Cross-peer
+        queries (assistant → user) return empty unless the assistant peer
+        has explicitly built its own view via update_peer_card tool calls.
         """
         session = self._cache.get(session_key)
         if not session:
@@ -844,7 +850,7 @@ class HonchoSessionManager:
                 summary=False,
                 tokens=200,
                 peer_target=session.user_peer_id,
-                peer_perspective=session.assistant_peer_id,
+                peer_perspective=session.user_peer_id,
             )
             card = ctx.peer_card or []
             return card if isinstance(card, list) else [str(card)]


### PR DESCRIPTION
## Summary

`get_peer_card()` was querying the cross-peer dimension (`assistant -> user`), which returns empty because `peer_card` data is written at the **self-observation level** (`user -> user`) by the deriver's `update_peer_card` tool.

This caused `honcho_profile` MCP tool to always return `No profile facts available yet` even when peer_card data exists in Honcho.

## Root Cause

In `HonchoSessionManager.get_peer_card()`, the context call used:
- `peer_target=session.user_peer_id` (correct)
- `peer_perspective=session.assistant_peer_id` (wrong -- asks how hermes views banana)

Peer card data lives at `banana -> banana` (user self-observes), not `hermes -> banana`.

## Fix

Change `peer_perspective` from `session.assistant_peer_id` to `session.user_peer_id` -- this asks how banana views itself, which is where the deriver writes peer_card data.

## API Verification

```bash
# Self-observation: banana -> banana -> peer_card has data
GET /peers/banana/context
-> peer_card: [6 facts]

# Cross-peer: hermes -> banana -> peer_card is null
GET /peers/hermes/context?target=banana
-> peer_card: null
```

## Testing

After fix, `honcho_profile` MCP tool returns populated peer card data instead of `"No profile facts available yet"`.