### PR TITLE
feat(api_server): add API_SERVER_MODEL_NAME env var for multi-profile support

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -46,6 +46,7 @@ logger = logging.getLogger(__name__)
 # Default settings
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8642
+DEFAULT_MODEL_NAME = os.getenv("API_SERVER_MODEL_NAME", "hermes-agent")
 MAX_STORED_RESPONSES = 100
 MAX_REQUEST_BYTES = 1_000_000  # 1 MB default limit for POST bodies
 
@@ -455,10 +456,10 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _handle_health(self, request: "web.Request") -> "web.Response":
         """GET /health — simple health check."""
-        return web.json_response({"status": "ok", "platform": "hermes-agent"})
+        return web.json_response({"status": "ok", "platform": DEFAULT_MODEL_NAME})
 
     async def _handle_models(self, request: "web.Request") -> "web.Response":
-        """GET /v1/models — return hermes-agent as an available model."""
+        """GET /v1/models — return the configured model name."""
         auth_err = self._check_auth(request)
         if auth_err:
             return auth_err
@@ -467,12 +468,12 @@ class APIServerAdapter(BasePlatformAdapter):
             "object": "list",
             "data": [
                 {
-                    "id": "hermes-agent",
+                    "id": DEFAULT_MODEL_NAME,
                     "object": "model",
                     "created": int(time.time()),
                     "owned_by": "hermes",
                     "permission": [],
-                    "root": "hermes-agent",
+                    "root": DEFAULT_MODEL_NAME,
                     "parent": None,
                 }
             ],
@@ -545,7 +546,7 @@ class APIServerAdapter(BasePlatformAdapter):
             # history already set from request body above
 
         completion_id = f"chatcmpl-{uuid.uuid4().hex[:29]}"
-        model_name = body.get("model", "hermes-agent")
+        model_name = body.get("model", DEFAULT_MODEL_NAME)
         created = int(time.time())
 
         if stream:
@@ -900,7 +901,7 @@ class APIServerAdapter(BasePlatformAdapter):
             "object": "response",
             "status": "completed",
             "created_at": created_at,
-            "model": body.get("model", "hermes-agent"),
+            "model": body.get("model", DEFAULT_MODEL_NAME),
             "output": output_items,
             "usage": {
                 "input_tokens": usage.get("input_tokens", 0),


### PR DESCRIPTION
## What does this PR do?

When running multiple Hermes profiles with separate API servers (a supported multi-profile setup via `hermes profile create`), all profiles report `"hermes-agent"` as their model ID via `GET /v1/models`. OpenAI-compatible frontends (Open WebUI, LobeChat, LibreChat, AnythingLLM, etc.) use this ID to populate their model dropdown — so all profiles appear identical and clients cannot route requests to the correct profile.

This adds a `DEFAULT_MODEL_NAME` constant backed by the `API_SERVER_MODEL_NAME` environment variable, defaulting to `"hermes-agent"`. This follows the existing pattern used by `API_SERVER_HOST`, `API_SERVER_PORT`, `API_SERVER_KEY`, and `API_SERVER_CORS_ORIGINS` in the same file.

## Related Issue

No existing issue found for this. Happy to create one if preferred.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- \`gateway/platforms/api_server.py\`: Added \`DEFAULT_MODEL_NAME = os.getenv(\"API_SERVER_MODEL_NAME\", \"hermes-agent\")\` constant after \`DEFAULT_PORT\`
- \`gateway/platforms/api_server.py\`: Replaced 5 hardcoded \`\"hermes-agent\"\` string literals with \`DEFAULT_MODEL_NAME\` in:
  - \`_handle_health\` response
  - \`_handle_models\` response \`id\` and \`root\` fields
  - \`_handle_chat_completions\` default model fallback
  - \`_handle_responses\` default model fallback
- \`gateway/platforms/api_server.py\`: Updated \`_handle_models\` docstring to be generic

## How to Test

1. Create a profile: \`hermes profile create researcher --clone\`
2. Add to the profile's \`.env\`:
   \`\`\`
   API_SERVER_MODEL_NAME=hermes-researcher
   API_SERVER_PORT=8643
   \`\`\`
3. Start the profile gateway
4. Query the API: \`curl -H \"Authorization: Bearer <key>\" http://localhost:8643/v1/models\`
5. Verify the response shows \`\"id\": \"hermes-researcher\"\` instead of \`\"id\": \"hermes-agent\"\`
6. Verify that without the env var set, the default profile still reports \`\"hermes-agent\"\`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run \`pytest tests/ -q\` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (devlab VM, Docker container)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've updated \`cli-config.yaml.example\` if I added/changed config keys — or N/A
- [x] I've updated \`CONTRIBUTING.md\` or \`AGENTS.md\` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before (all profiles report same model):
\`\`\`json
{\"object\":\"list\",\"data\":[{\"id\":\"hermes-agent\",\"object\":\"model\",\"root\":\"hermes-agent\"}]}
\`\`\`

After (each profile reports its configured name):
\`\`\`json
{\"object\":\"list\",\"data\":[{\"id\":\"hermes-researcher\",\"object\":\"model\",\"root\":\"hermes-researcher\"}]}
\`\`\`

Verified in a live 4-profile deployment (default, researcher, cto, homelab) with Open WebUI correctly showing distinct models in the dropdown.