### PR TITLE
fix(hindsight): add custom endpoint support to local mode wizard

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -186,6 +186,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._bank_id = "hermes"
         self._budget = "mid"
         self._mode = "cloud"
+        self._llm_base_url = ""
         self._memory_mode = "hybrid"  # "context", "tools", or "hybrid"
         self._prefetch_method = "recall"  # "recall" or "reflect"
         self._client = None
@@ -231,9 +232,10 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "mode", "description": "Cloud API or local embedded mode", "default": "cloud", "choices": ["cloud", "local"]},
             {"key": "api_url", "description": "Hindsight API URL", "default": _DEFAULT_API_URL, "when": {"mode": "cloud"}},
             {"key": "api_key", "description": "Hindsight Cloud API key", "secret": True, "env_var": "HINDSIGHT_API_KEY", "url": "https://ui.hindsight.vectorize.io", "when": {"mode": "cloud"}},
-            {"key": "llm_provider", "description": "LLM provider for local mode", "default": "openai", "choices": ["openai", "anthropic", "gemini", "groq", "minimax", "ollama"], "when": {"mode": "local"}},
+            {"key": "llm_provider", "description": "LLM provider for local mode", "default": "openai", "choices": ["openai", "anthropic", "gemini", "groq", "minimax", "ollama", "lmstudio"], "when": {"mode": "local"}},
             {"key": "llm_api_key", "description": "LLM API key for local Hindsight", "secret": True, "env_var": "HINDSIGHT_LLM_API_KEY", "when": {"mode": "local"}},
             {"key": "llm_model", "description": "LLM model for local mode", "default": "gpt-4o-mini", "default_from": {"field": "llm_provider", "map": _PROVIDER_DEFAULT_MODELS}, "when": {"mode": "local"}},
+            {"key": "llm_base_url", "description": "Custom endpoint URL (e.g. http://192.168.1.10:8080/v1)", "default": "", "when": {"mode": "local"}},
             {"key": "bank_id", "description": "Memory bank name", "default": "hermes"},
             {"key": "budget", "description": "Recall thoroughness", "default": "mid", "choices": ["low", "mid", "high"]},
             {"key": "memory_mode", "description": "Memory integration mode", "default": "hybrid", "choices": ["hybrid", "context", "tools"]},
@@ -249,12 +251,15 @@ class HindsightMemoryProvider(MemoryProvider):
                 # different loop" errors during GC — we handle cleanup in
                 # shutdown() instead.
                 HindsightEmbedded.__del__ = lambda self: None
-                self._client = HindsightEmbedded(
+                kwargs = dict(
                     profile=self._config.get("profile", "hermes"),
                     llm_provider=self._config.get("llm_provider", ""),
                     llm_api_key=self._config.get("llmApiKey") or os.environ.get("HINDSIGHT_LLM_API_KEY", ""),
                     llm_model=self._config.get("llm_model", ""),
                 )
+                if self._llm_base_url:
+                    kwargs["llm_base_url"] = self._llm_base_url
+                self._client = HindsightEmbedded(**kwargs)
             else:
                 from hindsight_client import Hindsight
                 kwargs = {"base_url": self._api_url, "timeout": 30.0}
@@ -269,6 +274,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._api_key = self._config.get("apiKey") or os.environ.get("HINDSIGHT_API_KEY", "")
         default_url = _DEFAULT_LOCAL_URL if self._mode == "local" else _DEFAULT_API_URL
         self._api_url = self._config.get("api_url") or os.environ.get("HINDSIGHT_API_URL", default_url)
+        self._llm_base_url = self._config.get("llm_base_url", "")
 
         banks = self._config.get("banks", {}).get("hermes", {})
         self._bank_id = self._config.get("bank_id") or banks.get("bankId", "hermes")
@@ -313,6 +319,7 @@ class HindsightMemoryProvider(MemoryProvider):
                     current_key = self._config.get("llmApiKey") or os.environ.get("HINDSIGHT_LLM_API_KEY", "")
                     current_provider = self._config.get("llm_provider", "")
                     current_model = self._config.get("llm_model", "")
+                    current_base_url = self._config.get("llm_base_url", "")
 
                     # Read saved profile config
                     saved = {}
@@ -325,18 +332,22 @@ class HindsightMemoryProvider(MemoryProvider):
                     config_changed = (
                         saved.get("HINDSIGHT_API_LLM_PROVIDER") != current_provider or
                         saved.get("HINDSIGHT_API_LLM_MODEL") != current_model or
-                        saved.get("HINDSIGHT_API_LLM_API_KEY") != current_key
+                        saved.get("HINDSIGHT_API_LLM_API_KEY") != current_key or
+                        saved.get("HINDSIGHT_API_LLM_BASE_URL", "") != current_base_url
                     )
 
                     if config_changed:
                         # Write updated profile .env
                         profile_env.parent.mkdir(parents=True, exist_ok=True)
-                        profile_env.write_text(
+                        env_lines = (
                             f"HINDSIGHT_API_LLM_PROVIDER={current_provider}\n"
                             f"HINDSIGHT_API_LLM_API_KEY={current_key}\n"
                             f"HINDSIGHT_API_LLM_MODEL={current_model}\n"
                             f"HINDSIGHT_API_LOG_LEVEL=info\n"
                         )
+                        if current_base_url:
+                            env_lines += f"HINDSIGHT_API_LLM_BASE_URL={current_base_url}\n"
+                        profile_env.write_text(env_lines)
                         if client._manager.is_running(profile):
                             with open(log_path, "a") as f:
                                 f.write("\n=== Config changed, restarting daemon ===\n")


### PR DESCRIPTION
## Summary

- Adds an optional `llm_base_url` field to the Hindsight plugin's `get_config_schema()`, shown in local mode
- Users running llama.cpp, vLLM, LM Studio, or any OpenAI-compatible server on a custom endpoint can now configure it through the `hermes memory setup` wizard
- Adds `lmstudio` to the `llm_provider` choices list (it was already in `_PROVIDER_DEFAULT_MODELS` but missing from the wizard)
- `llm_base_url` is optional — blank by default, so existing setups are unaffected

## How it works

The new field passes through the full stack:
1. Wizard writes `llm_base_url` to `$HERMES_HOME/hindsight/config.json`
2. `initialize()` reads it into `self._llm_base_url`  
3. Daemon startup writes `HINDSIGHT_API_LLM_BASE_URL` to the profile `.env` (included in config-changed detection so the daemon restarts when it changes)
4. `_get_client()` passes `llm_base_url` to `HindsightEmbedded`

## Test plan

- [ ] Run `hermes memory setup`, select Hindsight → local mode
- [ ] Verify `lmstudio` appears in the provider list
- [ ] Select `openai`, enter a custom URL, confirm it's saved to config.json and the profile .env
- [ ] Start a Hermes session and confirm memory operations reach the custom endpoint

Closes #5559