### PR TITLE
fix(gateway): resolve UnboundLocalError in run_sync closure

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4992,6 +4992,7 @@ class GatewayRunner:
                 logger.debug("status_callback error (%s): %s", event_type, _e)
 
         def run_sync():
+            nonlocal message
             # Pass session_key to process registry via env var so background
             # processes can be mapped back to this gateway session
             os.environ["HERMES_SESSION_KEY"] = session_key or ""


### PR DESCRIPTION
## What does this PR do?

Fixes an `UnboundLocalError` that crashes **every gateway message** on all platforms (Signal, Discord, Matrix, WhatsApp, Slack, etc.).

In `run_sync()` (a closure inside `_run_agent(message, ...)`), the variable `message` is read at line 6255 (`_resolve_turn_agent_config(message, ...)`) but also assigned at line 6469 (`message = _msn + "\n\n" + message`, model-switch note prepending). Python compiles this as a local variable, so the read at 6255 hits an unbound variable every time.

The fix is a single `nonlocal message` declaration at the top of `run_sync()`, telling Python to use the enclosing scope's parameter from `_run_agent()`.

## Related Issue

No matching issue found. Related same-pattern bugs:
- #4331 — `UnboundLocalError` in CLI `show_banner()` (`ctx_len`, different scope)
- #4396 — duplicate of #4331
- #1158 — prior gateway crash on all message handling (different root cause)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py:6186` — Added `nonlocal message` to `run_sync()` closure

## How to Test

1. Start the gateway: `hermes gateway`
2. Send any message from Signal, Discord, or any other platform
3. **Before fix:** `UnboundLocalError: cannot access local variable 'message'` on every message
4. **After fix:** Normal agent response

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass; unless existing regression. 
- [x] I've tested on my platform: Ubuntu 24.04 (plus Bazzite), Python 3.11.14

### Documentation & Housekeeping

- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `nonlocal` is pure Python semantics, no OS-specific behavior

## Screenshots / Logs

```
2026-04-05 18:16:32 ERROR gateway.run: Agent error in session agent:main:discord:thread:...
Traceback (most recent call last):
  File "gateway/run.py", line 6255, in run_sync
    turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
                                                 ^^^^^^^
UnboundLocalError: cannot access local variable 'message' where it is not associated with a value
```