### PR TITLE
Add controls for background review artifacts and silence auto-reset notices

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -722,6 +722,11 @@ display:
   # Toggle at runtime with /verbose in the CLI
   tool_progress: all
 
+  # Show compact system blurbs from the agent's background review pass,
+  # such as "💾 Memory updated" or "User profile updated".
+  # Disable this if you want cleaner, more human-feeling conversation flow.
+  background_review_artifacts: true
+
   # What Enter does when Hermes is already busy in the CLI.
   #   interrupt: Interrupt the current run and redirect Hermes (default)
   #   queue:     Queue your message for the next turn

--- a/cli.py
+++ b/cli.py
@@ -2274,6 +2274,9 @@ class HermesCLI:
                 stream_delta_callback=self._stream_delta if self.streaming_enabled else None,
                 tool_gen_callback=self._on_tool_gen_start if self.streaming_enabled else None,
             )
+            self.agent.show_background_review_artifacts = self.config["display"].get(
+                "background_review_artifacts", True
+            )
             # Store reference for atexit memory provider shutdown
             global _active_agent_ref
             _active_agent_ref = self.agent

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2264,11 +2264,12 @@ class GatewayRunner:
         # Get or create session
         session_entry = self.session_store.get_or_create_session(source)
         session_key = session_entry.session_key
+        _was_auto_reset_session = bool(getattr(session_entry, "was_auto_reset", False))
         
         # Emit session:start for new or auto-reset sessions
         _is_new_session = (
             session_entry.created_at == session_entry.updated_at
-            or getattr(session_entry, "was_auto_reset", False)
+            or _was_auto_reset_session
         )
         if _is_new_session:
             await self.hooks.emit("session:start", {
@@ -2299,7 +2300,7 @@ class GatewayRunner:
         
         # If the previous session expired and was auto-reset, prepend a notice
         # so the agent knows this is a fresh conversation (not an intentional /reset).
-        if getattr(session_entry, 'was_auto_reset', False):
+        if _was_auto_reset_session:
             reset_reason = getattr(session_entry, 'auto_reset_reason', None) or 'idle'
             if reset_reason == "daily":
                 context_note = "[System note: The user's session was automatically reset by the daily schedule. This is a fresh conversation with no prior context.]"
@@ -2307,50 +2308,10 @@ class GatewayRunner:
                 context_note = "[System note: The user's previous session expired due to inactivity. This is a fresh conversation with no prior context.]"
             context_prompt = context_note + "\n\n" + context_prompt
 
-            # Send a user-facing notification explaining the reset, unless:
-            # - notifications are disabled in config
-            # - the platform is excluded (e.g. api_server, webhook)
-            # - the expired session had no activity (nothing was cleared)
-            try:
-                policy = self.session_store.config.get_reset_policy(
-                    platform=source.platform,
-                    session_type=getattr(source, 'chat_type', 'dm'),
-                )
-                platform_name = source.platform.value if source.platform else ""
-                had_activity = getattr(session_entry, 'reset_had_activity', False)
-                should_notify = (
-                    policy.notify
-                    and had_activity
-                    and platform_name not in policy.notify_exclude_platforms
-                )
-                if should_notify:
-                    adapter = self.adapters.get(source.platform)
-                    if adapter:
-                        if reset_reason == "daily":
-                            reason_text = f"daily schedule at {policy.at_hour}:00"
-                        else:
-                            hours = policy.idle_minutes // 60
-                            mins = policy.idle_minutes % 60
-                            duration = f"{hours}h" if not mins else f"{hours}h {mins}m" if hours else f"{mins}m"
-                            reason_text = f"inactive for {duration}"
-                        notice = (
-                            f"◐ Session automatically reset ({reason_text}). "
-                            f"Conversation history cleared.\n"
-                            f"Use /resume to browse and restore a previous session.\n"
-                            f"Adjust reset timing in config.yaml under session_reset."
-                        )
-                        try:
-                            session_info = self._format_session_info()
-                            if session_info:
-                                notice = f"{notice}\n\n{session_info}"
-                        except Exception:
-                            pass
-                        await adapter.send(
-                            source.chat_id, notice,
-                            metadata=getattr(event, 'metadata', None),
-                        )
-            except Exception as e:
-                logger.debug("Auto-reset notification failed (non-fatal): %s", e)
+            # Auto-resets are intentionally silent for the user. We still inject
+            # the context note above so the agent knows this is a fresh session,
+            # but only manual /reset or /new actions should produce a visible
+            # "session reset" confirmation in chat.
 
             session_entry.was_auto_reset = False
             session_entry.auto_reset_reason = None
@@ -2633,7 +2594,15 @@ class GatewayRunner:
         
         # One-time prompt if no home channel is set for this platform
         # Skip for webhooks - they deliver directly to configured targets (github_comment, etc.)
-        if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK:
+        # Auto-reset sessions are intentionally silent; don't replay onboarding
+        # notices like this when Hermes starts a fresh session automatically.
+        if (
+            not history
+            and not _was_auto_reset_session
+            and source.platform
+            and source.platform != Platform.LOCAL
+            and source.platform != Platform.WEBHOOK
+        ):
             platform_name = source.platform.value
             env_key = f"{platform_name.upper()}_HOME_CHANNEL"
             if not os.getenv(env_key):
@@ -6049,6 +6018,14 @@ class GatewayRunner:
             or os.getenv("HERMES_TOOL_PROGRESS_MODE")
             or "all"
         )
+        show_background_review_artifacts = user_config.get("display", {}).get(
+            "background_review_artifacts",
+            True,
+        )
+        if show_background_review_artifacts is False:
+            show_background_review_artifacts = False
+        else:
+            show_background_review_artifacts = bool(show_background_review_artifacts)
         # Disable tool progress for webhooks - they don't support message editing,
         # so each progress line would be sent as a separate message.
         from gateway.config import Platform
@@ -6430,6 +6407,7 @@ class GatewayRunner:
             agent.stream_delta_callback = _stream_delta_cb
             agent.status_callback = _status_callback_sync
             agent.reasoning_config = reasoning_config
+            agent.show_background_review_artifacts = show_background_review_artifacts
 
             # Background review delivery — send "💾 Memory updated" etc. to user
             def _bg_review_send(message: str) -> None:
@@ -6447,7 +6425,9 @@ class GatewayRunner:
                 except Exception as _e:
                     logger.debug("background_review_callback error: %s", _e)
 
-            agent.background_review_callback = _bg_review_send
+            agent.background_review_callback = (
+                _bg_review_send if show_background_review_artifacts else None
+            )
 
             # Store agent reference for interrupt support
             agent_holder[0] = agent

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -380,6 +380,7 @@ DEFAULT_CONFIG = {
         "skin": "default",
         "tool_progress_command": False,  # Enable /verbose command in messaging gateway
         "tool_preview_length": 0,  # Max chars for tool call previews (0 = no limit, show full paths/commands)
+        "background_review_artifacts": True,  # Show "Memory updated" / "User profile updated" review blurbs
     },
 
     # Privacy settings

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1719,6 +1719,22 @@ def setup_agent_settings(config: dict):
         f"Context compression threshold set to {config['compression'].get('threshold', 0.50)}"
     )
 
+    # ── Conversation Artifacts ──
+    print_header("Conversation Artifacts")
+    print_info("Controls non-tool status blurbs that can appear during normal chat flow.")
+    print_info('Examples: "💾 Memory updated" or "User profile updated".')
+    print_info("Disable this if you want replies to feel more conversational and less system-y.")
+
+    current_artifacts = bool(config.get("display", {}).get("background_review_artifacts", True))
+    show_artifacts = prompt_yes_no(
+        "Show background review artifacts in chat?",
+        current_artifacts,
+    )
+    config.setdefault("display", {})["background_review_artifacts"] = show_artifacts
+    save_config(config)
+    state = "enabled" if show_artifacts else "disabled"
+    print_success(f"Background review artifacts {state}")
+
     # ── Session Reset Policy ──
     print_header("Session Reset Policy")
     print_info(

--- a/run_agent.py
+++ b/run_agent.py
@@ -598,6 +598,7 @@ class AIAgent:
         # would mangle the escape sequences.  None = use builtins.print.
         self._print_fn = None
         self.background_review_callback = None  # Optional sync callback for gateway delivery
+        self.show_background_review_artifacts = True
         self.skip_context_files = skip_context_files
         self.pass_session_id = pass_session_id
         self.persist_session = persist_session
@@ -1941,7 +1942,7 @@ class AIAgent:
                         label = "Memory" if target == "memory" else "User profile" if target == "user" else target
                         actions.append(f"{label} updated")
 
-                if actions:
+                if actions and self.show_background_review_artifacts:
                     summary = " · ".join(dict.fromkeys(actions))
                     self._safe_print(f"  💾 {summary}")
                     _bg_cb = self.background_review_callback

--- a/tests/gateway/test_auto_reset_silence.py
+++ b/tests/gateway/test_auto_reset_silence.py
@@ -1,0 +1,112 @@
+"""Tests for silent automatic session resets in the gateway."""
+
+import asyncio
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource
+
+
+def _make_event(text="hello", platform=Platform.TELEGRAM, user_id="12345", chat_id="67890"):
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+        chat_type="dm",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner(adapter, session_entry, history=None):
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._show_reasoning = False
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner._background_tasks = set()
+    runner._session_db = None
+    runner.config = GatewayConfig()
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.hooks.loaded_hooks = []
+    runner._set_session_env = lambda context, event=None: None
+    runner._should_send_voice_reply = lambda *args, **kwargs: False
+    runner._deliver_media_from_response = AsyncMock()
+    runner._run_agent = AsyncMock(
+        return_value={
+            "final_response": "ok",
+            "messages": [],
+            "api_calls": 1,
+            "history_offset": 0,
+            "tools": [],
+            "last_prompt_tokens": 0,
+        }
+    )
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = history or []
+    runner.session_store.has_any_sessions.return_value = True
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_auto_reset_is_silent_for_user(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("privacy:\n  redact_pii: false\n", encoding="utf-8")
+    monkeypatch.setattr(gateway_run, "_config_path", config_path)
+    monkeypatch.setattr(gateway_run, "build_session_context", lambda source, config, entry: SimpleNamespace())
+    monkeypatch.setattr(gateway_run, "build_session_context_prompt", lambda context, redact_pii=False: "ctx")
+
+    adapter = SimpleNamespace(send=AsyncMock())
+    entry = SessionEntry(
+        session_key="telegram:67890:12345",
+        session_id="session-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        was_auto_reset=True,
+        auto_reset_reason="idle",
+        reset_had_activity=True,
+    )
+    runner = _make_runner(adapter, entry)
+
+    response = await runner._handle_message_with_agent(
+        _make_event(),
+        _make_event().source,
+        "telegram:67890:12345",
+    )
+
+    assert response == "ok"
+    adapter.send.assert_not_awaited()
+    assert entry.was_auto_reset is False
+    assert entry.auto_reset_reason is None
+
+
+@pytest.mark.asyncio
+async def test_manual_reset_still_returns_visible_confirmation():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.session_store = MagicMock()
+    runner.session_store._entries = {
+        "telegram:67890:12345": SimpleNamespace(session_id="old-session")
+    }
+    runner.session_store.reset_session.return_value = SimpleNamespace(session_id="new-session")
+    runner._background_tasks = set()
+    runner._evict_cached_agent = MagicMock()
+    runner._async_flush_memories = AsyncMock()
+    runner._format_session_info = lambda: ""
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+
+    result = await runner._handle_reset_command(_make_event(text="/reset"))
+
+    assert result == "✨ Session reset! Starting fresh."

--- a/tests/gateway/test_background_review_artifacts.py
+++ b/tests/gateway/test_background_review_artifacts.py
@@ -1,0 +1,145 @@
+"""Tests for gateway-side background review artifact visibility config."""
+
+import asyncio
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.session import SessionSource
+
+
+def _make_runner():
+    """Create a minimal GatewayRunner without full initialization."""
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._ephemeral_system_prompt = ""
+    runner._prefill_messages = []
+    runner._reasoning_config = None
+    runner._show_reasoning = False
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.hooks.loaded_hooks = []
+    runner._session_db = None
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
+    return runner
+
+
+class _CapturingAgent:
+    """Fake agent that records post-construction state."""
+
+    last_init = None
+    last_instance = None
+
+    def __init__(self, *args, **kwargs):
+        type(self).last_init = dict(kwargs)
+        type(self).last_instance = self
+        self.tools = []
+        self.background_review_callback = "unset"
+        self.show_background_review_artifacts = "unset"
+        self.tool_progress_callback = None
+        self.step_callback = None
+        self.stream_delta_callback = None
+        self.status_callback = None
+        self.reasoning_config = None
+
+    def run_conversation(self, user_message: str, conversation_history=None, task_id=None):
+        return {
+            "final_response": "ok",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+def _patch_runtime(monkeypatch, hermes_home):
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    monkeypatch.setattr(gateway_run, "_env_path", hermes_home / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "test-key",
+        },
+    )
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CapturingAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+
+def _make_source():
+    return SessionSource(
+        platform=Platform.LOCAL,
+        chat_id="cli",
+        chat_name="CLI",
+        chat_type="dm",
+        user_id="user-1",
+    )
+
+
+class TestGatewayBackgroundReviewArtifacts:
+    def test_run_agent_disables_background_review_artifacts_from_config(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "display:\n  background_review_artifacts: false\n",
+            encoding="utf-8",
+        )
+
+        _patch_runtime(monkeypatch, hermes_home)
+        _CapturingAgent.last_init = None
+        _CapturingAgent.last_instance = None
+
+        runner = _make_runner()
+        result = asyncio.run(
+            runner._run_agent(
+                message="ping",
+                context_prompt="",
+                history=[],
+                source=_make_source(),
+                session_id="session-1",
+                session_key="agent:main:local:dm",
+            )
+        )
+
+        assert result["final_response"] == "ok"
+        assert _CapturingAgent.last_instance is not None
+        assert _CapturingAgent.last_instance.show_background_review_artifacts is False
+        assert _CapturingAgent.last_instance.background_review_callback is None
+
+    def test_run_agent_defaults_background_review_artifacts_to_enabled(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("display:\n  tool_progress: all\n", encoding="utf-8")
+
+        _patch_runtime(monkeypatch, hermes_home)
+        _CapturingAgent.last_init = None
+        _CapturingAgent.last_instance = None
+
+        runner = _make_runner()
+        result = asyncio.run(
+            runner._run_agent(
+                message="ping",
+                context_prompt="",
+                history=[],
+                source=_make_source(),
+                session_id="session-1",
+                session_key="agent:main:local:dm",
+            )
+        )
+
+        assert result["final_response"] == "ok"
+        assert _CapturingAgent.last_instance is not None
+        assert _CapturingAgent.last_instance.show_background_review_artifacts is True
+        assert callable(_CapturingAgent.last_instance.background_review_callback)

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -8,6 +8,7 @@ are made.
 import json
 import logging
 import re
+import threading
 import uuid
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
@@ -134,6 +135,92 @@ def test_aiagent_reuses_existing_errors_log_handler():
                 handler.close()
         for handler in original_handlers:
             root_logger.addHandler(handler)
+
+
+class TestBackgroundReviewArtifacts:
+    @staticmethod
+    def _fake_thread_class():
+        class _ImmediateThread:
+            def __init__(self, target=None, daemon=None, name=None):
+                self._target = target
+
+            def start(self):
+                if self._target:
+                    self._target()
+
+        return _ImmediateThread
+
+    @staticmethod
+    def _fake_review_agent_class(messages):
+        class _FakeReviewAgent:
+            def __init__(self, *args, **kwargs):
+                self._session_messages = []
+                self.client = None
+                self._memory_store = None
+                self._memory_enabled = False
+                self._user_profile_enabled = False
+                self._memory_nudge_interval = 0
+                self._skill_nudge_interval = 0
+
+            def run_conversation(self, user_message, conversation_history):
+                self._session_messages = messages
+                return {"completed": True}
+
+        return _FakeReviewAgent
+
+    def test_background_review_artifacts_are_printed_and_forwarded_when_enabled(self, agent):
+        tool_messages = [
+            {
+                "role": "tool",
+                "content": json.dumps(
+                    {"success": True, "message": "Entry added", "target": "memory"}
+                ),
+            },
+            {
+                "role": "tool",
+                "content": json.dumps(
+                    {"success": True, "message": "Entry added", "target": "user"}
+                ),
+            },
+        ]
+        agent._safe_print = MagicMock()
+        agent.background_review_callback = MagicMock()
+        agent.show_background_review_artifacts = True
+
+        with (
+            patch.object(run_agent, "AIAgent", self._fake_review_agent_class(tool_messages)),
+            patch.object(threading, "Thread", self._fake_thread_class()),
+        ):
+            agent._spawn_background_review([], review_memory=True)
+
+        agent._safe_print.assert_called_once_with(
+            "  💾 Memory updated · User profile updated"
+        )
+        agent.background_review_callback.assert_called_once_with(
+            "💾 Memory updated · User profile updated"
+        )
+
+    def test_background_review_artifacts_are_suppressed_when_disabled(self, agent):
+        tool_messages = [
+            {
+                "role": "tool",
+                "content": json.dumps(
+                    {"success": True, "message": "Entry added", "target": "memory"}
+                ),
+            }
+        ]
+        agent._safe_print = MagicMock()
+        agent.background_review_callback = MagicMock()
+        agent.show_background_review_artifacts = False
+
+        with (
+            patch.object(run_agent, "AIAgent", self._fake_review_agent_class(tool_messages)),
+            patch.object(threading, "Thread", self._fake_thread_class()),
+        ):
+            agent._spawn_background_review([], review_memory=True)
+
+        agent._safe_print.assert_not_called()
+        agent.background_review_callback.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a dedicated Agent Settings toggle for background review artifacts such as "Memory updated"
- honor that toggle in CLI and gateway runtime paths and cover it with gateway + agent tests
- keep manual reset confirmations visible while making automatic session resets silent

## Testing
- source venv/bin/activate && pytest tests/test_run_agent.py -k background_review_artifacts -q
- source venv/bin/activate && pytest tests/gateway/test_background_review_artifacts.py -q
- source venv/bin/activate && pytest tests/gateway/test_auto_reset_silence.py -q
- python -m compileall hermes_cli/config.py hermes_cli/setup.py cli.py gateway/run.py run_agent.py tests/gateway/test_background_review_artifacts.py tests/gateway/test_auto_reset_silence.py