### PR TITLE
fix(gateway): avoid shadowing run message

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6465,14 +6465,15 @@ class GatewayRunner:
             # Prepend pending model switch note so the model knows about the switch
             _pending_notes = getattr(self, '_pending_model_notes', {})
             _msn = _pending_notes.pop(session_key, None) if session_key else None
+            prompt_message = message
             if _msn:
-                message = _msn + "\n\n" + message
+                prompt_message = _msn + "\n\n" + prompt_message
 
             _approval_session_key = session_key or ""
             _approval_session_token = set_current_session_key(_approval_session_key)
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
             try:
-                result = agent.run_conversation(message, conversation_history=agent_history, task_id=session_id)
+                result = agent.run_conversation(prompt_message, conversation_history=agent_history, task_id=session_id)
             finally:
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)

--- a/tests/test_codex_execution_paths.py
+++ b/tests/test_codex_execution_paths.py
@@ -138,6 +138,7 @@ def test_gateway_run_agent_codex_path_handles_internal_401_refresh(monkeypatch):
             "api_key": "codex-token",
         },
     )
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.3-codex")
     monkeypatch.setenv("HERMES_TOOL_PROGRESS", "false")
     monkeypatch.setenv("HERMES_MODEL", "gpt-5.3-codex")
 


### PR DESCRIPTION
## Summary
- avoid shadowing the `_run_agent` message parameter inside the gateway worker closure
- keep pending model-switch note prepending behavior using a separate local
- add a regression assertion for the gateway Codex refresh path with current model resolution

## Related
- fixes #5286

## Testing
- `source /Users/mbelleau/Projects/hermes-agent/venv/bin/activate && python -m pytest tests/test_codex_execution_paths.py -q`
