### PR TITLE
fix(test): mock getpass in OAuth flow test

### DIFF
--- a/tests/test_anthropic_oauth_flow.py
+++ b/tests/test_anthropic_oauth_flow.py
@@ -40,6 +40,7 @@ def test_run_anthropic_oauth_flow_manual_token_still_persists(tmp_path, monkeypa
     monkeypatch.setattr("agent.anthropic_adapter.read_claude_code_credentials", lambda: None)
     monkeypatch.setattr("agent.anthropic_adapter.is_claude_code_token_valid", lambda creds: False)
     monkeypatch.setattr("builtins.input", lambda _prompt="": "sk-ant-oat01-manual-token")
+    monkeypatch.setattr("getpass.getpass", lambda _prompt="": "sk-ant-oat01-manual-token")
 
     from hermes_cli.main import _run_anthropic_oauth_flow
 


### PR DESCRIPTION
Closes #5687

## Summary

- `test_run_anthropic_oauth_flow_manual_token_still_persists` mocked `builtins.input` but not `getpass.getpass`
- When `run_oauth_setup_token()` returns `None`, the flow falls through to `getpass.getpass()` which reads stdin under pytest capture, causing `OSError`
- Fix: add `monkeypatch.setattr("getpass.getpass", ...)` to return the test token

## Test plan

- [x] Previously failing test now passes
- [x] Both OAuth flow tests pass