### PR TITLE
fix(security): redact signed vision image URLs in logs and tracebacks

### DIFF
--- a/tests/tools/test_vision_tools_secret_logging.py
+++ b/tests/tools/test_vision_tools_secret_logging.py
@@ -1,0 +1,106 @@
+"""Regression tests for secret redaction in vision tool logging."""
+
+import importlib
+import json
+import logging
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _load_vision_tools(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("VISION_TOOLS_DEBUG", "true")
+
+    import tools.vision_tools as vision_tools
+
+    return importlib.reload(vision_tools)
+
+
+@pytest.mark.asyncio
+async def test_remote_image_url_is_redacted_in_logs_and_debug_json(
+    tmp_path, monkeypatch, caplog
+):
+    vision_tools = _load_vision_tools(monkeypatch, tmp_path)
+    image_url = (
+        "https://cdn.example.com/cat.png"
+        "?access_token=super-secret-token"
+        "&size=small"
+    )
+
+    async def fake_download(_url, destination, max_retries=3):
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)
+        return destination
+
+    with (
+        patch.object(vision_tools, "_validate_image_url", return_value=True),
+        patch.object(vision_tools, "_download_image", side_effect=fake_download),
+        patch.object(
+            vision_tools,
+            "_image_to_base64_data_url",
+            return_value="data:image/png;base64,abc",
+        ),
+        patch.object(
+            vision_tools,
+            "async_call_llm",
+            new_callable=AsyncMock,
+            return_value=MagicMock(),
+        ),
+        patch.object(
+            vision_tools,
+            "extract_content_or_reasoning",
+            return_value="A small cat",
+        ),
+        caplog.at_level(logging.INFO, logger="tools.vision_tools"),
+    ):
+        result = json.loads(await vision_tools.vision_analyze_tool(image_url, "describe"))
+
+    assert result["success"] is True
+    assert "super-secret-token" not in caplog.text
+    assert "access_token=***" in caplog.text
+
+    debug_path = Path(vision_tools.get_debug_session_info()["log_path"])
+    debug_payload = json.loads(debug_path.read_text(encoding="utf-8"))
+    debug_json = json.dumps(debug_payload)
+    assert "super-secret-token" not in debug_json
+    assert "access_token=***" in debug_json
+
+
+@pytest.mark.asyncio
+async def test_error_path_redacts_signed_url_in_logs_and_debug_json(
+    tmp_path, monkeypatch, caplog
+):
+    vision_tools = _load_vision_tools(monkeypatch, tmp_path)
+    image_url = (
+        "https://cdn.example.com/cat.png"
+        "?token=super-secret-token"
+        "&size=small"
+    )
+    download_error = RuntimeError(f"download failed for {image_url}")
+
+    with (
+        patch.object(vision_tools, "_validate_image_url", return_value=True),
+        patch.object(
+            vision_tools,
+            "_download_image",
+            new_callable=AsyncMock,
+            side_effect=download_error,
+        ),
+        caplog.at_level(logging.ERROR, logger="tools.vision_tools"),
+    ):
+        result = json.loads(await vision_tools.vision_analyze_tool(image_url, "describe"))
+
+    assert result["success"] is False
+    assert "super-secret-token" not in caplog.text
+    assert "token=***" in caplog.text
+    assert "super-secret-token" not in result["error"]
+    assert "token=***" in result["error"]
+
+    debug_path = Path(vision_tools.get_debug_session_info()["log_path"])
+    debug_payload = json.loads(debug_path.read_text(encoding="utf-8"))
+    debug_json = json.dumps(debug_payload)
+    assert "super-secret-token" not in debug_json
+    assert "token=***" in debug_json

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -32,12 +32,15 @@ import base64
 import json
 import logging
 import os
+import re
+import traceback
 import uuid
 from pathlib import Path
 from typing import Any, Awaitable, Dict, Optional
-from urllib.parse import urlparse
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 import httpx
 from agent.auxiliary_client import async_call_llm, extract_content_or_reasoning
+from agent.redact import redact_sensitive_text
 from tools.debug_helpers import DebugSession
 from tools.website_policy import check_website_access
 
@@ -66,6 +69,84 @@ def _resolve_download_timeout() -> float:
     return 30.0
 
 _VISION_DOWNLOAD_TIMEOUT = _resolve_download_timeout()
+
+_URL_RE = re.compile(r"https?://[^\s'\"<>]+")
+_SENSITIVE_QUERY_MARKERS = (
+    "token",
+    "secret",
+    "signature",
+    "credential",
+    "password",
+    "passwd",
+    "passcode",
+    "auth",
+    "apikey",
+)
+
+
+def _query_key_looks_sensitive(key: str) -> bool:
+    """Return True when a URL query parameter name likely carries a secret."""
+    collapsed = re.sub(r"[^a-z0-9]", "", key.lower())
+    if collapsed == "key":
+        return True
+    return any(marker in collapsed for marker in _SENSITIVE_QUERY_MARKERS)
+
+
+def _redact_url_for_log(value: str) -> str:
+    """Mask secret-bearing URL components before they reach logs/debug JSON."""
+    if value is None:
+        return value
+
+    text = str(value)
+    try:
+        parsed = urlparse(text)
+        if not parsed.scheme or not parsed.netloc:
+            return redact_sensitive_text(text)
+
+        hostname = parsed.hostname or ""
+        if ":" in hostname and not hostname.startswith("["):
+            hostname = f"[{hostname}]"
+        netloc = hostname
+        if parsed.port is not None:
+            netloc = f"{netloc}:{parsed.port}"
+
+        redacted_query = urlencode(
+            [
+                (key, "***" if _query_key_looks_sensitive(key) else query_value)
+                for key, query_value in parse_qsl(parsed.query, keep_blank_values=True)
+            ],
+            doseq=True,
+            safe="*",
+        )
+
+        sanitized = urlunparse(
+            parsed._replace(netloc=netloc, query=redacted_query, fragment="")
+        )
+        return redact_sensitive_text(sanitized)
+    except Exception:
+        return redact_sensitive_text(text)
+
+
+def _sanitize_log_text(value: object) -> str:
+    """Redact URL query secrets and known token formats inside free-form text."""
+    if value is None:
+        return ""
+
+    text = str(value)
+    text = _URL_RE.sub(lambda match: _redact_url_for_log(match.group(0)), text)
+    return redact_sensitive_text(text)
+
+
+def _truncate_for_log(text: str, max_length: int) -> str:
+    """Trim long log strings without dropping the redacted prefix."""
+    if len(text) <= max_length:
+        return text
+    return text[: max_length - 3] + "..."
+
+
+def _format_sanitized_exception(exc: BaseException) -> str:
+    """Return a sanitized traceback string safe for logging."""
+    return _sanitize_log_text("".join(traceback.format_exception(type(exc), exc, exc.__traceback__))).rstrip()
 
 
 def _validate_image_url(url: str) -> bool:
@@ -194,15 +275,21 @@ async def _download_image(image_url: str, destination: Path, max_retries: int = 
             last_error = e
             if attempt < max_retries - 1:
                 wait_time = 2 ** (attempt + 1)  # 2s, 4s, 8s
-                logger.warning("Image download failed (attempt %s/%s): %s", attempt + 1, max_retries, str(e)[:50])
+                logger.warning(
+                    "Image download failed (attempt %s/%s): %s",
+                    attempt + 1,
+                    max_retries,
+                    _truncate_for_log(_sanitize_log_text(e), 50),
+                )
                 logger.warning("Retrying in %ss...", wait_time)
                 await asyncio.sleep(wait_time)
             else:
+                sanitized_traceback = _format_sanitized_exception(e)
                 logger.error(
-                    "Image download failed after %s attempts: %s",
+                    "Image download failed after %s attempts: %s\n%s",
                     max_retries,
-                    str(e)[:100],
-                    exc_info=True,
+                    _truncate_for_log(_sanitize_log_text(e), 100),
+                    sanitized_traceback,
                 )
     
     if last_error is None:
@@ -300,7 +387,7 @@ async def vision_analyze_tool(
     """
     debug_call_data = {
         "parameters": {
-            "image_url": image_url,
+            "image_url": _redact_url_for_log(image_url),
             "user_prompt": user_prompt[:200] + "..." if len(user_prompt) > 200 else user_prompt,
             "model": model
         },
@@ -322,7 +409,10 @@ async def vision_analyze_tool(
         if is_interrupted():
             return json.dumps({"success": False, "error": "Interrupted"})
 
-        logger.info("Analyzing image: %s", image_url[:60])
+        logger.info(
+            "Analyzing image: %s",
+            _truncate_for_log(_sanitize_log_text(image_url), 60),
+        )
         logger.info("User prompt: %s", user_prompt[:100])
         
         # Determine if this is a local file path or a remote URL
@@ -441,8 +531,10 @@ async def vision_analyze_tool(
         return json.dumps(result, indent=2, ensure_ascii=False)
         
     except Exception as e:
-        error_msg = f"Error analyzing image: {str(e)}"
-        logger.error("%s", error_msg, exc_info=True)
+        sanitized_error = _sanitize_log_text(e)
+        sanitized_traceback = _format_sanitized_exception(e)
+        error_msg = f"Error analyzing image: {sanitized_error}"
+        logger.error("%s\n%s", error_msg, sanitized_traceback)
         
         # Detect vision capability errors — give the model a clear message
         # so it can inform the user instead of a cryptic API error.
@@ -452,7 +544,7 @@ async def vision_analyze_tool(
         )):
             analysis = (
                 "Insufficient credits or payment required. Please top up your "
-                f"API provider account and try again. Error: {e}"
+                f"API provider account and try again. Error: {sanitized_error}"
             )
         elif any(hint in err_str for hint in (
             "does not support", "not support image", "invalid_request",
@@ -461,12 +553,12 @@ async def vision_analyze_tool(
         )):
             analysis = (
                 f"{model} does not support vision or our request was not "
-                f"accepted by the server. Error: {e}"
+                f"accepted by the server. Error: {sanitized_error}"
             )
         else:
             analysis = (
                 "There was a problem with the request and the image could not "
-                f"be analyzed. Error: {e}"
+                f"be analyzed. Error: {sanitized_error}"
             )
         
         # Prepare error response


### PR DESCRIPTION
Summary
This PR fixes a secret-logging issue in [tools/vision_tools.py](app://-/index.html?hostId=local).

vision_analyze_tool() could previously leak signed image URLs in two places:

Normal info logs, by logging the input image_url directly.
Error logs, where the top-level message was redacted but the attached traceback still contained the raw signed URL via exc_info=True.
That meant query-string secrets such as token, access_token, signature, and similar credential-like parameters could end up in terminal output and debug JSON logs.

What Changed
Added local URL sanitization helpers in [tools/vision_tools.py](app://-/index.html?hostId=local) to redact sensitive query parameters before logging.
Applied redaction to:
the "Analyzing image" info log
stored debug metadata (VISION_TOOLS_DEBUG)
error messages derived from exceptions
Replaced raw exception traceback logging on the secret-bearing error path with a sanitized traceback string, so we keep debugging context without leaking signed URLs.
Added focused regression coverage in [tests/tools/test_vision_tools_secret_logging.py](app://-/index.html?hostId=local).
Reproduction
Before this change, a call like:

await vision_analyze_tool(
    "https://cdn.example.com/cat.png?token=super-secret-token&size=small",
    "describe"
)
could expose super-secret-token in logs, especially on failure paths where the traceback included the raw exception text.

Validation
Ran only the targeted test file for the modified module:

python -m pytest tests/tools/test_vision_tools_secret_logging.py -v
Result:

2 passed in 1.94s