### PR TITLE
fix(imessage): dedup flooding, per-message tracking, streaming cursor strip, read receipts

### DIFF
--- a/gateway/platforms/imessage.py
+++ b/gateway/platforms/imessage.py
@@ -14,7 +14,6 @@ Optional environment variables:
                            allowed to interact. Leave unset to allow all.
   IMESSAGE_HOME_CHANNEL    Chat rowid (integer) to use as default cron
                            delivery target.
-  IMESSAGE_POLL_INTERVAL   Seconds between polls (default: 30).
 """
 
 import asyncio
@@ -37,7 +36,9 @@ from gateway.platforms.base import (
 logger = logging.getLogger(__name__)
 
 MAX_MESSAGE_LENGTH = 8000
-DEFAULT_POLL_INTERVAL = 30.0
+
+# Seconds to wait before restarting a crashed watch process
+_WATCH_RESTART_DELAY = 5.0
 
 # Maximum seen message rowids to track per chat (prevents unbounded growth)
 _MAX_SEEN_IDS_PER_CHAT = 200
@@ -163,16 +164,12 @@ class IMessageAdapter(BasePlatformAdapter):
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.IMESSAGE)
-        self._poll_interval: float = float(
-            os.getenv("IMESSAGE_POLL_INTERVAL", str(DEFAULT_POLL_INTERVAL))
-        )
-        allowed_raw = os.getenv("IMESSAGE_ALLOWED_USERS", "+14806893441")
+        allowed_raw = os.getenv("IMESSAGE_ALLOWED_USERS", "+148****3441")
         self._allowed_users: List[str] = (
             _parse_comma_list(allowed_raw) if allowed_raw else []
         )
         self._allow_all = not self._allowed_users
         self._chat_identifiers: Dict[int, str] = {}
-        self._last_seen: Dict[int, str] = {}
 
         # Per-message dedup: track seen rowids per chat to avoid re-dispatching
         # messages whose timestamp predates (or equals) a reply we just sent.
@@ -180,14 +177,15 @@ class IMessageAdapter(BasePlatformAdapter):
         self._seen_message_ids: Dict[int, Set[int]] = {}
 
         # Per-chat processing lock: skip a chat that is already being handled
-        # so concurrent polls don't pile up duplicate dispatches.
+        # so concurrent watch events don't pile up duplicate dispatches.
         self._chat_locks: Dict[int, asyncio.Lock] = {}
 
         # Recent-dispatch dedup: (chat_rowid, text_hash) -> monotonic timestamp.
         # Drops a message that was already dispatched within _DEDUP_WINDOW_SECONDS.
         self._recent_dispatches: Dict[Tuple[int, str], float] = {}
 
-        self._poll_task: Optional[asyncio.Task] = None
+        # Per-chat watch tasks, keyed by chat rowid
+        self._watch_tasks: Dict[int, asyncio.Task] = {}
         self._running = False
 
     # ── Lifecycle ────────────────────────────────────────────────────────────
@@ -198,25 +196,49 @@ class IMessageAdapter(BasePlatformAdapter):
             return False
         await self._refresh_chat_map()
         if not self._chat_identifiers:
-            logger.warning("iMessage: no chats found — will keep polling until Messages.app has history")
+            logger.warning("iMessage: no chats found — will not watch any chats until restart")
         else:
             logger.info("iMessage: seeded %d chat(s): %s",
                 len(self._chat_identifiers),
                 [_redact(v) for v in self._chat_identifiers.values()])
-        await self._seed_last_seen()
+
         self._running = True
-        self._poll_task = asyncio.create_task(self._poll_loop())
-        logger.info("iMessage: connected (poll every %.1fs)", self._poll_interval)
+
+        # For each allowed chat, find the max message rowid then spawn a watch task
+        chats_to_watch = []
+        for rowid, identifier in self._chat_identifiers.items():
+            if not self._allow_all and identifier not in self._allowed_users:
+                continue
+            # Get current max rowid to avoid replaying history on connect
+            since_rowid = await self._get_max_rowid(rowid)
+            chats_to_watch.append((rowid, identifier, since_rowid))
+
+        for rowid, identifier, since_rowid in chats_to_watch:
+            task = asyncio.create_task(
+                self._watch_chat(rowid, identifier, since_rowid),
+                name=f"imsg-watch-{rowid}",
+            )
+            self._watch_tasks[rowid] = task
+            logger.info(
+                "iMessage: watching chat %d (%s) since rowid %d",
+                rowid, _redact(identifier), since_rowid,
+            )
+
+        logger.info(
+            "iMessage: connected — watching %d chat(s) via imsg watch",
+            len(self._watch_tasks),
+        )
         return True
 
     async def disconnect(self) -> None:
         self._running = False
-        if self._poll_task:
-            self._poll_task.cancel()
+        for rowid, task in list(self._watch_tasks.items()):
+            task.cancel()
             try:
-                await self._poll_task
+                await task
             except asyncio.CancelledError:
                 pass
+        self._watch_tasks.clear()
         logger.info("iMessage: disconnected")
 
     # ── Send ─────────────────────────────────────────────────────────────────
@@ -346,104 +368,146 @@ class IMessageAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.debug("iMessage: AppleScript error: %s", exc)
 
-    # ── Poll loop ─────────────────────────────────────────────────────────────
+    # ── Watch loop ────────────────────────────────────────────────────────────
 
-    async def _poll_loop(self) -> None:
-        while self._running:
-            try:
-                await self._check_new_messages()
-            except asyncio.CancelledError:
-                break
-            except Exception as exc:
-                logger.error("iMessage: poll error: %s", exc)
-            try:
-                await asyncio.sleep(self._poll_interval)
-            except asyncio.CancelledError:
-                break
-
-    async def _check_new_messages(self) -> None:
-        chats = await self._get_chats()
-        if not chats:
+    async def _watch_chat(self, chat_rowid: int, identifier: str, since_rowid: int) -> None:
+        """Persistent per-chat watch task using `imsg watch --since-rowid`."""
+        imsg = _find_imsg()
+        if not imsg:
+            logger.error("iMessage: imsg binary not found; cannot watch chat %d", chat_rowid)
             return
 
-        # Expire old recent-dispatch entries to keep the dict bounded.
+        current_since = since_rowid
+
+        while self._running:
+            logger.debug(
+                "iMessage: spawning watch for chat %d (%s) since rowid %d",
+                chat_rowid, _redact(identifier), current_since,
+            )
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    imsg, "watch",
+                    "--chat-id", str(chat_rowid),
+                    "--since-rowid", str(current_since),
+                    "--json",
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    stdin=asyncio.subprocess.DEVNULL,
+                    env=_SUBPROCESS_ENV,
+                )
+            except Exception as exc:
+                logger.error(
+                    "iMessage: failed to spawn watch for chat %d: %s; retrying in %.1fs",
+                    chat_rowid, exc, _WATCH_RESTART_DELAY,
+                )
+                await asyncio.sleep(_WATCH_RESTART_DELAY)
+                continue
+
+            try:
+                await self._read_watch_stream(proc, chat_rowid, identifier, current_since)
+            except asyncio.CancelledError:
+                # Disconnect requested — kill the process and bail out
+                try:
+                    proc.kill()
+                except Exception:
+                    pass
+                raise
+            except Exception as exc:
+                logger.error(
+                    "iMessage: watch stream error for chat %d: %s",
+                    chat_rowid, exc,
+                )
+
+            # Process exited unexpectedly (or errored) — grab the last seen rowid
+            # from our seen_ids so we don't re-replay on restart
+            seen_ids = self._seen_message_ids.get(chat_rowid)
+            if seen_ids:
+                current_since = max(seen_ids)
+
+            if self._running:
+                logger.warning(
+                    "iMessage: watch process for chat %d exited; restarting in %.1fs",
+                    chat_rowid, _WATCH_RESTART_DELAY,
+                )
+                await asyncio.sleep(_WATCH_RESTART_DELAY)
+
+    async def _read_watch_stream(
+        self,
+        proc: asyncio.subprocess.Process,
+        chat_rowid: int,
+        identifier: str,
+        since_rowid: int,
+    ) -> None:
+        """Read JSON lines from a running `imsg watch` process until it exits."""
+        assert proc.stdout is not None
+
+        # Expire old recent-dispatch entries to keep the dict bounded
         _now = time.monotonic()
         expired = [k for k, ts in self._recent_dispatches.items()
                    if _now - ts > _DEDUP_WINDOW_SECONDS * 2]
         for k in expired:
             del self._recent_dispatches[k]
 
-        for chat in chats:
-            rowid = chat.get("id")
-            identifier = chat.get("identifier", "")
-            last_msg_at = chat.get("last_message_at")
-            if rowid is None or not last_msg_at:
-                continue
-            if identifier:
-                self._chat_identifiers[rowid] = identifier
-            if not self._allow_all and identifier not in self._allowed_users:
+        while True:
+            try:
+                line_bytes = await proc.stdout.readline()
+            except Exception as exc:
+                logger.debug("iMessage: readline error for chat %d: %s", chat_rowid, exc)
+                break
+
+            if not line_bytes:
+                # EOF — process exited
+                break
+
+            line = line_bytes.decode("utf-8", errors="replace").strip()
+            if not line:
                 continue
 
-            # Skip chats that are already being processed to avoid concurrent
-            # duplicate dispatches when agent response time exceeds poll interval.
-            lock = self._chat_locks.get(rowid)
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError:
+                logger.debug("iMessage: non-JSON line from watch (chat %d): %s", chat_rowid, line[:120])
+                continue
+
+            # Filter: skip outbound messages
+            if msg.get("is_from_me", False):
+                continue
+
+            msg_rowid = msg.get("id") or msg.get("rowid")
+
+            # Rowid-based dedup (safety net)
+            seen_ids = self._seen_message_ids.setdefault(chat_rowid, set())
+            if msg_rowid is not None:
+                if msg_rowid in seen_ids:
+                    logger.debug(
+                        "iMessage: skipping already-seen rowid %d for chat %d",
+                        msg_rowid, chat_rowid,
+                    )
+                    continue
+                seen_ids.add(msg_rowid)
+                # Cap set size to avoid unbounded memory growth
+                if len(seen_ids) > _MAX_SEEN_IDS_PER_CHAT:
+                    overflow = len(seen_ids) - _MAX_SEEN_IDS_PER_CHAT
+                    for old_id in sorted(seen_ids)[:overflow]:
+                        seen_ids.discard(old_id)
+
+            # Per-chat lock: prevent concurrent dispatches for the same chat
+            lock = self._chat_locks.get(chat_rowid)
             if lock is None:
                 lock = asyncio.Lock()
-                self._chat_locks[rowid] = lock
-            if lock.locked():
-                logger.debug("iMessage: chat %d already processing, skipping poll", rowid)
-                continue
-
-            prev_seen = self._last_seen.get(rowid)
-            if prev_seen is None:
-                self._last_seen[rowid] = last_msg_at
-                continue
-            if last_msg_at <= prev_seen:
-                continue
-
-            messages = await self._get_history(rowid, limit=20)
-            new_messages = [
-                m for m in messages
-                if m.get("created_at", "") > prev_seen
-                and not m.get("is_from_me", True)
-            ]
-
-            # Secondary rowid-based filter: only messages we haven't seen before.
-            seen_ids = self._seen_message_ids.setdefault(rowid, set())
-            truly_new = []
-            for m in new_messages:
-                msg_rowid = m.get("rowid") or m.get("id")
-                if msg_rowid is None:
-                    # No rowid available — fall back to timestamp filter only
-                    truly_new.append(m)
-                elif msg_rowid not in seen_ids:
-                    truly_new.append(m)
-
-            if not truly_new:
-                # Update timestamp even if nothing new to dispatch so we
-                # don't keep re-fetching history on every poll.
-                self._last_seen[rowid] = last_msg_at
-                continue
-
-            # Mark all fetched rowids as seen *before* dispatching so that
-            # if a concurrent poll fires while we're awaiting the agent the
-            # rowids are already recorded.
-            for m in truly_new:
-                msg_rowid = m.get("rowid") or m.get("id")
-                if msg_rowid is not None:
-                    seen_ids.add(msg_rowid)
-            # Cap set size to avoid unbounded memory growth.
-            if len(seen_ids) > _MAX_SEEN_IDS_PER_CHAT:
-                overflow = len(seen_ids) - _MAX_SEEN_IDS_PER_CHAT
-                # Discard the smallest (oldest) rowids.
-                for old_id in sorted(seen_ids)[:overflow]:
-                    seen_ids.discard(old_id)
-
-            self._last_seen[rowid] = last_msg_at
+                self._chat_locks[chat_rowid] = lock
 
             async with lock:
-                for msg in truly_new:
-                    await self._dispatch_message(rowid, identifier, msg)
+                await self._dispatch_message(chat_rowid, identifier, msg)
+
+        # Wait for process to fully exit
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=5)
+        except asyncio.TimeoutError:
+            try:
+                proc.kill()
+            except Exception:
+                pass
 
     async def _dispatch_message(self, chat_rowid: int, identifier: str, msg: dict) -> None:
         text = (msg.get("text") or "").strip()
@@ -481,6 +545,8 @@ class IMessageAdapter(BasePlatformAdapter):
         )
         await self.handle_message(event)
 
+    # ── Helpers ───────────────────────────────────────────────────────────────
+
     async def _get_chats(self) -> List[dict]:
         output = await _run_imsg("chats", "--json")
         if not output:
@@ -511,6 +577,26 @@ class IMessageAdapter(BasePlatformAdapter):
                 pass
         return messages
 
+    async def _get_max_rowid(self, chat_rowid: int) -> int:
+        """Return the highest message rowid currently in the chat history.
+
+        Used at startup so `imsg watch --since-rowid` doesn't replay existing
+        messages. Falls back to 0 if history is empty or unavailable.
+        """
+        messages = await self._get_history(chat_rowid, limit=_MAX_SEEN_IDS_PER_CHAT)
+        if not messages:
+            return 0
+        # Pre-populate seen_ids as a safety net
+        seen_ids = self._seen_message_ids.setdefault(chat_rowid, set())
+        max_id = 0
+        for m in messages:
+            msg_rowid = m.get("id") or m.get("rowid")
+            if msg_rowid is not None:
+                seen_ids.add(msg_rowid)
+                if msg_rowid > max_id:
+                    max_id = msg_rowid
+        return max_id
+
     async def _refresh_chat_map(self) -> None:
         chats = await self._get_chats()
         for chat in chats:
@@ -518,25 +604,6 @@ class IMessageAdapter(BasePlatformAdapter):
             identifier = chat.get("identifier", "")
             if rowid is not None and identifier:
                 self._chat_identifiers[rowid] = identifier
-
-    async def _seed_last_seen(self) -> None:
-        """Seed last-seen timestamps and pre-populate seen rowids so existing
-        messages are not re-dispatched on first connect."""
-        chats = await self._get_chats()
-        for chat in chats:
-            rowid = chat.get("id")
-            last_msg_at = chat.get("last_message_at")
-            if rowid is None or not last_msg_at:
-                continue
-            self._last_seen[rowid] = last_msg_at
-            # Pre-populate seen rowids from the most recent messages so we
-            # don't dispatch historical messages after a restart.
-            messages = await self._get_history(rowid, limit=_MAX_SEEN_IDS_PER_CHAT)
-            seen_ids = self._seen_message_ids.setdefault(rowid, set())
-            for m in messages:
-                msg_rowid = m.get("rowid") or m.get("id")
-                if msg_rowid is not None:
-                    seen_ids.add(msg_rowid)
 
     def _split_message(self, text: str) -> List[str]:
         if len(text) <= self.MAX_MESSAGE_LENGTH:

--- a/gateway/platforms/imessage.py
+++ b/gateway/platforms/imessage.py
@@ -187,7 +187,6 @@ class IMessageAdapter(BasePlatformAdapter):
         # Per-chat watch tasks, keyed by chat rowid
         self._watch_tasks: Dict[int, asyncio.Task] = {}
         self._stream_chats: set = set()
-        self._last_sent_content: dict = {}
         self._running = False
 
     # ── Lifecycle ────────────────────────────────────────────────────────────
@@ -246,63 +245,33 @@ class IMessageAdapter(BasePlatformAdapter):
     # ── Send ─────────────────────────────────────────────────────────────────
 
     async def send(self, chat_id, content, *, reply_to=None, metadata=None, **kwargs) -> SendResult:
-        # iMessage cannot edit messages so streaming is handled by sending
-        # delta content as separate bubbles.
+        # Suppress all stream consumer sends (cursor and final got_done send).
+        # iMessage cannot edit messages so streaming produces mid-sentence splits.
+        # The normal response path delivers one clean complete message.
         #
-        # Cursor-bearing sends (intermediate streaming): strip cursor, send
-        # the new delta since last send, return a fake message_id so the
-        # stream consumer tracks a session (already_sent=True prevents
-        # the normal response path from double-sending).
-        #
-        # Non-cursor sends while in a stream session: this is the got_done
-        # final send -- also send as delta, also return fake message_id.
-        #
-        # Non-cursor sends outside any stream session: normal send.
+        # Cursor send: mark chat in-stream, suppress.
+        # No-cursor send while in-stream: final got_done send, suppress and clear.
+        # No-cursor send not in-stream: genuine send, deliver normally.
         has_cursor = any(content.endswith(c) for c in _STREAMING_CURSORS)
         if has_cursor:
-            for cursor in _STREAMING_CURSORS:
-                if content.endswith(cursor):
-                    content = content[:-len(cursor)]
-            content = content.rstrip()
-
-        content = content.lstrip("\n").rstrip()
-        if not content:
-            if has_cursor:
-                return SendResult(success=True, message_id=f"imsg-{chat_id}")
-            return SendResult(success=True)
-
-        # Delta: only send text that is new since the last send for this chat
-        last = self._last_sent_content.get(str(chat_id), "")
-        if last and content.startswith(last):
-            delta = content[len(last):].lstrip("\n").strip()
-        else:
-            delta = content
-
-        if not delta:
-            if has_cursor or str(chat_id) in self._stream_chats:
-                return SendResult(success=True, message_id=f"imsg-{chat_id}")
-            return SendResult(success=True)
-
-        if has_cursor or str(chat_id) in self._stream_chats:
             self._stream_chats.add(str(chat_id))
+            return SendResult(success=True)
 
-        chunks = self._split_message(delta)
+        if str(chat_id) in self._stream_chats:
+            self._stream_chats.discard(str(chat_id))
+            return SendResult(success=True)
+
+        content = content.lstrip(chr(10)).rstrip()
+        if not content:
+            return SendResult(success=True)
+
+        chunks = self._split_message(content)
         last_result = SendResult(success=False, error="no chunks")
         for chunk in chunks:
             last_result = await self._send_chunk(chat_id, chunk)
             if not last_result.success:
                 break
-
-        if last_result.success:
-            self._last_sent_content[str(chat_id)] = content
-            if str(chat_id) in self._stream_chats:
-                return SendResult(success=True, message_id=f"imsg-{chat_id}")
-
         return last_result
-
-    async def edit_message(self, chat_id, message_id, content, metadata=None, **kwargs) -> SendResult:
-        """Stream consumer edits -- deliver as delta send."""
-        return await self.send(chat_id, content, metadata=metadata)
 
     async def _send_chunk(self, chat_id: str, text: str) -> SendResult:
         if chat_id.isdigit():

--- a/gateway/platforms/imessage.py
+++ b/gateway/platforms/imessage.py
@@ -246,22 +246,54 @@ class IMessageAdapter(BasePlatformAdapter):
     async def send(self, chat_id, content, *, reply_to=None, metadata=None, **kwargs) -> SendResult:
         # Detect intermediate streaming updates: GatewayStreamConsumer appends
         # a cursor character while the agent is still generating.  iMessage has
-        # no edit-message API, so sending these partial fragments would leave a
-        # stray incomplete message in the conversation.  Suppress them silently;
-        # the final complete response is delivered without a cursor by the
-        # normal send path.
+        # no edit-message API so we suppress partial fragments.
+        # Returning a fake message_id lets the stream consumer establish an
+        # "edit session" -- subsequent streaming deltas go via edit_message()
+        # which we also suppress, and the final cursor-free edit is the only
+        # real send that reaches AppleScript.
         for cursor in _STREAMING_CURSORS:
             if content.endswith(cursor):
-                # Return success=True but no message_id so the stream consumer
-                # knows the send "worked" but cannot set up an edit session.
-                # This causes it to disable streaming for this adapter and fall
-                # back to the normal final-response send path.
-                return SendResult(success=True)
+                return SendResult(success=True, message_id=f"imsg-stream-{chat_id}")
 
-        # Strip any stray cursor characters that survived (defensive).
+        # Strip leading newlines (streaming artifacts) and trailing cursor chars.
+        content = content.lstrip(chr(10))
         for cursor in _STREAMING_CURSORS:
             if content.endswith(cursor):
                 content = content[: -len(cursor)].rstrip()
+
+        if not content.strip():
+            return SendResult(success=True)
+
+        chunks = self._split_message(content)
+        last_result = SendResult(success=False, error="no chunks")
+        for chunk in chunks:
+            last_result = await self._send_chunk(chat_id, chunk)
+            if not last_result.success:
+                break
+        return last_result
+
+    async def edit_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+        metadata=None,
+        **kwargs,
+    ) -> SendResult:
+        """Handle streaming edit calls from GatewayStreamConsumer.
+
+        Intermediate edits (content ends with cursor) are suppressed.
+        The final cursor-free edit is the one real send we deliver.
+        """
+        # Suppress all intermediate streaming edits (have cursor appended).
+        for cursor in _STREAMING_CURSORS:
+            if content.endswith(cursor):
+                return SendResult(success=True)
+
+        # Final edit: strip leading newlines and send the clean text.
+        content = content.lstrip(chr(10)).rstrip()
+        if not content:
+            return SendResult(success=True)
 
         chunks = self._split_message(content)
         last_result = SendResult(success=False, error="no chunks")

--- a/gateway/platforms/imessage.py
+++ b/gateway/platforms/imessage.py
@@ -14,6 +14,7 @@ Optional environment variables:
                            allowed to interact. Leave unset to allow all.
   IMESSAGE_HOME_CHANNEL    Chat rowid (integer) to use as default cron
                            delivery target.
+  IMESSAGE_POLL_INTERVAL   Seconds between polls (default: 30).
 """
 
 import asyncio
@@ -36,9 +37,7 @@ from gateway.platforms.base import (
 logger = logging.getLogger(__name__)
 
 MAX_MESSAGE_LENGTH = 8000
-
-# Seconds to wait before restarting a crashed watch process
-_WATCH_RESTART_DELAY = 5.0
+DEFAULT_POLL_INTERVAL = 30.0
 
 # Maximum seen message rowids to track per chat (prevents unbounded growth)
 _MAX_SEEN_IDS_PER_CHAT = 200
@@ -164,12 +163,16 @@ class IMessageAdapter(BasePlatformAdapter):
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.IMESSAGE)
-        allowed_raw = os.getenv("IMESSAGE_ALLOWED_USERS", "+148****3441")
+        self._poll_interval: float = float(
+            os.getenv("IMESSAGE_POLL_INTERVAL", str(DEFAULT_POLL_INTERVAL))
+        )
+        allowed_raw = os.getenv("IMESSAGE_ALLOWED_USERS", "+14806893441")
         self._allowed_users: List[str] = (
             _parse_comma_list(allowed_raw) if allowed_raw else []
         )
         self._allow_all = not self._allowed_users
         self._chat_identifiers: Dict[int, str] = {}
+        self._last_seen: Dict[int, str] = {}
 
         # Per-message dedup: track seen rowids per chat to avoid re-dispatching
         # messages whose timestamp predates (or equals) a reply we just sent.
@@ -177,17 +180,16 @@ class IMessageAdapter(BasePlatformAdapter):
         self._seen_message_ids: Dict[int, Set[int]] = {}
 
         # Per-chat processing lock: skip a chat that is already being handled
-        # so concurrent watch events don't pile up duplicate dispatches.
+        # so concurrent polls don't pile up duplicate dispatches.
         self._chat_locks: Dict[int, asyncio.Lock] = {}
 
         # Recent-dispatch dedup: (chat_rowid, text_hash) -> monotonic timestamp.
         # Drops a message that was already dispatched within _DEDUP_WINDOW_SECONDS.
         self._recent_dispatches: Dict[Tuple[int, str], float] = {}
 
-        # Per-chat watch tasks, keyed by chat rowid
-        self._watch_tasks: Dict[int, asyncio.Task] = {}
-        self._stream_chats: set = set()  # chat_ids mid-stream
-        self._last_sent_content: dict = {}  # chat_id -> last text sent (for delta)
+        self._poll_task: Optional[asyncio.Task] = None
+        self._stream_chats: set = set()
+        self._last_sent_content: dict = {}
         self._running = False
 
     # ── Lifecycle ────────────────────────────────────────────────────────────
@@ -198,104 +200,119 @@ class IMessageAdapter(BasePlatformAdapter):
             return False
         await self._refresh_chat_map()
         if not self._chat_identifiers:
-            logger.warning("iMessage: no chats found — will not watch any chats until restart")
+            logger.warning("iMessage: no chats found — will keep polling until Messages.app has history")
         else:
             logger.info("iMessage: seeded %d chat(s): %s",
                 len(self._chat_identifiers),
                 [_redact(v) for v in self._chat_identifiers.values()])
-
+        await self._seed_last_seen()
         self._running = True
-
-        # For each allowed chat, find the max message rowid then spawn a watch task
-        chats_to_watch = []
-        for rowid, identifier in self._chat_identifiers.items():
-            if not self._allow_all and identifier not in self._allowed_users:
-                continue
-            # Get current max rowid to avoid replaying history on connect
-            since_rowid = await self._get_max_rowid(rowid)
-            chats_to_watch.append((rowid, identifier, since_rowid))
-
-        for rowid, identifier, since_rowid in chats_to_watch:
-            task = asyncio.create_task(
-                self._watch_chat(rowid, identifier, since_rowid),
-                name=f"imsg-watch-{rowid}",
-            )
-            self._watch_tasks[rowid] = task
-            logger.info(
-                "iMessage: watching chat %d (%s) since rowid %d",
-                rowid, _redact(identifier), since_rowid,
-            )
-
-        logger.info(
-            "iMessage: connected — watching %d chat(s) via imsg watch",
-            len(self._watch_tasks),
-        )
+        self._poll_task = asyncio.create_task(self._poll_loop())
+        logger.info("iMessage: connected (poll every %.1fs)", self._poll_interval)
         return True
 
     async def disconnect(self) -> None:
-        self._stream_chats: set = set()  # chat_ids mid-stream
-        self._last_sent_content: dict = {}  # chat_id -> last text sent (for delta)
         self._running = False
-        for rowid, task in list(self._watch_tasks.items()):
-            task.cancel()
+        if self._poll_task:
+            self._poll_task.cancel()
             try:
-                await task
+                await self._poll_task
             except asyncio.CancelledError:
                 pass
-        self._watch_tasks.clear()
         logger.info("iMessage: disconnected")
 
     # ── Send ─────────────────────────────────────────────────────────────────
 
     async def send(self, chat_id, content, *, reply_to=None, metadata=None, **kwargs) -> SendResult:
-        # Strip cursor characters from streaming updates.
-        # iMessage cannot edit messages so we deliver delta content as
-        # separate bubbles. Each flush sends only the NEW text since last send.
-        # Returning a fake message_id causes the stream consumer to mark
-        # already_sent=True so the normal response path does not double-send.
+        # iMessage cannot edit messages so streaming is handled by sending
+        # delta content as separate bubbles.
+        #
+        # Cursor-bearing sends (intermediate streaming): strip cursor, send
+        # the new delta since last send, return a fake message_id so the
+        # stream consumer tracks a session (already_sent=True prevents
+        # the normal response path from double-sending).
+        #
+        # Non-cursor sends while in a stream session: this is the got_done
+        # final send -- also send as delta, also return fake message_id.
+        #
+        # Non-cursor sends outside any stream session: normal send.
         has_cursor = any(content.endswith(c) for c in _STREAMING_CURSORS)
         if has_cursor:
-            content = content
             for cursor in _STREAMING_CURSORS:
                 if content.endswith(cursor):
                     content = content[:-len(cursor)]
             content = content.rstrip()
 
-        content = content.lstrip(chr(10)).rstrip()
+        content = content.lstrip("\n").rstrip()
         if not content:
+            if has_cursor:
+                return SendResult(success=True, message_id=f"imsg-{chat_id}")
             return SendResult(success=True)
 
-        # Compute delta: only the new content since last send
-        last = self._last_sent_content.get(str(chat_id), )
+        # Delta: only send text that is new since the last send for this chat
+        last = self._last_sent_content.get(str(chat_id), "")
         if last and content.startswith(last):
-            delta = content[len(last):].lstrip(chr(10)).strip()
+            delta = content[len(last):].lstrip("\n").strip()
         else:
             delta = content
 
         if not delta:
-            # Nothing new to send but we're in streaming -- return fake id
-            # so stream consumer keeps session alive
-            if has_cursor:
-                return SendResult(success=True, message_id=fimsg-stream-{chat_id})
+            if has_cursor or str(chat_id) in self._stream_chats:
+                return SendResult(success=True, message_id=f"imsg-{chat_id}")
             return SendResult(success=True)
 
-        result = SendResult(success=False, error="no chunks")
-        for chunk in self._split_message(delta):
-            result = await self._send_chunk(chat_id, chunk)
-            if not result.success:
+        if has_cursor or str(chat_id) in self._stream_chats:
+            self._stream_chats.add(str(chat_id))
+
+        chunks = self._split_message(delta)
+        last_result = SendResult(success=False, error="no chunks")
+        for chunk in chunks:
+            last_result = await self._send_chunk(chat_id, chunk)
+            if not last_result.success:
                 break
 
-        if result.success:
-            # Track what we sent so next delta is computed correctly
+        if last_result.success:
             self._last_sent_content[str(chat_id)] = content
-            if has_cursor:
-                # Return fake id to establish stream session (already_sent=True)
-                return SendResult(success=True, message_id=fimsg-stream-{chat_id})
-        return result
+            if str(chat_id) in self._stream_chats:
+                return SendResult(success=True, message_id=f"imsg-{chat_id}")
+
+        return last_result
 
     async def edit_message(self, chat_id, message_id, content, metadata=None, **kwargs) -> SendResult:
-        """Handle edit calls from GatewayStreamConsumer -- deliver as delta sends."""
+        """Stream consumer edits -- deliver as delta send."""
         return await self.send(chat_id, content, metadata=metadata)
+
+    async def _send_chunk(self, chat_id: str, text: str) -> SendResult:
+        if chat_id.isdigit():
+            identifier = self._chat_identifiers.get(int(chat_id))
+            if not identifier:
+                return SendResult(success=False, error="no identifier for chat")
+        else:
+            identifier = chat_id
+        escaped = text.replace("\\", "\\\\").replace('"', '\\"')
+        script = (
+            'tell application "Messages"\n'
+            '  set targetService to 1st service whose service type = iMessage\n'
+            f'  send "{escaped}" to buddy "{identifier}" of targetService\n'
+            'end tell'
+        )
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "/usr/bin/osascript", "-e", script,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                stdin=asyncio.subprocess.DEVNULL,
+                env=_SUBPROCESS_ENV,
+            )
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=20)
+            if proc.returncode == 0:
+                return SendResult(success=True)
+            err = (stderr or stdout or b"unknown").decode(errors="replace").strip()
+            return SendResult(success=False, error=err)
+        except asyncio.TimeoutError:
+            return SendResult(success=False, error="timeout")
+        except Exception as exc:
+            return SendResult(success=False, error=str(exc))
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Start iMessage typing indicator via imsg."""
@@ -362,146 +379,104 @@ class IMessageAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.debug("iMessage: AppleScript error: %s", exc)
 
-    # ── Watch loop ────────────────────────────────────────────────────────────
+    # ── Poll loop ─────────────────────────────────────────────────────────────
 
-    async def _watch_chat(self, chat_rowid: int, identifier: str, since_rowid: int) -> None:
-        """Persistent per-chat watch task using `imsg watch --since-rowid`."""
-        imsg = _find_imsg()
-        if not imsg:
-            logger.error("iMessage: imsg binary not found; cannot watch chat %d", chat_rowid)
+    async def _poll_loop(self) -> None:
+        while self._running:
+            try:
+                await self._check_new_messages()
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:
+                logger.error("iMessage: poll error: %s", exc)
+            try:
+                await asyncio.sleep(self._poll_interval)
+            except asyncio.CancelledError:
+                break
+
+    async def _check_new_messages(self) -> None:
+        chats = await self._get_chats()
+        if not chats:
             return
 
-        current_since = since_rowid
-
-        while self._running:
-            logger.debug(
-                "iMessage: spawning watch for chat %d (%s) since rowid %d",
-                chat_rowid, _redact(identifier), current_since,
-            )
-            try:
-                proc = await asyncio.create_subprocess_exec(
-                    imsg, "watch",
-                    "--chat-id", str(chat_rowid),
-                    "--since-rowid", str(current_since),
-                    "--json",
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                    stdin=asyncio.subprocess.DEVNULL,
-                    env=_SUBPROCESS_ENV,
-                )
-            except Exception as exc:
-                logger.error(
-                    "iMessage: failed to spawn watch for chat %d: %s; retrying in %.1fs",
-                    chat_rowid, exc, _WATCH_RESTART_DELAY,
-                )
-                await asyncio.sleep(_WATCH_RESTART_DELAY)
-                continue
-
-            try:
-                await self._read_watch_stream(proc, chat_rowid, identifier, current_since)
-            except asyncio.CancelledError:
-                # Disconnect requested — kill the process and bail out
-                try:
-                    proc.kill()
-                except Exception:
-                    pass
-                raise
-            except Exception as exc:
-                logger.error(
-                    "iMessage: watch stream error for chat %d: %s",
-                    chat_rowid, exc,
-                )
-
-            # Process exited unexpectedly (or errored) — grab the last seen rowid
-            # from our seen_ids so we don't re-replay on restart
-            seen_ids = self._seen_message_ids.get(chat_rowid)
-            if seen_ids:
-                current_since = max(seen_ids)
-
-            if self._running:
-                logger.warning(
-                    "iMessage: watch process for chat %d exited; restarting in %.1fs",
-                    chat_rowid, _WATCH_RESTART_DELAY,
-                )
-                await asyncio.sleep(_WATCH_RESTART_DELAY)
-
-    async def _read_watch_stream(
-        self,
-        proc: asyncio.subprocess.Process,
-        chat_rowid: int,
-        identifier: str,
-        since_rowid: int,
-    ) -> None:
-        """Read JSON lines from a running `imsg watch` process until it exits."""
-        assert proc.stdout is not None
-
-        # Expire old recent-dispatch entries to keep the dict bounded
+        # Expire old recent-dispatch entries to keep the dict bounded.
         _now = time.monotonic()
         expired = [k for k, ts in self._recent_dispatches.items()
                    if _now - ts > _DEDUP_WINDOW_SECONDS * 2]
         for k in expired:
             del self._recent_dispatches[k]
 
-        while True:
-            try:
-                line_bytes = await proc.stdout.readline()
-            except Exception as exc:
-                logger.debug("iMessage: readline error for chat %d: %s", chat_rowid, exc)
-                break
-
-            if not line_bytes:
-                # EOF — process exited
-                break
-
-            line = line_bytes.decode("utf-8", errors="replace").strip()
-            if not line:
+        for chat in chats:
+            rowid = chat.get("id")
+            identifier = chat.get("identifier", "")
+            last_msg_at = chat.get("last_message_at")
+            if rowid is None or not last_msg_at:
+                continue
+            if identifier:
+                self._chat_identifiers[rowid] = identifier
+            if not self._allow_all and identifier not in self._allowed_users:
                 continue
 
-            try:
-                msg = json.loads(line)
-            except json.JSONDecodeError:
-                logger.debug("iMessage: non-JSON line from watch (chat %d): %s", chat_rowid, line[:120])
-                continue
-
-            # Filter: skip outbound messages
-            if msg.get("is_from_me", False):
-                continue
-
-            msg_rowid = msg.get("id") or msg.get("rowid")
-
-            # Rowid-based dedup (safety net)
-            seen_ids = self._seen_message_ids.setdefault(chat_rowid, set())
-            if msg_rowid is not None:
-                if msg_rowid in seen_ids:
-                    logger.debug(
-                        "iMessage: skipping already-seen rowid %d for chat %d",
-                        msg_rowid, chat_rowid,
-                    )
-                    continue
-                seen_ids.add(msg_rowid)
-                # Cap set size to avoid unbounded memory growth
-                if len(seen_ids) > _MAX_SEEN_IDS_PER_CHAT:
-                    overflow = len(seen_ids) - _MAX_SEEN_IDS_PER_CHAT
-                    for old_id in sorted(seen_ids)[:overflow]:
-                        seen_ids.discard(old_id)
-
-            # Per-chat lock: prevent concurrent dispatches for the same chat
-            lock = self._chat_locks.get(chat_rowid)
+            # Skip chats that are already being processed to avoid concurrent
+            # duplicate dispatches when agent response time exceeds poll interval.
+            lock = self._chat_locks.get(rowid)
             if lock is None:
                 lock = asyncio.Lock()
-                self._chat_locks[chat_rowid] = lock
+                self._chat_locks[rowid] = lock
+            if lock.locked():
+                logger.debug("iMessage: chat %d already processing, skipping poll", rowid)
+                continue
+
+            prev_seen = self._last_seen.get(rowid)
+            if prev_seen is None:
+                self._last_seen[rowid] = last_msg_at
+                continue
+            if last_msg_at <= prev_seen:
+                continue
+
+            messages = await self._get_history(rowid, limit=20)
+            new_messages = [
+                m for m in messages
+                if m.get("created_at", "") > prev_seen
+                and not m.get("is_from_me", True)
+            ]
+
+            # Secondary rowid-based filter: only messages we haven't seen before.
+            seen_ids = self._seen_message_ids.setdefault(rowid, set())
+            truly_new = []
+            for m in new_messages:
+                msg_rowid = m.get("rowid") or m.get("id")
+                if msg_rowid is None:
+                    # No rowid available — fall back to timestamp filter only
+                    truly_new.append(m)
+                elif msg_rowid not in seen_ids:
+                    truly_new.append(m)
+
+            if not truly_new:
+                # Update timestamp even if nothing new to dispatch so we
+                # don't keep re-fetching history on every poll.
+                self._last_seen[rowid] = last_msg_at
+                continue
+
+            # Mark all fetched rowids as seen *before* dispatching so that
+            # if a concurrent poll fires while we're awaiting the agent the
+            # rowids are already recorded.
+            for m in truly_new:
+                msg_rowid = m.get("rowid") or m.get("id")
+                if msg_rowid is not None:
+                    seen_ids.add(msg_rowid)
+            # Cap set size to avoid unbounded memory growth.
+            if len(seen_ids) > _MAX_SEEN_IDS_PER_CHAT:
+                overflow = len(seen_ids) - _MAX_SEEN_IDS_PER_CHAT
+                # Discard the smallest (oldest) rowids.
+                for old_id in sorted(seen_ids)[:overflow]:
+                    seen_ids.discard(old_id)
+
+            self._last_seen[rowid] = last_msg_at
 
             async with lock:
-                await self._dispatch_message(chat_rowid, identifier, msg)
-
-        # Wait for process to fully exit
-        try:
-            await asyncio.wait_for(proc.wait(), timeout=5)
-        except asyncio.TimeoutError:
-            try:
-                proc.kill()
-            except Exception:
-                pass
+                for msg in truly_new:
+                    await self._dispatch_message(rowid, identifier, msg)
 
     async def _dispatch_message(self, chat_rowid: int, identifier: str, msg: dict) -> None:
         text = (msg.get("text") or "").strip()
@@ -539,8 +514,6 @@ class IMessageAdapter(BasePlatformAdapter):
         )
         await self.handle_message(event)
 
-    # ── Helpers ───────────────────────────────────────────────────────────────
-
     async def _get_chats(self) -> List[dict]:
         output = await _run_imsg("chats", "--json")
         if not output:
@@ -571,26 +544,6 @@ class IMessageAdapter(BasePlatformAdapter):
                 pass
         return messages
 
-    async def _get_max_rowid(self, chat_rowid: int) -> int:
-        """Return the highest message rowid currently in the chat history.
-
-        Used at startup so `imsg watch --since-rowid` doesn't replay existing
-        messages. Falls back to 0 if history is empty or unavailable.
-        """
-        messages = await self._get_history(chat_rowid, limit=_MAX_SEEN_IDS_PER_CHAT)
-        if not messages:
-            return 0
-        # Pre-populate seen_ids as a safety net
-        seen_ids = self._seen_message_ids.setdefault(chat_rowid, set())
-        max_id = 0
-        for m in messages:
-            msg_rowid = m.get("id") or m.get("rowid")
-            if msg_rowid is not None:
-                seen_ids.add(msg_rowid)
-                if msg_rowid > max_id:
-                    max_id = msg_rowid
-        return max_id
-
     async def _refresh_chat_map(self) -> None:
         chats = await self._get_chats()
         for chat in chats:
@@ -598,6 +551,25 @@ class IMessageAdapter(BasePlatformAdapter):
             identifier = chat.get("identifier", "")
             if rowid is not None and identifier:
                 self._chat_identifiers[rowid] = identifier
+
+    async def _seed_last_seen(self) -> None:
+        """Seed last-seen timestamps and pre-populate seen rowids so existing
+        messages are not re-dispatched on first connect."""
+        chats = await self._get_chats()
+        for chat in chats:
+            rowid = chat.get("id")
+            last_msg_at = chat.get("last_message_at")
+            if rowid is None or not last_msg_at:
+                continue
+            self._last_seen[rowid] = last_msg_at
+            # Pre-populate seen rowids from the most recent messages so we
+            # don't dispatch historical messages after a restart.
+            messages = await self._get_history(rowid, limit=_MAX_SEEN_IDS_PER_CHAT)
+            seen_ids = self._seen_message_ids.setdefault(rowid, set())
+            for m in messages:
+                msg_rowid = m.get("rowid") or m.get("id")
+                if msg_rowid is not None:
+                    seen_ids.add(msg_rowid)
 
     def _split_message(self, text: str) -> List[str]:
         if len(text) <= self.MAX_MESSAGE_LENGTH:

--- a/gateway/platforms/imessage.py
+++ b/gateway/platforms/imessage.py
@@ -14,7 +14,6 @@ Optional environment variables:
                            allowed to interact. Leave unset to allow all.
   IMESSAGE_HOME_CHANNEL    Chat rowid (integer) to use as default cron
                            delivery target.
-  IMESSAGE_POLL_INTERVAL   Seconds between polls (default: 30).
 """
 
 import asyncio
@@ -37,7 +36,9 @@ from gateway.platforms.base import (
 logger = logging.getLogger(__name__)
 
 MAX_MESSAGE_LENGTH = 8000
-DEFAULT_POLL_INTERVAL = 30.0
+
+# Seconds to wait before restarting a crashed watch process
+_WATCH_RESTART_DELAY = 5.0
 
 # Maximum seen message rowids to track per chat (prevents unbounded growth)
 _MAX_SEEN_IDS_PER_CHAT = 200
@@ -163,16 +164,12 @@ class IMessageAdapter(BasePlatformAdapter):
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.IMESSAGE)
-        self._poll_interval: float = float(
-            os.getenv("IMESSAGE_POLL_INTERVAL", str(DEFAULT_POLL_INTERVAL))
-        )
-        allowed_raw = os.getenv("IMESSAGE_ALLOWED_USERS", "+14806893441")
+        allowed_raw = os.getenv("IMESSAGE_ALLOWED_USERS", "+148****3441")
         self._allowed_users: List[str] = (
             _parse_comma_list(allowed_raw) if allowed_raw else []
         )
         self._allow_all = not self._allowed_users
         self._chat_identifiers: Dict[int, str] = {}
-        self._last_seen: Dict[int, str] = {}
 
         # Per-message dedup: track seen rowids per chat to avoid re-dispatching
         # messages whose timestamp predates (or equals) a reply we just sent.
@@ -180,14 +177,15 @@ class IMessageAdapter(BasePlatformAdapter):
         self._seen_message_ids: Dict[int, Set[int]] = {}
 
         # Per-chat processing lock: skip a chat that is already being handled
-        # so concurrent polls don't pile up duplicate dispatches.
+        # so concurrent watch events don't pile up duplicate dispatches.
         self._chat_locks: Dict[int, asyncio.Lock] = {}
 
         # Recent-dispatch dedup: (chat_rowid, text_hash) -> monotonic timestamp.
         # Drops a message that was already dispatched within _DEDUP_WINDOW_SECONDS.
         self._recent_dispatches: Dict[Tuple[int, str], float] = {}
 
-        self._poll_task: Optional[asyncio.Task] = None
+        # Per-chat watch tasks, keyed by chat rowid
+        self._watch_tasks: Dict[int, asyncio.Task] = {}
         self._stream_chats: set = set()
         self._last_sent_content: dict = {}
         self._running = False
@@ -200,25 +198,49 @@ class IMessageAdapter(BasePlatformAdapter):
             return False
         await self._refresh_chat_map()
         if not self._chat_identifiers:
-            logger.warning("iMessage: no chats found — will keep polling until Messages.app has history")
+            logger.warning("iMessage: no chats found — will not watch any chats until restart")
         else:
             logger.info("iMessage: seeded %d chat(s): %s",
                 len(self._chat_identifiers),
                 [_redact(v) for v in self._chat_identifiers.values()])
-        await self._seed_last_seen()
+
         self._running = True
-        self._poll_task = asyncio.create_task(self._poll_loop())
-        logger.info("iMessage: connected (poll every %.1fs)", self._poll_interval)
+
+        # For each allowed chat, find the max message rowid then spawn a watch task
+        chats_to_watch = []
+        for rowid, identifier in self._chat_identifiers.items():
+            if not self._allow_all and identifier not in self._allowed_users:
+                continue
+            # Get current max rowid to avoid replaying history on connect
+            since_rowid = await self._get_max_rowid(rowid)
+            chats_to_watch.append((rowid, identifier, since_rowid))
+
+        for rowid, identifier, since_rowid in chats_to_watch:
+            task = asyncio.create_task(
+                self._watch_chat(rowid, identifier, since_rowid),
+                name=f"imsg-watch-{rowid}",
+            )
+            self._watch_tasks[rowid] = task
+            logger.info(
+                "iMessage: watching chat %d (%s) since rowid %d",
+                rowid, _redact(identifier), since_rowid,
+            )
+
+        logger.info(
+            "iMessage: connected — watching %d chat(s) via imsg watch",
+            len(self._watch_tasks),
+        )
         return True
 
     async def disconnect(self) -> None:
         self._running = False
-        if self._poll_task:
-            self._poll_task.cancel()
+        for rowid, task in list(self._watch_tasks.items()):
+            task.cancel()
             try:
-                await self._poll_task
+                await task
             except asyncio.CancelledError:
                 pass
+        self._watch_tasks.clear()
         logger.info("iMessage: disconnected")
 
     # ── Send ─────────────────────────────────────────────────────────────────
@@ -379,104 +401,146 @@ class IMessageAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.debug("iMessage: AppleScript error: %s", exc)
 
-    # ── Poll loop ─────────────────────────────────────────────────────────────
+    # ── Watch loop ────────────────────────────────────────────────────────────
 
-    async def _poll_loop(self) -> None:
-        while self._running:
-            try:
-                await self._check_new_messages()
-            except asyncio.CancelledError:
-                break
-            except Exception as exc:
-                logger.error("iMessage: poll error: %s", exc)
-            try:
-                await asyncio.sleep(self._poll_interval)
-            except asyncio.CancelledError:
-                break
-
-    async def _check_new_messages(self) -> None:
-        chats = await self._get_chats()
-        if not chats:
+    async def _watch_chat(self, chat_rowid: int, identifier: str, since_rowid: int) -> None:
+        """Persistent per-chat watch task using `imsg watch --since-rowid`."""
+        imsg = _find_imsg()
+        if not imsg:
+            logger.error("iMessage: imsg binary not found; cannot watch chat %d", chat_rowid)
             return
 
-        # Expire old recent-dispatch entries to keep the dict bounded.
+        current_since = since_rowid
+
+        while self._running:
+            logger.debug(
+                "iMessage: spawning watch for chat %d (%s) since rowid %d",
+                chat_rowid, _redact(identifier), current_since,
+            )
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    imsg, "watch",
+                    "--chat-id", str(chat_rowid),
+                    "--since-rowid", str(current_since),
+                    "--json",
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    stdin=asyncio.subprocess.DEVNULL,
+                    env=_SUBPROCESS_ENV,
+                )
+            except Exception as exc:
+                logger.error(
+                    "iMessage: failed to spawn watch for chat %d: %s; retrying in %.1fs",
+                    chat_rowid, exc, _WATCH_RESTART_DELAY,
+                )
+                await asyncio.sleep(_WATCH_RESTART_DELAY)
+                continue
+
+            try:
+                await self._read_watch_stream(proc, chat_rowid, identifier, current_since)
+            except asyncio.CancelledError:
+                # Disconnect requested — kill the process and bail out
+                try:
+                    proc.kill()
+                except Exception:
+                    pass
+                raise
+            except Exception as exc:
+                logger.error(
+                    "iMessage: watch stream error for chat %d: %s",
+                    chat_rowid, exc,
+                )
+
+            # Process exited unexpectedly (or errored) — grab the last seen rowid
+            # from our seen_ids so we don't re-replay on restart
+            seen_ids = self._seen_message_ids.get(chat_rowid)
+            if seen_ids:
+                current_since = max(seen_ids)
+
+            if self._running:
+                logger.warning(
+                    "iMessage: watch process for chat %d exited; restarting in %.1fs",
+                    chat_rowid, _WATCH_RESTART_DELAY,
+                )
+                await asyncio.sleep(_WATCH_RESTART_DELAY)
+
+    async def _read_watch_stream(
+        self,
+        proc: asyncio.subprocess.Process,
+        chat_rowid: int,
+        identifier: str,
+        since_rowid: int,
+    ) -> None:
+        """Read JSON lines from a running `imsg watch` process until it exits."""
+        assert proc.stdout is not None
+
+        # Expire old recent-dispatch entries to keep the dict bounded
         _now = time.monotonic()
         expired = [k for k, ts in self._recent_dispatches.items()
                    if _now - ts > _DEDUP_WINDOW_SECONDS * 2]
         for k in expired:
             del self._recent_dispatches[k]
 
-        for chat in chats:
-            rowid = chat.get("id")
-            identifier = chat.get("identifier", "")
-            last_msg_at = chat.get("last_message_at")
-            if rowid is None or not last_msg_at:
-                continue
-            if identifier:
-                self._chat_identifiers[rowid] = identifier
-            if not self._allow_all and identifier not in self._allowed_users:
+        while True:
+            try:
+                line_bytes = await proc.stdout.readline()
+            except Exception as exc:
+                logger.debug("iMessage: readline error for chat %d: %s", chat_rowid, exc)
+                break
+
+            if not line_bytes:
+                # EOF — process exited
+                break
+
+            line = line_bytes.decode("utf-8", errors="replace").strip()
+            if not line:
                 continue
 
-            # Skip chats that are already being processed to avoid concurrent
-            # duplicate dispatches when agent response time exceeds poll interval.
-            lock = self._chat_locks.get(rowid)
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError:
+                logger.debug("iMessage: non-JSON line from watch (chat %d): %s", chat_rowid, line[:120])
+                continue
+
+            # Filter: skip outbound messages
+            if msg.get("is_from_me", False):
+                continue
+
+            msg_rowid = msg.get("id") or msg.get("rowid")
+
+            # Rowid-based dedup (safety net)
+            seen_ids = self._seen_message_ids.setdefault(chat_rowid, set())
+            if msg_rowid is not None:
+                if msg_rowid in seen_ids:
+                    logger.debug(
+                        "iMessage: skipping already-seen rowid %d for chat %d",
+                        msg_rowid, chat_rowid,
+                    )
+                    continue
+                seen_ids.add(msg_rowid)
+                # Cap set size to avoid unbounded memory growth
+                if len(seen_ids) > _MAX_SEEN_IDS_PER_CHAT:
+                    overflow = len(seen_ids) - _MAX_SEEN_IDS_PER_CHAT
+                    for old_id in sorted(seen_ids)[:overflow]:
+                        seen_ids.discard(old_id)
+
+            # Per-chat lock: prevent concurrent dispatches for the same chat
+            lock = self._chat_locks.get(chat_rowid)
             if lock is None:
                 lock = asyncio.Lock()
-                self._chat_locks[rowid] = lock
-            if lock.locked():
-                logger.debug("iMessage: chat %d already processing, skipping poll", rowid)
-                continue
-
-            prev_seen = self._last_seen.get(rowid)
-            if prev_seen is None:
-                self._last_seen[rowid] = last_msg_at
-                continue
-            if last_msg_at <= prev_seen:
-                continue
-
-            messages = await self._get_history(rowid, limit=20)
-            new_messages = [
-                m for m in messages
-                if m.get("created_at", "") > prev_seen
-                and not m.get("is_from_me", True)
-            ]
-
-            # Secondary rowid-based filter: only messages we haven't seen before.
-            seen_ids = self._seen_message_ids.setdefault(rowid, set())
-            truly_new = []
-            for m in new_messages:
-                msg_rowid = m.get("rowid") or m.get("id")
-                if msg_rowid is None:
-                    # No rowid available — fall back to timestamp filter only
-                    truly_new.append(m)
-                elif msg_rowid not in seen_ids:
-                    truly_new.append(m)
-
-            if not truly_new:
-                # Update timestamp even if nothing new to dispatch so we
-                # don't keep re-fetching history on every poll.
-                self._last_seen[rowid] = last_msg_at
-                continue
-
-            # Mark all fetched rowids as seen *before* dispatching so that
-            # if a concurrent poll fires while we're awaiting the agent the
-            # rowids are already recorded.
-            for m in truly_new:
-                msg_rowid = m.get("rowid") or m.get("id")
-                if msg_rowid is not None:
-                    seen_ids.add(msg_rowid)
-            # Cap set size to avoid unbounded memory growth.
-            if len(seen_ids) > _MAX_SEEN_IDS_PER_CHAT:
-                overflow = len(seen_ids) - _MAX_SEEN_IDS_PER_CHAT
-                # Discard the smallest (oldest) rowids.
-                for old_id in sorted(seen_ids)[:overflow]:
-                    seen_ids.discard(old_id)
-
-            self._last_seen[rowid] = last_msg_at
+                self._chat_locks[chat_rowid] = lock
 
             async with lock:
-                for msg in truly_new:
-                    await self._dispatch_message(rowid, identifier, msg)
+                await self._dispatch_message(chat_rowid, identifier, msg)
+
+        # Wait for process to fully exit
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=5)
+        except asyncio.TimeoutError:
+            try:
+                proc.kill()
+            except Exception:
+                pass
 
     async def _dispatch_message(self, chat_rowid: int, identifier: str, msg: dict) -> None:
         text = (msg.get("text") or "").strip()
@@ -514,6 +578,8 @@ class IMessageAdapter(BasePlatformAdapter):
         )
         await self.handle_message(event)
 
+    # ── Helpers ───────────────────────────────────────────────────────────────
+
     async def _get_chats(self) -> List[dict]:
         output = await _run_imsg("chats", "--json")
         if not output:
@@ -544,6 +610,26 @@ class IMessageAdapter(BasePlatformAdapter):
                 pass
         return messages
 
+    async def _get_max_rowid(self, chat_rowid: int) -> int:
+        """Return the highest message rowid currently in the chat history.
+
+        Used at startup so `imsg watch --since-rowid` doesn't replay existing
+        messages. Falls back to 0 if history is empty or unavailable.
+        """
+        messages = await self._get_history(chat_rowid, limit=_MAX_SEEN_IDS_PER_CHAT)
+        if not messages:
+            return 0
+        # Pre-populate seen_ids as a safety net
+        seen_ids = self._seen_message_ids.setdefault(chat_rowid, set())
+        max_id = 0
+        for m in messages:
+            msg_rowid = m.get("id") or m.get("rowid")
+            if msg_rowid is not None:
+                seen_ids.add(msg_rowid)
+                if msg_rowid > max_id:
+                    max_id = msg_rowid
+        return max_id
+
     async def _refresh_chat_map(self) -> None:
         chats = await self._get_chats()
         for chat in chats:
@@ -551,25 +637,6 @@ class IMessageAdapter(BasePlatformAdapter):
             identifier = chat.get("identifier", "")
             if rowid is not None and identifier:
                 self._chat_identifiers[rowid] = identifier
-
-    async def _seed_last_seen(self) -> None:
-        """Seed last-seen timestamps and pre-populate seen rowids so existing
-        messages are not re-dispatched on first connect."""
-        chats = await self._get_chats()
-        for chat in chats:
-            rowid = chat.get("id")
-            last_msg_at = chat.get("last_message_at")
-            if rowid is None or not last_msg_at:
-                continue
-            self._last_seen[rowid] = last_msg_at
-            # Pre-populate seen rowids from the most recent messages so we
-            # don't dispatch historical messages after a restart.
-            messages = await self._get_history(rowid, limit=_MAX_SEEN_IDS_PER_CHAT)
-            seen_ids = self._seen_message_ids.setdefault(rowid, set())
-            for m in messages:
-                msg_rowid = m.get("rowid") or m.get("id")
-                if msg_rowid is not None:
-                    seen_ids.add(msg_rowid)
 
     def _split_message(self, text: str) -> List[str]:
         if len(text) <= self.MAX_MESSAGE_LENGTH:

--- a/gateway/platforms/imessage.py
+++ b/gateway/platforms/imessage.py
@@ -1,0 +1,528 @@
+"""iMessage platform adapter.
+
+Uses the `imsg` CLI (https://github.com/steipete/imsg) to send and receive
+iMessages via macOS Messages.app.
+
+Requirements:
+  - macOS with Messages.app signed in to an Apple ID
+  - `imsg` installed: brew install steipete/tap/imsg
+  - Full Disk Access granted to the process running hermes (System Settings
+    -> Privacy -> Full Disk Access)
+
+Optional environment variables:
+  IMESSAGE_ALLOWED_USERS   Comma-separated Apple IDs or E.164 phone numbers
+                           allowed to interact. Leave unset to allow all.
+  IMESSAGE_HOME_CHANNEL    Chat rowid (integer) to use as default cron
+                           delivery target.
+  IMESSAGE_POLL_INTERVAL   Seconds between polls (default: 30).
+"""
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import subprocess
+import time
+from typing import Dict, List, Optional, Set, Tuple
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
+
+logger = logging.getLogger(__name__)
+
+MAX_MESSAGE_LENGTH = 8000
+DEFAULT_POLL_INTERVAL = 30.0
+
+# Maximum seen message rowids to track per chat (prevents unbounded growth)
+_MAX_SEEN_IDS_PER_CHAT = 200
+
+# Seconds within which a (chat, text-hash) combo is considered a duplicate
+_DEDUP_WINDOW_SECONDS = 60
+
+# Streaming cursor characters appended by GatewayStreamConsumer during
+# intermediate (non-final) sends.  iMessage has no edit-message capability,
+# so we detect these and suppress the send entirely rather than letting a
+# partial-response fragment land in the conversation.
+_STREAMING_CURSORS = (" ▉", "▉", "▌", "█", "…")
+
+# Full path to imsg binary — gateway may run with a stripped PATH
+_IMSG_BIN: Optional[str] = None
+_IMSG_CANDIDATES = [
+    "/opt/homebrew/bin/imsg",
+    "/usr/local/bin/imsg",
+    "/opt/local/bin/imsg",
+]
+
+# Subprocess environment with homebrew bin in PATH
+_SUBPROCESS_ENV = os.environ.copy()
+if "/opt/homebrew/bin" not in _SUBPROCESS_ENV.get("PATH", ""):
+    _SUBPROCESS_ENV["PATH"] = "/opt/homebrew/bin:/usr/local/bin:" + _SUBPROCESS_ENV.get("PATH", "")
+
+
+def _find_imsg() -> Optional[str]:
+    """Locate the imsg binary, checking known paths then PATH."""
+    global _IMSG_BIN
+    if _IMSG_BIN:
+        return _IMSG_BIN
+    for candidate in _IMSG_CANDIDATES:
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            _IMSG_BIN = candidate
+            return _IMSG_BIN
+    import shutil
+    found = shutil.which("imsg")
+    if found:
+        _IMSG_BIN = found
+    return _IMSG_BIN
+
+
+def _redact(identifier: str) -> str:
+    """Redact an Apple ID or phone for safe logging."""
+    if not identifier:
+        return "<none>"
+    if "@" in identifier:
+        local, domain = identifier.split("@", 1)
+        return local[:3] + "***@" + domain if len(local) > 3 else "***@" + domain
+    if identifier.startswith("+"):
+        return identifier[:5] + "***" + identifier[-3:]
+    return identifier[:4] + "***"
+
+
+def _parse_comma_list(value: str) -> List[str]:
+    return [v.strip() for v in value.split(",") if v.strip()]
+
+
+def check_imessage_requirements() -> bool:
+    """Return True if imsg CLI is available."""
+    imsg = _find_imsg()
+    if not imsg:
+        return False
+    try:
+        result = subprocess.run(
+            [imsg, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env=_SUBPROCESS_ENV,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+async def _run_imsg(*args: str) -> Optional[str]:
+    """Run an imsg command async and return stdout, or None on failure."""
+    imsg = _find_imsg()
+    if not imsg:
+        logger.error("iMessage: imsg binary not found")
+        return None
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            imsg, *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            stdin=asyncio.subprocess.DEVNULL,
+            env=_SUBPROCESS_ENV,
+        )
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=15)
+        decoded = stdout.decode("utf-8", errors="replace")
+        if proc.returncode != 0:
+            err = stderr.decode(errors="replace").strip()
+            count = getattr(_run_imsg, "_perm_error_count", 0) + 1
+            _run_imsg._perm_error_count = count
+            if "permissionDenied" in decoded or "authorization denied" in decoded:
+                if count == 1 or count % 20 == 0:
+                    logger.warning(
+                        "iMessage: FDA not granted — grant Full Disk Access to the "
+                        "Python interpreter running this process in "
+                        "System Settings > Privacy > Full Disk Access (error %d)", count
+                    )
+            else:
+                logger.warning("iMessage: imsg %s exit=%d stderr=%s stdout=%s",
+                               args[0], proc.returncode, err[:200], decoded[:200])
+            return None
+        if not decoded.strip():
+            logger.debug("iMessage: imsg %s returned empty output", args[0])
+        _run_imsg._perm_error_count = 0
+        return decoded
+    except asyncio.TimeoutError:
+        logger.error("iMessage: imsg %s timed out", args[0] if args else "?")
+        return None
+    except Exception as exc:
+        logger.error("iMessage: imsg %s error: %s", args[0] if args else "?", exc)
+        return None
+
+
+class IMessageAdapter(BasePlatformAdapter):
+    MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform.IMESSAGE)
+        self._poll_interval: float = float(
+            os.getenv("IMESSAGE_POLL_INTERVAL", str(DEFAULT_POLL_INTERVAL))
+        )
+        allowed_raw = os.getenv("IMESSAGE_ALLOWED_USERS", "+14806893441")
+        self._allowed_users: List[str] = (
+            _parse_comma_list(allowed_raw) if allowed_raw else []
+        )
+        self._allow_all = not self._allowed_users
+        self._chat_identifiers: Dict[int, str] = {}
+        self._last_seen: Dict[int, str] = {}
+
+        # Per-message dedup: track seen rowids per chat to avoid re-dispatching
+        # messages whose timestamp predates (or equals) a reply we just sent.
+        # Capped at _MAX_SEEN_IDS_PER_CHAT entries per chat.
+        self._seen_message_ids: Dict[int, Set[int]] = {}
+
+        # Per-chat processing lock: skip a chat that is already being handled
+        # so concurrent polls don't pile up duplicate dispatches.
+        self._chat_locks: Dict[int, asyncio.Lock] = {}
+
+        # Recent-dispatch dedup: (chat_rowid, text_hash) -> monotonic timestamp.
+        # Drops a message that was already dispatched within _DEDUP_WINDOW_SECONDS.
+        self._recent_dispatches: Dict[Tuple[int, str], float] = {}
+
+        self._poll_task: Optional[asyncio.Task] = None
+        self._running = False
+
+    # ── Lifecycle ────────────────────────────────────────────────────────────
+
+    async def connect(self) -> bool:
+        if not check_imessage_requirements():
+            logger.error("iMessage: imsg not found. Install: brew install steipete/tap/imsg")
+            return False
+        await self._refresh_chat_map()
+        if not self._chat_identifiers:
+            logger.warning("iMessage: no chats found — will keep polling until Messages.app has history")
+        else:
+            logger.info("iMessage: seeded %d chat(s): %s",
+                len(self._chat_identifiers),
+                [_redact(v) for v in self._chat_identifiers.values()])
+        await self._seed_last_seen()
+        self._running = True
+        self._poll_task = asyncio.create_task(self._poll_loop())
+        logger.info("iMessage: connected (poll every %.1fs)", self._poll_interval)
+        return True
+
+    async def disconnect(self) -> None:
+        self._running = False
+        if self._poll_task:
+            self._poll_task.cancel()
+            try:
+                await self._poll_task
+            except asyncio.CancelledError:
+                pass
+        logger.info("iMessage: disconnected")
+
+    # ── Send ─────────────────────────────────────────────────────────────────
+
+    async def send(self, chat_id, content, *, reply_to=None, metadata=None, **kwargs) -> SendResult:
+        # Detect intermediate streaming updates: GatewayStreamConsumer appends
+        # a cursor character while the agent is still generating.  iMessage has
+        # no edit-message API, so sending these partial fragments would leave a
+        # stray incomplete message in the conversation.  Suppress them silently;
+        # the final complete response is delivered without a cursor by the
+        # normal send path.
+        for cursor in _STREAMING_CURSORS:
+            if content.endswith(cursor):
+                # Return success=True but no message_id so the stream consumer
+                # knows the send "worked" but cannot set up an edit session.
+                # This causes it to disable streaming for this adapter and fall
+                # back to the normal final-response send path.
+                return SendResult(success=True)
+
+        # Strip any stray cursor characters that survived (defensive).
+        for cursor in _STREAMING_CURSORS:
+            if content.endswith(cursor):
+                content = content[: -len(cursor)].rstrip()
+
+        chunks = self._split_message(content)
+        last_result = SendResult(success=False, error="no chunks")
+        for chunk in chunks:
+            last_result = await self._send_chunk(chat_id, chunk)
+            if not last_result.success:
+                break
+        return last_result
+
+    async def _send_chunk(self, chat_id: str, text: str) -> SendResult:
+        if chat_id.isdigit():
+            identifier = self._chat_identifiers.get(int(chat_id))
+            if not identifier:
+                return SendResult(success=False, error="no identifier for chat")
+        else:
+            identifier = chat_id
+        escaped = text.replace("\\", "\\\\").replace('"', '\\"')
+        script = (
+            'tell application "Messages"\n'
+            '  set targetService to 1st service whose service type = iMessage\n'
+            f'  send "{escaped}" to buddy "{identifier}" of targetService\n'
+            'end tell'
+        )
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "/usr/bin/osascript", "-e", script,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                stdin=asyncio.subprocess.DEVNULL,
+                env=_SUBPROCESS_ENV,
+            )
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=20)
+            if proc.returncode == 0:
+                return SendResult(success=True)
+            err = (stderr or stdout or b"unknown").decode(errors="replace").strip()
+            return SendResult(success=False, error=err)
+        except asyncio.TimeoutError:
+            return SendResult(success=False, error="timeout")
+        except Exception as exc:
+            return SendResult(success=False, error=str(exc))
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        pass  # iMessage doesn't expose typing indicators via imsg
+
+    async def get_chat_info(self, chat_id: str) -> dict:
+        identifier = self._chat_identifiers.get(int(chat_id) if chat_id.isdigit() else -1, chat_id)
+        return {"name": identifier, "type": "private", "chat_id": chat_id}
+
+    # ── Processing lifecycle hooks ────────────────────────────────────────────
+
+    async def on_processing_start(self, event: MessageEvent) -> None:
+        """Mark the conversation as read in Messages.app when processing begins."""
+        chat_id = event.source.chat_id if event.source else None
+        if not chat_id:
+            return
+        identifier = self._chat_identifiers.get(
+            int(chat_id) if str(chat_id).isdigit() else -1
+        )
+        if not identifier:
+            return
+        # AppleScript to mark all messages in the chat as read.
+        escaped_id = identifier.replace("\\", "\\\\").replace('"', '\\"')
+        script = (
+            f'tell application "Messages"\n'
+            f'  set targetChat to first chat whose id is "{escaped_id}"\n'
+            f'  mark targetChat as read\n'
+            f'end tell'
+        )
+        asyncio.create_task(self._run_applescript(script))
+
+    # ── Helpers ───────────────────────────────────────────────────────────────
+
+    async def _run_applescript(self, script: str) -> None:
+        """Fire-and-forget AppleScript execution."""
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "/usr/bin/osascript", "-e", script,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                stdin=asyncio.subprocess.DEVNULL,
+                env=_SUBPROCESS_ENV,
+            )
+            await asyncio.wait_for(proc.communicate(), timeout=10)
+        except Exception as exc:
+            logger.debug("iMessage: AppleScript error: %s", exc)
+
+    # ── Poll loop ─────────────────────────────────────────────────────────────
+
+    async def _poll_loop(self) -> None:
+        while self._running:
+            try:
+                await self._check_new_messages()
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:
+                logger.error("iMessage: poll error: %s", exc)
+            try:
+                await asyncio.sleep(self._poll_interval)
+            except asyncio.CancelledError:
+                break
+
+    async def _check_new_messages(self) -> None:
+        chats = await self._get_chats()
+        if not chats:
+            return
+
+        # Expire old recent-dispatch entries to keep the dict bounded.
+        _now = time.monotonic()
+        expired = [k for k, ts in self._recent_dispatches.items()
+                   if _now - ts > _DEDUP_WINDOW_SECONDS * 2]
+        for k in expired:
+            del self._recent_dispatches[k]
+
+        for chat in chats:
+            rowid = chat.get("id")
+            identifier = chat.get("identifier", "")
+            last_msg_at = chat.get("last_message_at")
+            if rowid is None or not last_msg_at:
+                continue
+            if identifier:
+                self._chat_identifiers[rowid] = identifier
+            if not self._allow_all and identifier not in self._allowed_users:
+                continue
+
+            # Skip chats that are already being processed to avoid concurrent
+            # duplicate dispatches when agent response time exceeds poll interval.
+            lock = self._chat_locks.get(rowid)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._chat_locks[rowid] = lock
+            if lock.locked():
+                logger.debug("iMessage: chat %d already processing, skipping poll", rowid)
+                continue
+
+            prev_seen = self._last_seen.get(rowid)
+            if prev_seen is None:
+                self._last_seen[rowid] = last_msg_at
+                continue
+            if last_msg_at <= prev_seen:
+                continue
+
+            messages = await self._get_history(rowid, limit=20)
+            new_messages = [
+                m for m in messages
+                if m.get("created_at", "") > prev_seen
+                and not m.get("is_from_me", True)
+            ]
+
+            # Secondary rowid-based filter: only messages we haven't seen before.
+            seen_ids = self._seen_message_ids.setdefault(rowid, set())
+            truly_new = []
+            for m in new_messages:
+                msg_rowid = m.get("rowid") or m.get("id")
+                if msg_rowid is None:
+                    # No rowid available — fall back to timestamp filter only
+                    truly_new.append(m)
+                elif msg_rowid not in seen_ids:
+                    truly_new.append(m)
+
+            if not truly_new:
+                # Update timestamp even if nothing new to dispatch so we
+                # don't keep re-fetching history on every poll.
+                self._last_seen[rowid] = last_msg_at
+                continue
+
+            # Mark all fetched rowids as seen *before* dispatching so that
+            # if a concurrent poll fires while we're awaiting the agent the
+            # rowids are already recorded.
+            for m in truly_new:
+                msg_rowid = m.get("rowid") or m.get("id")
+                if msg_rowid is not None:
+                    seen_ids.add(msg_rowid)
+            # Cap set size to avoid unbounded memory growth.
+            if len(seen_ids) > _MAX_SEEN_IDS_PER_CHAT:
+                overflow = len(seen_ids) - _MAX_SEEN_IDS_PER_CHAT
+                # Discard the smallest (oldest) rowids.
+                for old_id in sorted(seen_ids)[:overflow]:
+                    seen_ids.discard(old_id)
+
+            self._last_seen[rowid] = last_msg_at
+
+            async with lock:
+                for msg in truly_new:
+                    await self._dispatch_message(rowid, identifier, msg)
+
+    async def _dispatch_message(self, chat_rowid: int, identifier: str, msg: dict) -> None:
+        text = (msg.get("text") or "").strip()
+        if not text:
+            return
+
+        # Recent-dispatch dedup: drop if the same (chat, text) was dispatched
+        # within the dedup window (guards against edge-case race conditions not
+        # covered by the rowid filter alone).
+        text_hash = hashlib.md5(text.encode("utf-8", errors="replace")).hexdigest()
+        dedup_key = (chat_rowid, text_hash)
+        _now = time.monotonic()
+        last_dispatch = self._recent_dispatches.get(dedup_key)
+        if last_dispatch is not None and (_now - last_dispatch) < _DEDUP_WINDOW_SECONDS:
+            logger.warning(
+                "iMessage: dropping duplicate dispatch for chat %d (text hash %s, "
+                "%.1fs since last dispatch)",
+                chat_rowid, text_hash, _now - last_dispatch,
+            )
+            return
+        self._recent_dispatches[dedup_key] = _now
+
+        chat_id_str = str(chat_rowid)
+        source = self.build_source(
+            chat_id=chat_id_str,
+            user_id=identifier or chat_id_str,
+            chat_name=identifier or chat_id_str,
+            user_name=identifier or chat_id_str,
+        )
+        event = MessageEvent(
+            message_type=MessageType.TEXT,
+            text=text,
+            source=source,
+            raw_message=msg,
+        )
+        await self.handle_message(event)
+
+    async def _get_chats(self) -> List[dict]:
+        output = await _run_imsg("chats", "--json")
+        if not output:
+            return []
+        chats = []
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                chats.append(json.loads(line))
+            except json.JSONDecodeError:
+                pass
+        return chats
+
+    async def _get_history(self, chat_rowid: int, limit: int = 20) -> List[dict]:
+        output = await _run_imsg("history", "--chat-id", str(chat_rowid), "--limit", str(limit), "--json")
+        if not output:
+            return []
+        messages = []
+        for line in output.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                messages.append(json.loads(line))
+            except json.JSONDecodeError:
+                pass
+        return messages
+
+    async def _refresh_chat_map(self) -> None:
+        chats = await self._get_chats()
+        for chat in chats:
+            rowid = chat.get("id")
+            identifier = chat.get("identifier", "")
+            if rowid is not None and identifier:
+                self._chat_identifiers[rowid] = identifier
+
+    async def _seed_last_seen(self) -> None:
+        """Seed last-seen timestamps and pre-populate seen rowids so existing
+        messages are not re-dispatched on first connect."""
+        chats = await self._get_chats()
+        for chat in chats:
+            rowid = chat.get("id")
+            last_msg_at = chat.get("last_message_at")
+            if rowid is None or not last_msg_at:
+                continue
+            self._last_seen[rowid] = last_msg_at
+            # Pre-populate seen rowids from the most recent messages so we
+            # don't dispatch historical messages after a restart.
+            messages = await self._get_history(rowid, limit=_MAX_SEEN_IDS_PER_CHAT)
+            seen_ids = self._seen_message_ids.setdefault(rowid, set())
+            for m in messages:
+                msg_rowid = m.get("rowid") or m.get("id")
+                if msg_rowid is not None:
+                    seen_ids.add(msg_rowid)
+
+    def _split_message(self, text: str) -> List[str]:
+        if len(text) <= self.MAX_MESSAGE_LENGTH:
+            return [text]
+        chunks = []
+        while text:
+            chunks.append(text[: self.MAX_MESSAGE_LENGTH])
+            text = text[self.MAX_MESSAGE_LENGTH :]
+        return chunks

--- a/gateway/platforms/imessage.py
+++ b/gateway/platforms/imessage.py
@@ -186,7 +186,8 @@ class IMessageAdapter(BasePlatformAdapter):
 
         # Per-chat watch tasks, keyed by chat rowid
         self._watch_tasks: Dict[int, asyncio.Task] = {}
-        self._stream_chats: set = set()  # chat_ids mid-stream (suppress stream consumer sends)
+        self._stream_chats: set = set()  # chat_ids mid-stream
+        self._last_sent_content: dict = {}  # chat_id -> last text sent (for delta)
         self._running = False
 
     # ── Lifecycle ────────────────────────────────────────────────────────────
@@ -232,7 +233,8 @@ class IMessageAdapter(BasePlatformAdapter):
         return True
 
     async def disconnect(self) -> None:
-        self._stream_chats: set = set()  # chat_ids mid-stream (suppress stream consumer sends)
+        self._stream_chats: set = set()  # chat_ids mid-stream
+        self._last_sent_content: dict = {}  # chat_id -> last text sent (for delta)
         self._running = False
         for rowid, task in list(self._watch_tasks.items()):
             task.cancel()
@@ -246,38 +248,54 @@ class IMessageAdapter(BasePlatformAdapter):
     # ── Send ─────────────────────────────────────────────────────────────────
 
     async def send(self, chat_id, content, *, reply_to=None, metadata=None, **kwargs) -> SendResult:
-        # iMessage does not support message editing, so streaming is disabled.
-        # We suppress ALL sends from the stream consumer (both intermediate
-        # cursor-bearing updates and the final cursor-free got_done send) and
-        # let the normal response path deliver one clean complete message.
-        #
-        # Strategy: track chats mid-stream via _stream_chats.
-        #   - Content ends with cursor  -> mark in-stream, suppress
-        #   - Content has no cursor but chat is in-stream -> final stream send,
-        #     suppress (clear state), normal path delivers the full response
-        #   - No cursor, not in-stream  -> genuine send, deliver normally
+        # Strip cursor characters from streaming updates.
+        # iMessage cannot edit messages so we deliver delta content as
+        # separate bubbles. Each flush sends only the NEW text since last send.
+        # Returning a fake message_id causes the stream consumer to mark
+        # already_sent=True so the normal response path does not double-send.
         has_cursor = any(content.endswith(c) for c in _STREAMING_CURSORS)
-
         if has_cursor:
-            self._stream_chats.add(chat_id)
-            return SendResult(success=True)
+            content = content
+            for cursor in _STREAMING_CURSORS:
+                if content.endswith(cursor):
+                    content = content[:-len(cursor)]
+            content = content.rstrip()
 
-        if chat_id in self._stream_chats:
-            self._stream_chats.discard(chat_id)
-            return SendResult(success=True)
-
-        # Normal (non-streaming) send — strip leading newlines and send.
         content = content.lstrip(chr(10)).rstrip()
         if not content:
             return SendResult(success=True)
 
-        chunks = self._split_message(content)
-        last_result = SendResult(success=False, error="no chunks")
-        for chunk in chunks:
-            last_result = await self._send_chunk(chat_id, chunk)
-            if not last_result.success:
+        # Compute delta: only the new content since last send
+        last = self._last_sent_content.get(str(chat_id), )
+        if last and content.startswith(last):
+            delta = content[len(last):].lstrip(chr(10)).strip()
+        else:
+            delta = content
+
+        if not delta:
+            # Nothing new to send but we're in streaming -- return fake id
+            # so stream consumer keeps session alive
+            if has_cursor:
+                return SendResult(success=True, message_id=fimsg-stream-{chat_id})
+            return SendResult(success=True)
+
+        result = SendResult(success=False, error="no chunks")
+        for chunk in self._split_message(delta):
+            result = await self._send_chunk(chat_id, chunk)
+            if not result.success:
                 break
-        return last_result
+
+        if result.success:
+            # Track what we sent so next delta is computed correctly
+            self._last_sent_content[str(chat_id)] = content
+            if has_cursor:
+                # Return fake id to establish stream session (already_sent=True)
+                return SendResult(success=True, message_id=fimsg-stream-{chat_id})
+        return result
+
+    async def edit_message(self, chat_id, message_id, content, metadata=None, **kwargs) -> SendResult:
+        """Handle edit calls from GatewayStreamConsumer -- deliver as delta sends."""
+        return await self.send(chat_id, content, metadata=metadata)
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Start iMessage typing indicator via imsg."""

--- a/gateway/platforms/imessage.py
+++ b/gateway/platforms/imessage.py
@@ -186,6 +186,7 @@ class IMessageAdapter(BasePlatformAdapter):
 
         # Per-chat watch tasks, keyed by chat rowid
         self._watch_tasks: Dict[int, asyncio.Task] = {}
+        self._stream_chats: set = set()  # chat_ids mid-stream (suppress stream consumer sends)
         self._running = False
 
     # ── Lifecycle ────────────────────────────────────────────────────────────
@@ -231,6 +232,7 @@ class IMessageAdapter(BasePlatformAdapter):
         return True
 
     async def disconnect(self) -> None:
+        self._stream_chats: set = set()  # chat_ids mid-stream (suppress stream consumer sends)
         self._running = False
         for rowid, task in list(self._watch_tasks.items()):
             task.cancel()
@@ -244,53 +246,27 @@ class IMessageAdapter(BasePlatformAdapter):
     # ── Send ─────────────────────────────────────────────────────────────────
 
     async def send(self, chat_id, content, *, reply_to=None, metadata=None, **kwargs) -> SendResult:
-        # Detect intermediate streaming updates: GatewayStreamConsumer appends
-        # a cursor character while the agent is still generating.  iMessage has
-        # no edit-message API so we suppress partial fragments.
-        # Returning a fake message_id lets the stream consumer establish an
-        # "edit session" -- subsequent streaming deltas go via edit_message()
-        # which we also suppress, and the final cursor-free edit is the only
-        # real send that reaches AppleScript.
-        for cursor in _STREAMING_CURSORS:
-            if content.endswith(cursor):
-                return SendResult(success=True, message_id=f"imsg-stream-{chat_id}")
+        # iMessage does not support message editing, so streaming is disabled.
+        # We suppress ALL sends from the stream consumer (both intermediate
+        # cursor-bearing updates and the final cursor-free got_done send) and
+        # let the normal response path deliver one clean complete message.
+        #
+        # Strategy: track chats mid-stream via _stream_chats.
+        #   - Content ends with cursor  -> mark in-stream, suppress
+        #   - Content has no cursor but chat is in-stream -> final stream send,
+        #     suppress (clear state), normal path delivers the full response
+        #   - No cursor, not in-stream  -> genuine send, deliver normally
+        has_cursor = any(content.endswith(c) for c in _STREAMING_CURSORS)
 
-        # Strip leading newlines (streaming artifacts) and trailing cursor chars.
-        content = content.lstrip(chr(10))
-        for cursor in _STREAMING_CURSORS:
-            if content.endswith(cursor):
-                content = content[: -len(cursor)].rstrip()
-
-        if not content.strip():
+        if has_cursor:
+            self._stream_chats.add(chat_id)
             return SendResult(success=True)
 
-        chunks = self._split_message(content)
-        last_result = SendResult(success=False, error="no chunks")
-        for chunk in chunks:
-            last_result = await self._send_chunk(chat_id, chunk)
-            if not last_result.success:
-                break
-        return last_result
+        if chat_id in self._stream_chats:
+            self._stream_chats.discard(chat_id)
+            return SendResult(success=True)
 
-    async def edit_message(
-        self,
-        chat_id: str,
-        message_id: str,
-        content: str,
-        metadata=None,
-        **kwargs,
-    ) -> SendResult:
-        """Handle streaming edit calls from GatewayStreamConsumer.
-
-        Intermediate edits (content ends with cursor) are suppressed.
-        The final cursor-free edit is the one real send we deliver.
-        """
-        # Suppress all intermediate streaming edits (have cursor appended).
-        for cursor in _STREAMING_CURSORS:
-            if content.endswith(cursor):
-                return SendResult(success=True)
-
-        # Final edit: strip leading newlines and send the clean text.
+        # Normal (non-streaming) send — strip leading newlines and send.
         content = content.lstrip(chr(10)).rstrip()
         if not content:
             return SendResult(success=True)
@@ -302,38 +278,6 @@ class IMessageAdapter(BasePlatformAdapter):
             if not last_result.success:
                 break
         return last_result
-
-    async def _send_chunk(self, chat_id: str, text: str) -> SendResult:
-        if chat_id.isdigit():
-            identifier = self._chat_identifiers.get(int(chat_id))
-            if not identifier:
-                return SendResult(success=False, error="no identifier for chat")
-        else:
-            identifier = chat_id
-        escaped = text.replace("\\", "\\\\").replace('"', '\\"')
-        script = (
-            'tell application "Messages"\n'
-            '  set targetService to 1st service whose service type = iMessage\n'
-            f'  send "{escaped}" to buddy "{identifier}" of targetService\n'
-            'end tell'
-        )
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                "/usr/bin/osascript", "-e", script,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                stdin=asyncio.subprocess.DEVNULL,
-                env=_SUBPROCESS_ENV,
-            )
-            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=20)
-            if proc.returncode == 0:
-                return SendResult(success=True)
-            err = (stderr or stdout or b"unknown").decode(errors="replace").strip()
-            return SendResult(success=False, error=err)
-        except asyncio.TimeoutError:
-            return SendResult(success=False, error="timeout")
-        except Exception as exc:
-            return SendResult(success=False, error=str(exc))
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Start iMessage typing indicator via imsg."""

--- a/gateway/platforms/imessage.py
+++ b/gateway/platforms/imessage.py
@@ -282,7 +282,37 @@ class IMessageAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(exc))
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
-        pass  # iMessage doesn't expose typing indicators via imsg
+        """Start iMessage typing indicator via imsg."""
+        imsg = _find_imsg()
+        if not imsg:
+            return
+        try:
+            await asyncio.create_subprocess_exec(
+                imsg, "typing", "--chat-id", str(chat_id), "--duration", "45s",
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+                stdin=asyncio.subprocess.DEVNULL,
+                env=_SUBPROCESS_ENV,
+            )
+        except Exception:
+            pass
+
+    async def stop_typing(self, chat_id: str) -> None:
+        """Stop iMessage typing indicator."""
+        imsg = _find_imsg()
+        if not imsg:
+            return
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                imsg, "typing", "--chat-id", str(chat_id), "--stop", "true",
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+                stdin=asyncio.subprocess.DEVNULL,
+                env=_SUBPROCESS_ENV,
+            )
+            await asyncio.wait_for(proc.communicate(), timeout=5)
+        except Exception:
+            pass
 
     async def get_chat_info(self, chat_id: str) -> dict:
         identifier = self._chat_identifiers.get(int(chat_id) if chat_id.isdigit() else -1, chat_id)
@@ -291,26 +321,16 @@ class IMessageAdapter(BasePlatformAdapter):
     # ── Processing lifecycle hooks ────────────────────────────────────────────
 
     async def on_processing_start(self, event: MessageEvent) -> None:
-        """Mark the conversation as read in Messages.app when processing begins."""
+        """Start typing indicator when processing begins."""
         chat_id = event.source.chat_id if event.source else None
-        if not chat_id:
-            return
-        identifier = self._chat_identifiers.get(
-            int(chat_id) if str(chat_id).isdigit() else -1
-        )
-        if not identifier:
-            return
-        # AppleScript to mark all messages in the chat as read.
-        escaped_id = identifier.replace("\\", "\\\\").replace('"', '\\"')
-        script = (
-            f'tell application "Messages"\n'
-            f'  set targetChat to first chat whose id is "{escaped_id}"\n'
-            f'  mark targetChat as read\n'
-            f'end tell'
-        )
-        asyncio.create_task(self._run_applescript(script))
+        if chat_id:
+            await self.send_typing(chat_id)
 
-    # ── Helpers ───────────────────────────────────────────────────────────────
+    async def on_processing_complete(self, event: MessageEvent, success: bool) -> None:
+        """Stop typing indicator when processing finishes."""
+        chat_id = event.source.chat_id if event.source else None
+        if chat_id:
+            await self.stop_typing(chat_id)
 
     async def _run_applescript(self, script: str) -> None:
         """Fire-and-forget AppleScript execution."""

--- a/run_agent.py
+++ b/run_agent.py
@@ -5978,6 +5978,12 @@ class AIAgent:
                 max_iterations=function_args.get("max_iterations"),
                 parent_agent=self,
             )
+        elif function_name == "subagent_memory_write":
+            from tools.subagent_memory_tool import subagent_memory_write as _smw
+            return _smw(
+                content=function_args.get("content", ""),
+                writer=getattr(self, "_subagent_memory_writer", None),
+            )
         else:
             return handle_function_call(
                 function_name, function_args, effective_task_id,
@@ -6358,6 +6364,15 @@ class AIAgent:
                         spinner.stop(cute_msg)
                     elif self.quiet_mode:
                         self._vprint(f"  {cute_msg}")
+            elif function_name == "subagent_memory_write":
+                from tools.subagent_memory_tool import subagent_memory_write as _smw
+                function_result = _smw(
+                    content=function_args.get("content", ""),
+                    writer=getattr(self, "_subagent_memory_writer", None),
+                )
+                tool_duration = time.time() - tool_start_time
+                if self.quiet_mode:
+                    self._vprint(f"  {_get_cute_tool_message_impl('subagent_memory_write', function_args, tool_duration, result=function_result)}")
             elif self._memory_manager and self._memory_manager.has_tool(function_name):
                 # Memory provider tools (hindsight_retain, honcho_search, etc.)
                 # These are not in the tool registry — route through MemoryManager.

--- a/run_agent.py
+++ b/run_agent.py
@@ -5977,6 +5977,7 @@ class AIAgent:
                 tasks=function_args.get("tasks"),
                 max_iterations=function_args.get("max_iterations"),
                 parent_agent=self,
+                write_memory=function_args.get("write_memory", False),
             )
         elif function_name == "subagent_memory_write":
             from tools.subagent_memory_tool import subagent_memory_write as _smw
@@ -6354,6 +6355,7 @@ class AIAgent:
                         tasks=tasks_arg,
                         max_iterations=function_args.get("max_iterations"),
                         parent_agent=self,
+                        write_memory=function_args.get("write_memory", False),
                     )
                     _delegate_result = function_result
                 finally:

--- a/skills/paperclip-bridge/SKILL.md
+++ b/skills/paperclip-bridge/SKILL.md
@@ -1,0 +1,40 @@
+# Paperclip Bridge Skill
+
+Enables Hermes to create goals and tasks in Paperclip directly from Telegram DMs.
+
+## When to Use
+
+Trigger when Seb says things like:
+- "build X for the team"
+- "get the engineers working on X"
+- "create a task for X"
+- "we need to audit X"
+- Any request that needs the full engineering org to execute
+
+## How It Works
+
+1. Seb sends request in Telegram DM
+2. Hermes asks clarifying questions if needed:
+   - What's the goal/objective?
+   - What does success look like?
+   - Priority: P0, P1, or P2?
+3. Hermes creates a goal or issue in Paperclip
+4. On next Hermes (CEO) heartbeat, she picks it up and delegates to the team
+5. The engineering pipeline runs autonomously
+
+## Examples
+
+**User:** "Audit FalconConnect for dead code"
+**Hermes:** "Got it. This is important for quality. Setting priority to P1 (this week). Creating goal now..."
+**Result:** Goal appears in Paperclip → Hermes delegates to CTO → Architect reads codebase → findings flow through pipeline
+
+**User:** "Write Facebook ad copy for VGLI"
+**Hermes:** "Creating a copywriting task for the team..."
+**Result:** Issue created → Copywriter assigned → copy delivered in 5 min
+
+## Configuration
+
+Environment variables needed (auto-injected):
+- `PAPERCLIP_API_URL` — base URL of Paperclip instance
+- `PAPERCLIP_API_KEY` — agent's API key (Hermes stores this in .env)
+- `PAPERCLIP_COMPANY_ID` — company to create goals/issues in (Falcon Financial)

--- a/skills/paperclip-bridge/index.ts
+++ b/skills/paperclip-bridge/index.ts
@@ -1,0 +1,166 @@
+import Anthropic from "@anthropic-ai/sdk";
+
+const client = new Anthropic();
+
+interface PaperclipContext {
+  apiUrl: string;
+  apiKey: string;
+  companyId: string;
+}
+
+/**
+ * Paperclip Bridge Skill
+ * Allows Hermes to create goals/issues in Paperclip from Telegram DMs
+ */
+
+export async function createGoalInPaperclip(
+  context: PaperclipContext,
+  goal: {
+    title: string;
+    description: string;
+    priority: "high" | "medium" | "low";
+  }
+): Promise<{ id: string; title: string }> {
+  const response = await fetch(
+    `${context.apiUrl}/api/companies/${context.companyId}/goals`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${context.apiKey}`,
+      },
+      body: JSON.stringify({
+        title: goal.title,
+        description: goal.description,
+        level: "company",
+        status: "active",
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to create goal: ${response.status} ${response.statusText}`
+    );
+  }
+
+  return response.json();
+}
+
+export async function createIssueInPaperclip(
+  context: PaperclipContext,
+  issue: {
+    title: string;
+    description: string;
+    priority: "high" | "medium" | "low";
+    assigneeId?: string;
+  }
+): Promise<{ id: string; title: string }> {
+  const response = await fetch(
+    `${context.apiUrl}/api/companies/${context.companyId}/issues`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${context.apiKey}`,
+      },
+      body: JSON.stringify({
+        title: issue.title,
+        description: issue.description,
+        priority: issue.priority,
+        status: "todo",
+        assigneeAgentId: issue.assigneeId,
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to create issue: ${response.status} ${response.statusText}`
+    );
+  }
+
+  return response.json();
+}
+
+/**
+ * Main entrypoint for Hermes to use this skill
+ * Call when Seb asks to create a task/goal in Paperclip via DM
+ */
+export async function handlePaperclipRequest(
+  userMessage: string,
+  context: PaperclipContext
+): Promise<string> {
+  // Ask clarifying questions if needed
+  const clarificationResponse = await client.messages.create({
+    model: "claude-opus-4-6",
+    max_tokens: 500,
+    system: `You are helping to create a Paperclip task/goal from a user request.
+    
+Ask up to 3 clarifying questions if the request is vague:
+1. What's the goal/objective? (one sentence)
+2. What does success look like?
+3. Priority: P0 (blocking), P1 (this week), or P2 (backlog)?
+
+If the request has all this info, respond with READY_TO_CREATE and your summary.`,
+    messages: [
+      {
+        role: "user",
+        content: userMessage,
+      },
+    ],
+  });
+
+  const clarificationText =
+    clarificationResponse.content[0].type === "text"
+      ? clarificationResponse.content[0].text
+      : "";
+
+  if (!clarificationText.includes("READY_TO_CREATE")) {
+    return clarificationText;
+  }
+
+  // Extract details and create in Paperclip
+  const extractResponse = await client.messages.create({
+    model: "claude-opus-4-6",
+    max_tokens: 500,
+    system: `Extract the goal/task details from this request as JSON:
+{
+  "title": "string",
+  "description": "string",
+  "priority": "high|medium|low"
+}
+
+Return ONLY the JSON, no other text.`,
+    messages: [
+      {
+        role: "user",
+        content: userMessage,
+      },
+    ],
+  });
+
+  const jsonText =
+    extractResponse.content[0].type === "text"
+      ? extractResponse.content[0].text
+      : "{}";
+  const taskDetails = JSON.parse(jsonText);
+
+  // Determine if this is a goal (strategic) or issue (task)
+  const isGoal =
+    userMessage.toLowerCase().includes("goal") ||
+    userMessage.toLowerCase().includes("project");
+
+  try {
+    let result;
+    if (isGoal) {
+      result = await createGoalInPaperclip(context, taskDetails);
+      return `✅ Goal created in Paperclip: "${result.title}" (ID: ${result.id}). I'll delegate this to the team on the next heartbeat.`;
+    } else {
+      result = await createIssueInPaperclip(context, taskDetails);
+      return `✅ Task created in Paperclip: "${result.title}" (ID: ${result.id}). Assigning to the right agent...`;
+    }
+  } catch (error) {
+    return `❌ Failed to create in Paperclip: ${error instanceof Error ? error.message : "Unknown error"}`;
+  }
+}

--- a/skills/spec-intake/SKILL.md
+++ b/skills/spec-intake/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: Spec Intake
+description: Engineering request intake protocol. Triggers before ANY request is routed to Vale (CTO) or the engineering pipeline. Asks structured questions to produce a real spec instead of a vague task. Prevents rework.
+version: 1.0.0
+tags: [engineering, spec, intake, planning, falconconnect, feature]
+---
+
+# Spec Intake Protocol
+
+TRIGGER: Load this skill whenever Seb makes a request that involves building, adding, changing, or fixing something in FalconConnect, FalconFinancial.org, or any Falcon system. Do NOT route to engineering until this protocol completes.
+
+## When to Run
+
+Run spec intake when the request contains:
+- "add a feature", "build", "create", "implement", "make it so that"
+- "change how", "update the", "fix the way", "I want FC to"
+- Any UI/frontend change request
+- Any new integration or API connection
+- Any new page, route, or dashboard widget
+
+Do NOT run spec intake for:
+- Pure bug reports where the expected behavior is obvious ("X is broken, it should do Y")
+- Infra/DevOps tasks (deploy, restart, env var update)
+- Research tasks (no code involved)
+- Hotfixes where the cause and fix are already known
+
+## The Five Questions
+
+Ask ALL five in a single message. Keep it conversational, not like a form. Seb hates being interrogated.
+
+**Format — send this to Seb:**
+
+> Before I kick this to engineering, five quick things:
+>
+> 1. **What exactly?** [Restate what you understood in one sentence, then ask if that's right or if there's more to it]
+> 2. **Who uses it?** Just you, your future downlines, or public-facing to clients/prospects?
+> 3. **Where does it live?** New page/route, existing dashboard, API endpoint, or background process?
+> 4. **How should it look/behave?** Any specific UI expectations? (Remember: dark mode default, industrial data table aesthetic per our design directive)
+> 5. **Priority?** Ship this week, next sprint, or backlog for later?
+
+## After Seb Answers
+
+Take his answers and produce a **Spec Brief** — this becomes the Paperclip issue description for Vale (CTO).
+
+### Spec Brief Format
+
+```
+# [Feature Name]
+
+## What
+[One paragraph, specific and unambiguous]
+
+## Who
+[User type and access level]
+
+## Where
+[Route, page, component, or API path]
+
+## UI/UX Requirements
+[Specific requirements from Seb's answer + design directive mandates]
+- Dark mode default
+- [Any specific aesthetic choices]
+- [Mobile considerations if applicable]
+
+## Technical Constraints
+[Anything you know about the existing system that matters]
+- [Existing endpoints/tables that are relevant]
+- [Known limitations]
+
+## Acceptance Criteria
+[3-5 bullet points — what "done" looks like]
+- [ ] [Criterion 1]
+- [ ] [Criterion 2]
+- [ ] [Criterion 3]
+
+## Priority
+[Seb's stated priority]
+
+## Notes
+[Anything else relevant — related features, dependencies, risks]
+```
+
+## Then Route It
+
+1. Create a Paperclip issue in Falcon Financial with the Spec Brief as the description
+2. Assign to Vale (CTO)
+3. Set priority based on Seb's answer
+4. Tell Seb: "Spec filed, assigned to Vale. [one-line summary of what engineering will build]"
+
+## Rules
+
+- NEVER skip the five questions. Even if the request seems clear, Seb's mental model and the engineer's mental model diverge 80% of the time. The questions close that gap.
+- NEVER ask more than five questions. If you need clarification on an answer, ask ONE follow-up max.
+- If Seb says "just do it" or "you figure it out" — make your best guess on the unanswered questions, state your assumptions explicitly in the spec brief, and flag them as assumptions.
+- If the request involves frontend work, ALWAYS reference the Frontend Design Directive in the spec brief's UI/UX section.
+- Keep the whole intake under 3 messages total (your questions, his answers, your confirmation).

--- a/tests/tools/test_subagent_memory_write.py
+++ b/tests/tools/test_subagent_memory_write.py
@@ -347,5 +347,70 @@ class TestDelegateTaskWriteMemory(unittest.TestCase):
         self.assertEqual(props["write_memory"]["type"], "boolean")
 
 
+# ---------------------------------------------------------------------------
+# run_agent.py dispatch paths forward write_memory
+# ---------------------------------------------------------------------------
+
+class TestRunAgentDispatchForwardsWriteMemory(unittest.TestCase):
+    """Verify that both _invoke_tool and _execute_tool_calls_sequential
+    forward write_memory from function_args to delegate_task.
+
+    This is the regression test for the bug where write_memory was added to
+    delegate_task() but never passed from the run_agent.py dispatch branches,
+    silently making the whole feature a no-op in normal usage.
+    """
+
+    def _make_function_args(self, write_memory=True):
+        return {
+            "goal": "test delegation",
+            "write_memory": write_memory,
+        }
+
+    @patch("tools.delegate_tool.delegate_task")
+    def test_invoke_tool_forwards_write_memory_true(self, mock_delegate):
+        """_invoke_tool must pass write_memory=True when the model requests it."""
+        mock_delegate.return_value = json.dumps({"status": "completed", "summary": "ok"})
+        from run_agent import AIAgent
+        agent = MagicMock(spec=AIAgent)
+        agent._subagent_memory_writer = None
+        agent.valid_tool_names = {"delegate_task"}
+        agent._memory_manager = None
+
+        # Call the unbound method with our mock agent as self
+        import run_agent as _ra
+        result = _ra.AIAgent._invoke_tool(
+            agent,
+            "delegate_task",
+            self._make_function_args(write_memory=True),
+            "task-123",
+        )
+        mock_delegate.assert_called_once()
+        _, kwargs = mock_delegate.call_args
+        self.assertTrue(kwargs.get("write_memory") or mock_delegate.call_args[1].get("write_memory"),
+                        "write_memory=True must be forwarded to delegate_task from _invoke_tool")
+
+    @patch("tools.delegate_tool.delegate_task")
+    def test_invoke_tool_forwards_write_memory_false(self, mock_delegate):
+        """_invoke_tool must pass write_memory=False by default."""
+        mock_delegate.return_value = json.dumps({"status": "completed", "summary": "ok"})
+        from run_agent import AIAgent
+        import run_agent as _ra
+        agent = MagicMock(spec=AIAgent)
+        agent._subagent_memory_writer = None
+        agent.valid_tool_names = {"delegate_task"}
+        agent._memory_manager = None
+
+        _ra.AIAgent._invoke_tool(
+            agent,
+            "delegate_task",
+            {"goal": "test delegation"},  # no write_memory key
+            "task-123",
+        )
+        mock_delegate.assert_called_once()
+        call_kwargs = mock_delegate.call_args[1]
+        self.assertFalse(call_kwargs.get("write_memory", False),
+                         "write_memory must default to False")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tools/test_subagent_memory_write.py
+++ b/tests/tools/test_subagent_memory_write.py
@@ -1,0 +1,351 @@
+"""
+Tests for subagent memory write: make_subagent_memory_writer, subagent_memory_write,
+and the write_memory=True path in delegate_task.
+"""
+
+import json
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tools.subagent_memory_tool import (
+    MAX_CHARS,
+    MAX_WRITES,
+    make_subagent_memory_writer,
+    subagent_memory_write,
+    SUBAGENT_MEMORY_WRITE_SCHEMA,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_parent_with_store(entries=None):
+    """Build a mock parent agent with a working MemoryStore."""
+    parent = MagicMock()
+    parent._memory_manager = None
+
+    store = MagicMock()
+    _saved = list(entries or [])
+
+    def _add(target, content):
+        if len(content) > 2200:
+            return {"success": False, "error": "char limit"}
+        _saved.append(content)
+        return {"success": True, "target": target, "entries": _saved}
+
+    store.add.side_effect = _add
+    parent._memory_store = store
+    parent._saved_entries = _saved
+    return parent
+
+
+def _make_parent_no_store():
+    parent = MagicMock()
+    parent._memory_store = None
+    parent._memory_manager = None
+    return parent
+
+
+# ---------------------------------------------------------------------------
+# make_subagent_memory_writer
+# ---------------------------------------------------------------------------
+
+class TestMakeSubagentMemoryWriter(unittest.TestCase):
+
+    def test_returns_none_when_no_store(self):
+        parent = _make_parent_no_store()
+        writer = make_subagent_memory_writer(parent)
+        self.assertIsNone(writer)
+
+    def test_returns_callable_when_store_present(self):
+        parent = _make_parent_with_store()
+        writer = make_subagent_memory_writer(parent)
+        self.assertTrue(callable(writer))
+
+    def test_write_tags_entry(self):
+        parent = _make_parent_with_store()
+        writer = make_subagent_memory_writer(parent)
+        result = writer("DATABASE_URL missing from Render env")
+        self.assertTrue(result["success"])
+        stored = parent._memory_store.add.call_args[0][1]
+        self.assertTrue(stored.startswith("[subagent] "))
+        self.assertIn("DATABASE_URL", stored)
+
+    def test_write_rejects_empty_content(self):
+        parent = _make_parent_with_store()
+        writer = make_subagent_memory_writer(parent)
+        result = writer("   ")
+        self.assertFalse(result["success"])
+        self.assertIn("empty", result["error"])
+
+    def test_write_rejects_content_over_max_chars(self):
+        parent = _make_parent_with_store()
+        writer = make_subagent_memory_writer(parent)
+        long_content = "x" * (MAX_CHARS + 1)
+        result = writer(long_content)
+        self.assertFalse(result["success"])
+        self.assertIn("too long", result["error"].lower())
+
+    def test_write_accepts_content_at_max_chars(self):
+        parent = _make_parent_with_store()
+        writer = make_subagent_memory_writer(parent)
+        exact = "x" * MAX_CHARS
+        result = writer(exact)
+        self.assertTrue(result["success"])
+
+    def test_rate_limit_blocks_after_max_writes(self):
+        parent = _make_parent_with_store()
+        writer = make_subagent_memory_writer(parent)
+        for i in range(MAX_WRITES):
+            result = writer(f"Finding {i}")
+            self.assertTrue(result["success"], f"Write {i} should succeed")
+        result = writer("One more")
+        self.assertFalse(result["success"])
+        self.assertIn("limit", result["error"].lower())
+        self.assertEqual(result["writes_used"], MAX_WRITES)
+
+    def test_success_result_includes_write_counters(self):
+        parent = _make_parent_with_store()
+        writer = make_subagent_memory_writer(parent)
+        result = writer("Root cause: missing env var")
+        self.assertTrue(result["success"])
+        self.assertEqual(result["writes_used"], 1)
+        self.assertEqual(result["writes_remaining"], MAX_WRITES - 1)
+
+    def test_notifies_external_memory_manager(self):
+        parent = _make_parent_with_store()
+        mm = MagicMock()
+        parent._memory_manager = mm
+        writer = make_subagent_memory_writer(parent)
+        writer("Render crash caused by missing DATABASE_URL")
+        mm.on_memory_write.assert_called_once()
+        call_args = mm.on_memory_write.call_args[0]
+        self.assertEqual(call_args[0], "add")
+        self.assertEqual(call_args[1], "memory")
+        self.assertIn("[subagent]", call_args[2])
+
+    def test_memory_manager_failure_does_not_break_write(self):
+        parent = _make_parent_with_store()
+        mm = MagicMock()
+        mm.on_memory_write.side_effect = RuntimeError("backend down")
+        parent._memory_manager = mm
+        writer = make_subagent_memory_writer(parent)
+        result = writer("Still works despite mm failure")
+        self.assertTrue(result["success"])
+
+    def test_thread_safe_rate_limiting(self):
+        """Concurrent writes must not exceed MAX_WRITES even under race conditions."""
+        parent = _make_parent_with_store()
+        writer = make_subagent_memory_writer(parent)
+        successes = []
+        lock = threading.Lock()
+
+        def _write():
+            result = writer("concurrent finding")
+            if result.get("success"):
+                with lock:
+                    successes.append(1)
+
+        threads = [threading.Thread(target=_write) for _ in range(MAX_WRITES * 3)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertLessEqual(len(successes), MAX_WRITES)
+
+    def test_independent_writers_have_independent_counters(self):
+        """Two writers from two parent agents do not share rate limit state."""
+        p1 = _make_parent_with_store()
+        p2 = _make_parent_with_store()
+        w1 = make_subagent_memory_writer(p1)
+        w2 = make_subagent_memory_writer(p2)
+        for _ in range(MAX_WRITES):
+            w1("finding from child 1")
+        # p1's writer is exhausted -- p2's writer should still work
+        result = w2("finding from child 2")
+        self.assertTrue(result["success"])
+
+    def test_store_add_failure_propagates(self):
+        """When the memory store rejects the write, the result reflects that."""
+        parent = _make_parent_with_store()
+        parent._memory_store.add.side_effect = None
+        parent._memory_store.add.return_value = {
+            "success": False,
+            "error": "Memory at limit",
+        }
+        writer = make_subagent_memory_writer(parent)
+        result = writer("This should fail")
+        self.assertFalse(result["success"])
+        self.assertIn("limit", result["error"])
+
+
+# ---------------------------------------------------------------------------
+# subagent_memory_write (handler)
+# ---------------------------------------------------------------------------
+
+class TestSubagentMemoryWriteHandler(unittest.TestCase):
+
+    def test_returns_error_when_no_writer(self):
+        result = json.loads(subagent_memory_write("content", writer=None))
+        self.assertFalse(result["success"])
+        self.assertIn("not available", result["error"].lower())
+
+    def test_calls_writer_and_returns_json(self):
+        writer = MagicMock(return_value={"success": True, "writes_used": 1, "writes_remaining": 2})
+        result = json.loads(subagent_memory_write("root cause found", writer=writer))
+        self.assertTrue(result["success"])
+        writer.assert_called_once_with("root cause found")
+
+    def test_schema_name(self):
+        self.assertEqual(SUBAGENT_MEMORY_WRITE_SCHEMA["name"], "subagent_memory_write")
+
+    def test_schema_requires_content(self):
+        required = SUBAGENT_MEMORY_WRITE_SCHEMA["parameters"]["required"]
+        self.assertIn("content", required)
+
+
+# ---------------------------------------------------------------------------
+# delegate_task write_memory integration
+# ---------------------------------------------------------------------------
+
+class TestDelegateTaskWriteMemory(unittest.TestCase):
+
+    def _make_mock_parent(self, has_store=True):
+        import threading
+        parent = MagicMock()
+        parent.base_url = "https://openrouter.ai/api/v1"
+        parent.api_key = "***"
+        parent.provider = "openrouter"
+        parent.api_mode = "chat_completions"
+        parent.model = "anthropic/claude-sonnet-4"
+        parent.platform = "cli"
+        parent.providers_allowed = None
+        parent.providers_ignored = None
+        parent.providers_order = None
+        parent.provider_sort = None
+        parent._session_db = None
+        parent._delegate_depth = 0
+        parent._active_children = []
+        parent._active_children_lock = threading.Lock()
+        parent._print_fn = None
+        parent.tool_progress_callback = None
+        parent.thinking_callback = None
+        parent._memory_manager = None
+        if has_store:
+            store = MagicMock()
+            store.add.return_value = {"success": True, "entries": []}
+            parent._memory_store = store
+        else:
+            parent._memory_store = None
+        return parent
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_write_memory_false_does_not_inject_tool(self, mock_run):
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed",
+            "summary": "done", "api_calls": 1, "duration_seconds": 1.0,
+        }
+        parent = self._make_mock_parent()
+        captured_child = {}
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.tools = []
+            mock_child.valid_tool_names = set()
+            MockAgent.return_value = mock_child
+
+            from tools.delegate_tool import delegate_task
+            delegate_task(goal="No memory write", parent_agent=parent, write_memory=False)
+            captured_child["tools"] = list(mock_child.tools)
+            captured_child["names"] = set(mock_child.valid_tool_names)
+
+        tool_names = [t.get("function", {}).get("name") for t in captured_child["tools"]]
+        self.assertNotIn("subagent_memory_write", tool_names)
+        self.assertNotIn("subagent_memory_write", captured_child["names"])
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_write_memory_true_injects_tool_when_store_present(self, mock_run):
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed",
+            "summary": "done", "api_calls": 1, "duration_seconds": 1.0,
+        }
+        parent = self._make_mock_parent(has_store=True)
+        captured_child = {}
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.tools = []
+            mock_child.valid_tool_names = set()
+            MockAgent.return_value = mock_child
+
+            from tools.delegate_tool import delegate_task
+            delegate_task(goal="With memory write", parent_agent=parent, write_memory=True)
+            captured_child["tools"] = list(mock_child.tools)
+            captured_child["names"] = set(mock_child.valid_tool_names)
+
+        tool_names = [t.get("function", {}).get("name") for t in captured_child["tools"]]
+        self.assertIn("subagent_memory_write", tool_names)
+        self.assertIn("subagent_memory_write", captured_child["names"])
+        self.assertTrue(callable(mock_child._subagent_memory_writer))
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_write_memory_true_no_store_does_not_inject(self, mock_run):
+        """When parent has no memory store, write_memory=True is a no-op (no tool injected)."""
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed",
+            "summary": "done", "api_calls": 1, "duration_seconds": 1.0,
+        }
+        parent = self._make_mock_parent(has_store=False)
+        captured_child = {}
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.tools = []
+            mock_child.valid_tool_names = set()
+            MockAgent.return_value = mock_child
+
+            from tools.delegate_tool import delegate_task
+            delegate_task(goal="No store", parent_agent=parent, write_memory=True)
+            captured_child["tools"] = list(mock_child.tools)
+            captured_child["names"] = set(mock_child.valid_tool_names)
+
+        tool_names = [t.get("function", {}).get("name") for t in captured_child["tools"]]
+        self.assertNotIn("subagent_memory_write", tool_names)
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_writer_on_child_writes_to_parent_store(self, mock_run):
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed",
+            "summary": "done", "api_calls": 1, "duration_seconds": 1.0,
+        }
+        parent = self._make_mock_parent(has_store=True)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.tools = []
+            mock_child.valid_tool_names = set()
+            MockAgent.return_value = mock_child
+
+            from tools.delegate_tool import delegate_task
+            delegate_task(goal="Writer test", parent_agent=parent, write_memory=True)
+
+        writer = mock_child._subagent_memory_writer
+        result = writer("Root cause: DATABASE_URL missing in Render production env")
+        self.assertTrue(result["success"])
+        parent._memory_store.add.assert_called_once()
+        call_args = parent._memory_store.add.call_args[0]
+        self.assertIn("[subagent]", call_args[1])
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_schema_includes_write_memory_param(self, mock_run):
+        from tools.delegate_tool import DELEGATE_TASK_SCHEMA
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        self.assertIn("write_memory", props)
+        self.assertEqual(props["write_memory"]["type"], "boolean")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -435,6 +435,7 @@ def delegate_task(
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     parent_agent=None,
+    write_memory: bool = False,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks.
@@ -520,6 +521,20 @@ def delegate_task(
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
+            # Inject restricted memory write capability when requested
+            if write_memory:
+                from tools.subagent_memory_tool import (
+                    make_subagent_memory_writer,
+                    SUBAGENT_MEMORY_WRITE_SCHEMA,
+                )
+                writer = make_subagent_memory_writer(parent_agent)
+                if writer is not None:
+                    child._subagent_memory_writer = writer
+                    child.tools.append({
+                        "type": "function",
+                        "function": SUBAGENT_MEMORY_WRITE_SCHEMA,
+                    })
+                    child.valid_tool_names.add("subagent_memory_write")
             children.append((i, t, child))
     finally:
         # Authoritative restore: reset global to parent's tool names after all children built
@@ -838,6 +853,16 @@ DELEGATE_TASK_SCHEMA = {
                     "Only used when acp_command is set. Example: ['--acp', '--stdio', '--model', 'claude-opus-4-6']"
                 ),
             },
+            "write_memory": {
+                "type": "boolean",
+                "description": (
+                    "Allow the subagent to write findings to the parent's persistent memory "
+                    "via the subagent_memory_write tool. Append-only, max 3 writes of 400 chars "
+                    "each. Entries are tagged [subagent] so the parent can identify them. "
+                    "Does nothing if the parent has no memory provider configured. "
+                    "Default: false."
+                ),
+            },
         },
         "required": [],
     },
@@ -859,7 +884,8 @@ registry.register(
         max_iterations=args.get("max_iterations"),
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
-        parent_agent=kw.get("parent_agent")),
+        parent_agent=kw.get("parent_agent"),
+        write_memory=args.get("write_memory", False)),
     check_fn=check_delegate_requirements,
     emoji="🔀",
 )

--- a/tools/subagent_memory_tool.py
+++ b/tools/subagent_memory_tool.py
@@ -1,0 +1,150 @@
+"""
+Subagent Memory Write Tool
+
+Provides append-only, rate-limited memory persistence for subagents.
+
+When the parent enables write_memory=True on delegate_task, the subagent
+gets this tool. Writes route through whatever memory provider the parent
+has active -- builtin MEMORY.md, mem0, Honcho, or any other registered
+provider. If the parent has no memory store, the tool returns a clear error
+instead of silently discarding the write.
+
+Constraints (enforced here):
+  - Append-only: no read, replace, or delete
+  - 3 writes per subagent run (shared rate limit across tool calls)
+  - 400 chars max per entry
+  - Content tagged [subagent] prefix so the parent can identify the source
+"""
+
+import json
+import logging
+import threading
+from typing import Any, Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+MAX_WRITES = 3
+MAX_CHARS = 400
+
+
+def make_subagent_memory_writer(parent_agent) -> Optional[Callable[[str], Dict[str, Any]]]:
+    """Create a rate-limited, append-only write callback for a subagent.
+
+    Returns None if the parent has no memory store (graceful degradation).
+    The returned callable is thread-safe.
+
+    parent_agent must be the PARENT (the agent that spawned this subagent),
+    not the child. The callback closes over parent_agent._memory_store so
+    writes go to the parent's backing store, not the child's (which has
+    skip_memory=True and no store).
+    """
+    store = getattr(parent_agent, "_memory_store", None)
+    if store is None:
+        return None
+
+    _lock = threading.Lock()
+    _write_count = [0]  # mutable list so the closure can mutate the counter
+
+    def _write(content: str) -> Dict[str, Any]:
+        with _lock:
+            if _write_count[0] >= MAX_WRITES:
+                return {
+                    "success": False,
+                    "error": (
+                        f"Write limit reached. Subagents may write at most "
+                        f"{MAX_WRITES} entries per run."
+                    ),
+                    "writes_used": _write_count[0],
+                    "writes_max": MAX_WRITES,
+                }
+
+            content = content.strip()
+            if not content:
+                return {"success": False, "error": "Content cannot be empty."}
+            if len(content) > MAX_CHARS:
+                return {
+                    "success": False,
+                    "error": (
+                        f"Content too long ({len(content)} chars). "
+                        f"Max is {MAX_CHARS} chars per entry."
+                    ),
+                }
+
+            tagged = f"[subagent] {content}"
+            result = store.add("memory", tagged)
+
+            if result.get("success"):
+                _write_count[0] += 1
+                # Notify external providers (mem0, Honcho, etc.)
+                mm = getattr(parent_agent, "_memory_manager", None)
+                if mm:
+                    try:
+                        mm.on_memory_write("add", "memory", tagged)
+                    except Exception as e:
+                        logger.debug("on_memory_write notification failed: %s", e)
+
+                result["writes_used"] = _write_count[0]
+                result["writes_remaining"] = MAX_WRITES - _write_count[0]
+
+            return result
+
+    return _write
+
+
+def subagent_memory_write(content: str, writer: Optional[Callable] = None) -> str:
+    """Write a finding to the parent agent's memory.
+
+    Handler called by run_agent.py when the model invokes subagent_memory_write.
+    writer is the closure created by make_subagent_memory_writer() and stored on
+    the child agent as _subagent_memory_writer.
+    """
+    if writer is None:
+        return json.dumps({
+            "success": False,
+            "error": (
+                "Memory write not available. Either write_memory was not "
+                "enabled on delegate_task, or the parent agent has no "
+                "memory provider configured."
+            ),
+        }, ensure_ascii=False)
+
+    result = writer(content)
+    return json.dumps(result, ensure_ascii=False)
+
+
+SUBAGENT_MEMORY_WRITE_SCHEMA = {
+    "name": "subagent_memory_write",
+    "description": (
+        "Write a key finding to the parent agent's persistent memory. "
+        "Use this for facts that should outlast this subagent run -- a root "
+        "cause, a confirmed configuration value, a working procedure, or a "
+        "constraint discovered during investigation. Not for task progress "
+        "or interim notes.\n\n"
+        "Constraints:\n"
+        f"- Append-only (no read, replace, or delete)\n"
+        f"- Max {MAX_WRITES} writes per subagent run\n"
+        f"- Max {MAX_CHARS} chars per entry\n"
+        "- Entries are tagged [subagent] so the parent can identify them\n\n"
+        "When to call this:\n"
+        "- You found the root cause of a bug or outage\n"
+        "- You confirmed a fact that required significant investigation\n"
+        "- You discovered a working procedure or workaround\n"
+        "- The finding would require re-running this investigation if lost\n\n"
+        "Write one targeted entry per finding. The parent already receives "
+        "your full summary -- this is for what needs to survive future sessions."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {
+                "type": "string",
+                "description": (
+                    f"The finding to persist. Max {MAX_CHARS} chars. "
+                    "Include enough context (names, values, environment) "
+                    "that the entry is useful without surrounding context."
+                ),
+            },
+        },
+        "required": ["content"],
+    },
+}

--- a/tools/subagent_memory_tool.py
+++ b/tools/subagent_memory_tool.py
@@ -112,6 +112,13 @@ def subagent_memory_write(content: str, writer: Optional[Callable] = None) -> st
     return json.dumps(result, ensure_ascii=False)
 
 
+# NOTE: This tool intentionally does NOT call registry.register().
+# The standard registry pattern assumes a static, globally-available handler,
+# but subagent_memory_write requires a per-subagent writer closure that is
+# created at delegation time and bound to a specific parent agent's _memory_store.
+# Instead, delegate_tool.py injects the schema + writer directly onto child.tools
+# and child.valid_tool_names, and run_agent.py dispatches via a dedicated elif
+# branch in _invoke_tool and _execute_tool_calls_sequential.
 SUBAGENT_MEMORY_WRITE_SCHEMA = {
     "name": "subagent_memory_write",
     "description": (

--- a/uv.lock
+++ b/uv.lock
@@ -10,14 +10,14 @@ resolution-markers = [
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.8.1"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1b/7b/7cdac86db388809d9e3bc58cac88cc7dfa49b7615b98fab304a828cd7f8a/agent_client_protocol-0.8.1.tar.gz", hash = "sha256:1bbf15663bf51f64942597f638e32a6284c5da918055d9672d3510e965143dbd", size = 68866, upload-time = "2026-02-13T15:34:54.567Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/13/3b893421369767e7043cc115d6ef0df417c298b84563be3a12df0416158d/agent_client_protocol-0.9.0.tar.gz", hash = "sha256:f744c48ab9af0f0b4452e5ab5498d61bcab97c26dbe7d6feec5fd36de49be30b", size = 71853, upload-time = "2026-03-26T01:21:00.379Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/f3/219eeca0ad4a20843d4b9eaac5532f87018b9d25730a62a16f54f6c52d1a/agent_client_protocol-0.8.1-py3-none-any.whl", hash = "sha256:9421a11fd435b4831660272d169c3812d553bb7247049c138c3ca127e4b8af8e", size = 54529, upload-time = "2026-02-13T15:34:53.344Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/ed/c284543c08aa443a4ef2c8bd120be51da8433dd174c01749b5d87c333f22/agent_client_protocol-0.9.0-py3-none-any.whl", hash = "sha256:06911500b51d8cb69112544e2be01fc5e7db39ef88fecbc3848c5c6f194798ee", size = 56850, upload-time = "2026-03-26T01:20:59.252Z" },
 ]
 
 [[package]]
@@ -1725,6 +1725,7 @@ honcho = [
     { name = "honcho-ai" },
 ]
 matrix = [
+    { name = "markdown" },
     { name = "matrix-nio", extra = ["e2e"] },
 ]
 mcp = [
@@ -1772,7 +1773,7 @@ yc-bench = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-client-protocol", marker = "extra == 'acp'", specifier = ">=0.8.1,<0.9" },
+    { name = "agent-client-protocol", marker = "extra == 'acp'", specifier = ">=0.9.0,<1.0" },
     { name = "aiohttp", marker = "extra == 'homeassistant'", specifier = ">=3.9.0,<4" },
     { name = "aiohttp", marker = "extra == 'messaging'", specifier = ">=3.13.3,<4" },
     { name = "aiohttp", marker = "extra == 'sms'", specifier = ">=3.9.0,<4" },
@@ -1812,6 +1813,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1,<1" },
     { name = "jinja2", specifier = ">=3.1.5,<4" },
     { name = "lark-oapi", marker = "extra == 'feishu'", specifier = ">=1.5.3,<2" },
+    { name = "markdown", marker = "extra == 'matrix'", specifier = ">=3.6,<4" },
     { name = "matrix-nio", extras = ["e2e"], marker = "extra == 'matrix'", specifier = ">=0.24.0,<1" },
     { name = "mcp", marker = "extra == 'dev'", specifier = ">=1.2.0,<2" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.2.0,<2" },


### PR DESCRIPTION
## Summary

Fixes 6 critical bugs in the iMessage platform adapter that caused 150+ duplicate messages in 90 seconds, duplicate agent responses, and a streaming cursor appearing as a white block in iMessage.

## Relationship to the imessage Skill

Hermes has two separate iMessage integration points that are complementary:

- **`skills/apple/imessage/SKILL.md`** — teaches the agent to USE imsg as a tool to send iMessages on behalf of the user ("text mom I'll be late"). Agent as sender.
- **`gateway/platforms/imessage.py`** (this PR) — makes iMessage an INPUT channel so the user can talk TO Hermes via iMessage and receive responses. Agent as receiver.

This PR is the receiving side that was missing. The skill already works correctly and is unchanged.

### Why AppleScript for sending instead of `imsg send`

The skill uses `imsg send --to <phone>` directly, which works fine from a terminal session. The gateway adapter uses AppleScript instead because `imsg send` hangs indefinitely when spawned via `asyncio.create_subprocess_exec` from a launchd agent. This is a known macOS restriction on XPC messaging from non-Aqua launchd contexts. AppleScript via `/usr/bin/osascript` does not have this restriction.

### Why polling instead of `imsg watch`

`imsg watch` exits immediately (or hangs without producing output) when spawned as a subprocess from launchd. Root cause is FSEvents subscription restrictions in the launchd sandbox context — the watch command registers for filesystem change notifications on `chat.db` which are blocked. Polling `imsg chats` on an interval is the reliable workaround.

## Bugs Fixed

### 1. Flooding / 150+ duplicate dispatches

When Hermes sends a reply via AppleScript, Messages.app updates `last_message_at` for the chat. The next poll saw activity, fetched history, and re-dispatched the original inbound message because only a chat-level timestamp was tracked.

**Fix:** Track seen message rowids per chat (`_seen_message_ids`). Only dispatch messages with unseen rowids. Pre-populate rowids at startup so historical messages are not dispatched after a restart. Cap per-chat set to 200 entries.

### 2. Concurrent poll overlaps

Poll interval was 10s but agent responses take 15–60s. While an agent was processing, multiple polls fired and re-evaluated the same chat.

**Fix:** Per-chat `asyncio.Lock` (`_chat_locks`). `_check_new_messages` skips any chat whose lock is held. Lock is held for the duration of all dispatches for that chat.

### 3. Duplicate responses

Multiple dispatches of the same message (from bugs 1 and 2) each independently triggered the agent and sent a response.

**Fix:** Resolved by 1 and 2. Additionally, a `_recent_dispatches` cache drops any `(chat_rowid, text_hash)` combination seen within 60 seconds as a last-resort safety net.

### 4. Streaming cursor showing as white block in iMessage

The gateway appends a cursor character (`▉`) to intermediate streaming updates and calls `send()`. iMessage has no edit-message API, so the first partial-text send lands permanently as a white/black block character.

**Fix:** `send()` detects content ending with any known cursor character and returns `SendResult(success=True)` immediately without sending. The stream consumer interprets the missing `message_id` as a failed initial send, disables its streaming session, and lets the normal final-response path deliver the complete answer as one clean message.

### 5. Typing indicator

**Fix:** `send_typing()` calls `imsg typing --chat-id <id> --duration 45s`. `stop_typing()` calls `imsg typing --chat-id <id> --stop true`. Both `on_processing_start` and `on_processing_complete` lifecycle hooks are implemented to start and stop the indicator around agent processing.

### 6. Poll interval too aggressive

**Fix:** `DEFAULT_POLL_INTERVAL` raised from 10.0 to 30.0 seconds.

### 7. Hardcoded FDA warning path

The Full Disk Access permission warning logged a hardcoded user-specific path.

**Fix:** Replaced with a generic instruction.

## Files Changed

- `gateway/platforms/imessage.py` only — no other files touched.