### PR TITLE
Fix channel directory cache writes atomically to prevent transient corruption

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from hermes_cli.config import get_hermes_home
+from utils import atomic_json_write
 
 logger = logging.getLogger(__name__)
 
@@ -86,9 +87,7 @@ def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
     }
 
     try:
-        DIRECTORY_PATH.parent.mkdir(parents=True, exist_ok=True)
-        with open(DIRECTORY_PATH, "w", encoding="utf-8") as f:
-            json.dump(directory, f, indent=2, ensure_ascii=False)
+        atomic_json_write(DIRECTORY_PATH, directory)
     except Exception as e:
         logger.warning("Channel directory: failed to write: %s", e)
 

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from gateway.channel_directory import (
+    build_channel_directory,
     resolve_channel_name,
     format_directory_for_display,
     load_directory,
@@ -43,6 +44,27 @@ class TestLoadDirectory:
         with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file):
             result = load_directory()
         assert result["updated_at"] is None
+
+
+class TestBuildChannelDirectoryWrites:
+    def test_failed_write_preserves_previous_cache(self, tmp_path, monkeypatch):
+        cache_file = _write_directory(tmp_path, {
+            "telegram": [{"id": "123", "name": "Alice", "type": "dm"}]
+        })
+        previous = json.loads(cache_file.read_text())
+
+        def broken_dump(data, fp, *args, **kwargs):
+            fp.write('{"updated_at":')
+            fp.flush()
+            raise OSError("disk full")
+
+        monkeypatch.setattr(json, "dump", broken_dump)
+
+        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file):
+            build_channel_directory({})
+            result = load_directory()
+
+        assert result == previous
 
 
 class TestResolveChannelName:


### PR DESCRIPTION

### Summary
`gateway/channel_directory.py` was writing the channel directory cache directly to the destination file. If a write failed mid-save, the file could be truncated and left corrupted. That could temporarily break `send_message` target resolution and any flow relying on the cached directory.

This PR makes the cache write atomic so an interrupted write can no longer destroy the last valid cache file.

---

### Problem
The channel directory cache was previously written like this:

- open the destination file
- write JSON directly with `json.dump(...)`
- if the write fails midway, leave a partially written file behind

That means:

- the cache can become invalid JSON
- `load_directory()` falls back to an empty structure
- channel / target resolution can silently stop working until the next successful refresh

In practice, this is a `data loss / incorrect behavior` bug.

---

### Root Cause
`build_channel_directory()` updated the cache in-place instead of using an atomic replace strategy.

Previous behavior:
- write directly to the real cache file
- partial writes were possible
- failures did not preserve the previous valid cache

---

### Fix
This PR switches channel directory persistence to `atomic_json_write(...)`.

New behavior:

- write the new JSON payload to a temporary file
- flush + fsync it
- atomically replace the destination with `os.replace(...)`
- if writing fails, keep the previous valid cache untouched

This prevents refresh-time cache corruption from partial writes.

---

### Tests
Added a regression test in:

- `tests/gateway/test_channel_directory.py`

The new test verifies that:

- an existing valid cache file is present
- `json.dump()` fails during a rebuild
- the previous cache remains readable and unchanged

This reproduces the old failure mode and locks in the fix.

---

### Files Changed
- `gateway/channel_directory.py`
- `tests/gateway/test_channel_directory.py`

---

### Why This Matters
This is a small change with meaningful reliability impact:

- cached messaging target resolution becomes safer
- transient write failures no longer wipe the cache
- background refreshes cannot leave the system in a broken “empty directory” state

---


