### PR TITLE
fix: support env-backed keys for custom providers

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1029,14 +1029,34 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
     changed = False
     active_sources: Set[str] = set()
 
-    # Seed from the custom_providers config entry's api_key field
+    # Seed from the custom_providers config entry's api_key field or env-backed api_key_env/api_key_env_vars
     cp_config = _get_custom_provider_config(pool_key)
     if cp_config:
         api_key = str(cp_config.get("api_key") or "").strip()
+        api_key_source = None
+        if api_key:
+            api_key_source = f"config:{str(cp_config.get('name') or '').strip()}"
+        else:
+            env_var = str(cp_config.get("api_key_env") or "").strip()
+            env_vars = cp_config.get("api_key_env_vars") or []
+            if env_var:
+                env_vars = [env_var, *env_vars]
+            for env_name in env_vars:
+                if not isinstance(env_name, str):
+                    continue
+                env_name = env_name.strip()
+                if not env_name:
+                    continue
+                env_value = os.getenv(env_name, "").strip()
+                if env_value:
+                    api_key = env_value
+                    api_key_source = f"env:{env_name}"
+                    break
+
         base_url = str(cp_config.get("base_url") or "").strip().rstrip("/")
         name = str(cp_config.get("name") or "").strip()
         if api_key:
-            source = f"config:{name}"
+            source = api_key_source or f"config:{name}"
             active_sources.add(source)
             changed |= _upsert_entry(
                 entries,

--- a/tests/test_credential_pool.py
+++ b/tests/test_credential_pool.py
@@ -888,6 +888,62 @@ def test_custom_endpoint_pool_seeds_from_model_config(tmp_path, monkeypatch):
     assert model_entries[0].access_token == "sk-model-key"
 
 
+def test_custom_endpoint_pool_seeds_from_api_key_env(tmp_path, monkeypatch):
+    """Verify seeding from custom_providers api_key_env."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-google-key")
+    _write_auth_store(tmp_path, {"version": 1})
+
+    import yaml
+    config_path = tmp_path / "hermes" / "config.yaml"
+    config_path.write_text(yaml.dump({
+        "custom_providers": [
+            {
+                "name": "Google",
+                "base_url": "https://generativelanguage.googleapis.com/v1beta/openai",
+                "api_key_env": "GOOGLE_API_KEY",
+            }
+        ]
+    }))
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("custom:google")
+    assert pool.has_credentials()
+    entries = pool.entries()
+    assert len(entries) == 1
+    assert entries[0].access_token == "test-google-key"
+    assert entries[0].source == "env:GOOGLE_API_KEY"
+
+
+def test_custom_endpoint_pool_seeds_from_api_key_env_vars(tmp_path, monkeypatch):
+    """Verify seeding from the first available custom_providers api_key_env_vars entry."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("SECONDARY_CUSTOM_KEY", "secondary-test-key")
+    _write_auth_store(tmp_path, {"version": 1})
+
+    import yaml
+    config_path = tmp_path / "hermes" / "config.yaml"
+    config_path.write_text(yaml.dump({
+        "custom_providers": [
+            {
+                "name": "Google",
+                "base_url": "https://generativelanguage.googleapis.com/v1beta/openai",
+                "api_key_env_vars": ["MISSING_CUSTOM_KEY", "SECONDARY_CUSTOM_KEY"],
+            }
+        ]
+    }))
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("custom:google")
+    assert pool.has_credentials()
+    entries = pool.entries()
+    assert len(entries) == 1
+    assert entries[0].access_token == "secondary-test-key"
+    assert entries[0].source == "env:SECONDARY_CUSTOM_KEY"
+
+
 def test_custom_pool_does_not_break_existing_providers(tmp_path, monkeypatch):
     """Existing registry providers work exactly as before with custom pool support."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))


### PR DESCRIPTION
## Summary
- seed custom provider credential pools from `api_key_env` and `api_key_env_vars`
- keep existing inline `api_key` behavior unchanged
- add regression tests for both env-backed config paths

## Why
Custom OpenAI-compatible providers in `custom_providers` currently seed credentials from inline `api_key`, but not from env-backed key fields. That causes false "invalid API key" failures even when the configured environment variable is present and direct API calls work.

## Test Plan
- [x] `python -m pytest tests/test_credential_pool.py -q -o addopts=''`
- [x] Verified regression tests for `api_key_env` and `api_key_env_vars`
