### PR TITLE
feat(gateway): inject current timestamp into user messages

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6534,6 +6534,16 @@ class GatewayRunner:
             _approval_session_token = set_current_session_key(_approval_session_key)
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
             try:
+                # Inject current timestamp into every user message so the agent
+                # always knows the current time without needing a tool call.
+                _now = datetime.now()
+                import locale as _locale
+                try:
+                    _locale.setlocale(_locale.LC_TIME, 'en_US.UTF-8')
+                except Exception:
+                    pass
+                _ts_str = _now.strftime('%A, %B %d, %Y %I:%M %p')
+                message = f"[Current time: {_ts_str}]\n\n{message}"
                 result = agent.run_conversation(message, conversation_history=agent_history, task_id=session_id)
             finally:
                 unregister_gateway_notify(_approval_session_key)


### PR DESCRIPTION
## Summary

Injects a human-readable timestamp at the top of every user message before it reaches the agent, so the agent always knows the current date and time without needing to invoke a tool call.

**Format:** `[Current time: Monday, April 06, 2026 07:36 AM]`

## Why

Agents running long conversations often lose track of time. The only built-in mechanism is the `Conversation started:` header, which becomes stale after minutes or hours of back-and-forth. Currently the agent must spend a `date` tool call just to answer "what time is it?" or "what day is today?" — wasting tokens and latency.

This is especially important for:
- **Cron-scheduled tasks** — the agent wakes up with no conversation history and no time context
- **Long multi-turn conversations** — the original timestamp is hours old
- **Time-sensitive instructions** — "remind me at 3pm", "is it past midnight?", etc.

## What Changed

**`gateway/run.py`** — inside `_run_agent()`, right before `agent.run_conversation()`:
- Get current time via `datetime.now()`
- Set locale to `en_US.UTF-8` for consistent day/month names (with graceful fallback)
- Format as human-readable string: `Monday, April 06, %Y %I:%M %p`
- Prepend `[Current time: ...]

` to the message

## Design Decisions

| Decision | Rationale |
|---|---|
| `datetime.now()` instead of injecting into system prompt | The message-level approach works for ALL model providers (some strip system prompts) |
| Locale `en_US.UTF-8` with try/except fallback | Server locale may be non-English; we want consistent English output |
| Prepend to message, not modify agent API | Zero-impact change — no changes to agent interface, prompt builder, or context files |
| Only in `_run_agent` (gateway path) | CLI mode has direct terminal access; gateway agents need the injection |

## Testing

Manual testing on self-hosted instance:
- Agent correctly reports current time without any tool calls
- Works across long multi-turn conversations (timestamp updated per message)
- Cron jobs also receive timestamps (they pass through the same `_run_agent` path)
- Gracefully handles missing `en_US` locale (falls back to server default)

## Example

Agent responding with correct time awareness — no tool calls needed:
```
User: What time is it right now?
Agent: It's currently 7:58 AM on Monday, April 6, 2026.
```
