### PR TITLE
feat(skills): add career-ops job search pipeline skill

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -155,6 +155,136 @@ MEMORY_GUIDANCE = (
     "necessary later, save it as a skill with the skill tool."
 )
 
+CHUB_TRIGGER_KEYWORDS = (
+    "run | execute | invoke | call | apply | use "
+    "api | sdk | library | package | module | framework "
+    "install | import | require | from | import "
+    "pip | npm | yarn | brew | apt | conda | cargo "
+    "request | response | endpoint | route | method "
+    "auth | token | credential | key | secret "
+    "client | server | database | query | schema "
+    "function | method | class | object | interface "
+    "error | exception | traceback | bug | fix | crash "
+    "config | setting | environment | variable "
+    "build | compile | deploy | run "
+    "web | http | request | json | rest | graphql "
+    "browser | scraping | crawl | html | css "
+    "ssh | git | docker | container | image "
+    "cloud | aws | azure | gcp | serverless "
+    "machine learning | ml | model | training | inference "
+    "vector | embedding | rag | rag | chunk "
+    "agent | prompt | llm | completion | token "
+    "github | gitlab | bitbucket | repository "
+    "terminal | bash | shell | zsh | powershell "
+    "file | path | directory | folder | read | write "
+    "json | yaml | toml | config "
+    "stream | websocket | socket | real-time "
+    "webhook | callback | event | listener "
+).split(" | ")
+
+CHUB_EXPLICIT_TRIGGERS = (
+    "pip install", "npm install", "yarn add", "conda install",
+    "import json", "from typing", "from datetime", "import os",
+    "require(', 'from ', 'import ",
+    "requests.get", "requests.post", "curl -X", "fetch(",
+    "api_key", "api_key", "authenticate", "bearer token",
+    "playwright", "selenium", "puppeteer", "scrapy",
+    "fastapi", "flask", "django", "express", "nestjs",
+    "openai", "anthropic", "cohere", "mistral", "groq",
+    "stripe", "twilio", "sendgrid", "aws", "boto3",
+    "sqlalchemy", "prisma", "drizzle", "postgres",
+    "redis", "mongodb", "elasticsearch", "pinecone",
+    "docker build", "docker run", "kubectl", "helm",
+    "git commit", "git push", "git clone", "gh pr",
+    "terminal", "subprocess", "pexpect", "asyncio",
+    "regex", "re.compile", "json.loads", "json.dumps",
+).split(", ")
+
+CHUB_EXPLICIT_EXCEPTIONS = (
+    "what time is it", "what day is it", "what is my name",
+    "how are you", "hi ", "hello", "thanks", "thank you",
+    "whats the weather", "weather forecast",
+    "simple math", "what is 2+2", "basic arithmetic",
+    "casual conversation", "just saying", "by the way",
+    "pure opinion", "what do you think about x",
+).split(", ")
+
+
+def _looks_like_chub_query(text: str) -> bool:
+    """Return True if text contains strong chub trigger signals."""
+    t = text.lower()
+    # Check explicit triggers
+    for trigger in CHUB_EXPLICIT_TRIGGERS:
+        if trigger in t:
+            return True
+    # Check keyword density
+    word_count = len(t.split())
+    hits = sum(1 for kw in CHUB_TRIGGER_KEYWORDS if kw.lower() in t)
+    if hits >= 3:
+        return True
+    if hits >= 2 and word_count <= 12:
+        return True
+    return False
+
+
+CHUB_GUIDANCE = (
+    "## ContextHub (chub) — Pre-Flight for EVERY Technical Query [STRICTLY ENFORCED]\n"
+    "ContextHub (chub) is your mandatory pre-flight check for EVERY user query that "
+    "involves code, APIs, libraries, frameworks, tools, or technical implementation. "
+    "Running it prevents hallucinated code and wrong answers. chub is a CLI — it runs "
+    "via the terminal tool, not as a separate tool call.\n"
+    "\n"
+    "CHUB IS NON-OPTIONAL — THIS RULE IS STRICTLY ENFORCED:\n"
+    "  - You CANNOT write code without running chub first\n"
+    "  - You CANNOT answer a question about a library/API without running chub first\n"
+    "  - You CANNOT run a terminal command for an unfamiliar tool without chub first\n"
+    "  - Saying you know something is NOT a substitute for running chub — ALWAYS verify\n"
+    "  - Any answer to a technical question without chub output visible is a RULE VIOLATION\n"
+    "\n"
+    "MANDATORY WORKFLOW — run chub on EVERY query that contains:\n"
+    "  - Any library, API, SDK, framework, or package name\n"
+    "  - Any code: imports, function calls, class definitions\n"
+    "  - Any terminal command for an unfamiliar tool\n"
+    "  - Any question about how to use a specific tool or service\n"
+    "  - The keywords: api, sdk, library, package, install, import, request, endpoint\n"
+    "    auth, token, client, server, database, function, method, error, config\n"
+    "    build, compile, deploy, web, http, browser, scraping, git, ssh, docker\n"
+    "    cloud, ml, model, agent, prompt, llm, vector, regex, terminal, bash\n"
+    "\n"
+    "HOW TO RUN CHUB:\n"
+    "  1. Parse the core topic from the request\n"
+    "  2. Run: terminal(command='chub --json search \"<topic>\" --limit 5')\n"
+    "  3. If a specific package/API/SDK is detected: terminal(command='chub get <package-id> --lang py')\n"
+    "  4. Read the chub output BEFORE writing any code or answering\n"
+    "  5. If chub returns nothing: terminal(command='chub update --force && retry once')\n"
+    "\n"
+    "EXAMPLES — ALWAYS RUN CHUB WHEN:\n"
+    "  - \"install playwright\"         → chub --json search \"playwright python\" --limit 5\n"
+    "  - \"use the openai API\"          → chub --json search \"openai python\" --limit 5\n"
+    "  - \"how do I use FastAPI\"        → chub --json search \"fastapi\" --limit 5\n"
+    "  - \"fix AttributeError in X\"     → chub --json search \"python attribute error\" --limit 5\n"
+    "  - \"make a POST request\"         → chub --json search \"python requests post\" --limit 5\n"
+    "  - \"authenticate with bearer\"   → chub --json search \"bearer token python\" --limit 5\n"
+    "  - \"scrape a website\"           → chub --json search \"python web scraping\" --limit 5\n"
+    "  - \"connect to PostgreSQL\"      → chub --json search \"python postgres sqlalchemy\" --limit 5\n"
+    "  - \"use docker in a workflow\"   → chub --json search \"docker python sdk\" --limit 5\n"
+    "  - \"deploy to AWS Lambda\"       → chub --json search \"aws lambda python boto3\" --limit 5\n"
+    "  - \"git push to a fork\"          → chub --json search \"git push fork github\" --limit 5\n"
+    "  - \"parse a YAML file\"          → chub --json search \"python yaml\" --limit 5\n"
+    "\n"
+    "EXCEPTION — DO NOT run chub for:\n"
+    "  - Pure conversational text: 'hi', 'how are you', 'thanks'\n"
+    "  - Questions about yourself or general knowledge with no technical component\n"
+    "  - Simple arithmetic or time/date questions\n"
+    "  - If you are CERTAIN the topic is covered by a previously loaded skill\n"
+    "\n"
+    "WHEN CHUB IS AVAILABLE: skill_view(name='context-hub') — full CLI reference above.\n"
+    "CHUB runs as: terminal(background=False, command='chub --json search ...')\n"
+    "\n"
+    "VERIFICATION: Any technical answer without preceding chub terminal output is incomplete.\n"
+)
+
+
 SESSION_SEARCH_GUIDANCE = (
     "When the user references something from a past conversation or you suspect "
     "relevant cross-session context exists, use session_search to recall it before "

--- a/skills/productivity/career-ops/DESCRIPTION.md
+++ b/skills/productivity/career-ops/DESCRIPTION.md
@@ -1,0 +1,36 @@
+# Career-Ops Skill for Hermes Agent
+
+**Category:** Productivity  
+**Author:** Hermes Agent (wrapper)  
+**Credits:** [santifer](https://github.com/santifer/career-ops)  
+
+A wrapper skill that brings the career-ops AI job search pipeline into Hermes Agent. Enables autonomous job offer evaluation, ATS-optimized PDF generation, portal scanning, and application tracking through natural language commands.
+
+## Quick Start
+
+1. Say "evaluate this job: [URL or paste description]" — Hermes runs the full pipeline
+2. Say "scan portals" — Hermes searches 45+ companies for new offers
+3. Say "generate CV PDF for [job]" — Hermes creates a tailored ATS-optimized resume
+4. Say "show my tracker" — Hermes displays application status and statistics
+
+## What It Does
+
+- **Evaluate offers** with 6-block structured analysis (role summary, CV match, comp research, interview plan)
+- **Compare multiple offers** with 10-dimension weighted scoring
+- **Generate ATS-optimized PDFs** tailored per job description with keyword injection
+- **Scan 45+ company portals** (Ashby, Greenhouse, Lever, Wellfound) automatically
+- **Track all applications** in a single source of truth with dedup and integrity checks
+- **Draft application answers** personalized to each company's form
+- **Prepare for interviews** with STAR+Reflection story banks and negotiation scripts
+
+## Setup Required (One-Time)
+
+The skill will guide you through:
+1. Creating `cv.md` with your resume
+2. Filling in `config/profile.yml` (name, target roles, salary, location)
+3. Optionally configuring `portals.yml` with companies to track
+4. Running `npm install && npx playwright install chromium`
+
+## For Full Career-Ops System
+
+This skill is a wrapper — it needs the full career-ops system installed locally. See: https://github.com/santifer/career-ops

--- a/skills/productivity/career-ops/SETUP.md
+++ b/skills/productivity/career-ops/SETUP.md
@@ -1,0 +1,56 @@
+# Career-Ops Skill Setup Reference
+
+## Overview
+
+This skill is a **wrapper** — it provides the interface between Hermes Agent and the career-ops system (https://github.com/santifer/career-ops). The actual career-ops logic lives in a separate cloned repository on the user's machine.
+
+## Setup Location
+
+The career-ops system should be cloned to:
+```
+$CAREER_OPS_PATH  (environment variable, if set)
+OR
+./career-ops  (relative to hermes-agent root)
+OR
+~/.hermes/career-ops  (default user location)
+```
+
+## Installation Commands
+
+```bash
+# Clone career-ops to the user's preferred location
+git clone https://github.com/santifer/career-ops.git ~/.hermes/career-ops
+
+# Install dependencies
+cd ~/.hermes/career-ops && npm install
+
+# Install Playwright (required for PDF generation)
+npx playwright install chromium
+
+# Configure profile
+cp ~/.hermes/career-ops/config/profile.example.yml ~/.hermes/career-ops/config/profile.yml
+
+# Configure portals (optional)
+cp ~/.hermes/career-ops/templates/portals.example.yml ~/.hermes/career-ops/portals.yml
+```
+
+## For PR Maintainers
+
+This skill assumes:
+- Node.js 18+ is available
+- Playwright's Chromium is installed (`npx playwright install chromium`)
+- The user has a CV in markdown format
+- The user can fill in their profile.yml with target roles and compensation
+
+The skill gracefully degrades — if career-ops is not yet installed, it guides the user through setup rather than failing.
+
+## Skill Triggers
+
+- "evaluate job", "evaluate offer", "career-ops"
+- "scan portals", "find jobs", "job search"
+- "generate CV", "PDF resume", "ATS resume"
+- "track applications", "my applications"
+- "compare offers"
+- "LinkedIn outreach"
+- "fill application form", "application form"
+- "company research", "deep research company"

--- a/skills/productivity/career-ops/SKILL.md
+++ b/skills/productivity/career-ops/SKILL.md
@@ -1,0 +1,263 @@
+---
+name: career-ops
+description: AI-powered job search pipeline — evaluate offers, generate ATS-optimized PDFs, scan portals, track applications, and manage your entire job search. Built as a wrapper around github.com/santifer/career-ops with 14 skill modes for autonomous AI agents.
+version: 1.0.0
+author: Hermes Agent (wrapper skill)
+credits: "Based on career-ops by santifer — https://github.com/santifer/career-ops"
+license: MIT
+metadata:
+  hermes:
+    tags: [job-search, career, cv, pdf, ATS, portal-scanner, offer-evaluation, tracking, employment]
+    triggers: ["evaluate job offer", "scan portals", "generate CV PDF", "track applications", "compare offers", "LinkedIn outreach", "fill application form", "job application pipeline", "career-ops", "job hunt"]
+    category: productivity
+---
+
+# Career-Ops — AI Job Search Command Center (Hermes Agent Skill)
+
+## What This Is
+
+A **Hermes Agent skill** that wraps the [career-ops](https://github.com/santifer/career-ops) system — an open-source AI-powered job search pipeline. This skill tells Hermes how to use career-ops' 14 modes to evaluate job offers, generate tailored PDFs, scan 45+ company portals, and track applications — all autonomously.
+
+**Purpose:** Help people find better jobs faster by leveraging AI to evaluate offers intelligently, generate ATS-optimized resumes, and manage the entire job search pipeline — without the manual spreadsheet tracking.
+
+## Why Bundle This in Hermes Agent
+
+Job searching is a high-effort, high-stakes process that benefits enormously from AI assistance. career-ops brings:
+
+- **Structured evaluation** with 10-dimension weighted scoring (North Star alignment, CV match, comp research, etc.)
+- **ATS-optimized PDF generation** — tailored per job description with keyword injection
+- **Portal scanning** — 45+ companies pre-configured across Ashby, Greenhouse, Lever, Wellfound
+- **Interview preparation** — STAR+Reflection story banks, negotiation scripts
+- **Batch processing** — evaluate 10+ offers in parallel via sub-agents
+- **Application tracking** — single source of truth with dedup and integrity checks
+
+This is exactly the kind of persistent, multi-step, quality-over-quantity task that Hermes agents excel at. Wrapping it as a skill means any Hermes agent can run a full job search pipeline on behalf of the user — not just one-shot evaluation but ongoing scanning, tracking, and follow-up.
+
+## How It Works
+
+The skill points Hermes to the **career-ops workspace** on the local machine (see Setup section below). From there, Hermes reads:
+
+- `cv.md` — the user's CV in markdown (source of truth)
+- `config/profile.yml` — name, target roles, compensation, location preferences
+- `portals.yml` — companies and search queries for the scanner
+- `modes/*.md` — 14 mode files defining how each career-ops command works
+- `templates/cv-template.html` — ATS-optimized PDF template
+- `generate-pdf.mjs` — Playwright HTML→PDF generator
+
+**The skill itself is just the wrapper/interface. The actual career-ops system is the separate repo.**
+
+## Setup
+
+### One-Time Setup
+
+The first time a user invokes this skill, Hermes must complete onboarding:
+
+**Step 1 — Clone or locate career-ops:**
+```bash
+# If career-ops doesn't exist yet:
+git clone https://github.com/santifer/career-ops.git /path/to/career-ops
+
+# The skill detects the career-ops directory via:
+# - Environment variable: CAREER_OPS_PATH (if set)
+# - Default fallback: ./career-ops (relative to hermes-agent root)
+# - User-specified path via configuration
+```
+
+**Step 2 — Create cv.md** in the career-ops root:
+- User pastes their CV in markdown format, OR
+- User pastes a LinkedIn URL (Hermes extracts key info), OR
+- User describes their experience and Hermes drafts a CV
+
+**Step 3 — Configure profile:**
+```bash
+cp career-ops/config/profile.example.yml career-ops/config/profile.yml
+# Edit with: name, email, location, target roles, salary range, superpowers
+```
+
+**Step 4 — Configure portals (optional but recommended):**
+```bash
+cp career-ops/templates/portals.example.yml career-ops/portals.yml
+# Edit with target role keywords and companies to track
+```
+
+**Step 5 — Install dependencies:**
+```bash
+cd career-ops && npm install && npx playwright install chromium
+```
+
+### Verify Setup
+```bash
+cd $CAREER_OPS_PATH
+node cv-sync-check.mjs      # Should report "All checks passed"
+node verify-pipeline.mjs    # Should report "Pipeline is clean"
+```
+
+## The 14 Skill Modes
+
+When the user invokes career-ops, Hermes selects the appropriate mode:
+
+| Mode | Trigger | What It Does |
+|------|---------|-------------|
+| **auto-pipeline** | User pastes job URL/text | Full pipeline: evaluate → report → PDF → tracker |
+| **oferta** | "evaluate this offer" | 6-block evaluation: role summary, CV match, level strategy, comp, personalization, interview plan |
+| **ofertas** | "compare these offers" | 10-dimension weighted scoring, ranking, recommendation |
+| **pdf** | "generate CV PDF" | ATS-optimized PDF tailored to specific JD |
+| **scan** | "scan portals" / "find jobs" | 3-level discovery: Playwright + Greenhouse API + WebSearch, dedup, add to pipeline |
+| **pipeline** | "process pending URLs" | Process all URLs in data/pipeline.md |
+| **batch** | "batch evaluate" | Parallel sub-agent evaluation with conductor script |
+| **tracker** | "show my applications" | Application status table + statistics |
+| **apply** | "fill application form" | Live form assistant — extract questions, generate personalized answers |
+| **contacto** | "LinkedIn outreach" | 3-phrase outreach message framework for hiring managers/recruiters |
+| **deep** | "research this company" | 6-axis deep research prompt for interview prep |
+| **project** | "evaluate this project idea" | 6-dimension scoring for portfolio projects |
+| **training** | "evaluate this course/cert" | 6-dimension scoring for education investments |
+| **apply** | (see above) | |
+
+## Global Rules (Always Follow)
+
+### NEVER
+1. Invent experience or metrics
+2. Submit applications on behalf of the user — generate drafts only
+3. Share phone number in generated messages
+4. Recommend comp below market rate
+5. Generate a PDF without reading the JD first
+6. Use corporate-speak or fluff
+7. Ignore the tracker — every evaluated offer gets registered
+
+### ALWAYS
+1. Read cv.md + article-digest.md (if exists) before evaluating any offer
+2. Run `node cv-sync-check.mjs` at the start of each session
+3. Detect the role archetype and adapt framing
+4. Cite exact lines from CV when matching
+5. Use WebSearch for comp and company data
+6. Register in tracker after evaluating
+7. Generate content in the language of the JD (EN default)
+8. Include `**URL:**` in every report header
+9. Tracker additions go to `batch/tracker-additions/` — never edit applications.md directly
+10. Use Playwright (not WebSearch) to verify if an offer is still active
+
+## Report Format (for oferta mode)
+
+Every evaluation saves a report to `reports/{###}-{company-slug}-{YYYY-MM-DD}.md`:
+
+```markdown
+# Evaluación: {Empresa} — {Rol}
+
+**Fecha:** {YYYY-MM-DD}
+**Arquetipo:** {detected}
+**Score:** {X/5}
+**URL:** {url}
+**PDF:** {path or pendiente}
+
+---
+
+## A) Resumen del Rol
+## B) Match con CV
+## C) Nivel y Estrategia
+## D) Comp y Demanda
+## E) Plan de Personalización
+## F) Plan de Entrevistas
+## G) Draft Application Answers (score >= 4.5 only)
+
+---
+
+## Keywords extraídas
+(list of 15-20 ATS keywords)
+```
+
+## Archetypes (Role Classification)
+
+The system classifies every job into one of 6 archetypes to adapt proof point framing:
+
+| Archetype | Emphasize... |
+|-----------|--------------|
+| **AI Business Builder / Founder** | End-to-end product ownership, product-market fit, revenue |
+| **AI Solutions Architect** | Consulting delivery, AI implementation, workflow transformation |
+| **AI Transformation Lead** | Change management, AI adoption, org-level impact |
+| **AI GTM / Product Strategist** | Go-to-market, product strategy, demand generation |
+| **AI Operations / Head of AI** | Distributed team leadership, AI workflows, execution |
+| **AI Consulting Director** | Client delivery, strategy, revenue, consulting engagements |
+
+Customize archetypes by editing `modes/_shared.md` in the career-ops directory.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `cv.md` | User's CV — source of truth for all evaluations |
+| `article-digest.md` | (Optional) Detailed proof points with metrics |
+| `config/profile.yml` | Identity, target roles, compensation, narrative |
+| `portals.yml` | Companies and search queries for portal scanner |
+| `data/applications.md` | Application tracker with scores and status |
+| `data/pipeline.md` | Inbox of pending job URLs |
+| `modes/_shared.md` | Shared context, archetypes, rules (customize here) |
+| `templates/cv-template.html` | HTML template for ATS-optimized PDFs |
+| `generate-pdf.mjs` | Playwright HTML→PDF script |
+| `batch/batch-prompt.md` | Worker prompt for parallel batch evaluation |
+
+## NPM Scripts
+
+```bash
+cd $CAREER_OPS_PATH
+
+node verify-pipeline.mjs      # Check pipeline integrity
+node normalize-statuses.mjs  # Normalize all status values
+node dedup-tracker.mjs       # Deduplicate tracker entries
+node merge-tracker.mjs       # Merge batch tracker additions → applications.md
+node cv-sync-check.mjs       # Check CV vs config consistency
+```
+
+## Portal Scanner — Pre-configured Companies (45+)
+
+**AI Labs:** Anthropic, OpenAI, Mistral, Cohere, LangChain, Pinecone  
+**Voice AI:** ElevenLabs, PolyAI, Parloa, Hume AI, Deepgram, Vapi, Bland AI  
+**AI Platforms:** Retool, Airtable, Vercel, Temporal, Glean, Arize AI  
+**Contact Center:** Ada, LivePerson, Sierra, Decagon, Talkdesk, Genesys  
+**Enterprise:** Salesforce, Twilio, Gong, Dialpad  
+**LLMOps:** Langfuse, Weights & Biases, Lindy, Cognigy, Speechmatics  
+**Automation:** n8n, Zapier, Make.com  
+**European:** Factorial, Attio, Tinybird, Clarity AI, Travelperk
+
+**Job boards searched:** Ashby, Greenhouse, Lever, Wellfound, Workable, RemoteFront
+
+## Dashboard TUI (Optional)
+
+A Go-based terminal dashboard for browsing the pipeline visually:
+
+```bash
+cd $CAREER_OPS_PATH/dashboard
+go build -o career-dashboard .
+./career-dashboard
+```
+
+Requires: Go 1.21+
+
+## Customization
+
+The system is designed to be customized. Users can ask Hermes to:
+- "Change archetypes to [specific roles]" → edit `modes/_shared.md`
+- "Update my profile" → edit `config/profile.yml`
+- "Add these companies to my portals" → edit `portals.yml`
+- "Change CV template design" → edit `templates/cv-template.html`
+- "Adjust scoring weights" → edit `modes/_shared.md` and `batch/batch-prompt.md`
+
+## Credits
+
+This skill is a **wrapper** for the career-ops system built by [santifer](https://santifer.io).
+
+**Original repo:** https://github.com/santifer/career-ops
+
+The career-ops system was used to evaluate 740+ job offers, generate 100+ tailored CVs, and land a Head of Applied AI role. It is designed to be personalized — the archetypes, scoring, negotiation scripts, and modes can all be adapted to the user's specific career targets.
+
+This Hermes skill wrapper enables any Hermes agent to invoke career-ops capabilities on behalf of the user — making AI-powered job search automation accessible through natural language commands.
+
+---
+
+## Ethical Use
+
+**This system is designed for quality, not quantity.** The goal is to help users find and apply to roles where there is a genuine match — not to spam companies with mass applications.
+
+- **NEVER submit an application without the user reviewing it first.** Generate drafts only.
+- **Discourage low-fit applications.** If a score is below 3.0/5, explicitly recommend skipping.
+- **Quality over speed.** A well-targeted application to 5 companies beats a generic blast to 50.
+- **Respect recruiters' time.** Every application a human reads costs someone's attention.


### PR DESCRIPTION
## Summary

Add `skills/productivity/career-ops` — a wrapper skill that brings the [career-ops](https://github.com/santifer/career-ops) AI job search pipeline into Hermes Agent.

## Why This Skill Is Good for Hermes Agent

Job searching is a high-effort, high-stakes process that benefits enormously from AI assistance. career-ops brings:

- **Structured evaluation** with 10-dimension weighted scoring (North Star alignment, CV match, comp research, seniority, growth trajectory, etc.)
- **ATS-optimized PDF generation** — tailored per job description with keyword injection, custom formatting
- **Portal scanning** — 45+ companies pre-configured across Ashby, Greenhouse, Lever, Wellfound, Workable
- **Interview preparation** — STAR+Reflection story banks, negotiation scripts, case study recommendations  
- **Batch processing** — evaluate 10+ offers in parallel via sub-agents
- **Application tracking** — single source of truth with dedup and integrity checks
- **6 role archetypes** — AI Business Builder, Solutions Architect, Transformation Lead, GTM Strategist, Operations Lead, Consulting Director

This is exactly the kind of persistent, multi-step, quality-over-quantity task that Hermes agents excel at. Wrapping it as a skill means any Hermes agent can run a full job search pipeline on behalf of the user.

## What the Skill Does

The skill acts as an **interface wrapper** — it tells Hermes how to invoke career-ops' 14 modes:

| Mode | Trigger | What It Does |
|------|---------|-------------|
| auto-pipeline | User pastes job URL/text | Full pipeline: evaluate → report → PDF → tracker |
| oferta | Evaluate single offer | 6-block structured analysis |
| ofertas | Compare multiple offers | 10-dimension weighted scoring |
| pdf | Generate CV PDF | ATS-optimized, keyword-injected per JD |
| scan | Scan portals | 3-level discovery + dedup |
| tracker | Show applications | Status table + statistics |
| apply | Fill application form | Live form assistant |
| contacto | LinkedIn outreach | 3-phrase message framework |
| deep | Company research | 6-axis research prompt |
| project | Evaluate portfolio project | 6-dimension scoring |
| training | Evaluate course/cert | 6-dimension scoring |

## Architecture

The skill itself is the wrapper/interface. The actual career-ops logic runs from a local directory ( or similar) cloned from [github.com/santifer/career-ops](https://github.com/santifer/career-ops).

The skill:
1. Detects the career-ops installation on the local machine
2. Guides the user through one-time onboarding (cv.md, profile.yml, portals.yml)
3. Routes user commands to the appropriate career-ops mode
4. Manages report generation, PDF creation, and tracker updates

## Files Added



## Credits

This skill is a **wrapper** for career-ops built by [santifer](https://github.com/santifer/career-ops).

> career-ops was used to evaluate 740+ job offers, generate 100+ tailored CVs, and land a Head of Applied AI role. See: https://github.com/santifer/career-ops

## Ethical Use

The skill enforces quality over quantity:
- Never submit applications on behalf of the user — generate drafts only
- Score below 3.0/5 → explicitly recommend skipping
- Tracker additions go to batch queue — never edit applications.md directly

---

**Labels:** skills, productivity, enhancement