### PR TITLE
fix: allow env var overrides for Nous portal/inference URLs

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2577,10 +2577,10 @@ def _login_nous(args, pconfig: ProviderConfig) -> None:
 
     try:
         auth_state = _nous_device_code_login(
-            portal_base_url=getattr(args, "portal_url", None) or pconfig.portal_base_url,
-            inference_base_url=getattr(args, "inference_url", None) or pconfig.inference_base_url,
-            client_id=getattr(args, "client_id", None) or pconfig.client_id,
-            scope=getattr(args, "scope", None) or pconfig.scope,
+            portal_base_url=getattr(args, "portal_url", None),
+            inference_base_url=getattr(args, "inference_url", None),
+            client_id=getattr(args, "client_id", None),
+            scope=getattr(args, "scope", None),
             open_browser=not getattr(args, "no_browser", False),
             timeout_seconds=timeout_seconds,
             insecure=insecure,


### PR DESCRIPTION
## Summary

Fixes the bug reported in #5397 by @jquesnelle — env vars `HERMES_PORTAL_BASE_URL`, `NOUS_PORTAL_BASE_URL`, and `NOUS_INFERENCE_BASE_URL` could never override the default Nous portal/inference URLs during login.

**Root cause:** `_login_nous()` pre-filled all parameters with `pconfig.*` defaults before passing them to `_nous_device_code_login()`. Since the defaults are always truthy strings, the env var checks inside the function were dead code.

**Fix:** Remove the redundant `or pconfig.*` fallbacks at the call site. The function already handles those defaults internally, so passing `None` when no CLI flag is provided lets the priority chain work correctly:

1. Explicit `--portal-url` CLI flag (highest)
2. Env var (`HERMES_PORTAL_BASE_URL` / `NOUS_PORTAL_BASE_URL`)
3. `pconfig` default (lowest)

This preserves the standard convention of explicit args > env vars > defaults, rather than inverting the priority as the original PR proposed.

Also cleaned up `client_id` and `scope` parameters which had the same redundant pre-filling (no env var override for those, but the duplication was unnecessary).

Credit to @jquesnelle for identifying the issue in #5397.