### PR TITLE
security(agent): redact Slack Socket Mode app tokens in logs

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -27,6 +27,7 @@ _PREFIX_PATTERNS = [
     r"ghs_[A-Za-z0-9]{10,}",            # GitHub server-to-server token
     r"ghr_[A-Za-z0-9]{10,}",            # GitHub refresh token
     r"xox[baprs]-[A-Za-z0-9-]{10,}",    # Slack tokens
+    r"xapp-[A-Za-z0-9-]{10,}",          # Slack app-level tokens
     r"AIza[A-Za-z0-9_-]{30,}",          # Google API keys
     r"pplx-[A-Za-z0-9]{10,}",           # Perplexity
     r"fal_[A-Za-z0-9_-]{10,}",          # Fal.ai

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -42,6 +42,12 @@ class TestKnownPrefixes:
         result = redact_sensitive_text(token)
         assert "a" * 14 not in result
 
+    def test_slack_app_token(self):
+        token = "xapp-1-A1234567890-B1234567890-C1234567890"
+        result = redact_sensitive_text(token)
+        assert "A1234567890-B1234567890-C1234567890" not in result
+        assert "xapp-1" in result
+
     def test_google_api_key(self):
         result = redact_sensitive_text("AIzaSyB-abc123def456ghi789jklmno012345")
         assert "abc123def456" not in result


### PR DESCRIPTION
###  Problem Description
While bot and user tokens (`xoxb-`, `xoxp-`) were already being correctly redacted by the centralized logging utility, I noticed that Slack **App-level tokens** (`xapp-`) used for Socket Mode were slipping through and being logged in plain text during connection retries or adapter exceptions.

This created an inconsistency in how Slack credentials were handled across the codebase, specifically in `gateway/platforms/slack.py`.

###  Proposed Changes
- **Pattern Update:** Added the missing `xapp-` prefix pattern to `_PREFIX_PATTERNS` in `agent/redact.py`. 
- **Consistency:** This ensures that the `SLACK_APP_TOKEN` environment variable receives the same protection as other platform secrets during any automated logging event.

###  How was this tested?
1. **Unit Test:** Added a new test case to `tests/agent/test_redact.py` specifically targeting the Slack app token format.
2. **Regression Check:** Verified that existing redaction patterns for Google, GitHub, and other Slack tokens remain unaffected.
3. **Manual Check:** Confirmed via CLI that a sample `xapp-` token is now truncated to its prefix and last 4 characters.

**Local Test Output:**
```bash
pytest tests/agent/test_redact.py -q
# Result: 44 passed

Checklist
x] Security Fix (Secret Redaction)
[x] Zero behavior change to existing Slack connectivity
[x] Unit tests added and passing locally
[x] Adheres to Conventional Commits