### PR TITLE
fix(stt): pass language param to local faster-whisper

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -504,6 +504,136 @@ class TestTranscribeLocalExtended:
         assert result["success"] is True
         assert result["transcript"] == "Hello world"
 
+    def test_language_param_passed_to_whisper(self, tmp_path):
+        """When language is provided, it must be forwarded to whisper transcribe()."""
+        audio = tmp_path / "test.ogg"
+        audio.write_bytes(b"fake")
+
+        mock_segment = MagicMock()
+        mock_segment.text = "Czesc"
+        mock_info = MagicMock()
+        mock_info.language = "pl"
+        mock_info.duration = 2.0
+
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = ([mock_segment], mock_info)
+
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("faster_whisper.WhisperModel", return_value=mock_model), \
+             patch("tools.transcription_tools._local_model", None):
+            from tools.transcription_tools import _transcribe_local
+            result = _transcribe_local(str(audio), "base", language="pl")
+
+        mock_model.transcribe.assert_called_once_with(
+            str(audio), beam_size=5, language="pl",
+        )
+        assert result["success"] is True
+
+    def test_language_env_var_used_as_fallback(self, tmp_path, monkeypatch):
+        """HERMES_LOCAL_STT_LANGUAGE env var should be used when no explicit language."""
+        monkeypatch.setenv("HERMES_LOCAL_STT_LANGUAGE", "tr")
+        audio = tmp_path / "test.ogg"
+        audio.write_bytes(b"fake")
+
+        mock_segment = MagicMock()
+        mock_segment.text = "Merhaba"
+        mock_info = MagicMock()
+        mock_info.language = "tr"
+        mock_info.duration = 1.0
+
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = ([mock_segment], mock_info)
+
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("faster_whisper.WhisperModel", return_value=mock_model), \
+             patch("tools.transcription_tools._local_model", None):
+            from tools.transcription_tools import _transcribe_local
+            _transcribe_local(str(audio), "base")
+
+        mock_model.transcribe.assert_called_once_with(
+            str(audio), beam_size=5, language="tr",
+        )
+
+    def test_language_param_overrides_env_var(self, tmp_path, monkeypatch):
+        """Explicit language param takes precedence over env var."""
+        monkeypatch.setenv("HERMES_LOCAL_STT_LANGUAGE", "en")
+        audio = tmp_path / "test.ogg"
+        audio.write_bytes(b"fake")
+
+        mock_segment = MagicMock()
+        mock_segment.text = "Bonjour"
+        mock_info = MagicMock()
+        mock_info.language = "fr"
+        mock_info.duration = 1.0
+
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = ([mock_segment], mock_info)
+
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("faster_whisper.WhisperModel", return_value=mock_model), \
+             patch("tools.transcription_tools._local_model", None):
+            from tools.transcription_tools import _transcribe_local
+            _transcribe_local(str(audio), "base", language="fr")
+
+        mock_model.transcribe.assert_called_once_with(
+            str(audio), beam_size=5, language="fr",
+        )
+
+    def test_no_language_passes_none(self, tmp_path, monkeypatch):
+        """Without language param or env var, None is passed (auto-detect)."""
+        monkeypatch.delenv("HERMES_LOCAL_STT_LANGUAGE", raising=False)
+        audio = tmp_path / "test.ogg"
+        audio.write_bytes(b"fake")
+
+        mock_segment = MagicMock()
+        mock_segment.text = "hello"
+        mock_info = MagicMock()
+        mock_info.language = "en"
+        mock_info.duration = 1.0
+
+        mock_model = MagicMock()
+        mock_model.transcribe.return_value = ([mock_segment], mock_info)
+
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("faster_whisper.WhisperModel", return_value=mock_model), \
+             patch("tools.transcription_tools._local_model", None):
+            from tools.transcription_tools import _transcribe_local
+            _transcribe_local(str(audio), "base")
+
+        mock_model.transcribe.assert_called_once_with(
+            str(audio), beam_size=5, language=None,
+        )
+
+
+# ============================================================================
+# Dispatch: transcribe_audio — language from config
+# ============================================================================
+
+class TestTranscribeAudioLanguageConfig:
+    def test_config_language_passed_to_local(self, sample_ogg):
+        """stt.local.language from config.yaml should reach _transcribe_local."""
+        config = {"local": {"model": "base", "language": "pl"}}
+        with patch("tools.transcription_tools._load_stt_config", return_value=config), \
+             patch("tools.transcription_tools._get_provider", return_value="local"), \
+             patch("tools.transcription_tools._transcribe_local",
+                   return_value={"success": True, "transcript": "Czesc"}) as mock_local:
+            from tools.transcription_tools import transcribe_audio
+            transcribe_audio(sample_ogg)
+
+        assert mock_local.call_args[1]["language"] == "pl"
+
+    def test_no_config_language_passes_none(self, sample_ogg):
+        """Without language in config, None should be passed."""
+        config = {"local": {"model": "base"}}
+        with patch("tools.transcription_tools._load_stt_config", return_value=config), \
+             patch("tools.transcription_tools._get_provider", return_value="local"), \
+             patch("tools.transcription_tools._transcribe_local",
+                   return_value={"success": True, "transcript": "hi"}) as mock_local:
+            from tools.transcription_tools import transcribe_audio
+            transcribe_audio(sample_ogg)
+
+        assert mock_local.call_args[1]["language"] is None
+
 
 # ============================================================================
 # Model auto-correction

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -284,7 +284,7 @@ def _validate_audio_file(file_path: str) -> Optional[Dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
-def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
+def _transcribe_local(file_path: str, model_name: str, language: str = None) -> Dict[str, Any]:
     """Transcribe using faster-whisper (local, free)."""
     global _local_model, _local_model_name
 
@@ -299,7 +299,10 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
             _local_model = WhisperModel(model_name, device="auto", compute_type="auto")
             _local_model_name = model_name
 
-        segments, info = _local_model.transcribe(file_path, beam_size=5)
+        lang = language or os.getenv(LOCAL_STT_LANGUAGE_ENV) or None
+        segments, info = _local_model.transcribe(
+            file_path, beam_size=5, language=lang,
+        )
         transcript = " ".join(segment.text.strip() for segment in segments)
 
         logger.info(
@@ -548,7 +551,8 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
     if provider == "local":
         local_cfg = stt_config.get("local", {})
         model_name = model or local_cfg.get("model", DEFAULT_LOCAL_MODEL)
-        return _transcribe_local(file_path, model_name)
+        language = local_cfg.get("language") or None
+        return _transcribe_local(file_path, model_name, language=language)
 
     if provider == "local_command":
         local_cfg = stt_config.get("local", {})


### PR DESCRIPTION
## Summary

- `_transcribe_local()` (faster-whisper provider) ignored `HERMES_LOCAL_STT_LANGUAGE` env var and had no way to receive a language hint — Whisper always auto-detected the language.
- On short audio segments (<2s) with the `base` model, auto-detect frequently misidentifies non-English speech (Polish, Turkish, etc.) as German, Russian, or English, producing garbage transcripts that cascade into bad LLM responses.
- This also adds support for `stt.local.language` in config.yaml, making it easier to pin language for smaller models.

**Language resolution order:** config (`stt.local.language`) > env var (`HERMES_LOCAL_STT_LANGUAGE`) > `None` (auto-detect)

No changes to Groq, OpenAI, or `local_command` providers. Fully backward compatible — without explicit language, behavior is identical to before.

## Config example

```yaml
stt:
  provider: local
  local:
    model: base
    language: pl   # optional — pin language for better accuracy on small models
```

## Test plan

- [x] New tests: language param forwarded to whisper, env var fallback, param overrides env var, None when unset
- [x] New tests: config language passed through `transcribe_audio()` dispatch
- [x] All 68 existing transcription tests pass