### PR TITLE
fix(homeassistant): redact sensitive credentials from connection logs

### DIFF
--- a/gateway/platforms/homeassistant.py
+++ b/gateway/platforms/homeassistant.py
@@ -20,6 +20,7 @@ import time
 import uuid
 from datetime import datetime
 from typing import Any, Dict, Optional, Set
+from urllib.parse import urlsplit, urlunsplit
 
 try:
     import aiohttp
@@ -37,6 +38,17 @@ from gateway.platforms.base import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _safe_log_url(url: str) -> str:
+    """Remove URL credentials and auth query params before logging."""
+    parts = urlsplit(url)
+    host = parts.hostname or parts.netloc
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    if parts.port:
+        host = f"{host}:{parts.port}"
+    return urlunsplit((parts.scheme, host, parts.path, "", ""))
 
 
 def check_ha_requirements() -> bool:
@@ -130,7 +142,7 @@ class HomeAssistantAdapter(BasePlatformAdapter):
             # Start background listener
             self._listen_task = asyncio.create_task(self._listen_loop())
             self._running = True
-            logger.info("[%s] Connected to %s", self.name, self._hass_url)
+            logger.info("[%s] Connected to %s", self.name, _safe_log_url(self._hass_url))
             return True
 
         except Exception as e:

--- a/tests/gateway/test_homeassistant.py
+++ b/tests/gateway/test_homeassistant.py
@@ -241,6 +241,22 @@ class TestAdapterInit:
         assert adapter._watch_all is False
         assert adapter._cooldown_seconds == 30
 
+    @pytest.mark.asyncio
+    async def test_connect_log_redacts_hass_url_credentials(self):
+        adapter = HomeAssistantAdapter(
+            PlatformConfig(enabled=True, token="tok", extra={"url": "https://user:supersecret@ha.local:8123/base?access_token=abc123"})
+        )
+        with patch.object(adapter, "_ws_connect", AsyncMock(return_value=True)), \
+                patch.object(adapter, "_listen_loop", AsyncMock(return_value=None)), \
+                patch("gateway.platforms.homeassistant.aiohttp") as mock_aiohttp, \
+                patch("gateway.platforms.homeassistant.logger.info") as mock_info:
+            mock_aiohttp.ClientSession = MagicMock(return_value=MagicMock())
+            mock_aiohttp.ClientTimeout = lambda total: total
+            assert await adapter.connect() is True
+        assert mock_info.call_args_list[-1].args == (
+            "[%s] Connected to %s", "Homeassistant", "https://ha.local:8123/base",
+        )
+
 
 # ---------------------------------------------------------------------------
 # Event filtering pipeline (_handle_ha_event)


### PR DESCRIPTION
The Vulnerability
The Home Assistant adapter was logging the full self._hass_url upon a successful connection. Since this URL often contains Basic Auth credentials (user:pass@host) or sensitive query parameters like access_token, these secrets were being leaked into plaintext terminal output and JSON logs.

The Fix
I've implemented a robust _safe_log_url utility in gateway/platforms/homeassistant.py that utilizes urlsplit to:

Strip out any username/password credentials from the netloc.

Discard query strings and fragments entirely.

Keep the scheme, hostname, and path for diagnostic visibility without the security risk.

Verification
A specific regression test test_connect_log_redacts_hass_url_credentials was added. It mocks a credential-heavy URL and asserts that the log output only contains the sanitized version.

Execution:

PowerShell
python -m pytest tests/gateway/test_homeassistant.py -q
# Result: 50 passed