### PR TITLE
fix(gateway): add missing session_key param to _async_flush_memories

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -732,6 +732,7 @@ class GatewayRunner:
     async def _async_flush_memories(
         self,
         old_session_id: str,
+        session_key: str = "",
     ):
         """Run the sync memory flush in a thread pool so it won't block the event loop."""
         loop = asyncio.get_event_loop()


### PR DESCRIPTION
## Summary

- `_async_flush_memories` was defined with only `self` and `old_session_id` as parameters
- All 3 call sites pass a second positional argument (`session_key` / `key`), causing a `TypeError: _async_flush_memories() takes 2 positional arguments but 3 were given` at runtime
- As a result, memories are **never flushed** on session expiry (line 1285), session reset (line 3141), or session resume/switch (line 4871)

## Fix

Added `session_key: str = ""` as a second parameter to the function signature. The parameter is accepted but not used inside the function body — it is passed by callers for contextual logging at the call site and does not need to be forwarded into `_flush_memories_for_session`.

**One-line diff:**
```python
- async def _async_flush_memories(self, old_session_id: str):
+ async def _async_flush_memories(self, old_session_id: str, session_key: str = ""):
```

## Impact

Without this fix, any path that triggers memory flushing silently crashes (the `TypeError` is caught by surrounding `try/except` blocks), so accumulated memories are discarded on every session boundary instead of being persisted.

## Test plan

- [ ] Confirm no `TypeError` is raised when sessions expire, reset, or resume
- [ ] Verify memory flush tasks complete successfully via logging output (`"Pre-reset memory flush completed"`)
- [ ] Run existing unit/integration tests for the gateway module

🤖 Generated with [Claude Code](https://claude.com/claude-code)