### PR TITLE
feat(discord): observe channels, robust mention detection, reply quote toggle

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -343,7 +343,11 @@ class MessageEvent:
     
     # Auto-loaded skill for topic/channel bindings (e.g., Telegram DM Topics)
     auto_skill: Optional[str] = None
-    
+
+    # Observe-only: message is added to session context but no LLM response is generated.
+    # Used by DISCORD_OBSERVE_CHANNELS to let the agent passively see channel activity.
+    observe_only: bool = False
+
     # Timestamps
     timestamp: datetime = field(default_factory=datetime.now)
     
@@ -1176,7 +1180,7 @@ class BasePlatformAdapter(ABC):
         
         # Start continuous typing indicator (refreshes every 2 seconds)
         _thread_metadata = {"thread_id": event.source.thread_id} if event.source.thread_id else None
-        typing_task = asyncio.create_task(self._keep_typing(event.source.chat_id, metadata=_thread_metadata))
+        typing_task = None if event.observe_only else asyncio.create_task(self._keep_typing(event.source.chat_id, metadata=_thread_metadata))
         
         try:
             await self._run_processing_hook("on_processing_start", event)
@@ -1364,11 +1368,12 @@ class BasePlatformAdapter(ABC):
                 # Clean up current session before processing pending
                 if session_key in self._active_sessions:
                     del self._active_sessions[session_key]
-                typing_task.cancel()
-                try:
-                    await typing_task
-                except asyncio.CancelledError:
-                    pass
+                if typing_task:
+                    typing_task.cancel()
+                    try:
+                        await typing_task
+                    except asyncio.CancelledError:
+                        pass
                 # Process pending message in new background task
                 await self._process_message_background(pending_event, session_key)
                 return  # Already cleaned up
@@ -1397,11 +1402,12 @@ class BasePlatformAdapter(ABC):
                 pass  # Last resort — don't let error reporting crash the handler
         finally:
             # Stop typing indicator
-            typing_task.cancel()
-            try:
-                await typing_task
-            except asyncio.CancelledError:
-                pass
+            if typing_task:
+                typing_task.cancel()
+                try:
+                    await typing_task
+                except asyncio.CancelledError:
+                    pass
             # Also cancel any platform-level persistent typing tasks (e.g. Discord)
             # that may have been recreated by _keep_typing after the last stop_typing()
             try:

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -781,7 +781,11 @@ class DiscordAdapter(BasePlatformAdapter):
                     logger.debug("Could not fetch reply-to message: %s", e)
 
             for i, chunk in enumerate(chunks):
-                chunk_reference = reference if i == 0 else None
+                # DISCORD_REPLY_QUOTE: when "false", suppress the quote-reply
+                # embed above the bot's response.  Useful in shared channels
+                # where repeated quote blocks add visual noise.
+                _reply_quote = os.getenv("DISCORD_REPLY_QUOTE", "true").lower() in ("true", "1", "yes")
+                chunk_reference = (reference if i == 0 else None) if _reply_quote else None
                 try:
                     msg = await channel.send(
                         content=chunk,
@@ -2079,6 +2083,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
         thread_id = None
         parent_channel_id = None
+        _observe_only = False  # set True for observe-channel messages without @mention
         is_thread = isinstance(message.channel, discord.Thread)
         if is_thread:
             thread_id = str(message.channel.id)
@@ -2094,17 +2099,48 @@ class DiscordAdapter(BasePlatformAdapter):
             require_mention = os.getenv("DISCORD_REQUIRE_MENTION", "true").lower() not in ("false", "0", "no")
             is_free_channel = bool(channel_ids & free_channels)
 
-            # Skip the mention check if the message is in a thread where
-            # the bot has previously participated (auto-created or replied in).
             in_bot_thread = is_thread and thread_id in self._bot_participated_threads
 
-            if require_mention and not is_free_channel and not in_bot_thread:
-                if self._client.user not in message.mentions:
-                    return
+            # --- Mention detection ---
+            # Compute was_mentioned once, checking all signals:
+            #   1. Explicit: bot user object in message.mentions list
+            #   2. Snowflake: bot ID in raw mention strings in content
+            #   3. @everyone/@here
+            #   4. Implicit: message is a reply to the bot
+            bot_id = str(self._client.user.id) if self._client.user else None
+            explicitly_mentioned = self._client.user is not None and self._client.user in message.mentions
+            snowflake_mentioned = bot_id is not None and (f"<@{bot_id}>" in message.content or f"<@!{bot_id}>" in message.content)
+            implicit_mention = (
+                bot_id is not None
+                and message.reference is not None
+                and getattr(message.reference, "resolved", None) is not None
+                and getattr(message.reference.resolved, "author", None) is not None
+                and str(message.reference.resolved.author.id) == bot_id
+            )
+            was_mentioned = explicitly_mentioned or snowflake_mentioned or getattr(message, "mention_everyone", False) or implicit_mention
 
-            if self._client.user and self._client.user in message.mentions:
-                message.content = message.content.replace(f"<@{self._client.user.id}>", "").strip()
-                message.content = message.content.replace(f"<@!{self._client.user.id}>", "").strip()
+            # --- Observe channels ---
+            # DISCORD_OBSERVE_CHANNELS: channels where messages are added to
+            # session context (so the agent can see them) but no LLM response
+            # is generated unless the bot is @mentioned.  Useful in shared
+            # multi-bot or ops channels where the agent needs passive awareness
+            # of channel activity without responding to every message.
+            observe_channels_raw = os.getenv("DISCORD_OBSERVE_CHANNELS", "")
+            observe_channels = {ch.strip() for ch in observe_channels_raw.split(",") if ch.strip()}
+            is_observe_channel = bool(channel_ids & observe_channels)
+
+            # --- Mention gate ---
+            if require_mention and not is_free_channel and not in_bot_thread:
+                if not was_mentioned:
+                    if is_observe_channel:
+                        _observe_only = True
+                    else:
+                        return
+
+            # Strip bot mention from content so the agent sees clean text
+            if bot_id and was_mentioned:
+                message.content = message.content.replace(f"<@{bot_id}>", "").strip()
+                message.content = message.content.replace(f"<@!{bot_id}>", "").strip()
 
         # Auto-thread: when enabled, automatically create a thread for every
         # @mention in a text channel so each conversation is isolated (like Slack).
@@ -2286,6 +2322,7 @@ class DiscordAdapter(BasePlatformAdapter):
             media_types=media_types,
             reply_to_message_id=str(message.reference.message_id) if message.reference else None,
             timestamp=message.created_at,
+            observe_only=_observe_only,
         )
 
         # Track thread participation so the bot won't require @mention for

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -780,11 +780,12 @@ class DiscordAdapter(BasePlatformAdapter):
                 except Exception as e:
                     logger.debug("Could not fetch reply-to message: %s", e)
 
+            # DISCORD_REPLY_QUOTE: when "false", suppress the quote-reply
+            # embed above the bot's response.  Useful in shared channels
+            # where repeated quote blocks add visual noise.
+            _reply_quote = os.getenv("DISCORD_REPLY_QUOTE", "true").lower() in ("true", "1", "yes")
+
             for i, chunk in enumerate(chunks):
-                # DISCORD_REPLY_QUOTE: when "false", suppress the quote-reply
-                # embed above the bot's response.  Useful in shared channels
-                # where repeated quote blocks add visual noise.
-                _reply_quote = os.getenv("DISCORD_REPLY_QUOTE", "true").lower() in ("true", "1", "yes")
                 chunk_reference = (reference if i == 0 else None) if _reply_quote else None
                 try:
                     msg = await channel.send(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1796,6 +1796,24 @@ class GatewayRunner:
                 label = response_text if len(response_text) <= 20 else response_text[:20] + "…"
                 return f"✓ Sent `{label}` to the update process."
 
+        # Observe-only: add message to session transcript without calling the LLM.
+        # Used by DISCORD_OBSERVE_CHANNELS to let the agent see channel activity
+        # without responding to every message.  The message is recorded as a
+        # "[Channel message from ...]" user turn so the agent has context on its
+        # next real @mention, but no typing indicator or API call is triggered.
+        if getattr(event, "observe_only", False):
+            try:
+                session_entry = self.session_store.get_or_create_session(source)
+                user_label = source.user_name or source.user_id
+                self.session_store.append_to_transcript(session_entry.session_id, {
+                    "role": "user",
+                    "content": f"[Channel message from {user_label}]: {event.text}",
+                })
+                logger.info("[observe] Recorded message from %s in session %s", user_label, session_entry.session_id[:20])
+            except Exception as e:
+                logger.warning("[observe] Failed to record observe-only message: %s", e)
+            return None
+
         # PRIORITY handling when an agent is already running for this session.
         # Default behavior is to interrupt immediately so user text/stop messages
         # are handled with minimal latency.


### PR DESCRIPTION
## Summary

When `DISCORD_REQUIRE_MENTION=true`, any message that doesn't @mention the bot is hard-dropped before reaching the session. This makes multi-agent setups impossible — bots in a shared channel can't see each other's messages or coordinate with a human operator unless every message is a direct @mention. This PR adds passive channel awareness, fixes mention detection edge cases, and adds a reply quote toggle.

### Changes

**`DISCORD_OBSERVE_CHANNELS`** (new env var)
Comma-separated channel IDs where non-mentioned messages are silently appended to the session transcript as `[Channel message from {user}]` without triggering LLM inference, typing indicators, or a response. The agent has full context on its next @mention. Combined with `DISCORD_ALLOW_BOTS=all` and `group_sessions_per_user: false`, this enables multiple agents and humans to share a channel where everyone can see the full conversation but agents only respond when mentioned.

**Mention detection hardening**
Replaces the single `self._client.user in message.mentions` check with four signals: explicit (discord.py object), snowflake (`<@ID>` in content), `mention_everyone`, and implicit (reply-to-bot). Closes edge cases where the bot fails to recognize valid mentions.

**`DISCORD_REPLY_QUOTE`** (new env var)
When `"false"`, suppresses the quote-reply embed on bot responses. Default `"true"` preserves existing behavior.

### Files

- `gateway/platforms/base.py` — `observe_only` field on `MessageEvent`, conditional typing indicator with null-safe cleanup
- `gateway/platforms/discord.py` — mention detection rewrite, observe channel gate, configurable reply quoting
- `gateway/run.py` — observe-only early return (append to transcript, skip LLM)

## Test plan

- [ ] @mention in observe channel → bot responds normally
- [ ] @everyone in observe channel → bot responds
- [ ] Non-mentioned message in observe channel → no response, appears in transcript
- [ ] Next @mention after observed messages → agent references prior context
- [ ] Multiple agents in shared channel can see each other's messages via observe
- [ ] Agents can @mention each other to trigger direct responses
- [ ] `DISCORD_REPLY_QUOTE=false` → no quote embed; `true`/unset → quote preserved
- [ ] DMs and non-observe channels unaffected
- [ ] No typing indicator for observe-only messages