### PR TITLE
fix wecom prevent credential leakage by redacting websocket connection logs

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -139,6 +139,17 @@ def _entry_matches(entries: List[str], target: str) -> bool:
     return False
 
 
+def _safe_url_for_log(url: str) -> str:
+    """Drop credentials, query params, and fragments before logging a URL."""
+    parsed = urlparse(url)
+    host = parsed.hostname or parsed.netloc
+    if not host:
+        return url.split("?", 1)[0].split("#", 1)[0]
+    if parsed.port:
+        host = f"{host}:{parsed.port}"
+    return parsed._replace(netloc=host, query="", fragment="").geturl()
+
+
 class WeComAdapter(BasePlatformAdapter):
     """WeCom AI Bot adapter backed by a persistent WebSocket connection."""
 
@@ -200,7 +211,7 @@ class WeComAdapter(BasePlatformAdapter):
             self._mark_connected()
             self._listen_task = asyncio.create_task(self._listen_loop())
             self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
-            logger.info("[%s] Connected to %s", self.name, self._ws_url)
+            logger.info("[%s] Connected to %s", self.name, _safe_url_for_log(self._ws_url))
             return True
         except Exception as exc:
             message = f"WeCom startup failed: {exc}"

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -116,6 +116,36 @@ class TestWeComConnect:
         assert adapter.fatal_error_code == "wecom_connect_error"
         assert "invalid secret" in (adapter.fatal_error_message or "")
 
+    @pytest.mark.asyncio
+    async def test_connect_redacts_websocket_query_secrets_in_logs(self, monkeypatch, caplog):
+        import gateway.platforms.wecom as wecom_module
+        from gateway.platforms.wecom import WeComAdapter
+
+        class DummyClient:
+            async def aclose(self):
+                return None
+
+        monkeypatch.setattr(wecom_module, "AIOHTTP_AVAILABLE", True)
+        monkeypatch.setattr(wecom_module, "HTTPX_AVAILABLE", True)
+        monkeypatch.setattr(wecom_module, "httpx", SimpleNamespace(AsyncClient=lambda **kwargs: DummyClient()))
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True, extra={
+            "bot_id": "bot-1",
+            "secret": "secret-1",
+            "websocket_url": "wss://openws.work.weixin.qq.com/ws?access_token=topsecret123&tenant=acme",
+        }))
+        adapter._open_connection = AsyncMock(return_value=None)
+        adapter._listen_loop = AsyncMock()
+        adapter._heartbeat_loop = AsyncMock()
+
+        with caplog.at_level("INFO", logger="gateway.platforms.wecom"):
+            success = await adapter.connect()
+
+        assert success is True
+        assert "topsecret123" not in caplog.text
+        assert "wss://openws.work.weixin.qq.com/ws" in caplog.text
+        await adapter.disconnect()
+
 
 class TestWeComReplyMode:
     @pytest.mark.asyncio


### PR DESCRIPTION
The Issue
WeCom adapter had a "loud" connection log. When WeComAdapter.connect() successfully established a WebSocket session, it was dumping the entire URL—including sensitive query-string credentials like access_token—directly into the INFO logs.

In a production environment, this is a clear information disclosure risk for anyone with access to the log aggregator or terminal output.

The Solution
I didn’t just mask the string; I added a surgical utility function _safe_url_for_log() that:

Strips Credentials: Removes user/pass from the netloc.

Purges Query/Fragments: Completely drops the ?access_token=... and #fragment parts.

Preserves Context: Keeps the hostname and port so you still know where you are connected, just not how you authenticated.

Proof of Work
I've implemented a targeted regression test in tests/gateway/test_wecom.py that mocks a secret-bearing URL and asserts that the log output is properly sanitized.

Execution:

PowerShell
python -m pytest tests/gateway/test_wecom.py -v
# Status: 33 passed (Zero regressions)
Quick Look (Diff Highlights)
File: gateway/platforms/wecom.py -> Added _safe_url_for_log and updated the logger call.

File: tests/gateway/test_wecom.py -> Added test_connect_redacts_websocket_query_secrets_in_logs.