### PR TITLE
fix(discord): stop bot-bot loops with ALLOW_BOTS=mentions in participated threads

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2082,6 +2082,22 @@ class DiscordAdapter(BasePlatformAdapter):
                 if self._client.user not in message.mentions:
                     return
 
+            # OpenClaw-style: even when require_mention is bypassed (e.g. in_bot_thread),
+            # other bots must still satisfy DISCORD_ALLOW_BOTS — mentions mode requires an
+            # @mention of us here too (defense in depth vs on_message).
+            author = message.author
+            if (
+                self._client
+                and self._client.user
+                and getattr(author, "bot", False)
+                and author.id != self._client.user.id
+            ):
+                allow_bots = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
+                if allow_bots == "none":
+                    return
+                if allow_bots == "mentions" and self._client.user not in message.mentions:
+                    return
+
             if self._client.user and self._client.user in message.mentions:
                 message.content = message.content.replace(f"<@{self._client.user.id}>", "").strip()
                 message.content = message.content.replace(f"<@!{self._client.user.id}>", "").strip()

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -95,8 +95,9 @@ def adapter(monkeypatch):
     return adapter
 
 
-def make_message(*, channel, content: str, mentions=None):
-    author = SimpleNamespace(id=42, display_name="Jezza", name="Jezza")
+def make_message(*, channel, content: str, mentions=None, author=None):
+    if author is None:
+        author = SimpleNamespace(id=42, display_name="Jezza", name="Jezza")
     return SimpleNamespace(
         id=123,
         content=content,
@@ -358,3 +359,47 @@ async def test_discord_thread_participation_tracked_on_dispatch(adapter, monkeyp
     await adapter._handle_message(message)
 
     assert "777" in adapter._bot_participated_threads
+
+
+@pytest.mark.asyncio
+async def test_discord_allow_bots_mentions_blocks_bot_in_participated_thread(adapter, monkeypatch):
+    """OpenClaw-style: in_bot_thread bypass does not waive allowBots=mentions for other bots."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "mentions")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    adapter._bot_participated_threads.add("891")
+    thread = FakeThread(channel_id=891, name="relaxed")
+    our = adapter._client.user
+    ext_bot = SimpleNamespace(id=66001, bot=True, display_name="ExtBot", name="ExtBot")
+    message = make_message(channel=thread, content="hi", mentions=[], author=ext_bot)
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discord_allow_bots_mentions_allows_bot_with_mention_in_participated_thread(
+    adapter, monkeypatch,
+):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "mentions")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    adapter._bot_participated_threads.add("892")
+    thread = FakeThread(channel_id=892, name="relaxed")
+    our = adapter._client.user
+    ext_bot = SimpleNamespace(id=66002, bot=True, display_name="ExtBot", name="ExtBot")
+    message = make_message(
+        channel=thread,
+        content=f"<@{our.id}> hi",
+        mentions=[our],
+        author=ext_bot,
+    )
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()


### PR DESCRIPTION
## Summary

Fixes a Discord gateway case where two bots could ping-pong indefinitely when another bot is on `DISCORD_ALLOWED_USERS` and `DISCORD_ALLOW_BOTS=mentions`.

## What went wrong

After Hermes has participated in a thread, `DISCORD_REQUIRE_MENTION` is relaxed for that thread (`in_bot_thread`). External bots could then reach `_handle_message` without an `@mention` of Hermes even though `DISCORD_ALLOW_BOTS=mentions` is supposed to require one, because the allow-bots check only ran in `on_message` and the thread path skipped the guild mention gate.

## Change

Re-apply `DISCORD_ALLOW_BOTS` inside `_handle_message` for messages authored by other bots: `none` drops them; `mentions` requires Hermes in `message.mentions`.

## Note on `DISCORD_IGNORE_NO_MENTION`

That setting only applies when `message.mentions` is non-empty and Hermes is not among them. It does not address this loop: empty or Hermes-only mention paths, bot authors, and thread mention bypass are outside what `DISCORD_IGNORE_NO_MENTION` controls.
