### PR TITLE
fix(platform): correctness fixes across feishu, mcp, agent, session, gateway

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -29,7 +29,7 @@ import threading
 import time
 import uuid
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
@@ -1634,7 +1634,7 @@ class FeishuAdapter(BasePlatformAdapter):
             source=source,
             raw_message=data,
             message_id=message_id,
-            timestamp=datetime.now(),
+            timestamp=datetime.now(tz=timezone.utc),
         )
         logger.info("[Feishu] Routing reaction %s:%s on bot message %s as synthetic event", action, emoji_type, message_id)
         await self._handle_message_with_guards(synthetic_event)
@@ -1695,7 +1695,7 @@ class FeishuAdapter(BasePlatformAdapter):
             source=source,
             raw_message=data,
             message_id=token or str(uuid.uuid4()),
-            timestamp=datetime.now(),
+            timestamp=datetime.now(tz=timezone.utc),
         )
         logger.info("[Feishu] Routing card action %r from %s in %s as synthetic command", action_tag, open_id, chat_id)
         await self._handle_message_with_guards(synthetic_event)
@@ -1857,7 +1857,7 @@ class FeishuAdapter(BasePlatformAdapter):
             media_types=media_types,
             reply_to_message_id=reply_to_message_id,
             reply_to_text=reply_to_text,
-            timestamp=datetime.now(),
+            timestamp=datetime.now(tz=timezone.utc),
         )
         await self._dispatch_inbound_event(normalized)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2261,8 +2261,8 @@ class GatewayRunner:
             with open(_config_path, encoding="utf-8") as _pf:
                 _pcfg = _pii_yaml.safe_load(_pf) or {}
             _redact_pii = bool((_pcfg.get("privacy") or {}).get("redact_pii", False))
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("Failed to read PII redaction config: %s", e)
 
         # Build the context prompt to inject
         context_prompt = build_session_context_prompt(context, redact_pii=_redact_pii)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -765,10 +765,11 @@ class SessionStore:
                 try:
                     parent_history = self.load_transcript(parent_entry.session_id)
                     if parent_history:
-                        self.rewrite_transcript(entry.session_id, parent_history)
+                        seed = parent_history[-20:]  # seed last 20 messages for context, not full history
+                        self.rewrite_transcript(entry.session_id, seed)
                         logger.info(
                             "[Session] Seeded DM thread session %s with %d messages from parent %s",
-                            entry.session_id, len(parent_history), parent_entry.session_id,
+                            entry.session_id, len(seed), parent_entry.session_id,
                         )
                 except Exception as e:
                     logger.warning("[Session] Failed to seed thread session: %s", e)

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -581,6 +581,7 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
                         "id": str(msg.get("id", "")),
                         "role": role,
                         "content": content[:2000],
+                        "truncated": len(content) > 2000,
                         "timestamp": msg.get("timestamp", ""),
                     })
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -6635,11 +6635,11 @@ class AIAgent:
             "Please provide a final response summarizing what you've found and accomplished so far, "
             "without calling any more tools."
         )
-        messages.append({"role": "user", "content": summary_request})
-
         try:
             # Build API messages, stripping internal-only fields
             # (finish_reason, reasoning) that strict APIs like Mistral reject with 422
+            # Work on a local copy — do NOT append the synthetic user prompt to the
+            # shared messages list so it doesn't pollute the session transcript.
             _needs_sanitize = self._should_sanitize_tool_calls()
             api_messages = []
             for msg in messages:
@@ -6659,6 +6659,9 @@ class AIAgent:
                 sys_offset = 1 if effective_system else 0
                 for idx, pfm in enumerate(self.prefill_messages):
                     api_messages.insert(sys_offset + idx, pfm.copy())
+
+            # Append the synthetic summary request only to the local api_messages copy
+            api_messages.append({"role": "user", "content": summary_request})
 
             summary_extra_body = {}
             _is_nous = "nousresearch" in self._base_url_lower


### PR DESCRIPTION
## Summary

- **feishu**: replace `datetime.now()` with `datetime.now(tz=timezone.utc)` in all three `MessageEvent` construction sites to avoid naive datetime objects and DST/ambiguity bugs
- **mcp_serve**: add `"truncated": len(content) > 2000` alongside `content[:2000]` in `messages_read` so MCP clients can detect when a message was cut
- **run_agent**: in `_handle_max_iterations`, no longer appends the synthetic summary-request user message to the shared `messages` list — it is added only to the local `api_messages` copy used for the API call, preventing synthetic iteration-limit prompts from polluting the session transcript
- **session**: DM thread seeding now uses `parent_history[-20:]` instead of the full parent transcript, preventing unbounded transcript copying on long-running sessions
- **gateway/run.py**: `except Exception: pass` on PII redact config read replaced with `except Exception as e: logger.debug(...)` so silent failures are at least observable at debug level

## Test plan

- [ ] Feishu: create a `MessageEvent` in a reaction/card-action/inbound handler and verify `.timestamp.tzinfo` is not `None`
- [ ] MCP: call `messages_read` on a session with a message >2000 chars; confirm `"truncated": true` appears in the response
- [ ] run_agent: trigger max-iterations path; verify the synthetic user prompt (`"You've reached the maximum number..."`) does NOT appear in the saved session transcript
- [ ] Session: seed a DM thread from a parent with >20 messages; confirm exactly 20 messages are seeded
- [ ] Gateway: introduce a bad `_config_path` and run at debug log level; confirm the debug log line appears instead of silent failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)