### PR TITLE
fix(session,stream): correct reset_had_activity check and stream final-response drop

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -693,7 +693,7 @@ class SessionStore:
                     was_auto_reset = True
                     auto_reset_reason = reset_reason
                     # Track whether the expired session had any real conversation
-                    reset_had_activity = entry.total_tokens > 0
+                    reset_had_activity = entry.last_prompt_tokens > 0
                     db_end_session_id = entry.session_id
             else:
                 was_auto_reset = False

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -140,8 +140,9 @@ class GatewayStreamConsumer:
                     self._last_edit_time = time.monotonic()
 
                 if got_done:
-                    # Final edit without cursor
-                    if self._accumulated and self._message_id:
+                    if self._accumulated:
+                        # Send final content regardless of whether message_id is set —
+                        # message_id can be None after an overflow-split whose send failed.
                         await self._send_or_edit(self._accumulated)
                     return
 
@@ -149,7 +150,7 @@ class GatewayStreamConsumer:
 
         except asyncio.CancelledError:
             # Best-effort final edit on cancellation
-            if self._accumulated and self._message_id:
+            if self._accumulated:
                 try:
                     await self._send_or_edit(self._accumulated)
                 except Exception:


### PR DESCRIPTION
## Summary

- **gateway/session.py**: `reset_had_activity` was always `False` because `total_tokens` is never written after a refactor that moved token-count persistence to the agent directly. Switched the guard to `last_prompt_tokens`, which is updated on every turn via `update_session()` — session-reset notifications to users now fire correctly when the expired session had prior activity.

- **gateway/stream_consumer.py**: The final streamed response was silently dropped when `self._message_id` was `None` after an overflow-split whose follow-up send failed. Removed the `message_id` guard from both the `got_done` path and the `asyncio.CancelledError` path — if there is accumulated content, always attempt to deliver it.

## Test plan

- [ ] Trigger a session auto-reset on a chat that had at least one prior turn and verify the reset notification is sent to the user.
- [ ] Simulate an overflow-split where the re-send after the split fails (e.g. network error / rate-limit), then verify the remaining accumulated content is still delivered rather than dropped silently.
- [ ] Verify normal (non-overflow) streaming still works end-to-end on Telegram and WhatsApp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)