### PR TITLE
fix(nous): don't use OAuth access_token as inference API key

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -495,7 +495,11 @@ def _resolve_explicit_runtime(
             explicit_base_url
             or str(state.get("inference_base_url") or auth_mod.DEFAULT_NOUS_INFERENCE_URL).strip().rstrip("/")
         )
-        api_key = explicit_api_key or str(state.get("agent_key") or state.get("access_token") or "").strip()
+        # Only use agent_key for inference — access_token is an OAuth token for the
+        # portal API (minting keys, refreshing tokens), not for the inference API.
+        # Falling back to access_token sends an OAuth bearer token to the inference
+        # endpoint, which returns 404 because it is not a valid inference credential.
+        api_key = explicit_api_key or str(state.get("agent_key") or "").strip()
         expires_at = state.get("agent_key_expires_at") or state.get("expires_at")
         if not api_key:
             creds = resolve_nous_runtime_credentials(


### PR DESCRIPTION
## Problem

When `agent_key` is missing from auth state (expired, not yet minted, or mint failed silently), the credential resolution at `runtime_provider.py:498` fell through to `access_token`:

```python
api_key = explicit_api_key or str(state.get("agent_key") or state.get("access_token") or "").strip()
```

`access_token` is an OAuth bearer token for the Nous **portal** API (minting keys, refreshing tokens). It is not a valid inference credential. The Nous inference API returns 404 because the OAuth token doesn't authenticate against the inference endpoint.

## Fix

Remove `state.get("access_token")` from the fallback chain. When `agent_key` is missing, `api_key` is empty, which correctly triggers `resolve_nous_runtime_credentials()` at line 500 to mint a fresh agent key.

## Changes

1 line changed in `hermes_cli/runtime_provider.py`.

Closes #5562