### PR TITLE
fix(discord): add user to thread after /thread command

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1856,6 +1856,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 auto_archive_duration=auto_archive_duration,
                 reason=reason,
             )
+            # Add the command invoker to the thread so they can see and interact with it
+            # This is required for private threads where the creator isn't auto-added
+            try:
+                if interaction.user:
+                    await thread.add_user(interaction.user)
+            except Exception as add_err:
+                logger.warning("[%s] Failed to add user to thread: %s", self.name, add_err)
             if starter_message:
                 await thread.send(starter_message)
             return {
@@ -1872,6 +1879,12 @@ class DiscordAdapter(BasePlatformAdapter):
                     auto_archive_duration=auto_archive_duration,
                     reason=reason,
                 )
+                # Add the command invoker to the thread (fallback path)
+                try:
+                    if interaction.user:
+                        await thread.add_user(interaction.user)
+                except Exception as add_err:
+                    logger.warning("[%s] Failed to add user to thread (fallback): %s", self.name, add_err)
                 return {
                     "success": True,
                     "thread_id": str(thread.id),


### PR DESCRIPTION
## Summary
Fixes #5446

When a user creates a thread via the `/thread` slash command, they are not automatically added to private threads. This causes them to be unable to see or interact with the thread unless they are a mod/admin.

## Changes
Adds the command invoker to the thread immediately after creation using `thread.add_user()`. The call is wrapped in a try/except to gracefully handle cases where:
- The user is already in the thread
- The thread is public (add_user may fail but thread is visible anyway)
- Bot lacks MANAGE_THREADS permission

## Testing
- Tested with Discord.py's type system (interaction.user is available)
- The `add_user()` method is part of Discord.py's Thread class

## Notes
Applies to both the direct `create_thread` path and the fallback seed-message-based thread creation path.

Credit to @NashiKanjou for identifying the issue and proposing the fix in #5446.