### PR TITLE
fix(mcp): make OAuth token cache writes atomic on Windows

### DIFF
--- a/tests/tools/test_mcp_oauth.py
+++ b/tests/tools/test_mcp_oauth.py
@@ -67,6 +67,40 @@ class TestHermesTokenStorage:
         client_path = tmp_path / "mcp-tokens" / "test-server.client.json"
         assert client_path.exists()
 
+    def test_set_tokens_overwrites_existing_file_when_rename_cannot_replace(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        storage = HermesTokenStorage("test-server")
+        import asyncio
+
+        original_rename = Path.rename
+
+        def windows_style_rename(self, target):
+            if Path(target).exists():
+                raise FileExistsError("destination exists")
+            return original_rename(self, target)
+
+        monkeypatch.setattr(Path, "rename", windows_style_rename)
+
+        first_token = MagicMock()
+        first_token.model_dump.return_value = {
+            "access_token": "first-token",
+            "token_type": "Bearer",
+        }
+        second_token = MagicMock()
+        second_token.model_dump.return_value = {
+            "access_token": "second-token",
+            "token_type": "Bearer",
+        }
+
+        asyncio.run(storage.set_tokens(first_token))
+        asyncio.run(storage.set_tokens(second_token))
+
+        token_path = tmp_path / "mcp-tokens" / "test-server.json"
+        data = json.loads(token_path.read_text())
+        assert data["access_token"] == "second-token"
+
     def test_remove_cleans_up(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         storage = HermesTokenStorage("test-server")

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -40,6 +40,7 @@ import re
 import socket
 import sys
 import threading
+import tempfile
 import webbrowser
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
@@ -157,11 +158,19 @@ def _read_json(path: Path) -> dict | None:
 def _write_json(path: Path, data: dict) -> None:
     """Write a dict as JSON with restricted permissions (0o600)."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(".tmp")
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent),
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+    )
+    tmp = Path(tmp_name)
     try:
-        tmp.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(json.dumps(data, indent=2, default=str))
+            handle.flush()
+            os.fsync(handle.fileno())
         os.chmod(tmp, 0o600)
-        tmp.rename(path)
+        os.replace(tmp, path)
     except OSError:
         tmp.unlink(missing_ok=True)
         raise


### PR DESCRIPTION
Summary
This PR fixes a cross-platform bug in MCP OAuth token persistence.

tools/mcp_oauth.py was writing token and client-info JSON files by creating a fixed temporary path and then calling Path.rename() to move it into place. That flow is not safe on Windows when the destination file already exists, because rename does not reliably replace an existing file there.

As a result, once an OAuth token cache file had already been created, later updates such as token refreshes or client-info rewrites could fail instead of replacing the previous file.

What changed
Switched _write_json() in tools/mcp_oauth.py to use:
tempfile.mkstemp() for a unique temp file in the target directory
os.fsync() before replacement
os.replace() for atomic cross-platform overwrite semantics
Kept the existing cleanup behavior for failed writes
Added a regression test in tests/tools/test_mcp_oauth.py that simulates Windows-style rename behavior and verifies that writing tokens twice correctly overwrites the existing cache file
Why this matters
This fixes a real cross-platform reliability issue in the OAuth flow:

First token write succeeds
Later token refresh or cache update may fail on Windows
Cached OAuth state can become stale or stop updating
MCP servers using OAuth may require unnecessary re-authentication or behave inconsistently
This change makes the persistence path properly atomic and portable.

Reproduction
Before this fix:

Complete an MCP OAuth flow so a token file already exists under HERMES_HOME/mcp-tokens/
Trigger a second write to the same token/client-info path
On Windows-style rename semantics, the write can fail because the destination already exists
After this fix:

The new data is written to a unique temp file
os.replace() atomically swaps it into place
Existing cache files are updated correctly on all supported platforms
Test plan
Added regression coverage for the overwrite case:

test_set_tokens_overwrites_existing_file_when_rename_cannot_replace
Suggested verification:

pytest tests/tools/test_mcp_oauth.py -q
Impact
Fixes Windows compatibility for MCP OAuth persistence
Improves robustness of token refresh and client-info updates
No behavior change for normal read paths
Low-risk, localized change