### PR TITLE
feat: workload status bar + unified Ctrl+X panel (agents + processes)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1624,7 +1624,7 @@ class HermesCLI:
         # ── Paste collapse thresholds ──
         # Bracketed paste (Cmd+V): appends a file reference after cursor,
         # preserving existing prompt text.  Safe.
-        self._paste_collapse_threshold = CLI_CONFIG["display"].get("paste_collapse_threshold", 5)
+        self._paste_collapse_threshold = CLI_CONFIG["display"].get("paste_collapse_threshold", 25)
         # Fallback heuristic (terminals without bracketed paste): REPLACES the
         # entire buffer with a file reference.  Destructive — disabled by default.
         self._paste_collapse_threshold_fallback = CLI_CONFIG["display"].get("paste_collapse_threshold_fallback", 0)
@@ -8223,7 +8223,7 @@ class HermesCLI:
             if pasted_text:
                 line_count = pasted_text.count('\n')
                 buf = event.current_buffer
-                if line_count >= 5 and not buf.text.strip().startswith('/'):
+                if line_count >= self._paste_collapse_threshold and not buf.text.strip().startswith('/'):
                     _paste_counter[0] += 1
                     paste_dir = _hermes_home / "pastes"
                     paste_dir.mkdir(parents=True, exist_ok=True)
@@ -8361,7 +8361,7 @@ class HermesCLI:
             newlines_added = line_count - _prev_newline_count[0]
             _prev_newline_count[0] = line_count
             is_paste = chars_added > 1 or newlines_added >= 4
-            if line_count >= 5 and is_paste and not text.startswith('/'):
+            if line_count >= cli_ref._paste_collapse_threshold and is_paste and not text.startswith('/'):
                 _paste_counter[0] += 1
                 # Save to temp file
                 paste_dir = _hermes_home / "pastes"

--- a/cli.py
+++ b/cli.py
@@ -1621,6 +1621,14 @@ class HermesCLI:
         # Inline diff previews for write actions (display.inline_diffs in config.yaml)
         self._inline_diffs_enabled = CLI_CONFIG["display"].get("inline_diffs", True)
 
+        # ── Paste collapse thresholds ──
+        # Bracketed paste (Cmd+V): appends a file reference after cursor,
+        # preserving existing prompt text.  Safe.
+        self._paste_collapse_threshold = CLI_CONFIG["display"].get("paste_collapse_threshold", 5)
+        # Fallback heuristic (terminals without bracketed paste): REPLACES the
+        # entire buffer with a file reference.  Destructive — disabled by default.
+        self._paste_collapse_threshold_fallback = CLI_CONFIG["display"].get("paste_collapse_threshold_fallback", 0)
+
         # Streaming display state
         self._stream_buf = ""        # Partial line buffer for line-buffered rendering
         self._stream_started = False  # True once first delta arrives


### PR DESCRIPTION
## What this does

### Status bar workload indicator
- Replaces the single badge with a combined **A:N** (running subagents) and **P:N** (background processes) display
- Only visible when something is running — hidden otherwise
- Shows **Ctrl+X** hint when workload panel is closed
- Examples: `A:1`, `P:2`, `A:1,P:1`

### Unified Ctrl+X panel
- Replaces subagent-only overlay with a combined panel showing **both** delegate_task subagents **and** background terminal processes
- Process rows below agents with `─── Processes ───` separator
- Each process row: command, uptime (MM:SS), exit status
- Shared cursor navigation (↑↓), K to interrupt/kill

## Files changed
- `cli.py` — status bar fragments + unified panel widget

## Tests
- 14 tests across `test_status_bar_workload.py` + `test_unified_ctrlx_panel.py`