### PR TITLE
fix(model): resolve user-defined provider when switching by default_model name

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3573,6 +3573,15 @@ class HermesCLI:
         # Parse --provider and --global flags
         model_input, explicit_provider, persist_global = parse_model_flags(raw_args)
 
+        # Load user-defined providers from config (needed for both display and switching)
+        user_provs = None
+        try:
+            from hermes_cli.config import load_config as _load_config
+            _cfg = _load_config()
+            user_provs = _cfg.get("providers")
+        except Exception:
+            pass
+
         # No args at all: show available providers + models
         if not model_input and not explicit_provider:
             model_display = self.model or "unknown"
@@ -3582,15 +3591,6 @@ class HermesCLI:
 
             # Show authenticated providers with top models
             try:
-                # Load user providers from config
-                user_provs = None
-                try:
-                    from hermes_cli.config import load_config
-                    cfg = load_config()
-                    user_provs = cfg.get("providers")
-                except Exception:
-                    pass
-
                 providers = list_authenticated_providers(
                     current_provider=self.provider or "",
                     user_providers=user_provs,
@@ -3634,6 +3634,7 @@ class HermesCLI:
             current_api_key=self.api_key or "",
             is_global=persist_global,
             explicit_provider=explicit_provider,
+            user_providers=user_provs,
         )
 
         if not result.success:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3536,6 +3536,7 @@ class GatewayRunner:
             current_api_key=current_api_key,
             is_global=persist_global,
             explicit_provider=explicit_provider,
+            user_providers=user_provs,
         )
 
         if not result.success:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -558,6 +558,31 @@ def switch_model(
             if detected:
                 target_provider, new_model = detected
 
+        # --- Step f: Search user-defined providers by default_model ---
+        # Handles the case where multiple custom providers are configured and
+        # the requested model name matches a provider's default_model entry.
+        # This lets users switch by model name even without --provider when
+        # the model is listed under a user-defined endpoint.
+        if (
+            target_provider == current_provider
+            and not resolved_alias
+            and user_providers
+            and isinstance(user_providers, dict)
+        ):
+            new_model_lower = new_model.lower()
+            for pname, pcfg in user_providers.items():
+                if not isinstance(pcfg, dict):
+                    continue
+                default_model = pcfg.get("default_model", "")
+                if default_model and default_model.lower() == new_model_lower:
+                    target_provider = pname
+                    logger.debug(
+                        "Model '%s' matched user-defined provider '%s' via default_model",
+                        new_model,
+                        pname,
+                    )
+                    break
+
     # =================================================================
     # COMMON PATH: Resolve credentials, normalize, get metadata
     # =================================================================

--- a/tests/test_model_switch_user_provider.py
+++ b/tests/test_model_switch_user_provider.py
@@ -1,0 +1,157 @@
+"""Tests for user-defined provider resolution in switch_model.
+
+Regression tests for the bug where /model <name> with multiple custom
+providers would keep the current provider instead of switching to the
+provider whose default_model matches the requested model name.
+
+Fixes: https://github.com/NousResearch/hermes-agent/issues/5569
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from hermes_cli.model_switch import switch_model, DIRECT_ALIASES
+
+
+USER_PROVIDERS = {
+    "provider-a": {
+        "name": "Provider A",
+        "api": "https://api-a.example.com/v1",
+        "default_model": "qwen3.5-27b",
+    },
+    "provider-b": {
+        "name": "Provider B",
+        "api": "https://api-b.example.com/v1",
+        "default_model": "gemma-4-26b",
+    },
+}
+
+
+def _make_runtime(provider: str) -> dict:
+    return {
+        "api_key": f"key-for-{provider}",
+        "base_url": f"https://{provider}.example.com/v1",
+        "api_mode": "openai_chat",
+    }
+
+
+@pytest.fixture(autouse=True)
+def clear_direct_aliases():
+    """Ensure DIRECT_ALIASES cache is empty before each test."""
+    import hermes_cli.model_switch as msw
+    original = dict(msw.DIRECT_ALIASES)
+    msw.DIRECT_ALIASES.clear()
+    yield
+    msw.DIRECT_ALIASES.clear()
+    msw.DIRECT_ALIASES.update(original)
+
+
+@patch("hermes_cli.models.validate_requested_model")
+@patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+@patch("hermes_cli.models.detect_provider_for_model")
+@patch("hermes_cli.model_switch.get_model_info")
+def test_switch_to_user_provider_by_default_model(
+    mock_get_info, mock_detect, mock_runtime, mock_validate
+):
+    """Switching by model name should resolve to the user-defined provider
+    whose default_model matches, not stay on the current provider."""
+    mock_detect.return_value = None
+    mock_get_info.return_value = None
+    mock_validate.return_value = {"accepted": True, "persist": True, "recognized": False}
+    mock_runtime.side_effect = lambda requested: _make_runtime(requested)
+
+    result = switch_model(
+        raw_input="gemma-4-26b",
+        current_provider="provider-a",
+        current_model="qwen3.5-27b",
+        user_providers=USER_PROVIDERS,
+    )
+
+    assert result.success, result.error_message
+    assert result.target_provider == "provider-b"
+    assert result.new_model == "gemma-4-26b"
+    assert result.provider_changed is True
+
+
+@patch("hermes_cli.models.validate_requested_model")
+@patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+@patch("hermes_cli.models.detect_provider_for_model")
+@patch("hermes_cli.model_switch.get_model_info")
+def test_switch_by_model_name_case_insensitive(
+    mock_get_info, mock_detect, mock_runtime, mock_validate
+):
+    """Model name matching should be case-insensitive."""
+    mock_detect.return_value = None
+    mock_get_info.return_value = None
+    mock_validate.return_value = {"accepted": True, "persist": True, "recognized": False}
+    mock_runtime.side_effect = lambda requested: _make_runtime(requested)
+
+    result = switch_model(
+        raw_input="Gemma-4-26B",  # different case
+        current_provider="provider-a",
+        current_model="qwen3.5-27b",
+        user_providers=USER_PROVIDERS,
+    )
+
+    assert result.success, result.error_message
+    assert result.target_provider == "provider-b"
+
+
+@patch("hermes_cli.models.validate_requested_model")
+@patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+@patch("hermes_cli.models.detect_provider_for_model")
+@patch("hermes_cli.model_switch.get_model_info")
+def test_switch_without_user_providers_stays_on_current(
+    mock_get_info, mock_detect, mock_runtime, mock_validate
+):
+    """When user_providers is None, switching an unknown model stays on the
+    current provider (no regression in existing behaviour)."""
+    mock_detect.return_value = None
+    mock_get_info.return_value = None
+    mock_validate.return_value = {"accepted": True, "persist": True, "recognized": False}
+    mock_runtime.side_effect = lambda requested: _make_runtime(requested)
+
+    result = switch_model(
+        raw_input="gemma-4-26b",
+        current_provider="provider-a",
+        current_model="qwen3.5-27b",
+        user_providers=None,
+    )
+
+    assert result.success, result.error_message
+    assert result.target_provider == "provider-a"
+    assert result.provider_changed is False
+
+
+@patch("hermes_cli.models.validate_requested_model")
+@patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+@patch("hermes_cli.models.detect_provider_for_model")
+@patch("hermes_cli.model_switch.get_model_info")
+def test_explicit_provider_overrides_user_provider_lookup(
+    mock_get_info, mock_detect, mock_runtime, mock_validate
+):
+    """When --provider is given explicitly, it takes precedence over
+    the user-defined provider default_model lookup."""
+    from hermes_cli.providers import ProviderDef
+    mock_detect.return_value = None
+    mock_get_info.return_value = None
+    mock_validate.return_value = {"accepted": True, "persist": True, "recognized": False}
+    mock_runtime.side_effect = lambda requested: _make_runtime(requested)
+
+    pdef = ProviderDef(
+        id="provider-a",
+        name="Provider A",
+        transport="openai_chat",
+        api_key_env_vars=[],
+        base_url="https://api-a.example.com/v1",
+    )
+    with patch("hermes_cli.model_switch.resolve_provider_full", return_value=pdef):
+        result = switch_model(
+            raw_input="gemma-4-26b",
+            current_provider="provider-b",
+            current_model="gemma-4-26b",
+            explicit_provider="provider-a",  # explicit override
+            user_providers=USER_PROVIDERS,
+        )
+
+    assert result.success, result.error_message
+    assert result.target_provider == "provider-a"


### PR DESCRIPTION
## Summary

When a user has multiple custom providers configured and runs `/model <name>`, the provider should switch to whichever user-defined provider has that model as its `default_model`. Instead, it silently stayed on the current provider.

## Root Cause

`switch_model()` was never passed the user-defined providers from config, and had no lookup step for them. `list_authenticated_providers()` already shows user providers (with their `default_model`), so users naturally expect that typing `/model <name>` from that list will switch correctly.

Three issues combined to cause this:
1. `cli.py` only loaded `user_provs` inside the no-args display branch, not before the switch call
2. `gateway/run.py` had `user_provs` available but didn't pass it to `_switch_model()`
3. `model_switch.py` PATH B had no step to search user providers by `default_model`

## Changes

- **`hermes_cli/model_switch.py`**: Added step f in PATH B — after `detect_provider_for_model()` fails, scan `user_providers` for an entry whose `default_model` matches the requested model name (case-insensitive)
- **`cli.py`**: Moved `user_provs` loading before the model/no-args conditional so it's available for both display and switching; passed as `user_providers=user_provs` to `switch_model()`
- **`gateway/run.py`**: Added `user_providers=user_provs` to the `_switch_model()` call
- **`tests/test_model_switch_user_provider.py`**: 4 new unit tests covering the fix, case-insensitivity, no-regression with `user_providers=None`, and explicit `--provider` still taking precedence

## Reproduction

```yaml
# ~/.hermes/config.yaml
providers:
  provider-a:
    name: "Provider A"
    api: "https://api-a.example.com/v1"
    default_model: "qwen3.5-27b"
  provider-b:
    name: "Provider B"
    api: "https://api-b.example.com/v1"
    default_model: "gemma-4-26b"
model:
  provider: "provider-a"
  name: "qwen3.5-27b"
```

With current code: `/model gemma-4-26b` keeps `provider-a`  
After fix: `/model gemma-4-26b` switches to `provider-b`

## Test Plan

- [x] `pytest tests/test_model_switch_user_provider.py -v` — 4/4 pass
- [x] Related model/provider tests pass (3 pre-existing failures confirmed unrelated to this PR)
- [ ] Manual: configure two custom providers with different `default_model` values, run `/model <name-from-provider-b>`, confirm provider switches

**Tested on:** Linux/WSL2, Python 3.13

Fixes #5569