### PR TITLE
feat(skills): append Gmail sendAs signature on gws backend

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -184,13 +184,16 @@ $GAPI gmail search "has:attachment filename:pdf newer_than:7d"
 $GAPI gmail get MESSAGE_ID
 
 # Send
+# The primary Gmail send-as signature is appended when available.
 $GAPI gmail send --to user@example.com --subject "Hello" --body "Message text"
 $GAPI gmail send --to user@example.com --subject "Report" --body "<h1>Q4</h1><p>Details...</p>" --html
 $GAPI gmail send --to user@example.com --subject "Hello" --from '"Research Agent" <user@example.com>' --body "Message text"
+$GAPI gmail send --to user@example.com --subject "No signature" --body "Message text" --no-signature
 
 # Reply (automatically threads and sets In-Reply-To)
 $GAPI gmail reply MESSAGE_ID --body "Thanks, that works for me."
 $GAPI gmail reply MESSAGE_ID --from '"Support Bot" <user@example.com>' --body "Thanks"
+$GAPI gmail reply MESSAGE_ID --body "Thanks" --no-signature
 
 # Labels
 $GAPI gmail labels

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -8,9 +8,9 @@ libraries if `gws` is not installed.
 Usage:
   python google_api.py gmail search "is:unread" [--max 10]
   python google_api.py gmail get MESSAGE_ID
-  python google_api.py gmail send --to user@example.com --subject "Hi" --body "Hello"
-  python google_api.py gmail reply MESSAGE_ID --body "Thanks"
-  python google_api.py calendar list [--from DATE] [--to DATE] [--calendar primary]
+  python google_api.py gmail send --to user@example.com --subject "Hi" --body "Hello" [--html] [--no-signature]
+  python google_api.py gmail reply MESSAGE_ID --body "Thanks" [--html] [--no-signature]
+  python google_api.py calendar list [--start DATE] [--end DATE] [--calendar primary]
   python google_api.py calendar create --summary "Meeting" --start DATETIME --end DATETIME
   python google_api.py drive search "budget report" [--max 10]
   python google_api.py contacts list [--max 20]
@@ -119,6 +119,34 @@ def _run_gws(parts: list[str], *, params: dict | None = None, body: dict | None 
         print("ERROR: Unexpected non-JSON output from gws:", file=sys.stderr)
         print(stdout, file=sys.stderr)
         sys.exit(1)
+
+
+def _get_sendas_primary() -> dict:
+    if _gws_binary():
+        payload = _run_gws(
+            ["gmail", "users", "settings", "sendAs", "list"],
+            params={"userId": "me"},
+        )
+    else:
+        service = build_service("gmail", "v1")
+        payload = service.users().settings().sendAs().list(userId="me").execute()
+
+    aliases = payload.get("sendAs", [])
+    for alias in aliases:
+        if alias.get("isPrimary"):
+            return alias
+    for alias in aliases:
+        if alias.get("isDefault"):
+            return alias
+    return aliases[0] if aliases else {}
+
+
+def _apply_signature(body: str, *, html: bool, no_signature: bool) -> tuple[str, bool]:
+    alias = _get_sendas_primary()
+    signature = alias.get("signature")
+    if no_signature or not signature:
+        return body, html
+    return f"{body}<br><br>{signature}", True
 
 
 def _headers_dict(msg: dict) -> dict[str, str]:
@@ -305,8 +333,10 @@ def gmail_get(args):
 
 
 def gmail_send(args):
+    body_text, use_html = _apply_signature(args.body, html=args.html, no_signature=args.no_signature)
+
     if _gws_binary():
-        message = MIMEText(args.body, "html" if args.html else "plain")
+        message = MIMEText(body_text, "html" if use_html else "plain")
         message["to"] = args.to
         message["subject"] = args.subject
         if args.cc:
@@ -328,7 +358,7 @@ def gmail_send(args):
         return
 
     service = build_service("gmail", "v1")
-    message = MIMEText(args.body, "html" if args.html else "plain")
+    message = MIMEText(body_text, "html" if use_html else "plain")
     message["to"] = args.to
     message["subject"] = args.subject
     if args.cc:
@@ -348,6 +378,8 @@ def gmail_send(args):
 
 
 def gmail_reply(args):
+    body_text, use_html = _apply_signature(args.body, html=args.html, no_signature=args.no_signature)
+
     if _gws_binary():
         original = _run_gws(
             ["gmail", "users", "messages", "get"],
@@ -364,7 +396,7 @@ def gmail_reply(args):
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
 
-        message = MIMEText(args.body)
+        message = MIMEText(body_text, "html" if use_html else "plain")
         message["to"] = headers.get("From", "")
         message["subject"] = subject
         if args.from_header:
@@ -393,7 +425,7 @@ def gmail_reply(args):
     if not subject.startswith("Re:"):
         subject = f"Re: {subject}"
 
-    message = MIMEText(args.body)
+    message = MIMEText(body_text, "html" if use_html else "plain")
     message["to"] = headers.get("From", "")
     message["subject"] = subject
     if args.from_header:
@@ -756,6 +788,7 @@ def main():
     p.add_argument("--cc", default="")
     p.add_argument("--from", dest="from_header", default="", help="Custom From header (e.g. '\"Agent Name\" <user@example.com>')")
     p.add_argument("--html", action="store_true", help="Send body as HTML")
+    p.add_argument("--no-signature", action="store_true", help="Do not append the sender's Gmail signature")
     p.add_argument("--thread-id", default="", help="Thread ID for threading")
     p.set_defaults(func=gmail_send)
 
@@ -763,6 +796,8 @@ def main():
     p.add_argument("message_id", help="Message ID to reply to")
     p.add_argument("--body", required=True)
     p.add_argument("--from", dest="from_header", default="", help="Custom From header (e.g. '\"Agent Name\" <user@example.com>')")
+    p.add_argument("--html", action="store_true", help="Send body as HTML")
+    p.add_argument("--no-signature", action="store_true", help="Do not append the sender's Gmail signature")
     p.set_defaults(func=gmail_reply)
 
     p = gmail_sub.add_parser("labels")

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -8,9 +8,9 @@ libraries if `gws` is not installed.
 Usage:
   python google_api.py gmail search "is:unread" [--max 10]
   python google_api.py gmail get MESSAGE_ID
-  python google_api.py gmail send --to user@example.com --subject "Hi" --body "Hello"
-  python google_api.py gmail reply MESSAGE_ID --body "Thanks"
-  python google_api.py calendar list [--from DATE] [--to DATE] [--calendar primary]
+  python google_api.py gmail send --to user@example.com --subject "Hi" --body "Hello" [--html] [--no-signature]
+  python google_api.py gmail reply MESSAGE_ID --body "Thanks" [--html] [--no-signature]
+  python google_api.py calendar list [--start DATE] [--end DATE] [--calendar primary]
   python google_api.py calendar create --summary "Meeting" --start DATETIME --end DATETIME
   python google_api.py drive search "budget report" [--max 10]
   python google_api.py contacts list [--max 20]
@@ -126,6 +126,34 @@ def _run_gws(parts: list[str], *, params: dict | None = None, body: dict | None 
         print("ERROR: Unexpected non-JSON output from gws:", file=sys.stderr)
         print(stdout, file=sys.stderr)
         sys.exit(1)
+
+
+def _get_sendas_primary() -> dict:
+    if _gws_binary():
+        payload = _run_gws(
+            ["gmail", "users", "settings", "sendAs", "list"],
+            params={"userId": "me"},
+        )
+    else:
+        service = build_service("gmail", "v1")
+        payload = service.users().settings().sendAs().list(userId="me").execute()
+
+    aliases = payload.get("sendAs", [])
+    for alias in aliases:
+        if alias.get("isPrimary"):
+            return alias
+    for alias in aliases:
+        if alias.get("isDefault"):
+            return alias
+    return aliases[0] if aliases else {}
+
+
+def _apply_signature(body: str, *, html: bool, no_signature: bool) -> tuple[str, bool]:
+    alias = _get_sendas_primary()
+    signature = alias.get("signature")
+    if no_signature or not signature:
+        return body, html
+    return f"{body}<br><br>{signature}", True
 
 
 def _headers_dict(msg: dict) -> dict[str, str]:
@@ -316,8 +344,10 @@ def gmail_get(args):
 
 
 def gmail_send(args):
+    body_text, use_html = _apply_signature(args.body, html=args.html, no_signature=args.no_signature)
+
     if _gws_binary():
-        message = MIMEText(args.body, "html" if args.html else "plain")
+        message = MIMEText(body_text, "html" if use_html else "plain")
         message["To"] = args.to
         message["Subject"] = args.subject
         if args.cc:
@@ -339,7 +369,7 @@ def gmail_send(args):
         return
 
     service = build_service("gmail", "v1")
-    message = MIMEText(args.body, "html" if args.html else "plain")
+    message = MIMEText(body_text, "html" if use_html else "plain")
     message["To"] = args.to
     message["Subject"] = args.subject
     if args.cc:
@@ -359,6 +389,8 @@ def gmail_send(args):
 
 
 def gmail_reply(args):
+    body_text, use_html = _apply_signature(args.body, html=args.html, no_signature=args.no_signature)
+
     if _gws_binary():
         original = _run_gws(
             ["gmail", "users", "messages", "get"],
@@ -375,7 +407,7 @@ def gmail_reply(args):
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
 
-        message = MIMEText(args.body)
+        message = MIMEText(body_text, "html" if use_html else "plain")
         message["To"] = headers.get("from", "")
         message["Subject"] = subject
         if args.from_header:
@@ -404,7 +436,7 @@ def gmail_reply(args):
     if not subject.startswith("Re:"):
         subject = f"Re: {subject}"
 
-    message = MIMEText(args.body)
+    message = MIMEText(body_text, "html" if use_html else "plain")
     message["To"] = headers.get("from", "")
     message["Subject"] = subject
     if args.from_header:
@@ -1075,6 +1107,7 @@ def main():
     p.add_argument("--cc", default="")
     p.add_argument("--from", dest="from_header", default="", help="Custom From header (e.g. '\"Agent Name\" <user@example.com>')")
     p.add_argument("--html", action="store_true", help="Send body as HTML")
+    p.add_argument("--no-signature", action="store_true", help="Do not append the sender's Gmail signature")
     p.add_argument("--thread-id", default="", help="Thread ID for threading")
     p.set_defaults(func=gmail_send)
 
@@ -1082,6 +1115,8 @@ def main():
     p.add_argument("message_id", help="Message ID to reply to")
     p.add_argument("--body", required=True)
     p.add_argument("--from", dest="from_header", default="", help="Custom From header (e.g. '\"Agent Name\" <user@example.com>')")
+    p.add_argument("--html", action="store_true", help="Send body as HTML")
+    p.add_argument("--no-signature", action="store_true", help="Do not append the sender's Gmail signature")
     p.set_defaults(func=gmail_reply)
 
     p = gmail_sub.add_parser("labels")

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -129,14 +129,17 @@ def _run_gws(parts: list[str], *, params: dict | None = None, body: dict | None 
 
 
 def _get_sendas_primary() -> dict:
-    if _gws_binary():
-        payload = _run_gws(
-            ["gmail", "users", "settings", "sendAs", "list"],
-            params={"userId": "me"},
-        )
-    else:
-        service = build_service("gmail", "v1")
-        payload = service.users().settings().sendAs().list(userId="me").execute()
+    try:
+        if _gws_binary():
+            payload = _run_gws(
+                ["gmail", "users", "settings", "sendAs", "list"],
+                params={"userId": "me"},
+            )
+        else:
+            service = build_service("gmail", "v1")
+            payload = service.users().settings().sendAs().list(userId="me").execute()
+    except (Exception, SystemExit):
+        return {}
 
     aliases = payload.get("sendAs", [])
     for alias in aliases:
@@ -149,9 +152,12 @@ def _get_sendas_primary() -> dict:
 
 
 def _apply_signature(body: str, *, html: bool, no_signature: bool) -> tuple[str, bool]:
+    if no_signature:
+        return body, html
+
     alias = _get_sendas_primary()
     signature = alias.get("signature")
-    if no_signature or not signature:
+    if not signature:
         return body, html
     return f"{body}<br><br>{signature}", True
 

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -45,6 +45,7 @@ SCOPES = [
     "https://www.googleapis.com/auth/gmail.readonly",
     "https://www.googleapis.com/auth/gmail.send",
     "https://www.googleapis.com/auth/gmail.modify",
+    "https://www.googleapis.com/auth/gmail.settings.basic",
     "https://www.googleapis.com/auth/calendar",
     "https://www.googleapis.com/auth/drive.readonly",
     "https://www.googleapis.com/auth/contacts.readonly",

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -47,6 +47,7 @@ SCOPES = [
     "https://www.googleapis.com/auth/gmail.readonly",
     "https://www.googleapis.com/auth/gmail.send",
     "https://www.googleapis.com/auth/gmail.modify",
+    "https://www.googleapis.com/auth/gmail.settings.basic",
     "https://www.googleapis.com/auth/calendar",
     "https://www.googleapis.com/auth/drive",
     "https://www.googleapis.com/auth/contacts.readonly",

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -234,3 +234,164 @@ def test_api_get_credentials_refresh_persists_authorized_user_type(api_module, m
     assert isinstance(creds, FakeCredentials)
     assert saved["token"] == "ya29.refreshed"
     assert saved["type"] == "authorized_user"
+
+
+def test_api_get_sendas_primary_prefers_primary_alias(api_module):
+    completed = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=json.dumps(
+            {
+                "sendAs": [
+                    {"sendAsEmail": "alias@example.com", "isDefault": True, "signature": "<p>Default</p>"},
+                    {"sendAsEmail": "primary@example.com", "isPrimary": True, "signature": "<p>Primary</p>"},
+                ]
+            }
+        ),
+        stderr="",
+    )
+
+    with patch.object(subprocess, "run", return_value=completed):
+        alias = api_module._get_sendas_primary()
+
+    assert alias["sendAsEmail"] == "primary@example.com"
+    assert alias["signature"] == "<p>Primary</p>"
+
+
+def test_api_get_sendas_primary_gracefully_degrades_on_empty_list(api_module):
+    completed = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=json.dumps({"sendAs": []}),
+        stderr="",
+    )
+
+    with patch.object(subprocess, "run", return_value=completed):
+        alias = api_module._get_sendas_primary()
+
+    assert alias == {}
+
+
+def test_api_gmail_send_appends_signature_and_forces_html(api_module):
+    sendas_payload = {
+        "sendAs": [
+            {"sendAsEmail": "lev@valstratis.com", "isPrimary": True, "signature": "<table>sig</table>"}
+        ]
+    }
+    send_payload = {"id": "msg-123", "threadId": "thr-456"}
+    captured = []
+
+    def capture_run(cmd, **kwargs):
+        captured.append(cmd)
+        if "sendAs" in cmd:
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=json.dumps(sendas_payload), stderr="")
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=json.dumps(send_payload), stderr="")
+
+    args = api_module.argparse.Namespace(
+        to="user@example.com",
+        subject="Hi",
+        body="<p>Hello</p>",
+        cc="",
+        from_header="",
+        html=False,
+        no_signature=False,
+        thread_id="",
+        func=api_module.gmail_send,
+    )
+
+    with patch.object(api_module.subprocess, "run", side_effect=capture_run):
+        api_module.gmail_send(args)
+
+    send_cmd = captured[-1]
+    body = json.loads(send_cmd[send_cmd.index("--json") + 1])
+    raw = body["raw"]
+    decoded = base64.urlsafe_b64decode(raw + "=" * (-len(raw) % 4)).decode()
+    assert "<p>Hello</p><br><br><table>sig</table>" in decoded
+    assert "Content-Type: text/html" in decoded
+
+
+def test_api_gmail_send_no_signature_leaves_body_unchanged(api_module):
+    sendas_payload = {
+        "sendAs": [
+            {"sendAsEmail": "lev@valstratis.com", "isPrimary": True, "signature": "<table>sig</table>"}
+        ]
+    }
+    send_payload = {"id": "msg-123", "threadId": "thr-456"}
+    captured = []
+
+    def capture_run(cmd, **kwargs):
+        captured.append(cmd)
+        if "sendAs" in cmd:
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=json.dumps(sendas_payload), stderr="")
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=json.dumps(send_payload), stderr="")
+
+    args = api_module.argparse.Namespace(
+        to="user@example.com",
+        subject="Hi",
+        body="Hello",
+        cc="",
+        from_header="",
+        html=False,
+        no_signature=True,
+        thread_id="",
+        func=api_module.gmail_send,
+    )
+
+    with patch.object(api_module.subprocess, "run", side_effect=capture_run):
+        api_module.gmail_send(args)
+
+    send_cmd = captured[-1]
+    body = json.loads(send_cmd[send_cmd.index("--json") + 1])
+    raw = body["raw"]
+    decoded = base64.urlsafe_b64decode(raw + "=" * (-len(raw) % 4)).decode()
+    assert "\n\nHello" in decoded
+    assert "sig" not in decoded
+    assert "Content-Type: text/plain" in decoded
+
+
+def test_api_gmail_reply_appends_signature_and_forces_html(api_module):
+    sendas_payload = {
+        "sendAs": [
+            {"sendAsEmail": "lev@valstratis.com", "isDefault": True, "signature": "<p>sig</p>"}
+        ]
+    }
+    original_payload = {
+        "id": "orig-123",
+        "threadId": "thr-456",
+        "payload": {
+            "headers": [
+                {"name": "From", "value": "sender@example.com"},
+                {"name": "Subject", "value": "Status"},
+                {"name": "Message-ID", "value": "<abc@example.com>"},
+            ]
+        },
+    }
+    send_payload = {"id": "msg-789", "threadId": "thr-456"}
+    captured = []
+
+    def capture_run(cmd, **kwargs):
+        captured.append(cmd)
+        if "sendAs" in cmd:
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=json.dumps(sendas_payload), stderr="")
+        if "messages" in cmd and "get" in cmd:
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=json.dumps(original_payload), stderr="")
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=json.dumps(send_payload), stderr="")
+
+    args = api_module.argparse.Namespace(
+        message_id="abc123",
+        body="Thanks",
+        from_header="",
+        html=False,
+        no_signature=False,
+        func=api_module.gmail_reply,
+    )
+
+    with patch.object(api_module.subprocess, "run", side_effect=capture_run):
+        api_module.gmail_reply(args)
+
+    send_cmd = captured[-1]
+    body = json.loads(send_cmd[send_cmd.index("--json") + 1])
+    raw = body["raw"]
+    decoded = base64.urlsafe_b64decode(raw + "=" * (-len(raw) % 4)).decode()
+    assert "Thanks<br><br><p>sig</p>" in decoded
+    assert "Content-Type: text/html" in decoded

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -1,5 +1,6 @@
 """Tests for Google Workspace gws bridge and CLI wrapper."""
 
+import base64
 import importlib.util
 import json
 import os

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -1,5 +1,6 @@
 """Tests for Google Workspace gws bridge and CLI wrapper."""
 
+import base64
 import importlib.util
 import json
 import subprocess

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -353,6 +353,7 @@ def test_api_gmail_send_uses_conventional_mime_header_casing(api_module):
         subject="hello",
         body="body",
         html=False,
+        no_signature=True,
         cc="copy@example.com",
         from_header="sender@example.com",
         thread_id="thread-1",
@@ -415,6 +416,8 @@ def test_api_gmail_reply_reads_headers_case_insensitively_and_uses_conventional_
         message_id="msg-1",
         body="reply body",
         from_header="recipient@example.com",
+        html=False,
+        no_signature=True,
         func=api_module.gmail_reply,
     )
 
@@ -523,6 +526,20 @@ def test_api_get_sendas_primary_gracefully_degrades_on_empty_list(api_module):
     assert alias == {}
 
 
+def test_api_get_sendas_primary_gracefully_degrades_on_gws_error(api_module):
+    completed = subprocess.CompletedProcess(
+        args=[],
+        returncode=1,
+        stdout="",
+        stderr="missing gmail.settings.basic scope",
+    )
+
+    with patch.object(subprocess, "run", return_value=completed):
+        alias = api_module._get_sendas_primary()
+
+    assert alias == {}
+
+
 def test_api_gmail_send_appends_signature_and_forces_html(api_module):
     sendas_payload = {
         "sendAs": [
@@ -562,19 +579,14 @@ def test_api_gmail_send_appends_signature_and_forces_html(api_module):
 
 
 def test_api_gmail_send_no_signature_leaves_body_unchanged(api_module):
-    sendas_payload = {
-        "sendAs": [
-            {"sendAsEmail": "lev@valstratis.com", "isPrimary": True, "signature": "<table>sig</table>"}
-        ]
-    }
     send_payload = {"id": "msg-123", "threadId": "thr-456"}
-    captured = []
+    captured = {}
 
-    def capture_run(cmd, **kwargs):
-        captured.append(cmd)
-        if "sendAs" in cmd:
-            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=json.dumps(sendas_payload), stderr="")
-        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=json.dumps(send_payload), stderr="")
+    def fake_run_gws(parts, *, params=None, body=None):
+        captured["parts"] = parts
+        captured["params"] = params
+        captured["body"] = body
+        return send_payload
 
     args = api_module.argparse.Namespace(
         to="user@example.com",
@@ -588,12 +600,12 @@ def test_api_gmail_send_no_signature_leaves_body_unchanged(api_module):
         func=api_module.gmail_send,
     )
 
-    with patch.object(api_module.subprocess, "run", side_effect=capture_run):
+    api_module._run_gws = fake_run_gws
+    with patch.object(api_module, "_get_sendas_primary") as get_sendas:
         api_module.gmail_send(args)
 
-    send_cmd = captured[-1]
-    body = json.loads(send_cmd[send_cmd.index("--json") + 1])
-    raw = body["raw"]
+    get_sendas.assert_not_called()
+    raw = captured["body"]["raw"]
     decoded = base64.urlsafe_b64decode(raw + "=" * (-len(raw) % 4)).decode()
     assert "\n\nHello" in decoded
     assert "sig" not in decoded

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -484,3 +484,164 @@ def test_api_get_credentials_refresh_persists_authorized_user_type(api_module, m
     assert isinstance(creds, FakeCredentials)
     assert saved["token"] == "ya29.refreshed"
     assert saved["type"] == "authorized_user"
+
+
+def test_api_get_sendas_primary_prefers_primary_alias(api_module):
+    completed = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=json.dumps(
+            {
+                "sendAs": [
+                    {"sendAsEmail": "alias@example.com", "isDefault": True, "signature": "<p>Default</p>"},
+                    {"sendAsEmail": "primary@example.com", "isPrimary": True, "signature": "<p>Primary</p>"},
+                ]
+            }
+        ),
+        stderr="",
+    )
+
+    with patch.object(subprocess, "run", return_value=completed):
+        alias = api_module._get_sendas_primary()
+
+    assert alias["sendAsEmail"] == "primary@example.com"
+    assert alias["signature"] == "<p>Primary</p>"
+
+
+def test_api_get_sendas_primary_gracefully_degrades_on_empty_list(api_module):
+    completed = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=json.dumps({"sendAs": []}),
+        stderr="",
+    )
+
+    with patch.object(subprocess, "run", return_value=completed):
+        alias = api_module._get_sendas_primary()
+
+    assert alias == {}
+
+
+def test_api_gmail_send_appends_signature_and_forces_html(api_module):
+    sendas_payload = {
+        "sendAs": [
+            {"sendAsEmail": "lev@valstratis.com", "isPrimary": True, "signature": "<table>sig</table>"}
+        ]
+    }
+    send_payload = {"id": "msg-123", "threadId": "thr-456"}
+    captured = []
+
+    def capture_run(cmd, **kwargs):
+        captured.append(cmd)
+        if "sendAs" in cmd:
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=json.dumps(sendas_payload), stderr="")
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=json.dumps(send_payload), stderr="")
+
+    args = api_module.argparse.Namespace(
+        to="user@example.com",
+        subject="Hi",
+        body="<p>Hello</p>",
+        cc="",
+        from_header="",
+        html=False,
+        no_signature=False,
+        thread_id="",
+        func=api_module.gmail_send,
+    )
+
+    with patch.object(api_module.subprocess, "run", side_effect=capture_run):
+        api_module.gmail_send(args)
+
+    send_cmd = captured[-1]
+    body = json.loads(send_cmd[send_cmd.index("--json") + 1])
+    raw = body["raw"]
+    decoded = base64.urlsafe_b64decode(raw + "=" * (-len(raw) % 4)).decode()
+    assert "<p>Hello</p><br><br><table>sig</table>" in decoded
+    assert "Content-Type: text/html" in decoded
+
+
+def test_api_gmail_send_no_signature_leaves_body_unchanged(api_module):
+    sendas_payload = {
+        "sendAs": [
+            {"sendAsEmail": "lev@valstratis.com", "isPrimary": True, "signature": "<table>sig</table>"}
+        ]
+    }
+    send_payload = {"id": "msg-123", "threadId": "thr-456"}
+    captured = []
+
+    def capture_run(cmd, **kwargs):
+        captured.append(cmd)
+        if "sendAs" in cmd:
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=json.dumps(sendas_payload), stderr="")
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=json.dumps(send_payload), stderr="")
+
+    args = api_module.argparse.Namespace(
+        to="user@example.com",
+        subject="Hi",
+        body="Hello",
+        cc="",
+        from_header="",
+        html=False,
+        no_signature=True,
+        thread_id="",
+        func=api_module.gmail_send,
+    )
+
+    with patch.object(api_module.subprocess, "run", side_effect=capture_run):
+        api_module.gmail_send(args)
+
+    send_cmd = captured[-1]
+    body = json.loads(send_cmd[send_cmd.index("--json") + 1])
+    raw = body["raw"]
+    decoded = base64.urlsafe_b64decode(raw + "=" * (-len(raw) % 4)).decode()
+    assert "\n\nHello" in decoded
+    assert "sig" not in decoded
+    assert "Content-Type: text/plain" in decoded
+
+
+def test_api_gmail_reply_appends_signature_and_forces_html(api_module):
+    sendas_payload = {
+        "sendAs": [
+            {"sendAsEmail": "lev@valstratis.com", "isDefault": True, "signature": "<p>sig</p>"}
+        ]
+    }
+    original_payload = {
+        "id": "orig-123",
+        "threadId": "thr-456",
+        "payload": {
+            "headers": [
+                {"name": "From", "value": "sender@example.com"},
+                {"name": "Subject", "value": "Status"},
+                {"name": "Message-ID", "value": "<abc@example.com>"},
+            ]
+        },
+    }
+    send_payload = {"id": "msg-789", "threadId": "thr-456"}
+    captured = []
+
+    def capture_run(cmd, **kwargs):
+        captured.append(cmd)
+        if "sendAs" in cmd:
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=json.dumps(sendas_payload), stderr="")
+        if "messages" in cmd and "get" in cmd:
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=json.dumps(original_payload), stderr="")
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=json.dumps(send_payload), stderr="")
+
+    args = api_module.argparse.Namespace(
+        message_id="abc123",
+        body="Thanks",
+        from_header="",
+        html=False,
+        no_signature=False,
+        func=api_module.gmail_reply,
+    )
+
+    with patch.object(api_module.subprocess, "run", side_effect=capture_run):
+        api_module.gmail_reply(args)
+
+    send_cmd = captured[-1]
+    body = json.loads(send_cmd[send_cmd.index("--json") + 1])
+    raw = body["raw"]
+    decoded = base64.urlsafe_b64decode(raw + "=" * (-len(raw) % 4)).decode()
+    assert "Thanks<br><br><p>sig</p>" in decoded
+    assert "Content-Type: text/html" in decoded


### PR DESCRIPTION
## What does this PR do?

Since the Google Workspace skill migrated to the `gws` CLI backend, Hermes now inherits Gmail `sendAs` display-name handling from upstream `googleworkspace/cli`. That means the old display-name portion of this PR is no longer the missing behavior.

The remaining capability gap is Gmail signature insertion.

Gmail's API sends raw MIME messages exactly as constructed. Even when a `sendAs` alias has a stored HTML signature and Gmail web is configured to auto-insert it, API-sent messages do not get that signature appended automatically. After the GWS migration, Hermes still sends and replies correctly, but it no longer appends the alias signature.

This PR adds that feature on top of the new GWS backend:

1. Fetch the primary/default `sendAs` alias via `users.settings.sendAs.list()`.
2. Read the alias `signature` HTML.
3. Append that signature to `gmail send` and `gmail reply` bodies with `<br><br>` when signature injection is enabled.
4. Preserve `--no-signature` as an explicit opt-out.
5. Re-add `gmail.settings.basic` to the setup scopes so the `sendAs` settings endpoint is available.

`From` display-name enrichment remains upstream GWS behavior; this PR is specifically about adding signature insertion to the GWS-based wrapper.

## Related Context

- Existing PR updated for the post-GWS world rather than replaced.
- Upstream GWS already handles `From` / display-name enrichment from `sendAs`.
- Gmail API still requires clients to construct the outgoing MIME body themselves.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature (non-breaking Gmail signature support on the GWS wrapper)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `skills/productivity/google-workspace/scripts/google_api.py`
  - Add a small wrapper-side `sendAs` lookup for the primary/default alias.
  - Append alias signature HTML to `gmail send` and `gmail reply` bodies.
  - Preserve `--no-signature` and `--html` compatibility.
  - Keep actual send/reply execution on the GWS backend.
- `skills/productivity/google-workspace/scripts/setup.py`
  - Re-add `https://www.googleapis.com/auth/gmail.settings.basic` to requested scopes.
- `tests/skills/test_google_workspace_api.py`
  - Add coverage for `sendAs` lookup, graceful degradation, signature append behavior, and `--no-signature` suppression on the GWS wrapper.

## Automated Validation Performed

Ran targeted tests on current `upstream/main` in a temporary Python 3.12 virtualenv:

```bash
/tmp/hermes-pytest-venv/bin/python -m pytest -o addopts='' tests/skills/test_google_workspace_api.py tests/skills/test_google_oauth_setup.py
```

Result: `18 passed`

## Live Smoke Test Performed

Also verified end-to-end behavior against a real Gmail account using the patched `google_api.py` wrapper on top of the real `gws` CLI backend (with an isolated temporary Hermes home and copied token):

- `gmail send` appended the configured HTML signature
- `gmail send --no-signature` did not append the signature
- `gmail reply` appended the configured HTML signature

This confirmed the wrapper logic works with the actual GWS runtime path, not just in unit tests.

## Optional Manual Smoke Test

If you want to verify live Gmail behavior with a real account/token that includes `gmail.settings.basic`:

1. Authenticate with `python setup.py` if your existing token is missing the `gmail.settings.basic` scope.
2. Send a test email:
   ```bash
   python google_api.py gmail send --to you@example.com --subject "Test" --body "<p>Hello</p>"
   ```
   Verify the configured Gmail signature is appended.
3. Test opt-out:
   ```bash
   python google_api.py gmail send --to you@example.com --subject "Alert" --body "Automated message" --no-signature
   ```
   Verify the signature is not appended.
4. Test reply:
   ```bash
   python google_api.py gmail reply <message_id> --body "<p>Thanks</p>"
   ```
   Verify reply bodies also receive the signature unless `--no-signature` is used.
