### PR TITLE
fix(security): redact duplicate Feishu card action tokens

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -222,6 +222,15 @@ _SKIP_TEXT_KEYS = {
 }
 
 
+def _mask_secret_for_log(secret: str, keep_suffix: int = 4) -> str:
+    """Return a log-safe representation of a secret value."""
+    if not secret:
+        return "<redacted>"
+    if len(secret) <= keep_suffix:
+        return "<redacted>"
+    return f"***{secret[-keep_suffix:]}"
+
+
 @dataclass(frozen=True)
 class FeishuPostMediaRef:
     file_key: str
@@ -1656,7 +1665,10 @@ class FeishuAdapter(BasePlatformAdapter):
         event = getattr(data, "event", None)
         token = str(getattr(event, "token", "") or "")
         if token and self._is_card_action_duplicate(token):
-            logger.debug("[Feishu] Dropping duplicate card action token: %s", token)
+            logger.debug(
+                "[Feishu] Dropping duplicate card action token: %s",
+                _mask_secret_for_log(token),
+            )
             return
 
         context = getattr(event, "context", None)

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1537,6 +1537,39 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(event.reply_to_text, "父消息内容")
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_duplicate_card_action_logs_masked_token(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        token = "tok_super_secret_123456789"
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter.get_chat_info = AsyncMock(
+            return_value={"chat_id": "oc_chat", "name": "Feishu DM", "type": "dm"}
+        )
+        adapter._resolve_sender_profile = AsyncMock(
+            return_value={"user_id": "ou_user", "user_name": "User", "user_id_alt": None}
+        )
+        adapter._handle_message_with_guards = AsyncMock()
+        data = SimpleNamespace(
+            event=SimpleNamespace(
+                token=token,
+                context=SimpleNamespace(open_chat_id="oc_chat"),
+                operator=SimpleNamespace(open_id="ou_user"),
+                action=SimpleNamespace(tag="button", value={}),
+            )
+        )
+
+        with self.assertLogs("gateway.platforms.feishu", level="DEBUG") as logs:
+            asyncio.run(adapter._handle_card_action_event(data))
+            asyncio.run(adapter._handle_card_action_event(data))
+
+        self.assertTrue(
+            any("Dropping duplicate card action token: ***6789" in entry for entry in logs.output),
+            logs.output,
+        )
+        self.assertFalse(any(token in entry for entry in logs.output), logs.output)
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_replies_in_thread_when_thread_metadata_present(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter


### PR DESCRIPTION
Summary
This PR fixes a secret-logging issue in the Feishu gateway adapter.

The duplicate card-action path was logging the full raw Feishu card action token at debug level. Since this token is a sensitive identifier, it should not appear in plaintext logs.

Change
mask duplicate Feishu card action tokens before logging
add a regression test to verify the full token is never logged
Before
[Feishu] Dropping duplicate card action token: tok_super_secret_123456789
After
[Feishu] Dropping duplicate card action token: ***6789
Validation
Targeted test file only:

@'
import pathlib
import tempfile
import pytest

_fallback_home = pathlib.Path(tempfile.mkdtemp(prefix='hermes-home-'))
pathlib.Path.home = classmethod(lambda cls: _fallback_home)
raise SystemExit(pytest.main(['tests/gateway/test_feishu.py', '-q', '-n', '0']))
'@ | & 'C:\Users\Simba\AppData\Local\Programs\Python\Python312\python.exe' -
Result:

83 passed, 16 skipped, 1 warning in 0.62s