### PR TITLE
fix: serialize Pydantic AnyUrl fields when persisting MCP OAuth state

### DIFF
--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -203,7 +203,7 @@ class HermesTokenStorage:
             return None
 
     async def set_tokens(self, tokens: "OAuthToken") -> None:
-        _write_json(self._tokens_path(), tokens.model_dump(exclude_none=True))
+        _write_json(self._tokens_path(), tokens.model_dump(mode="json", exclude_none=True))
         logger.debug("OAuth tokens saved for %s", self._server_name)
 
     # -- client info -------------------------------------------------------
@@ -219,7 +219,7 @@ class HermesTokenStorage:
             return None
 
     async def set_client_info(self, client_info: "OAuthClientInformationFull") -> None:
-        _write_json(self._client_info_path(), client_info.model_dump(exclude_none=True))
+        _write_json(self._client_info_path(), client_info.model_dump(mode="json", exclude_none=True))
         logger.debug("OAuth client info saved for %s", self._server_name)
 
     # -- cleanup -----------------------------------------------------------
@@ -462,7 +462,7 @@ def build_oauth_auth(
             info_dict["scope"] = scope
 
         client_info = OAuthClientInformationFull.model_validate(info_dict)
-        _write_json(storage._client_info_path(), client_info.model_dump(exclude_none=True))
+        _write_json(storage._client_info_path(), client_info.model_dump(mode="json", exclude_none=True))
         logger.debug("Pre-registered client_id=%s for '%s'", client_id, server_name)
 
     # --- Base URL for discovery ---


### PR DESCRIPTION
## Summary
- Fix `TypeError: Object of type AnyUrl is not JSON serializable` crash when persisting OAuth state for MCP servers
- Three call sites in `tools/mcp_oauth.py` use `model_dump(exclude_none=True)` which leaves Pydantic `AnyUrl` objects in the returned dict, breaking the subsequent `json.dumps`

## Reproduction
Configure any OAuth-based MCP server (e.g. alphaxiv) and start hermes:

```
hermes
OAuth flow error
Traceback (most recent call last):
  File ".../mcp/client/auth/oauth2.py", line 583, in async_auth_flow
    await self.context.storage.set_client_info(client_information)
  File ".../tools/mcp_oauth.py", line 222, in set_client_info
    _write_json(self._client_info_path(), client_info.model_dump(exclude_none=True))
  File ".../tools/mcp_oauth.py", line 117, in _write_json
    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
  ...
TypeError: Object of type AnyUrl is not JSON serializable
Failed to connect to MCP server 'alphaxiv': Object of type AnyUrl is not JSON serializable
```

The MCP server fails registration and is marked as `failed` in the MCP servers list.

## Root Cause
`OAuthClientInformationFull` and `OAuthToken` from the MCP SDK contain Pydantic fields typed as `AnyUrl` (e.g. `client_uri`, `redirect_uris`, `jwks_uri`). Pydantic's default `model_dump()` preserves these as native `AnyUrl` instances rather than converting them to strings. The standard library `json.dumps` then has no way to serialize them.

## Fix
Use `model_dump(mode="json", ...)` instead. The `mode="json"` flag tells Pydantic to convert all fields to JSON-compatible primitives (`AnyUrl` → `str`, `datetime` → ISO string, etc.) before returning the dict, so the existing `_write_json` helper works without further changes.

Three call sites fixed:
- `HermesTokenStorage.set_tokens` (line 206)
- `HermesTokenStorage.set_client_info` (line 222)
- `build_oauth_auth` pre-registration write (line 465)

## Test plan
- [ ] Configure an OAuth-based MCP server (alphaxiv, GitHub MCP, etc.)
- [ ] Start hermes — verify no `OAuth flow error` traceback
- [ ] Verify MCP server registers successfully (not in failed list)
- [ ] Verify the persisted client info / token JSON files on disk are valid JSON
- [ ] Verify subsequent reads via `get_client_info` / `get_tokens` round-trip correctly through `model_validate`

Discovered while running hermes with the alphaxiv MCP server configured.