### PR TITLE
fix(paste): skip osascript image check when pasting text — prevents TUI freeze

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7347,7 +7347,10 @@ class HermesCLI:
             # Normalise line endings — Windows \r\n and old Mac \r both become \n
             # so the 5-line collapse threshold and display are consistent.
             pasted_text = pasted_text.replace('\r\n', '\n').replace('\r', '\n')
-            if self._try_attach_clipboard_image():
+            # Only check clipboard for image when paste carries no text.
+            # If text is present the clipboard holds text not an image, and
+            # running osascript/xclip here blocks the TUI event loop.
+            if not pasted_text and self._try_attach_clipboard_image():
                 event.app.invalidate()
             if pasted_text:
                 line_count = pasted_text.count('\n')


### PR DESCRIPTION
## Problem

Every paste event triggers `_try_attach_clipboard_image()` which calls `osascript clipboard info` (macOS) or `xclip` (Linux) via `subprocess.run()` with a **3-second timeout**, blocking the prompt_toolkit event loop. The terminal becomes unresponsive for up to 3 seconds after every paste.

## Root cause

The `Keys.BracketedPaste` handler unconditionally checks the clipboard for an image even when `event.data` already contains pasted text. If the user pasted text, the clipboard contains text — not an image — so the subprocess call is both unnecessary and harmful.

## Fix

One condition: `if not pasted_text and self._try_attach_clipboard_image():`

Image attach via Ctrl+V / Alt+V is unaffected — those handlers correctly only run when there is no text paste in progress.