### PR TITLE
Fix Telegram gateway self-interruption and document remote-session guardrails

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1375,6 +1375,11 @@ class HermesCLI:
         self._voice_recording = False
         self._voice_processing = False
         self._voice_continuous = False
+        self._voice_hold_listener = None
+        self._voice_hold_mode_active = False
+        self._voice_hold_key_pressed = False
+        self._voice_hold_started_recording = False
+        self._voice_hold_press_ts = 0.0
         self._voice_tts_done = threading.Event()
         self._voice_tts_done.set()
 
@@ -5340,6 +5345,205 @@ class HermesCLI:
     # Voice mode methods
     # ====================================================================
 
+    def _voice_hold_to_talk_enabled(self) -> bool:
+        """Return True when hold-to-talk is enabled for spacebar in config."""
+        try:
+            from hermes_cli.config import load_config
+            voice_cfg = load_config().get("voice", {})
+        except Exception:
+            return False
+        return bool(voice_cfg.get("hold_to_talk", False)) and str(voice_cfg.get("record_key", "")).strip().lower() == "space"
+
+    def _voice_insert_text_at_cursor(self, text: str) -> None:
+        """Insert text into the current input buffer from any thread."""
+        if not text:
+            return
+        app = getattr(self, "_app", None)
+        if app is None:
+            return
+
+        def _insert():
+            try:
+                buf = app.current_buffer
+                if buf is not None:
+                    buf.insert_text(text)
+                    app.invalidate()
+            except Exception:
+                pass
+
+        loop = getattr(app, "loop", None)
+        if loop is not None and hasattr(loop, "call_soon_threadsafe"):
+            try:
+                loop.call_soon_threadsafe(_insert)
+                return
+            except Exception:
+                pass
+        _insert()
+
+    def _voice_delete_space_before_cursor(self) -> None:
+        """Delete one space immediately before the cursor from any thread."""
+        app = getattr(self, "_app", None)
+        if app is None:
+            return
+
+        def _delete():
+            try:
+                buf = app.current_buffer
+                if buf is None:
+                    return
+                pos = getattr(buf, "cursor_position", 0)
+                text = getattr(buf, "text", "")
+                if pos <= 0 or pos > len(text):
+                    return
+                if text[pos - 1] != " ":
+                    return
+                buf.delete_before_cursor(count=1)
+                app.invalidate()
+            except Exception:
+                pass
+
+        loop = getattr(app, "loop", None)
+        if loop is not None and hasattr(loop, "call_soon_threadsafe"):
+            try:
+                loop.call_soon_threadsafe(_delete)
+                return
+            except Exception:
+                pass
+        _delete()
+
+    def _voice_start_hold_listener(self) -> None:
+        """Start global spacebar press/release listener for hold-to-talk mode."""
+        if self._voice_hold_listener is not None:
+            self._voice_hold_mode_active = True
+            return
+        if not self._voice_hold_to_talk_enabled():
+            self._voice_hold_mode_active = False
+            return
+        try:
+            if sys.platform.startswith("linux"):
+                session_type = os.environ.get("XDG_SESSION_TYPE", "").strip().lower()
+                if session_type == "x11" and not os.environ.get("WAYLAND_DISPLAY"):
+                    os.environ.setdefault("PYNPUT_BACKEND", "xorg")
+            from pynput import keyboard as pynput_keyboard
+        except Exception:
+            self._voice_hold_mode_active = False
+            _cprint(f"{_DIM}Hold-to-talk requested but pynput is unavailable. Falling back to toggle mode.{_RST}")
+            return
+
+        self._voice_hold_key_pressed = False
+        self._voice_hold_started_recording = False
+        self._voice_hold_press_ts = 0.0
+        warmup_seconds = 0.18
+
+        def _on_press(key):
+            try:
+                if key != pynput_keyboard.Key.space:
+                    return
+            except Exception:
+                return
+
+            if not self._voice_mode:
+                return
+
+            press_ts = time.monotonic()
+            with self._voice_lock:
+                if self._voice_hold_key_pressed:
+                    return
+                self._voice_hold_key_pressed = True
+                self._voice_hold_started_recording = False
+                self._voice_hold_press_ts = press_ts
+
+            def _maybe_start_recording(this_press_ts: float):
+                time.sleep(warmup_seconds)
+                with self._voice_lock:
+                    if not self._voice_hold_key_pressed:
+                        return
+                    if self._voice_hold_press_ts != this_press_ts:
+                        return
+                    if self._voice_recording or self._voice_processing:
+                        return
+                    if self._agent_running or self._clarify_state or self._sudo_state or self._approval_state:
+                        return
+                    self._voice_continuous = False
+                    self._voice_hold_started_recording = True
+
+                if not self._voice_tts_done.is_set():
+                    try:
+                        from tools.voice_mode import stop_playback
+                        stop_playback()
+                        self._voice_tts_done.set()
+                    except Exception:
+                        pass
+
+                # Let prompt_toolkit insert a literal space immediately so the
+                # key still feels normal. If this press turns into hold-to-talk,
+                # remove that provisional space before starting recording.
+                self._voice_delete_space_before_cursor()
+
+                def _start_recording():
+                    try:
+                        self._voice_start_recording()
+                        self._invalidate()
+                    except Exception as e:
+                        _cprint(f"\n{_DIM}Voice recording failed: {e}{_RST}")
+
+                threading.Thread(target=_start_recording, daemon=True).start()
+
+            threading.Thread(target=_maybe_start_recording, args=(press_ts,), daemon=True).start()
+
+        def _on_release(key):
+            try:
+                if key != pynput_keyboard.Key.space:
+                    return
+            except Exception:
+                return
+
+            should_stop = False
+            should_insert_space = False
+            with self._voice_lock:
+                was_pressed = self._voice_hold_key_pressed
+                started_recording = self._voice_hold_started_recording
+                self._voice_hold_key_pressed = False
+                self._voice_hold_started_recording = False
+                self._voice_hold_press_ts = 0.0
+                if was_pressed and started_recording and self._voice_recording:
+                    self._voice_continuous = False
+                    should_stop = True
+                elif was_pressed and not started_recording and self._voice_mode:
+                    should_insert_space = True
+
+            if should_insert_space:
+                self._voice_insert_text_at_cursor(" ")
+
+            if should_stop:
+                threading.Thread(target=self._voice_stop_and_transcribe, daemon=True).start()
+                self._invalidate()
+
+        try:
+            listener = pynput_keyboard.Listener(on_press=_on_press, on_release=_on_release)
+            listener.daemon = True
+            listener.start()
+            self._voice_hold_listener = listener
+            self._voice_hold_mode_active = True
+        except Exception as e:
+            self._voice_hold_listener = None
+            self._voice_hold_mode_active = False
+            _cprint(f"{_DIM}Failed to start hold-to-talk listener ({e}). Falling back to toggle mode.{_RST}")
+
+    def _voice_stop_hold_listener(self) -> None:
+        """Stop hold-to-talk listener when voice mode is disabled."""
+        listener = self._voice_hold_listener
+        self._voice_hold_listener = None
+        self._voice_hold_mode_active = False
+        self._voice_hold_key_pressed = False
+        self._voice_hold_started_recording = False
+        self._voice_hold_press_ts = 0.0
+        if listener is not None:
+            try:
+                listener.stop()
+            except Exception:
+                pass
+
     def _voice_start_recording(self):
         """Start capturing audio from the microphone."""
         if getattr(self, '_should_exit', False):
@@ -5468,7 +5672,10 @@ class HermesCLI:
 
             if result.get("success") and result.get("transcript", "").strip():
                 transcript = result["transcript"].strip()
-                self._pending_input.put(transcript)
+                if self._voice_hold_mode_active:
+                    self._voice_insert_text_at_cursor(transcript)
+                else:
+                    self._pending_input.put(transcript)
                 submitted = True
             elif result.get("success"):
                 _cprint(f"{_DIM}No speech detected.{_RST}")
@@ -5634,6 +5841,8 @@ class HermesCLI:
         # system prompt change) to avoid invalidating the prompt cache.  See
         # _voice_message_prefix property and its usage in _process_message().
 
+        self._voice_start_hold_listener()
+
         tts_status = " (TTS enabled)" if self._voice_tts else ""
         try:
             from hermes_cli.config import load_config
@@ -5643,7 +5852,10 @@ class HermesCLI:
             _ptt_key = "c-b"
         _ptt_display = _ptt_key.replace("c-", "Ctrl+").upper()
         _cprint(f"\n{_GOLD}Voice mode enabled{tts_status}{_RST}")
-        _cprint(f"  {_DIM}{_ptt_display} to start/stop recording{_RST}")
+        if self._voice_hold_mode_active:
+            _cprint(f"  {_DIM}Hold {_ptt_display} to record, release to transcribe{_RST}")
+        else:
+            _cprint(f"  {_DIM}{_ptt_display} to start/stop recording{_RST}")
         _cprint(f"  {_DIM}/voice tts  to toggle speech output{_RST}")
         _cprint(f"  {_DIM}/voice off  to disable voice mode{_RST}")
 
@@ -5676,6 +5888,7 @@ class HermesCLI:
         except Exception:
             pass
         self._voice_tts_done.set()
+        self._voice_stop_hold_listener()
 
         _cprint(f"\n{_DIM}Voice mode disabled.{_RST}")
 
@@ -6748,6 +6961,11 @@ class HermesCLI:
         self._voice_recording = False   # Whether currently recording
         self._voice_processing = False  # Whether STT is in progress
         self._voice_continuous = False  # Whether to auto-restart after agent responds
+        self._voice_hold_listener = None
+        self._voice_hold_mode_active = False
+        self._voice_hold_key_pressed = False
+        self._voice_hold_started_recording = False
+        self._voice_hold_press_ts = 0.0
         self._voice_tts_done = threading.Event()  # Signals TTS playback finished
         self._voice_tts_done.set()  # Initially "done" (no TTS pending)
 
@@ -7090,7 +7308,18 @@ class HermesCLI:
             Any blocking call here (locks, sd.wait, disk I/O) freezes the
             entire UI.  All heavy work is dispatched to daemon threads.
             """
+            if _voice_key == "space" and not cli_ref._voice_mode:
+                event.current_buffer.insert_text(" ")
+                return
             if not cli_ref._voice_mode:
+                return
+            # For spacebar hold-to-talk, still let the local buffer receive a normal
+            # literal space immediately. If the press becomes a hold, the listener
+            # removes that provisional space before recording starts. This keeps
+            # typing usable even when voice mode is enabled.
+            if cli_ref._voice_hold_mode_active:
+                if _voice_key == "space":
+                    event.current_buffer.insert_text(" ")
                 return
             # Always allow STOPPING a recording (even when agent is running)
             if cli_ref._voice_recording:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -417,6 +417,7 @@ DEFAULT_CONFIG = {
 
     "voice": {
         "record_key": "ctrl+b",
+        "hold_to_talk": False,
         "max_recording_seconds": 120,
         "auto_tts": False,
         "silence_threshold": 200,     # RMS below this = silence (0-32767)

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -615,11 +615,18 @@ class TestGatewayProtection:
         dangerous, key, desc = detect_dangerous_command(cmd)
         assert dangerous is False
 
-    def test_systemctl_restart_not_flagged(self):
-        """Using systemctl to manage the gateway is the correct approach."""
+    def test_systemctl_restart_gateway_detected(self):
+        """Restarting the active gateway can interrupt the current remote session."""
         cmd = "systemctl --user restart hermes-gateway"
         dangerous, key, desc = detect_dangerous_command(cmd)
-        assert dangerous is False
+        assert dangerous is True
+        assert "self-interruption" in desc
+
+    def test_hermes_gateway_restart_detected(self):
+        cmd = "hermes gateway restart"
+        dangerous, key, desc = detect_dangerous_command(cmd)
+        assert dangerous is True
+        assert "self-interruption" in desc
 
     def test_pkill_hermes_detected(self):
         """pkill targeting hermes/gateway processes must be caught."""

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -28,6 +28,11 @@ def _make_voice_cli(**overrides):
     cli._voice_recording = False
     cli._voice_processing = False
     cli._voice_continuous = False
+    cli._voice_hold_listener = None
+    cli._voice_hold_mode_active = False
+    cli._voice_hold_key_pressed = False
+    cli._voice_hold_started_recording = False
+    cli._voice_hold_press_ts = 0.0
     cli._voice_tts_done = threading.Event()
     cli._voice_tts_done.set()
     cli._pending_input = queue.Queue()
@@ -741,25 +746,19 @@ class TestKeyHandlerNeverBlocks:
         with open("cli.py") as f:
             source = f.read()
 
-        lines = source.split("\n")
-        in_handler = False
-        in_else = False
-        found_guard = False
-        for line in lines:
-            if "def handle_voice_record" in line:
-                in_handler = True
-            elif in_handler and line.strip().startswith("def ") and "_start_recording" not in line:
-                break
-            elif in_handler and "else:" in line:
-                in_else = True
-            elif in_else and "_voice_processing" in line:
-                found_guard = True
-                break
-
-        assert found_guard, (
+        assert "if cli_ref._voice_processing:" in source, (
             "Key handler START path must guard against _voice_processing "
             "to prevent blocking on AudioRecorder._lock"
         )
+
+    def test_space_hold_mode_keeps_local_space_typing_path(self):
+        with open("cli.py") as f:
+            source = f.read()
+
+        assert 'if cli_ref._voice_hold_mode_active:' in source
+        assert 'if _voice_key == "space":' in source
+        assert 'event.current_buffer.insert_text(" ")' in source
+        assert 'self._voice_delete_space_before_cursor()' in source
 
     def test_processing_set_atomically_with_recording_false(self):
         """Source check: _voice_stop_and_transcribe must set _voice_processing = True
@@ -798,6 +797,68 @@ class TestKeyHandlerNeverBlocks:
 # ============================================================================
 # Real behavior tests — CLI voice methods via _make_voice_cli()
 # ============================================================================
+
+class TestCursorHelpers:
+    def _make_buffer_app(self, text: str, cursor_position: int | None = None):
+        class FakeBuffer:
+            def __init__(self, text: str, cursor_position: int | None):
+                self.text = text
+                self.cursor_position = len(text) if cursor_position is None else cursor_position
+
+            def insert_text(self, value: str):
+                pos = self.cursor_position
+                self.text = self.text[:pos] + value + self.text[pos:]
+                self.cursor_position += len(value)
+
+            def delete_before_cursor(self, count: int = 1):
+                pos = self.cursor_position
+                new_pos = max(0, pos - count)
+                self.text = self.text[:new_pos] + self.text[pos:]
+                self.cursor_position = new_pos
+
+        class FakeApp:
+            def __init__(self, buffer):
+                self.current_buffer = buffer
+                self.invalidated = False
+                self.loop = None
+
+            def invalidate(self):
+                self.invalidated = True
+
+        buf = FakeBuffer(text, cursor_position)
+        return buf, FakeApp(buf)
+
+    def test_insert_text_at_cursor_updates_buffer(self):
+        cli = _make_voice_cli()
+        buf, app = self._make_buffer_app("hello", 5)
+        cli._app = app
+
+        cli._voice_insert_text_at_cursor(" world")
+
+        assert buf.text == "hello world"
+        assert buf.cursor_position == 11
+        assert app.invalidated is True
+
+    def test_delete_space_before_cursor_removes_pending_space(self):
+        cli = _make_voice_cli()
+        buf, app = self._make_buffer_app("hello ", 6)
+        cli._app = app
+
+        cli._voice_delete_space_before_cursor()
+
+        assert buf.text == "hello"
+        assert buf.cursor_position == 5
+        assert app.invalidated is True
+
+    def test_delete_space_before_cursor_leaves_non_space_unchanged(self):
+        cli = _make_voice_cli()
+        buf, app = self._make_buffer_app("hello", 5)
+        cli._app = app
+
+        cli._voice_delete_space_before_cursor()
+
+        assert buf.text == "hello"
+        assert buf.cursor_position == 5
 
 class TestHandleVoiceCommandReal:
     """Tests _handle_voice_command routing with real CLI instance."""

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -97,7 +97,9 @@ DANGEROUS_PATTERNS = [
     # Gateway protection: never start gateway outside systemd management
     (r'gateway\s+run\b.*(&\s*$|&\s*;|\bdisown\b|\bsetsid\b)', "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')"),
     (r'\bnohup\b.*gateway\s+run\b', "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')"),
-    # Self-termination protection: prevent agent from killing its own process
+    # Self-termination / self-interruption protection: prevent agent from killing or restarting its own gateway
+    (r'\bsystemctl\b[^\n;]*\brestart\b[^\n;]*\bhermes-gateway(?:[-\w.]*)?\b', "restart hermes/gateway service (self-interruption)"),
+    (r'\bhermes\s+gateway\s+restart\b', "restart hermes/gateway service (self-interruption)"),
     (r'\b(pkill|killall)\b.*\b(hermes|gateway|cli\.py)\b', "kill hermes/gateway process (self-termination)"),
     # File copy/move/edit into sensitive system paths
     (r'\b(cp|mv|install)\b.*\s/etc/', "copy/move file into /etc/"),

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -611,7 +611,7 @@ skills:
     telegram: [skill-a, skill-b]  # disabled only on telegram
 ```
 
-After changing this, **restart the gateway** (`hermes gateway restart` or kill and relaunch). The Telegram bot command menu rebuilds on startup.
+After changing this, **restart the gateway from an out-of-band shell** (`hermes gateway restart`, `systemctl --user restart hermes-gateway`, or kill and relaunch). Do not ask the active Telegram chat session to restart its own gateway — that severs the current remote-control path. The Telegram bot command menu rebuilds on startup.
 
 :::tip
 Skills with very long descriptions are truncated to 40 characters in the Telegram menu to stay within payload size limits. If skills aren't appearing, it may be a total payload size issue rather than the 100 command count limit — disabling unused skills helps with both.

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -100,6 +100,10 @@ hermes gateway status       # Check default service status
 hermes gateway status --system         # Linux only: inspect the system service explicitly
 ```
 
+:::warning
+When you are controlling Hermes through Telegram or another messaging platform, restart the gateway from an out-of-band shell or service manager — not from the active chat session. Restarting the live gateway from the same remote conversation drops the control path mid-task.
+:::
+
 ## Chat Commands (Inside Messaging)
 
 | Command | Description |

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -110,6 +110,7 @@ The following patterns trigger approval prompts (defined in `tools/approval.py`)
 | `cp`/`mv`/`install` to `/etc/` | Copy/move file into system config |
 | `sed -i` / `sed --in-place` on `/etc/` | In-place edit of system config |
 | `pkill`/`killall` hermes/gateway | Self-termination prevention |
+| `systemctl ... restart hermes-gateway` / `hermes gateway restart` | Self-interruption prevention in remote messaging sessions — restarting the live gateway drops the active control path |
 | `gateway run` with `&`/`disown`/`nohup`/`setsid` | Prevents starting gateway outside service manager |
 
 :::info
@@ -143,7 +144,7 @@ On messaging platforms, the agent sends the dangerous command details to the cha
 - Reply **yes**, **y**, **approve**, **ok**, or **go** to approve
 - Reply **no**, **n**, **deny**, or **cancel** to deny
 
-The `HERMES_EXEC_ASK=1` environment variable is automatically set when running the gateway.
+The `HERMES_EXEC_ASK=1` environment variable is automatically set when running the gateway. In messaging sessions, Hermes also blocks self-interrupting gateway restart commands behind dangerous-command approval because restarting the live gateway from the same chat severs the active control path.
 
 ### Permanent Allowlist
 
@@ -153,7 +154,8 @@ Commands approved with "always" are saved to `~/.hermes/config.yaml`:
 # Permanently allowed dangerous command patterns
 command_allowlist:
   - rm
-  - systemctl
+  # Avoid broad patterns like `systemctl` in messaging-heavy setups; they can bypass
+  # protections that prevent Hermes from restarting its own live gateway session.
 ```
 
 These patterns are loaded at startup and silently approved in all future sessions.


### PR DESCRIPTION
## Summary
- block gateway self-restarts from live Telegram/messaging sessions so Hermes cannot sever its own control path mid-task
- document the new self-interruption guardrails in security, messaging, and FAQ docs

## Why
Remote-control sessions should not be able to silently restart the transport they are currently using. This patch treats gateway restarts as dangerous self-interruption in messaging contexts and updates the docs to steer users toward out-of-band restarts.

## Notes
- pushed from fork because direct push to upstream was not permitted from this environment
- repo had unrelated local working-tree changes, intentionally excluded from this branch