### PR TITLE
fix(discord): stop bot ping-pong when DISCORD_ALLOW_BOTS=mentions

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -572,15 +572,14 @@ class DiscordAdapter(BasePlatformAdapter):
 
                 # Bot message filtering (DISCORD_ALLOW_BOTS):
                 #   "none"     — ignore all other bots (default)
-                #   "mentions" — accept bot messages only when they @mention us
+                #   "mentions" — ignore all other bots (same as none for inbound). Reply pings
+                #                and @-chains still put users in message.mentions, so "only when
+                #                @us" cannot stop multi-bot ping-pong. Use "all" for bot↔bot.
                 #   "all"      — accept all bot messages
                 if getattr(message.author, "bot", False):
                     allow_bots = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
-                    if allow_bots == "none":
+                    if allow_bots in ("none", "mentions"):
                         return
-                    elif allow_bots == "mentions":
-                        if not self._client.user or self._client.user not in message.mentions:
-                            return
                     # "all" falls through to handle_message
 
                 # If the message @mentions other users but NOT the bot, the
@@ -2052,6 +2051,9 @@ class DiscordAdapter(BasePlatformAdapter):
         # UNLESS the channel is in the free-response list or the message is
         # in a thread where the bot has already participated.
         #
+        # DISCORD_ALLOW_BOTS=mentions: in_bot_thread bypass applies to humans only; other bots
+        # are dropped in on_message and again below unless allow_bots=all.
+        #
         # Config (all settable via discord.* in config.yaml):
         #   discord.require_mention: Require @mention in server channels (default: true)
         #   discord.free_response_channels: Channel IDs where bot responds without mention
@@ -2081,6 +2083,18 @@ class DiscordAdapter(BasePlatformAdapter):
             if require_mention and not is_free_channel and not in_bot_thread:
                 if self._client.user not in message.mentions:
                     return
+
+            # Defense in depth: peer bots only when DISCORD_ALLOW_BOTS=all (see on_message).
+            allow_bots = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
+            author = message.author
+            if (
+                allow_bots != "all"
+                and self._client
+                and self._client.user
+                and getattr(author, "bot", False)
+                and author.id != self._client.user.id
+            ):
+                return
 
             if self._client.user and self._client.user in message.mentions:
                 message.content = message.content.replace(f"<@{self._client.user.id}>", "").strip()

--- a/tests/gateway/test_discord_bot_filter.py
+++ b/tests/gateway/test_discord_bot_filter.py
@@ -49,13 +49,10 @@ class TestDiscordBotFilter(unittest.TestCase):
 
         if getattr(message.author, "bot", False):
             allow = allow_bots.lower().strip()
-            if allow == "none":
+            if allow in ("none", "mentions"):
                 return False
-            elif allow == "mentions":
-                if not client_user or client_user not in message.mentions:
-                    return False
             # "all" falls through
-        
+
         return True  # message accepted
 
     def test_own_messages_always_ignored(self):
@@ -91,12 +88,12 @@ class TestDiscordBotFilter(unittest.TestCase):
         msg = _make_message(author=bot, mentions=[])
         self.assertFalse(self._run_filter(msg, "mentions", our_user))
 
-    def test_allow_bots_mentions_accepts_with_mention(self):
-        """With allow_bots=mentions, bot messages with @mention are accepted."""
+    def test_allow_bots_mentions_rejects_even_with_mention(self):
+        """mentions mode ignores peer bots even if they @ us (stops multi-bot ping-pong)."""
         our_user = _make_author(is_self=True)
         bot = _make_author(bot=True)
         msg = _make_message(author=bot, mentions=[our_user])
-        self.assertTrue(self._run_filter(msg, "mentions", our_user))
+        self.assertFalse(self._run_filter(msg, "mentions", our_user))
 
     def test_default_is_none(self):
         """Default behavior (no env var) should be 'none'."""

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -95,8 +95,9 @@ def adapter(monkeypatch):
     return adapter
 
 
-def make_message(*, channel, content: str, mentions=None):
-    author = SimpleNamespace(id=42, display_name="Jezza", name="Jezza")
+def make_message(*, channel, content: str, mentions=None, author=None):
+    if author is None:
+        author = SimpleNamespace(id=42, display_name="Jezza", name="Jezza")
     return SimpleNamespace(
         id=123,
         content=content,
@@ -358,3 +359,48 @@ async def test_discord_thread_participation_tracked_on_dispatch(adapter, monkeyp
     await adapter._handle_message(message)
 
     assert "777" in adapter._bot_participated_threads
+
+
+@pytest.mark.asyncio
+async def test_discord_allow_bots_mentions_peer_bot_without_mention_skipped_in_thread(
+    adapter, monkeypatch,
+):
+    """Peer bot in a participated thread must not bypass mentions mode without @hermes."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "mentions")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    adapter._bot_participated_threads.add("880")
+    thread = FakeThread(channel_id=880, name="t")
+    ext_bot = SimpleNamespace(id=77001, bot=True, display_name="PeerBot", name="PeerBot")
+    message = make_message(channel=thread, content="status update", mentions=[], author=ext_bot)
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discord_allow_bots_mentions_peer_bot_with_mention_still_skipped(
+    adapter, monkeypatch,
+):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "mentions")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    adapter._bot_participated_threads.add("881")
+    thread = FakeThread(channel_id=881, name="t")
+    our = adapter._client.user
+    ext_bot = SimpleNamespace(id=77002, bot=True, display_name="PeerBot", name="PeerBot")
+    message = make_message(
+        channel=thread,
+        content=f"<@{our.id}> ack",
+        mentions=[our],
+        author=ext_bot,
+    )
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()


### PR DESCRIPTION
## Problem
With `DISCORD_ALLOW_BOTS=mentions`, peer bot messages that included the bot in `message.mentions` (reply pings, @ chains, etc.) were still processed, which could cause multi-bot infinite loops.

## Change
- Treat `mentions` like `none` for **inbound messages from other bots** in `on_message`.
- Add defense-in-depth in `_handle_message` so thread/free-response paths cannot process peer bots unless `DISCORD_ALLOW_BOTS=all`.
- Document that bot↔bot requires `all`.

## Tests
- `test_discord_bot_filter`: `mentions` rejects peer bots even with @mention.
- `test_discord_free_response`: participated-thread cases for peer bot with/without mention.

## Migration
Users who relied on `mentions` specifically to allow **other bots** to drive the agent must set `DISCORD_ALLOW_BOTS=all`.

Made with [Cursor](https://cursor.com)