### PR TITLE
docs(migration): document OpenClaw agent profile migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ What gets imported:
 
 See `hermes claw migrate --help` for all options, or use the `openclaw-migration` skill for an interactive agent-guided migration with dry-run previews.
 
+For the advanced case where you want one Hermes profile per former OpenClaw agent or workspace (for example Filippo, Smarty, Sparky, Huggy), use the profile-migration skills `openclaw-agent-to-hermes-profile` and `openclaw-batch-agent-to-hermes-profiles`, plus the guide at https://hermes-agent.nousresearch.com/docs/guides/migrate-openclaw-agents-to-hermes-profiles.
+
 ---
 
 ## Contributing

--- a/docs/migration/openclaw-agent-profiles.md
+++ b/docs/migration/openclaw-agent-profiles.md
@@ -1,0 +1,164 @@
+# Migrating OpenClaw Agents into Hermes Profiles
+
+This guide covers the advanced migration path for users who had multiple named OpenClaw agents or separate OpenClaw workspaces and now want one Hermes profile per agent.
+
+Examples:
+- Filippo → Hermes profile `filippo`
+- Smarty → Hermes profile `smarty`
+- Sparky → Hermes profile `sparky`
+- Huggy → Hermes profile `huggy`
+
+## Pick the Right Migration Tier
+
+### Tier 1 — import one OpenClaw footprint into the current Hermes home
+Use this when you want to bring your main OpenClaw setup into your current Hermes installation:
+
+```bash
+hermes claw migrate
+```
+
+That path is documented here:
+- `docs/migration/openclaw.md`
+- `website/docs/guides/migrate-from-openclaw.md`
+
+It is the right choice for:
+- one primary OpenClaw setup
+- one current Hermes home
+- direct import of persona, memory, skills, config, and compatible secrets
+
+### Tier 2 — convert OpenClaw agents/workspaces into separate Hermes profiles
+Use this when you want one Hermes profile per former OpenClaw agent.
+
+This is the right choice for:
+- named specialist agents
+- separate OpenClaw workspaces
+- per-agent identity and memory isolation
+- preserving each source workspace while still making the resulting Hermes profile usable
+
+## What Makes Profile Migration Different
+
+A profile migration is not just “copy files into a new folder.”
+
+A correct migration does two things at the same time:
+1. preserves the OpenClaw workspace as evidence and rollback state
+2. creates active Hermes files that are actually useful at runtime
+
+That means separating:
+- archived source truth under `openclaw-workspace/`
+- active Hermes state under `SOUL.md`, `memories/`, and `config.yaml`
+
+If you blindly copy generic template files into active Hermes state, you can make the migration worse.
+
+## Shareable Assets in This Repo
+
+### Public CLI/script path
+- `hermes claw migrate`
+- `optional-skills/migration/openclaw-migration/SKILL.md`
+- `optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py`
+- `docs/migration/openclaw.md`
+- `website/docs/guides/migrate-from-openclaw.md`
+
+### Public profile-migration skills
+Single agent:
+- `optional-skills/migration/openclaw-agent-to-hermes-profile/SKILL.md`
+- `optional-skills/migration/openclaw-agent-to-hermes-profile/references/runbook.md`
+- `optional-skills/migration/openclaw-agent-to-hermes-profile/references/migration-checklist.md`
+- `optional-skills/migration/openclaw-agent-to-hermes-profile/references/operator-notes.md`
+
+Batch / multi-agent:
+- `optional-skills/migration/openclaw-batch-agent-to-hermes-profiles/SKILL.md`
+- `optional-skills/migration/openclaw-batch-agent-to-hermes-profiles/references/batch-runbook.md`
+- `optional-skills/migration/openclaw-batch-agent-to-hermes-profiles/references/batch-checklist.md`
+
+## Single-Agent Workflow
+
+Use the `openclaw-agent-to-hermes-profile` skill when migrating one agent/workspace.
+
+Core procedure:
+1. inspect and classify the OpenClaw workspace files
+2. create or clone the target Hermes profile
+3. archive the source workspace under `openclaw-workspace/`
+4. build active Hermes `SOUL.md`, `memories/MEMORY.md`, and `memories/USER.md`
+5. wire `terminal.cwd`
+6. wire `skills.external_dirs`
+7. verify the migrated profile is actually usable
+
+Use this skill when you care about preserving:
+- role-specific identity
+- continuity notes and daily memory
+- runtime working directory
+- live access to the old workspace skills surface
+
+## Batch / Multi-Agent Workflow
+
+Use the `openclaw-batch-agent-to-hermes-profiles` skill when migrating many agents/workspaces.
+
+Core rule:
+- one agent, one profile, one archive
+
+Process agents one by one:
+1. classify workspace
+2. create/clone target profile
+3. archive source workspace
+4. build active Hermes files
+5. set runtime cwd and live skill directories
+6. verify the profile
+7. move to the next agent
+
+Do not treat batch migration as a dumb copy loop. Each agent still needs separate classification and verification.
+
+## Recommended Commands
+
+Create a profile from a known-good base:
+```bash
+source venv/bin/activate && hermes profile create <name> --clone
+```
+
+Inspect a migrated profile:
+```bash
+source venv/bin/activate && hermes -p <name> profile show <name>
+```
+
+Export a migrated profile for sharing or backup:
+```bash
+source venv/bin/activate && hermes profile export <name> -o <name>.tar.gz
+```
+
+Import that profile elsewhere:
+```bash
+source venv/bin/activate && hermes profile import <name>.tar.gz --name <name>
+```
+
+## Success Criteria
+
+A profile migration is complete only when all of the following are true:
+- the source workspace is preserved under `openclaw-workspace/`
+- active `SOUL.md` is agent-specific
+- active `memories/MEMORY.md` is non-empty and role-specific
+- `terminal.cwd` points at the correct workspace
+- `skills.external_dirs` points at the live skills path when needed
+- at least one expected imported skill is visible to Hermes
+
+## Common Failure Modes
+
+### Generic templates got copied into active state
+Fix:
+- regenerate active `SOUL.md` and memory from `IDENTITY.md`, continuity notes, and role docs
+
+### Archive exists but runtime skills do not load
+Fix:
+- add the live workspace `skills/` directory to `skills.external_dirs`
+
+### Runtime works but provenance was lost
+Fix:
+- copy the full source workspace into `openclaw-workspace/`
+
+### A blank `USER.md` degraded the profile
+Fix:
+- restore the richer Hermes `memories/USER.md`
+- keep the OpenClaw `USER.md` only as archived source material
+
+## Bottom Line
+
+Use `hermes claw migrate` for the basic one-home import.
+Use the profile-migration skills when you want the “Filippo / Smarty / Sparky / Huggy” style result: one real Hermes profile per former OpenClaw agent, with preserved source truth and usable live state.

--- a/docs/migration/openclaw.md
+++ b/docs/migration/openclaw.md
@@ -92,6 +92,17 @@ Every migration (including dry runs) produces a report showing:
 
 For execute runs, the full report is saved to `~/.hermes/migration/openclaw/<timestamp>/`.
 
+## Advanced: one Hermes profile per former OpenClaw agent
+
+`hermes claw migrate` imports one OpenClaw footprint into the current Hermes home. If you want one Hermes profile per former OpenClaw agent or workspace, use the advanced profile-migration workflow instead.
+
+Public assets for that workflow:
+- `docs/migration/openclaw-agent-profiles.md`
+- `optional-skills/migration/openclaw-agent-to-hermes-profile/`
+- `optional-skills/migration/openclaw-batch-agent-to-hermes-profiles/`
+
+Use the single-agent skill for one workspace and the batch skill when you want to reproduce a multi-agent setup as separate Hermes profiles. Those workflows preserve the original workspace under `openclaw-workspace/`, synthesize active Hermes identity/memory files when needed, and wire runtime settings like `terminal.cwd` plus `skills.external_dirs`.
+
 ## Troubleshooting
 
 ### "OpenClaw directory not found"

--- a/optional-skills/migration/DESCRIPTION.md
+++ b/optional-skills/migration/DESCRIPTION.md
@@ -1,2 +1,7 @@
 Optional migration workflows for importing user state and customizations from
 other agent systems into Hermes Agent.
+
+Included skills:
+- `openclaw-migration` — import one OpenClaw footprint into the current Hermes home
+- `openclaw-agent-to-hermes-profile` — convert one OpenClaw agent/workspace into one Hermes profile
+- `openclaw-batch-agent-to-hermes-profiles` — repeat that workflow safely across many agents

--- a/optional-skills/migration/openclaw-agent-to-hermes-profile/SKILL.md
+++ b/optional-skills/migration/openclaw-agent-to-hermes-profile/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: openclaw-agent-to-hermes-profile
+description: Migrate one OpenClaw agent/workspace into one Hermes profile, preserving source workspace truth while creating usable active Hermes state.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [Migration, OpenClaw, Hermes, Profiles, Persona, Memory]
+    related_skills: [openclaw-migration, openclaw-batch-agent-to-hermes-profiles]
+---
+
+# OpenClaw Agent → Hermes Profile
+
+Use this skill for a single OpenClaw agent/workspace.
+
+If you are migrating multiple agents/workspaces, use `openclaw-batch-agent-to-hermes-profiles` instead.
+
+## When to Use
+Use this when migrating one OpenClaw agent/workspace into one Hermes profile and you want a true migration, not just a shell clone.
+
+This skill is for cases where you need to preserve:
+- agent identity
+- continuity files and daily notes
+- local skill surface
+- working directory/runtime setup
+
+## Core Principle
+True migration means two things at once:
+1. preserve the original OpenClaw workspace truth
+2. build active Hermes files that are actually usable
+
+Do not confuse “copied files” with “correct migration.”
+If the OpenClaw workspace contains generic templates, blindly copying them into active Hermes files can make the migration worse.
+
+## Fast Decision Tree
+- If `SOUL.md` is specific and good, adapt/promote it.
+- If `SOUL.md` is generic but `IDENTITY.md` is specific, synthesize active Hermes `SOUL.md` from `IDENTITY.md` + recent `memory/` notes.
+- If `MEMORY.md` exists and is substantive, copy/adapt it into `memories/MEMORY.md`.
+- If `MEMORY.md` is missing or weak, synthesize `memories/MEMORY.md` from `IDENTITY.md`, `memory/`, active-task files, and role docs.
+- If `USER.md` is blank template text, archive it but do not let it degrade the active Hermes user profile.
+- If `skills/` exists, preserve it in the archive and also wire the live path into `skills.external_dirs`.
+
+## What Success Looks Like
+A correct migration yields:
+- one isolated Hermes profile per former OpenClaw agent
+- agent-specific `SOUL.md`
+- non-empty, role-specific `memories/MEMORY.md`
+- correct `terminal.cwd`
+- working live skill imports via `skills.external_dirs`
+- archived source-of-truth workspace snapshot under `openclaw-workspace/`
+
+## Canonical Procedure
+Use the runbook as the primary execution doc:
+- `references/runbook.md`
+
+## Quick Operator References
+Use these alongside the runbook:
+- `references/migration-checklist.md`
+- `references/operator-notes.md`
+
+## Critical Pitfalls
+- `hermes profile create --clone` does not import OpenClaw continuity by itself.
+- Blindly copying generic `SOUL.md` / `USER.md` is not migration.
+- `skills.external_dirs` without an archived snapshot preserves runtime but loses provenance.
+- An archived snapshot without `skills.external_dirs` preserves provenance but can break runtime usefulness.
+- A true migration should not leave `memories/MEMORY.md` blank.
+- If Hermes is not on PATH, use the working virtualenv or absolute binary path.
+
+## Operator Guidance
+Default to the runbook for sequence, the checklist for execution, and the operator notes for failure handling.

--- a/optional-skills/migration/openclaw-agent-to-hermes-profile/references/migration-checklist.md
+++ b/optional-skills/migration/openclaw-agent-to-hermes-profile/references/migration-checklist.md
@@ -1,0 +1,56 @@
+# OpenClaw → Hermes Migration Checklist
+
+Use this as the literal execution checklist for one agent/workspace.
+
+## 0) Identify the source of truth
+Mark each as present / absent:
+- `SOUL.md`
+- `USER.md`
+- `MEMORY.md`
+- `IDENTITY.md`
+- `BOOTSTRAP.md`
+- `HEARTBEAT.md`
+- `AGENTS.md`
+- `TOOLS.md`
+- `memory/`
+- `skills/`
+- `openclaw.json`
+
+If `SOUL.md` or `USER.md` look generic, treat them as templates until `IDENTITY.md` and `memory/` prove otherwise.
+
+## 1) Decide what becomes active Hermes state
+Active Hermes files:
+- `SOUL.md`
+- `memories/MEMORY.md`
+- `memories/USER.md`
+
+Archive everything else under `openclaw-workspace/`.
+
+Rules:
+- Never leave `memories/MEMORY.md` empty for a true migration.
+- Never overwrite a richer Hermes `USER.md` with a blank template.
+- Never copy a generic OpenClaw `SOUL.md` into active Hermes if `IDENTITY.md` contains the real agent identity.
+
+## 2) Archive the OpenClaw workspace
+Copy the full workspace tree you care about into:
+- `~/.hermes/profiles/<name>/openclaw-workspace/`
+
+Include:
+- all root continuity files
+- full `memory/`
+- full `skills/`
+
+## 3) Build the active profile
+Set:
+- `terminal.cwd` to the OpenClaw workspace root
+- `skills.external_dirs` to the live OpenClaw `skills/` directory
+- `SOUL.md` to a real agent identity description
+- `memories/MEMORY.md` to a distilled continuity summary
+
+## 4) Verify
+At minimum verify:
+- active `SOUL.md` is agent-specific
+- active `memories/MEMORY.md` is non-empty
+- archived snapshot exists
+- live `skills.external_dirs` resolves
+- profile starts in the right cwd

--- a/optional-skills/migration/openclaw-agent-to-hermes-profile/references/operator-notes.md
+++ b/optional-skills/migration/openclaw-agent-to-hermes-profile/references/operator-notes.md
@@ -1,0 +1,62 @@
+# Operator Notes
+
+## Copy / archive layout
+For a migration of `<agent>` from OpenClaw to Hermes, the target profile should end up like this:
+
+```text
+~/.hermes/profiles/<agent>/
+├── SOUL.md
+├── memories/
+│   ├── MEMORY.md
+│   └── USER.md
+├── openclaw-workspace/
+│   ├── SOUL.md
+│   ├── USER.md
+│   ├── AGENTS.md
+│   ├── TOOLS.md
+│   ├── IDENTITY.md
+│   ├── BOOTSTRAP.md
+│   ├── HEARTBEAT.md
+│   ├── memory/
+│   └── skills/
+└── config.yaml
+```
+
+## Command templates
+Use these as starting points and substitute the real profile name and paths.
+
+Create profile:
+```bash
+source venv/bin/activate && hermes profile create <name> --clone
+```
+
+Inspect profile:
+```bash
+source venv/bin/activate && hermes -p <name> profile show <name>
+```
+
+Read active persona:
+```bash
+python - <<'PY'
+from pathlib import Path
+base = Path.home() / '.hermes' / 'profiles' / '<name>'
+print((base / 'SOUL.md').read_text())
+print((base / 'memories' / 'MEMORY.md').read_text())
+PY
+```
+
+Check external skills:
+```bash
+source venv/bin/activate && HERMES_HOME=/Users/you/.hermes/profiles/<name> python - <<'PY'
+from agent.skill_utils import get_external_skills_dirs
+print([str(p) for p in get_external_skills_dirs()])
+PY
+```
+
+## Failure modes
+- Blank template copied into active memory: fix by synthesizing `memories/MEMORY.md` from `IDENTITY.md` and `memory/`.
+- Generic OpenClaw `SOUL.md` copied verbatim: fix by synthesizing a real Hermes persona from workspace identity files.
+- Archived snapshot exists but runtime skills are missing: fix by setting `skills.external_dirs` to the live workspace `skills/` directory.
+- `USER.md` contains no user facts: archive it, but do not treat it as meaningful continuity.
+- A workspace has no `MEMORY.md`: do not skip the migration; synthesize one from the available sources.
+- `hermes` not found on PATH: use the installed virtualenv or absolute binary path.

--- a/optional-skills/migration/openclaw-agent-to-hermes-profile/references/runbook.md
+++ b/optional-skills/migration/openclaw-agent-to-hermes-profile/references/runbook.md
@@ -1,0 +1,162 @@
+# Runbook: OpenClaw Agent → Hermes Profile
+
+Use this runbook when migrating one OpenClaw agent/workspace into one Hermes profile.
+
+## Goal
+Produce a Hermes profile that is both:
+- faithful to the original OpenClaw workspace
+- actually usable at runtime inside Hermes
+
+That means preserving raw source material and also constructing non-generic active Hermes files.
+
+## Prerequisites
+You need:
+- the OpenClaw workspace path
+- the target Hermes profile name
+- a working Hermes profile to clone from
+- shell access to copy files and inspect configs
+
+Optional but useful:
+- access to `openclaw.json`
+- access to the old agent directory if one exists
+
+## Step 1 — Inspect the workspace and classify files
+Inspect these if present:
+- `SOUL.md`
+- `USER.md`
+- `MEMORY.md`
+- `IDENTITY.md`
+- `BOOTSTRAP.md`
+- `HEARTBEAT.md`
+- `AGENTS.md`
+- `TOOLS.md`
+- `memory/`
+- `skills/`
+
+Classify each file as one of:
+- authoritative active identity
+- useful archived continuity
+- generic template / bootstrap artifact
+
+Rules:
+- If `SOUL.md` is generic and `IDENTITY.md` is specific, trust `IDENTITY.md` more.
+- If `MEMORY.md` is missing, recent `memory/` notes become the best continuity source.
+- If `USER.md` is blank template text, preserve it in the archive but do not promote it over richer Hermes user context.
+
+## Step 2 — Create the Hermes profile
+Preferred command:
+```bash
+source venv/bin/activate && hermes profile create <name> --clone
+```
+
+Why clone:
+- inherits a sane `config.yaml`
+- inherits working `.env`
+- avoids rebuilding auth/runtime basics from scratch
+
+## Step 3 — Archive the original OpenClaw workspace inside the Hermes profile
+Create:
+- `~/.hermes/profiles/<name>/openclaw-workspace/`
+
+Copy into that snapshot every relevant source-of-truth file that exists:
+- `SOUL.md`
+- `USER.md`
+- `AGENTS.md`
+- `TOOLS.md`
+- `MEMORY.md`
+- `IDENTITY.md`
+- `BOOTSTRAP.md`
+- `HEARTBEAT.md`
+- full `memory/`
+- full `skills/`
+
+Why:
+- this preserves what OpenClaw actually knew at migration time
+- this gives you rollback and auditability
+- this prevents loss when active Hermes files are synthesized rather than copied verbatim
+
+## Step 4 — Build active Hermes identity files
+The active Hermes profile should use:
+- `SOUL.md`
+- `memories/MEMORY.md`
+- `memories/USER.md`
+
+### 4A. Build `SOUL.md`
+Do not blindly copy the OpenClaw `SOUL.md`.
+
+Instead:
+- if OpenClaw `SOUL.md` is already agent-specific, adapt or promote it
+- if OpenClaw `SOUL.md` is generic, synthesize Hermes `SOUL.md` from:
+  - `IDENTITY.md`
+  - role-specific notes
+  - recent `memory/` files
+  - active-task files
+
+### 4B. Build `memories/MEMORY.md`
+A true migration must leave this file non-empty.
+
+Preferred order:
+1. copy substantive OpenClaw `MEMORY.md`
+2. otherwise synthesize from:
+   - `IDENTITY.md`
+   - recent `memory/` notes
+   - active tasks / role docs
+   - stable operating boundaries
+
+### 4C. Build `memories/USER.md`
+- if OpenClaw `USER.md` has real user-specific facts, copy/adapt it
+- if it is blank template text, archive it only
+- do not overwrite richer Hermes user context with a worse file
+
+## Step 5 — Update the Hermes profile config
+Set or verify:
+- `terminal.cwd` = OpenClaw workspace root
+- `model.default` = OpenClaw agent model if known and still desired
+- `skills.external_dirs` includes the live OpenClaw `skills/` directory when present
+
+Important distinction:
+- `openclaw-workspace/` = frozen archive
+- `skills.external_dirs` = live runtime skill loading
+
+You usually want both.
+
+## Step 6 — Verify the migration
+Do not stop at file copy success. Verify usability.
+
+Required checks:
+1. `SOUL.md` is agent-specific and non-generic
+2. `memories/MEMORY.md` is non-empty and role-specific
+3. archived `openclaw-workspace/` exists
+4. `skills.external_dirs` resolves correctly
+5. the profile starts in the right cwd
+6. at least one expected imported skill is visible to Hermes
+
+## Step 7 — Fix common bad outcomes
+### Bad outcome: active `SOUL.md` is generic
+Fix:
+- regenerate from `IDENTITY.md` + role notes + `memory/`
+
+### Bad outcome: active `memories/MEMORY.md` is empty or shallow
+Fix:
+- synthesize from recent continuity artifacts instead of leaving the file blank
+
+### Bad outcome: archived snapshot exists but live skills are missing
+Fix:
+- add the live OpenClaw `skills/` path to `skills.external_dirs`
+
+### Bad outcome: copied `USER.md` degraded the profile
+Fix:
+- restore the richer Hermes `memories/USER.md`
+- keep the OpenClaw `USER.md` only in the archive if it was template junk
+
+## Completion criteria
+The migration is complete only when all of the following are true:
+- raw OpenClaw continuity is archived
+- active Hermes persona is agent-specific
+- active Hermes memory is non-empty and role-specific
+- runtime cwd is correct
+- runtime skill loading works
+
+## Related references
+- `references/migration-checklist.md`
+- `references/operator-notes.md`

--- a/optional-skills/migration/openclaw-batch-agent-to-hermes-profiles/SKILL.md
+++ b/optional-skills/migration/openclaw-batch-agent-to-hermes-profiles/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: openclaw-batch-agent-to-hermes-profiles
+description: Batch-migrate multiple OpenClaw agents/workspaces into separate Hermes profiles with per-agent archive, identity, memory, cwd, and skill verification.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [Migration, OpenClaw, Hermes, Profiles, Multi-Agent]
+    related_skills: [openclaw-migration, openclaw-agent-to-hermes-profile]
+---
+
+# Batch OpenClaw Agent → Hermes Profiles
+
+Use this skill for multiple OpenClaw agents/workspaces.
+
+If you are migrating only one agent/workspace, use `openclaw-agent-to-hermes-profile` instead.
+
+## When to Use
+Use this when you need to migrate multiple OpenClaw agents/workspaces into separate Hermes profiles in one batch.
+
+This is the multi-agent version of the single-agent migration runbook. It is for cases where you want:
+- one Hermes profile per OpenClaw agent
+- isolated identities and memory surfaces
+- preserved workspace provenance
+- runtime-usable profiles, not just archived copies
+
+## Core Principle
+Batch migration is just repeated true migration with stricter bookkeeping.
+
+Do not treat batch work as a dumb copy loop.
+Every agent still needs to be classified, archived, synthesized, and verified individually.
+
+## Prerequisites
+You need:
+- a list of OpenClaw agents and their workspace roots
+- a target Hermes profile name for each agent
+- a known-good Hermes base profile to clone from
+- shell access to copy files and inspect configs
+
+Optional but useful:
+- `openclaw.json`
+- old agent directories
+- shared skills directories
+
+## What to Capture Per Agent
+For each agent/workspace, inspect and preserve:
+- `SOUL.md`
+- `USER.md`
+- `MEMORY.md` if present
+- `IDENTITY.md`
+- `BOOTSTRAP.md`
+- `HEARTBEAT.md`
+- `AGENTS.md`
+- `TOOLS.md`
+- full `memory/`
+- full `skills/`
+- any agent-specific config or role notes
+
+If files are generic templates, archive them but do not automatically promote them into active Hermes identity.
+
+## Batch Strategy
+Process agents one by one in this order:
+1. classify the workspace
+2. clone or create the Hermes profile
+3. archive the source workspace under `openclaw-workspace/`
+4. synthesize active Hermes files
+5. wire `terminal.cwd` and `skills.external_dirs`
+6. verify the migrated profile
+7. move to the next agent
+
+This avoids batch-wide contamination from one bad workspace.
+
+## Step 1 — Classify Each Workspace
+For each agent, decide:
+- Is `SOUL.md` real or generic?
+- Is `USER.md` useful or template junk?
+- Is `MEMORY.md` substantive or absent?
+- Does `IDENTITY.md` carry the real persona?
+- Does `memory/` contain the continuity you actually need?
+- Does `skills/` contain local overrides or agent-specific tools?
+
+Rules:
+- generic `SOUL.md` does not beat a specific `IDENTITY.md`
+- blank `MEMORY.md` is not a real memory source
+- template `USER.md` should be archived, not treated as rich context
+
+## Step 2 — Create or Clone the Hermes Profile
+Preferred command pattern:
+```bash
+source venv/bin/activate && hermes profile create <name> --clone
+```
+
+Do this once per agent.
+
+## Step 3 — Archive the Workspace
+For each agent, create:
+- `~/.hermes/profiles/<name>/openclaw-workspace/`
+
+Copy into it every relevant source file that exists:
+- root continuity files
+- full `memory/`
+- full `skills/`
+
+The archive is your evidence trail and rollback point.
+
+## Step 4 — Build Active Hermes State
+For each profile, create/verify:
+- `SOUL.md`
+- `memories/MEMORY.md`
+- `memories/USER.md`
+
+Rules:
+- active `SOUL.md` must describe the agent
+- active `memories/MEMORY.md` must be non-empty and role-specific
+- do not overwrite a richer Hermes `USER.md` with a blank template
+- synthesize missing memory from identity files, recent notes, and role docs
+
+## Step 5 — Update Config
+For each profile, verify:
+- `terminal.cwd` points to the agent’s OpenClaw workspace root
+- `skills.external_dirs` includes the live OpenClaw `skills/` directory when present
+- `model.default` is set only if the agent truly depends on a different default model
+
+Keep archived snapshot and live skill loading distinct:
+- `openclaw-workspace/` = frozen record
+- `skills.external_dirs` = runtime load path
+
+## Step 6 — Verify Per Agent
+Do not call the batch complete until each profile passes:
+- agent-specific active `SOUL.md`
+- non-empty active `memories/MEMORY.md`
+- archived `openclaw-workspace/`
+- working `skills.external_dirs`
+- correct runtime cwd
+- at least one expected imported skill visible
+
+## Step 7 — Verify the Batch as a Whole
+After all agents are migrated, verify:
+- each agent got the right profile name
+- each profile has the right workspace root
+- no profile was left with only template content
+- no agent’s skills were pointed at the wrong workspace
+- no archived snapshot was skipped
+
+## Failure Modes
+### One bad workspace contaminates the batch
+Fix:
+- stop the batch
+- migrate the affected agent manually
+- resume from the next clean agent
+
+### Generic templates got copied into active files
+Fix:
+- replace active Hermes files with synthesized content from the authoritative sources
+
+### A profile has archive but no live skills
+Fix:
+- add the live `skills/` directory to `skills.external_dirs`
+
+### A profile has live skills but no archive
+Fix:
+- archive the source workspace before declaring success
+
+## Completion Criteria
+The batch is complete only when every agent has:
+- preserved source-of-truth workspace archive
+- agent-specific active persona
+- non-empty active memory
+- correct cwd
+- working runtime skills
+
+## Related References
+- `openclaw-agent-to-hermes-profile`
+- `references/batch-runbook.md`
+- `references/batch-checklist.md`

--- a/optional-skills/migration/openclaw-batch-agent-to-hermes-profiles/references/batch-checklist.md
+++ b/optional-skills/migration/openclaw-batch-agent-to-hermes-profiles/references/batch-checklist.md
@@ -1,0 +1,21 @@
+# Batch Migration Checklist
+
+Use this checklist once per agent, then once across the batch.
+
+## Per agent
+- [ ] Workspace classified: real identity vs template files
+- [ ] Hermes profile cloned from a known-good base
+- [ ] `openclaw-workspace/` archive created
+- [ ] Active `SOUL.md` is agent-specific
+- [ ] Active `memories/MEMORY.md` is non-empty
+- [ ] Active `memories/USER.md` is not degrading a richer profile
+- [ ] `terminal.cwd` points to the workspace root
+- [ ] `skills.external_dirs` includes the live workspace `skills/` directory
+- [ ] At least one expected skill is visible
+
+## Batch-wide
+- [ ] Every agent has a unique target profile
+- [ ] No workspace was skipped
+- [ ] No profile points at the wrong `skills/` directory
+- [ ] No profile was left with only copied templates
+- [ ] All archives are present for audit and rollback

--- a/optional-skills/migration/openclaw-batch-agent-to-hermes-profiles/references/batch-runbook.md
+++ b/optional-skills/migration/openclaw-batch-agent-to-hermes-profiles/references/batch-runbook.md
@@ -1,0 +1,46 @@
+# Batch Runbook: OpenClaw Agents → Hermes Profiles
+
+This runbook is the batch controller for migrating many agents. Execute the single-agent migration procedure once per agent, in a controlled loop.
+
+## Objective
+Migrate each OpenClaw agent into its own Hermes profile without cross-contamination.
+
+## Batch Rules
+- One agent, one profile, one archive.
+- Never assume two workspaces are interchangeable.
+- Never promote generic templates into active state.
+- Verify each agent before proceeding to the next.
+
+## Loop Structure
+For each agent:
+1. inspect workspace and classify files
+2. create/clone target Hermes profile
+3. archive source workspace under `openclaw-workspace/`
+4. synthesize active Hermes `SOUL.md`
+5. synthesize or copy `memories/MEMORY.md`
+6. verify `memories/USER.md` is not degrading the profile
+7. set `terminal.cwd`
+8. wire `skills.external_dirs`
+9. verify runtime skill visibility
+10. mark agent complete and proceed
+
+## Stop Conditions
+Stop the batch if:
+- a workspace is too ambiguous to classify
+- a synthesized active file would be too generic to trust
+- runtime skill loading fails
+- the target profile points at the wrong workspace
+
+## Recovery
+If an agent fails:
+- fix that agent manually
+- verify it independently
+- only then continue the batch
+
+## Batch Completion
+The batch is complete only when:
+- every agent has a preserved archive
+- every active profile is agent-specific
+- every profile has non-empty memory
+- every profile has correct cwd
+- every profile loads the expected skills

--- a/website/docs/guides/migrate-from-openclaw.md
+++ b/website/docs/guides/migrate-from-openclaw.md
@@ -223,6 +223,17 @@ The migration resolves all three formats. For env templates and SecretRef object
 
 6. **Re-pair WhatsApp** — WhatsApp uses QR code pairing (Baileys), not token migration. Run `hermes whatsapp` to pair.
 
+## Advanced: one Hermes profile per former OpenClaw agent
+
+`hermes claw migrate` imports one OpenClaw footprint into the current Hermes home. If you want one Hermes profile per former OpenClaw agent or workspace, use the advanced profile-migration workflow instead.
+
+Public assets for that workflow:
+- [Migrate OpenClaw Agents into Hermes Profiles](./migrate-openclaw-agents-to-hermes-profiles.md)
+- `optional-skills/migration/openclaw-agent-to-hermes-profile/`
+- `optional-skills/migration/openclaw-batch-agent-to-hermes-profiles/`
+
+Use the single-agent skill for one workspace and the batch skill when you want to reproduce a multi-agent setup as separate Hermes profiles. Those workflows preserve the original workspace under `openclaw-workspace/`, synthesize active Hermes identity and memory files when needed, and wire runtime settings like `terminal.cwd` plus `skills.external_dirs`.
+
 ## Troubleshooting
 
 ### "OpenClaw directory not found"

--- a/website/docs/guides/migrate-openclaw-agents-to-hermes-profiles.md
+++ b/website/docs/guides/migrate-openclaw-agents-to-hermes-profiles.md
@@ -1,0 +1,160 @@
+---
+sidebar_position: 8
+title: "Migrate OpenClaw Agents into Hermes Profiles"
+description: "Advanced guide for turning multiple named OpenClaw agents or workspaces into separate Hermes profiles with preserved archives and usable active state."
+---
+
+# Migrate OpenClaw Agents into Hermes Profiles
+
+This guide covers the advanced migration path for users who had multiple named OpenClaw agents or separate OpenClaw workspaces and now want one Hermes profile per agent.
+
+Examples:
+- Filippo → Hermes profile `filippo`
+- Smarty → Hermes profile `smarty`
+- Sparky → Hermes profile `sparky`
+- Huggy → Hermes profile `huggy`
+
+## Pick the right migration tier
+
+### Tier 1 — import one OpenClaw footprint into the current Hermes home
+Use this when you want to bring your main OpenClaw setup into your current Hermes installation:
+
+```bash
+hermes claw migrate
+```
+
+That path is documented in [Migrate from OpenClaw](./migrate-from-openclaw.md).
+
+It is the right choice for:
+- one primary OpenClaw setup
+- one current Hermes home
+- direct import of persona, memory, skills, config, and compatible secrets
+
+### Tier 2 — convert OpenClaw agents/workspaces into separate Hermes profiles
+Use this when you want one Hermes profile per former OpenClaw agent.
+
+This is the right choice for:
+- named specialist agents
+- separate OpenClaw workspaces
+- per-agent identity and memory isolation
+- preserving each source workspace while still making the resulting Hermes profile usable
+
+## What makes profile migration different
+
+A profile migration is not just “copy files into a new folder.”
+
+A correct migration does two things at the same time:
+1. preserves the OpenClaw workspace as evidence and rollback state
+2. creates active Hermes files that are actually useful at runtime
+
+That means separating:
+- archived source truth under `openclaw-workspace/`
+- active Hermes state under `SOUL.md`, `memories/`, and `config.yaml`
+
+If you blindly copy generic template files into active Hermes state, you can make the migration worse.
+
+## Shareable assets in this repo
+
+### Public CLI/script path
+- `hermes claw migrate`
+- `optional-skills/migration/openclaw-migration/SKILL.md`
+- `optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py`
+
+### Public profile-migration skills
+Single agent:
+- `optional-skills/migration/openclaw-agent-to-hermes-profile/SKILL.md`
+- `optional-skills/migration/openclaw-agent-to-hermes-profile/references/runbook.md`
+- `optional-skills/migration/openclaw-agent-to-hermes-profile/references/migration-checklist.md`
+- `optional-skills/migration/openclaw-agent-to-hermes-profile/references/operator-notes.md`
+
+Batch / multi-agent:
+- `optional-skills/migration/openclaw-batch-agent-to-hermes-profiles/SKILL.md`
+- `optional-skills/migration/openclaw-batch-agent-to-hermes-profiles/references/batch-runbook.md`
+- `optional-skills/migration/openclaw-batch-agent-to-hermes-profiles/references/batch-checklist.md`
+
+## Single-agent workflow
+
+Use the `openclaw-agent-to-hermes-profile` skill when migrating one agent/workspace.
+
+Core procedure:
+1. inspect and classify the OpenClaw workspace files
+2. create or clone the target Hermes profile
+3. archive the source workspace under `openclaw-workspace/`
+4. build active Hermes `SOUL.md`, `memories/MEMORY.md`, and `memories/USER.md`
+5. wire `terminal.cwd`
+6. wire `skills.external_dirs`
+7. verify the migrated profile is actually usable
+
+## Batch / multi-agent workflow
+
+Use the `openclaw-batch-agent-to-hermes-profiles` skill when migrating many agents/workspaces.
+
+Core rule:
+- one agent, one profile, one archive
+
+Process agents one by one:
+1. classify workspace
+2. create/clone target profile
+3. archive source workspace
+4. build active Hermes files
+5. set runtime cwd and live skill directories
+6. verify the profile
+7. move to the next agent
+
+Do not treat batch migration as a dumb copy loop. Each agent still needs separate classification and verification.
+
+## Recommended commands
+
+Create a profile from a known-good base:
+```bash
+source venv/bin/activate && hermes profile create <name> --clone
+```
+
+Inspect a migrated profile:
+```bash
+source venv/bin/activate && hermes -p <name> profile show <name>
+```
+
+Export a migrated profile for sharing or backup:
+```bash
+source venv/bin/activate && hermes profile export <name> -o <name>.tar.gz
+```
+
+Import that profile elsewhere:
+```bash
+source venv/bin/activate && hermes profile import <name>.tar.gz --name <name>
+```
+
+## Success criteria
+
+A profile migration is complete only when all of the following are true:
+- the source workspace is preserved under `openclaw-workspace/`
+- active `SOUL.md` is agent-specific
+- active `memories/MEMORY.md` is non-empty and role-specific
+- `terminal.cwd` points at the correct workspace
+- `skills.external_dirs` points at the live skills path when needed
+- at least one expected imported skill is visible to Hermes
+
+## Common failure modes
+
+### Generic templates got copied into active state
+Fix:
+- regenerate active `SOUL.md` and memory from `IDENTITY.md`, continuity notes, and role docs
+
+### Archive exists but runtime skills do not load
+Fix:
+- add the live workspace `skills/` directory to `skills.external_dirs`
+
+### Runtime works but provenance was lost
+Fix:
+- copy the full source workspace into `openclaw-workspace/`
+
+### A blank `USER.md` degraded the profile
+Fix:
+- restore the richer Hermes `memories/USER.md`
+- keep the OpenClaw `USER.md` only as archived source material
+
+## Bottom line
+
+Use `hermes claw migrate` for the basic one-home import.
+Use the profile-migration skills when you want the “Filippo / Smarty / Sparky / Huggy” style result: one real Hermes profile per former OpenClaw agent, with preserved source truth and usable live state.

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -86,6 +86,8 @@ hermes skills uninstall <skill-name>
 | Skill | Description |
 |-------|-------------|
 | **openclaw-migration** | Migrate a user's OpenClaw customization footprint into Hermes Agent. Imports memories, SOUL.md, command allowlists, user skills, and selected workspace assets. |
+| **openclaw-agent-to-hermes-profile** | Migrate one OpenClaw agent/workspace into one Hermes profile while preserving the source workspace and building usable active Hermes identity, memory, cwd, and skill state. |
+| **openclaw-batch-agent-to-hermes-profiles** | Batch-migrate multiple OpenClaw agents/workspaces into separate Hermes profiles with per-agent archive, identity, memory, cwd, and skill verification. |
 
 ## MLOps
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -140,6 +140,7 @@ const sidebars: SidebarsConfig = {
         'guides/use-soul-with-hermes',
         'guides/use-voice-mode-with-hermes',
         'guides/migrate-from-openclaw',
+        'guides/migrate-openclaw-agents-to-hermes-profiles',
       ],
     },
     {


### PR DESCRIPTION
## Summary
- document the advanced OpenClaw -> Hermes migration flow for one-profile-per-agent setups
- add optional skills and runbooks for single-agent and batch agent-to-profile migrations
- link the existing `hermes claw migrate` docs to the advanced path and add the new website guide to the docs sidebar

## Why
`hermes claw migrate` covers the basic one-home import case.

This PR covers the next layer: users who want one Hermes profile per former OpenClaw agent or workspace, while preserving both:
- a frozen source workspace archive under `openclaw-workspace/`
- usable active Hermes state (`SOUL.md`, `memories/`, `terminal.cwd`, and `skills.external_dirs`)

## Test Plan
- [x] `git diff --check`
- [x] verified no broken relative markdown links across the changed docs/skills files
- [x] added the new website guide to `website/sidebars.ts`
- [ ] `cd website && npm run build` (currently blocked by a pre-existing website issue: `website/src/pages/skills` cannot resolve `../../data/skills.json`)

## Notes
This is intentionally scoped to docs + optional skills, separated from the larger upstream/local merge work.