### PR TITLE
fix(tests): refresh gateway and sandbox coverage

### DIFF
--- a/tests/gateway/test_matrix_voice.py
+++ b/tests/gateway/test_matrix_voice.py
@@ -1,10 +1,56 @@
 """Tests for Matrix voice message support (MSC3245)."""
 import io
+import sys
+import types
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock
 
-nio = pytest.importorskip("nio", reason="matrix-nio not installed")
+try:
+    import nio  # type: ignore
+    _USING_FAKE_NIO = False
+except ImportError:
+    nio = types.ModuleType("nio")
+    _USING_FAKE_NIO = True
+
+    class _RoomMessageImage:
+        pass
+
+    class _RoomMessageAudio:
+        pass
+
+    class _RoomMessageVideo:
+        pass
+
+    class _RoomMessageFile:
+        pass
+
+    class _MemoryDownloadResponse:
+        pass
+
+    class _DownloadError:
+        pass
+
+    class _UploadResponse:
+        pass
+
+    class _RoomSendResponse:
+        pass
+
+    nio.RoomMessageImage = _RoomMessageImage
+    nio.RoomMessageAudio = _RoomMessageAudio
+    nio.RoomMessageVideo = _RoomMessageVideo
+    nio.RoomMessageFile = _RoomMessageFile
+    nio.MemoryDownloadResponse = _MemoryDownloadResponse
+    nio.DownloadError = _DownloadError
+    nio.UploadResponse = _UploadResponse
+    nio.RoomSendResponse = _RoomSendResponse
+
+
+@pytest.fixture(autouse=True)
+def _install_fake_nio(monkeypatch):
+    if _USING_FAKE_NIO:
+        monkeypatch.setitem(sys.modules, "nio", nio)
 
 from gateway.platforms.base import MessageType
 

--- a/tests/test_api_key_providers.py
+++ b/tests/test_api_key_providers.py
@@ -124,7 +124,7 @@ PROVIDER_ENV_VARS = (
     "AI_GATEWAY_API_KEY", "AI_GATEWAY_BASE_URL",
     "KILOCODE_API_KEY", "KILOCODE_BASE_URL",
     "DASHSCOPE_API_KEY", "OPENCODE_ZEN_API_KEY", "OPENCODE_GO_API_KEY",
-    "NOUS_API_KEY", "GITHUB_TOKEN", "GH_TOKEN",
+    "NOUS_API_KEY", "GITHUB_TOKEN", "GH_TOKEN", "COPILOT_GITHUB_TOKEN", "HF_TOKEN",
     "OPENAI_BASE_URL", "HERMES_COPILOT_ACP_COMMAND", "COPILOT_CLI_PATH",
     "HERMES_COPILOT_ACP_ARGS", "COPILOT_ACP_BASE_URL",
 )
@@ -642,6 +642,7 @@ class TestHasAnyProviderConfigured:
             "agent.anthropic_adapter.is_claude_code_token_valid",
             lambda creds: True,
         )
+        monkeypatch.setattr("hermes_cli.auth.get_auth_status", lambda provider_id=None: {"logged_in": False})
         from hermes_cli.main import _has_any_provider_configured
         assert _has_any_provider_configured() is False
 
@@ -719,6 +720,7 @@ class TestHasAnyProviderConfigured:
         for var in ("OPENROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
                      "ANTHROPIC_TOKEN", "OPENAI_BASE_URL"):
             monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr("hermes_cli.auth.get_auth_status", lambda provider_id=None: {"logged_in": False})
         from hermes_cli.main import _has_any_provider_configured
         assert _has_any_provider_configured() is False
 

--- a/tests/tools/test_browser_camofox_state.py
+++ b/tests/tools/test_browser_camofox_state.py
@@ -63,4 +63,4 @@ class TestCamofoxConfigDefaults:
         from hermes_cli.config import DEFAULT_CONFIG
 
         # managed_persistence is auto-merged by _deep_merge, no version bump needed
-        assert DEFAULT_CONFIG["_config_version"] == 11
+        assert DEFAULT_CONFIG["_config_version"] == 12

--- a/tests/tools/test_modal_sandbox_fixes.py
+++ b/tests/tools/test_modal_sandbox_fixes.py
@@ -140,13 +140,14 @@ class TestCwdHandling:
                     assert config["host_cwd"] == "/home/user/project"
 
     def test_local_backend_uses_getcwd(self):
-        """Local backend should use os.getcwd(), not /root."""
+        """Local backend should keep a current-directory cwd, not /root."""
         with patch.dict(os.environ, {"TERMINAL_ENV": "local"}, clear=False):
             env = os.environ.copy()
             env.pop("TERMINAL_CWD", None)
             with patch.dict(os.environ, env, clear=True):
                 config = _tt_mod._get_env_config()
-                assert config["cwd"] == os.getcwd()
+                assert config["cwd"] in (".", os.getcwd())
+                assert config["cwd"] != "/root"
 
     def test_create_environment_passes_docker_host_cwd_and_flag(self, monkeypatch):
         """Docker host cwd and mount flag should reach DockerEnvironment."""


### PR DESCRIPTION
## Summary
- refresh several stale test expectations to match current gateway and terminal behavior
- make the Matrix voice tests runnable without a global `nio` install by using a scoped fake module in the test file
- keep the cleanup scoped to behavior that exists on `upstream/main`

## Testing
- source /Users/mbelleau/Projects/hermes-agent/venv/bin/activate && python -m pytest -n0 -q tests/gateway/test_matrix_voice.py tests/test_api_key_providers.py tests/tools/test_browser_camofox_state.py tests/tools/test_modal_sandbox_fixes.py