### PR TITLE
gateway: expand agent:start hook context with chat and user metadata

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2856,11 +2856,21 @@ class GatewayRunner:
                 message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
 
         try:
-            # Emit agent:start hook
+            # Emit agent:start hook.
+            #
+            # hook_ctx intentionally carries the minimal-but-sufficient set of
+            # routing keys an external consumer needs to reply to the correct
+            # conversation. All fields except ``chat_id`` tolerate None sources
+            # and fall back to "" so handlers can unconditionally format them.
             hook_ctx = {
                 "platform": source.platform.value if source.platform else "",
                 "user_id": source.user_id,
+                "user_name": source.user_name or "",
                 "session_id": session_entry.session_id,
+                "chat_id": source.chat_id,
+                "chat_name": source.chat_name or "",
+                "chat_type": source.chat_type,
+                "thread_id": source.thread_id or "",
                 "message": message_text[:500],
             }
             await self.hooks.emit("agent:start", hook_ctx)


### PR DESCRIPTION
## What

Adds five additive fields to the `hook_ctx` dict passed to the `agent:start` hook in `gateway/run.py`:

| Field | Source (`SessionSource`) | Type | Default |
|---|---|---|---|
| `chat_id` | `source.chat_id` | `str` (required) | — |
| `chat_name` | `source.chat_name` | `Optional[str]` | `""` |
| `chat_type` | `source.chat_type` | `str` | — |
| `thread_id` | `source.thread_id` | `Optional[str]` | `""` |
| `user_name` | `source.user_name` | `Optional[str]` | `""` |

All five already exist on the `SessionSource` dataclass in `gateway/session.py` and are populated by every platform adapter. This is a one-line-per-field change in `run.py`: no adapter code touched, no new fields on `SessionSource`.

## Why

Hook consumers that forward inbound messages to an external system need per-conversation routing keys. The current `hook_ctx` has `platform` + `user_id` + `session_id`, which identifies **who** sent the message but not **where** to reply:

- **Group chats are ambiguous**. In Telegram / Slack / Matrix, `session_id` collapses every user in the group to a single hermes session, but the reply needs the `chat_id` (group or channel), not the user's private DM. Today, consumers either reuse `session_id` as a synthetic `chat_id` (breaks routing) or call back into `gateway/delivery.py` internals (breaks encapsulation).

- **Display names**. `user_id` is `12345678` on Telegram, a UUID on Signal, an email on Slack. External systems that log or display the sender need the human-readable name. Consumers currently fall back to `user_id` (ugly) or skip logging the sender entirely.

- **Thread / topic context** matters for Discord forum posts and Slack threads — a hook that wants to answer in-thread needs `thread_id`.

Concretely, one downstream project (a nico-relay hook that POSTs each inbound message to an external server with an HMAC signature) needs `chat_id` and `sender_name` to satisfy its contract. Today it synthesises them from `session_id` and `user_id` with a comment like:

```python
# Map Hermes hook context onto nico-server InboundBody. Two upstream
# gaps need defaults:
#   chatId      — Hermes uses session_id as the per-conversation key,
#                 reuse it so the server's device-mapping by
#                 (platform, platformUserId) still routes correctly.
#   senderName  — Hermes hook context omits the human display name;
#                 fall back to user_id so server logging stays useful.
```

Landing this PR lets that (and any other hook consumer) drop the fallbacks and get accurate routing on group chats.

## Why not do this in the hook consumer

A consumer could reach into `gateway.session` and re-derive the fields, but that couples the hook contract to upstream internals. Hooks are supposed to be a stable extension surface — adding commonly-needed, already-present fields to `hook_ctx` keeps the surface stable **and** useful.

## Backward compatibility

All five new fields are additive. Existing hook handlers that look up `platform`, `user_id`, `session_id`, `message` keep working unchanged — the `hook_ctx` dict only grows. Handlers that use `dict.get("chat_id")` with a default transparently pick up the new value.

No emit timing change: the `await self.hooks.emit("agent:start", hook_ctx)` call site and its `try:` wrapper are unchanged.

## Test plan

Manual:

1. Build the branch: `pip install -e ".[all]"`
2. Start a gateway: `hermes gateway run` with a Telegram or Discord adapter.
3. Create `${HERMES_HOME}/hooks/test-hook/handler.py`:
   ```python
   async def handle(event_type, context):
       print("[test-hook]", event_type, context, flush=True)
   ```
   with a matching `HOOK.yaml` declaring `events: [agent:start]`.
4. DM the bot and post in a group chat.
5. Observe that both messages emit `hook_ctx` containing `chat_id`, `chat_name`, `chat_type`, `thread_id`, `user_name` alongside the existing fields. The DM should show `chat_type: "dm"` and the group message should show `chat_type: "group"` with a populated `chat_name`.

## Out of scope

- No new fields on `SessionSource` — all five already exist.
- No changes to the `agent:end`, `session:start`, `session:end` hook contexts. Those can follow in separate PRs if consumer demand appears.
