### PR TITLE
fix: prevent model from re-addressing old messages after context compaction

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -65,7 +65,7 @@ class ContextCompressor:
         self,
         model: str,
         threshold_percent: float = 0.50,
-        protect_first_n: int = 3,
+        protect_first_n: int = 1,
         protect_last_n: int = 20,
         summary_target_ratio: float = 0.20,
         quiet_mode: bool = False,
@@ -640,6 +640,15 @@ Write only the summary body. Do not include any preamble or prefix."""
                     (msg.get("content") or "")
                     + "\n\n[Note: Some earlier conversation turns have been compacted into a handoff summary to preserve context space. The current session state may still reflect earlier work, so build on that summary and state rather than re-doing work.]"
                 )
+            elif msg.get("role") in ("user", "assistant") and not msg.get("tool_calls"):
+                # Mark preserved head messages as historical so the model
+                # doesn't re-address old user requests after compaction.
+                content = msg.get("content") or ""
+                if content and not content.startswith("[HISTORICAL"):
+                    msg["content"] = (
+                        "[HISTORICAL — from the start of this session, already addressed]\n"
+                        + content
+                    )
             compressed.append(msg)
 
         _merge_summary_into_tail = False

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -563,7 +563,8 @@ Write only the summary body. Do not include any preamble or prefix."""
     # Main compression entry point
     # ------------------------------------------------------------------
 
-    def compress(self, messages: List[Dict[str, Any]], current_tokens: int = None) -> List[Dict[str, Any]]:
+    def compress(self, messages: List[Dict[str, Any]], current_tokens: int = None,
+                 force_truncation: bool = False) -> List[Dict[str, Any]]:
         """Compress conversation messages by summarizing middle turns.
 
         Algorithm:
@@ -572,6 +573,11 @@ Write only the summary body. Do not include any preamble or prefix."""
           3. Find tail boundary by token budget (~20K tokens of recent context)
           4. Summarize middle turns with structured LLM prompt
           5. On re-compression, iteratively update the previous summary
+
+        Args:
+            force_truncation: When True, drop middle turns even if summary
+                generation fails (last-resort fallback for API context overflow).
+                When False (default), abort compaction to prevent data loss.
 
         After compression, orphaned tool_call / tool_result pairs are cleaned
         up so the API never receives mismatched IDs.
@@ -684,28 +690,32 @@ Write only the summary body. Do not include any preamble or prefix."""
                 compressed.append({"role": summary_role, "content": summary})
         else:
             # Summary generation failed (provider down, timeout, rate limit, etc.).
-            # Abort compaction entirely and return the original messages unchanged.
             #
-            # WHY NOT just drop the middle turns?  With protect_first_n=1 (system
-            # prompt only), the initial user/assistant exchange lives in the middle
-            # region.  Dropping it without a summary silently loses the session's
-            # opening context — the model would have no idea what was discussed.
+            # TWO MODES depending on force_truncation:
             #
-            # WHY NOT change protect_first_n back to 2 or 3?  That reintroduces
-            # the original bug: after compaction, the model sees the verbatim first
-            # user message in the context head, treats it as a new/pending request,
-            # and deviates from the current task.  Keeping protect_first_n=1 and
-            # aborting on summary failure is the safer trade-off.
+            # force_truncation=False (default, normal compaction at ~50% threshold):
+            #   Abort compaction entirely and return the original messages unchanged.
+            #   The 50% threshold provides a large buffer before the API hard-rejects,
+            #   so aborting once is safe.  The next turn will retry compaction.
             #
-            # The 85% compaction threshold provides a ~15% buffer before the API
-            # hard-rejects for context overflow, so aborting once is safe.  The
-            # next turn will retry compaction (transient failures usually resolve).
-            if not self.quiet_mode:
-                logger.warning(
-                    "Summary generation failed — aborting compaction to prevent "
-                    "data loss.  Will retry on next turn."
-                )
-            return messages
+            # force_truncation=True (hard fallback, API already rejected for overflow):
+            #   Drop the middle turns WITHOUT a summary.  Losing context is bad, but
+            #   crashing the conversation entirely is worse.  The model keeps the
+            #   system prompt + recent messages and can at least continue functioning.
+            if not force_truncation:
+                if not self.quiet_mode:
+                    logger.warning(
+                        "Summary generation failed — aborting compaction to prevent "
+                        "data loss.  Will retry on next turn."
+                    )
+                return messages
+            else:
+                if not self.quiet_mode:
+                    logger.warning(
+                        "Summary generation failed and force_truncation=True — "
+                        "dropping %d middle turns without summary (last resort).",
+                        len(turns_to_summarize),
+                    )
 
         for i in range(compress_end, n_messages):
             msg = messages[i].copy()

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -55,10 +55,12 @@ class ContextCompressor:
 
     Algorithm:
       1. Prune old tool results (cheap, no LLM call)
-      2. Protect head messages (system prompt + first exchange)
+      2. Protect head messages (system prompt only by default; configurable
+         via protect_first_n)
       3. Protect tail messages by token budget (most recent ~20K tokens)
       4. Summarize middle turns with structured LLM prompt
       5. On subsequent compactions, iteratively update the previous summary
+      6. If summary generation fails, abort compaction to prevent data loss
     """
 
     def __init__(
@@ -257,9 +259,8 @@ class ContextCompressor:
         inspired by Pi-mono and OpenCode. When a previous summary exists,
         generates an iterative update instead of summarizing from scratch.
 
-        Returns None if all attempts fail — the caller should drop
-        the middle turns without a summary rather than inject a useless
-        placeholder.
+        Returns None if all attempts fail — the caller should abort compaction
+        and return the original messages unchanged to prevent data loss.
         """
         now = time.monotonic()
         if now < self._summary_failure_cooldown_until:
@@ -643,8 +644,14 @@ Write only the summary body. Do not include any preamble or prefix."""
             elif msg.get("role") in ("user", "assistant") and not msg.get("tool_calls"):
                 # Mark preserved head messages as historical so the model
                 # doesn't re-address old user requests after compaction.
-                content = msg.get("content") or ""
-                if content and not content.startswith("[HISTORICAL"):
+                # Guard with isinstance() because some providers (e.g. OpenAI
+                # vision) send content as a list of dicts, not a plain string.
+                content = msg.get("content")
+                if (
+                    isinstance(content, str)
+                    and content
+                    and not content.startswith("[HISTORICAL")
+                ):
                     msg["content"] = (
                         "[HISTORICAL — from the start of this session, already addressed]\n"
                         + content
@@ -676,8 +683,29 @@ Write only the summary body. Do not include any preamble or prefix."""
             if not _merge_summary_into_tail:
                 compressed.append({"role": summary_role, "content": summary})
         else:
+            # Summary generation failed (provider down, timeout, rate limit, etc.).
+            # Abort compaction entirely and return the original messages unchanged.
+            #
+            # WHY NOT just drop the middle turns?  With protect_first_n=1 (system
+            # prompt only), the initial user/assistant exchange lives in the middle
+            # region.  Dropping it without a summary silently loses the session's
+            # opening context — the model would have no idea what was discussed.
+            #
+            # WHY NOT change protect_first_n back to 2 or 3?  That reintroduces
+            # the original bug: after compaction, the model sees the verbatim first
+            # user message in the context head, treats it as a new/pending request,
+            # and deviates from the current task.  Keeping protect_first_n=1 and
+            # aborting on summary failure is the safer trade-off.
+            #
+            # The 85% compaction threshold provides a ~15% buffer before the API
+            # hard-rejects for context overflow, so aborting once is safe.  The
+            # next turn will retry compaction (transient failures usually resolve).
             if not self.quiet_mode:
-                logger.debug("No summary model available — middle turns dropped without summary")
+                logger.warning(
+                    "Summary generation failed — aborting compaction to prevent "
+                    "data loss.  Will retry on next turn."
+                )
+            return messages
 
         for i in range(compress_end, n_messages):
             msg = messages[i].copy()

--- a/run_agent.py
+++ b/run_agent.py
@@ -5833,8 +5833,12 @@ class AIAgent:
             if messages and messages[-1].get("_flush_sentinel") == _sentinel:
                 messages.pop()
 
-    def _compress_context(self, messages: list, system_message: str, *, approx_tokens: int = None, task_id: str = "default") -> tuple:
+    def _compress_context(self, messages: list, system_message: str, *, approx_tokens: int = None, task_id: str = "default", force_truncation: bool = False) -> tuple:
         """Compress conversation context and split the session in SQLite.
+
+        Args:
+            force_truncation: When True, drop middle turns even if summary
+                generation fails (last-resort fallback for API context overflow).
 
         Returns:
             (compressed_messages, new_system_prompt) tuple
@@ -5855,7 +5859,8 @@ class AIAgent:
             except Exception:
                 pass
 
-        compressed = self.context_compressor.compress(messages, current_tokens=approx_tokens)
+        compressed = self.context_compressor.compress(messages, current_tokens=approx_tokens,
+                                                      force_truncation=force_truncation)
 
         todo_snapshot = self._todo_store.format_for_injection()
         if todo_snapshot:
@@ -8067,6 +8072,7 @@ class AIAgent:
                         messages, active_system_prompt = self._compress_context(
                             messages, system_message, approx_tokens=approx_tokens,
                             task_id=effective_task_id,
+                            force_truncation=True,
                         )
 
                         if len(messages) < original_len:
@@ -8192,9 +8198,13 @@ class AIAgent:
                         self._emit_status(f"🗜️ Context too large (~{approx_tokens:,} tokens) — compressing ({compression_attempts}/{max_compression_attempts})...")
 
                         original_len = len(messages)
+                        # force_truncation=True: API already rejected us for context
+                        # overflow, so dropping turns without summary is better than
+                        # crashing the conversation entirely.
                         messages, active_system_prompt = self._compress_context(
                             messages, system_message, approx_tokens=approx_tokens,
                             task_id=effective_task_id,
+                            force_truncation=True,
                         )
 
                         if len(messages) < original_len or new_ctx and new_ctx < old_ctx:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1095,6 +1095,7 @@ class AIAgent:
         compression_summary_model = _compression_cfg.get("summary_model") or None
         compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
         compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))
+        compression_protect_first = int(_compression_cfg.get("protect_first_n", 1))
 
         # Read explicit context_length override from model config
         _model_cfg = _agent_cfg.get("model", {})
@@ -1132,7 +1133,7 @@ class AIAgent:
         self.context_compressor = ContextCompressor(
             model=self.model,
             threshold_percent=compression_threshold,
-            protect_first_n=3,
+            protect_first_n=compression_protect_first,
             protect_last_n=compression_protect_last,
             summary_target_ratio=compression_target_ratio,
             summary_model_override=compression_summary_model,

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -851,3 +851,38 @@ class TestHistoricalPrefix:
         assert result[1]["content"] == "Build me a website"  # not dropped
         # compression_count should NOT have incremented
         assert c.compression_count == 0
+
+    def test_force_truncation_drops_middle_on_summary_failure(self):
+        """With force_truncation=True, failing summary should still compress (drop middle turns)."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=100_000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=1,
+                protect_last_n=2,
+            )
+
+        msgs = [
+            {"role": "system", "content": "system prompt"},
+            {"role": "user", "content": "Build me a website"},
+            {"role": "assistant", "content": "Sure thing"},
+            {"role": "user", "content": "middle 1"},
+            {"role": "assistant", "content": "middle 2"},
+            {"role": "user", "content": "middle 3"},
+            {"role": "assistant", "content": "middle 4"},
+            {"role": "user", "content": "recent msg"},
+            {"role": "assistant", "content": "recent reply"},
+        ]
+
+        # Simulate summary failure with force_truncation=True
+        with patch("agent.context_compressor.call_llm", side_effect=RuntimeError("no provider")):
+            result = c.compress(msgs, force_truncation=True)
+
+        # Should have FEWER messages — middle turns dropped without summary
+        assert len(result) < len(msgs)
+        # System prompt preserved
+        assert result[0]["role"] == "system"
+        # Recent messages preserved
+        assert result[-1]["content"] == "recent reply"
+        # compression_count SHOULD have incremented
+        assert c.compression_count == 1

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -89,21 +89,36 @@ class TestCompress:
         result = compressor.compress(msgs)
         assert result == msgs
 
-    def test_truncation_fallback_no_client(self, compressor):
-        # compressor has client=None, so should use truncation fallback
+    def test_abort_when_no_client(self, compressor):
+        # compressor has client=None, so _generate_summary returns None.
+        # With abort-on-failure semantics, compress() must return original
+        # messages unchanged to prevent silent data loss.
         msgs = [{"role": "system", "content": "System prompt"}] + self._make_messages(10)
         result = compressor.compress(msgs)
-        assert len(result) < len(msgs)
-        # Should keep system message and last N
+        assert len(result) == len(msgs)
         assert result[0]["role"] == "system"
-        assert compressor.compression_count == 1
+        assert compressor.compression_count == 0
 
-    def test_compression_increments_count(self, compressor):
+    def test_compression_increments_count(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "summary text"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100_000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=2,
+                protect_last_n=2,
+            )
+
         msgs = self._make_messages(10)
-        compressor.compress(msgs)
-        assert compressor.compression_count == 1
-        compressor.compress(msgs)
-        assert compressor.compression_count == 2
+        with patch("agent.context_compressor.call_llm", return_value=mock_response):
+            c.compress(msgs)
+        assert c.compression_count == 1
+        with patch("agent.context_compressor.call_llm", return_value=mock_response):
+            c.compress(msgs)
+        assert c.compression_count == 2
 
     def test_protects_first_and_last(self, compressor):
         msgs = self._make_messages(10)
@@ -145,7 +160,8 @@ class TestGenerateSummaryNoneContent:
         assert summary.startswith(SUMMARY_PREFIX)
 
     def test_none_content_in_system_message_compress(self):
-        """System message with content=None should not crash during compress."""
+        """System message with content=None should not crash during compress.
+        With no summary client, compress() aborts and returns messages unchanged."""
         with patch("agent.context_compressor.get_model_context_length", return_value=100000):
             c = ContextCompressor(model="test", quiet_mode=True, protect_first_n=2, protect_last_n=2)
 
@@ -154,7 +170,8 @@ class TestGenerateSummaryNoneContent:
             for i in range(10)
         ]
         result = c.compress(msgs)
-        assert len(result) < len(msgs)
+        # With abort-on-failure, original messages are returned unchanged
+        assert len(result) == len(msgs)
 
 
 class TestNonStringContent:
@@ -762,3 +779,75 @@ class TestHistoricalPrefix:
             if msg.get("tool_calls"):
                 content = msg.get("content") or ""
                 assert not content.startswith("[HISTORICAL")
+
+    def test_non_string_content_not_prefixed(self):
+        """Messages with non-string content (e.g. OpenAI vision list) must not crash."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "summary text"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100_000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=3,
+                protect_last_n=2,
+            )
+
+        msgs = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            # Vision-style message with list content
+            {"role": "user", "content": [
+                {"type": "text", "text": "What's in this image?"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/img.png"}},
+            ]},
+            {"role": "assistant", "content": "I see a cat."},
+            {"role": "user", "content": "middle 1"},
+            {"role": "assistant", "content": "middle 2"},
+            {"role": "user", "content": "middle 3"},
+            {"role": "assistant", "content": "middle 4"},
+            {"role": "user", "content": "recent"},
+            {"role": "assistant", "content": "recent reply"},
+        ]
+
+        with patch("agent.context_compressor.call_llm", return_value=mock_response):
+            result = c.compress(msgs)
+
+        # Should not crash.  The list-content message should survive unchanged.
+        list_msg = result[1]
+        assert isinstance(list_msg["content"], list)
+        assert not isinstance(list_msg["content"], str)
+        # The assistant message with string content SHOULD get the prefix
+        assert result[2]["content"].startswith("[HISTORICAL")
+
+    def test_abort_compaction_on_summary_failure(self):
+        """When summary generation fails, compress() must return original messages unchanged."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=100_000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=1,
+                protect_last_n=2,
+            )
+
+        msgs = [
+            {"role": "system", "content": "system prompt"},
+            {"role": "user", "content": "Build me a website"},
+            {"role": "assistant", "content": "Sure thing"},
+            {"role": "user", "content": "middle 1"},
+            {"role": "assistant", "content": "middle 2"},
+            {"role": "user", "content": "middle 3"},
+            {"role": "assistant", "content": "middle 4"},
+            {"role": "user", "content": "recent msg"},
+            {"role": "assistant", "content": "recent reply"},
+        ]
+
+        # Simulate summary failure (RuntimeError = no provider)
+        with patch("agent.context_compressor.call_llm", side_effect=RuntimeError("no provider")):
+            result = c.compress(msgs)
+
+        # Should return original messages unchanged — no data loss
+        assert len(result) == len(msgs)
+        assert result[1]["content"] == "Build me a website"  # not dropped
+        # compression_count should NOT have incremented
+        assert c.compression_count == 0

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -600,3 +600,165 @@ class TestSummaryTargetRatio:
         with patch("agent.context_compressor.get_model_context_length", return_value=100_000):
             c = ContextCompressor(model="test", quiet_mode=True)
         assert c.protect_last_n == 20
+
+    def test_default_protect_first_n_is_1(self):
+        """Default protect_first_n should be 1 (system prompt only)."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=100_000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+        assert c.protect_first_n == 1
+
+
+class TestHistoricalPrefix:
+    """Verify that preserved head user/assistant messages are marked [HISTORICAL]."""
+
+    def test_head_user_message_gets_historical_prefix(self):
+        """When protect_first_n > 1, preserved user messages should get [HISTORICAL] prefix."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "summary text"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100_000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=3,
+                protect_last_n=2,
+            )
+
+        msgs = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Build me a website"},
+            {"role": "assistant", "content": "Sure, I'll help you build a website."},
+            {"role": "user", "content": "middle msg 1"},
+            {"role": "assistant", "content": "middle msg 2"},
+            {"role": "user", "content": "middle msg 3"},
+            {"role": "assistant", "content": "middle msg 4"},
+            {"role": "user", "content": "recent user msg"},
+            {"role": "assistant", "content": "recent assistant msg"},
+        ]
+
+        with patch("agent.context_compressor.call_llm", return_value=mock_response):
+            result = c.compress(msgs)
+
+        # System prompt should NOT have HISTORICAL prefix
+        system_msg = result[0]
+        assert system_msg["role"] == "system"
+        assert not system_msg["content"].startswith("[HISTORICAL")
+
+        # Find preserved head user/assistant messages (index 1 and 2)
+        head_user = result[1]
+        head_assistant = result[2]
+        assert head_user["role"] == "user"
+        assert head_user["content"].startswith("[HISTORICAL")
+        assert "Build me a website" in head_user["content"]
+        assert head_assistant["role"] == "assistant"
+        assert head_assistant["content"].startswith("[HISTORICAL")
+        assert "help you build a website" in head_assistant["content"]
+
+    def test_historical_prefix_idempotent(self):
+        """Re-compressing should not double-prefix HISTORICAL messages."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "summary text"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100_000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=3,
+                protect_last_n=2,
+            )
+
+        msgs = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "[HISTORICAL — from the start of this session, already addressed]\nBuild me a website"},
+            {"role": "assistant", "content": "[HISTORICAL — from the start of this session, already addressed]\nSure thing."},
+            {"role": "user", "content": "middle 1"},
+            {"role": "assistant", "content": "middle 2"},
+            {"role": "user", "content": "middle 3"},
+            {"role": "assistant", "content": "middle 4"},
+            {"role": "user", "content": "recent 1"},
+            {"role": "assistant", "content": "recent 2"},
+        ]
+
+        with patch("agent.context_compressor.call_llm", return_value=mock_response):
+            result = c.compress(msgs)
+
+        head_user = result[1]
+        # Should not have double prefix
+        assert head_user["content"].count("[HISTORICAL") == 1
+
+    def test_no_historical_prefix_with_protect_first_1(self):
+        """With protect_first_n=1 (default), no user/assistant messages are in head, so no prefix needed."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "summary text"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100_000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=1,
+                protect_last_n=2,
+            )
+
+        msgs = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Build me a website"},
+            {"role": "assistant", "content": "Sure thing."},
+            {"role": "user", "content": "middle 1"},
+            {"role": "assistant", "content": "middle 2"},
+            {"role": "user", "content": "recent 1"},
+            {"role": "assistant", "content": "recent 2"},
+        ]
+
+        with patch("agent.context_compressor.call_llm", return_value=mock_response):
+            result = c.compress(msgs)
+
+        # Only system prompt in head — no user/assistant messages to prefix
+        assert result[0]["role"] == "system"
+        # No message should have HISTORICAL prefix
+        for msg in result:
+            content = msg.get("content") or ""
+            if msg["role"] != "system":
+                # Tail messages should NOT have HISTORICAL prefix
+                if not content.startswith("[CONTEXT COMPACTION]"):
+                    assert not content.startswith("[HISTORICAL")
+
+    def test_tool_call_messages_not_prefixed(self):
+        """Assistant messages with tool_calls should NOT get HISTORICAL prefix."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "summary text"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100_000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=4,
+                protect_last_n=2,
+            )
+
+        msgs = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Search for files"},
+            {"role": "assistant", "content": "", "tool_calls": [
+                {"id": "call_1", "type": "function", "function": {"name": "search", "arguments": "{}"}}
+            ]},
+            {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+            {"role": "user", "content": "middle 1"},
+            {"role": "assistant", "content": "middle 2"},
+            {"role": "user", "content": "middle 3"},
+            {"role": "assistant", "content": "middle 4"},
+            {"role": "user", "content": "recent 1"},
+            {"role": "assistant", "content": "recent 2"},
+        ]
+
+        with patch("agent.context_compressor.call_llm", return_value=mock_response):
+            result = c.compress(msgs)
+
+        # The assistant message with tool_calls should NOT have HISTORICAL prefix
+        for msg in result:
+            if msg.get("tool_calls"):
+                content = msg.get("content") or ""
+                assert not content.startswith("[HISTORICAL")


### PR DESCRIPTION
## Problem

After context compaction, the model frequently deviates from current work and starts re-addressing the very first user request from the session. This is a **session-breaking bug** that disrupts workflow.

### Root Cause

`protect_first_n=3` preserves the system prompt + first user message + first assistant reply verbatim in the context. After compaction, the model sees the original user request (e.g., "Build me a website") as a pending instruction and acts on it, ignoring the compaction summary and current context.

## Fix

### 1. Change default `protect_first_n` from 3 to 1

Only the system prompt is preserved in the head. The first user/assistant exchanges are already captured in the compaction summary, so **no information is lost**.

Users who need the old behavior can set `protect_first_n: 3` in their `config.yaml` under `compression:`.

### 2. Add `[HISTORICAL]` prefix to preserved head user/assistant messages

Safety net for users who configure `protect_first_n > 1`. Marks old messages with:

```
[HISTORICAL — from the start of this session, already addressed]
```

So the model knows they are already addressed and should not be re-acted upon.

- Skips system prompts (they get the existing `[Note: ...]` suffix)
- Skips assistant messages with `tool_calls` (to avoid breaking tool call integrity)
- Guards with `isinstance(content, str)` to handle non-string content (e.g., OpenAI vision list-of-dicts)
- Idempotent: does not double-prefix on re-compaction

### 3. Expose `protect_first_n` in config

Previously hardcoded in `run_agent.py` while `protect_last_n` was already configurable. Now reads from `config.yaml`:

```yaml
compression:
  protect_first_n: 1  # default, system prompt only
```

### 4. Two-tier compaction failure handling

When summary generation fails (provider down, timeout, rate limit), the system now has two tiers:

- **Tier 1 (normal compaction at ~50% threshold):** Abort compaction entirely, return original messages unchanged, and retry on the next turn. The 50% threshold provides a large buffer before the API hard-rejects, so aborting once is safe.

- **Tier 2 (API already rejected for context overflow):** Drop middle turns WITHOUT a summary as a last resort. Losing context is bad, but crashing the conversation entirely is worse. The model keeps system prompt + recent messages and can at least continue functioning.

Tier 2 is triggered by:
- `context_length_exceeded` errors from the API
- HTTP 413 "payload too large" errors

Both error handlers in `run_agent.py` now pass `force_truncation=True` to the compressor.

## Tests

10 new/updated tests in `tests/agent/test_context_compressor.py`:

- `test_default_protect_first_n_is_1` — confirms new default
- `test_head_user_message_gets_historical_prefix` — prefix applied to head user/assistant messages
- `test_historical_prefix_idempotent` — no double-prefix on re-compaction
- `test_no_historical_prefix_with_protect_first_1` — no prefix when only system prompt in head
- `test_tool_call_messages_not_prefixed` — tool_call messages excluded
- `test_non_string_content_not_prefixed` — vision-style list content handled safely
- `test_abort_compaction_on_summary_failure` — Tier 1: abort behavior verified
- `test_force_truncation_drops_middle_on_summary_failure` — Tier 2: force truncation verified
- `test_abort_when_no_client` — no-client scenario returns messages unchanged
- `test_compression_increments_count` — updated for new abort semantics

All 42 compressor tests pass.

## Files Changed

- `agent/context_compressor.py` — default `protect_first_n=1`, HISTORICAL prefix logic, `isinstance` type guard, two-tier failure handling with `force_truncation` parameter
- `run_agent.py` — read `protect_first_n` from config, pass `force_truncation=True` in context overflow/413 error handlers
- `tests/agent/test_context_compressor.py` — 10 new/updated tests
