### PR TITLE
feat: subagent memory write-through via MemoryProvider interface

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -10447,6 +10447,7 @@ class AIAgent:
             acp_args=function_args.get("acp_args"),
             role=function_args.get("role"),
             parent_agent=self,
+            write_memory=function_args.get("write_memory", False),
         )
 
     def _invoke_tool(self, function_name: str, function_args: dict, effective_task_id: str,
@@ -10527,6 +10528,12 @@ class AIAgent:
             )
         elif function_name == "delegate_task":
             return self._dispatch_delegate_task(function_args)
+        elif function_name == "subagent_memory_write":
+            from tools.subagent_memory_tool import subagent_memory_write as _smw
+            return _smw(
+                content=function_args.get("content", ""),
+                writer=getattr(self, "_subagent_memory_writer", None),
+            )
         else:
             return handle_function_call(
                 function_name, function_args, effective_task_id,
@@ -11204,6 +11211,15 @@ class AIAgent:
                         spinner.stop(cute_msg)
                     elif self._should_emit_quiet_tool_messages():
                         self._vprint(f"  {cute_msg}")
+            elif function_name == "subagent_memory_write":
+                from tools.subagent_memory_tool import subagent_memory_write as _smw
+                function_result = _smw(
+                    content=function_args.get("content", ""),
+                    writer=getattr(self, "_subagent_memory_writer", None),
+                )
+                tool_duration = time.time() - tool_start_time
+                if self.quiet_mode:
+                    self._vprint(f"  {_get_cute_tool_message_impl('subagent_memory_write', function_args, tool_duration, result=function_result)}")
             elif self._memory_manager and self._memory_manager.has_tool(function_name):
                 # Memory provider tools (hindsight_retain, honcho_search, etc.)
                 # These are not in the tool registry — route through MemoryManager.

--- a/tests/tools/test_subagent_memory_write.py
+++ b/tests/tools/test_subagent_memory_write.py
@@ -1,0 +1,351 @@
+"""
+Tests for subagent memory write: make_subagent_memory_writer, subagent_memory_write,
+and the write_memory=True path in delegate_task.
+"""
+
+import json
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tools.subagent_memory_tool import (
+    MAX_CHARS,
+    MAX_WRITES,
+    make_subagent_memory_writer,
+    subagent_memory_write,
+    SUBAGENT_MEMORY_WRITE_SCHEMA,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_parent_with_store(entries=None):
+    """Build a mock parent agent with a working MemoryStore."""
+    parent = MagicMock()
+    parent._memory_manager = None
+
+    store = MagicMock()
+    _saved = list(entries or [])
+
+    def _add(target, content):
+        if len(content) > 2200:
+            return {"success": False, "error": "char limit"}
+        _saved.append(content)
+        return {"success": True, "target": target, "entries": _saved}
+
+    store.add.side_effect = _add
+    parent._memory_store = store
+    parent._saved_entries = _saved
+    return parent
+
+
+def _make_parent_no_store():
+    parent = MagicMock()
+    parent._memory_store = None
+    parent._memory_manager = None
+    return parent
+
+
+# ---------------------------------------------------------------------------
+# make_subagent_memory_writer
+# ---------------------------------------------------------------------------
+
+class TestMakeSubagentMemoryWriter(unittest.TestCase):
+
+    def test_returns_none_when_no_store(self):
+        parent = _make_parent_no_store()
+        writer = make_subagent_memory_writer(parent)
+        self.assertIsNone(writer)
+
+    def test_returns_callable_when_store_present(self):
+        parent = _make_parent_with_store()
+        writer = make_subagent_memory_writer(parent)
+        self.assertTrue(callable(writer))
+
+    def test_write_tags_entry(self):
+        parent = _make_parent_with_store()
+        writer = make_subagent_memory_writer(parent)
+        result = writer("DATABASE_URL missing from Render env")
+        self.assertTrue(result["success"])
+        stored = parent._memory_store.add.call_args[0][1]
+        self.assertTrue(stored.startswith("[subagent] "))
+        self.assertIn("DATABASE_URL", stored)
+
+    def test_write_rejects_empty_content(self):
+        parent = _make_parent_with_store()
+        writer = make_subagent_memory_writer(parent)
+        result = writer("   ")
+        self.assertFalse(result["success"])
+        self.assertIn("empty", result["error"])
+
+    def test_write_rejects_content_over_max_chars(self):
+        parent = _make_parent_with_store()
+        writer = make_subagent_memory_writer(parent)
+        long_content = "x" * (MAX_CHARS + 1)
+        result = writer(long_content)
+        self.assertFalse(result["success"])
+        self.assertIn("too long", result["error"].lower())
+
+    def test_write_accepts_content_at_max_chars(self):
+        parent = _make_parent_with_store()
+        writer = make_subagent_memory_writer(parent)
+        exact = "x" * MAX_CHARS
+        result = writer(exact)
+        self.assertTrue(result["success"])
+
+    def test_rate_limit_blocks_after_max_writes(self):
+        parent = _make_parent_with_store()
+        writer = make_subagent_memory_writer(parent)
+        for i in range(MAX_WRITES):
+            result = writer(f"Finding {i}")
+            self.assertTrue(result["success"], f"Write {i} should succeed")
+        result = writer("One more")
+        self.assertFalse(result["success"])
+        self.assertIn("limit", result["error"].lower())
+        self.assertEqual(result["writes_used"], MAX_WRITES)
+
+    def test_success_result_includes_write_counters(self):
+        parent = _make_parent_with_store()
+        writer = make_subagent_memory_writer(parent)
+        result = writer("Root cause: missing env var")
+        self.assertTrue(result["success"])
+        self.assertEqual(result["writes_used"], 1)
+        self.assertEqual(result["writes_remaining"], MAX_WRITES - 1)
+
+    def test_notifies_external_memory_manager(self):
+        parent = _make_parent_with_store()
+        mm = MagicMock()
+        parent._memory_manager = mm
+        writer = make_subagent_memory_writer(parent)
+        writer("Render crash caused by missing DATABASE_URL")
+        mm.on_memory_write.assert_called_once()
+        call_args = mm.on_memory_write.call_args[0]
+        self.assertEqual(call_args[0], "add")
+        self.assertEqual(call_args[1], "memory")
+        self.assertIn("[subagent]", call_args[2])
+
+    def test_memory_manager_failure_does_not_break_write(self):
+        parent = _make_parent_with_store()
+        mm = MagicMock()
+        mm.on_memory_write.side_effect = RuntimeError("backend down")
+        parent._memory_manager = mm
+        writer = make_subagent_memory_writer(parent)
+        result = writer("Still works despite mm failure")
+        self.assertTrue(result["success"])
+
+    def test_thread_safe_rate_limiting(self):
+        """Concurrent writes must not exceed MAX_WRITES even under race conditions."""
+        parent = _make_parent_with_store()
+        writer = make_subagent_memory_writer(parent)
+        successes = []
+        lock = threading.Lock()
+
+        def _write():
+            result = writer("concurrent finding")
+            if result.get("success"):
+                with lock:
+                    successes.append(1)
+
+        threads = [threading.Thread(target=_write) for _ in range(MAX_WRITES * 3)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertLessEqual(len(successes), MAX_WRITES)
+
+    def test_independent_writers_have_independent_counters(self):
+        """Two writers from two parent agents do not share rate limit state."""
+        p1 = _make_parent_with_store()
+        p2 = _make_parent_with_store()
+        w1 = make_subagent_memory_writer(p1)
+        w2 = make_subagent_memory_writer(p2)
+        for _ in range(MAX_WRITES):
+            w1("finding from child 1")
+        # p1's writer is exhausted -- p2's writer should still work
+        result = w2("finding from child 2")
+        self.assertTrue(result["success"])
+
+    def test_store_add_failure_propagates(self):
+        """When the memory store rejects the write, the result reflects that."""
+        parent = _make_parent_with_store()
+        parent._memory_store.add.side_effect = None
+        parent._memory_store.add.return_value = {
+            "success": False,
+            "error": "Memory at limit",
+        }
+        writer = make_subagent_memory_writer(parent)
+        result = writer("This should fail")
+        self.assertFalse(result["success"])
+        self.assertIn("limit", result["error"])
+
+
+# ---------------------------------------------------------------------------
+# subagent_memory_write (handler)
+# ---------------------------------------------------------------------------
+
+class TestSubagentMemoryWriteHandler(unittest.TestCase):
+
+    def test_returns_error_when_no_writer(self):
+        result = json.loads(subagent_memory_write("content", writer=None))
+        self.assertFalse(result["success"])
+        self.assertIn("not available", result["error"].lower())
+
+    def test_calls_writer_and_returns_json(self):
+        writer = MagicMock(return_value={"success": True, "writes_used": 1, "writes_remaining": 2})
+        result = json.loads(subagent_memory_write("root cause found", writer=writer))
+        self.assertTrue(result["success"])
+        writer.assert_called_once_with("root cause found")
+
+    def test_schema_name(self):
+        self.assertEqual(SUBAGENT_MEMORY_WRITE_SCHEMA["name"], "subagent_memory_write")
+
+    def test_schema_requires_content(self):
+        required = SUBAGENT_MEMORY_WRITE_SCHEMA["parameters"]["required"]
+        self.assertIn("content", required)
+
+
+# ---------------------------------------------------------------------------
+# delegate_task write_memory integration
+# ---------------------------------------------------------------------------
+
+class TestDelegateTaskWriteMemory(unittest.TestCase):
+
+    def _make_mock_parent(self, has_store=True):
+        import threading
+        parent = MagicMock()
+        parent.base_url = "https://openrouter.ai/api/v1"
+        parent.api_key = "***"
+        parent.provider = "openrouter"
+        parent.api_mode = "chat_completions"
+        parent.model = "anthropic/claude-sonnet-4"
+        parent.platform = "cli"
+        parent.providers_allowed = None
+        parent.providers_ignored = None
+        parent.providers_order = None
+        parent.provider_sort = None
+        parent._session_db = None
+        parent._delegate_depth = 0
+        parent._active_children = []
+        parent._active_children_lock = threading.Lock()
+        parent._print_fn = None
+        parent.tool_progress_callback = None
+        parent.thinking_callback = None
+        parent._memory_manager = None
+        if has_store:
+            store = MagicMock()
+            store.add.return_value = {"success": True, "entries": []}
+            parent._memory_store = store
+        else:
+            parent._memory_store = None
+        return parent
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_write_memory_false_does_not_inject_tool(self, mock_run):
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed",
+            "summary": "done", "api_calls": 1, "duration_seconds": 1.0,
+        }
+        parent = self._make_mock_parent()
+        captured_child = {}
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.tools = []
+            mock_child.valid_tool_names = set()
+            MockAgent.return_value = mock_child
+
+            from tools.delegate_tool import delegate_task
+            delegate_task(goal="No memory write", parent_agent=parent, write_memory=False)
+            captured_child["tools"] = list(mock_child.tools)
+            captured_child["names"] = set(mock_child.valid_tool_names)
+
+        tool_names = [t.get("function", {}).get("name") for t in captured_child["tools"]]
+        self.assertNotIn("subagent_memory_write", tool_names)
+        self.assertNotIn("subagent_memory_write", captured_child["names"])
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_write_memory_true_injects_tool_when_store_present(self, mock_run):
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed",
+            "summary": "done", "api_calls": 1, "duration_seconds": 1.0,
+        }
+        parent = self._make_mock_parent(has_store=True)
+        captured_child = {}
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.tools = []
+            mock_child.valid_tool_names = set()
+            MockAgent.return_value = mock_child
+
+            from tools.delegate_tool import delegate_task
+            delegate_task(goal="With memory write", parent_agent=parent, write_memory=True)
+            captured_child["tools"] = list(mock_child.tools)
+            captured_child["names"] = set(mock_child.valid_tool_names)
+
+        tool_names = [t.get("function", {}).get("name") for t in captured_child["tools"]]
+        self.assertIn("subagent_memory_write", tool_names)
+        self.assertIn("subagent_memory_write", captured_child["names"])
+        self.assertTrue(callable(mock_child._subagent_memory_writer))
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_write_memory_true_no_store_does_not_inject(self, mock_run):
+        """When parent has no memory store, write_memory=True is a no-op (no tool injected)."""
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed",
+            "summary": "done", "api_calls": 1, "duration_seconds": 1.0,
+        }
+        parent = self._make_mock_parent(has_store=False)
+        captured_child = {}
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.tools = []
+            mock_child.valid_tool_names = set()
+            MockAgent.return_value = mock_child
+
+            from tools.delegate_tool import delegate_task
+            delegate_task(goal="No store", parent_agent=parent, write_memory=True)
+            captured_child["tools"] = list(mock_child.tools)
+            captured_child["names"] = set(mock_child.valid_tool_names)
+
+        tool_names = [t.get("function", {}).get("name") for t in captured_child["tools"]]
+        self.assertNotIn("subagent_memory_write", tool_names)
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_writer_on_child_writes_to_parent_store(self, mock_run):
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed",
+            "summary": "done", "api_calls": 1, "duration_seconds": 1.0,
+        }
+        parent = self._make_mock_parent(has_store=True)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.tools = []
+            mock_child.valid_tool_names = set()
+            MockAgent.return_value = mock_child
+
+            from tools.delegate_tool import delegate_task
+            delegate_task(goal="Writer test", parent_agent=parent, write_memory=True)
+
+        writer = mock_child._subagent_memory_writer
+        result = writer("Root cause: DATABASE_URL missing in Render production env")
+        self.assertTrue(result["success"])
+        parent._memory_store.add.assert_called_once()
+        call_args = parent._memory_store.add.call_args[0]
+        self.assertIn("[subagent]", call_args[1])
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_schema_includes_write_memory_param(self, mock_run):
+        from tools.delegate_tool import DELEGATE_TASK_SCHEMA
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        self.assertIn("write_memory", props)
+        self.assertEqual(props["write_memory"]["type"], "boolean")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1905,6 +1905,7 @@ def delegate_task(
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
     parent_agent=None,
+    write_memory: bool = False,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks.
@@ -2063,6 +2064,20 @@ def delegate_task(
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
+            # Inject restricted memory write capability when requested
+            if write_memory:
+                from tools.subagent_memory_tool import (
+                    make_subagent_memory_writer,
+                    SUBAGENT_MEMORY_WRITE_SCHEMA,
+                )
+                writer = make_subagent_memory_writer(parent_agent)
+                if writer is not None:
+                    child._subagent_memory_writer = writer
+                    child.tools.append({
+                        "type": "function",
+                        "function": SUBAGENT_MEMORY_WRITE_SCHEMA,
+                    })
+                    child.valid_tool_names.add("subagent_memory_write")
             children.append((i, t, child))
     finally:
         # Authoritative restore: reset global to parent's tool names after all children built
@@ -2737,6 +2752,16 @@ DELEGATE_TASK_SCHEMA = {
                     "Leave empty unless acp_command is explicitly provided."
                 ),
             },
+            "write_memory": {
+                "type": "boolean",
+                "description": (
+                    "Allow the subagent to write findings to the parent's persistent memory "
+                    "via the subagent_memory_write tool. Append-only, max 3 writes of 400 chars "
+                    "each. Entries are tagged [subagent] so the parent can identify them. "
+                    "Does nothing if the parent has no memory provider configured. "
+                    "Default: false."
+                ),
+            },
         },
         "required": [],
     },
@@ -2760,6 +2785,7 @@ registry.register(
         acp_args=args.get("acp_args"),
         role=args.get("role"),
         parent_agent=kw.get("parent_agent"),
+        write_memory=args.get("write_memory", False),
     ),
     check_fn=check_delegate_requirements,
     emoji="🔀",

--- a/tools/subagent_memory_tool.py
+++ b/tools/subagent_memory_tool.py
@@ -1,0 +1,150 @@
+"""
+Subagent Memory Write Tool
+
+Provides append-only, rate-limited memory persistence for subagents.
+
+When the parent enables write_memory=True on delegate_task, the subagent
+gets this tool. Writes route through whatever memory provider the parent
+has active -- builtin MEMORY.md, mem0, Honcho, or any other registered
+provider. If the parent has no memory store, the tool returns a clear error
+instead of silently discarding the write.
+
+Constraints (enforced here):
+  - Append-only: no read, replace, or delete
+  - 3 writes per subagent run (shared rate limit across tool calls)
+  - 400 chars max per entry
+  - Content tagged [subagent] prefix so the parent can identify the source
+"""
+
+import json
+import logging
+import threading
+from typing import Any, Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+MAX_WRITES = 3
+MAX_CHARS = 400
+
+
+def make_subagent_memory_writer(parent_agent) -> Optional[Callable[[str], Dict[str, Any]]]:
+    """Create a rate-limited, append-only write callback for a subagent.
+
+    Returns None if the parent has no memory store (graceful degradation).
+    The returned callable is thread-safe.
+
+    parent_agent must be the PARENT (the agent that spawned this subagent),
+    not the child. The callback closes over parent_agent._memory_store so
+    writes go to the parent's backing store, not the child's (which has
+    skip_memory=True and no store).
+    """
+    store = getattr(parent_agent, "_memory_store", None)
+    if store is None:
+        return None
+
+    _lock = threading.Lock()
+    _write_count = [0]  # mutable list so the closure can mutate the counter
+
+    def _write(content: str) -> Dict[str, Any]:
+        with _lock:
+            if _write_count[0] >= MAX_WRITES:
+                return {
+                    "success": False,
+                    "error": (
+                        f"Write limit reached. Subagents may write at most "
+                        f"{MAX_WRITES} entries per run."
+                    ),
+                    "writes_used": _write_count[0],
+                    "writes_max": MAX_WRITES,
+                }
+
+            content = content.strip()
+            if not content:
+                return {"success": False, "error": "Content cannot be empty."}
+            if len(content) > MAX_CHARS:
+                return {
+                    "success": False,
+                    "error": (
+                        f"Content too long ({len(content)} chars). "
+                        f"Max is {MAX_CHARS} chars per entry."
+                    ),
+                }
+
+            tagged = f"[subagent] {content}"
+            result = store.add("memory", tagged)
+
+            if result.get("success"):
+                _write_count[0] += 1
+                # Notify external providers (mem0, Honcho, etc.)
+                mm = getattr(parent_agent, "_memory_manager", None)
+                if mm:
+                    try:
+                        mm.on_memory_write("add", "memory", tagged)
+                    except Exception as e:
+                        logger.debug("on_memory_write notification failed: %s", e)
+
+                result["writes_used"] = _write_count[0]
+                result["writes_remaining"] = MAX_WRITES - _write_count[0]
+
+            return result
+
+    return _write
+
+
+def subagent_memory_write(content: str, writer: Optional[Callable] = None) -> str:
+    """Write a finding to the parent agent's memory.
+
+    Handler called by run_agent.py when the model invokes subagent_memory_write.
+    writer is the closure created by make_subagent_memory_writer() and stored on
+    the child agent as _subagent_memory_writer.
+    """
+    if writer is None:
+        return json.dumps({
+            "success": False,
+            "error": (
+                "Memory write not available. Either write_memory was not "
+                "enabled on delegate_task, or the parent agent has no "
+                "memory provider configured."
+            ),
+        }, ensure_ascii=False)
+
+    result = writer(content)
+    return json.dumps(result, ensure_ascii=False)
+
+
+SUBAGENT_MEMORY_WRITE_SCHEMA = {
+    "name": "subagent_memory_write",
+    "description": (
+        "Write a key finding to the parent agent's persistent memory. "
+        "Use this for facts that should outlast this subagent run -- a root "
+        "cause, a confirmed configuration value, a working procedure, or a "
+        "constraint discovered during investigation. Not for task progress "
+        "or interim notes.\n\n"
+        "Constraints:\n"
+        f"- Append-only (no read, replace, or delete)\n"
+        f"- Max {MAX_WRITES} writes per subagent run\n"
+        f"- Max {MAX_CHARS} chars per entry\n"
+        "- Entries are tagged [subagent] so the parent can identify them\n\n"
+        "When to call this:\n"
+        "- You found the root cause of a bug or outage\n"
+        "- You confirmed a fact that required significant investigation\n"
+        "- You discovered a working procedure or workaround\n"
+        "- The finding would require re-running this investigation if lost\n\n"
+        "Write one targeted entry per finding. The parent already receives "
+        "your full summary -- this is for what needs to survive future sessions."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {
+                "type": "string",
+                "description": (
+                    f"The finding to persist. Max {MAX_CHARS} chars. "
+                    "Include enough context (names, values, environment) "
+                    "that the entry is useful without surrounding context."
+                ),
+            },
+        },
+        "required": ["content"],
+    },
+}


### PR DESCRIPTION
When a subagent diagnoses a production issue and finds the root cause, that finding lives in the final summary text. The parent receives a string. If the parent does not immediately call memory to save it, the finding is gone when the session ends.

Concretely: a subagent diagnosed a database connectivity issue and traced the failure to a missing environment variable in the production configuration. The subagent wrote that up in its summary. The parent fixed the immediate issue and moved on. Three weeks later the same symptom appeared. The parent had no memory of the root cause and delegated again, running the same investigation twice.

This PR adds a `write_memory=True` parameter to `delegate_task`. When enabled, the subagent gets a `subagent_memory_write` tool that lets it write findings directly to the parent's active memory provider before it exits. The full memory tool stays blocked for subagents — this is a narrow append-only path, not general memory access.

## Relationship to on_delegation()

The existing `on_delegation()` hook in `MemoryManager` lets parent agents observe subagent results after the fact — the parent's memory provider receives the task and result summary when the child finishes. This PR extends that with a complementary mechanism: the subagent can push findings during execution, writing directly to the parent's `_memory_store` before it returns. The two are additive. `on_delegation()` gives the parent's provider visibility into what happened; `subagent_memory_write` gives the subagent agency to tag specific facts as worth persisting.

## What changed

### tools/subagent_memory_tool.py (new)

`make_subagent_memory_writer(parent_agent)` creates a rate-limited write callback that closes over the parent's `_memory_store`. The callback:
- Validates content length (max 400 chars)
- Tracks write count against a per-subagent limit (max 3)
- Tags each entry with `[subagent]` prefix
- Calls `store.add()` on the parent's backing store
- Notifies external providers via `on_memory_write()` so the write mirrors to mem0, Honcho, or any other registered provider
- Returns `None` when the parent has no store (graceful degradation)

This tool intentionally does not use `registry.register()`. The registry pattern assumes a static, globally-available handler, but this tool requires a per-subagent writer closure created at delegation time and bound to a specific parent agent's `_memory_store`. A comment in the file documents this design decision.

### tools/delegate_tool.py

Added `write_memory: bool = False` to `delegate_task`. When `True` and the parent has a memory store, the writer callback is stored on the child as `_subagent_memory_writer` and the `subagent_memory_write` schema is injected into `child.tools` and `child.valid_tool_names`. Children built without `write_memory=True` get no writer and no tool.

Added `write_memory` to `DELEGATE_TASK_SCHEMA` so the model can request it.

### run_agent.py

Added `subagent_memory_write` dispatch in both the concurrent (`_invoke_tool`) and sequential (`_execute_tool_calls_sequential`) tool execution paths. Both paths retrieve `getattr(self, '_subagent_memory_writer', None)` and pass it to the handler.

**Important:** `write_memory` is now forwarded from `function_args` in both `delegate_task` dispatch branches. This was missing in the initial implementation (both branches called `delegate_task()` directly without the parameter, silently making the feature a no-op at runtime). Both are now fixed.

### tests/tools/test_subagent_memory_write.py (new)

24 tests covering:
- Returns None when parent has no store
- Tags entries with `[subagent]` prefix
- Rejects empty content
- Rejects content over MAX_CHARS
- Accepts content at exactly MAX_CHARS
- Rate limit blocks after MAX_WRITES
- Success result includes write counters
- Notifies external memory manager
- Memory manager failure does not block the write
- Thread-safe rate limiting under concurrent writes
- Independent writers have independent counters
- Store failure propagates correctly
- Handler returns error when writer is None
- Handler calls writer and returns JSON
- `delegate_task` injects tool when `write_memory=True` and store present
- `delegate_task` does not inject tool when `write_memory=False`
- `delegate_task` does not inject tool when `write_memory=True` and no store
- Writer on child writes to parent store
- Schema includes `write_memory` param
- `_invoke_tool` forwards `write_memory=True` to `delegate_task` (regression test)
- `_invoke_tool` forwards `write_memory=False` (default) to `delegate_task` (regression test)