### PR TITLE
fix(env): harden ToolContext file transfers against shell and path bugs

### DIFF
--- a/environments/tool_context.py
+++ b/environments/tool_context.py
@@ -26,6 +26,7 @@ Example usage in a compute_reward():
 import json
 import logging
 import os
+import shlex
 from typing import Any, Dict, List, Optional
 
 import asyncio
@@ -39,6 +40,11 @@ logger = logging.getLogger(__name__)
 
 # Thread pool for running sync tool calls that internally use asyncio.run()
 _tool_executor = concurrent.futures.ThreadPoolExecutor(max_workers=4)
+
+
+def _shell_quote(value: str) -> str:
+    """Quote a shell operand for the sandbox's POSIX shell."""
+    return shlex.quote(str(value))
 
 
 def _run_tool_in_thread(tool_name: str, arguments: Dict[str, Any], task_id: str) -> str:
@@ -169,7 +175,7 @@ class ToolContext:
             Dict with 'exit_code' and 'output'
         """
         import base64
-        from pathlib import Path as _Path
+        from pathlib import Path as _Path, PurePosixPath
 
         local = _Path(local_path)
         if not local.exists():
@@ -179,26 +185,31 @@ class ToolContext:
         b64 = base64.b64encode(raw).decode("ascii")
 
         # Ensure parent directory exists in the sandbox
-        parent = str(_Path(remote_path).parent)
+        parent = str(PurePosixPath(remote_path).parent)
         if parent not in (".", "/"):
-            self.terminal(f"mkdir -p {parent}", timeout=10)
+            self.terminal(f"mkdir -p -- {_shell_quote(parent)}", timeout=10)
 
         # For small files, single command is fine
         chunk_size = 60_000  # ~60KB per chunk (well within shell limits)
         if len(b64) <= chunk_size:
             result = self.terminal(
-                f"printf '%s' '{b64}' | base64 -d > {remote_path}",
+                f"printf '%s' {_shell_quote(b64)} | base64 -d > {_shell_quote(remote_path)}",
                 timeout=30,
             )
         else:
             # For larger files, write base64 in chunks then decode
             tmp_b64 = "/tmp/_hermes_upload.b64"
-            self.terminal(f": > {tmp_b64}", timeout=5)  # truncate
+            tmp_b64_q = _shell_quote(tmp_b64)
+            remote_path_q = _shell_quote(remote_path)
+            self.terminal(f": > {tmp_b64_q}", timeout=5)  # truncate
             for i in range(0, len(b64), chunk_size):
                 chunk = b64[i : i + chunk_size]
-                self.terminal(f"printf '%s' '{chunk}' >> {tmp_b64}", timeout=15)
+                self.terminal(
+                    f"printf '%s' {_shell_quote(chunk)} >> {tmp_b64_q}",
+                    timeout=15,
+                )
             result = self.terminal(
-                f"base64 -d {tmp_b64} > {remote_path} && rm -f {tmp_b64}",
+                f"base64 -d {tmp_b64_q} > {remote_path_q} && rm -f -- {tmp_b64_q}",
                 timeout=30,
             )
 
@@ -217,7 +228,7 @@ class ToolContext:
         Returns:
             List of results, one per file uploaded
         """
-        from pathlib import Path as _Path
+        from pathlib import Path as _Path, PurePosixPath
 
         local = _Path(local_dir)
         if not local.exists() or not local.is_dir():
@@ -226,8 +237,8 @@ class ToolContext:
         results = []
         for file_path in sorted(local.rglob("*")):
             if file_path.is_file():
-                relative = file_path.relative_to(local)
-                target = f"{remote_dir}/{relative}"
+                relative = file_path.relative_to(local).as_posix()
+                target = str(PurePosixPath(remote_dir) / PurePosixPath(relative))
                 results.append(self.upload_file(str(file_path), target))
         return results
 
@@ -251,7 +262,7 @@ class ToolContext:
 
         # Base64-encode the file inside the sandbox and capture output
         result = self.terminal(
-            f"base64 {remote_path} 2>/dev/null",
+            f"base64 < {_shell_quote(remote_path)} 2>/dev/null",
             timeout=30,
         )
 
@@ -291,11 +302,11 @@ class ToolContext:
         Returns:
             List of results, one per file downloaded
         """
-        from pathlib import Path as _Path
+        from pathlib import Path as _Path, PurePosixPath
 
         # List files in the remote directory
         ls_result = self.terminal(
-            f"find {remote_dir} -type f 2>/dev/null",
+            f"find {_shell_quote(remote_dir)} -type f 2>/dev/null",
             timeout=15,
         )
 
@@ -312,10 +323,12 @@ class ToolContext:
             if not remote_file:
                 continue
             # Compute the relative path to preserve directory structure
-            if remote_file.startswith(remote_dir):
-                relative = remote_file[len(remote_dir):].lstrip("/")
-            else:
-                relative = _Path(remote_file).name
+            try:
+                relative = str(
+                    PurePosixPath(remote_file).relative_to(PurePosixPath(remote_dir))
+                )
+            except ValueError:
+                relative = PurePosixPath(remote_file).name
             local_file = str(_Path(local_dir) / relative)
             results.append(self.download_file(remote_file, local_file))
 

--- a/tests/test_tool_context.py
+++ b/tests/test_tool_context.py
@@ -1,0 +1,108 @@
+"""Regression tests for environments.tool_context file-transfer helpers."""
+
+import base64
+import shlex
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from unittest.mock import MagicMock
+
+from environments.tool_context import ToolContext
+
+
+def test_upload_file_quotes_remote_paths(tmp_path, monkeypatch):
+    """upload_file() must quote remote shell operands with spaces/quotes."""
+    local_file = tmp_path / "payload.bin"
+    local_file.write_bytes(b"hello world")
+
+    commands = []
+    ctx = ToolContext("task-123")
+    monkeypatch.setattr(
+        ctx,
+        "terminal",
+        lambda command, timeout=0: commands.append((command, timeout)) or {"exit_code": 0, "output": ""},
+    )
+
+    remote_path = "/tmp/space dir/quote's/file.bin"
+    result = ctx.upload_file(str(local_file), remote_path)
+
+    assert result["exit_code"] == 0
+    assert commands[0][0] == f"mkdir -p -- {shlex.quote(str(PurePosixPath(remote_path).parent))}"
+    assert commands[1][0].endswith(f"> {shlex.quote(remote_path)}")
+
+
+def test_download_file_quotes_remote_paths(tmp_path, monkeypatch):
+    """download_file() must quote remote shell operands before base64."""
+    payload = b"downloaded bytes"
+    encoded = base64.b64encode(payload).decode("ascii")
+
+    commands = []
+    ctx = ToolContext("task-123")
+    monkeypatch.setattr(
+        ctx,
+        "terminal",
+        lambda command, timeout=0: commands.append((command, timeout)) or {"exit_code": 0, "output": encoded},
+    )
+
+    local_path = tmp_path / "result.bin"
+    remote_path = "/tmp/space dir/quote's/file.bin"
+    result = ctx.download_file(remote_path, str(local_path))
+
+    assert result == {"success": True, "bytes": len(payload)}
+    assert local_path.read_bytes() == payload
+    assert commands == [
+        (f"base64 < {shlex.quote(remote_path)} 2>/dev/null", 30),
+    ]
+
+
+def test_download_dir_avoids_prefix_confusion(tmp_path, monkeypatch):
+    """Sibling paths sharing a prefix must not be treated as descendants."""
+    downloads = []
+    commands = []
+    ctx = ToolContext("task-123")
+
+    def fake_terminal(command, timeout=0):
+        commands.append((command, timeout))
+        return {
+            "exit_code": 0,
+            "output": "/tmp/run/output.txt\n/tmp/run-extra/secret.txt\n",
+        }
+
+    monkeypatch.setattr(ctx, "terminal", fake_terminal)
+    monkeypatch.setattr(
+        ctx,
+        "download_file",
+        lambda remote, local: downloads.append((remote, local)) or {"success": True},
+    )
+
+    results = ctx.download_dir("/tmp/run", str(tmp_path))
+
+    assert results == [{"success": True}, {"success": True}]
+    assert commands == [(f"find {shlex.quote('/tmp/run')} -type f 2>/dev/null", 15)]
+    assert downloads == [
+        ("/tmp/run/output.txt", str(tmp_path / "output.txt")),
+        ("/tmp/run-extra/secret.txt", str(tmp_path / "secret.txt")),
+    ]
+
+
+def test_upload_dir_normalizes_windows_relative_paths(tmp_path, monkeypatch):
+    """upload_dir() should convert host Windows separators to POSIX remote paths."""
+    uploads = []
+    ctx = ToolContext("task-123")
+    monkeypatch.setattr(
+        ctx,
+        "upload_file",
+        lambda local, remote: uploads.append((local, remote)) or {"exit_code": 0, "output": ""},
+    )
+
+    fake_file = MagicMock()
+    fake_file.is_file.return_value = True
+    fake_file.relative_to.return_value = PureWindowsPath(r"nested\file.txt")
+    fake_file.__str__.return_value = r"C:\workspace\nested\file.txt"
+
+    monkeypatch.setattr(Path, "rglob", lambda self, pattern: [fake_file])
+
+    result = ctx.upload_dir(str(tmp_path), "/sandbox/root")
+
+    assert result == [{"exit_code": 0, "output": ""}]
+    assert uploads == [
+        (r"C:\workspace\nested\file.txt", "/sandbox/root/nested/file.txt"),
+    ]


### PR DESCRIPTION
Summary
This fixes multiple path-handling bugs in ToolContext file transfer helpers used by rollout/verifier environments.

upload_file(), download_file(), upload_dir(), and download_dir() were building shell commands with unquoted paths and using fragile string-prefix logic for remote path handling. This caused incorrect behavior for valid paths and could mis-handle downloaded file layout.

What changed
Quote remote shell operands in ToolContext file transfer commands using shlex.quote()
Treat remote sandbox paths as POSIX paths via PurePosixPath
Fix download_dir() to compute relative paths with relative_to() instead of startswith()
Normalize uploaded nested paths so Windows host separators do not leak into remote sandbox paths
Add regression tests covering:
remote paths with spaces and quotes
download_dir() prefix-collision cases such as /tmp/run vs /tmp/run-extra
Windows-style relative paths when uploading directories
Why this matters
Before this change:

file transfers could fail for perfectly valid remote paths containing spaces or quotes
download_dir("/tmp/run", ...) could incorrectly trim sibling paths that merely shared the same prefix
uploads from Windows hosts could produce incorrect remote paths inside POSIX sandboxes
These bugs affect verifier/reward tooling directly, where reliable file movement is important for reproducibility and cross-platform behavior.

Files changed
environments/tool_context.py
tests/test_tool_context.py

Testing
Added targeted regression tests for the path quoting, prefix-boundary, and Windows path normalization cases.

I was not able to run pytest in this sandbox because the environment does not currently have python/pytest available.

Optional commit message
fix(env): quote ToolContext file transfers and fix remote path handling