### PR TITLE
feat: structured provider error classification

### DIFF
--- a/agent/provider_errors.py
+++ b/agent/provider_errors.py
@@ -1,0 +1,408 @@
+"""Structured provider error classification for Hermes Agent.
+
+Centralises the error-classification logic that was previously scattered
+as inline string-matching inside the retry loop of ``run_agent.py``.
+Every provider/transport error is mapped to a :class:`ProviderError`
+carrying a :class:`ProviderErrorReason` enum value and metadata (status
+code, retryability, suggested action).
+
+The public API is:
+
+* :func:`classify_provider_error` — the main classifier
+* :func:`is_retryable` — quick boolean check on a reason
+* :func:`suggested_action` — human-readable recovery strategy
+"""
+
+from __future__ import annotations
+
+import enum
+import time
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+# ── Enum ─────────────────────────────────────────────────────────────────
+
+class ProviderErrorReason(enum.Enum):
+    """Canonical error categories for LLM provider failures."""
+
+    AUTH = "auth"                              # 401/403 — may recover with credential refresh
+    AUTH_PERMANENT = "auth_permanent"          # invalid key / bad credentials — won't recover
+    RATE_LIMIT = "rate_limit"             # 429 / quota / too many requests
+    OVERLOADED = "overloaded"             # 529 (Anthropic overloaded)
+    BILLING = "billing"                   # 429 + extra-usage tier gate (not transient)
+    MODEL_NOT_FOUND = "model_not_found"   # invalid/unknown model ID
+    CONTEXT_OVERFLOW = "context_overflow" # context-length / token-limit exceeded
+    PAYLOAD_TOO_LARGE = "payload_too_large"  # 413 / request entity too large
+    FORMAT_ERROR = "format_error"         # ValueError/TypeError (local validation)
+    TIMEOUT = "timeout"                   # request timeout
+    SERVER_ERROR = "server_error"         # 5xx / generic transient server error
+    STREAM_DROP = "stream_drop"           # connection lost/reset during streaming
+    UNKNOWN = "unknown"                   # unclassified
+
+
+# ── Dataclass ────────────────────────────────────────────────────────────
+
+@dataclass
+class ProviderError:
+    """Structured representation of a provider error."""
+
+    reason: ProviderErrorReason
+    status_code: Optional[int] = None
+    message: str = ""
+    retryable: bool = True
+    provider: Optional[str] = None
+    original_error: Optional[Exception] = field(default=None, repr=False)
+
+
+# ── Context-length keyword phrases (order doesn't matter) ───────────────
+
+_CONTEXT_LENGTH_PHRASES = (
+    "context length",
+    "context size",
+    "maximum context",
+    "token limit",
+    "too many tokens",
+    "reduce the length",
+    "exceeds the limit",
+    "context window",
+    "request entity too large",       # OpenRouter/Nous 413 safety-net
+    "prompt is too long",             # Anthropic: "prompt is too long: N tokens > M maximum"
+    "prompt exceeds max length",      # Z.AI / GLM: generic 400 overflow wording
+)
+
+_STREAM_DROP_PHRASES = (
+    "connection lost",
+    "connection reset",
+    "connection closed",
+    "network connection",
+    "network error",
+    "terminated",
+)
+
+_SERVER_DISCONNECT_ERROR_TYPES = frozenset({
+    "ReadError",
+    "RemoteProtocolError",
+    "ServerDisconnectedError",
+})
+
+
+# ── Main classifier ─────────────────────────────────────────────────────
+
+def classify_provider_error(
+    error: Exception,
+    error_msg: str = "",
+    status_code: Optional[int] = None,
+    provider: Optional[str] = None,
+    *,
+    # Contextual hints the caller can provide for heuristic classification
+    model: str = "",
+    approx_tokens: int = 0,
+    num_messages: int = 0,
+    context_length: int = 200_000,
+    error_body: Optional[dict] = None,
+) -> ProviderError:
+    """Classify a provider/transport exception into a :class:`ProviderError`.
+
+    The function preserves the exact same classification priority and logic
+    that was previously inline in ``run_agent.py``'s retry loop.
+
+    Parameters
+    ----------
+    error:
+        The caught exception.
+    error_msg:
+        ``str(error).lower()`` — pre-lowered for efficiency since the
+        caller already computes this.
+    status_code:
+        HTTP status code (may be ``None`` for transport errors).
+    provider:
+        Provider name string (e.g. ``"anthropic"``, ``"openai"``).
+    model:
+        Model identifier (used for Sonnet long-context tier check).
+    approx_tokens:
+        Approximate token count of the current session.
+    num_messages:
+        Number of API messages in the current request.
+    context_length:
+        The compressor's current context_length (for heuristic checks).
+    error_body:
+        Parsed error body dict (``getattr(error, "body", None)``).
+    """
+
+    if not error_msg:
+        error_msg = str(error).lower()
+    error_type = type(error).__name__
+
+    def _make(reason: ProviderErrorReason, retryable: bool, msg: str = "") -> ProviderError:
+        return ProviderError(
+            reason=reason,
+            status_code=status_code,
+            message=msg or error_msg,
+            retryable=retryable,
+            provider=provider,
+            original_error=error,
+        )
+
+    # ── 1. Anthropic long-context tier gate (429 + extra usage + long context) ──
+    if (
+        status_code == 429
+        and "extra usage" in error_msg
+        and "long context" in error_msg
+    ):
+        return _make(ProviderErrorReason.BILLING, retryable=False,
+                     msg="Anthropic long-context tier requires extra usage subscription")
+
+    # ── 2. Rate limits (429 / quota phrases) ────────────────────────────
+    if (
+        status_code == 429
+        or "rate limit" in error_msg
+        or "too many requests" in error_msg
+        or "rate_limit" in error_msg
+        or "usage limit" in error_msg
+        or "quota" in error_msg
+    ):
+        return _make(ProviderErrorReason.RATE_LIMIT, retryable=True)
+
+    # ── 3. Payload too large (413 / phrases) ────────────────────────────
+    if (
+        status_code == 413
+        or "request entity too large" in error_msg
+        or "payload too large" in error_msg
+        or "error code: 413" in error_msg
+    ):
+        return _make(ProviderErrorReason.PAYLOAD_TOO_LARGE, retryable=True)
+
+    # ── 4. Context-length errors (explicit keyword phrases) ─────────────
+    if any(phrase in error_msg for phrase in _CONTEXT_LENGTH_PHRASES):
+        return _make(ProviderErrorReason.CONTEXT_OVERFLOW, retryable=True)
+
+    # ── 5. Generic 400 + large session heuristic → probable context overflow
+    if status_code == 400:
+        is_large_session = approx_tokens > context_length * 0.4 or num_messages > 80
+        is_generic_error = len(error_msg.strip()) < 30
+        if is_large_session and is_generic_error:
+            return _make(ProviderErrorReason.CONTEXT_OVERFLOW, retryable=True,
+                         msg=f"Generic 400 with large session (~{approx_tokens:,} tokens, "
+                             f"{num_messages} msgs) — probable context overflow")
+
+    # ── 6. Server disconnect + large session heuristic → context overflow
+    if not status_code:
+        _is_server_disconnect = (
+            "server disconnected" in error_msg
+            or "peer closed connection" in error_msg
+            or error_type in _SERVER_DISCONNECT_ERROR_TYPES
+        )
+        if _is_server_disconnect:
+            _is_large = approx_tokens > context_length * 0.6 or num_messages > 200
+            if _is_large:
+                return _make(ProviderErrorReason.CONTEXT_OVERFLOW, retryable=True,
+                             msg=f"Server disconnected with large session (~{approx_tokens:,} "
+                                 f"tokens, {num_messages} msgs) — probable context overflow")
+
+    # ── 7. Overloaded (529) ─────────────────────────────────────────────
+    if status_code == 529:
+        return _make(ProviderErrorReason.OVERLOADED, retryable=True)
+
+    # ── 8. Model not found ──────────────────────────────────────────────
+    if (
+        "is not a valid model" in error_msg
+        or "invalid model" in error_msg
+        or "model not found" in error_msg
+    ):
+        return _make(ProviderErrorReason.MODEL_NOT_FOUND, retryable=False)
+
+    # ── 9. Permanent auth failures (invalid key / authentication) ───────
+    if (
+        "invalid api key" in error_msg
+        or "invalid_api_key" in error_msg
+        or "authentication" in error_msg
+    ):
+        return _make(ProviderErrorReason.AUTH_PERMANENT, retryable=False)
+
+    # ── 10. Auth errors (401/403) ───────────────────────────────────────
+    if status_code in (401, 403):
+        return _make(ProviderErrorReason.AUTH, retryable=False)
+
+    # ── 11. Local validation errors (ValueError/TypeError, not UnicodeEncodeError)
+    if isinstance(error, (ValueError, TypeError)) and not isinstance(error, UnicodeEncodeError):
+        return _make(ProviderErrorReason.FORMAT_ERROR, retryable=False)
+
+    # ── 12. Generic 400 from Anthropic OAuth (transient "Error" / empty body)
+    if status_code == 400:
+        _body = error_body if error_body is not None else (getattr(error, "body", None) or {})
+        _err_message = (
+            _body.get("error", {}).get("message", "")
+            if isinstance(_body, dict)
+            else ""
+        )
+        if _err_message.strip().lower() in ("error", ""):
+            return _make(ProviderErrorReason.SERVER_ERROR, retryable=True,
+                         msg="Generic 400 (probable transient Anthropic OAuth error)")
+
+    # ── 13. Other 4xx client errors ─────────────────────────────────────
+    # Also catch error-code phrases from error messages (e.g. "error code: 401")
+    _has_client_error_phrase = any(phrase in error_msg for phrase in (
+        "error code: 401", "error code: 403",
+        "error code: 404", "error code: 422",
+        "unauthorized", "forbidden", "not found",
+    ))
+    if isinstance(status_code, int) and 400 <= status_code < 500:
+        # 413, 429, 529 already handled above; remaining 4xx are non-retryable
+        return _make(ProviderErrorReason.AUTH_PERMANENT, retryable=False)
+    if _has_client_error_phrase:
+        return _make(ProviderErrorReason.AUTH_PERMANENT, retryable=False)
+
+    # ── 14. Stream-drop / connection errors (no status code) ────────────
+    if not status_code and any(p in error_msg for p in _STREAM_DROP_PHRASES):
+        return _make(ProviderErrorReason.STREAM_DROP, retryable=True)
+
+    # ── 15. Server errors (5xx) ─────────────────────────────────────────
+    if isinstance(status_code, int) and 500 <= status_code < 600:
+        return _make(ProviderErrorReason.SERVER_ERROR, retryable=True)
+
+    # ── 16. Server disconnect (not large session — still retryable) ─────
+    if not status_code:
+        _is_server_disconnect = (
+            "server disconnected" in error_msg
+            or "peer closed connection" in error_msg
+            or error_type in _SERVER_DISCONNECT_ERROR_TYPES
+        )
+        if _is_server_disconnect:
+            return _make(ProviderErrorReason.STREAM_DROP, retryable=True)
+
+    # ── Fallback ────────────────────────────────────────────────────────
+    return _make(ProviderErrorReason.UNKNOWN, retryable=True)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+def is_retryable(reason: ProviderErrorReason) -> bool:
+    """Return whether the given error reason is retryable."""
+    _NON_RETRYABLE = frozenset({
+        ProviderErrorReason.AUTH_PERMANENT,
+        ProviderErrorReason.BILLING,
+        ProviderErrorReason.MODEL_NOT_FOUND,
+        ProviderErrorReason.FORMAT_ERROR,
+    })
+    return reason not in _NON_RETRYABLE
+
+
+def suggested_action(reason: ProviderErrorReason) -> str:
+    """Return a suggested recovery action for the given error reason.
+
+    Returns one of: ``'retry'``, ``'retry_with_backoff'``, ``'compress'``,
+    ``'fallback'``, ``'refresh_credentials'``, ``'abort'``.
+    """
+    _ACTION_MAP = {
+        ProviderErrorReason.AUTH: "refresh_credentials",
+        ProviderErrorReason.AUTH_PERMANENT: "abort",
+        ProviderErrorReason.RATE_LIMIT: "retry_with_backoff",
+        ProviderErrorReason.OVERLOADED: "retry_with_backoff",
+        ProviderErrorReason.BILLING: "abort",
+        ProviderErrorReason.MODEL_NOT_FOUND: "fallback",
+        ProviderErrorReason.CONTEXT_OVERFLOW: "compress",
+        ProviderErrorReason.PAYLOAD_TOO_LARGE: "compress",
+        ProviderErrorReason.FORMAT_ERROR: "abort",
+        ProviderErrorReason.TIMEOUT: "retry",
+        ProviderErrorReason.SERVER_ERROR: "retry",
+        ProviderErrorReason.STREAM_DROP: "retry",
+        ProviderErrorReason.UNKNOWN: "retry",
+    }
+    return _ACTION_MAP.get(reason, "retry")
+
+
+# ── Rate-limit header tracking ────────────────────────────────────────────
+
+@dataclass
+class RateLimitState:
+    """Tracks rate limit headers from provider responses."""
+
+    remaining: Optional[int] = None   # X-RateLimit-Remaining
+    limit: Optional[int] = None       # X-RateLimit-Limit
+    reset_at: Optional[float] = None  # X-RateLimit-Reset (epoch time)
+    updated_at: float = 0.0           # when last updated
+
+    def should_throttle(self) -> bool:
+        """Return True if remaining quota is below 10% of limit."""
+        if self.remaining is not None and self.limit and self.limit > 0:
+            return self.remaining / self.limit < 0.10
+        return False
+
+    def suggested_delay(self) -> float:
+        """Return seconds to wait based on reset time, or 0."""
+        if self.reset_at and self.reset_at > time.time():
+            return min(self.reset_at - time.time(), 30.0)  # cap at 30s
+        if self.should_throttle():
+            return 2.0  # conservative 2s delay when low on quota
+        return 0.0
+
+
+def parse_rate_limit_headers(response) -> Optional[RateLimitState]:
+    """Extract rate limit info from API response headers.
+
+    Works with both OpenAI SDK responses (response.headers) and
+    httpx responses. Handles common header names:
+    - x-ratelimit-remaining / X-RateLimit-Remaining
+    - x-ratelimit-limit / X-RateLimit-Limit
+    - x-ratelimit-reset / X-RateLimit-Reset
+    """
+    # Try to get headers from response or response's http_response
+    headers = None
+    for attr in ("headers", "_headers"):
+        h = getattr(response, attr, None)
+        if h and hasattr(h, "get"):
+            headers = h
+            break
+    if not headers:
+        http_resp = getattr(response, "http_response", None) or getattr(
+            response, "response", None
+        )
+        if http_resp:
+            headers = getattr(http_resp, "headers", None)
+    if not headers:
+        return None
+
+    remaining = _parse_int_header(
+        headers, "x-ratelimit-remaining", "X-RateLimit-Remaining", "ratelimit-remaining"
+    )
+    limit = _parse_int_header(
+        headers, "x-ratelimit-limit", "X-RateLimit-Limit", "ratelimit-limit"
+    )
+    reset_raw = _parse_header(
+        headers, "x-ratelimit-reset", "X-RateLimit-Reset", "ratelimit-reset"
+    )
+    reset_at = None
+    if reset_raw:
+        try:
+            val = float(reset_raw)
+            # If val > 1e9 treat as epoch timestamp; otherwise relative seconds
+            reset_at = val if val > 1e9 else time.time() + val
+        except (TypeError, ValueError):
+            pass
+
+    if remaining is None and limit is None and reset_at is None:
+        return None
+    return RateLimitState(
+        remaining=remaining, limit=limit, reset_at=reset_at, updated_at=time.time()
+    )
+
+
+def _parse_header(headers, *names) -> Optional[str]:
+    """Return the first matching header value as a string, or None."""
+    for name in names:
+        val = headers.get(name)
+        if val is not None:
+            return str(val)
+    return None
+
+
+def _parse_int_header(headers, *names) -> Optional[int]:
+    """Return the first matching header value as an int, or None."""
+    raw = _parse_header(headers, *names)
+    if raw:
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            pass
+    return None

--- a/run_agent.py
+++ b/run_agent.py
@@ -103,6 +103,11 @@ from agent.trajectory import (
     convert_scratchpad_to_think, has_incomplete_scratchpad,
     save_trajectory as _save_trajectory_to_file,
 )
+from agent.provider_errors import (
+    ProviderErrorReason,
+    classify_provider_error as _classify_provider_error,
+    parse_rate_limit_headers as _parse_rate_limit_headers,
+)
 from utils import atomic_json_write, env_var_enabled
 
 
@@ -1252,6 +1257,7 @@ class AIAgent:
             working_dir=os.getenv("TERMINAL_CWD") or None,
         )
         self._user_turn_count = 0
+        self._rate_limit_state = None  # RateLimitState from last API response
 
         # Cumulative token usage for the session
         self.session_prompt_tokens = 0
@@ -1335,6 +1341,7 @@ class AIAgent:
         
         # Turn counter (added after reset_session_state was first written — #2635)
         self._user_turn_count = 0
+        self._rate_limit_state = None  # Reset rate-limit tracking for new session
 
         # Context compressor internal counters (if present)
         if hasattr(self, "context_compressor") and self.context_compressor:
@@ -7269,6 +7276,13 @@ class AIAgent:
 
             while retry_count < max_retries:
                 try:
+                    # Pre-emptive rate-limit throttle based on previous response headers
+                    if self._rate_limit_state and self._rate_limit_state.should_throttle():
+                        _delay = self._rate_limit_state.suggested_delay()
+                        if _delay > 0:
+                            self._vprint(f"{self.log_prefix}\u23f1\ufe0f Rate limit quota low \u2014 throttling {_delay:.1f}s")
+                            time.sleep(_delay)
+
                     api_kwargs = self._build_api_kwargs(api_messages)
                     if self.api_mode == "codex_responses":
                         api_kwargs = self._preflight_codex_api_kwargs(api_kwargs, allow_stream=False)
@@ -7432,8 +7446,9 @@ class AIAgent:
                             }
                         
                         # Longer backoff for rate limiting (likely cause of None choices)
-                        wait_time = min(5 * (2 ** (retry_count - 1)), 120)  # 5s, 10s, 20s, 40s, 80s, 120s
-                        self._vprint(f"{self.log_prefix}⏳ Retrying in {wait_time}s (extended backoff for possible rate limit)...", force=True)
+                        _base_wait = min(5 * (2 ** (retry_count - 1)), 120)  # 5s, 10s, 20s, 40s, 80s, 120s
+                        wait_time = _base_wait + random.uniform(0, _base_wait * 0.25)
+                        self._vprint(f"{self.log_prefix}⏳ Retrying in {wait_time:.0f}s (extended backoff for possible rate limit)...", force=True)
                         logging.warning(f"Invalid API response (retry {retry_count}/{max_retries}): {', '.join(error_details)} | Provider: {provider_name}")
                         
                         # Sleep in small increments to stay responsive to interrupts
@@ -7699,6 +7714,12 @@ class AIAgent:
                                 self._vprint(f"{self.log_prefix}   💾 Cache: {cached:,}/{prompt:,} tokens ({hit_pct:.0f}% hit, {written:,} written)")
                     
                     has_retried_429 = False  # Reset on success
+
+                    # Track rate-limit headers for pre-emptive throttling
+                    _rls = _parse_rate_limit_headers(response)
+                    if _rls:
+                        self._rate_limit_state = _rls
+
                     self._touch_activity(f"API call #{api_call_count} completed")
                     break  # Success, exit retry loop
 
@@ -7803,6 +7824,21 @@ class AIAgent:
                     error_type = type(api_error).__name__
                     error_msg = str(api_error).lower()
                     _error_summary = self._summarize_api_error(api_error)
+
+                    # ── Structured error classification ──────────────────
+                    _classified = _classify_provider_error(
+                        api_error,
+                        error_msg=error_msg,
+                        status_code=status_code,
+                        provider=getattr(self, "provider", None),
+                        model=getattr(self, "model", ""),
+                        approx_tokens=approx_tokens,
+                        num_messages=len(api_messages),
+                        context_length=getattr(
+                            getattr(self, "context_compressor", None),
+                            "context_length", 200_000,
+                        ),
+                    )
                     logger.warning(
                         "API call failed (attempt %s/%s) error_type=%s %s summary=%s",
                         retry_count,
@@ -7904,13 +7940,9 @@ class AIAgent:
                     # When a fallback model is configured, switch immediately instead
                     # of burning through retries with exponential backoff -- the
                     # primary provider won't recover within the retry window.
-                    is_rate_limited = (
-                        status_code == 429
-                        or "rate limit" in error_msg
-                        or "too many requests" in error_msg
-                        or "rate_limit" in error_msg
-                        or "usage limit" in error_msg
-                        or "quota" in error_msg
+                    is_rate_limited = _classified.reason in (
+                        ProviderErrorReason.RATE_LIMIT,
+                        ProviderErrorReason.BILLING,
                     )
                     if is_rate_limited and self._fallback_index < len(self._fallback_chain):
                         # Don't eagerly fallback if credential pool rotation may
@@ -7926,10 +7958,7 @@ class AIAgent:
                                 continue
 
                     is_payload_too_large = (
-                        status_code == 413
-                        or 'request entity too large' in error_msg
-                        or 'payload too large' in error_msg
-                        or 'error code: 413' in error_msg
+                        _classified.reason == ProviderErrorReason.PAYLOAD_TOO_LARGE
                     )
 
                     if is_payload_too_large:
@@ -7973,64 +8002,38 @@ class AIAgent:
                             }
 
                     # Check for context-length errors BEFORE generic 4xx handler.
-                    # Local backends (LM Studio, Ollama, llama.cpp) often return
-                    # HTTP 400 with messages like "Context size has been exceeded"
-                    # which must trigger compression, not an immediate abort.
-                    is_context_length_error = any(phrase in error_msg for phrase in [
-                        'context length', 'context size', 'maximum context',
-                        'token limit', 'too many tokens', 'reduce the length',
-                        'exceeds the limit', 'context window',
-                        'request entity too large',  # OpenRouter/Nous 413 safety net
-                        'prompt is too long',  # Anthropic: "prompt is too long: N tokens > M maximum"
-                        'prompt exceeds max length',  # Z.AI / GLM: generic 400 overflow wording
-                    ])
+                    # Classification is handled by _classify_provider_error() which
+                    # covers: explicit keyword phrases, generic 400 + large session
+                    # heuristic (#1630), and server disconnect + large session (#2153).
+                    is_context_length_error = (
+                        _classified.reason == ProviderErrorReason.CONTEXT_OVERFLOW
+                    )
 
-                    # Fallback heuristic: Anthropic sometimes returns a generic
-                    # 400 invalid_request_error with just "Error" as the message
-                    # when the context is too large.  If the error message is very
-                    # short/generic AND the session is large, treat it as a
-                    # probable context-length error and attempt compression rather
-                    # than aborting.  This prevents an infinite failure loop where
-                    # each failed message gets persisted, making the session even
-                    # larger. (#1630)
-                    if not is_context_length_error and status_code == 400:
+                    # Preserve diagnostic messages for heuristic context-overflow cases
+                    if is_context_length_error and status_code == 400:
                         ctx_len = getattr(getattr(self, 'context_compressor', None), 'context_length', 200000)
                         is_large_session = approx_tokens > ctx_len * 0.4 or len(api_messages) > 80
-                        is_generic_error = len(error_msg.strip()) < 30  # e.g. just "error"
+                        is_generic_error = len(error_msg.strip()) < 30
                         if is_large_session and is_generic_error:
-                            is_context_length_error = True
                             self._vprint(
                                 f"{self.log_prefix}⚠️  Generic 400 with large session "
                                 f"(~{approx_tokens:,} tokens, {len(api_messages)} msgs) — "
                                 f"treating as probable context overflow.",
                                 force=True,
                             )
-
-                    # Server disconnects on large sessions are often caused by
-                    # the request exceeding the provider's context/payload limit
-                    # without a proper HTTP error response.  Treat these as
-                    # context-length errors to trigger compression rather than
-                    # burning through retries that will all fail the same way.
-                    # This breaks the death spiral: disconnect → no token data
-                    # → no compression → bigger session → more disconnects.
-                    # (#2153)
-                    if not is_context_length_error and not status_code:
+                    if is_context_length_error and not status_code:
                         _is_server_disconnect = (
                             'server disconnected' in error_msg
                             or 'peer closed connection' in error_msg
                             or error_type in ('ReadError', 'RemoteProtocolError', 'ServerDisconnectedError')
                         )
                         if _is_server_disconnect:
-                            ctx_len = getattr(getattr(self, 'context_compressor', None), 'context_length', 200000)
-                            _is_large = approx_tokens > ctx_len * 0.6 or len(api_messages) > 200
-                            if _is_large:
-                                is_context_length_error = True
-                                self._vprint(
-                                    f"{self.log_prefix}⚠️  Server disconnected with large session "
-                                    f"(~{approx_tokens:,} tokens, {len(api_messages)} msgs) — "
-                                    f"treating as context-length error, attempting compression.",
-                                    force=True,
-                                )
+                            self._vprint(
+                                f"{self.log_prefix}⚠️  Server disconnected with large session "
+                                f"(~{approx_tokens:,} tokens, {len(api_messages)} msgs) — "
+                                f"treating as context-length error, attempting compression.",
+                                force=True,
+                            )
 
                     if is_context_length_error:
                         compressor = self.context_compressor
@@ -8103,34 +8106,21 @@ class AIAgent:
                             }
 
                     # Check for non-retryable client errors (4xx HTTP status codes).
-                    # These indicate a problem with the request itself (bad model ID,
-                    # invalid API key, forbidden, etc.) and will never succeed on retry.
-                    # Note: 413 and context-length errors are excluded — handled above.
-                    # 429 (rate limit) is transient and MUST be retried with backoff.
-                    # 529 (Anthropic overloaded) is also transient.
-                    # Also catch local validation errors (ValueError, TypeError) — these
-                    # are programming bugs, not transient failures.
-                    # Exclude UnicodeEncodeError — it's a ValueError subclass but is
-                    # handled separately by the surrogate sanitization path above.
-                    _RETRYABLE_STATUS_CODES = {413, 429, 529}
-                    is_local_validation_error = (
-                        isinstance(api_error, (ValueError, TypeError))
-                        and not isinstance(api_error, UnicodeEncodeError)
+                    # Classification is handled by _classify_provider_error() which
+                    # covers: 4xx status codes (excluding retryable 413/429/529),
+                    # local validation errors (ValueError/TypeError), error-code
+                    # phrases, model-not-found, invalid-api-key, auth failures, and
+                    # the generic 400 Anthropic OAuth transient heuristic (#1608).
+                    # Context-length errors are excluded — handled above.
+                    is_client_error = (
+                        _classified.reason in (
+                            ProviderErrorReason.AUTH,
+                            ProviderErrorReason.AUTH_PERMANENT,
+                            ProviderErrorReason.MODEL_NOT_FOUND,
+                            ProviderErrorReason.FORMAT_ERROR,
+                        )
+                        and not is_context_length_error
                     )
-                    # Detect generic 400s from Anthropic OAuth (transient server-side failures).
-                    # Real invalid_request_error responses include a descriptive message;
-                    # transient ones contain only "Error" or are empty. (ref: issue #1608)
-                    _err_body = getattr(api_error, "body", None) or {}
-                    _err_message = (_err_body.get("error", {}).get("message", "") if isinstance(_err_body, dict) else "")
-                    _is_generic_400 = (status_code == 400 and _err_message.strip().lower() in ("error", ""))
-                    is_client_status_error = isinstance(status_code, int) and 400 <= status_code < 500 and status_code not in _RETRYABLE_STATUS_CODES and not _is_generic_400
-                    is_client_error = (is_local_validation_error or is_client_status_error or any(phrase in error_msg for phrase in [
-                        'error code: 401', 'error code: 403',
-                        'error code: 404', 'error code: 422',
-                        'is not a valid model', 'invalid model', 'model not found',
-                        'invalid api key', 'invalid_api_key', 'authentication',
-                        'unauthorized', 'forbidden', 'not found',
-                    ])) and not is_context_length_error
 
                     if is_client_error:
                         # Try fallback before aborting — a different provider
@@ -8210,12 +8200,7 @@ class AIAgent:
                         # very large tool call (write_file with huge content)
                         # and the proxy/CDN drops the stream mid-response.
                         _is_stream_drop = (
-                            not getattr(api_error, "status_code", None)
-                            and any(p in error_msg for p in (
-                                "connection lost", "connection reset",
-                                "connection closed", "network connection",
-                                "network error", "terminated",
-                            ))
+                            _classified.reason == ProviderErrorReason.STREAM_DROP
                         )
                         if _is_stream_drop:
                             self._vprint(
@@ -8272,7 +8257,10 @@ class AIAgent:
                                     _retry_after = min(int(_ra_raw), 120)  # Cap at 2 minutes
                                 except (TypeError, ValueError):
                                     pass
-                    wait_time = _retry_after if _retry_after else min(2 ** retry_count, 60)
+                    _base_wait = _retry_after if _retry_after else min(2 ** retry_count, 60)
+                    # Add jitter (0–25% of base) to avoid thundering-herd
+                    # when multiple sessions hit the same provider limit.
+                    wait_time = _base_wait + random.uniform(0, _base_wait * 0.25)
                     if is_rate_limited:
                         self._emit_status(f"⏱️ Rate limit reached. Waiting {wait_time}s before retry (attempt {retry_count + 1}/{max_retries})...")
                     else:

--- a/tests/agent/test_provider_errors.py
+++ b/tests/agent/test_provider_errors.py
@@ -1,0 +1,882 @@
+"""Comprehensive tests for agent.provider_errors — structured error classification.
+
+Covers:
+- Every ProviderErrorReason classification path
+- Edge cases: generic 400 + large session, Anthropic OAuth generic 400,
+  server disconnect heuristic, long-context tier gate
+- Retryable vs non-retryable classification
+- suggested_action() for each reason
+- Priority ordering (e.g. BILLING before RATE_LIMIT for 429 + extra usage)
+- RateLimitState tracking and pre-emptive throttling
+- parse_rate_limit_headers() with various response shapes
+"""
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from agent.provider_errors import (
+    ProviderError,
+    ProviderErrorReason,
+    RateLimitState,
+    classify_provider_error,
+    is_retryable,
+    parse_rate_limit_headers,
+    suggested_action,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class FakeAPIError(Exception):
+    """Simulates an API error with status_code and optional body."""
+    def __init__(self, message, status_code=None, body=None):
+        super().__init__(message)
+        self.status_code = status_code
+        self.body = body
+
+
+class FakeReadError(Exception):
+    """Simulates httpcore.ReadError — no status_code."""
+    pass
+
+# Trick: we need to test error_type name matching, so create classes with
+# the exact names the classifier checks.
+
+def _make_named_error(class_name, message):
+    """Create an exception with a specific class name for type-name matching."""
+    cls = type(class_name, (Exception,), {})
+    return cls(message)
+
+
+# =========================================================================
+# 1. BILLING — Anthropic long-context tier gate
+# =========================================================================
+
+class TestBillingClassification:
+    def test_429_extra_usage_long_context(self):
+        err = FakeAPIError("Extra usage is required for long context requests", status_code=429)
+        result = classify_provider_error(
+            err, error_msg=str(err).lower(), status_code=429, model="anthropic/claude-3.5-sonnet"
+        )
+        assert result.reason == ProviderErrorReason.BILLING
+        assert result.retryable is False
+
+    def test_429_extra_usage_without_long_context_is_rate_limit(self):
+        """429 with 'extra usage' but without 'long context' is a rate limit."""
+        err = FakeAPIError("Extra usage tier required", status_code=429)
+        result = classify_provider_error(err, error_msg=str(err).lower(), status_code=429)
+        assert result.reason == ProviderErrorReason.RATE_LIMIT
+
+    def test_billing_preserves_original_error(self):
+        err = FakeAPIError("Extra usage for long context", status_code=429)
+        result = classify_provider_error(err, error_msg=str(err).lower(), status_code=429)
+        assert result.original_error is err
+
+
+# =========================================================================
+# 2. RATE_LIMIT
+# =========================================================================
+
+class TestRateLimitClassification:
+    def test_status_429(self):
+        err = FakeAPIError("Too many requests", status_code=429)
+        result = classify_provider_error(err, error_msg=str(err).lower(), status_code=429)
+        assert result.reason == ProviderErrorReason.RATE_LIMIT
+        assert result.retryable is True
+
+    def test_rate_limit_in_message(self):
+        err = FakeAPIError("You hit a rate limit, please slow down")
+        result = classify_provider_error(err, error_msg=str(err).lower())
+        assert result.reason == ProviderErrorReason.RATE_LIMIT
+
+    def test_too_many_requests_in_message(self):
+        err = FakeAPIError("Too many requests to the API")
+        result = classify_provider_error(err, error_msg=str(err).lower())
+        assert result.reason == ProviderErrorReason.RATE_LIMIT
+
+    def test_rate_limit_underscore(self):
+        err = FakeAPIError("rate_limit exceeded")
+        result = classify_provider_error(err, error_msg=str(err).lower())
+        assert result.reason == ProviderErrorReason.RATE_LIMIT
+
+    def test_usage_limit(self):
+        err = FakeAPIError("usage limit exceeded for this key")
+        result = classify_provider_error(err, error_msg=str(err).lower())
+        assert result.reason == ProviderErrorReason.RATE_LIMIT
+
+    def test_quota(self):
+        err = FakeAPIError("quota exceeded for project")
+        result = classify_provider_error(err, error_msg=str(err).lower())
+        assert result.reason == ProviderErrorReason.RATE_LIMIT
+
+
+# =========================================================================
+# 3. PAYLOAD_TOO_LARGE
+# =========================================================================
+
+class TestPayloadTooLargeClassification:
+    def test_status_413(self):
+        err = FakeAPIError("Request entity too large", status_code=413)
+        result = classify_provider_error(err, error_msg=str(err).lower(), status_code=413)
+        assert result.reason == ProviderErrorReason.PAYLOAD_TOO_LARGE
+        assert result.retryable is True
+
+    def test_request_entity_too_large_message(self):
+        err = FakeAPIError("request entity too large for this endpoint")
+        result = classify_provider_error(err, error_msg=str(err).lower())
+        # Without status code, context-length phrases match first since
+        # "request entity too large" is in _CONTEXT_LENGTH_PHRASES too.
+        assert result.reason in (ProviderErrorReason.PAYLOAD_TOO_LARGE, ProviderErrorReason.CONTEXT_OVERFLOW)
+
+    def test_payload_too_large_message(self):
+        err = FakeAPIError("payload too large")
+        result = classify_provider_error(err, error_msg=str(err).lower())
+        assert result.reason == ProviderErrorReason.PAYLOAD_TOO_LARGE
+
+    def test_error_code_413_in_message(self):
+        err = FakeAPIError("Server returned error code: 413 entity too large")
+        result = classify_provider_error(err, error_msg=str(err).lower())
+        assert result.reason == ProviderErrorReason.PAYLOAD_TOO_LARGE
+
+
+# =========================================================================
+# 4. CONTEXT_OVERFLOW — explicit keywords
+# =========================================================================
+
+class TestContextOverflowClassification:
+    @pytest.mark.parametrize("phrase", [
+        "context length exceeded",
+        "context size has been exceeded",
+        "maximum context window",
+        "token limit reached",
+        "too many tokens in request",
+        "reduce the length of the messages",
+        "exceeds the limit of 128000",
+        "context window exceeded",
+        "prompt is too long: 200000 tokens > 128000 maximum",
+        "prompt exceeds max length",
+    ])
+    def test_context_length_phrases(self, phrase):
+        err = FakeAPIError(phrase, status_code=400)
+        result = classify_provider_error(
+            err, error_msg=phrase.lower(), status_code=400
+        )
+        assert result.reason == ProviderErrorReason.CONTEXT_OVERFLOW
+        assert result.retryable is True
+
+    def test_context_overflow_no_status_code(self):
+        err = FakeAPIError("context length exceeded")
+        result = classify_provider_error(err, error_msg="context length exceeded")
+        assert result.reason == ProviderErrorReason.CONTEXT_OVERFLOW
+
+
+# =========================================================================
+# 5. CONTEXT_OVERFLOW — generic 400 + large session heuristic
+# =========================================================================
+
+class TestGeneric400LargeSessionHeuristic:
+    def test_generic_400_large_tokens(self):
+        err = FakeAPIError("Error", status_code=400)
+        result = classify_provider_error(
+            err, error_msg="error", status_code=400,
+            approx_tokens=100_000, num_messages=10, context_length=200_000,
+        )
+        assert result.reason == ProviderErrorReason.CONTEXT_OVERFLOW
+
+    def test_generic_400_many_messages(self):
+        err = FakeAPIError("Error", status_code=400)
+        result = classify_provider_error(
+            err, error_msg="error", status_code=400,
+            approx_tokens=1000, num_messages=100, context_length=200_000,
+        )
+        assert result.reason == ProviderErrorReason.CONTEXT_OVERFLOW
+
+    def test_generic_400_small_session_not_context_overflow(self):
+        """Small session + generic 400 should NOT be context overflow."""
+        err = FakeAPIError("Error", status_code=400)
+        result = classify_provider_error(
+            err, error_msg="error", status_code=400,
+            approx_tokens=1000, num_messages=5, context_length=200_000,
+        )
+        # Should fall through to the Anthropic OAuth generic 400 check
+        assert result.reason != ProviderErrorReason.CONTEXT_OVERFLOW
+
+    def test_generic_400_long_error_message_not_heuristic(self):
+        """If the error message is long/descriptive, don't use heuristic."""
+        err = FakeAPIError("This is a detailed error message about something specific", status_code=400)
+        result = classify_provider_error(
+            err, error_msg=str(err).lower(), status_code=400,
+            approx_tokens=100_000, num_messages=100, context_length=200_000,
+        )
+        # Long message → not generic → doesn't trigger heuristic
+        assert result.reason != ProviderErrorReason.CONTEXT_OVERFLOW
+
+
+# =========================================================================
+# 6. CONTEXT_OVERFLOW — server disconnect + large session heuristic
+# =========================================================================
+
+class TestServerDisconnectHeuristic:
+    def test_server_disconnected_large_session(self):
+        err = FakeAPIError("Server disconnected without sending a response")
+        result = classify_provider_error(
+            err, error_msg=str(err).lower(), status_code=None,
+            approx_tokens=150_000, num_messages=50, context_length=200_000,
+        )
+        assert result.reason == ProviderErrorReason.CONTEXT_OVERFLOW
+
+    def test_peer_closed_large_session(self):
+        err = FakeAPIError("peer closed connection without response")
+        result = classify_provider_error(
+            err, error_msg=str(err).lower(), status_code=None,
+            approx_tokens=150_000, num_messages=50, context_length=200_000,
+        )
+        assert result.reason == ProviderErrorReason.CONTEXT_OVERFLOW
+
+    def test_read_error_type_large_session(self):
+        err = _make_named_error("ReadError", "connection reset")
+        result = classify_provider_error(
+            err, error_msg=str(err).lower(), status_code=None,
+            approx_tokens=150_000, num_messages=50, context_length=200_000,
+        )
+        assert result.reason == ProviderErrorReason.CONTEXT_OVERFLOW
+
+    def test_remote_protocol_error_type_large_session(self):
+        err = _make_named_error("RemoteProtocolError", "peer closed connection")
+        result = classify_provider_error(
+            err, error_msg=str(err).lower(), status_code=None,
+            approx_tokens=150_000, num_messages=50, context_length=200_000,
+        )
+        assert result.reason == ProviderErrorReason.CONTEXT_OVERFLOW
+
+    def test_server_disconnected_error_type_large_session(self):
+        err = _make_named_error("ServerDisconnectedError", "disconnected")
+        result = classify_provider_error(
+            err, error_msg=str(err).lower(), status_code=None,
+            approx_tokens=150_000, num_messages=50, context_length=200_000,
+        )
+        assert result.reason == ProviderErrorReason.CONTEXT_OVERFLOW
+
+    def test_server_disconnected_small_session_is_stream_drop(self):
+        """Small session disconnect should be STREAM_DROP, not CONTEXT_OVERFLOW."""
+        err = FakeAPIError("Server disconnected without sending a response")
+        result = classify_provider_error(
+            err, error_msg=str(err).lower(), status_code=None,
+            approx_tokens=1000, num_messages=5, context_length=200_000,
+        )
+        assert result.reason == ProviderErrorReason.STREAM_DROP
+
+
+# =========================================================================
+# 7. OVERLOADED (529)
+# =========================================================================
+
+class TestOverloadedClassification:
+    def test_status_529(self):
+        err = FakeAPIError("Overloaded", status_code=529)
+        result = classify_provider_error(err, error_msg=str(err).lower(), status_code=529)
+        assert result.reason == ProviderErrorReason.OVERLOADED
+        assert result.retryable is True
+
+
+# =========================================================================
+# 8. MODEL_NOT_FOUND
+# =========================================================================
+
+class TestModelNotFoundClassification:
+    def test_not_valid_model(self):
+        err = FakeAPIError("'gpt-5' is not a valid model for this endpoint")
+        result = classify_provider_error(err, error_msg=str(err).lower())
+        assert result.reason == ProviderErrorReason.MODEL_NOT_FOUND
+        assert result.retryable is False
+
+    def test_invalid_model(self):
+        err = FakeAPIError("Invalid model: xyz-model")
+        result = classify_provider_error(err, error_msg=str(err).lower())
+        assert result.reason == ProviderErrorReason.MODEL_NOT_FOUND
+
+    def test_model_not_found_message(self):
+        err = FakeAPIError("Model not found: some-model")
+        result = classify_provider_error(err, error_msg=str(err).lower())
+        assert result.reason == ProviderErrorReason.MODEL_NOT_FOUND
+
+
+# =========================================================================
+# 9. AUTH_PERMANENT
+# =========================================================================
+
+class TestAuthPermanentClassification:
+    def test_invalid_api_key(self):
+        err = FakeAPIError("Invalid API key provided")
+        result = classify_provider_error(err, error_msg=str(err).lower())
+        assert result.reason == ProviderErrorReason.AUTH_PERMANENT
+        assert result.retryable is False
+
+    def test_invalid_api_key_underscore(self):
+        err = FakeAPIError("invalid_api_key")
+        result = classify_provider_error(err, error_msg=str(err).lower())
+        assert result.reason == ProviderErrorReason.AUTH_PERMANENT
+
+    def test_authentication_error(self):
+        err = FakeAPIError("Authentication failed for this request")
+        result = classify_provider_error(err, error_msg=str(err).lower())
+        assert result.reason == ProviderErrorReason.AUTH_PERMANENT
+
+
+# =========================================================================
+# 10. AUTH (401/403)
+# =========================================================================
+
+class TestAuthClassification:
+    def test_status_401(self):
+        err = FakeAPIError("Unauthorized", status_code=401)
+        result = classify_provider_error(err, error_msg="unauthorized", status_code=401)
+        # "unauthorized" phrase triggers AUTH_PERMANENT before the 401 check
+        # BUT in the original code, 401 is handled by credential refresh first,
+        # then by the generic 4xx check. Let's verify classification:
+        # "unauthorized" in error_msg -> hits "unauthorized" in the 4xx phrase list
+        # but AUTH_PERMANENT check for "invalid api key"/"authentication" doesn't match "unauthorized"
+        # So 401 status_code → AUTH
+        assert result.reason == ProviderErrorReason.AUTH
+        assert result.retryable is False
+
+    def test_status_403(self):
+        err = FakeAPIError("Forbidden", status_code=403)
+        result = classify_provider_error(err, error_msg="forbidden", status_code=403)
+        assert result.reason == ProviderErrorReason.AUTH
+
+    def test_401_with_authentication_message(self):
+        """401 + 'authentication' → AUTH_PERMANENT takes priority."""
+        err = FakeAPIError("Authentication error: invalid token", status_code=401)
+        result = classify_provider_error(
+            err, error_msg=str(err).lower(), status_code=401,
+        )
+        assert result.reason == ProviderErrorReason.AUTH_PERMANENT
+
+
+# =========================================================================
+# 11. FORMAT_ERROR — ValueError/TypeError
+# =========================================================================
+
+class TestFormatErrorClassification:
+    def test_value_error(self):
+        err = ValueError("invalid literal for int()")
+        result = classify_provider_error(err, error_msg=str(err).lower())
+        assert result.reason == ProviderErrorReason.FORMAT_ERROR
+        assert result.retryable is False
+
+    def test_type_error(self):
+        err = TypeError("expected str, got int")
+        result = classify_provider_error(err, error_msg=str(err).lower())
+        assert result.reason == ProviderErrorReason.FORMAT_ERROR
+
+    def test_unicode_encode_error_is_not_format_error(self):
+        """UnicodeEncodeError is a ValueError subclass but should NOT be FORMAT_ERROR."""
+        err = UnicodeEncodeError("utf-8", "", 0, 1, "surrogates not allowed")
+        result = classify_provider_error(err, error_msg=str(err).lower())
+        assert result.reason != ProviderErrorReason.FORMAT_ERROR
+
+
+# =========================================================================
+# 12. SERVER_ERROR — Anthropic OAuth generic 400
+# =========================================================================
+
+class TestAnthropicOAuthGeneric400:
+    def test_generic_400_with_error_body(self):
+        err = FakeAPIError(
+            "Error",
+            status_code=400,
+            body={"error": {"type": "invalid_request_error", "message": "Error"}},
+        )
+        result = classify_provider_error(
+            err, error_msg="error", status_code=400,
+            approx_tokens=1000, num_messages=5, context_length=200_000,
+        )
+        assert result.reason == ProviderErrorReason.SERVER_ERROR
+        assert result.retryable is True
+
+    def test_generic_400_empty_message_body(self):
+        err = FakeAPIError(
+            "",
+            status_code=400,
+            body={"error": {"type": "invalid_request_error", "message": ""}},
+        )
+        result = classify_provider_error(
+            err, error_msg="", status_code=400,
+            approx_tokens=1000, num_messages=5, context_length=200_000,
+        )
+        assert result.reason == ProviderErrorReason.SERVER_ERROR
+        assert result.retryable is True
+
+    def test_400_with_descriptive_message_is_not_transient(self):
+        """A 400 with a real descriptive message is a real client error."""
+        err = FakeAPIError(
+            "max_tokens must be less than 4096",
+            status_code=400,
+            body={"error": {"type": "invalid_request_error", "message": "max_tokens must be less than 4096"}},
+        )
+        result = classify_provider_error(
+            err, error_msg=str(err).lower(), status_code=400,
+            approx_tokens=1000, num_messages=5, context_length=200_000,
+        )
+        # Not generic → not SERVER_ERROR → falls to other 4xx handler
+        assert result.reason == ProviderErrorReason.AUTH_PERMANENT
+        assert result.retryable is False
+
+
+# =========================================================================
+# 13. Other 4xx → AUTH_PERMANENT
+# =========================================================================
+
+class TestOther4xxClassification:
+    def test_status_404(self):
+        err = FakeAPIError("Not found", status_code=404)
+        result = classify_provider_error(err, error_msg="not found", status_code=404)
+        # "not found" phrase matches before generic 4xx
+        assert result.reason == ProviderErrorReason.AUTH_PERMANENT
+        assert result.retryable is False
+
+    def test_status_422(self):
+        err = FakeAPIError("Unprocessable entity", status_code=422)
+        result = classify_provider_error(err, error_msg="unprocessable entity", status_code=422)
+        assert result.reason == ProviderErrorReason.AUTH_PERMANENT
+
+    def test_error_code_phrases(self):
+        err = FakeAPIError("error code: 401 unauthorized")
+        result = classify_provider_error(err, error_msg=str(err).lower())
+        # "error code: 401" phrase + "unauthorized" phrase → AUTH_PERMANENT
+        assert result.reason == ProviderErrorReason.AUTH_PERMANENT
+
+
+# =========================================================================
+# 14. SERVER_ERROR (5xx)
+# =========================================================================
+
+class TestServerErrorClassification:
+    def test_status_500(self):
+        err = FakeAPIError("Internal server error", status_code=500)
+        result = classify_provider_error(err, error_msg=str(err).lower(), status_code=500)
+        assert result.reason == ProviderErrorReason.SERVER_ERROR
+        assert result.retryable is True
+
+    def test_status_502(self):
+        err = FakeAPIError("Bad gateway", status_code=502)
+        result = classify_provider_error(err, error_msg=str(err).lower(), status_code=502)
+        assert result.reason == ProviderErrorReason.SERVER_ERROR
+
+    def test_status_503(self):
+        err = FakeAPIError("Service unavailable", status_code=503)
+        result = classify_provider_error(err, error_msg=str(err).lower(), status_code=503)
+        assert result.reason == ProviderErrorReason.SERVER_ERROR
+
+
+# =========================================================================
+# 15. STREAM_DROP — connection errors
+# =========================================================================
+
+class TestStreamDropClassification:
+    @pytest.mark.parametrize("phrase", [
+        "connection lost during streaming",
+        "connection reset by peer",
+        "connection closed unexpectedly",
+        "network connection failed",
+        "network error occurred",
+        "request terminated by server",
+    ])
+    def test_stream_drop_phrases(self, phrase):
+        err = FakeAPIError(phrase)
+        result = classify_provider_error(err, error_msg=phrase.lower(), status_code=None)
+        assert result.reason == ProviderErrorReason.STREAM_DROP
+        assert result.retryable is True
+
+    def test_connection_error_with_status_code_is_not_stream_drop(self):
+        """If there's a status code, it should be classified by status, not as stream drop."""
+        err = FakeAPIError("connection lost", status_code=500)
+        result = classify_provider_error(err, error_msg="connection lost", status_code=500)
+        assert result.reason == ProviderErrorReason.SERVER_ERROR
+
+
+# =========================================================================
+# 16. UNKNOWN
+# =========================================================================
+
+class TestUnknownClassification:
+    def test_generic_exception(self):
+        err = Exception("Something unexpected happened")
+        result = classify_provider_error(err, error_msg=str(err).lower())
+        assert result.reason == ProviderErrorReason.UNKNOWN
+        assert result.retryable is True
+
+    def test_runtime_error(self):
+        err = RuntimeError("Unexpected internal failure")
+        result = classify_provider_error(err, error_msg=str(err).lower())
+        assert result.reason == ProviderErrorReason.UNKNOWN
+
+
+# =========================================================================
+# is_retryable() tests
+# =========================================================================
+
+class TestIsRetryable:
+    @pytest.mark.parametrize("reason,expected", [
+        (ProviderErrorReason.AUTH, True),
+        (ProviderErrorReason.AUTH_PERMANENT, False),
+        (ProviderErrorReason.RATE_LIMIT, True),
+        (ProviderErrorReason.OVERLOADED, True),
+        (ProviderErrorReason.BILLING, False),
+        (ProviderErrorReason.MODEL_NOT_FOUND, False),
+        (ProviderErrorReason.CONTEXT_OVERFLOW, True),
+        (ProviderErrorReason.PAYLOAD_TOO_LARGE, True),
+        (ProviderErrorReason.FORMAT_ERROR, False),
+        (ProviderErrorReason.TIMEOUT, True),
+        (ProviderErrorReason.SERVER_ERROR, True),
+        (ProviderErrorReason.STREAM_DROP, True),
+        (ProviderErrorReason.UNKNOWN, True),
+    ])
+    def test_retryable(self, reason, expected):
+        assert is_retryable(reason) is expected
+
+
+# =========================================================================
+# suggested_action() tests
+# =========================================================================
+
+class TestSuggestedAction:
+    @pytest.mark.parametrize("reason,expected", [
+        (ProviderErrorReason.AUTH, "refresh_credentials"),
+        (ProviderErrorReason.AUTH_PERMANENT, "abort"),
+        (ProviderErrorReason.RATE_LIMIT, "retry_with_backoff"),
+        (ProviderErrorReason.OVERLOADED, "retry_with_backoff"),
+        (ProviderErrorReason.BILLING, "abort"),
+        (ProviderErrorReason.MODEL_NOT_FOUND, "fallback"),
+        (ProviderErrorReason.CONTEXT_OVERFLOW, "compress"),
+        (ProviderErrorReason.PAYLOAD_TOO_LARGE, "compress"),
+        (ProviderErrorReason.FORMAT_ERROR, "abort"),
+        (ProviderErrorReason.TIMEOUT, "retry"),
+        (ProviderErrorReason.SERVER_ERROR, "retry"),
+        (ProviderErrorReason.STREAM_DROP, "retry"),
+        (ProviderErrorReason.UNKNOWN, "retry"),
+    ])
+    def test_suggested_action(self, reason, expected):
+        assert suggested_action(reason) == expected
+
+
+# =========================================================================
+# ProviderError dataclass tests
+# =========================================================================
+
+class TestProviderErrorDataclass:
+    def test_defaults(self):
+        pe = ProviderError(reason=ProviderErrorReason.UNKNOWN)
+        assert pe.status_code is None
+        assert pe.message == ""
+        assert pe.retryable is True
+        assert pe.provider is None
+        assert pe.original_error is None
+
+    def test_full_construction(self):
+        orig = Exception("test")
+        pe = ProviderError(
+            reason=ProviderErrorReason.RATE_LIMIT,
+            status_code=429,
+            message="Rate limited",
+            retryable=True,
+            provider="openai",
+            original_error=orig,
+        )
+        assert pe.reason == ProviderErrorReason.RATE_LIMIT
+        assert pe.status_code == 429
+        assert pe.message == "Rate limited"
+        assert pe.provider == "openai"
+        assert pe.original_error is orig
+
+    def test_provider_passed_through(self):
+        err = FakeAPIError("error", status_code=500)
+        result = classify_provider_error(
+            err, error_msg="error", status_code=500, provider="anthropic"
+        )
+        assert result.provider == "anthropic"
+
+
+# =========================================================================
+# Priority / edge case tests
+# =========================================================================
+
+class TestClassificationPriority:
+    def test_billing_before_rate_limit(self):
+        """429 + extra usage + long context → BILLING, not RATE_LIMIT."""
+        err = FakeAPIError(
+            "Extra usage is required for long context requests",
+            status_code=429,
+        )
+        result = classify_provider_error(
+            err, error_msg=str(err).lower(), status_code=429,
+        )
+        assert result.reason == ProviderErrorReason.BILLING
+
+    def test_context_overflow_before_generic_4xx(self):
+        """400 + context length phrase → CONTEXT_OVERFLOW, not AUTH_PERMANENT."""
+        err = FakeAPIError("context length exceeded", status_code=400)
+        result = classify_provider_error(
+            err, error_msg=str(err).lower(), status_code=400,
+        )
+        assert result.reason == ProviderErrorReason.CONTEXT_OVERFLOW
+
+    def test_payload_too_large_before_context_overflow_with_413(self):
+        """413 → PAYLOAD_TOO_LARGE (not CONTEXT_OVERFLOW even though phrases overlap)."""
+        err = FakeAPIError("request entity too large", status_code=413)
+        result = classify_provider_error(
+            err, error_msg=str(err).lower(), status_code=413,
+        )
+        assert result.reason == ProviderErrorReason.PAYLOAD_TOO_LARGE
+
+    def test_model_not_found_without_status_code(self):
+        """Model not found from error message without HTTP status."""
+        err = Exception("The model 'xyz' is not a valid model")
+        result = classify_provider_error(err, error_msg=str(err).lower())
+        assert result.reason == ProviderErrorReason.MODEL_NOT_FOUND
+
+    def test_auth_permanent_takes_priority_over_auth_for_invalid_key(self):
+        """'invalid api key' with 401 → AUTH_PERMANENT, not AUTH."""
+        err = FakeAPIError("Invalid API key", status_code=401)
+        result = classify_provider_error(
+            err, error_msg=str(err).lower(), status_code=401,
+        )
+        assert result.reason == ProviderErrorReason.AUTH_PERMANENT
+
+    def test_context_overflow_heuristic_400_before_anthropic_oauth_check(self):
+        """Generic 400 + large session → CONTEXT_OVERFLOW even if body is 'Error'."""
+        err = FakeAPIError(
+            "Error", status_code=400,
+            body={"error": {"type": "invalid_request_error", "message": "Error"}},
+        )
+        result = classify_provider_error(
+            err, error_msg="error", status_code=400,
+            approx_tokens=100_000, num_messages=90, context_length=200_000,
+        )
+        # Large session + generic error → CONTEXT_OVERFLOW (heuristic #5)
+        # takes priority over Anthropic OAuth generic 400 (heuristic #12)
+        assert result.reason == ProviderErrorReason.CONTEXT_OVERFLOW
+
+    def test_error_msg_auto_computed_if_empty(self):
+        """If error_msg is not provided, it should be computed from str(error)."""
+        err = FakeAPIError("Rate limit exceeded")
+        result = classify_provider_error(err)
+        assert result.reason == ProviderErrorReason.RATE_LIMIT
+
+
+# =========================================================================
+# ProviderErrorReason enum completeness
+# =========================================================================
+
+class TestEnumCompleteness:
+    def test_all_reasons_have_retryable_mapping(self):
+        for reason in ProviderErrorReason:
+            # Should not raise
+            is_retryable(reason)
+
+    def test_all_reasons_have_action_mapping(self):
+        for reason in ProviderErrorReason:
+            action = suggested_action(reason)
+            assert action in (
+                "retry", "retry_with_backoff", "compress",
+                "fallback", "refresh_credentials", "abort",
+            )
+
+    def test_enum_values(self):
+        expected = {
+            "AUTH", "AUTH_PERMANENT", "RATE_LIMIT", "OVERLOADED",
+            "BILLING", "MODEL_NOT_FOUND", "CONTEXT_OVERFLOW",
+            "PAYLOAD_TOO_LARGE", "FORMAT_ERROR", "TIMEOUT",
+            "SERVER_ERROR", "STREAM_DROP", "UNKNOWN",
+        }
+        assert {r.name for r in ProviderErrorReason} == expected
+
+
+# =========================================================================
+# RateLimitState — should_throttle()
+# =========================================================================
+
+class TestRateLimitStateShouldThrottle:
+    def test_below_10_percent(self):
+        state = RateLimitState(remaining=5, limit=100)
+        assert state.should_throttle() is True
+
+    def test_at_10_percent(self):
+        state = RateLimitState(remaining=10, limit=100)
+        # 10/100 == 0.10, not < 0.10
+        assert state.should_throttle() is False
+
+    def test_above_10_percent(self):
+        state = RateLimitState(remaining=50, limit=100)
+        assert state.should_throttle() is False
+
+    def test_zero_remaining(self):
+        state = RateLimitState(remaining=0, limit=100)
+        assert state.should_throttle() is True
+
+    def test_remaining_none(self):
+        state = RateLimitState(remaining=None, limit=100)
+        assert state.should_throttle() is False
+
+    def test_limit_none(self):
+        state = RateLimitState(remaining=5, limit=None)
+        assert state.should_throttle() is False
+
+    def test_limit_zero(self):
+        state = RateLimitState(remaining=0, limit=0)
+        assert state.should_throttle() is False
+
+    def test_both_none(self):
+        state = RateLimitState()
+        assert state.should_throttle() is False
+
+
+# =========================================================================
+# RateLimitState — suggested_delay()
+# =========================================================================
+
+class TestRateLimitStateSuggestedDelay:
+    def test_reset_in_future(self):
+        future = time.time() + 10.0
+        state = RateLimitState(remaining=5, limit=100, reset_at=future)
+        delay = state.suggested_delay()
+        assert 9.0 < delay <= 10.0  # should be close to 10s
+
+    def test_reset_far_future_capped_at_30(self):
+        future = time.time() + 120.0
+        state = RateLimitState(remaining=5, limit=100, reset_at=future)
+        delay = state.suggested_delay()
+        assert delay == 30.0
+
+    def test_reset_in_past(self):
+        past = time.time() - 5.0
+        state = RateLimitState(remaining=5, limit=100, reset_at=past)
+        # reset_at in past => falls through to should_throttle() check
+        delay = state.suggested_delay()
+        assert delay == 2.0  # remaining/limit = 5/100 = 5% < 10%
+
+    def test_reset_none_throttle_needed(self):
+        state = RateLimitState(remaining=3, limit=100, reset_at=None)
+        delay = state.suggested_delay()
+        assert delay == 2.0
+
+    def test_reset_none_no_throttle(self):
+        state = RateLimitState(remaining=50, limit=100, reset_at=None)
+        delay = state.suggested_delay()
+        assert delay == 0.0
+
+    def test_all_none(self):
+        state = RateLimitState()
+        assert state.suggested_delay() == 0.0
+
+
+# =========================================================================
+# parse_rate_limit_headers()
+# =========================================================================
+
+class TestParseRateLimitHeaders:
+    def test_response_with_headers_attr(self):
+        resp = SimpleNamespace(headers={
+            "x-ratelimit-remaining": "42",
+            "x-ratelimit-limit": "1000",
+            "x-ratelimit-reset": "1700000000",
+        })
+        state = parse_rate_limit_headers(resp)
+        assert state is not None
+        assert state.remaining == 42
+        assert state.limit == 1000
+        assert state.reset_at == 1700000000.0
+
+    def test_response_with_capitalized_headers(self):
+        resp = SimpleNamespace(headers={
+            "X-RateLimit-Remaining": "10",
+            "X-RateLimit-Limit": "500",
+        })
+        state = parse_rate_limit_headers(resp)
+        assert state is not None
+        assert state.remaining == 10
+        assert state.limit == 500
+        assert state.reset_at is None
+
+    def test_response_with_relative_reset(self):
+        resp = SimpleNamespace(headers={
+            "x-ratelimit-remaining": "5",
+            "x-ratelimit-limit": "100",
+            "x-ratelimit-reset": "60",  # 60 seconds from now
+        })
+        before = time.time()
+        state = parse_rate_limit_headers(resp)
+        after = time.time()
+        assert state is not None
+        # reset_at should be approximately now + 60
+        assert before + 59.5 < state.reset_at < after + 60.5
+
+    def test_response_with_http_response_attr(self):
+        inner = SimpleNamespace(headers={
+            "ratelimit-remaining": "7",
+            "ratelimit-limit": "200",
+        })
+        resp = SimpleNamespace(http_response=inner)
+        state = parse_rate_limit_headers(resp)
+        assert state is not None
+        assert state.remaining == 7
+        assert state.limit == 200
+
+    def test_response_with_response_attr(self):
+        inner = SimpleNamespace(headers={
+            "x-ratelimit-remaining": "1",
+            "x-ratelimit-limit": "50",
+        })
+        resp = SimpleNamespace(response=inner)
+        state = parse_rate_limit_headers(resp)
+        assert state is not None
+        assert state.remaining == 1
+        assert state.limit == 50
+
+    def test_no_headers_returns_none(self):
+        resp = SimpleNamespace(model="gpt-4", usage=None)
+        state = parse_rate_limit_headers(resp)
+        assert state is None
+
+    def test_empty_headers_returns_none(self):
+        resp = SimpleNamespace(headers={})
+        state = parse_rate_limit_headers(resp)
+        assert state is None
+
+    def test_none_response(self):
+        assert parse_rate_limit_headers(None) is None
+
+    def test_non_numeric_header_values(self):
+        resp = SimpleNamespace(headers={
+            "x-ratelimit-remaining": "not-a-number",
+            "x-ratelimit-limit": "also-not",
+            "x-ratelimit-reset": "bad",
+        })
+        state = parse_rate_limit_headers(resp)
+        assert state is None
+
+    def test_partial_headers(self):
+        resp = SimpleNamespace(headers={
+            "x-ratelimit-remaining": "15",
+        })
+        state = parse_rate_limit_headers(resp)
+        assert state is not None
+        assert state.remaining == 15
+        assert state.limit is None
+        assert state.reset_at is None
+
+    def test_updated_at_is_set(self):
+        resp = SimpleNamespace(headers={
+            "x-ratelimit-remaining": "10",
+            "x-ratelimit-limit": "100",
+        })
+        before = time.time()
+        state = parse_rate_limit_headers(resp)
+        after = time.time()
+        assert state is not None
+        assert before <= state.updated_at <= after


### PR DESCRIPTION
Fixes #5435. Also addresses #5449 (rate limit header pre-emption) and adds retry jitter.

## Summary

Extracts the fragile inline string-matching error classification from `run_agent.py`'s retry loop into a typed, testable module. Also adds proactive rate limit tracking and retry jitter.

### 1. Structured error classification

**Current state:** Error classification is ~90 lines of inline `any(phrase in error_msg for phrase in [...])` scattered across the retry loop. New providers with different wording can slip through, causing retryable errors to be treated as permanent or vice versa.

Introduces `agent/provider_errors.py` with:
- `ProviderErrorReason` enum (13 typed reasons: AUTH, AUTH_PERMANENT, RATE_LIMIT, OVERLOADED, BILLING, MODEL_NOT_FOUND, CONTEXT_OVERFLOW, PAYLOAD_TOO_LARGE, FORMAT_ERROR, TIMEOUT, SERVER_ERROR, STREAM_DROP, UNKNOWN)
- `ProviderError` dataclass with reason, status_code, retryable flag
- `classify_provider_error()` function preserving ALL existing classification logic
- `is_retryable()` and `suggested_action()` helpers

~87 lines of inline matching removed, replaced by single classify call. **Zero behavior change** for classification.

### 2. Rate limit header pre-emption

**Problem:** Hermes only reacts to rate limits after receiving a 429. Response headers like `X-RateLimit-Remaining` are ignored.

Adds `RateLimitState` tracker and `parse_rate_limit_headers()`:
- Parses `X-RateLimit-Remaining`, `X-RateLimit-Limit`, `X-RateLimit-Reset` from successful responses
- When remaining quota drops below 10%, inserts a small adaptive delay before the next API call
- Prevents hard 429s by smoothing out request rate proactively

### 3. Retry jitter

Adds 0–25% random jitter to both retry backoff paths to prevent thundering-herd when multiple sessions hit the same provider limit.

## Tests

129 tests covering every classification path, rate limit header parsing, throttle decisions, edge cases, priority ordering, retryability, and suggested actions. All 226 existing `test_run_agent.py` tests pass.
