### PR TITLE
fix(security): harden auth checks across api_server, discord, feishu, whatsapp

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15,6 +15,7 @@ Usage:
 
 import logging
 import os
+import shlex
 import shutil
 import sys
 import json
@@ -4421,8 +4422,9 @@ class HermesCLI:
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
                         try:
+                            _cmd_args = exec_cmd if isinstance(exec_cmd, list) else shlex.split(exec_cmd)
                             result = subprocess.run(
-                                exec_cmd, shell=True, capture_output=True,
+                                _cmd_args, shell=False, capture_output=True,
                                 text=True, timeout=30
                             )
                             output = result.stdout.strip() or result.stderr.strip()

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -20,6 +20,7 @@ Requires:
 """
 
 import asyncio
+import hmac
 import json
 import logging
 import os
@@ -370,7 +371,7 @@ class APIServerAdapter(BasePlatformAdapter):
         auth_header = request.headers.get("Authorization", "")
         if auth_header.startswith("Bearer "):
             token = auth_header[7:].strip()
-            if token == self._api_key:
+            if hmac.compare_digest(token, self._api_key):
                 return None  # Auth OK
 
         return web.json_response(

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2321,7 +2321,7 @@ if DISCORD_AVAILABLE:
         def _check_auth(self, interaction: discord.Interaction) -> bool:
             """Verify the user clicking is authorized."""
             if not self.allowed_user_ids:
-                return True  # No allowlist = anyone can approve
+                return False  # No allowlist configured — fail closed
             return str(interaction.user.id) in self.allowed_user_ids
 
         async def _resolve(
@@ -2413,7 +2413,7 @@ if DISCORD_AVAILABLE:
 
         def _check_auth(self, interaction: discord.Interaction) -> bool:
             if not self.allowed_user_ids:
-                return True
+                return False  # No allowlist configured — fail closed
             return str(interaction.user.id) in self.allowed_user_ids
 
         async def _respond(

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -971,6 +971,11 @@ class FeishuAdapter(BasePlatformAdapter):
         self._pending_media_batches = self._media_batch_state.events
         self._pending_media_batch_tasks = self._media_batch_state.tasks
         self._load_seen_message_ids()
+        if not self._encrypt_key and not self._verification_token:
+            logger.warning(
+                "[Feishu] Neither encrypt_key nor verification_token is configured — "
+                "webhook endpoint has no authentication. Set encrypt_key in config.yaml."
+            )
 
     @staticmethod
     def _load_settings(extra: Dict[str, Any]) -> FeishuAdapterSettings:
@@ -2146,9 +2151,9 @@ class FeishuAdapter(BasePlatformAdapter):
             ]
             for k in stale_keys:
                 del self._webhook_rate_counts[k]
-            # If still at capacity after pruning, allow through without tracking.
+            # If still at capacity after pruning, deny untracked IPs (fail closed).
             if rate_key not in self._webhook_rate_counts and len(self._webhook_rate_counts) >= _FEISHU_WEBHOOK_RATE_MAX_KEYS:
-                return True
+                return False
         self._webhook_rate_counts[rate_key] = (1, now)
         return True
 

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -32,6 +32,10 @@ from hermes_constants import get_hermes_dir
 
 logger = logging.getLogger(__name__)
 
+# Allowed root for bridge-provided local media paths — any absolute path from
+# the bridge JSON must resolve inside this directory to be accepted.
+_ALLOWED_MEDIA_ROOT = Path(get_hermes_home()) / "cache"
+
 
 def _kill_port_process(port: int) -> None:
     """Kill any process listening on the given TCP port."""
@@ -861,9 +865,12 @@ class WhatsAppAdapter(BasePlatformAdapter):
                         media_types.append("image/jpeg")
                 elif msg_type == MessageType.PHOTO and os.path.isabs(url):
                     # Local file path — bridge already downloaded the image
-                    cached_urls.append(url)
-                    media_types.append("image/jpeg")
-                    print(f"[{self.name}] Using bridge-cached image: {url}", flush=True)
+                    if Path(url).resolve().is_relative_to(_ALLOWED_MEDIA_ROOT):
+                        cached_urls.append(url)
+                        media_types.append("image/jpeg")
+                        print(f"[{self.name}] Using bridge-cached image: {url}", flush=True)
+                    else:
+                        print(f"[{self.name}] Rejected bridge image path outside cache dir: {url}", flush=True)
                 elif msg_type == MessageType.VOICE and url.startswith(("http://", "https://")):
                     try:
                         cached_path = await cache_audio_from_url(url, ext=".ogg")
@@ -876,20 +883,29 @@ class WhatsAppAdapter(BasePlatformAdapter):
                         media_types.append("audio/ogg")
                 elif msg_type == MessageType.VOICE and os.path.isabs(url):
                     # Local file path — bridge already downloaded the audio
-                    cached_urls.append(url)
-                    media_types.append("audio/ogg")
-                    print(f"[{self.name}] Using bridge-cached audio: {url}", flush=True)
+                    if Path(url).resolve().is_relative_to(_ALLOWED_MEDIA_ROOT):
+                        cached_urls.append(url)
+                        media_types.append("audio/ogg")
+                        print(f"[{self.name}] Using bridge-cached audio: {url}", flush=True)
+                    else:
+                        print(f"[{self.name}] Rejected bridge audio path outside cache dir: {url}", flush=True)
                 elif msg_type == MessageType.DOCUMENT and os.path.isabs(url):
                     # Local file path — bridge already downloaded the document
-                    cached_urls.append(url)
-                    ext = Path(url).suffix.lower()
-                    mime = SUPPORTED_DOCUMENT_TYPES.get(ext, "application/octet-stream")
-                    media_types.append(mime)
-                    print(f"[{self.name}] Using bridge-cached document: {url}", flush=True)
+                    if Path(url).resolve().is_relative_to(_ALLOWED_MEDIA_ROOT):
+                        cached_urls.append(url)
+                        ext = Path(url).suffix.lower()
+                        mime = SUPPORTED_DOCUMENT_TYPES.get(ext, "application/octet-stream")
+                        media_types.append(mime)
+                        print(f"[{self.name}] Using bridge-cached document: {url}", flush=True)
+                    else:
+                        print(f"[{self.name}] Rejected bridge document path outside cache dir: {url}", flush=True)
                 elif msg_type == MessageType.VIDEO and os.path.isabs(url):
-                    cached_urls.append(url)
-                    media_types.append("video/mp4")
-                    print(f"[{self.name}] Using bridge-cached video: {url}", flush=True)
+                    if Path(url).resolve().is_relative_to(_ALLOWED_MEDIA_ROOT):
+                        cached_urls.append(url)
+                        media_types.append("video/mp4")
+                        print(f"[{self.name}] Using bridge-cached video: {url}", flush=True)
+                    else:
+                        print(f"[{self.name}] Rejected bridge video path outside cache dir: {url}", flush=True)
                 else:
                     cached_urls.append(url)
                     media_types.append("unknown")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -732,6 +732,7 @@ class GatewayRunner:
     async def _async_flush_memories(
         self,
         old_session_id: str,
+        session_key: str = "",
     ):
         """Run the sync memory flush in a thread pool so it won't block the event loop."""
         loop = asyncio.get_event_loop()


### PR DESCRIPTION
## Summary

- **cli**: Replace `shell=True` with `shlex.split` + `shell=False` for `quick_commands` exec type — eliminates shell injection via user-controlled config values
- **api_server**: Replace `token == self._api_key` with `hmac.compare_digest` to prevent timing oracle attacks on bearer token verification
- **discord**: Change `_check_auth` to fail-closed (`return False`) when no `allowed_user_ids` is configured — previously any Discord user could click approval buttons when no allowlist was set
- **whatsapp**: Validate that absolute file paths received from the bridge JSON resolve within `~/.hermes/cache` before accepting them — prevents path traversal / arbitrary file access via a compromised bridge process
- **feishu**: Emit a `WARNING` log at adapter startup when neither `encrypt_key` nor `verification_token` is configured, alerting operators that the webhook endpoint is unauthenticated
- **feishu**: Change rate limiter to fail-closed (`return False`) when the tracking table is full — previously exhausting the rate-limit table allowed unlimited untracked requests through

## Test plan

- [ ] `quick_commands` of type `exec` still runs correctly with a standard shell command string
- [ ] `quick_commands` of type `exec` with a list value is handled without error
- [ ] API server rejects requests with an invalid bearer token (unchanged behavior); valid token still works
- [ ] Discord approval buttons reject clicks when `allowed_user_ids` is empty; users see an ephemeral error message
- [ ] WhatsApp bridge paths inside `~/.hermes/cache/` are accepted; paths outside (e.g. `/etc/passwd`) are rejected with a log line
- [ ] Feishu adapter logs a WARNING on startup when no auth keys are set
- [ ] Feishu rate limiter returns `False` (deny) when tracking table is at capacity and the incoming IP is not already tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)