### PR TITLE
fix(tools): make memory tool import and locking Windows-safe

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -1,8 +1,10 @@
 """Tests for tools/memory_tool.py — MemoryStore, security scanning, and tool dispatcher."""
 
+import ast
 import json
-import pytest
 from pathlib import Path
+
+import pytest
 
 from tools.memory_tool import (
     MemoryStore,
@@ -210,6 +212,20 @@ class TestMemoryStorePersistence:
         store.load_from_disk()
         assert len(store.memory_entries) == 2
 
+    def test_add_works_without_platform_lock_modules(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.memory_tool.MEMORY_DIR", tmp_path)
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        monkeypatch.setattr("tools.memory_tool.fcntl", None)
+        monkeypatch.setattr("tools.memory_tool.msvcrt", None)
+
+        store = MemoryStore()
+        store.load_from_disk()
+
+        result = store.add("memory", "portable memory entry")
+
+        assert result["success"] is True
+        assert "portable memory entry" in store.memory_entries
+
 
 class TestMemoryStoreSnapshot:
     def test_snapshot_frozen_at_load(self, store):
@@ -258,3 +274,24 @@ class TestMemoryToolDispatcher:
     def test_remove_requires_old_text(self, store):
         result = json.loads(memory_tool(action="remove", store=store))
         assert result["success"] is False
+
+
+class TestMemoryToolWindowsCompatibility:
+    def test_fcntl_import_is_guarded(self):
+        source_path = Path(__file__).resolve().parents[2] / "tools" / "memory_tool.py"
+        tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+
+        guarded_fcntl_import = False
+        for node in tree.body:
+            if not isinstance(node, ast.Try):
+                continue
+            for stmt in node.body:
+                if not isinstance(stmt, ast.Import):
+                    continue
+                if any(alias.name == "fcntl" for alias in stmt.names):
+                    guarded_fcntl_import = True
+                    break
+            if guarded_fcntl_import:
+                break
+
+        assert guarded_fcntl_import, "memory_tool.py should guard fcntl imports for Windows compatibility"

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -23,7 +23,6 @@ Design:
 - Frozen snapshot pattern: system prompt is stable, tool responses show live state
 """
 
-import fcntl
 import json
 import logging
 import os
@@ -33,6 +32,16 @@ from contextlib import contextmanager
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Dict, Any, List, Optional
+
+try:
+    import fcntl
+except Exception:
+    fcntl = None
+
+try:
+    import msvcrt
+except Exception:
+    msvcrt = None
 
 logger = logging.getLogger(__name__)
 
@@ -144,13 +153,30 @@ class MemoryStore:
         """
         lock_path = path.with_suffix(path.suffix + ".lock")
         lock_path.parent.mkdir(parents=True, exist_ok=True)
-        fd = open(lock_path, "w")
-        try:
-            fcntl.flock(fd, fcntl.LOCK_EX)
+        if fcntl is None and msvcrt is None:
             yield
-        finally:
-            fcntl.flock(fd, fcntl.LOCK_UN)
-            fd.close()
+            return
+
+        if msvcrt and (not lock_path.exists() or lock_path.stat().st_size == 0):
+            lock_path.write_text(" ", encoding="utf-8")
+
+        with lock_path.open("r+" if msvcrt else "a+") as fd:
+            try:
+                if fcntl:
+                    fcntl.flock(fd.fileno(), fcntl.LOCK_EX)
+                elif msvcrt:
+                    fd.seek(0)
+                    msvcrt.locking(fd.fileno(), msvcrt.LK_LOCK, 1)
+                yield
+            finally:
+                if fcntl:
+                    fcntl.flock(fd.fileno(), fcntl.LOCK_UN)
+                elif msvcrt:
+                    try:
+                        fd.seek(0)
+                        msvcrt.locking(fd.fileno(), msvcrt.LK_UNLCK, 1)
+                    except (OSError, IOError):
+                        pass
 
     @staticmethod
     def _path_for(target: str) -> Path:


### PR DESCRIPTION
## What changed

This fixes a Windows compatibility issue in `tools/memory_tool.py`.

Previously, the module imported `fcntl` unconditionally. On Windows, that import can fail during tool discovery, which causes the memory tool to be skipped silently because `model_tools.py` logs the import failure and continues loading other tools.

This PR:
- guards the `fcntl` import
- adds a Windows lock fallback using `msvcrt`
- falls back safely when neither locking module is available
- adds regression tests for the guarded import and fallback behavior

## Why

`memory` is a core user-facing capability. On Windows, it could disappear without a clear error, which is both a cross-platform compatibility bug and a poor UX failure mode.

## How to reproduce

1. Run Hermes on Windows
2. Trigger tool discovery that imports `tools.memory_tool`
3. Observe that unconditional `fcntl` import can fail
4. The memory tool is not registered, and memory functionality becomes unavailable

## How to test

Run:

```bash
pytest tests/tools/test_memory_tool.py -q

Focus on:

guarded import behavior
adding memory entries when lock modules are unavailable
existing memory tool behavior remaining unchanged

Platforms tested
Code-path reviewed for Windows compatibility
Runtime tests not executed in this workspace because python/pytest were not available in the current environment