### PR TITLE
fix(auth): kimi-coding pool base_url seeding + PKCE endpoint fallback

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -591,7 +591,10 @@ def run_oauth_setup_token() -> Optional[str]:
 # Stores credentials in ~/.hermes/.anthropic_oauth.json (our own file).
 
 _OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
-_OAUTH_TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
+_OAUTH_TOKEN_URLS = [
+    "https://platform.claude.com/v1/oauth/token",
+    "https://console.anthropic.com/v1/oauth/token",
+]
 _OAUTH_REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"
 _OAUTH_SCOPES = "org:create_api_key user:profile user:inference"
 _HERMES_OAUTH_FILE = get_hermes_home() / ".anthropic_oauth.json"
@@ -676,18 +679,29 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
             "code_verifier": verifier,
         }).encode()
 
-        req = urllib.request.Request(
-            _OAUTH_TOKEN_URL,
-            data=exchange_data,
-            headers={
-                "Content-Type": "application/json",
-                "User-Agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
-            },
-            method="POST",
-        )
+        result = None
+        last_error = None
+        for endpoint in _OAUTH_TOKEN_URLS:
+            req = urllib.request.Request(
+                endpoint,
+                data=exchange_data,
+                headers={
+                    "Content-Type": "application/json",
+                    "User-Agent": f"claude-cli/{_get_claude_code_version()} (external, cli)",
+                },
+                method="POST",
+            )
+            try:
+                with urllib.request.urlopen(req, timeout=15) as resp:
+                    result = json.loads(resp.read().decode())
+                break
+            except Exception as exc:
+                logger.debug("Token exchange failed at %s: %s", endpoint, exc)
+                last_error = exc
+                continue
 
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            result = json.loads(resp.read().decode())
+        if result is None:
+            raise last_error or ValueError("Token exchange failed on all endpoints")
     except Exception as e:
         print(f"Token exchange failed: {e}")
         return None

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -27,6 +27,7 @@ from hermes_cli.auth import (
     _is_expiring,
     _load_auth_store,
     _load_provider_state,
+    _resolve_kimi_base_url,
     read_credential_pool,
     write_credential_pool,
 )
@@ -1085,7 +1086,10 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
         source = f"env:{env_var}"
         active_sources.add(source)
         auth_type = AUTH_TYPE_OAUTH if provider == "anthropic" and not token.startswith("sk-ant-api") else AUTH_TYPE_API_KEY
-        base_url = env_url or pconfig.inference_base_url
+        if provider == "kimi-coding":
+            base_url = _resolve_kimi_base_url(token, pconfig.inference_base_url, env_url)
+        else:
+            base_url = env_url or pconfig.inference_base_url
         changed |= _upsert_entry(
             entries,
             provider,


### PR DESCRIPTION
## Summary

Two auth reliability fixes:

### 1. kimi-coding credential pool seeds correct base_url (fixes #5561)

`_seed_from_env()` in `credential_pool.py` now calls `_resolve_kimi_base_url()` for kimi-coding, matching the runtime resolver logic in `auth.py`. Previously, `sk-kimi-` prefixed keys were seeded with the default `api.moonshot.ai/v1` URL (from `pconfig.inference_base_url`), causing HTTP 401 on the first request. The pool would mark the entry exhausted, and the second request would bypass the pool and succeed via the runtime resolver.

### 2. PKCE OAuth token exchange uses endpoint fallback

The Hermes-native PKCE login flow (`run_hermes_oauth_login_pure`) now tries `platform.claude.com` first with `console.anthropic.com` fallback for the token exchange, consistent with `refresh_anthropic_oauth_pure()` which was fixed in PR #3246. The old `_OAUTH_TOKEN_URL` constant hardcoded only `console.anthropic.com`.

## Test plan

- `tests/test_credential_pool.py` — 145 passed
- `tests/test_api_key_providers.py` — all passed
- `tests/test_anthropic_adapter.py` — 107 passed
- E2E verified: sk-kimi- key routes to api.kimi.com/coding/v1, legacy key stays on moonshot, env override wins
- E2E verified: `_OAUTH_TOKEN_URLS` list has platform.claude.com first, old constant removed

## Related issues closed

- #2374 — MiniMax auth override (already fixed on main)
- #2962 — OAuth refresh endpoint (fixed in #3246, remaining PKCE inconsistency fixed here)
- PR #2968 — superseded by #3246
- #933 — Multiple OAuth tokens with fallback (implemented by credential pool system)
- #2783 — Telegram auth creds lost (addressed by 401 refresh system)
- #1826 — User-friendly 429 messages (already implemented)