### PR TITLE
feat: conversational cron delivery — inject scheduled output into agent session

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -13,6 +13,7 @@ import concurrent.futures
 import json
 import logging
 import os
+import queue
 import subprocess
 import sys
 
@@ -53,6 +54,29 @@ from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_
 # response with this marker to suppress delivery.  Output is still saved
 # locally for audit.
 SILENT_MARKER = "[SILENT]"
+
+# Thread-safe queue for conversational cron delivery.
+# When a job has conversational=true, its result is placed here instead of
+# being sent directly to the platform. The gateway polls this queue and
+# injects the output as a synthetic user message through the normal message
+# handling pipeline, giving the agent full visibility and session context.
+_conversational_queue: queue.Queue = queue.Queue()
+
+
+def get_conversational_results() -> list:
+    """Drain and return all pending conversational cron results.
+
+    Called by the gateway's cron ticker after each tick.  Returns a list of
+    dicts with keys: platform, chat_id, thread_id, job_name, content.
+    """
+    results = []
+    while True:
+        try:
+            results.append(_conversational_queue.get_nowait())
+        except queue.Empty:
+            break
+    return results
+
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
 _hermes_home = get_hermes_home()
@@ -200,6 +224,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     """
     Deliver job output to the configured target (origin chat, specific platform, etc.).
 
+    When ``conversational: true`` is set on the job, the output is placed in the
+    conversational queue instead of being sent directly. The gateway picks it up
+    and injects it as a synthetic user message, triggering the agent to respond
+    with full session context.
+
     When ``adapters`` and ``loop`` are provided (gateway is running), tries to
     use the live adapter first — this supports E2EE rooms (e.g. Matrix) where
     the standalone HTTP path cannot encrypt.  Falls back to standalone send if
@@ -214,6 +243,24 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             logger.warning("Job '%s': %s", job["id"], msg)
             return msg
         return None  # local-only jobs don't deliver — not a failure
+
+    # Conversational delivery: enqueue for gateway injection instead of
+    # sending directly. The gateway will create a synthetic MessageEvent,
+    # process it through the normal pipeline, and the agent will respond
+    # with full session context.
+    if job.get("conversational", False):
+        _conversational_queue.put({
+            "platform": target["platform"],
+            "chat_id": target["chat_id"],
+            "thread_id": target.get("thread_id"),
+            "job_name": job.get("name", job["id"]),
+            "content": content,
+        })
+        logger.info(
+            "Job '%s': enqueued for conversational delivery to %s:%s",
+            job["id"], target["platform"], target["chat_id"],
+        )
+        return
 
     platform_name = target["platform"]
     chat_id = target["chat_id"]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1683,7 +1683,11 @@ class GatewayRunner:
         # connection, so HA events are always authorized.
         # Webhook events are authenticated via HMAC signature validation in
         # the adapter itself — no user allowlist applies.
+        # Cron conversational messages are system-generated and injected by
+        # the gateway's own cron ticker — always authorized.
         if source.platform in (Platform.HOMEASSISTANT, Platform.WEBHOOK):
+            return True
+        if source.user_id == "cron_system":
             return True
 
         user_id = source.user_id
@@ -1776,7 +1780,80 @@ class GatewayRunner:
         if config and hasattr(config, "get_unauthorized_dm_behavior"):
             return config.get_unauthorized_dm_behavior(platform)
         return "pair"
-    
+
+    async def _handle_cron_conversational(self, result: dict) -> None:
+        """
+        Handle a conversational cron delivery by injecting the cron output
+        as a synthetic user message through the normal message pipeline.
+
+        This gives the agent full visibility into the cron output, enables
+        it to respond, and ensures both the output and response are saved
+        to session history.
+
+        Args:
+            result: Dict with keys platform, chat_id, thread_id, job_name, content.
+        """
+        from gateway.platforms.base import Platform as _PlatMap
+        platform_str = result["platform"]
+        chat_id = result["chat_id"]
+        thread_id = result.get("thread_id")
+        job_name = result.get("job_name", "cron")
+        content = result["content"]
+
+        # Resolve Platform enum from string
+        platform_map = {p.value: p for p in _PlatMap}
+        platform = platform_map.get(platform_str)
+        if not platform:
+            logger.warning("Conversational cron: unknown platform '%s'", platform_str)
+            return
+
+        # Build a synthetic SessionSource — appears as a "cron system" user
+        source = SessionSource(
+            platform=platform,
+            chat_id=chat_id,
+            chat_type="thread" if thread_id else "group",
+            user_id="cron_system",
+            user_name=f"Cron: {job_name}",
+            thread_id=thread_id,
+        )
+
+        # Build synthetic message text — prefixed so the agent knows this
+        # is an automated scheduled output, not a real user message.
+        synthetic_text = (
+            f"[Scheduled Task: {job_name}]\n\n"
+            f"{content}"
+        )
+
+        # Create a synthetic MessageEvent
+        from gateway.platforms.base import MessageEvent, MessageType
+        event = MessageEvent(
+            text=synthetic_text,
+            message_type=MessageType.TEXT,
+            source=source,
+        )
+
+        logger.info(
+            "Conversational cron: injecting '%s' into %s:%s (thread=%s)",
+            job_name, platform_str, chat_id, thread_id,
+        )
+
+        try:
+            response = await self._handle_message(event)
+            if response:
+                logger.info("Conversational cron: agent responded (%d chars)", len(response))
+                # Send the response through the platform adapter
+                adapter = self.adapters.get(platform)
+                if adapter:
+                    send_metadata = {"thread_id": thread_id} if thread_id else None
+                    await adapter.send(chat_id, response, metadata=send_metadata)
+                    logger.info("Conversational cron: response sent via adapter")
+                else:
+                    logger.warning("Conversational cron: no adapter for platform '%s'", platform_str)
+            else:
+                logger.info("Conversational cron: no agent response")
+        except Exception as e:
+            logger.error("Conversational cron: failed to process '%s': %s", job_name, e)
+
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
         """
         Handle an incoming message from any platform.
@@ -7413,7 +7490,7 @@ class GatewayRunner:
         return response
 
 
-def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, interval: int = 60):
+def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, interval: int = 60, runner=None):
     """
     Background thread that ticks the cron scheduler at a regular interval.
     
@@ -7423,10 +7500,15 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     When ``adapters`` and ``loop`` are provided, passes them through to the
     cron delivery path so live adapters can be used for E2EE rooms.
 
+    When ``runner`` (a GatewayRunner) is provided, conversational cron results
+    are drained from the queue and injected as synthetic messages through the
+    gateway's normal message pipeline.
+
     Also refreshes the channel directory every 5 minutes and prunes the
     image/audio/document cache once per hour.
     """
     from cron.scheduler import tick as cron_tick
+    from cron.scheduler import get_conversational_results
     from gateway.platforms.base import cleanup_image_cache, cleanup_document_cache
 
     IMAGE_CACHE_EVERY = 60   # ticks — once per hour at default 60s interval
@@ -7439,6 +7521,17 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
             cron_tick(verbose=False, adapters=adapters, loop=loop)
         except Exception as e:
             logger.debug("Cron tick error: %s", e)
+
+        # Drain conversational cron results and inject as synthetic messages
+        if runner is not None and loop is not None and not loop.is_closed():
+            try:
+                conv_results = get_conversational_results()
+                for result in conv_results:
+                    asyncio.run_coroutine_threadsafe(
+                        runner._handle_cron_conversational(result), loop,
+                    ).result(timeout=120)
+            except Exception as e:
+                logger.warning("Conversational cron delivery error: %s", e)
 
         tick_count += 1
 
@@ -7623,7 +7716,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     cron_thread = threading.Thread(
         target=_start_cron_ticker,
         args=(cron_stop,),
-        kwargs={"adapters": runner.adapters, "loop": asyncio.get_running_loop()},
+        kwargs={"adapters": runner.adapters, "loop": asyncio.get_running_loop(), "runner": runner},
         daemon=True,
         name="cron-ticker",
     )


### PR DESCRIPTION
## Summary

Adds a `conversational: true` option to cron job configuration that injects cron output into the gateway as a synthetic user message instead of sending it directly to the platform. The agent processes it through the normal pipeline with full session context and can respond naturally.

Closes #2990

## Problem

Cron job outputs are currently one-way broadcasts — sent directly to the platform via Bot API, bypassing the gateway entirely. This means:

1. The agent has **no visibility** into what the cron job generated
2. The output is **not saved** to session history
3. The agent **cannot respond** to or discuss the cron output
4. Users must copy-paste cron output back to the agent to continue the conversation

## Solution

When `conversational: true` is set on a cron job:

1. Cron output is placed in a thread-safe queue (instead of direct send)
2. The gateway drains the queue after each tick
3. Each result is wrapped in a synthetic `MessageEvent` and routed through `_handle_message()`
4. The agent sees it as `[Scheduled Task: {job_name}]\n\n{content}`
5. The agent responds normally — both output and response saved to session history

Default behavior is **unchanged** — `conversational` defaults to `false`, so existing cron jobs continue broadcasting one-way.

## Changes

### `cron/scheduler.py` (47 lines added)
- Added `queue` import and `_conversational_queue` (thread-safe `queue.Queue`)
- Added `get_conversational_results()` — drains the queue, called by gateway ticker
- Modified `_deliver_result()` — when `conversational: true`, enqueues result and returns early instead of sending directly

### `gateway/run.py` (91 lines added, 3 changed)
- `_is_user_authorized()` — `cron_system` user is always authorized (like HomeAssistant/webhook)
- `_start_cron_ticker()` — now accepts `runner` param, drains conversational results after each tick via `asyncio.run_coroutine_threadsafe()`
- `_handle_cron_conversational()` — new method on `GatewayRunner` that creates a synthetic `SessionSource` + `MessageEvent` and routes through `_handle_message()`
- Thread start kwargs — passes `runner=runner` to ticker

## Usage

```yaml
# In cron job config (via /cron create or API):
{
    "prompt": "Send morning briefing...",
    "schedule": "0 7 * * *",
    "deliver": "origin",
    "conversational": true  # NEW: agent sees output and can respond
}
```

## Design Decisions

- **Thread-safe queue** — Cron ticker runs in a background thread, gateway runs in asyncio event loop. `queue.Queue` bridges the two without race conditions.
- **Synthetic MessageEvent** — Reuses the existing `_handle_message()` pipeline for authorization, session management, context building, and agent execution. No code duplication.
- **`cron_system` user** — Clearly identifiable in logs and session history. Authorized by a single check in `_is_user_authorized()`, following the HomeAssistant/webhook pattern.
- **Prefix `[Scheduled Task: ...]`** — Agent and user can distinguish cron-generated messages from real user messages.

## Testing

- Syntax check passes for both modified files
- 1 clean commit, no merge commits or unrelated changes
- No new dependencies

## Diff Stats

```
 cron/scheduler.py | 47 +++++++++++++++++++++
 gateway/run.py    | 91 ++++++++++++++++++++++++++++++++++++++--
 2 files changed, 135 insertions(+), 3 deletions(-)
```