### PR TITLE
[codex] fix stale gateway platform status reporting

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -643,7 +643,7 @@ class DiscordAdapter(BasePlatformAdapter):
             # Wait for ready
             await asyncio.wait_for(self._ready_event.wait(), timeout=30)
 
-            self._running = True
+            self._mark_connected()
             return True
 
         except asyncio.TimeoutError:
@@ -668,7 +668,7 @@ class DiscordAdapter(BasePlatformAdapter):
             except Exception as e:  # pragma: no cover - defensive logging
                 logger.warning("[%s] Error during disconnect: %s", self.name, e, exc_info=True)
 
-        self._running = False
+        self._mark_disconnected()
         self._client = None
         self._ready_event.clear()
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1048,7 +1048,11 @@ class GatewayRunner:
             pass
         try:
             from gateway.status import write_runtime_status
-            write_runtime_status(gateway_state="starting", exit_reason=None)
+            write_runtime_status(
+                gateway_state="starting",
+                exit_reason=None,
+                reset_platforms=True,
+            )
         except Exception:
             pass
         

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -23,6 +23,7 @@ from typing import Any, Optional
 _GATEWAY_KIND = "hermes-gateway"
 _RUNTIME_STATUS_FILE = "gateway_state.json"
 _LOCKS_DIRNAME = "gateway-locks"
+_UNSET = object()
 
 
 def _get_pid_path() -> Path:
@@ -186,34 +187,38 @@ def write_pid_file() -> None:
 
 def write_runtime_status(
     *,
-    gateway_state: Optional[str] = None,
-    exit_reason: Optional[str] = None,
+    gateway_state: Optional[str] | object = _UNSET,
+    exit_reason: Optional[str] | object = _UNSET,
     platform: Optional[str] = None,
-    platform_state: Optional[str] = None,
-    error_code: Optional[str] = None,
-    error_message: Optional[str] = None,
+    platform_state: Optional[str] | object = _UNSET,
+    error_code: Optional[str] | object = _UNSET,
+    error_message: Optional[str] | object = _UNSET,
+    reset_platforms: bool = False,
 ) -> None:
     """Persist gateway runtime health information for diagnostics/status."""
     path = _get_runtime_status_path()
     payload = _read_json_file(path) or _build_runtime_status_record()
-    payload.setdefault("platforms", {})
+    if reset_platforms:
+        payload["platforms"] = {}
+    else:
+        payload.setdefault("platforms", {})
     payload.setdefault("kind", _GATEWAY_KIND)
     payload["pid"] = os.getpid()
     payload["start_time"] = _get_process_start_time(os.getpid())
     payload["updated_at"] = _utc_now_iso()
 
-    if gateway_state is not None:
+    if gateway_state is not _UNSET:
         payload["gateway_state"] = gateway_state
-    if exit_reason is not None:
+    if exit_reason is not _UNSET:
         payload["exit_reason"] = exit_reason
 
     if platform is not None:
         platform_payload = payload["platforms"].get(platform, {})
-        if platform_state is not None:
+        if platform_state is not _UNSET:
             platform_payload["state"] = platform_state
-        if error_code is not None:
+        if error_code is not _UNSET:
             platform_payload["error_code"] = error_code
-        if error_message is not None:
+        if error_message is not _UNSET:
             platform_payload["error_message"] = error_message
         platform_payload["updated_at"] = _utc_now_iso()
         payload["platforms"][platform] = platform_payload

--- a/tests/gateway/test_discord_status.py
+++ b/tests/gateway/test_discord_status.py
@@ -1,0 +1,43 @@
+from unittest.mock import AsyncMock, MagicMock
+
+from gateway.config import PlatformConfig
+from gateway.platforms.discord import DiscordAdapter
+
+
+def test_disconnect_marks_runtime_status(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(token="test-token"))
+    client = AsyncMock()
+    adapter._client = client
+    adapter._token_lock_identity = "test-token"
+
+    release_mock = MagicMock()
+    status_mock = MagicMock()
+
+    monkeypatch.setattr("gateway.status.release_scoped_lock", release_mock)
+    monkeypatch.setattr("gateway.status.write_runtime_status", status_mock)
+
+    adapter._mark_connected()
+
+    assert adapter.is_connected is True
+    status_mock.assert_called_with(
+        platform="discord",
+        platform_state="connected",
+        error_code=None,
+        error_message=None,
+    )
+
+    status_mock.reset_mock()
+
+    import asyncio
+
+    asyncio.run(adapter.disconnect())
+
+    assert adapter.is_connected is False
+    client.close.assert_awaited_once()
+    release_mock.assert_called_once_with("discord-bot-token", "test-token")
+    status_mock.assert_called_once_with(
+        platform="discord",
+        platform_state="disconnected",
+        error_code=None,
+        error_message=None,
+    )

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -103,6 +103,56 @@ class TestGatewayRuntimeStatus:
         assert payload["platforms"]["telegram"]["error_code"] == "telegram_polling_conflict"
         assert payload["platforms"]["telegram"]["error_message"] == "another poller is active"
 
+    def test_write_runtime_status_clears_gateway_and_platform_errors(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        status.write_runtime_status(
+            gateway_state="startup_failed",
+            exit_reason="discord conflict",
+            platform="discord",
+            platform_state="fatal",
+            error_code="discord_token_lock",
+            error_message="Discord bot token already in use.",
+        )
+
+        status.write_runtime_status(
+            gateway_state="running",
+            exit_reason=None,
+            platform="discord",
+            platform_state="connected",
+            error_code=None,
+            error_message=None,
+        )
+
+        payload = status.read_runtime_status()
+        assert payload["gateway_state"] == "running"
+        assert payload["exit_reason"] is None
+        assert payload["platforms"]["discord"]["state"] == "connected"
+        assert payload["platforms"]["discord"]["error_code"] is None
+        assert payload["platforms"]["discord"]["error_message"] is None
+
+    def test_write_runtime_status_can_reset_stale_platforms_for_new_run(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        status.write_runtime_status(
+            gateway_state="running",
+            platform="feishu",
+            platform_state="connected",
+            error_code=None,
+            error_message=None,
+        )
+
+        status.write_runtime_status(
+            gateway_state="starting",
+            exit_reason=None,
+            reset_platforms=True,
+        )
+
+        payload = status.read_runtime_status()
+        assert payload["gateway_state"] == "starting"
+        assert payload["exit_reason"] is None
+        assert payload["platforms"] == {}
+
 
 class TestScopedLocks:
     def test_acquire_scoped_lock_rejects_live_other_process(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## What changed

This fixes stale gateway runtime status so recovered platform errors do not remain visible as current failures.

- allow `write_runtime_status()` to explicitly clear gateway and platform error fields instead of treating `None` as "leave the old value in place"
- reset persisted platform state when a new gateway run starts so platforms from prior runs do not linger in `gateway_state.json`
- route Discord connect and disconnect through the shared adapter status bookkeeping so Discord writes `connected` and `disconnected` state the same way other adapters do
- add regression tests for stale error clearing, platform reset on startup, and Discord status writes during disconnect

## Why

`gateway_state.json` could continue reporting a stale fatal platform error long after the platform had recovered. In the Discord case, this made the system appear unhealthy even while the gateway was actively connected and serving messages.

## Root cause

There were two bugs working together:

1. `write_runtime_status()` only updated `error_code` and `error_message` when the new value was non-null, so recovery writes with `None` never cleared old errors.
2. The Discord adapter bypassed the base adapter's `_mark_connected()` and `_mark_disconnected()` helpers, so successful reconnects did not persist fresh runtime status.

A third cleanup issue also existed: startup preserved platform entries from prior runs, which let stale configured platforms remain in the runtime file.

## Impact

- fixes false-positive health alerts sourced from `~/.hermes/gateway_state.json`
- makes platform status reflect the current run rather than accumulated history
- improves confidence in operational diagnostics and cron summaries that inspect gateway runtime state

## Validation

- `./venv/bin/pytest tests/gateway/test_status.py tests/gateway/test_discord_status.py`
- manually restarted the local gateway and verified `~/.hermes/gateway_state.json` reports Discord as `connected` with null error fields and no stale Feishu entry
