### PR TITLE
fix: accept streamed Codex text when final Responses output is empty

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3443,8 +3443,8 @@ class AIAgent:
     def _normalize_codex_response(self, response: Any) -> tuple[Any, str]:
         """Normalize a Responses API object to an assistant_message-like object."""
         output = getattr(response, "output", None)
-        if not isinstance(output, list) or not output:
-            raise RuntimeError("Responses API returned no output items")
+        if not isinstance(output, list):
+            output = []
 
         response_status = getattr(response, "status", None)
         if isinstance(response_status, str):
@@ -3563,6 +3563,10 @@ class AIAgent:
             out_text = getattr(response, "output_text", "")
             if isinstance(out_text, str):
                 final_text = out_text.strip()
+        if not final_text:
+            streamed_text = getattr(self, "_latest_codex_stream_text", "")
+            if isinstance(streamed_text, str):
+                final_text = streamed_text.strip()
 
         assistant_message = SimpleNamespace(
             content=final_text,
@@ -3868,6 +3872,7 @@ class AIAgent:
         has_tool_calls = False
         first_delta_fired = False
         self._reasoning_deltas_fired = False
+        self._latest_codex_stream_text = ""
         for attempt in range(max_stream_retries + 1):
             try:
                 with active_client.responses.stream(**api_kwargs) as stream:
@@ -3879,6 +3884,7 @@ class AIAgent:
                         if "output_text.delta" in event_type or event_type == "response.output_text.delta":
                             delta_text = getattr(event, "delta", "")
                             if delta_text and not has_tool_calls:
+                                self._latest_codex_stream_text += delta_text
                                 if not first_delta_fired:
                                     first_delta_fired = True
                                     if on_first_delta:
@@ -7359,13 +7365,18 @@ class AIAgent:
                     error_details = []
                     if self.api_mode == "codex_responses":
                         output_items = getattr(response, "output", None) if response is not None else None
+                        output_text = getattr(response, "output_text", None) if response is not None else None
+                        streamed_text = getattr(self, "_latest_codex_stream_text", "")
+                        has_output_text = isinstance(output_text, str) and bool(output_text.strip())
+                        has_streamed_text = isinstance(streamed_text, str) and bool(streamed_text.strip())
                         if response is None:
                             response_invalid = True
                             error_details.append("response is None")
                         elif not isinstance(output_items, list):
-                            response_invalid = True
-                            error_details.append("response.output is not a list")
-                        elif len(output_items) == 0:
+                            if not has_output_text and not has_streamed_text:
+                                response_invalid = True
+                                error_details.append("response.output is not a list")
+                        elif len(output_items) == 0 and not has_output_text and not has_streamed_text:
                             response_invalid = True
                             error_details.append("response.output is empty")
                     elif self.api_mode == "anthropic_messages":

--- a/tests/test_run_agent_codex_responses.py
+++ b/tests/test_run_agent_codex_responses.py
@@ -374,6 +374,24 @@ def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     assert response.output[0].content[0].text == "streamed create ok"
 
 
+def test_normalize_codex_response_accepts_streamed_text_when_final_output_is_empty(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    agent._latest_codex_stream_text = "Hello world"
+
+    empty_final_response = SimpleNamespace(
+        output=[],
+        output_text="",
+        usage=SimpleNamespace(input_tokens=5, output_tokens=3, total_tokens=8),
+        status="completed",
+        model="gpt-5-codex",
+    )
+
+    assistant_message, finish_reason = agent._normalize_codex_response(empty_final_response)
+
+    assert finish_reason == "stop"
+    assert assistant_message.content == "Hello world"
+
+
 def test_run_conversation_codex_plain_text(monkeypatch):
     agent = _build_agent(monkeypatch)
     monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: _codex_message_response("OK"))


### PR DESCRIPTION
## Summary

Fix a false invalid-response failure in the `openai-codex` / `codex_responses` path.

Hermes could visibly stream assistant text to the UI, then still fail the turn with:

- `response.output is empty`
- `Invalid API response shape. Likely rate limited or malformed provider response.`

This happened because the streaming path and the final response validator were not using the same source of truth.

## Problem

In the Codex Responses API path, Hermes currently does two separate things:

1. streams `response.output_text.delta` tokens to the terminal
2. later validates the final response object by requiring a non-empty `response.output` list

If the provider streams usable text but returns an empty final `output` list, Hermes ends up in a contradictory state:

- user sees real assistant text
- Hermes still marks the response invalid
- retries/fallbacks trigger unnecessarily
- the turn can fail even though content was already produced

## Repro

I reproduced this on the main repo before this patch by:

- setting `_latest_codex_stream_text = "Hello world"`
- passing a completed Codex response with `output=[]`
- calling `_normalize_codex_response(...)`

Before this patch, that raised:

`RuntimeError: Responses API returned no output items`

## Root cause

The `codex_responses` path assumed that a valid final response must always have a non-empty `response.output`.

That assumption is too strict for streamed Codex responses. In practice, usable visible text can already have been delivered via stream deltas even when the final response object has:

- `output=[]`
- empty or missing `output_text`

So Hermes was validating one field while rendering from another path.

## What changed

### `run_agent.py`

- buffer streamed Codex text in `_run_codex_stream()`
- allow Codex response validation to succeed when either:
  - `response.output_text` has text, or
  - streamed text was already captured
- relax `_normalize_codex_response()` so it does not hard-fail solely because `response.output` is empty/non-list
- use buffered streamed text as a fallback final response when normalized message content is otherwise empty

### `tests/test_run_agent_codex_responses.py`

Added a regression test covering:

- empty final `response.output`
- empty `response.output_text`
- non-empty buffered streamed text

Expected result: `_normalize_codex_response()` still returns a valid assistant message with the streamed text.

## Why this matters

This fixes the specific UX where Hermes prints assistant output and then immediately says the provider returned an invalid empty response.

It also reduces unnecessary retries and false “likely rate limited or malformed provider response” errors for the Codex Responses API path.

## Scope

Small and isolated:

- only affects `api_mode == "codex_responses"`
- no behavior change for chat completions or Anthropic paths
- only changes fallback behavior when final structured Codex output is empty

## Validation

### Repro before patch
Confirmed on the main repo that `_normalize_codex_response()` raised:

`RuntimeError: Responses API returned no output items`

even when streamed text had already been captured.

### Repro after patch
Confirmed the same repro now returns:

- `finish_reason == "stop"`
- `assistant_message.content == "Hello world"`

### Targeted tests
Ran:

```bash
/Users/matthewsegura/Documents/Dev/hermes-agent/venv/bin/python -m pytest tests/test_run_agent_codex_responses.py -k "normalize_codex_response_accepts_streamed_text_when_final_output_is_empty or run_codex_stream_retries_when_completed_event_missing or run_codex_stream_fallback_parses_create_stream_events or run_conversation_codex_plain_text"
```

Result:

- `4 passed`

## Risk

Low.

The main behavior change is that Hermes now trusts streamed Codex text as valid fallback content when the final Responses API object is empty, instead of retrying/failing a turn that already produced visible text.

## Rollback

Revert this PR to restore the previous strict `response.output` requirement.
