### PR TITLE
fix: subagent toolset inheritance when parent enabled_toolsets is None

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -185,12 +185,28 @@ def _build_child_agent(
 
     # When no explicit toolsets given, inherit from parent's enabled toolsets
     # so disabled tools (e.g. web) don't leak to subagents.
-    parent_toolsets = set(getattr(parent_agent, "enabled_toolsets", None) or DEFAULT_TOOLSETS)
+    # Note: enabled_toolsets=None means "all tools enabled" (the default),
+    # so we must derive effective toolsets from the parent's loaded tools.
+    parent_enabled = getattr(parent_agent, "enabled_toolsets", None)
+    if parent_enabled is not None:
+        parent_toolsets = set(parent_enabled)
+    elif parent_agent and hasattr(parent_agent, "valid_tool_names"):
+        # enabled_toolsets is None (all tools) — derive from loaded tool names
+        import model_tools
+        parent_toolsets = {
+            ts for name in parent_agent.valid_tool_names
+            if (ts := model_tools.get_toolset_for_tool(name)) is not None
+        }
+    else:
+        parent_toolsets = set(DEFAULT_TOOLSETS)
+
     if toolsets:
         # Intersect with parent — subagent must not gain tools the parent lacks
         child_toolsets = _strip_blocked_tools([t for t in toolsets if t in parent_toolsets])
-    elif parent_agent and getattr(parent_agent, "enabled_toolsets", None):
-        child_toolsets = _strip_blocked_tools(parent_agent.enabled_toolsets)
+    elif parent_agent and parent_enabled is not None:
+        child_toolsets = _strip_blocked_tools(parent_enabled)
+    elif parent_toolsets:
+        child_toolsets = _strip_blocked_tools(sorted(parent_toolsets))
     else:
         child_toolsets = _strip_blocked_tools(DEFAULT_TOOLSETS)
 


### PR DESCRIPTION
## Summary

Fixes #5590 — Subagents incorrectly fall back to `DEFAULT_TOOLSETS` when the parent has `enabled_toolsets=None` (the default, meaning all tools enabled).

## The Problem

In `tools/delegate_tool.py`, two code paths treat `None` ("all tools") the same as "no toolsets"):

1. `getattr(parent_agent, "enabled_toolsets", None) or DEFAULT_TOOLSETS` — Python's `or` replaces `None` with `DEFAULT_TOOLSETS`
2. `elif parent_agent and getattr(parent_agent, "enabled_toolsets", None):` — `None` is falsy, so this branch is skipped

Result: subagents are silently limited to `["terminal", "file", "web"]` even when the parent has many more tools available (browser, skills, MCP tools, etc.).

## The Fix

- Replace truthiness checks with explicit `is not None` checks
- When `enabled_toolsets is None`, derive the effective parent toolsets from `parent_agent.valid_tool_names` using the tool registry's `get_toolset_for_tool()`

## Changes

```diff
- parent_toolsets = set(getattr(parent_agent, "enabled_toolsets", None) or DEFAULT_TOOLSETS)
+ parent_enabled = getattr(parent_agent, "enabled_toolsets", None)
+ if parent_enabled is not None:
+     parent_toolsets = set(parent_enabled)
+ elif parent_agent and hasattr(parent_agent, "valid_tool_names"):
+     import model_tools
+     parent_toolsets = {
+         ts for name in parent_agent.valid_tool_names
+         if (ts := model_tools.get_toolset_for_tool(name)) is not None
+     }
+ else:
+     parent_toolsets = set(DEFAULT_TOOLSETS)

- elif parent_agent and getattr(parent_agent, "enabled_toolsets", None):
-     child_toolsets = _strip_blocked_tools(parent_agent.enabled_toolsets)
+ elif parent_agent and parent_enabled is not None:
+     child_toolsets = _strip_blocked_tools(parent_enabled)
+ elif parent_toolsets:
+     child_toolsets = _strip_blocked_tools(sorted(parent_toolsets))
```

## Testing

- All 5 existing tests in `tests/tools/test_delegate_toolset_scope.py` pass
- Full `tests/tools/` suite: **2464 passed**, 12 failed (pre-existing, unrelated to this change), 12 skipped
- Tested on Oracle Linux 9.7 (aarch64), Python 3.11.15

## Platforms Tested

- **Linux** (Oracle Linux 9.7, aarch64) — all delegate-related tests pass