### PR TITLE
fix(agent): prevent tool name duplication when reasoning enabled with tool_visibility new

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4180,7 +4180,13 @@ class AIAgent:
                             entry["id"] = tc_delta.id
                         if tc_delta.function:
                             if tc_delta.function.name:
-                                entry["function"]["name"] += tc_delta.function.name
+                                # Only append if this is a new fragment (streaming builds name char by char).
+                                # Guard against duplicate full-name delivery (seen with reasoning enabled +
+                                # tool_visibility "new") which causes write_file → write_filewrite_file.
+                                current = entry["function"]["name"]
+                                fragment = tc_delta.function.name
+                                if not current.endswith(fragment):
+                                    entry["function"]["name"] += fragment
                             if tc_delta.function.arguments:
                                 entry["function"]["arguments"] += tc_delta.function.arguments
                         extra = getattr(tc_delta, "extra_content", None)


### PR DESCRIPTION
Fixes tool name duplication (write_file → write_filewrite_file) when reasoning is enabled with tool_visibility: new.

Adds endswith() guard before appending tc_delta.function.name to prevent duplicate full-name delivery from compounding. Normal char-by-char streaming is unaffected.