### PR TITLE
fix(nix): switch nixpkgs input to nixos-unstable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Hermes Agent - AI agent framework by Nous Research";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-parts = {
       url = "github:hercules-ci/flake-parts";
       inputs.nixpkgs-lib.follows = "nixpkgs";


### PR DESCRIPTION
Switch flake `nixpkgs` input from `nixos-24.11` (EOL) to `nixos-unstable` so `nix develop` stays on supported, up-to-date packages.

Fixes #5514
