### PR TITLE
fix: redact secrets from CDP URLs before writing to logs

### DIFF
--- a/tests/tools/test_browser_cdp_override.py
+++ b/tests/tools/test_browser_cdp_override.py
@@ -45,3 +45,49 @@ class TestResolveCdpOverride:
 
         with patch("tools.browser_tool.requests.get", side_effect=RuntimeError("boom")):
             assert _resolve_cdp_override(HTTP_URL) == HTTP_URL
+
+    def test_redacts_secret_query_params_in_success_log(self):
+        from tools.browser_tool import _resolve_cdp_override
+
+        raw = "https://cdp.example/json/version?access_token=super-secret-token-123456"
+        resolved_ws = "wss://cdp.example/devtools/browser/abc?token=super-secret-token-123456"
+
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"webSocketDebuggerUrl": resolved_ws}
+
+        with patch("tools.browser_tool.requests.get", return_value=response), \
+                patch("tools.browser_tool.logger.info") as mock_info:
+            resolved = _resolve_cdp_override(raw)
+
+        assert resolved == resolved_ws
+        mock_info.assert_called_once()
+        _, logged_raw, logged_ws = mock_info.call_args.args
+        assert "super-secret-token-123456" not in logged_raw
+        assert "super-secret-token-123456" not in logged_ws
+        assert "access_token=***" in logged_raw
+        assert "token=***" in logged_ws
+
+    def test_redacts_secret_query_params_in_failure_log(self):
+        from tools.browser_tool import _resolve_cdp_override
+
+        raw = "https://cdp.example?access_token=super-secret-token-123456"
+        secret_version_url = "https://cdp.example/json/version?access_token=super-secret-token-123456"
+        secret_error = RuntimeError(
+            "upstream rejected https://cdp.example/json/version?access_token=super-secret-token-123456"
+        )
+
+        with patch("tools.browser_tool.requests.get", side_effect=secret_error), \
+                patch("tools.browser_tool.logger.warning") as mock_warning:
+            resolved = _resolve_cdp_override(raw)
+
+        assert resolved == raw
+        mock_warning.assert_called_once()
+        _, logged_raw, logged_version_url, logged_error = mock_warning.call_args.args
+        assert "super-secret-token-123456" not in logged_raw
+        assert "super-secret-token-123456" not in logged_version_url
+        assert "super-secret-token-123456" not in logged_error
+        assert "access_token=***" in logged_raw
+        assert "access_token=***" in logged_version_url
+        assert "access_token=***" in logged_error
+        assert logged_version_url.startswith("https://cdp.example")

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -64,7 +64,9 @@ import time
 import requests
 from typing import Dict, Any, Optional, List
 from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
 from agent.auxiliary_client import call_llm
+from agent.redact import redact_sensitive_text
 from hermes_constants import get_hermes_home
 
 try:
@@ -137,6 +139,40 @@ DEFAULT_SESSION_TIMEOUT = 300
 # Max tokens for snapshot content before summarization
 SNAPSHOT_SUMMARIZE_THRESHOLD = 8000
 
+_SENSITIVE_URL_QUERY_PARAM_RE = re.compile(
+    r"([?&](?:access_token|auth_token|token|api_key|client_secret|secret|password)=)([^&#\s]+)",
+    re.IGNORECASE,
+)
+_URL_USERINFO_PASSWORD_RE = re.compile(
+    r"(((?:https?|wss?)://[^/\s:@]+:))([^@/\s]+)(@)",
+    re.IGNORECASE,
+)
+
+
+def _sanitize_url_for_logs(value: object) -> str:
+    """Mask secrets in logged browser endpoint URLs and URL-like errors."""
+    text = redact_sensitive_text(value)
+    if not text:
+        return text
+
+    text = _SENSITIVE_URL_QUERY_PARAM_RE.sub(r"\1***", text)
+    text = _URL_USERINFO_PASSWORD_RE.sub(r"\1***\4", text)
+
+    try:
+        parts = urlsplit(text)
+    except Exception:
+        return text
+
+    if parts.password is None:
+        return text
+
+    netloc = parts.hostname or ""
+    if parts.username:
+        netloc = f"{parts.username}:***@{netloc}"
+    if parts.port:
+        netloc = f"{netloc}:{parts.port}"
+    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
+
 
 def _get_command_timeout() -> int:
     """Return the configured browser command timeout from config.yaml.
@@ -206,15 +242,27 @@ def _resolve_cdp_override(cdp_url: str) -> str:
         response.raise_for_status()
         payload = response.json()
     except Exception as exc:
-        logger.warning("Failed to resolve CDP endpoint %s via %s: %s", raw, version_url, exc)
+        logger.warning(
+            "Failed to resolve CDP endpoint %s via %s: %s",
+            _sanitize_url_for_logs(raw),
+            _sanitize_url_for_logs(version_url),
+            _sanitize_url_for_logs(exc),
+        )
         return raw
 
     ws_url = str(payload.get("webSocketDebuggerUrl") or "").strip()
     if ws_url:
-        logger.info("Resolved CDP endpoint %s -> %s", raw, ws_url)
+        logger.info(
+            "Resolved CDP endpoint %s -> %s",
+            _sanitize_url_for_logs(raw),
+            _sanitize_url_for_logs(ws_url),
+        )
         return ws_url
 
-    logger.warning("CDP discovery at %s did not return webSocketDebuggerUrl; using raw endpoint", version_url)
+    logger.warning(
+        "CDP discovery at %s did not return webSocketDebuggerUrl; using raw endpoint",
+        _sanitize_url_for_logs(version_url),
+    )
     return raw
 
 


### PR DESCRIPTION
## Problem

`_resolve_cdp_override()` in `tools/browser_tool.py` passed raw CDP discovery
URLs directly to `logger.info` and `logger.warning`. Any secrets embedded in
query parameters (`access_token`, `token`, `api_key`, `secret`, etc.) or in
the userinfo block of the URL were written to log output in plain text.

**Log output before fix:**

INFO:Resolved CDP endpoint [https://cdp.example?access_token=super-secret-token-123456](https://cdp.example/?access_token=super-secret-token-123456)
-> wss://cdp.example/devtools/browser/abc?token=super-secret-token-123456

## Changes

### `tools/browser_tool.py`
- Added `_sanitize_url_for_logs(value)` helper that masks sensitive query
  parameters (`access_token`, `auth_token`, `token`, `api_key`, `client_secret`,
  `secret`, `password`) and userinfo passwords with `***`. Secrets embedded
  inside exception message strings are covered as well. Applies
  `redact_sensitive_text()` first, then regex-based URL masking.
- All `logger.info` / `logger.warning` call sites in `_resolve_cdp_override()`
  now pipe URLs and exception objects through `_sanitize_url_for_logs()`.
  The value returned to the caller is not modified.
- Added imports: `urllib.parse.urlsplit` / `urlunsplit`,
  `agent.redact.redact_sensitive_text`.

### `tests/tools/test_browser_cdp_override.py`
- `test_redacts_secret_query_params_in_success_log` — asserts the success-path
  log does not leak secrets in either the input or resolved URL.
- `test_redacts_secret_query_params_in_failure_log` — asserts the failure-path
  log does not leak secrets in the raw URL, version URL, or the exception string.

## Testing
```bash
python -m pytest tests/tools/test_browser_cdp_override.py -q
# 6 passed in 2.42s
```

## Notes

- Masking is log-only; the value returned by `_resolve_cdp_override()` is unchanged.
- All 4 pre-existing tests continue to pass.