### PR TITLE
fix(session_search): load content from FTS-matched session, not empty compaction root

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -257,7 +257,7 @@ class TestSessionSearch:
         assert result["sessions_searched"] == 0
 
     def test_current_root_session_excludes_child_lineage(self):
-        """Delegation child hits should be excluded when they resolve to the current root session."""
+        """Compression/delegation parents should be excluded for the active child session."""
         from unittest.mock import MagicMock
         from tools.session_search_tool import session_search
 
@@ -284,3 +284,87 @@ class TestSessionSearch:
         assert result["count"] == 0
         assert result["results"] == []
         assert result["sessions_searched"] == 0
+
+    def test_compaction_chain_search_uses_matched_session(self):
+        """FTS match in a compacted child session should load content from the
+        child (where messages live), not the empty root."""
+        from unittest.mock import MagicMock, AsyncMock, patch as _patch
+        from tools.session_search_tool import session_search
+
+        mock_db = MagicMock()
+        # FTS finds a match in the leaf session of a compaction chain
+        mock_db.search_messages.return_value = [
+            {"session_id": "leaf_sid", "content": "Infomoris migration",
+             "source": "cli", "session_started": 1709500000, "model": "test"},
+        ]
+
+        def _get_session(session_id):
+            # 3-level compaction chain: root -> mid -> leaf
+            if session_id == "root_sid":
+                return {"parent_session_id": None, "end_reason": None}
+            if session_id == "mid_sid":
+                return {"parent_session_id": "root_sid", "end_reason": "compression"}
+            if session_id == "leaf_sid":
+                return {"parent_session_id": "mid_sid", "end_reason": "cli_close"}
+            return None
+
+        mock_db.get_session.side_effect = _get_session
+        mock_db.get_messages_as_conversation.return_value = [
+            {"role": "user", "content": "Let's work on Infomoris"},
+            {"role": "assistant", "content": "Sure, let me help with that."},
+        ]
+
+        with _patch("tools.session_search_tool.async_call_llm",
+                     new_callable=AsyncMock,
+                     side_effect=RuntimeError("no provider")):
+            result = json.loads(session_search(
+                query="Infomoris", db=mock_db, current_session_id="other_session",
+            ))
+
+        assert result["success"] is True
+        assert result["count"] == 1
+        # Verify that get_messages_as_conversation was called with the LEAF
+        # session (where FTS found the match), NOT the root
+        mock_db.get_messages_as_conversation.assert_called_once_with("leaf_sid")
+
+    def test_compaction_chain_deduplicates_same_lineage(self):
+        """Multiple FTS hits in different fragments of the same compaction chain
+        should produce only one result."""
+        from unittest.mock import MagicMock, AsyncMock, patch as _patch
+        from tools.session_search_tool import session_search
+
+        mock_db = MagicMock()
+        # FTS finds matches in TWO different sessions of the same chain
+        mock_db.search_messages.return_value = [
+            {"session_id": "leaf_sid", "content": "Infomoris leaf",
+             "source": "cli", "session_started": 1709500000, "model": "test"},
+            {"session_id": "mid_sid", "content": "Infomoris mid",
+             "source": "cli", "session_started": 1709400000, "model": "test"},
+        ]
+
+        def _get_session(session_id):
+            if session_id == "root_sid":
+                return {"parent_session_id": None, "end_reason": None}
+            if session_id == "mid_sid":
+                return {"parent_session_id": "root_sid", "end_reason": "compression"}
+            if session_id == "leaf_sid":
+                return {"parent_session_id": "mid_sid", "end_reason": "cli_close"}
+            if session_id == "other_session":
+                return {"parent_session_id": None}
+            return None
+
+        mock_db.get_session.side_effect = _get_session
+        mock_db.get_messages_as_conversation.return_value = [
+            {"role": "user", "content": "test"},
+        ]
+
+        with _patch("tools.session_search_tool.async_call_llm",
+                     new_callable=AsyncMock,
+                     side_effect=RuntimeError("no provider")):
+            result = json.loads(session_search(
+                query="Infomoris", db=mock_db, current_session_id="other_session",
+            ))
+
+        assert result["success"] is True
+        # Should deduplicate: only 1 result for the whole chain
+        assert result["sessions_searched"] == 1

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -257,7 +257,8 @@ class TestSessionSearch:
         assert result["sessions_searched"] == 0
 
     def test_current_root_session_excludes_child_lineage(self):
-        """Compression/delegation parents should be excluded for the active child session."""
+        """When the current session is the root, child sessions in the same
+        lineage should be excluded from search results."""
         from unittest.mock import MagicMock
         from tools.session_search_tool import session_search
 
@@ -368,3 +369,190 @@ class TestSessionSearch:
         assert result["success"] is True
         # Should deduplicate: only 1 result for the whole chain
         assert result["sessions_searched"] == 1
+
+
+class TestRecentSessionsCompaction:
+    """Tests for _list_recent_sessions with compaction chains."""
+
+    def _make_mock_db(self, sessions, session_map, children_map=None):
+        """Create a MagicMock DB with list_sessions_rich, get_session, and
+        proper _lock/_conn for the BFS child query in _get_lineage_ids."""
+        from unittest.mock import MagicMock
+        import threading
+
+        mock_db = MagicMock()
+        mock_db.list_sessions_rich.return_value = sessions
+
+        def _get_session(sid):
+            return session_map.get(sid)
+        mock_db.get_session.side_effect = _get_session
+
+        # For _get_lineage_ids BFS child query: db._lock + db._conn.execute
+        mock_db._lock = threading.Lock()
+        _children_map = children_map or {}
+
+        def _execute(query, params):
+            """Mock cursor for child-session queries."""
+            cursor = MagicMock()
+            parent_id = params[0] if params else None
+            children = _children_map.get(parent_id, [])
+            cursor.fetchall.return_value = [(cid,) for cid in children]
+            return cursor
+        mock_db._conn.execute.side_effect = _execute
+
+        return mock_db
+
+    def test_leaf_shown_intermediates_hidden(self):
+        """Compaction chain leaf should appear; intermediates (end_reason=compression)
+        should be hidden. Root with end_reason=compression should also be hidden."""
+        from tools.session_search_tool import session_search
+
+        sessions = [
+            # Leaf (most recent, has parent, active session)
+            {"id": "leaf", "title": "My Conversation", "source": "cli",
+             "started_at": "2026-04-06T10:00:00", "last_active": "2026-04-06T11:00:00",
+             "message_count": 50, "preview": "Hello world",
+             "parent_session_id": "mid", "end_reason": "cli_close"},
+            # Intermediate compaction node (should be hidden)
+            {"id": "mid", "title": None, "source": "cli",
+             "started_at": "2026-04-06T09:30:00", "last_active": "2026-04-06T09:45:00",
+             "message_count": 0, "preview": "",
+             "parent_session_id": "root", "end_reason": "compression"},
+            # Root compaction node (should be hidden - end_reason=compression)
+            {"id": "root", "title": None, "source": "cli",
+             "started_at": "2026-04-06T09:00:00", "last_active": "2026-04-06T09:10:00",
+             "message_count": 0, "preview": "",
+             "parent_session_id": None, "end_reason": "compression"},
+        ]
+        session_map = {
+            "root": {"parent_session_id": None, "end_reason": "compression"},
+            "mid": {"parent_session_id": "root", "end_reason": "compression"},
+            "leaf": {"parent_session_id": "mid", "end_reason": "cli_close"},
+        }
+        children_map = {
+            "root": ["mid"],
+            "mid": ["leaf"],
+        }
+        mock_db = self._make_mock_db(sessions, session_map, children_map)
+
+        result = json.loads(session_search(
+            query="", db=mock_db, current_session_id="other_session",
+        ))
+
+        assert result["success"] is True
+        assert result["mode"] == "recent"
+        # Only the leaf should appear
+        assert len(result["results"]) == 1
+        assert result["results"][0]["session_id"] == "leaf"
+
+    def test_dedup_same_chain(self):
+        """Multiple non-compression sessions in the same chain should be
+        deduplicated to show only the first one encountered."""
+        from tools.session_search_tool import session_search
+
+        sessions = [
+            # Two leaf-like sessions from the same chain
+            {"id": "leaf2", "title": "Continued", "source": "cli",
+             "started_at": "2026-04-06T12:00:00", "last_active": "2026-04-06T13:00:00",
+             "message_count": 30, "preview": "continuing work",
+             "parent_session_id": "leaf1", "end_reason": "cli_close"},
+            {"id": "leaf1", "title": "Started", "source": "cli",
+             "started_at": "2026-04-06T11:00:00", "last_active": "2026-04-06T11:30:00",
+             "message_count": 20, "preview": "starting work",
+             "parent_session_id": "root", "end_reason": None},
+            # Root - has compression end_reason so it's hidden
+            {"id": "root", "title": None, "source": "cli",
+             "started_at": "2026-04-06T10:00:00", "last_active": "2026-04-06T10:10:00",
+             "message_count": 0, "preview": "",
+             "parent_session_id": None, "end_reason": "compression"},
+        ]
+        session_map = {
+            "root": {"parent_session_id": None, "end_reason": "compression"},
+            "leaf1": {"parent_session_id": "root", "end_reason": None},
+            "leaf2": {"parent_session_id": "leaf1", "end_reason": "cli_close"},
+        }
+        children_map = {
+            "root": ["leaf1"],
+            "leaf1": ["leaf2"],
+        }
+        mock_db = self._make_mock_db(sessions, session_map, children_map)
+
+        result = json.loads(session_search(
+            query="", db=mock_db, current_session_id="other_session",
+        ))
+
+        assert result["success"] is True
+        assert result["mode"] == "recent"
+        # Only ONE session from the chain should appear (first encountered = leaf2)
+        assert len(result["results"]) == 1
+        assert result["results"][0]["session_id"] == "leaf2"
+
+    def test_current_session_lineage_excluded(self):
+        """When the current session is in a compaction chain, ALL fragments
+        of that chain should be excluded from recent listing."""
+        from tools.session_search_tool import session_search
+
+        sessions = [
+            # Current session's leaf
+            {"id": "current_leaf", "title": "Current", "source": "cli",
+             "started_at": "2026-04-06T12:00:00", "last_active": "2026-04-06T13:00:00",
+             "message_count": 10, "preview": "current work",
+             "parent_session_id": "current_root", "end_reason": None},
+            # An unrelated session
+            {"id": "other", "title": "Other Work", "source": "cli",
+             "started_at": "2026-04-06T10:00:00", "last_active": "2026-04-06T10:30:00",
+             "message_count": 5, "preview": "other work",
+             "parent_session_id": None, "end_reason": "cli_close"},
+            # Current session's root (compression)
+            {"id": "current_root", "title": None, "source": "cli",
+             "started_at": "2026-04-06T11:00:00", "last_active": "2026-04-06T11:10:00",
+             "message_count": 0, "preview": "",
+             "parent_session_id": None, "end_reason": "compression"},
+        ]
+        session_map = {
+            "current_root": {"parent_session_id": None, "end_reason": "compression"},
+            "current_leaf": {"parent_session_id": "current_root", "end_reason": None},
+            "other": {"parent_session_id": None, "end_reason": "cli_close"},
+        }
+        children_map = {
+            "current_root": ["current_leaf"],
+        }
+        mock_db = self._make_mock_db(sessions, session_map, children_map)
+
+        result = json.loads(session_search(
+            query="", db=mock_db, current_session_id="current_leaf",
+        ))
+
+        assert result["success"] is True
+        assert result["mode"] == "recent"
+        # Only the unrelated session should appear
+        assert len(result["results"]) == 1
+        assert result["results"][0]["session_id"] == "other"
+
+    def test_normal_sessions_unaffected(self):
+        """Sessions without compaction chains should appear normally."""
+        from tools.session_search_tool import session_search
+
+        sessions = [
+            {"id": "s1", "title": "Session 1", "source": "cli",
+             "started_at": "2026-04-06T12:00:00", "last_active": "2026-04-06T13:00:00",
+             "message_count": 10, "preview": "hello",
+             "parent_session_id": None, "end_reason": "cli_close"},
+            {"id": "s2", "title": "Session 2", "source": "telegram",
+             "started_at": "2026-04-06T11:00:00", "last_active": "2026-04-06T11:30:00",
+             "message_count": 5, "preview": "world",
+             "parent_session_id": None, "end_reason": "cli_close"},
+        ]
+        session_map = {
+            "s1": {"parent_session_id": None},
+            "s2": {"parent_session_id": None},
+        }
+        mock_db = self._make_mock_db(sessions, session_map)
+
+        result = json.loads(session_search(
+            query="", db=mock_db, current_session_id="other_session",
+        ))
+
+        assert result["success"] is True
+        assert result["mode"] == "recent"
+        assert len(result["results"]) == 2

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -192,34 +192,66 @@ async def _summarize_session(
 _HIDDEN_SESSION_SOURCES = ("tool",)
 
 
+def _get_lineage_ids(db, session_id: str) -> set:
+    """Return the set of all session IDs in a compaction chain (parents + children)."""
+    ids = set()
+    # Walk up to root
+    sid = session_id
+    visited = set()
+    while sid and sid not in visited:
+        visited.add(sid)
+        ids.add(sid)
+        try:
+            s = db.get_session(sid)
+            parent = s.get("parent_session_id") if s else None
+            sid = parent if parent else None
+        except Exception:
+            break
+    return ids
+
+
 def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str:
     """Return metadata for the most recent sessions (no LLM calls)."""
     try:
-        sessions = db.list_sessions_rich(limit=limit + 5, exclude_sources=list(_HIDDEN_SESSION_SOURCES))  # fetch extra to skip current
+        # Fetch extra to account for skipping current session and compaction
+        # intermediates.  Context compaction creates chains of sessions linked
+        # via parent_session_id.  Intermediate nodes (end_reason='compression',
+        # typically 0 messages) are just handoff points — the real conversation
+        # lives in the leaf.  We skip intermediates but show the leaf even
+        # though it has a parent_session_id.
+        sessions = db.list_sessions_rich(limit=limit + 20, exclude_sources=list(_HIDDEN_SESSION_SOURCES))
 
         # Resolve current session lineage to exclude it
-        current_root = None
+        current_lineage = set()
         if current_session_id:
             try:
-                sid = current_session_id
-                visited = set()
-                while sid and sid not in visited:
-                    visited.add(sid)
-                    s = db.get_session(sid)
-                    parent = s.get("parent_session_id") if s else None
-                    sid = parent if parent else None
-                current_root = max(visited, key=len) if visited else current_session_id
+                current_lineage = _get_lineage_ids(db, current_session_id)
             except Exception:
-                current_root = current_session_id
+                current_lineage = {current_session_id}
+
+        # Track which compaction chains we've already shown a session for,
+        # so we don't show multiple fragments of the same conversation.
+        seen_lineage_roots = set()
 
         results = []
         for s in sessions:
             sid = s.get("id", "")
-            if current_root and (sid == current_root or sid == current_session_id):
+            if sid in current_lineage:
                 continue
-            # Skip child/delegation sessions (they have parent_session_id)
+            # Skip intermediate compaction nodes — they have a parent and
+            # ended due to compression (typically 0 messages).  The leaf
+            # session of the chain will appear later and has the real content.
+            if s.get("parent_session_id") and s.get("end_reason") == "compression":
+                continue
+            # Deduplicate: if this session belongs to a compaction chain
+            # we've already shown, skip it.
             if s.get("parent_session_id"):
-                continue
+                lineage = _get_lineage_ids(db, sid)
+                # Use the earliest ID in the lineage as the chain key
+                chain_key = min(lineage) if lineage else sid
+                if chain_key in seen_lineage_roots:
+                    continue
+                seen_lineage_roots.add(chain_key)
             results.append({
                 "session_id": sid,
                 "title": s.get("title") or None,
@@ -293,10 +325,14 @@ def session_search(
                 "message": "No matching sessions found.",
             }, ensure_ascii=False)
 
-        # Resolve child sessions to their parent — delegation stores detailed
-        # content in child sessions, but the user's conversation is the parent.
-        def _resolve_to_parent(session_id: str) -> str:
-            """Walk delegation chain to find the root parent session ID."""
+        # Resolve child sessions to their lineage root for deduplication.
+        # Context compaction creates chains: root → ... → leaf.  The FTS
+        # match may be in any fragment.  We group by lineage so the same
+        # conversation doesn't appear multiple times, but we load content
+        # from the *matched* session (which actually has the messages),
+        # not the root (which may be empty after compaction).
+        def _resolve_to_root(session_id: str) -> str:
+            """Walk parent chain to find the root session ID."""
             visited = set()
             sid = session_id
             while sid and sid not in visited:
@@ -321,44 +357,52 @@ def session_search(
             return sid
 
         current_lineage_root = (
-            _resolve_to_parent(current_session_id) if current_session_id else None
+            _resolve_to_root(current_session_id) if current_session_id else None
+        )
+        current_lineage = (
+            _get_lineage_ids(db, current_session_id) if current_session_id else set()
         )
 
-        # Group by resolved (parent) session_id, dedup, skip the current
-        # session lineage. Compression and delegation create child sessions
-        # that still belong to the same active conversation.
+        # Group by lineage root for dedup, but keep the *matched* session_id
+        # for loading content (it has the actual messages).
         seen_sessions = {}
         for result in raw_results:
             raw_sid = result["session_id"]
-            resolved_sid = _resolve_to_parent(raw_sid)
             # Skip the current session lineage — the agent already has that
             # context, even if older turns live in parent fragments.
-            if current_lineage_root and resolved_sid == current_lineage_root:
+            if raw_sid in current_lineage:
                 continue
-            if current_session_id and raw_sid == current_session_id:
+            lineage_root = _resolve_to_root(raw_sid)
+            if current_lineage_root and lineage_root == current_lineage_root:
                 continue
-            if resolved_sid not in seen_sessions:
+            if lineage_root not in seen_sessions:
                 result = dict(result)
-                result["session_id"] = resolved_sid
-                seen_sessions[resolved_sid] = result
+                # Keep raw_sid as the content source (where FTS found the match)
+                # but use lineage_root as the dedup key.
+                result["_content_session_id"] = raw_sid
+                seen_sessions[lineage_root] = result
             if len(seen_sessions) >= limit:
                 break
 
         # Prepare all sessions for parallel summarization
         tasks = []
-        for session_id, match_info in seen_sessions.items():
+        for lineage_root, match_info in seen_sessions.items():
             try:
-                messages = db.get_messages_as_conversation(session_id)
+                # Load conversation from the session where FTS found the
+                # match — not the lineage root which may be empty after
+                # context compaction.
+                content_sid = match_info["_content_session_id"]
+                messages = db.get_messages_as_conversation(content_sid)
                 if not messages:
                     continue
-                session_meta = db.get_session(session_id) or {}
+                session_meta = db.get_session(content_sid) or {}
                 conversation_text = _format_conversation(messages)
                 conversation_text = _truncate_around_matches(conversation_text, query)
-                tasks.append((session_id, match_info, conversation_text, session_meta))
+                tasks.append((content_sid, match_info, conversation_text, session_meta))
             except Exception as e:
                 logging.warning(
                     "Failed to prepare session %s: %s",
-                    session_id,
+                    lineage_root,
                     e,
                     exc_info=True,
                 )

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -192,21 +192,54 @@ async def _summarize_session(
 _HIDDEN_SESSION_SOURCES = ("tool",)
 
 
-def _get_lineage_ids(db, session_id: str) -> set:
-    """Return the set of all session IDs in a compaction chain (parents + children)."""
-    ids = set()
-    # Walk up to root
+def _resolve_to_lineage_root(db, session_id: str) -> str:
+    """Walk parent_session_id chain to the root and return the root ID."""
     sid = session_id
     visited = set()
     while sid and sid not in visited:
         visited.add(sid)
-        ids.add(sid)
         try:
             s = db.get_session(sid)
             parent = s.get("parent_session_id") if s else None
-            sid = parent if parent else None
+            if parent:
+                sid = parent
+            else:
+                break
         except Exception:
             break
+    return sid
+
+
+def _get_lineage_ids(db, session_id: str) -> set:
+    """Return all session IDs in a compaction chain — ancestors AND descendants.
+
+    Walks *up* from ``session_id`` to the root, then walks *down* from the
+    root collecting every descendant.  This is necessary for current-session
+    exclusion: regardless of whether the active session is a root or a leaf,
+    all fragments of the same conversation must be excluded.
+    """
+    # Walk up to root, collecting ancestors
+    root = _resolve_to_lineage_root(db, session_id)
+    ids = set()
+
+    # Walk down from the root using BFS to collect all descendants
+    queue = [root]
+    while queue:
+        current = queue.pop(0)
+        if current in ids:
+            continue
+        ids.add(current)
+        try:
+            # Find direct children via the DB connection
+            with db._lock:
+                cursor = db._conn.execute(
+                    "SELECT id FROM sessions WHERE parent_session_id = ?",
+                    (current,),
+                )
+                children = [row[0] for row in cursor.fetchall()]
+            queue.extend(children)
+        except Exception:
+            pass
     return ids
 
 
@@ -219,7 +252,7 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str
         # typically 0 messages) are just handoff points — the real conversation
         # lives in the leaf.  We skip intermediates but show the leaf even
         # though it has a parent_session_id.
-        sessions = db.list_sessions_rich(limit=limit + 20, exclude_sources=list(_HIDDEN_SESSION_SOURCES))
+        sessions = db.list_sessions_rich(limit=limit + 20, exclude_sources=list(_HIDDEN_SESSION_SOURCES), include_children=True)
 
         # Resolve current session lineage to exclude it
         current_lineage = set()
@@ -238,20 +271,20 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str
             sid = s.get("id", "")
             if sid in current_lineage:
                 continue
-            # Skip intermediate compaction nodes — they have a parent and
-            # ended due to compression (typically 0 messages).  The leaf
-            # session of the chain will appear later and has the real content.
-            if s.get("parent_session_id") and s.get("end_reason") == "compression":
+            # Skip compaction nodes — sessions that ended due to compression
+            # are handoff points with typically 0 messages.  This includes
+            # both intermediate nodes (which have parent_session_id) AND root
+            # fragments whose end_reason is 'compression' (the root can also
+            # be empty after its content was compressed into a summary).
+            if s.get("end_reason") == "compression":
                 continue
             # Deduplicate: if this session belongs to a compaction chain
             # we've already shown, skip it.
             if s.get("parent_session_id"):
-                lineage = _get_lineage_ids(db, sid)
-                # Use the earliest ID in the lineage as the chain key
-                chain_key = min(lineage) if lineage else sid
-                if chain_key in seen_lineage_roots:
+                chain_root = _resolve_to_lineage_root(db, sid)
+                if chain_root in seen_lineage_roots:
                     continue
-                seen_lineage_roots.add(chain_key)
+                seen_lineage_roots.add(chain_root)
             results.append({
                 "session_id": sid,
                 "title": s.get("title") or None,
@@ -331,33 +364,9 @@ def session_search(
         # conversation doesn't appear multiple times, but we load content
         # from the *matched* session (which actually has the messages),
         # not the root (which may be empty after compaction).
-        def _resolve_to_root(session_id: str) -> str:
-            """Walk parent chain to find the root session ID."""
-            visited = set()
-            sid = session_id
-            while sid and sid not in visited:
-                visited.add(sid)
-                try:
-                    session = db.get_session(sid)
-                    if not session:
-                        break
-                    parent = session.get("parent_session_id")
-                    if parent:
-                        sid = parent
-                    else:
-                        break
-                except Exception as e:
-                    logging.debug(
-                        "Error resolving parent for session %s: %s",
-                        sid,
-                        e,
-                        exc_info=True,
-                    )
-                    break
-            return sid
 
         current_lineage_root = (
-            _resolve_to_root(current_session_id) if current_session_id else None
+            _resolve_to_lineage_root(db, current_session_id) if current_session_id else None
         )
         current_lineage = (
             _get_lineage_ids(db, current_session_id) if current_session_id else set()
@@ -372,7 +381,7 @@ def session_search(
             # context, even if older turns live in parent fragments.
             if raw_sid in current_lineage:
                 continue
-            lineage_root = _resolve_to_root(raw_sid)
+            lineage_root = _resolve_to_lineage_root(db, raw_sid)
             if current_lineage_root and lineage_root == current_lineage_root:
                 continue
             if lineage_root not in seen_sessions:


### PR DESCRIPTION
## Problem

Context compaction creates chains of sessions linked via `parent_session_id`. The session search tool had two bugs related to how it handled these chains:

### Bug 1: Search results silently dropped
When FTS5 found a match in a compaction child session, the code resolved it to the **root parent** for both deduplication AND content loading. The root session is often empty (0 messages) after compaction, so `get_messages_as_conversation(root)` returned nothing, and the result was silently skipped.

**Example:** A 193-message session (9 levels deep in a compaction chain) with 66 FTS matches for "deployment" was completely invisible to search because the root had 0 messages.

### Bug 2: Recent sessions listing hid compaction leaves
`_list_recent_sessions` skipped ALL sessions with `parent_session_id`, assuming they were delegation sub-tasks. However, `parent_session_id` is exclusively used for context compaction chains — delegation subagents don't set it. This meant the leaf sessions (where the real conversation lives) were hidden from the recent listing.

## Fix

### Search (`session_search`)
- Use lineage root **only for deduplication** (so the same chain doesn't appear multiple times)
- Load conversation content from the **FTS-matched session** (where messages actually live)
- Use `_get_lineage_ids()` for proper current-session exclusion across the chain

### Recent listing (`_list_recent_sessions`)
- Only skip intermediate compaction nodes (`end_reason='compression'`, typically 0 messages)
- Show the leaf session of each chain (it has the real conversation)
- Deduplicate chains so the same conversation doesn't appear multiple times

### New helper
- `_get_lineage_ids(db, session_id)`: walks the parent chain to collect all session IDs in a compaction lineage

## Tests
- All 25 existing tests pass unchanged
- Added 2 new tests:
  - `test_compaction_chain_search_uses_matched_session`: Verifies content is loaded from the leaf, not the empty root
  - `test_compaction_chain_deduplicates_same_lineage`: Verifies FTS hits from the same chain produce only one result