### PR TITLE
feat(api-server): let clients suppress streamed tool progress

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -50,6 +50,19 @@ MAX_STORED_RESPONSES = 100
 MAX_REQUEST_BYTES = 1_000_000  # 1 MB default limit for POST bodies
 
 
+def _coerce_optional_bool(value: Any) -> Optional[bool]:
+    """Parse optional request booleans without rejecting unknown OpenAI fields."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+    return None
+
+
 def check_api_server_requirements() -> bool:
     """Check if API server dependencies are available."""
     return AIOHTTP_AVAILABLE
@@ -498,6 +511,8 @@ class APIServerAdapter(BasePlatformAdapter):
             )
 
         stream = body.get("stream", False)
+        verbose_requested = _coerce_optional_bool(body.get("verbose"))
+        stream_tool_progress_requested = _coerce_optional_bool(body.get("stream_tool_progress"))
 
         # Extract system message (becomes ephemeral system prompt layered ON TOP of core)
         system_prompt = None
@@ -551,6 +566,11 @@ class APIServerAdapter(BasePlatformAdapter):
         if stream:
             import queue as _q
             _stream_q: _q.Queue = _q.Queue()
+            stream_tool_progress = True
+            if stream_tool_progress_requested is not None:
+                stream_tool_progress = stream_tool_progress_requested
+            elif verbose_requested is not None:
+                stream_tool_progress = verbose_requested
 
             def _on_delta(delta):
                 # Filter out None — the agent fires stream_delta_callback(None)
@@ -581,7 +601,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 stream_delta_callback=_on_delta,
-                tool_progress_callback=_on_tool_progress,
+                tool_progress_callback=_on_tool_progress if stream_tool_progress else None,
                 agent_ref=agent_ref,
             ))
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -503,6 +503,115 @@ class TestChatCompletionsEndpoint:
                 assert "Python docs" in body
 
     @pytest.mark.asyncio
+    async def test_stream_tool_progress_suppressed_when_verbose_false(self, adapter):
+        """API clients can suppress streamed tool progress with verbose=false."""
+        import asyncio
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                tp_cb = kwargs.get("tool_progress_callback")
+                if tp_cb:
+                    tp_cb("terminal", "ls -la", {"command": "ls -la"})
+                if cb:
+                    await asyncio.sleep(0.05)
+                    cb("Here are the files.")
+                return (
+                    {"final_response": "Here are the files.", "messages": [], "api_calls": 1},
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "list files"}],
+                        "stream": True,
+                        "verbose": False,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+                assert "[DONE]" in body
+                assert "ls -la" not in body
+                assert "Here are the files." in body
+
+    @pytest.mark.asyncio
+    async def test_stream_tool_progress_enabled_when_verbose_true(self, adapter):
+        """API clients can explicitly opt into streamed tool progress with verbose=true."""
+        import asyncio
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                tp_cb = kwargs.get("tool_progress_callback")
+                if tp_cb:
+                    tp_cb("terminal", "ls -la", {"command": "ls -la"})
+                if cb:
+                    await asyncio.sleep(0.05)
+                    cb("Here are the files.")
+                return (
+                    {"final_response": "Here are the files.", "messages": [], "api_calls": 1},
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "list files"}],
+                        "stream": True,
+                        "verbose": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+                assert "[DONE]" in body
+                assert "ls -la" in body
+                assert "Here are the files." in body
+
+    @pytest.mark.asyncio
+    async def test_stream_tool_progress_request_flag_overrides_verbose(self, adapter):
+        """Explicit stream_tool_progress wins over verbose aliases for compatibility."""
+        import asyncio
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                tp_cb = kwargs.get("tool_progress_callback")
+                if tp_cb:
+                    tp_cb("terminal", "ls -la", {"command": "ls -la"})
+                if cb:
+                    await asyncio.sleep(0.05)
+                    cb("Here are the files.")
+                return (
+                    {"final_response": "Here are the files.", "messages": [], "api_calls": 1},
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "list files"}],
+                        "stream": True,
+                        "verbose": True,
+                        "stream_tool_progress": False,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+                assert "[DONE]" in body
+                assert "ls -la" not in body
+                assert "Here are the files." in body
+
+    @pytest.mark.asyncio
     async def test_no_user_message_returns_400(self, adapter):
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -87,6 +87,8 @@ Standard OpenAI Chat Completions format. Stateless — the full conversation is 
 
 **Tool progress in streams**: When the agent calls tools during a streaming request, brief progress indicators are injected into the content stream as the tools start executing (e.g. `` `💻 pwd` ``, `` `🔍 Python docs` ``). These appear as inline markdown before the agent's response text, giving frontends like Open WebUI real-time visibility into tool execution.
 
+If a client wants a cleaner stream, it can suppress those inline tool updates per request by sending either `"verbose": false` or `"stream_tool_progress": false`. `"stream_tool_progress"` takes precedence when both are present.
+
 ### POST /v1/responses
 
 OpenAI Responses API format. Supports server-side conversation state via `previous_response_id` — the server stores full conversation history (including tool calls and results) so multi-turn context is preserved without the client managing it.

--- a/website/docs/user-guide/messaging/open-webui.md
+++ b/website/docs/user-guide/messaging/open-webui.md
@@ -155,6 +155,8 @@ Your agent has access to all the same tools and capabilities as when using the C
 
 :::tip Tool Progress
 With streaming enabled (the default), you'll see brief inline indicators as tools run — the tool emoji and its key argument. These appear in the response stream before the agent's final answer, giving you visibility into what's happening behind the scenes.
+
+If your frontend wants the cleaner "final answer only" style, send `"verbose": false` (or the more explicit `"stream_tool_progress": false`) in the chat-completions request body.
 :::
 
 ## Configuration Reference


### PR DESCRIPTION
## Summary

Fixes #5352

This does not flip the API server's current default. Instead, it adds a safe per-request way to suppress inline tool-progress chunks in `/v1/chat/completions` streams.

What changed:
- `verbose: false` on a streaming chat-completions request now suppresses inline tool-progress chunks
- `stream_tool_progress` is also accepted as the explicit request knob
- `stream_tool_progress` wins if both are present
- default behavior stays the same as today for backward compatibility

Why this shape:
- issue #5352 reads more like a feature/expectation mismatch than a regression
- v0.7.0 already shipped API-server tool-progress streaming, so making it default-off now would be a breaking behavior change
- this gives Open WebUI / other frontends a clean opt-out without removing the existing default for clients that already rely on it

## Test Plan

I tested this in an isolated worktree + venv only.

Commands run:

```bash
source .venv/bin/activate
python -m pytest -q tests/gateway/test_api_server.py -k 'stream_tool_progress_suppressed_when_verbose_false or stream_tool_progress_enabled_when_verbose_true' -o addopts="-m '\''not integration'\''"
python -m pytest -q tests/gateway/test_api_server.py -k 'stream_includes_tool_progress or stream_tool_progress_skips_internal_events or stream_tool_progress_suppressed_when_verbose_false or stream_tool_progress_enabled_when_verbose_true or stream_tool_progress_request_flag_overrides_verbose' -o addopts="-m '\''not integration'\''"
python -m pytest -q tests/gateway/test_api_server.py -o addopts="-m '\''not integration'\''"
```

Results:
- new `verbose=false` regression test failed before the implementation and passed after
- full `tests/gateway/test_api_server.py` suite passed: `97 passed`

## Files Changed

- `gateway/platforms/api_server.py`
- `tests/gateway/test_api_server.py`
- `website/docs/user-guide/features/api-server.md`
- `website/docs/user-guide/messaging/open-webui.md`


