### PR TITLE
fix(api-server): correct tool_progress_callback signature — fixes silent TypeError breaking SSE tool progress

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -563,13 +563,20 @@ class APIServerAdapter(BasePlatformAdapter):
                 if delta is not None:
                     _stream_q.put(delta)
 
-            def _on_tool_progress(name, preview, args):
-                """Inject tool progress into the SSE stream for Open WebUI."""
-                if name.startswith("_"):
-                    return  # Skip internal events (_thinking)
+            def _on_tool_progress(event_type, tool_name=None, preview=None, args=None, **kwargs):
+                """Inject tool progress into the SSE stream for Open WebUI.
+
+                The agent calls this as tool_progress_callback(event_type, tool_name, preview, args).
+                We only surface "tool.started" events to avoid spamming the stream with
+                tool.completed, reasoning.available, and other lifecycle events.
+                """
+                if event_type != "tool.started":
+                    return  # Skip tool.completed, reasoning.available, _thinking, etc.
+                if not tool_name:
+                    return
                 from agent.display import get_tool_emoji
-                emoji = get_tool_emoji(name)
-                label = preview or name
+                emoji = get_tool_emoji(tool_name)
+                label = preview or tool_name
                 _stream_q.put(f"\n`{emoji} {label}`\n")
 
             # Start agent in background.  agent_ref is a mutable container

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -439,7 +439,7 @@ class TestChatCompletionsEndpoint:
                 tp_cb = kwargs.get("tool_progress_callback")
                 # Simulate tool progress before streaming content
                 if tp_cb:
-                    tp_cb("terminal", "ls -la", {"command": "ls -la"})
+                    tp_cb("tool.started", "terminal", "ls -la", {"command": "ls -la"})
                 if cb:
                     await asyncio.sleep(0.05)
                     cb("Here are the files.")
@@ -467,7 +467,7 @@ class TestChatCompletionsEndpoint:
 
     @pytest.mark.asyncio
     async def test_stream_tool_progress_skips_internal_events(self, adapter):
-        """Internal events (name starting with _) are not streamed."""
+        """Non-tool.started events (e.g. _thinking, tool.completed) are not streamed."""
         import asyncio
 
         app = _create_app(adapter)
@@ -476,8 +476,8 @@ class TestChatCompletionsEndpoint:
                 cb = kwargs.get("stream_delta_callback")
                 tp_cb = kwargs.get("tool_progress_callback")
                 if tp_cb:
-                    tp_cb("_thinking", "some internal state", {})
-                    tp_cb("web_search", "Python docs", {"query": "Python docs"})
+                    tp_cb("_thinking", "some internal state")
+                    tp_cb("tool.started", "web_search", "Python docs", {"query": "Python docs"})
                 if cb:
                     await asyncio.sleep(0.05)
                     cb("Found it.")


### PR DESCRIPTION
## Root cause

Closes #5352.

`_on_tool_progress` in `gateway/platforms/api_server.py` accepted **3 positional arguments** (`name, preview, args`) but `run_agent.py` calls `tool_progress_callback` with **4**:

```python
# run_agent.py — actual call
self.tool_progress_callback("tool.started", name, preview, args)
```

Python raised `TypeError: _on_tool_progress() takes 3 positional arguments but 4 were given`, which was silently swallowed by the surrounding `try/except` in the agent loop. Result: **zero tool progress events ever reached the SSE stream** in Open WebUI (or any other frontend using `/v1/chat/completions?stream=true`).

## Changes

### `gateway/platforms/api_server.py`

| Before | After |
|--------|-------|
| `def _on_tool_progress(name, preview, args)` | `def _on_tool_progress(event_type, tool_name=None, preview=None, args=None, **kwargs)` |
| `if name.startswith("_"): return` | `if event_type != "tool.started": return` |
| `get_tool_emoji(name)` | `get_tool_emoji(tool_name)` |

The new event-type filter correctly suppresses `tool.completed`, `reasoning.available`, and `_thinking` events (the old `startswith("_")` check only caught `_thinking`). The `**kwargs` future-proofs against new keyword arguments like `duration=` already used in `tool.completed` calls.

### `tests/gateway/test_api_server.py`

Both tests were calling the callback with the old 3-argument signature, so they passed against broken code. Updated to match the real agent call site:

```python
# Before (wrong — masked the bug)
tp_cb("terminal", "ls -la", {"command": "ls -la"})
tp_cb("_thinking", "some internal state", {})
tp_cb("web_search", "Python docs", {"query": "Python docs"})

# After (matches run_agent.py)
tp_cb("tool.started", "terminal", "ls -la", {"command": "ls -la"})
tp_cb("_thinking", "some internal state")          # real agent only passes 2 args for _thinking
tp_cb("tool.started", "web_search", "Python docs", {"query": "Python docs"})
```

## Test plan

- [ ] Existing `test_stream_includes_tool_progress` — verifies tool progress text appears in SSE stream
- [ ] Existing `test_stream_tool_progress_skips_internal_events` — verifies `_thinking` and non-`tool.started` events are suppressed
- [ ] Manual: `curl -N -X POST http://localhost:8642/v1/chat/completions -d '{"model":"hermes-agent","stream":true,"messages":[{"role":"user","content":"list files"}]}'` — tool progress line (e.g. `` `📁 ls` ``) should appear in the stream before the final answer

🤖 Generated with [Claude Code](https://claude.com/claude-code)