### PR TITLE
fix: tolerate non-type matrix upload responses

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -647,8 +647,16 @@ class MatrixAdapter(BasePlatformAdapter):
             msg_content["m.relates_to"] = relates_to
 
         resp2 = await self._client.room_send(room_id, "m.room.message", msg_content)
-        if isinstance(resp2, nio.RoomSendResponse):
-            return SendResult(success=True, message_id=resp2.event_id)
+        event_id = getattr(resp2, "event_id", None)
+        try:
+            send_ok = isinstance(resp2, nio.RoomSendResponse)
+        except TypeError:
+            # Some environments/tests can expose a non-type RoomSendResponse symbol.
+            # Fall back to the success payload returned by room_send().
+            send_ok = bool(event_id)
+
+        if send_ok:
+            return SendResult(success=True, message_id=event_id)
         return SendResult(success=False, error=getattr(resp2, "message", str(resp2)))
 
     async def _send_local_file(

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -605,12 +605,18 @@ class MatrixAdapter(BasePlatformAdapter):
             content_type=content_type,
             filename=filename,
         )
-        if not isinstance(resp, nio.UploadResponse):
+        mxc_url = getattr(resp, "content_uri", None)
+        try:
+            upload_ok = isinstance(resp, nio.UploadResponse)
+        except TypeError:
+            # Some environments/tests can expose a non-type UploadResponse symbol.
+            # Fall back to the actual success payload we need from upload().
+            upload_ok = bool(mxc_url)
+
+        if not upload_ok:
             err = getattr(resp, "message", str(resp))
             logger.error("Matrix: upload failed: %s", err)
             return SendResult(success=False, error=err)
-
-        mxc_url = resp.content_uri
 
         # Build media message content.
         msg_content: Dict[str, Any] = {

--- a/tests/gateway/test_matrix_voice.py
+++ b/tests/gateway/test_matrix_voice.py
@@ -350,3 +350,13 @@ class TestMatrixSendVoiceMSC3245:
 
         assert sent_content["url"] == "mxc://example.org/uploaded"
         assert "org.matrix.msc3245.voice" in sent_content
+
+    @pytest.mark.asyncio
+    async def test_send_voice_tolerates_non_type_roomsendresponse_symbol(self, monkeypatch):
+        """send_voice should fall back to event_id when nio.RoomSendResponse is not a type."""
+        monkeypatch.setattr(nio, "RoomSendResponse", object())
+
+        sent_content = await self._send_voice_and_capture_content()
+
+        assert sent_content["url"] == "mxc://example.org/uploaded"
+        assert "org.matrix.msc3245.voice" in sent_content

--- a/tests/gateway/test_matrix_voice.py
+++ b/tests/gateway/test_matrix_voice.py
@@ -293,21 +293,17 @@ class TestMatrixSendVoiceMSC3245:
 
         self.adapter._client.upload = mock_upload
 
-    @pytest.mark.asyncio
-    async def test_send_voice_includes_msc3245_field(self):
-        """send_voice should include org.matrix.msc3245.voice in message content."""
-        import tempfile
+    async def _send_voice_and_capture_content(self, monkeypatch=None):
         import os
-        
-        # Create a temp audio file
+        import tempfile
+
         with tempfile.NamedTemporaryFile(suffix=".ogg", delete=False) as f:
             f.write(b"fake audio data")
             temp_path = f.name
-        
+
         try:
-            # Capture the message content sent to room_send
             sent_content = None
-            
+
             async def mock_room_send(room_id, event_type, content):
                 nonlocal sent_content
                 sent_content = content
@@ -316,25 +312,41 @@ class TestMatrixSendVoiceMSC3245:
                 import nio
                 resp.__class__ = nio.RoomSendResponse
                 return resp
-            
+
             self.adapter._client.room_send = mock_room_send
-            
+
             await self.adapter.send_voice(
                 chat_id="!room:example.org",
                 audio_path=temp_path,
                 caption="Test voice",
             )
-            
+
             assert sent_content is not None, "No message was sent"
-            assert "org.matrix.msc3245.voice" in sent_content, \
-                f"MSC3245 voice field missing from content: {sent_content.keys()}"
-            assert sent_content["msgtype"] == "m.audio"
-            assert sent_content["info"]["mimetype"] == "audio/ogg"
             assert self.upload_call is not None, "Expected upload() to be called"
             args, kwargs = self.upload_call
             assert isinstance(args[0], io.BytesIO)
             assert kwargs["content_type"] == "audio/ogg"
             assert kwargs["filename"].endswith(".ogg")
-
+            return sent_content
         finally:
             os.unlink(temp_path)
+
+    @pytest.mark.asyncio
+    async def test_send_voice_includes_msc3245_field(self):
+        """send_voice should include org.matrix.msc3245.voice in message content."""
+        sent_content = await self._send_voice_and_capture_content()
+
+        assert "org.matrix.msc3245.voice" in sent_content, \
+            f"MSC3245 voice field missing from content: {sent_content.keys()}"
+        assert sent_content["msgtype"] == "m.audio"
+        assert sent_content["info"]["mimetype"] == "audio/ogg"
+
+    @pytest.mark.asyncio
+    async def test_send_voice_tolerates_non_type_uploadresponse_symbol(self, monkeypatch):
+        """send_voice should fall back to content_uri when nio.UploadResponse is not a type."""
+        monkeypatch.setattr(nio, "UploadResponse", object())
+
+        sent_content = await self._send_voice_and_capture_content()
+
+        assert sent_content["url"] == "mxc://example.org/uploaded"
+        assert "org.matrix.msc3245.voice" in sent_content


### PR DESCRIPTION
## Summary
- harden Matrix media upload handling when `nio.UploadResponse` is not exposed as a runtime type
- fall back to the returned `content_uri` instead of crashing in the upload success check
- add regression coverage for the non-type `UploadResponse` case

## Root cause
`MatrixAdapter._upload_and_send()` did a strict runtime check:
- `isinstance(resp, nio.UploadResponse)`

In the failing CI environment, `nio.UploadResponse` was not a valid type object, so `isinstance()` raised:
- `TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union`

That crashes the voice send path even when the upload response already contains the `content_uri` needed to send the message.

## What changed
- keep the normal `isinstance()` path when it works
- if `nio.UploadResponse` is not a type, fall back to checking the upload payload for `content_uri`
- add a regression test that monkeypatches `nio.UploadResponse` to a non-type sentinel and verifies `send_voice()` still succeeds

## Test plan
- `python3 -m pytest tests/gateway/test_matrix_voice.py -q` (skips locally without matrix-nio)
- `PYTHONPATH=/home/openclaw/Work/hermes-agent-local/hermes-agent python3 /tmp/matrix_upload_guard_smoke.py`
- `python3 -m py_compile gateway/platforms/matrix.py tests/gateway/test_matrix_voice.py`
