### PR TITLE
fix(gateway): resolve UnboundLocalError on message in run_sync

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6540,14 +6540,13 @@ class GatewayRunner:
             # Prepend pending model switch note so the model knows about the switch
             _pending_notes = getattr(self, '_pending_model_notes', {})
             _msn = _pending_notes.pop(session_key, None) if session_key else None
-            if _msn:
-                message = _msn + "\n\n" + message
+            final_message = (_msn + "\n\n" + message) if _msn else message
 
             _approval_session_key = session_key or ""
             _approval_session_token = set_current_session_key(_approval_session_key)
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
             try:
-                result = agent.run_conversation(message, conversation_history=agent_history, task_id=session_id)
+                result = agent.run_conversation(final_message, conversation_history=agent_history, task_id=session_id)
             finally:
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)


### PR DESCRIPTION
## Summary

- Fixes Python variable scoping bug where conditional `message =` assignment inside `run_sync()` shadows the closure-captured `message` parameter from `_run_agent()`, causing `UnboundLocalError` on every incoming Telegram/Discord/Slack message when no model switch is pending

## Root Cause

```python
# run_sync() is a nested function inside _run_agent(self, message, ...)
def run_sync():
    # ... line ~6330 uses 'message' from enclosing scope:
    turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
    
    # ... line ~6544 conditionally reassigns it:
    if _msn:
        message = _msn + "\n\n" + message  # ← makes 'message' local to ALL of run_sync()
```

Python sees `message =` anywhere in `run_sync()` and classifies `message` as local for the entire function. When `_msn` is `None` (no pending `/model` switch — the common path), the assignment never runs → `UnboundLocalError` at line ~6330.

## Fix

Use a new `final_message` variable instead of reassigning `message`:

```python
final_message = (_msn + "\n\n" + message) if _msn else message
result = agent.run_conversation(final_message, ...)
```

## Test plan

- [x] Send Telegram message with no prior `/model` switch → response works (was crashing)
- [x] Model switch note prepending still works when `_msn` is set (ternary preserves behavior)

Closes #5387