### PR TITLE
fix: register Ollama Cloud as known provider for context length resolution

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -181,6 +181,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "api.githubcopilot.com": "copilot",
     "models.github.ai": "copilot",
     "api.fireworks.ai": "fireworks",
+    "ollama.com": "ollama-cloud",
 }
 
 

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -168,6 +168,7 @@ PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "togetherai": "togetherai",
     "perplexity": "perplexity",
     "cohere": "cohere",
+    "ollama-cloud": "ollama-cloud",
 }
 
 # Reverse mapping: models.dev → Hermes (built lazily)


### PR DESCRIPTION
## What does this PR do?

Registers Ollama Cloud (`ollama.com/v1`) as a recognized provider in the URL-to-provider and models.dev provider mappings. Without this, all Ollama Cloud models silently default to 128K context length instead of their actual capacity.

The existing `get_model_context_length()` resolution chain (step 5: provider-aware models.dev lookup) already handles this correctly for every other cloud provider — Ollama Cloud was simply missing from the two mapping dicts that feed it.

## Related Issue

<!-- No existing issue — discovered during Ollama Cloud usage testing. -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py`: Added `"ollama.com": "ollama-cloud"` to `_URL_TO_PROVIDER` dict — enables `_infer_provider_from_url()` to recognize Ollama Cloud base URLs.
- `agent/models_dev.py`: Added `"ollama-cloud": "ollama-cloud"` to `PROVIDER_TO_MODELS_DEV` dict — enables `lookup_models_dev_context()` to resolve model context lengths from the models.dev cache.

## Impact

Affects all users on Ollama Cloud (Free, Pro, Max tiers) who use `https://ollama.com/v1` as their base URL. Before this fix, every model on that endpoint reported 128K context regardless of actual capacity:

| Model | Actual context | Was reported |
|---|---|---|
| qwen3.5:397b | 256K | 128K |
| glm-5 | 202K | 128K |
| kimi-k2.5 | 262K | 128K |
| deepseek-v3.2 | 65K | 128K (overcounted) |

This caused the status bar to display wrong values and — more critically — could lead to premature context compression or missed compression triggers.

## How to Test

1. Configure Ollama Cloud: set `OLLAMA_API_KEY` and use `base_url: https://ollama.com/v1`
2. Switch to any Ollama Cloud model (e.g. `/model qwen3.5:397b --provider custom`)
3. Check status bar — should show ~256K context, not 128K
4. Run existing tests: `pytest tests/agent/test_model_metadata.py tests/agent/test_models_dev.py -v`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — The fix adds dict entries consumed by existing tested code paths. Adding a test for a specific URL→provider mapping entry would test the data, not the logic.
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (no new config keys or user-facing API changes)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure dict additions, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
