### PR TITLE
fix(cron): add delivery guidance to cron prompt — stop send_message thrashing

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -383,17 +383,20 @@ def _build_job_prompt(job: dict) -> str:
                 f"{prompt}"
             )
 
-    # Always prepend [SILENT] guidance so the cron agent can suppress
-    # delivery when it has nothing new or noteworthy to report.
-    silent_hint = (
-        "[SYSTEM: If you have a meaningful status report or findings, "
-        "send them — that is the whole point of this job. Only respond "
-        "with exactly \"[SILENT]\" (nothing else) when there is genuinely "
-        "nothing new to report. [SILENT] suppresses delivery to the user. "
+    # Always prepend cron execution guidance so the agent knows how
+    # delivery works and can suppress delivery when appropriate.
+    cron_hint = (
+        "[SYSTEM: You are running as a scheduled cron job. "
+        "DELIVERY: Your final response will be automatically delivered "
+        "to the user — do NOT use send_message or try to deliver "
+        "the output yourself. Just produce your report/output as your "
+        "final response and the system handles the rest. "
+        "SILENT: If there is genuinely nothing new to report, respond "
+        "with exactly \"[SILENT]\" (nothing else) to suppress delivery. "
         "Never combine [SILENT] with content — either report your "
         "findings normally, or say [SILENT] and nothing more.]\n\n"
     )
-    prompt = silent_hint + prompt
+    prompt = cron_hint + prompt
     if skills is None:
         legacy = job.get("skill")
         skills = [legacy] if legacy else []

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -730,6 +730,21 @@ class TestBuildJobPromptSilentHint:
         result = _build_job_prompt(job)
         assert "[SILENT]" in result
 
+    def test_delivery_guidance_present(self):
+        """Cron hint tells agents their final response is auto-delivered."""
+        job = {"prompt": "Generate a report"}
+        result = _build_job_prompt(job)
+        assert "do NOT use send_message" in result
+        assert "automatically delivered" in result
+
+    def test_delivery_guidance_precedes_user_prompt(self):
+        """System guidance appears before the user's prompt text."""
+        job = {"prompt": "My custom prompt"}
+        result = _build_job_prompt(job)
+        system_pos = result.index("do NOT use send_message")
+        prompt_pos = result.index("My custom prompt")
+        assert system_pos < prompt_pos
+
 
 class TestBuildJobPromptMissingSkill:
     """Verify that a missing skill logs a warning and does not crash the job."""


### PR DESCRIPTION
## Summary

Cron agents were burning iterations trying to use `send_message` (which is disabled via the `messaging` toolset) because user prompts said things like "send the report to Telegram." The agent would hallucinate-call the unavailable tool, get errors, then retry with different target formats — wasting 4-5 iterations per run.

The scheduler already handles delivery automatically via the `deliver` setting, but nothing told the agent that.

### Fix

Add a delivery guidance hint to `_build_job_prompt()` alongside the existing `[SILENT]` hint:

```
[SYSTEM: You are running as a scheduled cron job. 
DELIVERY: Your final response will be automatically delivered 
to the user — do NOT use send_message or try to deliver 
the output yourself. Just produce your report/output as your 
final response and the system handles the rest. 
SILENT: If there is genuinely nothing new to report, respond 
with exactly "[SILENT]" (nothing else) to suppress delivery...]
```

### Test plan

- 2 new tests: delivery guidance present + precedes user prompt
- All 119 existing cron tests pass (0 failures)