### PR TITLE
fix(doctor): use recall_mode instead of memory_mode on HonchoClientConfig

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -836,7 +836,7 @@ def run_doctor(args):
                 get_honcho_client(hcfg)
                 check_ok(
                     "Honcho connected",
-                    f"workspace={hcfg.workspace_id} mode={hcfg.memory_mode} freq={hcfg.write_frequency}",
+                    f"workspace={hcfg.workspace_id} mode={hcfg.recall_mode} freq={hcfg.write_frequency}",
                 )
             except Exception as _e:
                 check_fail("Honcho connection failed", str(_e))


### PR DESCRIPTION
Fixes `hermes doctor` failing with:

```
Honcho connection failed 'HonchoClientConfig' object has no attribute 'memory_mode'
```

The `HonchoClientConfig` field was renamed from `memory_mode` to `recall_mode` but
`doctor.py` line 839 still references the old name, causing a crash when Honcho
is enabled.