### PR TITLE
fix(gateway): filter session_meta from /btw history to prevent API validation error

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4147,7 +4147,12 @@ class GatewayRunner:
                 history_snapshot = list(getattr(running_agent, "_session_messages", []) or [])
             else:
                 session_entry = self.session_store.get_or_create_session(source)
-                history_snapshot = self.session_store.load_transcript(session_entry.session_id)
+                raw_history = self.session_store.load_transcript(session_entry.session_id)
+                # Filter out session_meta entries (internal bookkeeping, not for LLM API)
+                history_snapshot = [
+                    msg for msg in raw_history
+                    if msg.get("role") != "session_meta"
+                ]
 
             btw_prompt = (
                 "[Ephemeral /btw side question. Answer using the conversation "


### PR DESCRIPTION
## Bug: /btw command fails with validation error when session has transcript history

### Description
The `/btw` (by the way) command fails with a cryptic API validation error when there's an existing session transcript. The error message indicates that `session_meta` entries are being passed to the LLM API, which rejects them as invalid.

### Error Message
```
API call failed after 3 retries: HTTP 400: Error code: 400 - {'error': "[object Object] failed the following checks:
[object Object] failed the following checks:
...
null failed the following checks:
null is not a string
null is not an array
session_meta is not equa
```

### Root Cause
In `gateway/run.py`, the `_run_btw_task()` method loads the session transcript to provide context for the side question:

```python
history_snapshot = self.session_store.load_transcript(session_entry.session_id)
```

However, `load_transcript()` returns the raw transcript including `session_meta` entries (internal metadata with tool definitions, model info, etc.). These entries have `"role": "session_meta"` which is **not a valid role** for the LLM API.

The main message handler at line 5798 correctly filters out `session_meta` entries:
```python
if role in ("session_meta",):
    continue
```

But the `/btw` handler was missing this filtering.

### Steps to Reproduce
1. Start a conversation (any platform)
2. Have some back-and-forth to populate the session transcript
3. Run `/btw <any question>`
4. The command fails with the validation error

### Expected Behavior
The `/btw` command should filter out `session_meta` entries from the conversation history before passing to the AI agent, just like the main message handler does.

### Proposed Fix
Filter `session_meta` entries from the loaded transcript:

```python
raw_history = self.session_store.load_transcript(session_entry.session_id)
# Filter out session_meta entries (internal bookkeeping, not for LLM API)
history_snapshot = [
    msg for msg in raw_history
    if msg.get("role") != "session_meta"
]
```

### Additional Context
- CLI mode `/btw` is not affected because `self.conversation_history` in the CLI doesn't include `session_meta` entries
- This only affects the gateway mode where transcripts are stored with metadata
- The fix aligns with how the main handler processes history (line 5798)