### PR TITLE
fix: handle LM-Studio tool call fragmentation in streaming mode

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1840,14 +1840,29 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         and raw_idx in _last_id_at_idx
                         and delta_id != _last_id_at_idx[raw_idx]
                     ):
-                        # Genuinely new tool calls always carry the function name
-                        # in the first chunk (OpenAI streaming spec). If the name
-                        # is missing but the ID changed, this is a fragment of the
-                        # current tool call's arguments (Kimi/LM-Studio bug).
+                        # ID changed at a reused raw index — ambiguous.
+                        # It could be:
+                        #   1. A new parallel tool call (Ollama)     → redirect to fresh slot
+                        #   2. Argument fragmentation (Kimi/LM-Studio) → keep accumulating
+                        #   3. Redundant name on every chunk (MiniMax) → keep accumulating
+                        #
+                        # Per the OpenAI streaming spec, a delta without a function.name
+                        # cannot be the start of a new tool call — always accumulate.
+                        #
+                        # For deltas that DO carry a name, only create a new slot if the
+                        # name differs from the current slot's name. A matching name means
+                        # the provider is redundantly resending the name on every chunk
+                        # (known pattern: MiniMax M2.7 via NVIDIA NIM), which is still the
+                        # same tool call, not a new one.
                         has_name = tc_delta.function and tc_delta.function.name
                         if has_name:
-                            new_slot = max(tool_calls_acc, default=-1) + 1
-                            _active_slot_by_idx[raw_idx] = new_slot
+                            cur_slot = _active_slot_by_idx[raw_idx]
+                            cur_name = (
+                                (tool_calls_acc.get(cur_slot, {}).get("function", {}) or {}).get("name", "") or ""
+                            )
+                            if cur_name != tc_delta.function.name:
+                                new_slot = max(tool_calls_acc, default=-1) + 1
+                                _active_slot_by_idx[raw_idx] = new_slot
                     if delta_id:
                         _last_id_at_idx[raw_idx] = delta_id
                     idx = _active_slot_by_idx[raw_idx]

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1840,8 +1840,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         and raw_idx in _last_id_at_idx
                         and delta_id != _last_id_at_idx[raw_idx]
                     ):
-                        new_slot = max(tool_calls_acc, default=-1) + 1
-                        _active_slot_by_idx[raw_idx] = new_slot
+                        # Genuinely new tool calls always carry the function name
+                        # in the first chunk (OpenAI streaming spec). If the name
+                        # is missing but the ID changed, this is a fragment of the
+                        # current tool call's arguments (Kimi/LM-Studio bug).
+                        has_name = tc_delta.function and tc_delta.function.name
+                        if has_name:
+                            new_slot = max(tool_calls_acc, default=-1) + 1
+                            _active_slot_by_idx[raw_idx] = new_slot
                     if delta_id:
                         _last_id_at_idx[raw_idx] = delta_id
                     idx = _active_slot_by_idx[raw_idx]

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5899,6 +5899,30 @@ class TestStreamingApiCall:
         assert tc[1].function.name == "read_file"
         assert tc[1].function.arguments == '{"path":"x.py"}'
 
+    def test_fragmented_with_redundant_name_every_chunk(self, agent):
+        """Provider resends function name on every fragment chunk (MiniMax pattern).
+
+        Some providers (MiniMax M2.7 via NVIDIA NIM) send the function name
+        on every delta chunk, combined with unique IDs per chunk. The name
+        comparison guard should prevent this from creating extra tool call slots.
+        """
+        chunks = [
+            # First chunk: has name, empty args
+            _make_chunk(tool_calls=[_make_tc_delta(0, "call_1", "shell", "")]),
+            # Fragments: same name repeated, unique IDs
+            _make_chunk(tool_calls=[_make_tc_delta(0, "call_2", "shell", '{"cmd"')]),
+            _make_chunk(tool_calls=[_make_tc_delta(0, "call_3", "shell", ':"ls"}')]),
+            _make_chunk(finish_reason="tool_calls"),
+        ]
+        agent.client.chat.completions.create.return_value = iter(chunks)
+
+        resp = agent._interruptible_streaming_api_call({"messages": []})
+
+        tc = resp.choices[0].message.tool_calls
+        assert len(tc) == 1, f"Expected 1 tool call, got {len(tc)}"
+        assert tc[0].function.name == "shell"
+        assert tc[0].function.arguments == '{"cmd":"ls"}'
+
     def test_content_and_tool_calls_together(self, agent):
         chunks = [
             _make_chunk(content="I'll search"),

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5846,6 +5846,59 @@ class TestStreamingApiCall:
         assert tc[1].function.name == "read"
         assert tc[1].function.arguments == '{}'
 
+    def test_lmstudio_fragmented_tool_calls(self, agent):
+        """LM-Studio sends each argument chunk with a unique id.
+
+        Without the fix, each chunk becomes a separate tool call.
+        With the fix, all chunks accumulate into one tool call.
+        """
+        chunks = [
+            # First chunk: has name, empty args
+            _make_chunk(tool_calls=[_make_tc_delta(0, "call_123", "shell", "")]),
+            # Subsequent chunks: no name, unique ids, short args
+            _make_chunk(tool_calls=[_make_tc_delta(0, "tool-call-1", None, "{\n")]),
+            _make_chunk(tool_calls=[_make_tc_delta(0, "tool-call-2", None, " ")]),
+            _make_chunk(
+                tool_calls=[_make_tc_delta(0, "tool-call-3", None, '"command"')]
+            ),
+            _make_chunk(tool_calls=[_make_tc_delta(0, "tool-call-4", None, ': "ls"}')]),
+            _make_chunk(finish_reason="tool_calls"),
+        ]
+        agent.client.chat.completions.create.return_value = iter(chunks)
+
+        resp = agent._interruptible_streaming_api_call({"messages": []})
+
+        tc = resp.choices[0].message.tool_calls
+        assert len(tc) == 1, f"Expected 1 tool call, got {len(tc)}"
+        assert tc[0].function.name == "shell"
+        assert tc[0].function.arguments == '{\n "command": "ls"}'
+
+    def test_lmstudio_multiple_fragmented_tool_calls(self, agent):
+        """LM-Studio with two tool calls, each fragmented across chunks."""
+        chunks = [
+            # Tool call 1: name
+            _make_chunk(tool_calls=[_make_tc_delta(0, "call_a", "search", "")]),
+            # Tool call 1: args fragments
+            _make_chunk(tool_calls=[_make_tc_delta(0, "tool-1", None, '{"q":')]),
+            _make_chunk(tool_calls=[_make_tc_delta(0, "tool-2", None, '"hello"}')]),
+            # Tool call 2: name (new tool, same index)
+            _make_chunk(tool_calls=[_make_tc_delta(0, "call_b", "read_file", "")]),
+            # Tool call 2: args fragments
+            _make_chunk(tool_calls=[_make_tc_delta(0, "tool-3", None, '{"path":')]),
+            _make_chunk(tool_calls=[_make_tc_delta(0, "tool-4", None, '"x.py"}')]),
+            _make_chunk(finish_reason="tool_calls"),
+        ]
+        agent.client.chat.completions.create.return_value = iter(chunks)
+
+        resp = agent._interruptible_streaming_api_call({"messages": []})
+
+        tc = resp.choices[0].message.tool_calls
+        assert len(tc) == 2, f"Expected 2 tool calls, got {len(tc)}"
+        assert tc[0].function.name == "search"
+        assert tc[0].function.arguments == '{"q":"hello"}'
+        assert tc[1].function.name == "read_file"
+        assert tc[1].function.arguments == '{"path":"x.py"}'
+
     def test_content_and_tool_calls_together(self, agent):
         chunks = [
             _make_chunk(content="I'll search"),


### PR DESCRIPTION
## What does this PR do?
Fixes tool call fragmentation when using LM-Studio or similar local LLM servers. Without this fix, a single tool call gets split into dozens of separate calls because each streaming chunk has a unique ID instead of accumulating under one ID. The fix detects the fragmentation pattern (empty name + short arguments + unique ID) and correctly accumulates all chunks into a single tool call.
## Related Issue
Fixes #5254
## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
## Changes Made
- `run_agent.py:4871-4907` — Added LM-Studio fragmentation detection in streaming tool call accumulator
- `tests/test_run_agent.py` — Added 2 new tests: `test_lmstudio_fragmented_tool_calls` and `test_lmstudio_multiple_fragmented_tool_calls`
## How to Test
1. Configure Hermes to use LM-Studio as the provider (e.g., `hermes -m lmstudio:gemma4`)
2. Send a message that triggers a tool call (e.g., "run `ls` in the current directory")
3. Verify the tool call executes correctly as a single call, not fragmented into dozens of separate calls
4. Run the unit tests: `pytest tests/test_run_agent.py::TestStreamingApiCall -v` — all 15 tests pass
## Checklist
### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `pytest tests/test_run_agent.py::TestStreamingApiCall -v` and all 15 tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS
### Documentation & Housekeeping
- [x] N/A — Bug fix only, no documentation changes needed