### PR TITLE
fix(gateway): sanitize media URLs in base platform logs

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -12,6 +12,7 @@ import random
 import re
 import uuid
 from abc import ABC, abstractmethod
+from urllib.parse import urlsplit
 
 logger = logging.getLogger(__name__)
 from dataclasses import dataclass, field
@@ -34,6 +35,43 @@ GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE = (
     "Secure secret entry is not supported over messaging. "
     "Load this skill in the local CLI to be prompted, or add the key to ~/.hermes/.env manually."
 )
+
+
+def _safe_url_for_log(url: str, max_len: int = 80) -> str:
+    """Return a URL string safe for logs (no query/fragment/userinfo)."""
+    if max_len <= 0:
+        return ""
+
+    if url is None:
+        return ""
+
+    raw = str(url)
+    if not raw:
+        return ""
+
+    try:
+        parsed = urlsplit(raw)
+    except Exception:
+        return raw[:max_len]
+
+    if parsed.scheme and parsed.netloc:
+        # Strip potential embedded credentials (user:pass@host).
+        netloc = parsed.netloc.rsplit("@", 1)[-1]
+        base = f"{parsed.scheme}://{netloc}"
+        path = parsed.path or ""
+        if path and path != "/":
+            basename = path.rsplit("/", 1)[-1]
+            safe = f"{base}/.../{basename}" if basename else f"{base}/..."
+        else:
+            safe = base
+    else:
+        safe = raw
+
+    if len(safe) <= max_len:
+        return safe
+    if max_len <= 3:
+        return "." * max_len
+    return f"{safe[:max_len - 3]}..."
 
 
 # ---------------------------------------------------------------------------
@@ -112,8 +150,14 @@ async def cache_image_from_url(url: str, ext: str = ".jpg", retries: int = 2) ->
                     raise
                 if attempt < retries:
                     wait = 1.5 * (attempt + 1)
-                    _log.debug("Media cache retry %d/%d for %s (%.1fs): %s",
-                               attempt + 1, retries, url[:80], wait, exc)
+                    _log.debug(
+                        "Media cache retry %d/%d for %s (%.1fs): %s",
+                        attempt + 1,
+                        retries,
+                        _safe_url_for_log(url),
+                        wait,
+                        exc,
+                    )
                     await asyncio.sleep(wait)
                     continue
                 raise
@@ -214,8 +258,14 @@ async def cache_audio_from_url(url: str, ext: str = ".ogg", retries: int = 2) ->
                     raise
                 if attempt < retries:
                     wait = 1.5 * (attempt + 1)
-                    _log.debug("Audio cache retry %d/%d for %s (%.1fs): %s",
-                               attempt + 1, retries, url[:80], wait, exc)
+                    _log.debug(
+                        "Audio cache retry %d/%d for %s (%.1fs): %s",
+                        attempt + 1,
+                        retries,
+                        _safe_url_for_log(url),
+                        wait,
+                        exc,
+                    )
                     await asyncio.sleep(wait)
                     continue
                 raise
@@ -1266,7 +1316,12 @@ class BasePlatformAdapter(ABC):
                     if human_delay > 0:
                         await asyncio.sleep(human_delay)
                     try:
-                        logger.info("[%s] Sending image: %s (alt=%s)", self.name, image_url[:80], alt_text[:30] if alt_text else "")
+                        logger.info(
+                            "[%s] Sending image: %s (alt=%s)",
+                            self.name,
+                            _safe_url_for_log(image_url),
+                            alt_text[:30] if alt_text else "",
+                        )
                         # Route animated GIFs through send_animation for proper playback
                         if self._is_animation_url(image_url):
                             img_result = await self.send_animation(

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -8,6 +8,7 @@ from gateway.platforms.base import (
     GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE,
     MessageEvent,
     MessageType,
+    _safe_url_for_log,
 )
 
 
@@ -16,6 +17,31 @@ class TestSecretCaptureGuidance:
         message = GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE
         assert "local cli" in message.lower()
         assert "~/.hermes/.env" in message
+
+
+class TestSafeUrlForLog:
+    def test_strips_query_fragment_and_userinfo(self):
+        url = (
+            "https://user:pass@example.com/private/path/image.png"
+            "?X-Amz-Signature=supersecret&token=abc#frag"
+        )
+        result = _safe_url_for_log(url)
+        assert result == "https://example.com/.../image.png"
+        assert "supersecret" not in result
+        assert "token=abc" not in result
+        assert "user:pass@" not in result
+
+    def test_truncates_long_values(self):
+        long_url = "https://example.com/" + ("a" * 300)
+        result = _safe_url_for_log(long_url, max_len=40)
+        assert len(result) == 40
+        assert result.endswith("...")
+
+    def test_handles_small_and_non_positive_max_len(self):
+        url = "https://example.com/very/long/path/file.png?token=secret"
+        assert _safe_url_for_log(url, max_len=3) == "..."
+        assert _safe_url_for_log(url, max_len=2) == ".."
+        assert _safe_url_for_log(url, max_len=0) == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION

This PR hardens gateway logging by sanitizing media URLs before writing them to logs in the shared base adapter.

## Problem

Several shared gateway log lines printed raw media URLs (or truncated prefixes), which could include sensitive query parameters (e.g. signed CDN URLs, temporary access tokens) and embedded userinfo.

## What Changed

- Added `_safe_url_for_log(url, max_len=80)` in `gateway/platforms/base.py`:
  - strips query and fragment
  - strips embedded credentials (`user:pass@`)
  - preserves a minimal, useful path hint (`.../filename`)
  - handles small/non-positive `max_len` safely
- Replaced direct URL logging with sanitized URL logging in:
  - media cache retry debug log
  - audio cache retry debug log
  - image send info log
- Added tests in `tests/gateway/test_platform_base.py`:
  - strips query/fragment/userinfo
  - truncates to configured max length
  - handles `max_len <= 3` and `max_len <= 0` edge cases

## Why This Is Safe

- Change is limited to logging output only; runtime media fetch/send behavior is unchanged.
- Uses stdlib (`urllib.parse.urlsplit`) and is cross-platform.

## Testing

```powershell
.\venv\Scripts\Activate.ps1
python -m pytest tests/gateway/test_platform_base.py -q

Files Changed
gateway/platforms/base.py
tests/gateway/test_platform_base.py

Security Impact
Reduces risk of secret leakage through logs from signed media URLs and credential-bearing URLs.