### PR TITLE
feat(memory): raise default memory_char_limit and user_char_limit (refs #5320)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -377,8 +377,8 @@ memory:
   user_profile_enabled: true
   
   # Character limits (~2.75 chars per token, model-independent)
-  memory_char_limit: 2200   # ~800 tokens
-  user_char_limit: 1375     # ~500 tokens
+  memory_char_limit: 8800   # ~800 tokens
+  user_char_limit: 5500     # ~500 tokens
 
   # Periodic memory nudge: remind the agent to consider saving memories
   # every N user turns. Set to 0 to disable. Only active when memory is enabled.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -583,8 +583,8 @@ DEFAULT_CONFIG = {
     "memory": {
         "memory_enabled": True,
         "user_profile_enabled": True,
-        "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
-        "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
+        "memory_char_limit": 8800,   # ~3200 tokens at 2.75 chars/token
+        "user_char_limit": 5500,     # ~2000 tokens at 2.75 chars/token
         # External memory provider plugin (empty = built-in only).
         # Set to a provider name to activate: "openviking", "mem0",
         # "hindsight", "holographic", "retaindb", "byterover".

--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -26,8 +26,8 @@ except Exception:  # pragma: no cover - handled at runtime
 
 
 ENTRY_DELIMITER = "\n§\n"
-DEFAULT_MEMORY_CHAR_LIMIT = 2200
-DEFAULT_USER_CHAR_LIMIT = 1375
+DEFAULT_MEMORY_CHAR_LIMIT = 8800
+DEFAULT_USER_CHAR_LIMIT = 5500
 SKILL_CATEGORY_DIRNAME = "openclaw-imports"
 SKILL_CATEGORY_DESCRIPTION = (
     "Skills migrated from an OpenClaw workspace."

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -108,7 +108,7 @@ class MemoryStore:
         Tool responses always reflect this live state.
     """
 
-    def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375):
+    def __init__(self, memory_char_limit: int = 8800, user_char_limit: int = 5500):
         self.memory_entries: List[str] = []
         self.user_entries: List[str] = []
         self.memory_char_limit = memory_char_limit


### PR DESCRIPTION
## Problem
Default memory limits in `hermes_cli/config.py` were sized for 8k-context 
models (~800 tokens total). Current models routinely have 125k+ context windows, 
making the 2200/1375 char defaults hit quickly on long-running sessions.

When the limit is reached, `MemoryStore.add()` rejects writes silently with no 
path forward except manually culling entries.

## Change
Raise defaults to 4x current values:
- `memory_char_limit`: 2200 → 8800 (~800 → ~3200 tokens)
- `user_char_limit`: 1375 → 5500 (~500 → ~2000 tokens)

This is the standalone defaults-only change suggested in #5320. The auto-scaling 
and `hermes memory stats` command proposed there can follow as separate PRs.

Also updates `DEFAULT_MEMORY_CHAR_LIMIT` and `DEFAULT_USER_CHAR_LIMIT` 
constants in the OpenClaw migration script to match the new defaults.

Refs #5320