### PR TITLE
fix: /model --global writes model.name instead of model.default

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3721,7 +3721,7 @@ class HermesCLI:
 
         # Persistence
         if persist_global:
-            save_config_value("model.name", result.new_model)
+            save_config_value("model.default", result.new_model)
             if result.provider_changed:
                 save_config_value("model.provider", result.target_provider)
             _cprint("    Saved to config.yaml (--global)")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3481,7 +3481,7 @@ class GatewayRunner:
                     cfg = yaml.safe_load(f) or {}
                 model_cfg = cfg.get("model", {})
                 if isinstance(model_cfg, dict):
-                    current_model = model_cfg.get("name", "")
+                    current_model = model_cfg.get("default", "")
                     current_provider = model_cfg.get("provider", current_provider)
                     current_base_url = model_cfg.get("base_url", "")
                 user_provs = cfg.get("providers")
@@ -3591,7 +3591,7 @@ class GatewayRunner:
                 else:
                     cfg = {}
                 model_cfg = cfg.setdefault("model", {})
-                model_cfg["name"] = result.new_model
+                model_cfg["default"] = result.new_model
                 model_cfg["provider"] = result.target_provider
                 if result.base_url:
                     model_cfg["base_url"] = result.base_url


### PR DESCRIPTION
## Bug

`/model <name> --global` persists the model name under `model.name` in config.yaml, but every other part of the codebase reads `model.default`:

- `hermes setup`, `hermes login` → write `model.default`
- `_resolve_gateway_model()` → reads `model.default`
- `runtime_provider._get_model_config()` → reads `model.default`
- `hermes profile list` → reads `model.default`
- CLI startup (`main.py`) → reads `model.default`

This means after `/model claude-opus-4-6 --global`:
- `hermes profile list` shows the **old** model
- A gateway restart **reverts** to the old model
- A new CLI session uses the **old** model
- Only the gateway's own `/model` display reads `name` and shows the correct model

The switch appeared to work in Telegram because the cached agent object was updated in-place — the config was never actually read back correctly.

## Fix

3 lines: change the 2 gateway sites and 1 CLI site to use `model.default` (the canonical key) instead of `model.name`.

| File | Line | Change |
|------|------|--------|
| `gateway/run.py` | 3484 | Read: `model_cfg.get("name")` → `model_cfg.get("default")` |
| `gateway/run.py` | 3594 | Write: `model_cfg["name"]` → `model_cfg["default"]` |
| `cli.py` | 3724 | Write: `"model.name"` → `"model.default"` |