### PR TITLE
fix(terminal): avoid sourcing login/logout files locally

### DIFF
--- a/tests/tools/test_local_persistent.py
+++ b/tests/tools/test_local_persistent.py
@@ -75,6 +75,19 @@ class TestLocalOneShotRegression:
         assert "printf '" not in r["output"]
         assert "exit $" not in r["output"]
 
+    def test_oneshot_does_not_source_login_or_logout_files(self, tmp_path):
+        home = tmp_path / "fake-home"
+        home.mkdir()
+        (home / ".bash_profile").write_text("echo sourced-profile\n")
+        (home / ".bash_logout").write_text("echo sourced-logout\nsleep 30\n")
+        env = LocalEnvironment(persistent=False, env={"HOME": str(home)})
+        r = env.execute("printf ok", timeout=2)
+        env.cleanup()
+        assert r["returncode"] == 0
+        assert r["output"] == "ok"
+        assert "sourced-profile" not in r["output"]
+        assert "sourced-logout" not in r["output"]
+
 
 class TestLocalPersistent:
     @pytest.fixture
@@ -158,6 +171,22 @@ class TestLocalPersistent:
     def test_pipe_command(self, env):
         r = env.execute("echo hello | tr 'h' 'H'")
         assert r["output"].strip() == "Hello"
+
+
+    def test_persistent_shell_does_not_source_login_or_logout_files(self, tmp_path):
+        home = tmp_path / "fake-home"
+        home.mkdir()
+        (home / ".bash_profile").write_text("echo sourced-profile\n")
+        (home / ".bash_logout").write_text("echo sourced-logout\nsleep 30\n")
+        env = LocalEnvironment(persistent=True, env={"HOME": str(home)})
+        try:
+            r = env.execute("printf ok", timeout=2)
+            assert r["returncode"] == 0
+            assert r["output"] == "ok"
+            assert "sourced-profile" not in r["output"]
+            assert "sourced-logout" not in r["output"]
+        finally:
+            env.cleanup()
 
     def test_multiple_commands_semicolon(self, env):
         r = env.execute("X=42; echo $X")

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -341,7 +341,7 @@ class LocalEnvironment(PersistentShellMixin, BaseEnvironment):
         user_shell = _find_bash()
         run_env = _make_run_env(self.env)
         return subprocess.Popen(
-            [user_shell, "-l"],
+            [user_shell, "--noprofile", "--norc"],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
@@ -406,7 +406,7 @@ class LocalEnvironment(PersistentShellMixin, BaseEnvironment):
         run_env = _make_run_env(self.env)
 
         proc = subprocess.Popen(
-            [user_shell, "-lic", fenced_cmd],
+            [user_shell, "--noprofile", "--norc", "-c", fenced_cmd],
             text=True,
             cwd=work_dir,
             env=run_env,


### PR DESCRIPTION
## What does this PR do?

This fixes a bug in the local terminal backend where non-PTY commands were being executed through login/interactive bash shells.

For local one-shot commands, Hermes was using bash -lic. For local persistent shells, Hermes was starting bash -l. That allows user shell startup/logout files such as .bash_profile, .bashrc, and .bash_logout to run during Hermes terminal execution.

That behavior can introduce shell noise, delay shell exit, and make local terminal command completion flaky in non-interactive contexts. For a tool backend, that coupling is too fragile. Local non-PTY terminal execution should be isolated from user login/logout shell hooks.

This PR switches those code paths to use bash --noprofile --norc instead, and adds regression tests to verify local execution does not source login/logout files.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated tools/environments/local.py
  - changed local persistent shell startup from bash -l to bash --noprofile --norc
  - changed local one-shot execution from bash -lic to bash --noprofile --norc -c
- Updated tests/tools/test_local_persistent.py
  - added a regression test verifying one-shot local execution does not source .bash_profile or .bash_logout
  - added a regression test verifying persistent local shell execution does not source .bash_profile or .bash_logout

## How to Test

1. Create a fake HOME containing shell hooks, for example:
   - .bash_profile that prints a marker
   - .bash_logout that prints a marker and sleeps
2. Run local terminal execution through LocalEnvironment in both:
   - persistent=False
   - persistent=True
3. Verify:
   - the command returns successfully
   - the output contains only the command output
   - the .bash_profile / .bash_logout markers do not appear

Targeted regression tests run for this PR:
- python -m pytest tests/tools/test_local_persistent.py -q
- python -m pytest tests/tools/test_terminal_timeout_output.py -q
- python -m pytest tests/tools/test_interrupt.py -q

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (fix(scope):, feat(scope):, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted test results:

tests/tools/test_local_persistent.py
28 passed in 3.40s

tests/tools/test_terminal_timeout_output.py
2 passed in 2.66s

tests/tools/test_interrupt.py
6 passed in 2.49s