### PR TITLE
feat(routing): provider-aware session affinity hints for prompt caching

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -48,6 +48,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from openai import OpenAI
 
 from agent.credential_pool import load_pool
+from agent.model_metadata import build_openai_request_session_routing
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
 
@@ -226,6 +227,11 @@ class _CodexCompletionsAdapter:
             "store": False,
         }
 
+        for field in ("prompt_cache_key", "extra_headers", "extra_body"):
+            value = kwargs.get(field)
+            if value is not None:
+                resp_kwargs[field] = value
+
         # Note: the Codex endpoint (chatgpt.com/backend-api/codex) does NOT
         # support max_output_tokens or temperature — omit to avoid 400 errors.
 
@@ -327,6 +333,7 @@ class CodexAuxiliaryClient:
         self.chat = _CodexChatShim(adapter)
         self.api_key = real_client.api_key
         self.base_url = real_client.base_url
+        self.api_mode = "codex_responses"
 
     def close(self):
         self._real_client.close()
@@ -361,6 +368,7 @@ class AsyncCodexAuxiliaryClient:
         self.chat = _AsyncCodexChatShim(async_adapter)
         self.api_key = sync_wrapper.api_key
         self.base_url = sync_wrapper.base_url
+        self.api_mode = sync_wrapper.api_mode
 
 
 class _AnthropicCompletionsAdapter:
@@ -443,6 +451,7 @@ class AnthropicAuxiliaryClient:
         self.chat = _AnthropicChatShim(adapter)
         self.api_key = api_key
         self.base_url = base_url
+        self.api_mode = "anthropic_messages"
 
     def close(self):
         close_fn = getattr(self._real_client, "close", None)
@@ -471,6 +480,7 @@ class AsyncAnthropicAuxiliaryClient:
         self.chat = _AsyncAnthropicChatShim(async_adapter)
         self.api_key = sync_wrapper.api_key
         self.base_url = sync_wrapper.base_url
+        self.api_mode = sync_wrapper.api_mode
 
 
 def _read_nous_auth() -> Optional[dict]:
@@ -716,6 +726,32 @@ def _read_main_provider() -> str:
     return ""
 
 
+def _has_explicit_custom_runtime() -> bool:
+    env_openai_base_url = os.getenv("OPENAI_BASE_URL", "").strip()
+    if env_openai_base_url:
+        return True
+
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        model_cfg = cfg.get("model", {}) if isinstance(cfg, dict) else {}
+        if isinstance(model_cfg, dict):
+            base_url = str(model_cfg.get("base_url") or "").strip()
+            provider = str(model_cfg.get("provider") or "").strip().lower()
+            if (
+                base_url
+                and provider in {"", "auto", "custom", "main"}
+                and "openrouter.ai" not in base_url.lower()
+            ):
+                return True
+    except Exception:
+        pass
+
+    return False
+
+
+
 def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str]]:
     """Resolve the active custom/main endpoint the same way the main CLI does.
 
@@ -723,6 +759,9 @@ def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str]]:
     endpoints where the base URL lives in config.yaml instead of the live
     environment.
     """
+    if not _has_explicit_custom_runtime():
+        return None, None
+
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider
 
@@ -1656,6 +1695,21 @@ def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> float
     return default
 
 
+def _resolve_request_api_mode(client: Any, provider: str, base_url: Optional[str]) -> str:
+    """Infer the actual wire protocol used by the resolved auxiliary client."""
+    client_api_mode = str(getattr(client, "api_mode", "") or "").strip().lower()
+    if client_api_mode in {"chat_completions", "codex_responses", "anthropic_messages"}:
+        return client_api_mode
+
+    normalized_provider = (provider or "").strip().lower()
+    normalized_base_url = str(base_url or getattr(client, "base_url", "") or "").strip().lower()
+    if normalized_provider == "openai-codex" or "chatgpt.com/backend-api/codex" in normalized_base_url:
+        return "codex_responses"
+    if normalized_provider == "anthropic" or normalized_base_url.rstrip("/").endswith("/anthropic"):
+        return "anthropic_messages"
+    return "chat_completions"
+
+
 def _build_call_kwargs(
     provider: str,
     model: str,
@@ -1666,6 +1720,8 @@ def _build_call_kwargs(
     timeout: float = 30.0,
     extra_body: Optional[dict] = None,
     base_url: Optional[str] = None,
+    api_mode: str = "chat_completions",
+    session_id: Optional[str] = None,
 ) -> dict:
     """Build kwargs for .chat.completions.create() with model/provider adjustments."""
     kwargs: Dict[str, Any] = {
@@ -1696,8 +1752,26 @@ def _build_call_kwargs(
     merged_extra = dict(extra_body or {})
     if provider == "nous" or auxiliary_is_nous:
         merged_extra.setdefault("tags", []).extend(["product=hermes-agent"])
+
+    routing = build_openai_request_session_routing(
+        provider=provider,
+        base_url=base_url or "",
+        api_mode=api_mode,
+        session_id=session_id,
+    )
+    routing_extra_body = routing.get("extra_body") or {}
+    if routing_extra_body:
+        merged_extra.update(routing_extra_body)
     if merged_extra:
         kwargs["extra_body"] = merged_extra
+
+    extra_headers = routing.get("extra_headers") or {}
+    if extra_headers:
+        kwargs.setdefault("extra_headers", {}).update(extra_headers)
+
+    prompt_cache_key = routing.get("prompt_cache_key")
+    if prompt_cache_key:
+        kwargs["prompt_cache_key"] = prompt_cache_key
 
     return kwargs
 
@@ -1715,6 +1789,7 @@ def call_llm(
     tools: list = None,
     timeout: float = None,
     extra_body: dict = None,
+    session_id: str = None,
 ) -> Any:
     """Centralized synchronous LLM call.
 
@@ -1733,6 +1808,7 @@ def call_llm(
         tools: Tool definitions (for function calling).
         timeout: Request timeout in seconds (None = read from auxiliary.{task}.timeout config).
         extra_body: Additional request body fields.
+        session_id: Stable Hermes session identifier for request-level affinity hints.
 
     Returns:
         Response object with .choices[0].message.content
@@ -1805,11 +1881,13 @@ def call_llm(
                      task, resolved_provider or "auto", final_model or "default",
                      f" at {_base_info}" if _base_info and "openrouter" not in _base_info else "")
 
+    request_base_url = resolved_base_url or str(getattr(client, "base_url", "") or "")
+    request_api_mode = _resolve_request_api_mode(client, resolved_provider, request_base_url)
     kwargs = _build_call_kwargs(
         resolved_provider, final_model, messages,
         temperature=temperature, max_tokens=max_tokens,
         tools=tools, timeout=effective_timeout, extra_body=extra_body,
-        base_url=resolved_base_url)
+        base_url=request_base_url, api_mode=request_api_mode, session_id=session_id)
 
     # Handle max_tokens vs max_completion_tokens retry
     try:
@@ -1892,6 +1970,7 @@ async def async_call_llm(
     tools: list = None,
     timeout: float = None,
     extra_body: dict = None,
+    session_id: str = None,
 ) -> Any:
     """Centralized asynchronous LLM call.
 
@@ -1953,11 +2032,13 @@ async def async_call_llm(
 
     effective_timeout = timeout if timeout is not None else _get_task_timeout(task)
 
+    request_base_url = resolved_base_url or str(getattr(client, "base_url", "") or "")
+    request_api_mode = _resolve_request_api_mode(client, resolved_provider, request_base_url)
     kwargs = _build_call_kwargs(
         resolved_provider, final_model, messages,
         temperature=temperature, max_tokens=max_tokens,
         tools=tools, timeout=effective_timeout, extra_body=extra_body,
-        base_url=resolved_base_url)
+        base_url=request_base_url, api_mode=request_api_mode, session_id=session_id)
 
     try:
         return await client.chat.completions.create(**kwargs)

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -72,11 +72,13 @@ class ContextCompressor:
         api_key: str = "",
         config_context_length: int | None = None,
         provider: str = "",
+        session_id: str = "",
     ):
         self.model = model
         self.base_url = base_url
         self.api_key = api_key
         self.provider = provider
+        self.session_id = session_id
         self.threshold_percent = threshold_percent
         self.protect_first_n = protect_first_n
         self.protect_last_n = protect_last_n
@@ -351,6 +353,8 @@ Write only the summary body. Do not include any preamble or prefix."""
             }
             if self.summary_model:
                 call_kwargs["model"] = self.summary_model
+            if self.session_id:
+                call_kwargs["session_id"] = self.session_id
             response = call_llm(**call_kwargs)
             content = response.choices[0].message.content
             # Handle cases where content is not a string (e.g., dict from llama.cpp)

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -9,7 +9,7 @@ import os
 import re
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, TypedDict
 from urllib.parse import urlparse
 
 import requests
@@ -184,6 +184,37 @@ _URL_TO_PROVIDER: Dict[str, str] = {
 }
 
 
+class OpenAIRequestSessionRouting(TypedDict, total=False):
+    """Request-local session routing metadata for OpenAI-compatible APIs."""
+
+    extra_headers: Dict[str, str]
+    extra_body: Dict[str, Any]
+    prompt_cache_key: str
+
+
+class _OpenAIRequestSessionRoutingCapability(TypedDict, total=False):
+    """Data-driven routing policy for a provider + transport pair."""
+
+    extra_headers: Dict[str, str]
+    extra_body: Dict[str, Any]
+    prompt_cache_key: bool
+
+
+_GENERIC_RUNTIME_PROVIDERS = {"", "auto", "custom", "main", "local"}
+_SESSION_ID_TEMPLATE = "{session_id}"
+_OPENAI_SESSION_ROUTING_CAPABILITIES: Dict[tuple[str, str], _OpenAIRequestSessionRoutingCapability] = {
+    ("fireworks", "chat_completions"): {
+        "extra_headers": {"x-session-affinity": _SESSION_ID_TEMPLATE},
+    },
+    ("openai", "codex_responses"): {
+        "prompt_cache_key": True,
+    },
+    ("openai-codex", "codex_responses"): {
+        "prompt_cache_key": True,
+    },
+}
+
+
 def _infer_provider_from_url(base_url: str) -> Optional[str]:
     """Infer the models.dev provider name from a base URL.
 
@@ -204,6 +235,87 @@ def _infer_provider_from_url(base_url: str) -> Optional[str]:
 
 def _is_known_provider_base_url(base_url: str) -> bool:
     return _infer_provider_from_url(base_url) is not None
+
+
+def _normalize_request_provider(provider: str) -> str:
+    normalized = (provider or "").strip().lower()
+    if not normalized or normalized in _GENERIC_RUNTIME_PROVIDERS:
+        return ""
+    try:
+        from hermes_cli.auth import AuthError, resolve_provider
+
+        return resolve_provider(normalized)
+    except Exception as exc:
+        try:
+            if isinstance(exc, AuthError):
+                return normalized
+        except Exception:
+            pass
+        return normalized
+
+
+
+def _resolve_request_provider(provider: str, base_url: str) -> Optional[str]:
+    normalized = _normalize_request_provider(provider)
+    inferred = _infer_provider_from_url(base_url)
+    if normalized:
+        if normalized in {"openrouter"} and inferred and inferred != normalized:
+            return inferred
+        return normalized
+    return inferred
+
+
+
+def _render_request_session_routing(
+    capability: _OpenAIRequestSessionRoutingCapability,
+    session_id: str,
+) -> OpenAIRequestSessionRouting:
+    routing: OpenAIRequestSessionRouting = {}
+
+    extra_headers = capability.get("extra_headers") or {}
+    if extra_headers:
+        routing["extra_headers"] = {
+            key: value.format(session_id=session_id)
+            for key, value in extra_headers.items()
+        }
+
+    extra_body = capability.get("extra_body") or {}
+    if extra_body:
+        routing["extra_body"] = {
+            key: value.format(session_id=session_id)
+            if isinstance(value, str) else value
+            for key, value in extra_body.items()
+        }
+
+    if capability.get("prompt_cache_key"):
+        routing["prompt_cache_key"] = session_id
+
+    return routing
+
+
+
+def build_openai_request_session_routing(
+    *,
+    provider: str = "",
+    base_url: str = "",
+    api_mode: str = "",
+    session_id: Optional[str] = None,
+) -> OpenAIRequestSessionRouting:
+    """Return request-local session routing metadata for OpenAI-compatible APIs."""
+    if not session_id:
+        return {}
+
+    effective_provider = _resolve_request_provider(provider, base_url)
+    effective_api_mode = (api_mode or "").strip().lower()
+    if not effective_provider or effective_api_mode not in {"chat_completions", "codex_responses"}:
+        return {}
+
+    capability = _OPENAI_SESSION_ROUTING_CAPABILITIES.get((effective_provider, effective_api_mode))
+    if not capability:
+        return {}
+
+    return _render_request_session_routing(capability, session_id)
+
 
 
 def is_local_endpoint(base_url: str) -> bool:

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -19,7 +19,12 @@ _TITLE_PROMPT = (
 )
 
 
-def generate_title(user_message: str, assistant_response: str, timeout: float = 30.0) -> Optional[str]:
+def generate_title(
+    user_message: str,
+    assistant_response: str,
+    timeout: float = 30.0,
+    session_id: str = "",
+) -> Optional[str]:
     """Generate a session title from the first exchange.
 
     Uses the auxiliary LLM client (cheapest/fastest available model).
@@ -41,6 +46,7 @@ def generate_title(user_message: str, assistant_response: str, timeout: float = 
             max_tokens=30,
             temperature=0.3,
             timeout=timeout,
+            session_id=session_id or None,
         )
         title = (response.choices[0].message.content or "").strip()
         # Clean up: remove quotes, trailing punctuation, prefixes like "Title: "
@@ -81,7 +87,7 @@ def auto_title_session(
     except Exception:
         return
 
-    title = generate_title(user_message, assistant_response)
+    title = generate_title(user_message, assistant_response, session_id=session_id)
     if not title:
         return
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -82,6 +82,7 @@ from agent.prompt_builder import (
     build_nous_subscription_prompt,
 )
 from agent.model_metadata import (
+    build_openai_request_session_routing,
     fetch_model_metadata,
     estimate_tokens_rough, estimate_messages_tokens_rough, estimate_request_tokens_rough,
     get_next_probe_tier, parse_context_limit_from_error,
@@ -1170,7 +1171,9 @@ class AIAgent:
             api_key=getattr(self, "api_key", ""),
             config_context_length=_config_context_length,
             provider=self.provider,
+            session_id=session_id or "",
         )
+        self.context_compressor.session_id = self.session_id
         self.compression_enabled = compression_enabled
         self._user_turn_count = 0
 
@@ -5117,6 +5120,25 @@ class AIAgent:
         base = (getattr(self, "base_url", "") or "").lower()
         return "dashscope" in base or "aliyuncs" in base
 
+    def _apply_request_session_routing(self, api_kwargs: dict, *, api_mode: Optional[str] = None) -> dict:
+        """Attach request-local session routing metadata for OpenAI-compatible routes."""
+        routing = build_openai_request_session_routing(
+            provider=getattr(self, "provider", ""),
+            base_url=getattr(self, "base_url", ""),
+            api_mode=api_mode or getattr(self, "api_mode", ""),
+            session_id=getattr(self, "session_id", None),
+        )
+        extra_body = routing.get("extra_body") or {}
+        if extra_body:
+            api_kwargs.setdefault("extra_body", {}).update(extra_body)
+        extra_headers = routing.get("extra_headers") or {}
+        if extra_headers:
+            api_kwargs.setdefault("extra_headers", {}).update(extra_headers)
+        prompt_cache_key = routing.get("prompt_cache_key")
+        if prompt_cache_key:
+            api_kwargs["prompt_cache_key"] = prompt_cache_key
+        return api_kwargs
+
     def _build_api_kwargs(self, api_messages: list) -> dict:
         """Build the keyword arguments dict for the active API mode."""
         if self.api_mode == "anthropic_messages":
@@ -5170,8 +5192,7 @@ class AIAgent:
                 "store": False,
             }
 
-            if not is_github_responses:
-                kwargs["prompt_cache_key"] = self.session_id
+            self._apply_request_session_routing(kwargs)
 
             if reasoning_enabled:
                 if is_github_responses:
@@ -5323,7 +5344,7 @@ class AIAgent:
         if extra_body:
             api_kwargs["extra_body"] = extra_body
 
-        return api_kwargs
+        return self._apply_request_session_routing(api_kwargs)
 
     def _supports_reasoning_extra_body(self) -> bool:
         """Return True when reasoning extra_body is safe to send for this route/model.
@@ -5629,6 +5650,7 @@ class AIAgent:
                     temperature=0.3,
                     max_tokens=5120,
                     timeout=30.0,
+                    session_id=self.session_id,
                 )
             except RuntimeError:
                 _aux_available = False
@@ -5660,6 +5682,7 @@ class AIAgent:
                     "temperature": 0.3,
                     **self._max_tokens_param(5120),
                 }
+                self._apply_request_session_routing(api_kwargs, api_mode="chat_completions")
                 response = self._ensure_primary_openai_client(reason="flush_memories").chat.completions.create(**api_kwargs, timeout=30.0)
 
             # Extract tool calls from the response, handling all API formats
@@ -5740,6 +5763,7 @@ class AIAgent:
                 self._session_db.end_session(self.session_id, "compression")
                 old_session_id = self.session_id
                 self.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
+                self.context_compressor.session_id = self.session_id
                 # Update session_log_file to point to the new session's JSON file
                 self.session_log_file = self.logs_dir / f"session_{self.session_id}.json"
                 self._session_db.create_session(
@@ -6547,6 +6571,7 @@ class AIAgent:
                     _msg, _ = _nar(summary_response, strip_tool_prefix=self._is_anthropic_oauth)
                     final_response = (_msg.content or "").strip()
                 else:
+                    self._apply_request_session_routing(summary_kwargs, api_mode="chat_completions")
                     summary_response = self._ensure_primary_openai_client(reason="iteration_limit_summary").chat.completions.create(**summary_kwargs)
 
                     if summary_response.choices and summary_response.choices[0].message.content:
@@ -6588,6 +6613,7 @@ class AIAgent:
                     if summary_extra_body:
                         summary_kwargs["extra_body"] = summary_extra_body
 
+                    self._apply_request_session_routing(summary_kwargs, api_mode="chat_completions")
                     summary_response = self._ensure_primary_openai_client(reason="iteration_limit_summary_retry").chat.completions.create(**summary_kwargs)
 
                     if summary_response.choices and summary_response.choices[0].message.content:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2,18 +2,23 @@
 
 import json
 import os
+import asyncio
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from types import SimpleNamespace
+from unittest.mock import patch, MagicMock, AsyncMock
 
 import pytest
 
 from agent.auxiliary_client import (
+    call_llm,
+    async_call_llm,
     get_text_auxiliary_client,
     get_vision_auxiliary_client,
     get_available_vision_backends,
     resolve_vision_provider_client,
     resolve_provider_client,
     auxiliary_max_tokens_param,
+    _CodexCompletionsAdapter,
     _read_codex_access_token,
     _get_auxiliary_provider,
     _resolve_forced_provider,
@@ -1106,3 +1111,194 @@ class TestAuxiliaryMaxTokensParam:
              patch("agent.auxiliary_client._read_codex_access_token", return_value=None):
             result = auxiliary_max_tokens_param(1024)
         assert result == {"max_tokens": 1024}
+
+
+class TestSessionRoutingMetadata:
+    def test_call_llm_adds_session_routing_header_for_fireworks_route(self):
+        client = MagicMock()
+        client.base_url = "https://api.fireworks.ai/inference/v1"
+        client.chat.completions.create.return_value = object()
+
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("custom", "fw-model", "https://api.fireworks.ai/inference/v1", "fw-key"),
+        ), patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(client, "fw-model"),
+        ):
+            call_llm(
+                provider="custom",
+                messages=[{"role": "user", "content": "hi"}],
+                session_id="sess-123",
+            )
+
+        assert client.chat.completions.create.call_args.kwargs["extra_headers"] == {
+            "x-session-affinity": "sess-123"
+        }
+
+    def test_call_llm_omits_session_routing_without_session_id(self):
+        client = MagicMock()
+        client.base_url = "https://api.fireworks.ai/inference/v1"
+        client.chat.completions.create.return_value = object()
+
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("custom", "fw-model", "https://api.fireworks.ai/inference/v1", "fw-key"),
+        ), patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(client, "fw-model"),
+        ):
+            call_llm(
+                provider="custom",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert "x-session-affinity" not in client.chat.completions.create.call_args.kwargs.get("extra_headers", {})
+
+    def test_call_llm_omits_session_routing_for_unknown_custom_route(self):
+        client = MagicMock()
+        client.base_url = "http://localhost:1234/v1"
+        client.chat.completions.create.return_value = object()
+
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("custom", "local-model", "http://localhost:1234/v1", "local-key"),
+        ), patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(client, "local-model"),
+        ):
+            call_llm(
+                provider="custom",
+                messages=[{"role": "user", "content": "hi"}],
+                session_id="sess-local-1",
+            )
+
+        assert "x-session-affinity" not in client.chat.completions.create.call_args.kwargs.get("extra_headers", {})
+
+    def test_call_llm_infers_session_routing_from_client_base_url(self):
+        client = MagicMock()
+        client.base_url = "https://api.fireworks.ai/inference/v1"
+        client.chat.completions.create.return_value = object()
+
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("custom", "fw-model", None, "fw-key"),
+        ), patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(client, "fw-model"),
+        ):
+            call_llm(
+                provider="custom",
+                messages=[{"role": "user", "content": "hi"}],
+                session_id="sess-fallback",
+            )
+
+        assert client.chat.completions.create.call_args.kwargs["extra_headers"] == {
+            "x-session-affinity": "sess-fallback"
+        }
+
+    def test_call_llm_main_provider_still_infers_session_routing_from_base_url(self):
+        client = MagicMock()
+        client.base_url = "https://api.fireworks.ai/inference/v1"
+        client.chat.completions.create.return_value = object()
+
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("main", "fw-model", "https://api.fireworks.ai/inference/v1", "fw-key"),
+        ), patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(client, "fw-model"),
+        ):
+            call_llm(
+                provider="main",
+                messages=[{"role": "user", "content": "hi"}],
+                session_id="sess-main-1",
+            )
+
+        assert client.chat.completions.create.call_args.kwargs["extra_headers"] == {
+            "x-session-affinity": "sess-main-1"
+        }
+
+    def test_call_llm_adds_prompt_cache_key_for_codex_responses_transport(self):
+        client = MagicMock()
+        client.api_mode = "codex_responses"
+        client.base_url = "https://chatgpt.com/backend-api/codex"
+        client.chat.completions.create.return_value = object()
+
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("auto", "gpt-5.2-codex", None, "codex-key"),
+        ), patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(client, "gpt-5.2-codex"),
+        ):
+            call_llm(
+                provider="auto",
+                messages=[{"role": "user", "content": "hi"}],
+                session_id="sess-codex-aux",
+            )
+
+        assert client.chat.completions.create.call_args.kwargs["prompt_cache_key"] == "sess-codex-aux"
+
+    def test_async_call_llm_adds_session_routing_header_for_fireworks_route(self):
+        create = AsyncMock(return_value=object())
+        client = MagicMock()
+        client.base_url = "https://api.fireworks.ai/inference/v1"
+        client.chat.completions.create = create
+
+        with patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("custom", "fw-model", None, "fw-key"),
+        ), patch(
+            "agent.auxiliary_client._get_cached_client",
+            return_value=(client, "fw-model"),
+        ):
+            asyncio.run(
+                async_call_llm(
+                    provider="custom",
+                    messages=[{"role": "user", "content": "hi"}],
+                    session_id="async-sess-123",
+                )
+            )
+
+        assert create.call_args.kwargs["extra_headers"] == {
+            "x-session-affinity": "async-sess-123"
+        }
+
+
+class TestCodexResponsesAdapterRouting:
+    def test_codex_adapter_forwards_responses_routing_kwargs(self):
+        final_response = SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    type="message",
+                    content=[SimpleNamespace(type="output_text", text="ok")],
+                )
+            ],
+            usage=SimpleNamespace(input_tokens=1, output_tokens=1, total_tokens=2),
+        )
+
+        class _FakeStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                return iter(())
+
+            def get_final_response(self):
+                return final_response
+
+        real_client = MagicMock()
+        real_client.responses.stream.return_value = _FakeStream()
+        adapter = _CodexCompletionsAdapter(real_client, "gpt-5.2-codex")
+
+        response = adapter.create(
+            messages=[{"role": "user", "content": "hi"}],
+            prompt_cache_key="sess-codex-wire",
+        )
+
+        assert response.choices[0].message.content == "ok"
+        assert real_client.responses.stream.call_args.kwargs["prompt_cache_key"] == "sess-codex-wire"

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -121,6 +121,25 @@ class TestCompress:
 class TestGenerateSummaryNoneContent:
     """Regression: content=None (from tool-call-only assistant messages) must not crash."""
 
+    def test_generate_summary_forwards_session_identity(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "[CONTEXT SUMMARY]: summarized"
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True, session_id="compress-sess-1")
+
+        captured = {}
+
+        def _mock_call_llm(**kwargs):
+            captured.update(kwargs)
+            return mock_response
+
+        with patch("agent.context_compressor.call_llm", side_effect=_mock_call_llm):
+            c._generate_summary([{"role": "user", "content": "compress this"}])
+
+        assert captured["session_id"] == "compress-sess-1"
+
     def test_none_content_does_not_crash(self):
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -22,16 +22,17 @@ from unittest.mock import patch, MagicMock
 from agent.model_metadata import (
     CONTEXT_PROBE_TIERS,
     DEFAULT_CONTEXT_LENGTHS,
+    _MODEL_CACHE_TTL,
     _strip_provider_prefix,
-    estimate_tokens_rough,
+    build_openai_request_session_routing,
     estimate_messages_tokens_rough,
+    estimate_tokens_rough,
+    fetch_model_metadata,
+    get_cached_context_length,
     get_model_context_length,
     get_next_probe_tier,
-    get_cached_context_length,
     parse_context_limit_from_error,
     save_context_length,
-    fetch_model_metadata,
-    _MODEL_CACHE_TTL,
 )
 
 
@@ -194,6 +195,100 @@ class TestGetModelContextLength:
             result = get_model_context_length("custom/model")
             assert result == CONTEXT_PROBE_TIERS[0]
 
+
+class TestBuildOpenAIRequestSessionRouting:
+    def test_chat_completions_fireworks_route_uses_session_affinity_header(self):
+        routing = build_openai_request_session_routing(
+            provider="custom",
+            base_url="https://api.fireworks.ai/inference/v1",
+            api_mode="chat_completions",
+            session_id="sess-123",
+        )
+
+        assert routing == {"extra_headers": {"x-session-affinity": "sess-123"}}
+
+    def test_chat_completions_unknown_custom_route_omits_session_routing(self):
+        routing = build_openai_request_session_routing(
+            provider="custom",
+            base_url="http://localhost:1234/v1",
+            api_mode="chat_completions",
+            session_id="sess-123",
+        )
+
+        assert routing == {}
+
+    def test_chat_completions_without_session_id_omits_session_routing(self):
+        routing = build_openai_request_session_routing(
+            provider="custom",
+            base_url="https://api.fireworks.ai/inference/v1",
+            api_mode="chat_completions",
+            session_id=None,
+        )
+
+        assert routing == {}
+
+    def test_codex_responses_openai_routes_use_prompt_cache_key(self):
+        routing = build_openai_request_session_routing(
+            provider="openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_mode="codex_responses",
+            session_id="sess-codex-1",
+        )
+
+        assert routing == {"prompt_cache_key": "sess-codex-1"}
+
+    def test_codex_responses_direct_openai_route_uses_prompt_cache_key(self):
+        routing = build_openai_request_session_routing(
+            provider="custom",
+            base_url="https://api.openai.com/v1",
+            api_mode="codex_responses",
+            session_id="sess-openai-1",
+        )
+
+        assert routing == {"prompt_cache_key": "sess-openai-1"}
+
+    def test_codex_responses_github_route_omits_prompt_cache_key(self):
+        routing = build_openai_request_session_routing(
+            provider="copilot",
+            base_url="https://api.githubcopilot.com",
+            api_mode="codex_responses",
+            session_id="sess-gh-1",
+        )
+
+        assert routing == {}
+
+    def test_openrouter_provider_yields_to_specific_fireworks_base_url(self):
+        routing = build_openai_request_session_routing(
+            provider="openrouter",
+            base_url="https://api.fireworks.ai/inference/v1",
+            api_mode="chat_completions",
+            session_id="sess-fw-via-or",
+        )
+
+        assert routing == {"extra_headers": {"x-session-affinity": "sess-fw-via-or"}}
+
+    def test_openrouter_provider_yields_to_direct_openai_base_url_for_responses(self):
+        routing = build_openai_request_session_routing(
+            provider="openrouter",
+            base_url="https://api.openai.com/v1",
+            api_mode="codex_responses",
+            session_id="sess-openai-via-or",
+        )
+
+        assert routing == {"prompt_cache_key": "sess-openai-via-or"}
+
+    def test_codex_responses_unknown_custom_route_omits_prompt_cache_key(self):
+        routing = build_openai_request_session_routing(
+            provider="custom",
+            base_url="https://llm.example.com/v1",
+            api_mode="codex_responses",
+            session_id="sess-custom-1",
+        )
+
+        assert routing == {}
+
+
+class TestGetModelContextLengthCustomEndpoints:
     @patch("agent.model_metadata.fetch_model_metadata")
     @patch("agent.model_metadata.fetch_endpoint_model_metadata")
     def test_custom_endpoint_metadata_beats_fuzzy_default(self, mock_endpoint_fetch, mock_fetch):

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -82,6 +82,21 @@ class TestGenerateTitle:
         user_content = captured_kwargs["messages"][1]["content"]
         assert len(user_content) < 1100  # 500 + 500 + formatting
 
+    def test_forwards_session_identity_to_auxiliary_call(self):
+        captured_kwargs = {}
+
+        def mock_call_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = "Short Title"
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            generate_title("question", "answer", session_id="title-sess-1")
+
+        assert captured_kwargs["session_id"] == "title-sess-1"
+
 
 class TestAutoTitleSession:
     """Tests for auto_title_session() — the sync worker function."""
@@ -104,6 +119,15 @@ class TestAutoTitleSession:
         with patch("agent.title_generator.generate_title", return_value="New Title"):
             auto_title_session(db, "sess-1", "hi", "hello")
             db.set_session_title.assert_called_once_with("sess-1", "New Title")
+
+    def test_auto_title_passes_session_identity_to_generator(self):
+        db = MagicMock()
+        db.get_session_title.return_value = None
+
+        with patch("agent.title_generator.generate_title", return_value="New Title") as gen:
+            auto_title_session(db, "sess-1", "hi", "hello")
+
+        gen.assert_called_once_with("hi", "hello", session_id="sess-1")
 
     def test_skips_if_generation_fails(self):
         db = MagicMock()

--- a/tests/test_provider_parity.py
+++ b/tests/test_provider_parity.py
@@ -290,7 +290,7 @@ class TestBuildApiKwargsCustomEndpoint:
         extra = kwargs.get("extra_body", {})
         assert "reasoning" not in extra
 
-    def test_fireworks_tool_call_payload_strips_codex_only_fields(self, monkeypatch):
+    def test_fireworks_custom_route_sanitizes_payload_and_applies_session_routing(self, monkeypatch):
         agent = _make_agent(
             monkeypatch,
             "custom",
@@ -325,6 +325,7 @@ class TestBuildApiKwargsCustomEndpoint:
         assert kwargs["tools"][0]["function"]["name"] == "web_search"
         assert "input" not in kwargs
         assert kwargs.get("extra_body", {}) == {}
+        assert kwargs["extra_headers"]["x-session-affinity"] == agent.session_id
 
         assistant_msg = kwargs["messages"][1]
         tool_call = assistant_msg["tool_calls"][0]

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -872,6 +872,25 @@ class TestBuildApiKwargs:
         kwargs = agent._build_api_kwargs(messages)
         assert kwargs["max_tokens"] == 4096
 
+    def test_chat_completions_session_routing_uses_session_id_for_fireworks(self, agent):
+        agent.base_url = "https://api.fireworks.ai/inference/v1"
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["extra_headers"]["x-session-affinity"] == agent.session_id
+
+    def test_chat_completions_session_routing_omits_fireworks_header_for_unknown_custom_route(self, agent):
+        agent.base_url = "http://localhost:1234/v1"
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert "x-session-affinity" not in kwargs.get("extra_headers", {})
+
+    def test_chat_completions_session_routing_uses_current_session_id(self, agent):
+        agent.base_url = "https://api.fireworks.ai/inference/v1"
+        agent.session_id = "continued-session-123"
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["extra_headers"]["x-session-affinity"] == "continued-session-123"
+
 
 class TestBuildAssistantMessage:
     def test_basic_message(self, agent):

--- a/tests/test_run_agent_codex_responses.py
+++ b/tests/test_run_agent_codex_responses.py
@@ -258,8 +258,7 @@ def test_build_api_kwargs_codex(monkeypatch):
     assert kwargs["store"] is False
     assert kwargs["tool_choice"] == "auto"
     assert kwargs["parallel_tool_calls"] is True
-    assert isinstance(kwargs["prompt_cache_key"], str)
-    assert len(kwargs["prompt_cache_key"]) > 0
+    assert kwargs["prompt_cache_key"] == agent.session_id
     assert "timeout" not in kwargs
     assert "max_tokens" not in kwargs
     assert "extra_body" not in kwargs


### PR DESCRIPTION
## What does this PR do?

Most inference providers now support some form of prompt prefix caching, but the cache-hint mechanism varies per provider: Fireworks uses an `x-session-affinity` header, OpenAI uses a `prompt_cache_key` body field, xAI has `x-grok-conv-id`, etc. There's no standard, and this is a real pain point across the ecosystem: several PRs and issues in other agentic clients are stalled or incomplete because each one hits the same "which provider am I actually talking to?" problem before it can send the right hint.

This PR introduces a data-driven routing table that maps `(provider, api_mode)` → request metadata, so each provider gets exactly the cache hint it understands and unknown routes get nothing. It also generalizes the existing hardcoded `prompt_cache_key` for OpenAI Codex into this same table, and threads `session_id` through all LLM call sites (primary, auxiliary, context compression, title generation, memory flush, iteration-limit summaries).

## Related Issue

N/A — standalone improvement. See "Related ecosystem work" below for cross-project context.

## Type of Change

Performance & robustness

## Changes Made

**Core routing logic:**
- `agent/model_metadata.py` — new `build_openai_request_session_routing()` with a provider/api_mode lookup table, provider inference from base_url, and template rendering

**Current routing entries:**
| Provider | API mode | Routing |
|---|---|---|
| `fireworks` | `chat_completions` | `x-session-affinity: {session_id}` header |
| `openai` / `openai-codex` | `codex_responses` | `prompt_cache_key: {session_id}` |

**Future / WIP — not yet wired, pending testing:**
| Provider | Likely mechanism | Notes |
|---|---|---|
| Cloudflare Workers AI | `x-session-affinity` header | [Documented for prefix-cache locality](https://blog.cloudflare.com/workers-ai-large-models/) |
| xAI | `x-grok-conv-id` header or `prompt_cache_key` | [Supports both](https://docs.x.ai/developers/advanced-api-usage/prompt-caching); needs testing to confirm which path works via OpenAI-compat |
| Mistral | `x-session-affinity` or similar | Anecdotal reports of prefix caching with affinity headers; no public docs yet |

**Integration points:**
- `run_agent.py` — `_apply_request_session_routing()` method applied to primary `_build_api_kwargs`, memory flush, and iteration-limit summary calls
- `agent/auxiliary_client.py` — `session_id` param on `call_llm`/`async_call_llm`, routing applied in `_build_call_kwargs`, `api_mode` attribute on all auxiliary client wrappers, `_CodexCompletionsAdapter` forwards `prompt_cache_key`/`extra_headers`/`extra_body`
- `agent/context_compressor.py` — forwards `session_id` to auxiliary `call_llm`
- `agent/title_generator.py` — forwards `session_id` to auxiliary `call_llm`

## How to Test

1. `pytest tests/ -q` — new tests pass, but there are prexisting failures in my current env (WIP)
2. Configure a Fireworks endpoint and inspect outgoing requests — `x-session-affinity` header should be present with the session ID
3. Use OpenAI Codex route — `prompt_cache_key` should still be set to `session_id` (unchanged behavior, now via the routing table)
4. Use GitHub Copilot route — no `prompt_cache_key` should be sent (unchanged behavior, copilot provider is not in the table)
5. Use a local/unknown endpoint — no routing metadata should be added

## Provider docs

- [Fireworks prompt caching](https://docs.fireworks.ai/guides/prompt-caching)
- [Fireworks changelog — session affinity via `user` / `x-session-affinity`](https://docs.fireworks.ai/updates/changelog)
- [OpenAI prompt caching / `prompt_cache_key`](https://platform.openai.com/docs/guides/prompt-caching)
- [Azure OpenAI prompt caching / `prompt_cache_key`](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/prompt-caching)
- [xAI prompt caching / `x-grok-conv-id` / `prompt_cache_key`](https://docs.x.ai/developers/advanced-api-usage/prompt-caching)
- [Cloudflare on `x-session-affinity` for prefix-cache locality](https://blog.cloudflare.com/workers-ai-large-models/)

## Related ecosystem work

These all circle around the same problem — agentic clients need provider-aware gating to send the right cache hint on the right route:

- [OmniRoute #518 — preserving `prompt_cache_key` through Responses → Chat translation](https://github.com/diegosouzapw/OmniRoute/pull/518)
- [OpenCode #4317 — stable conversation IDs / provider cache-key hooks](https://github.com/anomalyco/opencode/issues/4317)
- [OpenClaw #16387 — provider-aware session cache hints](https://github.com/openclaw/openclaw/issues/16387)
- [Zed #36215 — why vendor-native cache hints need provider-aware gating](https://github.com/zed-industries/zed/issues/36215)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (**I'm seeing preexisting test failures on main: will continue to iterate**)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility
guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A