### PR TITLE
feat(gateway): add inline image inputs to API server

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -53,7 +53,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8642
 MAX_STORED_RESPONSES = 100
-MAX_REQUEST_BYTES = 1_000_000  # 1 MB default limit for POST bodies
+MAX_REQUEST_BYTES = 10 * 1024 * 1024  # 10 MiB default limit for POST bodies
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
@@ -115,6 +115,26 @@ def _normalize_chat_content(
         return result[:MAX_NORMALIZED_TEXT_LENGTH] if len(result) > MAX_NORMALIZED_TEXT_LENGTH else result
     except Exception:
         return ""
+
+
+class _APIRequestError(Exception):
+    """Structured request validation error for OpenAI-style responses."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        param: str = None,
+        code: str = None,
+        status: int = 400,
+        err_type: str = "invalid_request_error",
+    ):
+        super().__init__(message)
+        self.message = message
+        self.param = param
+        self.code = code
+        self.status = status
+        self.err_type = err_type
 
 
 def check_api_server_requirements() -> bool:
@@ -281,10 +301,12 @@ if AIOHTTP_AVAILABLE:
     async def body_limit_middleware(request, handler):
         """Reject overly large request bodies early based on Content-Length."""
         if request.method in ("POST", "PUT", "PATCH"):
+            adapter = request.app.get("api_server_adapter")
+            max_request_bytes = getattr(adapter, "_max_request_bytes", MAX_REQUEST_BYTES)
             cl = request.headers.get("Content-Length")
             if cl is not None:
                 try:
-                    if int(cl) > MAX_REQUEST_BYTES:
+                    if int(cl) > max_request_bytes:
                         return web.json_response(_openai_error("Request body too large.", code="body_too_large"), status=413)
                 except ValueError:
                     return web.json_response(_openai_error("Invalid Content-Length header.", code="invalid_content_length"), status=400)
@@ -386,6 +408,11 @@ class APIServerAdapter(BasePlatformAdapter):
         self._model_name: str = self._resolve_model_name(
             extra.get("model_name", os.getenv("API_SERVER_MODEL_NAME", "")),
         )
+        self._max_request_bytes: int = self._parse_positive_int(
+            extra.get("max_request_bytes", os.getenv("API_SERVER_MAX_REQUEST_BYTES")),
+            default=MAX_REQUEST_BYTES,
+            setting_name="API_SERVER_MAX_REQUEST_BYTES",
+        )
         self._app: Optional["web.Application"] = None
         self._runner: Optional["web.AppRunner"] = None
         self._site: Optional["web.TCPSite"] = None
@@ -460,6 +487,279 @@ class APIServerAdapter(BasePlatformAdapter):
             return False
 
         return "*" in self._cors_origins or origin in self._cors_origins
+
+    @staticmethod
+    def _parse_positive_int(value: Any, *, default: int, setting_name: str) -> int:
+        """Parse a positive integer setting, falling back to a safe default."""
+        if value in (None, ""):
+            return default
+
+        if isinstance(value, str):
+            candidate = value.strip().replace("_", "")
+        else:
+            candidate = value
+
+        try:
+            parsed = int(candidate)
+        except (TypeError, ValueError):
+            logger.warning("Invalid %s=%r; using default %d", setting_name, value, default)
+            return default
+
+        if parsed <= 0:
+            logger.warning("Invalid %s=%r; using default %d", setting_name, value, default)
+            return default
+
+        return parsed
+
+    @staticmethod
+    def _error_response(error: "_APIRequestError") -> "web.Response":
+        """Convert a structured validation error into an OpenAI-style HTTP response."""
+        return web.json_response(
+            _openai_error(
+                error.message,
+                err_type=error.err_type,
+                param=error.param,
+                code=error.code,
+            ),
+            status=error.status,
+        )
+
+    async def _parse_json_body(self, request: "web.Request") -> Dict[str, Any]:
+        """Parse the request body and return OpenAI-style errors for common failures."""
+        try:
+            return await request.json()
+        except web.HTTPRequestEntityTooLarge:
+            raise _APIRequestError("Request body too large.", code="body_too_large", status=413)
+        except (json.JSONDecodeError, Exception):
+            raise _APIRequestError("Invalid JSON in request body")
+
+    @staticmethod
+    def _is_supported_image_source(source: Any) -> bool:
+        """Allow remote http(s) URLs and inline data:image/... URLs."""
+        if not isinstance(source, str):
+            return False
+
+        candidate = source.strip()
+        lowered = candidate.lower()
+        if lowered.startswith("http://") or lowered.startswith("https://"):
+            return True
+        if lowered.startswith("data:image/") and "," in candidate:
+            return True
+        return False
+
+    @staticmethod
+    def _extract_image_payload(
+        image_value: Any,
+        *,
+        detail: Any = None,
+        param_prefix: str,
+    ) -> Dict[str, Any]:
+        """Validate an image payload and normalize it to {'url', 'detail'?}."""
+        image_detail = detail
+        if isinstance(image_value, dict):
+            image_detail = image_value.get("detail", image_detail)
+            image_value = image_value.get("url")
+
+        if not isinstance(image_value, str) or not image_value.strip():
+            raise _APIRequestError(
+                "Image content parts must include a non-empty image URL.",
+                param=param_prefix,
+                code="invalid_image_url",
+            )
+
+        image_url = image_value.strip()
+        if not APIServerAdapter._is_supported_image_source(image_url):
+            lowered = image_url.lower()
+            if lowered.startswith("data:") and not lowered.startswith("data:image/"):
+                raise _APIRequestError(
+                    "Only image data URLs are supported. Uploaded files and non-image data payloads are not supported.",
+                    param=param_prefix,
+                    code="unsupported_content_type",
+                )
+            raise _APIRequestError(
+                "Image inputs must use http(s) URLs or data:image/... URLs.",
+                param=param_prefix,
+                code="invalid_image_url",
+            )
+
+        normalized = {"url": image_url}
+        if image_detail is not None:
+            if not isinstance(image_detail, str) or not image_detail.strip():
+                raise _APIRequestError(
+                    "Image detail must be a non-empty string when provided.",
+                    param=f"{param_prefix}.detail",
+                    code="invalid_detail",
+                )
+            normalized["detail"] = image_detail.strip()
+        return normalized
+
+    def _normalize_chat_content(self, content: Any, *, param_prefix: str) -> Any:
+        """Validate Chat Completions content and preserve text/image parts."""
+        if isinstance(content, str):
+            return content
+        if content is None:
+            return ""
+        if not isinstance(content, list):
+            raise _APIRequestError(
+                "Chat message content must be a string or an array of content parts.",
+                param=param_prefix,
+                code="invalid_content",
+            )
+
+        normalized_parts: List[Dict[str, Any]] = []
+        for idx, part in enumerate(content):
+            part_param = f"{param_prefix}[{idx}]"
+            if not isinstance(part, dict):
+                raise _APIRequestError(
+                    "Each chat content part must be an object.",
+                    param=part_param,
+                    code="invalid_content_part",
+                )
+
+            part_type = part.get("type")
+            if part_type == "text":
+                text = part.get("text")
+                if not isinstance(text, str):
+                    raise _APIRequestError(
+                        "Text content parts must include a string 'text' field.",
+                        param=f"{part_param}.text",
+                        code="invalid_content_part",
+                    )
+                normalized_parts.append({"type": "text", "text": text})
+                continue
+
+            if part_type == "image_url":
+                normalized_parts.append(
+                    {
+                        "type": "image_url",
+                        "image_url": self._extract_image_payload(
+                            part.get("image_url"),
+                            detail=part.get("detail"),
+                            param_prefix=f"{part_param}.image_url",
+                        ),
+                    }
+                )
+                continue
+
+            if part_type in {"file", "input_file"}:
+                raise _APIRequestError(
+                    "Inline image inputs are supported, but uploaded files and document inputs are not supported on this endpoint.",
+                    param=f"{part_param}.type",
+                    code="unsupported_content_type",
+                )
+
+            raise _APIRequestError(
+                "Unsupported chat content part type. Only 'text' and 'image_url' are supported.",
+                param=f"{part_param}.type",
+                code="unsupported_content_type",
+            )
+
+        return normalized_parts
+
+    def _system_content_to_text(self, content: Any, *, param_prefix: str) -> str:
+        """Flatten system content to text while rejecting non-text multimodal parts."""
+        normalized = self._normalize_chat_content(content, param_prefix=param_prefix)
+        if isinstance(normalized, str):
+            return normalized
+
+        text_parts: List[str] = []
+        for idx, part in enumerate(normalized):
+            if part.get("type") != "text":
+                raise _APIRequestError(
+                    "System messages only support text content.",
+                    param=f"{param_prefix}[{idx}].type",
+                    code="unsupported_content_type",
+                )
+            text_parts.append(part.get("text", ""))
+        return "\n".join(text_parts)
+
+    def _normalize_responses_content(self, content: Any, *, param_prefix: str) -> Any:
+        """Normalize Responses API content to Hermes's internal chat-style format."""
+        if isinstance(content, str):
+            return content
+        if content is None:
+            return ""
+        if not isinstance(content, list):
+            raise _APIRequestError(
+                "Responses input content must be a string or an array of content parts.",
+                param=param_prefix,
+                code="invalid_content",
+            )
+
+        normalized_parts: List[Dict[str, Any]] = []
+        for idx, part in enumerate(content):
+            part_param = f"{param_prefix}[{idx}]"
+            if isinstance(part, str):
+                normalized_parts.append({"type": "text", "text": part})
+                continue
+
+            if not isinstance(part, dict):
+                raise _APIRequestError(
+                    "Each responses content part must be an object.",
+                    param=part_param,
+                    code="invalid_content_part",
+                )
+
+            part_type = part.get("type")
+            if part_type in {"input_text", "output_text", "text"}:
+                text = part.get("text")
+                if not isinstance(text, str):
+                    raise _APIRequestError(
+                        "Text content parts must include a string 'text' field.",
+                        param=f"{part_param}.text",
+                        code="invalid_content_part",
+                    )
+                normalized_parts.append({"type": "text", "text": text})
+                continue
+
+            if part_type in {"input_image", "image_url"}:
+                normalized_parts.append(
+                    {
+                        "type": "image_url",
+                        "image_url": self._extract_image_payload(
+                            part.get("image_url"),
+                            detail=part.get("detail"),
+                            param_prefix=f"{part_param}.image_url",
+                        ),
+                    }
+                )
+                continue
+
+            if part_type in {"input_file", "file"}:
+                raise _APIRequestError(
+                    "Inline image inputs are supported, but uploaded files and document inputs are not supported on this endpoint.",
+                    param=f"{part_param}.type",
+                    code="unsupported_content_type",
+                )
+
+            raise _APIRequestError(
+                "Unsupported responses content part type. Only 'input_text' and 'input_image' are supported.",
+                param=f"{part_param}.type",
+                code="unsupported_content_type",
+            )
+
+        return normalized_parts
+
+    @staticmethod
+    def _content_has_visible_payload(content: Any) -> bool:
+        """True when content contains text or at least one image attachment."""
+        if isinstance(content, str):
+            return bool(content.strip())
+        if not isinstance(content, list):
+            return False
+
+        for part in content:
+            if isinstance(part, str) and part.strip():
+                return True
+            if not isinstance(part, dict):
+                continue
+            part_type = part.get("type")
+            if part_type in {"text", "input_text", "output_text"} and str(part.get("text", "") or "").strip():
+                return True
+            if part_type in {"image_url", "input_image"}:
+                return True
+
+        return False
 
     # ------------------------------------------------------------------
     # Auth helper
@@ -620,9 +920,9 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Parse request body
         try:
-            body = await request.json()
-        except (json.JSONDecodeError, Exception):
-            return web.json_response(_openai_error("Invalid JSON in request body"), status=400)
+            body = await self._parse_json_body(request)
+        except _APIRequestError as error:
+            return self._error_response(error)
 
         messages = body.get("messages")
         if not messages or not isinstance(messages, list):
@@ -635,28 +935,48 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Extract system message (becomes ephemeral system prompt layered ON TOP of core)
         system_prompt = None
-        conversation_messages: List[Dict[str, str]] = []
+        conversation_messages: List[Dict[str, Any]] = []
+        try:
+            for idx, msg in enumerate(messages):
+                if not isinstance(msg, dict):
+                    raise _APIRequestError(
+                        "Each chat message must be an object.",
+                        param=f"messages[{idx}]",
+                        code="invalid_message",
+                    )
 
-        for msg in messages:
-            role = msg.get("role", "")
-            content = _normalize_chat_content(msg.get("content", ""))
-            if role == "system":
-                # Accumulate system messages
-                if system_prompt is None:
-                    system_prompt = content
-                else:
-                    system_prompt = system_prompt + "\n" + content
-            elif role in ("user", "assistant"):
-                conversation_messages.append({"role": role, "content": content})
+                role = msg.get("role", "")
+                content = msg.get("content", "")
+                if role == "system":
+                    normalized_system = self._system_content_to_text(
+                        content,
+                        param_prefix=f"messages[{idx}].content",
+                    )
+                    if system_prompt is None:
+                        system_prompt = normalized_system
+                    else:
+                        system_prompt = system_prompt + "\n" + normalized_system
+                elif role in ("user", "assistant"):
+                    conversation_messages.append(
+                        {
+                            "role": role,
+                            "content": self._normalize_chat_content(
+                                content,
+                                param_prefix=f"messages[{idx}].content",
+                            ),
+                        }
+                    )
+        except _APIRequestError as error:
+            return self._error_response(error)
 
         # Extract the last user message as the primary input
-        user_message = ""
+        user_message: Any = ""
         history = []
         if conversation_messages:
             user_message = conversation_messages[-1].get("content", "")
             history = conversation_messages[:-1]
 
-        if not user_message:
+        if not self._content_has_visible_payload(user_message):
             return web.json_response(
                 {"error": {"message": "No user message found in messages", "type": "invalid_request_error"}},
                 status=400,
@@ -1398,12 +1718,9 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Parse request body
         try:
-            body = await request.json()
-        except (json.JSONDecodeError, Exception):
-            return web.json_response(
-                {"error": {"message": "Invalid JSON in request body", "type": "invalid_request_error"}},
-                status=400,
-            )
+            body = await self._parse_json_body(request)
+        except _APIRequestError as error:
+            return self._error_response(error)
 
         raw_input = body.get("input")
         if raw_input is None:
@@ -1424,25 +1741,43 @@ class APIServerAdapter(BasePlatformAdapter):
             # No error if conversation doesn't exist yet — it's a new conversation
 
         # Normalize input to message list
-        input_messages: List[Dict[str, str]] = []
-        if isinstance(raw_input, str):
-            input_messages = [{"role": "user", "content": raw_input}]
-        elif isinstance(raw_input, list):
-            for item in raw_input:
-                if isinstance(item, str):
-                    input_messages.append({"role": "user", "content": item})
-                elif isinstance(item, dict):
-                    role = item.get("role", "user")
-                    content = _normalize_chat_content(item.get("content", ""))
-                    input_messages.append({"role": role, "content": content})
-        else:
-            return web.json_response(_openai_error("'input' must be a string or array"), status=400)
+        input_messages: List[Dict[str, Any]] = []
+        try:
+            if isinstance(raw_input, str):
+                input_messages = [{"role": "user", "content": raw_input}]
+            elif isinstance(raw_input, list):
+                for idx, item in enumerate(raw_input):
+                    if isinstance(item, str):
+                        input_messages.append({"role": "user", "content": item})
+                    elif isinstance(item, dict):
+                        role = item.get("role", "user")
+                        if not isinstance(role, str) or not role.strip():
+                            role = "user"
+                        input_messages.append(
+                            {
+                                "role": role,
+                                "content": self._normalize_responses_content(
+                                    item.get("content", ""),
+                                    param_prefix=f"input[{idx}].content",
+                                ),
+                            }
+                        )
+                    else:
+                        raise _APIRequestError(
+                            "'input' array items must be strings or message objects.",
+                            param=f"input[{idx}]",
+                            code="invalid_input",
+                        )
+            else:
+                raise _APIRequestError("'input' must be a string or array", code="invalid_input")
+        except _APIRequestError as error:
+            return self._error_response(error)
 
         # Accept explicit conversation_history from the request body.
         # This lets stateless clients supply their own history instead of
         # relying on server-side response chaining via previous_response_id.
         # Precedence: explicit conversation_history > previous_response_id.
-        conversation_history: List[Dict[str, str]] = []
+        conversation_history: List[Dict[str, Any]] = []
         raw_history = body.get("conversation_history")
         if raw_history:
             if not isinstance(raw_history, list):
@@ -1456,7 +1791,17 @@ class APIServerAdapter(BasePlatformAdapter):
                         _openai_error(f"conversation_history[{i}] must have 'role' and 'content' fields"),
                         status=400,
                     )
-                conversation_history.append({"role": str(entry["role"]), "content": str(entry["content"])})
+                role = entry["role"]
+                if not isinstance(role, str) or not role.strip():
+                    role = "user"
+                try:
+                    normalized_content = self._normalize_responses_content(
+                        entry["content"],
+                        param_prefix=f"conversation_history[{i}].content",
+                    )
+                except _APIRequestError as error:
+                    return self._error_response(error)
+                conversation_history.append({"role": role, "content": normalized_content})
             if previous_response_id:
                 logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
 
@@ -1476,8 +1821,8 @@ class APIServerAdapter(BasePlatformAdapter):
             conversation_history.append(msg)
 
         # Last input message is the user_message
-        user_message = input_messages[-1].get("content", "") if input_messages else ""
-        if not user_message:
+        user_message: Any = input_messages[-1].get("content", "") if input_messages else ""
+        if not self._content_has_visible_payload(user_message):
             return web.json_response(_openai_error("No user message found in input"), status=400)
 
         # Truncation support
@@ -1983,8 +2328,8 @@ class APIServerAdapter(BasePlatformAdapter):
 
     async def _run_agent(
         self,
-        user_message: str,
-        conversation_history: List[Dict[str, str]],
+        user_message: Any,
+        conversation_history: List[Dict[str, Any]],
         ephemeral_system_prompt: Optional[str] = None,
         session_id: Optional[str] = None,
         stream_delta_callback=None,
@@ -2311,7 +2656,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         try:
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
-            self._app = web.Application(middlewares=mws)
+            self._app = web.Application(middlewares=mws, client_max_size=self._max_request_bytes)
             self._app["api_server_adapter"] = self
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)

--- a/run_agent.py
+++ b/run_agent.py
@@ -4057,7 +4057,10 @@ class AIAgent:
 
             if role in {"user", "assistant"}:
                 content = msg.get("content", "")
-                content_text = str(content) if content is not None else ""
+                content_text = ""
+                if not isinstance(content, list):
+                    content_text = str(content) if content is not None else ""
+                content_parts = self._chat_content_to_responses_parts(content)
 
                 if role == "assistant":
                     # Replay encrypted reasoning items from previous turns
@@ -4080,7 +4083,9 @@ class AIAgent:
                                     seen_item_ids.add(item_id)
                                 has_codex_reasoning = True
 
-                    if content_text.strip():
+                    if content_parts:
+                        items.append({"role": "assistant", "content": content_parts})
+                    elif content_text.strip():
                         items.append({"role": "assistant", "content": content_text})
                     elif has_codex_reasoning:
                         # The Responses API requires a following item after each
@@ -4133,7 +4138,10 @@ class AIAgent:
                             })
                     continue
 
-                items.append({"role": role, "content": content_text})
+                if content_parts:
+                    items.append({"role": role, "content": content_parts})
+                else:
+                    items.append({"role": role, "content": content_text})
                 continue
 
             if role == "tool":
@@ -4151,6 +4159,48 @@ class AIAgent:
                 })
 
         return items
+
+    @staticmethod
+    def _chat_content_to_responses_parts(content: Any) -> List[Dict[str, Any]]:
+        """Convert chat-style multimodal parts to Responses API content parts."""
+        if not isinstance(content, list):
+            return []
+
+        converted: List[Dict[str, Any]] = []
+        for part in content:
+            if isinstance(part, str):
+                if part:
+                    converted.append({"type": "input_text", "text": part})
+                continue
+            if not isinstance(part, dict):
+                continue
+
+            part_type = part.get("type")
+            if part_type in {"text", "input_text", "output_text"}:
+                text = part.get("text")
+                if isinstance(text, str):
+                    converted.append({"type": "input_text", "text": text})
+                continue
+
+            if part_type in {"image_url", "input_image"}:
+                image_data = part.get("image_url", {})
+                detail = part.get("detail")
+                if isinstance(image_data, dict):
+                    detail = image_data.get("detail", detail)
+                    image_data = image_data.get("url")
+                if not isinstance(image_data, str) or not image_data:
+                    continue
+                image_part: Dict[str, Any] = {"type": "input_image", "image_url": image_data}
+                if isinstance(detail, str) and detail.strip():
+                    image_part["detail"] = detail.strip()
+                converted.append(image_part)
+                continue
+
+            text = part.get("text")
+            if isinstance(text, str) and text:
+                converted.append({"type": "input_text", "text": text})
+
+        return converted
 
     def _preflight_codex_input_items(self, raw_items: Any) -> List[Dict[str, Any]]:
         if not isinstance(raw_items, list):
@@ -4233,6 +4283,55 @@ class AIAgent:
                 content = item.get("content", "")
                 if content is None:
                     content = ""
+                if isinstance(content, list):
+                    normalized_content: List[Dict[str, Any]] = []
+                    for part_idx, part in enumerate(content):
+                        if isinstance(part, str):
+                            if part:
+                                normalized_content.append({"type": "input_text", "text": part})
+                            continue
+
+                        if not isinstance(part, dict):
+                            raise ValueError(
+                                f"Codex Responses input[{idx}].content[{part_idx}] must be an object."
+                            )
+
+                        part_type = part.get("type")
+                        if part_type in {"input_text", "output_text", "text"}:
+                            text = part.get("text")
+                            if text is None:
+                                text = ""
+                            if not isinstance(text, str):
+                                text = str(text)
+                            normalized_content.append({"type": "input_text", "text": text})
+                            continue
+
+                        if part_type in {"input_image", "image_url"}:
+                            image_data = part.get("image_url", {})
+                            detail = part.get("detail")
+                            if isinstance(image_data, dict):
+                                detail = image_data.get("detail", detail)
+                                image_data = image_data.get("url")
+                            if image_data is None:
+                                image_data = ""
+                            if not isinstance(image_data, str):
+                                image_data = str(image_data)
+                            image_part: Dict[str, Any] = {
+                                "type": "input_image",
+                                "image_url": image_data,
+                            }
+                            if isinstance(detail, str) and detail.strip():
+                                image_part["detail"] = detail.strip()
+                            normalized_content.append(image_part)
+                            continue
+
+                        raise ValueError(
+                            f"Codex Responses input[{idx}].content[{part_idx}] has unsupported part type {part_type!r}."
+                        )
+
+                    normalized.append({"role": role, "content": normalized_content})
+                    continue
+
                 if not isinstance(content, str):
                     content = str(content)
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -27,6 +27,7 @@ from gateway.platforms.api_server import (
     ResponseStore,
     _CORS_HEADERS,
     _derive_chat_session_id,
+    body_limit_middleware,
     check_api_server_requirements,
     cors_middleware,
     security_headers_middleware,
@@ -139,6 +140,7 @@ class TestAdapterInit:
         monkeypatch.setenv("API_SERVER_PORT", "7777")
         monkeypatch.setenv("API_SERVER_KEY", "sk-env")
         monkeypatch.setenv("API_SERVER_CORS_ORIGINS", "http://localhost:3000, http://127.0.0.1:3000")
+        monkeypatch.setenv("API_SERVER_MAX_REQUEST_BYTES", "2097152")
         config = PlatformConfig(enabled=True)
         adapter = APIServerAdapter(config)
         assert adapter._host == "10.0.0.1"
@@ -148,6 +150,7 @@ class TestAdapterInit:
             "http://localhost:3000",
             "http://127.0.0.1:3000",
         )
+        assert adapter._max_request_bytes == 2_097_152
 
 
 # ---------------------------------------------------------------------------
@@ -216,8 +219,8 @@ def _make_adapter(api_key: str = "", cors_origins=None) -> APIServerAdapter:
 
 def _create_app(adapter: APIServerAdapter) -> web.Application:
     """Create the aiohttp app from the adapter (without starting the full server)."""
-    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
-    app = web.Application(middlewares=mws)
+    mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
+    app = web.Application(middlewares=mws, client_max_size=adapter._max_request_bytes)
     app["api_server_adapter"] = adapter
     app.router.add_get("/health", adapter._handle_health)
     app.router.add_get("/health/detailed", adapter._handle_health_detailed)
@@ -753,6 +756,32 @@ class TestChatCompletionsEndpoint:
             assert call_kwargs["conversation_history"][1] == {"role": "assistant", "content": "2"}
 
     @pytest.mark.asyncio
+    async def test_multimodal_content_passed_through(self, adapter):
+        """Chat Completions preserves text + image_url content arrays."""
+        mock_result = {"final_response": "That looks like a cat.", "messages": [], "api_calls": 1}
+        multimodal_message = [
+            {"type": "text", "text": "Describe this image."},
+            {"type": "image_url", "image_url": {"url": "https://example.com/cat.png", "detail": "high"}},
+        ]
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [{"role": "user", "content": multimodal_message}],
+                    },
+                )
+
+            assert resp.status == 200
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["user_message"] == multimodal_message
+            assert call_kwargs["conversation_history"] == []
+
+    @pytest.mark.asyncio
     async def test_agent_error_returns_500(self, adapter):
         """Agent exception returns 500."""
         app = _create_app(adapter)
@@ -946,6 +975,40 @@ class TestResponsesEndpoint:
             # Last message is user_message, rest are history
             assert call_kwargs["user_message"] == "What is 2+2?"
             assert len(call_kwargs["conversation_history"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_multimodal_input_is_normalized_to_chat_style(self, adapter):
+        """Responses input_text/input_image parts become internal text/image_url parts."""
+        mock_result = {"final_response": "It is a cat.", "messages": [], "api_calls": 1}
+        expected_user_message = [
+            {"type": "text", "text": "Describe this image."},
+            {"type": "image_url", "image_url": {"url": "https://example.com/cat.png", "detail": "high"}},
+        ]
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "input_text", "text": "Describe this image."},
+                                    {"type": "input_image", "image_url": "https://example.com/cat.png", "detail": "high"},
+                                ],
+                            }
+                        ],
+                    },
+                )
+
+            assert resp.status == 200
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["user_message"] == expected_user_message
+            assert call_kwargs["conversation_history"] == []
 
     @pytest.mark.asyncio
     async def test_instructions_as_ephemeral_prompt(self, adapter):
@@ -1154,6 +1217,134 @@ class TestResponsesEndpoint:
                 json={"model": "hermes-agent", "input": 42},
             )
             assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_previous_response_id_replays_multimodal_history(self, adapter):
+        """Stored multimodal turns survive previous_response_id chaining."""
+        first_result = {"final_response": "It looks like a cat.", "messages": [], "api_calls": 1}
+        second_result = {"final_response": "It is orange.", "messages": [], "api_calls": 1}
+        data_url = "data:image/png;base64,QUFBQQ=="
+        expected_first_user = [
+            {"type": "text", "text": "What is in this image?"},
+            {"type": "image_url", "image_url": {"url": data_url}},
+        ]
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (first_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp1 = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "input_text", "text": "What is in this image?"},
+                                    {"type": "input_image", "image_url": data_url},
+                                ],
+                            }
+                        ],
+                    },
+                )
+
+            assert resp1.status == 200
+            response_id = (await resp1.json())["id"]
+
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (second_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp2 = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "What color is it?",
+                        "previous_response_id": response_id,
+                    },
+                )
+
+            assert resp2.status == 200
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["conversation_history"][0] == {
+                "role": "user",
+                "content": expected_first_user,
+            }
+            assert call_kwargs["conversation_history"][1] == {
+                "role": "assistant",
+                "content": "It looks like a cat.",
+            }
+
+    @pytest.mark.asyncio
+    async def test_chat_file_content_part_rejected(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "hermes-agent",
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "file", "file": {"file_id": "file_123"}},
+                            ],
+                        }
+                    ],
+                },
+            )
+
+            assert resp.status == 400
+            data = await resp.json()
+            assert data["error"]["type"] == "invalid_request_error"
+            assert data["error"]["code"] == "unsupported_content_type"
+
+    @pytest.mark.asyncio
+    async def test_responses_input_file_content_part_rejected(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/responses",
+                json={
+                    "model": "hermes-agent",
+                    "input": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "input_file", "file_id": "file_123"},
+                            ],
+                        }
+                    ],
+                },
+            )
+
+            assert resp.status == 400
+            data = await resp.json()
+            assert data["error"]["type"] == "invalid_request_error"
+            assert data["error"]["code"] == "unsupported_content_type"
+
+    @pytest.mark.asyncio
+    async def test_non_image_data_url_rejected(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/responses",
+                json={
+                    "model": "hermes-agent",
+                    "input": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "input_image", "image_url": "data:text/plain;base64,SGVsbG8="},
+                            ],
+                        }
+                    ],
+                },
+            )
+
+            assert resp.status == 400
+            data = await resp.json()
+            assert data["error"]["type"] == "invalid_request_error"
+            assert data["error"]["code"] == "unsupported_content_type"
 
 
 class TestResponsesStreaming:
@@ -2091,3 +2282,70 @@ class TestSessionIdHeader:
             call_kwargs = mock_run.call_args.kwargs
             assert call_kwargs["conversation_history"] == []
             assert call_kwargs["session_id"] == "some-session"
+
+    @pytest.mark.asyncio
+    async def test_session_history_supports_multimodal_content(self, adapter):
+        """Session continuity keeps multimodal history and accepts a new multimodal turn."""
+        mock_result = {"final_response": "Still looks like a cat.", "messages": [], "api_calls": 1}
+        db_history = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Earlier image"},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/earlier.png"}},
+                ],
+            },
+            {"role": "assistant", "content": "I saw a cat."},
+        ]
+        new_message = [
+            {"type": "text", "text": "And this one?"},
+            {"type": "image_url", "image_url": {"url": "https://example.com/new.png", "detail": "low"}},
+        ]
+        mock_db = MagicMock()
+        mock_db.get_messages_as_conversation.return_value = db_history
+        adapter._session_db = mock_db
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"X-Hermes-Session-Id": "multimodal-session"},
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": new_message}]},
+                )
+
+            assert resp.status == 200
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["conversation_history"] == db_history
+            assert call_kwargs["user_message"] == new_message
+
+
+# ---------------------------------------------------------------------------
+# Body limits
+# ---------------------------------------------------------------------------
+
+
+class TestBodyLimits:
+    @pytest.mark.asyncio
+    async def test_custom_body_limit_rejects_large_request(self):
+        adapter = _make_adapter()
+        adapter._max_request_bytes = 256
+        app = _create_app(adapter)
+
+        payload = {
+            "model": "hermes-agent",
+            "messages": [{"role": "user", "content": "x" * 1024}],
+        }
+
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                data=json.dumps(payload),
+                headers={"Content-Type": "application/json"},
+            )
+
+            assert resp.status == 413
+            data = await resp.json()
+            assert data["error"]["type"] == "invalid_request_error"
+            assert data["error"]["code"] == "body_too_large"

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -694,6 +694,62 @@ def test_chat_messages_to_responses_input_accepts_call_pipe_fc_ids(monkeypatch):
     assert function_output["call_id"] == "call_pair123"
 
 
+def test_chat_messages_to_responses_input_preserves_multimodal_content(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    items = agent._chat_messages_to_responses_input(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this image."},
+                    {"type": "image_url", "image_url": {"url": "https://example.com/cat.png", "detail": "high"}},
+                ],
+            }
+        ]
+    )
+
+    assert items == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "Describe this image."},
+                {"type": "input_image", "image_url": "https://example.com/cat.png", "detail": "high"},
+            ],
+        }
+    ]
+
+
+def test_preflight_codex_api_kwargs_accepts_multimodal_content_parts(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    result = agent._preflight_codex_api_kwargs(
+        {
+            "model": "gpt-5-codex",
+            "instructions": "You are Hermes.",
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "Describe this image."},
+                        {"type": "input_image", "image_url": "https://example.com/cat.png", "detail": "low"},
+                    ],
+                }
+            ],
+            "tools": [],
+            "store": False,
+        }
+    )
+
+    assert result["input"] == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "Describe this image."},
+                {"type": "input_image", "image_url": "https://example.com/cat.png", "detail": "low"},
+            ],
+        }
+    ]
+
+
 def test_preflight_codex_api_kwargs_strips_optional_function_call_id(monkeypatch):
     agent = _build_agent(monkeypatch)
     preflight = agent._preflight_codex_api_kwargs(

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -83,6 +83,23 @@ Standard OpenAI Chat Completions format. Stateless — the full conversation is 
 }
 ```
 
+**Inline image input:** `messages[].content` can also be an array containing `text` and `image_url` parts:
+
+```json
+{
+  "model": "hermes-agent",
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {"type": "text", "text": "What is in this image?"},
+        {"type": "image_url", "image_url": {"url": "https://example.com/cat.png", "detail": "high"}}
+      ]
+    }
+  ]
+}
+```
+
 **Streaming** (`"stream": true`): Returns Server-Sent Events (SSE) with token-by-token response chunks. For **Chat Completions**, the stream uses standard `chat.completion.chunk` events plus Hermes' custom `hermes.tool.progress` event for tool-start UX. For **Responses**, the stream uses OpenAI Responses event types such as `response.created`, `response.output_text.delta`, `response.output_item.added`, `response.output_item.done`, and `response.completed`.
 
 **Tool progress in streams**:
@@ -116,6 +133,23 @@ OpenAI Responses API format. Supports server-side conversation state via `previo
     {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "Your project has..."}]}
   ],
   "usage": {"input_tokens": 50, "output_tokens": 200, "total_tokens": 250}
+}
+```
+
+**Inline image input:** `input[].content` can contain `input_text` and `input_image` parts. Remote image URLs and `data:image/...` URLs are supported:
+
+```json
+{
+  "model": "hermes-agent",
+  "input": [
+    {
+      "role": "user",
+      "content": [
+        {"type": "input_text", "text": "Describe this screenshot."},
+        {"type": "input_image", "image_url": "data:image/png;base64,QUFBQQ=="}
+      ]
+    }
+  ]
 }
 ```
 
@@ -248,6 +282,7 @@ The default bind address (`127.0.0.1`) is for local-only use. Browser access is 
 | `API_SERVER_KEY` | _(none)_ | Bearer token for auth |
 | `API_SERVER_CORS_ORIGINS` | _(none)_ | Comma-separated allowed browser origins |
 | `API_SERVER_MODEL_NAME` | _(profile name)_ | Model name on `/v1/models`. Defaults to profile name, or `hermes-agent` for default profile. |
+| `API_SERVER_MAX_REQUEST_BYTES` | `10485760` | Maximum JSON request size in bytes (default 10 MiB) |
 
 ### config.yaml
 
@@ -330,7 +365,7 @@ In Open WebUI, add each as a separate connection. The model dropdown shows `alic
 ## Limitations
 
 - **Response storage** — stored responses (for `previous_response_id`) are persisted in SQLite and survive gateway restarts. Max 100 stored responses (LRU eviction).
-- **No file upload** — vision/document analysis via uploaded files is not yet supported through the API.
+- **Uploads/documents still unsupported** — inline image inputs are supported, but uploaded files, `file_id`/`input_file`, PDFs, and other document inputs are not available through the API server yet.
 - **Model field is cosmetic** — the `model` field in requests is accepted but the actual LLM model used is configured server-side in config.yaml.
 
 ## Proxy Mode


### PR DESCRIPTION
## What does this PR do?

Adds inline image support to the OpenAI-compatible API server without adding file uploads. `/v1/chat/completions` now accepts `text` + `image_url` parts, `/v1/responses` accepts `input_text` + `input_image` and normalizes them into Hermes's canonical multimodal format, and the Codex/Responses conversion path preserves image parts instead of flattening them to text. This keeps the existing auth, SSE, idempotency, and session continuity behavior intact while unblocking inline image inputs and documenting the remaining file/document limitation.

## Related Issue

None.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added OpenAI-style validation and normalization for multimodal request parts in `gateway/platforms/api_server.py`
- Preserved canonical `text` / `image_url` parts when converting chat history into Responses/Codex input in `run_agent.py`
- Raised the API server JSON body limit to configurable `API_SERVER_MAX_REQUEST_BYTES` with a default of 10 MiB
- Added coverage for inline images, invalid file/document inputs, base64 data URLs, replay through `previous_response_id`, and session continuity
- Updated the API-server docs to describe inline image support and the remaining uploaded-file/document limitation

## How to Test

1. `source .venv/bin/activate && python -m pytest tests/gateway/test_api_server.py tests/test_run_agent_codex_responses.py -q`
2. `source .venv/bin/activate && python -m pytest tests/ -v`
3. `source .venv/bin/activate && export HERMES_HOME=/tmp/hermes-inline-images-pr API_SERVER_ENABLED=true API_SERVER_PORT=8765 GATEWAY_ALLOW_ALL_USERS=true && mkdir -p "$HERMES_HOME"/{cron,sessions,logs,memories,skills} && touch "$HERMES_HOME"/.env && hermes gateway run`
   Then, from another shell:
   - POST an `input_file` payload to `/v1/responses` and expect an `unsupported_content_type` 400
   - POST an `input_image` data URL payload to `/v1/responses` and confirm it is accepted past validation (in my environment it reached downstream auth and returned a 401 because no provider credentials were configured)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.4

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Focused regression tests passed: `source .venv/bin/activate && python -m pytest tests/gateway/test_api_server.py tests/test_run_agent_codex_responses.py -q` -> `137 passed`
- Full suite in this checkout is not green today: `source .venv/bin/activate && python -m pytest tests/ -v` -> `16 failed, 7642 passed, 214 skipped, 1 xfailed, 138 warnings, 5 errors`
- The full-suite errors include missing local `acp` module imports in `tests/acp/*`; unrelated failures also reproduce in areas like `tests/tools/test_file_read_guards.py`
- Manual API-server smoke test via `hermes gateway run`:
  - unsupported `input_file` returned `unsupported_content_type` with message `Inline image inputs are supported, but uploaded files and document inputs are not supported on this endpoint.`
  - supported `input_image` accepted the request shape and reached the downstream auth layer, which returned `Error code: 401 - {'error': {'message': 'Missing Authentication header', 'code': 401}}`
