### PR TITLE
fix: register /queue, /background, /btw as native Discord slash commands

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1680,6 +1680,21 @@ class DiscordAdapter(BasePlatformAdapter):
             await interaction.response.defer(ephemeral=True)
             await self._handle_thread_create_slash(interaction, name, message, auto_archive_duration)
 
+        @tree.command(name="queue", description="Queue a prompt for the next turn (doesn't interrupt)")
+        @discord.app_commands.describe(prompt="The prompt to queue")
+        async def slash_queue(interaction: discord.Interaction, prompt: str):
+            await self._run_simple_slash(interaction, f"/queue {prompt}", "Queued for the next turn.")
+
+        @tree.command(name="background", description="Run a prompt in the background")
+        @discord.app_commands.describe(prompt="The prompt to run in the background")
+        async def slash_background(interaction: discord.Interaction, prompt: str):
+            await self._run_simple_slash(interaction, f"/background {prompt}", "Background task started~")
+
+        @tree.command(name="btw", description="Ephemeral side question using session context")
+        @discord.app_commands.describe(question="Your side question (no tools, not persisted)")
+        async def slash_btw(interaction: discord.Interaction, question: str):
+            await self._run_simple_slash(interaction, f"/btw {question}")
+
     def _build_slash_event(self, interaction: discord.Interaction, text: str) -> MessageEvent:
         """Build a MessageEvent from a Discord slash command interaction."""
         is_dm = isinstance(interaction.channel, discord.DMChannel)


### PR DESCRIPTION
## Summary

Community bug report: `/queue` command works on Telegram but not Discord.

**Root cause:** These three commands were defined in the central `COMMAND_REGISTRY` and handled by the gateway runner, but were never registered as native Discord slash commands via `@tree.command()` in `_register_slash_commands()`. Discord requires explicit registration for commands to appear in the slash command picker UI.

**Commands added:**
- `/queue <prompt>` — Queue a prompt for the next turn without interrupting
- `/background <prompt>` — Run a prompt in the background
- `/btw <question>` — Ephemeral side question using session context

**Files changed:** `gateway/platforms/discord.py` — 15 lines added

**Tests:** All 80 Discord tests + 17 slash command tests pass.