### PR TITLE
fix(delegate): share credential pools with subagents

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -26,6 +26,7 @@ from tools.delegate_tool import (
     _build_child_agent,
     _build_child_system_prompt,
     _strip_blocked_tools,
+    _resolve_child_credential_pool,
     _resolve_delegation_credentials,
 )
 
@@ -928,6 +929,76 @@ class TestDelegationProviderIntegration(unittest.TestCase):
             # But provider/base_url/api_key should inherit from parent
             self.assertEqual(kwargs["provider"], parent.provider)
             self.assertEqual(kwargs["base_url"], parent.base_url)
+
+
+class TestChildCredentialPoolResolution(unittest.TestCase):
+    def test_same_provider_shares_parent_pool(self):
+        parent = _make_mock_parent()
+        mock_pool = MagicMock()
+        parent._credential_pool = mock_pool
+
+        result = _resolve_child_credential_pool("openrouter", parent)
+        self.assertIs(result, mock_pool)
+
+    def test_no_provider_inherits_parent_pool(self):
+        parent = _make_mock_parent()
+        mock_pool = MagicMock()
+        parent._credential_pool = mock_pool
+
+        result = _resolve_child_credential_pool(None, parent)
+        self.assertIs(result, mock_pool)
+
+    def test_different_provider_loads_own_pool(self):
+        parent = _make_mock_parent()
+        parent._credential_pool = MagicMock()
+        mock_pool = MagicMock()
+        mock_pool.has_credentials.return_value = True
+
+        with patch("agent.credential_pool.load_pool", return_value=mock_pool):
+            result = _resolve_child_credential_pool("anthropic", parent)
+
+        self.assertIs(result, mock_pool)
+
+    def test_different_provider_empty_pool_returns_none(self):
+        parent = _make_mock_parent()
+        parent._credential_pool = MagicMock()
+        mock_pool = MagicMock()
+        mock_pool.has_credentials.return_value = False
+
+        with patch("agent.credential_pool.load_pool", return_value=mock_pool):
+            result = _resolve_child_credential_pool("anthropic", parent)
+
+        self.assertIsNone(result)
+
+    def test_different_provider_load_failure_returns_none(self):
+        parent = _make_mock_parent()
+        parent._credential_pool = MagicMock()
+
+        with patch("agent.credential_pool.load_pool", side_effect=Exception("disk error")):
+            result = _resolve_child_credential_pool("anthropic", parent)
+
+        self.assertIsNone(result)
+
+    def test_build_child_agent_assigns_parent_pool_when_shared(self):
+        parent = _make_mock_parent()
+        mock_pool = MagicMock()
+        parent._credential_pool = mock_pool
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="Test pool assignment",
+                context=None,
+                toolsets=["terminal"],
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+            )
+
+            self.assertEqual(mock_child._credential_pool, mock_pool)
 
 
 if __name__ == "__main__":

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -263,6 +263,12 @@ def _build_child_agent(
     # Set delegation depth so children can't spawn grandchildren
     child._delegate_depth = getattr(parent_agent, '_delegate_depth', 0) + 1
 
+    # Share a credential pool with the child when possible so subagents can
+    # rotate credentials on rate limits instead of getting pinned to one key.
+    child_pool = _resolve_child_credential_pool(effective_provider, parent_agent)
+    if child_pool is not None:
+        child._credential_pool = child_pool
+
     # Register child for interrupt propagation
     if hasattr(parent_agent, '_active_children'):
         lock = getattr(parent_agent, '_active_children_lock', None)
@@ -608,6 +614,38 @@ def delegate_task(
         "results": results,
         "total_duration_seconds": total_duration,
     }, ensure_ascii=False)
+
+
+def _resolve_child_credential_pool(effective_provider: Optional[str], parent_agent):
+    """Resolve a credential pool for the child agent.
+
+    Rules:
+    1. Same provider as the parent -> share the parent's pool so cooldown state
+       and rotation stay synchronized.
+    2. Different provider -> try to load that provider's own pool.
+    3. No pool available -> return None and let the child keep the inherited
+       fixed credential behavior.
+    """
+    if not effective_provider:
+        return getattr(parent_agent, "_credential_pool", None)
+
+    parent_provider = getattr(parent_agent, "provider", None) or ""
+    parent_pool = getattr(parent_agent, "_credential_pool", None)
+    if parent_pool is not None and effective_provider == parent_provider:
+        return parent_pool
+
+    try:
+        from agent.credential_pool import load_pool
+        pool = load_pool(effective_provider)
+        if pool is not None and pool.has_credentials():
+            return pool
+    except Exception as exc:
+        logger.debug(
+            "Could not load credential pool for child provider '%s': %s",
+            effective_provider,
+            exc,
+        )
+    return None
 
 
 def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:


### PR DESCRIPTION
## Summary
This PR makes delegated child agents participate in credential-pool rotation instead of inheriting a single fixed credential from the parent.

Today, even when a parent agent has access to a healthy credential pool, a subagent can end up knowing only one effective credential. If that credential hits a rate limit or quota wall, the child stalls even though the pool still has other usable entries.

This patch keeps the change intentionally small:
- resolve an appropriate credential pool for the child
- share the parent's pool when parent and child use the same provider
- otherwise try to load the child's provider pool directly
- fall back gracefully to the old fixed-credential behavior when no pool exists
- add focused delegation tests for the child-pool resolution path

## What changed
- added `_resolve_child_credential_pool()` in `tools/delegate_tool.py`
- `_build_child_agent()` now assigns a credential pool to the child when available
- same-provider children share the parent's pool so cooldown/rotation state stays synchronized
- different-provider children try to load their own provider pool
- empty or unavailable pools fall back to the previous behavior (no pool assignment)

## Why
This is the smallest useful extraction from the larger credential-pool hardening branch.

It improves real subagent resilience without pulling in the more invasive pieces yet:
- no lease scheduler
- no tier profiles
- no retry-header parsing
- no fallback-precedence rewrite

## Validation
### Automated
- `/home/ubuntu/.hermes/hermes-agent/venv/bin/python -m py_compile tools/delegate_tool.py tests/tools/test_delegate.py`
- `/home/ubuntu/.hermes/hermes-agent/venv/bin/python -m pytest -q -o addopts='' tests/tools/test_delegate.py -k 'ChildCredentialPoolResolution or DelegationProviderIntegration'`
- Result: `13 passed, 44 deselected`

Additional focused validation:
- `/home/ubuntu/.hermes/hermes-agent/venv/bin/python -m pytest -q -o addopts='' tests/tools/test_delegate.py`
- Result: `57 passed`

## Related context
- Extracted from the larger draft: #5374
- Related issue: #933 (multiple OAuth tokens / automatic fallback)
- Intentionally does **not** implement proactive throttling from #5449

## Scope notes
This PR only makes child agents see and use credential pools.
It does not yet add:
- lease-based concurrency control
- tiered delegation profiles
- structured provider failure classification
- fallback precedence changes
