### PR TITLE
feat(memory): add Pallium memory provider plugin

### DIFF
--- a/plugins/memory/pallium/README.md
+++ b/plugins/memory/pallium/README.md
@@ -1,0 +1,116 @@
+# Pallium Memory Provider
+
+Local-first memory sidecar with automatic fact extraction, hybrid retrieval (lexical + vector RRF), and evidence provenance. No cloud dependency, no API key required.
+
+Two extraction packages run in parallel over every ingested turn:
+
+- **Work continuity** — decisions, investigation outcomes, task checkpoints ("why did we choose this?", "where did we leave off?")
+- **Factual recall** — names, dates, preferences, events, relationships extracted from conversation threads, consolidated by subject across sessions
+
+**Multilingual by design** — memory is preserved in the original language and cross-language recall works natively. A query in one language retrieves memory stored in another.
+
+## Requirements
+
+- Python 3.12+
+- A running Pallium server
+- An LLM API key for Pallium's extraction (Anthropic or OpenAI-compatible)
+
+## Setup
+
+**1. Install and start Pallium:**
+
+```bash
+git clone https://github.com/rotemhermon/pallium
+cd pallium
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev,vector]"
+cp pallium.example.toml pallium.local.toml
+cp .env.example .env.local
+# Set your LLM API key in .env.local
+
+python -m app.run serve --host 127.0.0.1 --port 8000
+```
+
+**2. Configure Hermes:**
+
+```bash
+hermes memory setup    # select "pallium"
+# Or manually:
+hermes config set memory.provider pallium
+```
+
+**3. Verify:**
+
+```bash
+hermes memory status
+curl http://localhost:8000/health
+```
+
+## Configuration
+
+Config is stored in `$HERMES_HOME/pallium.json`:
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `base_url` | `http://localhost:8000` | Pallium server URL |
+| `actor_ref` | `hermes-user` | Stable user identifier for cross-session memory scoping |
+| `container_ref` | `hermes` | Memory container identifier |
+
+Example:
+
+```json
+{
+  "base_url": "http://localhost:8000",
+  "actor_ref": "your-name",
+  "container_ref": "hermes"
+}
+```
+
+## Tools
+
+### `pallium_query`
+
+Search Pallium's persistent memory for relevant context.
+
+```
+pallium_query(query="why did we choose event time for ordering?")
+```
+
+Returns compact evidence-backed cards: decisions, investigation outcomes, checkpoints, extracted facts.
+
+### `pallium_remember`
+
+Store an important piece of information explicitly.
+
+```
+pallium_remember(content="Decided to use PostgreSQL for the main store — SQLite won't scale past 10k users", kind="decision")
+```
+
+`kind` options: `note` (default), `decision`, `finding`.
+
+## How Memory Is Built
+
+Pallium runs automatic extraction in the background — the agent doesn't need to decide what to remember. Every ingested turn feeds two parallel packages:
+
+1. **conversational_knowledge** — extracts atomic facts per thread (subject, statement, category), consolidates by subject across threads into `fact_summary` objects
+2. **agent_conversation_memory** — extracts higher-level memories: decisions, investigation outcomes, task checkpoints, thread summaries
+
+Retrieval combines IDF-weighted lexical search with vector similarity, fused via RRF (Reciprocal Rank Fusion). Every memory object is linked back to the source items it was derived from.
+
+## Profile Isolation
+
+Each Hermes profile gets isolated memory via `container_ref`. By default this is `hermes` — change it per profile to fully separate memory across profiles:
+
+```json
+{ "container_ref": "hermes-coder" }
+```
+
+## Debugging
+
+Pallium exposes a debug endpoint that shows the full retrieval and routing trace:
+
+```bash
+curl -X POST http://localhost:8000/query/debug \
+  -H 'Content-Type: application/json' \
+  -d '{"query": "your question", "container_ref": "hermes"}'
+```

--- a/plugins/memory/pallium/__init__.py
+++ b/plugins/memory/pallium/__init__.py
@@ -117,7 +117,7 @@ REMEMBER_SCHEMA = {
 # HTTP helpers
 # ---------------------------------------------------------------------------
 
-def _http_post(url: str, payload: dict, timeout: float = 8.0) -> dict:
+def _http_post(url: str, payload: dict | list, timeout: float = 8.0) -> dict:
     """POST JSON to Pallium. Returns parsed response or raises."""
     try:
         import httpx
@@ -126,19 +126,6 @@ def _http_post(url: str, payload: dict, timeout: float = 8.0) -> dict:
 
     with httpx.Client(timeout=timeout) as client:
         response = client.post(url, json=payload)
-        response.raise_for_status()
-        return response.json()
-
-
-def _http_get(url: str, timeout: float = 4.0) -> dict:
-    """GET from Pallium. Returns parsed response or raises."""
-    try:
-        import httpx
-    except ImportError:
-        raise RuntimeError("httpx not installed. Run: pip install httpx")
-
-    with httpx.Client(timeout=timeout) as client:
-        response = client.get(url)
         response.raise_for_status()
         return response.json()
 
@@ -260,7 +247,7 @@ class PalliumMemoryProvider(MemoryProvider):
                 data = _http_post(
                     f"{self._base_url}/query",
                     {
-                        "query": query,
+                        "text": query,
                         "container_ref": self._container_ref,
                         "actor_ref": self._actor_ref,
                         "visibility": "private",
@@ -268,13 +255,21 @@ class PalliumMemoryProvider(MemoryProvider):
                     timeout=6.0,
                 )
                 blocks = data.get("injectable_blocks", [])
+                results = data.get("results", [])
+                lines = []
                 if blocks:
-                    lines = []
                     for block in blocks:
                         title = block.get("title", "")
                         text = block.get("text", "")
                         if text:
                             lines.append(f"[{title}] {text}" if title else text)
+                elif results:
+                    # Fall back to source excerpts when no blocks yet
+                    for r in results[:5]:
+                        excerpt = r.get("excerpt", "")
+                        if excerpt:
+                            lines.append(excerpt)
+                if lines:
                     with self._prefetch_lock:
                         self._prefetch_result = "\n".join(lines)
                 self._record_success()
@@ -298,22 +293,21 @@ class PalliumMemoryProvider(MemoryProvider):
 
         def _sync():
             try:
+                items = []
                 for role, content in (("user", user_content), ("assistant", assistant_content)):
-                    _http_post(
-                        f"{self._base_url}/items",
-                        {
-                            "source_type": "hermes_turn",
-                            "source_id": f"{sid}:{turn}:{role}",
-                            "content_type": "text/plain",
-                            "content": content,
-                            "role": role,
-                            "artifact_kind": "message",
-                            "container_ref": self._container_ref,
-                            "actor_ref": self._actor_ref,
-                            "visibility": "private",
-                        },
-                        timeout=10.0,
-                    )
+                    items.append({
+                        "source_type": "hermes_turn",
+                        "source_id": f"{sid}:{turn}:{role}",
+                        "content_type": "text/plain",
+                        "content": content,
+                        "role": role,
+                        "artifact_kind": "message",
+                        "container_ref": self._container_ref,
+                        "thread_ref": sid,
+                        "actor_ref": self._actor_ref,
+                        "visibility": "private",
+                    })
+                _http_post(f"{self._base_url}/items", items, timeout=10.0)
                 self._record_success()
             except Exception as e:
                 self._record_failure()
@@ -336,7 +330,7 @@ class PalliumMemoryProvider(MemoryProvider):
             try:
                 _http_post(
                     f"{self._base_url}/items",
-                    {
+                    [{
                         "source_type": f"hermes_{label}",
                         "source_id": f"{self._container_ref}:{label}:{hash(content) & 0xFFFFFFFF}",
                         "content_type": "text/plain",
@@ -345,7 +339,7 @@ class PalliumMemoryProvider(MemoryProvider):
                         "container_ref": self._container_ref,
                         "actor_ref": self._actor_ref,
                         "visibility": "private",
-                    },
+                    }],
                     timeout=10.0,
                 )
             except Exception as e:
@@ -372,7 +366,7 @@ class PalliumMemoryProvider(MemoryProvider):
                         continue
                     _http_post(
                         f"{self._base_url}/items",
-                        {
+                        [{
                             "source_type": "hermes_compression_flush",
                             "source_id": f"{sid}:compress:{i}:{role}",
                             "content_type": "text/plain",
@@ -382,7 +376,7 @@ class PalliumMemoryProvider(MemoryProvider):
                             "container_ref": self._container_ref,
                             "actor_ref": self._actor_ref,
                             "visibility": "private",
-                        },
+                        }],
                         timeout=10.0,
                     )
             except Exception as e:
@@ -419,7 +413,7 @@ class PalliumMemoryProvider(MemoryProvider):
             data = _http_post(
                 f"{self._base_url}/query",
                 {
-                    "query": query,
+                    "text": query,
                     "container_ref": self._container_ref,
                     "actor_ref": self._actor_ref,
                     "visibility": "private",
@@ -431,14 +425,25 @@ class PalliumMemoryProvider(MemoryProvider):
             return json.dumps({"error": f"Pallium query failed: {e}"})
 
         blocks = data.get("injectable_blocks", [])
-        if not blocks:
-            return json.dumps({"result": "No relevant memories found."})
+        results = data.get("results", [])
 
-        items = [
-            {"type": b.get("memory_type", b.get("block_type", "")), "text": b.get("text", "")}
-            for b in blocks if b.get("text")
-        ]
-        return json.dumps({"results": items, "count": len(items)})
+        if blocks:
+            items = [
+                {"type": b.get("memory_type", b.get("block_type", "")), "text": b.get("text", "")}
+                for b in blocks if b.get("text")
+            ]
+            return json.dumps({"results": items, "count": len(items)})
+
+        if results:
+            # Fall back to source excerpts when memory objects not yet extracted
+            items = [
+                {"type": r.get("result_kind", "source_hit"), "text": r.get("excerpt", "")}
+                for r in results[:5] if r.get("excerpt")
+            ]
+            if items:
+                return json.dumps({"results": items, "count": len(items)})
+
+        return json.dumps({"result": "No relevant memories found."})
 
     def _tool_remember(self, args: dict) -> str:
         content = args.get("content", "")
@@ -452,7 +457,7 @@ class PalliumMemoryProvider(MemoryProvider):
         try:
             _http_post(
                 f"{self._base_url}/items",
-                {
+                [{
                     "source_type": "hermes_explicit_memory",
                     "source_id": f"{self._container_ref}:explicit:{hash(content) & 0xFFFFFFFF}",
                     "content_type": "text/plain",
@@ -461,7 +466,7 @@ class PalliumMemoryProvider(MemoryProvider):
                     "container_ref": self._container_ref,
                     "actor_ref": self._actor_ref,
                     "visibility": "private",
-                },
+                }],
             )
             self._record_success()
             return json.dumps({"result": "Stored."})

--- a/plugins/memory/pallium/__init__.py
+++ b/plugins/memory/pallium/__init__.py
@@ -1,0 +1,509 @@
+"""Pallium memory plugin — MemoryProvider interface.
+
+Local-first memory sidecar with automatic fact extraction, hybrid retrieval
+(lexical + vector RRF), and evidence provenance. Two extraction packages run
+in parallel over every ingested turn:
+
+  - Work continuity: decisions, investigation outcomes, task checkpoints
+  - Factual recall: names, dates, preferences, events, relationships
+
+Multilingual by design — memory is stored and recalled in the original language.
+Cross-language recall works natively (query in one language, retrieve another).
+
+Requires a running Pallium server. See https://github.com/rotemhermon/pallium
+or start with: python -m app.run serve --host 127.0.0.1 --port 8000
+
+Config via $HERMES_HOME/pallium.json:
+  base_url    — Pallium server URL (default: http://localhost:8000)
+  actor_ref   — stable user identifier for cross-session scoping (default: hermes-user)
+  container_ref — memory container (default: hermes)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agent.memory_provider import MemoryProvider
+
+logger = logging.getLogger(__name__)
+
+# Circuit breaker: pause API calls after consecutive failures
+_BREAKER_THRESHOLD = 5
+_BREAKER_COOLDOWN_SECS = 120
+
+# Prefetch: join background thread before LLM call (max wait)
+_PREFETCH_TIMEOUT_SECS = 4.0
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+def _load_config(hermes_home: str = "") -> dict:
+    """Load config from $HERMES_HOME/pallium.json, with defaults."""
+    config = {
+        "base_url": "http://localhost:8000",
+        "actor_ref": "hermes-user",
+        "container_ref": "hermes",
+    }
+
+    if hermes_home:
+        config_path = Path(hermes_home) / "pallium.json"
+    else:
+        try:
+            from hermes_constants import get_hermes_home
+            config_path = get_hermes_home() / "pallium.json"
+        except Exception:
+            return config
+
+    if config_path.exists():
+        try:
+            file_cfg = json.loads(config_path.read_text(encoding="utf-8"))
+            config.update({k: v for k, v in file_cfg.items() if v})
+        except Exception:
+            pass
+
+    return config
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas
+# ---------------------------------------------------------------------------
+
+QUERY_SCHEMA = {
+    "name": "pallium_query",
+    "description": (
+        "Search Pallium's persistent memory for relevant context. Returns compact "
+        "evidence-backed cards: decisions, investigation outcomes, task checkpoints, "
+        "and extracted facts. Use for any question where past context would help — "
+        "'why did we choose X?', 'where did we leave off?', 'what do we know about Y?'"
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "What to search for."},
+        },
+        "required": ["query"],
+    },
+}
+
+REMEMBER_SCHEMA = {
+    "name": "pallium_remember",
+    "description": (
+        "Store an important piece of information in Pallium's persistent memory. "
+        "Use for decisions, investigation findings, or facts worth keeping across sessions."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "content": {"type": "string", "description": "The information to remember."},
+            "kind": {
+                "type": "string",
+                "description": "Type of memory: 'note' (default), 'decision', 'finding'.",
+                "enum": ["note", "decision", "finding"],
+            },
+        },
+        "required": ["content"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+def _http_post(url: str, payload: dict, timeout: float = 8.0) -> dict:
+    """POST JSON to Pallium. Returns parsed response or raises."""
+    try:
+        import httpx
+    except ImportError:
+        raise RuntimeError("httpx not installed. Run: pip install httpx")
+
+    with httpx.Client(timeout=timeout) as client:
+        response = client.post(url, json=payload)
+        response.raise_for_status()
+        return response.json()
+
+
+def _http_get(url: str, timeout: float = 4.0) -> dict:
+    """GET from Pallium. Returns parsed response or raises."""
+    try:
+        import httpx
+    except ImportError:
+        raise RuntimeError("httpx not installed. Run: pip install httpx")
+
+    with httpx.Client(timeout=timeout) as client:
+        response = client.get(url)
+        response.raise_for_status()
+        return response.json()
+
+
+# ---------------------------------------------------------------------------
+# MemoryProvider implementation
+# ---------------------------------------------------------------------------
+
+class PalliumMemoryProvider(MemoryProvider):
+    """Pallium — local-first memory sidecar with hybrid retrieval and evidence provenance."""
+
+    def __init__(self):
+        self._base_url = "http://localhost:8000"
+        self._actor_ref = "hermes-user"
+        self._container_ref = "hermes"
+        self._session_id = ""
+        self._turn_count = 0
+
+        # Background prefetch
+        self._prefetch_result = ""
+        self._prefetch_lock = threading.Lock()
+        self._prefetch_thread: Optional[threading.Thread] = None
+
+        # Background sync
+        self._sync_thread: Optional[threading.Thread] = None
+
+        # Circuit breaker
+        self._consecutive_failures = 0
+        self._breaker_open_until = 0.0
+
+    @property
+    def name(self) -> str:
+        return "pallium"
+
+    # -- Availability --------------------------------------------------------
+
+    def is_available(self) -> bool:
+        """True if pallium.json exists with a base_url, or default localhost is configured.
+
+        Does NOT make a network call — just checks config presence.
+        """
+        cfg = _load_config()
+        return bool(cfg.get("base_url"))
+
+    # -- Config wizard -------------------------------------------------------
+
+    def get_config_schema(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "key": "base_url",
+                "description": "Pallium server URL",
+                "default": "http://localhost:8000",
+                "required": False,
+            },
+            {
+                "key": "actor_ref",
+                "description": "Stable user identifier for cross-session memory scoping",
+                "default": "hermes-user",
+                "required": False,
+            },
+            {
+                "key": "container_ref",
+                "description": "Memory container identifier",
+                "default": "hermes",
+                "required": False,
+            },
+        ]
+
+    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+        config_path = Path(hermes_home) / "pallium.json"
+        existing = {}
+        if config_path.exists():
+            try:
+                existing = json.loads(config_path.read_text(encoding="utf-8"))
+            except Exception:
+                pass
+        existing.update(values)
+        config_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
+
+    # -- Lifecycle -----------------------------------------------------------
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        hermes_home = kwargs.get("hermes_home", "")
+        cfg = _load_config(hermes_home)
+        self._base_url = cfg["base_url"].rstrip("/")
+        self._actor_ref = cfg["actor_ref"]
+        self._container_ref = cfg["container_ref"]
+        self._session_id = session_id
+        self._turn_count = 0
+
+    def system_prompt_block(self) -> str:
+        return (
+            "# Pallium Memory\n"
+            f"Active. Container: {self._container_ref}. User: {self._actor_ref}.\n"
+            "Use pallium_query to search past decisions, findings, and facts. "
+            "Use pallium_remember to store important information."
+        )
+
+    # -- Retrieval -----------------------------------------------------------
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        """Return cached prefetch result queued after the previous turn."""
+        if self._prefetch_thread and self._prefetch_thread.is_alive():
+            self._prefetch_thread.join(timeout=_PREFETCH_TIMEOUT_SECS)
+        with self._prefetch_lock:
+            result = self._prefetch_result
+            self._prefetch_result = ""
+        if not result:
+            return ""
+        return f"## Pallium Memory\n{result}"
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        """Queue a background Pallium query for the next turn."""
+        if self._is_breaker_open():
+            return
+
+        def _run():
+            try:
+                data = _http_post(
+                    f"{self._base_url}/query",
+                    {
+                        "query": query,
+                        "container_ref": self._container_ref,
+                        "actor_ref": self._actor_ref,
+                        "visibility": "private",
+                    },
+                    timeout=6.0,
+                )
+                blocks = data.get("injectable_blocks", [])
+                if blocks:
+                    lines = []
+                    for block in blocks:
+                        title = block.get("title", "")
+                        text = block.get("text", "")
+                        if text:
+                            lines.append(f"[{title}] {text}" if title else text)
+                    with self._prefetch_lock:
+                        self._prefetch_result = "\n".join(lines)
+                self._record_success()
+            except Exception as e:
+                self._record_failure()
+                logger.debug("Pallium prefetch failed: %s", e)
+
+        self._prefetch_thread = threading.Thread(target=_run, daemon=True, name="pallium-prefetch")
+        self._prefetch_thread.start()
+
+    # -- Ingest --------------------------------------------------------------
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        """Ingest the completed turn into Pallium (non-blocking)."""
+        if self._is_breaker_open():
+            return
+
+        self._turn_count += 1
+        turn = self._turn_count
+        sid = session_id or self._session_id
+
+        def _sync():
+            try:
+                for role, content in (("user", user_content), ("assistant", assistant_content)):
+                    _http_post(
+                        f"{self._base_url}/items",
+                        {
+                            "source_type": "hermes_turn",
+                            "source_id": f"{sid}:{turn}:{role}",
+                            "content_type": "text/plain",
+                            "content": content,
+                            "role": role,
+                            "artifact_kind": "message",
+                            "container_ref": self._container_ref,
+                            "actor_ref": self._actor_ref,
+                            "visibility": "private",
+                        },
+                        timeout=10.0,
+                    )
+                self._record_success()
+            except Exception as e:
+                self._record_failure()
+                logger.warning("Pallium sync failed: %s", e)
+
+        if self._sync_thread and self._sync_thread.is_alive():
+            self._sync_thread.join(timeout=5.0)
+
+        self._sync_thread = threading.Thread(target=_sync, daemon=True, name="pallium-sync")
+        self._sync_thread.start()
+
+    def on_memory_write(self, action: str, target: str, content: str) -> None:
+        """Mirror built-in MEMORY.md / USER.md writes to Pallium."""
+        if action not in ("add", "replace") or not content:
+            return
+
+        label = "user-profile" if target == "user" else "agent-memory"
+
+        def _write():
+            try:
+                _http_post(
+                    f"{self._base_url}/items",
+                    {
+                        "source_type": f"hermes_{label}",
+                        "source_id": f"{self._container_ref}:{label}:{hash(content) & 0xFFFFFFFF}",
+                        "content_type": "text/plain",
+                        "content": content,
+                        "role": "user" if target == "user" else "assistant",
+                        "container_ref": self._container_ref,
+                        "actor_ref": self._actor_ref,
+                        "visibility": "private",
+                    },
+                    timeout=10.0,
+                )
+            except Exception as e:
+                logger.debug("Pallium memory mirror failed: %s", e)
+
+        t = threading.Thread(target=_write, daemon=True, name="pallium-memwrite")
+        t.start()
+
+    def on_pre_compress(self, messages: List[Dict[str, Any]]) -> str:
+        """Ingest messages about to be discarded before context compression."""
+        if not messages:
+            return ""
+
+        sid = self._session_id
+
+        def _flush():
+            try:
+                for i, msg in enumerate(messages):
+                    role = msg.get("role", "")
+                    content = msg.get("content", "")
+                    if not isinstance(content, str) or not content.strip():
+                        continue
+                    if role not in ("user", "assistant"):
+                        continue
+                    _http_post(
+                        f"{self._base_url}/items",
+                        {
+                            "source_type": "hermes_compression_flush",
+                            "source_id": f"{sid}:compress:{i}:{role}",
+                            "content_type": "text/plain",
+                            "content": content,
+                            "role": role,
+                            "artifact_kind": "message",
+                            "container_ref": self._container_ref,
+                            "actor_ref": self._actor_ref,
+                            "visibility": "private",
+                        },
+                        timeout=10.0,
+                    )
+            except Exception as e:
+                logger.debug("Pallium pre-compress flush failed: %s", e)
+
+        t = threading.Thread(target=_flush, daemon=True, name="pallium-compress")
+        t.start()
+        return ""
+
+    # -- Tools ---------------------------------------------------------------
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [QUERY_SCHEMA, REMEMBER_SCHEMA]
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+        if self._is_breaker_open():
+            return json.dumps({
+                "error": "Pallium temporarily unavailable (multiple consecutive failures). Will retry automatically."
+            })
+
+        if tool_name == "pallium_query":
+            return self._tool_query(args)
+        elif tool_name == "pallium_remember":
+            return self._tool_remember(args)
+
+        return json.dumps({"error": f"Unknown tool: {tool_name}"})
+
+    def _tool_query(self, args: dict) -> str:
+        query = args.get("query", "")
+        if not query:
+            return json.dumps({"error": "query is required"})
+
+        try:
+            data = _http_post(
+                f"{self._base_url}/query",
+                {
+                    "query": query,
+                    "container_ref": self._container_ref,
+                    "actor_ref": self._actor_ref,
+                    "visibility": "private",
+                },
+            )
+            self._record_success()
+        except Exception as e:
+            self._record_failure()
+            return json.dumps({"error": f"Pallium query failed: {e}"})
+
+        blocks = data.get("injectable_blocks", [])
+        if not blocks:
+            return json.dumps({"result": "No relevant memories found."})
+
+        items = [
+            {"type": b.get("memory_type", b.get("block_type", "")), "text": b.get("text", "")}
+            for b in blocks if b.get("text")
+        ]
+        return json.dumps({"results": items, "count": len(items)})
+
+    def _tool_remember(self, args: dict) -> str:
+        content = args.get("content", "")
+        if not content:
+            return json.dumps({"error": "content is required"})
+
+        kind = args.get("kind", "note")
+        role_map = {"decision": "assistant", "finding": "assistant", "note": "user"}
+        role = role_map.get(kind, "user")
+
+        try:
+            _http_post(
+                f"{self._base_url}/items",
+                {
+                    "source_type": "hermes_explicit_memory",
+                    "source_id": f"{self._container_ref}:explicit:{hash(content) & 0xFFFFFFFF}",
+                    "content_type": "text/plain",
+                    "content": content,
+                    "role": role,
+                    "container_ref": self._container_ref,
+                    "actor_ref": self._actor_ref,
+                    "visibility": "private",
+                },
+            )
+            self._record_success()
+            return json.dumps({"result": "Stored."})
+        except Exception as e:
+            self._record_failure()
+            return json.dumps({"error": f"Failed to store: {e}"})
+
+    # -- Shutdown ------------------------------------------------------------
+
+    def shutdown(self) -> None:
+        for t in (self._prefetch_thread, self._sync_thread):
+            if t and t.is_alive():
+                t.join(timeout=5.0)
+
+    # -- Circuit breaker -----------------------------------------------------
+
+    def _is_breaker_open(self) -> bool:
+        if self._consecutive_failures < _BREAKER_THRESHOLD:
+            return False
+        if time.monotonic() >= self._breaker_open_until:
+            self._consecutive_failures = 0
+            return False
+        return True
+
+    def _record_success(self):
+        self._consecutive_failures = 0
+
+    def _record_failure(self):
+        self._consecutive_failures += 1
+        if self._consecutive_failures >= _BREAKER_THRESHOLD:
+            self._breaker_open_until = time.monotonic() + _BREAKER_COOLDOWN_SECS
+            logger.warning(
+                "Pallium circuit breaker tripped after %d consecutive failures. "
+                "Pausing for %ds.",
+                self._consecutive_failures, _BREAKER_COOLDOWN_SECS,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Plugin entry point
+# ---------------------------------------------------------------------------
+
+def register(ctx) -> None:
+    """Register Pallium as a memory provider plugin."""
+    ctx.register_memory_provider(PalliumMemoryProvider())

--- a/plugins/memory/pallium/plugin.yaml
+++ b/plugins/memory/pallium/plugin.yaml
@@ -1,0 +1,12 @@
+name: pallium
+version: 1.0.0
+description: "Pallium — local-first memory sidecar with automatic fact extraction, hybrid retrieval, and evidence provenance. No cloud, no API key."
+pip_dependencies:
+  - httpx
+external_dependencies:
+  - name: pallium-server
+    install: "python -m app.run serve --host 127.0.0.1 --port 8000"
+    check: "curl -sf http://localhost:8000/health"
+hooks:
+  - on_memory_write
+  - on_pre_compress

--- a/tests/plugins/test_pallium_plugin.py
+++ b/tests/plugins/test_pallium_plugin.py
@@ -205,7 +205,7 @@ class TestTools:
 
         mock_post.assert_called_once()
         _, payload = mock_post.call_args[0]
-        assert payload["query"] == "why postgresql?"
+        assert payload["text"] == "why postgresql?"
         assert payload["container_ref"] == "hermes"
         assert "results" in result
         assert result["results"][0]["text"] == "We chose PostgreSQL."
@@ -218,9 +218,11 @@ class TestTools:
 
         mock_post.assert_called_once()
         _, payload = mock_post.call_args[0]
-        assert payload["content"] == "Use UTC for all timestamps"
-        assert payload["role"] == "assistant"  # decision → assistant
-        assert payload["container_ref"] == "hermes"
+        # /items receives a list; the item is the first element
+        item = payload[0]
+        assert item["content"] == "Use UTC for all timestamps"
+        assert item["role"] == "assistant"  # decision → assistant
+        assert item["container_ref"] == "hermes"
         assert result["result"] == "Stored."
 
     def test_remember_note_uses_user_role(self, initialized_provider):
@@ -229,7 +231,7 @@ class TestTools:
                 "pallium_remember", {"content": "Just a note", "kind": "note"}
             )
         _, payload = mock_post.call_args[0]
-        assert payload["role"] == "user"
+        assert payload[0]["role"] == "user"
 
     def test_query_no_blocks_returns_no_results_message(self, initialized_provider):
         with patch("plugins.memory.pallium._http_post", return_value={"injectable_blocks": []}):
@@ -258,10 +260,13 @@ class TestSyncTurn:
             if initialized_provider._sync_thread:
                 initialized_provider._sync_thread.join(timeout=5.0)
 
-        assert len(posted) == 2
-        roles = {p["role"] for p in posted}
+        # One call to /items with a list of 2 items
+        assert len(posted) == 1
+        items = posted[0]
+        assert len(items) == 2
+        roles = {p["role"] for p in items}
         assert roles == {"user", "assistant"}
-        contents = {p["content"] for p in posted}
+        contents = {p["content"] for p in items}
         assert "Hello" in contents
         assert "Hi there" in contents
 
@@ -277,7 +282,8 @@ class TestSyncTurn:
             if initialized_provider._sync_thread:
                 initialized_provider._sync_thread.join(timeout=5.0)
 
-        source_ids = {p["source_id"] for p in posted}
+        items = posted[0]
+        source_ids = {p["source_id"] for p in items}
         # All source_ids contain session id and turn count
         for sid in source_ids:
             assert "test-session-1" in sid
@@ -333,8 +339,9 @@ class TestOnMemoryWrite:
                 t.join(timeout=5.0)
 
         assert len(posted) == 1
-        assert posted[0]["content"] == "Important fact"
-        assert posted[0]["source_type"] == "hermes_agent-memory"
+        item = posted[0][0]  # /items receives a list; unwrap
+        assert item["content"] == "Important fact"
+        assert item["source_type"] == "hermes_agent-memory"
 
     def test_mirrors_user_profile_writes(self, initialized_provider):
         posted = []
@@ -349,8 +356,9 @@ class TestOnMemoryWrite:
             for t in threads:
                 t.join(timeout=5.0)
 
-        assert posted[0]["source_type"] == "hermes_user-profile"
-        assert posted[0]["role"] == "user"
+        item = posted[0][0]
+        assert item["source_type"] == "hermes_user-profile"
+        assert item["role"] == "user"
 
     def test_ignores_remove_action(self, initialized_provider):
         with patch("plugins.memory.pallium._http_post") as mock_post:
@@ -487,7 +495,8 @@ class TestOnPreCompress:
             for t in threads:
                 t.join(timeout=5.0)
 
-        roles = {p["role"] for p in posted}
+        # Each accepted message is posted as a single-item list
+        roles = {p[0]["role"] for p in posted}
         assert "user" in roles
         assert "assistant" in roles
         assert "tool" not in roles

--- a/tests/plugins/test_pallium_plugin.py
+++ b/tests/plugins/test_pallium_plugin.py
@@ -1,0 +1,541 @@
+"""Tests for the Pallium memory plugin.
+
+Covers: config loading, is_available, initialize, tool schemas, tool routing,
+sync_turn payloads, on_memory_write mirroring, circuit breaker, prefetch threading.
+
+No Pallium server required — all HTTP calls are mocked.
+"""
+
+import json
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+import sys
+_repo_root = str(Path(__file__).resolve().parents[2])
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+from plugins.memory.pallium import PalliumMemoryProvider, _load_config, register
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _isolate_env(tmp_path, monkeypatch):
+    """Isolate HERMES_HOME per test."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir(exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    return hermes_home
+
+
+@pytest.fixture
+def provider():
+    return PalliumMemoryProvider()
+
+
+@pytest.fixture
+def initialized_provider(provider, tmp_path):
+    hermes_home = tmp_path / ".hermes"
+    provider.initialize("test-session-1", hermes_home=str(hermes_home), platform="cli")
+    return provider
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+class TestConfigLoading:
+
+    def test_defaults_when_no_config_file(self, tmp_path):
+        cfg = _load_config(str(tmp_path / "nonexistent"))
+        assert cfg["base_url"] == "http://localhost:8000"
+        assert cfg["actor_ref"] == "hermes-user"
+        assert cfg["container_ref"] == "hermes"
+
+    def test_loads_from_json_file(self, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(exist_ok=True)
+        (hermes_home / "pallium.json").write_text(json.dumps({
+            "base_url": "http://myhost:9000",
+            "actor_ref": "alice",
+            "container_ref": "myproject",
+        }))
+        cfg = _load_config(str(hermes_home))
+        assert cfg["base_url"] == "http://myhost:9000"
+        assert cfg["actor_ref"] == "alice"
+        assert cfg["container_ref"] == "myproject"
+
+    def test_partial_override_keeps_defaults(self, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(exist_ok=True)
+        (hermes_home / "pallium.json").write_text(json.dumps({"actor_ref": "bob"}))
+        cfg = _load_config(str(hermes_home))
+        assert cfg["actor_ref"] == "bob"
+        assert cfg["base_url"] == "http://localhost:8000"  # default preserved
+
+    def test_malformed_json_falls_back_to_defaults(self, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(exist_ok=True)
+        (hermes_home / "pallium.json").write_text("{bad json}")
+        cfg = _load_config(str(hermes_home))
+        assert cfg["base_url"] == "http://localhost:8000"
+
+
+# ---------------------------------------------------------------------------
+# Availability and config schema
+# ---------------------------------------------------------------------------
+
+class TestAvailability:
+
+    def test_is_available_true_by_default(self, provider):
+        # Default config always has a base_url
+        assert provider.is_available() is True
+
+    def test_get_config_schema_fields(self, provider):
+        schema = provider.get_config_schema()
+        keys = [f["key"] for f in schema]
+        assert "base_url" in keys
+        assert "actor_ref" in keys
+        assert "container_ref" in keys
+
+    def test_no_required_fields(self, provider):
+        schema = provider.get_config_schema()
+        required = [f for f in schema if f.get("required")]
+        assert required == []
+
+    def test_save_config_writes_json(self, provider, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(exist_ok=True)
+        provider.save_config({"base_url": "http://newhost:8888"}, str(hermes_home))
+        saved = json.loads((hermes_home / "pallium.json").read_text())
+        assert saved["base_url"] == "http://newhost:8888"
+
+    def test_save_config_merges_existing(self, provider, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(exist_ok=True)
+        (hermes_home / "pallium.json").write_text(json.dumps({"actor_ref": "carol"}))
+        provider.save_config({"base_url": "http://newhost:8888"}, str(hermes_home))
+        saved = json.loads((hermes_home / "pallium.json").read_text())
+        assert saved["actor_ref"] == "carol"
+        assert saved["base_url"] == "http://newhost:8888"
+
+
+# ---------------------------------------------------------------------------
+# Initialization
+# ---------------------------------------------------------------------------
+
+class TestInitialize:
+
+    def test_initialize_sets_fields(self, provider, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(exist_ok=True)
+        (hermes_home / "pallium.json").write_text(json.dumps({
+            "base_url": "http://pallium:8000",
+            "actor_ref": "dave",
+            "container_ref": "project-x",
+        }))
+        provider.initialize("sess-42", hermes_home=str(hermes_home), platform="cli")
+        assert provider._base_url == "http://pallium:8000"
+        assert provider._actor_ref == "dave"
+        assert provider._container_ref == "project-x"
+        assert provider._session_id == "sess-42"
+
+    def test_initialize_strips_trailing_slash(self, provider, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(exist_ok=True)
+        (hermes_home / "pallium.json").write_text(json.dumps({"base_url": "http://pallium:8000/"}))
+        provider.initialize("s", hermes_home=str(hermes_home))
+        assert provider._base_url == "http://pallium:8000"
+
+    def test_system_prompt_block_mentions_container(self, initialized_provider):
+        block = initialized_provider.system_prompt_block()
+        assert "Pallium" in block
+        assert "hermes" in block  # default container_ref
+
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+class TestTools:
+
+    def test_tool_schemas_returned(self, provider):
+        schemas = provider.get_tool_schemas()
+        names = {s["name"] for s in schemas}
+        assert "pallium_query" in names
+        assert "pallium_remember" in names
+
+    def test_pallium_query_has_required_query_param(self, provider):
+        schema = next(s for s in provider.get_tool_schemas() if s["name"] == "pallium_query")
+        assert "query" in schema["parameters"]["required"]
+
+    def test_pallium_remember_has_required_content_param(self, provider):
+        schema = next(s for s in provider.get_tool_schemas() if s["name"] == "pallium_remember")
+        assert "content" in schema["parameters"]["required"]
+
+    def test_handle_tool_call_query_missing_param(self, initialized_provider):
+        result = json.loads(initialized_provider.handle_tool_call("pallium_query", {}))
+        assert "error" in result
+
+    def test_handle_tool_call_remember_missing_param(self, initialized_provider):
+        result = json.loads(initialized_provider.handle_tool_call("pallium_remember", {}))
+        assert "error" in result
+
+    def test_handle_unknown_tool(self, initialized_provider):
+        result = json.loads(initialized_provider.handle_tool_call("unknown_tool", {}))
+        assert "error" in result
+
+    def test_handle_tool_call_query_posts_correct_payload(self, initialized_provider):
+        mock_response = {
+            "injectable_blocks": [
+                {"title": "decision", "text": "We chose PostgreSQL.", "memory_type": "decision"}
+            ]
+        }
+        with patch("plugins.memory.pallium._http_post", return_value=mock_response) as mock_post:
+            result = json.loads(initialized_provider.handle_tool_call(
+                "pallium_query", {"query": "why postgresql?"}
+            ))
+
+        mock_post.assert_called_once()
+        _, payload = mock_post.call_args[0]
+        assert payload["query"] == "why postgresql?"
+        assert payload["container_ref"] == "hermes"
+        assert "results" in result
+        assert result["results"][0]["text"] == "We chose PostgreSQL."
+
+    def test_handle_tool_call_remember_posts_item(self, initialized_provider):
+        with patch("plugins.memory.pallium._http_post", return_value={}) as mock_post:
+            result = json.loads(initialized_provider.handle_tool_call(
+                "pallium_remember", {"content": "Use UTC for all timestamps", "kind": "decision"}
+            ))
+
+        mock_post.assert_called_once()
+        _, payload = mock_post.call_args[0]
+        assert payload["content"] == "Use UTC for all timestamps"
+        assert payload["role"] == "assistant"  # decision → assistant
+        assert payload["container_ref"] == "hermes"
+        assert result["result"] == "Stored."
+
+    def test_remember_note_uses_user_role(self, initialized_provider):
+        with patch("plugins.memory.pallium._http_post", return_value={}) as mock_post:
+            initialized_provider.handle_tool_call(
+                "pallium_remember", {"content": "Just a note", "kind": "note"}
+            )
+        _, payload = mock_post.call_args[0]
+        assert payload["role"] == "user"
+
+    def test_query_no_blocks_returns_no_results_message(self, initialized_provider):
+        with patch("plugins.memory.pallium._http_post", return_value={"injectable_blocks": []}):
+            result = json.loads(initialized_provider.handle_tool_call(
+                "pallium_query", {"query": "anything"}
+            ))
+        assert "No relevant memories" in result["result"]
+
+
+# ---------------------------------------------------------------------------
+# sync_turn
+# ---------------------------------------------------------------------------
+
+class TestSyncTurn:
+
+    def test_sync_turn_posts_both_messages(self, initialized_provider):
+        posted = []
+
+        def fake_post(url, payload, **kwargs):
+            posted.append(payload)
+            return {}
+
+        with patch("plugins.memory.pallium._http_post", side_effect=fake_post):
+            initialized_provider.sync_turn("Hello", "Hi there")
+            # Wait for background thread
+            if initialized_provider._sync_thread:
+                initialized_provider._sync_thread.join(timeout=5.0)
+
+        assert len(posted) == 2
+        roles = {p["role"] for p in posted}
+        assert roles == {"user", "assistant"}
+        contents = {p["content"] for p in posted}
+        assert "Hello" in contents
+        assert "Hi there" in contents
+
+    def test_sync_turn_includes_session_and_turn_in_source_id(self, initialized_provider):
+        posted = []
+
+        def fake_post(url, payload, **kwargs):
+            posted.append(payload)
+            return {}
+
+        with patch("plugins.memory.pallium._http_post", side_effect=fake_post):
+            initialized_provider.sync_turn("msg1", "reply1")
+            if initialized_provider._sync_thread:
+                initialized_provider._sync_thread.join(timeout=5.0)
+
+        source_ids = {p["source_id"] for p in posted}
+        # All source_ids contain session id and turn count
+        for sid in source_ids:
+            assert "test-session-1" in sid
+            assert "1" in sid  # turn 1
+
+    def test_sync_turn_increments_turn_count(self, initialized_provider):
+        with patch("plugins.memory.pallium._http_post", return_value={}):
+            initialized_provider.sync_turn("a", "b")
+            if initialized_provider._sync_thread:
+                initialized_provider._sync_thread.join(timeout=5.0)
+            initialized_provider.sync_turn("c", "d")
+            if initialized_provider._sync_thread:
+                initialized_provider._sync_thread.join(timeout=5.0)
+        assert initialized_provider._turn_count == 2
+
+    def test_sync_turn_is_non_blocking(self, initialized_provider):
+        """sync_turn should return immediately, not block on HTTP."""
+        slow_event = threading.Event()
+
+        def slow_post(url, payload, **kwargs):
+            slow_event.wait(timeout=10)
+            return {}
+
+        start = time.monotonic()
+        with patch("plugins.memory.pallium._http_post", side_effect=slow_post):
+            initialized_provider.sync_turn("test", "test")
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 0.5  # returned immediately
+        slow_event.set()  # unblock background thread
+        if initialized_provider._sync_thread:
+            initialized_provider._sync_thread.join(timeout=5.0)
+
+
+# ---------------------------------------------------------------------------
+# on_memory_write
+# ---------------------------------------------------------------------------
+
+class TestOnMemoryWrite:
+
+    def test_mirrors_add_action(self, initialized_provider):
+        posted = []
+
+        def fake_post(url, payload, **kwargs):
+            posted.append(payload)
+            return {}
+
+        with patch("plugins.memory.pallium._http_post", side_effect=fake_post):
+            initialized_provider.on_memory_write("add", "memory", "Important fact")
+            # Find and join the thread
+            threads = [t for t in threading.enumerate() if "pallium-memwrite" in t.name]
+            for t in threads:
+                t.join(timeout=5.0)
+
+        assert len(posted) == 1
+        assert posted[0]["content"] == "Important fact"
+        assert posted[0]["source_type"] == "hermes_agent-memory"
+
+    def test_mirrors_user_profile_writes(self, initialized_provider):
+        posted = []
+
+        def fake_post(url, payload, **kwargs):
+            posted.append(payload)
+            return {}
+
+        with patch("plugins.memory.pallium._http_post", side_effect=fake_post):
+            initialized_provider.on_memory_write("add", "user", "User name: Alice")
+            threads = [t for t in threading.enumerate() if "pallium-memwrite" in t.name]
+            for t in threads:
+                t.join(timeout=5.0)
+
+        assert posted[0]["source_type"] == "hermes_user-profile"
+        assert posted[0]["role"] == "user"
+
+    def test_ignores_remove_action(self, initialized_provider):
+        with patch("plugins.memory.pallium._http_post") as mock_post:
+            initialized_provider.on_memory_write("remove", "memory", "something")
+            time.sleep(0.05)
+        mock_post.assert_not_called()
+
+    def test_ignores_empty_content(self, initialized_provider):
+        with patch("plugins.memory.pallium._http_post") as mock_post:
+            initialized_provider.on_memory_write("add", "memory", "")
+            time.sleep(0.05)
+        mock_post.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker
+# ---------------------------------------------------------------------------
+
+class TestCircuitBreaker:
+
+    def test_breaker_opens_after_threshold_failures(self, initialized_provider):
+        assert not initialized_provider._is_breaker_open()
+        for _ in range(5):
+            initialized_provider._record_failure()
+        assert initialized_provider._is_breaker_open()
+
+    def test_breaker_resets_after_success(self, initialized_provider):
+        for _ in range(5):
+            initialized_provider._record_failure()
+        assert initialized_provider._is_breaker_open()
+        initialized_provider._record_success()
+        assert initialized_provider._consecutive_failures == 0
+
+    def test_breaker_blocks_tool_calls(self, initialized_provider):
+        for _ in range(5):
+            initialized_provider._record_failure()
+
+        with patch("plugins.memory.pallium._http_post") as mock_post:
+            result = json.loads(initialized_provider.handle_tool_call(
+                "pallium_query", {"query": "test"}
+            ))
+        mock_post.assert_not_called()
+        assert "unavailable" in result["error"].lower()
+
+    def test_breaker_blocks_prefetch(self, initialized_provider):
+        for _ in range(5):
+            initialized_provider._record_failure()
+
+        with patch("plugins.memory.pallium._http_post") as mock_post:
+            initialized_provider.queue_prefetch("test query")
+            time.sleep(0.05)
+        mock_post.assert_not_called()
+
+    def test_breaker_cooldown_resets(self, initialized_provider):
+        """After cooldown expires, breaker resets on next check."""
+        for _ in range(5):
+            initialized_provider._record_failure()
+        # Backdate the cooldown so it's already expired
+        initialized_provider._breaker_open_until = time.monotonic() - 1
+        assert not initialized_provider._is_breaker_open()
+        assert initialized_provider._consecutive_failures == 0
+
+
+# ---------------------------------------------------------------------------
+# Prefetch
+# ---------------------------------------------------------------------------
+
+class TestPrefetch:
+
+    def test_prefetch_returns_empty_when_no_result(self, initialized_provider):
+        result = initialized_provider.prefetch("anything")
+        assert result == ""
+
+    def test_queue_prefetch_then_prefetch(self, initialized_provider):
+        mock_response = {
+            "injectable_blocks": [
+                {"title": "decision", "text": "Always use UTC."}
+            ]
+        }
+        with patch("plugins.memory.pallium._http_post", return_value=mock_response):
+            initialized_provider.queue_prefetch("timezone handling")
+            if initialized_provider._prefetch_thread:
+                initialized_provider._prefetch_thread.join(timeout=5.0)
+
+        result = initialized_provider.prefetch("timezone handling")
+        assert "Pallium Memory" in result
+        assert "Always use UTC" in result
+
+    def test_prefetch_clears_cache_after_read(self, initialized_provider):
+        with initialized_provider._prefetch_lock:
+            initialized_provider._prefetch_result = "cached content"
+
+        initialized_provider.prefetch("query")
+        with initialized_provider._prefetch_lock:
+            assert initialized_provider._prefetch_result == ""
+
+
+# ---------------------------------------------------------------------------
+# on_pre_compress
+# ---------------------------------------------------------------------------
+
+class TestOnPreCompress:
+
+    def test_returns_empty_string(self, initialized_provider):
+        with patch("plugins.memory.pallium._http_post", return_value={}):
+            result = initialized_provider.on_pre_compress([
+                {"role": "user", "content": "old message"},
+                {"role": "assistant", "content": "old reply"},
+            ])
+        assert result == ""
+
+    def test_empty_messages_does_nothing(self, initialized_provider):
+        with patch("plugins.memory.pallium._http_post") as mock_post:
+            initialized_provider.on_pre_compress([])
+            time.sleep(0.05)
+        mock_post.assert_not_called()
+
+    def test_ingests_user_and_assistant_messages(self, initialized_provider):
+        posted = []
+
+        def fake_post(url, payload, **kwargs):
+            posted.append(payload)
+            return {}
+
+        messages = [
+            {"role": "user", "content": "old question"},
+            {"role": "assistant", "content": "old answer"},
+            {"role": "tool", "content": "tool output"},  # should be skipped
+        ]
+
+        with patch("plugins.memory.pallium._http_post", side_effect=fake_post):
+            initialized_provider.on_pre_compress(messages)
+            threads = [t for t in threading.enumerate() if "pallium-compress" in t.name]
+            for t in threads:
+                t.join(timeout=5.0)
+
+        roles = {p["role"] for p in posted}
+        assert "user" in roles
+        assert "assistant" in roles
+        assert "tool" not in roles
+
+
+# ---------------------------------------------------------------------------
+# Shutdown
+# ---------------------------------------------------------------------------
+
+class TestShutdown:
+
+    def test_shutdown_joins_threads(self, initialized_provider):
+        """shutdown() joins background threads without error."""
+        with patch("plugins.memory.pallium._http_post", return_value={}):
+            initialized_provider.sync_turn("a", "b")
+        initialized_provider.shutdown()  # should not raise or hang
+
+
+# ---------------------------------------------------------------------------
+# Plugin registration
+# ---------------------------------------------------------------------------
+
+class TestPluginRegistration:
+
+    def test_register_function_exists(self):
+        assert callable(register)
+
+    def test_register_adds_provider(self):
+        ctx = MagicMock()
+        register(ctx)
+        ctx.register_memory_provider.assert_called_once()
+        provider = ctx.register_memory_provider.call_args[0][0]
+        assert provider.name == "pallium"
+        assert isinstance(provider, PalliumMemoryProvider)
+
+    def test_provider_name(self):
+        p = PalliumMemoryProvider()
+        assert p.name == "pallium"
+
+    def test_integrates_with_memory_manager(self):
+        """Plugin wires correctly into MemoryManager."""
+        from agent.memory_manager import MemoryManager
+        from agent.builtin_memory_provider import BuiltinMemoryProvider
+
+        mgr = MemoryManager()
+        mgr.add_provider(BuiltinMemoryProvider())
+        mgr.add_provider(PalliumMemoryProvider())
+
+        assert "pallium" in mgr.provider_names
+        assert mgr.has_tool("pallium_query")
+        assert mgr.has_tool("pallium_remember")

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 4
 title: "Memory Providers"
-description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory"
+description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, Supermemory, Pallium"
 ---
 
 # Memory Providers
@@ -22,7 +22,7 @@ Or set manually in `~/.hermes/config.yaml`:
 
 ```yaml
 memory:
-  provider: openviking   # or honcho, mem0, hindsight, holographic, retaindb, byterover, supermemory
+  provider: openviking   # or honcho, mem0, hindsight, holographic, retaindb, byterover, supermemory, pallium
 ```
 
 ## How It Works
@@ -458,6 +458,48 @@ echo 'SUPERMEMORY_API_KEY=***' >> ~/.hermes/.env
 
 ---
 
+### Pallium
+
+Local-first memory sidecar with automatic fact extraction, hybrid retrieval (lexical + vector RRF), and evidence provenance. Multilingual by design — memory is preserved in the original language and cross-language recall works natively.
+
+| | |
+|---|---|
+| **Best for** | Local-only memory with automatic extraction, multilingual agents, long autonomous runs |
+| **Requires** | Running Pallium server (`pip install` from source) + LLM API key for extraction |
+| **Data storage** | Local SQLite + local vector index |
+| **Cost** | Free |
+
+**Tools:** `pallium_query` (search decisions, facts, checkpoints), `pallium_remember` (store explicit facts/decisions)
+
+**Setup:**
+```bash
+# Start Pallium server first (see https://github.com/rotemhermon/pallium)
+python -m app.run serve --host 127.0.0.1 --port 8000
+
+# Then configure Hermes
+hermes memory setup    # select "pallium"
+# Or manually:
+hermes config set memory.provider pallium
+```
+
+**Config:** `$HERMES_HOME/pallium.json`
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `base_url` | `http://localhost:8000` | Pallium server URL |
+| `actor_ref` | `hermes-user` | Stable user identifier for cross-session memory scoping |
+| `container_ref` | `hermes` | Memory container identifier |
+
+**How memory builds automatically:**
+
+Every conversation turn is ingested and processed by two parallel extraction packages:
+- **Work continuity** — decisions, investigation outcomes, task checkpoints
+- **Factual recall** — names, dates, preferences, events, relationships, consolidated by subject across sessions
+
+The agent doesn't need to decide what to remember — extraction is automatic and runs in the background.
+
+---
+
 ## Provider Comparison
 
 | Provider | Storage | Cost | Tools | Dependencies | Unique Feature |
@@ -470,6 +512,7 @@ echo 'SUPERMEMORY_API_KEY=***' >> ~/.hermes/.env
 | **RetainDB** | Cloud | $20/mo | 5 | `requests` | Delta compression |
 | **ByteRover** | Local/Cloud | Free/Paid | 3 | `brv` CLI | Pre-compression extraction |
 | **Supermemory** | Cloud | Paid | 4 | `supermemory` | Context fencing + session graph ingest + multi-container |
+| **Pallium** | Local | Free | 2 | `httpx` + Pallium server | Hybrid retrieval + evidence provenance + multilingual |
 
 ## Profile Isolation
 


### PR DESCRIPTION
## Summary

- Add Pallium as the 8th memory provider plugin — local-first memory sidecar with automatic fact extraction, hybrid retrieval (lexical + vector RRF), and evidence provenance
- No cloud dependency, no API key required — just a running Pallium server
- Multilingual by design — memory preserved in original language, cross-language recall works natively

**Pallium**: https://github.com/rotemhermon/pallium

## What's included

- **Plugin** (`plugins/memory/pallium/`): full `MemoryProvider` implementation with `pallium_query` and `pallium_remember` tools, background sync, prefetch, memory mirroring, pre-compression extraction, and circuit breaker
- **Tests** (`tests/plugins/test_pallium_plugin.py`): 46 unit tests covering config loading, tool routing, sync payloads, circuit breaker, prefetch threading, lifecycle hooks, and MemoryManager integration — no server required
- **Docs**: Pallium section added to `memory-providers.md` with setup instructions, config reference, and comparison table entry
- **README** (`plugins/memory/pallium/README.md`): standalone setup guide

## How memory builds automatically

Every conversation turn is ingested and processed by two parallel extraction packages:
- **Work continuity** — decisions, investigation outcomes, task checkpoints
- **Factual recall** — names, dates, preferences, events, relationships, consolidated by subject across sessions

The agent doesn't need to decide what to remember — extraction is automatic and runs in the background.

## Test plan

- [x] 46 unit tests pass (`pytest tests/plugins/test_pallium_plugin.py`)
- [x] Plugin auto-discovery works (`discover_memory_providers()` finds pallium)
- [x] MemoryManager integration verified — coexistence with BuiltinMemoryProvider, tool routing, on_memory_write mirroring
- [x] Live e2e test against running Pallium server — all lifecycle stages pass
- [x] Full Hermes Agent interactive session — LLM autonomously calls `pallium_remember` and `pallium_query`, cross-session recall confirmed via `/new`