### PR TITLE
feat: add xAI prompt caching via x-grok-conv-id header

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5438,6 +5438,12 @@ class AIAgent:
         if extra_body:
             api_kwargs["extra_body"] = extra_body
 
+        # xAI prompt caching: send x-grok-conv-id header to route requests
+        # to the same server, maximizing automatic cache hits.
+        # https://docs.x.ai/developers/advanced-api-usage/prompt-caching
+        if "x.ai" in self._base_url_lower and hasattr(self, "session_id") and self.session_id:
+            api_kwargs["extra_headers"] = {"x-grok-conv-id": self.session_id}
+
         return api_kwargs
 
     def _supports_reasoning_extra_body(self) -> bool:


### PR DESCRIPTION
## Summary

Cherry-picked from #5548 by @Julientalbot onto current main.

When using xAI's API directly (`base_url` contains `x.ai`), sends the `x-grok-conv-id` header set to the Hermes `session_id`. This routes consecutive requests to the same xAI server, maximizing automatic prompt cache hits across turns.

## Changes
- `run_agent.py`: 6-line addition in `_build_api_kwargs()` — detects xAI base URL, adds header using session_id

## Reference
- Original PR: #5548
- xAI prompt caching docs: https://docs.x.ai/developers/advanced-api-usage/prompt-caching
- Companion to #5531 (Grok tool-use enforcement)