### PR TITLE
feat: provider cooldown / circuit breaker

### DIFF
--- a/agent/provider_cooldown.py
+++ b/agent/provider_cooldown.py
@@ -1,0 +1,321 @@
+"""Provider cooldown / circuit breaker for Hermes Agent.
+
+Tracks provider failures and applies escalating backoff to prevent
+hammering providers that are rate-limiting, overloaded, or rejecting
+requests with auth/billing errors.
+
+Cooldown schedules:
+- Transient errors (rate_limit, overloaded): 30s → 60s → 5min
+- Permanent errors (auth_permanent, billing): 5min → 10min → 30min
+- Generic auth errors: treated as transient (may be refreshable)
+
+Thread-safe via threading.Lock for use in concurrent subagent scenarios.
+
+This module is intentionally standalone — it does NOT depend on
+provider_errors.py (P0) and uses plain string reason codes.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Dict, Optional
+
+
+# ── Reason codes (plain strings, no enum dependency) ──────────────
+# These match the categories that run_agent.py error handlers detect.
+# When P0 (structured error classification) lands, a follow-up can
+# map ErrorCategory → reason string.
+REASON_RATE_LIMIT = "rate_limit"
+REASON_AUTH = "auth"
+REASON_AUTH_PERMANENT = "auth_permanent"
+REASON_OVERLOADED = "overloaded"
+REASON_BILLING = "billing"
+
+# Reasons that use the "permanent" (longer) backoff schedule
+_PERMANENT_REASONS = frozenset({REASON_AUTH_PERMANENT, REASON_BILLING})
+
+# ── Backoff schedules (seconds) ──────────────────────────────────
+# Index by min(error_count, len(schedule)) - 1
+_TRANSIENT_BACKOFF = (30, 60, 300)       # 30s → 60s → 5min
+_PERMANENT_BACKOFF = (300, 600, 1800)    # 5min → 10min → 30min
+
+
+@dataclass
+class ProviderHealthStats:
+    """Runtime health counters for a provider endpoint."""
+
+    success_count: int = 0
+    error_count: int = 0
+    total_latency_ms: float = 0.0
+    last_error_reason: Optional[str] = None
+    last_error_at: Optional[float] = None
+    last_success_at: Optional[float] = None
+
+    @property
+    def total_calls(self) -> int:
+        return self.success_count + self.error_count
+
+    @property
+    def error_rate(self) -> float:
+        """Error rate as 0.0-1.0."""
+        if self.total_calls == 0:
+            return 0.0
+        return self.error_count / self.total_calls
+
+    @property
+    def avg_latency_ms(self) -> float:
+        if self.success_count == 0:
+            return 0.0
+        return self.total_latency_ms / self.success_count
+
+
+@dataclass
+class CooldownEntry:
+    """Tracks cooldown state for a single provider endpoint."""
+
+    provider_key: str        # 'provider::base_url'
+    reason: str              # last failure reason
+    error_count: int = 0     # consecutive failures
+    cooldown_until: float = 0.0   # time.time() when cooldown expires
+    last_failure_at: float = 0.0  # time.time() of most recent failure
+
+
+def _backoff_seconds(error_count: int, reason: str) -> float:
+    """Return the backoff duration for the given error count and reason."""
+    schedule = _PERMANENT_BACKOFF if reason in _PERMANENT_REASONS else _TRANSIENT_BACKOFF
+    idx = min(error_count, len(schedule)) - 1
+    idx = max(idx, 0)
+    return float(schedule[idx])
+
+
+def _make_key(provider: str, base_url: str) -> str:
+    """Build a canonical key for provider + endpoint."""
+    return f"{provider}::{base_url or ''}"
+
+
+class ProviderCooldownTracker:
+    """Process-scoped tracker for provider cooldown / circuit breaker.
+
+    Usage::
+
+        tracker = get_cooldown_tracker()
+        tracker.record_failure("openrouter", "https://openrouter.ai/api/v1", "rate_limit")
+        entry = tracker.is_in_cooldown("openrouter", "https://openrouter.ai/api/v1")
+        if entry:
+            print(f"In cooldown until {entry.cooldown_until}")
+
+    Thread-safe — all mutations are guarded by an internal lock.
+    """
+
+    _instance: Optional["ProviderCooldownTracker"] = None
+    _instance_lock = threading.Lock()
+
+    def __init__(self) -> None:
+        self._cooldowns: Dict[str, CooldownEntry] = {}
+        self._health: Dict[str, ProviderHealthStats] = {}
+        self._lock = threading.Lock()
+
+    # ── Singleton accessor ────────────────────────────────────────
+
+    @classmethod
+    def get_instance(cls) -> "ProviderCooldownTracker":
+        """Return the process-scoped singleton, creating it on first call."""
+        if cls._instance is None:
+            with cls._instance_lock:
+                if cls._instance is None:
+                    cls._instance = cls()
+        return cls._instance
+
+    @classmethod
+    def _reset_singleton(cls) -> None:
+        """Reset the singleton — for tests only."""
+        with cls._instance_lock:
+            cls._instance = None
+
+    # ── Public API ────────────────────────────────────────────────
+
+    def record_failure(self, provider: str, base_url: str, reason: str) -> CooldownEntry:
+        """Record a failure and compute the new cooldown window.
+
+        Returns the updated CooldownEntry.
+        """
+        key = _make_key(provider, base_url)
+        now = time.time()
+
+        with self._lock:
+            entry = self._cooldowns.get(key)
+            if entry is None:
+                entry = CooldownEntry(provider_key=key, reason=reason)
+                self._cooldowns[key] = entry
+
+            entry.error_count += 1
+            entry.reason = reason
+            entry.last_failure_at = now
+
+            backoff = _backoff_seconds(entry.error_count, reason)
+            entry.cooldown_until = now + backoff
+
+            # Update health stats
+            health = self._health.get(key)
+            if health is None:
+                health = ProviderHealthStats()
+                self._health[key] = health
+            health.error_count += 1
+            health.last_error_reason = reason
+            health.last_error_at = now
+
+            return entry
+
+    def record_success(self, provider: str, base_url: str, latency_ms: Optional[float] = None) -> None:
+        """Record a successful request — resets (closes) the circuit.
+
+        Also updates health stats.  Pass *latency_ms* to track API latency.
+        """
+        key = _make_key(provider, base_url)
+        now = time.time()
+        with self._lock:
+            self._cooldowns.pop(key, None)
+
+            # Update health stats
+            health = self._health.get(key)
+            if health is None:
+                health = ProviderHealthStats()
+                self._health[key] = health
+            health.success_count += 1
+            health.last_success_at = now
+            if latency_ms is not None:
+                health.total_latency_ms += latency_ms
+
+    def is_in_cooldown(self, provider: str, base_url: str) -> Optional[CooldownEntry]:
+        """Check if a provider is currently in cooldown.
+
+        Returns the CooldownEntry if still active, or None if OK.
+        Automatically clears expired entries.
+        """
+        key = _make_key(provider, base_url)
+        now = time.time()
+
+        with self._lock:
+            entry = self._cooldowns.get(key)
+            if entry is None:
+                return None
+
+            if now >= entry.cooldown_until:
+                # Cooldown expired — auto-clear
+                del self._cooldowns[key]
+                return None
+
+            return entry
+
+    def clear_all(self) -> None:
+        """Reset all cooldown entries and health stats (for tests / session reset)."""
+        with self._lock:
+            self._cooldowns.clear()
+            self._health.clear()
+
+    def clear_provider(self, provider: str, base_url: str) -> None:
+        """Clear cooldown for a specific provider endpoint."""
+        key = _make_key(provider, base_url)
+        with self._lock:
+            self._cooldowns.pop(key, None)
+
+    def get_cooldown_summary(self) -> dict:
+        """Return a diagnostic summary of all active cooldowns.
+
+        Returns a dict mapping provider keys to their status::
+
+            {
+                "openrouter::https://openrouter.ai/api/v1": {
+                    "reason": "rate_limit",
+                    "error_count": 2,
+                    "remaining_seconds": 45.3,
+                    "cooldown_until": 1700000045.3,
+                    "last_failure_at": 1700000000.0,
+                },
+                ...
+            }
+        """
+        now = time.time()
+        summary = {}
+
+        with self._lock:
+            # Clean expired entries while building summary
+            expired_keys = []
+            for key, entry in self._cooldowns.items():
+                if now >= entry.cooldown_until:
+                    expired_keys.append(key)
+                else:
+                    summary[key] = {
+                        "reason": entry.reason,
+                        "error_count": entry.error_count,
+                        "remaining_seconds": round(entry.cooldown_until - now, 1),
+                        "cooldown_until": entry.cooldown_until,
+                        "last_failure_at": entry.last_failure_at,
+                    }
+            for key in expired_keys:
+                del self._cooldowns[key]
+
+        return summary
+
+    def get_health_stats(
+        self,
+        provider: Optional[str] = None,
+        base_url: Optional[str] = None,
+    ) -> Dict[str, ProviderHealthStats]:
+        """Return health stats, optionally filtered by provider/base_url.
+
+        If *provider* and *base_url* are both given, return just that key.
+        If only *provider* is given, return all keys whose provider segment matches.
+        If neither is given, return everything.
+        """
+        with self._lock:
+            if provider is not None and base_url is not None:
+                key = _make_key(provider, base_url)
+                entry = self._health.get(key)
+                if entry is not None:
+                    return {key: entry}
+                return {}
+
+            if provider is not None:
+                prefix = f"{provider}::"
+                return {k: v for k, v in self._health.items() if k.startswith(prefix)}
+
+            # Return a shallow copy so callers can iterate safely
+            return dict(self._health)
+
+    def get_health_summary(self) -> dict:
+        """Compact health summary suitable for /status display.
+
+        Returns::
+
+            {
+                "openrouter::https://...": {
+                    "total_calls": 15,
+                    "success": 12,
+                    "errors": 3,
+                    "error_rate": 0.2,
+                    "avg_latency_ms": 1234.5,
+                    "last_error_reason": "rate_limit",
+                },
+                ...
+            }
+        """
+        with self._lock:
+            summary: dict = {}
+            for key, stats in self._health.items():
+                summary[key] = {
+                    "total_calls": stats.total_calls,
+                    "success": stats.success_count,
+                    "errors": stats.error_count,
+                    "error_rate": round(stats.error_rate, 3),
+                    "avg_latency_ms": round(stats.avg_latency_ms, 1),
+                    "last_error_reason": stats.last_error_reason,
+                }
+            return summary
+
+
+def get_cooldown_tracker() -> ProviderCooldownTracker:
+    """Module-level convenience accessor for the singleton tracker."""
+    return ProviderCooldownTracker.get_instance()

--- a/run_agent.py
+++ b/run_agent.py
@@ -93,6 +93,7 @@ from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, DEVELOPER_ROLE_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
+from agent.provider_cooldown import get_cooldown_tracker
 from agent.display import (
     KawaiiSpinner, build_tool_preview as _build_tool_preview,
     get_cute_tool_message as _get_cute_tool_message_impl,
@@ -1346,6 +1347,11 @@ class AIAgent:
             self.context_compressor._context_probe_persistable = False
             # Iterative summary from previous session must not bleed into new one (#2635)
             self.context_compressor._previous_summary = None
+
+        # Clear provider cooldown for the current provider so a new session
+        # starts with a clean slate (the provider may have recovered).
+        if hasattr(self, "provider") and hasattr(self, "base_url"):
+            get_cooldown_tracker().clear_provider(self.provider, self.base_url)
     
     def switch_model(self, new_model, new_provider, api_key='', base_url='', api_mode=''):
         """Switch the model/provider in-place for a live agent.
@@ -7269,6 +7275,19 @@ class AIAgent:
 
             while retry_count < max_retries:
                 try:
+                    # ── Provider cooldown / circuit breaker check ──
+                    _cooldown = get_cooldown_tracker().is_in_cooldown(self.provider, self.base_url)
+                    if _cooldown:
+                        # Try fallback immediately instead of waiting
+                        if self._try_activate_fallback():
+                            retry_count = 0
+                            continue
+                        # No fallback available — wait out the remaining cooldown
+                        _remaining = _cooldown.cooldown_until - time.time()
+                        if _remaining > 0:
+                            self._emit_status(f'Provider {self.provider} in cooldown ({_remaining:.0f}s remaining)...')
+                            time.sleep(min(_remaining, 10))  # cap wait at 10s chunks
+
                     api_kwargs = self._build_api_kwargs(api_messages)
                     if self.api_mode == "codex_responses":
                         api_kwargs = self._preflight_codex_api_kwargs(api_kwargs, allow_stream=False)
@@ -7699,6 +7718,8 @@ class AIAgent:
                                 self._vprint(f"{self.log_prefix}   💾 Cache: {cached:,}/{prompt:,} tokens ({hit_pct:.0f}% hit, {written:,} written)")
                     
                     has_retried_429 = False  # Reset on success
+                    _api_latency_ms = (time.time() - api_start_time) * 1000
+                    get_cooldown_tracker().record_success(self.provider, self.base_url, latency_ms=_api_latency_ms)
                     self._touch_activity(f"API call #{api_call_count} completed")
                     break  # Success, exit retry loop
 
@@ -7912,6 +7933,27 @@ class AIAgent:
                         or "usage limit" in error_msg
                         or "quota" in error_msg
                     )
+
+                    # ── Record failure in provider cooldown tracker ──
+                    # Classify the error reason for cooldown backoff scheduling.
+                    _cooldown_reason = None
+                    if is_rate_limited:
+                        _cooldown_reason = "rate_limit"
+                    elif status_code == 529 or "overloaded" in error_msg:
+                        _cooldown_reason = "overloaded"
+                    elif status_code == 402 or "billing" in error_msg or "payment" in error_msg or "insufficient" in error_msg:
+                        _cooldown_reason = "billing"
+                    elif status_code in (401, 403) or "unauthorized" in error_msg or "forbidden" in error_msg:
+                        # Distinguish permanent auth (after refresh attempts exhausted) from transient
+                        _auth_refreshed = (
+                            codex_auth_retry_attempted
+                            or anthropic_auth_retry_attempted
+                            or nous_auth_retry_attempted
+                        )
+                        _cooldown_reason = "auth_permanent" if _auth_refreshed else "auth"
+                    if _cooldown_reason:
+                        get_cooldown_tracker().record_failure(self.provider, self.base_url, _cooldown_reason)
+
                     if is_rate_limited and self._fallback_index < len(self._fallback_chain):
                         # Don't eagerly fallback if credential pool rotation may
                         # still recover.  The pool's retry-then-rotate cycle needs

--- a/tests/agent/test_provider_cooldown.py
+++ b/tests/agent/test_provider_cooldown.py
@@ -1,0 +1,662 @@
+"""Tests for agent/provider_cooldown.py — provider cooldown / circuit breaker."""
+
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+from agent.provider_cooldown import (
+    CooldownEntry,
+    ProviderCooldownTracker,
+    ProviderHealthStats,
+    get_cooldown_tracker,
+    _backoff_seconds,
+    _make_key,
+    REASON_RATE_LIMIT,
+    REASON_AUTH,
+    REASON_AUTH_PERMANENT,
+    REASON_OVERLOADED,
+    REASON_BILLING,
+    _TRANSIENT_BACKOFF,
+    _PERMANENT_BACKOFF,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    """Reset the singleton between tests to avoid cross-contamination."""
+    ProviderCooldownTracker._reset_singleton()
+    yield
+    ProviderCooldownTracker._reset_singleton()
+
+
+@pytest.fixture
+def tracker():
+    """Return a fresh tracker instance (via singleton)."""
+    return get_cooldown_tracker()
+
+
+# ---------------------------------------------------------------------------
+# CooldownEntry dataclass
+# ---------------------------------------------------------------------------
+
+class TestCooldownEntry:
+    def test_defaults(self):
+        entry = CooldownEntry(provider_key="p::u", reason="rate_limit")
+        assert entry.provider_key == "p::u"
+        assert entry.reason == "rate_limit"
+        assert entry.error_count == 0
+        assert entry.cooldown_until == 0.0
+        assert entry.last_failure_at == 0.0
+
+
+# ---------------------------------------------------------------------------
+# _backoff_seconds helper
+# ---------------------------------------------------------------------------
+
+class TestBackoffSeconds:
+    def test_transient_escalation(self):
+        assert _backoff_seconds(1, REASON_RATE_LIMIT) == 30.0
+        assert _backoff_seconds(2, REASON_RATE_LIMIT) == 60.0
+        assert _backoff_seconds(3, REASON_RATE_LIMIT) == 300.0
+        # 4+ errors stay at max tier
+        assert _backoff_seconds(5, REASON_RATE_LIMIT) == 300.0
+        assert _backoff_seconds(100, REASON_RATE_LIMIT) == 300.0
+
+    def test_overloaded_uses_transient_schedule(self):
+        assert _backoff_seconds(1, REASON_OVERLOADED) == 30.0
+        assert _backoff_seconds(2, REASON_OVERLOADED) == 60.0
+        assert _backoff_seconds(3, REASON_OVERLOADED) == 300.0
+
+    def test_auth_uses_transient_schedule(self):
+        # Generic auth is transient (may be refreshable)
+        assert _backoff_seconds(1, REASON_AUTH) == 30.0
+        assert _backoff_seconds(2, REASON_AUTH) == 60.0
+
+    def test_permanent_escalation(self):
+        assert _backoff_seconds(1, REASON_AUTH_PERMANENT) == 300.0
+        assert _backoff_seconds(2, REASON_AUTH_PERMANENT) == 600.0
+        assert _backoff_seconds(3, REASON_AUTH_PERMANENT) == 1800.0
+        assert _backoff_seconds(10, REASON_AUTH_PERMANENT) == 1800.0
+
+    def test_billing_uses_permanent_schedule(self):
+        assert _backoff_seconds(1, REASON_BILLING) == 300.0
+        assert _backoff_seconds(2, REASON_BILLING) == 600.0
+        assert _backoff_seconds(3, REASON_BILLING) == 1800.0
+
+    def test_zero_error_count_clamps_to_first_tier(self):
+        # Edge case: should not crash
+        assert _backoff_seconds(0, REASON_RATE_LIMIT) == 30.0
+
+
+# ---------------------------------------------------------------------------
+# _make_key helper
+# ---------------------------------------------------------------------------
+
+class TestMakeKey:
+    def test_basic(self):
+        assert _make_key("openrouter", "https://api.example.com") == "openrouter::https://api.example.com"
+
+    def test_empty_base_url(self):
+        assert _make_key("anthropic", "") == "anthropic::"
+        assert _make_key("anthropic", None) == "anthropic::"
+
+
+# ---------------------------------------------------------------------------
+# ProviderCooldownTracker
+# ---------------------------------------------------------------------------
+
+class TestRecordFailure:
+    def test_first_failure_creates_entry(self, tracker):
+        entry = tracker.record_failure("openrouter", "https://api.example.com", REASON_RATE_LIMIT)
+        assert entry.error_count == 1
+        assert entry.reason == REASON_RATE_LIMIT
+        assert entry.cooldown_until > time.time()
+        assert entry.last_failure_at > 0
+
+    def test_escalating_error_count(self, tracker):
+        tracker.record_failure("p", "u", REASON_RATE_LIMIT)
+        entry = tracker.record_failure("p", "u", REASON_RATE_LIMIT)
+        assert entry.error_count == 2
+
+        entry = tracker.record_failure("p", "u", REASON_RATE_LIMIT)
+        assert entry.error_count == 3
+
+    def test_escalating_cooldown_duration(self, tracker):
+        now = time.time()
+
+        entry1 = tracker.record_failure("p", "u", REASON_RATE_LIMIT)
+        # First failure: ~30s backoff
+        assert 29 <= (entry1.cooldown_until - now) <= 32
+
+        entry2 = tracker.record_failure("p", "u", REASON_RATE_LIMIT)
+        now2 = time.time()
+        # Second failure: ~60s backoff
+        assert 59 <= (entry2.cooldown_until - now2) <= 62
+
+        entry3 = tracker.record_failure("p", "u", REASON_RATE_LIMIT)
+        now3 = time.time()
+        # Third failure: ~300s backoff
+        assert 299 <= (entry3.cooldown_until - now3) <= 302
+
+    def test_reason_changes_on_subsequent_failure(self, tracker):
+        tracker.record_failure("p", "u", REASON_RATE_LIMIT)
+        entry = tracker.record_failure("p", "u", REASON_OVERLOADED)
+        assert entry.reason == REASON_OVERLOADED
+        assert entry.error_count == 2
+
+    def test_permanent_reason_gets_longer_backoff(self, tracker):
+        now = time.time()
+        entry = tracker.record_failure("p", "u", REASON_BILLING)
+        # Billing first failure: ~300s
+        assert 299 <= (entry.cooldown_until - now) <= 302
+
+
+class TestRecordSuccess:
+    def test_success_clears_entry(self, tracker):
+        tracker.record_failure("p", "u", REASON_RATE_LIMIT)
+        assert tracker.is_in_cooldown("p", "u") is not None
+
+        tracker.record_success("p", "u")
+        assert tracker.is_in_cooldown("p", "u") is None
+
+    def test_success_on_unknown_provider_is_noop(self, tracker):
+        # Should not raise
+        tracker.record_success("unknown", "unknown")
+
+    def test_success_resets_error_count(self, tracker):
+        tracker.record_failure("p", "u", REASON_RATE_LIMIT)
+        tracker.record_failure("p", "u", REASON_RATE_LIMIT)
+        tracker.record_success("p", "u")
+
+        # New failure should start at count 1 again
+        entry = tracker.record_failure("p", "u", REASON_RATE_LIMIT)
+        assert entry.error_count == 1
+
+
+class TestIsInCooldown:
+    def test_returns_none_for_unknown_provider(self, tracker):
+        assert tracker.is_in_cooldown("unknown", "url") is None
+
+    def test_returns_entry_during_cooldown(self, tracker):
+        tracker.record_failure("p", "u", REASON_RATE_LIMIT)
+        entry = tracker.is_in_cooldown("p", "u")
+        assert entry is not None
+        assert entry.error_count == 1
+
+    def test_auto_clears_expired_cooldown(self, tracker):
+        tracker.record_failure("p", "u", REASON_RATE_LIMIT)
+
+        # Manually expire the cooldown
+        key = _make_key("p", "u")
+        with tracker._lock:
+            tracker._cooldowns[key].cooldown_until = time.time() - 1
+
+        assert tracker.is_in_cooldown("p", "u") is None
+
+        # Entry should be removed
+        with tracker._lock:
+            assert key not in tracker._cooldowns
+
+    def test_returns_entry_when_not_yet_expired(self, tracker):
+        tracker.record_failure("p", "u", REASON_RATE_LIMIT)
+        entry = tracker.is_in_cooldown("p", "u")
+        assert entry is not None
+        assert entry.cooldown_until > time.time()
+
+
+class TestClearAll:
+    def test_clears_all_entries(self, tracker):
+        tracker.record_failure("p1", "u1", REASON_RATE_LIMIT)
+        tracker.record_failure("p2", "u2", REASON_BILLING)
+
+        tracker.clear_all()
+
+        assert tracker.is_in_cooldown("p1", "u1") is None
+        assert tracker.is_in_cooldown("p2", "u2") is None
+
+    def test_clear_all_on_empty_tracker(self, tracker):
+        # Should not raise
+        tracker.clear_all()
+
+
+class TestClearProvider:
+    def test_clears_specific_provider(self, tracker):
+        tracker.record_failure("p1", "u1", REASON_RATE_LIMIT)
+        tracker.record_failure("p2", "u2", REASON_BILLING)
+
+        tracker.clear_provider("p1", "u1")
+
+        assert tracker.is_in_cooldown("p1", "u1") is None
+        assert tracker.is_in_cooldown("p2", "u2") is not None
+
+    def test_clear_unknown_provider_is_noop(self, tracker):
+        tracker.clear_provider("unknown", "url")
+
+
+class TestGetCooldownSummary:
+    def test_empty_summary(self, tracker):
+        assert tracker.get_cooldown_summary() == {}
+
+    def test_summary_contains_active_entries(self, tracker):
+        tracker.record_failure("p1", "u1", REASON_RATE_LIMIT)
+        tracker.record_failure("p2", "u2", REASON_BILLING)
+
+        summary = tracker.get_cooldown_summary()
+        assert len(summary) == 2
+        assert "p1::u1" in summary
+        assert "p2::u2" in summary
+
+        entry = summary["p1::u1"]
+        assert entry["reason"] == REASON_RATE_LIMIT
+        assert entry["error_count"] == 1
+        assert entry["remaining_seconds"] > 0
+        assert "cooldown_until" in entry
+        assert "last_failure_at" in entry
+
+    def test_summary_excludes_expired(self, tracker):
+        tracker.record_failure("p1", "u1", REASON_RATE_LIMIT)
+
+        # Expire the entry
+        key = _make_key("p1", "u1")
+        with tracker._lock:
+            tracker._cooldowns[key].cooldown_until = time.time() - 1
+
+        summary = tracker.get_cooldown_summary()
+        assert len(summary) == 0
+
+        # Expired entry should have been cleaned up
+        with tracker._lock:
+            assert key not in tracker._cooldowns
+
+
+# ---------------------------------------------------------------------------
+# Singleton pattern
+# ---------------------------------------------------------------------------
+
+class TestSingleton:
+    def test_get_instance_returns_same_object(self):
+        t1 = ProviderCooldownTracker.get_instance()
+        t2 = ProviderCooldownTracker.get_instance()
+        assert t1 is t2
+
+    def test_get_cooldown_tracker_returns_singleton(self):
+        t1 = get_cooldown_tracker()
+        t2 = get_cooldown_tracker()
+        assert t1 is t2
+
+    def test_reset_singleton_creates_new_instance(self):
+        t1 = get_cooldown_tracker()
+        ProviderCooldownTracker._reset_singleton()
+        t2 = get_cooldown_tracker()
+        assert t1 is not t2
+
+    def test_state_isolated_after_reset(self):
+        t1 = get_cooldown_tracker()
+        t1.record_failure("p", "u", REASON_RATE_LIMIT)
+
+        ProviderCooldownTracker._reset_singleton()
+        t2 = get_cooldown_tracker()
+        assert t2.is_in_cooldown("p", "u") is None
+
+
+# ---------------------------------------------------------------------------
+# Thread safety
+# ---------------------------------------------------------------------------
+
+class TestThreadSafety:
+    def test_concurrent_record_failure(self, tracker):
+        """Multiple threads recording failures should not corrupt state."""
+        errors = []
+        barrier = threading.Barrier(10)
+
+        def worker(provider_id):
+            try:
+                barrier.wait(timeout=5)
+                for _ in range(50):
+                    tracker.record_failure(f"p{provider_id}", "u", REASON_RATE_LIMIT)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert not errors, f"Thread errors: {errors}"
+
+        # Each provider should have exactly 50 errors
+        for i in range(10):
+            key = _make_key(f"p{i}", "u")
+            with tracker._lock:
+                entry = tracker._cooldowns.get(key)
+                assert entry is not None
+                assert entry.error_count == 50
+
+    def test_concurrent_mixed_operations(self, tracker):
+        """Mix of record_failure, record_success, is_in_cooldown shouldn't crash."""
+        errors = []
+        barrier = threading.Barrier(6)
+
+        def fail_worker():
+            try:
+                barrier.wait(timeout=5)
+                for _ in range(100):
+                    tracker.record_failure("p", "u", REASON_RATE_LIMIT)
+            except Exception as e:
+                errors.append(e)
+
+        def success_worker():
+            try:
+                barrier.wait(timeout=5)
+                for _ in range(100):
+                    tracker.record_success("p", "u")
+            except Exception as e:
+                errors.append(e)
+
+        def check_worker():
+            try:
+                barrier.wait(timeout=5)
+                for _ in range(100):
+                    tracker.is_in_cooldown("p", "u")
+            except Exception as e:
+                errors.append(e)
+
+        threads = []
+        for _ in range(2):
+            threads.append(threading.Thread(target=fail_worker))
+            threads.append(threading.Thread(target=success_worker))
+            threads.append(threading.Thread(target=check_worker))
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert not errors, f"Thread errors: {errors}"
+
+
+# ---------------------------------------------------------------------------
+# Different reason types produce different backoff schedules
+# ---------------------------------------------------------------------------
+
+class TestReasonSchedules:
+    def test_rate_limit_uses_transient_schedule(self, tracker):
+        entry = tracker.record_failure("p", "u", REASON_RATE_LIMIT)
+        expected = _TRANSIENT_BACKOFF[0]
+        actual = entry.cooldown_until - entry.last_failure_at
+        assert abs(actual - expected) < 1.0
+
+    def test_overloaded_uses_transient_schedule(self, tracker):
+        entry = tracker.record_failure("p", "u", REASON_OVERLOADED)
+        expected = _TRANSIENT_BACKOFF[0]
+        actual = entry.cooldown_until - entry.last_failure_at
+        assert abs(actual - expected) < 1.0
+
+    def test_auth_uses_transient_schedule(self, tracker):
+        entry = tracker.record_failure("p", "u", REASON_AUTH)
+        expected = _TRANSIENT_BACKOFF[0]
+        actual = entry.cooldown_until - entry.last_failure_at
+        assert abs(actual - expected) < 1.0
+
+    def test_auth_permanent_uses_permanent_schedule(self, tracker):
+        entry = tracker.record_failure("p", "u", REASON_AUTH_PERMANENT)
+        expected = _PERMANENT_BACKOFF[0]
+        actual = entry.cooldown_until - entry.last_failure_at
+        assert abs(actual - expected) < 1.0
+
+    def test_billing_uses_permanent_schedule(self, tracker):
+        entry = tracker.record_failure("p", "u", REASON_BILLING)
+        expected = _PERMANENT_BACKOFF[0]
+        actual = entry.cooldown_until - entry.last_failure_at
+        assert abs(actual - expected) < 1.0
+
+
+# ---------------------------------------------------------------------------
+# Integration: multiple providers tracked independently
+# ---------------------------------------------------------------------------
+
+class TestMultiProvider:
+    def test_independent_tracking(self, tracker):
+        tracker.record_failure("openrouter", "https://api.openrouter.ai/v1", REASON_RATE_LIMIT)
+        tracker.record_failure("anthropic", "https://api.anthropic.com", REASON_OVERLOADED)
+
+        assert tracker.is_in_cooldown("openrouter", "https://api.openrouter.ai/v1") is not None
+        assert tracker.is_in_cooldown("anthropic", "https://api.anthropic.com") is not None
+
+        tracker.record_success("openrouter", "https://api.openrouter.ai/v1")
+        assert tracker.is_in_cooldown("openrouter", "https://api.openrouter.ai/v1") is None
+        assert tracker.is_in_cooldown("anthropic", "https://api.anthropic.com") is not None
+
+    def test_same_provider_different_urls(self, tracker):
+        tracker.record_failure("openai", "https://api.openai.com/v1", REASON_RATE_LIMIT)
+        tracker.record_failure("openai", "https://custom-proxy.com/v1", REASON_BILLING)
+
+        e1 = tracker.is_in_cooldown("openai", "https://api.openai.com/v1")
+        e2 = tracker.is_in_cooldown("openai", "https://custom-proxy.com/v1")
+
+        assert e1 is not None
+        assert e2 is not None
+        assert e1.reason == REASON_RATE_LIMIT
+        assert e2.reason == REASON_BILLING
+
+
+# ---------------------------------------------------------------------------
+# ProviderHealthStats dataclass
+# ---------------------------------------------------------------------------
+
+class TestProviderHealthStats:
+    def test_defaults(self):
+        stats = ProviderHealthStats()
+        assert stats.success_count == 0
+        assert stats.error_count == 0
+        assert stats.total_latency_ms == 0.0
+        assert stats.last_error_reason is None
+        assert stats.last_error_at is None
+        assert stats.last_success_at is None
+
+    def test_total_calls(self):
+        stats = ProviderHealthStats(success_count=5, error_count=3)
+        assert stats.total_calls == 8
+
+    def test_error_rate_zero_calls(self):
+        stats = ProviderHealthStats()
+        assert stats.error_rate == 0.0
+
+    def test_error_rate(self):
+        stats = ProviderHealthStats(success_count=7, error_count=3)
+        assert abs(stats.error_rate - 0.3) < 1e-9
+
+    def test_error_rate_all_errors(self):
+        stats = ProviderHealthStats(success_count=0, error_count=5)
+        assert stats.error_rate == 1.0
+
+    def test_avg_latency_no_successes(self):
+        stats = ProviderHealthStats()
+        assert stats.avg_latency_ms == 0.0
+
+    def test_avg_latency(self):
+        stats = ProviderHealthStats(success_count=4, total_latency_ms=2000.0)
+        assert stats.avg_latency_ms == 500.0
+
+
+# ---------------------------------------------------------------------------
+# Health stats accumulation
+# ---------------------------------------------------------------------------
+
+class TestHealthStatsAccumulation:
+    def test_success_updates_health(self, tracker):
+        tracker.record_success("p", "u", latency_ms=100.0)
+        stats = tracker.get_health_stats("p", "u")
+        key = _make_key("p", "u")
+        assert key in stats
+        h = stats[key]
+        assert h.success_count == 1
+        assert h.error_count == 0
+        assert h.total_latency_ms == 100.0
+        assert h.last_success_at is not None
+
+    def test_failure_updates_health(self, tracker):
+        tracker.record_failure("p", "u", REASON_RATE_LIMIT)
+        stats = tracker.get_health_stats("p", "u")
+        key = _make_key("p", "u")
+        h = stats[key]
+        assert h.error_count == 1
+        assert h.success_count == 0
+        assert h.last_error_reason == REASON_RATE_LIMIT
+        assert h.last_error_at is not None
+
+    def test_mixed_accumulation(self, tracker):
+        tracker.record_success("p", "u", latency_ms=100.0)
+        tracker.record_success("p", "u", latency_ms=200.0)
+        tracker.record_failure("p", "u", REASON_RATE_LIMIT)
+        tracker.record_success("p", "u", latency_ms=150.0)
+
+        key = _make_key("p", "u")
+        h = tracker.get_health_stats("p", "u")[key]
+        assert h.success_count == 3
+        assert h.error_count == 1
+        assert h.total_latency_ms == 450.0
+        assert abs(h.avg_latency_ms - 150.0) < 1e-9
+        assert abs(h.error_rate - 0.25) < 1e-9
+
+    def test_success_without_latency(self, tracker):
+        tracker.record_success("p", "u")
+        key = _make_key("p", "u")
+        h = tracker.get_health_stats("p", "u")[key]
+        assert h.success_count == 1
+        assert h.total_latency_ms == 0.0
+        assert h.avg_latency_ms == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Health stats survive cooldown expiry
+# ---------------------------------------------------------------------------
+
+class TestHealthStatsPersistence:
+    def test_health_survives_cooldown_expiry(self, tracker):
+        """Health stats persist even when cooldown entry is auto-cleared."""
+        tracker.record_failure("p", "u", REASON_RATE_LIMIT)
+        tracker.record_success("p", "u", latency_ms=200.0)
+
+        # Cooldown entry is cleared by record_success
+        assert tracker.is_in_cooldown("p", "u") is None
+
+        # But health stats still exist
+        key = _make_key("p", "u")
+        h = tracker.get_health_stats("p", "u")[key]
+        assert h.error_count == 1
+        assert h.success_count == 1
+        assert h.total_latency_ms == 200.0
+
+    def test_health_survives_expired_cooldown_auto_clear(self, tracker):
+        """Health stats persist when is_in_cooldown auto-clears expired entry."""
+        tracker.record_failure("p", "u", REASON_RATE_LIMIT)
+
+        # Manually expire the cooldown
+        key = _make_key("p", "u")
+        with tracker._lock:
+            tracker._cooldowns[key].cooldown_until = time.time() - 1
+
+        # is_in_cooldown will auto-clear the expired entry
+        assert tracker.is_in_cooldown("p", "u") is None
+
+        # Health stats should still be there
+        h = tracker.get_health_stats("p", "u")[key]
+        assert h.error_count == 1
+
+
+# ---------------------------------------------------------------------------
+# get_health_summary
+# ---------------------------------------------------------------------------
+
+class TestGetHealthSummary:
+    def test_empty_summary(self, tracker):
+        assert tracker.get_health_summary() == {}
+
+    def test_summary_format(self, tracker):
+        tracker.record_success("p1", "u1", latency_ms=100.0)
+        tracker.record_success("p1", "u1", latency_ms=300.0)
+        tracker.record_failure("p1", "u1", REASON_RATE_LIMIT)
+
+        summary = tracker.get_health_summary()
+        key = _make_key("p1", "u1")
+        assert key in summary
+        entry = summary[key]
+
+        assert entry["total_calls"] == 3
+        assert entry["success"] == 2
+        assert entry["errors"] == 1
+        assert abs(entry["error_rate"] - 0.333) < 0.01
+        assert entry["avg_latency_ms"] == 200.0
+        assert entry["last_error_reason"] == REASON_RATE_LIMIT
+
+    def test_summary_multiple_providers(self, tracker):
+        tracker.record_success("p1", "u1", latency_ms=100.0)
+        tracker.record_failure("p2", "u2", REASON_BILLING)
+
+        summary = tracker.get_health_summary()
+        assert len(summary) == 2
+        assert _make_key("p1", "u1") in summary
+        assert _make_key("p2", "u2") in summary
+
+
+# ---------------------------------------------------------------------------
+# clear_all clears health stats
+# ---------------------------------------------------------------------------
+
+class TestClearAllHealth:
+    def test_clear_all_clears_health(self, tracker):
+        tracker.record_success("p1", "u1", latency_ms=100.0)
+        tracker.record_failure("p2", "u2", REASON_RATE_LIMIT)
+
+        tracker.clear_all()
+
+        assert tracker.get_health_stats() == {}
+        assert tracker.get_health_summary() == {}
+
+
+# ---------------------------------------------------------------------------
+# get_health_stats filtering
+# ---------------------------------------------------------------------------
+
+class TestGetHealthStatsFiltering:
+    def test_no_filter_returns_all(self, tracker):
+        tracker.record_success("p1", "u1")
+        tracker.record_success("p2", "u2")
+
+        stats = tracker.get_health_stats()
+        assert len(stats) == 2
+
+    def test_filter_by_provider_and_url(self, tracker):
+        tracker.record_success("p1", "u1")
+        tracker.record_success("p2", "u2")
+
+        stats = tracker.get_health_stats(provider="p1", base_url="u1")
+        assert len(stats) == 1
+        assert _make_key("p1", "u1") in stats
+
+    def test_filter_by_provider_only(self, tracker):
+        tracker.record_success("openai", "https://api.openai.com/v1")
+        tracker.record_success("openai", "https://custom-proxy.com/v1")
+        tracker.record_success("anthropic", "https://api.anthropic.com")
+
+        stats = tracker.get_health_stats(provider="openai")
+        assert len(stats) == 2
+        assert all(k.startswith("openai::") for k in stats)
+
+    def test_filter_nonexistent_provider(self, tracker):
+        tracker.record_success("p1", "u1")
+        stats = tracker.get_health_stats(provider="nonexistent", base_url="u1")
+        assert stats == {}
+
+    def test_filter_provider_only_nonexistent(self, tracker):
+        tracker.record_success("p1", "u1")
+        stats = tracker.get_health_stats(provider="nonexistent")
+        assert stats == {}


### PR DESCRIPTION
Fixes #5436. Also addresses #5451 (provider runtime health observability).

## Summary

Adds a process-scoped provider cooldown tracker (circuit breaker) and runtime health observability.

### 1. Provider cooldown / circuit breaker

**Problem:** When a provider returns 401/403/429, Hermes retries then possibly falls back, but on the next iteration it hits the same broken provider again with no memory of prior failures.

Introduces `agent/provider_cooldown.py` with:
- `CooldownEntry` dataclass tracking error count, cooldown expiry, failure reason
- `ProviderCooldownTracker` (thread-safe singleton) with escalating backoff:
  - Transient errors (rate_limit, overloaded, auth): 30s → 60s → 5min
  - Permanent errors (auth_permanent, billing): 5min → 10min → 30min
- Circuit breaker semantics: `record_failure()` opens/escalates, `record_success()` closes

Integration: checked before each API call → fallback or wait. Reset on success.

### 2. Provider health observability

Extends the tracker with `ProviderHealthStats`:
- Tracks per-provider success count, error count, average latency, last error reason
- `get_health_summary()` returns a compact dict suitable for `/status` display
- Health stats survive cooldown expiry (session-scoped)
- Latency captured from actual API call timing

Independent of #5441 (P0 error classification) — uses plain string reason codes.

## Tests

63 tests covering escalating backoff, circuit close on success, thread safety, expired auto-clear, singleton pattern, health stats accumulation/persistence/filtering, and diagnostics.
