### PR TITLE
test: avoid brittle camofox config version pin

### DIFF
--- a/tests/tools/test_browser_camofox_state.py
+++ b/tests/tools/test_browser_camofox_state.py
@@ -59,8 +59,10 @@ class TestCamofoxConfigDefaults:
         browser_cfg = DEFAULT_CONFIG["browser"]
         assert browser_cfg["camofox"]["managed_persistence"] is False
 
-    def test_config_version_unchanged(self):
-        from hermes_cli.config import DEFAULT_CONFIG
+    def test_config_version_covers_declared_migrations(self):
+        from hermes_cli.config import DEFAULT_CONFIG, ENV_VARS_BY_VERSION
 
-        # managed_persistence is auto-merged by _deep_merge, no version bump needed
-        assert DEFAULT_CONFIG["_config_version"] == 11
+        # managed_persistence is auto-merged by _deep_merge, so this feature
+        # should not require its own version bump. Guard only that the current
+        # config version still covers all declared migrations.
+        assert DEFAULT_CONFIG["_config_version"] >= max(ENV_VARS_BY_VERSION)


### PR DESCRIPTION
## Summary
- replace the exact `_config_version == 11` assertion in the Camofox state test
- keep the intended regression guard without tying the test to unrelated future config migrations

## Root cause
`tests/tools/test_browser_camofox_state.py` hardcoded `_config_version == 11` to assert that adding the Camofox `managed_persistence` toggle did not require a config version bump.

That became stale once `_config_version` was legitimately bumped to 12 for an unrelated config migration. The current failure is not a Camofox regression; it is a brittle exact-version assertion.

## What changed
- switch the test to assert that the current config version still covers all declared migration/env-var versions via `ENV_VARS_BY_VERSION`
- keep the comment explaining that `managed_persistence` itself is deep-merged and should not require its own version bump

## Test plan
- `python3 -m pytest tests/tools/test_browser_camofox_state.py -q`
- `python3 -m pytest tests/gateway/test_whatsapp_reply_prefix.py -q`
