### PR TITLE
fix: guard Unix-only fcntl import and SIGKILL lookups

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6949,7 +6949,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                     existing_pid,
                 )
                 try:
-                    os.kill(existing_pid, signal.SIGKILL)
+                    os.kill(existing_pid, getattr(signal, "SIGKILL", signal.SIGTERM))
                     _time.sleep(0.5)
                 except (ProcessLookupError, PermissionError):
                     pass

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1072,7 +1072,7 @@ def _wait_for_gateway_exit(timeout: float = 10.0, force_after: float = 5.0):
         if not force_sent and time.monotonic() >= force_deadline:
             # Grace period expired — force-kill the specific PID.
             try:
-                os.kill(pid, signal.SIGKILL)
+                os.kill(pid, getattr(signal, "SIGKILL", signal.SIGTERM))
                 print(f"⚠ Gateway PID {pid} did not exit gracefully; sent SIGKILL")
             except (ProcessLookupError, PermissionError):
                 return  # Already gone or we can't touch it.

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -645,7 +645,7 @@ def _stop_gateway_process(profile_dir: Path) -> None:
                 return
         # Force kill
         try:
-            os.kill(pid, _signal.SIGKILL)
+            os.kill(pid, getattr(_signal, "SIGKILL", _signal.SIGTERM))
         except ProcessLookupError:
             pass
         print(f"✓ Gateway force-stopped (PID {pid})")

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -230,7 +230,7 @@ class TestWaitForGatewayExit:
         monkeypatch.setattr("os.kill", mock_kill)
 
         gateway._wait_for_gateway_exit(timeout=10.0, force_after=5.0)
-        assert (42, signal.SIGKILL) in kills
+        assert (42, getattr(signal, "SIGKILL", signal.SIGTERM)) in kills
 
     def test_handles_process_already_gone_on_kill(self, monkeypatch):
         """ProcessLookupError during SIGKILL is not fatal."""

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2138,7 +2138,7 @@ def _kill_orphaned_mcp_children() -> None:
 
     for pid in pids:
         try:
-            os.kill(pid, _signal.SIGKILL)
+            os.kill(pid, getattr(_signal, "SIGKILL", _signal.SIGTERM))
             logger.debug("Force-killed orphaned MCP stdio process %d", pid)
         except (ProcessLookupError, PermissionError, OSError):
             pass  # Already exited or inaccessible

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -23,7 +23,15 @@ Design:
 - Frozen snapshot pattern: system prompt is stable, tool responses show live state
 """
 
-import fcntl
+# fcntl is Unix-only; on Windows use msvcrt for file locking
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
+    try:
+        import msvcrt
+    except ImportError:
+        msvcrt = None
 import json
 import logging
 import os
@@ -144,13 +152,28 @@ class MemoryStore:
         """
         lock_path = path.with_suffix(path.suffix + ".lock")
         lock_path.parent.mkdir(parents=True, exist_ok=True)
-        fd = open(lock_path, "w")
-        try:
-            fcntl.flock(fd, fcntl.LOCK_EX)
+        if fcntl is not None:
+            fd = open(lock_path, "w")
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX)
+                yield
+            finally:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+                fd.close()
+        elif msvcrt is not None:
+            fd = open(lock_path, "w")
+            fd.write(" ")
+            fd.flush()
+            fd.seek(0)
+            try:
+                msvcrt.locking(fd.fileno(), msvcrt.LK_LOCK, 1)
+                yield
+            finally:
+                fd.seek(0)
+                msvcrt.locking(fd.fileno(), msvcrt.LK_UNLCK, 1)
+                fd.close()
+        else:
             yield
-        finally:
-            fcntl.flock(fd, fcntl.LOCK_UN)
-            fd.close()
 
     @staticmethod
     def _path_for(target: str) -> Path:


### PR DESCRIPTION
## Summary

Applies existing defensive patterns to a few remaining Unix-specific call sites:

- Guard `tools/memory_tool.py` with the same `fcntl`/`msvcrt` fallback already used in `scheduler.py` and `auth.py`
- Replace direct `signal.SIGKILL` lookups with `getattr(signal, "SIGKILL", signal.SIGTERM)` in 4 files. This only prevents `AttributeError` on Windows; on Windows, `os.kill(pid, SIGTERM)` already performs forceful termination, so the runtime behavior is equivalent.
- Update 1 related test assertion to use the same guard

No behavior change on Linux/macOS.

Fixes #5246

## Testing

Tested on Windows 11 with Python 3.11, 3.12, and 3.13:

- `hermes doctor` shows memory tool as available (no `fcntl` error)
- `python -c "import tools.memory_tool; print('OK')"` succeeds
- `pytest tests/tools/test_memory_tool.py tests/tools/test_mcp_tool.py tests/hermes_cli/test_gateway.py tests/hermes_cli/test_profiles.py -v` passes (fixes 1 previously failing test, no regressions)
