### PR TITLE
fix(skills): classify builtin skills by dir_name

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -530,7 +530,7 @@ def do_list(source_filter: str = "all", console: Optional[Console] = None) -> No
             source_display = hub_entry.get("source", "hub")
             trust = hub_entry.get("trust_level", "community")
             hub_count += 1
-        elif name in builtin_names:
+        elif name in builtin_names or skill.get("dir_name") in builtin_names:
             source_type = "builtin"
             source_display = "builtin"
             trust = "builtin"

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -580,6 +580,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                 seen_names.add(name)
                 skills.append({
                     "name": name,
+                    "dir_name": skill_dir.name,
                     "description": description,
                     "category": category,
                 })


### PR DESCRIPTION
Fix `hermes skills list` misclassifying bundled skills as local when SKILL.md frontmatter name differs from the bundled directory name.

Bundled manifest keys are directory names; skill discovery may return the frontmatter `name`. We now carry `dir_name` in discovery results and treat a skill as builtin if either `name` or `dir_name` matches the manifest.

Fixes #5433
