### PR TITLE
fix(registry): log WARNING when check_fn fails in quiet mode (fixes #5304)

### DIFF
--- a/tools/registry.py
+++ b/tools/registry.py
@@ -128,9 +128,13 @@ class ToolRegistry:
                         check_results[entry.check_fn] = False
                         if not quiet:
                             logger.debug("Tool %s check raised; skipping", name)
+                        else:
+                            logger.warning("Tool %s check raised exception; subagent will not have access", name, exc_info=True)
                 if not check_results[entry.check_fn]:
                     if not quiet:
                         logger.debug("Tool %s unavailable (check failed)", name)
+                    else:
+                        logger.warning("Tool %s unavailable (check failed); subagent will not have access", name)
                     continue
             # Ensure schema always has a "name" field — use entry.name as fallback
             schema_with_name = {**entry.schema, "name": entry.name}


### PR DESCRIPTION
## Problem
When `registry.get_definitions()` is called with `quiet=True` (always the 
case for subagents via `delegate_tool.py:222`), `check_fn` failures are 
completely silent — no log output. The only evidence of tool loss is the 
subagent's session file showing a single tool.

## Fix
When `quiet=True`, log at WARNING level instead of suppressing entirely:
- `check_fn()` returns False → `logger.warning("Tool %s unavailable...")`
- `check_fn()` raises exception → `logger.warning("Tool %s check raised...", exc_info=True)`

When `quiet=False` (interactive CLI), behavior is unchanged — debug level only.

This addresses the logging/diagnosability part of #5304. The caching fix 
for `check_terminal_requirements()` is a separate concern.

Fixes #5304