### PR TITLE
fix(gateway): flush JSONL transcript writes immediately

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -966,6 +966,7 @@ class SessionStore:
         transcript_path = self.get_transcript_path(session_id)
         with open(transcript_path, "a", encoding="utf-8") as f:
             f.write(json.dumps(message, ensure_ascii=False) + "\n")
+            f.flush()
     
     def rewrite_transcript(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
         """Replace the entire transcript for a session with new messages.
@@ -998,6 +999,7 @@ class SessionStore:
         with open(transcript_path, "w", encoding="utf-8") as f:
             for msg in messages:
                 f.write(json.dumps(msg, ensure_ascii=False) + "\n")
+            f.flush()
 
     def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
         """Load all messages from a session's transcript."""

--- a/tests/gateway/test_transcript_flush.py
+++ b/tests/gateway/test_transcript_flush.py
@@ -1,0 +1,75 @@
+"""Tests that JSONL transcript writes are flushed to disk immediately."""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from gateway.session import SessionStore
+
+
+def _make_store(tmp_path: Path) -> SessionStore:
+    """Create a minimal SessionStore pointing at a temp directory."""
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    store = SessionStore.__new__(SessionStore)
+    store.sessions_dir = sessions_dir
+    store._sessions = {}
+    store._lock = __import__("threading").Lock()
+    store._db = None
+    store._sessions_json_path = tmp_path / "sessions.json"
+    return store
+
+
+class TestTranscriptFlush:
+    def test_append_is_readable_before_close(self, tmp_path: Path):
+        """After append_to_transcript, the data must be on disk immediately
+        (not stuck in Python's write buffer)."""
+        store = _make_store(tmp_path)
+        session_id = "test_session_001"
+        msg = {"role": "user", "content": "hello"}
+
+        store.append_to_transcript(session_id, msg)
+
+        # Read raw file — if flush works, data is there now
+        transcript = store.get_transcript_path(session_id)
+        assert transcript.exists()
+        lines = transcript.read_text().strip().splitlines()
+        assert len(lines) == 1
+        assert json.loads(lines[0]) == msg
+
+    def test_append_multiple_all_visible(self, tmp_path: Path):
+        """Multiple appends should all be visible on disk immediately."""
+        store = _make_store(tmp_path)
+        session_id = "test_session_002"
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+            {"role": "user", "content": "bye"},
+        ]
+
+        for msg in messages:
+            store.append_to_transcript(session_id, msg)
+
+        transcript = store.get_transcript_path(session_id)
+        lines = transcript.read_text().strip().splitlines()
+        assert len(lines) == 3
+        for i, line in enumerate(lines):
+            assert json.loads(line) == messages[i]
+
+    def test_rewrite_is_readable_immediately(self, tmp_path: Path):
+        """rewrite_transcript should flush all data to disk."""
+        store = _make_store(tmp_path)
+        session_id = "test_session_003"
+        messages = [
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "second"},
+        ]
+
+        store.rewrite_transcript(session_id, messages)
+
+        transcript = store.get_transcript_path(session_id)
+        lines = transcript.read_text().strip().splitlines()
+        assert len(lines) == 2
+        for i, line in enumerate(lines):
+            assert json.loads(line) == messages[i]


### PR DESCRIPTION
Python's file buffering (~8KB) means JSONL session logs may not appear on disk until the buffer fills or the handle closes. This causes external readers (like hermes-watch) to see stale or empty files, especially for short delegated tasks with small messages.

Adding `f.flush()` after each write pushes data to the OS immediately without the cost of `fsync`.

Context: https://github.com/cliftonc/hermes-watch

## What does this PR do?

Adds `f.flush()` to `append_to_transcript` and `rewrite_transcript` in `gateway/session.py` so that JSONL session data is immediately visible to external processes reading the files. Without this, Python's internal write buffer (~8KB) holds data in memory, and short sessions (especially delegated tasks) may never fill the buffer before the file handle closes.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/session.py`: Added `f.flush()` after write in `append_to_transcript`
- `gateway/session.py`: Added `f.flush()` after write loop in `rewrite_transcript`
- `tests/gateway/test_transcript_flush.py`: Added 3 tests verifying data is on disk immediately after write

## How to Test

1. Start a Hermes session that delegates a short task
2. While the session is active, read the JSONL file from another process (`tail -f sessions/<id>.jsonl`)
3. Verify messages appear immediately rather than being delayed until session end

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (117 pre-existing failures unrelated to this change)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15, Python 3.14

### Documentation & Housekeeping

- [x] N/A — no docs, config, or tool schema changes needed