### PR TITLE
fix(gateway,cli): respect model.provider and model.base_url from config

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1214,7 +1214,10 @@ class HermesCLI:
         )
 
         self._explicit_api_key = api_key
-        self._explicit_base_url = base_url
+        # Include config base_url as an explicit override so _ensure_runtime_credentials()
+        # passes it to resolve_runtime_provider and _resolve_explicit_runtime honours it
+        # for all provider types (not just "auto"/"custom"). CLI arg takes precedence.
+        self._explicit_base_url = base_url or CLI_CONFIG["model"].get("base_url") or None
 
         # Provider selection is resolved lazily at use-time via _ensure_runtime_credentials().
         self.requested_provider = (

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -284,10 +284,28 @@ def _resolve_runtime_agent_kwargs() -> dict:
         resolve_runtime_provider,
         format_runtime_provider_error,
     )
+    from hermes_cli.config import load_config
+
+    config = load_config()
+    model_cfg = config.get("model") if isinstance(config.get("model"), dict) else {}
+
+    # HERMES_INFERENCE_PROVIDER env var takes explicit precedence.
+    # Otherwise fall back to config so model.provider / model.base_url are respected
+    # and don't silently fall through to OpenRouter when OPENROUTER_API_KEY is present.
+    env_provider = os.getenv("HERMES_INFERENCE_PROVIDER")
+    if env_provider:
+        requested = env_provider
+        explicit_base_url = None
+    else:
+        requested = model_cfg.get("provider") or None
+        # Pass config base_url explicitly so _resolve_explicit_runtime honours it
+        # for all provider types, not just "auto"/"custom".
+        explicit_base_url = model_cfg.get("base_url") or None
 
     try:
         runtime = resolve_runtime_provider(
-            requested=os.getenv("HERMES_INFERENCE_PROVIDER"),
+            requested=requested,
+            explicit_base_url=explicit_base_url,
         )
     except Exception as exc:
         raise RuntimeError(format_runtime_provider_error(exc)) from exc


### PR DESCRIPTION
## Problem

Fixes #5358.

When `HERMES_INFERENCE_PROVIDER` is not set in the environment, the gateway's `_resolve_runtime_agent_kwargs()` was calling:

```python
resolve_runtime_provider(requested=os.getenv("HERMES_INFERENCE_PROVIDER"))
# → resolve_runtime_provider(requested=None)
```

This could fall through to OpenRouter auto-detection whenever `OPENROUTER_API_KEY` was present — silently ignoring an explicit `model.provider` / `model.base_url` in `config.yaml`.

The CLI had the same gap: `_explicit_base_url` was only initialised from the CLI `--base-url` argument, so `_ensure_runtime_credentials()` never forwarded `config.yaml`'s `model.base_url` to `resolve_runtime_provider`. As a result `_resolve_explicit_runtime` silently fell back to the hard-coded provider URL (or OpenRouter) for all non-`auto`/non-`custom` providers.

## Root cause

- **Gateway** (`gateway/run.py`): `model.provider` and `model.base_url` from config were never read; only the env var was passed.
- **CLI** (`cli.py`): `self._explicit_base_url` was set only from the CLI arg, not from `CLI_CONFIG["model"]["base_url"]`, so config's endpoint was dropped when `_ensure_runtime_credentials()` re-resolved on each turn.

## Fix

**`gateway/run.py` — `_resolve_runtime_agent_kwargs()`**

Read `model.provider` and `model.base_url` from config and pass them as `requested` + `explicit_base_url` when no env var override is present:

```python
env_provider = os.getenv("HERMES_INFERENCE_PROVIDER")
if env_provider:
    requested = env_provider
    explicit_base_url = None
else:
    requested = model_cfg.get("provider") or None
    explicit_base_url = model_cfg.get("base_url") or None

runtime = resolve_runtime_provider(
    requested=requested,
    explicit_base_url=explicit_base_url,
)
```

**`cli.py` — `HermesCLI.__init__()`**

Seed `_explicit_base_url` from config so it is forwarded on every credential refresh:

```python
self._explicit_base_url = base_url or CLI_CONFIG["model"].get("base_url") or None
```

## Priority order (unchanged)

`CLI arg` > `HERMES_INFERENCE_PROVIDER env var` > `config.yaml` > auto-detection

## Testing

1. Configure `~/.hermes/config.yaml` with a non-OpenRouter provider:
   ```yaml
   model:
     base_url: https://api.minimax.io/anthropic
     default: MiniMax-M2.7
     provider: minimax
   ```
2. Ensure `OPENROUTER_API_KEY` is set (but no `MINIMAX_API_KEY`)
3. Start the gateway: `hermes gateway`
4. **Before fix:** requests silently routed to OpenRouter
5. **After fix:** `resolve_runtime_provider` receives `requested="minimax"` and `explicit_base_url="https://api.minimax.io/anthropic"` — no OpenRouter fallback