### PR TITLE
Add "grok" to TOOL_USE_ENFORCEMENT_MODELS for direct xAI usage

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -187,7 +187,7 @@ TOOL_USE_ENFORCEMENT_GUIDANCE = (
 
 # Model name substrings that trigger tool-use enforcement guidance.
 # Add new patterns here when a model family needs explicit steering.
-TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex", "gemini", "gemma")
+TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex", "gemini", "gemma", "grok")
 
 # Gemini/Gemma-specific operational guidance, adapted from OpenCode's gemini.txt.
 # Injected alongside TOOL_USE_ENFORCEMENT_GUIDANCE when the model is Gemini or Gemma.


### PR DESCRIPTION
When using Grok models via the direct xAI endpoint (`provider: custom` + `base_url: https://api.x.ai/v1`), the model frequently narrates what it plans to do instead of immediately calling tools.

This happens even though `TOOL_USE_ENFORCEMENT_GUIDANCE` exists.

**Proposed fix:**

```diff
- TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex", "gemini", "gemma")
+ TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex", "gemini", "gemma", "grok")
```

This one-line change (in `agent/prompt_builder.py`) makes Grok receive the strict "You MUST use your tools..." instruction on every turn, just like the other models.

Already running successfully in production on several AaaS client instances.

---

**Additional context:**
- A similar fix was needed for other models in the past (see GPT_TOOL_USE_GUIDANCE in the release notes).
- Particularly important for users configuring custom providers pointing to x.ai.