### PR TITLE
feat(skills): skills.shared shorthand for cross-profile sharing

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -167,6 +167,67 @@ def _normalize_string_set(values) -> Set[str]:
     return {str(v).strip() for v in values if str(v).strip()}
 
 
+# ── Shared skills directory ──────────────────────────────────────────────
+
+# Conventional directory for skills that are shared across multiple profiles
+# on a single host. Referenced by the ``skills.shared`` config shorthand,
+# which lists skill names (subdirectories under this path) to include in a
+# profile's skill search path. Unlike ``skills.external_dirs`` (which takes
+# arbitrary directory paths), this gives a single rooted convention so users
+# can list shared skills by name and the location is implicit.
+DEFAULT_SHARED_SKILLS = Path.home() / ".hermes" / "shared-skills"
+
+
+def get_shared_skill_dirs() -> List[Path]:
+    """Resolve ``skills.shared`` config entries to directories.
+
+    Reads ``skills.shared`` from the active profile's ``config.yaml`` —
+    a list of skill names — and returns the corresponding subdirectories
+    under ``~/.hermes/shared-skills/`` that actually exist.
+
+    Each name must be a bare directory name (no slashes, no leading dot).
+    Invalid names and missing directories are silently skipped so a typo
+    or a half-provisioned host doesn't break the agent.
+    """
+    config_path = get_hermes_home() / "config.yaml"
+    if not config_path.exists():
+        return []
+    try:
+        parsed = yaml_load(config_path.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+    if not isinstance(parsed, dict):
+        return []
+
+    skills_cfg = parsed.get("skills")
+    if not isinstance(skills_cfg, dict):
+        return []
+
+    raw = skills_cfg.get("shared")
+    if not raw:
+        return []
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, list):
+        return []
+
+    result: List[Path] = []
+    for entry in raw:
+        name = str(entry).strip()
+        if not name or "/" in name or "\\" in name or name.startswith("."):
+            # Reject path traversal and hidden directories
+            logger.debug("Skipping invalid skills.shared entry: %r", entry)
+            continue
+        skill_dir = DEFAULT_SHARED_SKILLS / name
+        if skill_dir.is_dir():
+            result.append(skill_dir)
+        else:
+            logger.debug(
+                "Shared skill '%s' not found at %s, skipping", name, skill_dir
+            )
+    return result
+
+
 # ── External skills directories ──────────────────────────────────────────
 
 
@@ -224,13 +285,37 @@ def get_external_skills_dirs() -> List[Path]:
 
 
 def get_all_skills_dirs() -> List[Path]:
-    """Return all skill directories: local ``~/.hermes/skills/`` first, then external.
+    """Return all skill directories in precedence order:
 
-    The local dir is always first (and always included even if it doesn't exist
-    yet — callers handle that).  External dirs follow in config order.
+    1. Profile-local ``HERMES_HOME/skills/`` (read/write, highest precedence)
+    2. Shared skills named in ``skills.shared`` config, resolved to
+       subdirectories of ``~/.hermes/shared-skills/``
+    3. Entries from ``skills.external_dirs`` in ``config.yaml``
+
+    The profile-local dir is always first and always included (even if it
+    doesn't exist yet — callers handle that). Duplicates (same resolved
+    path) are filtered: a path that appears in both ``skills.shared`` and
+    ``skills.external_dirs``, or that resolves to the local skills dir,
+    will appear at most once.
     """
-    dirs = [get_hermes_home() / "skills"]
-    dirs.extend(get_external_skills_dirs())
+    local_skills = (get_hermes_home() / "skills").resolve()
+    dirs: List[Path] = [get_hermes_home() / "skills"]
+    seen: Set[Path] = {local_skills}
+
+    for p in get_shared_skill_dirs():
+        rp = p.resolve()
+        if rp in seen:
+            continue
+        seen.add(rp)
+        dirs.append(p)
+
+    for p in get_external_skills_dirs():
+        rp = p.resolve()
+        if rp in seen:
+            continue
+        seen.add(rp)
+        dirs.append(p)
+
     return dirs
 
 

--- a/tests/agent/test_external_skills.py
+++ b/tests/agent/test_external_skills.py
@@ -155,3 +155,205 @@ class TestExternalSkillView:
             result = json.loads(skill_view("my-external-skill"))
         assert result["success"] is True
         assert "external things" in result["content"]
+
+
+# ---------------------------------------------------------------------------
+# Shared skills (skills.shared config + ~/.hermes/shared-skills/ convention)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def shared_skills_root(tmp_path, monkeypatch):
+    """Create ~/.hermes/shared-skills/ under a fake HOME and return its path."""
+    fake_home = tmp_path / "fakehome"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    # Re-import skill_utils so DEFAULT_SHARED_SKILLS picks up the patched HOME.
+    # Path.home() is evaluated lazily inside the helper, so we just need the
+    # env var to be set before each call.
+    shared_root = fake_home / ".hermes" / "shared-skills"
+    shared_root.mkdir(parents=True)
+    return shared_root
+
+
+def _make_shared_skill(shared_root, name, description="A shared skill"):
+    skill_dir = shared_root / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n\n# {name}\n\nShared step.\n"
+    )
+    return skill_dir
+
+
+class TestGetSharedSkillDirs:
+    def test_no_shared_config_returns_empty(self, hermes_home, shared_skills_root, monkeypatch):
+        _make_shared_skill(shared_skills_root, "available")
+        # config.yaml has no skills.shared key
+        (hermes_home / "config.yaml").write_text("skills:\n  external_dirs: []\n")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        # Force-reload the module so DEFAULT_SHARED_SKILLS reflects patched HOME
+        import importlib, agent.skill_utils as su
+        importlib.reload(su)
+        assert su.get_shared_skill_dirs() == []
+
+    def test_shared_skill_resolved_by_name(self, hermes_home, shared_skills_root, monkeypatch):
+        _make_shared_skill(shared_skills_root, "team-runbook")
+        (hermes_home / "config.yaml").write_text(
+            "skills:\n  shared:\n    - team-runbook\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        import importlib, agent.skill_utils as su
+        importlib.reload(su)
+        result = su.get_shared_skill_dirs()
+        assert len(result) == 1
+        assert result[0].name == "team-runbook"
+        assert result[0].resolve() == (shared_skills_root / "team-runbook").resolve()
+
+    def test_missing_shared_skill_silently_skipped(self, hermes_home, shared_skills_root, monkeypatch):
+        _make_shared_skill(shared_skills_root, "exists")
+        (hermes_home / "config.yaml").write_text(
+            "skills:\n  shared:\n    - exists\n    - does-not-exist\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        import importlib, agent.skill_utils as su
+        importlib.reload(su)
+        result = su.get_shared_skill_dirs()
+        assert len(result) == 1
+        assert result[0].name == "exists"
+
+    def test_path_traversal_rejected(self, hermes_home, shared_skills_root, monkeypatch):
+        _make_shared_skill(shared_skills_root, "ok")
+        (hermes_home / "config.yaml").write_text(
+            "skills:\n  shared:\n    - ok\n    - ../../etc\n    - foo/bar\n    - .hidden\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        import importlib, agent.skill_utils as su
+        importlib.reload(su)
+        result = su.get_shared_skill_dirs()
+        # Only "ok" is accepted; the malicious / structural entries are dropped.
+        assert len(result) == 1
+        assert result[0].name == "ok"
+
+    def test_string_value_converted_to_list(self, hermes_home, shared_skills_root, monkeypatch):
+        _make_shared_skill(shared_skills_root, "alone")
+        (hermes_home / "config.yaml").write_text(
+            "skills:\n  shared: alone\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        import importlib, agent.skill_utils as su
+        importlib.reload(su)
+        assert len(su.get_shared_skill_dirs()) == 1
+
+
+class TestSharedInGetAllSkillsDirs:
+    def test_shared_appears_after_local_before_external(self, hermes_home, external_skills_dir, shared_skills_root, monkeypatch):
+        _make_shared_skill(shared_skills_root, "team-runbook")
+        (hermes_home / "config.yaml").write_text(
+            "skills:\n"
+            "  shared:\n    - team-runbook\n"
+            f"  external_dirs:\n    - {external_skills_dir}\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        import importlib, agent.skill_utils as su
+        importlib.reload(su)
+        dirs = su.get_all_skills_dirs()
+        # Order: local, shared, external
+        assert dirs[0] == hermes_home / "skills"
+        assert dirs[1].resolve() == (shared_skills_root / "team-runbook").resolve()
+        assert dirs[2].resolve() == external_skills_dir.resolve()
+
+    def test_no_shared_config_backward_compat(self, hermes_home, external_skills_dir, shared_skills_root, monkeypatch):
+        # No skills.shared key — must behave exactly as before this PR
+        (hermes_home / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {external_skills_dir}\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        import importlib, agent.skill_utils as su
+        importlib.reload(su)
+        dirs = su.get_all_skills_dirs()
+        assert len(dirs) == 2
+        assert dirs[0] == hermes_home / "skills"
+        assert dirs[1].resolve() == external_skills_dir.resolve()
+
+    def test_shared_not_duplicated_when_also_in_external_dirs(self, hermes_home, shared_skills_root, monkeypatch):
+        skill_dir = _make_shared_skill(shared_skills_root, "team-runbook")
+        # User points external_dirs at the same individual skill dir AND
+        # references it via skills.shared. Should only appear once.
+        (hermes_home / "config.yaml").write_text(
+            "skills:\n"
+            "  shared:\n    - team-runbook\n"
+            f"  external_dirs:\n    - {skill_dir}\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        import importlib, agent.skill_utils as su
+        importlib.reload(su)
+        dirs = su.get_all_skills_dirs()
+        resolved = [d.resolve() for d in dirs]
+        assert resolved.count(skill_dir.resolve()) == 1
+
+
+class TestSelectiveSharingAcrossProfiles:
+    """Two profiles with different skills.shared lists each see their own subset."""
+
+    def test_profile_a_and_b_see_different_subsets(self, tmp_path, monkeypatch):
+        fake_home = tmp_path / "fakehome"
+        fake_home.mkdir()
+        monkeypatch.setenv("HOME", str(fake_home))
+        shared = fake_home / ".hermes" / "shared-skills"
+        shared.mkdir(parents=True)
+        _make_shared_skill(shared, "tool-one")
+        _make_shared_skill(shared, "tool-two")
+        _make_shared_skill(shared, "tool-three")
+
+        profile_a = tmp_path / "profile-a"
+        (profile_a / "skills").mkdir(parents=True)
+        (profile_a / "config.yaml").write_text(
+            "skills:\n  shared:\n    - tool-one\n    - tool-two\n"
+        )
+        profile_b = tmp_path / "profile-b"
+        (profile_b / "skills").mkdir(parents=True)
+        (profile_b / "config.yaml").write_text(
+            "skills:\n  shared:\n    - tool-three\n"
+        )
+
+        import importlib, agent.skill_utils as su
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_a))
+        importlib.reload(su)
+        a_dirs = [d.name for d in su.get_all_skills_dirs()]
+        assert "tool-one" in a_dirs
+        assert "tool-two" in a_dirs
+        assert "tool-three" not in a_dirs
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_b))
+        importlib.reload(su)
+        b_dirs = [d.name for d in su.get_all_skills_dirs()]
+        assert "tool-three" in b_dirs
+        assert "tool-one" not in b_dirs
+        assert "tool-two" not in b_dirs
+
+
+class TestLocalShadowsShared:
+    def test_profile_local_skill_takes_precedence_over_shared_by_position(
+        self, hermes_home, shared_skills_root, monkeypatch,
+    ):
+        # Same skill name in profile-local and shared.
+        # get_all_skills_dirs returns local first, so any consumer that
+        # iterates in order will pick up the local copy.
+        (hermes_home / "skills").mkdir(exist_ok=True)
+        local = hermes_home / "skills" / "clash"
+        local.mkdir()
+        (local / "SKILL.md").write_text(
+            "---\nname: clash\ndescription: local version\n---\n\n# local\n"
+        )
+        _make_shared_skill(shared_skills_root, "clash", "shared version")
+        (hermes_home / "config.yaml").write_text(
+            "skills:\n  shared:\n    - clash\n"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        import importlib, agent.skill_utils as su
+        importlib.reload(su)
+        dirs = su.get_all_skills_dirs()
+        # Local first, shared second
+        assert dirs[0].resolve() == (hermes_home / "skills").resolve()
+        assert dirs[1].resolve() == (shared_skills_root / "clash").resolve()

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -1,6 +1,7 @@
 """Tests for tools/skill_manager_tool.py — skill creation, editing, and deletion."""
 
 import json
+import os
 from pathlib import Path
 from unittest.mock import patch
 
@@ -17,6 +18,8 @@ from tools.skill_manager_tool import (
     _delete_skill,
     _write_file,
     _remove_file,
+    _is_external_skill,
+    _copy_on_write_to_local,
     skill_manage,
     VALID_NAME_RE,
     ALLOWED_SUBDIRS,
@@ -411,3 +414,256 @@ class TestSkillManageDispatcher:
             raw = skill_manage(action="create", name="test-skill", content=VALID_SKILL_CONTENT)
         result = json.loads(raw)
         assert result["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# Copy-on-write for external (shared / external_dirs) skills
+# ---------------------------------------------------------------------------
+
+
+def _write_external_skill(root: Path, name: str, description: str = "Ext skill") -> Path:
+    """Helper: create a skill at root/name/SKILL.md and return the skill dir."""
+    d = root / name
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text(
+        f"---\nname: {name}\ndescription: {description}\n---\n\n# {name}\n\nStep 1: original step.\n"
+    )
+    return d
+
+
+class TestIsExternalSkill:
+    def test_local_skill_is_not_external(self, tmp_path):
+        local = tmp_path / "local-skills"
+        local.mkdir()
+        skill = local / "a"
+        skill.mkdir()
+        with patch("tools.skill_manager_tool.SKILLS_DIR", local):
+            assert _is_external_skill(skill) is False
+
+    def test_sibling_skill_is_external(self, tmp_path):
+        local = tmp_path / "local-skills"
+        ext = tmp_path / "external"
+        local.mkdir()
+        ext.mkdir()
+        skill = ext / "a"
+        skill.mkdir()
+        with patch("tools.skill_manager_tool.SKILLS_DIR", local):
+            assert _is_external_skill(skill) is True
+
+
+class TestCopyOnWriteHelper:
+    def test_copies_directory_contents(self, tmp_path):
+        local = tmp_path / "local"
+        ext = tmp_path / "external"
+        local.mkdir()
+        source = _write_external_skill(ext, "shared-skill")
+        (source / "references").mkdir()
+        (source / "references" / "notes.md").write_text("notes")
+        with patch("tools.skill_manager_tool.SKILLS_DIR", local):
+            result = _copy_on_write_to_local(source)
+        assert result == local / "shared-skill"
+        assert (result / "SKILL.md").read_text() == (source / "SKILL.md").read_text()
+        assert (result / "references" / "notes.md").read_text() == "notes"
+
+    def test_raises_when_local_already_exists(self, tmp_path):
+        local = tmp_path / "local"
+        ext = tmp_path / "external"
+        (local / "clash").mkdir(parents=True)
+        source = _write_external_skill(ext, "clash")
+        with patch("tools.skill_manager_tool.SKILLS_DIR", local):
+            try:
+                _copy_on_write_to_local(source)
+            except RuntimeError as exc:
+                assert "already exists" in str(exc)
+            else:
+                raise AssertionError("expected RuntimeError")
+
+
+class TestEditExternalSkillCopyOnWrite:
+    """Verify _edit_skill copy-on-writes external skills instead of mutating them in place."""
+
+    def _setup(self, tmp_path):
+        local = tmp_path / "hermes" / "skills"
+        local.mkdir(parents=True)
+        ext = tmp_path / "shared-skills"
+        ext.mkdir()
+        _write_external_skill(ext, "shared-editable", "original desc")
+        hermes_home = tmp_path / "hermes"
+        (hermes_home / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {ext}\n"
+        )
+        return local, ext, hermes_home
+
+    def test_edit_external_skill_creates_local_copy(self, tmp_path):
+        local, ext, hermes_home = self._setup(tmp_path)
+        new_content = (
+            "---\nname: shared-editable\ndescription: edited from profile A\n---\n\n"
+            "# shared-editable\n\nStep 1: edited step.\n"
+        )
+        with (
+            patch("tools.skill_manager_tool.SKILLS_DIR", local),
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+        ):
+            result = _edit_skill("shared-editable", new_content)
+        # Edit succeeded
+        assert result["success"] is True
+        # A note was attached explaining the copy-on-write
+        assert "note" in result
+        assert "override" in result["note"].lower() or "profile-local" in result["note"].lower()
+        # Local copy was created with the new content
+        local_copy = local / "shared-editable" / "SKILL.md"
+        assert local_copy.exists()
+        assert "edited from profile A" in local_copy.read_text()
+        # External skill is untouched
+        external_original = ext / "shared-editable" / "SKILL.md"
+        assert "original desc" in external_original.read_text()
+        # Returned path points at the local copy, not the external
+        assert str(local / "shared-editable") == result["path"]
+
+    def test_edit_local_skill_still_writes_in_place(self, tmp_path):
+        local, ext, hermes_home = self._setup(tmp_path)
+        with (
+            patch("tools.skill_manager_tool.SKILLS_DIR", local),
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+        ):
+            _create_skill("local-only", VALID_SKILL_CONTENT)
+            result = _edit_skill("local-only", VALID_SKILL_CONTENT_2)
+        assert result["success"] is True
+        # No CoW note for local skills
+        assert "note" not in result
+        assert "Updated description" in (local / "local-only" / "SKILL.md").read_text()
+
+
+class TestPatchExternalSkillCopyOnWrite:
+    def _setup(self, tmp_path):
+        local = tmp_path / "hermes" / "skills"
+        local.mkdir(parents=True)
+        ext = tmp_path / "shared-skills"
+        ext.mkdir()
+        _write_external_skill(ext, "shared-patchable")
+        hermes_home = tmp_path / "hermes"
+        (hermes_home / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {ext}\n"
+        )
+        return local, ext, hermes_home
+
+    def test_patch_external_skill_creates_local_copy(self, tmp_path):
+        local, ext, hermes_home = self._setup(tmp_path)
+        with (
+            patch("tools.skill_manager_tool.SKILLS_DIR", local),
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+        ):
+            result = _patch_skill(
+                "shared-patchable", "original step", "patched step",
+            )
+        assert result["success"] is True
+        assert "note" in result
+        # Local copy has the patched content
+        assert "patched step" in (local / "shared-patchable" / "SKILL.md").read_text()
+        # External source is unchanged
+        assert "original step" in (ext / "shared-patchable" / "SKILL.md").read_text()
+
+    def test_patch_external_skill_rolls_back_copy_on_invalid_match(self, tmp_path):
+        local, ext, hermes_home = self._setup(tmp_path)
+        with (
+            patch("tools.skill_manager_tool.SKILLS_DIR", local),
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+        ):
+            result = _patch_skill(
+                "shared-patchable", "this does not exist", "whatever",
+            )
+        assert result["success"] is False
+        # The CoW copy should have been rolled back; local dir is empty.
+        assert not (local / "shared-patchable").exists()
+        # External still untouched
+        assert "original step" in (ext / "shared-patchable" / "SKILL.md").read_text()
+
+
+class TestWriteFileExternalSkillCopyOnWrite:
+    def test_write_file_on_external_copies_skill_first(self, tmp_path):
+        local = tmp_path / "hermes" / "skills"
+        local.mkdir(parents=True)
+        ext = tmp_path / "shared-skills"
+        ext.mkdir()
+        _write_external_skill(ext, "shared-writefile")
+        hermes_home = tmp_path / "hermes"
+        (hermes_home / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {ext}\n"
+        )
+        with (
+            patch("tools.skill_manager_tool.SKILLS_DIR", local),
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+        ):
+            result = _write_file(
+                "shared-writefile", "references/notes.md", "local override notes",
+            )
+        assert result["success"] is True
+        assert "note" in result
+        # New file is in the local copy
+        assert (local / "shared-writefile" / "references" / "notes.md").read_text() == "local override notes"
+        # Original SKILL.md was also copied over as part of the CoW
+        assert (local / "shared-writefile" / "SKILL.md").exists()
+        # External skill has no new file
+        assert not (ext / "shared-writefile" / "references" / "notes.md").exists()
+
+
+class TestRemoveFileExternalSkillCopyOnWrite:
+    def test_remove_file_on_external_copies_then_removes(self, tmp_path):
+        local = tmp_path / "hermes" / "skills"
+        local.mkdir(parents=True)
+        ext = tmp_path / "shared-skills"
+        ext.mkdir()
+        source = _write_external_skill(ext, "shared-removefile")
+        (source / "references").mkdir()
+        (source / "references" / "notes.md").write_text("to be removed")
+        hermes_home = tmp_path / "hermes"
+        (hermes_home / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {ext}\n"
+        )
+        with (
+            patch("tools.skill_manager_tool.SKILLS_DIR", local),
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+        ):
+            result = _remove_file("shared-removefile", "references/notes.md")
+        assert result["success"] is True
+        assert "note" in result
+        # Local copy exists, but the file is gone from the copy
+        assert (local / "shared-removefile" / "SKILL.md").exists()
+        assert not (local / "shared-removefile" / "references" / "notes.md").exists()
+        # External source still has the file
+        assert (ext / "shared-removefile" / "references" / "notes.md").exists()
+
+
+class TestDeleteExternalSkillRejected:
+    def test_delete_external_skill_returns_error(self, tmp_path):
+        local = tmp_path / "hermes" / "skills"
+        local.mkdir(parents=True)
+        ext = tmp_path / "shared-skills"
+        ext.mkdir()
+        _write_external_skill(ext, "shared-undeletable")
+        hermes_home = tmp_path / "hermes"
+        (hermes_home / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {ext}\n"
+        )
+        with (
+            patch("tools.skill_manager_tool.SKILLS_DIR", local),
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+        ):
+            result = _delete_skill("shared-undeletable")
+        assert result["success"] is False
+        assert "skills.disabled" in result["error"]
+        # External skill still exists
+        assert (ext / "shared-undeletable" / "SKILL.md").exists()
+
+    def test_delete_local_skill_still_works(self, tmp_path):
+        local = tmp_path / "hermes" / "skills"
+        local.mkdir(parents=True)
+        hermes_home = tmp_path / "hermes"
+        with (
+            patch("tools.skill_manager_tool.SKILLS_DIR", local),
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+        ):
+            _create_skill("local-goner", VALID_SKILL_CONTENT)
+            result = _delete_skill("local-goner")
+        assert result["success"] is True
+        assert not (local / "local-goner").exists()

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -219,6 +219,55 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     return None
 
 
+def _is_external_skill(skill_path: Path) -> bool:
+    """True if the skill lives outside the profile-local SKILLS_DIR.
+
+    An "external" skill is anything resolved from ``skills.external_dirs``
+    (or any future shared-skills mechanism). Such skills are treated as
+    read-only by the agent: mutations are copy-on-written into the local
+    profile ``skills/`` directory so they become profile-local overrides,
+    matching the documented behavior at
+    https://hermes-agent.nousresearch.com/docs/user-guide/features/skills/#external-skill-directories
+    """
+    try:
+        skill_path.resolve().relative_to(SKILLS_DIR.resolve())
+        return False
+    except ValueError:
+        return True
+
+
+def _copy_on_write_to_local(skill_path: Path) -> Path:
+    """Copy an external skill dir into the profile-local SKILLS_DIR.
+
+    Preserves the skill's directory name. Returns the path to the new
+    local copy. Raises RuntimeError if a skill with the same name already
+    exists locally (which would indicate ``_find_skill`` should have
+    returned the local one instead).
+    """
+    name = skill_path.name
+    local_dir = SKILLS_DIR / name
+    if local_dir.exists():
+        raise RuntimeError(
+            f"Cannot copy-on-write: {local_dir} already exists. "
+            f"This suggests the skill resolver returned an external path "
+            f"despite a local copy being available."
+        )
+    local_dir.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(skill_path, local_dir)
+    return local_dir
+
+
+# Human-readable note attached to mutation responses when a copy-on-write
+# occurred. The agent should surface this to the user so they understand
+# why the change didn't propagate to other profiles using the shared copy.
+_COPY_ON_WRITE_NOTE_TEMPLATE = (
+    "This skill originally lived at {original} (external / shared). "
+    "Your change was saved as a profile-local override at {local} and the "
+    "original is unchanged. To propagate the change to every profile that "
+    "uses this skill, edit the source file directly outside the agent."
+)
+
+
 def _validate_file_path(file_path: str) -> Optional[str]:
     """
     Validate a file path for write_file/remove_file.
@@ -339,7 +388,12 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
 
 
 def _edit_skill(name: str, content: str) -> Dict[str, Any]:
-    """Replace the SKILL.md of any existing skill (full rewrite)."""
+    """Replace the SKILL.md of any existing skill (full rewrite).
+
+    External / shared skills are copied to the profile-local SKILLS_DIR
+    before editing (copy-on-write) so the original remains untouched and
+    the edit only affects the current profile.
+    """
     err = _validate_frontmatter(content)
     if err:
         return {"success": False, "error": err}
@@ -352,23 +406,46 @@ def _edit_skill(name: str, content: str) -> Dict[str, Any]:
     if not existing:
         return {"success": False, "error": f"Skill '{name}' not found. Use skills_list() to see available skills."}
 
-    skill_md = existing["path"] / "SKILL.md"
-    # Back up original content for rollback
+    original_skill_dir = existing["path"]
+    was_external = _is_external_skill(original_skill_dir)
+    copy_on_write_note = None
+    copied_dir = None
+
+    if was_external:
+        try:
+            copied_dir = _copy_on_write_to_local(original_skill_dir)
+        except RuntimeError as exc:
+            return {"success": False, "error": str(exc)}
+        skill_dir = copied_dir
+        copy_on_write_note = _COPY_ON_WRITE_NOTE_TEMPLATE.format(
+            original=original_skill_dir, local=skill_dir,
+        )
+    else:
+        skill_dir = original_skill_dir
+
+    skill_md = skill_dir / "SKILL.md"
+    # Back up original content for rollback (of the file we're about to write).
     original_content = skill_md.read_text(encoding="utf-8") if skill_md.exists() else None
     _atomic_write_text(skill_md, content)
 
-    # Security scan — roll back on block
-    scan_error = _security_scan_skill(existing["path"])
+    # Security scan — roll back on block.
+    scan_error = _security_scan_skill(skill_dir)
     if scan_error:
-        if original_content is not None:
+        if was_external:
+            # Roll back the copy entirely; nothing was mutated in place.
+            shutil.rmtree(copied_dir, ignore_errors=True)
+        elif original_content is not None:
             _atomic_write_text(skill_md, original_content)
         return {"success": False, "error": scan_error}
 
-    return {
+    result = {
         "success": True,
         "message": f"Skill '{name}' updated.",
-        "path": str(existing["path"]),
+        "path": str(skill_dir),
     }
+    if copy_on_write_note:
+        result["note"] = copy_on_write_note
+    return result
 
 
 def _patch_skill(
@@ -392,22 +469,47 @@ def _patch_skill(
     if not existing:
         return {"success": False, "error": f"Skill '{name}' not found."}
 
-    skill_dir = existing["path"]
+    original_skill_dir = existing["path"]
+    was_external = _is_external_skill(original_skill_dir)
+    copy_on_write_note = None
+    copied_dir = None
 
     if file_path:
-        # Patching a supporting file
+        # Patching a supporting file — validate the path up front so an
+        # invalid request doesn't trigger a copy-on-write.
         err = _validate_file_path(file_path)
         if err:
             return {"success": False, "error": err}
-        target = skill_dir / file_path
+
+    # Read the current content from the *original* location before
+    # copying, so we can validate the patch target exists without
+    # allocating disk space for the copy on the error path.
+    src_target = original_skill_dir / (file_path or "SKILL.md")
+    if not src_target.exists():
+        return {
+            "success": False,
+            "error": f"File not found: {src_target.relative_to(original_skill_dir)}",
+        }
+    content = src_target.read_text(encoding="utf-8")
+
+    if was_external:
+        try:
+            copied_dir = _copy_on_write_to_local(original_skill_dir)
+        except RuntimeError as exc:
+            return {"success": False, "error": str(exc)}
+        skill_dir = copied_dir
+        copy_on_write_note = _COPY_ON_WRITE_NOTE_TEMPLATE.format(
+            original=original_skill_dir, local=skill_dir,
+        )
     else:
-        # Patching SKILL.md
-        target = skill_dir / "SKILL.md"
+        skill_dir = original_skill_dir
 
-    if not target.exists():
-        return {"success": False, "error": f"File not found: {target.relative_to(skill_dir)}"}
+    target = skill_dir / (file_path or "SKILL.md")
 
-    content = target.read_text(encoding="utf-8")
+    def _cleanup_cow_on_failure() -> None:
+        """If we copied the skill for CoW, delete the copy so nothing lingers."""
+        if was_external and copied_dir is not None:
+            shutil.rmtree(copied_dir, ignore_errors=True)
 
     # Use the same fuzzy matching engine as the file patch tool.
     # This handles whitespace normalization, indentation differences,
@@ -419,6 +521,7 @@ def _patch_skill(
         content, old_string, new_string, replace_all
     )
     if match_error:
+        _cleanup_cow_on_failure()
         # Show a short preview of the file so the model can self-correct
         preview = content[:500] + ("..." if len(content) > 500 else "")
         return {
@@ -431,12 +534,14 @@ def _patch_skill(
     target_label = "SKILL.md" if not file_path else file_path
     err = _validate_content_size(new_content, label=target_label)
     if err:
+        _cleanup_cow_on_failure()
         return {"success": False, "error": err}
 
     # If patching SKILL.md, validate frontmatter is still intact
     if not file_path:
         err = _validate_frontmatter(new_content)
         if err:
+            _cleanup_cow_on_failure()
             return {
                 "success": False,
                 "error": f"Patch would break SKILL.md structure: {err}",
@@ -448,22 +553,48 @@ def _patch_skill(
     # Security scan — roll back on block
     scan_error = _security_scan_skill(skill_dir)
     if scan_error:
-        _atomic_write_text(target, original_content)
+        if was_external:
+            _cleanup_cow_on_failure()
+        else:
+            _atomic_write_text(target, original_content)
         return {"success": False, "error": scan_error}
 
-    return {
+    result = {
         "success": True,
         "message": f"Patched {'SKILL.md' if not file_path else file_path} in skill '{name}' ({match_count} replacement{'s' if match_count > 1 else ''}).",
     }
+    if copy_on_write_note:
+        result["note"] = copy_on_write_note
+    return result
 
 
 def _delete_skill(name: str) -> Dict[str, Any]:
-    """Delete a skill."""
+    """Delete a skill.
+
+    External / shared skills cannot be deleted via this tool — they live
+    outside the profile's own skills dir and may be in use by other
+    profiles. To hide a shared skill from the current profile, add it to
+    the ``skills.disabled`` list in ``config.yaml``. To actually remove a
+    shared skill, delete the source directory directly outside the agent.
+    """
     existing = _find_skill(name)
     if not existing:
         return {"success": False, "error": f"Skill '{name}' not found."}
 
     skill_dir = existing["path"]
+
+    if _is_external_skill(skill_dir):
+        return {
+            "success": False,
+            "error": (
+                f"Skill '{name}' is external/shared (located at {skill_dir}) "
+                f"and cannot be deleted via this tool. To hide it from the "
+                f"current profile, add '{name}' to skills.disabled in "
+                f"config.yaml. To fully remove it, delete the source "
+                f"directory directly outside the agent."
+            ),
+        }
+
     shutil.rmtree(skill_dir)
 
     # Clean up empty category directories (don't remove SKILLS_DIR itself)
@@ -505,30 +636,58 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     if not existing:
         return {"success": False, "error": f"Skill '{name}' not found. Create it first with action='create'."}
 
-    target = existing["path"] / file_path
+    original_skill_dir = existing["path"]
+    was_external = _is_external_skill(original_skill_dir)
+    copy_on_write_note = None
+    copied_dir = None
+
+    if was_external:
+        try:
+            copied_dir = _copy_on_write_to_local(original_skill_dir)
+        except RuntimeError as exc:
+            return {"success": False, "error": str(exc)}
+        skill_dir = copied_dir
+        copy_on_write_note = _COPY_ON_WRITE_NOTE_TEMPLATE.format(
+            original=original_skill_dir, local=skill_dir,
+        )
+    else:
+        skill_dir = original_skill_dir
+
+    target = skill_dir / file_path
     target.parent.mkdir(parents=True, exist_ok=True)
     # Back up for rollback
     original_content = target.read_text(encoding="utf-8") if target.exists() else None
     _atomic_write_text(target, file_content)
 
     # Security scan — roll back on block
-    scan_error = _security_scan_skill(existing["path"])
+    scan_error = _security_scan_skill(skill_dir)
     if scan_error:
-        if original_content is not None:
+        if was_external:
+            # Throw away the whole copy; nothing existed before it.
+            shutil.rmtree(copied_dir, ignore_errors=True)
+        elif original_content is not None:
             _atomic_write_text(target, original_content)
         else:
             target.unlink(missing_ok=True)
         return {"success": False, "error": scan_error}
 
-    return {
+    result = {
         "success": True,
         "message": f"File '{file_path}' written to skill '{name}'.",
         "path": str(target),
     }
+    if copy_on_write_note:
+        result["note"] = copy_on_write_note
+    return result
 
 
 def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
-    """Remove a supporting file from any skill directory."""
+    """Remove a supporting file from any skill directory.
+
+    For external / shared skills, the whole skill is first copy-on-written
+    into the profile-local SKILLS_DIR, then the file is removed from the
+    copy. The original external skill is untouched.
+    """
     err = _validate_file_path(file_path)
     if err:
         return {"success": False, "error": err}
@@ -536,24 +695,41 @@ def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
     existing = _find_skill(name)
     if not existing:
         return {"success": False, "error": f"Skill '{name}' not found."}
-    skill_dir = existing["path"]
+    original_skill_dir = existing["path"]
 
-    target = skill_dir / file_path
-    if not target.exists():
-        # List what's actually there for the model to see
+    # Validate the target file exists in the original skill before doing
+    # anything destructive or disk-allocating.
+    if not (original_skill_dir / file_path).exists():
         available = []
         for subdir in ALLOWED_SUBDIRS:
-            d = skill_dir / subdir
+            d = original_skill_dir / subdir
             if d.exists():
                 for f in d.rglob("*"):
                     if f.is_file():
-                        available.append(str(f.relative_to(skill_dir)))
+                        available.append(str(f.relative_to(original_skill_dir)))
         return {
             "success": False,
             "error": f"File '{file_path}' not found in skill '{name}'.",
             "available_files": available if available else None,
         }
 
+    was_external = _is_external_skill(original_skill_dir)
+    copy_on_write_note = None
+    copied_dir = None
+
+    if was_external:
+        try:
+            copied_dir = _copy_on_write_to_local(original_skill_dir)
+        except RuntimeError as exc:
+            return {"success": False, "error": str(exc)}
+        skill_dir = copied_dir
+        copy_on_write_note = _COPY_ON_WRITE_NOTE_TEMPLATE.format(
+            original=original_skill_dir, local=skill_dir,
+        )
+    else:
+        skill_dir = original_skill_dir
+
+    target = skill_dir / file_path
     target.unlink()
 
     # Clean up empty subdirectories
@@ -561,10 +737,13 @@ def _remove_file(name: str, file_path: str) -> Dict[str, Any]:
     if parent != skill_dir and parent.exists() and not any(parent.iterdir()):
         parent.rmdir()
 
-    return {
+    result = {
         "success": True,
         "message": f"File '{file_path}' removed from skill '{name}'.",
     }
+    if copy_on_write_note:
+        result["note"] = copy_on_write_note
+    return result
 
 
 # =============================================================================

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -207,6 +207,65 @@ Paths support `~` expansion and `${VAR}` environment variable substitution.
 
 All four skills appear in your skill index. If you create a new skill called `my-custom-workflow` locally, it shadows the external version.
 
+## Sharing Specific Skills Across Profiles
+
+For skills you want to share across **some** (but not all) profiles, use the `skills.shared` shorthand. Place each shared skill under `~/.hermes/shared-skills/`:
+
+```text
+~/.hermes/shared-skills/
+├── team-runbook/
+│   └── SKILL.md
+└── company-style-guide/
+    └── SKILL.md
+```
+
+Then list the names in each profile's `config.yaml`:
+
+```yaml
+# Profile A — includes both
+skills:
+  shared:
+    - team-runbook
+    - company-style-guide
+```
+
+```yaml
+# Profile B — only style guide
+skills:
+  shared:
+    - company-style-guide
+```
+
+```yaml
+# Profile C — neither (no shared entry, no implicit inclusion)
+skills:
+  external_dirs: []
+```
+
+Each profile sees only the shared skills it explicitly opts into. Profiles with no `skills.shared` key see no shared skills at all — sharing is opt-in, not automatic.
+
+### How it relates to `external_dirs`
+
+Internally, `skills.shared: [team-runbook]` is equivalent to `skills.external_dirs: [~/.hermes/shared-skills/team-runbook]`. The `shared` key is just a shorthand that:
+
+- Establishes `~/.hermes/shared-skills/` as the canonical shared location, so users don't have to remember a path
+- Lets you list shared skills by **name** instead of repeating the full path each time
+- Validates names (no slashes, no `..`, no leading dot) to prevent path-traversal mistakes in config
+
+Use `skills.shared` for the common case ("share skills X and Y across these profiles"). Use `skills.external_dirs` when you need full paths, environment-variable substitution, or to share entire directories of skills from outside `~/.hermes/`.
+
+### Precedence
+
+The full skill search order is:
+
+1. **Profile-local** (`HERMES_HOME/skills/`) — highest precedence, read/write
+2. **`skills.shared`** entries from `~/.hermes/shared-skills/`
+3. **`skills.external_dirs`** entries
+
+Duplicates (same resolved path) are filtered: a skill listed in both `shared` and `external_dirs` only appears once. A profile-local skill with the same name as a shared one shadows it.
+
+Shared skills are read-only from the agent's perspective — `skill_edit`, `skill_patch`, `skill_write_file`, and `skill_remove_file` copy-on-write into the profile-local `skills/` directory before applying changes (see [External Skill Directories — How it works](#how-it-works)). The shared source is never mutated by the agent.
+
 ## Agent-Managed Skills (skill_manage tool)
 
 The agent can create, update, and delete its own skills via the `skill_manage` tool. This is the agent's **procedural memory** — when it figures out a non-trivial workflow, it saves the approach as a skill for future reuse.

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -184,7 +184,7 @@ Paths support `~` expansion and `${VAR}` environment variable substitution.
 
 ### How it works
 
-- **Read-only**: External dirs are only scanned for skill discovery. When the agent creates or edits a skill, it always writes to `~/.hermes/skills/`.
+- **Read-only (copy-on-write)**: External dirs are treated as read-only. When the agent creates a new skill, it always writes to `~/.hermes/skills/`. When the agent **edits an existing external skill** (via `skill_edit`, `skill_patch`, `skill_write_file`, or `skill_remove_file`), Hermes first copies the whole skill directory into the profile-local `~/.hermes/skills/` and then applies the change to the copy. The external source is never mutated by the agent — the edited skill becomes a profile-local override that shadows the shared version by name. Deleting an external skill is rejected with a message pointing to `skills.disabled` (to hide it from the current profile) or direct filesystem removal (to unshare it from all profiles).
 - **Local precedence**: If the same skill name exists in both the local dir and an external dir, the local version wins.
 - **Full integration**: External skills appear in the system prompt index, `skills_list`, `skill_view`, and as `/skill-name` slash commands — no different from local skills.
 - **Non-existent paths are silently skipped**: If a configured directory doesn't exist, Hermes ignores it without errors. Useful for optional shared directories that may not be present on every machine.


### PR DESCRIPTION
## What does this PR do?

Adds a small, opt-in convention for sharing **specific** skills across **some** (but not all) profiles on a single host, without requiring users to repeat full directory paths in every profile's `config.yaml`.

The convention:

```text
~/.hermes/shared-skills/
├── team-runbook/
│   └── SKILL.md
└── company-style-guide/
    └── SKILL.md
```

Profiles opt in by name in their `config.yaml`:

```yaml
skills:
  shared:
    - team-runbook
    - company-style-guide
```

Internally, `skills.shared` resolves to subdirectories of `~/.hermes/shared-skills/` that are appended to the skill search path between the profile-local `skills/` dir and any `skills.external_dirs` entries. The end result is identical to listing the individual skill directories under `skills.external_dirs` (which has always worked) — this just gives a shorthand and a canonical location.

### Why a shorthand instead of asking users to use `external_dirs`?

- **Less typing.** List a name once instead of a full path per profile.
- **Less error-prone.** Bare names with strict validation (no slashes, no `..` traversal, no leading dot) are harder to mis-configure than raw paths.
- **Discoverability.** The docs can point at one canonical location.
- **Composes cleanly with copy-on-write** for shared skills (see #5407, the prerequisite PR) — the agent never mutates the shared source, only profile-local overrides.

### What it is NOT

- **Not automatic.** Behavior is fully opt-in: profiles with no `skills.shared` key see no shared skills. There is no implicit inclusion of `~/.hermes/shared-skills/` contents — sharing is always explicit, per-profile, per-skill. This preserves the existing profile-isolation guarantee.
- **Not a replacement for `external_dirs`.** `skills.external_dirs` is still the right tool for skills outside `~/.hermes/`, env-var-substituted paths, or whole directories of skills.
- **Not a copy.** The skill lives in exactly one place on disk (`~/.hermes/shared-skills/<name>/`); profiles reference it. Edits in one profile don't affect another (copy-on-write handles this — see #5407).

## Related Issue / PR

Depends on #5407 (`fix(skills): copy-on-write for agent edits of external skills`). That PR ensures that when an agent edits a shared skill, the edit becomes a profile-local override instead of mutating the shared source. Without it, this PR would be a footgun.

This PR is mergeable on its own, but the safety story is only complete with both.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

### `agent/skill_utils.py`
- New constant `DEFAULT_SHARED_SKILLS = ~/.hermes/shared-skills/`.
- New function `get_shared_skill_dirs()`: reads `skills.shared` from the active profile's `config.yaml`, validates each entry (rejects path traversal, slashes, hidden directories), returns paths to existing subdirectories under `DEFAULT_SHARED_SKILLS`. Invalid names and missing directories are silently skipped so a typo or half-provisioned host doesn't break the agent.
- Updated `get_all_skills_dirs()`: inserts shared skill dirs between the profile-local `skills/` dir and `skills.external_dirs` entries. Duplicates (same resolved path) are filtered, so listing a shared skill in both `skills.shared` and `skills.external_dirs` only includes it once. Updated docstring documents the full precedence order.

### `tests/agent/test_external_skills.py` — 10 new tests
- `TestGetSharedSkillDirs`:
  - `test_no_shared_config_returns_empty` — no `skills.shared` key → empty list
  - `test_shared_skill_resolved_by_name` — name is resolved to the right directory
  - `test_missing_shared_skill_silently_skipped` — typo in config doesn't break discovery
  - `test_path_traversal_rejected` — `../../etc`, `foo/bar`, `.hidden` are dropped
  - `test_string_value_converted_to_list` — `shared: name` (single string) works
- `TestSharedInGetAllSkillsDirs`:
  - `test_shared_appears_after_local_before_external` — order is local → shared → external
  - `test_no_shared_config_backward_compat` — pre-PR behavior preserved when key absent
  - `test_shared_not_duplicated_when_also_in_external_dirs` — dedup works
- `TestSelectiveSharingAcrossProfiles`:
  - `test_profile_a_and_b_see_different_subsets` — proves the per-profile, per-skill selectivity
- `TestLocalShadowsShared`:
  - `test_profile_local_skill_takes_precedence_over_shared_by_position` — local skills come first

### `website/docs/user-guide/features/skills.md`
- New section "Sharing Specific Skills Across Profiles" documenting the convention, config syntax, relationship to `external_dirs`, precedence rules, and a pointer to the read-only / copy-on-write semantics from the External Skill Directories section.

## How to Test

```bash
# 1. Run the new tests
pytest tests/agent/test_external_skills.py::TestGetSharedSkillDirs \
       tests/agent/test_external_skills.py::TestSharedInGetAllSkillsDirs \
       tests/agent/test_external_skills.py::TestSelectiveSharingAcrossProfiles \
       tests/agent/test_external_skills.py::TestLocalShadowsShared -v
# Expect: 10 passed

# Full external_skills suite (regression check)
pytest tests/agent/test_external_skills.py -q
# Expect: 21 passed

# 2. Manual end-to-end verification
mkdir -p ~/.hermes/shared-skills/team-runbook
cat > ~/.hermes/shared-skills/team-runbook/SKILL.md <<MD
---
name: team-runbook
description: Shared team operational runbook.
---

# Team Runbook

Shared step here.
MD

# Add to a profile's config:
#   skills:
#     shared:
#       - team-runbook
# Then start the agent and run: /skills_list
# Confirm "team-runbook" appears.
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(skills): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] All new tests pass; full `tests/agent/test_external_skills.py` suite passes
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 / Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/user-guide/features/skills.md`)
- [x] N/A — no changes to `cli-config.yaml.example` (the new key is per-profile, not global)
- [x] N/A — no architecture changes
- [x] N/A — Python-only change, no platform-specific code paths
- [x] N/A — no tool behavior changes (skill_manage tool already handles external/shared correctly via #5407)