### PR TITLE
fix: allow google-workspace skill scripts to run directly

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -37,7 +37,13 @@ on CLI, Telegram, Discord, or any platform.
 Define a shorthand first:
 
 ```bash
-GSETUP="python ~/.hermes/skills/productivity/google-workspace/scripts/setup.py"
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+GWORKSPACE_SKILL_DIR="$HERMES_HOME/skills/productivity/google-workspace"
+PYTHON_BIN="${HERMES_PYTHON:-python3}"
+if [ -x "$HERMES_HOME/hermes-agent/venv/bin/python" ]; then
+  PYTHON_BIN="$HERMES_HOME/hermes-agent/venv/bin/python"
+fi
+GSETUP="$PYTHON_BIN $GWORKSPACE_SKILL_DIR/scripts/setup.py"
 ```
 
 ### Step 0: Check if already set up
@@ -135,7 +141,13 @@ Should print `AUTHENTICATED`. Setup is complete — token refreshes automaticall
 All commands go through the API script. Set `GAPI` as a shorthand:
 
 ```bash
-GAPI="python ~/.hermes/skills/productivity/google-workspace/scripts/google_api.py"
+HERMES_HOME="${HERMES_HOME:-$HOME/.hermes}"
+GWORKSPACE_SKILL_DIR="$HERMES_HOME/skills/productivity/google-workspace"
+PYTHON_BIN="${HERMES_PYTHON:-python3}"
+if [ -x "$HERMES_HOME/hermes-agent/venv/bin/python" ]; then
+  PYTHON_BIN="$HERMES_HOME/hermes-agent/venv/bin/python"
+fi
+GAPI="$PYTHON_BIN $GWORKSPACE_SKILL_DIR/scripts/google_api.py"
 ```
 
 ### Gmail

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -27,7 +27,13 @@ from datetime import datetime, timedelta, timezone
 from email.mime.text import MIMEText
 from pathlib import Path
 
-from hermes_constants import display_hermes_home, get_hermes_home
+try:
+    from hermes_constants import display_hermes_home, get_hermes_home
+except ModuleNotFoundError:
+    HERMES_AGENT_ROOT = Path(__file__).resolve().parents[4]
+    if HERMES_AGENT_ROOT.exists():
+        sys.path.insert(0, str(HERMES_AGENT_ROOT))
+    from hermes_constants import display_hermes_home, get_hermes_home
 
 HERMES_HOME = get_hermes_home()
 TOKEN_PATH = HERMES_HOME / "google_token.json"

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -27,7 +27,13 @@ import subprocess
 import sys
 from pathlib import Path
 
-from hermes_constants import display_hermes_home, get_hermes_home
+try:
+    from hermes_constants import display_hermes_home, get_hermes_home
+except ModuleNotFoundError:
+    HERMES_AGENT_ROOT = Path(__file__).resolve().parents[4]
+    if HERMES_AGENT_ROOT.exists():
+        sys.path.insert(0, str(HERMES_AGENT_ROOT))
+    from hermes_constants import display_hermes_home, get_hermes_home
 
 HERMES_HOME = get_hermes_home()
 TOKEN_PATH = HERMES_HOME / "google_token.json"


### PR DESCRIPTION
## Summary
- add a small import fallback in the google-workspace skill scripts
- when `hermes_constants` is not importable, prepend the repo root to `sys.path`
- update the skill examples to use `HERMES_HOME` instead of hard-coded `~/.hermes` paths
- this lets `setup.py` and `google_api.py` run directly from a repo checkout and keeps the docs profile-aware

## Why
The current scripts assume `hermes_constants` is already importable. In a normal repo checkout, running:

- `python3 skills/productivity/google-workspace/scripts/setup.py --check`
- `python3 skills/productivity/google-workspace/scripts/google_api.py --help`

can fail with `ModuleNotFoundError: No module named "hermes_constants"`.

The current skill examples also hard-code `~/.hermes`, which is awkward for profile-aware setups that already standardize on `HERMES_HOME`.

This change keeps the runtime behavior the same when imports already work, and only adds a minimal fallback for direct script execution while making the docs match Hermes conventions.

## Test Plan
- `venv/bin/python -m pytest tests/skills/test_google_oauth_setup.py -q`
- `venv/bin/python skills/productivity/google-workspace/scripts/setup.py --check`
- `venv/bin/python skills/productivity/google-workspace/scripts/google_api.py --help`