### PR TITLE
fix(mem0): complete API v2 compatibility for reads and writes

### DIFF
--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -234,10 +234,12 @@ class Mem0MemoryProvider(MemoryProvider):
                 client = self._get_client()
                 results = client.search(
                     query=query,
-                    user_id=self._user_id,
+                    filters={"user_id": self._user_id},
                     rerank=self._rerank,
                     top_k=5,
                 )
+                if isinstance(results, dict):
+                    results = results.get("results", [])
                 if results:
                     lines = [r.get("memory", "") for r in results if r.get("memory")]
                     with self._prefetch_lock:
@@ -291,7 +293,9 @@ class Mem0MemoryProvider(MemoryProvider):
 
         if tool_name == "mem0_profile":
             try:
-                memories = client.get_all(user_id=self._user_id)
+                memories = client.get_all(filters={"user_id": self._user_id})
+                if isinstance(memories, dict):
+                    memories = memories.get("results", [])
                 self._record_success()
                 if not memories:
                     return json.dumps({"result": "No memories stored yet."})
@@ -309,9 +313,13 @@ class Mem0MemoryProvider(MemoryProvider):
             top_k = min(int(args.get("top_k", 10)), 50)
             try:
                 results = client.search(
-                    query=query, user_id=self._user_id,
-                    rerank=rerank, top_k=top_k,
+                    query=query,
+                    filters={"user_id": self._user_id},
+                    rerank=rerank,
+                    top_k=top_k,
                 )
+                if isinstance(results, dict):
+                    results = results.get("results", [])
                 self._record_success()
                 if not results:
                     return json.dumps({"result": "No relevant memories found."})

--- a/plugins/memory/mem0/__init__.py
+++ b/plugins/memory/mem0/__init__.py
@@ -7,7 +7,7 @@ Original PR #2933 by kartik-mem0, adapted to MemoryProvider ABC.
 
 Config via environment variables:
   MEM0_API_KEY       — Mem0 Platform API key (required)
-  MEM0_USER_ID       — User identifier (default: hermes-user)
+  MEM0_USER_ID       — User identifier (default: ctx)
   MEM0_AGENT_ID      — Agent identifier (default: hermes)
 
 Or via $HERMES_HOME/mem0.json.
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import threading
 import time
 from pathlib import Path
@@ -31,6 +32,15 @@ logger = logging.getLogger(__name__)
 # for _BREAKER_COOLDOWN_SECS to avoid hammering a down server.
 _BREAKER_THRESHOLD = 5
 _BREAKER_COOLDOWN_SECS = 120
+
+
+def _normalize_run_id(session_id: str) -> str:
+    value = (session_id or "").strip()
+    if not value:
+        return ""
+    slug = re.sub(r"[^A-Za-z0-9._:-]+", "-", value)
+    slug = re.sub(r"-+", "-", slug).strip("-")
+    return slug or value
 
 
 # ---------------------------------------------------------------------------
@@ -48,7 +58,7 @@ def _load_config() -> dict:
 
     config = {
         "api_key": os.environ.get("MEM0_API_KEY", ""),
-        "user_id": os.environ.get("MEM0_USER_ID", "hermes-user"),
+        "user_id": os.environ.get("MEM0_USER_ID", "ctx"),
         "agent_id": os.environ.get("MEM0_AGENT_ID", "hermes"),
         "rerank": True,
         "keyword_search": False,
@@ -124,8 +134,9 @@ class Mem0MemoryProvider(MemoryProvider):
         self._client = None
         self._client_lock = threading.Lock()
         self._api_key = ""
-        self._user_id = "hermes-user"
+        self._user_id = "ctx"
         self._agent_id = "hermes"
+        self._run_id = ""
         self._rerank = True
         self._prefetch_result = ""
         self._prefetch_lock = threading.Lock()
@@ -160,7 +171,7 @@ class Mem0MemoryProvider(MemoryProvider):
     def get_config_schema(self):
         return [
             {"key": "api_key", "description": "Mem0 Platform API key", "secret": True, "required": True, "env_var": "MEM0_API_KEY", "url": "https://app.mem0.ai"},
-            {"key": "user_id", "description": "User identifier", "default": "hermes-user"},
+            {"key": "user_id", "description": "User identifier", "default": "ctx"},
             {"key": "agent_id", "description": "Agent identifier", "default": "hermes"},
             {"key": "rerank", "description": "Enable reranking for recall", "default": "true", "choices": ["true", "false"]},
         ]
@@ -203,9 +214,19 @@ class Mem0MemoryProvider(MemoryProvider):
     def initialize(self, session_id: str, **kwargs) -> None:
         self._config = _load_config()
         self._api_key = self._config.get("api_key", "")
-        self._user_id = self._config.get("user_id", "hermes-user")
+        self._user_id = self._config.get("user_id", "ctx")
         self._agent_id = self._config.get("agent_id", "hermes")
+        self._run_id = _normalize_run_id(session_id)
         self._rerank = self._config.get("rerank", True)
+
+    def _build_filters(self) -> Dict[str, Any]:
+        filters: Dict[str, Any] = {
+            "user_id": self._user_id,
+            "agent_id": self._agent_id,
+        }
+        if self._run_id:
+            filters["run_id"] = self._run_id
+        return filters
 
     def system_prompt_block(self) -> str:
         return (
@@ -234,7 +255,7 @@ class Mem0MemoryProvider(MemoryProvider):
                 client = self._get_client()
                 results = client.search(
                     query=query,
-                    filters={"user_id": self._user_id},
+                    filters=self._build_filters(),
                     rerank=self._rerank,
                     top_k=5,
                 )
@@ -264,7 +285,7 @@ class Mem0MemoryProvider(MemoryProvider):
                     {"role": "user", "content": user_content},
                     {"role": "assistant", "content": assistant_content},
                 ]
-                client.add(messages, user_id=self._user_id, agent_id=self._agent_id)
+                client.add(messages, **self._build_filters())
                 self._record_success()
             except Exception as e:
                 self._record_failure()
@@ -293,7 +314,7 @@ class Mem0MemoryProvider(MemoryProvider):
 
         if tool_name == "mem0_profile":
             try:
-                memories = client.get_all(filters={"user_id": self._user_id})
+                memories = client.get_all(filters=self._build_filters())
                 if isinstance(memories, dict):
                     memories = memories.get("results", [])
                 self._record_success()
@@ -314,7 +335,7 @@ class Mem0MemoryProvider(MemoryProvider):
             try:
                 results = client.search(
                     query=query,
-                    filters={"user_id": self._user_id},
+                    filters=self._build_filters(),
                     rerank=rerank,
                     top_k=top_k,
                 )
@@ -336,8 +357,7 @@ class Mem0MemoryProvider(MemoryProvider):
             try:
                 client.add(
                     [{"role": "user", "content": conclusion}],
-                    user_id=self._user_id,
-                    agent_id=self._agent_id,
+                    **self._build_filters(),
                     infer=False,
                 )
                 self._record_success()

--- a/tests/plugins/memory/test_mem0_filters.py
+++ b/tests/plugins/memory/test_mem0_filters.py
@@ -1,0 +1,106 @@
+from plugins.memory.mem0 import Mem0MemoryProvider
+
+
+def test_mem0_search_uses_filters_not_top_level_user_id(monkeypatch):
+    provider = Mem0MemoryProvider()
+    provider.initialize("test")
+    provider._user_id = "u123"
+
+    captured = {}
+
+    class FakeClient:
+        def search(self, **kwargs):
+            captured.update(kwargs)
+            return {"results": []}
+
+    monkeypatch.setattr(provider, "_get_client", lambda: FakeClient())
+
+    result = provider.handle_tool_call(
+        "mem0_search",
+        {"query": "hello", "top_k": 3, "rerank": False},
+    )
+
+    assert '"result": "No relevant memories found."' in result
+    assert captured["query"] == "hello"
+    assert captured["top_k"] == 3
+    assert captured["rerank"] is False
+    assert captured["filters"] == {"user_id": "u123"}
+    assert "user_id" not in captured
+
+
+def test_mem0_profile_uses_filters_not_top_level_user_id(monkeypatch):
+    provider = Mem0MemoryProvider()
+    provider.initialize("test")
+    provider._user_id = "u123"
+
+    captured = {}
+
+    class FakeClient:
+        def get_all(self, **kwargs):
+            captured.update(kwargs)
+            return {"results": []}
+
+    monkeypatch.setattr(provider, "_get_client", lambda: FakeClient())
+
+    result = provider.handle_tool_call("mem0_profile", {})
+
+    assert '"result": "No memories stored yet."' in result
+    assert captured["filters"] == {"user_id": "u123"}
+    assert "user_id" not in captured
+
+
+def test_mem0_prefetch_uses_filters_not_top_level_user_id(monkeypatch):
+    provider = Mem0MemoryProvider()
+    provider.initialize("test")
+    provider._user_id = "u123"
+
+    captured = {}
+
+    class FakeClient:
+        def search(self, **kwargs):
+            captured.update(kwargs)
+            return {"results": []}
+
+    monkeypatch.setattr(provider, "_get_client", lambda: FakeClient())
+
+    provider.queue_prefetch("hello")
+    provider._prefetch_thread.join(timeout=2)
+
+    assert captured["query"] == "hello"
+    assert captured["top_k"] == 5
+    assert captured["filters"] == {"user_id": "u123"}
+    assert "user_id" not in captured
+
+
+def test_mem0_profile_accepts_dict_results(monkeypatch):
+    provider = Mem0MemoryProvider()
+    provider.initialize("test")
+
+    class FakeClient:
+        def get_all(self, **kwargs):
+            return {"results": [{"memory": "alpha"}, {"memory": "beta"}]}
+
+    monkeypatch.setattr(provider, "_get_client", lambda: FakeClient())
+
+    result = provider.handle_tool_call("mem0_profile", {})
+
+    assert '"count": 2' in result
+    assert "alpha" in result
+    assert "beta" in result
+
+
+def test_mem0_search_accepts_dict_results(monkeypatch):
+    provider = Mem0MemoryProvider()
+    provider.initialize("test")
+
+    class FakeClient:
+        def search(self, **kwargs):
+            return {"results": [{"memory": "alpha", "score": 0.9}]}
+
+    monkeypatch.setattr(provider, "_get_client", lambda: FakeClient())
+
+    result = provider.handle_tool_call("mem0_search", {"query": "alpha"})
+
+    assert '"count": 1' in result
+    assert "alpha" in result
+    assert '"score": 0.9' in result

--- a/tests/plugins/memory/test_mem0_filters.py
+++ b/tests/plugins/memory/test_mem0_filters.py
@@ -1,10 +1,12 @@
-from plugins.memory.mem0 import Mem0MemoryProvider
+from plugins.memory.mem0 import Mem0MemoryProvider, _normalize_run_id
 
 
 def test_mem0_search_uses_filters_not_top_level_user_id(monkeypatch):
     provider = Mem0MemoryProvider()
     provider.initialize("test")
     provider._user_id = "u123"
+    provider._agent_id = "hermes"
+    provider._run_id = "test"
 
     captured = {}
 
@@ -24,7 +26,7 @@ def test_mem0_search_uses_filters_not_top_level_user_id(monkeypatch):
     assert captured["query"] == "hello"
     assert captured["top_k"] == 3
     assert captured["rerank"] is False
-    assert captured["filters"] == {"user_id": "u123"}
+    assert captured["filters"] == {"user_id": "u123", "agent_id": "hermes", "run_id": "test"}
     assert "user_id" not in captured
 
 
@@ -32,6 +34,8 @@ def test_mem0_profile_uses_filters_not_top_level_user_id(monkeypatch):
     provider = Mem0MemoryProvider()
     provider.initialize("test")
     provider._user_id = "u123"
+    provider._agent_id = "hermes"
+    provider._run_id = "test"
 
     captured = {}
 
@@ -45,7 +49,7 @@ def test_mem0_profile_uses_filters_not_top_level_user_id(monkeypatch):
     result = provider.handle_tool_call("mem0_profile", {})
 
     assert '"result": "No memories stored yet."' in result
-    assert captured["filters"] == {"user_id": "u123"}
+    assert captured["filters"] == {"user_id": "u123", "agent_id": "hermes", "run_id": "test"}
     assert "user_id" not in captured
 
 
@@ -53,6 +57,8 @@ def test_mem0_prefetch_uses_filters_not_top_level_user_id(monkeypatch):
     provider = Mem0MemoryProvider()
     provider.initialize("test")
     provider._user_id = "u123"
+    provider._agent_id = "hermes"
+    provider._run_id = "test"
 
     captured = {}
 
@@ -68,7 +74,7 @@ def test_mem0_prefetch_uses_filters_not_top_level_user_id(monkeypatch):
 
     assert captured["query"] == "hello"
     assert captured["top_k"] == 5
-    assert captured["filters"] == {"user_id": "u123"}
+    assert captured["filters"] == {"user_id": "u123", "agent_id": "hermes", "run_id": "test"}
     assert "user_id" not in captured
 
 
@@ -104,3 +110,55 @@ def test_mem0_search_accepts_dict_results(monkeypatch):
     assert '"count": 1' in result
     assert "alpha" in result
     assert '"score": 0.9' in result
+
+
+def test_mem0_sync_turn_writes_include_agent_and_run_id(monkeypatch):
+    provider = Mem0MemoryProvider()
+    provider.initialize("session 1")
+    provider._user_id = "ctx"
+    provider._agent_id = "hermes"
+
+    captured = {}
+
+    class FakeClient:
+        def add(self, messages, **kwargs):
+            captured["messages"] = messages
+            captured.update(kwargs)
+
+    monkeypatch.setattr(provider, "_get_client", lambda: FakeClient())
+
+    provider.sync_turn("u", "a", session_id="session 1")
+    provider._sync_thread.join(timeout=2)
+
+    assert captured["user_id"] == "ctx"
+    assert captured["agent_id"] == "hermes"
+    assert captured["run_id"] == "session-1"
+    assert captured["messages"][0]["content"] == "u"
+
+
+def test_mem0_conclude_writes_include_agent_and_run_id(monkeypatch):
+    provider = Mem0MemoryProvider()
+    provider.initialize("session 1")
+    provider._user_id = "ctx"
+    provider._agent_id = "hermes"
+
+    captured = {}
+
+    class FakeClient:
+        def add(self, messages, **kwargs):
+            captured["messages"] = messages
+            captured.update(kwargs)
+
+    monkeypatch.setattr(provider, "_get_client", lambda: FakeClient())
+
+    result = provider.handle_tool_call("mem0_conclude", {"conclusion": "fact"})
+
+    assert '"result": "Fact stored."' in result
+    assert captured["user_id"] == "ctx"
+    assert captured["agent_id"] == "hermes"
+    assert captured["run_id"] == "session-1"
+    assert captured["infer"] is False
+
+
+def test_normalize_run_id_slugifies_session_name():
+    assert _normalize_run_id("  session name / 42 ") == "session-name-42"


### PR DESCRIPTION
## Summary
- update the Mem0 provider to use `filters={...}` consistently for read, prefetch, and write paths
- normalize current Mem0 SDK responses that return `{ "results": [...] }` instead of raw lists
- scope Mem0 operations with `user_id`, `agent_id`, and normalized `run_id`
- add regression tests covering both retrieval and storage behavior

## Problem
The original fix only partially covered the current Mem0 API/SDK behavior.

In practice we had two classes of failures:
- retrieval calls like `mem0_profile` / `mem0_search` / prefetch failed because current Mem0 expects `filters` instead of top-level `user_id`
- storage/query behavior was not fully scoped consistently across Hermes sessions, and current SDK payloads can come back as `{ "results": [...] }`

This meant Hermes could still break or behave inconsistently even after the initial partial compatibility patch.

## Fix
This PR now completes the compatibility update across all relevant Mem0 paths:

### Retrieval / recall
- `queue_prefetch()`: use `filters` and normalize dict payloads
- `mem0_profile`: use `client.get_all(filters=...)` and normalize dict payloads
- `mem0_search`: use `client.search(..., filters=..., ...)` and normalize dict payloads

### Storage / write-through
- `sync_turn()`: write with `user_id`, `agent_id`, and normalized `run_id`
- `mem0_conclude`: write with the same scoped identifiers and keep `infer=False`

### Scoping / defaults
- default `user_id` updated to `ctx`
- default `agent_id` remains `hermes`
- add `_normalize_run_id(session_id)` and include `run_id` when present

## Verification
Added regression tests covering:
- search uses `filters`, not top-level `user_id`
- profile uses `filters`, not top-level `user_id`
- prefetch uses `filters`
- profile handles dict payloads `{ "results": [...] }`
- search handles dict payloads `{ "results": [...] }`
- sync_turn writes include `user_id`, `agent_id`, and normalized `run_id`
- conclude writes include `user_id`, `agent_id`, normalized `run_id`, and `infer=False`
- run-id normalization behavior

Ran:
- `python -m pytest tests/plugins/memory/test_mem0_filters.py -q`

Result:
- `8 passed`

## Notes
This is still a Hermes-side compatibility fix for current Mem0 API/SDK behavior. It expands the original PR so the provider is consistent across retrieval, prefetch, and write paths rather than only partially addressing the read path.
