### PR TITLE
fix gateway stop ghosting Windows file attachments from agent replies

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -815,8 +815,9 @@ class BasePlatformAdapter(ABC):
         """
         Detect bare local file paths in response text for native media delivery.
 
-        Matches absolute paths (/...) and tilde paths (~/) ending in common
-        image or video extensions.  Validates each candidate with
+        Matches Unix absolute paths (/...), tilde paths (~/), and Windows
+        drive-absolute paths (C:\...) ending in common image or video
+        extensions.  Validates each candidate with
         ``os.path.isfile()`` to avoid false positives from URLs or
         non-existent paths.
 
@@ -836,8 +837,16 @@ class BasePlatformAdapter(ABC):
         # (?<![/:\w.]) prevents matching inside URLs (e.g. https://…/img.png)
         #             and relative paths (./foo.png)
         # (?:~/|/)    anchors to absolute or home-relative paths
+        # Match Unix absolute, home-relative, and Windows drive-absolute
+        # paths without firing on URLs or relative-path examples.
         path_re = re.compile(
-            r'(?<![/:\w.])(?:~/|/)(?:[\w.\-]+/)*[\w.\-]+\.(?:' + ext_part + r')\b',
+            r'(?<![/:\w.\\])'
+            r'(?:'
+            r'(?:~/|/)(?:[\w.\-]+/)*[\w.\-]+'
+            r'|'
+            r'[A-Za-z]:\\(?:[\w.\-]+\\)*[\w.\-]+'
+            r')'
+            r'\.(?:' + ext_part + r')\b',
             re.IGNORECASE,
         )
 

--- a/tests/gateway/test_extract_local_files.py
+++ b/tests/gateway/test_extract_local_files.py
@@ -278,10 +278,25 @@ class TestEdgeCases:
         paths, _ = _extract("File at /tmp/my file.png here")
         assert paths == []
 
-    def test_windows_path_not_matched(self):
-        """Windows-style paths should not match."""
-        paths, _ = _extract("See C:\\Users\\test\\image.png")
+    def test_windows_path_matched_when_file_exists(self):
+        """Windows drive-absolute media paths should be extracted."""
+        win_path = r"C:\Users\test\image.png"
+        paths, cleaned = _extract(
+            f"See {win_path}",
+            existing_files={win_path},
+        )
+        assert paths == [win_path]
+        assert win_path not in cleaned
+
+    def test_windows_path_skipped_when_missing(self):
+        """Non-existent Windows paths should still be ignored."""
+        win_path = r"C:\Users\test\image.png"
+        paths, cleaned = _extract(
+            f"See {win_path}",
+            existing_files=set(),
+        )
         assert paths == []
+        assert win_path in cleaned
 
     def test_relative_path_not_matched(self):
         """Relative paths like ./image.png should not match."""


### PR DESCRIPTION
### What changed
This fixes a cross-platform bug in gateway media delivery on Windows.
`BasePlatformAdapter.extract_local_files()` previously only detected Unix-style absolute paths (`/...`) and home-relative paths (`~/...`) when scanning agent responses for local media files to send as native attachments. That meant Windows drive-absolute paths like `C:\Users\...\image.png` were ignored entirely, even when the file existed on disk.

With this change, the gateway now recognizes Windows absolute media paths as valid local attachments alongside the existing Unix path handling.

### Why this matters
Hermes is supposed to work well across Linux, macOS, and Windows. In practice, this bug caused a pretty noticeable Windows regression:
- The agent could generate or reference a real local screenshot/video/audio file.
- The gateway would fail to detect that path.
- The platform adapter would never send the file as a native attachment.
- Users would just see plain text containing a Windows path instead of the actual media.

### Implementation details
The change updates the local file extraction regex to support:
- Unix absolute paths like `/tmp/image.png`
- Home-relative paths like `~/image.png`
- Windows drive-absolute paths like `C:\Users\name\image.png`

**Safeguards preserved:**
- Still requires `os.path.isfile()`
- Ignores paths inside fenced code blocks and inline code.
- Avoids matching relative paths and URL fragments.

### Tests
Added coverage for the Windows-specific behavior:
- Extracts an existing Windows absolute media path.
- Skips a non-existent Windows absolute media path.

### Notes
This is intentionally scoped to drive-absolute Windows paths only to keep false positives low.