### PR TITLE
fix(agent): #5544 strictly enforce toolset filters for memory provide…

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1112,14 +1112,21 @@ class AIAgent:
                 self._memory_manager = None
 
         # Inject memory provider tool schemas into the tool surface
-        if self._memory_manager and self.tools is not None:
+        # Respect both enabled and disabled toolsets configurations
+        _memory_allowed = True
+        if self.enabled_toolsets is not None and "memory" not in self.enabled_toolsets:
+            _memory_allowed = False
+        if self.disabled_toolsets is not None and "memory" in self.disabled_toolsets:
+            _memory_allowed = False
+
+        if self._memory_manager and self.tools is not None and _memory_allowed:
             for _schema in self._memory_manager.get_all_tool_schemas():
                 _wrapped = {"type": "function", "function": _schema}
                 self.tools.append(_wrapped)
                 _tname = _schema.get("name", "")
                 if _tname:
                     self.valid_tool_names.add(_tname)
-
+                    
         # Skills config: nudge interval for skill creation reminders
         self._skill_nudge_interval = 10
         try:


### PR DESCRIPTION
…r injection




## What does this PR do?

Fixes #5544

The `MemoryManager` dynamically injects `fact_store` tools after the primary tool registry initialization. Previously, this bypassed `enabled_toolsets` and `disabled_toolsets` filters, causing massive token overhead and tool-loops for local models when platforms (e.g. Telegram) explicitly requested zero tools (`telegram: []`).

Added explicit validation against both `self.enabled_toolsets` and `self.disabled_toolsets` before appending memory schemas to `self.tools`, ensuring full compliance with user configurations.
  
Fixes #5544