### PR TITLE
fix(gateway): Apply markdown-to-mrkdwn conversion in edit_message

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -276,10 +276,13 @@ class SlackAdapter(BasePlatformAdapter):
         if not self._app:
             return SendResult(success=False, error="Not connected")
         try:
+            # Convert standard markdown → Slack mrkdwn
+            formatted = self.format_message(content)
+
             await self._get_client(chat_id).chat_update(
                 channel=chat_id,
                 ts=message_id,
-                text=content,
+                text=formatted,
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:  # pragma: no cover - defensive logging


### PR DESCRIPTION
## Summary

Fixes missing markdown → mrkdwn conversion in `edit_message()`, causing broken formatting and malformed URLs when editing messages.

## Problem

The `send()` method in the Slack adapter correctly converts standard markdown to Slack's `mrkdwn` format using `format_message()`. However, `edit_message()` was sending raw content directly to `chat_update`, skipping this conversion.

### Impact

- **Bold text**: `**text**` rendered literally instead of *text*
- **Links with formatting**: `[link](https://...)` in bold/context became `<https://...|link>**` with trailing `**` included in the clickable URL → 404 errors
- **Headers/code blocks**: Rendered with raw markdown syntax visible

This was discovered after PR #5558 links were unclickable due to trailing `**` from bold syntax becoming part of the URL.

## Solution

Added `format_message(content)` call in `edit_message()` before sending to `chat_update`, matching the behavior of `send()`.

```python
# Convert standard markdown → Slack mrkdwn
formatted = self.format_message(content)

await self._get_client(chat_id).chat_update(
    channel=chat_id,
    ts=message_id,
    text=formatted,  # Was: text=content
)
```

## Changes

- `gateway/platforms/slack.py`: Added `format_message()` call in `edit_message()`

## Testing

All 69 Slack gateway tests pass. The existing test suite validates the `format_message()` function; this fix ensures `edit_message()` uses it consistently with `send()`.

## Backwards Compatibility

Fully backwards compatible — only fixes broken behavior. Edited messages will now render correctly instead of showing raw markdown.