### PR TITLE
fix(gateway): avoid pending-note UnboundLocalError

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6462,17 +6462,24 @@ class GatewayRunner:
                 except Exception as _e:
                     logger.error("Failed to send approval request: %s", _e)
 
-            # Prepend pending model switch note so the model knows about the switch
+            # Avoid rebinding the outer parameter directly here: assigning to
+            # `message` inside this nested function would make it a local and
+            # trigger UnboundLocalError when we try to read it first.
+            effective_message = message
             _pending_notes = getattr(self, '_pending_model_notes', {})
             _msn = _pending_notes.pop(session_key, None) if session_key else None
             if _msn:
-                message = _msn + "\n\n" + message
+                effective_message = _msn + "\n\n" + effective_message
 
             _approval_session_key = session_key or ""
             _approval_session_token = set_current_session_key(_approval_session_key)
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
             try:
-                result = agent.run_conversation(message, conversation_history=agent_history, task_id=session_id)
+                result = agent.run_conversation(
+                    effective_message,
+                    conversation_history=agent_history,
+                    task_id=session_id,
+                )
             finally:
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)

--- a/tests/gateway/test_reasoning_command.py
+++ b/tests/gateway/test_reasoning_command.py
@@ -49,12 +49,14 @@ class _CapturingAgent:
     """Fake agent that records init kwargs for assertions."""
 
     last_init = None
+    last_user_message = None
 
     def __init__(self, *args, **kwargs):
         type(self).last_init = dict(kwargs)
         self.tools = []
 
     def run_conversation(self, user_message: str, conversation_history=None, task_id=None):
+        type(self).last_user_message = user_message
         return {
             "final_response": "ok",
             "messages": [],
@@ -327,3 +329,60 @@ class TestReasoningCommand:
         assert result["final_response"] == "ok"
         assert _CapturingAgent.last_init is not None
         assert "homeassistant" in set(_CapturingAgent.last_init["enabled_toolsets"])
+
+    def test_run_agent_prepends_pending_model_note_without_scoping_error(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+        monkeypatch.setattr(gateway_run, "_env_path", hermes_home / ".env")
+        monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            gateway_run,
+            "_resolve_runtime_agent_kwargs",
+            lambda: {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "test-key",
+            },
+        )
+        fake_run_agent = types.ModuleType("run_agent")
+        fake_run_agent.AIAgent = _CapturingAgent
+        monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+        _CapturingAgent.last_init = None
+        _CapturingAgent.last_user_message = None
+
+        runner = _make_runner()
+        session_key = "agent:main:local:dm"
+        runner._pending_model_notes = {session_key: "[Model switched to gemma-3-27b-it]"}
+
+        source = SessionSource(
+            platform=Platform.LOCAL,
+            chat_id="cli",
+            chat_name="CLI",
+            chat_type="dm",
+            user_id="user-1",
+        )
+
+        result = asyncio.run(
+            runner._run_agent(
+                message="ping",
+                context_prompt="",
+                history=[],
+                source=source,
+                session_id="session-1",
+                session_key=session_key,
+            )
+        )
+
+        assert result["final_response"] == "ok"
+        assert (
+            _CapturingAgent.last_user_message
+            == "[Model switched to gemma-3-27b-it]\n\nping"
+        )
+        assert runner._pending_model_notes == {}


### PR DESCRIPTION
## What does this PR do?

This fixes a gateway crash in gateway/run.py when a pending model-switch note is prepended before calling agent.run_conversation().

Inside the nested run_sync() function, the code reassigned message while also reading from it, which makes Python treat message as a local variable in that scope and can raise UnboundLocalError before the provider call happens.

This change avoids rebinding the outer variable and instead uses a local effective_message, preserving the intended behavior without tripping Python scoping rules.

This PR also adds a regression test covering the pending model-note path so the crash is caught by tests going forward.

## Related Issue

No issue number is linked for this report.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Updated gateway/run.py to use a local effective_message inside run_sync() instead of rebinding the outer message variable
- Preserved the pending model-note prepend behavior before calling agent.run_conversation()
- Added a regression test in tests/gateway/test_reasoning_command.py to verify pending model notes are prepended without raising a scoping error
- Confirmed the targeted gateway tests pass with the new regression coverage

## How to Test

1. Activate the repo environment: source /home/gille/.hermes/hermes-agent/venv/bin/activate
2. Run the targeted regression file: python -m pytest tests/gateway/test_reasoning_command.py -q
3. Confirm the test run reports 9 passed
4. Optionally run the full suite: python -m pytest tests/ -q
5. Note that the full suite currently has unrelated pre-existing failures in this repo state, but the targeted file for this bug passes

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix or feature
- [ ] I have run pytest tests/ -q and all tests pass
- [x] I have added tests for my changes
- [x] I have tested on my platform: Ubuntu 24.04 via WSL

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A
- [x] cli-config.yaml.example updates are N/A
- [x] CONTRIBUTING.md or AGENTS.md updates are N/A
- [x] Cross-platform impact has been considered or is N/A
- [x] Tool description or schema updates are N/A

## Screenshots / Logs

Targeted regression test: 9 passed in 6.54s
Full suite in current repo state: 39 failed, 8350 passed, 30 skipped, 1 xpassed in 192.98s
