### PR TITLE
fix(tools): portable base64 encoding for image reading on macOS

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -580,8 +580,10 @@ class ShellFileOperations(FileOperations):
                 ),
             )
         
-        # Get base64 content
-        b64_cmd = f"base64 -w 0 {self._escape_shell_arg(path)} 2>/dev/null"
+        # Get base64 content — pipe through tr to strip newlines portably.
+        # GNU base64 supports -w 0 but macOS base64 does not; both wrap by
+        # default, so stripping with tr is portable across all backends.
+        b64_cmd = f"base64 {self._escape_shell_arg(path)} 2>/dev/null | tr -d '\\n'"
         b64_result = self._exec(b64_cmd, timeout=30)
         
         if b64_result.exit_code != 0:


### PR DESCRIPTION
## Problem
`_read_image()` in `tools/file_operations.py` called `base64 -w 0` to
produce unwrapped base64 output. The `-w 0` flag is GNU coreutils syntax
and is not supported by macOS `base64`. On macOS with the local terminal
backend this caused every `read_file` call on an image to fail silently
(exit code != 0), returning a generic error instead of the base64 content.
Docker/Modal/SSH backends running Linux were unaffected.

## Fix
Replaced `base64 -w 0 <path>` with `base64 <path> | tr -d '\n'`.

Both GNU and macOS `base64` wrap output by default; piping through
`tr -d '\n'` strips the newlines without needing any platform detection.
This is portable across all terminal backends (local macOS, local Linux,
Docker, Modal, SSH to macOS or Linux hosts).

## Testing
On macOS with the local terminal backend:
1. `hermes chat -q "Read this image: /path/to/some/image.png"`
2. Verify the agent receives base64 content instead of a read error