### PR TITLE
fix(mattermost): set message type to DOCUMENT when post has file attachments

### DIFF
--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -661,8 +661,6 @@ class MattermostAdapter(BasePlatformAdapter):
         msg_type = MessageType.TEXT
         if message_text.startswith("/"):
             msg_type = MessageType.COMMAND
-        elif file_ids:
-            msg_type = MessageType.DOCUMENT
 
         # Download file attachments immediately (URLs require auth headers
         # that downstream tools won't have).
@@ -702,6 +700,15 @@ class MattermostAdapter(BasePlatformAdapter):
                         logger.warning("Mattermost: failed to download file %s: HTTP %s", fid, resp.status)
             except Exception as exc:
                 logger.warning("Mattermost: error downloading file %s: %s", fid, exc)
+
+        # Set message type based on downloaded media types.
+        if media_types and msg_type == MessageType.TEXT:
+            if any(m.startswith("image/") for m in media_types):
+                msg_type = MessageType.PHOTO
+            elif any(m.startswith("audio/") for m in media_types):
+                msg_type = MessageType.VOICE
+            elif media_types:
+                msg_type = MessageType.DOCUMENT
 
         source = self.build_source(
             chat_id=channel_id,

--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -661,6 +661,8 @@ class MattermostAdapter(BasePlatformAdapter):
         msg_type = MessageType.TEXT
         if message_text.startswith("/"):
             msg_type = MessageType.COMMAND
+        elif file_ids:
+            msg_type = MessageType.DOCUMENT
 
         # Download file attachments immediately (URLs require auth headers
         # that downstream tools won't have).


### PR DESCRIPTION
## Summary

The Mattermost adapter downloads file attachments correctly via the `/api/v4/files/{id}` endpoint and caches them locally, but never updates `msg_type` from `TEXT` to `DOCUMENT`. This means the document enrichment block in `gateway/run.py` (which requires `MessageType.DOCUMENT`) never executes.

**Result:** the user sends a file, the adapter downloads it to the local cache, but the agent sees a plain text message and responds with "I didn't receive any file."

**Fix:** set `msg_type = MessageType.DOCUMENT` when `file_ids` is non-empty, matching the behavior of the Telegram and Discord adapters.

## Steps to reproduce

1. Send a file attachment (e.g. `.txt`, `.pdf`) to the bot via Mattermost
2. The bot responds saying it didn't receive any file
3. Check `media_urls` in the `MessageEvent` — the file is downloaded but `message_type` is `TEXT` instead of `DOCUMENT`

## Test plan

- [x] Send a text file (.txt) via Mattermost DM → agent sees content inline
- [x] Send a file with text in the same message → agent sees both text and file
- [x] Send a file without text → agent receives the file as DOCUMENT
- [x] Verify commands still detected (`/command` → COMMAND type)