### PR TITLE
fix: validate_toolset should recognize MCP server names from config

### DIFF
--- a/toolsets.py
+++ b/toolsets.py
@@ -546,7 +546,19 @@ def validate_toolset(name: str) -> bool:
     if name in TOOLSETS:
         return True
     # Check tool registry for plugin-provided toolsets
-    return name in _get_plugin_toolset_names()
+    if name in _get_plugin_toolset_names():
+        return True
+    # Accept MCP server names from config — _get_platform_tools() adds bare MCP
+    # server names to enabled_toolsets, but they are not real toolsets in TOOLSETS.
+    # The MCP system registers them dynamically as "mcp-{name}" at startup.
+    try:
+        from hermes_cli.config import load_config
+        mcp_servers = load_config().get("mcp_servers") or {}
+        if name in mcp_servers:
+            return True
+    except Exception:
+        pass
+    return False
 
 
 def create_custom_toolset(


### PR DESCRIPTION
## Problem

`_get_platform_tools()` adds bare MCP server names (e.g. `annas`, `libgen`) to `enabled_toolsets`, which are validated at CLI startup against the static `TOOLSETS` dict. 

MCP servers are defined in `config.yaml` under `mcp_servers:` and get registered dynamically by `mcp_tool.py` as `mcp-{name}`. Since these names are not in the static `TOOLSETS` dict, `validate_toolset()` returns False for them, causing a false warning:

```
Warning: Unknown toolsets: annas, libgen, qmd, research-hub
```

## Solution

`validate_toolset()` now also checks MCP server names from `mcp_servers` in config. If a name matches an MCP server in config, it returns True — suppressing the false warning while keeping MCP tools working as intended.

## Files changed

- `toolsets.py` — Added MCP server name lookup to `validate_toolset()`
