### PR TITLE
fix(models): resolve custom providers when switching models by name (…

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -542,6 +542,15 @@ def switch_model(
                             if bare.lower() == new_model_lower:
                                 new_model = mid
                                 break
+        # --- Step d.5: Check user-defined providers for the requested model ---
+        if target_provider == current_provider and not resolved_alias and user_providers and isinstance(user_providers, dict):
+            for ep_name, ep_cfg in user_providers.items():
+                if isinstance(ep_cfg, dict):
+                    _p_models = ep_cfg.get("models", [])
+                    _p_default = ep_cfg.get("default_model", "")
+                    if new_model == _p_default or (isinstance(_p_models, list) and new_model in _p_models):
+                        target_provider = ep_name
+                        break                      
 
         # --- Step e: detect_provider_for_model() as last resort ---
         _base = current_base_url or ""


### PR DESCRIPTION
…#5569)

Fixes #5569

When users selected a model by name from the Telegram inline keyboard (which triggers a model switch without an explicit `--provider` flag), the `switch_model` pipeline in `PATH B` completely skipped checking `user_providers`. This caused the agent to default to the `current_provider` and fail when selecting custom models that belonged to a different custom endpoint.

Added a new resolution step (Step d.5) that iterates over `user_providers` to check if the requested `new_model` exists in a custom provider's `models` list or matches its `default_model`. The agent now seamlessly and automatically switches to the correct custom provider when a user switches models via gateway platforms.

## Related Issue

Fixes #5569

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `Step d.5` resolution logic in `hermes_cli/model_switch.py` to iterate over `user_providers` and match the requested model name with custom endpoints.

## How to Test

1. Configure multiple custom providers (e.g., Provider A and Provider B) with different models in `config.yaml`.
2. Start the gateway platform (e.g., Telegram).
3. Use the `/model` command or inline keyboard to switch to a model belonging to Provider B while currently using Provider A.
4. Verify that the session provider is correctly updated to Provider B and API calls route successfully.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A