### PR TITLE
fix: repair Google Workspace OAuth setup on local machines

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -26,8 +26,8 @@ Gmail, Calendar, Drive, Contacts, Sheets, and Docs — all through Python script
 
 ## Scripts
 
-- `scripts/setup.py` — OAuth2 setup (run once to authorize)
-- `scripts/google_api.py` — API wrapper CLI (agent uses this for all operations)
+- `scripts/setup.py` — OAuth2 setup (run once to authorize). Auto-detects the Hermes repo path for imports and installs Python deps into `~/.hermes/.pythonlibs/google-workspace/` when system package installation is unavailable.
+- `scripts/google_api.py` — API wrapper CLI (agent uses this for all operations). Auto-detects the Hermes repo path for imports and loads deps from `~/.hermes/.pythonlibs/google-workspace/`.
 
 ## First-Time Setup
 
@@ -106,7 +106,7 @@ This prints a URL. **Send the URL to the user** and tell them:
 
 ### Step 4: Exchange the code
 
-The user will paste back either a URL like `http://localhost:1/?code=4/0A...&scope=...`
+The user will paste back either a URL like `http://localhost/?code=4/0A...&scope=...`
 or just the code string. Either works. The `--auth-url` step stores a temporary
 pending OAuth session locally so `--auth-code` can complete the PKCE exchange
 later, even on headless systems:

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -27,6 +27,16 @@ from datetime import datetime, timedelta, timezone
 from email.mime.text import MIMEText
 from pathlib import Path
 
+LOCAL_LIB_PATH = Path.home() / ".hermes" / ".pythonlibs" / "google-workspace"
+for candidate in [
+    LOCAL_LIB_PATH,
+    Path(__file__).resolve().parents[3],
+    Path.home() / ".hermes" / "hermes-agent",
+]:
+    candidate_str = str(candidate)
+    if candidate.exists() and candidate_str not in sys.path:
+        sys.path.insert(0, candidate_str)
+
 from hermes_constants import display_hermes_home, get_hermes_home
 
 HERMES_HOME = get_hermes_home()

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -23,9 +23,21 @@ Agent workflow:
 
 import argparse
 import json
+import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+LOCAL_LIB_PATH = Path.home() / ".hermes" / ".pythonlibs" / "google-workspace"
+for candidate in [
+    LOCAL_LIB_PATH,
+    Path(__file__).resolve().parents[3],
+    Path.home() / ".hermes" / "hermes-agent",
+]:
+    candidate_str = str(candidate)
+    if candidate.exists() and candidate_str not in sys.path:
+        sys.path.insert(0, candidate_str)
 
 from hermes_constants import display_hermes_home, get_hermes_home
 
@@ -48,9 +60,10 @@ SCOPES = [
 REQUIRED_PACKAGES = ["google-api-python-client", "google-auth-oauthlib", "google-auth-httplib2"]
 
 # OAuth redirect for "out of band" manual code copy flow.
-# Google deprecated OOB, so we use a localhost redirect and tell the user to
-# copy the code from the browser's URL bar (or the page body).
-REDIRECT_URI = "http://localhost:1"
+# Use plain localhost so it matches default Desktop app OAuth credentials.
+# The browser may land on an error page because nothing is listening there;
+# that's fine — copy the full final URL from the address bar.
+REDIRECT_URI = "http://localhost"
 
 
 def _load_token_payload(path: Path = TOKEN_PATH) -> dict:
@@ -88,10 +101,17 @@ def install_deps():
         pass
 
     print("Installing Google API dependencies...")
+    LOCAL_LIB_PATH.mkdir(parents=True, exist_ok=True)
+    pip_cmd = [sys.executable, "-m", "pip", "install", "--quiet", "--target", str(LOCAL_LIB_PATH)]
+    if shutil.which("uv"):
+        pip_cmd = ["uv", "pip", "install", "--target", str(LOCAL_LIB_PATH)]
+
+    env = os.environ.copy()
     try:
         subprocess.check_call(
-            [sys.executable, "-m", "pip", "install", "--quiet"] + REQUIRED_PACKAGES,
+            pip_cmd + REQUIRED_PACKAGES,
             stdout=subprocess.DEVNULL,
+            env=env,
         )
         print("Dependencies installed.")
         return True

--- a/tests/skills/test_google_oauth_setup.py
+++ b/tests/skills/test_google_oauth_setup.py
@@ -133,6 +133,9 @@ def setup_module(monkeypatch, tmp_path):
 
 
 class TestGetAuthUrl:
+    def test_uses_plain_localhost_redirect(self, setup_module):
+        assert setup_module.REDIRECT_URI == "http://localhost"
+
     def test_persists_state_and_code_verifier_for_later_exchange(self, setup_module, capsys):
         setup_module.get_auth_url()
 
@@ -144,6 +147,7 @@ class TestGetAuthUrl:
         assert saved["code_verifier"] == "generated-code-verifier"
 
         flow = FakeFlow.created[-1]
+        assert flow.redirect_uri == "http://localhost"
         assert flow.autogenerate_code_verifier is True
         assert flow.authorization_kwargs == {"access_type": "offline", "prompt": "consent"}
 
@@ -169,7 +173,7 @@ class TestExchangeAuthCode:
         )
 
         setup_module.exchange_auth_code(
-            "http://localhost:1/?code=4/extracted-code&state=saved-state&scope=gmail"
+            "http://localhost/?code=4/extracted-code&state=saved-state&scope=gmail"
         )
 
         flow = FakeFlow.created[-1]
@@ -182,7 +186,7 @@ class TestExchangeAuthCode:
 
         with pytest.raises(SystemExit):
             setup_module.exchange_auth_code(
-                "http://localhost:1/?code=4/extracted-code&state=wrong-state"
+                "http://localhost/?code=4/extracted-code&state=wrong-state"
             )
 
         out = capsys.readouterr().out


### PR DESCRIPTION
## Summary
- switch the Google Workspace OAuth redirect URI from `http://localhost:1` to `http://localhost` so it matches the default Desktop OAuth client config
- make the scripts self-locate the Hermes repo for `hermes_constants` imports when run outside the repo root
- install Google client deps into `~/.hermes/.pythonlibs/google-workspace/` so setup works on systems without global `pip` access
- update the skill docs and regression tests for the localhost redirect flow

## Why
I hit this bug for real while setting up Google Workspace through Hermes on a machine where the OAuth client only allowed `http://localhost`. The generated `http://localhost:1` redirect got stuck on the browser loading screen, and the setup script also tripped over missing import paths / system package install assumptions.

## Test Plan
- `source venv/bin/activate && pytest -q tests/skills/test_google_oauth_setup.py`
- manually completed the Google Workspace setup flow locally using the patched script
