### PR TITLE
[DRAFT] fix(tools): support delegation reasoning overrides for subagents

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -458,6 +458,7 @@ DEFAULT_CONFIG = {
         "provider": "",    # e.g. "openrouter" (empty = inherit parent provider + credentials)
         "base_url": "",    # direct OpenAI-compatible endpoint for subagents
         "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
+        "reasoning_effort": "",  # e.g. "low" (empty = inherit parent reasoning config)
         "max_iterations": 50,  # per-subagent iteration cap (each subagent gets its own budget,
                                # independent of the parent's max_iterations)
     },

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -932,3 +932,38 @@ class TestDelegationProviderIntegration(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestDelegationReasoningEffort(unittest.TestCase):
+    def test_resolve_delegation_credentials_includes_reasoning_effort(self):
+        parent = _make_mock_parent(depth=0)
+        cfg = {"model": "gpt-5.4-mini", "provider": "", "reasoning_effort": "low"}
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["reasoning_effort"], "low")
+
+    def test_build_child_agent_applies_override_reasoning_effort(self):
+        parent = _make_mock_parent(depth=0)
+        parent.reasoning_config = {"enabled": True, "effort": "xhigh"}
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="Test child",
+                context=None,
+                toolsets=["terminal"],
+                model="gpt-5.4-mini",
+                max_iterations=10,
+                parent_agent=parent,
+                override_provider="openai-codex",
+                override_base_url="https://chatgpt.com/backend-api/codex",
+                override_api_key="test-key",
+                override_api_mode="codex_responses",
+                override_reasoning_effort="low",
+            )
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["reasoning_config"]["effort"], "low")
+            self.assertTrue(kwargs["reasoning_config"]["enabled"])

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -171,6 +171,7 @@ def _build_child_agent(
     # ACP transport overrides — lets a non-ACP parent spawn ACP child agents
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
+    override_reasoning_effort: Optional[str] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -229,6 +230,19 @@ def _build_child_agent(
     effective_acp_command = override_acp_command or getattr(parent_agent, "acp_command", None)
     effective_acp_args = list(override_acp_args if override_acp_args is not None else (getattr(parent_agent, "acp_args", []) or []))
 
+    effective_reasoning_config = getattr(parent_agent, "reasoning_config", None)
+    if override_reasoning_effort is not None:
+        effort = str(override_reasoning_effort).strip().lower()
+        if effort == "none":
+            effective_reasoning_config = {"enabled": False, "effort": "none"}
+        elif effort:
+            if isinstance(effective_reasoning_config, dict):
+                effective_reasoning_config = dict(effective_reasoning_config)
+            else:
+                effective_reasoning_config = {}
+            effective_reasoning_config["enabled"] = True
+            effective_reasoning_config["effort"] = effort
+
     child = AIAgent(
         base_url=effective_base_url,
         api_key=effective_api_key,
@@ -239,7 +253,7 @@ def _build_child_agent(
         acp_args=effective_acp_args,
         max_iterations=max_iterations,
         max_tokens=getattr(parent_agent, "max_tokens", None),
-        reasoning_config=getattr(parent_agent, "reasoning_config", None),
+        reasoning_config=effective_reasoning_config,
         prefill_messages=getattr(parent_agent, "prefill_messages", None),
         enabled_toolsets=child_toolsets,
         quiet_mode=True,
@@ -517,6 +531,7 @@ def delegate_task(
                 override_api_mode=creds["api_mode"],
                 override_acp_command=t.get("acp_command") or acp_command,
                 override_acp_args=t.get("acp_args") or acp_args,
+                override_reasoning_effort=creds.get("reasoning_effort"),
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
@@ -629,6 +644,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     configured_provider = str(cfg.get("provider") or "").strip() or None
     configured_base_url = str(cfg.get("base_url") or "").strip() or None
     configured_api_key = str(cfg.get("api_key") or "").strip() or None
+    configured_reasoning_effort = str(cfg.get("reasoning_effort") or "").strip().lower() or None
 
     if configured_base_url:
         api_key = (
@@ -657,6 +673,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             "base_url": configured_base_url,
             "api_key": api_key,
             "api_mode": api_mode,
+            "reasoning_effort": configured_reasoning_effort,
         }
 
     if not configured_provider:
@@ -667,6 +684,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             "base_url": None,
             "api_key": None,
             "api_mode": None,
+            "reasoning_effort": configured_reasoning_effort,
         }
 
     # Provider is configured — resolve full credentials
@@ -696,6 +714,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         "api_mode": runtime.get("api_mode"),
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
+        "reasoning_effort": configured_reasoning_effort,
     }
 
 


### PR DESCRIPTION
This PR is logically independent from the ACP adapter fixes.
It came out of the same GitHub Copilot / delegation audit, and I’m opening it as a draft early to reduce the risk of upstream drift.

## Summary
This PR improves delegation behavior so subagents can use explicit reasoning settings instead of blindly inheriting the parent agent’s reasoning configuration.

## What changed
- add support for `delegation.reasoning_effort`
- pass the resolved reasoning configuration into child agents
- preserve the newer ACP delegation transport overrides (`acp_command` / `acp_args`) while wiring reasoning overrides on top
- add focused tests covering reasoning override behavior for delegated subagents

## Why
Delegation should be predictable and configurable, especially when the parent agent is using a different reasoning profile than the intended worker/subagent lane.

This makes subagent routing more explicit and less surprising.

## Validation
### Automated
- `python3 -m py_compile tools/delegate_tool.py hermes_cli/config.py tests/tools/test_delegate.py`
- `uv run --extra dev python -m pytest -o addopts='' tests/tools/test_delegate.py -q -k 'DelegationReasoningEffort'`
- Result: `2 passed, 51 deselected`

## Notes
- On current upstream this required a small refresh because `tools/delegate_tool.py` has evolved since the original branch, specifically around ACP delegation transport overrides.
- The resulting patch is still small and localized.
