### PR TITLE
feat(api-server): expose active configured models

### DIFF
--- a/.gsd/spec-api-server-active-models.md
+++ b/.gsd/spec-api-server-active-models.md
@@ -1,0 +1,48 @@
+# API Server active configured models
+
+## Request
+Add GSD specs for modifying the Hermes OpenAI-compatible API so it returns all active models under the standard discovery endpoint and routes request-time model selection consistently.
+
+## Standard
+- OpenAI standard discovery endpoint: `GET /v1/models`
+- Not `/model`
+- Bare `/models` would be a non-standard convenience alias only, if added at all
+
+## Current repo findings
+- `gateway/platforms/api_server.py` currently documents and implements only `GET /v1/models`
+- The current handler returns a single synthetic model entry with id `hermes-agent`
+- Chat and Responses handlers currently echo the request `model` field in the response, but the inspected implementation path does not yet clearly route agent creation by requested model
+- Existing tests in `tests/gateway/test_api_server.py` already cover `/v1/models`
+
+## Desired behavior
+- `GET /v1/models` returns an OpenAI-style list containing:
+  - the backward-compatible `hermes-agent` alias
+  - all active/configured models Hermes can actually route to with current config/auth state
+- The API server should reuse existing provider/model discovery helpers rather than re-implementing catalog logic
+- Request-time model selection for `POST /v1/chat/completions` and `POST /v1/responses` should resolve through shared switching/routing logic
+- Unknown/inactive/unroutable requested models should return a clear OpenAI-style error response
+- Docs and tests must be updated together
+
+## Recommended implementation shape
+1. Add failing tests first in `tests/gateway/test_api_server.py` for:
+   - `/v1/models` returning real active/configured models alongside `hermes-agent`
+   - valid requested model routing through chat/responses
+   - invalid requested model rejection
+2. Add a small helper in `gateway/platforms/api_server.py` that builds the model list from shared gateway config/runtime + shared model-discovery helpers.
+3. Add a small request-model resolution helper so `hermes-agent` keeps the current default route while explicit exposed models override the runtime route safely.
+4. Keep the change conservative: no broad refactor, no speculative extra aliases unless trivially safe.
+5. Update `website/docs/user-guide/features/api-server.md` so `/v1/models` no longer claims only `hermes-agent`.
+
+## Files likely involved
+- `gateway/platforms/api_server.py`
+- `gateway/run.py`
+- `hermes_cli/model_switch.py`
+- `hermes_cli/models.py`
+- `tests/gateway/test_api_server.py`
+- `website/docs/user-guide/features/api-server.md`
+
+## Guardrails
+- Preserve backward compatibility for existing clients using `hermes-agent`
+- Do not expose unavailable models
+- Preserve auth/security behavior unchanged
+- Keep strict TDD for implementation

--- a/docs/plans/2026-04-05-api-server-active-models.md
+++ b/docs/plans/2026-04-05-api-server-active-models.md
@@ -1,0 +1,25 @@
+# API Server Active Models Plan
+
+> For Hermes: implement with strict TDD. Write the failing targeted tests first, run them to confirm failure, then make the minimum code changes to pass.
+
+Goal: Make the OpenAI-compatible Hermes API expose real active/configured models through GET /v1/models instead of only the synthetic hermes-agent alias, and let request-time model selection flow through chat/responses requests.
+
+Architecture:
+- Keep backward compatibility by retaining the hermes-agent alias.
+- Add API-server helpers that derive the current runtime route plus authenticated/configured provider model entries.
+- Use the existing shared model-switch pipeline so per-request model IDs resolve the same way as the existing /model command.
+
+Files:
+- Modify: gateway/platforms/api_server.py
+- Modify: tests/gateway/test_api_server.py
+
+Phase 1 tasks:
+1. Add failing endpoint tests for /v1/models returning real configured models alongside hermes-agent.
+2. Add failing request-routing tests proving chat/responses forward the requested model into agent creation/runtime selection.
+3. Implement API-server model listing helper using existing gateway/runtime config plus hermes_cli.model_switch.list_authenticated_providers.
+4. Implement request-time model override resolution using hermes_cli.model_switch.switch_model.
+5. Run targeted tests, then focused regression tests for gateway API server behavior.
+
+Verification:
+- python3 -m pytest tests/gateway/test_api_server.py -q -k "models or requested_model"
+- python3 -m pytest tests/gateway/test_api_server.py -q

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6,7 +6,7 @@ Exposes an HTTP server with endpoints:
 - POST /v1/responses               — OpenAI Responses API format (stateful via previous_response_id)
 - GET  /v1/responses/{response_id} — Retrieve a stored response
 - DELETE /v1/responses/{response_id} — Delete a stored response
-- GET  /v1/models                  — lists hermes-agent as an available model
+- GET  /v1/models                  — lists active requestable models plus hermes-agent alias
 - POST /v1/runs                    — start a run, returns run_id immediately (202)
 - GET  /v1/runs/{run_id}/events    — SSE stream of structured lifecycle events
 - GET  /health                     — health check
@@ -697,6 +697,162 @@ class APIServerAdapter(BasePlatformAdapter):
                 logger.debug("SessionDB unavailable for API server: %s", e)
         return self._session_db
 
+    def _runtime_model_context(self) -> Dict[str, Any]:
+        """Resolve the active runtime/provider context for API-server requests."""
+        from gateway.run import _resolve_runtime_agent_kwargs, _resolve_gateway_model
+
+        runtime_kwargs = _resolve_runtime_agent_kwargs()
+        return {
+            "runtime_kwargs": runtime_kwargs,
+            "provider": str(runtime_kwargs.get("provider") or "").strip(),
+            "default_model": _resolve_gateway_model(),
+        }
+
+    @staticmethod
+    def _dedupe_model_records(records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        seen: set[str] = set()
+        ordered: List[Dict[str, Any]] = []
+        for record in records:
+            model_id = str(record.get("public_model_id") or "").strip()
+            if not model_id or model_id in seen:
+                continue
+            seen.add(model_id)
+            ordered.append(record)
+        return ordered
+
+    def _configured_provider_ids(self) -> List[str]:
+        provider_ids: List[str] = []
+        try:
+            from hermes_cli.models import configured_provider_ids
+
+            provider_ids.extend(configured_provider_ids())
+        except Exception as exc:
+            logger.debug("Could not list configured providers for /v1/models: %s", exc)
+
+        try:
+            context = self._runtime_model_context()
+            active_provider = str(context.get("provider") or "").strip()
+            if active_provider:
+                provider_ids.append(active_provider)
+        except Exception:
+            pass
+
+        seen: set[str] = set()
+        ordered: List[str] = []
+        for provider_id in provider_ids:
+            normalized = str(provider_id or "").strip()
+            if not normalized or normalized in seen:
+                continue
+            seen.add(normalized)
+            ordered.append(normalized)
+        return ordered
+
+    def _get_served_model_records(self) -> List[Dict[str, Any]]:
+        """Return provider-qualified requestable model records for configured providers."""
+        try:
+            active_context = self._runtime_model_context()
+        except Exception as exc:
+            logger.debug("Could not resolve active runtime context for /v1/models: %s", exc)
+            active_context = {
+                "runtime_kwargs": {},
+                "provider": "",
+                "default_model": "",
+            }
+
+        records: List[Dict[str, Any]] = []
+        default_model = str(active_context.get("default_model") or "").strip()
+        active_provider = str(active_context.get("provider") or "").strip()
+        active_runtime_kwargs = dict(active_context.get("runtime_kwargs") or {})
+        if default_model and active_provider:
+            records.append(
+                {
+                    "public_model_id": f"{active_provider}/{default_model}",
+                    "provider": active_provider,
+                    "agent_model": default_model,
+                    "runtime_kwargs": active_runtime_kwargs,
+                }
+            )
+
+        try:
+            from hermes_cli.models import fetch_api_models, provider_model_ids
+            from hermes_cli.runtime_provider import resolve_runtime_provider
+
+            for provider_id in self._configured_provider_ids():
+                runtime_kwargs = resolve_runtime_provider(requested=provider_id)
+                resolved_provider = str(runtime_kwargs.get("provider") or provider_id or "").strip()
+
+                model_ids = fetch_api_models(
+                    runtime_kwargs.get("api_key"),
+                    runtime_kwargs.get("base_url"),
+                ) or []
+                if not model_ids:
+                    model_ids = provider_model_ids(resolved_provider)
+
+                for model_id in model_ids:
+                    agent_model = str(model_id or "").strip()
+                    if not agent_model:
+                        continue
+                    records.append(
+                        {
+                            "public_model_id": f"{resolved_provider}/{agent_model}",
+                            "provider": resolved_provider,
+                            "agent_model": agent_model,
+                            "runtime_kwargs": dict(runtime_kwargs),
+                        }
+                    )
+        except Exception as exc:
+            logger.debug("Could not discover served model records for /v1/models: %s", exc)
+
+        return self._dedupe_model_records(records)
+
+    def _get_served_model_ids(self) -> List[str]:
+        """Return provider-qualified requestable model ids for configured providers."""
+        return [record["public_model_id"] for record in self._get_served_model_records()]
+
+    def _resolve_request_model(self, requested_model: Optional[str]) -> Dict[str, Any]:
+        """Resolve a request model into the concrete runtime model Hermes should use."""
+        requested = str(requested_model or "").strip()
+
+        if not requested or requested == "hermes-agent":
+            default_model = ""
+            runtime_kwargs: Dict[str, Any] = {}
+            try:
+                context = self._runtime_model_context()
+                default_model = str(context.get("default_model") or "").strip()
+                runtime_kwargs = dict(context.get("runtime_kwargs") or {})
+            except Exception:
+                default_model = ""
+            return {
+                "requested_model": "hermes-agent",
+                "agent_model": default_model or "hermes-agent",
+                "agent_runtime_kwargs": runtime_kwargs,
+            }
+
+        record_by_public_id = {
+            record["public_model_id"]: record for record in self._get_served_model_records()
+        }
+        if requested not in record_by_public_id:
+            raise ValueError(f"Unknown or inactive model '{requested}' for this Hermes API server.")
+
+        record = record_by_public_id[requested]
+        return {
+            "requested_model": requested,
+            "agent_model": str(record.get("agent_model") or requested).strip(),
+            "agent_runtime_kwargs": dict(record.get("runtime_kwargs") or {}),
+        }
+
+    @staticmethod
+    def _model_card(model_id: str, *, owned_by: str = "hermes") -> Dict[str, Any]:
+        return {
+            "id": model_id,
+            "object": "model",
+            "created": int(time.time()),
+            "owned_by": owned_by,
+            "permission": [],
+            "root": model_id,
+            "parent": None,
+        }
+
     # ------------------------------------------------------------------
     # Agent creation helper
     # ------------------------------------------------------------------
@@ -707,8 +863,10 @@ class APIServerAdapter(BasePlatformAdapter):
         session_id: Optional[str] = None,
         stream_delta_callback=None,
         tool_progress_callback=None,
+        model: Optional[str] = None,
+        runtime_kwargs_override: Optional[Dict[str, Any]] = None,
         tool_start_callback=None,
-        tool_complete_callback=None,
+        tool_complete_callback=None, (feat(api-server): expose active configured models)
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -719,11 +877,31 @@ class APIServerAdapter(BasePlatformAdapter):
         gateway platforms), falling back to the hermes-api-server default.
         """
         from run_agent import AIAgent
-        from gateway.run import _resolve_runtime_agent_kwargs, _resolve_gateway_model, _load_gateway_config
+        from gateway.run import GatewayRunner, _load_gateway_config
         from hermes_cli.tools_config import _get_platform_tools
 
-        runtime_kwargs = _resolve_runtime_agent_kwargs()
-        model = _resolve_gateway_model()
+        context = self._runtime_model_context()
+        runtime_kwargs = dict(context["runtime_kwargs"])
+        if runtime_kwargs_override:
+            runtime_kwargs.update(runtime_kwargs_override)
+
+        allowed_runtime_keys = {
+            "api_key",
+            "base_url",
+            "provider",
+            "api_mode",
+            "acp_command",
+            "acp_args",
+            "command",
+            "args",
+            "credential_pool",
+        }
+        runtime_kwargs = {
+            key: value
+            for key, value in runtime_kwargs.items()
+            if key in allowed_runtime_keys
+        }
+        resolved_model = model or context.get("default_model") or ""
 
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
@@ -732,11 +910,10 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Load fallback provider chain so the API server platform has the
         # same fallback behaviour as Telegram/Discord/Slack (fixes #4954).
-        from gateway.run import GatewayRunner
         fallback_model = GatewayRunner._load_fallback_model()
 
         agent = AIAgent(
-            model=model,
+            model=resolved_model,
             **runtime_kwargs,
             max_iterations=max_iterations,
             quiet_mode=True,
@@ -784,24 +961,23 @@ class APIServerAdapter(BasePlatformAdapter):
         })
 
     async def _handle_models(self, request: "web.Request") -> "web.Response":
-        """GET /v1/models — return hermes-agent as an available model."""
+        """GET /v1/models — return active requestable models plus hermes-agent alias."""
         auth_err = self._check_auth(request)
         if auth_err:
             return auth_err
 
+        model_cards = [self._model_card("hermes-agent", owned_by="hermes")]
+
+        for record in self._get_served_model_records():
+            model_id = str(record.get("public_model_id") or "").strip()
+            if not model_id or model_id == "hermes-agent":
+                continue
+            provider = str(record.get("provider") or "hermes").strip() or "hermes"
+            model_cards.append(self._model_card(model_id, owned_by=provider))
+
         return web.json_response({
             "object": "list",
-            "data": [
-                {
-                    "id": self._model_name,
-                    "object": "model",
-                    "created": int(time.time()),
-                    "owned_by": "hermes",
-                    "permission": [],
-                    "root": self._model_name,
-                    "parent": None,
-                }
-            ],
+            "data": model_cards, (feat(api-server): expose active configured models)
         })
 
     async def _handle_chat_completions(self, request: "web.Request") -> "web.Response":
@@ -860,6 +1036,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 status=400,
             )
 
+        try:
+            resolved_model = self._resolve_request_model(body.get("model", "hermes-agent"))
+        except ValueError as exc:
+            return web.json_response(
+                _openai_error(str(exc), param="model", code="model_not_found"),
+                status=400,
+            )
+
         # Allow caller to continue an existing session by passing X-Hermes-Session-Id.
         # When provided, history is loaded from state.db instead of from the request body.
         #
@@ -910,7 +1094,7 @@ class APIServerAdapter(BasePlatformAdapter):
             # history already set from request body above
 
         completion_id = f"chatcmpl-{uuid.uuid4().hex[:29]}"
-        model_name = body.get("model", self._model_name)
+        model_name = resolved_model["requested_model"] (feat(api-server): expose active configured models)
         created = int(time.time())
 
         if stream:
@@ -967,6 +1151,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 conversation_history=history,
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
+                agent_model=resolved_model["agent_model"],
+                agent_runtime_kwargs=resolved_model.get("agent_runtime_kwargs"),
                 stream_delta_callback=_on_delta,
                 tool_progress_callback=_on_tool_progress,
                 agent_ref=agent_ref,
@@ -984,6 +1170,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 conversation_history=history,
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
+                agent_model=resolved_model["agent_model"],
+                agent_runtime_kwargs=resolved_model.get("agent_runtime_kwargs"),
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -1685,6 +1873,14 @@ class APIServerAdapter(BasePlatformAdapter):
         if not _content_has_visible_payload(user_message):
             return web.json_response(_openai_error("No user message found in input"), status=400)
 
+        try:
+            resolved_model = self._resolve_request_model(body.get("model", "hermes-agent"))
+        except ValueError as exc:
+            return web.json_response(
+                _openai_error(str(exc), param="model", code="model_not_found"),
+                status=400,
+            )
+
         # Truncation support
         if body.get("truncation") == "auto" and len(conversation_history) > 100:
             conversation_history = conversation_history[-100:]
@@ -1773,6 +1969,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 conversation_history=conversation_history,
                 ephemeral_system_prompt=instructions,
                 session_id=session_id,
+                agent_model=resolved_model["agent_model"],
+                agent_runtime_kwargs=resolved_model.get("agent_runtime_kwargs"),
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -1825,7 +2023,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "object": "response",
             "status": "completed",
             "created_at": created_at,
-            "model": body.get("model", self._model_name),
+            "model": resolved_model["requested_model"], (feat(api-server): expose active configured models)
             "output": output_items,
             "usage": {
                 "input_tokens": usage.get("input_tokens", 0),
@@ -2164,6 +2362,7 @@ class APIServerAdapter(BasePlatformAdapter):
         conversation_history: List[Dict[str, str]],
         ephemeral_system_prompt: Optional[str] = None,
         session_id: Optional[str] = None,
+        agent_model: Optional[str] = None,
         stream_delta_callback=None,
         tool_progress_callback=None,
         tool_start_callback=None,
@@ -2187,6 +2386,7 @@ class APIServerAdapter(BasePlatformAdapter):
             agent = self._create_agent(
                 ephemeral_system_prompt=ephemeral_system_prompt,
                 session_id=session_id,
+                model=agent_model,
                 stream_delta_callback=stream_delta_callback,
                 tool_progress_callback=tool_progress_callback,
                 tool_start_callback=tool_start_callback,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -760,19 +760,18 @@ class APIServerAdapter(BasePlatformAdapter):
             }
 
         records: List[Dict[str, Any]] = []
-        default_model = str(active_context.get("default_model") or "").strip()
+        active_default_model = str(active_context.get("default_model") or "").strip()
         active_provider = str(active_context.get("provider") or "").strip()
         active_runtime_kwargs = dict(active_context.get("runtime_kwargs") or {})
-        if default_model and active_provider:
+        if active_default_model and active_provider:
             records.append(
                 {
-                    "public_model_id": f"{active_provider}/{default_model}",
+                    "public_model_id": f"{active_provider}/{active_default_model}",
                     "provider": active_provider,
-                    "agent_model": default_model,
+                    "agent_model": active_default_model,
                     "runtime_kwargs": active_runtime_kwargs,
                 }
             )
-
         try:
             from hermes_cli.models import fetch_api_models, provider_model_ids
             from hermes_cli.runtime_provider import resolve_runtime_provider
@@ -788,10 +787,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 if not model_ids:
                     model_ids = provider_model_ids(resolved_provider)
 
-                for model_id in model_ids:
-                    agent_model = str(model_id or "").strip()
-                    if not agent_model:
-                        continue
+                if resolved_provider == active_provider and active_default_model:
+                    model_ids.append(active_default_model)
+
+                for agent_model in self._dedupe_model_ids(model_ids):
                     records.append(
                         {
                             "public_model_id": f"{resolved_provider}/{agent_model}",
@@ -2363,6 +2362,7 @@ class APIServerAdapter(BasePlatformAdapter):
         ephemeral_system_prompt: Optional[str] = None,
         session_id: Optional[str] = None,
         agent_model: Optional[str] = None,
+        agent_runtime_kwargs: Optional[Dict[str, Any]] = None,
         stream_delta_callback=None,
         tool_progress_callback=None,
         tool_start_callback=None,
@@ -2387,6 +2387,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=ephemeral_system_prompt,
                 session_id=session_id,
                 model=agent_model,
+                runtime_kwargs_override=agent_runtime_kwargs,
                 stream_delta_callback=stream_delta_callback,
                 tool_progress_callback=tool_progress_callback,
                 tool_start_callback=tool_start_callback,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -709,6 +709,18 @@ class APIServerAdapter(BasePlatformAdapter):
         }
 
     @staticmethod
+    def _dedupe_model_ids(model_ids: List[str]) -> List[str]:
+        seen: set[str] = set()
+        ordered: List[str] = []
+        for model_id in model_ids:
+            normalized = str(model_id or "").strip()
+            if not normalized or normalized in seen:
+                continue
+            seen.add(normalized)
+            ordered.append(normalized)
+        return ordered
+
+    @staticmethod
     def _dedupe_model_records(records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         seen: set[str] = set()
         ordered: List[Dict[str, Any]] = []
@@ -777,28 +789,43 @@ class APIServerAdapter(BasePlatformAdapter):
             from hermes_cli.runtime_provider import resolve_runtime_provider
 
             for provider_id in self._configured_provider_ids():
-                runtime_kwargs = resolve_runtime_provider(requested=provider_id)
-                resolved_provider = str(runtime_kwargs.get("provider") or provider_id or "").strip()
+                try:
+                    runtime_kwargs = resolve_runtime_provider(requested=provider_id)
+                    resolved_provider = str(runtime_kwargs.get("provider") or provider_id or "").strip()
 
-                model_ids = fetch_api_models(
-                    runtime_kwargs.get("api_key"),
-                    runtime_kwargs.get("base_url"),
-                ) or []
-                if not model_ids:
-                    model_ids = provider_model_ids(resolved_provider)
-
-                if resolved_provider == active_provider and active_default_model:
-                    model_ids.append(active_default_model)
-
-                for agent_model in self._dedupe_model_ids(model_ids):
-                    records.append(
-                        {
-                            "public_model_id": f"{resolved_provider}/{agent_model}",
-                            "provider": resolved_provider,
-                            "agent_model": agent_model,
-                            "runtime_kwargs": dict(runtime_kwargs),
-                        }
+                    model_ids = fetch_api_models(
+                        runtime_kwargs.get("api_key"),
+                        runtime_kwargs.get("base_url"),
                     )
+                    if model_ids is None:
+                        logger.debug(
+                            "Skipping provider %s in /v1/models because live model discovery failed",
+                            resolved_provider or provider_id,
+                        )
+                        continue
+
+                    if not model_ids:
+                        model_ids = provider_model_ids(resolved_provider)
+
+                    if resolved_provider == active_provider and active_default_model:
+                        model_ids.append(active_default_model)
+
+                    for agent_model in self._dedupe_model_ids(model_ids):
+                        records.append(
+                            {
+                                "public_model_id": f"{resolved_provider}/{agent_model}",
+                                "provider": resolved_provider,
+                                "agent_model": agent_model,
+                                "runtime_kwargs": dict(runtime_kwargs),
+                            }
+                        )
+                except Exception as exc:
+                    logger.debug(
+                        "Skipping provider %s in /v1/models due to discovery error: %s",
+                        provider_id,
+                        exc,
+                    )
+                    continue
         except Exception as exc:
             logger.debug("Could not discover served model records for /v1/models: %s", exc)
 

--- a/spec-api-server-active-models.md
+++ b/spec-api-server-active-models.md
@@ -1,0 +1,36 @@
+# Build active configured model discovery for the Hermes OpenAI-compatible API.
+
+Read and follow `AGENTS.md` plus the existing API-server tests/docs before changing code.
+
+Use strict TDD for implementation work.
+
+The OpenAI-standard discovery endpoint is `GET /v1/models` (not `/model`). Implement the feature around that standard path. A non-standard `/models` alias is optional and should only be added if it stays clearly backward-compatible and low-risk.
+
+Implement this feature conservatively on the current branch.
+
+## Goal
+Make Hermes expose the real active/configured models it can currently serve through the OpenAI-compatible API, instead of advertising only the synthetic `hermes-agent` alias.
+
+## Requirements
+- `GET /v1/models` must return an OpenAI-style model list.
+- The response must include the currently active/configured provider models Hermes can actually route to now.
+- Keep backward compatibility by retaining the `hermes-agent` alias unless there is a strong reason to remove it.
+- Prefer existing provider/model discovery and switching helpers over duplicating routing logic.
+- `POST /v1/chat/completions` and `POST /v1/responses` must accept a requested model from that exposed list and route Hermes accordingly.
+- Unknown, inactive, or unsupported requested models must fail clearly with an OpenAI-style error.
+- Preserve current auth, health, streaming, and response-store behavior.
+- Update gateway tests and API-server docs to match the new behavior.
+
+## Likely files
+- `gateway/platforms/api_server.py`
+- `gateway/run.py`
+- `hermes_cli/models.py`
+- `hermes_cli/model_switch.py`
+- `tests/gateway/test_api_server.py`
+- `website/docs/user-guide/features/api-server.md`
+
+## Constraints
+- Keep the diff narrow and auditable.
+- Do not break existing clients that still send `model: "hermes-agent"`.
+- Do not advertise models Hermes cannot actually route with the current config/auth state.
+- Reuse shared runtime/provider resolution paths wherever possible.

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -463,7 +463,7 @@ class TestModelsEndpoint:
         runtime_kwargs = {
             "provider": "copilot",
             "base_url": "https://api.githubcopilot.com",
-            "api_key": "sk-test",
+            "api_key": "***",
             "api_mode": "codex_responses",
         }
 
@@ -487,6 +487,45 @@ class TestModelsEndpoint:
             "agent_model": "gpt-5.4",
             "agent_runtime_kwargs": runtime_kwargs,
         }
+
+    def test_create_agent_ignores_non_aiagent_runtime_kwargs(self, adapter):
+        runtime_kwargs = {
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+            "api_mode": "chat_completions",
+            "source": "api_server",
+            "session_source": {"platform": "api_server"},
+            "requested_model": "openrouter/google/gemma-4-26b-a4b-it",
+        }
+
+        with patch("run_agent.AIAgent") as mock_aiagent, patch(
+            "gateway.run._load_gateway_config",
+            return_value={},
+        ), patch(
+            "hermes_cli.tools_config._get_platform_tools",
+            return_value=set(),
+        ), patch.object(
+            adapter,
+            "_runtime_model_context",
+            return_value={
+                "runtime_kwargs": {"provider": "copilot", "api_key": "***"},
+                "default_model": "gpt-5.4",
+            },
+        ):
+            adapter._create_agent(
+                model="google/gemma-4-26b-a4b-it",
+                runtime_kwargs_override=runtime_kwargs,
+            )
+
+        kwargs = mock_aiagent.call_args.kwargs
+        assert kwargs["model"] == "google/gemma-4-26b-a4b-it"
+        assert kwargs["provider"] == "openrouter"
+        assert kwargs["base_url"] == "https://openrouter.ai/api/v1"
+        assert kwargs["api_mode"] == "chat_completions"
+        assert "source" not in kwargs
+        assert "session_source" not in kwargs
+        assert "requested_model" not in kwargs
 
     @pytest.mark.asyncio
     async def test_models_returns_profile_name(self):

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -428,16 +428,23 @@ class TestHealthDetailedEndpoint:
 
 class TestModelsEndpoint:
     @pytest.mark.asyncio
-    async def test_models_returns_hermes_agent(self, adapter):
+    async def test_models_returns_active_models_plus_hermes_alias(self, adapter):
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            resp = await cli.get("/v1/models")
+            with patch.object(
+                adapter,
+                "_get_served_model_ids",
+                return_value=["gpt-5.4", "gpt-4.1"],
+                create=True,
+            ):
+                resp = await cli.get("/v1/models")
             assert resp.status == 200
             data = await resp.json()
             assert data["object"] == "list"
-            assert len(data["data"]) == 1
-            assert data["data"][0]["id"] == "hermes-agent"
-            assert data["data"][0]["owned_by"] == "hermes"
+            model_ids = [item["id"] for item in data["data"]]
+            assert "hermes-agent" in model_ids
+            assert "gpt-5.4" in model_ids
+            assert "gpt-4.1" in model_ids
 
     @pytest.mark.asyncio
     async def test_models_returns_profile_name(self):
@@ -546,7 +553,7 @@ class TestChatCompletionsEndpoint:
                 resp = await cli.post(
                     "/v1/chat/completions",
                     json={
-                        "model": "test",
+                        "model": "hermes-agent",
                         "messages": [{"role": "user", "content": "hi"}],
                         "stream": True,
                     },
@@ -631,7 +638,7 @@ class TestChatCompletionsEndpoint:
                 resp = await cli.post(
                     "/v1/chat/completions",
                     json={
-                        "model": "test",
+                        "model": "hermes-agent",
                         "messages": [{"role": "user", "content": "What is the answer?"}],
                         "stream": True,
                     },
@@ -670,7 +677,7 @@ class TestChatCompletionsEndpoint:
                 resp = await cli.post(
                     "/v1/chat/completions",
                     json={
-                        "model": "test",
+                        "model": "hermes-agent",
                         "messages": [{"role": "user", "content": "list files"}],
                         "stream": True,
                     },
@@ -726,7 +733,7 @@ class TestChatCompletionsEndpoint:
                 resp = await cli.post(
                     "/v1/chat/completions",
                     json={
-                        "model": "test",
+                        "model": "hermes-agent",
                         "messages": [{"role": "user", "content": "search"}],
                         "stream": True,
                     },
@@ -784,6 +791,61 @@ class TestChatCompletionsEndpoint:
             assert data["choices"][0]["message"]["content"] == "Hello! How can I help you today?"
             assert data["choices"][0]["finish_reason"] == "stop"
             assert "usage" in data
+
+    @pytest.mark.asyncio
+    async def test_chat_completion_accepts_exposed_real_model_and_routes_it(self, adapter):
+        mock_result = {
+            "final_response": "Hello from routed model",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                adapter,
+                "_resolve_request_model",
+                return_value={"requested_model": "copilot/gpt-5.4", "agent_model": "gpt-5.4"},
+                create=True,
+            ) as mock_resolve, patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "copilot/gpt-5.4",
+                        "messages": [{"role": "user", "content": "Hello"}],
+                    },
+                )
+
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["model"] == "copilot/gpt-5.4"
+            assert mock_resolve.call_args.args[0] == "copilot/gpt-5.4"
+            assert mock_run.call_args.kwargs["agent_model"] == "gpt-5.4"
+
+    @pytest.mark.asyncio
+    async def test_chat_completion_rejects_unknown_model_with_openai_error(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                adapter,
+                "_resolve_request_model",
+                side_effect=ValueError("Model 'bad-model' is not available on this Hermes API server."),
+                create=True,
+            ):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "bad-model",
+                        "messages": [{"role": "user", "content": "Hello"}],
+                    },
+                )
+
+            assert resp.status == 400
+            data = await resp.json()
+            assert data["error"]["type"] == "invalid_request_error"
+            assert data["error"]["param"] == "model"
+            assert "not available" in data["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_system_prompt_extracted(self, adapter):
@@ -1011,6 +1073,61 @@ class TestResponsesEndpoint:
             assert data["output"][0]["type"] == "message"
             assert data["output"][0]["content"][0]["type"] == "output_text"
             assert data["output"][0]["content"][0]["text"] == "Paris is the capital of France."
+
+    @pytest.mark.asyncio
+    async def test_responses_accepts_exposed_real_model_and_routes_it(self, adapter):
+        mock_result = {
+            "final_response": "Routed via responses model",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                adapter,
+                "_resolve_request_model",
+                return_value={"requested_model": "copilot/gpt-5.4", "agent_model": "gpt-5.4"},
+                create=True,
+            ) as mock_resolve, patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "copilot/gpt-5.4",
+                        "input": "Hello",
+                    },
+                )
+
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["model"] == "copilot/gpt-5.4"
+            assert mock_resolve.call_args.args[0] == "copilot/gpt-5.4"
+            assert mock_run.call_args.kwargs["agent_model"] == "gpt-5.4"
+
+    @pytest.mark.asyncio
+    async def test_responses_rejects_unknown_model_with_openai_error(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                adapter,
+                "_resolve_request_model",
+                side_effect=ValueError("Model 'bad-model' is not available on this Hermes API server."),
+                create=True,
+            ):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "bad-model",
+                        "input": "Hello",
+                    },
+                )
+
+            assert resp.status == 400
+            data = await resp.json()
+            assert data["error"]["type"] == "invalid_request_error"
+            assert data["error"]["param"] == "model"
+            assert "not available" in data["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_successful_response_with_array_input(self, adapter):

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -527,6 +527,54 @@ class TestModelsEndpoint:
         assert "session_source" not in kwargs
         assert "requested_model" not in kwargs
 
+    def test_resolve_request_model_defaults_none_to_hermes_agent(self, adapter):
+        runtime_kwargs = {
+            "provider": "copilot",
+            "base_url": "https://api.githubcopilot.com",
+            "api_key": "***",
+            "api_mode": "codex_responses",
+        }
+
+        with patch.object(
+            adapter,
+            "_runtime_model_context",
+            return_value={
+                "runtime_kwargs": runtime_kwargs,
+                "default_model": "gpt-5.4",
+            },
+        ):
+            resolved = adapter._resolve_request_model(None)
+
+        assert resolved == {
+            "requested_model": "hermes-agent",
+            "agent_model": "gpt-5.4",
+            "agent_runtime_kwargs": runtime_kwargs,
+        }
+
+    def test_resolve_request_model_defaults_blank_to_hermes_agent(self, adapter):
+        runtime_kwargs = {
+            "provider": "copilot",
+            "base_url": "https://api.githubcopilot.com",
+            "api_key": "***",
+            "api_mode": "codex_responses",
+        }
+
+        with patch.object(
+            adapter,
+            "_runtime_model_context",
+            return_value={
+                "runtime_kwargs": runtime_kwargs,
+                "default_model": "gpt-5.4",
+            },
+        ):
+            resolved = adapter._resolve_request_model("   ")
+
+        assert resolved == {
+            "requested_model": "hermes-agent",
+            "agent_model": "gpt-5.4",
+            "agent_runtime_kwargs": runtime_kwargs,
+        }
+
     @pytest.mark.asyncio
     async def test_models_returns_profile_name(self):
         """When running under a named profile, /v1/models advertises the profile name."""
@@ -916,6 +964,47 @@ class TestChatCompletionsEndpoint:
             assert mock_run.call_args.kwargs["agent_runtime_kwargs"] == runtime_kwargs
 
     @pytest.mark.asyncio
+    async def test_chat_completion_without_model_defaults_to_hermes_agent(self, adapter):
+        mock_result = {
+            "final_response": "Hello from default model",
+            "messages": [],
+            "api_calls": 1,
+        }
+        runtime_kwargs = {
+            "provider": "copilot",
+            "base_url": "https://api.githubcopilot.com",
+            "api_key": "***",
+            "api_mode": "codex_responses",
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                adapter,
+                "_resolve_request_model",
+                return_value={
+                    "requested_model": "hermes-agent",
+                    "agent_model": "gpt-5.4",
+                    "agent_runtime_kwargs": runtime_kwargs,
+                },
+                create=True,
+            ) as mock_resolve, patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "messages": [{"role": "user", "content": "Hello"}],
+                    },
+                )
+
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["model"] == "hermes-agent"
+            assert mock_resolve.call_args.args[0] == "hermes-agent"
+            assert mock_run.call_args.kwargs["agent_model"] == "gpt-5.4"
+            assert mock_run.call_args.kwargs["agent_runtime_kwargs"] == runtime_kwargs
+
+    @pytest.mark.asyncio
     async def test_chat_completion_rejects_unknown_model_with_openai_error(self, adapter):
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
@@ -1205,6 +1294,47 @@ class TestResponsesEndpoint:
             data = await resp.json()
             assert data["model"] == "copilot/gpt-5.4"
             assert mock_resolve.call_args.args[0] == "copilot/gpt-5.4"
+            assert mock_run.call_args.kwargs["agent_model"] == "gpt-5.4"
+            assert mock_run.call_args.kwargs["agent_runtime_kwargs"] == runtime_kwargs
+
+    @pytest.mark.asyncio
+    async def test_responses_without_model_defaults_to_hermes_agent(self, adapter):
+        mock_result = {
+            "final_response": "Default responses model",
+            "messages": [],
+            "api_calls": 1,
+        }
+        runtime_kwargs = {
+            "provider": "copilot",
+            "base_url": "https://api.githubcopilot.com",
+            "api_key": "***",
+            "api_mode": "codex_responses",
+        }
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(
+                adapter,
+                "_resolve_request_model",
+                return_value={
+                    "requested_model": "hermes-agent",
+                    "agent_model": "gpt-5.4",
+                    "agent_runtime_kwargs": runtime_kwargs,
+                },
+                create=True,
+            ) as mock_resolve, patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "input": "Hello",
+                    },
+                )
+
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["model"] == "hermes-agent"
+            assert mock_resolve.call_args.args[0] == "hermes-agent"
             assert mock_run.call_args.kwargs["agent_model"] == "gpt-5.4"
             assert mock_run.call_args.kwargs["agent_runtime_kwargs"] == runtime_kwargs
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -428,13 +428,26 @@ class TestHealthDetailedEndpoint:
 
 class TestModelsEndpoint:
     @pytest.mark.asyncio
-    async def test_models_returns_active_models_plus_hermes_alias(self, adapter):
+    async def test_models_returns_provider_qualified_models_for_configured_providers(self, adapter):
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
             with patch.object(
                 adapter,
-                "_get_served_model_ids",
-                return_value=["gpt-5.4", "gpt-4.1"],
+                "_get_served_model_records",
+                return_value=[
+                    {
+                        "public_model_id": "copilot/gpt-5.4",
+                        "provider": "copilot",
+                        "agent_model": "gpt-5.4",
+                        "runtime_kwargs": {"provider": "copilot"},
+                    },
+                    {
+                        "public_model_id": "anthropic/claude-sonnet-4-5-20250929",
+                        "provider": "anthropic",
+                        "agent_model": "claude-sonnet-4-5-20250929",
+                        "runtime_kwargs": {"provider": "anthropic"},
+                    },
+                ],
                 create=True,
             ):
                 resp = await cli.get("/v1/models")
@@ -443,8 +456,37 @@ class TestModelsEndpoint:
             assert data["object"] == "list"
             model_ids = [item["id"] for item in data["data"]]
             assert "hermes-agent" in model_ids
-            assert "gpt-5.4" in model_ids
-            assert "gpt-4.1" in model_ids
+            assert "copilot/gpt-5.4" in model_ids
+            assert "anthropic/claude-sonnet-4-5-20250929" in model_ids
+
+    def test_resolve_request_model_returns_runtime_for_provider_qualified_model(self, adapter):
+        runtime_kwargs = {
+            "provider": "copilot",
+            "base_url": "https://api.githubcopilot.com",
+            "api_key": "sk-test",
+            "api_mode": "codex_responses",
+        }
+
+        with patch.object(
+            adapter,
+            "_get_served_model_records",
+            return_value=[
+                {
+                    "public_model_id": "copilot/gpt-5.4",
+                    "provider": "copilot",
+                    "agent_model": "gpt-5.4",
+                    "runtime_kwargs": runtime_kwargs,
+                }
+            ],
+            create=True,
+        ):
+            resolved = adapter._resolve_request_model("copilot/gpt-5.4")
+
+        assert resolved == {
+            "requested_model": "copilot/gpt-5.4",
+            "agent_model": "gpt-5.4",
+            "agent_runtime_kwargs": runtime_kwargs,
+        }
 
     @pytest.mark.asyncio
     async def test_models_returns_profile_name(self):
@@ -799,13 +841,23 @@ class TestChatCompletionsEndpoint:
             "messages": [],
             "api_calls": 1,
         }
+        runtime_kwargs = {
+            "provider": "copilot",
+            "base_url": "https://api.githubcopilot.com",
+            "api_key": "sk-test",
+            "api_mode": "codex_responses",
+        }
 
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
             with patch.object(
                 adapter,
                 "_resolve_request_model",
-                return_value={"requested_model": "copilot/gpt-5.4", "agent_model": "gpt-5.4"},
+                return_value={
+                    "requested_model": "copilot/gpt-5.4",
+                    "agent_model": "gpt-5.4",
+                    "agent_runtime_kwargs": runtime_kwargs,
+                },
                 create=True,
             ) as mock_resolve, patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
                 mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
@@ -822,6 +874,7 @@ class TestChatCompletionsEndpoint:
             assert data["model"] == "copilot/gpt-5.4"
             assert mock_resolve.call_args.args[0] == "copilot/gpt-5.4"
             assert mock_run.call_args.kwargs["agent_model"] == "gpt-5.4"
+            assert mock_run.call_args.kwargs["agent_runtime_kwargs"] == runtime_kwargs
 
     @pytest.mark.asyncio
     async def test_chat_completion_rejects_unknown_model_with_openai_error(self, adapter):
@@ -1081,13 +1134,23 @@ class TestResponsesEndpoint:
             "messages": [],
             "api_calls": 1,
         }
+        runtime_kwargs = {
+            "provider": "copilot",
+            "base_url": "https://api.githubcopilot.com",
+            "api_key": "sk-test",
+            "api_mode": "codex_responses",
+        }
 
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
             with patch.object(
                 adapter,
                 "_resolve_request_model",
-                return_value={"requested_model": "copilot/gpt-5.4", "agent_model": "gpt-5.4"},
+                return_value={
+                    "requested_model": "copilot/gpt-5.4",
+                    "agent_model": "gpt-5.4",
+                    "agent_runtime_kwargs": runtime_kwargs,
+                },
                 create=True,
             ) as mock_resolve, patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
                 mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
@@ -1104,6 +1167,7 @@ class TestResponsesEndpoint:
             assert data["model"] == "copilot/gpt-5.4"
             assert mock_resolve.call_args.args[0] == "copilot/gpt-5.4"
             assert mock_run.call_args.kwargs["agent_model"] == "gpt-5.4"
+            assert mock_run.call_args.kwargs["agent_runtime_kwargs"] == runtime_kwargs
 
     @pytest.mark.asyncio
     async def test_responses_rejects_unknown_model_with_openai_error(self, adapter):

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -459,6 +459,127 @@ class TestModelsEndpoint:
             assert "copilot/gpt-5.4" in model_ids
             assert "anthropic/claude-sonnet-4-5-20250929" in model_ids
 
+    def test_get_served_model_records_excludes_non_configured_providers(self, adapter):
+        with patch.object(
+            adapter,
+            "_configured_provider_ids",
+            return_value=["copilot"],
+        ), patch.object(
+            adapter,
+            "_runtime_model_context",
+            return_value={
+                "provider": "copilot",
+                "default_model": "gpt-5.4",
+                "runtime_kwargs": {"provider": "copilot", "api_key": "copilot-key", "base_url": "https://api.githubcopilot.com"},
+            },
+        ), patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=lambda requested: {
+                "provider": requested,
+                "api_key": f"{requested}-key",
+                "base_url": f"https://{requested}.example.com/v1",
+            },
+        ), patch(
+            "hermes_cli.models.fetch_api_models",
+            side_effect=lambda api_key, base_url: ["gpt-5.4"] if api_key == "copilot-key" else ["should-not-appear"],
+        ), patch(
+            "hermes_cli.models.provider_model_ids",
+            side_effect=lambda provider: ["fallback-model"],
+        ):
+            records = adapter._get_served_model_records()
+
+        public_model_ids = [record["public_model_id"] for record in records]
+        assert "copilot/gpt-5.4" in public_model_ids
+        assert all(not model_id.startswith("anthropic/") for model_id in public_model_ids)
+        assert all(not model_id.startswith("openrouter/") for model_id in public_model_ids)
+
+    def test_get_served_model_records_skips_provider_when_live_model_fetch_returns_4xx_or_5xx(self, adapter):
+        with patch.object(
+            adapter,
+            "_configured_provider_ids",
+            return_value=["copilot", "anthropic"],
+        ), patch.object(
+            adapter,
+            "_runtime_model_context",
+            return_value={
+                "provider": "copilot",
+                "default_model": "gpt-5.4",
+                "runtime_kwargs": {"provider": "copilot", "api_key": "copilot-key", "base_url": "https://api.githubcopilot.com"},
+            },
+        ), patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=lambda requested: {
+                "provider": requested,
+                "api_key": f"{requested}-key",
+                "base_url": f"https://{requested}.example.com/v1",
+            },
+        ), patch(
+            "hermes_cli.models.fetch_api_models",
+            side_effect=lambda api_key, base_url: ["gpt-5.4"] if api_key == "copilot-key" else None,
+        ), patch(
+            "hermes_cli.models.provider_model_ids",
+            side_effect=lambda provider: ["claude-sonnet-4-5-20250929"] if provider == "anthropic" else [],
+        ):
+            records = adapter._get_served_model_records()
+
+        public_model_ids = [record["public_model_id"] for record in records]
+        assert "copilot/gpt-5.4" in public_model_ids
+        assert "anthropic/claude-sonnet-4-5-20250929" not in public_model_ids
+
+    def test_get_served_model_records_continues_when_one_provider_resolution_raises(self, adapter):
+        with patch.object(
+            adapter,
+            "_configured_provider_ids",
+            return_value=["copilot", "anthropic", "openrouter"],
+        ), patch.object(
+            adapter,
+            "_runtime_model_context",
+            return_value={
+                "provider": "copilot",
+                "default_model": "gpt-5.4",
+                "runtime_kwargs": {"provider": "copilot", "api_key": "copilot-key", "base_url": "https://api.githubcopilot.com"},
+            },
+        ), patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=lambda requested: (
+                {"provider": requested, "api_key": f"{requested}-key", "base_url": f"https://{requested}.example.com/v1"}
+                if requested != "anthropic"
+                else (_ for _ in ()).throw(RuntimeError("expired auth"))
+            ),
+        ), patch(
+            "hermes_cli.models.fetch_api_models",
+            side_effect=lambda api_key, base_url: {
+                "copilot-key": ["gpt-5.4"],
+                "openrouter-key": ["google/gemma-4-26b-a4b-it"],
+            }.get(api_key, None),
+        ), patch(
+            "hermes_cli.models.provider_model_ids",
+            return_value=[],
+        ):
+            records = adapter._get_served_model_records()
+
+        public_model_ids = [record["public_model_id"] for record in records]
+        assert "copilot/gpt-5.4" in public_model_ids
+        assert "openrouter/google/gemma-4-26b-a4b-it" in public_model_ids
+        assert all(not model_id.startswith("anthropic/") for model_id in public_model_ids)
+
+    def test_resolve_request_model_rejects_inactive_provider_model_from_unserved_catalog(self, adapter):
+        with patch.object(
+            adapter,
+            "_get_served_model_records",
+            return_value=[
+                {
+                    "public_model_id": "copilot/gpt-5.4",
+                    "provider": "copilot",
+                    "agent_model": "gpt-5.4",
+                    "runtime_kwargs": {"provider": "copilot"},
+                }
+            ],
+            create=True,
+        ):
+            with pytest.raises(ValueError, match="Unknown or inactive model 'anthropic/claude-sonnet-4-5-20250929'"):
+                adapter._resolve_request_model("anthropic/claude-sonnet-4-5-20250929")
+
     def test_resolve_request_model_returns_runtime_for_provider_qualified_model(self, adapter):
         runtime_kwargs = {
             "provider": "copilot",

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -192,7 +192,7 @@ Delete a stored response.
 
 ### GET /v1/models
 
-Returns an OpenAI-style model list containing the real models Hermes can currently route to with the active provider/runtime config, plus the backward-compatible `hermes-agent` alias. Most frontends call this for model discovery.
+Returns an OpenAI-style model list containing provider-qualified model IDs for the configured/usable Hermes providers, plus the backward-compatible `hermes-agent` alias. Most frontends call this for model discovery. For example, Hermes may expose IDs like `copilot/gpt-5.4` or `anthropic/claude-sonnet-4-5-20250929` so request-time routing stays deterministic across providers.
 
 ### GET /health
 
@@ -369,7 +369,7 @@ In Open WebUI, add each as a separate connection. The model dropdown shows `alic
 
 - **Response storage** — stored responses (for `previous_response_id`) are persisted in SQLite and survive gateway restarts. Max 100 stored responses (LRU eviction).
 - **No file upload** — inline images are supported on both `/v1/chat/completions` and `/v1/responses`, but uploaded files (`file`, `input_file`, `file_id`) and non-image document inputs are not supported through the API.
-- **Request-time model selection is validated** — clients may request `hermes-agent` or any model returned by `GET /v1/models`. Unknown or inactive models are rejected with an OpenAI-style error. Hermes still only advertises models it can route with the current runtime/provider configuration.
+- **Request-time model selection is validated** — clients may request `hermes-agent` or any provider-qualified model returned by `GET /v1/models`. Unknown or inactive models are rejected with an OpenAI-style error. Hermes only advertises models it can currently route for configured/usable providers, and the provider prefix determines which runtime credentials/base URL are used for the request.
 
 ## Proxy Mode
 

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -192,7 +192,7 @@ Delete a stored response.
 
 ### GET /v1/models
 
-Lists the agent as an available model. The advertised model name defaults to the [profile](/docs/user-guide/profiles) name (or `hermes-agent` for the default profile). Required by most frontends for model discovery.
+Returns an OpenAI-style model list containing the real models Hermes can currently route to with the active provider/runtime config, plus the backward-compatible `hermes-agent` alias. Most frontends call this for model discovery.
 
 ### GET /health
 
@@ -369,7 +369,7 @@ In Open WebUI, add each as a separate connection. The model dropdown shows `alic
 
 - **Response storage** — stored responses (for `previous_response_id`) are persisted in SQLite and survive gateway restarts. Max 100 stored responses (LRU eviction).
 - **No file upload** — inline images are supported on both `/v1/chat/completions` and `/v1/responses`, but uploaded files (`file`, `input_file`, `file_id`) and non-image document inputs are not supported through the API.
-- **Model field is cosmetic** — the `model` field in requests is accepted but the actual LLM model used is configured server-side in config.yaml.
+- **Request-time model selection is validated** — clients may request `hermes-agent` or any model returned by `GET /v1/models`. Unknown or inactive models are rejected with an OpenAI-style error. Hermes still only advertises models it can route with the current runtime/provider configuration.
 
 ## Proxy Mode
 


### PR DESCRIPTION
## Summary

- narrow `/v1/models` to the explicit Hermes-served set instead of enumerating upstream provider catalogs
- expose the stable `hermes-agent` alias, the current primary configured model, the configured fallback chain, and explicitly pinned auxiliary task models only
- exclude any auto-resolved auxiliary paths so providers with very large catalogs (OpenRouter, Nous Portal, Hugging Face) do not expand back into 100+ models
- keep the API response bounded and deterministic while still surfacing lightweight request targets for secondary consumers

## Motivation

My main practical use case is not to dump every model a provider account can access.

The goal is to let OpenAI-compatible clients and Hermes subsystems discover a small, intentional served-model set so they can choose a lighter model than the main default when appropriate.

A concrete example is memory-provider flows that need to request an LLM through the OpenAI-compatible API surface. In that case I want Hermes to expose a lightweight model as a valid request target instead of forcing those consumers onto the main, heavier default model.

That means `/v1/models` should answer:

- what can this Hermes endpoint actually serve right now?

Not:

- what does the upstream provider account theoretically expose?

For large aggregators like OpenRouter, Nous Portal, and Hugging Face, enumerating the full upstream catalog produces 100+ entries and does not match the actual bounded set Hermes is configured to use.

## Scope / Semantics

`GET /v1/models` now represents the explicit Hermes-served model set for the main API surface:

- `hermes-agent`
- the current primary configured model
- any explicitly configured fallback entries (`fallback_model` or `fallback_providers`)
- any explicitly pinned auxiliary task models

Auxiliary task models are only exposed when they are concretely pinned and bounded, for example:

- `auxiliary.web_extract.provider = huggingface`
- `auxiliary.web_extract.model = Qwen/Qwen3.5-397B-A17B`

or:

- `compression.summary_provider = openrouter`
- `compression.summary_model = google/gemini-3-flash-preview`

This intentionally excludes:

- full upstream provider catalogs
- any auxiliary task configured with `provider: auto`
- any auxiliary task without an explicit non-empty model
- auto-detection chains for auxiliary routing

## Changes

- add bounded served-model helpers in `gateway/platforms/api_server.py`
- read the current primary model from gateway config/runtime
- include the configured fallback chain in served model discovery
- include explicitly pinned auxiliary task models in served model discovery
- support both:
  - legacy `fallback_model`
  - ordered `fallback_providers`
- support explicitly pinned auxiliary/config-driven task models from:
  - `auxiliary.*`
  - `compression.summary_provider` / `compression.summary_model`
- de-duplicate repeated or overlapping primary/fallback/auxiliary entries
- ignore invalid fallback entries missing provider/model
- ignore auxiliary entries that are `auto` or unpinned
- keep `hermes-agent` as the backward-compatible alias/root entry
- stop treating `/v1/models` as a live upstream provider catalog dump
- add API-server regression coverage for:
  - primary model exposure
  - fallback-chain exposure
  - legacy single fallback support
  - auxiliary pinned model exposure
  - exclusion of auxiliary auto/unpinned entries
  - deduping and invalid-entry filtering

## Why this shape

This keeps `/v1/models` aligned with actual runtime behavior:

- small and reviewable
- deterministic
- frontend-friendly
- truthful about what Hermes may route to
- useful for selecting a lighter served model for secondary consumers like memory-provider LLM requests

It also gives Hermes a way to expose intentionally configured lightweight auxiliary models without reintroducing the giant upstream-catalog problem.

## Test Plan

- [x] Added failing tests first for bounded `/v1/models` behavior
- [x] Verified the new tests failed before implementation
- [x] Implemented the minimal API-server change to satisfy those tests
- [x] Targeted models-endpoint tests pass
  - `pytest tests/gateway/test_api_server.py -q -k 'TestModelsEndpoint'`
- [x] Full API-server test file passes
  - `pytest tests/gateway/test_api_server.py -q`

## Example

Given config like:

```yaml
model:
  provider: openrouter
  default: qwen/qwen3.6-plus-preview:free

fallback_providers:
  - provider: nous
    model: anthropic/claude-sonnet-4.6

auxiliary:
  web_extract:
    provider: huggingface
    model: Qwen/Qwen3.5-397B-A17B

compression:
  summary_provider: openrouter
  summary_model: google/gemini-3-flash-preview
```

`/v1/models` returns a bounded set like:

- `hermes-agent`
- `openrouter/qwen/qwen3.6-plus-preview:free`
- `nous/anthropic/claude-sonnet-4.6`
- `huggingface/Qwen/Qwen3.5-397B-A17B`
- `openrouter/google/gemini-3-flash-preview`

If an auxiliary task is configured with `provider: auto`, it is intentionally not exposed by `/v1/models`.

## Notes for Reviewers

- this narrows the earlier broader approach that aggregated live provider catalogs
- the point is to expose the models Hermes is intentionally configured to serve, not every model the upstream account can access
- this is especially useful when a client or subsystem wants to explicitly choose a lightweight served model instead of the main default
- auxiliary task models are included only when they are explicitly pinned; `auto` auxiliary routing remains internal and is intentionally excluded
