### PR TITLE
feat(cli): add bell_on_prompt for interactive prompts

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6159,17 +6159,13 @@ class HermesCLI:
 
         # Play terminal bell to alert the user that input is needed.
         # Propagates over SSH, tmux, screen, and web terminals.
-        if self.bell_on_prompt:
+        if getattr(self, "bell_on_prompt", True):
             try:
                 sys.stdout.write("\a")
                 sys.stdout.flush()
             except Exception:
                 pass
 
-        # Poll for the user's response.  The countdown in the hint line
-        # updates on each invalidate — but frequent repaints cause visible
-        # flicker in some terminals (Kitty, ghostty).  We only refresh the
-        # countdown every 5 s; selection changes (↑/↓) trigger instant
         # Poll for the user's response.  The countdown in the hint line
         # updates on each invalidate — but frequent repaints cause visible
         # flicker in some terminals (Kitty, ghostty).  We only refresh the
@@ -6187,9 +6183,6 @@ class HermesCLI:
                     break
                 # Only repaint every 5 s for the countdown — avoids flicker
                 now = _time.monotonic()
-                if now - _last_countdown_refresh >= 5.0:
-                    _last_countdown_refresh = now
-                    self._invalidate()
                 if now - _last_countdown_refresh >= 5.0:
                     _last_countdown_refresh = now
                     self._invalidate()
@@ -6226,7 +6219,7 @@ class HermesCLI:
         self._invalidate()
 
         # Play terminal bell to alert the user that sudo password is needed.
-        if self.bell_on_prompt:
+        if getattr(self, "bell_on_prompt", True):
             try:
                 sys.stdout.write("\a")
                 sys.stdout.flush()
@@ -6289,7 +6282,7 @@ class HermesCLI:
             self._invalidate()
 
             # Play terminal bell to alert the user that command approval is needed.
-            if self.bell_on_prompt:
+            if getattr(self, "bell_on_prompt", True):
                 try:
                     sys.stdout.write("\a")
                     sys.stdout.flush()

--- a/cli.py
+++ b/cli.py
@@ -1353,6 +1353,10 @@ class HermesCLI:
         self.resume_display = CLI_CONFIG["display"].get("resume_display", "full")
         # bell_on_complete: play terminal bell (\a) when agent finishes a response
         self.bell_on_complete = CLI_CONFIG["display"].get("bell_on_complete", False)
+        # bell_on_prompt: play terminal bell (\a) when the agent needs user input
+        # (clarify questions, sudo prompts, approval requests). Useful for
+        # getting attention over SSH, in multiplexers, or via web terminals.
+        self.bell_on_prompt = CLI_CONFIG["display"].get("bell_on_prompt", True)
         # show_reasoning: display model thinking/reasoning before the response
         self.show_reasoning = CLI_CONFIG["display"].get("show_reasoning", False)
         # busy_input_mode: "interrupt" (Enter interrupts current run) or "queue" (Enter queues for next turn)
@@ -6153,6 +6157,15 @@ class HermesCLI:
         # Trigger prompt_toolkit repaint from this (non-main) thread
         self._invalidate()
 
+        # Play terminal bell to alert the user that input is needed.
+        # Propagates over SSH, tmux, screen, and web terminals.
+        if self.bell_on_prompt:
+            try:
+                sys.stdout.write("\a")
+                sys.stdout.flush()
+            except Exception:
+                pass
+
         # Poll for the user's response.  The countdown in the hint line
         # updates on each invalidate — but frequent repaints cause visible
         # flicker in some terminals (Kitty, ghostty).  We only refresh the
@@ -6212,6 +6225,14 @@ class HermesCLI:
 
         self._invalidate()
 
+        # Play terminal bell to alert the user that sudo password is needed.
+        if self.bell_on_prompt:
+            try:
+                sys.stdout.write("\a")
+                sys.stdout.flush()
+            except Exception:
+                pass
+
         while True:
             try:
                 result = response_queue.get(timeout=1)
@@ -6266,6 +6287,14 @@ class HermesCLI:
             self._approval_deadline = _time.monotonic() + timeout
 
             self._invalidate()
+
+            # Play terminal bell to alert the user that command approval is needed.
+            if self.bell_on_prompt:
+                try:
+                    sys.stdout.write("\a")
+                    sys.stdout.flush()
+                except Exception:
+                    pass
 
             _last_countdown_refresh = _time.monotonic()
             while True:

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -149,6 +149,16 @@ class TestBusyInputMode:
         assert cli._pending_input.empty()
 
 
+class TestBellOnPrompt:
+    def test_default_bell_on_prompt_is_true(self):
+        cli = _make_cli()
+        assert cli.bell_on_prompt is True
+
+    def test_bell_on_prompt_false_override(self):
+        cli = _make_cli(config_overrides={"display": {"bell_on_prompt": False}})
+        assert cli.bell_on_prompt is False
+
+
 class TestSingleQueryState:
     def test_voice_and_interrupt_state_initialized_before_run(self):
         """Single-query mode calls chat() without going through run()."""


### PR DESCRIPTION
## Motivation

When the agent needs user input (clarify questions, sudo passwords, command approvals), there's no audible notification. If the user is in another window, on another monitor, or has the terminal in the background, they won't notice until they happen to check — leading to timeouts and missed prompts.

The existing `bell_on_complete` option fires when the agent finishes a response, but there's no equivalent for when the agent is **waiting** for the user.

## Solution

Add a new `bell_on_prompt` config option (default: `true`) that plays a terminal bell (`\a` / BEL / `0x07`) whenever the agent needs human attention:

- **Clarify questions** — when the agent asks the user to choose or type a response
- **Sudo password prompts** — when a command needs elevated privileges
- **Command approval requests** — when a dangerous command needs user confirmation

## Why terminal bell?

The terminal bell is the most universal notification mechanism:
- Works over **SSH** (bell propagates to the client terminal)
- Works in **tmux/screen** (configurable via `visual-bell` / `bell-action`)
- Works in **web terminals** that detect BEL character (e.g. xterm.js)
- Works in any **terminal emulator** with bell support
- Zero dependencies — just a single byte written to stdout

## Configuration

In `config.yaml` under `cli.display`:

```yaml
display:
  bell_on_prompt: true   # default — play bell on interactive prompts
  bell_on_prompt: false  # disable if the bell is distracting
```

## Changes

- `cli.py`: Add `bell_on_prompt` config (follows existing `bell_on_complete` pattern)
- `cli.py`: Emit `\a` in `_clarify_callback`, `_sudo_password_callback`, and `_approval_callback`

## Testing

Manually tested in:
- Local terminal (bell sound plays)
- tmux session (visual bell indicator appears)
- Web terminal with BEL detection (browser notification fires)