### PR TITLE
feat(delegate): add tiered subagent profiles

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -458,6 +458,7 @@ DEFAULT_CONFIG = {
         "provider": "",    # e.g. "openrouter" (empty = inherit parent provider + credentials)
         "base_url": "",    # direct OpenAI-compatible endpoint for subagents
         "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
+        "reasoning_effort": "",  # e.g. "low" (empty = inherit parent reasoning config)
         "max_iterations": 50,  # per-subagent iteration cap (each subagent gets its own budget,
                                # independent of the parent's max_iterations)
     },

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -932,3 +932,38 @@ class TestDelegationProviderIntegration(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestDelegationReasoningEffort(unittest.TestCase):
+    def test_resolve_delegation_credentials_includes_reasoning_effort(self):
+        parent = _make_mock_parent(depth=0)
+        cfg = {"model": "gpt-5.4-mini", "provider": "", "reasoning_effort": "low"}
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["reasoning_effort"], "low")
+
+    def test_build_child_agent_applies_override_reasoning_effort(self):
+        parent = _make_mock_parent(depth=0)
+        parent.reasoning_config = {"enabled": True, "effort": "xhigh"}
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="Test child",
+                context=None,
+                toolsets=["terminal"],
+                model="gpt-5.4-mini",
+                max_iterations=10,
+                parent_agent=parent,
+                override_provider="openai-codex",
+                override_base_url="https://chatgpt.com/backend-api/codex",
+                override_api_key="test-key",
+                override_api_mode="codex_responses",
+                override_reasoning_effort="low",
+            )
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["reasoning_config"]["effort"], "low")
+            self.assertTrue(kwargs["reasoning_config"]["enabled"])

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -23,6 +23,7 @@ from tools.delegate_tool import (
     MAX_DEPTH,
     check_delegate_requirements,
     delegate_task,
+    resolve_tier_config,
     _build_child_agent,
     _build_child_system_prompt,
     _strip_blocked_tools,
@@ -967,3 +968,128 @@ class TestDelegationReasoningEffort(unittest.TestCase):
             _, kwargs = MockAgent.call_args
             self.assertEqual(kwargs["reasoning_config"]["effort"], "low")
             self.assertTrue(kwargs["reasoning_config"]["enabled"])
+
+
+class TestTierResolution(unittest.TestCase):
+    def test_no_tiers_returns_flat_config(self):
+        cfg = {"model": "gpt-5.4-mini", "reasoning_effort": "low"}
+        result = resolve_tier_config(cfg, tier="heavy")
+        self.assertEqual(result, cfg)
+
+    def test_explicit_tier_overrides_flat(self):
+        cfg = {
+            "model": "gpt-5.4-mini",
+            "reasoning_effort": "low",
+            "max_iterations": 25,
+            "tiers": {
+                "heavy": {
+                    "model": "claude-opus-4-6",
+                    "reasoning_effort": "medium",
+                    "max_iterations": 50,
+                },
+            },
+        }
+        result = resolve_tier_config(cfg, tier="heavy")
+        self.assertEqual(result["model"], "claude-opus-4-6")
+        self.assertEqual(result["reasoning_effort"], "medium")
+        self.assertEqual(result["max_iterations"], 50)
+        self.assertNotIn("tiers", result)
+        self.assertNotIn("default_tier", result)
+
+    def test_default_tier_used_when_no_explicit_tier(self):
+        cfg = {
+            "model": "gpt-5.4-mini",
+            "reasoning_effort": "low",
+            "default_tier": "review",
+            "tiers": {
+                "review": {
+                    "model": "claude-opus-4-6",
+                    "reasoning_effort": "high",
+                },
+            },
+        }
+        result = resolve_tier_config(cfg, tier=None)
+        self.assertEqual(result["model"], "claude-opus-4-6")
+        self.assertEqual(result["reasoning_effort"], "high")
+
+    def test_review_tier_never_degrades_below_high_reasoning(self):
+        cfg = {
+            "model": "gpt-5.4-mini",
+            "reasoning_effort": "low",
+            "tiers": {
+                "review": {
+                    "model": "gpt-5.4-mini",
+                    "reasoning_effort": "low",
+                },
+            },
+        }
+        result = resolve_tier_config(cfg, tier="review")
+        self.assertEqual(result["reasoning_effort"], "high")
+
+    def test_schema_includes_tier_fields(self):
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        self.assertIn("tier", props)
+        self.assertIn("light", props["tier"]["enum"])
+        task_props = props["tasks"]["items"]["properties"]
+        self.assertIn("tier", task_props)
+        self.assertIn("planning", task_props["tier"]["enum"])
+
+    def test_batch_tasks_can_override_tier_independently(self):
+        parent = _make_mock_parent()
+        cfg = {
+            "model": "gpt-5.4-mini",
+            "provider": "openai-codex",
+            "reasoning_effort": "low",
+            "max_iterations": 25,
+            "default_tier": "light",
+            "tiers": {
+                "light": {
+                    "model": "gpt-5.4-mini",
+                    "provider": "openai-codex",
+                    "reasoning_effort": "low",
+                    "max_iterations": 25,
+                },
+                "review": {
+                    "model": "gpt-5.4",
+                    "provider": "openai-codex",
+                    "reasoning_effort": "high",
+                    "max_iterations": 60,
+                },
+            },
+        }
+
+        with patch("tools.delegate_tool._load_config", return_value=cfg), \
+             patch("tools.delegate_tool._resolve_delegation_credentials", side_effect=lambda resolved_cfg, _parent: {
+                 "model": resolved_cfg.get("model"),
+                 "provider": resolved_cfg.get("provider"),
+                 "base_url": None,
+                 "api_key": None,
+                 "api_mode": None,
+                 "reasoning_effort": resolved_cfg.get("reasoning_effort"),
+             }), \
+             patch("tools.delegate_tool._run_single_child") as mock_run, \
+             patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "ok", "completed": True, "api_calls": 1
+            }
+            MockAgent.return_value = mock_child
+            mock_run.return_value = {
+                "task_index": 0, "status": "completed", "summary": "ok", "api_calls": 1, "duration_seconds": 0.1
+            }
+
+            delegate_task(
+                tasks=[
+                    {"goal": "Quick inspect", "tier": "light"},
+                    {"goal": "Deep review", "tier": "review"},
+                ],
+                parent_agent=parent,
+            )
+
+            calls = MockAgent.call_args_list
+            self.assertEqual(calls[0].kwargs["model"], "gpt-5.4-mini")
+            self.assertEqual(calls[0].kwargs["reasoning_config"]["effort"], "low")
+            self.assertEqual(calls[0].kwargs["max_iterations"], 25)
+            self.assertEqual(calls[1].kwargs["model"], "gpt-5.4")
+            self.assertEqual(calls[1].kwargs["reasoning_config"]["effort"], "high")
+            self.assertEqual(calls[1].kwargs["max_iterations"], 60)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -171,6 +171,7 @@ def _build_child_agent(
     # ACP transport overrides — lets a non-ACP parent spawn ACP child agents
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
+    override_reasoning_effort: Optional[str] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -229,6 +230,19 @@ def _build_child_agent(
     effective_acp_command = override_acp_command or getattr(parent_agent, "acp_command", None)
     effective_acp_args = list(override_acp_args if override_acp_args is not None else (getattr(parent_agent, "acp_args", []) or []))
 
+    effective_reasoning_config = getattr(parent_agent, "reasoning_config", None)
+    if override_reasoning_effort is not None:
+        effort = str(override_reasoning_effort).strip().lower()
+        if effort == "none":
+            effective_reasoning_config = {"enabled": False, "effort": "none"}
+        elif effort:
+            if isinstance(effective_reasoning_config, dict):
+                effective_reasoning_config = dict(effective_reasoning_config)
+            else:
+                effective_reasoning_config = {}
+            effective_reasoning_config["enabled"] = True
+            effective_reasoning_config["effort"] = effort
+
     child = AIAgent(
         base_url=effective_base_url,
         api_key=effective_api_key,
@@ -239,7 +253,7 @@ def _build_child_agent(
         acp_args=effective_acp_args,
         max_iterations=max_iterations,
         max_tokens=getattr(parent_agent, "max_tokens", None),
-        reasoning_config=getattr(parent_agent, "reasoning_config", None),
+        reasoning_config=effective_reasoning_config,
         prefill_messages=getattr(parent_agent, "prefill_messages", None),
         enabled_toolsets=child_toolsets,
         quiet_mode=True,
@@ -517,6 +531,7 @@ def delegate_task(
                 override_api_mode=creds["api_mode"],
                 override_acp_command=t.get("acp_command") or acp_command,
                 override_acp_args=t.get("acp_args") or acp_args,
+                override_reasoning_effort=creds.get("reasoning_effort"),
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
@@ -629,6 +644,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     configured_provider = str(cfg.get("provider") or "").strip() or None
     configured_base_url = str(cfg.get("base_url") or "").strip() or None
     configured_api_key = str(cfg.get("api_key") or "").strip() or None
+    configured_reasoning_effort = str(cfg.get("reasoning_effort") or "").strip().lower() or None
 
     if configured_base_url:
         api_key = (
@@ -657,6 +673,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             "base_url": configured_base_url,
             "api_key": api_key,
             "api_mode": api_mode,
+            "reasoning_effort": configured_reasoning_effort,
         }
 
     if not configured_provider:
@@ -667,6 +684,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             "base_url": None,
             "api_key": None,
             "api_mode": None,
+            "reasoning_effort": configured_reasoning_effort,
         }
 
     # Provider is configured — resolve full credentials
@@ -696,6 +714,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         "api_mode": runtime.get("api_mode"),
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
+        "reasoning_effort": configured_reasoning_effort,
     }
 
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -446,6 +446,7 @@ def delegate_task(
     toolsets: Optional[List[str]] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
+    tier: Optional[str] = None,
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     parent_agent=None,
@@ -472,16 +473,14 @@ def delegate_task(
             )
         })
 
-    # Load config
-    cfg = _load_config()
+    # Load config and resolve top-level tier first
+    raw_cfg = _load_config()
+    cfg = resolve_tier_config(raw_cfg, tier=tier)
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
     effective_max_iter = max_iterations or default_max_iter
 
-    # Resolve delegation credentials (provider:model pair).
-    # When delegation.provider is configured, this resolves the full credential
-    # bundle (base_url, api_key, api_mode) via the same runtime provider system
-    # used by CLI/gateway startup.  When unconfigured, returns None values so
-    # children inherit from the parent.
+    # Resolve effective model/provider/credentials.
+    # When unconfigured, returns None values so children inherit from the parent.
     try:
         creds = _resolve_delegation_credentials(cfg, parent_agent)
     except ValueError as exc:
@@ -522,16 +521,24 @@ def delegate_task(
     children = []
     try:
         for i, t in enumerate(task_list):
+            task_tier = t.get("tier") or tier
+            task_cfg = resolve_tier_config(raw_cfg, tier=task_tier)
+            task_max_iter = max_iterations or task_cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
+            try:
+                task_creds = _resolve_delegation_credentials(task_cfg, parent_agent)
+            except ValueError:
+                task_creds = creds
+
             child = _build_child_agent(
                 task_index=i, goal=t["goal"], context=t.get("context"),
-                toolsets=t.get("toolsets") or toolsets, model=creds["model"],
-                max_iterations=effective_max_iter, parent_agent=parent_agent,
-                override_provider=creds["provider"], override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
+                toolsets=t.get("toolsets") or toolsets, model=task_creds["model"],
+                max_iterations=task_max_iter, parent_agent=parent_agent,
+                override_provider=task_creds["provider"], override_base_url=task_creds["base_url"],
+                override_api_key=task_creds["api_key"],
+                override_api_mode=task_creds["api_mode"],
                 override_acp_command=t.get("acp_command") or acp_command,
                 override_acp_args=t.get("acp_args") or acp_args,
-                override_reasoning_effort=creds.get("reasoning_effort"),
+                override_reasoning_effort=task_creds.get("reasoning_effort"),
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
@@ -623,6 +630,48 @@ def delegate_task(
         "results": results,
         "total_duration_seconds": total_duration,
     }, ensure_ascii=False)
+
+
+SUPPORTED_TIERS = frozenset({"light", "heavy", "review", "planning", "research"})
+
+
+def resolve_tier_config(cfg: dict, tier: Optional[str] = None) -> dict:
+    """Resolve a delegation tier into an effective config dict.
+
+    Tier values override the flat delegation config. When no matching tier is
+    configured, returns the original flat config unchanged.
+    """
+    tiers = cfg.get("tiers")
+    if not isinstance(tiers, dict) or not tiers:
+        return cfg
+
+    effective_tier = str(tier or cfg.get("default_tier") or "").strip().lower() or None
+    if not effective_tier or effective_tier not in tiers:
+        return cfg
+
+    tier_cfg = tiers.get(effective_tier)
+    if not isinstance(tier_cfg, dict):
+        return cfg
+
+    merged = dict(cfg)
+    merged.pop("tiers", None)
+    merged.pop("default_tier", None)
+    merged.update(tier_cfg)
+
+    tier_reasoning_floor = {
+        "heavy": "medium",
+        "research": "medium",
+        "planning": "high",
+        "review": "high",
+    }
+    floor = tier_reasoning_floor.get(effective_tier)
+    if floor:
+        current = str(merged.get("reasoning_effort") or "").strip().lower()
+        order = {"none": 0, "low": 1, "medium": 2, "high": 3, "max": 4, "xhigh": 4}
+        if order.get(current, 0) < order[floor]:
+            merged["reasoning_effort"] = floor
+
+    return merged
 
 
 def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
@@ -809,6 +858,11 @@ DELEGATE_TASK_SCHEMA = {
                     "properties": {
                         "goal": {"type": "string", "description": "Task goal"},
                         "context": {"type": "string", "description": "Task-specific context"},
+                        "tier": {
+                            "type": "string",
+                            "enum": ["light", "heavy", "review", "planning", "research"],
+                            "description": "Task-specific tier override for this batch item",
+                        },
                         "toolsets": {
                             "type": "array",
                             "items": {"type": "string"},
@@ -838,6 +892,16 @@ DELEGATE_TASK_SCHEMA = {
                 "description": (
                     "Max tool-calling turns per subagent (default: 50). "
                     "Only set lower for simple tasks."
+                ),
+            },
+            "tier": {
+                "type": "string",
+                "enum": ["light", "heavy", "review", "planning", "research"],
+                "description": (
+                    "Task complexity tier. Controls which model, reasoning effort, "
+                    "and iteration budget the subagent uses. Tiers are defined in "
+                    "config.yaml under delegation.tiers. When omitted, uses "
+                    "delegation.default_tier or the flat delegation config."
                 ),
             },
             "acp_command": {
@@ -876,6 +940,7 @@ registry.register(
         toolsets=args.get("toolsets"),
         tasks=args.get("tasks"),
         max_iterations=args.get("max_iterations"),
+        tier=args.get("tier"),
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         parent_agent=kw.get("parent_agent")),


### PR DESCRIPTION
## Summary
This PR adds small, config-driven delegation tiers so subagents can use different model/reasoning/iteration profiles without forcing every task to share one flat delegation config.

This is a focused extraction from the larger delegation/credential-pool draft, but unlike the credential-pool slices it builds on the already separated reasoning-override work from #5337.

## What changed
- add `resolve_tier_config()` in `tools/delegate_tool.py`
- support `delegation.default_tier`
- support `delegation.tiers.<name>` overrides
- add top-level `tier` to `delegate_task`
- add per-task `tier` in batch mode
- allow tier-specific overrides for:
  - `model`
  - `provider`
  - `reasoning_effort`
  - `max_iterations`
- add guardrails so heavier tiers do not silently degrade reasoning too far:
  - `review` / `planning` floor at `high`
  - `heavy` / `research` floor at `medium`

## Why
Flat delegation config is too coarse once subagents start serving different roles.
A light worker, a deep review pass, and a planning agent often should not share the same model/reasoning settings.

This keeps the feature small and runtime-local:
- no new persistence layer
- no provider pool logic
- no retry/rate-limit changes
- no lease scheduling changes

## Validation
### Automated
- `/home/ubuntu/.hermes/hermes-agent/venv/bin/python -m py_compile tools/delegate_tool.py hermes_cli/config.py tests/tools/test_delegate.py`
- `/home/ubuntu/.hermes/hermes-agent/venv/bin/python -m pytest -q -o addopts='' tests/tools/test_delegate.py -k 'DelegationReasoningEffort or TierResolution'`
- Result: `8 passed, 51 deselected`

Additional focused validation:
- `/home/ubuntu/.hermes/hermes-agent/venv/bin/python -m pytest -q -o addopts='' tests/tools/test_delegate.py`
- Result: `59 passed`

## Related context
- Builds logically on #5337 (`fix(tools): support delegation reasoning overrides for subagents`)
- Extracted from the larger draft: #5374
- Related issue: #4928 (named delegation capability profiles for subagents)
- Related PR thread: #4929

## Scope notes
This PR is intentionally limited to config-driven tier selection in delegation.
It does not add:
- credential-pool participation (#5576)
- lease-based child concurrency (#5580)
- structured provider failure classification
- Retry-After parsing or fallback-precedence changes
