### PR TITLE
fix(gateway): use resolved runtime for BOOT.md

### DIFF
--- a/gateway/builtin_hooks/boot_md.py
+++ b/gateway/builtin_hooks/boot_md.py
@@ -46,14 +46,19 @@ def _build_boot_prompt(content: str) -> str:
 def _run_boot_agent(content: str) -> None:
     """Spawn a one-shot agent session to execute the boot instructions."""
     try:
+        from gateway.run import _resolve_gateway_model, _resolve_runtime_agent_kwargs
         from run_agent import AIAgent
 
         prompt = _build_boot_prompt(content)
+        runtime_kwargs = _resolve_runtime_agent_kwargs()
         agent = AIAgent(
+            model=_resolve_gateway_model(),
+            platform="gateway",
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,
             max_iterations=20,
+            **runtime_kwargs,
         )
         result = agent.run_conversation(prompt)
         response = result.get("final_response", "")

--- a/tests/gateway/test_boot_md.py
+++ b/tests/gateway/test_boot_md.py
@@ -1,0 +1,52 @@
+from unittest.mock import patch
+
+import pytest
+
+from gateway.builtin_hooks import boot_md
+
+
+def test_run_boot_agent_uses_gateway_runtime():
+    captured = {}
+    pool = object()
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            captured["kwargs"] = kwargs
+
+        def run_conversation(self, prompt):
+            captured["prompt"] = prompt
+            return {"final_response": "[SILENT]"}
+
+    runtime_kwargs = {
+        "api_key": "sk-test",
+        "base_url": "http://example.test/v1",
+        "provider": "openai",
+        "api_mode": "chat_completions",
+        "command": "copilot-acp",
+        "args": ["serve", "--stdio"],
+        "credential_pool": pool,
+    }
+
+    with patch("gateway.run._resolve_gateway_model", return_value="gpt-test"), patch(
+        "gateway.run._resolve_runtime_agent_kwargs", return_value=runtime_kwargs
+    ), patch("run_agent.AIAgent", FakeAgent):
+        boot_md._run_boot_agent("Check the startup state.")
+
+    assert captured["kwargs"]["model"] == "gpt-test"
+    assert captured["kwargs"]["platform"] == "gateway"
+    assert captured["kwargs"]["api_key"] == "sk-test"
+    assert captured["kwargs"]["base_url"] == "http://example.test/v1"
+    assert captured["kwargs"]["provider"] == "openai"
+    assert captured["kwargs"]["api_mode"] == "chat_completions"
+    assert captured["kwargs"]["command"] == "copilot-acp"
+    assert captured["kwargs"]["args"] == ["serve", "--stdio"]
+    assert captured["kwargs"]["credential_pool"] is pool
+    assert "BOOT.md" in captured["prompt"]
+    assert "Check the startup state." in captured["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_handle_skips_missing_boot_file(tmp_path):
+    missing = tmp_path / "BOOT.md"
+    with patch("gateway.builtin_hooks.boot_md.BOOT_FILE", missing):
+        assert await boot_md.handle("gateway:startup", {}) is None


### PR DESCRIPTION
## Summary
- resolve the BOOT.md startup agent with the same gateway model/runtime helpers used for normal turns
- run the startup agent in the gateway platform context instead of as a bare default agent
- add a regression test covering both HTTP-style and command-based runtime kwargs

Closes #5239

## Testing
- `source venv/bin/activate && python -m pytest tests/gateway/test_boot_md.py tests/gateway/test_hooks.py -q`