### PR TITLE
Make completion menu colors skin-aware instead of hardcoded

### DIFF
--- a/hermes_cli/skin_engine.py
+++ b/hermes_cli/skin_engine.py
@@ -691,6 +691,13 @@ def get_prompt_toolkit_style_overrides() -> Dict[str, str]:
     warn = skin.get_color("ui_warn", "#FF8C00")
     error = skin.get_color("ui_error", "#FF6B6B")
 
+    completion_bg = skin.get_color("completion_bg", "#1a1a2e")
+    completion_active_bg = skin.get_color("completion_active_bg", "#333355")
+    completion_text_color = skin.get_color("completion_text", text)
+    completion_active_text_color = skin.get_color("completion_active_text", title)
+    completion_meta_color = skin.get_color("completion_meta", dim)
+    completion_meta_active_color = skin.get_color("completion_meta_active", label)
+
     return {
         "input-area": prompt,
         "placeholder": f"{dim} italic",
@@ -699,11 +706,11 @@ def get_prompt_toolkit_style_overrides() -> Dict[str, str]:
         "hint": f"{dim} italic",
         "input-rule": input_rule,
         "image-badge": f"{label} bold",
-        "completion-menu": f"bg:#1a1a2e {text}",
-        "completion-menu.completion": f"bg:#1a1a2e {text}",
-        "completion-menu.completion.current": f"bg:#333355 {title}",
-        "completion-menu.meta.completion": f"bg:#1a1a2e {dim}",
-        "completion-menu.meta.completion.current": f"bg:#333355 {label}",
+        "completion-menu": f"bg:{completion_bg} {completion_text_color}",
+        "completion-menu.completion": f"bg:{completion_bg} {completion_text_color}",
+        "completion-menu.completion.current": f"bg:{completion_active_bg} {completion_active_text_color}",
+        "completion-menu.meta.completion": f"bg:{completion_bg} {completion_meta_color}",
+        "completion-menu.meta.completion.current": f"bg:{completion_active_bg} {completion_meta_active_color}",
         "clarify-border": input_rule,
         "clarify-title": f"{title} bold",
         "clarify-question": f"{text} bold",


### PR DESCRIPTION
The completion menu in `get_prompt_toolkit_style_overrides()` has hardcoded dark backgrounds (`bg:#1a1a2e`, `bg:#333355`) that ignore the active skin's color settings. This makes the completion menu unusable for:

- Light terminal themes (dark text on dark bg = invisible/unselectable)
- Users of pywal, matugen, or stylix for adaptive terminal theming
- Any custom skin that doesn't use dark backgrounds

## This change

Replaces hardcoded completion menu colors with `skin.get_color()` calls:

**New skin color keys** (all backwards-compatible with existing defaults):
- `completion_bg`, `completion_active_bg` — menu backgrounds
- `completion_text`, `completion_active_text` — text colors
- `completion_meta`, `completion_meta_active` — description/meta text

Skins that don't define these keys get the existing values as defaults, so this is a zero-breaking-change improvement.

## A note on adaptive terminal theming from a NixOS user (SSH'd from a workstation with pywal/matugen/stylix):

It would be great to consider these directions for future development:

1. **Adaptive terminal color detection**: Many of us use pywal, matugen, or stylix to auto-generate terminal colors from our wallpaper. An `auto` skin type that reads from `~/.cache/wal/colors` or similar caches to derive the full UI palette — including the completion menu — would make the TUI adapt naturally when switching between light and dark terminal themes. Bonus points for WCAG contrast enforcement.

2. **Customizable TUI layouts**: Tools like [opencode](https://github.com/opencode-ai/opencode) and [kilo](https://github.com/klocm/kilo) let users pick or code their own panel layouts. The skin system today only affects colors. Consider exposing the Rich layout configuration so users can customize panel arrangements, status bar style, or prompt layout without forking.

Thanks for an excellent project. The skin system is one of its best features — this change makes it work for everyone.