### PR TITLE
feat: expand OpenViking memory tools

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -244,6 +244,170 @@ ADD_RESOURCE_SCHEMA = {
     },
 }
 
+WRITE_SCHEMA = {
+    "name": "viking_write",
+    "description": (
+        "Write structured content directly to a viking:// URI. "
+        "Use this when you already know where the entry should live "
+        "and want to store exact text without waiting for session extraction."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "uri": {
+                "type": "string",
+                "description": "Target viking:// URI to write the content to.",
+            },
+            "content": {
+                "type": "string",
+                "description": "The text to persist under the URI.",
+            },
+            "metadata": {
+                "type": "object",
+                "description": "Optional metadata or tags to associate with the entry.",
+            },
+        },
+        "required": ["uri", "content"],
+    },
+}
+
+LINK_SCHEMA = {
+    "name": "viking_link",
+    "description": (
+        "Create a semantic relation between two OpenViking entries. "
+        "This lets the knowledge graph understand how entities, events, and resources connect."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "source": {
+                "type": "string",
+                "description": "URI of the source entry (e.g., entity or note).",
+            },
+            "target": {
+                "type": "string",
+                "description": "URI of the related entry (e.g., project, event, skill).",
+            },
+            "relation": {
+                "type": "string",
+                "description": "Relation name, such as 'related', 'author', or 'part_of'.",
+            },
+        },
+        "required": ["source", "target"],
+    },
+}
+
+GREP_SCHEMA = {
+    "name": "viking_grep",
+    "description": (
+        "Run OpenViking's exact-match grep search. Use for filenames, error codes, "
+        "or phrases the semantic search might miss."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Term or regex to match."},
+            "scope": {
+                "type": "string",
+                "description": "URI prefix to limit the search (default: viking://).",
+            },
+            "limit": {"type": "integer", "description": "Max entries to return."},
+        },
+        "required": ["query"],
+    },
+}
+
+GLOB_SCHEMA = {
+    "name": "viking_glob",
+    "description": (
+        "Find OpenViking entries by path/glob patterns. Useful when you know part of "
+        "a filename or directory structure."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "pattern": {"type": "string", "description": "Glob pattern like viking://docs/*.md."},
+            "limit": {"type": "integer", "description": "Max results (default: 20)."},
+        },
+        "required": ["pattern"],
+    },
+}
+
+EXTRACT_SCHEMA = {
+    "name": "viking_extract",
+    "description": (
+        "Force extraction on an ongoing OpenViking session so writes become searchable "
+        "before the session commits."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "session_id": {
+                "type": "string",
+                "description": "Session ID to extract (defaults to current session).",
+            },
+            "categories": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional list of categories to limit extraction (e.g., ['events']).",
+            },
+        },
+    },
+}
+
+WRITE_SCHEMA = {
+    "name": "viking_write",
+    "description": (
+        "Write structured content directly to a viking:// URI. "
+        "Use this when you already know where the entry should live "
+        "and want to store exact text without waiting for session extraction."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "uri": {
+                "type": "string",
+                "description": "Target viking:// URI to write the content to.",
+            },
+            "content": {
+                "type": "string",
+                "description": "The text to persist under the URI.",
+            },
+            "metadata": {
+                "type": "object",
+                "description": "Optional metadata or tags to associate with the entry.",
+            },
+        },
+        "required": ["uri", "content"],
+    },
+}
+
+LINK_SCHEMA = {
+    "name": "viking_link",
+    "description": (
+        "Create a semantic relation between two OpenViking entries. "
+        "This lets the knowledge graph understand how entities, events, and resources connect."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "source": {
+                "type": "string",
+                "description": "URI of the source entry (e.g., entity or note).",
+            },
+            "target": {
+                "type": "string",
+                "description": "URI of the related entry (e.g., project, event, skill).",
+            },
+            "relation": {
+                "type": "string",
+                "description": "Relation name, such as 'related', 'author', or 'part_of'.",
+            },
+        },
+        "required": ["source", "target"],
+    },
+}
+
 
 # ---------------------------------------------------------------------------
 # MemoryProvider implementation
@@ -458,7 +622,18 @@ class OpenVikingMemoryProvider(MemoryProvider):
         t.start()
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
-        return [SEARCH_SCHEMA, READ_SCHEMA, BROWSE_SCHEMA, REMEMBER_SCHEMA, ADD_RESOURCE_SCHEMA]
+        return [
+            SEARCH_SCHEMA,
+            READ_SCHEMA,
+            BROWSE_SCHEMA,
+            REMEMBER_SCHEMA,
+            ADD_RESOURCE_SCHEMA,
+            WRITE_SCHEMA,
+            LINK_SCHEMA,
+            GREP_SCHEMA,
+            GLOB_SCHEMA,
+            EXTRACT_SCHEMA,
+        ]
 
     def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
         if not self._client:
@@ -475,6 +650,16 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 return self._tool_remember(args)
             elif tool_name == "viking_add_resource":
                 return self._tool_add_resource(args)
+            elif tool_name == "viking_write":
+                return self._tool_write(args)
+            elif tool_name == "viking_link":
+                return self._tool_link(args)
+            elif tool_name == "viking_grep":
+                return self._tool_grep(args)
+            elif tool_name == "viking_glob":
+                return self._tool_glob(args)
+            elif tool_name == "viking_extract":
+                return self._tool_extract(args)
             return tool_error(f"Unknown tool: {tool_name}")
         except Exception as e:
             return tool_error(str(e))
@@ -620,6 +805,110 @@ class OpenVikingMemoryProvider(MemoryProvider):
             "status": "added",
             "root_uri": result.get("root_uri", ""),
             "message": "Resource queued for processing. Use viking_search after a moment to find it.",
+        }, ensure_ascii=False)
+
+    def _tool_write(self, args: dict) -> str:
+        uri = args.get("uri", "")
+        content = args.get("content", "")
+        if not uri or not content:
+            return tool_error("uri and content are required")
+
+        payload: Dict[str, Any] = {
+            "uri": uri,
+            "content": content,
+        }
+        if args.get("metadata"):
+            payload["metadata"] = args["metadata"]
+
+        resp = self._client.post("/api/v1/content/write", payload)
+        result = resp.get("result", {})
+
+        return json.dumps({
+            "status": "written",
+            "uri": uri,
+            "metadata": result.get("metadata"),
+            "message": "Content written directly to OpenViking.",
+        }, ensure_ascii=False)
+
+    def _tool_link(self, args: dict) -> str:
+        source = args.get("source", "")
+        target = args.get("target", "")
+        if not source or not target:
+            return tool_error("source and target are required")
+
+        relation = args.get("relation", "related")
+        payload = {
+            "from_uri": source,
+            "to_uri": target,
+            "relation": relation,
+        }
+
+        resp = self._client.post("/api/v1/relations/link", payload)
+        data = resp.get("result", {})
+
+        return json.dumps({
+            "status": "linked",
+            "source": source,
+            "target": target,
+            "relation": relation,
+            "details": data,
+        }, ensure_ascii=False)
+
+    def _tool_grep(self, args: dict) -> str:
+        query = args.get("query", "")
+        if not query:
+            return tool_error("query is required")
+
+        payload: Dict[str, Any] = {"query": query}
+        if args.get("scope"):
+            payload["uri_prefix"] = args["scope"]
+        if args.get("limit"):
+            payload["top_k"] = args["limit"]
+
+        resp = self._client.post("/api/v1/search/grep", payload)
+        result = resp.get("result", [])
+
+        formatted = []
+        for item in result:
+            formatted.append({
+                "uri": item.get("uri"),
+                "snippet": item.get("snippet"),
+                "line": item.get("line"),
+            })
+
+        return json.dumps({"results": formatted}, ensure_ascii=False)
+
+    def _tool_glob(self, args: dict) -> str:
+        pattern = args.get("pattern", "")
+        if not pattern:
+            return tool_error("pattern is required")
+
+        payload = {"pattern": pattern}
+        if args.get("limit"):
+            payload["limit"] = args["limit"]
+
+        resp = self._client.post("/api/v1/search/glob", payload)
+        result = resp.get("result", [])
+
+        entries = [{"uri": e.get("uri"), "name": e.get("name")} for e in result]
+        return json.dumps({"entries": entries}, ensure_ascii=False)
+
+    def _tool_extract(self, args: dict) -> str:
+        session_id = args.get("session_id", self._session_id)
+        if not session_id:
+            return tool_error("session_id is required")
+
+        payload: Dict[str, Any] = {}
+        if args.get("categories"):
+            payload["categories"] = args["categories"]
+
+        resp = self._client.post(f"/api/v1/sessions/{session_id}/extract", payload)
+        result = resp.get("result", {})
+
+        return json.dumps({
+            "status": "extracted",
+            "session_id": session_id,
+            "details": result,
         }, ensure_ascii=False)
 
 

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -262,9 +262,10 @@ WRITE_SCHEMA = {
                 "type": "string",
                 "description": "The text to persist under the URI.",
             },
-            "metadata": {
-                "type": "object",
-                "description": "Optional metadata or tags to associate with the entry.",
+            "mode": {
+                "type": "string",
+                "enum": ["replace", "append"],
+                "description": "Write mode: 'replace' (default) or 'append'.",
             },
         },
         "required": ["uri", "content"],
@@ -282,15 +283,15 @@ LINK_SCHEMA = {
         "properties": {
             "source": {
                 "type": "string",
-                "description": "URI of the source entry (e.g., entity or note).",
+                "description": "URI of the source entry (from_uri).",
             },
             "target": {
                 "type": "string",
-                "description": "URI of the related entry (e.g., project, event, skill).",
+                "description": "URI of the related entry (to_uri).",
             },
-            "relation": {
+            "reason": {
                 "type": "string",
-                "description": "Relation name, such as 'related', 'author', or 'part_of'.",
+                "description": "Why these entries are related (improves graph quality).",
             },
         },
         "required": ["source", "target"],
@@ -306,14 +307,18 @@ GREP_SCHEMA = {
     "parameters": {
         "type": "object",
         "properties": {
-            "query": {"type": "string", "description": "Term or regex to match."},
-            "scope": {
+            "pattern": {"type": "string", "description": "Term or regex pattern to match."},
+            "uri": {
                 "type": "string",
                 "description": "URI prefix to limit the search (default: viking://).",
             },
-            "limit": {"type": "integer", "description": "Max entries to return."},
+            "case_insensitive": {
+                "type": "boolean",
+                "description": "Case-insensitive match (default: false).",
+            },
+            "limit": {"type": "integer", "description": "Max entries to return (node_limit)."},
         },
-        "required": ["query"],
+        "required": ["pattern"],
     },
 }
 
@@ -327,7 +332,11 @@ GLOB_SCHEMA = {
         "type": "object",
         "properties": {
             "pattern": {"type": "string", "description": "Glob pattern like viking://docs/*.md."},
-            "limit": {"type": "integer", "description": "Max results (default: 20)."},
+            "uri": {
+                "type": "string",
+                "description": "Root URI to search under (default: viking://).",
+            },
+            "limit": {"type": "integer", "description": "Max results (node_limit)."},
         },
         "required": ["pattern"],
     },
@@ -336,8 +345,8 @@ GLOB_SCHEMA = {
 EXTRACT_SCHEMA = {
     "name": "viking_extract",
     "description": (
-        "Force extraction on an ongoing OpenViking session so writes become searchable "
-        "before the session commits."
+        "Force memory extraction on an ongoing OpenViking session so memories become "
+        "searchable before the session commits."
     ),
     "parameters": {
         "type": "object",
@@ -346,65 +355,7 @@ EXTRACT_SCHEMA = {
                 "type": "string",
                 "description": "Session ID to extract (defaults to current session).",
             },
-            "categories": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": "Optional list of categories to limit extraction (e.g., ['events']).",
-            },
         },
-    },
-}
-
-WRITE_SCHEMA = {
-    "name": "viking_write",
-    "description": (
-        "Write structured content directly to a viking:// URI. "
-        "Use this when you already know where the entry should live "
-        "and want to store exact text without waiting for session extraction."
-    ),
-    "parameters": {
-        "type": "object",
-        "properties": {
-            "uri": {
-                "type": "string",
-                "description": "Target viking:// URI to write the content to.",
-            },
-            "content": {
-                "type": "string",
-                "description": "The text to persist under the URI.",
-            },
-            "metadata": {
-                "type": "object",
-                "description": "Optional metadata or tags to associate with the entry.",
-            },
-        },
-        "required": ["uri", "content"],
-    },
-}
-
-LINK_SCHEMA = {
-    "name": "viking_link",
-    "description": (
-        "Create a semantic relation between two OpenViking entries. "
-        "This lets the knowledge graph understand how entities, events, and resources connect."
-    ),
-    "parameters": {
-        "type": "object",
-        "properties": {
-            "source": {
-                "type": "string",
-                "description": "URI of the source entry (e.g., entity or note).",
-            },
-            "target": {
-                "type": "string",
-                "description": "URI of the related entry (e.g., project, event, skill).",
-            },
-            "relation": {
-                "type": "string",
-                "description": "Relation name, such as 'related', 'author', or 'part_of'.",
-            },
-        },
-        "required": ["source", "target"],
     },
 }
 
@@ -808,17 +759,16 @@ class OpenVikingMemoryProvider(MemoryProvider):
         }, ensure_ascii=False)
 
     def _tool_write(self, args: dict) -> str:
+        # POST /api/v1/content/write — WriteContentRequest (extra="forbid")
+        # Accepted fields: uri, content, mode, wait, timeout, telemetry
         uri = args.get("uri", "")
         content = args.get("content", "")
         if not uri or not content:
             return tool_error("uri and content are required")
 
-        payload: Dict[str, Any] = {
-            "uri": uri,
-            "content": content,
-        }
-        if args.get("metadata"):
-            payload["metadata"] = args["metadata"]
+        payload: Dict[str, Any] = {"uri": uri, "content": content}
+        if args.get("mode"):
+            payload["mode"] = args["mode"]
 
         resp = self._client.post("/api/v1/content/write", payload)
         result = resp.get("result", {})
@@ -826,22 +776,22 @@ class OpenVikingMemoryProvider(MemoryProvider):
         return json.dumps({
             "status": "written",
             "uri": uri,
-            "metadata": result.get("metadata"),
-            "message": "Content written directly to OpenViking.",
+            "result": result,
         }, ensure_ascii=False)
 
     def _tool_link(self, args: dict) -> str:
+        # POST /api/v1/relations/link — LinkRequest: from_uri, to_uris, reason
         source = args.get("source", "")
         target = args.get("target", "")
         if not source or not target:
             return tool_error("source and target are required")
 
-        relation = args.get("relation", "related")
-        payload = {
+        payload: Dict[str, Any] = {
             "from_uri": source,
-            "to_uri": target,
-            "relation": relation,
+            "to_uris": target,
         }
+        if args.get("reason"):
+            payload["reason"] = args["reason"]
 
         resp = self._client.post("/api/v1/relations/link", payload)
         data = resp.get("result", {})
@@ -850,20 +800,24 @@ class OpenVikingMemoryProvider(MemoryProvider):
             "status": "linked",
             "source": source,
             "target": target,
-            "relation": relation,
             "details": data,
         }, ensure_ascii=False)
 
     def _tool_grep(self, args: dict) -> str:
-        query = args.get("query", "")
-        if not query:
-            return tool_error("query is required")
+        # POST /api/v1/search/grep — GrepRequest: uri (required), pattern (required),
+        # case_insensitive, node_limit, level_limit
+        pattern = args.get("pattern", "")
+        if not pattern:
+            return tool_error("pattern is required")
 
-        payload: Dict[str, Any] = {"query": query}
-        if args.get("scope"):
-            payload["uri_prefix"] = args["scope"]
+        payload: Dict[str, Any] = {
+            "uri": args.get("uri", "viking://"),
+            "pattern": pattern,
+        }
+        if args.get("case_insensitive"):
+            payload["case_insensitive"] = args["case_insensitive"]
         if args.get("limit"):
-            payload["top_k"] = args["limit"]
+            payload["node_limit"] = args["limit"]
 
         resp = self._client.post("/api/v1/search/grep", payload)
         result = resp.get("result", [])
@@ -879,13 +833,16 @@ class OpenVikingMemoryProvider(MemoryProvider):
         return json.dumps({"results": formatted}, ensure_ascii=False)
 
     def _tool_glob(self, args: dict) -> str:
+        # POST /api/v1/search/glob — GlobRequest: pattern (required), uri, node_limit
         pattern = args.get("pattern", "")
         if not pattern:
             return tool_error("pattern is required")
 
-        payload = {"pattern": pattern}
+        payload: Dict[str, Any] = {"pattern": pattern}
+        if args.get("uri"):
+            payload["uri"] = args["uri"]
         if args.get("limit"):
-            payload["limit"] = args["limit"]
+            payload["node_limit"] = args["limit"]
 
         resp = self._client.post("/api/v1/search/glob", payload)
         result = resp.get("result", [])
@@ -894,15 +851,12 @@ class OpenVikingMemoryProvider(MemoryProvider):
         return json.dumps({"entries": entries}, ensure_ascii=False)
 
     def _tool_extract(self, args: dict) -> str:
+        # POST /api/v1/sessions/{session_id}/extract — no request body
         session_id = args.get("session_id", self._session_id)
         if not session_id:
             return tool_error("session_id is required")
 
-        payload: Dict[str, Any] = {}
-        if args.get("categories"):
-            payload["categories"] = args["categories"]
-
-        resp = self._client.post(f"/api/v1/sessions/{session_id}/extract", payload)
+        resp = self._client.post(f"/api/v1/sessions/{session_id}/extract")
         result = resp.get("result", {})
 
         return json.dumps({

--- a/tests/plugins/memory/test_openviking_tools.py
+++ b/tests/plugins/memory/test_openviking_tools.py
@@ -1,0 +1,173 @@
+"""Smoke tests for the expanded OpenViking memory tools.
+
+Verifies that viking_write, viking_link, viking_grep, viking_glob, and
+viking_extract are wired into get_tool_schemas() and handle_tool_call(),
+and that each tool returns the expected JSON structure when the HTTP
+client is mocked.
+"""
+
+import json
+
+import pytest
+
+from plugins.memory.openviking import OpenVikingMemoryProvider
+
+
+# ---------------------------------------------------------------------------
+# Fake HTTP client — replaces _VikingClient for all tests
+# ---------------------------------------------------------------------------
+
+class FakeVikingClient:
+    def __init__(self, *args, **kwargs):
+        self.calls: list[dict] = []
+        self._health = True
+
+    def health(self) -> bool:
+        return self._health
+
+    def get(self, path: str, **kwargs) -> dict:
+        self.calls.append({"method": "GET", "path": path, **kwargs})
+        return {"result": {}}
+
+    def post(self, path: str, payload: dict = None, **kwargs) -> dict:
+        self.calls.append({"method": "POST", "path": path, "payload": payload or {}})
+        # Return shapes that match what each tool reads
+        if path.endswith("/extract"):
+            return {"result": {"categories_extracted": 3}}
+        if "/search/grep" in path:
+            return {"result": [{"uri": "viking://a", "snippet": "foo", "line": 1}]}
+        if "/search/glob" in path:
+            return {"result": [{"uri": "viking://b", "name": "b"}]}
+        if "/content/write" in path:
+            return {"result": {"metadata": {"version": 1}}}
+        if "/relations/link" in path:
+            return {"result": {"edge_id": "e1"}}
+        return {"result": {}}
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def provider(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENVIKING_ENDPOINT", "http://localhost:1933")
+    monkeypatch.setenv("OPENVIKING_API_KEY", "test-key")
+    monkeypatch.setattr(
+        "plugins.memory.openviking._VikingClient", FakeVikingClient
+    )
+    p = OpenVikingMemoryProvider()
+    p.initialize("session-test", hermes_home=str(tmp_path), platform="cli")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# get_tool_schemas
+# ---------------------------------------------------------------------------
+
+def test_new_tools_in_schemas(provider):
+    names = {s["name"] for s in provider.get_tool_schemas()}
+    assert "viking_write" in names
+    assert "viking_link" in names
+    assert "viking_grep" in names
+    assert "viking_glob" in names
+    assert "viking_extract" in names
+
+
+# ---------------------------------------------------------------------------
+# viking_write
+# ---------------------------------------------------------------------------
+
+def test_viking_write_success(provider):
+    result = json.loads(
+        provider.handle_tool_call("viking_write", {"uri": "viking://x", "content": "hello"})
+    )
+    assert result["status"] == "written"
+    assert result["uri"] == "viking://x"
+
+
+def test_viking_write_missing_args(provider):
+    result = json.loads(provider.handle_tool_call("viking_write", {}))
+    assert "error" in result or "uri and content" in str(result)
+
+
+# ---------------------------------------------------------------------------
+# viking_link
+# ---------------------------------------------------------------------------
+
+def test_viking_link_success(provider):
+    result = json.loads(
+        provider.handle_tool_call(
+            "viking_link",
+            {"source": "viking://a", "target": "viking://b", "relation": "related"},
+        )
+    )
+    assert result["status"] == "linked"
+    assert result["relation"] == "related"
+
+
+def test_viking_link_missing_args(provider):
+    result = json.loads(provider.handle_tool_call("viking_link", {}))
+    assert "error" in result or "source" in str(result)
+
+
+# ---------------------------------------------------------------------------
+# viking_grep
+# ---------------------------------------------------------------------------
+
+def test_viking_grep_success(provider):
+    result = json.loads(
+        provider.handle_tool_call("viking_grep", {"query": "foo"})
+    )
+    assert "results" in result
+    assert result["results"][0]["uri"] == "viking://a"
+
+
+def test_viking_grep_missing_query(provider):
+    result = json.loads(provider.handle_tool_call("viking_grep", {}))
+    assert "error" in result or "query" in str(result)
+
+
+# ---------------------------------------------------------------------------
+# viking_glob
+# ---------------------------------------------------------------------------
+
+def test_viking_glob_success(provider):
+    result = json.loads(
+        provider.handle_tool_call("viking_glob", {"pattern": "viking://**"})
+    )
+    assert "entries" in result
+    assert result["entries"][0]["uri"] == "viking://b"
+
+
+def test_viking_glob_missing_pattern(provider):
+    result = json.loads(provider.handle_tool_call("viking_glob", {}))
+    assert "error" in result or "pattern" in str(result)
+
+
+# ---------------------------------------------------------------------------
+# viking_extract
+# ---------------------------------------------------------------------------
+
+def test_viking_extract_success(provider):
+    result = json.loads(
+        provider.handle_tool_call("viking_extract", {"session_id": "session-test"})
+    )
+    assert result["status"] == "extracted"
+    assert result["session_id"] == "session-test"
+
+
+def test_viking_extract_uses_active_session(provider):
+    """session_id defaults to the provider's own session when omitted."""
+    result = json.loads(provider.handle_tool_call("viking_extract", {}))
+    assert result["status"] == "extracted"
+
+
+# ---------------------------------------------------------------------------
+# Unknown tool routing
+# ---------------------------------------------------------------------------
+
+def test_unknown_tool_returns_error(provider):
+    result = provider.handle_tool_call("viking_nonexistent", {})
+    # tool_error returns a string; make sure it signals an error
+    assert "Unknown tool" in result or "error" in result.lower()

--- a/tests/plugins/memory/test_openviking_tools.py
+++ b/tests/plugins/memory/test_openviking_tools.py
@@ -99,11 +99,11 @@ def test_viking_link_success(provider):
     result = json.loads(
         provider.handle_tool_call(
             "viking_link",
-            {"source": "viking://a", "target": "viking://b", "relation": "related"},
+            {"source": "viking://a", "target": "viking://b", "reason": "dependency"},
         )
     )
     assert result["status"] == "linked"
-    assert result["relation"] == "related"
+    assert result["source"] == "viking://a"
 
 
 def test_viking_link_missing_args(provider):
@@ -117,15 +117,15 @@ def test_viking_link_missing_args(provider):
 
 def test_viking_grep_success(provider):
     result = json.loads(
-        provider.handle_tool_call("viking_grep", {"query": "foo"})
+        provider.handle_tool_call("viking_grep", {"pattern": "foo"})
     )
     assert "results" in result
     assert result["results"][0]["uri"] == "viking://a"
 
 
-def test_viking_grep_missing_query(provider):
+def test_viking_grep_missing_pattern(provider):
     result = json.loads(provider.handle_tool_call("viking_grep", {}))
-    assert "error" in result or "query" in str(result)
+    assert "error" in result or "pattern" in str(result)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
 - Problem: The OpenViking memory provider exposed only session-commit-based remember/add_resource/search/read/browse tools, leaving the majority of the official REST surface unused and the knowledge base acting like a passive sink.
 
  Related: #5627

 - Changes: Added schemas and handlers for viking_write (POST /api/v1/content/write), viking_link (POST /api/v1/relations/link), viking_grep/viking_glob (grep/glob search), and viking_extract (POST /api/v1/sessions/{id}/extract). Each tool now calls the real OpenViking endpoint and returns a concise JSON summary.
 
 - Remaining work: The low-priority endpoints (export/import, skills, content reindex) remain untouched; this patch focuses on the high- and medium-priority surface suggested in the issue.