### PR TITLE
feat: inject current time into system prompt on every API call

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6365,6 +6365,10 @@ class AIAgent:
             if self.ephemeral_system_prompt:
                 effective_system = (effective_system + "\n\n" + self.ephemeral_system_prompt).strip()
             if effective_system:
+                # Inject current time into system prompt on every API call
+                from hermes_time import now as _hermes_now
+                _current_time = _hermes_now().strftime("%A, %B %d, %Y %I:%M %p")
+                effective_system = effective_system + f"\n\nCurrent time: {_current_time}"
                 api_messages = [{"role": "system", "content": effective_system}] + api_messages
             if self.prefill_messages:
                 sys_offset = 1 if effective_system else 0
@@ -6900,6 +6904,10 @@ class AIAgent:
             # This is intentional — system prompt modifications break the prompt
             # cache prefix.  The system prompt is reserved for Hermes internals.
             if effective_system:
+                # Inject current time into system prompt on every API call
+                from hermes_time import now as _hermes_now
+                _current_time = _hermes_now().strftime("%A, %B %d, %Y %I:%M %p")
+                effective_system = effective_system + f"\n\nCurrent time: {_current_time}"
                 api_messages = [{"role": "system", "content": effective_system}] + api_messages
 
             # Inject ephemeral prefill messages right after the system prompt


### PR DESCRIPTION
Appends `Current time: Sunday, April 05, 2026 11:45 AM` to the bottom of the system prompt on every API call so the model knows what time it is — not just when the conversation started.

---

## Details

Without this, the model only sees a static `Conversation started:` timestamp from session creation. In a long-running session, it has no idea hours have passed.

One 4-line block added in the two places in `run_agent.py` that build the system message before calling the LLM:

1. `run_conversation()` — main conversation loop
2. `_handle_max_iterations()` — final summary when max tool calls reached

Inserted right before the existing `api_messages = [{"role": "system", ...}] + api_messages` line in each:

```python
# Inject current time into system prompt on every API call
from hermes_time import now as _hermes_now
_current_time = _hermes_now().strftime("%A, %B %d, %Y %I:%M %p")
effective_system = effective_system + f"\n\nCurrent time: {_current_time}"
```

- Uses `hermes_time.now()` (respects `HERMES_TIMEZONE` / `config.yaml`)
- Local import follows the existing pattern at line ~2613 in `_build_system_prompt()`
- Appended at the tail so the stable prefix above stays unchanged for prompt caching
- 8 lines added, 1 file changed, no new dependencies