### PR TITLE
fix(skills): respect local skill dir in skill manager

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -219,6 +219,37 @@ class TestCreateSkill:
         assert "Invalid category '../escape'" in result["error"]
         assert not (tmp_path / "escape").exists()
 
+
+class TestFindSkill:
+    def test_find_skill_respects_patched_skills_dir(self, tmp_path):
+        with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            result = _find_skill("my-skill")
+
+        assert result is not None
+        assert result["path"] == tmp_path / "my-skill"
+
+    def test_find_skill_includes_external_dirs(self, tmp_path, monkeypatch):
+        local_skills = tmp_path / "local-skills"
+        external_skills = tmp_path / "external-skills"
+        local_skills.mkdir()
+        external_skills.mkdir()
+        (external_skills / "ext-skill").mkdir()
+        (external_skills / "ext-skill" / "SKILL.md").write_text(
+            VALID_SKILL_CONTENT,
+            encoding="utf-8",
+        )
+
+        with patch("tools.skill_manager_tool.SKILLS_DIR", local_skills):
+            monkeypatch.setattr(
+                "agent.skill_utils.get_external_skills_dirs",
+                lambda: [external_skills],
+            )
+            result = _find_skill("ext-skill")
+
+        assert result is not None
+        assert result["path"] == external_skills / "ext-skill"
+
     def test_create_rejects_absolute_category(self, tmp_path):
         skills_dir = tmp_path / "skills"
         skills_dir.mkdir()

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -209,8 +209,20 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     external dirs configured via skills.external_dirs.  Returns
     {"path": Path} or None.
     """
-    from agent.skill_utils import get_all_skills_dirs
-    for skills_dir in get_all_skills_dirs():
+    # Use the module-level SKILLS_DIR first so tests and callers that
+    # monkeypatch it get the expected local-first behavior. Then append any
+    # configured external dirs.
+    all_dirs = [SKILLS_DIR]
+    try:
+        from agent.skill_utils import get_external_skills_dirs
+
+        for ext_dir in get_external_skills_dirs():
+            if ext_dir not in all_dirs:
+                all_dirs.append(ext_dir)
+    except Exception:
+        pass
+
+    for skills_dir in all_dirs:
         if not skills_dir.exists():
             continue
         for skill_md in skills_dir.rglob("SKILL.md"):


### PR DESCRIPTION
## Summary
- restore local-first skill lookup in `skill_manager_tool`
- keep support for `skills.external_dirs`
- add regression coverage for patched `SKILLS_DIR` and external dir lookup

## Related
- fixes #4759

## Testing
- `source /Users/mbelleau/Projects/hermes-agent/venv/bin/activate && python -m pytest tests/tools/test_skill_manager_tool.py -q`
