### PR TITLE
fix(mcp-oauth): fix token storage serialization and cached token refresh

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -335,3 +335,103 @@ class TestBuildOAuthAuthNonInteractive:
 
         assert auth is not None
         assert "no cached tokens found" not in caplog.text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests for fixes: AnyUrl serialization, port reuse, expired token refresh
+# ---------------------------------------------------------------------------
+
+class TestAnyUrlSerialization:
+    """model_dump(mode='json') handles Pydantic AnyUrl objects."""
+
+    def test_set_tokens_with_anyurl(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("test-anyurl")
+        import asyncio
+
+        mock_token = MagicMock()
+        mock_token.model_dump.return_value = {
+            "access_token": "abc",
+            "token_type": "Bearer",
+        }
+        # Verify mode="json" is passed
+        asyncio.run(storage.set_tokens(mock_token))
+        mock_token.model_dump.assert_called_with(mode="json", exclude_none=True)
+
+    def test_set_client_info_with_anyurl(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("test-anyurl")
+        import asyncio
+
+        mock_client = MagicMock()
+        mock_client.model_dump.return_value = {"client_id": "test"}
+        asyncio.run(storage.set_client_info(mock_client))
+        mock_client.model_dump.assert_called_with(mode="json", exclude_none=True)
+
+
+class TestExpiredTokenRefresh:
+    """get_tokens() clears expired access_token to trigger refresh flow."""
+
+    def test_expired_token_cleared(self, tmp_path, monkeypatch):
+        """When access token is expired, get_tokens() clears it but keeps refresh_token."""
+        try:
+            from mcp.shared.auth import OAuthToken
+        except ImportError:
+            pytest.skip("MCP SDK auth not available")
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("test-expired")
+
+        # Write token file with expires_in=1
+        d = tmp_path / "mcp-tokens"
+        d.mkdir(parents=True)
+        token_path = d / "test-expired.json"
+        token_path.write_text(json.dumps({
+            "access_token": "old-expired-token",
+            "token_type": "Bearer",
+            "refresh_token": "valid-refresh",
+            "expires_in": 1,
+        }))
+
+        # Set mtime to 2 hours ago so token is expired
+        import time
+        old_mtime = time.time() - 7200
+        os.utime(token_path, (old_mtime, old_mtime))
+
+        import asyncio
+        token = asyncio.run(storage.get_tokens())
+
+        assert token is not None
+        assert token.access_token == ""  # cleared
+        assert token.refresh_token == "valid-refresh"  # kept
+
+    def test_fresh_token_not_cleared(self, tmp_path, monkeypatch):
+        """When access token is still valid, get_tokens() returns it as-is."""
+        try:
+            from mcp.shared.auth import OAuthToken
+        except ImportError:
+            pytest.skip("MCP SDK auth not available")
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("test-fresh")
+
+        d = tmp_path / "mcp-tokens"
+        d.mkdir(parents=True)
+        token_path = d / "test-fresh.json"
+        token_path.write_text(json.dumps({
+            "access_token": "valid-token",
+            "token_type": "Bearer",
+            "refresh_token": "valid-refresh",
+            "expires_in": 3600,
+        }))
+        # mtime is now, so token is fresh
+
+        import asyncio
+        token = asyncio.run(storage.get_tokens())
+
+        assert token is not None
+        assert token.access_token == "valid-token"
+        assert token.refresh_token == "valid-refresh"
+
+
+

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -81,12 +81,34 @@ class HermesTokenStorage:
             return None
         try:
             from mcp.shared.auth import OAuthToken
+
+            # Check if the access token has expired based on file mtime + expires_in.
+            # The SDK only tracks expiry for tokens obtained during the current session,
+            # not for tokens loaded from storage.  Without this check, the SDK sends
+            # an expired access token, gets 401, and goes straight to full browser auth
+            # instead of trying the refresh token first.
+            expires_in = data.get("expires_in")
+            if expires_in and self._tokens_path().exists():
+                import time
+                file_mtime = self._tokens_path().stat().st_mtime
+                if time.time() > file_mtime + expires_in:
+                    # Access token expired — clear it so the SDK knows to refresh.
+                    # Keep refresh_token so can_refresh_token() returns True.
+                    data["access_token"] = ""
+                    logger.debug(
+                        "Cached access token for '%s' has expired (age %.0fs > %ds), "
+                        "will use refresh token",
+                        self._server_name,
+                        time.time() - file_mtime,
+                        expires_in,
+                    )
+
             return OAuthToken(**data)
         except Exception:
             return None
 
     async def set_tokens(self, tokens) -> None:
-        self._write_json(self._tokens_path(), tokens.model_dump(exclude_none=True))
+        self._write_json(self._tokens_path(), tokens.model_dump(mode="json", exclude_none=True))
 
     async def get_client_info(self):
         data = self._read_json(self._client_path())
@@ -99,7 +121,7 @@ class HermesTokenStorage:
             return None
 
     async def set_client_info(self, client_info) -> None:
-        self._write_json(self._client_path(), client_info.model_dump(exclude_none=True))
+        self._write_json(self._client_path(), client_info.model_dump(mode="json", exclude_none=True))
 
     # -- helpers --
 


### PR DESCRIPTION
## What does this PR do?

Fixes two bugs in `tools/mcp_oauth.py` that cause MCP OAuth to break in non-interactive environments (gateways, Docker containers, cron jobs). Together these bugs mean any deployment without a browser loses MCP connectivity after ~1 hour and cannot recover, even with a valid refresh token.

## Related Issue

Relates to #5344 (redirect URI port reuse addressed separately in #5345).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📚 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎉 New skill (bundled or hub)

## Changes Made

- **`HermesTokenStorage.set_tokens()` and `set_client_info()`**: Changed `model_dump(exclude_none=True)` to `model_dump(mode="json", exclude_none=True)`. Pydantic `AnyUrl` fields in the MCP SDK's token/client models aren't serializable by the default JSON encoder, causing `TypeError: Object of type AnyUrl is not JSON serializable` on first OAuth connection.

- **`HermesTokenStorage.get_tokens()`**: When loading cached tokens from disk, checks whether the access token has expired by comparing `file_mtime + expires_in` against the current time. If expired, clears `access_token` (sets to empty string) but preserves `refresh_token`. This causes the MCP SDK's `is_token_valid()` to return False and `can_refresh_token()` to return True, so it correctly uses the refresh flow instead of sending an expired token, receiving 401, and falling through to the full browser authorization flow.

## How to Test

1. Configure an MCP server with `auth: oauth` in `~/.hermes/config.yaml`
2. Complete the initial browser OAuth flow
3. Wait for the access token to expire (~1 hour) or manually set the token file's mtime to the past: `touch -t 202401010000 ~/.hermes/mcp-tokens/<server>.json`
4. Reconnect to the MCP server — it should auto-refresh using the refresh token without opening a browser
5. Run the test suite: `pytest tests/tools/test_mcp_oauth.py -v`

### New test cases added:
- `TestAnyUrlSerialization::test_set_tokens_with_anyurl` — verifies `mode="json"` is passed
- `TestAnyUrlSerialization::test_set_client_info_with_anyurl` — verifies `mode="json"` is passed
- `TestExpiredTokenRefresh::test_expired_token_cleared` — verifies expired access token is cleared, refresh token preserved
- `TestExpiredTokenRefresh::test_fresh_token_not_cleared` — verifies fresh tokens are returned as-is

🤖 Generated with Claude Code assistance