### PR TITLE
fix(honcho): accept legacy config keys

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -105,3 +105,4 @@ tesseracttars-creator <tesseracttars@gmail.com> <tesseracttars@gmail.com>
 xinbenlv <zzn+pa@zzn.im> <zzn+pa@zzn.im>
 SaulJWu <saul.jj.wu@gmail.com> <saul.jj.wu@gmail.com>
 angelos <angelos@oikos.lan.home.malaiwah.com> <angelos@oikos.lan.home.malaiwah.com>
+MestreY0d4-Uninter <MestreY0d4-Uninter@users.noreply.github.com> <MestreY0d4-Uninter@users.noreply.github.com>

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -276,6 +276,8 @@ class HonchoClientConfig:
         api_key = (
             host_block.get("apiKey")
             or raw.get("apiKey")
+            or host_block.get("api_key")
+            or raw.get("api_key")
             or os.environ.get("HONCHO_API_KEY")
         )
 
@@ -369,6 +371,8 @@ class HonchoClientConfig:
             recall_mode=_normalize_recall_mode(
                 host_block.get("recallMode")
                 or raw.get("recallMode")
+                or host_block.get("memoryMode")
+                or raw.get("memoryMode")
                 or "hybrid"
             ),
             init_on_session_start=_resolve_bool(

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -62,6 +62,7 @@ AUTHOR_MAP = {
     "258577966+voidborne-d@users.noreply.github.com": "voidborne-d",
     "70424851+insecurejezza@users.noreply.github.com": "insecurejezza",
     "259807879+Bartok9@users.noreply.github.com": "Bartok9",
+    "MestreY0d4-Uninter@users.noreply.github.com": "MestreY0d4-Uninter",
     # contributors (manual mapping from git names)
     "dmayhem93@gmail.com": "dmahan93",
     "samherring99@gmail.com": "samherring99",

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -186,6 +186,23 @@ class TestFromGlobalConfig:
         config = HonchoClientConfig.from_global_config(config_path=config_file)
         assert config.recall_mode == "hybrid"
 
+    def test_recall_mode_legacy_memory_mode_is_accepted(self, tmp_path):
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "apiKey": "***",
+            "memoryMode": "tools",
+            "hosts": {"hermes": {"memoryMode": "context"}},
+        }))
+        config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.recall_mode == "context"
+
+    def test_api_key_legacy_snake_case_is_accepted(self, tmp_path):
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({"api_key": "legacy-key"}))
+        config = HonchoClientConfig.from_global_config(config_path=config_file)
+        assert config.api_key == "legacy-key"
+        assert config.enabled is True
+
     def test_corrupt_config_falls_back_to_env(self, tmp_path):
         config_file = tmp_path / "config.json"
         config_file.write_text("not valid json{{{")


### PR DESCRIPTION
## Summary
This PR makes the Honcho config parser accept legacy/local config keys that are still present in existing Hermes environments.

In particular, the runtime currently expects:
- `apiKey`
- `recallMode`

But some existing configs use:
- `api_key`
- `memoryMode`

That mismatch can cause the Honcho integration to ignore the intended runtime mode or credentials.

## What changed
- accept legacy `api_key` as a read-time fallback for `apiKey`
- accept legacy `memoryMode` as a read-time fallback for `recallMode`
- keep the modern camelCase config format as the primary/canonical one
- add focused tests covering both compatibility cases

## Why
This is a small backward-compatibility fix for environments that still have older/alternate Honcho config shapes on disk.

The patch is intentionally minimal:
- no architecture changes
- no automatic rewrite of user config files
- no CLI setup behavior change
- compatibility only at parse time

## Validation
### Automated
- `/home/ubuntu/.hermes/hermes-agent/venv/bin/python -m py_compile plugins/memory/honcho/client.py tests/honcho_plugin/test_client.py`
- `/home/ubuntu/.hermes/hermes-agent/venv/bin/python -m pytest tests/honcho_plugin/test_client.py -q`
- Result: `51 passed`

### Practical
Validated with a real runtime comparison using legacy-shaped Honcho config (`api_key`, `memoryMode`) and `copilot-acp`:

- On upstream `main`, legacy `memoryMode: context` was ignored in practice and Honcho tools remained visible.
- On this patched branch, legacy `memoryMode: context` was respected in practice and Honcho tools were no longer exposed.
- On this patched branch, legacy `memoryMode: tools` also behaved correctly and exposed the Honcho tools.

## Scope notes
This PR is intentionally limited to config compatibility only.

The later runtime/bootstrap observability fix lives separately in #5574.
Keeping them separate keeps review and regression surface smaller.

## Notes
If we want a stronger follow-up later, the next step would be optional migration/warning logic so legacy keys are normalized on write. That is intentionally out of scope for this minimal compatibility fix.
