### PR TITLE
feat: subagent memory write through the plugin memory interface

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5978,6 +5978,12 @@ class AIAgent:
                 max_iterations=function_args.get("max_iterations"),
                 parent_agent=self,
             )
+        elif function_name == "subagent_memory_write":
+            from tools.subagent_memory_tool import subagent_memory_write as _smw
+            return _smw(
+                content=function_args.get("content", ""),
+                writer=getattr(self, "_subagent_memory_writer", None),
+            )
         else:
             return handle_function_call(
                 function_name, function_args, effective_task_id,
@@ -6358,6 +6364,15 @@ class AIAgent:
                         spinner.stop(cute_msg)
                     elif self.quiet_mode:
                         self._vprint(f"  {cute_msg}")
+            elif function_name == "subagent_memory_write":
+                from tools.subagent_memory_tool import subagent_memory_write as _smw
+                function_result = _smw(
+                    content=function_args.get("content", ""),
+                    writer=getattr(self, "_subagent_memory_writer", None),
+                )
+                tool_duration = time.time() - tool_start_time
+                if self.quiet_mode:
+                    self._vprint(f"  {_get_cute_tool_message_impl('subagent_memory_write', function_args, tool_duration, result=function_result)}")
             elif self._memory_manager and self._memory_manager.has_tool(function_name):
                 # Memory provider tools (hindsight_retain, honcho_search, etc.)
                 # These are not in the tool registry — route through MemoryManager.

--- a/skills/paperclip-bridge/SKILL.md
+++ b/skills/paperclip-bridge/SKILL.md
@@ -1,0 +1,40 @@
+# Paperclip Bridge Skill
+
+Enables Hermes to create goals and tasks in Paperclip directly from Telegram DMs.
+
+## When to Use
+
+Trigger when Seb says things like:
+- "build X for the team"
+- "get the engineers working on X"
+- "create a task for X"
+- "we need to audit X"
+- Any request that needs the full engineering org to execute
+
+## How It Works
+
+1. Seb sends request in Telegram DM
+2. Hermes asks clarifying questions if needed:
+   - What's the goal/objective?
+   - What does success look like?
+   - Priority: P0, P1, or P2?
+3. Hermes creates a goal or issue in Paperclip
+4. On next Hermes (CEO) heartbeat, she picks it up and delegates to the team
+5. The engineering pipeline runs autonomously
+
+## Examples
+
+**User:** "Audit FalconConnect for dead code"
+**Hermes:** "Got it. This is important for quality. Setting priority to P1 (this week). Creating goal now..."
+**Result:** Goal appears in Paperclip → Hermes delegates to CTO → Architect reads codebase → findings flow through pipeline
+
+**User:** "Write Facebook ad copy for VGLI"
+**Hermes:** "Creating a copywriting task for the team..."
+**Result:** Issue created → Copywriter assigned → copy delivered in 5 min
+
+## Configuration
+
+Environment variables needed (auto-injected):
+- `PAPERCLIP_API_URL` — base URL of Paperclip instance
+- `PAPERCLIP_API_KEY` — agent's API key (Hermes stores this in .env)
+- `PAPERCLIP_COMPANY_ID` — company to create goals/issues in (Falcon Financial)

--- a/skills/paperclip-bridge/index.ts
+++ b/skills/paperclip-bridge/index.ts
@@ -1,0 +1,166 @@
+import Anthropic from "@anthropic-ai/sdk";
+
+const client = new Anthropic();
+
+interface PaperclipContext {
+  apiUrl: string;
+  apiKey: string;
+  companyId: string;
+}
+
+/**
+ * Paperclip Bridge Skill
+ * Allows Hermes to create goals/issues in Paperclip from Telegram DMs
+ */
+
+export async function createGoalInPaperclip(
+  context: PaperclipContext,
+  goal: {
+    title: string;
+    description: string;
+    priority: "high" | "medium" | "low";
+  }
+): Promise<{ id: string; title: string }> {
+  const response = await fetch(
+    `${context.apiUrl}/api/companies/${context.companyId}/goals`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${context.apiKey}`,
+      },
+      body: JSON.stringify({
+        title: goal.title,
+        description: goal.description,
+        level: "company",
+        status: "active",
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to create goal: ${response.status} ${response.statusText}`
+    );
+  }
+
+  return response.json();
+}
+
+export async function createIssueInPaperclip(
+  context: PaperclipContext,
+  issue: {
+    title: string;
+    description: string;
+    priority: "high" | "medium" | "low";
+    assigneeId?: string;
+  }
+): Promise<{ id: string; title: string }> {
+  const response = await fetch(
+    `${context.apiUrl}/api/companies/${context.companyId}/issues`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${context.apiKey}`,
+      },
+      body: JSON.stringify({
+        title: issue.title,
+        description: issue.description,
+        priority: issue.priority,
+        status: "todo",
+        assigneeAgentId: issue.assigneeId,
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to create issue: ${response.status} ${response.statusText}`
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * Main entrypoint for Hermes to use this skill
+ * Call when Seb asks to create a task/goal in Paperclip via DM
+ */
+export async function handlePaperclipRequest(
+  userMessage: string,
+  context: PaperclipContext
+): Promise<string> {
+  // Ask clarifying questions if needed
+  const clarificationResponse = await client.messages.create({
+    model: "claude-opus-4-6",
+    max_tokens: 500,
+    system: `You are helping to create a Paperclip task/goal from a user request.
+    
+Ask up to 3 clarifying questions if the request is vague:
+1. What's the goal/objective? (one sentence)
+2. What does success look like?
+3. Priority: P0 (blocking), P1 (this week), or P2 (backlog)?
+
+If the request has all this info, respond with READY_TO_CREATE and your summary.`,
+    messages: [
+      {
+        role: "user",
+        content: userMessage,
+      },
+    ],
+  });
+
+  const clarificationText =
+    clarificationResponse.content[0].type === "text"
+      ? clarificationResponse.content[0].text
+      : "";
+
+  if (!clarificationText.includes("READY_TO_CREATE")) {
+    return clarificationText;
+  }
+
+  // Extract details and create in Paperclip
+  const extractResponse = await client.messages.create({
+    model: "claude-opus-4-6",
+    max_tokens: 500,
+    system: `Extract the goal/task details from this request as JSON:
+{
+  "title": "string",
+  "description": "string",
+  "priority": "high|medium|low"
+}
+
+Return ONLY the JSON, no other text.`,
+    messages: [
+      {
+        role: "user",
+        content: userMessage,
+      },
+    ],
+  });
+
+  const jsonText =
+    extractResponse.content[0].type === "text"
+      ? extractResponse.content[0].text
+      : "{}";
+  const taskDetails = JSON.parse(jsonText);
+
+  // Determine if this is a goal (strategic) or issue (task)
+  const isGoal =
+    userMessage.toLowerCase().includes("goal") ||
+    userMessage.toLowerCase().includes("project");
+
+  try {
+    let result;
+    if (isGoal) {
+      result = await createGoalInPaperclip(context, taskDetails);
+      return `✅ Goal created in Paperclip: "${result.title}" (ID: ${result.id}). I'll delegate this to the team on the next heartbeat.`;
+    } else {
+      result = await createIssueInPaperclip(context, taskDetails);
+      return `✅ Task created in Paperclip: "${result.title}" (ID: ${result.id}). Assigning to the right agent...`;
+    }
+  } catch (error) {
+    return `❌ Failed to create in Paperclip: ${error instanceof Error ? error.message : "Unknown error"}`;
+  }
+}

--- a/skills/spec-intake/SKILL.md
+++ b/skills/spec-intake/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: Spec Intake
+description: Engineering request intake protocol. Triggers before ANY request is routed to Vale (CTO) or the engineering pipeline. Asks structured questions to produce a real spec instead of a vague task. Prevents rework.
+version: 1.0.0
+tags: [engineering, spec, intake, planning, falconconnect, feature]
+---
+
+# Spec Intake Protocol
+
+TRIGGER: Load this skill whenever Seb makes a request that involves building, adding, changing, or fixing something in FalconConnect, FalconFinancial.org, or any Falcon system. Do NOT route to engineering until this protocol completes.
+
+## When to Run
+
+Run spec intake when the request contains:
+- "add a feature", "build", "create", "implement", "make it so that"
+- "change how", "update the", "fix the way", "I want FC to"
+- Any UI/frontend change request
+- Any new integration or API connection
+- Any new page, route, or dashboard widget
+
+Do NOT run spec intake for:
+- Pure bug reports where the expected behavior is obvious ("X is broken, it should do Y")
+- Infra/DevOps tasks (deploy, restart, env var update)
+- Research tasks (no code involved)
+- Hotfixes where the cause and fix are already known
+
+## The Five Questions
+
+Ask ALL five in a single message. Keep it conversational, not like a form. Seb hates being interrogated.
+
+**Format — send this to Seb:**
+
+> Before I kick this to engineering, five quick things:
+>
+> 1. **What exactly?** [Restate what you understood in one sentence, then ask if that's right or if there's more to it]
+> 2. **Who uses it?** Just you, your future downlines, or public-facing to clients/prospects?
+> 3. **Where does it live?** New page/route, existing dashboard, API endpoint, or background process?
+> 4. **How should it look/behave?** Any specific UI expectations? (Remember: dark mode default, industrial data table aesthetic per our design directive)
+> 5. **Priority?** Ship this week, next sprint, or backlog for later?
+
+## After Seb Answers
+
+Take his answers and produce a **Spec Brief** — this becomes the Paperclip issue description for Vale (CTO).
+
+### Spec Brief Format
+
+```
+# [Feature Name]
+
+## What
+[One paragraph, specific and unambiguous]
+
+## Who
+[User type and access level]
+
+## Where
+[Route, page, component, or API path]
+
+## UI/UX Requirements
+[Specific requirements from Seb's answer + design directive mandates]
+- Dark mode default
+- [Any specific aesthetic choices]
+- [Mobile considerations if applicable]
+
+## Technical Constraints
+[Anything you know about the existing system that matters]
+- [Existing endpoints/tables that are relevant]
+- [Known limitations]
+
+## Acceptance Criteria
+[3-5 bullet points — what "done" looks like]
+- [ ] [Criterion 1]
+- [ ] [Criterion 2]
+- [ ] [Criterion 3]
+
+## Priority
+[Seb's stated priority]
+
+## Notes
+[Anything else relevant — related features, dependencies, risks]
+```
+
+## Then Route It
+
+1. Create a Paperclip issue in Falcon Financial with the Spec Brief as the description
+2. Assign to Vale (CTO)
+3. Set priority based on Seb's answer
+4. Tell Seb: "Spec filed, assigned to Vale. [one-line summary of what engineering will build]"
+
+## Rules
+
+- NEVER skip the five questions. Even if the request seems clear, Seb's mental model and the engineer's mental model diverge 80% of the time. The questions close that gap.
+- NEVER ask more than five questions. If you need clarification on an answer, ask ONE follow-up max.
+- If Seb says "just do it" or "you figure it out" — make your best guess on the unanswered questions, state your assumptions explicitly in the spec brief, and flag them as assumptions.
+- If the request involves frontend work, ALWAYS reference the Frontend Design Directive in the spec brief's UI/UX section.
+- Keep the whole intake under 3 messages total (your questions, his answers, your confirmation).

--- a/tests/tools/test_subagent_memory_write.py
+++ b/tests/tools/test_subagent_memory_write.py
@@ -1,0 +1,351 @@
+"""
+Tests for subagent memory write: make_subagent_memory_writer, subagent_memory_write,
+and the write_memory=True path in delegate_task.
+"""
+
+import json
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tools.subagent_memory_tool import (
+    MAX_CHARS,
+    MAX_WRITES,
+    make_subagent_memory_writer,
+    subagent_memory_write,
+    SUBAGENT_MEMORY_WRITE_SCHEMA,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_parent_with_store(entries=None):
+    """Build a mock parent agent with a working MemoryStore."""
+    parent = MagicMock()
+    parent._memory_manager = None
+
+    store = MagicMock()
+    _saved = list(entries or [])
+
+    def _add(target, content):
+        if len(content) > 2200:
+            return {"success": False, "error": "char limit"}
+        _saved.append(content)
+        return {"success": True, "target": target, "entries": _saved}
+
+    store.add.side_effect = _add
+    parent._memory_store = store
+    parent._saved_entries = _saved
+    return parent
+
+
+def _make_parent_no_store():
+    parent = MagicMock()
+    parent._memory_store = None
+    parent._memory_manager = None
+    return parent
+
+
+# ---------------------------------------------------------------------------
+# make_subagent_memory_writer
+# ---------------------------------------------------------------------------
+
+class TestMakeSubagentMemoryWriter(unittest.TestCase):
+
+    def test_returns_none_when_no_store(self):
+        parent = _make_parent_no_store()
+        writer = make_subagent_memory_writer(parent)
+        self.assertIsNone(writer)
+
+    def test_returns_callable_when_store_present(self):
+        parent = _make_parent_with_store()
+        writer = make_subagent_memory_writer(parent)
+        self.assertTrue(callable(writer))
+
+    def test_write_tags_entry(self):
+        parent = _make_parent_with_store()
+        writer = make_subagent_memory_writer(parent)
+        result = writer("DATABASE_URL missing from Render env")
+        self.assertTrue(result["success"])
+        stored = parent._memory_store.add.call_args[0][1]
+        self.assertTrue(stored.startswith("[subagent] "))
+        self.assertIn("DATABASE_URL", stored)
+
+    def test_write_rejects_empty_content(self):
+        parent = _make_parent_with_store()
+        writer = make_subagent_memory_writer(parent)
+        result = writer("   ")
+        self.assertFalse(result["success"])
+        self.assertIn("empty", result["error"])
+
+    def test_write_rejects_content_over_max_chars(self):
+        parent = _make_parent_with_store()
+        writer = make_subagent_memory_writer(parent)
+        long_content = "x" * (MAX_CHARS + 1)
+        result = writer(long_content)
+        self.assertFalse(result["success"])
+        self.assertIn("too long", result["error"].lower())
+
+    def test_write_accepts_content_at_max_chars(self):
+        parent = _make_parent_with_store()
+        writer = make_subagent_memory_writer(parent)
+        exact = "x" * MAX_CHARS
+        result = writer(exact)
+        self.assertTrue(result["success"])
+
+    def test_rate_limit_blocks_after_max_writes(self):
+        parent = _make_parent_with_store()
+        writer = make_subagent_memory_writer(parent)
+        for i in range(MAX_WRITES):
+            result = writer(f"Finding {i}")
+            self.assertTrue(result["success"], f"Write {i} should succeed")
+        result = writer("One more")
+        self.assertFalse(result["success"])
+        self.assertIn("limit", result["error"].lower())
+        self.assertEqual(result["writes_used"], MAX_WRITES)
+
+    def test_success_result_includes_write_counters(self):
+        parent = _make_parent_with_store()
+        writer = make_subagent_memory_writer(parent)
+        result = writer("Root cause: missing env var")
+        self.assertTrue(result["success"])
+        self.assertEqual(result["writes_used"], 1)
+        self.assertEqual(result["writes_remaining"], MAX_WRITES - 1)
+
+    def test_notifies_external_memory_manager(self):
+        parent = _make_parent_with_store()
+        mm = MagicMock()
+        parent._memory_manager = mm
+        writer = make_subagent_memory_writer(parent)
+        writer("Render crash caused by missing DATABASE_URL")
+        mm.on_memory_write.assert_called_once()
+        call_args = mm.on_memory_write.call_args[0]
+        self.assertEqual(call_args[0], "add")
+        self.assertEqual(call_args[1], "memory")
+        self.assertIn("[subagent]", call_args[2])
+
+    def test_memory_manager_failure_does_not_break_write(self):
+        parent = _make_parent_with_store()
+        mm = MagicMock()
+        mm.on_memory_write.side_effect = RuntimeError("backend down")
+        parent._memory_manager = mm
+        writer = make_subagent_memory_writer(parent)
+        result = writer("Still works despite mm failure")
+        self.assertTrue(result["success"])
+
+    def test_thread_safe_rate_limiting(self):
+        """Concurrent writes must not exceed MAX_WRITES even under race conditions."""
+        parent = _make_parent_with_store()
+        writer = make_subagent_memory_writer(parent)
+        successes = []
+        lock = threading.Lock()
+
+        def _write():
+            result = writer("concurrent finding")
+            if result.get("success"):
+                with lock:
+                    successes.append(1)
+
+        threads = [threading.Thread(target=_write) for _ in range(MAX_WRITES * 3)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertLessEqual(len(successes), MAX_WRITES)
+
+    def test_independent_writers_have_independent_counters(self):
+        """Two writers from two parent agents do not share rate limit state."""
+        p1 = _make_parent_with_store()
+        p2 = _make_parent_with_store()
+        w1 = make_subagent_memory_writer(p1)
+        w2 = make_subagent_memory_writer(p2)
+        for _ in range(MAX_WRITES):
+            w1("finding from child 1")
+        # p1's writer is exhausted -- p2's writer should still work
+        result = w2("finding from child 2")
+        self.assertTrue(result["success"])
+
+    def test_store_add_failure_propagates(self):
+        """When the memory store rejects the write, the result reflects that."""
+        parent = _make_parent_with_store()
+        parent._memory_store.add.side_effect = None
+        parent._memory_store.add.return_value = {
+            "success": False,
+            "error": "Memory at limit",
+        }
+        writer = make_subagent_memory_writer(parent)
+        result = writer("This should fail")
+        self.assertFalse(result["success"])
+        self.assertIn("limit", result["error"])
+
+
+# ---------------------------------------------------------------------------
+# subagent_memory_write (handler)
+# ---------------------------------------------------------------------------
+
+class TestSubagentMemoryWriteHandler(unittest.TestCase):
+
+    def test_returns_error_when_no_writer(self):
+        result = json.loads(subagent_memory_write("content", writer=None))
+        self.assertFalse(result["success"])
+        self.assertIn("not available", result["error"].lower())
+
+    def test_calls_writer_and_returns_json(self):
+        writer = MagicMock(return_value={"success": True, "writes_used": 1, "writes_remaining": 2})
+        result = json.loads(subagent_memory_write("root cause found", writer=writer))
+        self.assertTrue(result["success"])
+        writer.assert_called_once_with("root cause found")
+
+    def test_schema_name(self):
+        self.assertEqual(SUBAGENT_MEMORY_WRITE_SCHEMA["name"], "subagent_memory_write")
+
+    def test_schema_requires_content(self):
+        required = SUBAGENT_MEMORY_WRITE_SCHEMA["parameters"]["required"]
+        self.assertIn("content", required)
+
+
+# ---------------------------------------------------------------------------
+# delegate_task write_memory integration
+# ---------------------------------------------------------------------------
+
+class TestDelegateTaskWriteMemory(unittest.TestCase):
+
+    def _make_mock_parent(self, has_store=True):
+        import threading
+        parent = MagicMock()
+        parent.base_url = "https://openrouter.ai/api/v1"
+        parent.api_key = "***"
+        parent.provider = "openrouter"
+        parent.api_mode = "chat_completions"
+        parent.model = "anthropic/claude-sonnet-4"
+        parent.platform = "cli"
+        parent.providers_allowed = None
+        parent.providers_ignored = None
+        parent.providers_order = None
+        parent.provider_sort = None
+        parent._session_db = None
+        parent._delegate_depth = 0
+        parent._active_children = []
+        parent._active_children_lock = threading.Lock()
+        parent._print_fn = None
+        parent.tool_progress_callback = None
+        parent.thinking_callback = None
+        parent._memory_manager = None
+        if has_store:
+            store = MagicMock()
+            store.add.return_value = {"success": True, "entries": []}
+            parent._memory_store = store
+        else:
+            parent._memory_store = None
+        return parent
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_write_memory_false_does_not_inject_tool(self, mock_run):
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed",
+            "summary": "done", "api_calls": 1, "duration_seconds": 1.0,
+        }
+        parent = self._make_mock_parent()
+        captured_child = {}
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.tools = []
+            mock_child.valid_tool_names = set()
+            MockAgent.return_value = mock_child
+
+            from tools.delegate_tool import delegate_task
+            delegate_task(goal="No memory write", parent_agent=parent, write_memory=False)
+            captured_child["tools"] = list(mock_child.tools)
+            captured_child["names"] = set(mock_child.valid_tool_names)
+
+        tool_names = [t.get("function", {}).get("name") for t in captured_child["tools"]]
+        self.assertNotIn("subagent_memory_write", tool_names)
+        self.assertNotIn("subagent_memory_write", captured_child["names"])
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_write_memory_true_injects_tool_when_store_present(self, mock_run):
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed",
+            "summary": "done", "api_calls": 1, "duration_seconds": 1.0,
+        }
+        parent = self._make_mock_parent(has_store=True)
+        captured_child = {}
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.tools = []
+            mock_child.valid_tool_names = set()
+            MockAgent.return_value = mock_child
+
+            from tools.delegate_tool import delegate_task
+            delegate_task(goal="With memory write", parent_agent=parent, write_memory=True)
+            captured_child["tools"] = list(mock_child.tools)
+            captured_child["names"] = set(mock_child.valid_tool_names)
+
+        tool_names = [t.get("function", {}).get("name") for t in captured_child["tools"]]
+        self.assertIn("subagent_memory_write", tool_names)
+        self.assertIn("subagent_memory_write", captured_child["names"])
+        self.assertTrue(callable(mock_child._subagent_memory_writer))
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_write_memory_true_no_store_does_not_inject(self, mock_run):
+        """When parent has no memory store, write_memory=True is a no-op (no tool injected)."""
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed",
+            "summary": "done", "api_calls": 1, "duration_seconds": 1.0,
+        }
+        parent = self._make_mock_parent(has_store=False)
+        captured_child = {}
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.tools = []
+            mock_child.valid_tool_names = set()
+            MockAgent.return_value = mock_child
+
+            from tools.delegate_tool import delegate_task
+            delegate_task(goal="No store", parent_agent=parent, write_memory=True)
+            captured_child["tools"] = list(mock_child.tools)
+            captured_child["names"] = set(mock_child.valid_tool_names)
+
+        tool_names = [t.get("function", {}).get("name") for t in captured_child["tools"]]
+        self.assertNotIn("subagent_memory_write", tool_names)
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_writer_on_child_writes_to_parent_store(self, mock_run):
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed",
+            "summary": "done", "api_calls": 1, "duration_seconds": 1.0,
+        }
+        parent = self._make_mock_parent(has_store=True)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.tools = []
+            mock_child.valid_tool_names = set()
+            MockAgent.return_value = mock_child
+
+            from tools.delegate_tool import delegate_task
+            delegate_task(goal="Writer test", parent_agent=parent, write_memory=True)
+
+        writer = mock_child._subagent_memory_writer
+        result = writer("Root cause: DATABASE_URL missing in Render production env")
+        self.assertTrue(result["success"])
+        parent._memory_store.add.assert_called_once()
+        call_args = parent._memory_store.add.call_args[0]
+        self.assertIn("[subagent]", call_args[1])
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_schema_includes_write_memory_param(self, mock_run):
+        from tools.delegate_tool import DELEGATE_TASK_SCHEMA
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        self.assertIn("write_memory", props)
+        self.assertEqual(props["write_memory"]["type"], "boolean")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -435,6 +435,7 @@ def delegate_task(
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     parent_agent=None,
+    write_memory: bool = False,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks.
@@ -520,6 +521,20 @@ def delegate_task(
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
+            # Inject restricted memory write capability when requested
+            if write_memory:
+                from tools.subagent_memory_tool import (
+                    make_subagent_memory_writer,
+                    SUBAGENT_MEMORY_WRITE_SCHEMA,
+                )
+                writer = make_subagent_memory_writer(parent_agent)
+                if writer is not None:
+                    child._subagent_memory_writer = writer
+                    child.tools.append({
+                        "type": "function",
+                        "function": SUBAGENT_MEMORY_WRITE_SCHEMA,
+                    })
+                    child.valid_tool_names.add("subagent_memory_write")
             children.append((i, t, child))
     finally:
         # Authoritative restore: reset global to parent's tool names after all children built
@@ -838,6 +853,16 @@ DELEGATE_TASK_SCHEMA = {
                     "Only used when acp_command is set. Example: ['--acp', '--stdio', '--model', 'claude-opus-4-6']"
                 ),
             },
+            "write_memory": {
+                "type": "boolean",
+                "description": (
+                    "Allow the subagent to write findings to the parent's persistent memory "
+                    "via the subagent_memory_write tool. Append-only, max 3 writes of 400 chars "
+                    "each. Entries are tagged [subagent] so the parent can identify them. "
+                    "Does nothing if the parent has no memory provider configured. "
+                    "Default: false."
+                ),
+            },
         },
         "required": [],
     },
@@ -859,7 +884,8 @@ registry.register(
         max_iterations=args.get("max_iterations"),
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
-        parent_agent=kw.get("parent_agent")),
+        parent_agent=kw.get("parent_agent"),
+        write_memory=args.get("write_memory", False)),
     check_fn=check_delegate_requirements,
     emoji="🔀",
 )

--- a/tools/subagent_memory_tool.py
+++ b/tools/subagent_memory_tool.py
@@ -1,0 +1,150 @@
+"""
+Subagent Memory Write Tool
+
+Provides append-only, rate-limited memory persistence for subagents.
+
+When the parent enables write_memory=True on delegate_task, the subagent
+gets this tool. Writes route through whatever memory provider the parent
+has active -- builtin MEMORY.md, mem0, Honcho, or any other registered
+provider. If the parent has no memory store, the tool returns a clear error
+instead of silently discarding the write.
+
+Constraints (enforced here):
+  - Append-only: no read, replace, or delete
+  - 3 writes per subagent run (shared rate limit across tool calls)
+  - 400 chars max per entry
+  - Content tagged [subagent] prefix so the parent can identify the source
+"""
+
+import json
+import logging
+import threading
+from typing import Any, Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+MAX_WRITES = 3
+MAX_CHARS = 400
+
+
+def make_subagent_memory_writer(parent_agent) -> Optional[Callable[[str], Dict[str, Any]]]:
+    """Create a rate-limited, append-only write callback for a subagent.
+
+    Returns None if the parent has no memory store (graceful degradation).
+    The returned callable is thread-safe.
+
+    parent_agent must be the PARENT (the agent that spawned this subagent),
+    not the child. The callback closes over parent_agent._memory_store so
+    writes go to the parent's backing store, not the child's (which has
+    skip_memory=True and no store).
+    """
+    store = getattr(parent_agent, "_memory_store", None)
+    if store is None:
+        return None
+
+    _lock = threading.Lock()
+    _write_count = [0]  # mutable list so the closure can mutate the counter
+
+    def _write(content: str) -> Dict[str, Any]:
+        with _lock:
+            if _write_count[0] >= MAX_WRITES:
+                return {
+                    "success": False,
+                    "error": (
+                        f"Write limit reached. Subagents may write at most "
+                        f"{MAX_WRITES} entries per run."
+                    ),
+                    "writes_used": _write_count[0],
+                    "writes_max": MAX_WRITES,
+                }
+
+            content = content.strip()
+            if not content:
+                return {"success": False, "error": "Content cannot be empty."}
+            if len(content) > MAX_CHARS:
+                return {
+                    "success": False,
+                    "error": (
+                        f"Content too long ({len(content)} chars). "
+                        f"Max is {MAX_CHARS} chars per entry."
+                    ),
+                }
+
+            tagged = f"[subagent] {content}"
+            result = store.add("memory", tagged)
+
+            if result.get("success"):
+                _write_count[0] += 1
+                # Notify external providers (mem0, Honcho, etc.)
+                mm = getattr(parent_agent, "_memory_manager", None)
+                if mm:
+                    try:
+                        mm.on_memory_write("add", "memory", tagged)
+                    except Exception as e:
+                        logger.debug("on_memory_write notification failed: %s", e)
+
+                result["writes_used"] = _write_count[0]
+                result["writes_remaining"] = MAX_WRITES - _write_count[0]
+
+            return result
+
+    return _write
+
+
+def subagent_memory_write(content: str, writer: Optional[Callable] = None) -> str:
+    """Write a finding to the parent agent's memory.
+
+    Handler called by run_agent.py when the model invokes subagent_memory_write.
+    writer is the closure created by make_subagent_memory_writer() and stored on
+    the child agent as _subagent_memory_writer.
+    """
+    if writer is None:
+        return json.dumps({
+            "success": False,
+            "error": (
+                "Memory write not available. Either write_memory was not "
+                "enabled on delegate_task, or the parent agent has no "
+                "memory provider configured."
+            ),
+        }, ensure_ascii=False)
+
+    result = writer(content)
+    return json.dumps(result, ensure_ascii=False)
+
+
+SUBAGENT_MEMORY_WRITE_SCHEMA = {
+    "name": "subagent_memory_write",
+    "description": (
+        "Write a key finding to the parent agent's persistent memory. "
+        "Use this for facts that should outlast this subagent run -- a root "
+        "cause, a confirmed configuration value, a working procedure, or a "
+        "constraint discovered during investigation. Not for task progress "
+        "or interim notes.\n\n"
+        "Constraints:\n"
+        f"- Append-only (no read, replace, or delete)\n"
+        f"- Max {MAX_WRITES} writes per subagent run\n"
+        f"- Max {MAX_CHARS} chars per entry\n"
+        "- Entries are tagged [subagent] so the parent can identify them\n\n"
+        "When to call this:\n"
+        "- You found the root cause of a bug or outage\n"
+        "- You confirmed a fact that required significant investigation\n"
+        "- You discovered a working procedure or workaround\n"
+        "- The finding would require re-running this investigation if lost\n\n"
+        "Write one targeted entry per finding. The parent already receives "
+        "your full summary -- this is for what needs to survive future sessions."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {
+                "type": "string",
+                "description": (
+                    f"The finding to persist. Max {MAX_CHARS} chars. "
+                    "Include enough context (names, values, environment) "
+                    "that the entry is useful without surrounding context."
+                ),
+            },
+        },
+        "required": ["content"],
+    },
+}

--- a/uv.lock
+++ b/uv.lock
@@ -10,14 +10,14 @@ resolution-markers = [
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.8.1"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/7b/7cdac86db388809d9e3bc58cac88cc7dfa49b7615b98fab304a828cd7f8a/agent_client_protocol-0.8.1.tar.gz", hash = "sha256:1bbf15663bf51f64942597f638e32a6284c5da918055d9672d3510e965143dbd", size = 68866, upload-time = "2026-02-13T15:34:54.567Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/13/3b893421369767e7043cc115d6ef0df417c298b84563be3a12df0416158d/agent_client_protocol-0.9.0.tar.gz", hash = "sha256:f744c48ab9af0f0b4452e5ab5498d61bcab97c26dbe7d6feec5fd36de49be30b", size = 71853, upload-time = "2026-03-26T01:21:00.379Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/f3/219eeca0ad4a20843d4b9eaac5532f87018b9d25730a62a16f54f6c52d1a/agent_client_protocol-0.8.1-py3-none-any.whl", hash = "sha256:9421a11fd435b4831660272d169c3812d553bb7247049c138c3ca127e4b8af8e", size = 54529, upload-time = "2026-02-13T15:34:53.344Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/ed/c284543c08aa443a4ef2c8bd120be51da8433dd174c01749b5d87c333f22/agent_client_protocol-0.9.0-py3-none-any.whl", hash = "sha256:06911500b51d8cb69112544e2be01fc5e7db39ef88fecbc3848c5c6f194798ee", size = 56850, upload-time = "2026-03-26T01:20:59.252Z" },
 ]
 
 [[package]]
@@ -1725,6 +1725,7 @@ honcho = [
     { name = "honcho-ai" },
 ]
 matrix = [
+    { name = "markdown" },
     { name = "matrix-nio", extra = ["e2e"] },
 ]
 mcp = [
@@ -1772,7 +1773,7 @@ yc-bench = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-client-protocol", marker = "extra == 'acp'", specifier = ">=0.8.1,<0.9" },
+    { name = "agent-client-protocol", marker = "extra == 'acp'", specifier = ">=0.9.0,<1.0" },
     { name = "aiohttp", marker = "extra == 'homeassistant'", specifier = ">=3.9.0,<4" },
     { name = "aiohttp", marker = "extra == 'messaging'", specifier = ">=3.13.3,<4" },
     { name = "aiohttp", marker = "extra == 'sms'", specifier = ">=3.9.0,<4" },
@@ -1812,6 +1813,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1,<1" },
     { name = "jinja2", specifier = ">=3.1.5,<4" },
     { name = "lark-oapi", marker = "extra == 'feishu'", specifier = ">=1.5.3,<2" },
+    { name = "markdown", marker = "extra == 'matrix'", specifier = ">=3.6,<4" },
     { name = "matrix-nio", extras = ["e2e"], marker = "extra == 'matrix'", specifier = ">=0.24.0,<1" },
     { name = "mcp", marker = "extra == 'dev'", specifier = ">=1.2.0,<2" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.2.0,<2" },


### PR DESCRIPTION
When a subagent diagnoses a production outage and finds the root cause, that finding lives in the final summary text. The parent receives a string. If the parent does not immediately call memory to save it, the finding is gone when the session ends.

Concretely: a parent delegated a Render crash diagnosis. The subagent traced the failure to a missing DATABASE_URL in the production environment -- three deploys in a row had failed because of it. The subagent wrote that up in its summary. The parent fixed the immediate issue and moved on. Three weeks later the same symptom appeared. The parent had no memory of the root cause and delegated again, running the same investigation twice.

This PR adds a write_memory=True parameter to delegate_task. When enabled, the subagent gets a subagent_memory_write tool that lets it write findings directly to the parents active memory provider before it exits. The full memory tool stays blocked for subagents -- this is a narrow append-only path, not general memory access.

## What changed

### tools/subagent_memory_tool.py (new)

make_subagent_memory_writer(parent_agent) creates a rate-limited write callback that closes over the parents _memory_store. The callback:
- Validates content length (max 400 chars)
- Tracks write count against a per-subagent limit (max 3)
- Tags each entry with [subagent] prefix
- Calls store.add() on the parents backing store
- Notifies external providers via on_memory_write() so the write mirrors to mem0, Honcho, or any other registered provider
- Returns None when the parent has no store (graceful degradation)

### tools/delegate_tool.py

Added write_memory: bool = False to delegate_task. When True and the parent has a memory store, the writer callback is stored on the child as _subagent_memory_writer and the subagent_memory_write schema is injected into child.tools and child.valid_tool_names. Children built without write_memory=True get no writer and no tool.

Added write_memory to DELEGATE_TASK_SCHEMA so the model can request it.

### run_agent.py

Added subagent_memory_write dispatch in both _invoke_tool (concurrent path) and _execute_tool_calls_sequential. Both paths retrieve getattr(self, _subagent_memory_writer, None) and pass it to the handler.

### tests/tools/test_subagent_memory_write.py (new)

Tests cover:
- Returns None when parent has no store
- Tags entries with [subagent] prefix
- Rejects empty content
- Rejects content over MAX_CHARS
- Rate limit blocks after MAX_WRITES
- Success result includes write counters
- Notifies external memory manager
- Memory manager failure does not block the write
- Thread-safe rate limiting under concurrent writes
- Independent writers have independent counters
- Store failure propagates correctly
- Handler returns error when writer is None
- delegate_task injects tool when write_memory=True and store present
- delegate_task does not inject tool when write_memory=False
- delegate_task does not inject tool when write_memory=True and no store
- Writer on child writes to parent store
- Schema includes write_memory param