### PR TITLE
fix(tests): isolate runner env from CI

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,27 @@ def _isolate_hermes_home(tmp_path, monkeypatch):
     monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
     monkeypatch.delenv("HERMES_SESSION_CHAT_NAME", raising=False)
     monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    # Tests should not inherit CI/operator terminal backend or provider auth
+    # from the outer runner environment. Individual tests set these explicitly.
+    for key in (
+        "TERMINAL_ENV",
+        "TERMINAL_MODAL_MODE",
+        "MODAL_TOKEN_ID",
+        "MODAL_TOKEN_SECRET",
+        "HERMES_ENABLE_NOUS_MANAGED_TOOLS",
+        "OPENAI_BASE_URL",
+        "OPENAI_API_KEY",
+        "OPENROUTER_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_TOKEN",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "GITHUB_TOKEN",
+        "GH_TOKEN",
+        "COPILOT_GITHUB_TOKEN",
+        "NOUS_API_KEY",
+        "HF_TOKEN",
+    ):
+        monkeypatch.delenv(key, raising=False)
 
 
 @pytest.fixture()

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -499,7 +499,17 @@ class TestGeneratedUnitIncludesLocalBin:
         home = str(Path.home())
         assert f"{home}/.local/bin" in unit
 
-    def test_system_unit_includes_local_bin_in_path(self):
+    def test_system_unit_includes_local_bin_in_path(self, monkeypatch):
+        gateway_cli._service_identity_cache = None
+        gateway_cli._service_identity_cache_run_as_user = None
+        monkeypatch.setattr(
+            gateway_cli, "_system_service_identity",
+            lambda run_as_user=None: ("alice", "alice", "/home/alice"),
+        )
+        monkeypatch.setattr(
+            gateway_cli, "_build_user_local_paths",
+            lambda home_dir, existing: [f"{home_dir}/.local/bin"],
+        )
         unit = gateway_cli.generate_systemd_unit(system=True)
         # System unit uses the resolved home dir from _system_service_identity
         assert "/.local/bin" in unit

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -93,8 +93,16 @@ class TestGeneratedSystemdUnits:
 
         assert "/home/test/.nvm/versions/node/v24.14.0/bin" in unit
 
-    def test_system_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout(self):
-        unit = gateway_cli.generate_systemd_unit(system=True)
+    def test_system_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout(self, monkeypatch):
+        monkeypatch.setattr(
+            gateway_cli, "_system_service_identity",
+            lambda run_as_user=None: ("alice", "alice", "/home/alice"),
+        )
+        monkeypatch.setattr(
+            gateway_cli, "_build_user_local_paths",
+            lambda home, existing: [],
+        )
+        unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
 
         assert "ExecStart=" in unit
         assert "ExecStop=" not in unit

--- a/tests/test_api_key_providers.py
+++ b/tests/test_api_key_providers.py
@@ -642,6 +642,7 @@ class TestHasAnyProviderConfigured:
             "agent.anthropic_adapter.is_claude_code_token_valid",
             lambda creds: True,
         )
+        monkeypatch.setattr("hermes_cli.auth.get_auth_status", lambda provider_id: {"logged_in": False})
         from hermes_cli.main import _has_any_provider_configured
         assert _has_any_provider_configured() is False
 
@@ -719,6 +720,7 @@ class TestHasAnyProviderConfigured:
         for var in ("OPENROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
                      "ANTHROPIC_TOKEN", "OPENAI_BASE_URL"):
             monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr("hermes_cli.auth.get_auth_status", lambda provider_id: {"logged_in": False})
         from hermes_cli.main import _has_any_provider_configured
         assert _has_any_provider_configured() is False
 

--- a/tests/test_cli_provider_resolution.py
+++ b/tests/test_cli_provider_resolution.py
@@ -1,4 +1,5 @@
 import importlib
+import copy
 import sys
 import types
 from contextlib import nullcontext
@@ -569,25 +570,44 @@ def test_model_flow_custom_saves_verified_v1_base_url(monkeypatch, capsys):
             "used_fallback": True,
         },
     )
+    saved_calls = []
     monkeypatch.setattr(
         "hermes_cli.config.load_config",
         lambda: {"model": {"default": "", "provider": "custom", "base_url": ""}},
     )
-    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+    monkeypatch.setattr(
+        "hermes_cli.config.save_config",
+        lambda cfg: saved_calls.append(copy.deepcopy(cfg)),
+    )
 
     # After the probe detects a single model ("llm"), the flow asks
     # "Use this model? [Y/n]:" — confirm with Enter, then context length.
     answers = iter(["http://localhost:8000", "local-key", "", ""])
     monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
 
-    hermes_main._model_flow_custom({})
+    config = {}
+    hermes_main._model_flow_custom(config)
     output = capsys.readouterr().out
+
+    saved_model = None
+    for call in saved_calls:
+        model_cfg = call.get("model")
+        if isinstance(model_cfg, dict) and model_cfg.get("provider") == "custom":
+            saved_model = model_cfg
+            break
 
     assert "Saving the working base URL instead" in output
     assert "Detected model: llm" in output
     # OPENAI_BASE_URL is no longer saved to .env — config.yaml is authoritative
     assert "OPENAI_BASE_URL" not in saved_env
     assert saved_env["MODEL"] == "llm"
+    assert saved_model is not None
+    assert saved_model["provider"] == "custom"
+    assert saved_model["base_url"] == "http://localhost:8000/v1"
+    assert saved_model["api_key"] == "local-key"
+    assert config["model"]["provider"] == "custom"
+    assert config["model"]["base_url"] == "http://localhost:8000/v1"
+    assert config["model"]["api_key"] == "local-key"
 
 
 def test_cmd_model_forwards_nous_login_tls_options(monkeypatch):

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -1098,6 +1098,12 @@ class TestEventBridgePollE2E:
         # Update sessions.json updated_at to trigger re-check
         sessions_data["agent:main:telegram:dm:new"]["updated_at"] = "2026-03-29T15:00:10"
         (sessions_dir / "sessions.json").write_text(json.dumps(sessions_data))
+        # Ensure the watcher observes a later mtime even on filesystems with
+        # coarse timestamp resolution (for example whole-second mtimes).
+        sessions_file = sessions_dir / "sessions.json"
+        current_mtime = sessions_file.stat().st_mtime
+        forced_mtime = max(time.time(), current_mtime + 1.1)
+        os.utime(sessions_file, (forced_mtime, forced_mtime))
 
         # Second poll — should detect the new message
         bridge._poll_once(db)

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -290,10 +290,51 @@ class TestDelegateTask(unittest.TestCase):
                 max_iterations=10,
                 parent_agent=parent,
             )
-
         self.assertTrue(callable(mock_child.thinking_callback))
         mock_child.thinking_callback("deliberating...")
         parent.tool_progress_callback.assert_not_called()
+    def test_workspace_visibility_registers_child_task_overrides(self):
+        parent = _make_mock_parent(depth=0)
+
+        with patch.dict(os.environ, {
+            "TERMINAL_ENV": "docker",
+            "TERMINAL_CWD": "/tmp/delegate-workspace",
+        }, clear=False), \
+            patch("run_agent.AIAgent") as MockAgent, \
+            patch("tools.terminal_tool.register_task_env_overrides") as mock_register, \
+            patch("tools.terminal_tool.clear_task_env_overrides") as mock_clear, \
+            patch("pathlib.Path.exists", return_value=True), \
+            patch("pathlib.Path.is_dir", return_value=True):
+            mock_child = MagicMock()
+            mock_child.session_id = "child-session"
+            mock_child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "api_calls": 1,
+                "messages": [],
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(
+                delegate_task(
+                    goal="Inspect the repo",
+                    workspace_visibility="full_ro",
+                    parent_agent=parent,
+                )
+            )
+
+            assert result["results"][0]["status"] == "completed"
+            mock_child.run_conversation.assert_called_once_with(
+                user_message="Inspect the repo",
+                task_id="child-session",
+            )
+            mock_register.assert_called_once()
+            registered_task_id, registered_overrides = mock_register.call_args.args
+            assert registered_task_id == "child-session"
+            assert registered_overrides["cwd"] == "/workspace"
+            expected_host = os.path.realpath("/tmp/delegate-workspace")
+            assert registered_overrides["docker_volumes"] == [f"{expected_host}:/workspace:ro"]
+            mock_clear.assert_called_once_with("child-session")
 
 
 class TestToolNamePreservation(unittest.TestCase):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -293,48 +293,6 @@ class TestDelegateTask(unittest.TestCase):
         self.assertTrue(callable(mock_child.thinking_callback))
         mock_child.thinking_callback("deliberating...")
         parent.tool_progress_callback.assert_not_called()
-    def test_workspace_visibility_registers_child_task_overrides(self):
-        parent = _make_mock_parent(depth=0)
-
-        with patch.dict(os.environ, {
-            "TERMINAL_ENV": "docker",
-            "TERMINAL_CWD": "/tmp/delegate-workspace",
-        }, clear=False), \
-            patch("run_agent.AIAgent") as MockAgent, \
-            patch("tools.terminal_tool.register_task_env_overrides") as mock_register, \
-            patch("tools.terminal_tool.clear_task_env_overrides") as mock_clear, \
-            patch("pathlib.Path.exists", return_value=True), \
-            patch("pathlib.Path.is_dir", return_value=True):
-            mock_child = MagicMock()
-            mock_child.session_id = "child-session"
-            mock_child.run_conversation.return_value = {
-                "final_response": "done",
-                "completed": True,
-                "api_calls": 1,
-                "messages": [],
-            }
-            MockAgent.return_value = mock_child
-
-            result = json.loads(
-                delegate_task(
-                    goal="Inspect the repo",
-                    workspace_visibility="full_ro",
-                    parent_agent=parent,
-                )
-            )
-
-            assert result["results"][0]["status"] == "completed"
-            mock_child.run_conversation.assert_called_once_with(
-                user_message="Inspect the repo",
-                task_id="child-session",
-            )
-            mock_register.assert_called_once()
-            registered_task_id, registered_overrides = mock_register.call_args.args
-            assert registered_task_id == "child-session"
-            assert registered_overrides["cwd"] == "/workspace"
-            expected_host = os.path.realpath("/tmp/delegate-workspace")
-            assert registered_overrides["docker_volumes"] == [f"{expected_host}:/workspace:ro"]
-            mock_clear.assert_called_once_with("child-session")
 
 
 class TestToolNamePreservation(unittest.TestCase):


### PR DESCRIPTION
## Summary
- isolate tests from inherited CI backend and auth environment
- make the Linux system-unit test stub service identity explicitly
- stabilize the MCP event-bridge mtime test on coarse filesystems
- make provider-auth tests stub auth-state fallbacks explicitly

## Validation
- `source /Users/mbelleau/Projects/hermes-agent/venv/bin/activate && env TERMINAL_ENV=modal MODAL_TOKEN_ID=bad MODAL_TOKEN_SECRET=bad GITHUB_TOKEN=gh-ci HERMES_ENABLE_NOUS_MANAGED_TOOLS=1 python -m pytest -n0 -q tests/tools/test_code_execution.py tests/hermes_cli/test_gateway_service.py tests/test_api_key_providers.py tests/test_cli_provider_resolution.py tests/test_mcp_serve.py`
  - `278 passed, 39 skipped`

## Related
- Closes #5333
