### PR TITLE
fix(tests): isolate terminal runtime state between tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,6 +106,36 @@ def _ensure_current_event_loop(request):
 
 
 @pytest.fixture(autouse=True)
+def _reset_terminal_runtime_state():
+    """Isolate process-global terminal state between tests.
+
+    Terminal/code-execution/file tools cache environments and interrupt state at
+    module scope. Full-suite runs can otherwise reuse a sandbox created by an
+    earlier test with a different backend (for example Modal), which makes later
+    tests nondeterministically inherit the wrong environment.
+    """
+    from tools.interrupt import set_interrupt
+    from tools.file_tools import clear_file_ops_cache
+    from tools import terminal_tool as _terminal_tool
+
+    def _reset():
+        set_interrupt(False)
+        clear_file_ops_cache()
+        _terminal_tool._stop_cleanup_thread()
+        for task_id in list(_terminal_tool._active_environments.keys()):
+            _terminal_tool.cleanup_vm(task_id)
+        _terminal_tool._creation_locks.clear()
+        _terminal_tool._task_env_overrides.clear()
+
+    _reset()
+
+    try:
+        yield
+    finally:
+        _reset()
+
+
+@pytest.fixture(autouse=True)
 def _enforce_test_timeout():
     """Kill any individual test that takes longer than 30 seconds.
     SIGALRM is Unix-only; skip on Windows."""


### PR DESCRIPTION
## Summary
- reset process-global terminal/code-execution runtime state before and after each test
- clear cached environments, file-ops cache, interrupt state, and per-task overrides without probing sandbox directories on disk
- prevent full-suite contamination where a previous test's cached backend leaks into later tests

## Testing
- `source venv/bin/activate && python -m pytest tests/ -q`
  - `8312 passed, 27 skipped, 1 xfailed`
- `source /Users/mbelleau/Projects/hermes-agent/venv/bin/activate && python -m pytest -n0 -q tests/hermes_cli/test_gateway_service.py tests/test_timezone.py tests/tools/test_code_execution.py tests/tools/test_managed_media_gateways.py tests/tools/test_terminal_timeout_output.py tests/tools/test_terminal_tool_requirements.py`
  - `133 passed, 1 warning`
- `source /Users/mbelleau/Projects/hermes-agent/venv/bin/activate && python -m pytest tests/ -q`
  - current `upstream/main` baseline in this worktree remains red with 25 unrelated failures; this patch does not add to that baseline
