### PR TITLE
fix(gateway): preserve concurrent runtime status updates

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -15,14 +15,17 @@ import hashlib
 import json
 import os
 import sys
+import threading
 from datetime import datetime, timezone
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Any, Optional
+from utils import atomic_json_write
 
 _GATEWAY_KIND = "hermes-gateway"
 _RUNTIME_STATUS_FILE = "gateway_state.json"
 _LOCKS_DIRNAME = "gateway-locks"
+_RUNTIME_STATUS_LOCK = threading.Lock()
 
 
 def _get_pid_path() -> Path:
@@ -138,7 +141,7 @@ def _read_json_file(path: Path) -> Optional[dict[str, Any]]:
     if not path.exists():
         return None
     try:
-        raw = path.read_text().strip()
+        raw = path.read_text(encoding="utf-8").strip()
     except OSError:
         return None
     if not raw:
@@ -151,8 +154,7 @@ def _read_json_file(path: Path) -> Optional[dict[str, Any]]:
 
 
 def _write_json_file(path: Path, payload: dict[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload))
+    atomic_json_write(path, payload, indent=None, separators=(",", ":"))
 
 
 def _read_pid_record() -> Optional[dict]:
@@ -160,7 +162,7 @@ def _read_pid_record() -> Optional[dict]:
     if not pid_path.exists():
         return None
 
-    raw = pid_path.read_text().strip()
+    raw = pid_path.read_text(encoding="utf-8").strip()
     if not raw:
         return None
 
@@ -195,30 +197,31 @@ def write_runtime_status(
 ) -> None:
     """Persist gateway runtime health information for diagnostics/status."""
     path = _get_runtime_status_path()
-    payload = _read_json_file(path) or _build_runtime_status_record()
-    payload.setdefault("platforms", {})
-    payload.setdefault("kind", _GATEWAY_KIND)
-    payload["pid"] = os.getpid()
-    payload["start_time"] = _get_process_start_time(os.getpid())
-    payload["updated_at"] = _utc_now_iso()
+    with _RUNTIME_STATUS_LOCK:
+        payload = _read_json_file(path) or _build_runtime_status_record()
+        payload.setdefault("platforms", {})
+        payload.setdefault("kind", _GATEWAY_KIND)
+        payload["pid"] = os.getpid()
+        payload["start_time"] = _get_process_start_time(os.getpid())
+        payload["updated_at"] = _utc_now_iso()
 
-    if gateway_state is not None:
-        payload["gateway_state"] = gateway_state
-    if exit_reason is not None:
-        payload["exit_reason"] = exit_reason
+        if gateway_state is not None:
+            payload["gateway_state"] = gateway_state
+        if exit_reason is not None:
+            payload["exit_reason"] = exit_reason
 
-    if platform is not None:
-        platform_payload = payload["platforms"].get(platform, {})
-        if platform_state is not None:
-            platform_payload["state"] = platform_state
-        if error_code is not None:
-            platform_payload["error_code"] = error_code
-        if error_message is not None:
-            platform_payload["error_message"] = error_message
-        platform_payload["updated_at"] = _utc_now_iso()
-        payload["platforms"][platform] = platform_payload
+        if platform is not None:
+            platform_payload = payload["platforms"].get(platform, {})
+            if platform_state is not None:
+                platform_payload["state"] = platform_state
+            if error_code is not None:
+                platform_payload["error_code"] = error_code
+            if error_message is not None:
+                platform_payload["error_message"] = error_message
+            platform_payload["updated_at"] = _utc_now_iso()
+            payload["platforms"][platform] = platform_payload
 
-    _write_json_file(path, payload)
+        _write_json_file(path, payload)
 
 
 def read_runtime_status() -> Optional[dict[str, Any]]:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -2,6 +2,8 @@
 
 import json
 import os
+import threading
+import time
 
 from gateway import status
 
@@ -102,6 +104,58 @@ class TestGatewayRuntimeStatus:
         assert payload["platforms"]["telegram"]["state"] == "fatal"
         assert payload["platforms"]["telegram"]["error_code"] == "telegram_polling_conflict"
         assert payload["platforms"]["telegram"]["error_message"] == "another poller is active"
+
+    def test_write_runtime_status_preserves_concurrent_platform_updates(self, tmp_path, monkeypatch):
+        """Concurrent platform updates must merge instead of clobbering each other."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        state_path = tmp_path / "gateway_state.json"
+        status.write_runtime_status(gateway_state="starting")
+
+        original_write = status._write_json_file
+        write_call_count = {"value": 0}
+        discord_done = threading.Event()
+        discord_errors = []
+        spawned_threads = []
+
+        def update_discord():
+            try:
+                status.write_runtime_status(platform="discord", platform_state="connected")
+            except Exception as exc:  # pragma: no cover - surfaced via assertion below
+                discord_errors.append(exc)
+            finally:
+                discord_done.set()
+
+        def blocking_write(path, payload):
+            write_call_count["value"] += 1
+            is_first_platform_write = path == state_path and write_call_count["value"] == 1
+            if is_first_platform_write:
+                discord_thread = threading.Thread(target=update_discord)
+                spawned_threads.append(discord_thread)
+                discord_thread.start()
+                time.sleep(0.2)
+                original_write(path, payload)
+                return
+            original_write(path, payload)
+
+        monkeypatch.setattr(status, "_write_json_file", blocking_write)
+
+        def update_telegram():
+            status.write_runtime_status(platform="telegram", platform_state="connected")
+
+        t1 = threading.Thread(target=update_telegram)
+        t1.start()
+        t1.join(timeout=2)
+        assert not t1.is_alive()
+        assert spawned_threads, "discord update thread was never started"
+        spawned_threads[0].join(timeout=2)
+        assert not spawned_threads[0].is_alive()
+        assert discord_done.wait(timeout=2), "discord update never completed"
+        assert not discord_errors
+
+        payload = status.read_runtime_status()
+        assert payload["platforms"]["telegram"]["state"] == "connected"
+        assert payload["platforms"]["discord"]["state"] == "connected"
 
 
 class TestScopedLocks:


### PR DESCRIPTION
What changed
This PR fixes a race in gateway runtime health persistence where concurrent calls to write_runtime_status() could overwrite each other and silently drop per-platform state from gateway_state.json.

The fix does two things:

serializes in-process runtime status updates with a lock
writes the JSON file atomically to avoid partial or clobbered state during overlapping updates
I also added a regression test that reproduces the failure mode by triggering overlapping Telegram and Discord status writes and verifies that both platform states survive.

Why this matters
Gateway startup and reconnect flows can update runtime health from multiple platform adapters in quick succession. Before this change, the status file used an unguarded read-modify-write pattern, so one platform update could erase another. That made diagnostics less trustworthy and could hide the real platform state after failures or reconnects.

Implementation notes
gateway/status.py
switched runtime status persistence to atomic JSON writes
wrapped write_runtime_status() in a process-local lock
normalized JSON reads to explicit UTF-8
tests/gateway/test_status.py
added a concurrency regression test for overlapping platform updates

How to test

Run:

python -m pytest tests/gateway/test_status.py -q -n 0 -k "write_runtime_status_overwrites_stale_pid_on_restart or write_runtime_status_records_platform_failure or preserves_concurrent_platform_updates"

Impact
This is a low-risk fix scoped to gateway status persistence. It does not change adapter behavior or user-facing command flow, but it makes gateway health reporting more reliable under concurrent platform activity.