### PR TITLE
fix(test): mock is_linux in systemd restart test

### DIFF
--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -368,6 +368,9 @@ class TestCmdUpdateLaunchdRestart:
         monkeypatch.setattr(
             gateway_cli, "is_macos", lambda: False,
         )
+        monkeypatch.setattr(
+            gateway_cli, "is_linux", lambda: True,
+        )
 
         mock_run.side_effect = _make_run_side_effect(
             commit_count="3",


### PR DESCRIPTION
Closes #5686

## Summary

- Test mocked `is_macos=False` but not `is_linux=True`
- On macOS hosts, `is_linux()` returns `False` so the systemd restart block in `cmd_update` never executes
- Fix: add `monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)`

## Test plan

- [x] Previously failing test now passes
- [x] All 29 gateway restart tests pass