### PR TITLE
fix(core): prevent cross-tenant data leakage by migrating state to contextvars

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -490,9 +490,10 @@ def build_skills_system_prompt(
     # ── Layer 1: in-process LRU cache ─────────────────────────────────
     # Include the resolved platform so per-platform disabled-skill lists
     # produce distinct cache entries (gateway serves multiple platforms).
+    from hermes_constants import get_session_env
     _platform_hint = (
-        os.environ.get("HERMES_PLATFORM")
-        or os.environ.get("HERMES_SESSION_PLATFORM")
+        get_session_env("HERMES_PLATFORM")
+        or get_session_env("HERMES_SESSION_PLATFORM")
         or ""
     )
     cache_key = (

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -145,10 +145,11 @@ def get_disabled_skill_names(platform: str | None = None) -> Set[str]:
     if not isinstance(skills_cfg, dict):
         return set()
 
+    from hermes_constants import get_session_env
     resolved_platform = (
         platform
-        or os.getenv("HERMES_PLATFORM")
-        or os.getenv("HERMES_SESSION_PLATFORM")
+        or get_session_env("HERMES_PLATFORM")
+        or get_session_env("HERMES_SESSION_PLATFORM")
     )
     if resolved_platform:
         platform_disabled = (skills_cfg.get("platform_disabled") or {}).get(

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -411,10 +411,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 
     # Inject origin context so the agent's send_message tool knows the chat
     if origin:
-        os.environ["HERMES_SESSION_PLATFORM"] = origin["platform"]
-        os.environ["HERMES_SESSION_CHAT_ID"] = str(origin["chat_id"])
+        from hermes_constants import set_session_env
+        set_session_env("HERMES_SESSION_PLATFORM", origin["platform"])
+        set_session_env("HERMES_SESSION_CHAT_ID", str(origin["chat_id"]))
         if origin.get("chat_name"):
-            os.environ["HERMES_SESSION_CHAT_NAME"] = origin["chat_name"]
+            set_session_env("HERMES_SESSION_CHAT_NAME", origin["chat_name"])
 
     try:
         # Re-read .env and config.yaml fresh every run so provider/key
@@ -427,10 +428,11 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 
         delivery_target = _resolve_delivery_target(job)
         if delivery_target:
-            os.environ["HERMES_CRON_AUTO_DELIVER_PLATFORM"] = delivery_target["platform"]
-            os.environ["HERMES_CRON_AUTO_DELIVER_CHAT_ID"] = str(delivery_target["chat_id"])
+            from hermes_constants import set_session_env
+            set_session_env("HERMES_CRON_AUTO_DELIVER_PLATFORM", delivery_target["platform"])
+            set_session_env("HERMES_CRON_AUTO_DELIVER_CHAT_ID", str(delivery_target["chat_id"]))
             if delivery_target.get("thread_id") is not None:
-                os.environ["HERMES_CRON_AUTO_DELIVER_THREAD_ID"] = str(delivery_target["thread_id"])
+                set_session_env("HERMES_CRON_AUTO_DELIVER_THREAD_ID", str(delivery_target["thread_id"]))
 
         model = job.get("model") or os.getenv("HERMES_MODEL") or ""
 
@@ -609,15 +611,8 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 
     finally:
         # Clean up injected env vars so they don't leak to other jobs
-        for key in (
-            "HERMES_SESSION_PLATFORM",
-            "HERMES_SESSION_CHAT_ID",
-            "HERMES_SESSION_CHAT_NAME",
-            "HERMES_CRON_AUTO_DELIVER_PLATFORM",
-            "HERMES_CRON_AUTO_DELIVER_CHAT_ID",
-            "HERMES_CRON_AUTO_DELIVER_THREAD_ID",
-        ):
-            os.environ.pop(key, None)
+        from hermes_constants import clear_session_env
+        clear_session_env()
         if _session_db:
             try:
                 _session_db.end_session(_cron_session_id, "cron_complete")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4559,12 +4559,13 @@ class GatewayRunner:
 
     async def _handle_yolo_command(self, event: MessageEvent) -> str:
         """Handle /yolo — toggle dangerous command approval bypass."""
-        current = bool(os.environ.get("HERMES_YOLO_MODE"))
+        from hermes_constants import get_session_env, set_session_env
+        current = bool(get_session_env("HERMES_YOLO_MODE"))
         if current:
-            os.environ.pop("HERMES_YOLO_MODE", None)
+            set_session_env("HERMES_YOLO_MODE", None)
             return "⚠️ YOLO mode **OFF** — dangerous commands will require approval."
         else:
-            os.environ["HERMES_YOLO_MODE"] = "1"
+            set_session_env("HERMES_YOLO_MODE", "1")
             return "⚡ YOLO mode **ON** — all commands auto-approved. Use with caution."
 
     async def _handle_verbose_command(self, event: MessageEvent) -> str:
@@ -5557,18 +5558,18 @@ class GatewayRunner:
 
     def _set_session_env(self, context: SessionContext) -> None:
         """Set environment variables for the current session."""
-        os.environ["HERMES_SESSION_PLATFORM"] = context.source.platform.value
-        os.environ["HERMES_SESSION_CHAT_ID"] = context.source.chat_id
+        from hermes_constants import set_session_env
+        set_session_env("HERMES_SESSION_PLATFORM", context.source.platform.value)
+        set_session_env("HERMES_SESSION_CHAT_ID", context.source.chat_id)
         if context.source.chat_name:
-            os.environ["HERMES_SESSION_CHAT_NAME"] = context.source.chat_name
+            set_session_env("HERMES_SESSION_CHAT_NAME", context.source.chat_name)
         if context.source.thread_id:
-            os.environ["HERMES_SESSION_THREAD_ID"] = str(context.source.thread_id)
+            set_session_env("HERMES_SESSION_THREAD_ID", str(context.source.thread_id))
     
     def _clear_session_env(self) -> None:
         """Clear session environment variables."""
-        for var in ["HERMES_SESSION_PLATFORM", "HERMES_SESSION_CHAT_ID", "HERMES_SESSION_CHAT_NAME", "HERMES_SESSION_THREAD_ID"]:
-            if var in os.environ:
-                del os.environ[var]
+        from hermes_constants import clear_session_env
+        clear_session_env()
     
     async def _enrich_message_with_vision(
         self,
@@ -6163,7 +6164,8 @@ class GatewayRunner:
         def run_sync():
             # Pass session_key to process registry via env var so background
             # processes can be mapped back to this gateway session
-            os.environ["HERMES_SESSION_KEY"] = session_key or ""
+            from hermes_constants import set_session_env
+            set_session_env("HERMES_SESSION_KEY", session_key or "")
 
             # Read from env var or use default (same as CLI)
             max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -103,3 +103,54 @@ AI_GATEWAY_CHAT_URL = f"{AI_GATEWAY_BASE_URL}/chat/completions"
 
 NOUS_API_BASE_URL = "https://inference-api.nousresearch.com/v1"
 NOUS_API_CHAT_URL = f"{NOUS_API_BASE_URL}/chat/completions"
+
+import contextvars
+
+# Thread-safe context variables for session state
+_SESSION_PLATFORM = contextvars.ContextVar("HERMES_SESSION_PLATFORM", default="")
+_SESSION_CHAT_ID = contextvars.ContextVar("HERMES_SESSION_CHAT_ID", default="")
+_SESSION_CHAT_NAME = contextvars.ContextVar("HERMES_SESSION_CHAT_NAME", default="")
+_SESSION_THREAD_ID = contextvars.ContextVar("HERMES_SESSION_THREAD_ID", default="")
+_SESSION_KEY = contextvars.ContextVar("HERMES_SESSION_KEY", default="")
+_YOLO_MODE = contextvars.ContextVar("HERMES_YOLO_MODE", default="")
+_CRON_AUTO_DELIVER_PLATFORM = contextvars.ContextVar("HERMES_CRON_AUTO_DELIVER_PLATFORM", default="")
+_CRON_AUTO_DELIVER_CHAT_ID = contextvars.ContextVar("HERMES_CRON_AUTO_DELIVER_CHAT_ID", default="")
+_CRON_AUTO_DELIVER_THREAD_ID = contextvars.ContextVar("HERMES_CRON_AUTO_DELIVER_THREAD_ID", default="")
+
+_CONTEXT_VAR_MAP = {
+    "HERMES_SESSION_PLATFORM": _SESSION_PLATFORM,
+    "HERMES_SESSION_CHAT_ID": _SESSION_CHAT_ID,
+    "HERMES_SESSION_CHAT_NAME": _SESSION_CHAT_NAME,
+    "HERMES_SESSION_THREAD_ID": _SESSION_THREAD_ID,
+    "HERMES_SESSION_KEY": _SESSION_KEY,
+    "HERMES_YOLO_MODE": _YOLO_MODE,
+    "HERMES_CRON_AUTO_DELIVER_PLATFORM": _CRON_AUTO_DELIVER_PLATFORM,
+    "HERMES_CRON_AUTO_DELIVER_CHAT_ID": _CRON_AUTO_DELIVER_CHAT_ID,
+    "HERMES_CRON_AUTO_DELIVER_THREAD_ID": _CRON_AUTO_DELIVER_THREAD_ID,
+}
+
+def get_session_env(key: str, default=None):
+    """Get a session env var from contextvars, falling back to os.environ for CLI/tests."""
+    if key in _CONTEXT_VAR_MAP:
+        val = _CONTEXT_VAR_MAP[key].get()
+        if val:
+            return val
+    return os.environ.get(key, default)
+
+def set_session_env(key: str, value: str):
+    """Set a session env var in contextvars only (does not pollute global os.environ)."""
+    if key in _CONTEXT_VAR_MAP:
+        if value is None:
+            _CONTEXT_VAR_MAP[key].set("")
+        else:
+            _CONTEXT_VAR_MAP[key].set(str(value))
+    else:
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = str(value)
+            
+def clear_session_env():
+    """Clear all session contextvars."""
+    for cvar in _CONTEXT_VAR_MAP.values():
+        cvar.set("")

--- a/run_agent.py
+++ b/run_agent.py
@@ -965,9 +965,10 @@ class AIAgent:
         self._last_flushed_db_idx = 0  # tracks DB-write cursor to prevent duplicate writes
         if self._session_db:
             try:
+                from hermes_constants import get_session_env
                 self._session_db.create_session(
                     session_id=self.session_id,
-                    source=self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                    source=self.platform or get_session_env("HERMES_SESSION_SOURCE", "cli"),
                     model=self.model,
                     model_config={
                         "max_iterations": self.max_iterations,
@@ -5742,9 +5743,10 @@ class AIAgent:
                 self.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
                 # Update session_log_file to point to the new session's JSON file
                 self.session_log_file = self.logs_dir / f"session_{self.session_id}.json"
+                from hermes_constants import get_session_env
                 self._session_db.create_session(
                     session_id=self.session_id,
-                    source=self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
+                    source=self.platform or get_session_env("HERMES_SESSION_SOURCE", "cli"),
                     model=self.model,
                     parent_session_id=old_session_id,
                 )

--- a/tests/test_session_isolation.py
+++ b/tests/test_session_isolation.py
@@ -1,0 +1,78 @@
+import threading
+import time
+import asyncio
+import pytest
+from hermes_constants import set_session_env, get_session_env, clear_session_env
+
+def thread_worker(session_id, results):
+    set_session_env("HERMES_SESSION_KEY", session_id)
+    # Simulate some work and potential concurrency
+    time.sleep(0.1)
+    # Verify that the session key is still what we set
+    results[session_id] = get_session_env("HERMES_SESSION_KEY")
+
+def test_session_env_thread_isolation():
+    results = {}
+    threads = []
+    # Clear any existing state
+    clear_session_env()
+    
+    for i in range(10):
+        t = threading.Thread(target=thread_worker, args=(f"session_{i}", results))
+        threads.append(t)
+        t.start()
+        
+    for t in threads:
+        t.join()
+        
+    for i in range(10):
+        assert results[f"session_{i}"] == f"session_{i}", f"Thread isolation failed for session_{i}"
+
+async def async_worker(session_id, results):
+    set_session_env("HERMES_SESSION_KEY", session_id)
+    # Yield control to other tasks
+    await asyncio.sleep(0.1)
+    # Verify that the session key is still what we set
+    results[session_id] = get_session_env("HERMES_SESSION_KEY")
+
+@pytest.mark.asyncio
+async def test_session_env_async_isolation():
+    results = {}
+    # Clear any existing state
+    clear_session_env()
+    
+    tasks = []
+    for i in range(10):
+        tasks.append(async_worker(f"session_{i}", results))
+        
+    await asyncio.gather(*tasks)
+    
+    for i in range(10):
+        assert results[f"session_{i}"] == f"session_{i}", f"Async isolation failed for session_{i}"
+
+def test_session_env_fallback():
+    """Verify that get_session_env falls back to os.environ if contextvar is not set."""
+    import os
+    import uuid
+    test_key = f"TEST_VAR_{uuid.uuid4().hex}"
+    test_val = "global_value"
+    
+    os.environ[test_key] = test_val
+    try:
+        # Since it's not in _CONTEXT_VAR_MAP, it should go to os.environ
+        assert get_session_env(test_key) == test_val
+        
+        # Now test a key that IS in _CONTEXT_VAR_MAP but not set in context
+        # (Should fall back to os.environ if context val is empty string)
+        os.environ["HERMES_SESSION_PLATFORM"] = "global_platform"
+        clear_session_env() # Ensure it's empty in context
+        assert get_session_env("HERMES_SESSION_PLATFORM") == "global_platform"
+        
+        # Now set it in context and ensure it takes precedence
+        set_session_env("HERMES_SESSION_PLATFORM", "local_platform")
+        assert get_session_env("HERMES_SESSION_PLATFORM") == "local_platform"
+    finally:
+        if test_key in os.environ:
+            del os.environ[test_key]
+        if "HERMES_SESSION_PLATFORM" in os.environ:
+            del os.environ["HERMES_SESSION_PLATFORM"]

--- a/tests/tools/test_search_hidden_dirs.py
+++ b/tests/tools/test_search_hidden_dirs.py
@@ -14,6 +14,7 @@ directories, matching ripgrep's default behavior.
 """
 
 import os
+import shutil
 import subprocess
 
 import pytest
@@ -98,7 +99,7 @@ class TestRipgrepAlreadyExcludesHidden:
     """Verify ripgrep's default behavior is to skip hidden directories."""
 
     @pytest.mark.skipif(
-        subprocess.run(["which", "rg"], capture_output=True).returncode != 0,
+        not shutil.which("rg"),
         reason="ripgrep not installed",
     )
     def test_rg_skips_hub_by_default(self, searchable_tree):
@@ -111,7 +112,7 @@ class TestRipgrepAlreadyExcludesHidden:
         assert "catalog.json" not in result.stdout
 
     @pytest.mark.skipif(
-        subprocess.run(["which", "rg"], capture_output=True).returncode != 0,
+        not shutil.which("rg"),
         reason="ripgrep not installed",
     )
     def test_rg_finds_visible_content(self, searchable_tree):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -44,7 +44,8 @@ def get_current_session_key(default: str = "default") -> str:
     session_key = _approval_session_key.get()
     if session_key:
         return session_key
-    return os.getenv("HERMES_SESSION_KEY", default)
+    from hermes_constants import get_session_env
+    return get_session_env("HERMES_SESSION_KEY", default)
 
 # Sensitive write targets that should trigger approval even when referenced
 # via shell expansions like $HOME or $HERMES_HOME.
@@ -555,7 +556,8 @@ def check_dangerous_command(command: str, env_type: str,
         return {"approved": True, "message": None}
 
     # --yolo: bypass all approval prompts
-    if os.getenv("HERMES_YOLO_MODE"):
+    from hermes_constants import get_session_env
+    if get_session_env("HERMES_YOLO_MODE"):
         return {"approved": True, "message": None}
 
     is_dangerous, pattern_key, description = detect_dangerous_command(command)
@@ -657,7 +659,8 @@ def check_all_command_guards(command: str, env_type: str,
 
     # --yolo or approvals.mode=off: bypass all approval prompts
     approval_mode = _get_approval_mode()
-    if os.getenv("HERMES_YOLO_MODE") or approval_mode == "off":
+    from hermes_constants import get_session_env
+    if get_session_env("HERMES_YOLO_MODE") or approval_mode == "off":
         return {"approved": True, "message": None}
 
     is_cli = os.getenv("HERMES_INTERACTIVE")

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -64,14 +64,15 @@ def _scan_cron_prompt(prompt: str) -> str:
 
 
 def _origin_from_env() -> Optional[Dict[str, str]]:
-    origin_platform = os.getenv("HERMES_SESSION_PLATFORM")
-    origin_chat_id = os.getenv("HERMES_SESSION_CHAT_ID")
+    from hermes_constants import get_session_env
+    origin_platform = get_session_env("HERMES_SESSION_PLATFORM")
+    origin_chat_id = get_session_env("HERMES_SESSION_CHAT_ID")
     if origin_platform and origin_chat_id:
         return {
             "platform": origin_platform,
             "chat_id": origin_chat_id,
-            "chat_name": os.getenv("HERMES_SESSION_CHAT_NAME"),
-            "thread_id": os.getenv("HERMES_SESSION_THREAD_ID"),
+            "chat_name": get_session_env("HERMES_SESSION_CHAT_NAME"),
+            "thread_id": get_session_env("HERMES_SESSION_THREAD_ID"),
         }
     return None
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -184,7 +184,8 @@ def _handle_send(args):
         if isinstance(result, dict) and result.get("success") and mirror_text:
             try:
                 from gateway.mirror import mirror_to_session
-                source_label = os.getenv("HERMES_SESSION_PLATFORM", "cli")
+                from hermes_constants import get_session_env
+                source_label = get_session_env("HERMES_SESSION_PLATFORM", "cli")
                 if mirror_to_session(platform_name, chat_id, mirror_text, source_label=source_label, thread_id=thread_id):
                     result["mirrored"] = True
             except Exception:
@@ -231,11 +232,12 @@ def _describe_media_for_mirror(media_files):
 
 def _get_cron_auto_delivery_target():
     """Return the cron scheduler's auto-delivery target for the current run, if any."""
-    platform = os.getenv("HERMES_CRON_AUTO_DELIVER_PLATFORM", "").strip().lower()
-    chat_id = os.getenv("HERMES_CRON_AUTO_DELIVER_CHAT_ID", "").strip()
+    from hermes_constants import get_session_env
+    platform = get_session_env("HERMES_CRON_AUTO_DELIVER_PLATFORM", "").strip().lower()
+    chat_id = get_session_env("HERMES_CRON_AUTO_DELIVER_CHAT_ID", "").strip()
     if not platform or not chat_id:
         return None
-    thread_id = os.getenv("HERMES_CRON_AUTO_DELIVER_THREAD_ID", "").strip() or None
+    thread_id = get_session_env("HERMES_CRON_AUTO_DELIVER_THREAD_ID", "").strip() or None
     return {
         "platform": platform,
         "chat_id": chat_id,
@@ -883,7 +885,8 @@ async def _send_feishu(pconfig, chat_id, message, media_files=None, thread_id=No
 
 def _check_send_message():
     """Gate send_message on gateway running (always available on messaging platforms)."""
-    platform = os.getenv("HERMES_SESSION_PLATFORM", "")
+    from hermes_constants import get_session_env
+    platform = get_session_env("HERMES_SESSION_PLATFORM", "")
     if platform and platform != "local":
         return True
     try:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -349,7 +349,8 @@ def _capture_required_environment_variables(
 def _is_gateway_surface() -> bool:
     if os.getenv("HERMES_GATEWAY_SESSION"):
         return True
-    return bool(os.getenv("HERMES_SESSION_PLATFORM"))
+    from hermes_constants import get_session_env
+    return bool(get_session_env("HERMES_SESSION_PLATFORM"))
 
 
 def _get_terminal_backend_name() -> str:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1220,9 +1220,10 @@ def terminal_tool(
                         result_data["check_interval_note"] = (
                             f"Requested {check_interval}s raised to minimum 30s"
                         )
-                    watcher_platform = os.getenv("HERMES_SESSION_PLATFORM", "")
-                    watcher_chat_id = os.getenv("HERMES_SESSION_CHAT_ID", "")
-                    watcher_thread_id = os.getenv("HERMES_SESSION_THREAD_ID", "")
+                    from hermes_constants import get_session_env
+                    watcher_platform = get_session_env("HERMES_SESSION_PLATFORM", "")
+                    watcher_chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "")
+                    watcher_thread_id = get_session_env("HERMES_SESSION_THREAD_ID", "")
 
                     # Store on session for checkpoint persistence
                     proc_session.watcher_platform = watcher_platform

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -480,7 +480,8 @@ def text_to_speech_tool(
     # Telegram voice bubbles require Opus (.ogg); OpenAI and ElevenLabs can
     # produce Opus natively (no ffmpeg needed).  Edge TTS always outputs MP3
     # and needs ffmpeg for conversion.
-    platform = os.getenv("HERMES_SESSION_PLATFORM", "").lower()
+    from hermes_constants import get_session_env
+    platform = get_session_env("HERMES_SESSION_PLATFORM", "").lower()
     want_opus = (platform == "telegram")
 
     # Determine output path


### PR DESCRIPTION
## 🔒 Security Fix: Prevent Cross-Tenant Data Leakage

### 📝 Summary
This PR remediates a critical cross-session data bleed vulnerability in the Hermes Gateway and Scheduler. By migrating session-specific metadata from the process-global `os.environ` to thread-safe and async-aware `contextvars`, we ensure strict isolation between concurrent agent sessions.

### 🚨 The Issue & Impact
Previously, Hermes used `os.environ` to store per-conversation state (e.g., `HERMES_SESSION_KEY`, `HERMES_YOLO_MODE`, `HERMES_SESSION_PLATFORM`).
* **The Exploit Scenario:** In multi-tenant environments (Gateway/Messaging) or parallel cron jobs, a race condition existed where one session could overwrite or "bleed" its identity into another concurrent session.
* **Impact:** This led to incorrect message routing, session key collisions in the approval system, and unauthorized YOLO-mode bypass inheritance across sessions.

### 🛠️ The Solution (ContextVars Migration)
Implemented a robust, scoped state management system using Python's `contextvars`:
* **[MODIFY] `hermes_constants.py`:** Introduced a centralized, thread-local store for session environment variables (`_CONTEXT_VAR_MAP`), alongside `get_session_env`, `set_session_env`, and `clear_session_env`.
* **[MODIFY] `gateway/run.py` & `cron/scheduler.py`:** Updated environment injection to use scoped setters, removing global environment pollution.
* **[MODIFY] `run_agent.py` & Core Tools:** Updated `approval.py`, `send_message_tool.py`, and `terminal_tool.py` to use scoped getters. Ensures platform and chat ID resolution strictly respects the active session thread.

### ✅ Verification Results
* **New Isolation Test:** Added `tests/test_session_isolation.py`. Spawns 10 concurrent threads and 10 concurrent async tasks. Verified that all 20 concurrent workers maintained unique state without any bleed or corruption.
* **Platform Compatibility:** Fixed a Windows-specific failure in `tests/tools/test_search_hidden_dirs.py` by replacing the Linux-only `which` command with `shutil.which`. Verified on Windows (PowerShell).

### 📋 Checklist
- [x] Security patch (closes a critical concurrency/data-bleed vector)
- [x] State management architecture refactored
- [x] Tested locally (Isolation tests & Windows compatibility)
- [x] Non-breaking for existing CLI users