### PR TITLE
fix(tools): cache check_terminal_requirements to prevent intermittent tool loss in subagents

### DIFF
--- a/tests/tools/test_terminal_requirements.py
+++ b/tests/tools/test_terminal_requirements.py
@@ -19,6 +19,8 @@ def _clear_terminal_env(monkeypatch):
     ]
     for key in keys:
         monkeypatch.delenv(key, raising=False)
+    # Reset the module-level cache so each test starts clean.
+    monkeypatch.setattr(terminal_tool_module, "_terminal_requirements_cache", None)
 
 
 def test_local_terminal_requirements(monkeypatch, caplog):

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -126,11 +126,11 @@ class ToolRegistry:
                         check_results[entry.check_fn] = bool(entry.check_fn())
                     except Exception:
                         check_results[entry.check_fn] = False
-                        if not quiet:
-                            logger.debug("Tool %s check raised; skipping", name)
+                        # Always log check failures — silent drops in quiet
+                        # mode (subagents) make tool loss undiagnosable.
+                        logger.warning("Tool %s check raised; skipping", name)
                 if not check_results[entry.check_fn]:
-                    if not quiet:
-                        logger.debug("Tool %s unavailable (check failed)", name)
+                    logger.debug("Tool %s unavailable (check failed)", name)
                     continue
             # Ensure schema always has a "name" field — use entry.name as fallback
             schema_with_name = {**entry.schema, "name": entry.name}

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1344,13 +1344,26 @@ def terminal_tool(
         }, ensure_ascii=False)
 
 
+_terminal_requirements_cache: Optional[bool] = None
+
+
 def check_terminal_requirements() -> bool:
-    """Check if all requirements for the terminal tool are met."""
+    """Check if all requirements for the terminal tool are met.
+
+    Results are cached after the first successful check so that transient
+    failures (e.g. Docker daemon momentarily busy) cannot strip tools from
+    subagents mid-session.
+    """
+    global _terminal_requirements_cache
+    if _terminal_requirements_cache is True:
+        return True
+
     config = _get_env_config()
     env_type = config["env_type"]
 
     try:
         if env_type == "local":
+            _terminal_requirements_cache = True
             return True
 
         elif env_type == "docker":
@@ -1360,7 +1373,11 @@ def check_terminal_requirements() -> bool:
                 logger.error("Docker executable not found in PATH or common install locations")
                 return False
             result = subprocess.run([docker, "version"], capture_output=True, timeout=5)
-            return result.returncode == 0
+            if result.returncode == 0:
+                _terminal_requirements_cache = True
+                return True
+            logger.warning("Docker version check failed (rc=%d)", result.returncode)
+            return False
 
         elif env_type == "singularity":
             executable = shutil.which("apptainer") or shutil.which("singularity")


### PR DESCRIPTION
 ## What does this PR do?

`check_terminal_requirements()` runs `subprocess.run([docker, "version"], timeout=5)` on every `get_tool_definitions()` call with no result caching. When a transient failure occurs (daemon busy, socket contention, subprocess timeout), the terminal tool is stripped — and because `check_file_requirements()` (tools/__init__.py:18) delegates to the same function, all file tools (read_file, write_file, patch, search_files) are also stripped.

This is most impactful for subagents spawned via delegate_task, where the parent agent passes the same check moments earlier in the same process, but the child's re-check can fail intermittently, leaving it with only process (which has no check_fn).

The fix caches the check result at module level after the first success and ensures check failures are always logged regardless of quiet mode.

# Related Issue

  Fixes #5304 

## Type of Change

  - 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

  - tools/terminal_tool.py: Add module-level _terminal_requirements_cache that short-circuits check_terminal_requirements() after the first successful check. Cache is set for local (line 1358) and docker (line 1379) backends. Failed checks are not cached, so the check will retry next time.
  - tools/registry.py: Log check_fn exceptions at WARNING level regardless of the quiet flag (line 129). Previously, failures were silently swallowed when quiet=True (which subagents always use), making tool loss undiagnosable.
  - tests/tools/test_terminal_requirements.py: Reset _terminal_requirements_cache via monkeypatch.setattr in _clear_terminal_env() so tests remain
  isolated from the new caching behavior.

##  How to Test

  1. Run existing tests: pytest tests/tools/test_terminal_requirements.py -v — all 9 pass
  2. Run the broader test suite: pytest tests/tools/test_terminal_requirements.py tests/gateway/test_matrix.py tests/gateway/test_config.py
  tests/tools/test_registry.py -v — 101 pass
  3. To verify the fix in practice: run the gateway with `TERMINAL_ENV=docker`, send a message that triggers `delegate_task` with `toolsets=['terminal',
  'file']`, and confirm the subagent session file contains terminal, read_file, write_file, patch, and search_files in its tools array

##  Checklist

  - I've read the Contributing Guide
  - My commit messages follow Conventional Commits (fix(scope):, feat(scope):, etc.)
  - I searched for existing PRs to make sure this isn't a duplicate
  - My PR contains only changes related to this fix/feature (no unrelated commits)
  - I've run pytest tests/ -q and all tests pass
  - I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - I've tested on my platform: macOS 15 (Darwin arm64), Python 3.11.11, Hermes v0.7.0

  Documentation & Housekeeping

  - I've updated relevant documentation (README, docs/, docstrings) - N/A
  - I've updated cli-config.yaml.example if I added/changed config keys - N/A
  - I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows - N/A
  - I've considered cross-platform impact (Windows, macOS) per the compatibility guide
  - I've updated tool descriptions/schemas if I changed tool behavior

  Screenshots / Logs

  Subagent session file before fix — only process available:
  "tools": [
      {"type": "function", "function": {"name": "process"}}
  ]

  Gateway log after fix — check failures now visible at WARNING:
  WARNING tools.registry: Tool terminal check raised; skipping