### PR TITLE
test(cli): force linux update restart path

### DIFF
--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -368,6 +368,9 @@ class TestCmdUpdateLaunchdRestart:
         monkeypatch.setattr(
             gateway_cli, "is_macos", lambda: False,
         )
+        monkeypatch.setattr(
+            gateway_cli, "is_linux", lambda: True,
+        )
 
         mock_run.side_effect = _make_run_side_effect(
             commit_count="3",


### PR DESCRIPTION
## Summary
- force the Linux restart test onto the Linux systemd path explicitly
- avoid relying on the host platform when asserting systemctl restart behavior

## Testing
- source /Users/mbelleau/Projects/hermes-agent/venv/bin/activate && python -m pytest tests/hermes_cli/test_update_gateway_restart.py -q