### PR TITLE
fix(cron): recover recurring jobs with null next_run_at

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -666,19 +666,25 @@ def get_due_jobs() -> List[Dict[str, Any]]:
 
         next_run = job.get("next_run_at")
         if not next_run:
-            recovered_next = _recoverable_oneshot_run_at(
-                job.get("schedule", {}),
-                now,
-                last_run_at=job.get("last_run_at"),
-            )
+            schedule = job.get("schedule", {})
+            kind = schedule.get("kind")
+            if kind in ("cron", "interval"):
+                recovered_next = compute_next_run(schedule, job.get("last_run_at"))
+            else:
+                recovered_next = _recoverable_oneshot_run_at(
+                    schedule,
+                    now,
+                    last_run_at=job.get("last_run_at"),
+                )
             if not recovered_next:
                 continue
 
             job["next_run_at"] = recovered_next
             next_run = recovered_next
             logger.info(
-                "Job '%s' had no next_run_at; recovering one-shot run at %s",
+                "Job '%s' had no next_run_at; recovered %s run at %s",
                 job.get("name", job["id"]),
+                kind or "unknown",
                 recovered_next,
             )
             for rj in raw_jobs:

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -506,6 +506,74 @@ class TestGetDueJobs:
         assert [job["id"] for job in due] == ["oneshot-recover"]
         assert get_job("oneshot-recover")["next_run_at"] == run_at
 
+    def test_recurring_cron_job_without_next_run_is_recovered(self, tmp_cron_dir, monkeypatch):
+        """Recurring cron jobs with null next_run_at should recompute via compute_next_run()."""
+        now = datetime(2026, 3, 18, 10, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        save_jobs(
+            [{
+                "id": "cron-recover",
+                "name": "Daily standup",
+                "prompt": "Good morning",
+                "schedule": {"kind": "cron", "expr": "0 9 * * *", "display": "daily at 09:00"},
+                "schedule_display": "daily at 09:00",
+                "repeat": {"times": -1, "completed": 3},
+                "enabled": True,
+                "state": "scheduled",
+                "paused_at": None,
+                "paused_reason": None,
+                "created_at": "2026-03-10T08:00:00+00:00",
+                "next_run_at": None,
+                "last_run_at": "2026-03-17T09:00:00+00:00",
+                "last_status": None,
+                "last_error": None,
+                "deliver": "local",
+                "origin": None,
+            }]
+        )
+
+        due = get_due_jobs()
+
+        # The job should not be due right now (next cron hit is tomorrow 09:00),
+        # but its next_run_at should have been recovered and persisted.
+        recovered = get_job("cron-recover")
+        assert recovered["next_run_at"] is not None, "Recurring cron job next_run_at was not recovered"
+
+    def test_recurring_interval_job_without_next_run_is_recovered(self, tmp_cron_dir, monkeypatch):
+        """Recurring interval jobs with null next_run_at should recompute via compute_next_run()."""
+        now = datetime(2026, 3, 18, 10, 0, 0, tzinfo=timezone.utc)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        save_jobs(
+            [{
+                "id": "interval-recover",
+                "name": "Health check",
+                "prompt": "Check health",
+                "schedule": {"kind": "interval", "minutes": 30, "display": "every 30 minutes"},
+                "schedule_display": "every 30 minutes",
+                "repeat": {"times": -1, "completed": 10},
+                "enabled": True,
+                "state": "scheduled",
+                "paused_at": None,
+                "paused_reason": None,
+                "created_at": "2026-03-10T08:00:00+00:00",
+                "next_run_at": None,
+                "last_run_at": "2026-03-18T09:30:00+00:00",
+                "last_status": None,
+                "last_error": None,
+                "deliver": "local",
+                "origin": None,
+            }]
+        )
+
+        due = get_due_jobs()
+
+        # Interval job: last_run + 30min = 10:00, which equals now, so it should be due.
+        assert [job["id"] for job in due] == ["interval-recover"]
+        recovered = get_job("interval-recover")
+        assert recovered["next_run_at"] is not None, "Recurring interval job next_run_at was not recovered"
+
     def test_broken_stale_one_shot_without_next_run_is_not_recovered(self, tmp_cron_dir, monkeypatch):
         now = datetime(2026, 3, 18, 4, 30, 0, tzinfo=timezone.utc)
         monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)


### PR DESCRIPTION
## Summary

- **Problem:** Recurring cron/interval jobs silently stop firing when `next_run_at` is null. The recovery path in `get_due_jobs()` only handles one-shot jobs via `_recoverable_oneshot_run_at()`, which returns `None` for recurring schedules, causing a silent `continue`.
- **Fix:** Route recurring jobs (`cron`/`interval`) through `compute_next_run()` to recompute the next fire time from the schedule expression and `last_run_at`. One-shot recovery behavior is unchanged.
- **Tests:** Added two regression tests covering both cron-expression and interval recovery paths. All 54 existing tests pass.

## Root Cause

In `get_due_jobs()` (line 668), when `next_run_at` is null:

```python
# Before (broken for recurring jobs):
recovered_next = _recoverable_oneshot_run_at(schedule, now, ...)
# _recoverable_oneshot_run_at returns None for kind != "once"
if not recovered_next:
    continue  # recurring job silently skipped forever
```

`_recoverable_oneshot_run_at()` (line 237) immediately returns `None` for any schedule kind other than `"once"`, so recurring cron/interval jobs with null `next_run_at` are permanently lost.

## Changes

| File | Change |
|------|--------|
| `cron/jobs.py` | Route `cron`/`interval` jobs through `compute_next_run()` before falling back to one-shot recovery |
| `tests/cron/test_jobs.py` | Add `test_recurring_cron_job_without_next_run_is_recovered` and `test_recurring_interval_job_without_next_run_is_recovered` |

## Test Plan

- [x] New: cron job with null `next_run_at` → `compute_next_run()` recomputes next fire time
- [x] New: interval job with null `next_run_at` → `compute_next_run()` recomputes from `last_run_at`
- [x] Existing: one-shot recovery unchanged (2 existing tests still pass)
- [x] Full suite: 54/54 tests pass, 0 regressions

Fixes #5518

Signed-off-by: supermario_leo <leo.stack@outlook.com>