### PR TITLE
fix(delegation): preserve child workspace hints and queue busy input while subagents run

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6238,6 +6238,18 @@ class HermesCLI:
             except Exception:
                 pass
 
+    def _should_queue_busy_input(self) -> bool:
+        """Return True when busy input should be queued instead of interrupting.
+
+        Queue mode always queues. In interrupt mode, we still prefer queueing when
+        active delegated child agents are running, because interrupting the parent
+        will propagate to those children and discard in-flight delegated work.
+        """
+        if getattr(self, "busy_input_mode", "interrupt") == "queue":
+            return True
+        agent = getattr(self, "agent", None)
+        children = getattr(agent, "_active_children", None) or []
+        return bool(children)
 
     def chat(self, message, images: list = None) -> Optional[str]:
         """
@@ -6450,6 +6462,9 @@ class HermesCLI:
                             # input directly; this queue shouldn't have anything.
                             # But if it does (race condition), don't interrupt.
                             if self._clarify_state or self._clarify_freetext:
+                                continue
+                            if self._should_queue_busy_input():
+                                self._pending_input.put(interrupt_msg)
                                 continue
                             print("\n⚡ New message detected, interrupting...")
                             # Signal TTS to stop on interrupt
@@ -7074,7 +7089,7 @@ class HermesCLI:
                 # Bundle text + images as a tuple when images are present
                 payload = (text, images) if images else text
                 if self._agent_running and not (text and _looks_like_slash_command(text)):
-                    if self.busy_input_mode == "queue":
+                    if self._should_queue_busy_input():
                         # Queue for the next turn instead of interrupting
                         self._pending_input.put(payload)
                         preview = text if text else f"[{len(images)} image{'s' if len(images) != 1 else ''} attached]"

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -148,6 +148,22 @@ class TestBusyInputMode:
         assert cli._interrupt_queue.get_nowait() == "redirect"
         assert cli._pending_input.empty()
 
+    def test_active_subagents_force_queue_even_in_interrupt_mode(self):
+        cli = _make_cli()
+        cli._agent_running = True
+        cli.agent = MagicMock()
+        cli.agent._active_children = [MagicMock()]
+        assert cli.busy_input_mode == "interrupt"
+        assert cli._should_queue_busy_input() is True
+
+    def test_no_active_subagents_keeps_interrupt_mode_behavior(self):
+        cli = _make_cli()
+        cli._agent_running = True
+        cli.agent = MagicMock()
+        cli.agent._active_children = []
+        assert cli.busy_input_mode == "interrupt"
+        assert cli._should_queue_busy_input() is False
+
 
 class TestSingleQueryState:
     def test_voice_and_interrupt_state_initialized_before_run(self):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -74,12 +74,23 @@ class TestChildSystemPrompt(unittest.TestCase):
         self.assertIn("Fix the tests", prompt)
         self.assertIn("YOUR TASK", prompt)
         self.assertNotIn("CONTEXT", prompt)
+        self.assertIn("Never assume a repository lives at", prompt)
 
     def test_goal_with_context(self):
         prompt = _build_child_system_prompt("Fix the tests", "Error: assertion failed in test_foo.py line 42")
         self.assertIn("Fix the tests", prompt)
         self.assertIn("CONTEXT", prompt)
         self.assertIn("assertion failed", prompt)
+
+    def test_goal_with_workspace_hint(self):
+        prompt = _build_child_system_prompt(
+            "Inspect the repo",
+            "Need local validation",
+            workspace_path="/home/ubuntu/.hermes/hermes-agent",
+        )
+        self.assertIn("WORKSPACE PATH", prompt)
+        self.assertIn("/home/ubuntu/.hermes/hermes-agent", prompt)
+        self.assertIn("Use this exact path", prompt)
 
     def test_empty_context_ignored(self):
         prompt = _build_child_system_prompt("Do something", "  ")
@@ -126,6 +137,29 @@ class TestDelegateTask(unittest.TestCase):
         parent = _make_mock_parent()
         result = json.loads(delegate_task(tasks=[{"context": "no goal here"}], parent_agent=parent))
         self.assertIn("error", result)
+
+    @patch("run_agent.AIAgent")
+    def test_child_prompt_includes_workspace_hint_when_parent_cwd_is_repo(self, MockAgent):
+        parent = _make_mock_parent()
+        mock_child = MagicMock()
+        MockAgent.return_value = mock_child
+
+        with patch("tools.delegate_tool.os.getenv", return_value="/home/ubuntu/.hermes/hermes-agent"), \
+             patch("tools.delegate_tool.os.path.isdir", return_value=True):
+            _build_child_agent(
+                task_index=0,
+                goal="Inspect repo",
+                context="Need local git commands",
+                toolsets=["terminal"],
+                model=None,
+                max_iterations=5,
+                parent_agent=parent,
+            )
+
+        _, kwargs = MockAgent.call_args
+        prompt = kwargs["ephemeral_system_prompt"]
+        self.assertIn("WORKSPACE PATH", prompt)
+        self.assertIn("/home/ubuntu/.hermes/hermes-agent", prompt)
 
     @patch("tools.delegate_tool._run_single_child")
     def test_single_task_mode(self, mock_run):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -45,7 +45,12 @@ def check_delegate_requirements() -> bool:
     return True
 
 
-def _build_child_system_prompt(goal: str, context: Optional[str] = None) -> str:
+def _build_child_system_prompt(
+    goal: str,
+    context: Optional[str] = None,
+    *,
+    workspace_path: Optional[str] = None,
+) -> str:
     """Build a focused system prompt for a child agent."""
     parts = [
         "You are a focused subagent working on a specific delegated task.",
@@ -54,6 +59,12 @@ def _build_child_system_prompt(goal: str, context: Optional[str] = None) -> str:
     ]
     if context and context.strip():
         parts.append(f"\nCONTEXT:\n{context}")
+    if workspace_path and str(workspace_path).strip():
+        parts.append(
+            "\nWORKSPACE PATH:\n"
+            f"{workspace_path}\n"
+            "Use this exact path for local repository/workdir operations unless the task explicitly says otherwise."
+        )
     parts.append(
         "\nComplete this task using the tools available to you. "
         "When finished, provide a clear, concise summary of:\n"
@@ -61,6 +72,8 @@ def _build_child_system_prompt(goal: str, context: Optional[str] = None) -> str:
         "- What you found or accomplished\n"
         "- Any files you created or modified\n"
         "- Any issues encountered\n\n"
+        "Important workspace rule: Never assume a repository lives at /workspace/... or any other container-style path unless the task/context explicitly gives that path. "
+        "If no exact local path is provided, discover it first before issuing git/workdir-specific commands.\n\n"
         "Be thorough but concise -- your response is returned to the "
         "parent agent as a summary."
     )
@@ -73,6 +86,31 @@ def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
         "delegation", "clarify", "memory", "code_execution",
     }
     return [t for t in toolsets if t not in blocked_toolset_names]
+
+
+def _resolve_workspace_hint(parent_agent) -> Optional[str]:
+    """Best-effort local workspace hint for child prompts.
+
+    We only inject a path when we have a concrete absolute directory. This avoids
+    teaching subagents a fake container path while still helping them avoid
+    guessing `/workspace/...` for local repo tasks.
+    """
+    candidates = [
+        os.getenv("TERMINAL_CWD"),
+        getattr(getattr(parent_agent, "_subdirectory_hints", None), "working_dir", None),
+        getattr(parent_agent, "terminal_cwd", None),
+        getattr(parent_agent, "cwd", None),
+    ]
+    for candidate in candidates:
+        if not candidate:
+            continue
+        try:
+            text = os.path.abspath(os.path.expanduser(str(candidate)))
+        except Exception:
+            continue
+        if os.path.isabs(text) and os.path.isdir(text):
+            return text
+    return None
 
 
 def _build_child_progress_callback(task_index: int, parent_agent, task_count: int = 1) -> Optional[callable]:
@@ -194,7 +232,8 @@ def _build_child_agent(
     else:
         child_toolsets = _strip_blocked_tools(DEFAULT_TOOLSETS)
 
-    child_prompt = _build_child_system_prompt(goal, context)
+    workspace_hint = _resolve_workspace_hint(parent_agent)
+    child_prompt = _build_child_system_prompt(goal, context, workspace_path=workspace_hint)
     # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
     parent_api_key = getattr(parent_agent, "api_key", None)
     if (not parent_api_key) and hasattr(parent_agent, "_client_kwargs"):


### PR DESCRIPTION
## Summary
- inject a concrete local workspace hint into delegated child prompts when Hermes knows the parent workspace path
- explicitly steer child agents away from guessing container-style paths like `/workspace/...` for local repo tasks
- queue busy input instead of interrupting when delegated child agents are still active in the CLI

## Problem
A real delegated batch hit two separate failure modes at once:

1. A child agent guessed an invalid local workdir (`/workspace/hermes-agent`) and immediately failed terminal calls on the local backend.
2. While other children were still running, a follow-up user message triggered the parent interrupt path, which propagated to active children and discarded in-flight delegated work.

These are independent failures, so fixing only one still leaves the delegation flow fragile.

## Root cause
### 1. Missing explicit workspace hint for child agents
Repo-centric child tasks had enough context to know they should inspect a repository, but not enough to know the exact local path. In that situation, the child could guess a container-style path and emit invalid terminal tool calls.

### 2. CLI interrupt policy was too aggressive during active delegation
`display.busy_input_mode: interrupt` is reasonable for a single active agent, but when delegated child agents are still running it is too destructive. Interrupting the parent propagates directly to active children, which turns an ordinary follow-up message into delegated work loss.

## What changed
### Delegation workspace hinting
- extended `tools/delegate_tool.py:_build_child_system_prompt()` with an optional `workspace_path`
- added explicit prompt guidance telling child agents not to assume `/workspace/...` unless that path is explicitly provided
- added `_resolve_workspace_hint(parent_agent)` to derive a best-effort absolute local path from the parent runtime (`TERMINAL_CWD`, subdirectory hints, or parent cwd fields)
- `_build_child_agent()` now injects that workspace hint into the child prompt when available

### Busy-input handling during active child runs
- added `HermesCLI._should_queue_busy_input()`
- queue mode still always queues
- interrupt mode now also queues when delegated child agents are active
- applied the guard in both:
  - busy Enter-path input handling
  - the interrupt-monitor loop inside `HermesCLI.chat()`

This preserves the normal interrupt behavior when no children are active, while protecting active delegated work from being aborted by a routine follow-up message.

## Files changed
- `tools/delegate_tool.py`
- `cli.py`
- `tests/tools/test_delegate.py`
- `tests/test_cli_init.py`

## Validation
### Focused tests on the patched checkout
- [x] `uv run pytest tests/tools/test_delegate.py -q -o addopts=''`
- [x] `uv run pytest tests/test_cli_init.py -q -o addopts=''`
- [x] `uv run pytest tests/test_real_interrupt_subagent.py -q -o addopts=''`

### Focused tests on a clean worktree from latest `origin/main`
Applied the patch on top of a clean worktree created from the latest upstream `main`, then ran:
- [x] `uv run pytest tests/tools/test_delegate.py -q -o addopts=''`
- [x] `uv run pytest tests/test_cli_init.py -q -o addopts=''`
- [x] `uv run pytest tests/test_real_interrupt_subagent.py -q -o addopts=''`

### Additional runtime smoke
Ran a small runtime harness against the clean worktree to verify the intended CLI behavior:
- with active child agents, a second message was queued and `interrupt()` was not called
- without active child agents, the same second message still followed the normal interrupt path

## Why this shape
This keeps the change small and local:
- prompt shaping solves the invalid guessed workdir case without inventing new delegation API surface
- CLI queueing only activates for the risky case (active child agents), so the existing interrupt UX remains intact elsewhere
