### PR TITLE
fix(credential-pool): harden multi-account pool — health scoring, dynamic cooldown, leases, mark_success

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -101,6 +101,14 @@ class PooledCredential:
     last_error_reason: Optional[str] = None
     last_error_message: Optional[str] = None
     last_error_reset_at: Optional[float] = None
+    cooldown_until: Optional[float] = None
+    last_retry_after_seconds: Optional[float] = None
+    last_error_category: Optional[str] = None
+    last_success_at: Optional[float] = None
+    consecutive_failures: int = 0
+    consecutive_429s: int = 0
+    transient_error_count: int = 0
+    structural_error_count: int = 0
     base_url: Optional[str] = None
     expires_at: Optional[str] = None
     expires_at_ms: Optional[int] = None
@@ -191,6 +199,14 @@ def _exhausted_ttl(error_code: Optional[int]) -> int:
     if error_code == 429:
         return EXHAUSTED_TTL_429_SECONDS
     return EXHAUSTED_TTL_DEFAULT_SECONDS
+
+
+def _is_structural_error(error_code: Optional[int]) -> bool:
+    return error_code in {401, 402, 403}
+
+
+def _is_transient_error(error_code: Optional[int]) -> bool:
+    return error_code in {408, 409, 425, 429, 500, 502, 503, 504, 529}
 
 
 def _parse_absolute_timestamp(value: Any) -> Optional[float]:
@@ -349,12 +365,16 @@ def get_pool_strategy(provider: str) -> str:
 
 
 class CredentialPool:
+    DEFAULT_MAX_CONCURRENT_PER_CREDENTIAL = 2
+
     def __init__(self, provider: str, entries: List[PooledCredential]):
         self.provider = provider
         self._entries = sorted(entries, key=lambda entry: entry.priority)
         self._current_id: Optional[str] = None
         self._strategy = get_pool_strategy(provider)
         self._lock = threading.Lock()
+        self._active_leases: Dict[str, int] = {}
+        self._max_concurrent: int = self.DEFAULT_MAX_CONCURRENT_PER_CREDENTIAL
 
     def has_credentials(self) -> bool:
         return bool(self._entries)
@@ -389,16 +409,34 @@ class CredentialPool:
         entry: PooledCredential,
         status_code: Optional[int],
         error_context: Optional[Dict[str, Any]] = None,
+        retry_after_seconds: Optional[float] = None,
+        error_category: Optional[str] = None,
     ) -> PooledCredential:
         normalized_error = _normalize_error_context(error_context)
+        now = time.time()
+        cooldown_until = None
+        if retry_after_seconds is not None:
+            try:
+                retry_after_seconds = max(0.0, float(retry_after_seconds))
+            except (TypeError, ValueError):
+                retry_after_seconds = None
+        if retry_after_seconds is not None:
+            cooldown_until = now + retry_after_seconds
         updated = replace(
             entry,
             last_status=STATUS_EXHAUSTED,
-            last_status_at=time.time(),
+            last_status_at=now,
             last_error_code=status_code,
             last_error_reason=normalized_error.get("reason"),
             last_error_message=normalized_error.get("message"),
             last_error_reset_at=normalized_error.get("reset_at"),
+            last_error_category=error_category,
+            cooldown_until=cooldown_until,
+            last_retry_after_seconds=retry_after_seconds,
+            consecutive_failures=entry.consecutive_failures + 1,
+            consecutive_429s=(entry.consecutive_429s + 1) if status_code == 429 else 0,
+            transient_error_count=entry.transient_error_count + (1 if _is_transient_error(status_code) else 0),
+            structural_error_count=entry.structural_error_count + (1 if _is_structural_error(status_code) else 0),
         )
         self._replace_entry(entry, updated)
         self._persist()
@@ -643,6 +681,19 @@ class CredentialPool:
         with self._lock:
             return self._select_unlocked()
 
+    def _entry_health_score(self, entry: PooledCredential, *, now: Optional[float] = None) -> float:
+        """Compute a health score for an entry. Higher is better."""
+        now = time.time() if now is None else now
+        score = 100.0
+        score -= min(entry.consecutive_failures * 8.0, 40.0)
+        score -= min(entry.consecutive_429s * 12.0, 36.0)
+        score -= min(entry.transient_error_count * 2.5, 20.0)
+        score -= min(entry.structural_error_count * 10.0, 50.0)
+        if entry.last_success_at:
+            age = max(0.0, now - entry.last_success_at)
+            score += max(0.0, 8.0 - min(age / 60.0, 8.0))
+        return score
+
     def _available_entries(self, *, clear_expired: bool = False, refresh: bool = False) -> List[PooledCredential]:
         """Return entries not currently in exhaustion cooldown.
 
@@ -674,8 +725,16 @@ class CredentialPool:
                     entry = synced
                     cleared_any = True
             if entry.last_status == STATUS_EXHAUSTED:
-                exhausted_until = _exhausted_until(entry)
-                if exhausted_until is not None and now < exhausted_until:
+                # 1. Check dynamic cooldown_until first (from Retry-After headers)
+                if entry.cooldown_until is not None and now < entry.cooldown_until:
+                    continue
+                # 2. Check explicit reset_at from error context (e.g. provider-reported weekly reset)
+                reset_at = _parse_absolute_timestamp(getattr(entry, "last_error_reset_at", None))
+                if reset_at is not None and now < reset_at:
+                    continue
+                # 3. Fallback to fixed TTL
+                ttl = _exhausted_ttl(entry.last_error_code)
+                if entry.last_status_at and now - entry.last_status_at < ttl:
                     continue
                 if clear_expired:
                     cleared = replace(
@@ -686,6 +745,8 @@ class CredentialPool:
                         last_error_reason=None,
                         last_error_message=None,
                         last_error_reset_at=None,
+                        cooldown_until=None,
+                        last_retry_after_seconds=None,
                     )
                     self._replace_entry(entry, cleared)
                     entry = cleared
@@ -707,18 +768,27 @@ class CredentialPool:
             logger.info("credential pool: no available entries (all exhausted or empty)")
             return None
 
+        now = time.time()
+        # Sort by health score descending, then priority, then request_count
+        prioritized = sorted(
+            available,
+            key=lambda e: (-self._entry_health_score(e, now=now), e.priority, e.request_count),
+        )
+
         if self._strategy == STRATEGY_RANDOM:
-            entry = random.choice(available)
+            best_score = self._entry_health_score(prioritized[0], now=now)
+            candidates = [e for e in prioritized if self._entry_health_score(e, now=now) == best_score]
+            entry = random.choice(candidates)
             self._current_id = entry.id
             return entry
 
-        if self._strategy == STRATEGY_LEAST_USED and len(available) > 1:
-            entry = min(available, key=lambda e: e.request_count)
+        if self._strategy == STRATEGY_LEAST_USED and len(prioritized) > 1:
+            entry = min(prioritized, key=lambda e: (-self._entry_health_score(e, now=now), e.request_count, e.priority))
             self._current_id = entry.id
             return entry
 
-        if self._strategy == STRATEGY_ROUND_ROBIN and len(available) > 1:
-            entry = available[0]
+        if self._strategy == STRATEGY_ROUND_ROBIN and len(prioritized) > 1:
+            entry = prioritized[0]
             rotated = [candidate for candidate in self._entries if candidate.id != entry.id]
             rotated.append(replace(entry, priority=len(self._entries) - 1))
             self._entries = [replace(candidate, priority=idx) for idx, candidate in enumerate(rotated)]
@@ -726,9 +796,13 @@ class CredentialPool:
             self._current_id = entry.id
             return self.current() or entry
 
-        entry = available[0]
+        entry = prioritized[0]
         self._current_id = entry.id
         return entry
+
+    def size(self) -> int:
+        """Return the total number of entries in the pool."""
+        return len(self._entries)
 
     def peek(self) -> Optional[PooledCredential]:
         current = self.current()
@@ -742,6 +816,8 @@ class CredentialPool:
         *,
         status_code: Optional[int],
         error_context: Optional[Dict[str, Any]] = None,
+        retry_after_seconds: Optional[float] = None,
+        error_category: Optional[str] = None,
     ) -> Optional[PooledCredential]:
         with self._lock:
             entry = self.current() or self._select_unlocked()
@@ -752,13 +828,87 @@ class CredentialPool:
                 "credential pool: marking %s exhausted (status=%s), rotating",
                 _label, status_code,
             )
-            self._mark_exhausted(entry, status_code, error_context)
+            self._mark_exhausted(
+                entry, status_code, error_context,
+                retry_after_seconds=retry_after_seconds,
+                error_category=error_category,
+            )
             self._current_id = None
             next_entry = self._select_unlocked()
             if next_entry:
                 _next_label = next_entry.label or next_entry.id[:8]
                 logger.info("credential pool: rotated to %s", _next_label)
             return next_entry
+
+    def acquire_lease(self, credential_id: Optional[str] = None) -> Optional[str]:
+        """Acquire a lease on a credential, preferring the least-leased available entry.
+
+        If *credential_id* is given, lease that specific entry.
+        Otherwise, select the best available entry considering both availability
+        and current lease count. Returns the leased credential ID, or None.
+        """
+        with self._lock:
+            if credential_id:
+                self._active_leases[credential_id] = self._active_leases.get(credential_id, 0) + 1
+                return credential_id
+
+            available = self._available_entries(clear_expired=True, refresh=True)
+            if not available:
+                return None
+
+            below_cap = [e for e in available if self._active_leases.get(e.id, 0) < self._max_concurrent]
+            candidates = below_cap if below_cap else available
+
+            chosen = min(
+                candidates,
+                key=lambda e: (
+                    self._active_leases.get(e.id, 0),
+                    -self._entry_health_score(e),
+                    e.priority,
+                ),
+            )
+            self._active_leases[chosen.id] = self._active_leases.get(chosen.id, 0) + 1
+            self._current_id = chosen.id
+            return chosen.id
+
+    def release_lease(self, credential_id: str) -> None:
+        """Release a lease on a credential."""
+        with self._lock:
+            count = self._active_leases.get(credential_id, 0)
+            if count <= 1:
+                self._active_leases.pop(credential_id, None)
+            else:
+                self._active_leases[credential_id] = count - 1
+
+    def active_lease_count(self, credential_id: str) -> int:
+        """Return the number of active leases on a credential (thread-safe)."""
+        with self._lock:
+            return self._active_leases.get(credential_id, 0)
+
+    def mark_success(self, credential_id: Optional[str] = None) -> None:
+        """Record a successful request, resetting error counters and updating last_success_at.
+
+        Call this after any request that completes without an API error so the
+        health score reflects current credential health rather than stale history.
+        If *credential_id* is None, the current credential is used.
+        """
+        with self._lock:
+            target_id = credential_id or self._current_id
+            if not target_id:
+                return
+            for idx, entry in enumerate(self._entries):
+                if entry.id != target_id:
+                    continue
+                updated = replace(
+                    entry,
+                    last_success_at=time.time(),
+                    last_status=STATUS_OK,
+                    consecutive_failures=0,
+                    consecutive_429s=0,
+                )
+                self._entries[idx] = updated
+                self._persist()
+                return
 
     def try_refresh_current(self) -> Optional[PooledCredential]:
         with self._lock:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -458,6 +458,7 @@ DEFAULT_CONFIG = {
         "provider": "",    # e.g. "openrouter" (empty = inherit parent provider + credentials)
         "base_url": "",    # direct OpenAI-compatible endpoint for subagents
         "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
+        "reasoning_effort": "",  # e.g. "low" (empty = inherit parent reasoning config)
         "max_iterations": 50,  # per-subagent iteration cap (each subagent gets its own budget,
                                # independent of the parent's max_iterations)
     },

--- a/run_agent.py
+++ b/run_agent.py
@@ -36,6 +36,7 @@ import sys
 import tempfile
 import time
 import threading
+from email.utils import parsedate_to_datetime
 import weakref
 from types import SimpleNamespace
 import uuid
@@ -4167,12 +4168,106 @@ class AIAgent:
         self._apply_client_headers_for_base_url(self.base_url)
         self._replace_primary_openai_client(reason="credential_rotation")
 
+    def _extract_retry_after_seconds(self, api_error: Any) -> Optional[float]:
+        """Extract Retry-After/reset hints from an API error response if present."""
+        response = getattr(api_error, "response", None)
+        headers = getattr(response, "headers", None) if response is not None else None
+        if not headers:
+            headers = getattr(api_error, "headers", None)
+        if not headers:
+            return None
+
+        def _header(name: str) -> Optional[str]:
+            value = None
+            try:
+                value = headers.get(name)
+            except Exception:
+                value = None
+            if value is None:
+                try:
+                    value = headers.get(name.lower())
+                except Exception:
+                    value = None
+            if value is None:
+                try:
+                    value = headers[name]
+                except Exception:
+                    value = None
+            if value is None:
+                return None
+            text = str(value).strip()
+            return text or None
+
+        retry_after = _header("Retry-After")
+        if retry_after:
+            try:
+                return max(0.0, float(retry_after))
+            except ValueError:
+                try:
+                    retry_dt = parsedate_to_datetime(retry_after)
+                    return max(0.0, retry_dt.timestamp() - time.time())
+                except Exception:
+                    pass
+
+        for header_name in (
+            "x-ratelimit-reset",
+            "x-rate-limit-reset",
+            "ratelimit-reset",
+            "rate-limit-reset",
+        ):
+            raw_reset = _header(header_name)
+            if not raw_reset:
+                continue
+            try:
+                reset_value = float(raw_reset)
+            except ValueError:
+                continue
+            now = time.time()
+            if reset_value > now + 1:
+                return max(0.0, reset_value - now)
+            if reset_value > 0:
+                return reset_value
+        return None
+
+    def _classify_api_failure(self, api_error: Any, status_code: Optional[int]) -> str:
+        """Classify API failures into stable categories for pool/logging decisions."""
+        error_msg = str(api_error).lower() if api_error is not None else ""
+
+        if status_code == 429 or any(term in error_msg for term in ("rate limit", "too many requests", "rate_limit")):
+            return "transient_rate_limit"
+        if status_code == 402 or "quota" in error_msg or "usage limit" in error_msg:
+            return "quota_exhausted"
+        if status_code in (500, 502, 503, 504, 529) or any(term in error_msg for term in ("overloaded", "temporarily unavailable", "service unavailable", "bad gateway")):
+            return "transient_overload"
+        if status_code == 401:
+            return "auth_structural"
+        if status_code == 403:
+            return "provider_misconfigured"
+        if isinstance(api_error, TimeoutError) or any(term in error_msg for term in ("timed out", "timeout", "read timeout", "connect timeout")):
+            return "transient_network"
+        if any(term in error_msg for term in ("connection reset", "connection aborted", "connection refused", "network error", "temporary failure in name resolution")):
+            return "transient_network"
+        if status_code == 413:
+            return "payload_too_large"
+        return "unknown_error"
+
+    def _should_defer_fallback_to_credential_pool(self) -> bool:
+        """Return True when fallback providers should wait for pool recovery first.
+
+        We prefer exhausting healthy credentials within the current provider before
+        jumping to a fallback provider. This keeps the runtime on the same backend
+        when the issue is account-local rather than provider-wide.
+        """
+        pool = self._credential_pool
+        return bool(pool is not None and pool.has_available())
+
     def _recover_with_credential_pool(
         self,
         *,
         status_code: Optional[int],
         has_retried_429: bool,
         error_context: Optional[Dict[str, Any]] = None,
+        api_error: Any = None,
     ) -> tuple[bool, bool]:
         """Attempt credential recovery via pool rotation.
 
@@ -4186,8 +4281,16 @@ class AIAgent:
         if pool is None or status_code is None:
             return False, has_retried_429
 
+        retry_after_seconds = self._extract_retry_after_seconds(api_error)
+        error_category = self._classify_api_failure(api_error, status_code)
+
         if status_code == 402:
-            next_entry = pool.mark_exhausted_and_rotate(status_code=402, error_context=error_context)
+            next_entry = pool.mark_exhausted_and_rotate(
+                status_code=402,
+                error_context=error_context,
+                retry_after_seconds=retry_after_seconds,
+                error_category=error_category,
+            )
             if next_entry is not None:
                 logger.info(f"Credential 402 (billing) — rotated to pool entry {getattr(next_entry, 'id', '?')}")
                 self._swap_credential(next_entry)
@@ -4197,7 +4300,12 @@ class AIAgent:
         if status_code == 429:
             if not has_retried_429:
                 return False, True
-            next_entry = pool.mark_exhausted_and_rotate(status_code=429, error_context=error_context)
+            next_entry = pool.mark_exhausted_and_rotate(
+                status_code=429,
+                error_context=error_context,
+                retry_after_seconds=retry_after_seconds,
+                error_category=error_category,
+            )
             if next_entry is not None:
                 logger.info(f"Credential 429 (rate limit) — rotated to pool entry {getattr(next_entry, 'id', '?')}")
                 self._swap_credential(next_entry)
@@ -4211,8 +4319,12 @@ class AIAgent:
                 self._swap_credential(refreshed)
                 return True, has_retried_429
             # Refresh failed — rotate to next credential instead of giving up.
-            # The failed entry is already marked exhausted by try_refresh_current().
-            next_entry = pool.mark_exhausted_and_rotate(status_code=401, error_context=error_context)
+            next_entry = pool.mark_exhausted_and_rotate(
+                status_code=401,
+                error_context=error_context,
+                retry_after_seconds=retry_after_seconds,
+                error_category=error_category,
+            )
             if next_entry is not None:
                 logger.info(f"Credential 401 (refresh failed) — rotated to pool entry {getattr(next_entry, 'id', '?')}")
                 self._swap_credential(next_entry)
@@ -7799,6 +7911,11 @@ class AIAgent:
                     
                     has_retried_429 = False  # Reset on success
                     self._touch_activity(f"API call #{api_call_count} completed")
+                    # Notify the credential pool of a successful request so it
+                    # can reset error counters and update last_success_at for
+                    # accurate health scoring on subsequent selections.
+                    if self._credential_pool is not None:
+                        self._credential_pool.mark_success()
                     break  # Success, exit retry loop
 
                 except InterruptedError:
@@ -7846,6 +7963,7 @@ class AIAgent:
                         status_code=status_code,
                         has_retried_429=has_retried_429,
                         error_context=error_context,
+                        api_error=api_error,
                     )
                     if recovered_with_pool:
                         continue
@@ -7901,13 +8019,15 @@ class AIAgent:
                     
                     error_type = type(api_error).__name__
                     error_msg = str(api_error).lower()
+                    failure_category = self._classify_api_failure(api_error, status_code)
                     _error_summary = self._summarize_api_error(api_error)
                     logger.warning(
-                        "API call failed (attempt %s/%s) error_type=%s %s summary=%s",
+                        "API call failed (attempt %s/%s) error_type=%s %s category=%s summary=%s",
                         retry_count,
                         max_retries,
                         error_type,
                         self._client_log_context(),
+                        failure_category,
                         _error_summary,
                     )
 
@@ -7918,6 +8038,7 @@ class AIAgent:
                     self._vprint(f"{self.log_prefix}⚠️  API call failed (attempt {retry_count}/{max_retries}): {error_type}{_status_code_str}", force=True)
                     self._vprint(f"{self.log_prefix}   🔌 Provider: {_provider}  Model: {_model}", force=True)
                     self._vprint(f"{self.log_prefix}   🌐 Endpoint: {_base}", force=True)
+                    self._vprint(f"{self.log_prefix}   🧭 Category: {failure_category}", force=True)
                     self._vprint(f"{self.log_prefix}   📝 Error: {_error_summary}", force=True)
                     if status_code and status_code < 500:
                         _err_body = getattr(api_error, "body", None)
@@ -8003,22 +8124,13 @@ class AIAgent:
                     # When a fallback model is configured, switch immediately instead
                     # of burning through retries with exponential backoff -- the
                     # primary provider won't recover within the retry window.
-                    is_rate_limited = (
-                        status_code == 429
-                        or "rate limit" in error_msg
-                        or "too many requests" in error_msg
-                        or "rate_limit" in error_msg
-                        or "usage limit" in error_msg
-                        or "quota" in error_msg
-                    )
+                    is_rate_limited = failure_category in {"transient_rate_limit", "quota_exhausted"}
                     if is_rate_limited and self._fallback_index < len(self._fallback_chain):
                         # Don't eagerly fallback if credential pool rotation may
                         # still recover.  The pool's retry-then-rotate cycle needs
                         # at least one more attempt to fire — jumping to a fallback
                         # provider here short-circuits it.
-                        pool = self._credential_pool
-                        pool_may_recover = pool is not None and pool.has_available()
-                        if not pool_may_recover:
+                        if not self._should_defer_fallback_to_credential_pool():
                             self._emit_status("⚠️ Rate limited — switching to fallback provider...")
                             if self._try_activate_fallback():
                                 retry_count = 0

--- a/tests/test_credential_pool_routing.py
+++ b/tests/test_credential_pool_routing.py
@@ -275,7 +275,7 @@ class TestPoolRotationCycle:
         # mark_exhausted_and_rotate returns next entry until exhausted
         self._rotation_index = 0
 
-        def rotate(status_code=None, error_context=None):
+        def rotate(status_code=None, error_context=None, retry_after_seconds=None, error_category=None):
             self._rotation_index += 1
             if self._rotation_index < pool_entries:
                 return entries[self._rotation_index]
@@ -307,7 +307,10 @@ class TestPoolRotationCycle:
         )
         assert recovered is True
         assert has_retried is False  # reset after rotation
-        pool.mark_exhausted_and_rotate.assert_called_once_with(status_code=429, error_context=None)
+        pool.mark_exhausted_and_rotate.assert_called_once_with(
+            status_code=429, error_context=None,
+            retry_after_seconds=None, error_category="transient_rate_limit"
+        )
         agent._swap_credential.assert_called_once_with(entries[1])
 
     def test_pool_exhaustion_returns_false(self):
@@ -333,7 +336,10 @@ class TestPoolRotationCycle:
         )
         assert recovered is True
         assert has_retried is False
-        pool.mark_exhausted_and_rotate.assert_called_once_with(status_code=402, error_context=None)
+        pool.mark_exhausted_and_rotate.assert_called_once_with(
+            status_code=402, error_context=None,
+            retry_after_seconds=None, error_category="quota_exhausted"
+        )
 
     def test_no_pool_returns_false(self):
         """No pool should return (False, unchanged)."""

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1993,7 +1993,7 @@ class TestCredentialPoolRecovery:
             def current(self):
                 return current
 
-            def mark_exhausted_and_rotate(self, *, status_code, error_context=None):
+            def mark_exhausted_and_rotate(self, *, status_code, error_context=None, retry_after_seconds=None, error_category=None):
                 assert status_code == 402
                 assert error_context is None
                 return next_entry
@@ -2017,7 +2017,7 @@ class TestCredentialPoolRecovery:
             def current(self):
                 return SimpleNamespace(label="primary")
 
-            def mark_exhausted_and_rotate(self, *, status_code, error_context=None):
+            def mark_exhausted_and_rotate(self, *, status_code, error_context=None, retry_after_seconds=None, error_category=None):
                 assert status_code == 429
                 assert error_context is None
                 return next_entry
@@ -2069,7 +2069,7 @@ class TestCredentialPoolRecovery:
             def try_refresh_current(self):
                 return None  # refresh failed
 
-            def mark_exhausted_and_rotate(self, *, status_code, error_context=None):
+            def mark_exhausted_and_rotate(self, *, status_code, error_context=None, retry_after_seconds=None, error_category=None):
                 assert status_code == 401
                 assert error_context is None
                 return next_entry
@@ -2093,7 +2093,7 @@ class TestCredentialPoolRecovery:
             def try_refresh_current(self):
                 return None
 
-            def mark_exhausted_and_rotate(self, *, status_code, error_context=None):
+            def mark_exhausted_and_rotate(self, *, status_code, error_context=None, retry_after_seconds=None, error_category=None):
                 assert error_context is None
                 return None  # no more credentials
 
@@ -2135,7 +2135,7 @@ class TestCredentialPoolRecovery:
             def current(self):
                 return SimpleNamespace(label="primary")
 
-            def mark_exhausted_and_rotate(self, *, status_code, error_context=None):
+            def mark_exhausted_and_rotate(self, *, status_code, error_context=None, retry_after_seconds=None, error_category=None):
                 captured["status_code"] = status_code
                 captured["error_context"] = error_context
                 return next_entry

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -27,6 +27,8 @@ from tools.delegate_tool import (
     _build_child_system_prompt,
     _strip_blocked_tools,
     _resolve_delegation_credentials,
+    _resolve_child_credential_pool,
+    resolve_tier_config,
 )
 
 
@@ -928,6 +930,359 @@ class TestDelegationProviderIntegration(unittest.TestCase):
             # But provider/base_url/api_key should inherit from parent
             self.assertEqual(kwargs["provider"], parent.provider)
             self.assertEqual(kwargs["base_url"], parent.base_url)
+
+
+class TestDelegationReasoningEffort(unittest.TestCase):
+    def test_resolve_delegation_credentials_includes_reasoning_effort(self):
+        parent = _make_mock_parent(depth=0)
+        cfg = {"model": "gpt-5.4-mini", "provider": "", "reasoning_effort": "low"}
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["reasoning_effort"], "low")
+
+    def test_build_child_agent_applies_override_reasoning_effort(self):
+        parent = _make_mock_parent(depth=0)
+        parent.reasoning_config = {"enabled": True, "effort": "xhigh"}
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="Test child",
+                context=None,
+                toolsets=["terminal"],
+                model="gpt-5.4-mini",
+                max_iterations=10,
+                parent_agent=parent,
+                override_provider="openai-codex",
+                override_base_url="https://chatgpt.com/backend-api/codex",
+                override_api_key="test-key",
+                override_api_mode="codex_responses",
+                override_reasoning_effort="low",
+            )
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["reasoning_config"]["effort"], "low")
+            self.assertTrue(kwargs["reasoning_config"]["enabled"])
+
+
+class TestChildCredentialPoolResolution(unittest.TestCase):
+    """Tests for _resolve_child_credential_pool — ensuring subagents participate
+    in the credential pool for rate-limit recovery."""
+
+    def test_same_provider_shares_parent_pool(self):
+        """When child uses the same provider as parent, share the parent's pool."""
+        parent = _make_mock_parent()
+        parent.provider = "openrouter"
+        mock_pool = MagicMock()
+        parent._credential_pool = mock_pool
+
+        result = _resolve_child_credential_pool("openrouter", parent)
+        self.assertIs(result, mock_pool)
+
+    def test_no_provider_inherits_parent_pool(self):
+        """When no explicit provider is set, child inherits the parent's pool."""
+        parent = _make_mock_parent()
+        mock_pool = MagicMock()
+        parent._credential_pool = mock_pool
+
+        result = _resolve_child_credential_pool(None, parent)
+        self.assertIs(result, mock_pool)
+
+    def test_no_provider_no_parent_pool_returns_none(self):
+        """When no explicit provider and parent has no pool, return None."""
+        parent = _make_mock_parent()
+        parent._credential_pool = None
+
+        result = _resolve_child_credential_pool(None, parent)
+        self.assertIsNone(result)
+
+    def test_different_provider_loads_own_pool(self):
+        """When child uses a different provider, try to load its own pool."""
+        parent = _make_mock_parent()
+        parent.provider = "openrouter"
+        parent._credential_pool = MagicMock()
+
+        mock_pool = MagicMock()
+        mock_pool.size.return_value = 2
+
+        with patch("agent.credential_pool.load_pool", return_value=mock_pool):
+            result = _resolve_child_credential_pool("anthropic", parent)
+
+        self.assertIs(result, mock_pool)
+
+    def test_different_provider_empty_pool_returns_none(self):
+        """When child's provider has an empty pool, return None (graceful fallback)."""
+        parent = _make_mock_parent()
+        parent.provider = "openrouter"
+        parent._credential_pool = MagicMock()
+
+        mock_pool = MagicMock()
+        mock_pool.size.return_value = 0
+
+        with patch("agent.credential_pool.load_pool", return_value=mock_pool):
+            result = _resolve_child_credential_pool("anthropic", parent)
+
+        self.assertIsNone(result)
+
+    def test_different_provider_load_failure_returns_none(self):
+        """When loading a pool for the child's provider fails, return None gracefully."""
+        parent = _make_mock_parent()
+        parent.provider = "openrouter"
+        parent._credential_pool = MagicMock()
+
+        with patch("agent.credential_pool.load_pool", side_effect=Exception("disk error")):
+            result = _resolve_child_credential_pool("anthropic", parent)
+
+        self.assertIsNone(result)
+
+    def test_child_agent_gets_pool_assigned(self):
+        """Integration: _build_child_agent assigns pool to the constructed child."""
+        parent = _make_mock_parent()
+        mock_pool = MagicMock()
+        parent._credential_pool = mock_pool
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="Test pool assignment",
+                context=None,
+                toolsets=["terminal"],
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+            )
+
+            # The child should have gotten the parent's pool assigned
+            self.assertEqual(mock_child._credential_pool, mock_pool)
+
+
+class TestChildCredentialLeasing(unittest.TestCase):
+    def test_run_single_child_releases_lease_even_when_task_uses_different_tier_lane(self):
+        from tools.delegate_tool import _run_single_child
+
+        leased_entry = MagicMock()
+        leased_entry.id = "cred-review"
+
+        child = MagicMock()
+        child._credential_pool = MagicMock()
+        child._credential_pool.acquire_lease.return_value = "cred-review"
+        child._credential_pool.current.return_value = leased_entry
+        child.run_conversation.return_value = {
+            "final_response": "done",
+            "completed": True,
+            "interrupted": False,
+            "api_calls": 1,
+            "messages": [],
+        }
+        child.reasoning_effort = "high"
+        child.model = "gpt-5.4"
+
+        result = _run_single_child(
+            task_index=1,
+            goal="Deep review",
+            child=child,
+            parent_agent=_make_mock_parent(),
+        )
+
+        self.assertEqual(result["status"], "completed")
+        child._credential_pool.acquire_lease.assert_called_once_with()
+        child._swap_credential.assert_called_once_with(leased_entry)
+        child._credential_pool.release_lease.assert_called_once_with("cred-review")
+
+    def test_run_single_child_uses_least_leased_pool_entry_and_swaps_child(self):
+        from tools.delegate_tool import _run_single_child
+
+        leased_entry = MagicMock()
+        leased_entry.id = "cred-b"
+
+        child = MagicMock()
+        child._credential_pool = MagicMock()
+        child._credential_pool.acquire_lease.return_value = "cred-b"
+        child._credential_pool.current.return_value = leased_entry
+        child.run_conversation.return_value = {
+            "final_response": "done",
+            "completed": True,
+            "interrupted": False,
+            "api_calls": 1,
+            "messages": [],
+        }
+
+        result = _run_single_child(
+            task_index=0,
+            goal="Investigate rate limits",
+            child=child,
+            parent_agent=_make_mock_parent(),
+        )
+
+        self.assertEqual(result["status"], "completed")
+        child._credential_pool.acquire_lease.assert_called_once_with()
+        child._swap_credential.assert_called_once_with(leased_entry)
+        child._credential_pool.release_lease.assert_called_once_with("cred-b")
+
+
+class TestTierResolution(unittest.TestCase):
+    """Tests for resolve_tier_config — task profile selection."""
+
+    def test_no_tiers_returns_flat_config(self):
+        cfg = {"model": "gpt-5.4-mini", "reasoning_effort": "low"}
+        result = resolve_tier_config(cfg, tier="heavy")
+        self.assertEqual(result, cfg)
+
+    def test_explicit_tier_overrides_flat(self):
+        cfg = {
+            "model": "gpt-5.4-mini",
+            "reasoning_effort": "low",
+            "max_iterations": 25,
+            "tiers": {
+                "heavy": {
+                    "model": "claude-opus-4-6",
+                    "reasoning_effort": "medium",
+                    "max_iterations": 50,
+                },
+            },
+        }
+        result = resolve_tier_config(cfg, tier="heavy")
+        self.assertEqual(result["model"], "claude-opus-4-6")
+        self.assertEqual(result["reasoning_effort"], "medium")
+        self.assertEqual(result["max_iterations"], 50)
+        self.assertNotIn("tiers", result)
+        self.assertNotIn("default_tier", result)
+
+    def test_default_tier_used_when_no_explicit_tier(self):
+        cfg = {
+            "model": "gpt-5.4-mini",
+            "reasoning_effort": "low",
+            "default_tier": "review",
+            "tiers": {
+                "review": {
+                    "model": "claude-opus-4-6",
+                    "reasoning_effort": "high",
+                },
+            },
+        }
+        result = resolve_tier_config(cfg, tier=None)
+        self.assertEqual(result["model"], "claude-opus-4-6")
+        self.assertEqual(result["reasoning_effort"], "high")
+
+    def test_unknown_tier_falls_back_to_flat(self):
+        cfg = {
+            "model": "gpt-5.4-mini",
+            "tiers": {
+                "light": {"model": "gpt-5.4-mini"},
+            },
+        }
+        result = resolve_tier_config(cfg, tier="nonexistent")
+        self.assertEqual(result["model"], "gpt-5.4-mini")
+
+    def test_tier_preserves_flat_keys_not_overridden(self):
+        cfg = {
+            "model": "gpt-5.4-mini",
+            "provider": "openai-codex",
+            "reasoning_effort": "low",
+            "tiers": {
+                "heavy": {
+                    "model": "claude-opus-4-6",
+                    "reasoning_effort": "high",
+                },
+            },
+        }
+        result = resolve_tier_config(cfg, tier="heavy")
+        self.assertEqual(result["model"], "claude-opus-4-6")
+        self.assertEqual(result["reasoning_effort"], "high")
+        # provider not overridden by tier — should be preserved from flat config
+        self.assertEqual(result["provider"], "openai-codex")
+
+    def test_schema_includes_tier_field(self):
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        self.assertIn("tier", props)
+        self.assertEqual(props["tier"]["type"], "string")
+        self.assertIn("light", props["tier"]["enum"])
+        self.assertIn("heavy", props["tier"]["enum"])
+        self.assertIn("review", props["tier"]["enum"])
+
+    def test_batch_task_schema_includes_tier_field(self):
+        task_props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]["tasks"]["items"]["properties"]
+        self.assertIn("tier", task_props)
+        self.assertIn("planning", task_props["tier"]["enum"])
+
+    def test_review_tier_never_degrades_below_high_reasoning(self):
+        cfg = {
+            "model": "gpt-5.4-mini",
+            "reasoning_effort": "low",
+            "tiers": {
+                "review": {
+                    "model": "gpt-5.4-mini",
+                    "reasoning_effort": "low",
+                },
+            },
+        }
+        result = resolve_tier_config(cfg, tier="review")
+        self.assertEqual(result["reasoning_effort"], "high")
+
+    def test_batch_tasks_can_override_tier_independently(self):
+        parent = _make_mock_parent()
+        cfg = {
+            "model": "gpt-5.4-mini",
+            "provider": "openai-codex",
+            "reasoning_effort": "low",
+            "max_iterations": 25,
+            "default_tier": "light",
+            "tiers": {
+                "light": {
+                    "model": "gpt-5.4-mini",
+                    "provider": "openai-codex",
+                    "reasoning_effort": "low",
+                    "max_iterations": 25,
+                },
+                "review": {
+                    "model": "gpt-5.4",
+                    "provider": "openai-codex",
+                    "reasoning_effort": "high",
+                    "max_iterations": 60,
+                },
+            },
+        }
+
+        with patch("tools.delegate_tool._load_config", return_value=cfg), \
+             patch("tools.delegate_tool._resolve_delegation_credentials", side_effect=lambda resolved_cfg, _parent: {
+                 "model": resolved_cfg.get("model"),
+                 "provider": resolved_cfg.get("provider"),
+                 "base_url": None,
+                 "api_key": None,
+                 "api_mode": None,
+                 "reasoning_effort": resolved_cfg.get("reasoning_effort"),
+             }), \
+             patch("tools.delegate_tool._run_single_child") as mock_run, \
+             patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "ok", "completed": True, "api_calls": 1
+            }
+            MockAgent.return_value = mock_child
+            mock_run.return_value = {
+                "task_index": 0, "status": "completed", "summary": "ok", "api_calls": 1, "duration_seconds": 0.1
+            }
+
+            delegate_task(
+                tasks=[
+                    {"goal": "Quick inspect", "tier": "light"},
+                    {"goal": "Deep review", "tier": "review"},
+                ],
+                parent_agent=parent,
+            )
+
+            calls = MockAgent.call_args_list
+            self.assertEqual(calls[0].kwargs["model"], "gpt-5.4-mini")
+            self.assertEqual(calls[0].kwargs["reasoning_config"]["effort"], "low")
+            self.assertEqual(calls[0].kwargs["max_iterations"], 25)
+            self.assertEqual(calls[1].kwargs["model"], "gpt-5.4")
+            self.assertEqual(calls[1].kwargs["reasoning_config"]["effort"], "high")
+            self.assertEqual(calls[1].kwargs["max_iterations"], 60)
 
 
 if __name__ == "__main__":

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -168,6 +168,7 @@ def _build_child_agent(
     override_base_url: Optional[str] = None,
     override_api_key: Optional[str] = None,
     override_api_mode: Optional[str] = None,
+    override_reasoning_effort: Optional[str] = None,
     # ACP transport overrides — lets a non-ACP parent spawn ACP child agents
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
@@ -245,6 +246,19 @@ def _build_child_agent(
     effective_acp_command = override_acp_command or getattr(parent_agent, "acp_command", None)
     effective_acp_args = list(override_acp_args if override_acp_args is not None else (getattr(parent_agent, "acp_args", []) or []))
 
+    effective_reasoning_config = getattr(parent_agent, "reasoning_config", None)
+    if override_reasoning_effort is not None:
+        effort = str(override_reasoning_effort).strip().lower()
+        if effort == "none":
+            effective_reasoning_config = {"enabled": False, "effort": "none"}
+        elif effort:
+            if isinstance(effective_reasoning_config, dict):
+                effective_reasoning_config = dict(effective_reasoning_config)
+            else:
+                effective_reasoning_config = {}
+            effective_reasoning_config["enabled"] = True
+            effective_reasoning_config["effort"] = effort
+
     child = AIAgent(
         base_url=effective_base_url,
         api_key=effective_api_key,
@@ -255,7 +269,7 @@ def _build_child_agent(
         acp_args=effective_acp_args,
         max_iterations=max_iterations,
         max_tokens=getattr(parent_agent, "max_tokens", None),
-        reasoning_config=getattr(parent_agent, "reasoning_config", None),
+        reasoning_config=effective_reasoning_config,
         prefill_messages=getattr(parent_agent, "prefill_messages", None),
         enabled_toolsets=child_toolsets,
         quiet_mode=True,
@@ -278,6 +292,12 @@ def _build_child_agent(
     child._print_fn = getattr(parent_agent, '_print_fn', None)
     # Set delegation depth so children can't spawn grandchildren
     child._delegate_depth = getattr(parent_agent, '_delegate_depth', 0) + 1
+
+    # Share the parent's credential pool with the child so it can rotate
+    # credentials on 429/402 instead of being stuck on a single fixed key.
+    _child_pool = _resolve_child_credential_pool(effective_provider, parent_agent)
+    if _child_pool is not None:
+        child._credential_pool = _child_pool
 
     # Register child for interrupt propagation
     if hasattr(parent_agent, '_active_children'):
@@ -311,6 +331,21 @@ def _run_single_child(
     import model_tools
     _saved_tool_names = getattr(child, "_delegate_saved_tool_names",
                                 list(model_tools._last_resolved_tool_names))
+
+    # Acquire a lease on the child's credential pool so parallel subagents
+    # don't stampede the same account. Let the pool choose the least-leased
+    # available credential instead of pinning to current.
+    _child_pool = getattr(child, '_credential_pool', None)
+    _leased_cred_id = None
+    if _child_pool is not None:
+        _leased_cred_id = _child_pool.acquire_lease()
+        if _leased_cred_id is not None:
+            try:
+                _leased_entry = _child_pool.current()
+                if _leased_entry is not None and hasattr(child, '_swap_credential'):
+                    child._swap_credential(_leased_entry)
+            except Exception as exc:
+                logger.debug("Failed to bind child to leased credential: %s", exc)
 
     try:
         result = child.run_conversation(user_message=goal)
@@ -422,6 +457,13 @@ def _run_single_child(
         }
 
     finally:
+        # Release the credential lease so the pool knows this slot is free.
+        if _child_pool is not None and _leased_cred_id is not None:
+            try:
+                _child_pool.release_lease(_leased_cred_id)
+            except Exception as exc:
+                logger.debug("Failed to release credential lease: %s", exc)
+
         # Restore the parent's tool names so the process-global is correct
         # for any subsequent execute_code calls or other consumers.
         import model_tools
@@ -448,6 +490,7 @@ def delegate_task(
     toolsets: Optional[List[str]] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
+    tier: Optional[str] = None,
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     parent_agent=None,
@@ -474,8 +517,9 @@ def delegate_task(
             )
         })
 
-    # Load config
-    cfg = _load_config()
+    # Load config and resolve tier
+    raw_cfg = _load_config()
+    cfg = resolve_tier_config(raw_cfg, tier=tier)
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
     effective_max_iter = max_iterations or default_max_iter
 
@@ -524,13 +568,21 @@ def delegate_task(
     children = []
     try:
         for i, t in enumerate(task_list):
+            task_tier = t.get("tier") or tier
+            task_cfg = resolve_tier_config(raw_cfg, tier=task_tier)
+            task_max_iter = max_iterations or task_cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
+            try:
+                task_creds = _resolve_delegation_credentials(task_cfg, parent_agent)
+            except ValueError:
+                task_creds = creds
             child = _build_child_agent(
                 task_index=i, goal=t["goal"], context=t.get("context"),
-                toolsets=t.get("toolsets") or toolsets, model=creds["model"],
-                max_iterations=effective_max_iter, parent_agent=parent_agent,
-                override_provider=creds["provider"], override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
+                toolsets=t.get("toolsets") or toolsets, model=task_creds["model"],
+                max_iterations=task_max_iter, parent_agent=parent_agent,
+                override_provider=task_creds["provider"], override_base_url=task_creds["base_url"],
+                override_api_key=task_creds["api_key"],
+                override_api_mode=task_creds["api_mode"],
+                override_reasoning_effort=task_creds.get("reasoning_effort"),
                 override_acp_command=t.get("acp_command") or acp_command,
                 override_acp_args=t.get("acp_args") or acp_args,
             )
@@ -626,6 +678,84 @@ def delegate_task(
     }, ensure_ascii=False)
 
 
+def _resolve_child_credential_pool(effective_provider: Optional[str], parent_agent):
+    """Resolve a credential pool for the child agent.
+
+    Strategy:
+    1. Same provider as parent -> share parent's pool (synchronized cooldown state).
+    2. Different provider -> try to load a pool for that provider.
+    3. No pool available -> return None (graceful fallback, fixed credential).
+    """
+    if not effective_provider:
+        return getattr(parent_agent, '_credential_pool', None)
+
+    parent_provider = getattr(parent_agent, 'provider', None) or ''
+    parent_pool = getattr(parent_agent, '_credential_pool', None)
+
+    if parent_pool is not None and effective_provider == parent_provider:
+        return parent_pool
+
+    try:
+        from agent.credential_pool import load_pool
+        pool = load_pool(effective_provider)
+        if pool is not None and pool.size() > 0:
+            return pool
+    except Exception as exc:
+        logger.debug("Could not load credential pool for child provider '%s': %s",
+                     effective_provider, exc)
+    return None
+
+
+# --- Task Profile / Tier Resolution ---
+
+SUPPORTED_TIERS = frozenset({"light", "heavy", "review", "planning", "research"})
+
+
+def resolve_tier_config(cfg: dict, tier: Optional[str] = None) -> dict:
+    """Resolve a delegation tier into an effective config dict.
+
+    Resolution order:
+    1. If tier is given and exists in tiers{}, use that tier's config merged
+       over the flat delegation config (tier values win).
+    2. If tier is not given, use default_tier from config if set.
+    3. If no tiers section exists at all, return the flat config unchanged.
+    """
+    tiers = cfg.get("tiers")
+    if not isinstance(tiers, dict) or not tiers:
+        return cfg
+
+    effective_tier = tier
+    if not effective_tier:
+        effective_tier = str(cfg.get("default_tier") or "").strip().lower() or None
+
+    if not effective_tier or effective_tier not in tiers:
+        return cfg
+
+    tier_cfg = tiers[effective_tier]
+    if not isinstance(tier_cfg, dict):
+        return cfg
+
+    merged = dict(cfg)
+    merged.pop("tiers", None)
+    merged.pop("default_tier", None)
+    merged.update(tier_cfg)
+
+    # Guardrails: heavier tiers must not silently degrade to weak reasoning.
+    tier_reasoning_floor = {
+        "heavy": "medium",
+        "research": "medium",
+        "planning": "high",
+        "review": "high",
+    }
+    floor = tier_reasoning_floor.get(effective_tier)
+    if floor:
+        current = str(merged.get("reasoning_effort") or "").strip().lower()
+        order = {"none": 0, "low": 1, "medium": 2, "high": 3, "max": 4, "xhigh": 4}
+        if order.get(current, 0) < order[floor]:
+            merged["reasoning_effort"] = floor
+    return merged
+
+
 def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     """Resolve credentials for subagent delegation.
 
@@ -645,6 +775,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     configured_provider = str(cfg.get("provider") or "").strip() or None
     configured_base_url = str(cfg.get("base_url") or "").strip() or None
     configured_api_key = str(cfg.get("api_key") or "").strip() or None
+    configured_reasoning_effort = str(cfg.get("reasoning_effort") or "").strip() or None
 
     if configured_base_url:
         api_key = (
@@ -673,6 +804,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             "base_url": configured_base_url,
             "api_key": api_key,
             "api_mode": api_mode,
+            "reasoning_effort": configured_reasoning_effort,
         }
 
     if not configured_provider:
@@ -683,6 +815,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             "base_url": None,
             "api_key": None,
             "api_mode": None,
+            "reasoning_effort": configured_reasoning_effort,
         }
 
     # Provider is configured — resolve full credentials
@@ -710,6 +843,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         "base_url": runtime.get("base_url"),
         "api_key": api_key,
         "api_mode": runtime.get("api_mode"),
+        "reasoning_effort": configured_reasoning_effort,
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
     }
@@ -806,6 +940,11 @@ DELEGATE_TASK_SCHEMA = {
                     "properties": {
                         "goal": {"type": "string", "description": "Task goal"},
                         "context": {"type": "string", "description": "Task-specific context"},
+                        "tier": {
+                            "type": "string",
+                            "enum": ["light", "heavy", "review", "planning", "research"],
+                            "description": "Task-specific tier override for this batch item",
+                        },
                         "toolsets": {
                             "type": "array",
                             "items": {"type": "string"},
@@ -835,6 +974,16 @@ DELEGATE_TASK_SCHEMA = {
                 "description": (
                     "Max tool-calling turns per subagent (default: 50). "
                     "Only set lower for simple tasks."
+                ),
+            },
+            "tier": {
+                "type": "string",
+                "enum": ["light", "heavy", "review", "planning", "research"],
+                "description": (
+                    "Task complexity tier. Controls which model, reasoning effort, "
+                    "and iteration budget the subagent uses. Tiers are defined in "
+                    "config.yaml under delegation.tiers. When omitted, uses "
+                    "delegation.default_tier or the flat delegation config."
                 ),
             },
             "acp_command": {
@@ -873,6 +1022,7 @@ registry.register(
         toolsets=args.get("toolsets"),
         tasks=args.get("tasks"),
         max_iterations=args.get("max_iterations"),
+        tier=args.get("tier"),
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         parent_agent=kw.get("parent_agent")),


### PR DESCRIPTION
## Summary

Ports and refreshes the multi-account credential-pool hardening work onto current `main`.

This PR improves credential selection, cooldown handling, fallback behavior, and subagent concurrency when a provider has multiple accounts/credentials in the pool.

It also fixes three functional gaps in the earlier version of this work:
- `api_error` was not passed into pool recovery, so `Retry-After` extraction was unreachable
- `last_success_at` existed but was never updated
- success never reset `consecutive_failures` / `consecutive_429s`

## What changes

### Credential pool health and cooldown
- add health fields to `PooledCredential`
- add `_entry_health_score()`
- sort available credentials by health before applying `fill_first`, `round_robin`, `random`, or `least_used`
- support tri-level cooldown precedence:
  1. `Retry-After` / rate-limit headers
  2. provider reset timestamp (`reset_at` / `resets_at`)
  3. fixed TTL fallback

### Success-path recovery
- add `mark_success()` to update `last_success_at`
- reset `consecutive_failures` and `consecutive_429s` after a successful request
- call `mark_success()` from the main API success path

### Failure classification and fallback behavior
- add `_extract_retry_after_seconds()`
- add `_classify_api_failure()`
- pass `api_error` into `_recover_with_credential_pool()`
- defer fallback-provider activation while the current provider's credential pool can still recover

### Subagent coordination
- child agents resolve into the parent credential pool
- add lease-based coordination to reduce subagent stampedes on the same credential
- keep task-tier delegation controls in `delegate_tool.py`

## Why this helps

Without these changes, a multi-account pool can still behave poorly under rate limits:
- stale or degraded credentials may keep winning selection
- precise cooldown hints from providers are ignored
- success does not repair health score state
- parallel child agents can pile onto the same credential

## Testing

Passed locally:
- `python -m pytest tests/test_credential_pool_routing.py tests/tools/test_delegate.py tests/test_run_agent.py -o 'addopts=' -q`
- Result: `312 passed`

## Notes

This PR is the current-upstream refresh of the earlier `fix/credential-pool-hardening` work, rebased as a clean replacement on top of today's `main` rather than continuing from the stale branch history.
