### PR TITLE
feat: add grok to TOOL_USE_ENFORCEMENT_MODELS for direct xAI usage

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -187,7 +187,7 @@ TOOL_USE_ENFORCEMENT_GUIDANCE = (
 
 # Model name substrings that trigger tool-use enforcement guidance.
 # Add new patterns here when a model family needs explicit steering.
-TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex", "gemini", "gemma")
+TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex", "gemini", "gemma", "grok")
 
 # OpenAI GPT/Codex-specific execution guidance.  Addresses known failure modes
 # where GPT models abandon work on partial results, skip prerequisite lookups,

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1018,6 +1018,9 @@ class TestToolUseEnforcementGuidance:
     def test_enforcement_models_includes_codex(self):
         assert "codex" in TOOL_USE_ENFORCEMENT_MODELS
 
+    def test_enforcement_models_includes_grok(self):
+        assert "grok" in TOOL_USE_ENFORCEMENT_MODELS
+
     def test_enforcement_models_is_tuple(self):
         assert isinstance(TOOL_USE_ENFORCEMENT_MODELS, tuple)
 


### PR DESCRIPTION
## Summary

Adds `"grok"` to the `TOOL_USE_ENFORCEMENT_MODELS` tuple so Grok models receive tool-use enforcement guidance in the system prompt.

Closes #5531

## What changed
- `agent/prompt_builder.py`: Added `"grok"` to `TOOL_USE_ENFORCEMENT_MODELS`
- `tests/agent/test_prompt_builder.py`: Added assertion test for grok inclusion

## Why
Grok models (`x-ai/grok-4.20-beta`, `grok-code-fast-1`) accessed via OpenRouter or direct xAI API were not getting the tool-use enforcement guidance that steers models to actually call tools instead of describing intended actions. The substring match on `"grok"` covers both routing paths.

## Test plan
- `python -m pytest tests/agent/test_prompt_builder.py -n0 -q` — 119 passed