### PR TITLE
feat: add xAI prompt caching via x-grok-conv-id header

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5436,6 +5436,12 @@ class AIAgent:
         if extra_body:
             api_kwargs["extra_body"] = extra_body
 
+        # xAI prompt caching: send x-grok-conv-id header to route requests
+        # to the same server, maximizing automatic cache hits.
+        # https://docs.x.ai/developers/advanced-api-usage/prompt-caching
+        if "x.ai" in self._base_url_lower and hasattr(self, "session_id") and self.session_id:
+            api_kwargs["extra_headers"] = {"x-grok-conv-id": self.session_id}
+
         return api_kwargs
 
     def _supports_reasoning_extra_body(self) -> bool:


### PR DESCRIPTION
## What

When using xAI's API directly (`base_url` contains `x.ai`), send the `x-grok-conv-id` header set to the Hermes `session_id`. This routes consecutive requests to the same server, maximizing automatic prompt cache hits.

## Why

xAI supports [automatic prompt caching](https://docs.x.ai/developers/advanced-api-usage/prompt-caching) — repeated prefixes are cached server-side. However, requests must hit the same server. Without `x-grok-conv-id`, requests are load-balanced randomly, wasting the cache.

With this header, a multi-turn Hermes conversation with Grok stays on one server, giving significant latency and cost reductions on long conversations.

## How

6-line addition in `_build_api_kwargs()` — detects xAI base URL, adds the header using the existing `session_id` as a stable conversation identifier. Zero impact on non-xAI providers.

## Related

- Companion to #5531 (Grok tool-use enforcement)
- Ref: https://docs.x.ai/developers/advanced-api-usage/prompt-caching