### PR TITLE
feat(cron): add complexity-based context optimization for cron jobs

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -376,6 +376,7 @@ def create_job(
     provider: Optional[str] = None,
     base_url: Optional[str] = None,
     script: Optional[str] = None,
+    complexity: Optional[str] = "medium",
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -395,6 +396,11 @@ def create_job(
         script: Optional path to a Python script whose stdout is injected into the
                 prompt each run.  The script runs before the agent turn, and its output
                 is prepended as context.  Useful for data collection / change detection.
+        complexity: Prompt complexity classification ("lightweight", "medium", "heavy").
+                   Controls how much context is loaded for the cron session.
+                   - lightweight: minimal identity, essential tools, capped iterations (~2-3k tokens)
+                   - medium: minimal identity, all toolsets, full iterations (~5-7k tokens)
+                   - heavy: full SOUL.md + context files, all toolsets, full iterations (~10-15k tokens)
 
     Returns:
         The created job dict
@@ -426,6 +432,12 @@ def create_job(
     normalized_script = str(script).strip() if isinstance(script, str) else None
     normalized_script = normalized_script or None
 
+    # Validate and normalize complexity
+    valid_complexities = {"lightweight", "medium", "heavy"}
+    normalized_complexity = (complexity or "medium").strip().lower()
+    if normalized_complexity not in valid_complexities:
+        normalized_complexity = "medium"  # Fallback to default
+
     label_source = (prompt or (normalized_skills[0] if normalized_skills else None)) or "cron job"
     job = {
         "id": job_id,
@@ -437,6 +449,7 @@ def create_job(
         "provider": normalized_provider,
         "base_url": normalized_base_url,
         "script": normalized_script,
+        "complexity": normalized_complexity,
         "schedule": parsed_schedule,
         "schedule_display": parsed_schedule.get("display", schedule),
         "repeat": {

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -593,6 +593,74 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             },
         )
 
+        # ── Complexity-based context optimization ─────────────────────────
+        # The job's complexity field (lightweight/medium/heavy) controls how
+        # much context the cron agent receives.  Each tier is genuinely
+        # different — not just a label.
+        #
+        # The three axes that differentiate tiers:
+        #   1. Identity/context  — SOUL.md + context files (AGENTS.md, etc.)
+        #   2. Toolset breadth   — which tools the agent can call
+        #   3. Iteration budget  — how many turns before stopping
+        #
+        # Tiers (each step adds one meaningful layer):
+        #   lightweight  — fetch-and-report, summaries, simple monitors.
+        #                  Minimal identity, essential tools only, capped
+        #                  iterations.  ~2-3k token system prompt.
+        #   medium       — default.  Minimal identity (SOUL.md is dead
+        #                  weight for autonomous tasks), all standard
+        #                  toolsets, full iteration budget.  ~5-7k tokens.
+        #   heavy        — complex analysis needing full cognitive framework.
+        #                  Full SOUL.md + context files, all toolsets,
+        #                  full iterations.  ~10-15k tokens.
+        # ─────────────────────────────────────────────────────────────────
+        complexity = (job.get("complexity") or "medium").strip().lower()
+
+        # Toolsets always disabled for cron jobs (regardless of complexity)
+        _CRON_ALWAYS_DISABLED = ["cronjob", "messaging", "clarify"]
+
+        if complexity == "lightweight":
+            # Strip everything that isn't directly needed for task execution.
+            # Skills content is still injected via _build_job_prompt() (user
+            # message), but the skills *catalog* and management tools are
+            # removed from the system prompt and tool list.
+            disabled_toolsets = _CRON_ALWAYS_DISABLED + [
+                "skills",           # no skill catalog/management in system prompt
+                "todo",             # no task planning overhead
+                "session_search",   # no cross-session recall
+                "delegation",       # no subagent spawning
+                "memory",           # no persistent memory tools (store already skipped)
+                "tts",              # no voice synthesis
+                "browser",          # no browser automation
+                "image_gen",        # no image generation
+                "moa",              # no mixture-of-agents
+            ]
+            skip_context_files = True   # skip SOUL.md, AGENTS.md, .cursorrules
+            max_iterations = min(max_iterations, 25)
+            logger.info(
+                "Job '%s': lightweight — minimal context, %d max iterations",
+                job_name, max_iterations,
+            )
+        elif complexity == "heavy":
+            # Full cognitive framework: SOUL.md personality/reasoning priming
+            # + project context files.  Use for tasks that genuinely benefit
+            # from the agent's full reasoning scaffolding (research synthesis,
+            # multi-step analysis, complex code generation).
+            disabled_toolsets = _CRON_ALWAYS_DISABLED
+            skip_context_files = False
+            logger.info(
+                "Job '%s': heavy — full SOUL.md + context, %d max iterations",
+                job_name, max_iterations,
+            )
+        else:
+            # medium (default): all toolsets but no personality/context bloat.
+            # SOUL.md is dead weight for autonomous cron tasks — the agent
+            # doesn't need cognitive priming, communication style, or
+            # relational stance to fetch data and produce a report.  The cron
+            # execution hint in the user message provides sufficient context.
+            disabled_toolsets = _CRON_ALWAYS_DISABLED
+            skip_context_files = True
+
         agent = AIAgent(
             model=turn_route["model"],
             api_key=turn_route["runtime"].get("api_key"),
@@ -608,8 +676,9 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             providers_ignored=pr.get("ignore"),
             providers_order=pr.get("order"),
             provider_sort=pr.get("sort"),
-            disabled_toolsets=["cronjob", "messaging", "clarify"],
+            disabled_toolsets=disabled_toolsets,
             quiet_mode=True,
+            skip_context_files=skip_context_files,
             skip_memory=True,  # Cron system prompts would corrupt user representations
             platform="cron",
             session_id=_cron_session_id,

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -862,3 +862,173 @@ class TestTickAdvanceBeforeRun:
         adv_mock.assert_called_once_with("test-advance")
         # advance must happen before run
         assert call_order == [("advance", "test-advance"), ("run", "test-advance")]
+
+
+class TestComplexityBasedContextOptimization:
+    """Verify that the job complexity field controls AIAgent construction.
+
+    lightweight → skip_context_files=True, extra toolsets disabled, capped iterations
+    medium     → skip_context_files=True, all toolsets, full iterations
+    heavy      → skip_context_files=False, all toolsets, full iterations
+    """
+
+    _ALWAYS_DISABLED = {"cronjob", "messaging", "clarify"}
+    _LIGHTWEIGHT_EXTRA_DISABLED = {
+        "skills", "todo", "session_search", "delegation",
+        "memory", "tts", "browser", "image_gen", "moa",
+    }
+
+    def _run_job_with_complexity(self, complexity, tmp_path, max_turns=90):
+        """Helper: run_job for a job with the given complexity, return AIAgent kwargs."""
+        job = {
+            "id": f"test-{complexity}",
+            "name": f"test {complexity}",
+            "prompt": "Summarize the latest messages.",
+            "complexity": complexity,
+        }
+        fake_db = MagicMock()
+
+        cfg = {"agent": {"max_turns": max_turns}}
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("yaml.safe_load", return_value=cfg), \
+             patch("builtins.open", MagicMock()), \
+             patch("os.path.exists", return_value=True), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "done"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        return mock_agent_cls.call_args.kwargs
+
+    # ── lightweight ──────────────────────────────────────────────────
+
+    def test_lightweight_skips_context_files(self, tmp_path):
+        kwargs = self._run_job_with_complexity("lightweight", tmp_path)
+        assert kwargs["skip_context_files"] is True
+
+    def test_lightweight_disables_extra_toolsets(self, tmp_path):
+        kwargs = self._run_job_with_complexity("lightweight", tmp_path)
+        disabled = set(kwargs["disabled_toolsets"])
+        assert self._ALWAYS_DISABLED.issubset(disabled)
+        assert self._LIGHTWEIGHT_EXTRA_DISABLED.issubset(disabled)
+
+    def test_lightweight_caps_max_iterations(self, tmp_path):
+        kwargs = self._run_job_with_complexity("lightweight", tmp_path, max_turns=90)
+        assert kwargs["max_iterations"] <= 25
+
+    def test_lightweight_respects_lower_configured_max(self, tmp_path):
+        """If config sets max_turns=10, lightweight should use 10 (not inflate to 25)."""
+        kwargs = self._run_job_with_complexity("lightweight", tmp_path, max_turns=10)
+        assert kwargs["max_iterations"] == 10
+
+    # ── medium (default) ─────────────────────────────────────────────
+    # medium skips SOUL.md/context files (personality is dead weight for
+    # autonomous cron) but keeps all toolsets and full iterations.
+
+    def test_medium_skips_context_files(self, tmp_path):
+        """SOUL.md and context files are dead weight for autonomous cron tasks."""
+        kwargs = self._run_job_with_complexity("medium", tmp_path)
+        assert kwargs["skip_context_files"] is True
+
+    def test_medium_only_disables_cron_toolsets(self, tmp_path):
+        kwargs = self._run_job_with_complexity("medium", tmp_path)
+        disabled = set(kwargs["disabled_toolsets"])
+        assert disabled == self._ALWAYS_DISABLED
+
+    def test_medium_preserves_full_iterations(self, tmp_path):
+        kwargs = self._run_job_with_complexity("medium", tmp_path, max_turns=90)
+        assert kwargs["max_iterations"] == 90
+
+    # ── heavy ────────────────────────────────────────────────────────
+    # heavy is the only tier that loads SOUL.md + context files — for
+    # tasks that genuinely benefit from the full cognitive framework.
+
+    def test_heavy_includes_context_files(self, tmp_path):
+        """Heavy loads full SOUL.md + context files for complex reasoning tasks."""
+        kwargs = self._run_job_with_complexity("heavy", tmp_path)
+        assert kwargs["skip_context_files"] is False
+
+    def test_heavy_only_disables_cron_toolsets(self, tmp_path):
+        kwargs = self._run_job_with_complexity("heavy", tmp_path)
+        disabled = set(kwargs["disabled_toolsets"])
+        assert disabled == self._ALWAYS_DISABLED
+
+    def test_heavy_preserves_full_iterations(self, tmp_path):
+        kwargs = self._run_job_with_complexity("heavy", tmp_path, max_turns=90)
+        assert kwargs["max_iterations"] == 90
+
+    # ── tier differentiation ─────────────────────────────────────────
+
+    def test_each_tier_is_genuinely_different(self, tmp_path):
+        """No two tiers should produce identical AIAgent kwargs."""
+        lw = self._run_job_with_complexity("lightweight", tmp_path)
+        md = self._run_job_with_complexity("medium", tmp_path)
+        hv = self._run_job_with_complexity("heavy", tmp_path)
+
+        # lightweight vs medium: different toolsets + different iteration cap
+        assert set(lw["disabled_toolsets"]) != set(md["disabled_toolsets"])
+
+        # medium vs heavy: different skip_context_files
+        assert md["skip_context_files"] != hv["skip_context_files"]
+
+        # lightweight vs heavy: different on both axes
+        assert set(lw["disabled_toolsets"]) != set(hv["disabled_toolsets"])
+        assert lw["skip_context_files"] == True
+        assert hv["skip_context_files"] == False
+
+    # ── default fallback ─────────────────────────────────────────────
+
+    def test_missing_complexity_defaults_to_medium(self, tmp_path):
+        """A job with no complexity field should behave like medium."""
+        job = {
+            "id": "test-default",
+            "name": "test default",
+            "prompt": "Do the thing.",
+        }
+        fake_db = MagicMock()
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "***",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "done"}
+            mock_agent_cls.return_value = mock_agent
+            run_job(job)
+
+        kwargs = mock_agent_cls.call_args.kwargs
+        disabled = set(kwargs["disabled_toolsets"])
+        assert disabled == self._ALWAYS_DISABLED
+        assert kwargs["skip_context_files"] is True
+
+    # ── skip_memory is always True (all tiers) ───────────────────────
+
+    def test_skip_memory_always_true(self, tmp_path):
+        for tier in ("lightweight", "medium", "heavy"):
+            kwargs = self._run_job_with_complexity(tier, tmp_path)
+            assert kwargs["skip_memory"] is True, f"skip_memory should be True for {tier}"

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -174,6 +174,7 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         "state": job.get("state", "scheduled" if job.get("enabled", True) else "paused"),
         "paused_at": job.get("paused_at"),
         "paused_reason": job.get("paused_reason"),
+        "complexity": job.get("complexity", "medium"),
     }
     if job.get("script"):
         result["script"] = job["script"]
@@ -196,6 +197,7 @@ def cronjob(
     base_url: Optional[str] = None,
     reason: Optional[str] = None,
     script: Optional[str] = None,
+    complexity: Optional[str] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -215,6 +217,19 @@ def cronjob(
                 if scan_error:
                     return json.dumps({"success": False, "error": scan_error}, indent=2)
 
+            # Validate complexity
+            valid_complexity = {"lightweight", "medium", "heavy"}
+            if complexity is not None:
+                complexity_lower = (complexity or "").strip().lower()
+                if complexity_lower not in valid_complexity:
+                    return json.dumps(
+                        {"success": False, "error": f"complexity must be one of {valid_complexity}, got: {complexity!r}"},
+                        indent=2,
+                    )
+                complexity = complexity_lower
+            else:
+                complexity = "medium"  # Default
+
             # Validate script path before storing
             if script:
                 script_error = _validate_cron_script_path(script)
@@ -233,6 +248,7 @@ def cronjob(
                 provider=_normalize_optional_job_value(provider),
                 base_url=_normalize_optional_job_value(base_url, strip_trailing_slash=True),
                 script=_normalize_optional_job_value(script),
+                complexity=complexity,
             )
             return json.dumps(
                 {
@@ -335,6 +351,15 @@ def cronjob(
                 if job.get("state") != "paused":
                     updates["state"] = "scheduled"
                     updates["enabled"] = True
+            if complexity is not None:
+                complexity_lower = (complexity or "").strip().lower()
+                valid_complexity = {"lightweight", "medium", "heavy"}
+                if complexity_lower not in valid_complexity:
+                    return json.dumps(
+                        {"success": False, "error": f"complexity must be one of {valid_complexity}, got: {complexity!r}"},
+                        indent=2,
+                    )
+                updates["complexity"] = complexity_lower
             if not updates:
                 return json.dumps({"success": False, "error": "No updates provided."}, indent=2)
             updated = update_job(job_id, updates)
@@ -468,6 +493,10 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
             "script": {
                 "type": "string",
                 "description": "Optional path to a Python script that runs before each cron job execution. Its stdout is injected into the prompt as context. Use for data collection and change detection. Relative paths resolve under ~/.hermes/scripts/. On update, pass empty string to clear."
+            },
+            "complexity": {
+                "type": "string",
+                "description": "Optional prompt complexity classification: 'lightweight' (minimal identity, essential tools, capped iterations, ~2-3k tokens), 'medium' (minimal identity, all toolsets, full iterations, ~5-7k tokens), or 'heavy' (full SOUL.md + context files, all toolsets, ~10-15k tokens). Defaults to 'medium'."
             }
         },
         "required": ["action"]


### PR DESCRIPTION
## What does this PR do?

Adds complexity-based context optimization for cron jobs, wiring a per-job `complexity` field to control how much context the cron agent receives at execution time.

**Problem:** Every cron job — whether a simple "fetch 10 messages and summarize" or a complex multi-step analysis — spawns an AIAgent with the full ~15k token system prompt (SOUL.md, skills catalog, context files, all toolsets). For simple scheduled tasks that run frequently, this wastes significant tokens.

**Approach:** Introduce a per-job `complexity` field (`lightweight` / `medium` / `heavy`) that tunes the AIAgent construction along three axes:

| Tier | Identity | Context Files | Toolsets | Max Iterations | ~Tokens |
|------|----------|---------------|----------|----------------|---------|
| **lightweight** | DEFAULT_AGENT_IDENTITY | skipped | essential only | ≤25 | ~2-3k |
| **medium** (default) | DEFAULT_AGENT_IDENTITY | skipped | all standard | config default | ~5-7k |
| **heavy** | full SOUL.md | included | all standard | config default | ~10-15k |

Each step up adds exactly one meaningful layer — no two tiers produce identical AIAgent kwargs (enforced by test). Uses existing AIAgent knobs (`skip_context_files`, `disabled_toolsets`, `max_iterations`) — no changes to the agent core.

### Default behavior change

The **medium** tier (default for all jobs, including existing ones) now passes `skip_context_files=True` to AIAgent. Previously, cron jobs loaded SOUL.md, AGENTS.md, and .cursorrules into every agent's system prompt. This context is not useful for autonomous scheduled tasks — SOUL.md is personality/cognitive priming for interactive conversations, AGENTS.md is typically repo development documentation, and .cursorrules is editor configuration. The cron execution hint in the user message provides sufficient task context.

Users who need the full cognitive framework for complex cron jobs can set `complexity: heavy` to restore the previous behavior.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

> **Note:** The default cron behavior changes — medium (default) now skips context files that were previously loaded but unused. This is a deliberate improvement with `heavy` as the opt-in escape hatch. No existing API contracts or config formats change.

## Changes Made

- **`cron/jobs.py`**: Add `complexity` parameter to `create_job()` with validation and storage. Defaults to `"medium"`.
- **`tools/cronjob_tools.py`**: Add `complexity` to the unified `cronjob()` tool function — validation on create/update, `_format_job()` output, and `CRONJOB_SCHEMA` with accurate per-tier descriptions.
- **`cron/scheduler.py`**: Wire `complexity` to AIAgent construction in `run_job()`. Lightweight disables 9 non-essential toolsets (`skills`, `todo`, `session_search`, `delegation`, `memory`, `tts`, `browser`, `image_gen`, `moa`), sets `skip_context_files=True`, and caps iterations at 25. Medium keeps all toolsets but still skips context files. Heavy loads the full SOUL.md + context files. Consumer-side normalization (`strip().lower()`) for defense-in-depth against hand-edited jobs.json.
- **`tests/cron/test_scheduler.py`**: 13 new tests in `TestComplexityBasedContextOptimization` covering all tiers, edge cases (missing field defaults to medium, lower configured max_turns preserved), tier differentiation invariant, and the `skip_memory=True` invariant across all tiers.

## How to Test

1. Run the cron test suite:
   ```bash
   python -m pytest tests/cron/ tests/tools/test_cronjob_tools.py -v
   ```
   Expected: 205 passed (192 existing + 13 new).

2. Create a lightweight cron job and verify reduced context:
   ```python
   from tools.cronjob_tools import cronjob
   result = cronjob(action="create", prompt="Summarize latest news", schedule="every 2h", complexity="lightweight")
   ```

3. Verify existing jobs (no `complexity` field) default to medium behavior — all standard toolsets, context files skipped, full iteration budget.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (13 new tests)
- [x] I've tested on my platform: WSL2 Ubuntu 22.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation — docstrings in `create_job()` describe all three tiers with token estimates
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A: complexity is a per-job parameter set via the `cronjob()` tool, not a config.yaml key
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A: neither file documents cron job parameters or `run_job()` internals; complexity is documented in `create_job()` docstring and `CRONJOB_SCHEMA`
- [x] I've considered cross-platform impact — uses existing AIAgent parameters, no platform-specific code
- [x] I've updated tool descriptions/schemas — `CRONJOB_SCHEMA` includes the `complexity` parameter with accurate tier descriptions
