### PR TITLE
fix(cli): invalidate stale update banner cache on manual git changes

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -147,13 +147,35 @@ def check_for_updates() -> Optional[int]:
     if not (repo_dir / ".git").exists():
         return None
 
+    def _rev_parse(ref: str) -> Optional[str]:
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", ref],
+                capture_output=True, text=True, timeout=5,
+                cwd=str(repo_dir),
+            )
+            if result.returncode == 0:
+                value = result.stdout.strip()
+                return value or None
+        except Exception:
+            pass
+        return None
+
+    current_head = _rev_parse("HEAD")
+    current_origin_main = _rev_parse("origin/main")
+
     # Read cache
     now = time.time()
     try:
         if cache_file.exists():
             cached = json.loads(cache_file.read_text())
             if now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS:
-                return cached.get("behind")
+                cached_head = cached.get("head")
+                cached_origin_main = cached.get("origin_main")
+                if current_head is None and current_origin_main is None:
+                    return cached.get("behind")
+                if cached_head == current_head and cached_origin_main == current_origin_main:
+                    return cached.get("behind")
     except Exception:
         pass
 
@@ -181,9 +203,17 @@ def check_for_updates() -> Optional[int]:
     except Exception:
         behind = None
 
+    current_head = _rev_parse("HEAD") or current_head
+    current_origin_main = _rev_parse("origin/main") or current_origin_main
+
     # Write cache
     try:
-        cache_file.write_text(json.dumps({"ts": now, "behind": behind}))
+        cache_file.write_text(json.dumps({
+            "ts": now,
+            "behind": behind,
+            "head": current_head,
+            "origin_main": current_origin_main,
+        }))
     except Exception:
         pass
 

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -32,7 +32,7 @@ def test_check_for_updates_uses_cache(tmp_path):
             result = check_for_updates()
 
     assert result == 3
-    mock_run.assert_not_called()
+    assert mock_run.call_count == 2  # rev-parse HEAD + rev-parse origin/main to validate cache freshness
 
 
 def test_check_for_updates_expired_cache(tmp_path):
@@ -54,7 +54,42 @@ def test_check_for_updates_expired_cache(tmp_path):
             result = check_for_updates()
 
     assert result == 5
-    assert mock_run.call_count == 2  # git fetch + git rev-list
+    assert mock_run.call_count == 6  # initial rev-parse pair + fetch + rev-list + cache write rev-parse pair
+
+
+def test_check_for_updates_ignores_fresh_cache_when_repo_refs_changed(tmp_path):
+    """Fresh cache must be invalidated when HEAD/origin-main changed via manual git commands."""
+    from hermes_cli.banner import check_for_updates
+
+    repo_dir = tmp_path / "hermes-agent"
+    repo_dir.mkdir()
+    (repo_dir / ".git").mkdir()
+
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(json.dumps({
+        "ts": time.time(),
+        "behind": 74,
+        "head": "old-head",
+        "origin_main": "old-origin-main",
+    }))
+
+    def fake_run(cmd, *args, **kwargs):
+        if cmd[:3] == ["git", "rev-parse", "HEAD"]:
+            return MagicMock(returncode=0, stdout="new-head\n")
+        if cmd[:3] == ["git", "rev-parse", "origin/main"]:
+            return MagicMock(returncode=0, stdout="new-origin-main\n")
+        if cmd[:3] == ["git", "fetch", "origin"]:
+            return MagicMock(returncode=0, stdout="")
+        if cmd[:3] == ["git", "rev-list", "--count"]:
+            return MagicMock(returncode=0, stdout="0\n")
+        raise AssertionError(f"unexpected git command: {cmd}")
+
+    with patch("hermes_cli.banner.os.getenv", return_value=str(tmp_path)):
+        with patch("hermes_cli.banner.subprocess.run", side_effect=fake_run) as mock_run:
+            result = check_for_updates()
+
+    assert result == 0
+    assert mock_run.call_count == 6  # initial rev-parse pair + fetch + rev-list + cache write rev-parse pair
 
 
 def test_check_for_updates_no_git_dir(tmp_path):


### PR DESCRIPTION
## Summary
- invalidate the cached commits-behind banner when local `HEAD` or `origin/main` changed outside `hermes update`
- store repo state refs alongside the cached behind count
- add regression coverage for fresh-but-stale cache after manual git operations

## Test Plan
- `python3 -m py_compile hermes_cli/banner.py tests/hermes_cli/test_update_check.py`
- `./venv/bin/pytest -q tests/hermes_cli/test_update_check.py -q`

Fixes the stale banner case where manual `git merge`/`git pull` leaves Hermes claiming the repo is still behind for up to 6 hours.