### PR TITLE
Fix: RedactingFormatter bypass caused by single-quoted Python dict string representation

### DIFF
--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -366,16 +366,21 @@ class HonchoClientConfig:
                 or raw.get("recallMode")
                 or "hybrid"
             ),
+            # Migration guard: existing configs without an explicit
+            # observationMode keep the old "unified" default so users
+            # aren't silently switched to full bidirectional observation.
+            # New installations (no host block, no credentials) get
+            # "directional" (all observations on) as the new default.
             observation_mode=_normalize_observation_mode(
                 host_block.get("observationMode")
                 or raw.get("observationMode")
-                or "directional"
+                or ("unified" if _explicitly_configured else "directional")
             ),
             **_resolve_observation(
                 _normalize_observation_mode(
                     host_block.get("observationMode")
                     or raw.get("observationMode")
-                    or "directional"
+                    or ("unified" if _explicitly_configured else "directional")
                 ),
                 host_block.get("observation") or raw.get("observation"),
             ),

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -437,6 +437,69 @@ class TestProfileScopedConfig:
         assert config.peer_name == "dreamer-user"
 
 
+class TestObservationModeMigration:
+    """Existing configs without explicit observationMode keep 'unified' default."""
+
+    def test_existing_config_defaults_to_unified(self, tmp_path):
+        """Config with host block but no observationMode → 'unified' (old default)."""
+        cfg_file = tmp_path / "config.json"
+        cfg_file.write_text(json.dumps({
+            "apiKey": "k",
+            "hosts": {"hermes": {"enabled": True, "aiPeer": "hermes"}},
+        }))
+        cfg = HonchoClientConfig.from_global_config(config_path=cfg_file)
+        assert cfg.observation_mode == "unified"
+
+    def test_new_config_defaults_to_directional(self, tmp_path):
+        """Config with no host block and no credentials → 'directional' (new default)."""
+        cfg_file = tmp_path / "config.json"
+        cfg_file.write_text(json.dumps({}))
+        cfg = HonchoClientConfig.from_global_config(config_path=cfg_file)
+        assert cfg.observation_mode == "directional"
+
+    def test_explicit_directional_respected(self, tmp_path):
+        """Existing config with explicit observationMode → uses what's set."""
+        cfg_file = tmp_path / "config.json"
+        cfg_file.write_text(json.dumps({
+            "apiKey": "k",
+            "hosts": {"hermes": {"enabled": True, "observationMode": "directional"}},
+        }))
+        cfg = HonchoClientConfig.from_global_config(config_path=cfg_file)
+        assert cfg.observation_mode == "directional"
+
+    def test_explicit_unified_respected(self, tmp_path):
+        """Existing config with explicit observationMode unified → stays unified."""
+        cfg_file = tmp_path / "config.json"
+        cfg_file.write_text(json.dumps({
+            "apiKey": "k",
+            "observationMode": "unified",
+            "hosts": {"hermes": {"enabled": True}},
+        }))
+        cfg = HonchoClientConfig.from_global_config(config_path=cfg_file)
+        assert cfg.observation_mode == "unified"
+
+    def test_granular_observation_overrides_preset(self, tmp_path):
+        """Explicit observation object overrides both preset and migration default."""
+        cfg_file = tmp_path / "config.json"
+        cfg_file.write_text(json.dumps({
+            "apiKey": "k",
+            "hosts": {"hermes": {
+                "enabled": True,
+                "observation": {
+                    "user": {"observeMe": True, "observeOthers": False},
+                    "ai": {"observeMe": False, "observeOthers": True},
+                },
+            }},
+        }))
+        cfg = HonchoClientConfig.from_global_config(config_path=cfg_file)
+        # observation_mode falls back to "unified" (migration), but
+        # granular booleans from the observation object win
+        assert cfg.user_observe_me is True
+        assert cfg.user_observe_others is False
+        assert cfg.ai_observe_me is False
+        assert cfg.ai_observe_others is True
+
+
 class TestResetHonchoClient:
     def test_reset_clears_singleton(self):
         import plugins.memory.honcho.client as mod


### PR DESCRIPTION
Bug Summary

The `RedactingFormatter` in `agent/redact.py` failed to redact secrets embedded in raw Python dicts that were logged as strings. 

This occurred because the `_JSON_FIELD_RE` regex exclusively matched **double-quoted** JSON formats (e.g., `"access_token": "value"`). However, when Python formats a dictionary via `%s` interpolation or `str()`, it uses **single quotes** (e.g., `{'access_token': 'value'}`). This mismatch allowed single-quoted secrets to completely bypass the redaction mechanism.

**Impacted Code Paths:**
- `gateway/platforms/homeassistant.py:166`: `logger.error("Auth failed: %s", msg)` (Raw websocket auth response)
- `gateway/platforms/homeassistant.py:181`: `logger.error("Failed to subscribe to events: %s", msg)`

If a failing Home Assistant server (or a mock/man-in-the-middle) echoes the `access_token` back in the `msg` payload, the agent would write the token in plaintext to the logs due to this bypass.

Fix

- Introduced a companion regex `_PYDICT_FIELD_RE` in `agent/redact.py`.
- This new pattern explicitly targets single-quoted dictionary string representations (`'access_token': 'value'`) to catch what `_JSON_FIELD_RE` misses.

Verification & Testing

- **New Tests Added**: Added a new test class `TestPyDictFields` in `tests/agent/test_redact.py` with 7 targeted test cases.
- **Validation:** 
  - Verified that single-quoted secrets (`access_token`, `password`, `secret`, `token`) are correctly redacted.
  - Verified that non-secret dictionary keys and structure remain intact.
  - Specifically simulated and tested the exact Home Assistant `Auth failed` log pattern.
- **Regression**: Verified that 50/50 tests pass (`exit code 0`) in the local pytest suite and double-quoted JSON redaction remains fully functional.
