### PR TITLE
fix: model alias fallback resolves to authenticated providers instead of hardcoded openrouter/nous

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -339,12 +339,37 @@ def resolve_alias(
     return None
 
 
+def get_authenticated_provider_slugs(
+    current_provider: str = "",
+    user_providers: dict = None,
+) -> list[str]:
+    """Return slugs of providers that have credentials.
+
+    Uses ``list_authenticated_providers()`` which is backed by the models.dev
+    in-memory cache (1 hr TTL) — no extra network cost.
+    """
+    try:
+        providers = list_authenticated_providers(
+            current_provider=current_provider,
+            user_providers=user_providers,
+            max_models=0,
+        )
+        return [p["slug"] for p in providers]
+    except Exception:
+        return []
+
+
 def _resolve_alias_fallback(
     raw_input: str,
-    fallback_providers: tuple[str, ...] = ("openrouter", "nous"),
+    authenticated_providers: list[str] = (),
 ) -> Optional[tuple[str, str, str]]:
-    """Try to resolve an alias on fallback providers."""
-    for provider in fallback_providers:
+    """Try to resolve an alias on the user's authenticated providers.
+
+    Falls back to ``("openrouter", "nous")`` only when no authenticated
+    providers are supplied (backwards compat for non-interactive callers).
+    """
+    providers = authenticated_providers or ("openrouter", "nous")
+    for provider in providers:
         result = resolve_alias(raw_input, provider)
         if result is not None:
             return result
@@ -494,7 +519,11 @@ def switch_model(
             # --- Step b: Alias exists but not on current provider -> fallback ---
             key = raw_input.strip().lower()
             if key in MODEL_ALIASES:
-                fallback_result = _resolve_alias_fallback(raw_input)
+                authed = get_authenticated_provider_slugs(
+                    current_provider=current_provider,
+                    user_providers=user_providers,
+                )
+                fallback_result = _resolve_alias_fallback(raw_input, authed)
                 if fallback_result is not None:
                     target_provider, new_model, resolved_alias = fallback_result
                     logger.debug(


### PR DESCRIPTION
## Bug

When an alias like `claude` can't be resolved on the current provider (e.g. user is on z.ai), `_resolve_alias_fallback()` tries other providers. It hardcodes `("openrouter", "nous")` — so `/model claude` resolves to openrouter even if the user has no openrouter credentials but does have anthropic configured.

Example: user has anthropic, openai, z.ai. Types `/model claude` while on z.ai:
- z.ai has no claude models → alias fallback triggers
- Fallback tries openrouter first → finds claude there → switches to openrouter
- User gets credential errors or wrong provider

Expected: fallback should try anthropic (which the user has) and find claude there.

## Fix

- New `get_authenticated_provider_slugs()` helper — returns slugs of providers that have credentials, using `list_authenticated_providers()` (backed by models.dev in-memory cache, no network cost)
- `_resolve_alias_fallback()` now accepts an `authenticated_providers` list and tries those first
- Falls back to `("openrouter", "nous")` only when no authenticated providers are supplied (backwards compat)
- `switch_model()` step b passes the authenticated provider list to the fallback

## Files changed

`hermes_cli/model_switch.py` — 1 new function, 1 modified function, 1 modified call site