### PR TITLE
fix(tools): terminal_tool unresponsive to /stop during command execution

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1253,11 +1253,56 @@ def terminal_tool(
             result = None
             
             while retry_count <= max_retries:
+                # Check interrupt before each attempt
+                if is_interrupted():
+                    return json.dumps({
+                        "output": "",
+                        "exit_code": 130,
+                        "error": "Command interrupted — user sent a new message"
+                    }, ensure_ascii=False)
+
                 try:
                     execute_kwargs = {"timeout": effective_timeout}
                     if workdir:
                         execute_kwargs["cwd"] = workdir
-                    result = env.execute(command, **execute_kwargs)
+
+                    # Run env.execute() in a thread so we can poll the
+                    # interrupt event while waiting.  The env backends
+                    # already check is_interrupted() internally, but
+                    # some paths (e.g. network-bound Modal/Daytona calls)
+                    # may block for seconds before reaching the next poll.
+                    _exc_holder: list[Exception | None] = [None]
+                    _result_holder: list[dict | None] = [None]
+
+                    def _run_execute():
+                        try:
+                            _result_holder[0] = env.execute(command, **execute_kwargs)
+                        except Exception as exc:
+                            _exc_holder[0] = exc
+
+                    exec_thread = threading.Thread(target=_run_execute, daemon=True)
+                    exec_thread.start()
+
+                    while exec_thread.is_alive():
+                        exec_thread.join(timeout=0.3)
+                        if is_interrupted():
+                            logger.info("Interrupt detected during env.execute() — killing running command")
+                            try:
+                                env.cleanup()
+                            except Exception:
+                                pass
+                            exec_thread.join(timeout=3)
+                            return json.dumps({
+                                "output": "",
+                                "exit_code": 130,
+                                "error": "Command interrupted — user sent a new message"
+                            }, ensure_ascii=False)
+
+                    # Thread finished — propagate any exception
+                    if _exc_holder[0] is not None:
+                        raise _exc_holder[0]
+                    result = _result_holder[0]
+
                 except Exception as e:
                     error_str = str(e).lower()
                     if "timeout" in error_str:
@@ -1267,13 +1312,22 @@ def terminal_tool(
                             "error": f"Command timed out after {effective_timeout} seconds"
                         }, ensure_ascii=False)
                     
-                    # Retry on transient errors
+                    # Retry on transient errors (with interrupt-aware sleep)
                     if retry_count < max_retries:
                         retry_count += 1
                         wait_time = 2 ** retry_count
                         logger.warning("Execution error, retrying in %ds (attempt %d/%d) - Command: %s - Error: %s: %s - Task: %s, Backend: %s",
                                        wait_time, retry_count, max_retries, command[:200], type(e).__name__, e, effective_task_id, env_type)
-                        time.sleep(wait_time)
+                        # Interrupt-aware sleep: wake early if interrupted
+                        _sleep_end = time.monotonic() + wait_time
+                        while time.monotonic() < _sleep_end:
+                            if is_interrupted():
+                                return json.dumps({
+                                    "output": "",
+                                    "exit_code": 130,
+                                    "error": "Command interrupted — user sent a new message"
+                                }, ensure_ascii=False)
+                            time.sleep(0.3)
                         continue
                     
                     logger.error("Execution failed after %d retries - Command: %s - Error: %s: %s - Task: %s, Backend: %s",


### PR DESCRIPTION
## Bug Description

When a user sends `/stop` while the agent is executing a terminal command (via `terminal_tool`), the command continues running until it naturally completes. The agent appears stuck — `/stop` cancels the LLM stream but cannot cancel the in-flight `env.execute()` call.

## Root Cause

`env.execute()` in `terminal_tool.py` is a **synchronous blocking call**. While the environment backends (Local, Docker, Modal, Daytona) do internally poll `_interrupt_event`, network-bound paths (e.g., Modal/Daytona API calls) can block for several seconds before reaching the next poll point. Additionally, the retry `time.sleep(wait_time)` (up to 16s) blocks entirely without checking interrupts.

## Fix

**`tools/terminal_tool.py`** (+57 lines, -3 lines):

1. **Threaded `env.execute()`** — The synchronous call is now wrapped in a daemon thread. The main thread polls `is_interrupted()` every 0.3s. On interrupt, `env.cleanup()` kills the running process and returns immediately.

2. **Pre-attempt interrupt check** — `is_interrupted()` is checked before each retry attempt.

3. **Interrupt-aware retry sleep** — `time.sleep(wait_time)` replaced with a polling loop that checks `is_interrupted()` every 0.3s, allowing instant response during retry waits.

All interrupt paths return a consistent format: `{"output": "", "exit_code": 130, "error": "Command interrupted — user sent a new message"}`.

This mirrors the existing pattern in `code_execution_tool.py` (lines ~1086-1094).

## How to Verify

1. Start a long-running command: ask the agent to run `sleep 60`
2. While it's running, send `/stop`
3. Expected: the agent responds with an interrupt message within ~0.3s, instead of hanging for the full 60s

## Test Plan

- [x] Existing tests still pass
- [ ] Manual verification with long-running commands + /stop
- [ ] Verify retry paths also respond to /stop (e.g., network timeout scenarios)

## Risk Assessment

**Low** — Changes are additive (threading wrapper around existing call). No existing code paths are removed or restructured. If the interrupt event is never set, behavior is identical to before (thread finishes, result is used).