### PR TITLE
feat(irc): add IRC support

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -285,6 +285,12 @@ PLATFORM_HINTS = {
         "only — no markdown, no formatting. SMS messages are limited to ~1600 "
         "characters, so be brief and direct."
     ),
+    "irc": (
+        "You are on IRC (Internet Relay Chat). "
+        "Markdown is supported and will be rendered. "
+        "IRC has no native file transfer — include MEDIA:/path for files and they will be uploaded to a configured host. "
+        "Individual messages are limited to ~512 bytes per line."
+    ),
 }
 
 CONTEXT_FILE_MAX_CHARS = 20_000

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -196,6 +196,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> None:
         "wecom": Platform.WECOM,
         "email": Platform.EMAIL,
         "sms": Platform.SMS,
+        "irc": Platform.IRC,
     }
     platform = platform_map.get(platform_name.lower())
     if not platform:

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -63,6 +63,7 @@ class Platform(Enum):
     WEBHOOK = "webhook"
     FEISHU = "feishu"
     WECOM = "wecom"
+    IRC = "irc"
 
 
 @dataclass
@@ -286,6 +287,9 @@ class GatewayConfig:
                 connected.append(platform)
             # WeCom uses extra dict for bot credentials
             elif platform == Platform.WECOM and config.extra.get("bot_id"):
+                connected.append(platform)
+            # IRC uses extra dict for server/nick
+            elif platform == Platform.IRC and config.extra.get("server"):
                 connected.append(platform)
         return connected
     
@@ -924,6 +928,32 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 name=os.getenv("WECOM_HOME_CHANNEL_NAME", "Home"),
             )
 
+    # IRC
+    irc_server = os.getenv("IRC_SERVER")
+    irc_nick = os.getenv("IRC_NICK")
+    if irc_server and irc_nick:
+        if Platform.IRC not in config.platforms:
+            config.platforms[Platform.IRC] = PlatformConfig()
+        config.platforms[Platform.IRC].enabled = True
+        config.platforms[Platform.IRC].extra.update({
+            "server": irc_server,
+            "port": os.getenv("IRC_PORT", "6667"),
+            "nick": irc_nick,
+            "password": os.getenv("IRC_PASSWORD", ""),
+            "use_tls": os.getenv("IRC_USE_TLS", "").lower() in ("true", "1", "yes"),
+            "channels": os.getenv("IRC_CHANNELS", ""),
+            "message_chunk_limit": int(os.getenv("IRC_MESSAGE_CHUNK_LIMIT", "350")),
+            "require_multiline": os.getenv("IRC_REQUIRE_MULTILINE", "").lower() in ("true", "1", "yes"),
+            "nickserv_password": os.getenv("IRC_NICKSERV_PASSWORD", ""),
+            "nickserv_service": os.getenv("IRC_NICKSERV_SERVICE", "NickServ"),
+        })
+        irc_home = os.getenv("IRC_HOME_CHANNEL")
+        if irc_home:
+            config.platforms[Platform.IRC].home_channel = HomeChannel(
+                platform=Platform.IRC,
+                chat_id=irc_home,
+                name=os.getenv("IRC_HOME_CHANNEL_NAME", "Home"),
+            )
     # Session settings
     idle_minutes = os.getenv("SESSION_IDLE_MINUTES")
     if idle_minutes:

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1476,6 +1476,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
     def _on_message_event(self, data: Any) -> None:
         """Normalize Feishu inbound events into MessageEvent."""
+        logger.info("[Feishu] _on_message_event called with data: %s", type(data).__name__)
         if self._loop is None:
             logger.warning("[Feishu] Dropping inbound message before adapter loop is ready")
             return
@@ -1495,12 +1496,13 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.debug("[Feishu] Dropping malformed inbound event: missing message or sender_id")
             return
 
+        # Debug log: show sender type for all messages
+        sender_type = getattr(sender, "sender_type", "")
+        logger.debug("[Feishu] Inbound message from sender_type=%s, sender_id=%s", sender_type, sender_id)
+
         message_id = getattr(message, "message_id", None)
         if not message_id or self._is_duplicate(message_id):
             logger.debug("[Feishu] Dropping duplicate/missing message_id: %s", message_id)
-            return
-        if getattr(sender, "sender_type", "") == "bot":
-            logger.debug("[Feishu] Dropping bot-originated event: %s", message_id)
             return
 
         chat_type = getattr(message, "chat_type", "p2p")

--- a/gateway/platforms/irc.py
+++ b/gateway/platforms/irc.py
@@ -1,0 +1,772 @@
+"""IRC gateway adapter.
+
+Connects to any IRC server (IRCd) via asyncio sockets with IRCv3 protocol
+support, including draft/multiline for multiline messages.
+
+Environment variables:
+    IRC_SERVER           IRC server hostname (e.g. irc.libera.chat)
+    IRC_PORT             IRC server port (default: 6667, use 6697 for TLS)
+    IRC_NICK             Bot nickname
+    IRC_USERNAME          Username for USER command (default: IRC_NICK)
+    IRC_REALNAME         Realname for USER command (default: "Hermes Agent")
+    IRC_PASSWORD         Server password (optional)
+    IRC_CHANNELS         Comma-separated list of channels to join (e.g. #bots,#help)
+    IRC_USE_TLS          Set "true" to enable TLS (default: false)
+    IRC_MESSAGE_CHUNK_LIMIT  Max characters per message when BATCH unavailable (default: 350)
+    IRC_REQUIRE_MULTILINE Set "true" to fail connection if server doesn't support draft/multiline (default: false)
+    IRC_NICKSERV_PASSWORD NickServ password for authentication (optional)
+    IRC_NICKSERV_SERVICE NickServ service name (default: NickServ)
+    IRC_ALLOWED_USERS    Comma-separated nicks/hosts allowed to command bot
+    IRC_HOME_CHANNEL     Default channel for cron/notification delivery
+
+Notes:
+    - IRC is text-only; no media support (images, voice, documents)
+    - Markdown is supported and will be rendered
+    - Uses IRCv3 draft/multiline for sending multiline messages when available
+    - Falls back to splitting multiline messages into separate PRIVMSG when
+      draft/multiline is not supported by the server
+    - Message length is limited to ~512 bytes per IRC protocol
+    - NickServ authentication sends IDENTIFY after successful registration (001)
+    - Nick collision (433/436 errors) attempts fallback nick with "_" suffix
+      then gives up as fatal error
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import ssl
+import time
+from typing import Any, Dict, List, Optional, Set
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+    SessionSource,
+)
+
+logger = logging.getLogger(__name__)
+
+# Grace period: ignore messages older than this many seconds before startup.
+_STARTUP_GRACE_SECONDS = 5
+
+# Regex patterns for IRC protocol parsing
+# Updated to support IRCv3 message tags: @tag=value;tag2=value2 PREFIX COMMAND ...
+IRC_MESSAGE_RE = re.compile(
+    r"(?:@(?P<tags>[^ ]+) )?(?::(?P<prefix>[^ ]+) )?(?P<command>[A-Z0-9]+)(?P<params>(?: [^ :][^ ]*)*)?(?: :(?P<trailing>.*))?"
+)
+
+IRC_PREFIX_RE = re.compile(
+    r"(?P<nick>[^!@]+)(?:!(?P<user>[^@]+))?(?:@(?P<host>.+))?"
+)
+
+
+def parse_tags(tags_str: str) -> Dict[str, str]:
+    """Parse IRCv3 message tags into a dictionary."""
+    if not tags_str:
+        return {}
+    tags = {}
+    for tag in tags_str.split(";"):
+        tag = tag.strip()
+        if not tag:
+            continue
+        if "=" in tag:
+            key, value = tag.split("=", 1)
+            # Unescape tag values per IRCv3 spec
+            value = value.replace(r"\:", ";").replace(r"\s", " ").replace(r"\\", "\\").replace(r"\r", "\r").replace(r"\n", "\n").replace(r"\0", "\0")
+            tags[key] = value
+        else:
+            tags[tag] = ""
+    return tags
+
+
+def check_irc_requirements() -> bool:
+    """Return True if the IRC adapter can be used."""
+    server = os.getenv("IRC_SERVER", "")
+    nick = os.getenv("IRC_NICK", "")
+    if not server or not nick:
+        logger.debug("IRC: IRC_SERVER or IRC_NICK not set")
+        return False
+    return True
+
+
+class IRCAdapter(BasePlatformAdapter):
+    """Gateway adapter for IRC (any server)."""
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform.IRC)
+
+        # Connection settings
+        self._server: str = os.getenv("IRC_SERVER", "")
+        self._port: int = int(os.getenv("IRC_PORT", "6667"))
+        self._nick: str = os.getenv("IRC_NICK", "")
+        self._username: str = os.getenv("IRC_USERNAME", "") or self._nick  # Default to nick if username not set
+        self._realname: str = os.getenv("IRC_REALNAME", "") or "Hermes Agent"  # Default to "Hermes Agent" if not set
+        self._password: str = os.getenv("IRC_PASSWORD", "")
+        self._use_tls: bool = os.getenv("IRC_USE_TLS", "").lower() in ("true", "1", "yes")
+
+        # Channels to join
+        channels_str = os.getenv("IRC_CHANNELS", "")
+        self._channels: Set[str] = {
+            ch.strip() if ch.strip().startswith("#") else f"#{ch.strip()}"
+            for ch in channels_str.split(",")
+            if ch.strip()
+        }
+
+        # Message chunk limit for long messages (when BATCH unavailable)
+        self._message_chunk_limit: int = int(os.getenv("IRC_MESSAGE_CHUNK_LIMIT", "350"))
+
+        # Require draft/multiline support (fail if server doesn't support it)
+        self._require_multiline: bool = os.getenv("IRC_REQUIRE_MULTILINE", "").lower() in ("true", "1", "yes")
+
+        # Warn if multiline is required but chunk limit is at default
+        if self._require_multiline and self._message_chunk_limit == 350:
+            logger.warning(
+                "IRC: require_multiline is enabled but message_chunk_limit is at default (350). "
+                "Consider increasing message_chunk_limit or disabling require_multiline to avoid unnecessary chunking."
+            )
+
+        # Connection state
+        self._reader: Optional[asyncio.StreamReader] = None
+        self._writer: Optional[asyncio.StreamWriter] = None
+        self._reader_task: Optional[asyncio.Task] = None
+        self._ping_task: Optional[asyncio.Task] = None
+        self._closing = False
+        self._startup_ts: float = 0.0
+        self._registered = False
+
+        # Message deduplication (bounded)
+        from collections import deque
+        self._processed_msgs: deque = deque(maxlen=500)
+        self._processed_msgs_set: set = set()
+
+        # IRCv3 multiline/draft support
+        self._multiline_cap: bool = False
+        self._batch_counter: int = 0
+        self._incoming_batches: Dict[str, List[Dict[str, Any]]] = {}
+        self._multiline_batch_ids: Set[str] = set()
+        self._cap_negotiated: bool = False
+        self._cap_negotiation_complete = asyncio.Event()
+        self._accumulated_caps: str = ""  # Accumulate caps from multi-chunk CAP LS
+
+        # NickServ authentication
+        self._nickserv_password: str = os.getenv("IRC_NICKSERV_PASSWORD", "")
+        self._nickserv_service: str = os.getenv("IRC_NICKSERV_SERVICE", "NickServ")
+
+        # Nick collision handling
+        # _nick = original configured name (what we wanted)
+        # _actual_nick = what server actually accepted (what we got)
+        self._actual_nick: str = self._nick  # Initially same, changes on collision
+        self._nick_collision_attempted: bool = False
+
+    def _parse_prefix(self, prefix: str) -> Dict[str, str]:
+        """Parse IRC prefix into nick, user, host components."""
+        match = IRC_PREFIX_RE.match(prefix or "")
+        if match:
+            return {
+                "nick": match.group("nick") or "",
+                "user": match.group("user") or "",
+                "host": match.group("host") or "",
+            }
+        return {"nick": prefix or "", "user": "", "host": ""}
+
+    def _parse_message(self, line: str) -> Optional[Dict[str, Any]]:
+        """Parse an IRC protocol line into components."""
+        match = IRC_MESSAGE_RE.match(line.rstrip("\r\n"))
+        if not match:
+            return None
+        return {
+            "tags": parse_tags(match.group("tags") or ""),
+            "prefix": match.group("prefix") or "",
+            "command": match.group("command") or "",
+            "params": (match.group("params") or "").strip().split(),
+            "trailing": match.group("trailing") or "",
+        }
+
+    def _build_source(self, prefix: str, channel: str) -> SessionSource:
+        """Build a SessionSource from IRC message metadata."""
+        parsed = self._parse_prefix(prefix)
+        nick = parsed.get("nick", "unknown")
+        host = parsed.get("host", "")
+
+        return SessionSource(
+            platform=Platform.IRC,
+            chat_id=channel,
+            user_id=f"{nick}@{host}" if host else nick,
+            user_name=nick,
+            chat_type="group" if channel.startswith("#") else "dm",
+        )
+
+    # ------------------------------------------------------------------
+    # Required overrides
+    # ------------------------------------------------------------------
+
+    async def connect(self) -> bool:
+        """Connect to the IRC server and join channels."""
+        logger.debug("IRC: connect() called - server=%s, nick=%s, port=%s, tls=%s", self._server, self._nick, self._port, self._use_tls)
+        logger.debug("IRC: Channels to join: %s", list(self._channels))
+        if not self._server or not self._nick:
+            logger.error("IRC: server or nick not configured")
+            return False
+
+        try:
+            logger.debug("IRC: Attempting to open_connection to %s:%s", self._server, self._port or 6667)
+            # Open connection
+            if self._use_tls:
+                ssl_context = ssl.create_default_context()
+                self._reader, self._writer = await asyncio.open_connection(
+                    self._server, self._port or 6697, ssl=ssl_context
+                )
+            else:
+                self._reader, self._writer = await asyncio.open_connection(
+                    self._server, self._port or 6667
+                )
+            logger.debug("IRC: Connection established successfully")
+        except Exception as exc:
+            logger.error("IRC: failed to connect to %s:%s: %s", self._server, self._port, exc)
+            return False
+
+        self._closing = False
+        self._startup_ts = time.time()
+
+        # Reset CAP negotiation state
+        self._cap_negotiated = False
+        self._cap_negotiation_complete.clear()
+
+        # Start reader loop
+        logger.debug("IRC: About to start reader_task")
+        self._reader_task = asyncio.create_task(self._reader_loop())
+        logger.debug("IRC: reader_task created")
+
+        # Add exception handler for reader task
+        def _reader_exception_handler(task):
+            try:
+                exc = task.exception()
+                logger.debug("IRC: Reader task died with exception: %s", exc)
+            except asyncio.CancelledError:
+                logger.debug("IRC: Reader task was cancelled")
+            except Exception as e:
+                logger.error("IRC: Reader task exception handler error: %s", e)
+
+        self._reader_task.add_done_callback(_reader_exception_handler)
+
+        # Start CAP negotiation for draft/multiline support
+        self._send_line("CAP LS 302")
+
+        # Send registration
+        if self._password:
+            self._send_line(f"PASS {self._password}")
+        self._send_line(f"NICK {self._nick}")
+        self._send_line(f"USER {self._username} 0 * :{self._realname}")
+
+        # Wait for registration (001 reply) with timeout
+        logger.debug("IRC: Waiting for registration (001 reply)...")
+        for i in range(450):  # 45 seconds max (slow networks)
+            if self._registered:
+                logger.debug("IRC: Registered after %.1f seconds", i * 0.1)
+                break
+            await asyncio.sleep(0.1)
+        else:
+            logger.error("IRC: registration timeout")
+            await self.disconnect()
+            return False
+
+        # Wait for CAP negotiation to complete (multiline support)
+        try:
+            await asyncio.wait_for(self._cap_negotiation_complete.wait(), timeout=5.0)
+        except asyncio.TimeoutError:
+            logger.warning("IRC: CAP negotiation timeout, proceeding without multiline support")
+
+        # Join configured channels
+        logger.debug("IRC: Joining channels: %s", list(self._channels))
+        for channel in self._channels:
+            logger.debug("IRC: Sending JOIN %s", channel)
+            self._send_line(f"JOIN {channel}")
+            logger.info("IRC: joined %s", channel)
+
+        # Start PING task
+        self._ping_task = asyncio.create_task(self._ping_loop())
+
+        self._mark_connected()
+        logger.info("IRC: connected to %s as %s", self._server, self._nick)
+
+        # Start a heartbeat to check if reader is still alive
+        async def _reader_heartbeat():
+            count = 0
+            while not self._closing and self._reader:
+                await asyncio.sleep(5)
+                count += 1
+                if self._reader_task and self._reader_task.done():
+                    logger.warning("IRC: Reader task is DONE at %ds!", count * 5)
+                elif not self._closing:
+                    logger.debug("IRC: Reader still running at %ds", count * 5)
+
+        asyncio.create_task(_reader_heartbeat())
+
+        return True
+
+    async def disconnect(self) -> None:
+        """Disconnect from IRC."""
+        self._closing = True
+
+        if self._ping_task and not self._ping_task.done():
+            self._ping_task.cancel()
+            try:
+                await self._ping_task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+        if self._reader_task and not self._reader_task.done():
+            self._reader_task.cancel()
+            try:
+                await self._reader_task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+        if self._writer:
+            try:
+                self._send_line("QUIT :Hermes Agent disconnecting")
+                await self._writer.drain()
+                self._writer.close()
+                await self._writer.wait_closed()
+            except Exception:
+                pass
+            self._writer = None
+
+        self._reader = None
+        self._registered = False
+        self._mark_disconnected()
+        logger.info("IRC: disconnected")
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a message to an IRC channel or user."""
+        if not content:
+            return SendResult(success=True)
+
+        if not self._writer:
+            return SendResult(success=False, error="Not connected")
+
+        has_newlines = "\n" in content
+
+        if self._multiline_cap and has_newlines:
+            # Use BATCH for multiline messages
+            # trim() removes trailing newlines but preserves blank lines in the middle (paragraph breaks)
+            lines = content.strip().split("\n")
+            self._batch_counter += 1
+            batch_id = f"m{self._batch_counter}"
+            self._send_line(f"BATCH +{batch_id} draft/multiline {chat_id}")
+            for line in lines:
+                # Send empty lines as a single space to preserve paragraph breaks
+                # without sending invalid empty PRIVMSG (just `:` which some servers reject)
+                line_content = line or " "
+                # Write directly to avoid _send_line for tag support
+                self._writer.write(f"@batch={batch_id} PRIVMSG {chat_id} :{line_content}\r\n".encode("utf-8"))
+            self._send_line(f"BATCH -{batch_id}")
+        else:
+            # Fallback: flatten newlines to spaces, then split at message_chunk_limit
+            flat = content.replace("\n", " ")
+            remaining = flat
+            while remaining:
+                if len(remaining) <= self._message_chunk_limit:
+                    # Send remaining text
+                    piece = remaining.strip()
+                    if piece:
+                        self._send_line(f"PRIVMSG {chat_id} :{piece}")
+                    break
+                # Find last space before limit
+                split_at = remaining.rfind(" ", 0, self._message_chunk_limit)
+                # If no space found before halfway point, split at limit
+                if split_at < self._message_chunk_limit // 2:
+                    split_at = self._message_chunk_limit
+                piece = remaining[:split_at].strip()
+                if piece:
+                    self._send_line(f"PRIVMSG {chat_id} :{piece}")
+                remaining = remaining[split_at:].lstrip()
+
+        try:
+            await self._writer.drain()
+            return SendResult(success=True)
+        except Exception as exc:
+            logger.error("IRC: failed to send to %s: %s", chat_id, exc)
+            return SendResult(success=False, error=str(exc), retryable=True)
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        """Return channel/user info."""
+        if chat_id.startswith("#"):
+            return {"name": chat_id, "type": "group", "chat_id": chat_id}
+        return {"name": chat_id, "type": "dm", "chat_id": chat_id}
+
+    # ------------------------------------------------------------------
+    # Optional overrides
+    # ------------------------------------------------------------------
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        """IRC has no typing indicator - no-op."""
+        pass
+
+    def format_message(self, content: str) -> str:
+        """Return content unchanged."""
+        return content
+
+    # ------------------------------------------------------------------
+    # IRC protocol helpers
+    # ------------------------------------------------------------------
+
+    def _send_line(self, line: str) -> None:
+        """Send a raw IRC line."""
+        if self._writer:
+            try:
+                self._writer.write((line + "\r\n").encode("utf-8"))
+            except Exception as exc:
+                logger.warning("IRC: failed to send line: %s", exc)
+
+    async def _reader_loop(self) -> None:
+        """Read and process incoming IRC messages."""
+        line_count = 0
+        logger.info("IRC: Reader loop starting")
+        while not self._closing and self._reader:
+            try:
+                line = await asyncio.wait_for(self._reader.readline(), timeout=300)
+                line_count += 1
+                if line_count < 5 or line_count % 100 == 0:
+                    logger.debug("IRC: Read line #%d: %d bytes", line_count, len(line))
+            except asyncio.TimeoutError:
+                logger.warning("IRC: read timeout, connection may be dead")
+                continue
+            except asyncio.CancelledError:
+                logger.info("IRC: Reader loop cancelled")
+                break
+            except Exception as exc:
+                if not self._closing:
+                    logger.error("IRC: read error: %s", exc)
+                break
+
+            if not line:
+                if not self._closing:
+                    logger.warning("IRC: connection closed by server")
+                break
+
+            try:
+                line = line.decode("utf-8", errors="replace").strip()
+            except Exception as exc:
+                logger.error("IRC: decode error: %s", exc)
+                continue
+
+            if not line:
+                continue
+
+            await self._handle_line(line)
+
+    async def _handle_line(self, line: str) -> None:
+        """Parse and handle an incoming IRC line."""
+        logger.debug("IRC: Received line: %s", line[:200])
+
+        msg = self._parse_message(line)
+        if not msg:
+            logger.debug("IRC: Failed to parse line: %s", line[:100])
+            return
+
+        cmd = msg["command"]
+        prefix = msg["prefix"]
+        params = msg["params"]
+        trailing = msg["trailing"]
+
+        # Log ALL commands for debugging
+        if cmd not in ("PING", "PONG"):
+            logger.debug("IRC: Parsed cmd=%s prefix=%s params=%s trailing=%s",
+                      cmd, prefix[:30] if prefix else "none",
+                      params[:5] if params else "none",
+                      trailing[:50] if trailing else "none")
+
+        logger.debug("IRC: Parsed command=%s prefix=%s params=%s", cmd, prefix[:50] if prefix else "", params)
+
+        # Handle PING
+        if cmd == "PING":
+            logger.debug("IRC: PING received, sending PONG")
+            self._send_line(f"PONG :{trailing}")
+            return
+
+        # Handle CAP LS for draft/multiline support
+        if cmd == "CAP" and len(params) >= 2 and params[1] == "LS":
+            # Accumulate caps from each chunk - capability can be in trailing OR params[2]
+            caps = trailing if trailing else (params[2] if len(params) >= 3 else "")
+            self._accumulated_caps += " " + caps.lower()
+            # params[2] === "*" means more chunks coming; wait for final chunk
+            if len(params) >= 3 and params[2] == "*":
+                return
+            # Final chunk - process accumulated caps
+            if "draft/multiline" in self._accumulated_caps:
+                self._send_line("CAP REQ :draft/multiline")
+            else:
+                if self._require_multiline:
+                    # Fail connection if multiline is required but not available
+                    logger.error("IRC: draft/multiline required but not supported by server")
+                    self._set_fatal_error("multiline_required", "Server does not support draft/multiline", retryable=False)
+                    self._send_line("QUIT")
+                    return
+                self._cap_negotiated = True
+                self._cap_negotiation_complete.set()
+                self._send_line("CAP END")
+            return
+
+        # Handle CAP ACK
+        if cmd == "CAP" and len(params) >= 2 and params[1] == "ACK":
+            # Capability can be in trailing OR in params[2] depending on server
+            acked = trailing.lower() if trailing else (params[2].lower() if len(params) >= 3 else "")
+            if "draft/multiline" in acked:
+                self._multiline_cap = True
+                logger.info("IRC: draft/multiline capability enabled")
+            self._cap_negotiated = True
+            self._cap_negotiation_complete.set()
+            self._send_line("CAP END")
+            return
+
+        # Handle CAP NAK
+        if cmd == "CAP" and len(params) >= 2 and params[1] == "NAK":
+            rejected = trailing.lower() if trailing else (params[2].lower() if len(params) >= 3 else "")
+            if self._require_multiline and "draft/multiline" in rejected:
+                # Fail connection if multiline is required but server rejected it
+                logger.error("IRC: draft/multiline required but server rejected CAP REQ")
+                self._set_fatal_error("multiline_required", "Server rejected draft/multiline capability", retryable=False)
+                self._send_line("QUIT")
+                return
+            self._cap_negotiated = True
+            self._cap_negotiation_complete.set()
+            self._send_line("CAP END")
+            return
+
+        # Handle BATCH commands for draft/multiline
+        if cmd == "BATCH":
+            await self._handle_batch(params, trailing)
+            return
+
+        # Handle JOIN confirmation
+        if cmd == "JOIN":
+            logger.info("IRC: JOIN confirmed: %s (we are now in the channel)", trailing)
+            return
+
+        # Handle numeric 353 (RPL_NAMREPLY) - list of users in channel
+        if cmd == "353":
+            logger.info("IRC: Users in channel %s: %s", params[2] if len(params) > 2 else "unknown", trailing[:200])
+            return
+
+        # Handle nick collision (433/436 errors) - only before registration
+        if cmd in ("433", "436") and not self._registered:
+            if not self._nick_collision_attempted:
+                # First attempt: try fallback nick with "_" suffix
+                self._nick_collision_attempted = True
+                fallback_nick = f"{self._nick}_"
+                # Sanitize: max 30 chars, remove invalid chars, strip whitespace
+                fallback_nick = fallback_nick.replace(" ", "")[:30]
+                fallback_nick = "".join(c for c in fallback_nick if c.isalnum() or c in "_-[]\\`^{}|")
+
+                if fallback_nick.lower() != self._actual_nick.lower():
+                    logger.warning("IRC: nick collision (error %s), trying fallback nick: %s", cmd, fallback_nick)
+                    self._actual_nick = fallback_nick
+                    self._send_line(f"NICK {fallback_nick}")
+                    return
+                else:
+                    logger.error("IRC: nick collision and fallback nick is same, cannot recover")
+                    self._set_fatal_error("nick_collision", f"Nickname {self._nick} is in use", retryable=False)
+                    self._send_line("QUIT")
+                    return
+            else:
+                # Already tried fallback, give up
+                logger.error("IRC: nick collision, already tried fallback nick, giving up")
+                self._set_fatal_error("nick_collision", f"Nickname {self._nick} is in use and fallback also failed", retryable=False)
+                self._send_line("QUIT")
+                return
+
+        # Handle registration confirmation
+        if cmd == "001":
+            self._registered = True
+            logger.info("IRC: registered with server")
+            # Fallback: if CAP negotiation didn't complete, resolve it now
+            if not self._cap_negotiated:
+                self._cap_negotiated = True
+                self._cap_negotiation_complete.set()
+
+            # Send NickServ IDENTIFY if configured
+            if self._nickserv_password:
+                nickserv_identify = f"PRIVMSG {self._nickserv_service} :IDENTIFY {self._nick} {self._nickserv_password}"
+                self._send_line(nickserv_identify)
+                logger.info("IRC: sent NickServ IDENTIFY")
+
+            return
+
+        # Handle PRIVMSG (actual chat messages)
+        if cmd == "PRIVMSG":
+            tags = msg["tags"]
+            await self._handle_privmsg(prefix, params, trailing, tags)
+            return
+
+        # Handle other commands as needed
+        if cmd == "KICK" and len(params) >= 2:
+            # We were kicked from a channel
+            channel = params[0]
+            target = params[1]
+            if target == self._actual_nick:
+                logger.warning("IRC: kicked from %s, rejoining in 5s", channel)
+                await asyncio.sleep(5)
+                self._send_line(f"JOIN {channel}")
+
+        elif cmd in ("ERROR",):
+            logger.error("IRC: server error: %s", trailing)
+            self._set_fatal_error("irc_error", trailing, retryable=True)
+
+    async def _handle_batch(
+        self, params: List[str], trailing: str
+    ) -> None:
+        """Handle BATCH commands for draft/multiline support."""
+        if not params:
+            return
+
+        batch_param = params[0] or trailing
+        if not batch_param:
+            return
+
+        if batch_param.startswith("+"):
+            # Start of batch - only track draft/multiline batches
+            batch_id = batch_param[1:]
+            batch_type = params[1].lower() if len(params) >= 2 else ""
+            if batch_type == "draft/multiline":
+                self._incoming_batches[batch_id] = []
+                self._multiline_batch_ids.add(batch_id)
+
+        elif batch_param.startswith("-"):
+            # End of batch - combine and emit only for multiline batches
+            batch_id = batch_param[1:]
+            messages = self._incoming_batches.pop(batch_id, [])
+            self._multiline_batch_ids.discard(batch_id)
+
+            if messages and self._message_handler:
+                # Combine all messages in the batch
+                first = messages[0]
+                combined_text = "\n".join(m["text"] for m in messages)
+
+                # Build session source
+                source = self._build_source(first["prefix"], first["chat_id"])
+
+                # Create message event
+                event = MessageEvent(
+                    text=combined_text,
+                    message_type=MessageType.TEXT,
+                    source=source,
+                    raw_message={
+                        "prefix": first["prefix"],
+                        "params": first["params"],
+                        "trailing": combined_text,
+                        "batch_id": batch_id,
+                    },
+                )
+
+                try:
+                    await self._message_handler(event)
+                except Exception as exc:
+                    logger.error("IRC: message handler error: %s", exc)
+
+    async def _handle_privmsg(
+        self, prefix: str, params: List[str], trailing: str, tags: Dict[str, str]
+    ) -> None:
+        """Handle an incoming PRIVMSG."""
+        if not params:
+            return
+
+        target = params[0]  # Channel or our nick (for DMs)
+        text = trailing
+
+        logger.info("IRC: PRIVMSG from %s to %s: %s", prefix, target, text[:100])
+
+        # Check if this message is part of a multiline batch *before* filtering empty text
+        batch_tag = tags.get("batch")
+        if batch_tag and batch_tag in self._multiline_batch_ids:
+            # Buffer the message for later
+            parsed = self._parse_prefix(prefix)
+            self._incoming_batches[batch_tag].append({
+                "prefix": prefix,
+                "params": params,
+                "text": text,  # preserve blank lines; joining happens at BATCH -<id>
+                "sender_nick": parsed.get("nick", ""),
+                "sender_user": parsed.get("user", ""),
+                "sender_host": parsed.get("host", ""),
+                "chat_id": target if target.startswith("#") else parsed.get("nick", prefix),
+            })
+            return  # Don't emit yet - wait for BATCH -<id>
+
+        if not text.strip():
+            return
+
+        # Determine if this is a channel message or DM
+        if target.startswith("#"):
+            chat_id = target
+
+            # For channels: only respond to messages that mention us at the beginning
+            # Must start with "<nickname>:" (colon immediately after nickname, no space)
+            # Check against original nick (what users will type) in case of collision
+            mention_pattern = re.compile(f"^{re.escape(self._nick)}:", re.IGNORECASE)
+            if not mention_pattern.match(text):
+                logger.debug("IRC: Filtered channel message (no mention): %s", text[:100])
+                return
+        else:
+            # DM - use sender's nick as chat_id
+            # DMs always respond, no mention filtering
+            parsed = self._parse_prefix(prefix)
+            chat_id = parsed.get("nick", prefix)
+
+        # Filter self-messages
+        parsed = self._parse_prefix(prefix)
+        sender_nick = parsed.get("nick", "")
+        if sender_nick == self._actual_nick:
+            logger.debug("IRC: Filtered self-message from %s", sender_nick)
+            return
+
+        # Check for CTCP (actions, etc.) - skip them
+        if text.startswith("\x01") and text.endswith("\x01"):
+            logger.debug("IRC: Filtered CTCP message from %s", sender_nick)
+            # CTCP message - could parse /me actions, but skip for now
+            return
+
+        logger.debug("IRC: Processing message from %s to %s: %s", sender_nick, chat_id, text[:100])
+
+        # Build session source
+        source = self._build_source(prefix, chat_id)
+
+        # Create message event
+        event = MessageEvent(
+            text=text,
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message={"prefix": prefix, "params": params, "trailing": trailing},
+        )
+
+        # Dispatch to handler using base adapter's handle_message method
+        # This spawns a background task that handles response sending
+        if self._message_handler:
+            logger.debug("IRC: About to dispatch to handler")
+            logger.info("IRC: Dispatching message from %s (%s) to handler", sender_nick, chat_id)
+            try:
+                await self.handle_message(event)
+                logger.debug("IRC: Message dispatched successfully")
+                logger.info("IRC: Message from %s dispatched successfully", sender_nick)
+            except Exception as exc:
+                logger.error("IRC: message handler error: %s", exc, exc_info=True)
+        else:
+            logger.warning("IRC: No message handler set - message from %s will be dropped", sender_nick)
+
+    async def _ping_loop(self) -> None:
+        """Periodically send PING to keep connection alive."""
+        while not self._closing:
+            await asyncio.sleep(60)
+            if not self._closing:
+                self._send_line(f"PING :{self._server}")

--- a/gateway/platforms/irc.py
+++ b/gateway/platforms/irc.py
@@ -12,6 +12,7 @@ Environment variables:
     IRC_PASSWORD         Server password (optional)
     IRC_CHANNELS         Comma-separated list of channels to join (e.g. #bots,#help)
     IRC_USE_TLS          Set "true" to enable TLS (default: false)
+    IRC_TLS_CA_CERT      Path to PEM-encoded certificate file to trust for TLS (optional)
     IRC_MESSAGE_CHUNK_LIMIT  Max characters per message when BATCH unavailable (default: 350)
     IRC_REQUIRE_MULTILINE Set "true" to fail connection if server doesn't support draft/multiline (default: false)
     IRC_NICKSERV_PASSWORD NickServ password for authentication (optional)
@@ -219,6 +220,17 @@ class IRCAdapter(BasePlatformAdapter):
             # Open connection
             if self._use_tls:
                 ssl_context = ssl.create_default_context()
+
+                # Load custom certificate if provided
+                custom_cert_path = os.getenv("IRC_TLS_CA_CERT", "")
+                if custom_cert_path:
+                    if os.path.exists(custom_cert_path):
+                        ssl_context.load_verify_locations(cafile=custom_cert_path)
+                        logger.info("IRC: Loaded custom TLS certificate from %s", custom_cert_path)
+                    else:
+                        logger.error("IRC: TLS certificate file not found: %s", custom_cert_path)
+                        return False
+
                 self._reader, self._writer = await asyncio.open_connection(
                     self._server, self._port or 6697, ssl=ssl_context
                 )

--- a/gateway/platforms/irc.py
+++ b/gateway/platforms/irc.py
@@ -96,6 +96,28 @@ def check_irc_requirements() -> bool:
     return True
 
 
+# Module-level reference to the running adapter instance.
+# Set on connect, cleared on disconnect.  Allows send_message_tool
+# to reach the adapter without needing the GatewayRunner.
+_running_adapter: Optional["IRCAdapter"] = None
+
+
+async def send_to_channel(channel: str, content: str) -> Dict[str, Any]:
+    """Send a message to a named IRC channel via the running adapter.
+
+    Only channels (starting with ``#``) are accepted.
+    Returns a dict with ``success`` and optional ``error`` keys.
+    """
+    if not _running_adapter:
+        return {"error": "IRC adapter not connected"}
+    if not channel.startswith("#"):
+        return {"error": f"Invalid IRC target '{channel}' — must be a channel starting with #"}
+    result = await _running_adapter.send(channel, content)
+    if result.success:
+        return {"success": True, "channel": channel}
+    return {"success": False, "error": result.error or "send failed"}
+
+
 class IRCAdapter(BasePlatformAdapter):
     """Gateway adapter for IRC (any server)."""
 
@@ -305,6 +327,8 @@ class IRCAdapter(BasePlatformAdapter):
         self._ping_task = asyncio.create_task(self._ping_loop())
 
         self._mark_connected()
+        global _running_adapter
+        _running_adapter = self
         logger.info("IRC: connected to %s as %s", self._server, self._nick)
 
         # Start a heartbeat to check if reader is still alive
@@ -353,6 +377,9 @@ class IRCAdapter(BasePlatformAdapter):
         self._reader = None
         self._registered = False
         self._mark_disconnected()
+        global _running_adapter
+        if _running_adapter is self:
+            _running_adapter = None
         logger.info("IRC: disconnected")
 
     async def send(

--- a/gateway/platforms/irc.py
+++ b/gateway/platforms/irc.py
@@ -369,6 +369,9 @@ class IRCAdapter(BasePlatformAdapter):
         if not self._writer:
             return SendResult(success=False, error="Not connected")
 
+        logger.debug("IRC: send() called with chat_id=%s, content_len=%d, content_preview=%s", 
+                    chat_id, len(content), content[:100])
+
         has_newlines = "\n" in content
 
         if self._multiline_cap and has_newlines:
@@ -439,6 +442,7 @@ class IRCAdapter(BasePlatformAdapter):
         """Send a raw IRC line."""
         if self._writer:
             try:
+                logger.debug("IRC: SENDING: %s", line)
                 self._writer.write((line + "\r\n").encode("utf-8"))
             except Exception as exc:
                 logger.warning("IRC: failed to send line: %s", exc)
@@ -602,10 +606,31 @@ class IRCAdapter(BasePlatformAdapter):
                 self._send_line("QUIT")
                 return
 
+        # Handle NICK command from server (server confirming nickname change)
+        if cmd == "NICK":
+            # params[0] is the new nickname
+            if params and params[0]:
+                new_nick = params[0]
+                old_nick = self._actual_nick
+                self._actual_nick = new_nick
+                if new_nick.lower() != old_nick.lower():
+                    logger.info("IRC: Server changed our nick from %s to %s", old_nick, new_nick)
+            return
+
         # Handle registration confirmation
         if cmd == "001":
             self._registered = True
-            logger.info("IRC: registered with server")
+            # Update actual_nick to the server-accepted nickname (params[0])
+            logger.info("IRC: Received 001 registration: params=%s, first_param=%s", params, params[0] if params else "None")
+            if params and params[0]:
+                self._actual_nick = params[0]
+                logger.info("IRC: Updated _actual_nick to %s (configured as %s)", self._actual_nick, self._nick)
+                if self._actual_nick.lower() != self._nick.lower():
+                    logger.info("IRC: server accepted different nick than configured: %s (was configured as %s)",
+                                self._actual_nick, self._nick)
+            else:
+                logger.warning("IRC: 001 received but params[0] is empty or missing")
+            logger.info("IRC: registered with server as %s", self._actual_nick)
             # Fallback: if CAP negotiation didn't complete, resolve it now
             if not self._cap_negotiated:
                 self._cap_negotiated = True
@@ -747,8 +772,10 @@ class IRCAdapter(BasePlatformAdapter):
                 if nick_part and nick_pattern.match(nick_part)
             ]
 
-            if self._nick.lower() not in mentioned_nicks:
-                logger.debug("IRC: Filtered channel message (we were not mentioned): %s", text[:100])
+            if self._actual_nick.lower() not in mentioned_nicks:
+                logger.warning("IRC: Filtered channel message (we were not mentioned): %s", text[:100])
+                logger.warning("IRC: _actual_nick=%s (lower=%s), mentioned_nicks=%s", 
+                           self._actual_nick, self._actual_nick.lower(), mentioned_nicks)
                 return
 
             # Check for command after mention block: /[a-zA-Z_][a-zA-Z0-9_-]+

--- a/gateway/platforms/irc.py
+++ b/gateway/platforms/irc.py
@@ -700,6 +700,12 @@ class IRCAdapter(BasePlatformAdapter):
         target = params[0]  # Channel or our nick (for DMs)
         text = trailing
 
+        # Handle space-prefixed IRC commands (user workaround for client interception)
+        # If message starts with "/" after lstrip(), trim the leading whitespace
+        # so upstream command detection (is_command()) works correctly
+        if text.lstrip().startswith("/"):
+            text = text.lstrip()
+
         logger.info("IRC: PRIVMSG from %s to %s: %s", prefix, target, text[:100])
 
         # Check if this message is part of a multiline batch *before* filtering empty text

--- a/gateway/platforms/irc.py
+++ b/gateway/platforms/irc.py
@@ -732,11 +732,23 @@ class IRCAdapter(BasePlatformAdapter):
             chat_id = target
 
             # For channels: only respond to messages that mention us at the beginning
-            # Must start with "<nickname>:" (colon immediately after nickname, no space)
-            # Check against original nick (what users will type) in case of collision
-            mention_pattern = re.compile(f"^{re.escape(self._nick)}:", re.IGNORECASE)
-            if not mention_pattern.match(text):
+            # Messages can have multiple mentions at the start, like "foo: bar: baz: Hi!"
+            mention_block_pattern = re.compile(r"^(([a-zA-Z_][a-zA-Z0-9_-]*:)+ )+", re.IGNORECASE)
+            match = mention_block_pattern.match(text)
+            if not match:
                 logger.debug("IRC: Filtered channel message (no mention): %s", text[:100])
+                return
+
+            # Split mention block on ": " to get individual nicks
+            nick_pattern = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_-]*$")
+            mentioned_nicks = [
+                nick_part.lower()
+                for nick_part in match.group(0).split(": ")
+                if nick_part and nick_pattern.match(nick_part)
+            ]
+
+            if self._nick.lower() not in mentioned_nicks:
+                logger.debug("IRC: Filtered channel message (we were not mentioned): %s", text[:100])
                 return
         else:
             # DM - use sender's nick as chat_id

--- a/gateway/platforms/irc.py
+++ b/gateway/platforms/irc.py
@@ -750,6 +750,14 @@ class IRCAdapter(BasePlatformAdapter):
             if self._nick.lower() not in mentioned_nicks:
                 logger.debug("IRC: Filtered channel message (we were not mentioned): %s", text[:100])
                 return
+
+            # Check for command after mention block: /[a-zA-Z_][a-zA-Z0-9_-]+
+            mention_block = match.group(0)
+            remainder = text[len(mention_block):]
+            command_pattern = re.compile(r"^/[a-zA-Z_][a-zA-Z0-9_-]+")
+            if command_pattern.match(remainder.lstrip()):
+                # Command detected - strip mention block and ensure first char is /
+                text = remainder.lstrip()
         else:
             # DM - use sender's nick as chat_id
             # DMs always respond, no mention filtering

--- a/gateway/platforms/irc.py
+++ b/gateway/platforms/irc.py
@@ -314,7 +314,7 @@ class IRCAdapter(BasePlatformAdapter):
                 await asyncio.sleep(5)
                 count += 1
                 if self._reader_task and self._reader_task.done():
-                    logger.warning("IRC: Reader task is DONE at %ds!", count * 5)
+                    logger.debug("IRC: Reader task is DONE at %ds", count * 5)
                 elif not self._closing:
                     logger.debug("IRC: Reader still running at %ds", count * 5)
 
@@ -467,6 +467,8 @@ class IRCAdapter(BasePlatformAdapter):
             if not line:
                 if not self._closing:
                     logger.warning("IRC: connection closed by server")
+                    self._set_fatal_error("connection_closed", "Server closed connection", retryable=True)
+                    await self._notify_fatal_error()
                 break
 
             try:
@@ -781,4 +783,11 @@ class IRCAdapter(BasePlatformAdapter):
         while not self._closing:
             await asyncio.sleep(60)
             if not self._closing:
-                self._send_line(f"PING :{self._server}")
+                try:
+                    self._send_line(f"PING :{self._server}")
+                    await self._writer.drain()  # Ensure it actually sent
+                except Exception as exc:
+                    logger.error("IRC: PING failed, connection is dead: %s", exc)
+                    self._set_fatal_error("ping_failed", f"PING failed: {exc}", retryable=True)
+                    await self._notify_fatal_error()
+                    return

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1581,6 +1581,13 @@ class GatewayRunner:
                 return None
             return WeComAdapter(config)
 
+        elif platform == Platform.IRC:
+            from gateway.platforms.irc import IRCAdapter, check_irc_requirements
+            if not check_irc_requirements():
+                logger.warning("IRC: IRC_SERVER or IRC_NICK not set")
+                return None
+            return IRCAdapter(config)
+
         elif platform == Platform.MATTERMOST:
             from gateway.platforms.mattermost import MattermostAdapter, check_mattermost_requirements
             if not check_mattermost_requirements():
@@ -1649,6 +1656,7 @@ class GatewayRunner:
             Platform.DINGTALK: "DINGTALK_ALLOWED_USERS",
             Platform.FEISHU: "FEISHU_ALLOWED_USERS",
             Platform.WECOM: "WECOM_ALLOWED_USERS",
+            Platform.IRC: "IRC_ALLOWED_USERS",
         }
         platform_allow_all_map = {
             Platform.TELEGRAM: "TELEGRAM_ALLOW_ALL_USERS",

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1459,6 +1459,37 @@ _PLATFORMS = [
              "help": "Chat ID for scheduled results and notifications."},
         ],
     },
+    {
+        "key": "irc",
+        "label": "IRC",
+        "emoji": "💬",
+        "token_var": "IRC_NICK",
+        "setup_instructions": [
+            "1. Choose an IRC server (e.g., irc.libera.chat, irc.oftc.net)",
+            "2. Pick a nickname for your bot",
+            "3. If the server requires SASL auth, get your password",
+            "4. List channels to join (comma-separated, e.g., #hermes,#bots)",
+        ],
+        "vars": [
+            {"name": "IRC_SERVER", "prompt": "IRC server hostname (e.g., irc.libera.chat)", "password": False,
+             "help": "The IRC server to connect to."},
+            {"name": "IRC_PORT", "prompt": "Port (default: 6667, TLS: 6697)", "password": False,
+             "help": "Server port. Use 6697 with TLS enabled."},
+            {"name": "IRC_NICK", "prompt": "Nickname", "password": False,
+             "help": "The bot's nickname on the server."},
+            {"name": "IRC_PASSWORD", "prompt": "Password (or SASL password, optional)", "password": True,
+             "help": "Leave empty if no authentication required."},
+            {"name": "IRC_CHANNELS", "prompt": "Channels to join (comma-separated, e.g., #bots,#test)", "password": False,
+             "help": "Channels the bot will join on connect."},
+            {"name": "IRC_USE_TLS", "prompt": "Use TLS? (true/false, default: false)", "password": False,
+             "help": "Enable for secure connections (port 6697)."},
+            {"name": "IRC_ALLOWED_USERS", "prompt": "Allowed nicks (comma-separated, or empty to allow all)", "password": False,
+             "is_allowlist": True,
+             "help": "Restrict which users can command the bot."},
+            {"name": "IRC_HOME_CHANNEL", "prompt": "Home channel (for cron/notification delivery)", "password": False,
+             "help": "Channel for scheduled results and notifications."},
+        ],
+    },
 ]
 
 

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -284,6 +284,7 @@ def show_status(args):
         "DingTalk": ("DINGTALK_CLIENT_ID", None),
         "Feishu": ("FEISHU_APP_ID", "FEISHU_HOME_CHANNEL"),
         "WeCom": ("WECOM_BOT_ID", "WECOM_HOME_CHANNEL"),
+        "IRC": ("IRC_NICK", "IRC_HOME_CHANNEL"),
     }
     
     for name, (token_var, home_var) in platforms.items():

--- a/tests/gateway/test_irc.py
+++ b/tests/gateway/test_irc.py
@@ -1,0 +1,152 @@
+"""Tests for IRC platform adapter."""
+import pytest
+from unittest.mock import MagicMock, patch
+
+from gateway.config import Platform, PlatformConfig
+
+
+# ---------------------------------------------------------------------------
+# Platform Enum
+# ---------------------------------------------------------------------------
+
+class TestIRCPlatformEnum:
+    def test_irc_enum_exists(self):
+        assert Platform.IRC.value == "irc"
+
+    def test_irc_in_platform_list(self):
+        platforms = [p.value for p in Platform]
+        assert "irc" in platforms
+
+
+# ---------------------------------------------------------------------------
+# Config Loading
+# ---------------------------------------------------------------------------
+
+class TestIRCConfigLoading:
+    def test_irc_disabled_without_server(self, monkeypatch):
+        """IRC should not be enabled without IRC_SERVER."""
+        monkeypatch.delenv("IRC_SERVER", raising=False)
+        monkeypatch.setenv("IRC_NICK", "hermesbot")
+
+        from gateway.config import GatewayConfig, _apply_env_overrides
+
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+
+        assert Platform.IRC not in config.platforms
+
+    def test_irc_home_channel_from_env(self, monkeypatch):
+        """IRC_HOME_CHANNEL should override the default."""
+        monkeypatch.setenv("IRC_SERVER", "irc.example.com")
+        monkeypatch.setenv("IRC_NICK", "hermesbot")
+        monkeypatch.setenv("IRC_CHANNELS", "#bots,#test")
+        monkeypatch.setenv("IRC_HOME_CHANNEL", "#test")
+
+        from gateway.config import GatewayConfig, _apply_env_overrides
+
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+
+        home = config.get_home_channel(Platform.IRC)
+        assert home is not None
+        assert home.chat_id == "#test"
+
+    def test_irc_tls_flag(self, monkeypatch):
+        """IRC_USE_TLS should be parsed as boolean."""
+        monkeypatch.setenv("IRC_SERVER", "irc.example.com")
+        monkeypatch.setenv("IRC_NICK", "hermesbot")
+        monkeypatch.setenv("IRC_USE_TLS", "true")
+
+        from gateway.config import GatewayConfig, _apply_env_overrides
+
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+
+        mc = config.platforms[Platform.IRC]
+        assert mc.extra.get("use_tls") is True
+
+    def test_irc_not_enabled_without_creds(self, monkeypatch):
+        """IRC should not appear in platforms without credentials."""
+        monkeypatch.delenv("IRC_SERVER", raising=False)
+        monkeypatch.delenv("IRC_NICK", raising=False)
+
+        from gateway.config import GatewayConfig, _apply_env_overrides
+
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+
+        assert Platform.IRC not in config.platforms
+
+
+# ---------------------------------------------------------------------------
+# Adapter Tests
+# ---------------------------------------------------------------------------
+
+class TestIRCAdapterFormatMessage:
+    """Tests for IRCAdapter.format_message (passthrough, no markdown stripping)."""
+
+    def test_format_message_returns_unchanged(self, monkeypatch):
+        """format_message should return content unchanged."""
+        monkeypatch.setenv("IRC_SERVER", "irc.example.com")
+        monkeypatch.setenv("IRC_NICK", "hermesbot")
+
+        from gateway.platforms.irc import IRCAdapter
+
+        adapter = IRCAdapter(PlatformConfig(enabled=True, extra={"server": "irc.example.com", "nick": "hermesbot"}))
+        
+        content = "**Hello world**"
+        assert adapter.format_message(content) == content
+
+    def test_format_message_preserves_markdown(self, monkeypatch):
+        """format_message should preserve markdown syntax."""
+        monkeypatch.setenv("IRC_SERVER", "irc.example.com")
+        monkeypatch.setenv("IRC_NICK", "hermesbot")
+
+        from gateway.platforms.irc import IRCAdapter
+
+        adapter = IRCAdapter(PlatformConfig(enabled=True, extra={"server": "irc.example.com", "nick": "hermesbot"}))
+
+        content = "**bold** and _italic_ and `code`"
+        assert adapter.format_message(content) == content
+
+    def test_format_message_preserves_newlines(self, monkeypatch):
+        """format_message should preserve newlines."""
+        monkeypatch.setenv("IRC_SERVER", "irc.example.com")
+        monkeypatch.setenv("IRC_NICK", "hermesbot")
+
+        from gateway.platforms.irc import IRCAdapter
+
+        adapter = IRCAdapter(PlatformConfig(enabled=True, extra={"server": "irc.example.com", "nick": "hermesbot"}))
+
+        content = "line 1\nline 2\nline 3"
+        assert adapter.format_message(content) == content
+
+    def test_format_message_empty_input(self, monkeypatch):
+        """format_message with empty input returns empty string."""
+        monkeypatch.setenv("IRC_SERVER", "irc.example.com")
+        monkeypatch.setenv("IRC_NICK", "hermesbot")
+
+        from gateway.platforms.irc import IRCAdapter
+
+        adapter = IRCAdapter(PlatformConfig(enabled=True, extra={"server": "irc.example.com", "nick": "hermesbot"}))
+
+        assert adapter.format_message("") == ""
+
+
+# ---------------------------------------------------------------------------
+# Integration Tests
+# ---------------------------------------------------------------------------
+
+class TestIRCIntegration:
+    def test_irc_not_in_connected_platforms_when_disabled(self, monkeypatch):
+        """IRC should not appear in get_connected_platforms when not configured."""
+        monkeypatch.delenv("IRC_SERVER", raising=False)
+        monkeypatch.delenv("IRC_NICK", raising=False)
+
+        from gateway.config import GatewayConfig, _apply_env_overrides
+
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+
+        connected = config.get_connected_platforms()
+        assert "irc" not in connected

--- a/tests/gateway/test_irc.py
+++ b/tests/gateway/test_irc.py
@@ -137,6 +137,190 @@ class TestIRCAdapterFormatMessage:
 # Integration Tests
 # ---------------------------------------------------------------------------
 
+class TestIRCAdapterMentions:
+    """Tests for IRCAdapter mention pattern matching."""
+
+    def test_single_mention_accepted(self, monkeypatch):
+        """Messages starting with a single mention should be accepted."""
+        monkeypatch.setenv("IRC_SERVER", "irc.example.com")
+        monkeypatch.setenv("IRC_NICK", "bot1")
+
+        from gateway.platforms.irc import IRCAdapter
+        import re
+
+        adapter = IRCAdapter(PlatformConfig(enabled=True, extra={"server": "irc.example.com", "nick": "bot1"}))
+
+        mention_block_pattern = re.compile(r"^(([a-zA-Z_][a-zA-Z0-9_-]*:)+ )+", re.IGNORECASE)
+
+        text = "bot1: hi"
+        match = mention_block_pattern.match(text)
+        assert match is not None
+
+        nick_pattern = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_-]*$")
+        mentioned_nicks = [
+            nick_part.lower()
+            for nick_part in match.group(0).split(": ")
+            if nick_part and nick_pattern.match(nick_part)
+        ]
+        assert mentioned_nicks == ["bot1"]
+
+    def test_multiple_mentions_accepted(self, monkeypatch):
+        """Messages starting with multiple mentions should extract all nicks."""
+        monkeypatch.setenv("IRC_SERVER", "irc.example.com")
+        monkeypatch.setenv("IRC_NICK", "bot1")
+
+        from gateway.platforms.irc import IRCAdapter
+        import re
+
+        adapter = IRCAdapter(PlatformConfig(enabled=True, extra={"server": "irc.example.com", "nick": "bot1"}))
+
+        mention_block_pattern = re.compile(r"^(([a-zA-Z_][a-zA-Z0-9_-]*:)+ )+", re.IGNORECASE)
+
+        text = "foo: bar: baz: hi"
+        match = mention_block_pattern.match(text)
+        assert match is not None
+
+        nick_pattern = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_-]*$")
+        mentioned_nicks = [
+            nick_part.lower()
+            for nick_part in match.group(0).split(": ")
+            if nick_part and nick_pattern.match(nick_part)
+        ]
+        assert mentioned_nicks == ["foo", "bar", "baz"]
+
+    def test_nick_among_mentions(self, monkeypatch):
+        """Bot should be extracted when its nick is among multiple mentions."""
+        monkeypatch.setenv("IRC_SERVER", "irc.example.com")
+        monkeypatch.setenv("IRC_NICK", "bot1")
+
+        from gateway.platforms.irc import IRCAdapter
+        import re
+
+        adapter = IRCAdapter(PlatformConfig(enabled=True, extra={"server": "irc.example.com", "nick": "bot1"}))
+
+        mention_block_pattern = re.compile(r"^(([a-zA-Z_][a-zA-Z0-9_-]*:)+ )+", re.IGNORECASE)
+        nick_pattern = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_-]*$")
+
+        # Bot mentioned second
+        text1 = "bot2: bot1: bot3: hi"
+        match1 = mention_block_pattern.match(text1)
+        mentioned_nicks1 = [
+            nick_part.lower()
+            for nick_part in match1.group(0).split(": ")
+            if nick_part and nick_pattern.match(nick_part)
+        ]
+        assert "bot1" in mentioned_nicks1
+
+        # Bot mentioned third
+        text2 = "bot2: bot3: bot1: hi"
+        match2 = mention_block_pattern.match(text2)
+        mentioned_nicks2 = [
+            nick_part.lower()
+            for nick_part in match2.group(0).split(": ")
+            if nick_part and nick_pattern.match(nick_part)
+        ]
+        assert "bot1" in mentioned_nicks2
+
+    def test_nick_not_mentioned(self, monkeypatch):
+        """Bot should NOT be extracted when its nick is not mentioned."""
+        monkeypatch.setenv("IRC_SERVER", "irc.example.com")
+        monkeypatch.setenv("IRC_NICK", "bot1")
+
+        from gateway.platforms.irc import IRCAdapter
+        import re
+
+        adapter = IRCAdapter(PlatformConfig(enabled=True, extra={"server": "irc.example.com", "nick": "bot1"}))
+
+        mention_block_pattern = re.compile(r"^(([a-zA-Z_][a-zA-Z0-9_-]*:)+ )+", re.IGNORECASE)
+        nick_pattern = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_-]*$")
+
+        text = "bot2: bot3: bot4: hi"
+        match = mention_block_pattern.match(text)
+        mentioned_nicks = [
+            nick_part.lower()
+            for nick_part in match.group(0).split(": ")
+            if nick_part and nick_pattern.match(nick_part)
+        ]
+        assert "bot1" not in mentioned_nicks
+
+    def test_no_leading_mention_block(self, monkeypatch):
+        """Messages without a leading mention block should not match."""
+        monkeypatch.setenv("IRC_SERVER", "irc.example.com")
+        monkeypatch.setenv("IRC_NICK", "bot1")
+
+        from gateway.platforms.irc import IRCAdapter
+        import re
+
+        adapter = IRCAdapter(PlatformConfig(enabled=True, extra={"server": "irc.example.com", "nick": "bot1"}))
+
+        mention_block_pattern = re.compile(r"^(([a-zA-Z_][a-zA-Z0-9_-]*:)+ )+", re.IGNORECASE)
+
+        # No mention at start
+        texts = [
+            "hi bot1:",
+            "hello world",
+            "bot1: hi",  # this actually has a mention block!
+        ]
+
+        match_count = 0
+        for text in texts:
+            if mention_block_pattern.match(text):
+                match_count += 1
+
+        # Only "bot1: hi" should match
+        assert match_count == 1
+
+    def test_no_space_after_colon(self, monkeypatch):
+        """Messages without space after colon are not valid mentions."""
+        monkeypatch.setenv("IRC_SERVER", "irc.example.com")
+        monkeypatch.setenv("IRC_NICK", "bot1")
+
+        from gateway.platforms.irc import IRCAdapter
+        import re
+
+        adapter = IRCAdapter(PlatformConfig(enabled=True, extra={"server": "irc.example.com", "nick": "bot1"}))
+
+        mention_block_pattern = re.compile(r"^(([a-zA-Z_][a-zA-Z0-9_-]*:)+ )+", re.IGNORECASE)
+
+        # No space after colon - should not match
+        text = "bot1:hi"
+        match = mention_block_pattern.match(text)
+        assert match is None
+
+    def test_case_insensitive(self, monkeypatch):
+        """Mention matching should be case-insensitive."""
+        monkeypatch.setenv("IRC_SERVER", "irc.example.com")
+        monkeypatch.setenv("IRC_NICK", "Bot1")
+
+        from gateway.platforms.irc import IRCAdapter
+        import re
+
+        adapter = IRCAdapter(PlatformConfig(enabled=True, extra={"server": "irc.example.com", "nick": "Bot1"}))
+
+        mention_block_pattern = re.compile(r"^(([a-zA-Z_][a-zA-Z0-9_-]*:)+ )+", re.IGNORECASE)
+        nick_pattern = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_-]*$")
+
+        texts = [
+            "bot1: hi",
+            "Bot1: hi",
+            "BOT1: hi",
+            "bot2: bot1: hi",
+        ]
+
+        for text in texts:
+            match = mention_block_pattern.match(text)
+            mentioned_nicks = [
+                nick_part.lower()
+                for nick_part in match.group(0).split(": ")
+                if nick_part and nick_pattern.match(nick_part)
+            ]
+            assert "bot1" in mentioned_nicks
+
+
+# ---------------------------------------------------------------------------
+# Integration Tests
+# ---------------------------------------------------------------------------
+
 class TestIRCIntegration:
     def test_irc_not_in_connected_platforms_when_disabled(self, monkeypatch):
         """IRC should not appear in get_connected_platforms when not configured."""

--- a/tests/gateway/test_irc.py
+++ b/tests/gateway/test_irc.py
@@ -316,6 +316,112 @@ class TestIRCAdapterMentions:
             ]
             assert "bot1" in mentioned_nicks
 
+    def test_command_strips_mention_block(self, monkeypatch):
+        """Commands after mention block should have mention block stripped."""
+        monkeypatch.setenv("IRC_SERVER", "irc.example.com")
+        monkeypatch.setenv("IRC_NICK", "bot1")
+
+        from gateway.platforms.irc import IRCAdapter
+        import re
+
+        adapter = IRCAdapter(PlatformConfig(enabled=True, extra={"server": "irc.example.com", "nick": "bot1"}))
+
+        mention_block_pattern = re.compile(r"^(([a-zA-Z_][a-zA-Z0-9_-]*:)+ )+", re.IGNORECASE)
+        command_pattern = re.compile(r"^/[a-zA-Z_][a-zA-Z0-9_-]+")
+
+        # Command after mention block
+        text = "bot1: /help"
+        match = mention_block_pattern.match(text)
+        mention_block = match.group(0)
+        remainder = text[len(mention_block):]
+
+        assert command_pattern.match(remainder) is not None
+        assert remainder.lstrip() == "/help"
+
+        # Multiple mentions with command
+        text2 = "bot2: bot1: /status"
+        match2 = mention_block_pattern.match(text2)
+        mention_block2 = match2.group(0)
+        remainder2 = text2[len(mention_block2):]
+
+        assert command_pattern.match(remainder2) is not None
+        assert remainder2.lstrip() == "/status"
+
+    def test_command_with_extra_spaces(self, monkeypatch):
+        """Commands should be lstrip() to ensure first char is / even with extra spaces."""
+        monkeypatch.setenv("IRC_SERVER", "irc.example.com")
+        monkeypatch.setenv("IRC_NICK", "bot1")
+
+        from gateway.platforms.irc import IRCAdapter
+        import re
+
+        adapter = IRCAdapter(PlatformConfig(enabled=True, extra={"server": "irc.example.com", "nick": "bot1"}))
+
+        mention_block_pattern = re.compile(r"^(([a-zA-Z_][a-zA-Z0-9_-]*:)+ )+", re.IGNORECASE)
+        command_pattern = re.compile(r"^/[a-zA-Z_][a-zA-Z0-9_-]+")
+
+        # Command with extra spaces before slash
+        text = "bot1:   /test command"
+        match = mention_block_pattern.match(text)
+        mention_block = match.group(0)
+        remainder = text[len(mention_block):]
+
+        # After lstrip(), it should match command pattern
+        assert command_pattern.match(remainder.lstrip()) is not None
+        assert remainder.lstrip() == "/test command"
+
+    def test_non_command_keeps_mention_block(self, monkeypatch):
+        """Non-command messages should keep the full text including mention block."""
+        monkeypatch.setenv("IRC_SERVER", "irc.example.com")
+        monkeypatch.setenv("IRC_NICK", "bot1")
+
+        from gateway.platforms.irc import IRCAdapter
+        import re
+
+        adapter = IRCAdapter(PlatformConfig(enabled=True, extra={"server": "irc.example.com", "nick": "bot1"}))
+
+        mention_block_pattern = re.compile(r"^(([a-zA-Z_][a-zA-Z0-9_-]*:)+ )+", re.IGNORECASE)
+        command_pattern = re.compile(r"^/[a-zA-Z_][a-zA-Z0-9_-]+")
+
+        # Regular message - not a command
+        text = "bot1: hello world"
+        match = mention_block_pattern.match(text)
+        mention_block = match.group(0)
+        remainder = text[len(mention_block):]
+
+        assert command_pattern.match(remainder) is None
+        # Text should remain unchanged
+        assert text == "bot1: hello world"
+
+    def test_slash_without_command_word(self, monkeypatch):
+        """Just a slash is not a command."""
+        monkeypatch.setenv("IRC_SERVER", "irc.example.com")
+        monkeypatch.setenv("IRC_NICK", "bot1")
+
+        from gateway.platforms.irc import IRCAdapter
+        import re
+
+        adapter = IRCAdapter(PlatformConfig(enabled=True, extra={"server": "irc.example.com", "nick": "bot1"}))
+
+        mention_block_pattern = re.compile(r"^(([a-zA-Z_][a-zA-Z0-9_-]*:)+ )+", re.IGNORECASE)
+        command_pattern = re.compile(r"^/[a-zA-Z_][a-zA-Z0-9_-]+")
+
+        # Slash without command word
+        text = "bot1: /"
+        match = mention_block_pattern.match(text)
+        mention_block = match.group(0)
+        remainder = text[len(mention_block):]
+
+        assert command_pattern.match(remainder) is None
+
+        # Slash without valid command word (starts with number)
+        text2 = "bot1: /123test"
+        match2 = mention_block_pattern.match(text2)
+        mention_block2 = match2.group(0)
+        remainder2 = text2[len(mention_block2):]
+
+        assert command_pattern.match(remainder2) is None
+
 
 # ---------------------------------------------------------------------------
 # Integration Tests

--- a/tests/gateway/test_irc_manual.py
+++ b/tests/gateway/test_irc_manual.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Manual integration test for IRC adapter.
+
+Shows all IRC traffic (sent and received) for debugging.
+
+Usage:
+    python tests/gateway/test_irc_manual.py --host irc.example.com --nick mybot --channels "#mytest"
+    python tests/gateway/test_irc_manual.py --host irc.example.com --port 6697 --tls --nick mybot --channels "#mytest"
+
+Manual Test Coverage:
+=====================
+This manual test validates end-to-end IRC adapter functionality:
+
+1. Connection:
+   - TLS/non-TLS connections (port 6667 vs 6697)
+   - Server password authentication (optional)
+   - Nick registration (NICK, USER commands)
+   - CAP negotiation (draft/multiline support)
+   - Connection timeout handling
+
+2. Channel Operations:
+   - JOIN command
+   - Presence detection (user list via 353 RPL_NAMREPLY)
+   - Message sending to channels
+
+3. Message Handling:
+   - PRIVMSG sending
+   - Line protocol parsing (prefix, command, params, trailing)
+   - Nick collision handling (automatic "_" suffix)
+   - CTCP filtering (ignores \x01ACTION\x01 etc.)
+
+4. Protocol Features:
+   - PING/PONG keepalive
+   - Batch multiline support (if server supports CAP draft/multiline)
+   - Message chunking for long messages (fallback when BATCH unavailable)
+
+5. NickServ Authentication:
+   - NickServ IDENTIFY on NOTICE (optional, via IRC_NICKSERV_PASSWORD)
+   - Graceful failure if NickServ auth fails
+
+Running with Pytest:
+    pytest tests/gateway/test_irc_manual.py -- --host irc.example.com --nick mybot --channels "#test"
+    pytest tests/gateway/test_irc_manual.py -- --host irc.example.com --port 6697 --tls --nick mybot --channels "#test"
+    pytest tests/gateway/test_irc_manual.py (requires IRC_TEST_HOST, IRC_TEST_NICK, IRC_TEST_CHANNELS env vars)
+
+Note: Unit tests in test_irc.py cover config loading, format_message, and IRC mask matching.
+This manual test covers runtime adapter behavior and protocol compliance.
+"""
+import argparse
+import asyncio
+import os
+import sys
+
+# Add project root to path for imports
+sys.path.insert(0, __file__.rsplit("/tests/", 1)[0])
+
+from gateway.config import PlatformConfig
+from gateway.platforms.irc import IRCAdapter
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Manual IRC adapter test")
+    parser.add_argument("--host", required=True, help="IRC server hostname")
+    parser.add_argument("--port", type=int, default=6667, help="IRC server port (default: 6667)")
+    parser.add_argument("--nick", required=True, help="Bot nickname")
+    parser.add_argument("--channels", required=True, help="Channels to join (comma-separated)")
+    parser.add_argument("--password", default="", help="Server password (optional)")
+    parser.add_argument("--tls", action="store_true", help="Use TLS encryption")
+    return parser.parse_args()
+
+
+def build_config(args):
+    return PlatformConfig(
+        enabled=True,
+        extra={
+            "server": args.host,
+            "port": args.port,
+            "nick": args.nick,
+            "password": args.password,
+            "channels": args.channels,
+            "use_tls": args.tls,
+        },
+    )
+
+
+def patch_adapter_for_verbose_output(adapter):
+    """Monkey-patch the adapter to print all IRC traffic."""
+    original_send_line = adapter._send_line
+    original_handle_line = adapter._handle_line
+
+    def verbose_send_line(line: str):
+        print(f">>> {line}")
+        return original_send_line(line)
+
+    async def verbose_handle_line(line: str):
+        print(f"<<< {line}")
+        await original_handle_line(line)
+
+    # Patch the methods
+    adapter._send_line = verbose_send_line
+    adapter._handle_line = verbose_handle_line
+
+
+async def run_tests(config):
+    """Run IRC adapter test."""
+    adapter = IRCAdapter(config)
+    patch_adapter_for_verbose_output(adapter)
+    channels_str = config.extra.get("channels", "")
+    channels = [c.strip() for c in channels_str.split(",") if c.strip()]
+    target = channels[0] if channels else None
+
+    if not target:
+        print("ERROR: No channels configured")
+        sys.exit(1)
+    print(f"\n--- Connecting to {config.extra['server']}:{config.extra['port']} as {config.extra['nick']} ---\n")
+    connected = await adapter.connect()
+    if not connected:
+        print("\nFAILED: connect() returned False")
+        print("Possible causes:")
+        print("  - Server unreachable")
+        print("  - Nick already in use (try a different --nick)")
+        print("  - Registration timeout (server didn't send 001)")
+        print("  - TLS required (try --tls)")
+        sys.exit(1)
+    print("\n--- Connected! Waiting for JOIN... ---")
+    await asyncio.sleep(2)
+    print(f"\n--- Sending test message to {target} ---\n")
+    await adapter.send(target, "Hello from Hermes IRC adapter test!")
+    print("\n--- Waiting 2 seconds... ---")
+    await asyncio.sleep(2)
+    print("\n--- Disconnecting ---\n")
+    await adapter.disconnect()
+    print("\n=== Done ===")
+
+
+# Pytest support (optional)
+def _get_pytest_config():
+    """Get config for pytest mode (from CLI args after -- or env vars)."""
+    if "--" in sys.argv:
+        separator_idx = sys.argv.index("--")
+        test_args = sys.argv[separator_idx + 1:]
+        if test_args:
+            parser = argparse.ArgumentParser()
+            parser.add_argument("--host")
+            parser.add_argument("--port", type=int, default=6667)
+            parser.add_argument("--nick")
+            parser.add_argument("--channels")
+            parser.add_argument("--password", default="")
+            parser.add_argument("--tls", action="store_true")
+            try:
+                args = parser.parse_args(test_args)
+                if args.host and args.nick and args.channels:
+                    return build_config(args)
+            except SystemExit:
+                pass
+    host = os.getenv("IRC_TEST_HOST")
+    if host:
+        channels_str = os.getenv("IRC_TEST_CHANNELS", "#hermes-test")
+        return PlatformConfig(
+            enabled=True,
+            extra={
+                "server": host,
+                "port": int(os.getenv("IRC_TEST_PORT", "6667")),
+                "nick": os.getenv("IRC_TEST_NICK", "hermes-test"),
+                "password": os.getenv("IRC_TEST_PASSWORD", ""),
+                "channels": channels_str,
+                "use_tls": os.getenv("IRC_TEST_TLS", "false").lower() == "true",
+            },
+        )
+    return None
+
+
+try:
+    import pytest
+    _PYTEST_CONFIG = _get_pytest_config()
+    pytestmark = pytest.mark.skipif(
+        not _PYTEST_CONFIG,
+        reason="No IRC config -- use -- --host HOST --nick NICK --channels '#chan' or set IRC_TEST_HOST",
+    )
+    @pytest.fixture
+    def irc_config():
+        return _PYTEST_CONFIG
+    @pytest.fixture
+    def irc_adapter(irc_config):
+        return IRCAdapter(irc_config)
+    @pytest.mark.asyncio
+    async def test_connect_and_send_message(irc_adapter):
+        channels_str = irc_adapter.config.extra.get("channels", "")
+        channels = [c.strip() for c in channels_str.split(",") if c.strip()]
+        if not channels:
+            return
+        connected = await irc_adapter.connect()
+        assert connected, "connect() returned False"
+        await asyncio.sleep(2)
+        await irc_adapter.send(channels[0], "Hello from Hermes IRC adapter test!")
+        await asyncio.sleep(2)
+        await irc_adapter.disconnect()
+except ImportError:
+    pass
+
+
+def main():
+    args = parse_args()
+    config = build_config(args)
+    asyncio.run(run_tests(config))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -133,6 +133,7 @@ def _handle_send(args):
         "wecom": Platform.WECOM,
         "email": Platform.EMAIL,
         "sms": Platform.SMS,
+        "irc": Platform.IRC,
     }
     platform = platform_map.get(platform_name)
     if not platform:
@@ -371,6 +372,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             result = await _send_feishu(pconfig, chat_id, chunk, thread_id=thread_id)
         elif platform == Platform.WECOM:
             result = await _send_wecom(pconfig.extra, chat_id, chunk)
+        elif platform == Platform.IRC:
+            result = {"error": "IRC direct sending not yet implemented"}
         else:
             result = {"error": f"Direct sending not yet implemented for {platform.value}"}
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -206,6 +206,8 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         match = _FEISHU_TARGET_RE.fullmatch(target_ref)
         if match:
             return match.group(1), match.group(2), True
+    if platform_name == "irc" and target_ref.startswith("#"):
+        return target_ref, None, True
     if target_ref.lstrip("-").isdigit():
         return target_ref, None, True
     return None, None, False
@@ -373,7 +375,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         elif platform == Platform.WECOM:
             result = await _send_wecom(pconfig.extra, chat_id, chunk)
         elif platform == Platform.IRC:
-            result = {"error": "IRC direct sending not yet implemented"}
+            from gateway.platforms.irc import send_to_channel
+            result = await send_to_channel(chat_id, chunk)
         else:
             result = {"error": f"Direct sending not yet implemented for {platform.value}"}
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -369,10 +369,16 @@ TOOLSETS = {
         "includes": []
     },
 
+    "hermes-irc": {
+        "description": "IRC bot toolset - interact with Hermes via IRC (prefer own private server)",
+        "tools": _HERMES_CORE_TOOLS,
+        "includes": []
+    },
+
     "hermes-gateway": {
         "description": "Gateway toolset - union of all messaging platform tools",
         "tools": [],
-        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-webhook"]
+        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-webhook", "hermes-irc"]
     }
 }
 

--- a/website/docs/user-guide/messaging/irc.md
+++ b/website/docs/user-guide/messaging/irc.md
@@ -1,0 +1,187 @@
+# irc for hermes-gateway
+
+An IRC client for hermes with multilines and very long lines support (`draft/multiline`),
+enabling multiline markdown messages (with possible colorization in clients).
+
+Warning: IRC is a protocol which can not be considered secure at all. 
+Even if you use it with TLS, admins can still see everything you send, 
+and potentially impersonate you or other nicknames.
+
+For these reasons, we recommend you use another platform with end-to-end encryption,
+or at like that host your own private IRC server, if you do:
+* Consider using a modern irc server like [Ergo](https://ergo.chat/) (written in go),
+* Enable draft/multiline to allow markdown (for Ergo, it's enabled by default)
+* Enable TLS for all client connections if possible
+* Restrict server access via:
+  - Ideally port forwarding (so it's all private)
+  - Or IRC server password and firewalls
+  - Client certificate authentication
+
+Despite these strong concerns with IRC, we still provide it because:
+
+- Other platforms are often proprietary (feishu, telegram, signal), 
+- or heavy/complex (e.g. matrix).
+- the simplicity of IRC can sometimes be see as an advantage in certain situation.
+
+### Configuration
+
+IRC bots get configured by environment variables.
+
+The location is in `~/.hermes/profiles/<name>/.env` (or in ~/.hermes/.env for the main profile).
+
+```bash
+IRC_SERVER=irc.example.com
+IRC_PORT=6667            # or 6697 if IRC_USE_TLS
+IRC_USE_TLS=false        # true for port 6697
+IRC_PASSWORD=            # optional password to connect to the server
+
+IRC_NICK=MyBotNick
+IRC_NICKSERV_PASSWORD=xyz      # optional, it will use /privmsg NickServ identify <IRC_NICK> <IRC_NICKSERV_PASSWORD>
+IRC_NICKSERV_SERVICE=NickServ
+IRC_USERNAME=mybot       # optional, defaults to IRC_NICK
+IRC_REALNAME="My AI Bot" # optional, defaults to "Hermes Agent"
+IRC_CHANNELS=#channel1,#channel2  # comma-separated list of channels to join
+IRC_ALLOWED_USERS=alice,bob    # case insensitive nicknames, use * to allow all users to talk to the bot
+
+IRC_MESSAGE_CHUNK_LIMIT=16384  # classically, irc chunks are 350 chars, but for multiline it's best to use more.
+IRC_REQUIRE_MULTILINE=true     # if possible use a server which has +draft/multiline
+```
+
+### Channel mentions
+
+For channels only, the bot only responds to messages that mention it in the list of nicknames at the very beginning,
+provided the sender nick is in `IRC_ALLOWED_USERS`.
+
+- Example: `Foo: hello` -> only agent 'Foo' would answer.
+- Example: `Foo: Bar: Baz: hello` -> the three agents 'Foo', 'Bar', 'Baz' would all answer.
+
+- **DMs are not affected** — they work normally
+
+### IRCv3 Multiline Support
+
+The IRC adapter supports IRCv3 `draft/multiline` capability 
+for sending and receiving multiline messages as a single unit. This allows 
+markdown to be sent and received! You will however need a client
+that supports this, and a plugin to render markdown.
+
+How it works:
+
+1. **CAP negotiation on connect:**
+   - Sends `CAP LS 302` to request server capabilities
+   - If `draft/multiline` is available, sends `CAP REQ :draft/multiline`
+   - Handles `CAP ACK` / `CAP NAK` responses
+   - Timeout: 5 seconds, then proceeds without multiline support
+
+2. **Sending multiline messages:**
+   - When `multiline_cap` is enabled and content contains newlines
+   - Sends `BATCH +<id> draft/multiline <target>`
+   - Each line tagged with `@batch=<id>`
+   - Closes with `BATCH -<id>`
+   - Blank lines preserved as single spaces for paragraph breaks
+   - Falls back to separate PRIVMSG if capability not available
+
+3. **Receiving multiline messages:**
+   - Parses IRCv3 message tags (`@key=value` prefix)
+   - Tracks incoming `draft/multiline` batches by ID
+   - Buffers messages until `BATCH -<id>` received
+   - Combines with `\n` separator preserving original structure
+   - Emits single MessageEvent with combined text
+
+Example
+
+**Without draft/multiline:**
+```
+>>> PRIVMSG #channel :Hello
+>>> PRIVMSG #channel :World
+```
+
+**With draft/multiline:**
+```
+>>> BATCH +m1 draft/multiline #channel
+>>> @batch=m1 PRIVMSG #channel :Hello
+>>> @batch=m1 PRIVMSG #channel :World
+>>> BATCH -m1
+```
+
+The recipient sees the same result, but the messages are grouped as a single unit.
+
+## Testing
+
+**Channel mention-only mode:**
+
+For channels only, the bot only responds to messages that mention it at the very beginning:
+
+- Must start with `<nickname>:` (colon immediately after nickname, no space)
+- Example: `YourBotName: hello` ✓ (responds), `hello YourBotName:` ✗ (ignored)
+- **DMs are not affected** — they work normally
+- Uses original `_nick` for detection (what users will type) while `_actual_nick` tracks what the server actually accepted
+- This handles nick collisions correctly — if bot connects as `YourBotName_` due to name conflict, it still responds to `YourBotName:` mentions
+
+**Quick development workflow (recommended for iterative changes):**
+
+Use the multi-terminal skill (see `/skills devops/multi-terminal`) to run a 4-pane tmux session:
+
+1. **Create session:**
+   ```
+   /multi-terminal start dev --project-dir ~/hermes-fork
+   ```
+
+2. **Start gateway:**
+   ```
+   /multi-terminal send dev gateway "source venv/bin/activate && python -m gateway.run"
+   ```
+
+3. **Connect test client:**
+   ```
+   /multi-terminal send dev irc "telnet 127.0.0.1 6667"
+   # Then send IRC commands:
+   # NICK TestUser
+   # USER TestUser 0 * :TestUser
+   # JOIN #home
+   # PRIVMSG #home :YourBotName: hello
+   ```
+
+4. **Monitor logs:**
+   ```
+   /multi-terminal capture dev gateway 50
+   /multi-terminal capture dev irc 20
+   ```
+
+5. **Edit files:**
+   ```
+   /multi-terminal send dev edit "vim gateway/platforms/irc.py"
+   ```
+
+6. **Restart gateway after changes:**
+   ```
+   tmux send-keys -t hermes-dev:0.1 C-c
+   /multi-terminal send dev gateway "source venv/bin/activate && python -m gateway.run"
+   ```
+
+This workflow lets you simultaneously:
+- Run the gateway with live logs
+- Send test IRC messages
+- Edit adapter code
+- Iterate quickly without terminal switching
+
+
+# Not implemented
+
+## Mask verification
+
+You may have wanted to have a `<nick>!<username>@<host>` verification (usually called a mask) 
+instead of a simple nick list. However masks are not implemented right now.
+
+The rationale behind this choice:
+
+- Modern IRC networks reject the /nick command instantly when the target is registered and services enforce protection, eliminating the historical grace period entirely. 
+- For pure identity verification, hostmask checking (<nick>!<user>@<host>) offers negligible benefit over verifying a registered, authenticated nick (Hostmasks are ephemeral (DHCP, mobile networks, bouncers), trivially spoofed (identd can be faked, proxies/VPNs mask hosts), and provide no cryptographic proof of identity.
+- Therefore the only thing that could be useful is the `host`, when used with a cloak set by the server. But it won't arguably provide any additional security compared to a registered nickname.
+
+# Todo
+
+* [x] IRCv3 draft/multiline support
+* [x] Message length splitting (~350 chars) for long messages when BATCH unavailable
+* [x] Handle nick collision (433/436 errors) with fallback nick recovery
+* [x] Add NickServ authentication support for networks requiring it
+

--- a/website/docs/user-guide/messaging/irc.md
+++ b/website/docs/user-guide/messaging/irc.md
@@ -105,6 +105,21 @@ Example
 
 The recipient sees the same result, but the messages are grouped as a single unit.
 
+## Debugging
+
+To enable debug logging for the IRC adapter, set the environment variable:
+
+```bash
+DEBUG=true
+```
+
+Or add it to your profile's `.env` file:
+```bash
+DEBUG=true
+```
+
+This will increase log verbosity and show detailed IRC protocol messages.
+
 ## Testing
 
 **Channel mention-only mode:**


### PR DESCRIPTION
## What does this PR do?

This PR adds IRC support. 

- supports NickServ authentication
- supports irc server password
- configurable responds to mentions on irc channels
- supports configurable message chunking for long messages (beyond the 350 bytes/line default limit)
- supports IRCv3 +draft/multiline (so bots can show multiline markdown in one message)
- note it does not support irc masks beyond nicknames right now (could be done, but brings little to the table, see doc)

Typical configuration goes in `~/.hermes/profiles/<name>/.env` or `.hermes/.env`:

IRC_SERVER=127.0.0.1
IRC_NICK=YourBotName
IRC_CHANNELS=#home
IRC_PORT=6667                      # Port (cleartext 6667, TLS uses 6697)
IRC_USE_TLS=false                  # Enable TLS (default false, use true as soon as you can)
IRC_PASSWORD=                      # Server password (optional)
IRC_NICKSERV_PASSWORD=             # NickServ password (optional)
IRC_NICKSERV_SERVICE=NickServ      # NickServ service name (default)
IRC_ALLOWED_USERS=bob,alice        # Comma-separated allowed nicks, "*" stands for everybody, default = nobody
IRC_HOME_CHANNEL=#home             # Default channel for cron notifications


## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

#4676 is a competing PR. I haven't had time to review it yet. 
I suppose we can always consolidate any of our 2 PRs.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)


### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate: there is #4676, however I believe it is not as complete as this one.
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A

## Screenshots / Logs

Below is how it is rendered on the [weechat](https://weechat.org) IRC client, with [markdown](https://github.com/grepsuzette/weechat-markdown) plugin.

<img width="886" height="1009" alt="570521131-6cf8d023-bc4d-4483-8ef5-0761664d0a06" src="https://github.com/user-attachments/assets/87986195-be14-4add-94a6-3413adb79c85" />
