### PR TITLE
feat(plugins): let pre_tool_call hooks block tool calls

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -548,6 +548,38 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
     return get_plugin_manager().invoke_hook(hook_name, **kwargs)
 
 
+def get_pre_tool_call_block_message(
+    tool_name: str,
+    args: Optional[Dict[str, Any]],
+    task_id: str = "",
+) -> Optional[str]:
+    """Return the supported ``pre_tool_call`` block directive message.
+
+    Supported directive::
+
+        {"action": "block", "message": "..."}
+
+    Invalid or irrelevant hook return values are ignored.
+    """
+    hook_results = invoke_hook(
+        "pre_tool_call",
+        tool_name=tool_name,
+        args=args if isinstance(args, dict) else {},
+        task_id=task_id,
+    )
+
+    for result in hook_results:
+        if not isinstance(result, dict):
+            continue
+        if result.get("action") != "block":
+            continue
+        message = result.get("message")
+        if isinstance(message, str) and message:
+            return message
+
+    return None
+
+
 def get_plugin_tool_names() -> Set[str]:
     """Return the set of tool names registered by plugins."""
     return get_plugin_manager()._plugin_tool_names

--- a/model_tools.py
+++ b/model_tools.py
@@ -462,6 +462,7 @@ def handle_function_call(
     task_id: Optional[str] = None,
     user_task: Optional[str] = None,
     enabled_tools: Optional[List[str]] = None,
+    skip_pre_tool_call_hook: bool = False,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -482,24 +483,33 @@ def handle_function_call(
     # Coerce string arguments to their schema-declared types (e.g. "42"→42)
     function_args = coerce_tool_args(function_name, function_args)
 
-    # Notify the read-loop tracker when a non-read/search tool runs,
-    # so the *consecutive* counter resets (reads after other work are fine).
-    if function_name not in _READ_SEARCH_TOOLS:
-        try:
-            from tools.file_tools import notify_other_tool_call
-            notify_other_tool_call(task_id or "default")
-        except Exception:
-            pass  # file_tools may not be loaded yet
-
     try:
         if function_name in _AGENT_LOOP_TOOLS:
             return json.dumps({"error": f"{function_name} must be handled by the agent loop"})
 
-        try:
-            from hermes_cli.plugins import invoke_hook
-            invoke_hook("pre_tool_call", tool_name=function_name, args=function_args, task_id=task_id or "")
-        except Exception:
-            pass
+        if not skip_pre_tool_call_hook:
+            block_message: Optional[str] = None
+            try:
+                from hermes_cli.plugins import get_pre_tool_call_block_message
+                block_message = get_pre_tool_call_block_message(
+                    function_name,
+                    function_args,
+                    task_id=task_id or "",
+                )
+            except Exception:
+                pass
+
+            if block_message is not None:
+                return json.dumps({"error": block_message}, ensure_ascii=False)
+
+        # Notify the read-loop tracker when a non-read/search tool runs,
+        # so the *consecutive* counter resets (reads after other work are fine).
+        if function_name not in _READ_SEARCH_TOOLS:
+            try:
+                from tools.file_tools import notify_other_tool_call
+                notify_other_tool_call(task_id or "default")
+            except Exception:
+                pass  # file_tools may not be loaded yet
 
         if function_name == "execute_code":
             # Prefer the caller-provided list so subagents can't overwrite

--- a/run_agent.py
+++ b/run_agent.py
@@ -5960,13 +5960,51 @@ class AIAgent:
         finally:
             self._executing_tools = False
 
-    def _invoke_tool(self, function_name: str, function_args: dict, effective_task_id: str) -> str:
+    def _get_pre_tool_call_block_message(
+        self,
+        function_name: str,
+        function_args: dict,
+        effective_task_id: str,
+    ) -> str | None:
+        try:
+            from hermes_cli.plugins import get_pre_tool_call_block_message
+            return get_pre_tool_call_block_message(
+                function_name,
+                function_args,
+                task_id=effective_task_id or "",
+            )
+        except Exception:
+            return None
+
+    def _invoke_tool(
+        self,
+        function_name: str,
+        function_args: dict,
+        effective_task_id: str,
+        *,
+        pre_tool_call_checked: bool = False,
+        block_message: str | None = None,
+    ) -> str:
         """Invoke a single tool and return the result string. No display logic.
 
         Handles both agent-level tools (todo, memory, etc.) and registry-dispatched
         tools. Used by the concurrent execution path; the sequential path retains
         its own inline invocation for backward-compatible display handling.
         """
+        if not pre_tool_call_checked:
+            block_message = self._get_pre_tool_call_block_message(
+                function_name,
+                function_args,
+                effective_task_id,
+            )
+        if block_message is not None:
+            return json.dumps({"error": block_message}, ensure_ascii=False)
+
+        if function_name == "memory":
+            self._turns_since_memory = 0
+        elif function_name == "skill_manage":
+            self._iters_since_skill = 0
+
         if function_name == "todo":
             from tools.todo_tool import todo_tool as _todo_tool
             return _todo_tool(
@@ -6029,6 +6067,7 @@ class AIAgent:
             return handle_function_call(
                 function_name, function_args, effective_task_id,
                 enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
+                skip_pre_tool_call_hook=True,
             )
 
     def _execute_tool_calls_concurrent(self, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0) -> None:
@@ -6052,15 +6091,9 @@ class AIAgent:
             return
 
         # ── Parse args + pre-execution bookkeeping ───────────────────────
-        parsed_calls = []  # list of (tool_call, function_name, function_args)
+        parsed_calls = []  # list of (tool_call, function_name, function_args, block_message)
         for tool_call in tool_calls:
             function_name = tool_call.function.name
-
-            # Reset nudge counters
-            if function_name == "memory":
-                self._turns_since_memory = 0
-            elif function_name == "skill_manage":
-                self._iters_since_skill = 0
 
             try:
                 function_args = json.loads(tool_call.function.arguments)
@@ -6069,8 +6102,18 @@ class AIAgent:
             if not isinstance(function_args, dict):
                 function_args = {}
 
+            block_message = self._get_pre_tool_call_block_message(
+                function_name,
+                function_args,
+                effective_task_id,
+            )
+
             # Checkpoint for file-mutating tools
-            if function_name in ("write_file", "patch") and self._checkpoint_mgr.enabled:
+            if (
+                block_message is None
+                and function_name in ("write_file", "patch")
+                and self._checkpoint_mgr.enabled
+            ):
                 try:
                     file_path = function_args.get("path", "")
                     if file_path:
@@ -6080,7 +6123,7 @@ class AIAgent:
                     pass
 
             # Checkpoint before destructive terminal commands
-            if function_name == "terminal" and self._checkpoint_mgr.enabled:
+            if block_message is None and function_name == "terminal" and self._checkpoint_mgr.enabled:
                 try:
                     cmd = function_args.get("command", "")
                     if _is_destructive_command(cmd):
@@ -6091,13 +6134,13 @@ class AIAgent:
                 except Exception:
                     pass
 
-            parsed_calls.append((tool_call, function_name, function_args))
+            parsed_calls.append((tool_call, function_name, function_args, block_message))
 
         # ── Logging / callbacks ──────────────────────────────────────────
-        tool_names_str = ", ".join(name for _, name, _ in parsed_calls)
+        tool_names_str = ", ".join(name for _, name, _, _ in parsed_calls)
         if not self.quiet_mode:
             print(f"  ⚡ Concurrent: {num_tools} tool calls — {tool_names_str}")
-            for i, (tc, name, args) in enumerate(parsed_calls, 1):
+            for i, (tc, name, args, _block_message) in enumerate(parsed_calls, 1):
                 args_str = json.dumps(args, ensure_ascii=False)
                 if self.verbose_logging:
                     print(f"  📞 Tool {i}: {name}({list(args.keys())})")
@@ -6106,7 +6149,9 @@ class AIAgent:
                     args_preview = args_str[:self.log_prefix_chars] + "..." if len(args_str) > self.log_prefix_chars else args_str
                     print(f"  📞 Tool {i}: {name}({list(args.keys())}) - {args_preview}")
 
-        for tc, name, args in parsed_calls:
+        for tc, name, args, block_message in parsed_calls:
+            if block_message is not None:
+                continue
             if self.tool_progress_callback:
                 try:
                     preview = _build_tool_preview(name, args)
@@ -6114,7 +6159,9 @@ class AIAgent:
                 except Exception as cb_err:
                     logging.debug(f"Tool progress callback error: {cb_err}")
 
-        for tc, name, args in parsed_calls:
+        for tc, name, args, block_message in parsed_calls:
+            if block_message is not None:
+                continue
             if self.tool_start_callback:
                 try:
                     self.tool_start_callback(tc.id, name, args)
@@ -6125,11 +6172,17 @@ class AIAgent:
         # Each slot holds (function_name, function_args, function_result, duration, error_flag)
         results = [None] * num_tools
 
-        def _run_tool(index, tool_call, function_name, function_args):
+        def _run_tool(index, tool_call, function_name, function_args, block_message):
             """Worker function executed in a thread."""
             start = time.time()
             try:
-                result = self._invoke_tool(function_name, function_args, effective_task_id)
+                result = self._invoke_tool(
+                    function_name,
+                    function_args,
+                    effective_task_id,
+                    pre_tool_call_checked=True,
+                    block_message=block_message,
+                )
             except Exception as tool_error:
                 result = f"Error executing tool '{function_name}': {tool_error}"
                 logger.error("_invoke_tool raised for %s: %s", function_name, tool_error, exc_info=True)
@@ -6148,8 +6201,8 @@ class AIAgent:
             max_workers = min(num_tools, _MAX_TOOL_WORKERS)
             with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
                 futures = []
-                for i, (tc, name, args) in enumerate(parsed_calls):
-                    f = executor.submit(_run_tool, i, tc, name, args)
+                for i, (tc, name, args, block_message) in enumerate(parsed_calls):
+                    f = executor.submit(_run_tool, i, tc, name, args, block_message)
                     futures.append(f)
 
                 # Wait for all to complete (exceptions are captured inside _run_tool)
@@ -6162,7 +6215,7 @@ class AIAgent:
                 spinner.stop(f"⚡ {completed}/{num_tools} tools completed in {total_dur:.1f}s total")
 
         # ── Post-execution: display per-tool results ─────────────────────
-        for i, (tc, name, args) in enumerate(parsed_calls):
+        for i, (tc, name, args, _block_message) in enumerate(parsed_calls):
             r = results[i]
             if r is None:
                 # Shouldn't happen, but safety fallback
@@ -6265,12 +6318,6 @@ class AIAgent:
 
             function_name = tool_call.function.name
 
-            # Reset nudge counters when the relevant tool is actually used
-            if function_name == "memory":
-                self._turns_since_memory = 0
-            elif function_name == "skill_manage":
-                self._iters_since_skill = 0
-
             try:
                 function_args = json.loads(tool_call.function.arguments)
             except json.JSONDecodeError as e:
@@ -6278,6 +6325,12 @@ class AIAgent:
                 function_args = {}
             if not isinstance(function_args, dict):
                 function_args = {}
+
+            block_message = self._get_pre_tool_call_block_message(
+                function_name,
+                function_args,
+                effective_task_id,
+            )
 
             if not self.quiet_mode:
                 args_str = json.dumps(function_args, ensure_ascii=False)
@@ -6288,24 +6341,29 @@ class AIAgent:
                     args_preview = args_str[:self.log_prefix_chars] + "..." if len(args_str) > self.log_prefix_chars else args_str
                     print(f"  📞 Tool {i}: {function_name}({list(function_args.keys())}) - {args_preview}")
 
-            self._current_tool = function_name
-            self._touch_activity(f"executing tool: {function_name}")
+            if block_message is None:
+                self._current_tool = function_name
+                self._touch_activity(f"executing tool: {function_name}")
 
-            if self.tool_progress_callback:
+            if block_message is None and self.tool_progress_callback:
                 try:
                     preview = _build_tool_preview(function_name, function_args)
                     self.tool_progress_callback("tool.started", function_name, preview, function_args)
                 except Exception as cb_err:
                     logging.debug(f"Tool progress callback error: {cb_err}")
 
-            if self.tool_start_callback:
+            if block_message is None and self.tool_start_callback:
                 try:
                     self.tool_start_callback(tool_call.id, function_name, function_args)
                 except Exception as cb_err:
                     logging.debug(f"Tool start callback error: {cb_err}")
 
             # Checkpoint: snapshot working dir before file-mutating tools
-            if function_name in ("write_file", "patch") and self._checkpoint_mgr.enabled:
+            if (
+                block_message is None
+                and function_name in ("write_file", "patch")
+                and self._checkpoint_mgr.enabled
+            ):
                 try:
                     file_path = function_args.get("path", "")
                     if file_path:
@@ -6317,7 +6375,7 @@ class AIAgent:
                     pass  # never block tool execution
 
             # Checkpoint before destructive terminal commands
-            if function_name == "terminal" and self._checkpoint_mgr.enabled:
+            if block_message is None and function_name == "terminal" and self._checkpoint_mgr.enabled:
                 try:
                     cmd = function_args.get("command", "")
                     if _is_destructive_command(cmd):
@@ -6329,8 +6387,18 @@ class AIAgent:
                     pass  # never block tool execution
 
             tool_start_time = time.time()
+            blocked_result = (
+                json.dumps({"error": block_message}, ensure_ascii=False)
+                if block_message is not None
+                else None
+            )
+            if blocked_result is None and function_name == "skill_manage":
+                self._iters_since_skill = 0
 
-            if function_name == "todo":
+            if blocked_result is not None:
+                function_result = blocked_result
+                tool_duration = time.time() - tool_start_time
+            elif function_name == "todo":
                 from tools.todo_tool import todo_tool as _todo_tool
                 function_result = _todo_tool(
                     todos=function_args.get("todos"),
@@ -6356,6 +6424,7 @@ class AIAgent:
                 if self.quiet_mode:
                     self._vprint(f"  {_get_cute_tool_message_impl('session_search', function_args, tool_duration, result=function_result)}")
             elif function_name == "memory":
+                self._turns_since_memory = 0
                 target = function_args.get("target", "memory")
                 from tools.memory_tool import memory_tool as _memory_tool
                 function_result = _memory_tool(
@@ -6448,6 +6517,7 @@ class AIAgent:
                     function_result = handle_function_call(
                         function_name, function_args, effective_task_id,
                         enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
+                        skip_pre_tool_call_hook=True,
                     )
                     _spinner_result = function_result
                 except Exception as tool_error:
@@ -6465,6 +6535,7 @@ class AIAgent:
                     function_result = handle_function_call(
                         function_name, function_args, effective_task_id,
                         enabled_tools=list(self.valid_tool_names) if self.valid_tool_names else None,
+                        skip_pre_tool_call_hook=True,
                     )
                 except Exception as tool_error:
                     function_result = f"Error executing tool '{function_name}': {tool_error}"

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -38,6 +38,82 @@ class TestHandleFunctionCall:
         assert len(parsed["error"]) > 0
         assert "error" in parsed["error"].lower() or "failed" in parsed["error"].lower()
 
+    def test_pre_tool_call_block_directive_returns_json_error_and_skips_dispatch(self, monkeypatch):
+        hook_calls = []
+        dispatch_called = False
+
+        def fake_invoke_hook(hook_name, **kwargs):
+            hook_calls.append(hook_name)
+            if hook_name == "pre_tool_call":
+                return [{"action": "block", "message": "Tool call blocked by plugin"}]
+            return []
+
+        def fake_dispatch(*args, **kwargs):
+            nonlocal dispatch_called
+            dispatch_called = True
+            raise AssertionError("dispatch should not run when pre_tool_call blocks")
+
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_invoke_hook)
+        monkeypatch.setattr("model_tools.registry.dispatch", fake_dispatch)
+
+        result = json.loads(handle_function_call("read_file", {"path": "notes.txt"}, task_id="t1"))
+
+        assert result == {"error": "Tool call blocked by plugin"}
+        assert dispatch_called is False
+        assert hook_calls == ["pre_tool_call"]
+
+    def test_blocked_tool_does_not_notify_other_tool_call(self, monkeypatch):
+        notifications = []
+
+        def fake_invoke_hook(hook_name, **kwargs):
+            if hook_name == "pre_tool_call":
+                return [{"action": "block", "message": "Tool call blocked by plugin"}]
+            return []
+
+        def fake_dispatch(*args, **kwargs):
+            raise AssertionError("dispatch should not run when pre_tool_call blocks")
+
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_invoke_hook)
+        monkeypatch.setattr(
+            "tools.file_tools.notify_other_tool_call",
+            lambda task_id: notifications.append(task_id),
+        )
+        monkeypatch.setattr("model_tools.registry.dispatch", fake_dispatch)
+
+        result = json.loads(handle_function_call("web_search", {"q": "test"}, task_id="t1"))
+
+        assert result == {"error": "Tool call blocked by plugin"}
+        assert notifications == []
+
+    def test_invalid_pre_tool_call_hook_returns_are_ignored(self, monkeypatch):
+        hook_calls = []
+
+        def fake_invoke_hook(hook_name, **kwargs):
+            hook_calls.append(hook_name)
+            if hook_name == "pre_tool_call":
+                return [
+                    "block",
+                    123,
+                    {"action": "block"},
+                    {"action": "deny", "message": "nope"},
+                    {"message": "missing action"},
+                    {"action": "block", "message": 123},
+                ]
+            return []
+
+        def fake_dispatch(tool_name, tool_args, **kwargs):
+            assert tool_name == "read_file"
+            assert tool_args == {"path": "notes.txt"}
+            return json.dumps({"ok": True})
+
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_invoke_hook)
+        monkeypatch.setattr("model_tools.registry.dispatch", fake_dispatch)
+
+        result = json.loads(handle_function_call("read_file", {"path": "notes.txt"}, task_id="t1"))
+
+        assert result == {"ok": True}
+        assert hook_calls == ["pre_tool_call", "post_tool_call"]
+
 
 # =========================================================================
 # Agent loop tools

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -18,6 +18,7 @@ from hermes_cli.plugins import (
     PluginManager,
     PluginManifest,
     get_plugin_manager,
+    get_pre_tool_call_block_message,
     get_plugin_tool_names,
     discover_plugins,
     invoke_hook,
@@ -276,6 +277,33 @@ class TestPluginHooks:
             mgr.discover_and_load()
 
         assert any("on_banana" in record.message for record in caplog.records)
+
+
+class TestPreToolCallDirective:
+    """Tests for the supported pre_tool_call block directive helper."""
+
+    def test_get_pre_tool_call_block_message_returns_block_message(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [{"action": "block", "message": "blocked by plugin"}],
+        )
+
+        assert get_pre_tool_call_block_message("todo", {"todos": []}, task_id="t1") == "blocked by plugin"
+
+    def test_get_pre_tool_call_block_message_ignores_invalid_returns(self, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_hook",
+            lambda hook_name, **kwargs: [
+                "block",
+                123,
+                {"action": "block"},
+                {"action": "deny", "message": "nope"},
+                {"message": "missing action"},
+                {"action": "block", "message": 123},
+            ],
+        )
+
+        assert get_pre_tool_call_block_message("todo", {"todos": []}, task_id="t1") is None
 
 
 # ── TestPluginContext ──────────────────────────────────────────────────────

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1259,7 +1259,7 @@ class TestConcurrentToolExecution:
             mock_hfc.assert_called_once_with(
                 "web_search", {"q": "test"}, "task-1",
                 enabled_tools=list(agent.valid_tool_names),
-
+                skip_pre_tool_call_hook=True,
             )
             assert result == "result"
 
@@ -1305,6 +1305,78 @@ class TestConcurrentToolExecution:
             result = agent._invoke_tool("todo", {"todos": []}, "task-1")
             mock_todo.assert_called_once()
         assert "ok" in result
+
+    def test_invoke_tool_blocked_agent_level_tool_skips_direct_execution(self, agent, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_pre_tool_call_block_message",
+            lambda *args, **kwargs: "Tool call blocked by plugin",
+        )
+
+        with patch("tools.todo_tool.todo_tool", side_effect=AssertionError("todo should not run")) as mock_todo:
+            result = agent._invoke_tool("todo", {"todos": []}, "task-1")
+
+        assert json.loads(result) == {"error": "Tool call blocked by plugin"}
+        mock_todo.assert_not_called()
+
+    def test_sequential_blocked_agent_level_tool_skips_execution_and_records_error(self, agent, monkeypatch):
+        tool_call = _mock_tool_call(name="todo", arguments='{"todos":[]}', call_id="c1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])
+        messages = []
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_pre_tool_call_block_message",
+            lambda *args, **kwargs: "Tool call blocked by plugin",
+        )
+
+        with patch("tools.todo_tool.todo_tool", side_effect=AssertionError("todo should not run")) as mock_todo:
+            agent._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+
+        mock_todo.assert_not_called()
+        assert len(messages) == 1
+        assert messages[0]["role"] == "tool"
+        assert messages[0]["tool_call_id"] == "c1"
+        assert json.loads(messages[0]["content"]) == {"error": "Tool call blocked by plugin"}
+
+    def test_blocked_memory_tool_does_not_reset_memory_counter(self, agent_with_memory_tool, monkeypatch):
+        agent_with_memory_tool._turns_since_memory = 5
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_pre_tool_call_block_message",
+            lambda *args, **kwargs: "Tool call blocked by plugin",
+        )
+
+        with patch("tools.memory_tool.memory_tool", side_effect=AssertionError("memory should not run")):
+            result = agent_with_memory_tool._invoke_tool(
+                "memory",
+                {"action": "add", "target": "memory", "content": "x"},
+                "task-1",
+            )
+
+        assert json.loads(result) == {"error": "Tool call blocked by plugin"}
+        assert agent_with_memory_tool._turns_since_memory == 5
+
+    def test_concurrent_blocked_registry_tool_skips_checkpoint_and_execution(self, agent, monkeypatch):
+        tool_call = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"notes.txt","content":"hello"}',
+            call_id="c1",
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])
+        messages = []
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_pre_tool_call_block_message",
+            lambda *args, **kwargs: "Tool call blocked by plugin",
+        )
+        agent._checkpoint_mgr.enabled = True
+        agent._checkpoint_mgr.ensure_checkpoint = MagicMock(side_effect=AssertionError("checkpoint should not run"))
+
+        with patch("run_agent.handle_function_call", side_effect=AssertionError("handle_function_call should not run")):
+            agent._execute_tool_calls_concurrent(mock_msg, messages, "task-1")
+
+        agent._checkpoint_mgr.ensure_checkpoint.assert_not_called()
+        assert len(messages) == 1
+        assert messages[0]["tool_call_id"] == "c1"
+        assert json.loads(messages[0]["content"]) == {"error": "Tool call blocked by plugin"}
 
 
 class TestPathsOverlap:


### PR DESCRIPTION
## What does this PR do?

This adds a simple plugin policy hook for tool calls.

A `pre_tool_call` hook can now block a tool call by returning:
`{"action":"block","message":"..."}`

This works for both:
- tools routed through `model_tools`
- agent-level tools handled directly in `run_agent`

If a tool is blocked, Hermes now returns a clean JSON error and skips execution side effects like:
- running the tool
- creating checkpoints
- resetting read-loop tracking
- marking a blocked tool as if it had run

## Related Issue

No tracked issue for this specific change.

Note: PR #4610 works on the same problem. This PR covers the same basic hook-blocking feature, but also applies it to direct agent-level tools and prevents side effects before blocked calls.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a helper in `hermes_cli/plugins.py` to read the supported `pre_tool_call` block result
- Updated `model_tools.handle_function_call()` to stop blocked calls cleanly
- Updated `run_agent.py` so the same blocking behavior also applies to agent-level tools
- Made sure blocked calls do not trigger pre-execution side effects
- Added focused tests for plugin hooks, `model_tools`, and `run_agent` paths

## How to Test

1. Run:
   `pytest -q tests/test_plugins.py tests/test_model_tools.py tests/test_run_agent.py`

2. Confirm all tests pass.

3. Optional: register a test `pre_tool_call` hook that returns:
   `{"action":"block","message":"blocked by policy"}`
   and confirm the tool returns a JSON error without running.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Validated locally:
- `pytest -q tests/test_plugins.py tests/test_model_tools.py tests/test_run_agent.py`
- Result: `264 passed`

Local full-suite note:
- In clean worktrees, `pytest tests/ -q -x` fails on both `main` and this branch with the same unrelated failure in `tests/gateway/test_matrix_voice.py`, so I am not claiming a clean local full-suite pass from this machine. CI should be the full-branch signal for this PR.

## AI assistance

This PR was implemented with AI assistance using GPT-5.4 xhigh.
