### PR TITLE
fix(auth): actionable error message when Codex refresh token is reused by another client

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -990,6 +990,14 @@ def refresh_codex_oauth_pure(
             pass
         if code in {"invalid_grant", "invalid_token", "invalid_request"}:
             relogin_required = True
+        if code == "refresh_token_reused":
+            message = (
+                "Codex refresh token was already consumed by another client "
+                "(e.g. Codex CLI or VS Code extension). "
+                "Run `codex` in your terminal to generate fresh tokens, "
+                "then run `hermes login --provider openai-codex` to re-authenticate."
+            )
+            relogin_required = True
         raise AuthError(
             message,
             provider="openai-codex",

--- a/run_agent.py
+++ b/run_agent.py
@@ -7764,11 +7764,17 @@ class AIAgent:
                         self._vprint(f"{self.log_prefix}   🌐 Endpoint: {_base}", force=True)
                         # Actionable guidance for common auth errors
                         if status_code in (401, 403) or "unauthorized" in error_msg or "forbidden" in error_msg or "permission" in error_msg:
-                            self._vprint(f"{self.log_prefix}   💡 Your API key was rejected by the provider. Check:", force=True)
-                            self._vprint(f"{self.log_prefix}      • Is the key valid? Run: hermes setup", force=True)
-                            self._vprint(f"{self.log_prefix}      • Does your account have access to {_model}?", force=True)
-                            if "openrouter" in str(_base).lower():
-                                self._vprint(f"{self.log_prefix}      • Check credits: https://openrouter.ai/settings/credits", force=True)
+                            if _provider == "openai-codex" and status_code == 401:
+                                self._vprint(f"{self.log_prefix}   💡 Codex OAuth token was rejected (HTTP 401). Your token may have been", force=True)
+                                self._vprint(f"{self.log_prefix}      refreshed by another client (Codex CLI, VS Code). To fix:", force=True)
+                                self._vprint(f"{self.log_prefix}      1. Run `codex` in your terminal to generate fresh tokens.", force=True)
+                                self._vprint(f"{self.log_prefix}      2. Then run `hermes login --provider openai-codex` to re-authenticate.", force=True)
+                            else:
+                                self._vprint(f"{self.log_prefix}   💡 Your API key was rejected by the provider. Check:", force=True)
+                                self._vprint(f"{self.log_prefix}      • Is the key valid? Run: hermes setup", force=True)
+                                self._vprint(f"{self.log_prefix}      • Does your account have access to {_model}?", force=True)
+                                if "openrouter" in str(_base).lower():
+                                    self._vprint(f"{self.log_prefix}      • Check credits: https://openrouter.ai/settings/credits", force=True)
                         else:
                             self._vprint(f"{self.log_prefix}   💡 This type of error won't be fixed by retrying.", force=True)
                         logging.error(f"{self.log_prefix}Non-retryable client error: {api_error}")


### PR DESCRIPTION
## Problem

When the Codex CLI or VS Code extension refreshes OAuth tokens, the shared refresh token is consumed. If Hermes then tries to refresh using the same (now-stale) token, the OpenAI OAuth endpoint returns \`refresh_token_reused\`. Hermes currently surfaces this as a generic 401 with advice to check your API key — which is confusing and unhelpful since the account is fine.

## Changes

**\`hermes_cli/auth.py\`** — detect \`refresh_token_reused\` specifically in \`refresh_codex_oauth_pure()\` and raise an \`AuthError\` with an explanation and recovery steps:
> "Codex refresh token was already consumed by another client (e.g. Codex CLI or VS Code extension). Run \`codex\` in your terminal to generate fresh tokens, then run \`hermes login --provider openai-codex\` to re-authenticate."

**\`run_agent.py\`** — when provider is \`openai-codex\` and HTTP 401 is received, show Codex-specific recovery steps instead of the generic "is your API key valid?" message.

## Why only these cases

The \`refresh_token_reused\` branch in \`auth.py\` is gated on the exact error code from the OAuth endpoint. The \`run_agent.py\` change is gated on \`_provider == "openai-codex" and status_code == 401\` — all other providers and status codes are unchanged.

## Reproduction

1. Authenticate Hermes with \`hermes login --provider openai-codex\`
2. Run \`codex\` from the terminal (or open VS Code with the Codex extension) — this consumes the shared refresh token
3. Trigger a Hermes request — previously showed a generic 401; now shows actionable steps