### PR TITLE
Populate reply_to_text for Discord message replies

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -464,6 +464,11 @@ class DiscordAdapter(BasePlatformAdapter):
         # Reply threading mode: "off" (no replies), "first" (reply on first
         # chunk only, default), "all" (reply-reference on every chunk).
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
+        # Reply message cache: message_id → (author_name, text, timestamp).
+        # Avoids redundant fetch_message API calls for the same referenced message.
+        self._reply_cache: Dict[str, tuple] = {}
+        self._REPLY_CACHE_TTL = 300   # 5 minutes
+        self._REPLY_CACHE_MAX = 500  # prune threshold
 
     async def connect(self) -> bool:
         """Connect to Discord and start receiving events."""
@@ -2227,6 +2232,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
     async def _handle_message(self, message: DiscordMessage) -> None:
         """Handle incoming Discord messages."""
+        _now = time.time()
         # In server channels (not DMs), require the bot to be @mentioned
         # UNLESS the channel is in the free-response list or the message is
         # in a thread where the bot has already participated.
@@ -2476,6 +2482,45 @@ class DiscordAdapter(BasePlatformAdapter):
         _parent_id = str(getattr(_chan, "parent_id", "") or "")
         _chan_id = str(getattr(_chan, "id", ""))
         _skills = self._resolve_channel_skills(_chan_id, _parent_id or None)
+
+        # Extract reply context — Discord provides message.reference with a
+        # message_id but not the content.  Try the cached resolved_reference
+        # first (free, no API call), then the in-memory reply cache, then
+        # fall back to fetch_message and cache the result.
+        reply_to_msg_id = None
+        reply_to_text = None
+        if message.reference and message.reference.message_id:
+            reply_to_msg_id = str(message.reference.message_id)
+
+            # 1) discord.py cached reference (messages the bot has seen)
+            ref_msg = message.reference.resolved
+            if ref_msg is None:
+                # 2) In-memory reply cache (avoids API calls)
+                cached = self._reply_cache.get(reply_to_msg_id)
+                if cached and (_now - cached[2]) < self._REPLY_CACHE_TTL:
+                    author, text = cached[0], cached[1]
+                    reply_to_text = f"{author}: {text}" if text else None
+                else:
+                    # 3) Fetch from Discord API
+                    try:
+                        ref_msg = await message.channel.fetch_message(message.reference.message_id)
+                    except Exception as e:
+                        logger.debug("Could not fetch reply-to message %s: %s", message.reference.message_id, e)
+
+            if ref_msg:
+                author = getattr(ref_msg.author, 'display_name', 'Unknown')
+                # Prefer content, fall back to caption for media messages
+                text = ref_msg.content or getattr(ref_msg, 'caption', None) or None
+                if text:
+                    reply_to_text = f"{author}: {text}"
+                # Store in cache
+                self._reply_cache[reply_to_msg_id] = (author, text or '', _now)
+                if len(self._reply_cache) > self._REPLY_CACHE_MAX:
+                    cutoff = _now - self._REPLY_CACHE_TTL
+                    self._reply_cache = {
+                        k: v for k, v in self._reply_cache.items()
+                        if v[2] > cutoff
+                    }
         event = MessageEvent(
             text=event_text,
             message_type=msg_type,


### PR DESCRIPTION
## Summary

Discord replies pass `reply_to_message_id` but never populate `reply_to_text`. Other platforms (Telegram, Feishu, WeCom) already set this field, and `run.py` (line 2750) injects it as `[Replying to: "..."]` context when the quoted message isn't in session history. Discord just skips this entirely.

## What it does

On incoming Discord messages with `message.reference`:

1. Check `reference.resolved` (cached by discord.py, no API call)
2. Check in-memory reply cache (avoids redundant API calls for repeated references)
3. Fall back to `channel.fetch_message()` for older messages
4. Include the author's display name in the reply text
5. Fall back to message caption for media-only messages

## In-memory reply cache

Repeated replies to the same message no longer trigger separate API calls. The cache stores `(author_name, text, timestamp)` per message ID, with a 5-minute TTL and 500-entry cap. Pruning follows the same pattern as the existing `_seen_messages` dedup cache.

## Author attribution

`reply_to_text` includes the author's display name (e.g. `"Lu: can you see that i replied?"`) so the agent knows who wrote the original message. This is baked into the text field rather than requiring changes to `MessageEvent` or `run.py`.

## Edge cases

- `message_id` is `None` on partial references (deleted messages) — guarded, `reply_to_text` stays `None`
- `resolved_reference` is `None` for older messages — fetched from API and cached
- Fetch fails (deleted message, permissions) — logged at debug, `reply_to_text` stays `None`
- Bot messages, system messages, messages with only embeds — `content` is empty, filtered to `None`
- Media messages with captions — caption used as fallback text
- Cache overflow — pruned to TTL, capped at 500 entries