### PR TITLE
fix(telegram): sanitize bot command names to fix Bot_command_invalid …

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -367,6 +367,7 @@ def telegram_bot_commands() -> list[tuple[str, str]]:
         if not _is_gateway_available(cmd, overrides):
             continue
         tg_name = cmd.name.replace("-", "_")
+        tg_name = re.sub(r'[^a-z0-9_]', '', tg_name.lower())
         result.append((tg_name, cmd.description))
     return result
 
@@ -437,6 +438,7 @@ def telegram_menu_commands(max_commands: int = 100) -> tuple[list[tuple[str, str
         plugin_cmds = getattr(pm, "_plugin_commands", {})
         for cmd_name in sorted(plugin_cmds):
             tg_name = cmd_name.replace("-", "_")
+            tg_name = re.sub(r'[^a-z0-9_]', '', tg_name.lower())
             desc = "Plugin command"
             if len(desc) > 40:
                 desc = desc[:37] + "..."
@@ -480,6 +482,7 @@ def telegram_menu_commands(max_commands: int = 100) -> tuple[list[tuple[str, str
             if skill_name in _platform_disabled:
                 continue
             name = cmd_key.lstrip("/").replace("-", "_")
+            name = re.sub(r'[^a-z0-9_]', '', name.lower())
             desc = info.get("description", "")
             # Keep descriptions short — setMyCommands has an undocumented
             # total payload limit.  40 chars fits 100 commands safely.


### PR DESCRIPTION
…(#5534)

## What does this PR do?


## Summary

Fixes an issue where the Telegram gateway fails to register commands when skill or command names contain characters that are not allowed by the Telegram Bot API.

The previous implementation only replaced `-` with `_`, which could leave other invalid characters (such as `+`, `/`, etc.) in the command name. This results in the following error when calling `set_my_commands`:

```
telegram.error.BadRequest: Bot_command_invalid
```

## Fix

Sanitize command names to comply with Telegram Bot API requirements by removing all characters except `a-z`, `0-9`, and `_`.

Applied the sanitization in all locations where Telegram command names are generated:

* core commands
* plugin commands
* skill commands

## Example

```
weather+today  ->  weathertoday
skill/test     ->  skilltest
hello-world    ->  hello_world
```

## Impact

Prevents Telegram gateway startup failures for users whose skill or command names contain unsupported characters.

## Related Issue

Fixes #5534

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

