### PR TITLE
fix(vision): apply non-aggregator provider fix to vision routing (follow-up to #5091)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1318,6 +1318,25 @@ def resolve_vision_provider_client(
             ordered.remove(preferred)
             ordered.insert(0, preferred)
 
+        # ── Non-aggregator main provider: try first (mirrors _resolve_auto fix #5091) ──
+        # Users on Alibaba, DeepSeek, ZAI, Gemini, etc. don't have OpenRouter/Nous keys.
+        # Their main provider supports vision but isn't in _VISION_AUTO_PROVIDER_ORDER,
+        # so the loop below skips them silently. We try their main provider first.
+        main_provider = _read_main_provider()
+        main_model = _read_main_model()
+        if (main_provider
+                and main_model
+                and main_provider not in _AGGREGATOR_PROVIDERS
+                and main_provider not in _VISION_AUTO_PROVIDER_ORDER
+                and main_provider not in ("auto", "")):
+            sync_client, resolved_model = resolve_provider_client(main_provider, main_model)
+            if sync_client is not None:
+                logger.info(
+                    "Vision auto-detect: using main provider %s (%s)",
+                    main_provider, resolved_model or main_model,
+                )
+                return _finalize(main_provider, sync_client, resolved_model or main_model)
+
         for candidate in ordered:
             sync_client, default_model = _resolve_strict_vision_backend(candidate)
             if sync_client is not None:


### PR DESCRIPTION
## Root cause

Closes #5366.

PR #5091 fixed `_resolve_auto()` so that users on **non-aggregator providers** (Alibaba, DeepSeek, ZAI, Gemini Direct, etc.) have their main provider used for auxiliary tasks instead of silently failing with a generic error.

However, **`resolve_vision_provider_client()` was not updated** at the same time. It has its own `"auto"` routing path that only iterates `_VISION_AUTO_PROVIDER_ORDER`:

```python
_VISION_AUTO_PROVIDER_ORDER = (
    "openrouter",
    "nous",
    "openai-codex",
    "anthropic",
    "custom",
)
```

`_preferred_main_vision_provider()` only promotes the user's main provider when it **already belongs to that tuple**. Providers like Alibaba, DeepSeek, ZAI, Gemini, etc. are absent → the entire loop runs, all backends return `None`, and vision silently returns `(None, None, None)` → vision tool fails every time.

## Fix

Mirror the exact same logic from the `_resolve_auto()` fix in #5091, inserted **before** the `_VISION_AUTO_PROVIDER_ORDER` loop in the `"auto"` branch of `resolve_vision_provider_client()`:

```python
# ── Non-aggregator main provider: try first ──
main_provider = _read_main_provider()
main_model = _read_main_model()
if (main_provider
        and main_model
        and main_provider not in _AGGREGATOR_PROVIDERS
        and main_provider not in _VISION_AUTO_PROVIDER_ORDER
        and main_provider not in ("auto", "")):
    sync_client, resolved_model = resolve_provider_client(main_provider, main_model)
    if sync_client is not None:
        return _finalize(main_provider, sync_client, resolved_model or main_model)
```

All existing paths (`resolved_base_url`, explicit provider, `_VISION_AUTO_PROVIDER_ORDER` loop) are unchanged.

## Why this fixes the report

Users experiencing "vision tool keep failing" who ask "why can't it just use the default model?" are on providers not in `_VISION_AUTO_PROVIDER_ORDER`. With this fix, vision routing tries their configured main provider first, exactly as `_resolve_auto()` does for compression/web-extract/etc.

## Test plan

- [ ] User on Alibaba/DeepSeek/ZAI: send an image → vision tool uses their main provider model
- [ ] User on OpenRouter: unchanged behaviour — openrouter still heads the priority list
- [ ] User with no provider configured: `main_provider = ""` → condition is false → unchanged fallback chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)