### PR TITLE
Ensure MCP EventBridge message integrity by tracking IDs during timestamp collisions

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -199,6 +199,7 @@ class EventBridge:
         self._running = False
         self._thread: Optional[threading.Thread] = None
         self._last_poll_timestamps: Dict[str, float] = {}  # session_key -> unix timestamp
+        self._last_poll_message_keys: Dict[str, set[str]] = {}
         # In-memory approval tracking (populated from events)
         self._pending_approvals: Dict[str, dict] = {}
         # mtime cache — skip expensive work when files haven't changed
@@ -366,6 +367,7 @@ class EventBridge:
                 continue
 
             last_seen = self._last_poll_timestamps.get(session_key, 0.0)
+            last_seen_keys = self._last_poll_message_keys.get(session_key, set())
 
             try:
                 messages = db.get_messages(session_id)
@@ -391,6 +393,20 @@ class EventBridge:
                             return 0.0
                 return 0.0
 
+            def _message_key(msg: dict) -> str:
+                msg_id = msg.get("id")
+                if msg_id not in (None, ""):
+                    return f"id:{msg_id}"
+                return json.dumps(
+                    {
+                        "role": msg.get("role", ""),
+                        "timestamp": msg.get("timestamp", ""),
+                        "content": _extract_message_content(msg),
+                    },
+                    ensure_ascii=False,
+                    sort_keys=True,
+                )
+
             # Find messages newer than our last seen timestamp
             new_messages = []
             for msg in messages:
@@ -398,7 +414,7 @@ class EventBridge:
                 role = msg.get("role", "")
                 if role not in ("user", "assistant"):
                     continue
-                if ts > last_seen:
+                if ts > last_seen or (ts == last_seen and _message_key(msg) not in last_seen_keys):
                     new_messages.append(msg)
 
             for msg in new_messages:
@@ -417,12 +433,27 @@ class EventBridge:
                     },
                 ))
 
-            # Update last seen to the most recent message timestamp
-            all_ts = [_ts_float(m.get("timestamp", 0)) for m in messages]
+            # Update the watermark using only user-visible message roles.
+            visible_messages = [
+                m for m in messages
+                if m.get("role", "") in ("user", "assistant")
+            ]
+            all_ts = [_ts_float(m.get("timestamp", 0)) for m in visible_messages]
             if all_ts:
                 latest = max(all_ts)
                 if latest > last_seen:
                     self._last_poll_timestamps[session_key] = latest
+                    self._last_poll_message_keys[session_key] = {
+                        _message_key(m)
+                        for m in visible_messages
+                        if _ts_float(m.get("timestamp", 0)) == latest
+                    }
+                elif latest == last_seen:
+                    self._last_poll_message_keys[session_key] = {
+                        _message_key(m)
+                        for m in visible_messages
+                        if _ts_float(m.get("timestamp", 0)) == latest
+                    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -1105,6 +1105,120 @@ class TestEventBridgePollE2E:
         assert len(r2["events"]) == 1
         assert r2["events"][0]["content"] == "New reply!"
 
+    def test_poll_detects_new_message_with_same_timestamp(self, tmp_path, monkeypatch):
+        """A new message with the same timestamp as the last seen one must not be dropped."""
+        import mcp_serve
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: sessions_dir)
+
+        session_id = "20260329_150000_same_ts"
+        db_path = tmp_path / "state.db"
+
+        sessions_data = {
+            "agent:main:telegram:dm:same-ts": {
+                "session_key": "agent:main:telegram:dm:same-ts",
+                "session_id": session_id,
+                "platform": "telegram",
+                "updated_at": "2026-03-29T15:00:05",
+                "origin": {"platform": "telegram", "chat_id": "same-ts"},
+            }
+        }
+        (sessions_dir / "sessions.json").write_text(json.dumps(sessions_data))
+        _create_test_db(db_path, session_id, [
+            {"role": "user", "content": "First", "timestamp": "2026-03-29T15:00:01"},
+        ])
+
+        class TestDB:
+            def get_messages(self, sid):
+                conn = sqlite3.connect(str(db_path))
+                conn.row_factory = sqlite3.Row
+                rows = conn.execute(
+                    "SELECT * FROM messages WHERE session_id = ? ORDER BY id",
+                    (sid,),
+                ).fetchall()
+                conn.close()
+                return [dict(r) for r in rows]
+
+        db = TestDB()
+        bridge = mcp_serve.EventBridge()
+
+        bridge._poll_once(db)
+        r1 = bridge.poll_events(after_cursor=0)
+        assert len(r1["events"]) == 1
+
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            (session_id, "assistant", "Same-second reply", "2026-03-29T15:00:01"),
+        )
+        conn.commit()
+        conn.close()
+        os.utime(db_path, None)
+
+        bridge._poll_once(db)
+        r2 = bridge.poll_events(after_cursor=r1["next_cursor"])
+        assert len(r2["events"]) == 1
+        assert r2["events"][0]["content"] == "Same-second reply"
+
+    def test_poll_ignores_tool_timestamps_for_watermark(self, tmp_path, monkeypatch):
+        """Tool-only rows must not move the watermark past later user-visible messages."""
+        import mcp_serve
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: sessions_dir)
+
+        session_id = "20260329_150000_tool_ts"
+        db_path = tmp_path / "state.db"
+
+        sessions_data = {
+            "agent:main:telegram:dm:tool-ts": {
+                "session_key": "agent:main:telegram:dm:tool-ts",
+                "session_id": session_id,
+                "platform": "telegram",
+                "updated_at": "2026-03-29T15:00:10",
+                "origin": {"platform": "telegram", "chat_id": "tool-ts"},
+            }
+        }
+        (sessions_dir / "sessions.json").write_text(json.dumps(sessions_data))
+        _create_test_db(db_path, session_id, [
+            {"role": "user", "content": "First", "timestamp": "2026-03-29T15:00:01"},
+            {"role": "tool", "content": '{"result":"ok"}', "timestamp": "2026-03-29T15:00:10"},
+        ])
+
+        class TestDB:
+            def get_messages(self, sid):
+                conn = sqlite3.connect(str(db_path))
+                conn.row_factory = sqlite3.Row
+                rows = conn.execute(
+                    "SELECT * FROM messages WHERE session_id = ? ORDER BY id",
+                    (sid,),
+                ).fetchall()
+                conn.close()
+                return [dict(r) for r in rows]
+
+        db = TestDB()
+        bridge = mcp_serve.EventBridge()
+
+        bridge._poll_once(db)
+        r1 = bridge.poll_events(after_cursor=0)
+        assert len(r1["events"]) == 1
+        assert r1["events"][0]["content"] == "First"
+
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            (session_id, "assistant", "Visible reply", "2026-03-29T15:00:05"),
+        )
+        conn.commit()
+        conn.close()
+        os.utime(db_path, None)
+
+        bridge._poll_once(db)
+        r2 = bridge.poll_events(after_cursor=r1["next_cursor"])
+        assert len(r2["events"]) == 1
+        assert r2["events"][0]["content"] == "Visible reply"
+
     def test_poll_interval_is_200ms(self):
         """Verify the poll interval constant."""
         from mcp_serve import POLL_INTERVAL


### PR DESCRIPTION
The Problem
The EventBridge in the MCP bridge was relying solely on the "last seen timestamp" to track progress. This caused two critical issues:

Timestamp Collisions: If multiple messages arrived with the exact same timestamp, only the first one was processed, and subsequent messages were dropped silently.

Watermark Corruption: Internal tool entries were incorrectly advancing the watermark, causing visible user/assistant messages to be skipped.

The Fix

Stateful Tracking: The bridge now tracks both the last_timestamp and a set of seen_message_ids for that specific timestamp.

Corrected Watermark Logic: Ensured that watermark advancement only occurs for messages that should actually trigger a state update.

Verification

Added regression tests in tests/test_mcp_serve.py covering:

Multiple messages with identical timestamps.

Watermark integrity during mixed tool/message flows.