### PR TITLE
fix: UnboundLocalError for message in run_sync

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6183,6 +6183,7 @@ class GatewayRunner:
                 logger.debug("status_callback error (%s): %s", event_type, _e)
 
         def run_sync():
+            nonlocal message
             # Pass session_key to process registry via env var so background
             # processes can be mapped back to this gateway session
             os.environ["HERMES_SESSION_KEY"] = session_key or ""


### PR DESCRIPTION
## Summary

- Adds `nonlocal message` declaration to the `run_sync()` closure inside `_run_agent()` in `gateway/run.py`
- Fixes `UnboundLocalError: cannot access local variable 'message' where it is not associated with a value` at line 6255

## Root Cause

The `message` parameter from `_run_agent` is conditionally reassigned at line 6469:
```python
message = _msn + "\n\n" + message
```

This assignment makes Python treat `message` as a local variable for the entire `run_sync` scope, causing an `UnboundLocalError` when `_resolve_turn_agent_config(message, ...)` reads it earlier at line 6255 (before the conditional assignment executes).

## Fix

One-line addition of `nonlocal message` at the top of `run_sync()`, which correctly tells Python to reference the enclosing scope's `message` variable.

## Test plan

- [x] Verified fix resolves the crash on Hermes gateway with Telegram DM input
- [x] Confirmed agent responds normally after patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)