### PR TITLE
security: sanitize telemetry and progress logs in web_tools

### DIFF
--- a/tests/tools/test_web_tools_logging.py
+++ b/tests/tools/test_web_tools_logging.py
@@ -1,0 +1,51 @@
+import pytest
+
+from tools.web_tools import _log_safe_url, web_crawl_tool
+
+
+def test_log_safe_url_redacts_credentials_query_and_fragment():
+    secret_url = (
+        "https://alice:s3cr3t@example.com/private/path"
+        "?api_key=sk-test-12345678901234567890&sig=abcdef#token=xyz"
+    )
+
+    safe_url = _log_safe_url(secret_url)
+
+    assert safe_url == "https://[REDACTED]@example.com/private/path?[REDACTED]#[REDACTED]"
+    assert "alice" not in safe_url
+    assert "s3cr3t" not in safe_url
+    assert "sk-test-12345678901234567890" not in safe_url
+    assert "sig=abcdef" not in safe_url
+    assert "token=xyz" not in safe_url
+
+
+@pytest.mark.asyncio
+async def test_web_crawl_tool_does_not_log_secret_url(caplog, monkeypatch):
+    secret_url = "https://example.com/private?api_key=sk-test-12345678901234567890#frag"
+
+    monkeypatch.setattr("tools.web_tools._get_backend", lambda: "tavily")
+    monkeypatch.setattr("tools.web_tools.check_auxiliary_model", lambda: False)
+    monkeypatch.setattr("tools.web_tools.is_safe_url", lambda url: True)
+    monkeypatch.setattr("tools.web_tools.check_website_access", lambda url: None)
+    monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+    monkeypatch.setattr(
+        "tools.web_tools._tavily_request",
+        lambda endpoint, payload: {
+            "results": [
+                {
+                    "url": secret_url,
+                    "title": "Secret page",
+                    "raw_content": "body",
+                }
+            ]
+        },
+    )
+
+    caplog.set_level("INFO", logger="tools.web_tools")
+
+    await web_crawl_tool(secret_url, use_llm_processing=False)
+
+    log_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert "sk-test-12345678901234567890" not in log_text
+    assert "api_key=" not in log_text
+    assert "Tavily crawl: https://example.com/private?[REDACTED]#[REDACTED]" in log_text

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -46,8 +46,10 @@ import os
 import re
 import asyncio
 from typing import List, Dict, Any, Optional
+from urllib.parse import urlsplit, urlunsplit
 import httpx
 from firecrawl import Firecrawl
+from agent.redact import redact_sensitive_text
 from agent.auxiliary_client import (
     async_call_llm,
     extract_content_or_reasoning,
@@ -79,6 +81,35 @@ def _load_web_config() -> dict:
         return load_config().get("web", {})
     except (ImportError, Exception):
         return {}
+
+
+def _log_safe_url(url: object) -> str:
+    """Return a redacted URL string safe to emit in logs.
+
+    Query strings, fragments, and embedded credentials frequently contain
+    signed tokens or API keys. Keep scheme/host/path for debugging, but never
+    log those secret-bearing components verbatim.
+    """
+    text = str(url)
+    try:
+        parts = urlsplit(text)
+    except Exception:
+        return redact_sensitive_text(text)
+
+    netloc = parts.hostname or ""
+    if parts.port:
+        netloc = f"{netloc}:{parts.port}"
+    if parts.username or parts.password:
+        netloc = f"[REDACTED]@{netloc}" if netloc else "[REDACTED]"
+
+    safe_url = urlunsplit((
+        parts.scheme,
+        netloc or parts.netloc,
+        parts.path,
+        "[REDACTED]" if parts.query else "",
+        "[REDACTED]" if parts.fragment else "",
+    ))
+    return redact_sensitive_text(safe_url)
 
 def _get_backend() -> str:
     """Determine which web backend to use.
@@ -1283,7 +1314,7 @@ async def web_extract_tool(
                         continue
 
                     try:
-                        logger.info("Scraping: %s", url)
+                        logger.info("Scraping: %s", _log_safe_url(url))
                         # Run synchronous Firecrawl scrape in a thread with a
                         # 60s timeout so a hung fetch doesn't block the session.
                         try:
@@ -1296,7 +1327,7 @@ async def web_extract_tool(
                                 timeout=60,
                             )
                         except asyncio.TimeoutError:
-                            logger.warning("Firecrawl scrape timed out for %s", url)
+                            logger.warning("Firecrawl scrape timed out for %s", _log_safe_url(url))
                             results.append({
                                 "url": url, "title": "", "content": "",
                                 "error": "Scrape timed out after 60s — page may be too large or unresponsive. Try browser_navigate instead.",
@@ -1345,7 +1376,7 @@ async def web_extract_tool(
                         })
 
                     except Exception as scrape_err:
-                        logger.debug("Scrape failed for %s: %s", url, scrape_err)
+                        logger.debug("Scrape failed for %s: %s", _log_safe_url(url), scrape_err)
                         results.append({
                             "url": url,
                             "title": "",
@@ -1428,12 +1459,12 @@ async def web_extract_tool(
                 if status == "processed":
                     debug_call_data["compression_metrics"].append(metrics)
                     debug_call_data["pages_processed_with_llm"] += 1
-                    logger.info("%s (processed)", url)
+                    logger.info("%s (processed)", _log_safe_url(url))
                 elif status == "too_short":
                     debug_call_data["compression_metrics"].append(metrics)
-                    logger.info("%s (no processing - content too short)", url)
+                    logger.info("%s (no processing - content too short)", _log_safe_url(url))
                 else:
-                    logger.warning("%s (no content to process)", url)
+                    logger.warning("%s (no content to process)", _log_safe_url(url))
         else:
             if use_llm_processing and not auxiliary_available:
                 logger.warning("LLM processing requested but no auxiliary model available, returning raw content")
@@ -1442,7 +1473,7 @@ async def web_extract_tool(
             for result in response.get('results', []):
                 url = result.get('url', 'Unknown URL')
                 content_length = len(result.get('raw_content', ''))
-                logger.info("%s (%d characters)", url, content_length)
+                logger.info("%s (%d characters)", _log_safe_url(url), content_length)
         
         # Trim output to minimal fields per entry: title, content, error
         trimmed_results = [
@@ -1562,7 +1593,7 @@ async def web_crawl_tool(
             if _is_int():
                 return json.dumps({"error": "Interrupted", "success": False})
 
-            logger.info("Tavily crawl: %s", url)
+            logger.info("Tavily crawl: %s", _log_safe_url(url))
             payload: Dict[str, Any] = {
                 "url": url,
                 "limit": 20,
@@ -1635,10 +1666,10 @@ async def web_crawl_tool(
         # Ensure URL has protocol
         if not url.startswith(('http://', 'https://')):
             url = f'https://{url}'
-            logger.info("Added https:// prefix to URL: %s", url)
+            logger.info("Added https:// prefix to URL: %s", _log_safe_url(url))
         
         instructions_text = f" with instructions: '{instructions}'" if instructions else ""
-        logger.info("Crawling %s%s", url, instructions_text)
+        logger.info("Crawling %s%s", _log_safe_url(url), instructions_text)
         
         # SSRF protection — block private/internal addresses
         if not is_safe_url(url):
@@ -1847,12 +1878,12 @@ async def web_crawl_tool(
                 if status == "processed":
                     debug_call_data["compression_metrics"].append(metrics)
                     debug_call_data["pages_processed_with_llm"] += 1
-                    logger.info("%s (processed)", page_url)
+                    logger.info("%s (processed)", _log_safe_url(page_url))
                 elif status == "too_short":
                     debug_call_data["compression_metrics"].append(metrics)
-                    logger.info("%s (no processing - content too short)", page_url)
+                    logger.info("%s (no processing - content too short)", _log_safe_url(page_url))
                 else:
-                    logger.warning("%s (no content to process)", page_url)
+                    logger.warning("%s (no content to process)", _log_safe_url(page_url))
         else:
             if use_llm_processing and not auxiliary_available:
                 logger.warning("LLM processing requested but no auxiliary model available, returning raw content")
@@ -1861,7 +1892,7 @@ async def web_crawl_tool(
             for result in response.get('results', []):
                 page_url = result.get('url', 'Unknown URL')
                 content_length = len(result.get('content', ''))
-                logger.info("%s (%d characters)", page_url, content_length)
+                logger.info("%s (%d characters)", _log_safe_url(page_url), content_length)
         
         # Trim output to minimal fields per entry: title, content, error
         trimmed_results = [


### PR DESCRIPTION
Summary & Context
During a code audit of the web automation suite, I identified an information disclosure risk in both web_extract_tool and web_crawl_tool. The current implementation was emitting raw strings to the logger, which inadvertently captured high-entropy secrets (API keys, session tokens) present in signed URLs or basic auth headers.

This PR introduces a mandatory redaction layer for all URL-based logging to ensure that diagnostic data remains clean of sensitive credentials.

Technical Changes
Core Utility: Implemented _log_safe_url() using urlsplit. It surgically removes query parameters and fragments, replacing them with a persistent [REDACTED] marker.

Credential Masking: Added logic to detect and wipe inline basic-auth (user:pass@host) while preserving the hostname for debugging.

Integration: Re-routed 14 distinct logging points (Scraping, Crawling, Timing, and Errors) through the new sanitizer.

Validation Deep-Dive
Instead of a broad test run, I focused on a "Secret Leak Negative Test" approach:

Redaction Accuracy: Verified that _log_safe_url correctly identifies and wipes multiple concurrent secrets (e.g., an api_key in the query AND a token in the fragment).

Mock Integration: Simulated a full web_crawl_tool execution using a Tavily backend. Using caplog, I performed a substring search for the raw secret.

Expected Behavior: No raw secret in log buffer.

Observed Behavior: The log contained ...?[REDACTED]#[REDACTED], confirming the filter is active at the integration level.

Test Coverage:

tests/tools/test_web_tools_logging.py (New regression suite)

Status: Verified & Green (Checked against Python 3.12.10)