### PR TITLE
fix(cron): suppress delivery when [SILENT] appears anywhere in response

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -817,7 +817,7 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                 # output is already saved above).  Failed jobs always deliver.
                 deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
                 should_deliver = bool(deliver_content)
-                if should_deliver and success and deliver_content.strip().upper().startswith(SILENT_MARKER):
+                if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
                     logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
                     should_deliver = False
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -709,6 +709,18 @@ class TestSilentDelivery:
             tick(verbose=False)
         deliver_mock.assert_not_called()
 
+    def test_silent_trailing_suppresses_delivery(self):
+        """Agent appended [SILENT] after explanation text — must still suppress."""
+        response = "2 deals filtered out (like<10, reply<15).\n\n[SILENT]"
+        with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
+             patch("cron.scheduler.run_job", return_value=(True, "# output", response, None)), \
+             patch("cron.scheduler.save_job_output", return_value="/tmp/out.md"), \
+             patch("cron.scheduler._deliver_result") as deliver_mock, \
+             patch("cron.scheduler.mark_job_run"):
+            from cron.scheduler import tick
+            tick(verbose=False)
+        deliver_mock.assert_not_called()
+
     def test_silent_is_case_insensitive(self):
         with patch("cron.scheduler.get_due_jobs", return_value=[self._make_job()]), \
              patch("cron.scheduler.run_job", return_value=(True, "# output", "[silent] nothing new", None)), \


### PR DESCRIPTION
## Problem

The scheduler checked `startswith('[SILENT]')` to suppress delivery, but agents sometimes append `[SILENT]` after an explanation rather than responding with it alone:

```
2 deals filtered out (like<10, reply<15).

[SILENT]
```

This caused the message to be delivered despite the intent to suppress it.

## Fix

Changed `startswith(SILENT_MARKER)` to `SILENT_MARKER in ...` so the marker is caught regardless of its position in the response.

## Test

Added `test_silent_trailing_suppresses_delivery` to `TestSilentDelivery` — covers the case where `[SILENT]` is appended after content rather than leading the response.