### PR TITLE
fix(tools): add fallback for env_var_enabled import in long-lived gateway processes

### DIFF
--- a/tools/tool_backend_helpers.py
+++ b/tools/tool_backend_helpers.py
@@ -6,7 +6,14 @@ import os
 from pathlib import Path
 from typing import Any, Dict
 
-from utils import env_var_enabled
+try:
+    from utils import env_var_enabled
+except ImportError:
+    # Fallback for long-lived gateway processes where the in-memory utils module
+    # may predate the addition of env_var_enabled (e.g. after hermes update).
+    def env_var_enabled(name: str, default: str = "") -> bool:  # type: ignore[misc]
+        val = os.environ.get(name, default).strip().lower()
+        return val in ("1", "true", "yes", "on")
 
 _DEFAULT_BROWSER_PROVIDER = "local"
 _DEFAULT_MODAL_MODE = "auto"


### PR DESCRIPTION
Fixes #5232

Long-lived gateway processes can keep a stale in-memory utils module after hermes update. If the cached module predates env_var_enabled, late imports fail with ImportError.

Adds try/except with an inline fallback that replicates the same behavior as utils.env_var_enabled.