### PR TITLE
fix: use assignment for SSE tool call name accumulation

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4494,7 +4494,7 @@ class AIAgent:
                             entry["id"] = tc_delta.id
                         if tc_delta.function:
                             if tc_delta.function.name:
-                                entry["function"]["name"] += tc_delta.function.name
+                                entry["function"]["name"] = tc_delta.function.name
                             if tc_delta.function.arguments:
                                 entry["function"]["arguments"] += tc_delta.function.arguments
                         extra = getattr(tc_delta, "extra_content", None)

--- a/run_agent.py
+++ b/run_agent.py
@@ -4496,7 +4496,24 @@ class AIAgent:
                             if tc_delta.function.name:
                                 entry["function"]["name"] = tc_delta.function.name
                             if tc_delta.function.arguments:
-                                entry["function"]["arguments"] += tc_delta.function.arguments
+                                # Smart accumulation: non-incremental backends (e.g.
+                                # codex-lb) send the complete JSON in every chunk.
+                                # Naively appending produces invalid JSON like
+                                # '{"task":"x"}{"task":"x"}'. If the new candidate
+                                # parses cleanly, use it. If it fails with "Extra
+                                # data", the previous accumulated value was already
+                                # complete and the new chunk is a duplicate — replace
+                                # it. Otherwise it's a normal partial fragment and we
+                                # keep accumulating.
+                                _new_args = entry["function"]["arguments"] + tc_delta.function.arguments
+                                try:
+                                    json.loads(_new_args)
+                                    entry["function"]["arguments"] = _new_args
+                                except json.JSONDecodeError as _e:
+                                    if "Extra data" in str(_e):
+                                        entry["function"]["arguments"] = tc_delta.function.arguments
+                                    else:
+                                        entry["function"]["arguments"] = _new_args
                         extra = getattr(tc_delta, "extra_content", None)
                         if extra is None and hasattr(tc_delta, "model_extra"):
                             extra = (tc_delta.model_extra or {}).get("extra_content")


### PR DESCRIPTION
## Summary
- Fix tool name doubling in SSE streaming accumulator
- Fix tool arguments doubling
- Both bugs share the same root cause: non-incremental backends(like lb's) sending complete values in every SSE delta chunk

## Problem
Non-standard LLM backends (load balancers, proxies, etc) may send the complete tool function name **and** arguments JSON in every SSE delta chunk rather than only in the first chunk. The `+=` accumulation produces:
- Doubled names like `apply_learningsapply_learnings` → "Unknown tool" errors
- Doubled JSON like `{"task":"x"}{"task":"x"}` → `Invalid JSON: Extra data: line 1 column 17`

## Bug 1 — Tool Name Doubling

### Standard OpenAI (no bug — `=` and `+=` identical):
```
Chunk 1: { function: { name: "apply_learnings", arguments: "" } }
Chunk 2: { function: { name: null,              arguments: '{"tas' } }
Chunk 3: { function: { name: null,              arguments: 'k":"debug"}' } }

Accumulator: "" = "apply_learnings" → "apply_learnings" ✓
```
### Non-incremental backend like codex-lb (bug with `+=`):
```
Chunk 1: { function: { name: "apply_learnings", arguments: '{"task":"debug"}' } }
Chunk 2: { function: { name: "apply_learnings", arguments: '{"task":"debug"}' } }

With +=: "" += "apply_learnings" → "apply_learnings" += "apply_learnings" → "apply_learningsapply_learnings" ✗
With  =: "" = "apply_learnings"  → "apply_learnings" = "apply_learnings"  → "apply_learnings" ✓
```

**Fix:** `=` instead of `+=`. Safe for all providers because standard OpenAI sends `name` only in the first delta (subsequent chunks have `name: null`), so `=` and `+=` produce identical results. For non-incremental backends, `=` is strictly more correct as it is idempotent.


## Bug 2 — Tool Arguments Doubling

Cannot use the same `=` strategy for arguments — standard OpenAI **does** send arguments incrementally, so we need to distinguish "partial fragment" from "duplicate complete value" (same issue as bug 1)

### Smart accumulation algorithm:
1. Try appending new chunk
2. Validate the result
   - Valid -> accept
   - "Extra data" error -> previous value was already a complete JSON object, new chunk is a dupe
   - Any other JSONDecodeError -> unchanged

### Standard OpenAI streaming (works correctly):
```
Chunk 1: arguments = "" → no-op (empty)
Chunk 2: arguments = '{"tas'
Chunk 3: arguments = 'k":"debug"}'

step 1: candidate = '{"tas' → JSONDecodeError "Unterminated string" → keep accumulating → '{"tas'
step 2: candidate = '{"task":"debug"}' → valid → '{"task":"debug"}' ✓
```

### codex-lb (bug fixed):
```
Chunk 1: arguments = '{"task":"debug"}'
Chunk 2: arguments = '{"task":"debug"}'

step 1: candidate = '{"task":"debug"}' → valid → '{"task":"debug"}'
step 2: candidate = '{"task":"debug"}{"task":"debug"}' → JSONDecodeError "Extra data" → replace with new chunk → '{"task":"debug"}' ✓
```

The `"Extra data"` error is the signal — it means the string up to this point was already valid JSON, and there's MORE stuff after it. 


## Test plan
- [ ] Verify standard OpenAI streaming works (name sent once, `=` identical to `+=`)
- [ ] Verify non-incremental backend (proxy/LB) no longer doubles tool names
- [ ] Verify Ollama parallel tool calls still work (index reuse handling is unaffected)

Discovered while routing Hermes through codex-lb (localhost:2455).