### PR TITLE
feat: warn users when loading non-agentic Hermes LLM models

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2358,6 +2358,22 @@ class HermesCLI:
                     "[dim]   Fix: Set model.context_length in config.yaml, or increase your server's context setting[/]"
                 )
 
+        # Warn if the configured model is a Nous Hermes LLM (not agentic)
+        model_name = getattr(self, "model", "") or ""
+        if "hermes" in model_name.lower():
+            self.console.print()
+            self.console.print(
+                "[bold yellow]⚠  Nous Research Hermes 3 & 4 models are NOT agentic and are not "
+                "designed for use with Hermes Agent.[/]"
+            )
+            self.console.print(
+                "[dim]   They lack tool-calling capabilities required for agent workflows. "
+                "Consider using an agentic model (Claude, GPT, Gemini, DeepSeek, etc.).[/]"
+            )
+            self.console.print(
+                "[dim]   Switch with: /model sonnet  or  /model gpt5[/]"
+            )
+
         self.console.print()
 
     def _preload_resumed_session(self) -> bool:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -52,6 +52,25 @@ logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
+# Non-agentic model warning
+# ---------------------------------------------------------------------------
+
+_HERMES_MODEL_WARNING = (
+    "Nous Research Hermes 3 & 4 models are NOT agentic and are not designed "
+    "for use with Hermes Agent. They lack the tool-calling capabilities "
+    "required for agent workflows. Consider using an agentic model instead "
+    "(Claude, GPT, Gemini, DeepSeek, etc.)."
+)
+
+
+def _check_hermes_model_warning(model_name: str) -> str:
+    """Return a warning string if *model_name* looks like a Hermes LLM model."""
+    if "hermes" in model_name.lower():
+        return _HERMES_MODEL_WARNING
+    return ""
+
+
+# ---------------------------------------------------------------------------
 # Model aliases -- short names -> (vendor, family) with NO version numbers.
 # Resolved dynamically against the live models.dev catalog.
 # ---------------------------------------------------------------------------
@@ -619,6 +638,14 @@ def switch_model(
     # --- Get full model info from models.dev ---
     model_info = get_model_info(target_provider, new_model)
 
+    # --- Collect warnings ---
+    warnings: list[str] = []
+    if validation.get("message"):
+        warnings.append(validation["message"])
+    hermes_warn = _check_hermes_model_warning(new_model)
+    if hermes_warn:
+        warnings.append(hermes_warn)
+
     # --- Build result ---
     return ModelSwitchResult(
         success=True,
@@ -628,7 +655,7 @@ def switch_model(
         api_key=api_key,
         base_url=base_url,
         api_mode=api_mode,
-        warning_message=validation.get("message") or "",
+        warning_message=" | ".join(warnings) if warnings else "",
         provider_label=provider_label,
         resolved_via_alias=resolved_alias,
         capabilities=capabilities,


### PR DESCRIPTION
## Summary

Adds a warning when users load a model with "hermes" in the name, notifying them that Nous Research Hermes 3 & 4 models are **not agentic** and should not be used with Hermes Agent.

## Changes

- **`hermes_cli/model_switch.py`** — Added `_check_hermes_model_warning()` helper + `_HERMES_MODEL_WARNING` constant. Injected into `switch_model()` result so both CLI and gateway `/model` handlers display the warning automatically.
- **`cli.py`** — Added warning in `show_banner()` for CLI session startup when the configured model contains "hermes". Includes a hint to switch (`/model sonnet` or `/model gpt5`).

## Coverage

| Path | Covered by |
|------|-----------|
| `/model hermes-3-...` on CLI | model_switch.py → CLI handler |
| `/model hermes-3-...` on gateway | model_switch.py → gateway handler |
| CLI session start with Hermes model | show_banner() |