### PR TITLE
fix(security) redact credentials from Signal daemon URL logs

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -22,7 +22,7 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Any
-from urllib.parse import quote, unquote
+from urllib.parse import quote, unquote, urlsplit, urlunsplit
 
 import httpx
 
@@ -66,6 +66,22 @@ def _redact_phone(phone: str) -> str:
     if len(phone) <= 8:
         return phone[:2] + "****" + phone[-2:] if len(phone) > 4 else "****"
     return phone[:4] + "****" + phone[-4:]
+
+
+def _redact_url_for_logging(url: str) -> str:
+    """Redact credentials and query data from a URL before logging it."""
+    if not url:
+        return "<none>"
+    try:
+        parsed = urlsplit(url)
+    except Exception:
+        return url
+    if not parsed.scheme or not parsed.netloc:
+        return url
+    netloc = parsed.netloc
+    if "@" in netloc:
+        netloc = "<redacted>@" + netloc.rsplit("@", 1)[-1]
+    return urlunsplit((parsed.scheme, netloc, parsed.path, "", ""))
 
 
 def _parse_comma_list(value: str) -> List[str]:
@@ -185,9 +201,10 @@ class SignalAdapter(BasePlatformAdapter):
         self._max_recent_timestamps = 50
 
         self._phone_lock_identity: Optional[str] = None
+        self._log_http_url = _redact_url_for_logging(self.http_url)
 
         logger.info("Signal adapter initialized: url=%s account=%s groups=%s",
-                     self.http_url, _redact_phone(self.account),
+                     self._log_http_url, _redact_phone(self.account),
                      "enabled" if self.group_allow_from else "disabled")
 
     # ------------------------------------------------------------------
@@ -232,7 +249,7 @@ class SignalAdapter(BasePlatformAdapter):
                 logger.error("Signal: health check failed (status %d)", resp.status_code)
                 return False
         except Exception as e:
-            logger.error("Signal: cannot reach signal-cli at %s: %s", self.http_url, e)
+            logger.error("Signal: cannot reach signal-cli at %s: %s", self._log_http_url, e)
             return False
 
         self._running = True
@@ -240,7 +257,7 @@ class SignalAdapter(BasePlatformAdapter):
         self._sse_task = asyncio.create_task(self._sse_listener())
         self._health_monitor_task = asyncio.create_task(self._health_monitor())
 
-        logger.info("Signal: connected to %s", self.http_url)
+        logger.info("Signal: connected to %s", self._log_http_url)
         return True
 
     async def disconnect(self) -> None:

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -1,6 +1,7 @@
 """Tests for Signal messenger platform adapter."""
 import base64
 import json
+import logging
 import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
 from urllib.parse import quote
@@ -97,6 +98,17 @@ class TestSignalAdapterInit:
         assert adapter.http_url == "http://localhost:8080"
         assert adapter.account == "+15551234567"
         assert "group123" in adapter.group_allow_from
+
+    def test_init_redacts_credentials_in_logged_url(self, monkeypatch, caplog):
+        with caplog.at_level(logging.INFO, logger="gateway.platforms.signal"):
+            _make_signal_adapter(
+                monkeypatch,
+                http_url="http://alice:supersecret@localhost:8080/signal?token=abc123#frag",
+            )
+
+        assert "supersecret" not in caplog.text
+        assert "token=abc123" not in caplog.text
+        assert "http://<redacted>@localhost:8080/signal" in caplog.text
 
     def test_init_empty_allowlist(self, monkeypatch):
         adapter = _make_signal_adapter(monkeypatch)


### PR DESCRIPTION
## Summary

This PR fixes a secret-logging issue in the Signal adapter.

`gateway/platforms/signal.py` was logging the configured Signal daemon URL directly. If the URL contained embedded credentials like `http://alice:supersecret@localhost:8080`, the password was written to logs in plaintext.

This change redacts credentials before logging and adds a regression test to prevent leaks.

## Validation

```bash
python -m pytest tests/gateway/test_signal.py -q
