### PR TITLE
fix(gateway): handle missing config in /provider command and resolve xfail test

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3657,6 +3657,7 @@ class GatewayRunner:
 
         # Resolve current provider from config
         current_provider = "openrouter"
+        model_cfg = {}
         config_path = _hermes_home / 'config.yaml'
         try:
             if config_path.exists():

--- a/tests/e2e/test_telegram_commands.py
+++ b/tests/e2e/test_telegram_commands.py
@@ -105,10 +105,6 @@ class TestTelegramSlashCommands:
         send_status.assert_called_once()
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="Bug: _handle_provider_command references unbound model_cfg when config.yaml is absent",
-        strict=False,
-    )
     async def test_provider_shows_current_provider(self, adapter):
         send = await send_and_capture(adapter, "/provider")
 


### PR DESCRIPTION
PR Description
This fixes a gateway regression where the /provider slash command could crash if config.yaml was missing or unreadable.

The root cause was that _handle_provider_command() only assigned model_cfg inside the config-loading branch, but later still referenced it when checking for a custom base_url. In sessions where no config file existed, that left model_cfg unbound and caused the command path to fail instead of returning the provider list.

This change initializes model_cfg to a safe default before reading config, so /provider now degrades gracefully and continues to report the active provider even when no user config is present.

What changed

Initialize model_cfg with a safe fallback in gateway/run.py
Convert the existing Telegram e2e /provider regression from xfail to a normal passing test
Why this matters

Fixes a user-facing gateway slash command crash
Improves robustness for fresh installs and minimal environments
Preserves expected fallback behavior when config is absent
How to test

Run the Telegram e2e command test:
python -m pytest tests/e2e/test_telegram_commands.py -q
Manually verify /provider in a setup without ~/.hermes/config.yaml
Confirm the command returns provider information instead of failing