### PR TITLE
Harden tool result failure detection for status/error contract

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -777,29 +777,53 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
     if result is None:
         return False, ""
 
+    def _error_from_structured_payload(data: dict, *, strict_status: bool = True) -> tuple[bool, str]:
+        """Enforce optional status/error contract for structured tool output."""
+        status = data.get("status")
+        if strict_status and status is not None:
+            status_str = str(status)
+            if status_str.lower() != "ok":
+                return True, f" [status={status_str}]"
+
+        err = data.get("error")
+        if err is not None and str(err).strip():
+            return True, " [error]"
+        return False, ""
+
     if tool_name == "terminal":
         try:
             data = json.loads(result)
+            if isinstance(data, dict):
+                is_error, suffix = _error_from_structured_payload(data)
+                if is_error:
+                    return True, suffix
             exit_code = data.get("exit_code")
             if exit_code is not None and exit_code != 0:
                 return True, f" [exit {exit_code}]"
         except (json.JSONDecodeError, TypeError, AttributeError):
-            logger.debug("Could not parse terminal result as JSON for exit code check")
-        return False, ""
+            logger.debug("Could not parse terminal result as JSON for status/exit check")
 
     # Memory-specific: distinguish "full" from real errors
     if tool_name == "memory":
         try:
             data = json.loads(result)
-            if data.get("success") is False and "exceed the limit" in data.get("error", ""):
+            if isinstance(data, dict) and data.get("success") is False and "exceed the limit" in data.get("error", ""):
                 return True, " [full]"
         except (json.JSONDecodeError, TypeError, AttributeError):
             logger.debug("Could not parse memory result as JSON for capacity check")
 
-    # Generic heuristic for non-terminal tools
+    # Generic heuristic for non-terminal tools (and fallback for non-JSON outputs)
     lower = result[:500].lower()
-    if '"error"' in lower or '"failed"' in lower or result.startswith("Error"):
+    if result.startswith("Error") or '"error"' in lower or '"failed"' in lower:
         return True, " [error]"
+    try:
+        data = json.loads(result)
+        if isinstance(data, dict):
+            is_error, suffix = _error_from_structured_payload(data, strict_status=True)
+            if is_error:
+                return True, suffix
+    except (json.JSONDecodeError, TypeError, AttributeError):
+        logger.debug("Could not parse result as JSON for structured tool-failure check")
 
     return False, ""
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -396,8 +396,8 @@ class TestDelegateObservability(unittest.TestCase):
         with patch("run_agent.AIAgent") as MockAgent:
             mock_child = MagicMock()
             mock_child.model = "claude-sonnet-4-6"
-            mock_child.session_prompt_tokens = 0
-            mock_child.session_completion_tokens = 0
+            mock_child.session_prompt_tokens = 5000
+            mock_child.session_completion_tokens = 1200
             mock_child.run_conversation.return_value = {
                 "final_response": "failed",
                 "completed": True,
@@ -415,6 +415,34 @@ class TestDelegateObservability(unittest.TestCase):
             result = json.loads(delegate_task(goal="Test error trace", parent_agent=parent))
             trace = result["results"][0]["tool_trace"]
             self.assertEqual(trace[0]["status"], "error")
+
+    def test_tool_trace_obeys_status_contract(self):
+        """Structured tool results must be error when status is not 'ok'."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 5000
+            mock_child.session_completion_tokens = 1200
+            mock_child.run_conversation.return_value = {
+                "final_response": "failed",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [
+                    {"role": "assistant", "tool_calls": [
+                        {"id": "tc_1", "function": {"name": "terminal", "arguments": '{"cmd": "echo ok"}'}}
+                    ]},
+                    {"role": "tool", "tool_call_id": "tc_1", "content": '{"status": "error", "error": "xero_post_update_verification_failed"}'},
+                ],
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(delegate_task(goal="Test status contract", parent_agent=parent))
+            trace = result["results"][0]["tool_trace"]
+            self.assertEqual(trace[0]["status"], "error")
+            self.assertEqual(trace[0]["error"], "tool status 'error'")
 
     def test_parallel_tool_calls_paired_correctly(self):
         """Parallel tool calls should each get their own result via tool_call_id matching."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -318,14 +318,42 @@ def _run_single_child(
                         if tc_id:
                             trace_by_id[tc_id] = entry_t
                 elif msg.get("role") == "tool":
-                    content = msg.get("content", "")
-                    is_error = bool(
-                        content and "error" in content[:80].lower()
-                    )
+                    raw_content = msg.get("content", "")
+                    content = raw_content if isinstance(raw_content, str) else str(raw_content)
+                    reason = None
+
+                    def _classify_tool_result(value: str) -> tuple[str, str | None]:
+                        if not value:
+                            return "ok", None
+                        try:
+                            payload = json.loads(value)
+                        except (json.JSONDecodeError, TypeError):
+                            payload = None
+
+                        if isinstance(payload, dict):
+                            status = payload.get("status")
+                            if status is not None and str(status).lower() != "ok":
+                                return "error", f"tool status {status!r}"
+
+                            err = payload.get("error")
+                            if err is not None and str(err).strip():
+                                return "error", str(err)
+
+                        if "error" in value[:80].lower():
+                            return "error", "tool result contains error marker"
+                        if "failed" in value[:80].lower():
+                            return "error", "tool result contains failure marker"
+                        if value.startswith("Error"):
+                            return "error", "tool result starts with Error"
+                        return "ok", None
+
+                    status, reason = _classify_tool_result(content)
                     result_meta = {
                         "result_bytes": len(content),
-                        "status": "error" if is_error else "ok",
+                        "status": status,
                     }
+                    if reason:
+                        result_meta["error"] = reason
                     # Match by tool_call_id for parallel calls
                     tc_id = msg.get("tool_call_id")
                     target = trace_by_id.get(tc_id) if tc_id else None


### PR DESCRIPTION
## Context
Addressed a bug where caller-layer tool handling could treat structured non-ok outputs as success for job-manager material_purchase and other flows.

## Changes
- agent/display.py: _detect_tool_failure now checks structured JSON result payloads (status != "ok" and error field) as failure, including terminal/fallback checks.
- tools/delegate_tool.py: tool result trace now marks status error when structured status != "ok" or error field present.
- tests/tools/test_delegate.py: added regression test to assert status contract is enforced in tool traces.

## Notes
- Kept changes surgical and focused on caller-layer contract.
