### PR TITLE
Reduce Telegram fallback IP activation log noise

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -518,7 +518,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     ", ".join(fallback_ips),
                 )
             if fallback_ips:
-                logger.warning(
+                logger.info(
                     "[%s] Telegram fallback IPs active: %s",
                     self.name,
                     ", ".join(fallback_ips),


### PR DESCRIPTION
## Summary
- lower Telegram fallback activation message from warning to info
- keeps the signal visible while avoiding warning-level noise during normal operation on restricted networks

## Validation
- /Users/yu/.hermes/hermes-agent/.venv/bin/python -m pytest -q /Users/yu/.hermes/hermes-agent/tests/gateway/test_telegram_network.py
- 45 passed