### PR TITLE
fix: HonchoClientConfig has `recall_mode`, doctor.py still references `memory_mode`

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -817,7 +817,7 @@ def run_doctor(args):
                 get_honcho_client(hcfg)
                 check_ok(
                     "Honcho connected",
-                    f"workspace={hcfg.workspace_id} mode={hcfg.memory_mode} freq={hcfg.write_frequency}",
+                    f"workspace={hcfg.workspace_id} mode={hcfg.recall_mode} freq={hcfg.write_frequency}",
                 )
             except Exception as _e:
                 check_fail("Honcho connection failed", str(_e))


### PR DESCRIPTION
## Bug

`hermes doctor` fails with:

```
'HonchoClientConfig' object has no attribute 'memory_mode'
```

`HonchoClientConfig` was refactored — `memory_mode` replaced by `recall_mode` (line 191 of `plugins/memory/honcho/client.py`). But `hermes_cli/doctor.py` line 820 still accesses `hcfg.memory_mode`, causing `AttributeError` whenever Honcho is configured.

## Fix

```diff
- f"workspace={hcfg.workspace_id} mode={hcfg.memory_mode} freq={hcfg.write_frequency}"
+ f"workspace={hcfg.workspace_id} mode={hcfg.recall_mode} freq={hcfg.write_frequency}"
```

## Testing

1. Configure Honcho in `honcho.json`
2. Run `hermes doctor`
3. Before: `AttributeError: 'HonchoClientConfig' object has no attribute 'memory_mode'`
4. After: `✓ Honcho connected  workspace=hermes mode=hybrid freq=async`

Fixes #5327
