### PR TITLE
fix: let gateway model resolution fall back to env

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -407,19 +407,22 @@ def _load_gateway_config() -> dict:
 
 
 def _resolve_gateway_model(config: dict | None = None) -> str:
-    """Read model from config.yaml — single source of truth.
+    """Resolve the gateway model from config.yaml, then env fallback.
 
-    Without this, temporary AIAgent instances (memory flush, /compress) fall
-    back to the hardcoded default which fails when the active provider is
-    openai-codex.
+    Prefer config.yaml when present, but fall back to ``HERMES_MODEL`` and then
+    ``LLM_MODEL`` so temporary or test-only gateway instances still inherit the
+    active runtime model when no persisted config exists.
     """
     cfg = config if config is not None else _load_gateway_config()
     model_cfg = cfg.get("model", {})
     if isinstance(model_cfg, str):
-        return model_cfg
+        resolved = model_cfg
     elif isinstance(model_cfg, dict):
-        return model_cfg.get("default") or model_cfg.get("model") or ""
-    return ""
+        resolved = model_cfg.get("default") or model_cfg.get("model") or ""
+    else:
+        resolved = ""
+
+    return resolved or os.getenv("HERMES_MODEL") or os.getenv("LLM_MODEL") or ""
 
 
 def _resolve_hermes_bin() -> Optional[list[str]]:

--- a/tests/test_codex_execution_paths.py
+++ b/tests/test_codex_execution_paths.py
@@ -135,9 +135,10 @@ def test_gateway_run_agent_codex_path_handles_internal_401_refresh(monkeypatch):
             "provider": "openai-codex",
             "api_mode": "codex_responses",
             "base_url": "https://chatgpt.com/backend-api/codex",
-            "api_key": "codex-token",
+            "api_key": "***",
         },
     )
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
     monkeypatch.setenv("HERMES_TOOL_PROGRESS", "false")
     monkeypatch.setenv("HERMES_MODEL", "gpt-5.3-codex")
 
@@ -181,3 +182,11 @@ def test_gateway_run_agent_codex_path_handles_internal_401_refresh(monkeypatch):
     assert _Codex401ThenSuccessAgent.refresh_attempts == 1
     assert _Codex401ThenSuccessAgent.last_init["provider"] == "openai-codex"
     assert _Codex401ThenSuccessAgent.last_init["api_mode"] == "codex_responses"
+
+
+def test_resolve_gateway_model_falls_back_to_env(monkeypatch):
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setenv("HERMES_MODEL", "gpt-5.3-codex")
+    monkeypatch.delenv("LLM_MODEL", raising=False)
+
+    assert gateway_run._resolve_gateway_model() == "gpt-5.3-codex"


### PR DESCRIPTION
## Summary
- let gateway model resolution fall back to `HERMES_MODEL` and `LLM_MODEL` when config.yaml has no model
- make the gateway Codex refresh regression test hermetic by stubbing config loading
- add a focused unit test for env fallback in `_resolve_gateway_model()`

## Root cause
The gateway path resolved provider/runtime kwargs correctly for Codex, but `_resolve_gateway_model()` only looked at config.yaml.

When no persisted config model was present, the gateway passed an empty model into the Codex responses path, which produced:
- `Codex Responses request 'model' must be a non-empty string.`

This is why the cron test passed while the gateway test failed: the cron path already falls back to `HERMES_MODEL`, but the gateway path did not.

## Test plan
- `python3 -m pytest tests/test_codex_execution_paths.py -q`
