### PR TITLE
fix(nix): add hermes_logging to py-modules in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ hermes-agent = "run_agent:main"
 hermes-acp = "acp_adapter.entry:main"
 
 [tool.setuptools]
-py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_constants", "hermes_state", "hermes_time", "rl_cli", "utils"]
+py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_constants", "hermes_logging", "hermes_state", "hermes_time", "rl_cli", "utils"]
 
 [tool.setuptools.packages.find]
 include = ["agent", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "cron", "acp_adapter", "plugins", "plugins.*"]


### PR DESCRIPTION
## What does this PR do?

`hermes_logging.py` was introduced in 9c96f66 but not added to the setuptools py-modules list. uv2nix relies on this metadata to include top-level modules in the wheel, causing ModuleNotFoundError at runtime when built via the NixOS module.

## Related Issue

Fixes #5502

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

 - Added "hermes_logging" to the py-modules list in pyproject.toml (alongside the other hermes_* modules)

## How to Test

1. Build a wheel from the repo: python -m build or via uv/nix
2. Install the wheel (non-editable) into a clean venv
3. Run hermes gateway — should no longer raise ModuleNotFoundError: No module named 'hermes_logging'

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — 53 pre-existing failures on `main` unrelated to this change (skill_manager,   transcription, write_deny, acp imports); 8624 pass- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS 25.11 aarch64-linux (Raspberry Pi 5)

### Documentation & Housekeeping

N/A

## Screenshots / Logs

1. git clone https://github.com/NousResearch/hermes-agent.git && cd hermes-agent
2. python3 -m venv .venv && .venv/bin/pip install build && .venv/bin/python -m build --wheel
3. python3 -m venv /tmp/test-venv && /tmp/test-venv/bin/pip install dist/*.whl
4. /tmp/test-venv/bin/python -c "import hermes_logging"
   → ModuleNotFoundError: No module named 'hermes_logging'