### PR TITLE
fix(cli): add DeepSeek to model picker and setup

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -918,6 +918,7 @@ def select_provider_and_model(args=None):
         "kimi-coding": "Kimi / Moonshot",
         "minimax": "MiniMax",
         "minimax-cn": "MiniMax (China)",
+        "deepseek": "DeepSeek",
         "opencode-zen": "OpenCode Zen",
         "opencode-go": "OpenCode Go",
         "ai-gateway": "AI Gateway",
@@ -945,6 +946,7 @@ def select_provider_and_model(args=None):
         ("kimi-coding", "Kimi / Moonshot (Moonshot AI direct API)"),
         ("minimax", "MiniMax (global direct API)"),
         ("minimax-cn", "MiniMax China (domestic direct API)"),
+        ("deepseek", "DeepSeek (direct API)"),
         ("kilocode", "Kilo Code (Kilo Gateway API)"),
         ("opencode-zen", "OpenCode Zen (35+ curated models, pay-as-you-go)"),
         ("opencode-go", "OpenCode Go (open models, $10/month subscription)"),
@@ -1023,7 +1025,7 @@ def select_provider_and_model(args=None):
         _model_flow_anthropic(config, current_model)
     elif selected_provider == "kimi-coding":
         _model_flow_kimi(config, current_model)
-    elif selected_provider in ("zai", "minimax", "minimax-cn", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface"):
+    elif selected_provider in ("zai", "minimax", "minimax-cn", "deepseek", "kilocode", "opencode-zen", "opencode-go", "ai-gateway", "alibaba", "huggingface"):
         _model_flow_api_key_provider(config, selected_provider, current_model)
 
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -115,6 +115,7 @@ _DEFAULT_PROVIDER_MODELS = {
     "kimi-coding": ["kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],
     "minimax": ["MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"],
     "minimax-cn": ["MiniMax-M2.7", "MiniMax-M2.7-highspeed", "MiniMax-M2.5", "MiniMax-M2.5-highspeed", "MiniMax-M2.1"],
+    "deepseek": ["deepseek-chat", "deepseek-reasoner"],
     "ai-gateway": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5", "google/gemini-3-flash"],
     "kilocode": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5.4", "google/gemini-3-pro-preview", "google/gemini-3-flash-preview"],
     "opencode-zen": ["gpt-5.4", "gpt-5.3-codex", "claude-sonnet-4-6", "gemini-3-flash", "glm-5", "kimi-k2.5", "minimax-m2.7"],

--- a/tests/test_model_picker_deepseek.py
+++ b/tests/test_model_picker_deepseek.py
@@ -1,0 +1,34 @@
+from types import SimpleNamespace
+
+
+def test_cmd_model_deepseek_picker_routes_to_api_key_flow(monkeypatch):
+    from hermes_cli import main as hermes_main
+
+    monkeypatch.setattr(hermes_main, "_require_tty", lambda *a: None)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"model": {"default": "gpt-5", "provider": "openrouter"}},
+    )
+    monkeypatch.setattr("hermes_cli.auth.resolve_provider", lambda requested, **kwargs: "openrouter")
+
+    captured = {}
+
+    def _fake_prompt_provider_choice(choices):
+        for idx, choice in enumerate(choices):
+            if choice.startswith("DeepSeek "):
+                return idx
+        raise AssertionError("DeepSeek was not listed in hermes model provider choices")
+
+    def _fake_api_key_flow(config, provider_id, current_model=""):
+        captured["provider_id"] = provider_id
+        captured["current_model"] = current_model
+
+    monkeypatch.setattr(hermes_main, "_prompt_provider_choice", _fake_prompt_provider_choice)
+    monkeypatch.setattr(hermes_main, "_model_flow_api_key_provider", _fake_api_key_flow)
+
+    hermes_main.cmd_model(SimpleNamespace())
+
+    assert captured == {
+        "provider_id": "deepseek",
+        "current_model": "gpt-5",
+    }


### PR DESCRIPTION
## What does this PR do?

Adds DeepSeek to the interactive provider picker used by `hermes model` and aligns setup's fallback provider model list with that support.

DeepSeek was already supported in provider auth/config and model metadata, but it was not selectable from the interactive model flow. This made the CLI picker and setup flow inconsistent with the rest of the codebase.

## Related Issue

Fixes https://discord.com/channels/1053877538025386074/1490477898040082585/1490477898040082585

## Type of Change

- Bug fix
- Tests

## Changes Made

- Added `deepseek` to the provider label map in `hermes_cli/main.py`
- Added DeepSeek to the interactive provider selection list in `hermes_cli/main.py`
- Routed DeepSeek through the existing API-key provider flow in `hermes_cli/main.py`
- Added DeepSeek to `_DEFAULT_PROVIDER_MODELS` in `hermes_cli/setup.py`
- Added a regression test in `tests/test_model_picker_deepseek.py`

## How to Test

1. Run `hermes model` and verify `DeepSeek` appears in the provider picker.
2. Select `DeepSeek` and verify the CLI enters the API-key provider flow.
3. Run `source venv/bin/activate && python -m pytest tests/test_model_picker_deepseek.py tests/hermes_cli/test_setup.py tests/hermes_cli/test_setup_model_provider.py tests/test_model_provider_persistence.py tests/test_cli_provider_resolution.py -q`.

## Screenshots / Logs

- Focused validation passed: `47 passed in 5.66s`
- Tested on Linux
