### PR TITLE
feat: add Mem0 OSS memory provider plugin with setup wizard, docs, and tests

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -121,6 +121,32 @@ def _prompt(label: str, default: str | None = None, secret: bool = False) -> str
     return val or (default or "")
 
 
+def _ensure_env_loaded():
+    """Load .env into os.environ so the wizard can detect existing API keys."""
+    try:
+        from hermes_cli.env_loader import load_hermes_dotenv
+        load_hermes_dotenv()
+    except Exception:
+        pass
+
+
+def _read_env_value(env_path: Path, key: str) -> str:
+    """Read a single value from the .env file (fallback when os.environ misses it)."""
+    if not env_path.exists():
+        return ""
+    try:
+        for line in env_path.read_text().splitlines():
+            stripped = line.strip()
+            if stripped.startswith("#") or "=" not in stripped:
+                continue
+            k, v = stripped.split("=", 1)
+            if k.strip() == key:
+                return v.strip()
+    except Exception:
+        pass
+    return ""
+
+
 # ---------------------------------------------------------------------------
 # Provider discovery
 # ---------------------------------------------------------------------------
@@ -210,6 +236,40 @@ def _install_dependencies(provider_name: str) -> None:
                     print(f"    {install_cmd}")
 
 
+def _install_extra_dependencies(packages: list[str]) -> None:
+    """Install extra pip packages required by the user's provider choices."""
+    if not packages:
+        return
+
+    import shutil
+    import subprocess
+
+    print(f"\n  Installing extra dependencies: {', '.join(packages)}")
+
+    uv_path = shutil.which("uv")
+    if not uv_path:
+        print(f"  ⚠ uv not found — please install manually:")
+        print(f"    pip install {' '.join(packages)}")
+        return
+
+    try:
+        subprocess.run(
+            [uv_path, "pip", "install", "--python", sys.executable, "--quiet"] + packages,
+            check=True, timeout=120,
+            capture_output=True,
+        )
+        print(f"  ✓ Installed {', '.join(packages)}")
+    except subprocess.CalledProcessError as e:
+        print(f"  ⚠ Failed to install {', '.join(packages)}")
+        stderr = (e.stderr or b"").decode()[:200]
+        if stderr:
+            print(f"    {stderr}")
+        print(f"  Run manually: pip install {' '.join(packages)}")
+    except Exception as e:
+        print(f"  ⚠ Install failed: {e}")
+        print(f"  Run manually: pip install {' '.join(packages)}")
+
+
 def _get_available_providers() -> list:
     """Discover memory providers from plugins/memory/.
 
@@ -254,6 +314,7 @@ def cmd_setup_provider(provider_name: str) -> None:
     """Run memory setup for a specific provider, skipping the picker."""
     from hermes_cli.config import load_config, save_config
 
+    _ensure_env_loaded()
     providers = _get_available_providers()
     match = None
     for name, desc, provider in providers:
@@ -286,9 +347,14 @@ def cmd_setup_provider(provider_name: str) -> None:
     print(f"  Activation saved to config.yaml\n")
 
 
+_MEM0_VARIANTS = {"mem0", "mem0_oss"}
+
+
 def cmd_setup(args) -> None:
     """Interactive memory provider setup wizard."""
     from hermes_cli.config import load_config, save_config
+
+    _ensure_env_loaded()
 
     providers = _get_available_providers()
 
@@ -297,10 +363,23 @@ def cmd_setup(args) -> None:
         print("  Install a plugin to ~/.hermes/plugins/ and try again.\n")
         return
 
-    # Build picker items
+    # Group mem0 variants into a single picker entry
+    mem0_map = {p[0]: p for p in providers if p[0] in _MEM0_VARIANTS}
+    has_mem0_group = len(mem0_map) >= 2
+
+    # Build picker: replace mem0 + mem0_oss with a single "Mem0" row
     items = []
-    for name, desc, _ in providers:
-        items.append((name, f"— {desc}"))
+    picker_entries = []  # parallel list of (name, desc, provider) or None for group
+    seen_mem0 = False
+    for entry in providers:
+        if has_mem0_group and entry[0] in _MEM0_VARIANTS:
+            if not seen_mem0:
+                items.append(("Mem0", "— memory for AI"))
+                picker_entries.append(None)  # resolved by sub-picker
+                seen_mem0 = True
+            continue
+        items.append((entry[0], f"— {entry[1]}"))
+        picker_entries.append(entry)
     items.append(("Built-in only", "— MEMORY.md / USER.md (default)"))
 
     builtin_idx = len(items) - 1
@@ -310,21 +389,37 @@ def cmd_setup(args) -> None:
     if not isinstance(config.get("memory"), dict):
         config["memory"] = {}
 
-    # Built-in only
-    if selected >= len(providers) or selected < 0:
+    # Built-in only (or quit)
+    if selected >= len(picker_entries) or selected < 0:
         config["memory"]["provider"] = ""
         save_config(config)
         print("\n  ✓ Memory provider: built-in only")
         print("  Saved to config.yaml\n")
         return
 
-    name, _, provider = providers[selected]
+    entry = picker_entries[selected]
 
+    # Grouped Mem0 — show sub-picker for Platform vs Self-hosted
+    if entry is None and has_mem0_group:
+        mode_items = [
+            ("Platform", "— Cloud API (app.mem0.ai)"),
+            ("Self-hosted (OSS)", "— Local LLM, embedder & vector store"),
+        ]
+        mode_sel = _curses_select("  Mem0 mode", mode_items)
+        chosen_name = "mem0_oss" if mode_sel == 1 else "mem0"
+        entry = mem0_map[chosen_name]
+
+    name, _, provider = entry
+
+    _run_provider_setup(name, provider, config, save_config)
+
+
+def _run_provider_setup(name, provider, config, save_config):
+    """Walk through a provider's config schema and write config + secrets."""
     # Install pip dependencies if declared in plugin.yaml
     _install_dependencies(name)
 
     # If the provider has a post_setup hook, delegate entirely to it.
-    # The hook handles its own config, connection test, and activation.
     if hasattr(provider, "post_setup"):
         hermes_home = str(Path(os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes"))))
         provider.post_setup(hermes_home, config)
@@ -375,8 +470,10 @@ def cmd_setup(args) -> None:
                 sel = _curses_select(f"  {desc}", choice_items, default=current_idx)
                 provider_config[key] = choices[sel]
             elif is_secret:
-                # Prompt for secret
+                # Prompt for secret — check os.environ, then fall back to .env file
                 existing = os.environ.get(env_var, "") if env_var else ""
+                if not existing and env_var:
+                    existing = _read_env_value(env_path, env_var)
                 if existing:
                     masked = f"...{existing[-4:]}" if len(existing) > 4 else "set"
                     val = _prompt(f"{desc} (current: {masked}, blank to keep)", secret=True)
@@ -394,6 +491,9 @@ def cmd_setup(args) -> None:
                 val = _prompt(desc, default=str(effective_default) if effective_default else None)
                 if val:
                     provider_config[key] = val
+
+    if hasattr(provider, "get_extra_dependencies"):
+        _install_extra_dependencies(provider.get_extra_dependencies(provider_config))
 
     # Write activation key to config.yaml
     config["memory"]["provider"] = name

--- a/plugins/memory/mem0/README.md
+++ b/plugins/memory/mem0/README.md
@@ -10,7 +10,7 @@ Server-side LLM fact extraction with semantic search, reranking, and automatic d
 ## Setup
 
 ```bash
-hermes memory setup    # select "mem0"
+hermes memory setup    # select "Mem0" → "Platform"
 ```
 
 Or manually:

--- a/plugins/memory/mem0_oss/README.md
+++ b/plugins/memory/mem0_oss/README.md
@@ -1,0 +1,54 @@
+# Mem0 OSS Memory Provider
+
+Self-hosted memory with full control over LLM, embedder, and vector store.
+
+## Requirements
+
+- `pip install mem0ai`
+- An LLM provider (OpenAI API key, or Ollama running locally)
+- If using Ollama: `pip install ollama`
+- If using PGVector: `pip install psycopg2-binary`
+- If using Milvus: `pip install pymilvus`
+
+## Setup
+
+```bash
+hermes memory setup    # select "Mem0" → "Self-hosted (OSS)"
+```
+
+Or manually create `$HERMES_HOME/mem0_oss.json`:
+
+```json
+{
+  "llm": {"provider": "openai", "config": {"model": "gpt-5.4", "temperature": 0.1}},
+  "embedder": {"provider": "openai", "config": {"model": "text-embedding-3-small"}},
+  "vector_store": {"provider": "qdrant", "config": {"path": "/tmp/qdrant", "collection_name": "mem0"}},
+  "user_id": "hermes-user",
+  "agent_id": "hermes"
+}
+```
+
+Then: `hermes config set memory.provider mem0_oss`
+
+## Supported Providers
+
+**LLMs:** OpenAI, Ollama
+**Embedders:** OpenAI, Ollama
+**Vector Stores:** Qdrant (local), PGVector, Milvus
+
+## Memory Extraction
+
+A custom fact extraction prompt filters out conversational noise (greetings,
+small talk, filler) so only durable facts are stored. This runs automatically
+on every conversation turn via `sync_turn`.
+
+Explicit facts stored via `mem0_oss_conclude` bypass extraction entirely and
+are saved verbatim.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `mem0_oss_profile` | All stored memories about the user |
+| `mem0_oss_search` | Semantic search with optional reranking |
+| `mem0_oss_conclude` | Store a fact verbatim (no LLM extraction) |

--- a/plugins/memory/mem0_oss/__init__.py
+++ b/plugins/memory/mem0_oss/__init__.py
@@ -1,0 +1,532 @@
+"""Mem0 OSS memory plugin — MemoryProvider interface.
+
+Self-hosted memory with configurable LLM, embedder, and vector store
+using the open-source mem0 Memory class.
+
+Config via $HERMES_HOME/mem0_oss.json.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+import os
+import threading
+import time
+from typing import Any, Dict, List
+
+from agent.memory_provider import MemoryProvider
+
+logger = logging.getLogger(__name__)
+
+_BREAKER_THRESHOLD = 5
+_BREAKER_COOLDOWN_SECS = 120
+
+# Provider defaults for LLM, embedder, vector store
+_DEFAULT_LLM = {"provider": "openai", "config": {"model": "gpt-5.4", "temperature": 0.1}}
+_DEFAULT_EMBEDDER = {"provider": "openai", "config": {"model": "text-embedding-3-small"}}
+_DEFAULT_VECTOR_STORE = {"provider": "qdrant", "config": {"path": "/tmp/qdrant", "collection_name": "mem0"}}
+
+# Custom extraction prompt — tells the LLM what to keep and what to skip.
+# Without this, the default prompt stores casual chat ("Doing fine") as memories.
+_FACT_EXTRACTION_PROMPT = """\
+Extract only durable, meaningful facts from the conversation.
+
+STORE: personal details, preferences, decisions, project context, technical choices,
+corrections, names, roles, goals, constraints, deadlines.
+
+SKIP: greetings, small talk, pleasantries, filler ("Doing fine", "sounds good",
+"let me check"), meta-conversation about the chat itself, questions without answers,
+acknowledgements, and anything that would be stale within minutes.
+
+If nothing meaningful is present, return {{"facts": []}}.
+"""
+
+# Providers that do NOT require an API key
+_LOCAL_LLM_PROVIDERS = {"ollama"}
+_LOCAL_EMBEDDER_PROVIDERS = {"ollama"}
+
+# LLM provider -> env var for API key
+_LLM_ENV_VARS = {
+    "openai": "OPENAI_API_KEY",
+}
+
+_EXTRA_DEPS = {
+    "ollama": ("ollama", "ollama"),
+    "pgvector": ("psycopg2", "psycopg2-binary"),
+    "milvus": ("pymilvus", "pymilvus"),
+}
+
+# Known embedding dimensions — used to auto-configure the vector store.
+# Without this, qdrant defaults to 1536 (OpenAI) and mismatches with
+# other embedders, causing shape errors at runtime.
+_EMBEDDER_DIMS = {
+    "openai": {
+        "text-embedding-3-small": 1536,
+        "text-embedding-3-large": 3072,
+        "text-embedding-ada-002": 1536,
+    },
+    "ollama": {
+        "nomic-embed-text": 768,
+        "mxbai-embed-large": 1024,
+        "all-minilm": 384,
+        "snowflake-arctic-embed": 1024,
+    },
+}
+
+
+def _check_dependencies(config: dict) -> list[str]:
+    """Return list of missing pip packages required by the configured providers."""
+    missing = []
+    # Check mem0ai itself
+    try:
+        import mem0  # noqa: F401
+    except ImportError:
+        missing.append("mem0ai")
+        return missing  # No point checking further
+
+    providers_used = set()
+    for section in ("llm", "embedder", "vector_store"):
+        prov = config.get(section, {}).get("provider", "")
+        if prov:
+            providers_used.add(prov)
+
+    for prov in providers_used:
+        if prov in _EXTRA_DEPS:
+            import_name, pip_name = _EXTRA_DEPS[prov]
+            try:
+                __import__(import_name)
+            except ImportError:
+                missing.append(pip_name)
+
+    return missing
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+def _load_config() -> dict:
+    """Load config from $HERMES_HOME/mem0_oss.json with defaults."""
+    from hermes_constants import get_hermes_home
+
+    config = {
+        "llm": copy.deepcopy(_DEFAULT_LLM),
+        "embedder": copy.deepcopy(_DEFAULT_EMBEDDER),
+        "vector_store": copy.deepcopy(_DEFAULT_VECTOR_STORE),
+        "user_id": "hermes-user",
+        "agent_id": "hermes",
+    }
+
+    config_path = get_hermes_home() / "mem0_oss.json"
+    if config_path.exists():
+        try:
+            file_cfg = json.loads(config_path.read_text(encoding="utf-8"))
+            for key in ("llm", "embedder", "vector_store"):
+                if key in file_cfg and isinstance(file_cfg[key], dict):
+                    config[key] = file_cfg[key]
+            for key in ("user_id", "agent_id"):
+                if file_cfg.get(key):
+                    config[key] = file_cfg[key]
+        except Exception:
+            pass
+
+    return config
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas
+# ---------------------------------------------------------------------------
+
+PROFILE_SCHEMA = {
+    "name": "mem0_oss_profile",
+    "description": (
+        "Retrieve all stored memories about the user — preferences, facts, "
+        "project context. Fast, no reranking. Use at conversation start."
+    ),
+    "parameters": {"type": "object", "properties": {}, "required": []},
+}
+
+SEARCH_SCHEMA = {
+    "name": "mem0_oss_search",
+    "description": (
+        "Search memories by meaning. Returns relevant facts ranked by similarity. "
+        "Set rerank=true for higher accuracy on important queries."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "What to search for."},
+            "rerank": {"type": "boolean", "description": "Enable reranking for precision (default: false)."},
+            "top_k": {"type": "integer", "description": "Max results (default: 10, max: 50)."},
+        },
+        "required": ["query"],
+    },
+}
+
+CONCLUDE_SCHEMA = {
+    "name": "mem0_oss_conclude",
+    "description": (
+        "Store a durable fact about the user. Stored verbatim (no LLM extraction). "
+        "Use for explicit preferences, corrections, or decisions."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "conclusion": {"type": "string", "description": "The fact to store."},
+        },
+        "required": ["conclusion"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# MemoryProvider implementation
+# ---------------------------------------------------------------------------
+
+class Mem0OSSMemoryProvider(MemoryProvider):
+    """Mem0 OSS memory — self-hosted with configurable LLM, embedder, vector store."""
+
+    def __init__(self):
+        self._config = None
+        self._client = None
+        self._client_lock = threading.Lock()
+        self._user_id = "hermes-user"
+        self._agent_id = "hermes"
+        self._prefetch_result = ""
+        self._prefetch_lock = threading.Lock()
+        self._prefetch_thread = None
+        self._sync_thread = None
+        self._consecutive_failures = 0
+        self._breaker_open_until = 0.0
+
+    @property
+    def name(self) -> str:
+        return "mem0_oss"
+
+    def is_available(self) -> bool:
+        from hermes_constants import get_hermes_home
+        config_path = get_hermes_home() / "mem0_oss.json"
+        if not config_path.exists():
+            return False
+        cfg = _load_config()
+        # Check that required Python packages are installed
+        missing = _check_dependencies(cfg)
+        if missing:
+            logger.warning(
+                "Mem0 OSS missing dependencies: %s. Run: pip install %s",
+                ", ".join(missing), " ".join(missing),
+            )
+            return False
+        llm_provider = cfg.get("llm", {}).get("provider", "openai")
+        if llm_provider in _LOCAL_LLM_PROVIDERS:
+            return True
+        env_var = _LLM_ENV_VARS.get(llm_provider, "")
+        return bool(env_var and os.environ.get(env_var))
+
+    def get_config_schema(self):
+        return [
+            {"key": "llm_provider", "description": "LLM provider", "default": "openai",
+             "choices": ["openai", "ollama"]},
+            {"key": "llm_model", "description": "LLM model name", "default": "gpt-5.4",
+             "default_from": {"field": "llm_provider", "map": {
+                 "openai": "gpt-5.4", "ollama": "llama3.1:8b"}}},
+            {"key": "llm_api_key", "description": "OpenAI API key", "secret": True,
+             "env_var": "OPENAI_API_KEY", "url": "https://platform.openai.com/api-keys",
+             "when": {"llm_provider": "openai"}},
+            {"key": "ollama_base_url", "description": "Ollama server URL", "default": "http://localhost:11434",
+             "when": {"llm_provider": "ollama"}},
+            {"key": "embedder_provider", "description": "Embedder provider", "default": "openai",
+             "choices": ["openai", "ollama"]},
+            {"key": "embedder_model", "description": "Embedding model name", "default": "text-embedding-3-small",
+             "default_from": {"field": "embedder_provider", "map": {
+                 "openai": "text-embedding-3-small", "ollama": "nomic-embed-text"}}},
+            {"key": "vector_store_provider", "description": "Vector store", "default": "qdrant",
+             "choices": ["qdrant", "pgvector", "milvus"]},
+            {"key": "vector_store_path", "description": "Local storage path", "default": "/tmp/qdrant",
+             "when": {"vector_store_provider": "qdrant"}},
+            {"key": "vector_store_connection_string", "description": "PostgreSQL connection string",
+             "when": {"vector_store_provider": "pgvector"}},
+            {"key": "vector_store_url", "description": "Milvus server URL", "default": "http://localhost:19530",
+             "when": {"vector_store_provider": "milvus"}},
+            {"key": "user_id", "description": "User identifier", "default": "hermes-user"},
+            {"key": "agent_id", "description": "Agent identifier", "default": "hermes"},
+        ]
+
+    def get_extra_dependencies(self, values: dict) -> list[str]:
+        """Return pip packages needed based on the user's provider choices."""
+        missing = []
+        for key in ("llm_provider", "embedder_provider", "vector_store_provider"):
+            prov = values.get(key, "")
+            if prov in _EXTRA_DEPS:
+                import_name, pip_name = _EXTRA_DEPS[prov]
+                try:
+                    __import__(import_name)
+                except ImportError:
+                    if pip_name not in missing:
+                        missing.append(pip_name)
+        return missing
+
+    def save_config(self, values, hermes_home):
+        """Restructure flat wizard values into nested mem0_oss.json."""
+        from pathlib import Path
+
+        llm_config = {"model": values.get("llm_model", "gpt-5.4"), "temperature": 0.1}
+        llm_provider = values.get("llm_provider", "openai")
+        if llm_provider == "ollama":
+            llm_config["ollama_base_url"] = values.get("ollama_base_url", "http://localhost:11434")
+
+        embedder_config = {"model": values.get("embedder_model", "text-embedding-3-small")}
+        embedder_provider = values.get("embedder_provider", "openai")
+        if embedder_provider == "ollama":
+            embedder_config["ollama_base_url"] = values.get("ollama_base_url", "http://localhost:11434")
+
+        vs_provider = values.get("vector_store_provider", "qdrant")
+        vs_config = {}
+        if vs_provider == "qdrant":
+            vs_config["path"] = values.get("vector_store_path", "/tmp/qdrant")
+            vs_config["collection_name"] = "mem0"
+        elif vs_provider == "pgvector":
+            vs_config["connection_string"] = values.get("vector_store_connection_string", "")
+            vs_config["collection_name"] = "mem0"
+        elif vs_provider == "milvus":
+            vs_config["url"] = values.get("vector_store_url", "http://localhost:19530")
+            vs_config["collection_name"] = "mem0"
+
+        # Auto-set embedding_model_dims so the vector store creates
+        # collections with the correct size for the chosen embedder.
+        # Without this, qdrant defaults to 1536 and mismatches with
+        # non-OpenAI embedders (e.g. Ollama nomic-embed-text = 768).
+        embedder_model = values.get("embedder_model", "")
+        provider_dims = _EMBEDDER_DIMS.get(embedder_provider, {})
+        dims = provider_dims.get(embedder_model)
+        if dims:
+            vs_config["embedding_model_dims"] = dims
+
+        config = {
+            "llm": {"provider": llm_provider, "config": llm_config},
+            "embedder": {"provider": embedder_provider, "config": embedder_config},
+            "vector_store": {"provider": vs_provider, "config": vs_config},
+            "user_id": values.get("user_id", "hermes-user"),
+            "agent_id": values.get("agent_id", "hermes"),
+        }
+
+        config_path = Path(hermes_home) / "mem0_oss.json"
+        config_path.write_text(json.dumps(config, indent=2))
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        self._config = _load_config()
+        self._user_id = self._config.get("user_id", "hermes-user")
+        self._agent_id = self._config.get("agent_id", "hermes")
+
+    def _get_client(self):
+        """Thread-safe client accessor with lazy initialization."""
+        with self._client_lock:
+            if self._client is not None:
+                return self._client
+            # Pre-check dependencies so we get a clear error instead of
+            # mem0's interactive input() prompt which hangs in Hermes.
+            missing = _check_dependencies(self._config)
+            if missing:
+                raise RuntimeError(
+                    f"Missing packages for Mem0 OSS: {', '.join(missing)}. "
+                    f"Run: pip install {' '.join(missing)}"
+                )
+            try:
+                from mem0 import Memory
+                mem0_config = {
+                    "llm": self._config["llm"],
+                    "embedder": self._config["embedder"],
+                    "vector_store": self._config["vector_store"],
+                    "custom_fact_extraction_prompt": _FACT_EXTRACTION_PROMPT,
+                }
+                self._client = Memory.from_config(mem0_config)
+                return self._client
+            except ImportError:
+                raise RuntimeError("mem0 package not installed. Run: pip install mem0ai")
+
+    def _is_breaker_open(self) -> bool:
+        if self._consecutive_failures < _BREAKER_THRESHOLD:
+            return False
+        if time.monotonic() >= self._breaker_open_until:
+            self._consecutive_failures = 0
+            return False
+        return True
+
+    def _record_success(self):
+        self._consecutive_failures = 0
+
+    def _record_failure(self):
+        self._consecutive_failures += 1
+        if self._consecutive_failures >= _BREAKER_THRESHOLD:
+            self._breaker_open_until = time.monotonic() + _BREAKER_COOLDOWN_SECS
+            logger.warning(
+                "Mem0 OSS circuit breaker tripped after %d consecutive failures. "
+                "Pausing API calls for %ds.",
+                self._consecutive_failures, _BREAKER_COOLDOWN_SECS,
+            )
+
+    def _read_kwargs(self) -> dict:
+        """Kwargs for search/get_all — scoped to user only."""
+        return {"user_id": self._user_id}
+
+    def _write_kwargs(self) -> dict:
+        """Kwargs for add — scoped to user + agent."""
+        return {"user_id": self._user_id, "agent_id": self._agent_id}
+
+    @staticmethod
+    def _unwrap_results(response: Any) -> list:
+        """Normalize mem0 response — dict wraps in {"results": [...]}."""
+        if isinstance(response, dict):
+            return response.get("results", [])
+        if isinstance(response, list):
+            return response
+        return []
+
+    def system_prompt_block(self) -> str:
+        return (
+            "# Mem0 Memory (Self-Hosted)\n"
+            f"Active. User: {self._user_id}.\n"
+            "Use mem0_oss_search to find memories, mem0_oss_conclude to store facts, "
+            "mem0_oss_profile for a full overview."
+        )
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if self._prefetch_thread and self._prefetch_thread.is_alive():
+            self._prefetch_thread.join(timeout=3.0)
+        with self._prefetch_lock:
+            result = self._prefetch_result
+            self._prefetch_result = ""
+        if not result:
+            return ""
+        return f"## Mem0 Memory (Self-Hosted)\n{result}"
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        if self._is_breaker_open():
+            return
+
+        def _run():
+            try:
+                client = self._get_client()
+                results = self._unwrap_results(client.search(
+                    query=query,
+                    **self._read_kwargs(),
+                    rerank=True,
+                    limit=5,
+                ))
+                if results:
+                    lines = [r.get("memory", "") for r in results if r.get("memory")]
+                    with self._prefetch_lock:
+                        self._prefetch_result = "\n".join(f"- {l}" for l in lines)
+                self._record_success()
+            except Exception as e:
+                self._record_failure()
+                logger.debug("Mem0 OSS prefetch failed: %s", e)
+
+        self._prefetch_thread = threading.Thread(target=_run, daemon=True, name="mem0-oss-prefetch")
+        self._prefetch_thread.start()
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        """Send the turn to mem0 for fact extraction (non-blocking)."""
+        if self._is_breaker_open():
+            return
+
+        def _sync():
+            try:
+                client = self._get_client()
+                messages = [
+                    {"role": "user", "content": user_content},
+                    {"role": "assistant", "content": assistant_content},
+                ]
+                client.add(messages, **self._write_kwargs(), infer=True)
+                self._record_success()
+            except Exception as e:
+                self._record_failure()
+                logger.warning("Mem0 OSS sync failed: %s", e)
+
+        if self._sync_thread and self._sync_thread.is_alive():
+            self._sync_thread.join(timeout=5.0)
+
+        self._sync_thread = threading.Thread(target=_sync, daemon=True, name="mem0-oss-sync")
+        self._sync_thread.start()
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [PROFILE_SCHEMA, SEARCH_SCHEMA, CONCLUDE_SCHEMA]
+
+    def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
+        if self._is_breaker_open():
+            return json.dumps({
+                "error": "Mem0 OSS temporarily unavailable (multiple consecutive failures). Will retry automatically."
+            })
+
+        try:
+            client = self._get_client()
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+        if tool_name == "mem0_oss_profile":
+            try:
+                memories = self._unwrap_results(
+                    client.get_all(**self._read_kwargs(), limit=100)
+                )
+                self._record_success()
+                if not memories:
+                    return json.dumps({"result": "No memories stored yet."})
+                lines = [m.get("memory", "") for m in memories if m.get("memory")]
+                return json.dumps({"result": "\n".join(lines), "count": len(lines)})
+            except Exception as e:
+                self._record_failure()
+                return json.dumps({"error": f"Failed to fetch profile: {e}"})
+
+        elif tool_name == "mem0_oss_search":
+            query = args.get("query", "")
+            if not query:
+                return json.dumps({"error": "Missing required parameter: query"})
+            rerank = args.get("rerank", False)
+            limit = min(int(args.get("top_k", 10)), 50)
+            try:
+                results = self._unwrap_results(client.search(
+                    query=query,
+                    **self._read_kwargs(),
+                    rerank=rerank,
+                    limit=limit,
+                ))
+                self._record_success()
+                if not results:
+                    return json.dumps({"result": "No relevant memories found."})
+                items = [{"memory": r.get("memory", ""), "score": r.get("score", 0)} for r in results]
+                return json.dumps({"results": items, "count": len(items)})
+            except Exception as e:
+                self._record_failure()
+                return json.dumps({"error": f"Search failed: {e}"})
+
+        elif tool_name == "mem0_oss_conclude":
+            conclusion = args.get("conclusion", "")
+            if not conclusion:
+                return json.dumps({"error": "Missing required parameter: conclusion"})
+            try:
+                client.add(
+                    [{"role": "user", "content": conclusion}],
+                    **self._write_kwargs(),
+                    infer=False,
+                )
+                self._record_success()
+                return json.dumps({"result": "Fact stored."})
+            except Exception as e:
+                self._record_failure()
+                return json.dumps({"error": f"Failed to store: {e}"})
+
+        return json.dumps({"error": f"Unknown tool: {tool_name}"})
+
+    def shutdown(self) -> None:
+        for t in (self._prefetch_thread, self._sync_thread):
+            if t and t.is_alive():
+                t.join(timeout=5.0)
+        with self._client_lock:
+            self._client = None
+
+
+def register(ctx) -> None:
+    """Register Mem0 OSS as a memory provider plugin."""
+    ctx.register_memory_provider(Mem0OSSMemoryProvider())

--- a/plugins/memory/mem0_oss/plugin.yaml
+++ b/plugins/memory/mem0_oss/plugin.yaml
@@ -1,0 +1,5 @@
+name: mem0_oss
+version: 1.0.0
+description: "Mem0 OSS — self-hosted memory with configurable LLM, embedder, and vector store."
+pip_dependencies:
+  - mem0ai

--- a/tests/plugins/memory/test_mem0_oss.py
+++ b/tests/plugins/memory/test_mem0_oss.py
@@ -1,0 +1,478 @@
+"""Tests for Mem0 OSS memory provider — config, filters, tools, circuit breaker."""
+
+import json
+import time
+import pytest
+
+from plugins.memory.mem0_oss import (
+    Mem0OSSMemoryProvider,
+    _BREAKER_THRESHOLD,
+    _load_config,
+)
+
+
+class FakeMemoryOSS:
+    """Fake mem0 Memory client that captures call kwargs."""
+
+    def __init__(self, search_results=None, all_results=None):
+        self._search_results = search_results or {"results": []}
+        self._all_results = all_results or {"results": []}
+        self.captured_search = {}
+        self.captured_get_all = {}
+        self.captured_add = []
+
+    def search(self, query, **kwargs):
+        self.captured_search = {"query": query, **kwargs}
+        return self._search_results
+
+    def get_all(self, **kwargs):
+        self.captured_get_all = kwargs
+        return self._all_results
+
+    def add(self, messages, **kwargs):
+        self.captured_add.append({"messages": messages, **kwargs})
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+
+class TestMem0OSSConfig:
+    """Config loads from mem0_oss.json with sensible defaults."""
+
+    def test_load_config_defaults(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        cfg = _load_config()
+        assert cfg["user_id"] == "hermes-user"
+        assert cfg["agent_id"] == "hermes"
+        assert cfg["llm"]["provider"] == "openai"
+
+    def test_load_config_from_file(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        config_file = tmp_path / "mem0_oss.json"
+        config_file.write_text(json.dumps({
+            "llm": {"provider": "ollama", "config": {"model": "llama3.1:8b"}},
+            "embedder": {"provider": "ollama", "config": {"model": "nomic-embed-text"}},
+            "vector_store": {"provider": "qdrant", "config": {"path": "/tmp/test-qdrant"}},
+            "user_id": "test-user",
+            "agent_id": "test-agent",
+        }))
+        cfg = _load_config()
+        assert cfg["user_id"] == "test-user"
+        assert cfg["agent_id"] == "test-agent"
+        assert cfg["llm"]["provider"] == "ollama"
+        assert cfg["embedder"]["provider"] == "ollama"
+
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+
+class TestMem0OSSDefaults:
+    """Default user_id and agent_id are preserved."""
+
+    def test_default_user_id(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        provider = Mem0OSSMemoryProvider()
+        provider.initialize("test")
+        assert provider._user_id == "hermes-user"
+
+    def test_default_agent_id(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        provider = Mem0OSSMemoryProvider()
+        provider.initialize("test")
+        assert provider._agent_id == "hermes"
+
+
+# ---------------------------------------------------------------------------
+# Kwargs (bare user_id=/agent_id= instead of filters={})
+# ---------------------------------------------------------------------------
+
+
+class TestMem0OSSKwargs:
+    """OSS uses bare user_id=/agent_id= kwargs, not filters={}."""
+
+    def test_read_kwargs_user_only(self):
+        provider = Mem0OSSMemoryProvider()
+        provider._user_id = "u123"
+        provider._agent_id = "hermes"
+        assert provider._read_kwargs() == {"user_id": "u123"}
+
+    def test_write_kwargs_user_and_agent(self):
+        provider = Mem0OSSMemoryProvider()
+        provider._user_id = "u123"
+        provider._agent_id = "hermes"
+        assert provider._write_kwargs() == {"user_id": "u123", "agent_id": "hermes"}
+
+
+# ---------------------------------------------------------------------------
+# Availability
+# ---------------------------------------------------------------------------
+
+
+class TestMem0OSSAvailability:
+    """is_available checks config file + LLM key."""
+
+    def test_available_with_openai_key(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        monkeypatch.setattr("plugins.memory.mem0_oss._check_dependencies", lambda cfg: [])
+        config_file = tmp_path / "mem0_oss.json"
+        config_file.write_text(json.dumps({
+            "llm": {"provider": "openai", "config": {"model": "gpt-5.4"}},
+            "embedder": {"provider": "openai", "config": {}},
+            "vector_store": {"provider": "qdrant", "config": {"path": "/tmp/q"}},
+        }))
+        provider = Mem0OSSMemoryProvider()
+        assert provider.is_available() is True
+
+    def test_available_with_ollama_no_key(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setattr("plugins.memory.mem0_oss._check_dependencies", lambda cfg: [])
+        config_file = tmp_path / "mem0_oss.json"
+        config_file.write_text(json.dumps({
+            "llm": {"provider": "ollama", "config": {"model": "llama3.1:8b"}},
+            "embedder": {"provider": "ollama", "config": {}},
+            "vector_store": {"provider": "qdrant", "config": {"path": "/tmp/q"}},
+        }))
+        provider = Mem0OSSMemoryProvider()
+        assert provider.is_available() is True
+
+    def test_not_available_missing_dependency(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr("plugins.memory.mem0_oss._check_dependencies", lambda cfg: ["ollama"])
+        config_file = tmp_path / "mem0_oss.json"
+        config_file.write_text(json.dumps({
+            "llm": {"provider": "ollama", "config": {"model": "llama3.1:8b"}},
+            "embedder": {"provider": "ollama", "config": {}},
+            "vector_store": {"provider": "qdrant", "config": {"path": "/tmp/q"}},
+        }))
+        provider = Mem0OSSMemoryProvider()
+        assert provider.is_available() is False
+
+    def test_not_available_no_config_file(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        provider = Mem0OSSMemoryProvider()
+        assert provider.is_available() is False
+
+    def test_not_available_missing_api_key(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setattr("plugins.memory.mem0_oss._check_dependencies", lambda cfg: [])
+        config_file = tmp_path / "mem0_oss.json"
+        config_file.write_text(json.dumps({
+            "llm": {"provider": "openai", "config": {}},
+            "embedder": {"provider": "openai", "config": {}},
+            "vector_store": {"provider": "qdrant", "config": {}},
+        }))
+        provider = Mem0OSSMemoryProvider()
+        assert provider.is_available() is False
+
+
+# ---------------------------------------------------------------------------
+# Tool dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestMem0OSSToolCalls:
+    """Tool dispatch uses bare kwargs and correct OSS param names."""
+
+    def _make_provider(self, monkeypatch, client):
+        provider = Mem0OSSMemoryProvider()
+        provider._config = {
+            "llm": {"provider": "openai", "config": {}},
+            "embedder": {"provider": "openai", "config": {}},
+            "vector_store": {"provider": "qdrant", "config": {}},
+            "user_id": "hermes-user",
+            "agent_id": "hermes",
+        }
+        provider._user_id = "u123"
+        provider._agent_id = "hermes"
+        monkeypatch.setattr(provider, "_get_client", lambda: client)
+        return provider
+
+    def test_profile_uses_bare_kwargs(self, monkeypatch):
+        client = FakeMemoryOSS(all_results={"results": [{"memory": "alpha"}, {"memory": "beta"}]})
+        provider = self._make_provider(monkeypatch, client)
+
+        result = json.loads(provider.handle_tool_call("mem0_oss_profile", {}))
+
+        assert result["count"] == 2
+        assert "alpha" in result["result"]
+        assert client.captured_get_all["user_id"] == "u123"
+        assert client.captured_get_all["limit"] == 100
+        assert "filters" not in client.captured_get_all
+
+    def test_search_uses_bare_kwargs_and_limit(self, monkeypatch):
+        client = FakeMemoryOSS(search_results={
+            "results": [{"memory": "foo", "score": 0.9}]
+        })
+        provider = self._make_provider(monkeypatch, client)
+
+        result = json.loads(provider.handle_tool_call(
+            "mem0_oss_search", {"query": "hello", "top_k": 5, "rerank": True}
+        ))
+
+        assert result["count"] == 1
+        assert client.captured_search["query"] == "hello"
+        assert client.captured_search["user_id"] == "u123"
+        assert client.captured_search["limit"] == 5
+        assert client.captured_search["rerank"] is True
+        assert "filters" not in client.captured_search
+        assert "top_k" not in client.captured_search
+
+    def test_search_missing_query(self, monkeypatch):
+        client = FakeMemoryOSS()
+        provider = self._make_provider(monkeypatch, client)
+        result = json.loads(provider.handle_tool_call("mem0_oss_search", {}))
+        assert "error" in result
+
+    def test_conclude_uses_bare_kwargs_and_infer_false(self, monkeypatch):
+        client = FakeMemoryOSS()
+        provider = self._make_provider(monkeypatch, client)
+
+        result = json.loads(provider.handle_tool_call(
+            "mem0_oss_conclude", {"conclusion": "user likes dark mode"}
+        ))
+
+        assert result["result"] == "Fact stored."
+        assert len(client.captured_add) == 1
+        call = client.captured_add[0]
+        assert call["user_id"] == "u123"
+        assert call["agent_id"] == "hermes"
+        assert call["infer"] is False
+        assert "filters" not in call
+
+    def test_conclude_missing_conclusion(self, monkeypatch):
+        client = FakeMemoryOSS()
+        provider = self._make_provider(monkeypatch, client)
+        result = json.loads(provider.handle_tool_call("mem0_oss_conclude", {}))
+        assert "error" in result
+
+    def test_unknown_tool(self, monkeypatch):
+        client = FakeMemoryOSS()
+        provider = self._make_provider(monkeypatch, client)
+        result = json.loads(provider.handle_tool_call("mem0_oss_unknown", {}))
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Prefetch and sync
+# ---------------------------------------------------------------------------
+
+
+class TestMem0OSSPrefetchSync:
+    """Background prefetch and sync use bare kwargs."""
+
+    def _make_provider(self, monkeypatch, client):
+        provider = Mem0OSSMemoryProvider()
+        provider._config = {
+            "llm": {"provider": "openai", "config": {}},
+            "embedder": {"provider": "openai", "config": {}},
+            "vector_store": {"provider": "qdrant", "config": {}},
+            "user_id": "hermes-user",
+            "agent_id": "hermes",
+        }
+        provider._user_id = "u123"
+        provider._agent_id = "hermes"
+        monkeypatch.setattr(provider, "_get_client", lambda: client)
+        return provider
+
+    def test_prefetch_uses_bare_kwargs(self, monkeypatch):
+        client = FakeMemoryOSS(search_results={
+            "results": [{"memory": "user prefers dark mode"}]
+        })
+        provider = self._make_provider(monkeypatch, client)
+
+        provider.queue_prefetch("preferences")
+        provider._prefetch_thread.join(timeout=2)
+        result = provider.prefetch("preferences")
+
+        assert "dark mode" in result
+        assert client.captured_search["user_id"] == "u123"
+        assert client.captured_search["rerank"] is True
+        assert client.captured_search["limit"] == 5
+        assert "filters" not in client.captured_search
+
+    def test_sync_turn_uses_write_kwargs(self, monkeypatch):
+        client = FakeMemoryOSS()
+        provider = self._make_provider(monkeypatch, client)
+
+        provider.sync_turn("user said this", "assistant replied")
+        provider._sync_thread.join(timeout=2)
+
+        assert len(client.captured_add) == 1
+        call = client.captured_add[0]
+        assert call["user_id"] == "u123"
+        assert call["agent_id"] == "hermes"
+        assert call["messages"][0]["content"] == "user said this"
+        assert call["infer"] is True
+        assert "filters" not in call
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker
+# ---------------------------------------------------------------------------
+
+
+class TestMem0OSSCircuitBreaker:
+    """Circuit breaker trips after 5 failures, resets after cooldown."""
+
+    def test_breaker_trips_after_threshold(self):
+        provider = Mem0OSSMemoryProvider()
+        for _ in range(_BREAKER_THRESHOLD):
+            provider._record_failure()
+        assert provider._is_breaker_open() is True
+
+    def test_breaker_resets_after_cooldown(self):
+        provider = Mem0OSSMemoryProvider()
+        for _ in range(_BREAKER_THRESHOLD):
+            provider._record_failure()
+        provider._breaker_open_until = time.monotonic() - 1
+        assert provider._is_breaker_open() is False
+        assert provider._consecutive_failures == 0
+
+    def test_breaker_resets_on_success(self):
+        provider = Mem0OSSMemoryProvider()
+        provider._consecutive_failures = 3
+        provider._record_success()
+        assert provider._consecutive_failures == 0
+
+    def test_tool_call_returns_error_when_breaker_open(self):
+        provider = Mem0OSSMemoryProvider()
+        provider._consecutive_failures = _BREAKER_THRESHOLD
+        provider._breaker_open_until = time.monotonic() + 999
+        result = json.loads(provider.handle_tool_call("mem0_oss_search", {"query": "test"}))
+        assert "temporarily unavailable" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Response unwrapping
+# ---------------------------------------------------------------------------
+
+
+class TestMem0OSSResponseUnwrapping:
+    """_unwrap_results handles dict, list, and edge cases."""
+
+    def test_dict_response(self):
+        assert Mem0OSSMemoryProvider._unwrap_results({"results": [1, 2]}) == [1, 2]
+
+    def test_list_response(self):
+        assert Mem0OSSMemoryProvider._unwrap_results([3, 4]) == [3, 4]
+
+    def test_empty_dict(self):
+        assert Mem0OSSMemoryProvider._unwrap_results({}) == []
+
+    def test_none(self):
+        assert Mem0OSSMemoryProvider._unwrap_results(None) == []
+
+    def test_unexpected_type(self):
+        assert Mem0OSSMemoryProvider._unwrap_results("string") == []
+
+
+# ---------------------------------------------------------------------------
+# Config schema and save_config
+# ---------------------------------------------------------------------------
+
+
+class TestMem0OSSConfigSchema:
+    """Setup wizard config schema and save_config."""
+
+    def test_config_schema_has_required_fields(self):
+        provider = Mem0OSSMemoryProvider()
+        schema = provider.get_config_schema()
+        keys = [f["key"] for f in schema]
+        assert "llm_provider" in keys
+        assert "llm_model" in keys
+        assert "embedder_provider" in keys
+        assert "vector_store_provider" in keys
+        assert "user_id" in keys
+
+    def test_save_config_writes_nested_json(self, tmp_path):
+        provider = Mem0OSSMemoryProvider()
+        values = {
+            "llm_provider": "ollama",
+            "llm_model": "llama3.1:8b",
+            "ollama_base_url": "http://localhost:11434",
+            "embedder_provider": "ollama",
+            "embedder_model": "nomic-embed-text",
+            "vector_store_provider": "qdrant",
+            "vector_store_path": "/tmp/test-qdrant",
+            "user_id": "test-user",
+            "agent_id": "test-agent",
+        }
+        provider.save_config(values, str(tmp_path))
+
+        config_file = tmp_path / "mem0_oss.json"
+        assert config_file.exists()
+        cfg = json.loads(config_file.read_text())
+        assert cfg["llm"]["provider"] == "ollama"
+        assert cfg["llm"]["config"]["model"] == "llama3.1:8b"
+        assert cfg["llm"]["config"]["ollama_base_url"] == "http://localhost:11434"
+        assert cfg["embedder"]["provider"] == "ollama"
+        assert cfg["embedder"]["config"]["model"] == "nomic-embed-text"
+        assert cfg["vector_store"]["provider"] == "qdrant"
+        assert cfg["vector_store"]["config"]["path"] == "/tmp/test-qdrant"
+        assert cfg["user_id"] == "test-user"
+        assert cfg["agent_id"] == "test-agent"
+
+    def test_save_config_ollama_pgvector(self, tmp_path):
+        provider = Mem0OSSMemoryProvider()
+        values = {
+            "llm_provider": "ollama",
+            "llm_model": "llama3.1:8b",
+            "ollama_base_url": "http://localhost:11434",
+            "embedder_provider": "ollama",
+            "embedder_model": "nomic-embed-text",
+            "vector_store_provider": "pgvector",
+            "vector_store_connection_string": "postgresql://user:pass@localhost/db",
+            "user_id": "hermes-user",
+            "agent_id": "hermes",
+        }
+        provider.save_config(values, str(tmp_path))
+
+        cfg = json.loads((tmp_path / "mem0_oss.json").read_text())
+        assert cfg["llm"]["provider"] == "ollama"
+        assert cfg["llm"]["config"]["ollama_base_url"] == "http://localhost:11434"
+        assert cfg["vector_store"]["provider"] == "pgvector"
+        assert cfg["vector_store"]["config"]["connection_string"] == "postgresql://user:pass@localhost/db"
+
+    def test_save_config_excludes_secrets(self, tmp_path):
+        provider = Mem0OSSMemoryProvider()
+        values = {
+            "llm_provider": "openai",
+            "llm_model": "gpt-5.4",
+            "llm_api_key": "sk-secret-key",
+            "embedder_provider": "openai",
+            "embedder_model": "text-embedding-3-small",
+            "vector_store_provider": "qdrant",
+            "vector_store_path": "/tmp/qdrant",
+        }
+        provider.save_config(values, str(tmp_path))
+
+        cfg_text = (tmp_path / "mem0_oss.json").read_text()
+        assert "sk-secret-key" not in cfg_text
+        assert "llm_api_key" not in cfg_text
+
+
+# ---------------------------------------------------------------------------
+# System prompt
+# ---------------------------------------------------------------------------
+
+
+class TestMem0OSSSystemPrompt:
+    """System prompt block contains expected content."""
+
+    def test_system_prompt_contains_self_hosted(self):
+        provider = Mem0OSSMemoryProvider()
+        provider._user_id = "test-user"
+        block = provider.system_prompt_block()
+        assert "Self-Hosted" in block
+        assert "test-user" in block
+        assert "mem0_oss_search" in block
+        assert "mem0_oss_conclude" in block
+        assert "mem0_oss_profile" in block

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 4
 title: "Memory Providers"
-description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover"
+description: "External memory provider plugins — Honcho, OpenViking, Mem0 (Platform & OSS), Hindsight, Holographic, RetainDB, ByteRover"
 ---
 
 # Memory Providers
@@ -20,7 +20,7 @@ Or set manually in `~/.hermes/config.yaml`:
 
 ```yaml
 memory:
-  provider: openviking   # or honcho, mem0, hindsight, holographic, retaindb, byterover
+  provider: openviking   # or honcho, mem0, mem0_oss, hindsight, holographic, retaindb, byterover
 ```
 
 ## How It Works
@@ -233,21 +233,25 @@ echo "OPENVIKING_ENDPOINT=http://localhost:1933" >> ~/.hermes/.env
 
 ### Mem0
 
-Server-side LLM fact extraction with semantic search, reranking, and automatic deduplication.
+LLM-powered memory with semantic search, reranking, and automatic deduplication. Available in two modes: **Platform** (cloud API) and **Self-hosted (OSS)** with your own LLM, embedder, and vector store.
+
+```bash
+hermes memory setup    # select "Mem0" → choose Platform or Self-hosted (OSS)
+```
+
+#### Mem0 Platform
 
 | | |
 |---|---|
 | **Best for** | Hands-off memory management — Mem0 handles extraction automatically |
-| **Requires** | `pip install mem0ai` + API key |
+| **Requires** | `pip install mem0ai` + [API key](https://app.mem0.ai) |
 | **Data storage** | Mem0 Cloud |
 | **Cost** | Mem0 pricing |
 
-**Tools:** `mem0_profile` (all stored memories), `mem0_search` (semantic search + reranking), `mem0_conclude` (store verbatim facts)
+**Tools:** `mem0_profile`, `mem0_search`, `mem0_conclude`
 
-**Setup:**
+**Manual setup:**
 ```bash
-hermes memory setup    # select "mem0"
-# Or manually:
 hermes config set memory.provider mem0
 echo "MEM0_API_KEY=your-key" >> ~/.hermes/.env
 ```
@@ -258,6 +262,45 @@ echo "MEM0_API_KEY=your-key" >> ~/.hermes/.env
 |-----|---------|-------------|
 | `user_id` | `hermes-user` | User identifier |
 | `agent_id` | `hermes` | Agent identifier |
+
+#### Mem0 Self-hosted (OSS)
+
+| | |
+|---|---|
+| **Best for** | Full control over LLM, embedder, and vector store — data stays on your infra |
+| **Requires** | `pip install mem0ai` + LLM provider (OpenAI key, or Ollama locally + `pip install ollama`) |
+| **Data storage** | Local vector store (Qdrant) or self-hosted (PGVector, Milvus) |
+| **Cost** | Free (plus LLM API costs if using a cloud LLM) |
+
+**Tools:** `mem0_oss_profile`, `mem0_oss_search`, `mem0_oss_conclude`
+
+**Manual setup:**
+```bash
+hermes config set memory.provider mem0_oss
+echo "OPENAI_API_KEY=your-key" >> ~/.hermes/.env
+```
+
+**Config:** `$HERMES_HOME/mem0_oss.json`
+
+```json
+{
+  "llm": {"provider": "openai", "config": {"model": "gpt-5.4", "temperature": 0.1}},
+  "embedder": {"provider": "openai", "config": {"model": "text-embedding-3-small"}},
+  "vector_store": {"provider": "qdrant", "config": {"path": "/tmp/qdrant", "collection_name": "mem0"}},
+  "user_id": "hermes-user",
+  "agent_id": "hermes"
+}
+```
+
+**Supported providers:**
+
+| Component | Options |
+|-----------|---------|
+| **LLM** | OpenAI, Ollama |
+| **Embedder** | OpenAI, Ollama |
+| **Vector Store** | Qdrant (local), PGVector, Milvus |
+
+A built-in fact extraction prompt filters out conversational noise (greetings, small talk) so only durable facts are stored during automatic turn sync.
 
 ---
 
@@ -388,7 +431,8 @@ hermes config set memory.provider byterover
 |----------|---------|------|-------|-------------|----------------|
 | **Honcho** | Cloud | Paid | 4 | `honcho-ai` | Dialectic user modeling |
 | **OpenViking** | Self-hosted | Free | 5 | `openviking` + server | Filesystem hierarchy + tiered loading |
-| **Mem0** | Cloud | Paid | 3 | `mem0ai` | Server-side LLM extraction |
+| **Mem0 Platform** | Cloud | Paid | 3 | `mem0ai` | Server-side LLM extraction |
+| **Mem0 OSS** | Local/Self-hosted | Free + LLM costs | 3 | `mem0ai` | Configurable LLM, embedder & vector store |
 | **Hindsight** | Cloud/Local | Free/Paid | 3 | `hindsight-client` | Knowledge graph + reflect synthesis |
 | **Holographic** | Local | Free | 2 | None | HRR algebra + trust scoring |
 | **RetainDB** | Cloud | $20/mo | 5 | `requests` | Delta compression |
@@ -399,7 +443,7 @@ hermes config set memory.provider byterover
 Each provider's data is isolated per [profile](/docs/user-guide/profiles):
 
 - **Local storage providers** (Holographic, ByteRover) use `$HERMES_HOME/` paths which differ per profile
-- **Config file providers** (Honcho, Mem0, Hindsight) store config in `$HERMES_HOME/` so each profile has its own credentials
+- **Config file providers** (Honcho, Mem0, Mem0 OSS, Hindsight) store config in `$HERMES_HOME/` so each profile has its own credentials
 - **Cloud providers** (RetainDB) auto-derive profile-scoped project names
 - **Env var providers** (OpenViking) are configured via each profile's `.env` file
 


### PR DESCRIPTION
## What does this PR do?

  Adds a self-hosted Mem0 OSS memory provider plugin alongside the existing cloud platform version. Users can now run memory entirely on their own infrastructure with configurable LLM (OpenAI/Ollama), embedder (OpenAI/Ollama), and vector store (Qdrant/PGVector/Milvus). The setup wizard merges both Mem0 variants into a single picker entry with a sub-selection for Platform vs
  Self-hosted.

  ## Type of Change

  - [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [x] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [x] 📝 Documentation update
  - [x] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️  Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  ## Changes Made

  - `plugins/memory/mem0_oss/__init__.py` — New `Mem0OSSMemoryProvider` with full lifecycle (initialize, prefetch, sync_turn, handle_tool_call, shutdown), circuit breaker, custom fact extraction
  prompt to filter conversational noise, auto-detection of embedding dimensions, and dependency checking for provider-specific packages (ollama, psycopg2-binary, pymilvus)
  - `plugins/memory/mem0_oss/plugin.yaml` — Plugin metadata with `mem0ai` as base dependency
  - `plugins/memory/mem0_oss/README.md` — Setup, config, supported providers, and tool documentation
  - `hermes_cli/memory_setup.py` — Unified Mem0 picker (groups `mem0` + `mem0_oss` into single entry with Platform/Self-hosted sub-picker), added `_install_extra_dependencies()` to auto-install
  provider-specific packages during onboarding
  - `plugins/memory/mem0/README.md` — Updated wizard command to reflect new grouped picker
  - `website/docs/user-guide/features/memory-providers.md` — Added Mem0 Self-hosted (OSS) section, updated comparison table and provider lists
  - `tests/plugins/memory/test_mem0_oss.py` — 33 unit tests covering config loading, availability checks (including missing dependency detection), tool calls, circuit breaker, kwargs, response
  unwrapping, config schema, and system prompt

  ## How to Test

  1. Run `hermes memory setup`, select "Mem0", then "Self-hosted (OSS)"
  2. Pick Ollama for LLM and embedder (or OpenAI), Qdrant for vector store — the wizard should auto-install any missing packages (e.g. `ollama`)
  3. Start a Hermes session and verify all three tools work:
     - `mem0_oss_conclude` — store a fact
     - `mem0_oss_search` — search for it
     - `mem0_oss_profile` — list all memories
  4. Run `pytest tests/plugins/memory/test_mem0_oss.py -v` — all 33 tests should pass

  ## Checklist

  ### Code

  - [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
  - [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
  - [x] I've run `pytest tests/ -q` and all tests pass
  - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - [x] I've tested on my platform: macOS 15 (Darwin 25.3.0)

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
  - [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
  - [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
  - [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) —
  or N/A
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A