### PR TITLE
fix(discord): body @ gate for peer bots, preserve human thread replies

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -74,6 +74,30 @@ def _clean_discord_id(entry: str) -> str:
     return entry.strip()
 
 
+def _discord_body_mentions_user(content: Optional[str], user_id: int) -> bool:
+    """True if the message text explicitly @'s this user (not only API message.mentions).
+
+    Discord may add users to ``message.mentions`` for reply pings without a stable
+    match to \"user typed @ in the body\"; gate on raw text instead.
+
+    Recognizes ``<@id>``, ``<@!id>`` (nickname mention), and plain ``@id``.
+    """
+    if not content or user_id is None:
+        return False
+    sid = str(int(user_id))
+    return f"<@{sid}>" in content or f"<@!{sid}>" in content or f"@{sid}" in content
+
+
+def _is_peer_bot_author(message: Any, bot_user: Any) -> bool:
+    """True if the message is from a bot account other than our own."""
+    if bot_user is None:
+        return False
+    author = message.author
+    return bool(getattr(author, "bot", False)) and getattr(author, "id", None) != getattr(
+        bot_user, "id", None
+    )
+
+
 def check_discord_requirements() -> bool:
     """Check if Discord dependencies are available."""
     return DISCORD_AVAILABLE
@@ -585,7 +609,9 @@ class DiscordAdapter(BasePlatformAdapter):
                     if allow_bots == "none":
                         return
                     elif allow_bots == "mentions":
-                        if not self._client.user or self._client.user not in message.mentions:
+                        if not self._client.user or not _discord_body_mentions_user(
+                            message.content, self._client.user.id
+                        ):
                             return
                     # "all" falls through to handle_message
 
@@ -598,10 +624,15 @@ class DiscordAdapter(BasePlatformAdapter):
                     "DISCORD_IGNORE_NO_MENTION", "true"
                 ).lower() in ("true", "1", "yes")
                 if _ignore_no_mention and message.mentions and not isinstance(message.channel, discord.DMChannel):
-                    _bot_mentioned = (
-                        self._client.user is not None
-                        and self._client.user in message.mentions
-                    )
+                    if _is_peer_bot_author(message, self._client.user):
+                        _bot_mentioned = self._client.user is not None and _discord_body_mentions_user(
+                            message.content, self._client.user.id
+                        )
+                    else:
+                        _bot_mentioned = (
+                            self._client.user is not None
+                            and self._client.user in message.mentions
+                        )
                     if not _bot_mentioned:
                         return  # Talking to someone else, don't interrupt
 
@@ -2068,9 +2099,12 @@ class DiscordAdapter(BasePlatformAdapter):
 
     async def _handle_message(self, message: DiscordMessage) -> None:
         """Handle incoming Discord messages."""
-        # In server channels (not DMs), require the bot to be @mentioned
-        # UNLESS the channel is in the free-response list or the message is
-        # in a thread where the bot has already participated.
+        # In server channels (not DMs), when require_mention is on and the channel
+        # is not free-response:
+        #   • From another bot: require an explicit body @ (<@id>, <@!id>, or @id).
+        #     message.mentions alone is unreliable (reply pings).
+        #   • From a human: use message.mentions, with the usual bypass for threads
+        #     where the bot has already participated.
         #
         # Config (all settable via discord.* in config.yaml):
         #   discord.require_mention: Require @mention in server channels (default: true)
@@ -2094,17 +2128,30 @@ class DiscordAdapter(BasePlatformAdapter):
             require_mention = os.getenv("DISCORD_REQUIRE_MENTION", "true").lower() not in ("false", "0", "no")
             is_free_channel = bool(channel_ids & free_channels)
 
-            # Skip the mention check if the message is in a thread where
-            # the bot has previously participated (auto-created or replied in).
             in_bot_thread = is_thread and thread_id in self._bot_participated_threads
+            peer_bot = _is_peer_bot_author(message, self._client.user)
 
-            if require_mention and not is_free_channel and not in_bot_thread:
-                if self._client.user not in message.mentions:
+            if require_mention and not is_free_channel:
+                if not self._client.user:
                     return
+                if peer_bot:
+                    if not _discord_body_mentions_user(message.content, self._client.user.id):
+                        return
+                elif not in_bot_thread:
+                    if self._client.user not in message.mentions:
+                        return
 
-            if self._client.user and self._client.user in message.mentions:
-                message.content = message.content.replace(f"<@{self._client.user.id}>", "").strip()
-                message.content = message.content.replace(f"<@!{self._client.user.id}>", "").strip()
+            if self._client.user:
+                uid = self._client.user.id
+                strip = _discord_body_mentions_user(message.content, uid) or (
+                    not peer_bot and self._client.user in message.mentions
+                )
+                if strip:
+                    text = message.content or ""
+                    text = text.replace(f"<@{uid}>", "").strip()
+                    text = text.replace(f"<@!{uid}>", "").strip()
+                    text = text.replace(f"@{uid}", "").strip()
+                    message.content = text
 
         # Auto-thread: when enabled, automatically create a thread for every
         # @mention in a text channel so each conversation is isolated (like Slack).

--- a/tests/gateway/test_discord_bot_filter.py
+++ b/tests/gateway/test_discord_bot_filter.py
@@ -5,6 +5,8 @@ import os
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from gateway.platforms.discord import _discord_body_mentions_user
+
 
 def _make_author(*, bot: bool = False, is_self: bool = False):
     """Create a mock Discord author."""
@@ -52,7 +54,9 @@ class TestDiscordBotFilter(unittest.TestCase):
             if allow == "none":
                 return False
             elif allow == "mentions":
-                if not client_user or client_user not in message.mentions:
+                if not client_user or not _discord_body_mentions_user(
+                    message.content, client_user.id
+                ):
                     return False
             # "all" falls through
         
@@ -85,17 +89,39 @@ class TestDiscordBotFilter(unittest.TestCase):
         self.assertTrue(self._run_filter(msg, "all"))
 
     def test_allow_bots_mentions_rejects_without_mention(self):
-        """With allow_bots=mentions, bot messages without @mention are rejected."""
+        """With allow_bots=mentions, bot messages without body @mention are rejected."""
         our_user = _make_author(is_self=True)
         bot = _make_author(bot=True)
-        msg = _make_message(author=bot, mentions=[])
+        msg = _make_message(author=bot, mentions=[], content="hi")
         self.assertFalse(self._run_filter(msg, "mentions", our_user))
 
-    def test_allow_bots_mentions_accepts_with_mention(self):
-        """With allow_bots=mentions, bot messages with @mention are accepted."""
+    def test_allow_bots_mentions_rejects_api_mention_only(self):
+        """API message.mentions without body text does not pass mentions mode."""
         our_user = _make_author(is_self=True)
         bot = _make_author(bot=True)
-        msg = _make_message(author=bot, mentions=[our_user])
+        msg = _make_message(author=bot, mentions=[our_user], content="reply ping only")
+        self.assertFalse(self._run_filter(msg, "mentions", our_user))
+
+    def test_allow_bots_mentions_accepts_with_body_mention(self):
+        """With allow_bots=mentions, bot messages with <@id> in content are accepted."""
+        our_user = _make_author(is_self=True)
+        bot = _make_author(bot=True)
+        msg = _make_message(
+            author=bot,
+            mentions=[our_user],
+            content=f"<@{our_user.id}> hello",
+        )
+        self.assertTrue(self._run_filter(msg, "mentions", our_user))
+
+    def test_allow_bots_mentions_accepts_raw_at_id(self):
+        """Plain @snowflake in body counts as a mention."""
+        our_user = _make_author(is_self=True)
+        bot = _make_author(bot=True)
+        msg = _make_message(
+            author=bot,
+            mentions=[],
+            content=f"hey @{our_user.id} there",
+        )
         self.assertTrue(self._run_filter(msg, "mentions", our_user))
 
     def test_default_is_none(self):

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -95,8 +95,9 @@ def adapter(monkeypatch):
     return adapter
 
 
-def make_message(*, channel, content: str, mentions=None):
-    author = SimpleNamespace(id=42, display_name="Jezza", name="Jezza")
+def make_message(*, channel, content: str, mentions=None, author=None):
+    if author is None:
+        author = SimpleNamespace(id=42, display_name="Jezza", name="Jezza")
     return SimpleNamespace(
         id=123,
         content=content,
@@ -294,16 +295,34 @@ async def test_discord_auto_thread_can_be_disabled(adapter, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_discord_bot_thread_skips_mention_requirement(adapter, monkeypatch):
-    """Messages in a thread the bot has participated in should not require @mention."""
+async def test_discord_bot_thread_requires_body_mention_for_peer_bot(adapter, monkeypatch):
+    """Peer bots must @ us in the body; thread participation does not waive that."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
     monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
     monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
 
-    # Simulate bot having previously participated in thread 456
     adapter._bot_participated_threads.add("456")
 
     thread = FakeThread(channel_id=456, name="existing thread")
+    peer = SimpleNamespace(id=77001, bot=True, display_name="PeerBot", name="PeerBot")
+    message = make_message(
+        channel=thread, content="follow-up without mention", author=peer
+    )
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discord_human_thread_skips_mention_requirement(adapter, monkeypatch):
+    """Humans in a thread the bot has participated in need not repeat @ every message."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    adapter._bot_participated_threads.add("458")
+    thread = FakeThread(channel_id=458, name="existing thread")
     message = make_message(channel=thread, content="follow-up without mention")
 
     await adapter._handle_message(message)
@@ -311,23 +330,85 @@ async def test_discord_bot_thread_skips_mention_requirement(adapter, monkeypatch
     adapter.handle_message.assert_awaited_once()
     event = adapter.handle_message.await_args.args[0]
     assert event.text == "follow-up without mention"
+
+
+@pytest.mark.asyncio
+async def test_discord_bot_thread_accepts_body_mention(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    adapter._bot_participated_threads.add("457")
+    thread = FakeThread(channel_id=457, name="existing thread")
+    bot = adapter._client.user
+    peer = SimpleNamespace(id=77002, bot=True, display_name="PeerBot", name="PeerBot")
+    message = make_message(
+        channel=thread,
+        content=f"<@{bot.id}> follow-up with mention",
+        author=peer,
+    )
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "follow-up with mention"
     assert event.source.chat_type == "thread"
 
 
 @pytest.mark.asyncio
 async def test_discord_unknown_thread_still_requires_mention(adapter, monkeypatch):
-    """Messages in a thread the bot hasn't participated in should still require @mention."""
+    """Unknown thread: humans still need the bot in message.mentions (or join a tracked thread)."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
     monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
     monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
 
-    # Bot has NOT participated in thread 789
     thread = FakeThread(channel_id=789, name="some thread")
     message = make_message(channel=thread, content="hello from unknown thread")
 
     await adapter._handle_message(message)
 
     adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discord_unknown_thread_accepts_body_mention(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    thread = FakeThread(channel_id=790, name="some thread")
+    bot = adapter._client.user
+    message = make_message(
+        channel=thread,
+        content=f"<@{bot.id}> hello from unknown thread",
+        mentions=[bot],
+    )
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_discord_strips_raw_at_id_mention(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    bot = adapter._client.user
+    peer = SimpleNamespace(id=77003, bot=True, display_name="PeerBot", name="PeerBot")
+    message = make_message(
+        channel=FakeTextChannel(channel_id=321),
+        content=f"yo @{bot.id} there",
+        mentions=[],
+        author=peer,
+    )
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "yo  there"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Peer-bot traffic can loop when Discord fills `message.mentions` from reply pings without a real body @. Humans still rely on `message.mentions` and the existing `in_bot_thread` bypass.

## Changes
- **`_discord_body_mentions_user`**: detect `<@id>`, `<@!id>`, plain `@id` in text.
- **`DISCORD_ALLOW_BOTS=mentions`**: other bots must include a body @ (not API mentions alone).
- **`require_mention`**: peer bots always need a body @ in non–free-response channels; humans unchanged (`message.mentions` + thread participation skip).
- **`DISCORD_IGNORE_NO_MENTION`**: peer bots use body check; humans use `message.mentions`.

## Tests
`tests/gateway/test_discord_free_response.py`, `tests/gateway/test_discord_bot_filter.py` updated (29 tests).

## Note
Branch name uses the requested spelling `fix/messasging-bot-reply-loop`.

Made with [Cursor](https://cursor.com)