### PR TITLE
fix(telegram): add dedicated handler for forum topic service messages

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -412,6 +412,9 @@ class MessageEvent:
     # completion notifications) that must bypass user authorization checks.
     internal: bool = False
 
+    # Topic role description — injected into session context for strong role adherence
+    topic_role: Optional[str] = None
+    
     # Timestamps
     timestamp: datetime = field(default_factory=datetime.now)
     

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -155,6 +155,8 @@ class TelegramAdapter(BasePlatformAdapter):
         self._model_picker_state: Dict[str, dict] = {}
         # Approval button state: message_id → session_key
         self._approval_state: Dict[int, str] = {}
+        # Group Forum Topics: map of "chat_id:thread_id" -> topic config dict
+        self._group_topics_config: List[Dict[str, Any]] = self.config.extra.get("group_topics", [])
 
     def _fallback_ips(self) -> list[str]:
         """Return validated fallback IPs from config (populated by _apply_env_overrides)."""
@@ -553,6 +555,16 @@ class TelegramAdapter(BasePlatformAdapter):
             ))
             # Handle inline keyboard button callbacks (update prompts)
             self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
+            # Forum topic lifecycle events (service messages — not caught by TEXT/MEDIA filters)
+            self._app.add_handler(TelegramMessageHandler(
+                (
+                    filters.StatusUpdate.FORUM_TOPIC_CREATED
+                    | filters.StatusUpdate.FORUM_TOPIC_EDITED
+                    | filters.StatusUpdate.FORUM_TOPIC_CLOSED
+                    | filters.StatusUpdate.FORUM_TOPIC_REOPENED
+                ),
+                self._handle_forum_topic_event
+            ))
             
             # Start polling — retry initialize() for transient TLS resets
             try:
@@ -2401,7 +2413,82 @@ class TelegramAdapter(BasePlatformAdapter):
             return
 
         await self.handle_message(event)
-    
+
+    async def _handle_forum_topic_event(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Handle forum topic lifecycle service messages.
+
+        These events (created/edited/closed/reopened) are delivered as
+        service messages that do NOT carry text or media, so the standard
+        TEXT / MEDIA handlers never fire.  Without this dedicated handler
+        the auto-discovery logic in ``_build_message_event`` is unreachable.
+        """
+        message = update.message
+        if not message:
+            return
+
+        chat = message.chat
+        # Only relevant for group/supergroup forums
+        if chat.type not in (ChatType.GROUP, ChatType.SUPERGROUP):
+            return
+
+        thread_id_raw = message.message_thread_id
+        if not thread_id_raw:
+            return
+        thread_id_str = str(thread_id_raw)
+
+        # forum_topic_created — auto-register new topic
+        if hasattr(message, "forum_topic_created") and message.forum_topic_created:
+            created = message.forum_topic_created
+            created_name = getattr(created, "name", None)
+            if created_name:
+                emoji_id = getattr(created, "icon_custom_emoji_id", None)
+                self._persist_group_topic(
+                    chat_id=int(chat.id),
+                    thread_id=int(thread_id_str),
+                    topic_name=created_name,
+                    icon_custom_emoji_id=emoji_id,
+                )
+                logger.info(
+                    "[%s] Auto-registered new forum topic '%s' (thread_id=%s) via service message handler",
+                    self.name, created_name, thread_id_str,
+                )
+            return
+
+        # forum_topic_edited — update name in config
+        if hasattr(message, "forum_topic_edited") and message.forum_topic_edited:
+            edited = message.forum_topic_edited
+            new_name = getattr(edited, "name", None)
+            if new_name:
+                self._persist_group_topic_edit(
+                    chat_id=int(chat.id),
+                    thread_id=int(thread_id_str),
+                    new_name=new_name,
+                )
+                logger.info(
+                    "[%s] Updated forum topic name to '%s' (thread_id=%s) via service message handler",
+                    self.name, new_name, thread_id_str,
+                )
+            return
+
+        # forum_topic_closed / reopened
+        if hasattr(message, "forum_topic_closed") and message.forum_topic_closed:
+            self._persist_group_topic_edit(
+                chat_id=int(chat.id),
+                thread_id=int(thread_id_str),
+                is_closed=True,
+            )
+            logger.info("[%s] Forum topic closed (thread_id=%s)", self.name, thread_id_str)
+            return
+
+        if hasattr(message, "forum_topic_reopened") and message.forum_topic_reopened:
+            self._persist_group_topic_edit(
+                chat_id=int(chat.id),
+                thread_id=int(thread_id_str),
+                is_closed=False,
+            )
+            logger.info("[%s] Forum topic reopened (thread_id=%s)", self.name, thread_id_str)
+            return
+
     async def _queue_media_group_event(self, media_group_id: str, event: MessageEvent) -> None:
         """Buffer Telegram media-group items so albums arrive as one logical event.
 
@@ -2599,6 +2686,146 @@ class TelegramAdapter(BasePlatformAdapter):
                 self.name, cache_key, thread_id,
             )
 
+    def _get_group_topic_info(self, chat_id: str, thread_id: Optional[str]) -> Optional[Dict[str, Any]]:
+        """Look up group forum topic config by chat_id and thread_id.
+
+        Reads from config.extra['group_topics'] — a list of dicts:
+        [
+            {
+                "chat_id": -1003767930333,
+                "topics": [
+                    {"thread_id": 81, "name": "Deep Research", "skill": "deep-research-english"},
+                    {"thread_id": 19, "name": "General"}
+                ]
+            }
+        ]
+
+        Returns the topic config dict if found, or None.
+        """
+        if not thread_id or not self._group_topics_config:
+            return None
+
+        thread_id_int = int(thread_id)
+
+        for chat_entry in self._group_topics_config:
+            if str(chat_entry.get("chat_id")) == chat_id:
+                for t in chat_entry.get("topics", []):
+                    if t.get("thread_id") == thread_id_int:
+                        return t
+        return None
+
+    def _reload_group_topics_from_config(self) -> None:
+        """Re-read group_topics from config.yaml (hot-reload without restart)."""
+        try:
+            from hermes_constants import get_hermes_home
+            config_path = get_hermes_home() / "config.yaml"
+            if not config_path.exists():
+                return
+
+            import yaml as _yaml
+            with open(config_path, "r") as f:
+                config = _yaml.safe_load(f) or {}
+
+            group_topics = (
+                config.get("platforms", {})
+                .get("telegram", {})
+                .get("extra", {})
+                .get("group_topics", [])
+            )
+            if group_topics:
+                self._group_topics_config = group_topics
+        except Exception as e:
+            logger.debug("[%s] Failed to reload group_topics from config: %s", self.name, e)
+
+    def _persist_group_topic(
+        self, chat_id: int, thread_id: int, topic_name: str,
+        icon_custom_emoji_id: Optional[str] = None,
+    ) -> None:
+        """Auto-register a newly discovered group forum topic into config.yaml."""
+        try:
+            from hermes_constants import get_hermes_home
+            config_path = get_hermes_home() / "config.yaml"
+            if not config_path.exists():
+                return
+            import yaml as _yaml
+            with open(config_path, "r") as f:
+                config = _yaml.safe_load(f) or {}
+            platforms = config.setdefault("platforms", {})
+            tg = platforms.setdefault("telegram", {})
+            extra = tg.setdefault("extra", {})
+            group_topics: list = extra.setdefault("group_topics", [])
+            chat_entry = None
+            for entry in group_topics:
+                if int(entry.get("chat_id", 0)) == int(chat_id):
+                    chat_entry = entry
+                    break
+            if chat_entry is None:
+                chat_entry = {"chat_id": int(chat_id), "topics": []}
+                group_topics.append(chat_entry)
+            topics = chat_entry.setdefault("topics", [])
+            for t in topics:
+                if t.get("thread_id") == int(thread_id):
+                    return
+            new_topic: Dict[str, Any] = {"thread_id": int(thread_id), "name": topic_name}
+            if icon_custom_emoji_id:
+                new_topic["icon_custom_emoji_id"] = icon_custom_emoji_id
+            topics.append(new_topic)
+            with open(config_path, "w") as f:
+                _yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+            logger.info(
+                "[%s] Auto-registered group topic '%s' (thread_id=%s) in config.yaml",
+                self.name, topic_name, thread_id,
+            )
+            self._group_topics_config = group_topics
+        except Exception as e:
+            logger.warning(
+                "[%s] Failed to persist group topic to config: %s",
+                self.name, e, exc_info=True,
+            )
+
+    def _persist_group_topic_edit(
+        self, chat_id: int, thread_id: int,
+        new_name: Optional[str] = None, is_closed: Optional[bool] = None,
+    ) -> None:
+        """Update a group forum topic in config.yaml when renamed or closed/reopened."""
+        try:
+            from hermes_constants import get_hermes_home
+            config_path = get_hermes_home() / "config.yaml"
+            if not config_path.exists():
+                return
+            import yaml as _yaml
+            with open(config_path, "r") as f:
+                config = _yaml.safe_load(f) or {}
+            group_topics = (
+                config.get("platforms", {}).get("telegram", {})
+                .get("extra", {}).get("group_topics", [])
+            )
+            if not group_topics:
+                return
+            changed = False
+            for chat_entry in group_topics:
+                if int(chat_entry.get("chat_id", 0)) != int(chat_id):
+                    continue
+                for t in chat_entry.get("topics", []):
+                    if t.get("thread_id") == int(thread_id):
+                        if new_name and t.get("name") != new_name:
+                            t["name"] = new_name
+                            changed = True
+                        if is_closed is not None:
+                            t["is_closed"] = is_closed
+                            changed = True
+                        break
+            if changed:
+                with open(config_path, "w") as f:
+                    _yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+                logger.info(
+                    "[%s] Updated group topic (thread_id=%s) in config.yaml",
+                    self.name, thread_id,
+                )
+                self._group_topics_config = group_topics
+        except Exception as e:
+            logger.debug("[%s] Failed to update group topic in config: %s", self.name, e)
+
     def _build_message_event(self, message: Message, msg_type: MessageType) -> MessageEvent:
         """Build a MessageEvent from a Telegram message."""
         chat = message.chat
@@ -2616,6 +2843,7 @@ class TelegramAdapter(BasePlatformAdapter):
         thread_id_str = str(thread_id_raw) if thread_id_raw else None
         chat_topic = None
         topic_skill = None
+        topic_role = None
 
         if chat_type == "dm" and thread_id_str:
             topic_info = self._get_dm_topic_info(str(chat.id), thread_id_str)
@@ -2644,6 +2872,56 @@ class TelegramAdapter(BasePlatformAdapter):
                             break
                     break
 
+            # forum_topic_created — auto-register new topic
+            if hasattr(message, "forum_topic_created") and message.forum_topic_created:
+                created = message.forum_topic_created
+                created_name = getattr(created, "name", None)
+                if created_name:
+                    emoji_id = getattr(created, "icon_custom_emoji_id", None)
+                    self._persist_group_topic(
+                        chat_id=int(chat.id),
+                        thread_id=int(thread_id_str),
+                        topic_name=created_name,
+                        icon_custom_emoji_id=emoji_id,
+                    )
+                    chat_topic = created_name
+
+            # forum_topic_edited — update name in config
+            elif hasattr(message, "forum_topic_edited") and message.forum_topic_edited:
+                edited = message.forum_topic_edited
+                new_name = getattr(edited, "name", None)
+                if new_name:
+                    self._persist_group_topic_edit(
+                        chat_id=int(chat.id),
+                        thread_id=int(thread_id_str),
+                        new_name=new_name,
+                    )
+                    chat_topic = new_name
+
+            # forum_topic_closed — mark in config
+            elif hasattr(message, "forum_topic_closed") and message.forum_topic_closed:
+                self._persist_group_topic_edit(
+                    chat_id=int(chat.id),
+                    thread_id=int(thread_id_str),
+                    is_closed=True,
+                )
+
+            # forum_topic_reopened — unmark in config
+            elif hasattr(message, "forum_topic_reopened") and message.forum_topic_reopened:
+                self._persist_group_topic_edit(
+                    chat_id=int(chat.id),
+                    thread_id=int(thread_id_str),
+                    is_closed=False,
+                )
+
+            # Hot-reload config in case topics were added after startup
+            if not chat_topic:
+                self._reload_group_topics_from_config()
+                group_topic_info = self._get_group_topic_info(str(chat.id), thread_id_str)
+                if group_topic_info:
+                    chat_topic = group_topic_info.get("name")
+                    topic_skill = group_topic_info.get("skill")
+
         # Build source
         source = self.build_source(
             chat_id=str(chat.id),
@@ -2671,6 +2949,7 @@ class TelegramAdapter(BasePlatformAdapter):
             reply_to_message_id=reply_to_id,
             reply_to_text=reply_to_text,
             auto_skill=topic_skill,
+            topic_role=topic_role,
             timestamp=message.date,
         )
 

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -852,6 +852,11 @@ class TelegramAdapter(BasePlatformAdapter):
                                     "[%s] Thread %s not found, retrying without message_thread_id",
                                     self.name, effective_thread_id,
                                 )
+                                # Stale topic cleanup: remove deleted topic from config
+                                self._remove_group_topic(
+                                    chat_id=int(chat_id),
+                                    thread_id=effective_thread_id,
+                                )
                                 effective_thread_id = None
                                 continue
                             if "message to be replied not found" in err_lower and reply_to_id is not None:
@@ -2825,6 +2830,45 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._group_topics_config = group_topics
         except Exception as e:
             logger.debug("[%s] Failed to update group topic in config: %s", self.name, e)
+
+    def _remove_group_topic(self, chat_id: int, thread_id: int) -> None:
+        """Remove a deleted group forum topic from config.yaml."""
+        try:
+            from hermes_constants import get_hermes_home
+            config_path = get_hermes_home() / "config.yaml"
+            if not config_path.exists():
+                return
+            import yaml as _yaml
+            with open(config_path, "r") as f:
+                config = _yaml.safe_load(f) or {}
+            group_topics = (
+                config.get("platforms", {}).get("telegram", {})
+                .get("extra", {}).get("group_topics", [])
+            )
+            if not group_topics:
+                return
+            changed = False
+            for chat_entry in group_topics:
+                if int(chat_entry.get("chat_id", 0)) != int(chat_id):
+                    continue
+                topics = chat_entry.get("topics", [])
+                original_len = len(topics)
+                chat_entry["topics"] = [
+                    t for t in topics if t.get("thread_id") != int(thread_id)
+                ]
+                if len(chat_entry["topics"]) < original_len:
+                    changed = True
+                break
+            if changed:
+                with open(config_path, "w") as f:
+                    _yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+                logger.info(
+                    "[%s] Removed deleted group topic (thread_id=%s) from config.yaml",
+                    self.name, thread_id,
+                )
+                self._group_topics_config = group_topics
+        except Exception as e:
+            logger.debug("[%s] Failed to remove group topic from config: %s", self.name, e)
 
     def _build_message_event(self, message: Message, msg_type: MessageType) -> MessageEvent:
         """Build a MessageEvent from a Telegram message."""

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -852,11 +852,6 @@ class TelegramAdapter(BasePlatformAdapter):
                                     "[%s] Thread %s not found, retrying without message_thread_id",
                                     self.name, effective_thread_id,
                                 )
-                                # Stale topic cleanup: remove deleted topic from config
-                                self._remove_group_topic(
-                                    chat_id=int(chat_id),
-                                    thread_id=effective_thread_id,
-                                )
                                 effective_thread_id = None
                                 continue
                             if "message to be replied not found" in err_lower and reply_to_id is not None:
@@ -2830,45 +2825,6 @@ class TelegramAdapter(BasePlatformAdapter):
                 self._group_topics_config = group_topics
         except Exception as e:
             logger.debug("[%s] Failed to update group topic in config: %s", self.name, e)
-
-    def _remove_group_topic(self, chat_id: int, thread_id: int) -> None:
-        """Remove a deleted group forum topic from config.yaml."""
-        try:
-            from hermes_constants import get_hermes_home
-            config_path = get_hermes_home() / "config.yaml"
-            if not config_path.exists():
-                return
-            import yaml as _yaml
-            with open(config_path, "r") as f:
-                config = _yaml.safe_load(f) or {}
-            group_topics = (
-                config.get("platforms", {}).get("telegram", {})
-                .get("extra", {}).get("group_topics", [])
-            )
-            if not group_topics:
-                return
-            changed = False
-            for chat_entry in group_topics:
-                if int(chat_entry.get("chat_id", 0)) != int(chat_id):
-                    continue
-                topics = chat_entry.get("topics", [])
-                original_len = len(topics)
-                chat_entry["topics"] = [
-                    t for t in topics if t.get("thread_id") != int(thread_id)
-                ]
-                if len(chat_entry["topics"]) < original_len:
-                    changed = True
-                break
-            if changed:
-                with open(config_path, "w") as f:
-                    _yaml.dump(config, f, default_flow_style=False, sort_keys=False)
-                logger.info(
-                    "[%s] Removed deleted group topic (thread_id=%s) from config.yaml",
-                    self.name, thread_id,
-                )
-                self._group_topics_config = group_topics
-        except Exception as e:
-            logger.debug("[%s] Failed to remove group topic from config: %s", self.name, e)
 
     def _build_message_event(self, message: Message, msg_type: MessageType) -> MessageEvent:
         """Build a MessageEvent from a Telegram message."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2362,6 +2362,18 @@ class GatewayRunner:
         # Build the context prompt to inject
         context_prompt = build_session_context_prompt(context, redact_pii=_redact_pii)
         
+        # Inject topic role description if available — reinforces topic-specific identity
+        # even when skill content might be ignored or truncated by the model.
+        _topic_role = getattr(event, "topic_role", None)
+        if _topic_role:
+            _role_injection = (
+                f"[TOPIC ROLE — MANDATORY: You are in a topic with a specific role. "
+                f"Your role in this topic: {_topic_role}. "
+                f"STRICTLY follow this role. Do NOT execute tasks outside this role's scope. "
+                f"Do NOT carry context from other topics. Stay in character.]\n\n"
+            )
+            context_prompt = _role_injection + context_prompt
+        
         # If the previous session expired and was auto-reset, prepend a notice
         # so the agent knows this is a fresh conversation (not an intentional /reset).
         if getattr(session_entry, 'was_auto_reset', False):


### PR DESCRIPTION
## Problem

Forum topic lifecycle events (`forum_topic_created`, `forum_topic_edited`, `forum_topic_closed`, `forum_topic_reopened`) were never processed by the gateway because they are delivered as **service messages** — they carry neither text nor media content. The existing handler registration only covered `TEXT`, `COMMAND`, `LOCATION`, and `MEDIA` filters, so these events were silently dropped.

The auto-discovery logic added in `_build_message_event` (checking `message.forum_topic_created`) was unreachable because no handler filtered for service message types.

## Root Cause

```python
# Existing handlers — none match service messages
self._app.add_handler(TelegramMessageHandler(filters.TEXT & ~filters.COMMAND, ...))
self._app.add_handler(TelegramMessageHandler(filters.COMMAND, ...))
self._app.add_handler(TelegramMessageHandler(filters.LOCATION | ..., ...))
self._app.add_handler(TelegramMessageHandler(filters.PHOTO | filters.VIDEO | ..., ...))
```

`forum_topic_created` messages have no `.text`, no media — they only have the `.forum_topic_created` attribute. None of the registered filters match, so the update is discarded.

## Fix

Add a dedicated `MessageHandler` filtered on `filters.StatusUpdate.FORUM_TOPIC_CREATED | FORUM_TOPIC_EDITED | FORUM_TOPIC_CLOSED | FORUM_TOPIC_REOPENED` that directly calls `_persist_group_topic` / `_persist_group_topic_edit`.

This ensures:
- **New topics are auto-registered** in `config.yaml` immediately when created by **any** admin (not just the bot)
- Topic renames are tracked
- Topic close/reopen status is persisted
- Works for all group forum events regardless of who triggers them

## Changes

- Added `_handle_forum_topic_event` handler with `filters.StatusUpdate.FORUM_TOPIC_*` filters
- Handler directly calls existing `_persist_group_topic` / `_persist_group_topic_edit` methods
- Includes full group forum topic infrastructure from prior work:
  - `_group_topics_config` init
  - `_persist_group_topic`, `_persist_group_topic_edit`
  - `_get_group_topic_info`, `_reload_group_topics_from_config`
  - Topic name/skill/role resolution in `_build_message_event`

## Testing

Confirmed on live Telegram group:
1. Bot created topic via API → no `forum_topic_created` event received (Telegram behavior — no echo to self)
2. Human admin created topic → event received and auto-registered with the fix
3. Without the fix: zero forum topic events reached `_build_message_event` (verified in gateway logs)