### PR TITLE
feat(gateway): inject current timestamp into user messages

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6913,6 +6913,16 @@ class GatewayRunner:
             _approval_session_token = set_current_session_key(_approval_session_key)
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
             try:
+                # Inject current timestamp into every user message so the agent
+                # always knows the current time without needing a tool call.
+                _now = datetime.now()
+                import locale as _locale
+                try:
+                    _locale.setlocale(_locale.LC_TIME, 'en_US.UTF-8')
+                except Exception:
+                    pass
+                _ts_str = _now.strftime('%A, %B %d, %Y %I:%M %p')
+                message = f"[Current time: {_ts_str}]\n\n{message}"
                 result = agent.run_conversation(message, conversation_history=agent_history, task_id=session_id)
             finally:
                 unregister_gateway_notify(_approval_session_key)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6974,7 +6974,12 @@ class GatewayRunner:
                 if isinstance(self.config, dict):
                     _inject_ts = self.config.get("display", {}).get("gateway_timestamp", True)
                 else:
-                    _inject_ts = getattr(getattr(self.config, "display", None), "gateway_timestamp", True)
+                    # GatewayConfig doesn't carry display settings — read from YAML directly
+                    try:
+                        _raw_cfg = _load_gateway_config()
+                        _inject_ts = _raw_cfg.get("display", {}).get("gateway_timestamp", True)
+                    except Exception:
+                        pass
                 if _inject_ts:
                     _now = datetime.now()
                     import locale as _locale

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2081,6 +2081,9 @@ class GatewayRunner:
         if canonical == "verbose":
             return await self._handle_verbose_command(event)
 
+        if canonical == "timestamps":
+            return await self._handle_timestamps_command(event)
+
         if canonical == "yolo":
             return await self._handle_yolo_command(event)
 
@@ -4989,6 +4992,57 @@ class GatewayRunner:
             logger.warning("Failed to save tool_progress mode: %s", e)
             return f"{descriptions[new_mode]}\n_(could not save to config: {e})_"
 
+    async def _handle_timestamps_command(self, event: MessageEvent) -> str:
+        """Handle /timestamps command — toggle gateway timestamp injection.
+
+        When enabled (default), a human-readable timestamp is prepended to every
+        user message before it reaches the agent.  When disabled, the raw message
+        is forwarded unchanged.
+
+        The setting is persisted in ``display.gateway_timestamp`` in config.yaml
+        and takes effect immediately (no restart required).
+        """
+        import yaml
+        config_path = _hermes_home / "config.yaml"
+
+        # Read current value
+        try:
+            user_config = {}
+            if config_path.exists():
+                with open(config_path, encoding="utf-8") as f:
+                    user_config = yaml.safe_load(f) or {}
+            current = user_config.get("display", {}).get("gateway_timestamp", True)
+        except Exception:
+            current = True
+
+        # Toggle
+        new_val = not current
+
+        # Save
+        try:
+            if "display" not in user_config:
+                user_config["display"] = {}
+            user_config["display"]["gateway_timestamp"] = new_val
+            from hermes_constants import atomic_yaml_write
+            atomic_yaml_write(config_path, user_config)
+        except Exception as e:
+            return f"Failed to save config: {e}"
+
+        # Also update the in-memory config so it takes effect immediately
+        if isinstance(self.config, dict):
+            if "display" not in self.config:
+                self.config["display"] = {}
+            self.config["display"]["gateway_timestamp"] = new_val
+        else:
+            _disp = getattr(self.config, "display", None)
+            if _disp is not None:
+                setattr(_disp, "gateway_timestamp", new_val)
+
+        if new_val:
+            return "Timestamp injection: ON -- [Current time: ...] will be prepended to every message."
+        else:
+            return "Timestamp injection: OFF -- messages forwarded without timestamp."
+
     async def _handle_compress_command(self, event: MessageEvent) -> str:
         """Handle /compress command -- manually compress conversation context."""
         source = event.source
@@ -6915,14 +6969,21 @@ class GatewayRunner:
             try:
                 # Inject current timestamp into every user message so the agent
                 # always knows the current time without needing a tool call.
-                _now = datetime.now()
-                import locale as _locale
-                try:
-                    _locale.setlocale(_locale.LC_TIME, 'en_US.UTF-8')
-                except Exception:
-                    pass
-                _ts_str = _now.strftime('%A, %B %d, %Y %I:%M %p')
-                message = f"[Current time: {_ts_str}]\n\n{message}"
+                # Toggle via display.gateway_timestamp in config.yaml (default: true).
+                _inject_ts = True
+                if isinstance(self.config, dict):
+                    _inject_ts = self.config.get("display", {}).get("gateway_timestamp", True)
+                else:
+                    _inject_ts = getattr(getattr(self.config, "display", None), "gateway_timestamp", True)
+                if _inject_ts:
+                    _now = datetime.now()
+                    import locale as _locale
+                    try:
+                        _locale.setlocale(_locale.LC_TIME, 'en_US.UTF-8')
+                    except Exception:
+                        pass
+                    _ts_str = _now.strftime('%A, %B %d, %Y %I:%M %p')
+                    message = f"[Current time: {_ts_str}]\n\n{message}"
                 result = agent.run_conversation(message, conversation_history=agent_history, task_id=session_id)
             finally:
                 unregister_gateway_notify(_approval_session_key)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5023,7 +5023,7 @@ class GatewayRunner:
             if "display" not in user_config:
                 user_config["display"] = {}
             user_config["display"]["gateway_timestamp"] = new_val
-            from hermes_constants import atomic_yaml_write
+            from utils import atomic_yaml_write
             atomic_yaml_write(config_path, user_config)
         except Exception as e:
             return f"Failed to save config: {e}"

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -96,6 +96,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("verbose", "Cycle tool progress display: off -> new -> all -> verbose",
                "Configuration", cli_only=True,
                gateway_config_gate="display.tool_progress_command"),
+    CommandDef("timestamps", "Toggle gateway timestamp injection on/off", "Configuration",
+               aliases=("ts",)),
     CommandDef("yolo", "Toggle YOLO mode (skip all dangerous command approvals)",
                "Configuration"),
     CommandDef("reasoning", "Manage reasoning effort and display", "Configuration",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -399,6 +399,7 @@ DEFAULT_CONFIG = {
         "tool_progress_command": False,  # Enable /verbose command in messaging gateway
         "tool_progress_overrides": {},  # Per-platform overrides: {"signal": "off", "telegram": "all"}
         "tool_preview_length": 0,  # Max chars for tool call previews (0 = no limit, show full paths/commands)
+        "gateway_timestamp": True,  # Inject [Current time: ...] into every gateway message
     },
 
     # Privacy settings


### PR DESCRIPTION
## Summary

Injects a human-readable timestamp at the top of every user message before it reaches the agent, so the agent always knows the current date and time without needing to invoke a tool call.

**Format:** `[Current time: Monday, April 06, 2026 07:36 AM]`

## Why

Agents running long conversations often lose track of time. The only built-in mechanism is the `Conversation started:` header, which becomes stale after minutes or hours of back-and-forth. Currently the agent must spend a `date` tool call just to answer "what time is it?" or "what day is today?" — wasting tokens and latency.

This is especially important for:
- **Cron-scheduled tasks** — the agent wakes up with no conversation history and no time context
- **Long multi-turn conversations** — the original timestamp is hours old
- **Time-sensitive instructions** — "remind me at 3pm", "is it past midnight?", etc.

## What Changed

### Core Injection (`gateway/run.py`)
Inside `_run_agent()`, right before `agent.run_conversation()`:
- Check `display.gateway_timestamp` config (default: `true`)
- Get current time via `datetime.now()`
- Set locale to `en_US.UTF-8` for consistent day/month names (with graceful fallback)
- Format as human-readable string: `Monday, April 06, %Y %I:%M %p`
- Prepend `[Current time: ...]\n\n` to the message

### Config Toggle (`hermes_cli/config.py`)
- Add `display.gateway_timestamp: true` to `DEFAULT_CONFIG`
- Persisted in `config.yaml` — survives restarts

### Slash Command (`hermes_cli/commands.py` + `gateway/run.py`)
- Add `/timestamps` (alias `/ts`) command — toggles injection on/off
- Available in both CLI and messaging gateway
- Takes effect immediately without restart
- Persists to `config.yaml`

## Design Decisions

| Decision | Rationale |
|---|---|
| `datetime.now()` instead of injecting into system prompt | The message-level approach works for ALL model providers (some strip system prompts) |
| Locale `en_US.UTF-8` with try/except fallback | Server locale may be non-English; we want consistent English output |
| Prepend to message, not modify agent API | Zero-impact change — no changes to agent interface, prompt builder, or context files |
| Only in `_run_agent` (gateway path) | CLI mode has direct terminal access; gateway agents need the injection |
| Config toggle + slash command | Some users may not want the token overhead; easy on/off without code changes |
| Default `true` | Time awareness is universally useful; users who don't want it can opt-out |

## Testing

Manual testing on self-hosted instance:
- Agent correctly reports current time without any tool calls
- Works across long multi-turn conversations (timestamp updated per message)
- Cron jobs also receive timestamps (they pass through the same `_run_agent` path)
- Gracefully handles missing `en_US` locale (falls back to server default)
- `/timestamps` toggle works — ON/OFF states persist across messages and restarts
- Config `display.gateway_timestamp: false` correctly disables injection