### PR TITLE
fix(cli): prevent crash on non-UTF-8 project .env files in hermes doctor

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -9,23 +9,18 @@ import sys
 import subprocess
 import shutil
 
-from hermes_cli.config import get_project_root, get_hermes_home, get_env_path
+from hermes_cli.config import get_project_root, get_hermes_home
+from hermes_cli.env_loader import load_hermes_dotenv
 from hermes_constants import display_hermes_home
 
 PROJECT_ROOT = get_project_root()
 HERMES_HOME = get_hermes_home()
 _DHH = display_hermes_home()  # user-facing display path (e.g. ~/.hermes or ~/.hermes/profiles/coder)
 
-# Load environment variables from ~/.hermes/.env so API key checks work
-from dotenv import load_dotenv
-_env_path = get_env_path()
-if _env_path.exists():
-    try:
-        load_dotenv(_env_path, encoding="utf-8")
-    except UnicodeDecodeError:
-        load_dotenv(_env_path, encoding="latin-1")
-# Also try project .env as dev fallback
-load_dotenv(PROJECT_ROOT / ".env", override=False, encoding="utf-8")
+# Load ~/.hermes/.env first so doctor sees user config, then project .env as a
+# dev fallback for local checkouts. Reuse the shared loader so both paths honor
+# the UTF-8 -> latin-1 fallback used elsewhere in the CLI.
+load_hermes_dotenv(hermes_home=HERMES_HOME, project_env=PROJECT_ROOT / ".env")
 
 from hermes_cli.colors import Colors, color
 from hermes_constants import OPENROUTER_MODELS_URL

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1,5 +1,6 @@
 """Tests for hermes_cli.doctor."""
 
+import importlib.util
 import os
 import sys
 import types
@@ -102,6 +103,39 @@ def test_run_doctor_sets_interactive_env_for_tool_checks(monkeypatch, tmp_path):
         doctor_mod.run_doctor(Namespace(fix=False))
 
     assert seen["interactive"] == "1"
+
+
+def test_doctor_import_uses_shared_env_loader(monkeypatch, tmp_path):
+    """Doctor should reuse the shared dotenv loader for project .env fallback."""
+    import hermes_cli.config as config_mod
+    import hermes_cli.env_loader as env_loader_mod
+    import hermes_constants as constants_mod
+
+    project_root = tmp_path / "project"
+    hermes_home = tmp_path / ".hermes"
+    project_root.mkdir()
+    hermes_home.mkdir()
+
+    seen = {}
+
+    def fake_load_hermes_dotenv(**kwargs):
+        seen.update(kwargs)
+        return []
+
+    monkeypatch.setattr(config_mod, "get_project_root", lambda: project_root)
+    monkeypatch.setattr(config_mod, "get_hermes_home", lambda: hermes_home)
+    monkeypatch.setattr(env_loader_mod, "load_hermes_dotenv", fake_load_hermes_dotenv)
+    monkeypatch.setattr(constants_mod, "display_hermes_home", lambda: "~/.hermes")
+
+    spec = importlib.util.spec_from_file_location("doctor_import_probe", doctor_mod.__file__)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    assert seen == {
+        "hermes_home": hermes_home,
+        "project_env": project_root / ".env",
+    }
 
 
 def test_check_gateway_service_linger_warns_when_disabled(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
## 🔒 Stability Fix: Prevent Doctor Crash on Non-UTF-8 Environment Files

### 📝 Summary
This PR fixes an issue where `hermes doctor` would crash with a `UnicodeDecodeError` when encountering a project-level `.env` file containing non-UTF-8 (e.g., Latin-1) characters. 

### 🐛 The Issue
Previously, `hermes doctor` manually implemented a retry logic for `~/.hermes/.env` with `latin-1` encoding, but the developer fallback for the project-root `.env` was strictly loaded as UTF-8. If a user had a Latin-1 encoded `.env` in their project root, executing `hermes doctor` would crash immediately at import time.

### 🛠️ The Solution
Refactored `hermes_cli/doctor.py` to reuse the shared `load_hermes_dotenv` loader from `hermes_cli.env_loader`. This ensures that both the user-config and project-fallback `.env` paths safely honor the UTF-8 -> Latin-1 fallback mechanism used elsewhere in the CLI.

### ✅ Verification
Added a regression test in `test_doctor.py` to ensure it correctly delegates to the shared loader. Executed the targeted test suite locally:

```bash
python -m pytest tests/hermes_cli/test_doctor.py -q
# Result: 11 passed

📋 Checklist
[x] Bug fix (non-breaking change which fixes an issue)

[x] Regression test added

[x] Tested locally

[x] Code adheres to the contribution guidelines