### PR TITLE
docs(manim-video): add 3D and lattice quantum examples

### DIFF
--- a/skills/creative/manim-video/examples/quantum/README.md
+++ b/skills/creative/manim-video/examples/quantum/README.md
@@ -1,0 +1,28 @@
+# Quantum Computing Animation Examples
+
+These scripts serve as advanced "Gold Standard" templates for generating Manim code and demonstrating how to orchestrate MathCode, Manim, and AI Voice generation into a single pipeline.
+
+## 1. Jordan's Lemma (3D)
+**File:** `jordans_lemma_3d.py`
+
+This script demonstrates advanced `ThreeDScene` usage, camera orientation shifts, and drawing translucent 3D planes (mirrors) to map 3D objects onto 2D slices.
+
+### The Pipeline Workflow
+This video was created using a 3-step AI agent pipeline:
+
+**Step 1: Formalization (MathCode)**
+We used MathCode to formalize the underlying mathematics:
+`echo "Formalize and prove Jordan's Lemma: The product of two reflections on a finite-dimensional Hilbert space is block-diagonalizable into 1D and 2D invariant subspaces." | ./run -p`
+
+**Step 2: Video Generation (Manim)**
+We generated the 3D visual using Manim:
+`manim -qm jordans_lemma_3d.py Scene1_JordanLemma`
+
+**Step 3: Audio & Muxing (Whisper/TTS & ffmpeg)**
+We generated an ELI5 voiceover using Hermes Agent's TTS tool and stitched it together:
+`ffmpeg -y -i media/videos/jordans_lemma_3d/720p30/Scene1_JordanLemma.mp4 -i voiceover.mp3 -c:v copy -c:a aac -map 0:v:0 -map 1:a:0 -shortest final_jordan_with_audio.mp4`
+
+## 2. Bacon-Shor Lattice (2D)
+**File:** `bacon_shor_lattice.py`
+
+Demonstrates 2D grid generation, grouping specific rows/columns, and highlighting overlaps. This represents the intersection parity of the X and Z stabilizers.

--- a/skills/creative/manim-video/examples/quantum/bacon_shor_lattice.py
+++ b/skills/creative/manim-video/examples/quantum/bacon_shor_lattice.py
@@ -1,0 +1,79 @@
+from manim import *
+
+BG = "#1C1C1C"
+PRIMARY = "#58C4DD"    # Blue (Z)
+SECONDARY = "#FFFF00"  # Yellow (X)
+ACCENT = "#83C167"     # Green (Intersection)
+TEXT_COLOR = "#EAEAEA"
+
+class Scene1_TheLattice(Scene):
+    def construct(self):
+        self.camera.background_color = BG
+        
+        # Title
+        title = Text("The Bacon-Shor Code", font_size=48, color=TEXT_COLOR)
+        self.add_subcaption("The Bacon-Shor code organizes qubits into a 2D grid.", duration=3)
+        
+        self.play(Write(title))
+        self.wait(1)
+        self.play(title.animate.to_edge(UP))
+        
+        # Create a 4x4 grid of dots representing qubits
+        qubits = VGroup(*[Dot(radius=0.15, color=TEXT_COLOR) for _ in range(16)])
+        qubits.arrange_in_grid(rows=4, cols=4, buff=1.0)
+        
+        self.play(LaggedStart(*[FadeIn(q, scale=0.5) for q in qubits], lag_ratio=0.05), run_time=1.5)
+        self.wait(1)
+        
+        self.play(FadeOut(title), FadeOut(qubits))
+
+
+class Scene2_Intersection(Scene):
+    def construct(self):
+        self.camera.background_color = BG
+        
+        # Recreate the 4x4 grid
+        qubits = VGroup(*[Dot(radius=0.15, color=TEXT_COLOR) for _ in range(16)])
+        qubits.arrange_in_grid(rows=4, cols=4, buff=1.0)
+        self.add(qubits)
+        
+        # Highlight two adjacent columns (Z stabilizer)
+        col_indices = [1, 2, 5, 6, 9, 10, 13, 14] # Columns 1 and 2 (0-indexed)
+        z_stabilizer = VGroup(*[qubits[i] for i in col_indices])
+        z_box = SurroundingRectangle(z_stabilizer, color=PRIMARY, fill_opacity=0.2, buff=0.3)
+        
+        self.add_subcaption("A Z-stabilizer protects against errors across two entire columns.", duration=3)
+        self.play(Create(z_box), z_stabilizer.animate.set_color(PRIMARY))
+        self.wait(1)
+        
+        # Highlight two adjacent rows (X stabilizer)
+        row_indices = [4, 5, 6, 7, 8, 9, 10, 11] # Rows 1 and 2 (0-indexed)
+        x_stabilizer = VGroup(*[qubits[i] for i in row_indices])
+        x_box = SurroundingRectangle(x_stabilizer, color=SECONDARY, fill_opacity=0.2, buff=0.3)
+        
+        self.add_subcaption("An X-stabilizer protects across two entire rows.", duration=3)
+        self.play(Create(x_box), x_stabilizer.animate.set_color(SECONDARY))
+        self.wait(1)
+        
+        # The intersection
+        intersection_indices = [5, 6, 9, 10]
+        intersection_qubits = VGroup(*[qubits[i] for i in intersection_indices])
+        intersection_box = SurroundingRectangle(intersection_qubits, color=ACCENT, fill_opacity=0.5, buff=0.4)
+        
+        self.add_subcaption("Notice where they overlap: exactly 4 qubits.", duration=3)
+        self.play(
+            Create(intersection_box),
+            intersection_qubits.animate.set_color(ACCENT).scale(1.5),
+            run_time=1.5
+        )
+        self.wait(2)
+        
+        # The explanation
+        explanation = Text("Even overlap (4) = They Commute!", font_size=36, color=ACCENT)
+        explanation.next_to(x_box, DOWN, buff=0.5)
+        
+        self.add_subcaption("In quantum mechanics, Pauli operators commute if they overlap on an even number of qubits. This is the secret of the code.", duration=4)
+        self.play(Write(explanation))
+        self.wait(3)
+        
+        self.play(FadeOut(Group(*self.mobjects)))

--- a/skills/creative/manim-video/examples/quantum/jordans_lemma_3d.py
+++ b/skills/creative/manim-video/examples/quantum/jordans_lemma_3d.py
@@ -1,0 +1,91 @@
+from manim import *
+
+BG = "#1C1C1C"
+PRIMARY = "#58C4DD"    # Blue
+SECONDARY = "#FF6B6B"  # Red
+ACCENT = "#83C167"     # Green
+TEXT_COLOR = "#EAEAEA"
+
+class Scene1_JordanLemma(ThreeDScene):
+    def construct(self):
+        self.camera.background_color = BG
+        
+        # Setup 3D camera
+        self.set_camera_orientation(phi=75 * DEGREES, theta=30 * DEGREES)
+        
+        # Title that stays in 2D space
+        title = Text("Jordan's Lemma", font_size=48, color=TEXT_COLOR).to_corner(UL)
+        self.add_fixed_in_frame_mobjects(title)
+        
+        # 1. THE MAZE (High dimensions)
+        axes = ThreeDAxes()
+        self.add(axes)
+        
+        dots = VGroup(*[
+            Dot3D(point=[
+                np.random.uniform(-3, 3),
+                np.random.uniform(-3, 3),
+                np.random.uniform(-3, 3)
+            ], radius=0.05, color=WHITE)
+            for _ in range(50)
+        ])
+        
+        self.add_subcaption("Imagine you are lost in a giant, multi-dimensional maze.", duration=5)
+        self.play(Write(title))
+        self.play(FadeIn(dots), run_time=2)
+        
+        # Rotate camera to show "millions of dimensions"
+        self.move_camera(phi=60 * DEGREES, theta=120 * DEGREES, run_time=3)
+        
+        # 2. THE TWO MIRRORS (Reflections)
+        self.add_subcaption("Grover's algorithm uses two magic mirrors—reflections.", duration=4)
+        
+        mirror1 = Surface(
+            lambda u, v: np.array([u, v, 0]),
+            u_range=[-3, 3], v_range=[-3, 3],
+            resolution=(10, 10),
+            fill_color=PRIMARY, fill_opacity=0.3, stroke_width=0
+        )
+        
+        mirror2 = Surface(
+            lambda u, v: np.array([u, u * 0.5, v]),
+            u_range=[-3, 3], v_range=[-3, 3],
+            resolution=(10, 10),
+            fill_color=SECONDARY, fill_opacity=0.3, stroke_width=0
+        )
+        
+        self.play(FadeOut(dots))
+        self.play(Create(mirror1), Create(mirror2))
+        self.wait(1)
+        
+        # 3. THE 2D PLANE (The Secret)
+        self.add_subcaption("Jordan's Lemma proves bouncing between them traps you on a flat 2D plane.", duration=6)
+        
+        # We fade out the mirrors and show just the 2D plane they create
+        self.move_camera(phi=0 * DEGREES, theta=-90 * DEGREES, run_time=2)
+        self.play(FadeOut(mirror1), FadeOut(mirror2), FadeOut(axes))
+        
+        # 2D View now
+        plane = NumberPlane(background_line_style={"stroke_opacity": 0.2})
+        self.play(Create(plane))
+        
+        circle = Circle(radius=2, color=ACCENT)
+        dot = Dot(point=[2, 0, 0], color=TEXT_COLOR, radius=0.1)
+        
+        self.play(Create(circle))
+        self.play(FadeIn(dot))
+        
+        self.add_subcaption("Instead of wandering, you just walk in a straight circle to the answer!", duration=5)
+        
+        # Trace the circle (representing the rotation from the two reflections)
+        self.play(MoveAlongPath(dot, circle), run_time=3, rate_func=linear)
+        
+        target_dot = Dot(point=[0, 2, 0], color=SECONDARY, radius=0.15)
+        target_label = Text("Answer", font_size=24, color=SECONDARY).next_to(target_dot, UR, buff=0.1)
+        
+        self.play(FadeIn(target_dot), FadeIn(target_label))
+        self.play(MoveAlongPath(dot, Arc(radius=2, start_angle=0, angle=PI/2)), run_time=1.5)
+        self.play(Flash(target_dot, color=SECONDARY, line_length=0.5))
+        
+        self.wait(2)
+        self.play(FadeOut(Group(*self.mobjects)))


### PR DESCRIPTION
Adds two advanced reference scripts to the manim-video skill. 
1. A 3D scene demonstrating camera movement and intersecting planes (Jordan's Lemma).
2. A 2D grid scene demonstrating VGroup highlighting and intersections (Bacon-Shor code).
These serve as context to help the agent write better complex geometric animations.