### PR TITLE
fix: clear session-scoped model overrides during session reset

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3252,12 +3252,12 @@ class GatewayRunner:
             logger.debug("Gateway memory flush on reset failed: %s", e)
         self._evict_cached_agent(session_key)
 
+        # Reset the session
+        new_entry = self.session_store.reset_session(session_key)
+
         # Clear any session-scoped model override so the next agent picks up
         # the configured default instead of the previously switched model.
         self._session_model_overrides.pop(session_key, None)
-
-        # Reset the session
-        new_entry = self.session_store.reset_session(session_key)
 
         # Emit session:end hook (session is ending)
         await self.hooks.emit("session:end", {

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3251,7 +3251,11 @@ class GatewayRunner:
         except Exception as e:
             logger.debug("Gateway memory flush on reset failed: %s", e)
         self._evict_cached_agent(session_key)
-        
+
+        # Clear any session-scoped model override so the next agent picks up
+        # the configured default instead of the previously switched model.
+        self._session_model_overrides.pop(session_key, None)
+
         # Reset the session
         new_entry = self.session_store.reset_session(session_key)
 

--- a/tests/gateway/test_session_model_reset.py
+++ b/tests/gateway/test_session_model_reset.py
@@ -1,0 +1,126 @@
+"""Tests that /new (and its /reset alias) clears the session-scoped model override."""
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner._session_model_overrides = {}
+    runner._pending_model_notes = {}
+    runner._background_tasks = set()
+
+    session_key = build_session_key(_make_source())
+    session_entry = SessionEntry(
+        session_key=session_key,
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.reset_session.return_value = session_entry
+    runner.session_store._entries = {session_key: session_entry}
+    runner.session_store._generate_session_key.return_value = session_key
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._agent_cache_lock = None  # disables _evict_cached_agent lock path
+    runner._is_user_authorized = lambda _source: True
+    runner._format_session_info = lambda: ""
+
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_new_command_clears_session_model_override():
+    """/new must remove the session-scoped model override for that session."""
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+
+    # Simulate a prior /model switch stored as a session override
+    runner._session_model_overrides[session_key] = {
+        "model": "gpt-4o",
+        "provider": "openai",
+        "api_key": "sk-test",
+        "base_url": "",
+        "api_mode": "openai",
+    }
+
+    await runner._handle_reset_command(_make_event("/new"))
+
+    assert session_key not in runner._session_model_overrides
+
+
+@pytest.mark.asyncio
+async def test_new_command_no_override_is_noop():
+    """/new with no prior model override must not raise."""
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+
+    assert session_key not in runner._session_model_overrides
+
+    await runner._handle_reset_command(_make_event("/new"))
+
+    assert session_key not in runner._session_model_overrides
+
+
+@pytest.mark.asyncio
+async def test_new_command_only_clears_own_session():
+    """/new must only clear the override for the session that triggered it."""
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+    other_key = "other_session_key"
+
+    runner._session_model_overrides[session_key] = {
+        "model": "gpt-4o",
+        "provider": "openai",
+        "api_key": "sk-test",
+        "base_url": "",
+        "api_mode": "openai",
+    }
+    runner._session_model_overrides[other_key] = {
+        "model": "claude-sonnet-4-6",
+        "provider": "anthropic",
+        "api_key": "sk-ant-test",
+        "base_url": "",
+        "api_mode": "anthropic",
+    }
+
+    await runner._handle_reset_command(_make_event("/new"))
+
+    assert session_key not in runner._session_model_overrides
+    assert other_key in runner._session_model_overrides


### PR DESCRIPTION
## What does this PR do?
When a user runs `/new` (or `/reset`) to start a fresh session, the session-scoped model override set by a previous `/model` command was not being cleared. This meant the next agent in the reset session would still use the overridden model instead of the configured default.

This PR fixes the bug by calling `_session_model_overrides.pop(session_key, None)` inside `_handle_reset_command` **after** `reset_session` succeeds, so that the next agent picks up the configured default model. Clearing the override only on success ensures that a failed reset doesn't leave the session in an inconsistent state (old session still active, model override already gone).


## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made
- `gateway/run.py`: In `_handle_reset_command`, pop the session key from `_session_model_overrides` before resetting the session.
- `tests/gateway/test_session_model_reset.py`: New test file with three cases:
  - `/new` clears an existing session-scoped model override.
  - `/new` with no prior override does not raise.
  - `/new` only clears the override for the triggering session, leaving other sessions' overrides intact.

## How to Test
1. Start a gateway session and switch models with `/model <some-model>`.
2. Run `/new` to reset the session.
3. Send a message and confirm the agent uses the default configured model, not the previously switched one.
4. Run `pytest tests/gateway/test_session_model_reset.py -q` — all three tests should pass.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

