### PR TITLE
fix: update CLI and gateway to persist model changes to model.default instead of model.name

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3690,7 +3690,7 @@ class HermesCLI:
 
         # Persistence
         if persist_global:
-            save_config_value("model.name", result.new_model)
+            save_config_value("model.default", result.new_model)
             if result.provider_changed:
                 save_config_value("model.provider", result.target_provider)
             _cprint("    Saved to config.yaml (--global)")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3485,7 +3485,7 @@ class GatewayRunner:
                 else:
                     cfg = {}
                 model_cfg = cfg.setdefault("model", {})
-                model_cfg["name"] = result.new_model
+                model_cfg["default"] = result.new_model
                 model_cfg["provider"] = result.target_provider
                 if result.base_url:
                     model_cfg["base_url"] = result.base_url

--- a/tests/test_model_global_persistence.py
+++ b/tests/test_model_global_persistence.py
@@ -1,0 +1,163 @@
+"""Regression tests for /model --global config persistence.
+
+Bug: both the CLI REPL and gateway /model handlers were writing to
+`model.name` instead of `model.default`, while all startup code reads
+`model.default`. This made --global persistence a silent no-op.
+
+CLI tests use source inspection (importing cli at module level fails due
+to optional prompt_toolkit dependency), gateway tests are functional.
+"""
+
+import inspect
+import yaml
+import pytest
+from unittest.mock import MagicMock, patch, AsyncMock
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+from hermes_cli.model_switch import ModelSwitchResult
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_switch_result(model="claude-sonnet-4-6", provider="openrouter"):
+    return ModelSwitchResult(
+        success=True,
+        new_model=model,
+        target_provider=provider,
+        provider_changed=True,
+    )
+
+
+def _make_gateway_runner():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._show_reasoning = False
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.hooks.loaded_hooks = []
+    runner._session_db = None
+    runner._session_model_overrides = {}
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+    return runner
+
+
+def _make_message_event(text: str):
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="user1",
+        chat_id="chat1",
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+# ---------------------------------------------------------------------------
+# CLI source inspection tests
+# (cli.py can't be imported at module level in tests due to optional deps)
+# ---------------------------------------------------------------------------
+
+class TestCliModelGlobalPersistenceSource:
+
+    def test_handler_uses_model_default_not_model_name(self):
+        """_handle_model_switch must call save_config_value with 'model.default'."""
+        source = inspect.getsource(gateway_run.GatewayRunner._handle_model_command)
+        # Verify via the gateway handler as a proxy for the shared fix pattern;
+        # the CLI source check is done by reading the raw file below.
+        import pathlib
+        cli_source = pathlib.Path("cli.py").read_text(encoding="utf-8")
+        assert 'save_config_value("model.default"' in cli_source, (
+            "CLI _handle_model_switch must use 'model.default', not 'model.name'"
+        )
+        assert 'save_config_value("model.name"' not in cli_source, (
+            "Found stale 'model.name' key in cli.py — regression of the --global bug"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Gateway functional tests
+# ---------------------------------------------------------------------------
+
+class TestGatewayModelGlobalPersistence:
+
+    @pytest.fixture
+    def hermes_env(self, tmp_path, monkeypatch):
+        """Isolated Hermes home wired into both gateway_run and hermes_constants."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        return hermes_home
+
+    @pytest.mark.asyncio
+    async def test_global_writes_model_default_not_name(self, hermes_env):
+        """Gateway /model --global must write model.default, not model.name."""
+        config_path = hermes_env / "config.yaml"
+        config_path.write_text(yaml.dump({
+            "model": {"default": "claude-opus-4-6", "provider": "openrouter"},
+        }))
+
+        runner = _make_gateway_runner()
+        event = _make_message_event("/model sonnet --global")
+
+        with patch("hermes_cli.model_switch.switch_model", return_value=_make_switch_result()), \
+             patch("hermes_cli.model_switch.list_authenticated_providers", return_value=[]):
+            await runner._handle_model_command(event)
+
+        saved = yaml.safe_load(config_path.read_text())
+        model = saved["model"]
+        assert model.get("default") == "claude-sonnet-4-6", (
+            f"Expected model.default to be set, got: {model}"
+        )
+        assert "name" not in model, (
+            f"model.name should not exist in config after --global, got: {model}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_global_does_not_clobber_other_config_keys(self, hermes_env):
+        """--global write must preserve unrelated config entries."""
+        config_path = hermes_env / "config.yaml"
+        config_path.write_text(yaml.dump({
+            "model": {"default": "claude-opus-4-6", "provider": "openrouter"},
+            "display": {"skin": "ares"},
+        }))
+
+        runner = _make_gateway_runner()
+        event = _make_message_event("/model sonnet --global")
+
+        with patch("hermes_cli.model_switch.switch_model", return_value=_make_switch_result()), \
+             patch("hermes_cli.model_switch.list_authenticated_providers", return_value=[]):
+            await runner._handle_model_command(event)
+
+        saved = yaml.safe_load(config_path.read_text())
+        assert saved["display"]["skin"] == "ares"
+
+    @pytest.mark.asyncio
+    async def test_session_only_does_not_write_config(self, hermes_env):
+        """Without --global, config.yaml must not be modified."""
+        config_path = hermes_env / "config.yaml"
+        original = yaml.dump({
+            "model": {"default": "claude-opus-4-6", "provider": "openrouter"},
+        })
+        config_path.write_text(original)
+
+        runner = _make_gateway_runner()
+        event = _make_message_event("/model sonnet")
+
+        with patch("hermes_cli.model_switch.switch_model", return_value=_make_switch_result()), \
+             patch("hermes_cli.model_switch.list_authenticated_providers", return_value=[]):
+            await runner._handle_model_command(event)
+
+        assert config_path.read_text() == original, (
+            "Session-only switch must not modify config.yaml"
+        )


### PR DESCRIPTION
## What does this PR do?

Both the CLI and the gateway `/model` command handlers were persisting the model selection to `model.name` in `config.yaml`, but all startup code reads from `model.default`. This made `/model <name> --global` a silent no-op - the value was written to the wrong key and never picked up on the next session.

This PR fixes both write sites to use the correct `model.default` key, ensuring that global model switches actually persist across sessions.


## Related Issue

Fixes https://github.com/NousResearch/hermes-agent/issues/5343

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`: Changed `save_config_value("model.name", ...)` → `save_config_value("model.default", ...)` in `_handle_model_switch`
- `gateway/run.py`: Changed `model_cfg["name"] = ...` → `model_cfg["default"] = ...` in `GatewayRunner._handle_model_command`
- `tests/test_model_global_persistence.py`: Added regression tests covering:
  - CLI source inspection to guard against re-introduction of `model.name`
  - Gateway functional test: `--global` writes `model.default`, not `model.name`
  - Gateway functional test: `--global` preserves unrelated config keys
  - Gateway functional test: session-only switch does not write to `config.yaml`


## How to Test

1. Run `/model <new-model> --global` in the CLI or via the gateway.
2. Open `~/.hermes/config.yaml` and confirm `model.default` is set to the new model (not `model.name`).
3. Restart Hermes and verify the new model is active in the next session.
4. Run `pytest tests/test_model_global_persistence.py -v` — all tests should pass.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

