### PR TITLE
fix(security): prevent approval 'once' session escalation + validate cron delivery platforms

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -13,6 +13,12 @@ import concurrent.futures
 import json
 import logging
 import os
+_KNOWN_DELIVERY_PLATFORMS = frozenset({
+    "telegram", "discord", "slack", "whatsapp", "signal",
+    "matrix", "mattermost", "dingtalk", "feishu", "wecom",
+    "sms", "email", "webhook",
+})
+import subprocess
 import subprocess
 import sys
 import traceback
@@ -134,14 +140,10 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
             "thread_id": origin.get("thread_id"),
         }
 
-    _KNOWN_PLATFORMS = {
-            "telegram", "discord", "slack", "whatsapp", "signal",
-            "matrix", "mattermost", "dingtalk", "feishu", "wecom",
-            "sms", "email", "webhook",
-        }
-        if platform_name.lower() not in _KNOWN_PLATFORMS:
-            return None
-        chat_id = os.getenv(f"{platform_name.upper()}_HOME_CHANNEL", "")
+    
+    if platform_name.lower() not in _KNOWN_DELIVERY_PLATFORMS:
+        return None
+    chat_id = os.getenv(f"{platform_name.upper()}_HOME_CHANNEL", "")
     if not chat_id:
         return None
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -13,12 +13,6 @@ import concurrent.futures
 import json
 import logging
 import os
-_KNOWN_DELIVERY_PLATFORMS = frozenset({
-    "telegram", "discord", "slack", "whatsapp", "signal",
-    "matrix", "mattermost", "dingtalk", "feishu", "wecom",
-    "sms", "email", "webhook",
-})
-import subprocess
 import subprocess
 import sys
 import traceback
@@ -40,6 +34,14 @@ from typing import Optional
 from hermes_time import now as _hermes_now
 
 logger = logging.getLogger(__name__)
+
+# Valid delivery platforms — used to validate user-supplied platform names
+# in cron delivery targets, preventing env var enumeration via crafted names.
+_KNOWN_DELIVERY_PLATFORMS = frozenset({
+    "telegram", "discord", "slack", "whatsapp", "signal",
+    "matrix", "mattermost", "homeassistant", "dingtalk", "feishu",
+    "wecom", "sms", "email", "webhook",
+})
 
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -140,7 +142,6 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
             "thread_id": origin.get("thread_id"),
         }
 
-    
     if platform_name.lower() not in _KNOWN_DELIVERY_PLATFORMS:
         return None
     chat_id = os.getenv(f"{platform_name.upper()}_HOME_CHANNEL", "")

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -134,7 +134,14 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
             "thread_id": origin.get("thread_id"),
         }
 
-    chat_id = os.getenv(f"{platform_name.upper()}_HOME_CHANNEL", "")
+    _KNOWN_PLATFORMS = {
+            "telegram", "discord", "slack", "whatsapp", "signal",
+            "matrix", "mattermost", "dingtalk", "feishu", "wecom",
+            "sms", "email", "webhook",
+        }
+        if platform_name.lower() not in _KNOWN_PLATFORMS:
+            return None
+        chat_id = os.getenv(f"{platform_name.upper()}_HOME_CHANNEL", "")
     if not chat_id:
         return None
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -813,12 +813,14 @@ def check_all_command_guards(command: str, env_type: str,
 
             # User approved — persist based on scope (same logic as CLI)
             for key, _, is_tirith in warnings:
-                if choice in ("once", "session") or (choice == "always" and is_tirith):
+                if choice == "session" or (choice == "always" and is_tirith):
                     approve_session(session_key, key)
                 elif choice == "always":
                     approve_session(session_key, key)
                     approve_permanent(key)
                     save_permanent_allowlist(_permanent_approved)
+                # choice == "once": no persistence — command allowed this
+                # single time only, matching the CLI's behavior.
 
             return {"approved": True, "message": None,
                     "user_approved": True, "description": combined_desc}


### PR DESCRIPTION
## Summary

Two security fixes salvaged from community PRs:

### 1. Approval 'once' → session escalation (#4806 by @Xowiek, #4973 by @Ruzzgar)

`check_all_command_guards()` in gateway approval treats `choice == "once"` the same as `"session"` — calling `approve_session()` which persists the approval for the entire session. When a user says "approve once", the command pattern is silently approved for all subsequent uses in that session, violating user intent.

**Fix:** Remove `"once"` from the condition that calls `approve_session()`. The "once" approval works via the return value `{approved: True}` flowing back to the caller — no persistence needed.

### 2. Cron delivery platform name validation (#5118 by @maymuneth)

`_resolve_delivery_target()` passes user-supplied platform names directly to `os.getenv(f"{platform_name.upper()}_HOME_CHANNEL")` with no validation. A crafted platform name like `"path"` probes `PATH_HOME_CHANNEL`, enabling env var enumeration.

**Fix:** Add `_KNOWN_DELIVERY_PLATFORMS` frozenset at module level. Reject platform names not in the allowlist before the `getenv` call.

**Follow-up cleanup:**
- Fixed duplicate `import subprocess` from original PR
- Moved frozenset from between imports to proper module-level position  
- Added `homeassistant` (existing platform missing from original PR's list)

## Test plan
- `python -m pytest tests/tools/test_approval.py tests/cron/ -o 'addopts=' -q` — 210 passed (1 pre-existing flaky)
- E2E verified: invalid platform returns None, valid platform resolves, approval 'once' does not persist

## Attribution
- Approval fix: cherry-picked from @Xowiek (#4806, first submission) — duplicate #4973 by @Ruzzgar
- Cron validation: cherry-picked from @maymuneth (#5118)