### PR TITLE
feat(gateway): add one-shot self-nudge tool

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -343,6 +343,9 @@ class MessageEvent:
     
     # Auto-loaded skill for topic/channel bindings (e.g., Telegram DM Topics)
     auto_skill: Optional[str] = None
+
+    # Optional transcript-safe substitute for internal/hidden user turns.
+    persist_user_message: Optional[str] = None
     
     # Timestamps
     timestamp: datetime = field(default_factory=datetime.now)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -27,7 +27,7 @@ import time
 import uuid
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Dict, Optional, Any, List
 
 # ---------------------------------------------------------------------------
@@ -276,6 +276,8 @@ logger = logging.getLogger(__name__)
 # session from bypassing the "already running" guard during the async gap
 # between the guard check and actual agent creation.
 _AGENT_PENDING_SENTINEL = object()
+_SELF_NUDGE_NO_REPLY = "NO_REPLY"
+_SELF_NUDGE_MAX_DELAY_SECONDS = 86400
 
 
 def _resolve_runtime_agent_kwargs() -> dict:
@@ -493,6 +495,9 @@ class GatewayRunner:
         self._running_agents: Dict[str, Any] = {}
         self._running_agents_ts: Dict[str, float] = {}  # start timestamp per session
         self._pending_messages: Dict[str, str] = {}  # Queued messages during interrupt
+        self._self_nudge_tasks: Dict[str, asyncio.Task] = {}
+        self._self_nudge_entries: Dict[str, Dict[str, Any]] = {}
+        self._pending_hidden_turns: Dict[str, Dict[str, Any]] = {}
 
         # Cache AIAgent instances per session to preserve prompt caching.
         # Without this, a new AIAgent is created per message, rebuilding the
@@ -848,6 +853,115 @@ class GatewayRunner:
         self._exit_cleanly = True
         self._exit_reason = reason
         self._shutdown_event.set()
+
+    def _build_self_nudge_text(self, entry: Dict[str, Any]) -> str:
+        """Build the hidden prompt text for a fired self-nudge."""
+        hidden_prefix = (
+            "[System note: A self-nudge timer you armed earlier has fired. "
+            "Resume from the last persisted context and continue the follow-up task below.]"
+        )
+        note = str(entry.get("note") or "").strip()
+        if note:
+            return f"{hidden_prefix}\n\nReminder:\n{note}"
+        return hidden_prefix
+
+    async def _cancel_self_nudge(self, session_key: str, reason: str = "") -> bool:
+        """Cancel the active self-nudge for a session, if any."""
+        task = getattr(self, "_self_nudge_tasks", {}).pop(session_key, None)
+        entry = getattr(self, "_self_nudge_entries", {}).pop(session_key, None)
+        getattr(self, "_pending_hidden_turns", {}).pop(session_key, None)
+        if task:
+            task.cancel()
+        if entry and reason:
+            logger.debug("Cancelled self-nudge for %s (%s)", session_key[:20], reason)
+        return bool(task or entry)
+
+    async def _arm_self_nudge(
+        self,
+        session_key: str,
+        source: SessionSource,
+        delay_seconds: int,
+        note: str = "",
+    ) -> Dict[str, Any]:
+        """Arm or replace a one-shot self-nudge for a session."""
+        seconds = int(delay_seconds)
+        if seconds <= 0:
+            return {"armed": False, "error": "delay_seconds must be greater than zero."}
+        if seconds > _SELF_NUDGE_MAX_DELAY_SECONDS:
+            return {
+                "armed": False,
+                "error": (
+                    f"delay_seconds exceeds the maximum of "
+                    f"{_SELF_NUDGE_MAX_DELAY_SECONDS} seconds."
+                ),
+            }
+
+        replaced = await self._cancel_self_nudge(session_key, reason="replaced")
+        due_at = datetime.now() + timedelta(seconds=seconds)
+        entry = {
+            "session_key": session_key,
+            "source": source.to_dict(),
+            "delay_seconds": seconds,
+            "note": str(note or "").strip(),
+            "due_at": due_at.isoformat(),
+        }
+        self._self_nudge_entries[session_key] = entry
+
+        task = asyncio.create_task(self._fire_self_nudge(entry))
+        self._self_nudge_tasks[session_key] = task
+
+        def _cleanup(done_task, key=session_key):
+            current = self._self_nudge_tasks.get(key)
+            if current is done_task:
+                self._self_nudge_tasks.pop(key, None)
+
+        task.add_done_callback(_cleanup)
+        return {
+            "armed": True,
+            "delay_seconds": seconds,
+            "due_at": due_at.isoformat(),
+            "replaced_existing": replaced,
+        }
+
+    async def _fire_self_nudge(self, entry: Dict[str, Any]) -> None:
+        """Wait for a self-nudge timer, then enqueue or run its hidden turn."""
+        session_key = entry.get("session_key") or ""
+        delay = max(int(entry.get("delay_seconds") or 0), 0)
+        if not session_key or delay <= 0:
+            return
+
+        try:
+            await asyncio.sleep(delay)
+        except asyncio.CancelledError:
+            raise
+
+        current = self._self_nudge_entries.get(session_key)
+        if current is not entry:
+            return
+        self._self_nudge_entries.pop(session_key, None)
+        if session_key in self._running_agents:
+            self._pending_hidden_turns[session_key] = entry
+            return
+        await self._run_self_nudge_entry(entry)
+
+    async def _run_self_nudge_entry(self, entry: Dict[str, Any]) -> None:
+        """Inject a hidden follow-up turn for a fired self-nudge."""
+        session_key = entry.get("session_key") or ""
+        if not session_key or session_key in self._running_agents:
+            return
+        try:
+            source = SessionSource.from_dict(entry.get("source") or {})
+        except Exception as e:
+            logger.warning("Skipping invalid self-nudge entry: %s", e)
+            return
+
+        event = MessageEvent(
+            text=self._build_self_nudge_text(entry),
+            source=source,
+            message_id=f"self-nudge-{uuid.uuid4().hex[:8]}",
+            persist_user_message="[System note: a self-nudge timer fired.]",
+        )
+        await self._handle_message_with_agent(event, source, session_key)
     
     @staticmethod
     def _load_prefill_messages() -> List[Dict[str, Any]]:
@@ -1444,6 +1558,11 @@ class GatewayRunner:
         for _task in list(self._background_tasks):
             _task.cancel()
         self._background_tasks.clear()
+        for _task in list(getattr(self, "_self_nudge_tasks", {}).values()):
+            _task.cancel()
+        getattr(self, "_self_nudge_tasks", {}).clear()
+        getattr(self, "_self_nudge_entries", {}).clear()
+        getattr(self, "_pending_hidden_turns", {}).clear()
 
         self.adapters.clear()
         self._running_agents.clear()
@@ -2171,6 +2290,9 @@ class GatewayRunner:
         # Get or create session
         session_entry = self.session_store.get_or_create_session(source)
         session_key = session_entry.session_key
+
+        if not str(getattr(event, "message_id", "") or "").startswith("self-nudge-"):
+            await self._cancel_self_nudge(session_key, reason="new_user_message")
         
         # Emit session:start for new or auto-reset sessions
         _is_new_session = (
@@ -2871,7 +2993,11 @@ class GatewayRunner:
                 if not new_messages:
                     self.session_store.append_to_transcript(
                         session_entry.session_id,
-                        {"role": "user", "content": message_text, "timestamp": ts}
+                        {
+                            "role": "user",
+                            "content": getattr(event, "persist_user_message", None) or message_text,
+                            "timestamp": ts,
+                        }
                     )
                     if response:
                         self.session_store.append_to_transcript(
@@ -2884,12 +3010,21 @@ class GatewayRunner:
                     # to prevent the duplicate-write bug (#860).  We still write
                     # to JSONL for backward compatibility and as a backup.
                     agent_persisted = self._session_db is not None
+                    _persist_override = getattr(event, "persist_user_message", None)
+                    _persist_override_applied = False
                     for msg in new_messages:
                         # Skip system messages (they're rebuilt each run)
                         if msg.get("role") == "system":
                             continue
                         # Add timestamp to each message for debugging
                         entry = {**msg, "timestamp": ts}
+                        if (
+                            _persist_override is not None
+                            and not _persist_override_applied
+                            and entry.get("role") == "user"
+                        ):
+                            entry["content"] = _persist_override
+                            _persist_override_applied = True
                         self.session_store.append_to_transcript(
                             session_entry.session_id, entry,
                             skip_db=agent_persisted,
@@ -3083,6 +3218,7 @@ class GatewayRunner:
         except Exception as e:
             logger.debug("Gateway memory flush on reset failed: %s", e)
         self._evict_cached_agent(session_key)
+        await self._cancel_self_nudge(session_key, reason="session_reset")
         
         # Reset the session
         new_entry = self.session_store.reset_session(session_key)
@@ -6160,6 +6296,21 @@ class GatewayRunner:
             except Exception as _e:
                 logger.debug("status_callback error (%s): %s", event_type, _e)
 
+        def _self_nudge_callback_sync(delay_seconds: int, note: str = "") -> dict:
+            try:
+                future = asyncio.run_coroutine_threadsafe(
+                    self._arm_self_nudge(
+                        session_key=session_key,
+                        source=source,
+                        delay_seconds=delay_seconds,
+                        note=note,
+                    ),
+                    _loop_for_step,
+                )
+                return future.result(timeout=15)
+            except Exception as _e:
+                return {"armed": False, "error": f"Failed to arm self-nudge: {_e}"}
+
         def run_sync():
             # Pass session_key to process registry via env var so background
             # processes can be mapped back to this gateway session
@@ -6284,6 +6435,7 @@ class GatewayRunner:
             agent.tool_progress_callback = progress_callback if tool_progress_enabled else None
             agent.step_callback = _step_callback_sync if _hooks_ref.loaded_hooks else None
             agent.stream_delta_callback = _stream_delta_cb
+            agent.self_nudge_callback = _self_nudge_callback_sync
             agent.status_callback = _status_callback_sync
             agent.reasoning_config = reasoning_config
 
@@ -6467,8 +6619,23 @@ class GatewayRunner:
                 _input_toks = getattr(_agent, "session_prompt_tokens", 0)
                 _output_toks = getattr(_agent, "session_completion_tokens", 0)
             _resolved_model = getattr(_agent, "model", None) if _agent else None
+            _self_nudge_armed = bool(_agent and getattr(_agent, "_self_nudge_armed_this_turn", False))
+            _suppress_reply = False
 
-            if not final_response:
+            if (
+                _self_nudge_armed
+                and isinstance(final_response, str)
+                and final_response.strip().upper() == _SELF_NUDGE_NO_REPLY
+            ):
+                _suppress_reply = True
+                final_response = ""
+                _messages = result.get("messages") or []
+                if _messages and _messages[-1].get("role") == "assistant":
+                    _last_content = (_messages[-1].get("content") or "").strip().upper()
+                    if _last_content == _SELF_NUDGE_NO_REPLY:
+                        _messages.pop()
+
+            if not final_response and not _suppress_reply:
                 error_msg = f"⚠️ {result['error']}" if result.get("error") else "(No response generated)"
                 return {
                     "final_response": error_msg,
@@ -6570,6 +6737,7 @@ class GatewayRunner:
                 "output_tokens": _output_toks,
                 "model": _resolved_model,
                 "session_id": effective_session_id,
+                "self_nudge_armed": _self_nudge_armed,
             }
         
         # Start progress message sender if enabled
@@ -6762,6 +6930,11 @@ class GatewayRunner:
                 # interrupted." is just noise; the user already knows they sent a
                 # new message).
 
+                await self._cancel_self_nudge(
+                    session_key,
+                    reason="queued_user_followup",
+                )
+
                 # Process the pending message with updated history
                 updated_history = result.get("messages", history)
                 return await self._run_agent(
@@ -6797,6 +6970,11 @@ class GatewayRunner:
                 del self._running_agents[session_key]
             if session_key:
                 self._running_agents_ts.pop(session_key, None)
+                hidden_entry = getattr(self, "_pending_hidden_turns", {}).pop(session_key, None)
+                if hidden_entry:
+                    hidden_task = asyncio.create_task(self._run_self_nudge_entry(hidden_entry))
+                    self._background_tasks.add(hidden_task)
+                    hidden_task.add_done_callback(self._background_tasks.discard)
             
             # Wait for cancelled tasks
             for task in [progress_task, interrupt_monitor, tracking_task, _notify_task]:

--- a/model_tools.py
+++ b/model_tools.py
@@ -152,6 +152,7 @@ def _discover_tools():
         "tools.memory_tool",
         "tools.session_search_tool",
         "tools.clarify_tool",
+        "tools.self_nudge_tool",
         "tools.code_execution_tool",
         "tools.delegate_tool",
         "tools.process_registry",
@@ -235,6 +236,7 @@ def get_tool_definitions(
     enabled_toolsets: List[str] = None,
     disabled_toolsets: List[str] = None,
     quiet_mode: bool = False,
+    platform: str | None = None,
 ) -> List[Dict[str, Any]]:
     """
     Get tool definitions for model API calls with toolset-based filtering.
@@ -301,6 +303,26 @@ def get_tool_definitions(
     # Ask the registry for schemas (only returns tools whose check_fn passes)
     filtered_tools = registry.get_definitions(tools_to_include, quiet=quiet_mode)
 
+    gateway_self_nudge_platforms = {
+        "discord",
+        "dingtalk",
+        "email",
+        "feishu",
+        "homeassistant",
+        "matrix",
+        "mattermost",
+        "signal",
+        "slack",
+        "telegram",
+        "wecom",
+        "whatsapp",
+    }
+    if platform not in gateway_self_nudge_platforms:
+        filtered_tools = [
+            td for td in filtered_tools
+            if td.get("function", {}).get("name") != "self_nudge"
+        ]
+
     # The set of tool names that actually passed check_fn filtering.
     # Use this (not tools_to_include) for any downstream schema that references
     # other tools by name — otherwise the model sees tools mentioned in
@@ -361,7 +383,7 @@ def get_tool_definitions(
 # because they need agent-level state (TodoStore, MemoryStore, etc.).
 # The registry still holds their schemas; dispatch just returns a stub error
 # so if something slips through, the LLM sees a sensible message.
-_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task"}
+_AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task", "self_nudge"}
 _READ_SEARCH_TOOLS = {"read_file", "search_files"}
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -208,7 +208,7 @@ class IterationBudget:
 
 # Tools that must never run concurrently (interactive / user-facing).
 # When any of these appear in a batch, we fall back to sequential execution.
-_NEVER_PARALLEL_TOOLS = frozenset({"clarify"})
+_NEVER_PARALLEL_TOOLS = frozenset({"clarify", "self_nudge"})
 
 # Read-only tools with no shared mutable session state.
 _PARALLEL_SAFE_TOOLS = frozenset({
@@ -587,6 +587,7 @@ class AIAgent:
         self.clarify_callback = clarify_callback
         self.step_callback = step_callback
         self.stream_delta_callback = stream_delta_callback
+        self.self_nudge_callback = None
         self.status_callback = status_callback
         self.tool_gen_callback = tool_gen_callback
         self._last_reported_tool = None  # Track for "new tool" mode
@@ -604,6 +605,7 @@ class AIAgent:
         self._delegate_depth = 0        # 0 = top-level agent, incremented for children
         self._active_children = []      # Running child AIAgents (for interrupt propagation)
         self._active_children_lock = threading.Lock()
+        self._self_nudge_armed_this_turn = False
         
         # Store OpenRouter provider preferences
         self.providers_allowed = providers_allowed
@@ -891,6 +893,7 @@ class AIAgent:
             enabled_toolsets=enabled_toolsets,
             disabled_toolsets=disabled_toolsets,
             quiet_mode=self.quiet_mode,
+            platform=self.platform,
         )
         
         # Show tool configuration and store valid tool names for validation
@@ -1448,6 +1451,45 @@ class AIAgent:
                 self.status_callback("lifecycle", message)
             except Exception:
                 logger.debug("status_callback error in _emit_status", exc_info=True)
+
+    def _emit_self_nudge(self, delay_seconds: int, note: str = "") -> str:
+        """Arm a one-shot hidden follow-up timer for the current session."""
+        try:
+            seconds = int(delay_seconds)
+        except (TypeError, ValueError):
+            return json.dumps(
+                {"error": "delay_seconds must be an integer number of seconds."},
+                ensure_ascii=False,
+            )
+
+        if seconds <= 0:
+            return json.dumps(
+                {"error": "delay_seconds must be greater than zero."},
+                ensure_ascii=False,
+            )
+
+        callback = getattr(self, "self_nudge_callback", None)
+        if not callback:
+            return json.dumps(
+                {"error": "self_nudge is not available in this execution context."},
+                ensure_ascii=False,
+            )
+
+        try:
+            payload = callback(seconds, str(note or ""))
+        except Exception as exc:
+            return json.dumps(
+                {"error": f"Failed to arm self-nudge: {exc}"},
+                ensure_ascii=False,
+            )
+
+        if isinstance(payload, dict) and payload.get("armed"):
+            self._self_nudge_armed_this_turn = True
+            return json.dumps(payload, ensure_ascii=False)
+
+        if isinstance(payload, dict):
+            return json.dumps(payload, ensure_ascii=False)
+        return json.dumps({"error": "Failed to arm self-nudge."}, ensure_ascii=False)
 
     def _is_direct_openai_url(self, base_url: str = None) -> bool:
         """Return True when a base URL targets OpenAI's native API."""
@@ -5493,7 +5535,10 @@ class AIAgent:
                     "type": tool_call.type,
                     "function": {
                         "name": tool_call.function.name,
-                        "arguments": tool_call.function.arguments
+                        "arguments": self._sanitize_private_tool_arguments(
+                            tool_call.function.name,
+                            tool_call.function.arguments,
+                        ),
                     },
                 }
                 # Preserve extra_content (e.g. Gemini thought_signature) so it
@@ -5508,6 +5553,21 @@ class AIAgent:
             msg["tool_calls"] = tool_calls
 
         return msg
+
+    @staticmethod
+    def _sanitize_private_tool_arguments(function_name: str, raw_arguments: Any) -> Any:
+        """Redact private tool-call fields before persisting/replaying history."""
+        if function_name != "self_nudge" or not isinstance(raw_arguments, str):
+            return raw_arguments
+        try:
+            parsed = json.loads(raw_arguments)
+        except Exception:
+            return raw_arguments
+        if not isinstance(parsed, dict) or "note" not in parsed:
+            return raw_arguments
+        parsed = dict(parsed)
+        parsed.pop("note", None)
+        return json.dumps(parsed, ensure_ascii=False)
 
     @staticmethod
     def _sanitize_tool_calls_for_strict_api(api_msg: dict) -> dict:
@@ -5869,6 +5929,11 @@ class AIAgent:
                 choices=function_args.get("choices"),
                 callback=self.clarify_callback,
             )
+        elif function_name == "self_nudge":
+            return self._emit_self_nudge(
+                function_args.get("delay_seconds", 0),
+                function_args.get("note", ""),
+            )
         elif function_name == "delegate_task":
             from tools.delegate_tool import delegate_task as _delegate_task
             return _delegate_task(
@@ -6219,6 +6284,14 @@ class AIAgent:
                 tool_duration = time.time() - tool_start_time
                 if self.quiet_mode:
                     self._vprint(f"  {_get_cute_tool_message_impl('clarify', function_args, tool_duration, result=function_result)}")
+            elif function_name == "self_nudge":
+                function_result = self._emit_self_nudge(
+                    function_args.get("delay_seconds", 0),
+                    function_args.get("note", ""),
+                )
+                tool_duration = time.time() - tool_start_time
+                if self.quiet_mode:
+                    self._vprint(f"  {_get_cute_tool_message_impl('self_nudge', function_args, tool_duration, result=function_result)}")
             elif function_name == "delegate_task":
                 from tools.delegate_tool import delegate_task as _delegate_task
                 tasks_arg = function_args.get("tasks")
@@ -6660,6 +6733,7 @@ class AIAgent:
         self._stream_callback = stream_callback
         self._persist_user_message_idx = None
         self._persist_user_message_override = persist_user_message
+        self._self_nudge_armed_this_turn = False
         # Generate unique task_id if not provided to isolate VMs between concurrent tasks
         effective_task_id = task_id or str(uuid.uuid4())
         

--- a/tests/gateway/test_api_server_toolset.py
+++ b/tests/gateway/test_api_server_toolset.py
@@ -55,6 +55,10 @@ class TestHermesApiServerToolset:
         tools = resolve_toolset("hermes-api-server")
         assert "send_message" not in tools
 
+    def test_toolset_excludes_self_nudge(self):
+        tools = resolve_toolset("hermes-api-server")
+        assert "self_nudge" not in tools
+
     def test_toolset_excludes_text_to_speech(self):
         tools = resolve_toolset("hermes-api-server")
         assert "text_to_speech" not in tools

--- a/tests/gateway/test_self_nudge.py
+++ b/tests/gateway/test_self_nudge.py
@@ -1,0 +1,144 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, SendResult
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, build_session_key
+
+
+class StubAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.TELEGRAM)
+
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return SendResult(success=True, message_id="1")
+
+    async def send_typing(self, chat_id, metadata=None):
+        return None
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+
+def _source(chat_id="123456"):
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id=chat_id,
+        chat_type="dm",
+    )
+
+
+@pytest.mark.asyncio
+async def test_arm_self_nudge_replaces_existing_timer():
+    runner = object.__new__(GatewayRunner)
+    runner._self_nudge_tasks = {}
+    runner._self_nudge_entries = {}
+    runner._pending_hidden_turns = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+
+    source = _source()
+    session_key = build_session_key(source)
+
+    first = await runner._arm_self_nudge(session_key, source, 300, "First note")
+    second = await runner._arm_self_nudge(session_key, source, 120, "Second note")
+
+    assert first["armed"] is True
+    assert second["armed"] is True
+    assert second["replaced_existing"] is True
+    assert runner._self_nudge_entries[session_key]["note"] == "Second note"
+
+    await runner._cancel_self_nudge(session_key, reason="test_cleanup")
+
+
+@pytest.mark.asyncio
+async def test_fire_self_nudge_queues_hidden_turn_when_session_busy(monkeypatch):
+    runner = object.__new__(GatewayRunner)
+    runner._self_nudge_tasks = {}
+    runner._self_nudge_entries = {}
+    runner._pending_hidden_turns = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+
+    source = _source()
+    session_key = build_session_key(source)
+    entry = {
+        "session_key": session_key,
+        "source": source.to_dict(),
+        "delay_seconds": 5,
+        "note": "Check the deploy result.",
+    }
+    runner._self_nudge_entries[session_key] = entry
+    runner._running_agents[session_key] = object()
+
+    async def _no_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    await runner._fire_self_nudge(entry)
+
+    assert session_key not in runner._self_nudge_entries
+    assert runner._pending_hidden_turns[session_key]["note"] == "Check the deploy result."
+
+
+@pytest.mark.asyncio
+async def test_run_self_nudge_entry_injects_hidden_turn():
+    runner = object.__new__(GatewayRunner)
+    runner._self_nudge_tasks = {}
+    runner._self_nudge_entries = {}
+    runner._pending_hidden_turns = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._handle_message_with_agent = AsyncMock(return_value=None)
+
+    source = _source()
+    session_key = build_session_key(source)
+    entry = {
+        "session_key": session_key,
+        "source": source.to_dict(),
+        "delay_seconds": 300,
+        "note": "Check whether the background task finished.",
+    }
+
+    await runner._run_self_nudge_entry(entry)
+
+    runner._handle_message_with_agent.assert_awaited_once()
+    event, call_source, call_session_key = runner._handle_message_with_agent.call_args.args
+    assert call_source.chat_id == source.chat_id
+    assert call_session_key == session_key
+    assert "self-nudge timer" in event.text.lower()
+    assert "background task finished" in event.text.lower()
+    assert event.persist_user_message == "[System note: a self-nudge timer fired.]"
+
+
+@pytest.mark.asyncio
+async def test_cancel_self_nudge_clears_pending_hidden_turn():
+    runner = object.__new__(GatewayRunner)
+    runner._self_nudge_tasks = {}
+    runner._self_nudge_entries = {}
+    runner._pending_hidden_turns = {}
+
+    source = _source()
+    session_key = build_session_key(source)
+    task = asyncio.create_task(asyncio.sleep(60))
+    runner._self_nudge_tasks[session_key] = task
+    runner._self_nudge_entries[session_key] = {"session_key": session_key, "source": source.to_dict()}
+    runner._pending_hidden_turns[session_key] = {"session_key": session_key}
+
+    cancelled = await runner._cancel_self_nudge(session_key, reason="user_message")
+
+    assert cancelled is True
+    assert session_key not in runner._self_nudge_tasks
+    assert session_key not in runner._self_nudge_entries
+    assert session_key not in runner._pending_hidden_turns
+    task.cancel()

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -6,6 +6,7 @@ import pytest
 from model_tools import (
     handle_function_call,
     get_all_tool_names,
+    get_tool_definitions,
     get_toolset_for_tool,
     _AGENT_LOOP_TOOLS,
     _LEGACY_TOOLSET_MAP,
@@ -49,10 +50,32 @@ class TestAgentLoopTools:
         assert "memory" in _AGENT_LOOP_TOOLS
         assert "session_search" in _AGENT_LOOP_TOOLS
         assert "delegate_task" in _AGENT_LOOP_TOOLS
+        assert "self_nudge" in _AGENT_LOOP_TOOLS
 
     def test_no_regular_tools_in_set(self):
         assert "web_search" not in _AGENT_LOOP_TOOLS
         assert "terminal" not in _AGENT_LOOP_TOOLS
+
+    def test_self_nudge_only_exposed_on_gateway_platforms(self):
+        telegram_tools = get_tool_definitions(
+            enabled_toolsets=["user_updates"],
+            quiet_mode=True,
+            platform="telegram",
+        )
+        cli_tools = get_tool_definitions(
+            enabled_toolsets=["user_updates"],
+            quiet_mode=True,
+            platform="cli",
+        )
+        api_tools = get_tool_definitions(
+            enabled_toolsets=["user_updates"],
+            quiet_mode=True,
+            platform="api_server",
+        )
+
+        assert [t["function"]["name"] for t in telegram_tools] == ["self_nudge"]
+        assert cli_tools == []
+        assert api_tools == []
 
 
 # =========================================================================

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -925,6 +925,17 @@ class TestBuildAssistantMessage:
         result = agent._build_assistant_message(msg, "tool_calls")
         assert "extra_content" not in result["tool_calls"][0]
 
+    def test_self_nudge_tool_call_redacts_private_note(self, agent):
+        tc = _mock_tool_call(
+            name="self_nudge",
+            arguments='{"delay_seconds":300,"note":"Check prod credentials."}',
+            call_id="call-1",
+        )
+        msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        result = agent._build_assistant_message(msg, "tool_calls")
+        persisted_args = result["tool_calls"][0]["function"]["arguments"]
+        assert json.loads(persisted_args) == {"delay_seconds": 300}
+
 
 class TestFormatToolsForSystemMessage:
     def test_no_tools_returns_empty_array(self, agent):
@@ -1032,6 +1043,21 @@ class TestConcurrentToolExecution:
         """Batch containing clarify should use sequential path."""
         tc1 = _mock_tool_call(name="web_search", arguments='{}', call_id="c1")
         tc2 = _mock_tool_call(name="clarify", arguments='{"question":"ok?"}', call_id="c2")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
+        messages = []
+        with patch.object(agent, "_execute_tool_calls_sequential") as mock_seq:
+            with patch.object(agent, "_execute_tool_calls_concurrent") as mock_con:
+                agent._execute_tool_calls(mock_msg, messages, "task-1")
+                mock_seq.assert_called_once()
+                mock_con.assert_not_called()
+
+    def test_self_nudge_forces_sequential(self, agent):
+        tc1 = _mock_tool_call(name="web_search", arguments='{}', call_id="c1")
+        tc2 = _mock_tool_call(
+            name="self_nudge",
+            arguments='{"delay_seconds":300,"note":"Check the deploy status."}',
+            call_id="c2",
+        )
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
         messages = []
         with patch.object(agent, "_execute_tool_calls_sequential") as mock_seq:
@@ -1299,6 +1325,36 @@ class TestConcurrentToolExecution:
             result = agent._invoke_tool("todo", {"todos": []}, "task-1")
             mock_todo.assert_called_once()
         assert "ok" in result
+
+    def test_invoke_tool_self_nudge_uses_callback(self, agent):
+        cb = MagicMock(return_value={"armed": True, "delay_seconds": 300})
+        agent.self_nudge_callback = cb
+
+        result = json.loads(
+            agent._invoke_tool(
+                "self_nudge",
+                {"delay_seconds": 300, "note": "Check the deploy output."},
+                "task-1",
+            )
+        )
+
+        cb.assert_called_once_with(300, "Check the deploy output.")
+        assert result["armed"] is True
+        assert agent._self_nudge_armed_this_turn is True
+
+    def test_invoke_tool_self_nudge_errors_without_callback(self, agent):
+        agent.self_nudge_callback = None
+
+        result = json.loads(
+            agent._invoke_tool(
+                "self_nudge",
+                {"delay_seconds": 60},
+                "task-1",
+            )
+        )
+
+        assert "error" in result
+        assert "not available" in result["error"].lower()
 
 
 class TestPathsOverlap:

--- a/tools/self_nudge_tool.py
+++ b/tools/self_nudge_tool.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""One-shot self-nudge tool for gateway sessions.
+
+Lets the agent arm a single in-memory timer that will later inject a hidden
+continuation turn back into the same session. This is lighter and safer than
+creating a cron job for short-lived follow-up work.
+"""
+
+import json
+
+from tools.registry import registry
+
+
+SELF_NUDGE_SCHEMA = {
+    "name": "self_nudge",
+    "description": (
+        "Arm a one-time self-nudge timer for the current session. When the "
+        "timer fires, Hermes injects a hidden follow-up turn back into this "
+        "same session. Use this instead of cron for short-lived reminders or "
+        "follow-up checks. Only one self-nudge is kept per session; arming a "
+        "new one replaces the previous timer."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "delay_seconds": {
+                "type": "integer",
+                "minimum": 1,
+                "description": (
+                    "How many seconds to wait before firing the one-time "
+                    "hidden follow-up turn."
+                ),
+            },
+            "note": {
+                "type": "string",
+                "description": (
+                    "Optional private reminder to inject into the hidden turn. "
+                    "Example: 'Check whether the deploy finished and report "
+                    "back if it failed.'"
+                ),
+            },
+        },
+        "required": ["delay_seconds"],
+    },
+}
+
+
+def check_self_nudge_requirements() -> bool:
+    """Tool availability is filtered by platform in model_tools."""
+    return True
+
+
+def self_nudge_tool(args, **kwargs):
+    """Stub dispatcher for the registry.
+
+    Real handling happens in run_agent.py because it needs the live session's
+    gateway callback.
+    """
+    return json.dumps(
+        {"error": "self_nudge must be handled by the agent loop"},
+        ensure_ascii=False,
+    )
+
+
+registry.register(
+    name="self_nudge",
+    toolset="user_updates",
+    schema=SELF_NUDGE_SCHEMA,
+    handler=self_nudge_tool,
+    check_fn=check_self_nudge_requirements,
+    description="Arm a one-shot hidden self-reminder for the current gateway session.",
+    emoji="⏰",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -54,6 +54,8 @@ _HERMES_CORE_TOOLS = [
     "session_search",
     # Clarifying questions
     "clarify",
+    # One-shot hidden follow-up timer for gateway sessions
+    "self_nudge",
     # Code execution + delegation
     "execute_code", "delegate_task",
     # Cronjob management
@@ -181,6 +183,12 @@ TOOLSETS = {
         "tools": ["clarify"],
         "includes": []
     },
+
+    "user_updates": {
+        "description": "Arm one-shot hidden follow-up nudges for the current gateway session",
+        "tools": ["self_nudge"],
+        "includes": []
+    },
     
     "code_execution": {
         "description": "Run Python scripts that call tools programmatically (reduces LLM round trips)",
@@ -245,7 +253,7 @@ TOOLSETS = {
     },
 
     "hermes-api-server": {
-        "description": "OpenAI-compatible API server — full agent tools accessible via HTTP (no interactive UI tools like clarify or send_message)",
+        "description": "OpenAI-compatible API server — full agent tools accessible via HTTP (no interactive UI tools like clarify, self_nudge, or send_message)",
         "tools": [
             # Web
             "web_search", "web_extract",


### PR DESCRIPTION
## Summary
- add a gateway-only `self_nudge` tool for one-shot hidden follow-up turns
- arm/cancel in-memory session timers and fire hidden nudges back into the same session
- support `NO_REPLY` for nudge-only turns and redact private `note` text from persisted tool-call args

## Why
This is a lighter and safer fit than cron for short-lived follow-up work. The model can ask to be nudged once later without leaving behind a recurring schedule.

Closes #5250.

## Validation
- `source venv/bin/activate && python -m pytest tests/test_model_tools.py tests/test_run_agent.py tests/gateway/test_api_server_toolset.py tests/gateway/test_self_nudge.py -q`
- `256 passed`
