### PR TITLE
fix: suppress false 'Unknown toolsets' warning for MCP server names

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1257,8 +1257,11 @@ class HermesCLI:
         # Parse and validate toolsets
         self.enabled_toolsets = toolsets
         if toolsets and "all" not in toolsets and "*" not in toolsets:
-            # Validate each toolset
-            invalid = [t for t in toolsets if not validate_toolset(t)]
+            # Validate each toolset — MCP server names are added by
+            # _get_platform_tools() but aren't registered in TOOLSETS yet
+            # (that happens later in _sync_mcp_toolsets), so exclude them.
+            mcp_names = set((CLI_CONFIG.get("mcp_servers") or {}).keys())
+            invalid = [t for t in toolsets if not validate_toolset(t) and t not in mcp_names]
             if invalid:
                 self.console.print(f"[bold red]Warning: Unknown toolsets: {', '.join(invalid)}[/]")
         


### PR DESCRIPTION
## Summary

MCP server names (e.g. `annas`, `libgen`) are added to `enabled_toolsets` by `_get_platform_tools()` but aren't registered in `TOOLSETS` until later when `_sync_mcp_toolsets()` runs during tool discovery. The validation in `HermesCLI.__init__()` fires before that registration, producing a false warning:

```
Warning: Unknown toolsets: annas, libgen, qmd, research-hub
```

## Fix

Exclude configured MCP server names from the validation check. `CLI_CONFIG` is already available at the call site — one line, no new cross-module dependencies.

Alternative to PR #5267 — fixes the same bug with a simpler approach (call-site filter vs adding `load_config()` import to `toolsets.py`).

Credit to @Floris-Jan for identifying the issue.