### PR TITLE
fix(cli): handle typed text in clarify choice mode

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6125,6 +6125,19 @@ class HermesCLI:
         for line in reqs["details"].split("\n"):
             _cprint(f"    {line}")
 
+    def _submit_clarify_response(self, response_text, event):
+        """Submit a user response to the active clarify prompt and reset UI state.
+
+        Centralizes the submit logic used by both freetext and choice-mode
+        Enter handlers so the two code paths stay consistent.
+        """
+        if self._clarify_state:
+            self._clarify_state["response_queue"].put(response_text)
+        self._clarify_state = None
+        self._clarify_freetext = False
+        event.app.current_buffer.reset()
+        event.app.invalidate()
+
     def _clarify_callback(self, question, choices):
         """
         Platform callback for the clarify tool. Called from the agent thread.
@@ -7223,11 +7236,7 @@ class HermesCLI:
             if self._clarify_freetext and self._clarify_state:
                 text = event.app.current_buffer.text.strip()
                 if text:
-                    self._clarify_state["response_queue"].put(text)
-                    self._clarify_state = None
-                    self._clarify_freetext = False
-                    event.app.current_buffer.reset()
-                    event.app.invalidate()
+                    self._submit_clarify_response(text, event)
                 return
 
             # --- Clarify choice mode: confirm the highlighted selection ---
@@ -7238,18 +7247,12 @@ class HermesCLI:
                 # the highlighted choice when they intended to type their own answer.
                 typed_text = event.app.current_buffer.text.strip()
                 if typed_text:
-                    state["response_queue"].put(typed_text)
-                    self._clarify_state = None
-                    self._clarify_freetext = False
-                    event.app.current_buffer.reset()
-                    event.app.invalidate()
+                    self._submit_clarify_response(typed_text, event)
                     return
                 selected = state["selected"]
                 choices = state.get("choices") or []
                 if selected < len(choices):
-                    state["response_queue"].put(choices[selected])
-                    self._clarify_state = None
-                    event.app.invalidate()
+                    self._submit_clarify_response(choices[selected], event)
                 else:
                     # "Other" selected → switch to freetext
                     self._clarify_freetext = True

--- a/cli.py
+++ b/cli.py
@@ -7233,6 +7233,17 @@ class HermesCLI:
             # --- Clarify choice mode: confirm the highlighted selection ---
             if self._clarify_state and not self._clarify_freetext:
                 state = self._clarify_state
+                # If the user typed text in the input buffer, treat it as
+                # an "Other" freetext response — don't accidentally submit
+                # the highlighted choice when they intended to type their own answer.
+                typed_text = event.app.current_buffer.text.strip()
+                if typed_text:
+                    state["response_queue"].put(typed_text)
+                    self._clarify_state = None
+                    self._clarify_freetext = False
+                    event.app.current_buffer.reset()
+                    event.app.invalidate()
+                    return
                 selected = state["selected"]
                 choices = state.get("choices") or []
                 if selected < len(choices):

--- a/tests/test_cli_clarify_submit.py
+++ b/tests/test_cli_clarify_submit.py
@@ -1,0 +1,83 @@
+"""Tests for the _submit_clarify_response helper and typed-text override."""
+import queue
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from cli import HermesCLI
+
+
+def _make_cli_stub():
+    """Create a minimal HermesCLI via __new__ with only the clarify-related attrs."""
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._clarify_state = None
+    cli._clarify_freetext = False
+    cli._clarify_deadline = 0
+    cli._invalidate = MagicMock()
+    cli._app = SimpleNamespace(invalidate=MagicMock())
+    return cli
+
+
+def _make_mock_event():
+    """Create a mock prompt_toolkit event with a resettable buffer."""
+    event = MagicMock()
+    event.app.current_buffer.text = ""
+    return event
+
+
+class TestSubmitClarifyResponse:
+    def test_enqueues_response_and_clears_state(self):
+        """_submit_clarify_response should put the response in the queue
+        and reset all clarify state."""
+        cli = _make_cli_stub()
+        response_queue = queue.Queue()
+        cli._clarify_state = {
+            "question": "Pick one",
+            "choices": ["a", "b"],
+            "selected": 0,
+            "response_queue": response_queue,
+        }
+        cli._clarify_freetext = True
+
+        event = _make_mock_event()
+        cli._submit_clarify_response("my answer", event)
+
+        assert response_queue.get_nowait() == "my answer"
+        assert cli._clarify_state is None
+        assert cli._clarify_freetext is False
+        event.app.current_buffer.reset.assert_called_once()
+        event.app.invalidate.assert_called_once()
+
+    def test_no_crash_without_clarify_state(self):
+        """Should not crash if _clarify_state is None (race condition guard)."""
+        cli = _make_cli_stub()
+        cli._clarify_state = None
+        event = _make_mock_event()
+        cli._submit_clarify_response("text", event)
+        assert cli._clarify_state is None
+
+    def test_choice_mode_typed_text_overrides_selection(self):
+        """When in choice mode, typed text should be submitted instead of
+        the highlighted choice — this is the bug fix."""
+        cli = _make_cli_stub()
+        response_queue = queue.Queue()
+        cli._clarify_state = {
+            "question": "Pick one",
+            "choices": ["option A", "option B", "Other"],
+            "selected": 0,  # "option A" is highlighted
+            "response_queue": response_queue,
+        }
+        cli._clarify_freetext = False
+
+        event = _make_mock_event()
+
+        # Simulate the logic from the Enter handler: if typed text exists,
+        # use _submit_clarify_response instead of the selected choice.
+        typed_text = "my custom answer"
+        if typed_text:
+            cli._submit_clarify_response(typed_text, event)
+
+        # The custom answer should be submitted, not "option A"
+        result = response_queue.get_nowait()
+        assert result == "my custom answer"
+        assert result != "option A"


### PR DESCRIPTION
## Problem

When the `clarify` tool presents multiple choices, the user can type their own answer directly into the input buffer without first selecting the 'Other' option. However, pressing Enter submits whichever choice happens to be highlighted, **ignoring the typed text entirely**.

This leads to frustrating accidental submissions where the user's intended free-form response is silently discarded.

## Fix

Before submitting the highlighted choice in clarify choice mode, check if the input buffer contains typed text. If text is present, treat it as a freetext response (same behavior as selecting 'Other' and typing) — this respects user intent and prevents accidental wrong answers.

## Changes

- `cli.py`: Add a typed-text check at the start of the clarify choice mode Enter handler. If the buffer has text, put it directly on the response queue and clear the clarify state.

## Testing

Manually tested:
1. Agent asks a clarify question with choices A, B, C, Other
2. User types 'my custom answer' without selecting Other
3. **Before**: Pressing Enter submits choice A (highlighted) → wrong answer
4. **After**: Pressing Enter submits 'my custom answer' → correct behavior
5. Normal choice selection (arrow keys + Enter without typing) still works as before