### PR TITLE
feat(plugins): add session:end and session:reset plugin hooks

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3467,6 +3467,12 @@ class HermesCLI:
 
     def reset_conversation(self):
         """Reset the conversation by starting a new session."""
+        # Plugin hook: session:end — lets plugins react to session resets.
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+            _invoke_hook("session:end", session_id=self.session_id, platform="cli")
+        except Exception:
+            pass
         # Shut down memory provider before resetting — actual session boundary
         if hasattr(self, 'agent') and self.agent:
             self.agent.shutdown_memory_provider(self.conversation_history)
@@ -4347,7 +4353,7 @@ class HermesCLI:
                 else:
                     _cprint("  Session database not available.")
         elif canonical == "new":
-            self.new_session()
+            self.reset_conversation()
         elif canonical == "resume":
             self._handle_resume_command(cmd_original)
         elif canonical == "model":

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3250,6 +3250,28 @@ class GatewayRunner:
                 _flush_task.add_done_callback(self._background_tasks.discard)
         except Exception as e:
             logger.debug("Gateway memory flush on reset failed: %s", e)
+        
+        # Shut down memory provider before evicting the agent — actual session boundary.
+        # This triggers MemoryProvider.on_session_end() for plugins that need cleanup.
+        cached_agent = self._agent_cache.get(session_key)
+        if cached_agent and cached_agent is not _AGENT_PENDING_SENTINEL:
+            try:
+                cached_agent.shutdown_memory_provider()
+            except Exception:
+                pass
+        
+        # Plugin hook: session:end — lets plugins react to session resets.
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+            _invoke_hook(
+                "session:end",
+                session_key=session_key,
+                platform=source.platform.value if source.platform else "",
+                user_id=source.user_id,
+            )
+        except Exception as exc:
+            logger.debug("session:end plugin hook failed: %s", exc)
+        
         self._evict_cached_agent(session_key)
         
         # Reset the session
@@ -3268,6 +3290,18 @@ class GatewayRunner:
             "user_id": source.user_id,
             "session_key": session_key,
         })
+
+        # Plugin hook: session:reset — lets plugins initialize for the new session.
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+            _invoke_hook(
+                "session:reset",
+                session_key=session_key,
+                platform=source.platform.value if source.platform else "",
+                user_id=source.user_id,
+            )
+        except Exception as exc:
+            logger.debug("session:reset plugin hook failed: %s", exc)
         
         # Resolve session config info to surface to the user
         try:


### PR DESCRIPTION
## Summary

Fixes #5592

Adds `session:end` and `session:reset` to the plugin hook system so plugins can reliably detect actual session boundaries (`/new`, `/reset`, auto-reset).

## Problem

See #5592 for full context. Plugins had no way to hook into session reset events — only per-turn `on_session_end` was available, and it fires on every `run_conversation()` call, not at real session boundaries. Additionally, the gateway never called `shutdown_memory_provider()` on `/new`/`/reset`, so `MemoryProvider.on_session_end()` was silently skipped.

## Changes

### `hermes_cli/plugins.py`
- Add `session:end` and `session:reset` to `VALID_HOOKS`

### `gateway/run.py`
- In `_handle_reset_command()`: call `shutdown_memory_provider()` on the cached agent before eviction (fixes the missing provider shutdown)
- Fire `invoke_hook("session:end")` after shutdown
- Fire `invoke_hook("session:reset")` after the new session is created

### `cli.py`
- `/new` now calls `reset_conversation()` instead of `new_session()` directly (includes provider shutdown)
- `reset_conversation()`: add `invoke_hook("session:end")` before shutdown

## How to test

1. Create a test plugin that registers a `session:end` hook:

```python
# ~/.hermes/plugins/test-hook/__init__.py
import logging

def register(ctx):
    def on_session_end(**kw):
        logging.warning("TEST_HOOK: session:end fired with %s", kw)
    ctx.register_hook("session:end", on_session_end)
```

2. Start gateway: `hermes gateway`
3. Send `/new` via Telegram or Discord
4. Check gateway logs for `TEST_HOOK: session:end fired` — should appear once on reset
5. Send a normal message — `on_session_end` (per-turn) fires as before
6. Verify `session:reset` also fires by adding a second hook

7. CLI test:
   - Run `hermes chat`
   - Type `/new`
   - Check terminal output for the hook firing

## Tested on

- **OS**: Oracle Linux 9 (aarch64)
- **Python**: 3.11
- **Platform**: Gateway (Telegram)

## Plugin usage

After this PR, any plugin can do:

```python
def register(ctx):
    provider = MyProvider()
    ctx.register_memory_provider(provider)
    ctx.register_hook("session:end", lambda **kw: provider.cleanup())
    ctx.register_hook("session:reset", lambda **kw: provider.on_new_session())
```

## Backward compatibility

- Fully backward compatible — new hooks are additive
- Existing plugins are unaffected
- The `shutdown_memory_provider()` call in gateway is a bug fix (it was always intended but missing)
