### PR TITLE
fix(security): sanitize workdir parameter in terminal tool backends

### DIFF
--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -8,6 +8,7 @@ persistence via bind mounts.
 import logging
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -484,9 +485,13 @@ class DockerEnvironment(BaseEnvironment):
         else:
             effective_stdin = stdin_data
 
-        # docker exec -w doesn't expand ~, so prepend a cd into the command
-        if work_dir == "~" or work_dir.startswith("~/"):
-            exec_command = f"cd {work_dir} && {exec_command}"
+        # docker exec -w doesn't expand ~, so prepend a cd into the command.
+        # Keep ~ unquoted (for shell expansion) and quote only the subpath.
+        if work_dir == "~":
+            exec_command = f"cd ~ && {exec_command}"
+            work_dir = "/"
+        elif work_dir.startswith("~/"):
+            exec_command = f"cd ~/{shlex.quote(work_dir[2:])} && {exec_command}"
             work_dir = "/"
 
         assert self._container_id, "Container not started"

--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -8,6 +8,7 @@ via writable overlay directories that survive across sessions.
 import json
 import logging
 import os
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -311,9 +312,13 @@ class SingularityEnvironment(BaseEnvironment):
         else:
             effective_stdin = stdin_data
 
-        # apptainer exec --pwd doesn't expand ~, so prepend a cd into the command
-        if work_dir == "~" or work_dir.startswith("~/"):
-            exec_command = f"cd {work_dir} && {exec_command}"
+        # apptainer exec --pwd doesn't expand ~, so prepend a cd into the command.
+        # Keep ~ unquoted (for shell expansion) and quote only the subpath.
+        if work_dir == "~":
+            exec_command = f"cd ~ && {exec_command}"
+            work_dir = "/tmp"
+        elif work_dir.startswith("~/"):
+            exec_command = f"cd ~/{shlex.quote(work_dir[2:])} && {exec_command}"
             work_dir = "/tmp"
 
         cmd = [self.executable, "exec", "--pwd", work_dir,

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -1,6 +1,7 @@
 """SSH remote execution environment with ControlMaster connection persistence."""
 
 import logging
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -228,7 +229,13 @@ class SSHEnvironment(PersistentShellMixin, BaseEnvironment):
                          stdin_data: str | None = None) -> dict:
         work_dir = cwd or self.cwd
         exec_command, sudo_stdin = self._prepare_command(command)
-        wrapped = f'cd {work_dir} && {exec_command}'
+        # Keep ~ unquoted (for shell expansion) and quote only the subpath.
+        if work_dir == "~":
+            wrapped = f'cd ~ && {exec_command}'
+        elif work_dir.startswith("~/"):
+            wrapped = f'cd ~/{shlex.quote(work_dir[2:])} && {exec_command}'
+        else:
+            wrapped = f'cd {shlex.quote(work_dir)} && {exec_command}'
         effective_timeout = timeout or self.timeout
 
         if sudo_stdin is not None and stdin_data is not None:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -154,6 +154,34 @@ def _check_all_guards(command: str, env_type: str) -> dict:
                                   approval_callback=_approval_callback)
 
 
+# Allowlist: characters that can legitimately appear in directory paths.
+# Covers alphanumeric, path separators, tilde, dot, hyphen, underscore, space,
+# plus, at, equals, and comma.  Everything else is rejected.
+_WORKDIR_SAFE_RE = re.compile(r'^[A-Za-z0-9/_\-.~ +@=,]+$')
+
+
+def _validate_workdir(workdir: str) -> str | None:
+    """Reject workdir values that don't look like a filesystem path.
+
+    Uses an allowlist of safe characters rather than a deny-list, so novel
+    shell metacharacters can't slip through.
+
+    Returns None if safe, or an error message string if dangerous.
+    """
+    if not workdir:
+        return None
+    if not _WORKDIR_SAFE_RE.match(workdir):
+        # Find the first offending character for a helpful message.
+        for ch in workdir:
+            if not _WORKDIR_SAFE_RE.match(ch):
+                return (
+                    f"Blocked: workdir contains disallowed character {repr(ch)}. "
+                    "Use a simple filesystem path without shell metacharacters."
+                )
+        return "Blocked: workdir contains disallowed characters."
+    return None
+
+
 def _handle_sudo_failure(output: str, env_type: str) -> str:
     """
     Check for sudo failure and add helpful message for messaging contexts.
@@ -1165,6 +1193,19 @@ def terminal_tool(
             elif approval.get("smart_approved"):
                 desc = approval.get("description", "flagged as dangerous")
                 approval_note = f"Command was flagged ({desc}) and auto-approved by smart approval."
+
+        # Validate workdir against shell injection
+        if workdir:
+            workdir_error = _validate_workdir(workdir)
+            if workdir_error:
+                logger.warning("Blocked dangerous workdir: %s (command: %s)",
+                               workdir[:200], command[:200])
+                return json.dumps({
+                    "output": "",
+                    "exit_code": -1,
+                    "error": workdir_error,
+                    "status": "blocked"
+                }, ensure_ascii=False)
 
         # Prepare command for execution
         if background:


### PR DESCRIPTION
## Summary

Fixes shell injection vulnerability where the `workdir` parameter is interpolated unquoted into `cd {work_dir} && ...` shell commands in docker, singularity, and SSH backends. A malicious AGENTS.md could poison workdir values to execute arbitrary commands (e.g. `workdir: "~/;id"`).

Salvaged from PR #5620 by @entropidelic with the following improvements:

### Fixes applied on top of #5620
1. **Tilde-aware quoting** — The original PR used `shlex.quote(work_dir)` which wraps the entire path in single quotes, breaking tilde expansion (`cd '~/project'` → tilde does NOT expand). Fixed to keep `~` unquoted and quote only the subpath: `cd ~/{shlex.quote(subpath)}`.
2. **Allowlist instead of deny-list** — The original `_WORKDIR_BANNED_CHARS` missed `&`, `>`, `<`, quotes, and other metacharacters. Replaced with a strict regex allowlist (`[A-Za-z0-9/_\-.~ +@=,]`) so novel metacharacters can't slip through.

### Changes
- `tools/environments/docker.py` — tilde-aware `shlex.quote` for `~/` workdir paths
- `tools/environments/singularity.py` — same
- `tools/environments/ssh.py` — tilde-aware quoting for all workdir paths in `_execute_oneshot`
- `tools/terminal_tool.py` — `_validate_workdir()` allowlist as defense-in-depth

### Backends NOT affected
- **Local** — passes workdir via `cwd=` parameter to `subprocess.run()`, not shell-interpolated
- **Modal/Daytona** — no unquoted workdir interpolation
- **Persistent shell** (SSH primary path) — already uses `shlex.quote` in `persistent_shell.py`

### Test plan
- E2E tested: 11 safe paths pass, 16 attack vectors blocked (including `&`, quotes, backticks, etc.)
- Verified tilde expansion works with quoting in bash
- All existing terminal tests pass (48/48)

Closes #5620