### PR TITLE
feat(custom): add explicit API type selection for custom endpoints

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -59,6 +59,8 @@ from hermes_constants import OPENROUTER_BASE_URL
 
 logger = logging.getLogger(__name__)
 
+_VALID_API_MODES = {"chat_completions", "codex_responses", "anthropic_messages"}
+
 # Default auxiliary models for direct API-key providers (cheap/fast for side tasks)
 _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "gemini": "gemini-3-flash-preview",
@@ -102,6 +104,73 @@ _AUTH_JSON_PATH = get_hermes_home() / "auth.json"
 # vision via Responses.
 _CODEX_AUX_MODEL = "gpt-5.2-codex"
 _CODEX_AUX_BASE_URL = "https://chatgpt.com/backend-api/codex"
+
+
+def _normalize_api_mode(value: Any) -> Optional[str]:
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in _VALID_API_MODES:
+            return normalized
+    return None
+
+
+def _coerce_custom_runtime(
+    value: Any,
+) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    if isinstance(value, tuple):
+        if len(value) == 3:
+            return value[0], value[1], _normalize_api_mode(value[2])
+        if len(value) == 2:
+            return value[0], value[1], None
+    return None, None, None
+
+
+def _coerce_task_resolution(
+    value: Any,
+) -> Tuple[str, Optional[str], Optional[str], Optional[str], Optional[str]]:
+    if isinstance(value, tuple):
+        if len(value) == 5:
+            provider, model, base_url, api_key, api_mode = value
+            return provider, model, base_url, api_key, _normalize_api_mode(api_mode)
+        if len(value) == 4:
+            provider, model, base_url, api_key = value
+            return provider, model, base_url, api_key, None
+    raise ValueError("Task provider resolution must return 4 or 5 values")
+
+
+def _build_explicit_custom_client(
+    *,
+    base_url: str,
+    api_key: str,
+    model: str,
+    api_mode: Optional[str] = None,
+) -> Tuple[Optional[Any], Optional[str]]:
+    resolved_mode = _normalize_api_mode(api_mode) or "chat_completions"
+    if resolved_mode == "codex_responses":
+        real_client = OpenAI(api_key=api_key, base_url=base_url)
+        return CodexAuxiliaryClient(real_client, model), model
+
+    if resolved_mode == "anthropic_messages":
+        try:
+            from agent.anthropic_adapter import build_anthropic_client, _is_oauth_token
+        except ImportError:
+            return None, None
+        try:
+            real_client = build_anthropic_client(api_key, base_url)
+        except ImportError:
+            return None, None
+        return (
+            AnthropicAuxiliaryClient(
+                real_client,
+                model,
+                api_key,
+                base_url,
+                is_oauth=_is_oauth_token(api_key),
+            ),
+            model,
+        )
+
+    return OpenAI(api_key=api_key, base_url=base_url), model
 
 
 def _select_pool_entry(provider: str) -> Tuple[bool, Optional[Any]]:
@@ -723,7 +792,7 @@ def _read_main_provider() -> str:
     return ""
 
 
-def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str]]:
+def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str], Optional[str]]:
     """Resolve the active custom/main endpoint the same way the main CLI does.
 
     This covers both env-driven OPENAI_BASE_URL setups and config-saved custom
@@ -736,18 +805,19 @@ def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str]]:
         runtime = resolve_runtime_provider(requested="custom")
     except Exception as exc:
         logger.debug("Auxiliary client: custom runtime resolution failed: %s", exc)
-        return None, None
+        return None, None, None
 
     custom_base = runtime.get("base_url")
     custom_key = runtime.get("api_key")
+    custom_api_mode = _normalize_api_mode(runtime.get("api_mode"))
     if not isinstance(custom_base, str) or not custom_base.strip():
-        return None, None
+        return None, None, None
 
     custom_base = custom_base.strip().rstrip("/")
     if "openrouter.ai" in custom_base.lower():
         # requested='custom' falls back to OpenRouter when no custom endpoint is
         # configured. Treat that as "no custom endpoint" for auxiliary routing.
-        return None, None
+        return None, None, None
 
     # Local servers (Ollama, llama.cpp, vLLM, LM Studio) don't require auth.
     # Use a placeholder key — the OpenAI SDK requires a non-empty string but
@@ -756,21 +826,26 @@ def _resolve_custom_runtime() -> Tuple[Optional[str], Optional[str]]:
     if not isinstance(custom_key, str) or not custom_key.strip():
         custom_key = "no-key-required"
 
-    return custom_base, custom_key.strip()
+    return custom_base, custom_key.strip(), custom_api_mode
 
 
 def _current_custom_base_url() -> str:
-    custom_base, _ = _resolve_custom_runtime()
+    custom_base, _, _ = _coerce_custom_runtime(_resolve_custom_runtime())
     return custom_base or ""
 
 
 def _try_custom_endpoint() -> Tuple[Optional[OpenAI], Optional[str]]:
-    custom_base, custom_key = _resolve_custom_runtime()
+    custom_base, custom_key, custom_api_mode = _coerce_custom_runtime(_resolve_custom_runtime())
     if not custom_base or not custom_key:
         return None, None
     model = _read_main_model() or "gpt-4o-mini"
     logger.debug("Auxiliary client: custom endpoint (%s)", model)
-    return OpenAI(api_key=custom_key, base_url=custom_base), model
+    return _build_explicit_custom_client(
+        base_url=custom_base,
+        api_key=custom_key,
+        model=model,
+        api_mode=custom_api_mode,
+    )
 
 
 def _try_codex() -> Tuple[Optional[Any], Optional[str]]:
@@ -1051,6 +1126,7 @@ def resolve_provider_client(
     raw_codex: bool = False,
     explicit_base_url: str = None,
     explicit_api_key: str = None,
+    explicit_api_mode: str = None,
 ) -> Tuple[Optional[Any], Optional[str]]:
     """Central router: given a provider name and optional model, return a
     configured client with the correct auth, base URL, and API format.
@@ -1074,6 +1150,7 @@ def resolve_provider_client(
             the main agent loop).
         explicit_base_url: Optional direct OpenAI-compatible endpoint.
         explicit_api_key: Optional API key paired with explicit_base_url.
+        explicit_api_mode: Optional explicit transport for direct endpoints.
 
     Returns:
         (client, resolved_model) or (None, None) if auth is unavailable.
@@ -1164,7 +1241,14 @@ def resolve_provider_client(
                 )
                 return None, None
             final_model = model or _read_main_model() or "gpt-4o-mini"
-            client = OpenAI(api_key=custom_key, base_url=custom_base)
+            client, final_model = _build_explicit_custom_client(
+                base_url=custom_base,
+                api_key=custom_key,
+                model=final_model,
+                api_mode=explicit_api_mode,
+            )
+            if client is None:
+                return None, None
             return (_to_async_client(client, final_model) if async_mode
                     else (client, final_model))
         # Try custom first, then codex, then API-key providers
@@ -1259,12 +1343,13 @@ def get_text_auxiliary_client(task: str = "") -> Tuple[Optional[OpenAI], Optiona
     Callers may override the returned model with a per-task env var
     (e.g. CONTEXT_COMPRESSION_MODEL, AUXILIARY_WEB_EXTRACT_MODEL).
     """
-    provider, model, base_url, api_key = _resolve_task_provider_model(task or None)
+    provider, model, base_url, api_key, api_mode = _coerce_task_resolution(_resolve_task_provider_model(task or None))
     return resolve_provider_client(
         provider,
         model=model,
         explicit_base_url=base_url,
         explicit_api_key=api_key,
+        explicit_api_mode=api_mode,
     )
 
 
@@ -1275,13 +1360,14 @@ def get_async_text_auxiliary_client(task: str = ""):
     (AsyncCodexAuxiliaryClient, model) which wraps the Responses API.
     Returns (None, None) when no provider is available.
     """
-    provider, model, base_url, api_key = _resolve_task_provider_model(task or None)
+    provider, model, base_url, api_key, api_mode = _coerce_task_resolution(_resolve_task_provider_model(task or None))
     return resolve_provider_client(
         provider,
         model=model,
         async_mode=True,
         explicit_base_url=base_url,
         explicit_api_key=api_key,
+        explicit_api_mode=api_mode,
     )
 
 
@@ -1360,6 +1446,7 @@ def resolve_vision_provider_client(
     *,
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
+    api_mode: Optional[str] = None,
     async_mode: bool = False,
 ) -> Tuple[Optional[str], Optional[Any], Optional[str]]:
     """Resolve the client actually used for vision tasks.
@@ -1369,8 +1456,8 @@ def resolve_vision_provider_client(
     backends, so users can intentionally force experimental providers. Auto mode
     stays conservative and only tries vision backends known to work today.
     """
-    requested, resolved_model, resolved_base_url, resolved_api_key = _resolve_task_provider_model(
-        "vision", provider, model, base_url, api_key
+    requested, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _coerce_task_resolution(
+        _resolve_task_provider_model("vision", provider, model, base_url, api_key, api_mode)
     )
     requested = _normalize_vision_provider(requested)
 
@@ -1390,6 +1477,7 @@ def resolve_vision_provider_client(
             async_mode=async_mode,
             explicit_base_url=resolved_base_url,
             explicit_api_key=resolved_api_key,
+            explicit_api_mode=resolved_api_mode,
         )
         if client is None:
             return "custom", None, None
@@ -1580,6 +1668,7 @@ def _get_cached_client(
     async_mode: bool = False,
     base_url: str = None,
     api_key: str = None,
+    api_mode: str = None,
 ) -> Tuple[Optional[Any], Optional[str]]:
     """Get or create a cached client for the given provider.
 
@@ -1603,7 +1692,7 @@ def _get_cached_client(
             loop_id = id(current_loop)
         except RuntimeError:
             pass
-    cache_key = (provider, async_mode, base_url or "", api_key or "", loop_id)
+    cache_key = (provider, async_mode, base_url or "", api_key or "", api_mode or "", loop_id)
     with _client_cache_lock:
         if cache_key in _client_cache:
             cached_client, cached_default, cached_loop = _client_cache[cache_key]
@@ -1625,6 +1714,7 @@ def _get_cached_client(
         async_mode,
         explicit_base_url=base_url,
         explicit_api_key=api_key,
+        explicit_api_mode=api_mode,
     )
     if client is not None:
         # For async clients, remember which loop they were created on so we
@@ -1644,7 +1734,8 @@ def _resolve_task_provider_model(
     model: str = None,
     base_url: str = None,
     api_key: str = None,
-) -> Tuple[str, Optional[str], Optional[str], Optional[str]]:
+    api_mode: str = None,
+) -> Tuple[str, Optional[str], Optional[str], Optional[str], Optional[str]]:
     """Determine provider + model for a call.
 
     Priority:
@@ -1653,7 +1744,7 @@ def _resolve_task_provider_model(
       3. Config file (auxiliary.{task}.* or compression.*)
       4. "auto" (full auto-detection chain)
 
-    Returns (provider, model, base_url, api_key) where model may be None
+    Returns (provider, model, base_url, api_key, api_mode) where model may be None
     (use provider default). When base_url is set, provider is forced to
     "custom" and the task uses that direct endpoint.
     """
@@ -1662,6 +1753,7 @@ def _resolve_task_provider_model(
     cfg_model = None
     cfg_base_url = None
     cfg_api_key = None
+    cfg_api_mode = None
 
     if task:
         try:
@@ -1678,6 +1770,7 @@ def _resolve_task_provider_model(
         cfg_model = str(task_config.get("model", "")).strip() or None
         cfg_base_url = str(task_config.get("base_url", "")).strip() or None
         cfg_api_key = str(task_config.get("api_key", "")).strip() or None
+        cfg_api_mode = _normalize_api_mode(task_config.get("api_mode"))
 
         # Backwards compat: compression section has its own keys.
         # The auxiliary.compression defaults to provider="auto", so treat
@@ -1689,32 +1782,35 @@ def _resolve_task_provider_model(
                 cfg_model = cfg_model or comp.get("summary_model", "").strip() or None
                 _sbu = comp.get("summary_base_url") or ""
                 cfg_base_url = cfg_base_url or _sbu.strip() or None
+                cfg_api_mode = cfg_api_mode or _normalize_api_mode(comp.get("summary_api_mode"))
 
     env_model = _get_auxiliary_env_override(task, "MODEL") if task else None
     resolved_model = model or env_model or cfg_model
+    resolved_api_mode = _normalize_api_mode(api_mode)
 
     if base_url:
-        return "custom", resolved_model, base_url, api_key
+        return "custom", resolved_model, base_url, api_key, resolved_api_mode
     if provider:
-        return provider, resolved_model, base_url, api_key
+        return provider, resolved_model, base_url, api_key, resolved_api_mode
 
     if task:
         env_base_url = _get_auxiliary_env_override(task, "BASE_URL")
         env_api_key = _get_auxiliary_env_override(task, "API_KEY")
+        env_api_mode = _normalize_api_mode(_get_auxiliary_env_override(task, "API_MODE"))
         if env_base_url:
-            return "custom", resolved_model, env_base_url, env_api_key or cfg_api_key
+            return "custom", resolved_model, env_base_url, env_api_key or cfg_api_key, env_api_mode or cfg_api_mode
 
         env_provider = _get_auxiliary_provider(task)
         if env_provider != "auto":
-            return env_provider, resolved_model, None, None
+            return env_provider, resolved_model, None, None, None
 
         if cfg_base_url:
-            return "custom", resolved_model, cfg_base_url, cfg_api_key
+            return "custom", resolved_model, cfg_base_url, cfg_api_key, cfg_api_mode
         if cfg_provider and cfg_provider != "auto":
-            return cfg_provider, resolved_model, None, None
-        return "auto", resolved_model, None, None
+            return cfg_provider, resolved_model, None, None, None
+        return "auto", resolved_model, None, None, None
 
-    return "auto", resolved_model, None, None
+    return "auto", resolved_model, None, None, None
 
 
 _DEFAULT_AUX_TIMEOUT = 30.0
@@ -1824,8 +1920,9 @@ def call_llm(
     Raises:
         RuntimeError: If no provider is configured.
     """
-    resolved_provider, resolved_model, resolved_base_url, resolved_api_key = _resolve_task_provider_model(
-        task, provider, model, base_url, api_key)
+    resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _coerce_task_resolution(
+        _resolve_task_provider_model(task, provider, model, base_url, api_key)
+    )
 
     if task == "vision":
         effective_provider, client, final_model = resolve_vision_provider_client(
@@ -1833,6 +1930,7 @@ def call_llm(
             model=model,
             base_url=base_url,
             api_key=api_key,
+            api_mode=resolved_api_mode,
             async_mode=False,
         )
         if client is None and resolved_provider != "auto" and not resolved_base_url:
@@ -1857,6 +1955,7 @@ def call_llm(
             resolved_model,
             base_url=resolved_base_url,
             api_key=resolved_api_key,
+            api_mode=resolved_api_mode,
         )
         if client is None:
             # When the user explicitly chose a non-OpenRouter provider but no
@@ -2007,8 +2106,9 @@ async def async_call_llm(
 
     Same as call_llm() but async. See call_llm() for full documentation.
     """
-    resolved_provider, resolved_model, resolved_base_url, resolved_api_key = _resolve_task_provider_model(
-        task, provider, model, base_url, api_key)
+    resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _coerce_task_resolution(
+        _resolve_task_provider_model(task, provider, model, base_url, api_key)
+    )
 
     if task == "vision":
         effective_provider, client, final_model = resolve_vision_provider_client(
@@ -2016,6 +2116,7 @@ async def async_call_llm(
             model=model,
             base_url=base_url,
             api_key=api_key,
+            api_mode=resolved_api_mode,
             async_mode=True,
         )
         if client is None and resolved_provider != "auto" and not resolved_base_url:
@@ -2041,6 +2142,7 @@ async def async_call_llm(
             async_mode=True,
             base_url=resolved_base_url,
             api_key=resolved_api_key,
+            api_mode=resolved_api_mode,
         )
         if client is None:
             _explicit = (resolved_provider or "").strip().lower()

--- a/cli.py
+++ b/cli.py
@@ -279,12 +279,14 @@ def load_cli_config() -> Dict[str, Any]:
                 "model": "",
                 "base_url": "",
                 "api_key": "",
+                "api_mode": "",
             },
             "web_extract": {
                 "provider": "auto",
                 "model": "",
                 "base_url": "",
                 "api_key": "",
+                "api_mode": "",
             },
         },
         "delegation": {
@@ -461,25 +463,28 @@ def load_cli_config() -> Dict[str, Any]:
     auxiliary_config = defaults.get("auxiliary", {})
     auxiliary_task_env = {
         # config key → env var mapping
-        "vision": {
-            "provider": "AUXILIARY_VISION_PROVIDER",
-            "model": "AUXILIARY_VISION_MODEL",
-            "base_url": "AUXILIARY_VISION_BASE_URL",
-            "api_key": "AUXILIARY_VISION_API_KEY",
-        },
-        "web_extract": {
-            "provider": "AUXILIARY_WEB_EXTRACT_PROVIDER",
-            "model": "AUXILIARY_WEB_EXTRACT_MODEL",
-            "base_url": "AUXILIARY_WEB_EXTRACT_BASE_URL",
-            "api_key": "AUXILIARY_WEB_EXTRACT_API_KEY",
-        },
-        "approval": {
-            "provider": "AUXILIARY_APPROVAL_PROVIDER",
-            "model": "AUXILIARY_APPROVAL_MODEL",
-            "base_url": "AUXILIARY_APPROVAL_BASE_URL",
-            "api_key": "AUXILIARY_APPROVAL_API_KEY",
-        },
-    }
+            "vision": {
+                "provider": "AUXILIARY_VISION_PROVIDER",
+                "model": "AUXILIARY_VISION_MODEL",
+                "base_url": "AUXILIARY_VISION_BASE_URL",
+                "api_key": "AUXILIARY_VISION_API_KEY",
+                "api_mode": "AUXILIARY_VISION_API_MODE",
+            },
+            "web_extract": {
+                "provider": "AUXILIARY_WEB_EXTRACT_PROVIDER",
+                "model": "AUXILIARY_WEB_EXTRACT_MODEL",
+                "base_url": "AUXILIARY_WEB_EXTRACT_BASE_URL",
+                "api_key": "AUXILIARY_WEB_EXTRACT_API_KEY",
+                "api_mode": "AUXILIARY_WEB_EXTRACT_API_MODE",
+            },
+            "approval": {
+                "provider": "AUXILIARY_APPROVAL_PROVIDER",
+                "model": "AUXILIARY_APPROVAL_MODEL",
+                "base_url": "AUXILIARY_APPROVAL_BASE_URL",
+                "api_key": "AUXILIARY_APPROVAL_API_KEY",
+                "api_mode": "AUXILIARY_APPROVAL_API_MODE",
+            },
+        }
     
     for task_key, env_map in auxiliary_task_env.items():
         task_cfg = auxiliary_config.get(task_key, {})
@@ -489,6 +494,7 @@ def load_cli_config() -> Dict[str, Any]:
         model = str(task_cfg.get("model", "")).strip()
         base_url = str(task_cfg.get("base_url", "")).strip()
         api_key = str(task_cfg.get("api_key", "")).strip()
+        api_mode = str(task_cfg.get("api_mode", "")).strip()
         if prov and prov != "auto":
             os.environ[env_map["provider"]] = prov
         if model:
@@ -497,6 +503,8 @@ def load_cli_config() -> Dict[str, Any]:
             os.environ[env_map["base_url"]] = base_url
         if api_key:
             os.environ[env_map["api_key"]] = api_key
+        if api_mode:
+            os.environ[env_map["api_mode"]] = api_mode
     
     # Security settings
     security_config = defaults.get("security", {})

--- a/docs/plans/2026-04-07-explicit-custom-api-mode-design.md
+++ b/docs/plans/2026-04-07-explicit-custom-api-mode-design.md
@@ -1,0 +1,24 @@
+# Explicit Custom API Mode Design
+
+**Context**
+
+Hermes supports multiple wire protocols behind a shared provider abstraction. For custom OpenAI-compatible endpoints, users need a way to explicitly declare that an endpoint should use the OpenAI Responses API. URL heuristics are not reliable enough for self-hosted providers.
+
+**Decision**
+
+- `model.api_mode` remains the authoritative explicit override for the active model runtime.
+- `custom_providers[].api_mode` stores the explicit transport for a named custom provider.
+- If `api_mode` is explicitly configured, Hermes must honor it.
+- If `api_mode` is not configured, Hermes keeps existing behavior. This change does not add any new heuristics.
+
+**Scope**
+
+- Runtime provider resolution for named and active custom providers
+- Custom provider persistence in `config.yaml`
+- Custom provider activation flows in `hermes model`
+
+**Non-Goals**
+
+- No new endpoint probing logic
+- No automatic Responses API detection for localhost or `/v1`
+- No change to built-in provider transport selection

--- a/docs/plans/2026-04-07-explicit-custom-api-mode.md
+++ b/docs/plans/2026-04-07-explicit-custom-api-mode.md
@@ -1,0 +1,81 @@
+# Explicit Custom API Mode Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make Hermes honor explicitly configured `api_mode` for custom providers and preserve it across custom provider save/switch flows, without adding new heuristics.
+
+**Architecture:** Keep runtime resolution behavior unchanged unless `api_mode` is explicitly configured. Persist explicit `api_mode` on named custom providers, sync it into the active `model` config when a named custom provider is activated, and avoid silently preserving stale transport when no explicit mode exists.
+
+**Tech Stack:** Python, pytest, YAML-backed config persistence
+
+---
+
+### Task 1: Red Tests For Explicit Custom Provider API Mode
+
+**Files:**
+- Modify: `tests/test_model_provider_persistence.py`
+
+**Step 1: Write the failing test**
+
+Add tests that prove:
+- `_save_custom_provider(..., api_mode="codex_responses")` persists the explicit mode on a new custom provider entry.
+- `_model_flow_named_custom()` writes `model.api_mode` when the named provider includes an explicit `api_mode`.
+- `_model_flow_named_custom()` clears stale `model.api_mode` when the named provider does not define one.
+
+**Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_model_provider_persistence.py -k "custom_provider_api_mode or named_custom_provider_api_mode" -v`
+Expected: FAIL because the helper does not yet accept/persist `api_mode`, and named custom activation does not synchronize it.
+
+**Step 3: Write minimal implementation**
+
+Update the custom provider save/switch code to persist and synchronize explicit `api_mode`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_model_provider_persistence.py -k "custom_provider_api_mode or named_custom_provider_api_mode" -v`
+Expected: PASS
+
+### Task 2: Runtime Resolution Coverage
+
+**Files:**
+- Modify: `tests/test_runtime_provider_resolution.py`
+- Modify: `hermes_cli/runtime_provider.py`
+
+**Step 1: Write the failing test**
+
+Add a test showing that a named custom provider with `api_mode: codex_responses` resolves as `codex_responses` even for a localhost endpoint.
+
+**Step 2: Run test to verify it fails or protects behavior**
+
+Run: `pytest tests/test_runtime_provider_resolution.py -k "named_custom_provider_explicit_api_mode" -v`
+Expected: PASS if current runtime already honors explicit config, otherwise FAIL and document the gap.
+
+**Step 3: Write minimal implementation**
+
+Only adjust runtime resolution if the red test reveals a real gap. Do not add new heuristics.
+
+**Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_runtime_provider_resolution.py -k "named_custom_provider_explicit_api_mode" -v`
+Expected: PASS
+
+### Task 3: End-to-End Regression Verification
+
+**Files:**
+- Modify: `hermes_cli/main.py`
+
+**Step 1: Run focused regression suite**
+
+Run:
+- `pytest tests/test_model_provider_persistence.py -k "custom_provider_api_mode or named_custom_provider_api_mode" -v`
+- `pytest tests/test_runtime_provider_resolution.py -k "named_custom_provider_explicit_api_mode" -v`
+
+**Step 2: Run broader safety net**
+
+Run:
+- `pytest tests/test_model_provider_persistence.py tests/test_runtime_provider_resolution.py tests/test_cli_provider_resolution.py -q`
+
+**Step 3: Confirm no config drift**
+
+Verify that explicit `api_mode` survives save/switch flows and that omitted `api_mode` keeps existing behavior.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -143,24 +143,27 @@ if _config_path.exists():
         if _auxiliary_cfg and isinstance(_auxiliary_cfg, dict):
             _aux_task_env = {
                 "vision": {
-                    "provider": "AUXILIARY_VISION_PROVIDER",
-                    "model": "AUXILIARY_VISION_MODEL",
-                    "base_url": "AUXILIARY_VISION_BASE_URL",
-                    "api_key": "AUXILIARY_VISION_API_KEY",
-                },
-                "web_extract": {
-                    "provider": "AUXILIARY_WEB_EXTRACT_PROVIDER",
-                    "model": "AUXILIARY_WEB_EXTRACT_MODEL",
-                    "base_url": "AUXILIARY_WEB_EXTRACT_BASE_URL",
-                    "api_key": "AUXILIARY_WEB_EXTRACT_API_KEY",
-                },
-                "approval": {
-                    "provider": "AUXILIARY_APPROVAL_PROVIDER",
-                    "model": "AUXILIARY_APPROVAL_MODEL",
-                    "base_url": "AUXILIARY_APPROVAL_BASE_URL",
-                    "api_key": "AUXILIARY_APPROVAL_API_KEY",
-                },
-            }
+                "provider": "AUXILIARY_VISION_PROVIDER",
+                "model": "AUXILIARY_VISION_MODEL",
+                "base_url": "AUXILIARY_VISION_BASE_URL",
+                "api_key": "AUXILIARY_VISION_API_KEY",
+                "api_mode": "AUXILIARY_VISION_API_MODE",
+            },
+            "web_extract": {
+                "provider": "AUXILIARY_WEB_EXTRACT_PROVIDER",
+                "model": "AUXILIARY_WEB_EXTRACT_MODEL",
+                "base_url": "AUXILIARY_WEB_EXTRACT_BASE_URL",
+                "api_key": "AUXILIARY_WEB_EXTRACT_API_KEY",
+                "api_mode": "AUXILIARY_WEB_EXTRACT_API_MODE",
+            },
+            "approval": {
+                "provider": "AUXILIARY_APPROVAL_PROVIDER",
+                "model": "AUXILIARY_APPROVAL_MODEL",
+                "base_url": "AUXILIARY_APPROVAL_BASE_URL",
+                "api_key": "AUXILIARY_APPROVAL_API_KEY",
+                "api_mode": "AUXILIARY_APPROVAL_API_MODE",
+            },
+        }
             for _task_key, _env_map in _aux_task_env.items():
                 _task_cfg = _auxiliary_cfg.get(_task_key, {})
                 if not isinstance(_task_cfg, dict):
@@ -169,6 +172,7 @@ if _config_path.exists():
                 _model = str(_task_cfg.get("model", "")).strip()
                 _base_url = str(_task_cfg.get("base_url", "")).strip()
                 _api_key = str(_task_cfg.get("api_key", "")).strip()
+                _api_mode = str(_task_cfg.get("api_mode", "")).strip()
                 if _prov and _prov != "auto":
                     os.environ[_env_map["provider"]] = _prov
                 if _model:
@@ -177,6 +181,8 @@ if _config_path.exists():
                     os.environ[_env_map["base_url"]] = _base_url
                 if _api_key:
                     os.environ[_env_map["api_key"]] = _api_key
+                if _api_mode:
+                    os.environ[_env_map["api_mode"]] = _api_mode
         _agent_cfg = _cfg.get("agent", {})
         if _agent_cfg and isinstance(_agent_cfg, dict):
             if "max_turns" in _agent_cfg:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -313,6 +313,7 @@ DEFAULT_CONFIG = {
             "model": "",           # e.g. "google/gemini-2.5-flash", "gpt-4o"
             "base_url": "",        # direct OpenAI-compatible endpoint (takes precedence over provider)
             "api_key": "",         # API key for base_url (falls back to OPENAI_API_KEY)
+            "api_mode": "",        # explicit transport for direct endpoints
             "timeout": 30,         # seconds — LLM API call timeout; increase for slow local vision models
             "download_timeout": 30,  # seconds — image HTTP download timeout; increase for slow connections
         },
@@ -321,6 +322,7 @@ DEFAULT_CONFIG = {
             "model": "",
             "base_url": "",
             "api_key": "",
+            "api_mode": "",
             "timeout": 360,        # seconds (6min) — per-attempt LLM summarization timeout; increase for slow local models
         },
         "compression": {
@@ -328,6 +330,7 @@ DEFAULT_CONFIG = {
             "model": "",
             "base_url": "",
             "api_key": "",
+            "api_mode": "",
             "timeout": 120,        # seconds — compression summarises large contexts; increase for local models
         },
         "session_search": {
@@ -335,6 +338,7 @@ DEFAULT_CONFIG = {
             "model": "",
             "base_url": "",
             "api_key": "",
+            "api_mode": "",
             "timeout": 30,
         },
         "skills_hub": {
@@ -342,6 +346,7 @@ DEFAULT_CONFIG = {
             "model": "",
             "base_url": "",
             "api_key": "",
+            "api_mode": "",
             "timeout": 30,
         },
         "approval": {
@@ -349,6 +354,7 @@ DEFAULT_CONFIG = {
             "model": "",           # fast/cheap model recommended (e.g. gemini-flash, haiku)
             "base_url": "",
             "api_key": "",
+            "api_mode": "",
             "timeout": 30,
         },
         "mcp": {
@@ -356,6 +362,7 @@ DEFAULT_CONFIG = {
             "model": "",
             "base_url": "",
             "api_key": "",
+            "api_mode": "",
             "timeout": 30,
         },
         "flush_memories": {
@@ -363,6 +370,7 @@ DEFAULT_CONFIG = {
             "model": "",
             "base_url": "",
             "api_key": "",
+            "api_mode": "",
             "timeout": 30,
         },
     },

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1100,6 +1100,54 @@ def _prompt_provider_choice(choices, *, default=0):
             return None
 
 
+def _prompt_custom_api_mode_choice(current_api_mode=None):
+    """Prompt for the API protocol used by a custom endpoint."""
+    choices = [
+        ("OpenAI Chat Completions", "chat_completions"),
+        ("OpenAI Responses API", "codex_responses"),
+        ("Anthropic Messages", "anthropic_messages"),
+    ]
+    default_map = {
+        "chat_completions": 0,
+        "codex_responses": 1,
+        "anthropic_messages": 2,
+    }
+    default_idx = default_map.get(_normalize_explicit_api_mode(current_api_mode), 0)
+
+    try:
+        from hermes_cli.setup import _curses_prompt_choice
+        idx = _curses_prompt_choice(
+            "Select API type:",
+            [label for label, _ in choices],
+            default_idx,
+        )
+        if idx >= 0:
+            print()
+            return choices[idx][1]
+    except Exception:
+        pass
+
+    print("Select API type:")
+    for i, (label, _) in enumerate(choices, 1):
+        marker = "→" if i - 1 == default_idx else " "
+        print(f"  {marker} {i}. {label}")
+    print()
+    while True:
+        try:
+            val = input(f"Choice [1-{len(choices)}] ({default_idx + 1}): ").strip()
+            if not val:
+                return choices[default_idx][1]
+            idx = int(val) - 1
+            if 0 <= idx < len(choices):
+                return choices[idx][1]
+            print(f"Please enter 1-{len(choices)}")
+        except ValueError:
+            print("Please enter a number")
+        except (KeyboardInterrupt, EOFError):
+            print()
+            return choices[default_idx][1]
+
+
 def _model_flow_openrouter(config, current_model=""):
     """OpenRouter provider: ensure API key, then pick model."""
     from hermes_cli.auth import _prompt_model_selection, _save_model_choice, deactivate_provider
@@ -1415,7 +1463,8 @@ def _model_flow_custom(config):
             print(f"Invalid context length: {context_length_str} — will auto-detect.")
             context_length = None
 
-    explicit_api_mode = _get_matching_custom_api_mode(config.get("model"), effective_url)
+    existing_api_mode = _get_matching_custom_api_mode(config.get("model"), effective_url)
+    explicit_api_mode = _prompt_custom_api_mode_choice(existing_api_mode)
 
     if model_name:
         _save_model_choice(model_name)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -986,6 +986,7 @@ def select_provider_and_model(args=None):
                 "base_url": base_url,
                 "api_key": entry.get("api_key", ""),
                 "model": saved_model,
+                "api_mode": entry.get("api_mode", ""),
             }
 
     top_keys = {k for k, _ in top_providers}
@@ -1414,6 +1415,8 @@ def _model_flow_custom(config):
             print(f"Invalid context length: {context_length_str} — will auto-detect.")
             context_length = None
 
+    explicit_api_mode = _get_matching_custom_api_mode(config.get("model"), effective_url)
+
     if model_name:
         _save_model_choice(model_name)
 
@@ -1427,7 +1430,10 @@ def _model_flow_custom(config):
         model["base_url"] = effective_url
         if effective_key:
             model["api_key"] = effective_key
-        model.pop("api_mode", None)  # let runtime auto-detect from URL
+        if explicit_api_mode:
+            model["api_mode"] = explicit_api_mode
+        else:
+            model.pop("api_mode", None)
         save_config(cfg)
         deactivate_provider()
 
@@ -1450,15 +1456,44 @@ def _model_flow_custom(config):
         _caller_model["base_url"] = effective_url
         if effective_key:
             _caller_model["api_key"] = effective_key
-        _caller_model.pop("api_mode", None)
+        if explicit_api_mode:
+            _caller_model["api_mode"] = explicit_api_mode
+        else:
+            _caller_model.pop("api_mode", None)
         config["model"] = _caller_model
         print("Endpoint saved. Use `/model` in chat or `hermes model` to set a model.")
 
     # Auto-save to custom_providers so it appears in the menu next time
-    _save_custom_provider(effective_url, effective_key, model_name or "", context_length=context_length)
+    _save_custom_provider(
+        effective_url,
+        effective_key,
+        model_name or "",
+        context_length=context_length,
+        api_mode=explicit_api_mode,
+    )
 
 
-def _save_custom_provider(base_url, api_key="", model="", context_length=None):
+def _normalize_explicit_api_mode(raw):
+    if not isinstance(raw, str):
+        return None
+    normalized = raw.strip().lower()
+    if normalized in {"chat_completions", "codex_responses", "anthropic_messages"}:
+        return normalized
+    return None
+
+
+def _get_matching_custom_api_mode(model_config, base_url):
+    if not isinstance(model_config, dict):
+        return None
+    if str(model_config.get("provider") or "").strip().lower() != "custom":
+        return None
+    configured_base_url = str(model_config.get("base_url") or "").strip().rstrip("/")
+    if not configured_base_url or configured_base_url != str(base_url or "").strip().rstrip("/"):
+        return None
+    return _normalize_explicit_api_mode(model_config.get("api_mode"))
+
+
+def _save_custom_provider(base_url, api_key="", model="", context_length=None, api_mode=None):
     """Save a custom endpoint to custom_providers in config.yaml.
 
     Deduplicates by base_url — if the URL already exists, updates the
@@ -1471,6 +1506,7 @@ def _save_custom_provider(base_url, api_key="", model="", context_length=None):
     providers = cfg.get("custom_providers") or []
     if not isinstance(providers, list):
         providers = []
+    explicit_api_mode = _normalize_explicit_api_mode(api_mode)
 
     # Check if this URL is already saved — update model/context_length if so
     for entry in providers:
@@ -1485,6 +1521,9 @@ def _save_custom_provider(base_url, api_key="", model="", context_length=None):
                     models_cfg = {}
                 models_cfg[model] = {"context_length": context_length}
                 entry["models"] = models_cfg
+                changed = True
+            if explicit_api_mode and entry.get("api_mode") != explicit_api_mode:
+                entry["api_mode"] = explicit_api_mode
                 changed = True
             if changed:
                 cfg["custom_providers"] = providers
@@ -1513,6 +1552,8 @@ def _save_custom_provider(base_url, api_key="", model="", context_length=None):
         entry["model"] = model
     if model and context_length:
         entry["models"] = {model: {"context_length": context_length}}
+    if explicit_api_mode:
+        entry["api_mode"] = explicit_api_mode
 
     providers.append(entry)
     cfg["custom_providers"] = providers
@@ -1589,6 +1630,7 @@ def _model_flow_named_custom(config, provider_info):
     base_url = provider_info["base_url"]
     api_key = provider_info.get("api_key", "")
     saved_model = provider_info.get("model", "")
+    explicit_api_mode = _normalize_explicit_api_mode(provider_info.get("api_mode"))
 
     # If a model is saved, just activate immediately — no probing needed
     if saved_model:
@@ -1603,6 +1645,10 @@ def _model_flow_named_custom(config, provider_info):
         model["base_url"] = base_url
         if api_key:
             model["api_key"] = api_key
+        if explicit_api_mode:
+            model["api_mode"] = explicit_api_mode
+        else:
+            model.pop("api_mode", None)
         save_config(cfg)
         deactivate_provider()
 
@@ -1676,11 +1722,15 @@ def _model_flow_named_custom(config, provider_info):
     model["base_url"] = base_url
     if api_key:
         model["api_key"] = api_key
+    if explicit_api_mode:
+        model["api_mode"] = explicit_api_mode
+    else:
+        model.pop("api_mode", None)
     save_config(cfg)
     deactivate_provider()
 
     # Save model name to the custom_providers entry for next time
-    _save_custom_provider(base_url, api_key, model_name)
+    _save_custom_provider(base_url, api_key, model_name, api_mode=explicit_api_mode)
 
     print(f"\n✅ Model set to: {model_name}")
     print(f"   Provider: {name} ({base_url})")

--- a/run_agent.py
+++ b/run_agent.py
@@ -3868,7 +3868,12 @@ class AIAgent:
         has_tool_calls = False
         first_delta_fired = False
         self._reasoning_deltas_fired = False
+        # Accumulate streamed text so we can recover if get_final_response()
+        # returns empty output (e.g. chatgpt.com backend-api sends
+        # response.incomplete instead of response.completed).
+        self._codex_streamed_text_parts: list = []
         for attempt in range(max_stream_retries + 1):
+            collected_output_items: list = []
             try:
                 with active_client.responses.stream(**api_kwargs) as stream:
                     for event in stream:
@@ -3878,6 +3883,8 @@ class AIAgent:
                         # Fire callbacks on text content deltas (suppress during tool calls)
                         if "output_text.delta" in event_type or event_type == "response.output_text.delta":
                             delta_text = getattr(event, "delta", "")
+                            if delta_text:
+                                self._codex_streamed_text_parts.append(delta_text)
                             if delta_text and not has_tool_calls:
                                 if not first_delta_fired:
                                     first_delta_fired = True
@@ -3895,7 +3902,51 @@ class AIAgent:
                             reasoning_text = getattr(event, "delta", "")
                             if reasoning_text:
                                 self._fire_reasoning_delta(reasoning_text)
-                    return stream.get_final_response()
+                        # Collect completed output items — some backends
+                        # (chatgpt.com/backend-api/codex) stream valid items
+                        # via response.output_item.done but the SDK's
+                        # get_final_response() returns an empty output list.
+                        elif event_type == "response.output_item.done":
+                            done_item = getattr(event, "item", None)
+                            if done_item is not None:
+                                collected_output_items.append(done_item)
+                        # Log non-completed terminal events for diagnostics
+                        elif event_type in ("response.incomplete", "response.failed"):
+                            resp_obj = getattr(event, "response", None)
+                            status = getattr(resp_obj, "status", None) if resp_obj else None
+                            incomplete_details = getattr(resp_obj, "incomplete_details", None) if resp_obj else None
+                            logger.warning(
+                                "Codex Responses stream received terminal event %s "
+                                "(status=%s, incomplete_details=%s, streamed_chars=%d). %s",
+                                event_type, status, incomplete_details,
+                                sum(len(p) for p in self._codex_streamed_text_parts),
+                                self._client_log_context(),
+                            )
+                    final_response = stream.get_final_response()
+                    # PATCH: ChatGPT Codex backend streams valid output items
+                    # but get_final_response() can return an empty output list.
+                    # Backfill from collected items or synthesize from deltas.
+                    _out = getattr(final_response, "output", None)
+                    if isinstance(_out, list) and not _out:
+                        if collected_output_items:
+                            final_response.output = list(collected_output_items)
+                            logger.debug(
+                                "Codex stream: backfilled %d output items from stream events",
+                                len(collected_output_items),
+                            )
+                        elif self._codex_streamed_text_parts and not has_tool_calls:
+                            assembled = "".join(self._codex_streamed_text_parts)
+                            final_response.output = [SimpleNamespace(
+                                type="message",
+                                role="assistant",
+                                status="completed",
+                                content=[SimpleNamespace(type="output_text", text=assembled)],
+                            )]
+                            logger.debug(
+                                "Codex stream: synthesized output from %d text deltas (%d chars)",
+                                len(self._codex_streamed_text_parts), len(assembled),
+                            )
+                    return final_response
             except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
                 if attempt < max_stream_retries:
                     logger.debug(
@@ -7366,6 +7417,18 @@ class AIAgent:
                             response_invalid = True
                             error_details.append("response.output is not a list")
                         elif len(output_items) == 0:
+                            # If we reach here, _run_codex_stream's backfill
+                            # from output_item.done events and text-delta
+                            # synthesis both failed to populate output.
+                            _resp_status = getattr(response, "status", None)
+                            _resp_incomplete = getattr(response, "incomplete_details", None)
+                            logging.warning(
+                                "Codex response.output is empty after stream backfill "
+                                "(status=%s, incomplete_details=%s, model=%s). %s",
+                                _resp_status, _resp_incomplete,
+                                getattr(response, "model", None),
+                                f"api_mode={self.api_mode} provider={self.provider}",
+                            )
                             response_invalid = True
                             error_details.append("response.output is empty")
                     elif self.api_mode == "anthropic_messages":

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -35,8 +35,10 @@ def _clean_env(monkeypatch):
         # Per-task provider/model/direct-endpoint overrides
         "AUXILIARY_VISION_PROVIDER", "AUXILIARY_VISION_MODEL",
         "AUXILIARY_VISION_BASE_URL", "AUXILIARY_VISION_API_KEY",
+        "AUXILIARY_VISION_API_MODE",
         "AUXILIARY_WEB_EXTRACT_PROVIDER", "AUXILIARY_WEB_EXTRACT_MODEL",
         "AUXILIARY_WEB_EXTRACT_BASE_URL", "AUXILIARY_WEB_EXTRACT_API_KEY",
+        "AUXILIARY_WEB_EXTRACT_API_MODE",
         "CONTEXT_COMPRESSION_PROVIDER", "CONTEXT_COMPRESSION_MODEL",
     ):
         monkeypatch.delenv(key, raising=False)
@@ -542,6 +544,52 @@ class TestGetTextAuxiliaryClient:
         assert mock_openai.call_args.kwargs["api_key"] == "no-key-required"
         assert mock_openai.call_args.kwargs["base_url"] == "http://localhost:2345/v1"
 
+    def test_task_direct_endpoint_honors_explicit_codex_responses_api_mode(self, monkeypatch):
+        monkeypatch.setenv("AUXILIARY_WEB_EXTRACT_BASE_URL", "http://localhost:2345/v1")
+        monkeypatch.setenv("AUXILIARY_WEB_EXTRACT_API_KEY", "task-key")
+        monkeypatch.setenv("AUXILIARY_WEB_EXTRACT_API_MODE", "codex_responses")
+        monkeypatch.setenv("AUXILIARY_WEB_EXTRACT_MODEL", "task-model")
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            client, model = get_text_auxiliary_client("web_extract")
+
+        from agent.auxiliary_client import CodexAuxiliaryClient
+
+        assert isinstance(client, CodexAuxiliaryClient)
+        assert model == "task-model"
+        assert mock_openai.call_args.kwargs["base_url"] == "http://localhost:2345/v1"
+        assert mock_openai.call_args.kwargs["api_key"] == "task-key"
+
+    def test_custom_provider_runtime_honors_explicit_codex_responses_api_mode(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_custom_runtime",
+            lambda: ("http://localhost:1234/v1", "runtime-key", "codex_responses"),
+        )
+        monkeypatch.setattr("agent.auxiliary_client._read_main_model", lambda: "runtime-model")
+
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            client, model = resolve_provider_client("custom")
+
+        from agent.auxiliary_client import CodexAuxiliaryClient
+
+        assert isinstance(client, CodexAuxiliaryClient)
+        assert model == "runtime-model"
+        assert mock_openai.call_args.kwargs["base_url"] == "http://localhost:1234/v1"
+        assert mock_openai.call_args.kwargs["api_key"] == "runtime-key"
+
+    def test_task_direct_endpoint_honors_explicit_anthropic_messages_api_mode(self, monkeypatch):
+        monkeypatch.setenv("AUXILIARY_WEB_EXTRACT_BASE_URL", "https://api.example.test/anthropic")
+        monkeypatch.setenv("AUXILIARY_WEB_EXTRACT_API_KEY", "anthropic-key")
+        monkeypatch.setenv("AUXILIARY_WEB_EXTRACT_API_MODE", "anthropic_messages")
+        monkeypatch.setenv("AUXILIARY_WEB_EXTRACT_MODEL", "claude-test")
+        with patch("agent.anthropic_adapter.build_anthropic_client", return_value=MagicMock()):
+            client, model = get_text_auxiliary_client("web_extract")
+
+        assert client is not None
+        assert client.__class__.__name__ == "AnthropicAuxiliaryClient"
+        assert model == "claude-test"
+
     def test_custom_endpoint_uses_config_saved_base_url(self, monkeypatch):
         config = {
             "model": {
@@ -567,6 +615,7 @@ class TestGetTextAuxiliaryClient:
 
     def test_codex_fallback_when_nothing_else(self, codex_auth_dir):
         with patch("agent.auxiliary_client._read_nous_auth", return_value=None), \
+             patch("agent.auxiliary_client._resolve_custom_runtime", return_value=(None, None, None)), \
              patch("agent.auxiliary_client.OpenAI") as mock_openai:
             client, model = get_text_auxiliary_client()
         assert model == "gpt-5.2-codex"
@@ -780,7 +829,7 @@ class TestAuxiliaryPoolAwareness:
              patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
              patch("agent.auxiliary_client._read_codex_access_token", return_value=None), \
              patch("agent.auxiliary_client._resolve_custom_runtime",
-                   return_value=("http://localhost:1234/v1", "local-key")), \
+                   return_value=("http://localhost:1234/v1", "local-key", None)), \
              patch("agent.auxiliary_client.OpenAI") as mock_openai:
             client, model = get_vision_auxiliary_client()
         assert client is not None  # Custom endpoint picked up as fallback
@@ -806,6 +855,22 @@ class TestAuxiliaryPoolAwareness:
         assert client is not None
         assert model == "vision-model"
         assert mock_openai.call_args.kwargs["api_key"] == "no-key-required"
+
+    def test_vision_direct_endpoint_honors_explicit_codex_responses_api_mode(self, monkeypatch):
+        monkeypatch.setenv("AUXILIARY_VISION_BASE_URL", "http://localhost:4567/v1")
+        monkeypatch.setenv("AUXILIARY_VISION_API_KEY", "vision-key")
+        monkeypatch.setenv("AUXILIARY_VISION_API_MODE", "codex_responses")
+        monkeypatch.setenv("AUXILIARY_VISION_MODEL", "vision-model")
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            client, model = get_vision_auxiliary_client()
+
+        from agent.auxiliary_client import CodexAuxiliaryClient
+
+        assert isinstance(client, CodexAuxiliaryClient)
+        assert model == "vision-model"
+        assert mock_openai.call_args.kwargs["base_url"] == "http://localhost:4567/v1"
+        assert mock_openai.call_args.kwargs["api_key"] == "vision-key"
 
     def test_vision_uses_openrouter_when_available(self, monkeypatch):
         monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
@@ -847,6 +912,7 @@ class TestAuxiliaryPoolAwareness:
         monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         with patch("agent.auxiliary_client._read_nous_auth", return_value=None), \
+             patch("agent.auxiliary_client._resolve_custom_runtime", return_value=(None, None, None)), \
              patch("agent.auxiliary_client._read_codex_access_token", return_value=None), \
              patch("agent.auxiliary_client._resolve_api_key_provider", return_value=(None, None)):
             client, model = get_vision_auxiliary_client()
@@ -989,6 +1055,7 @@ class TestResolveForcedProvider:
 
     def test_forced_main_falls_to_codex(self, codex_auth_dir, monkeypatch):
         with patch("agent.auxiliary_client._read_nous_auth", return_value=None), \
+             patch("agent.auxiliary_client._resolve_custom_runtime", return_value=(None, None, None)), \
              patch("agent.auxiliary_client.OpenAI"):
             client, model = _resolve_forced_provider("main")
         from agent.auxiliary_client import CodexAuxiliaryClient

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -142,6 +142,42 @@ def test_setup_custom_providers_synced(tmp_path, monkeypatch):
     assert reloaded.get("custom_providers") == [{"name": "Local", "base_url": "http://localhost:8080/v1"}]
 
 
+def test_setup_syncs_custom_provider_api_mode_from_disk(tmp_path, monkeypatch):
+    """setup wizard should preserve custom provider api_mode written by model flow."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_env(monkeypatch)
+    _stub_tts(monkeypatch)
+
+    config = load_config()
+
+    def fake_select():
+        cfg = load_config()
+        cfg["model"] = {
+            "provider": "custom",
+            "base_url": "http://localhost:23000/v1",
+            "default": "gpt-oss",
+            "api_mode": "codex_responses",
+        }
+        cfg["custom_providers"] = [
+            {
+                "name": "Local Responses",
+                "base_url": "http://localhost:23000/v1",
+                "model": "gpt-oss",
+                "api_mode": "codex_responses",
+            }
+        ]
+        save_config(cfg)
+
+    monkeypatch.setattr("hermes_cli.main.select_provider_and_model", fake_select)
+
+    setup_model_provider(config)
+    save_config(config)
+
+    reloaded = load_config()
+    assert reloaded["model"]["api_mode"] == "codex_responses"
+    assert reloaded["custom_providers"][0]["api_mode"] == "codex_responses"
+
+
 def test_setup_cancel_preserves_existing_config(tmp_path, monkeypatch):
     """When the user cancels provider selection, existing config is preserved."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tests/test_auxiliary_config_bridge.py
+++ b/tests/test_auxiliary_config_bridge.py
@@ -26,8 +26,10 @@ def _run_auxiliary_bridge(config_dict, monkeypatch):
     for key in (
         "AUXILIARY_VISION_PROVIDER", "AUXILIARY_VISION_MODEL",
         "AUXILIARY_VISION_BASE_URL", "AUXILIARY_VISION_API_KEY",
+        "AUXILIARY_VISION_API_MODE",
         "AUXILIARY_WEB_EXTRACT_PROVIDER", "AUXILIARY_WEB_EXTRACT_MODEL",
         "AUXILIARY_WEB_EXTRACT_BASE_URL", "AUXILIARY_WEB_EXTRACT_API_KEY",
+        "AUXILIARY_WEB_EXTRACT_API_MODE",
     ):
         monkeypatch.delenv(key, raising=False)
 
@@ -42,12 +44,14 @@ def _run_auxiliary_bridge(config_dict, monkeypatch):
                 "model": "AUXILIARY_VISION_MODEL",
                 "base_url": "AUXILIARY_VISION_BASE_URL",
                 "api_key": "AUXILIARY_VISION_API_KEY",
+                "api_mode": "AUXILIARY_VISION_API_MODE",
             },
             "web_extract": {
                 "provider": "AUXILIARY_WEB_EXTRACT_PROVIDER",
                 "model": "AUXILIARY_WEB_EXTRACT_MODEL",
                 "base_url": "AUXILIARY_WEB_EXTRACT_BASE_URL",
                 "api_key": "AUXILIARY_WEB_EXTRACT_API_KEY",
+                "api_mode": "AUXILIARY_WEB_EXTRACT_API_MODE",
             },
         }
         for task_key, env_map in aux_task_env.items():
@@ -58,6 +62,7 @@ def _run_auxiliary_bridge(config_dict, monkeypatch):
             model = str(task_cfg.get("model", "")).strip()
             base_url = str(task_cfg.get("base_url", "")).strip()
             api_key = str(task_cfg.get("api_key", "")).strip()
+            api_mode = str(task_cfg.get("api_mode", "")).strip()
             if prov and prov != "auto":
                 os.environ[env_map["provider"]] = prov
             if model:
@@ -66,6 +71,8 @@ def _run_auxiliary_bridge(config_dict, monkeypatch):
                 os.environ[env_map["base_url"]] = base_url
             if api_key:
                 os.environ[env_map["api_key"]] = api_key
+            if api_mode:
+                os.environ[env_map["api_mode"]] = api_mode
 
 
 # ── Config bridging tests ────────────────────────────────────────────────────
@@ -113,6 +120,7 @@ class TestAuxiliaryConfigBridge:
                 "vision": {
                     "base_url": "http://localhost:1234/v1",
                     "api_key": "local-key",
+                    "api_mode": "codex_responses",
                     "model": "qwen2.5-vl",
                 }
             }
@@ -120,6 +128,7 @@ class TestAuxiliaryConfigBridge:
         _run_auxiliary_bridge(config, monkeypatch)
         assert os.environ.get("AUXILIARY_VISION_BASE_URL") == "http://localhost:1234/v1"
         assert os.environ.get("AUXILIARY_VISION_API_KEY") == "local-key"
+        assert os.environ.get("AUXILIARY_VISION_API_MODE") == "codex_responses"
         assert os.environ.get("AUXILIARY_VISION_MODEL") == "qwen2.5-vl"
 
     def test_empty_values_not_bridged(self, monkeypatch):
@@ -206,10 +215,12 @@ class TestGatewayBridgeCodeParity:
         assert "AUXILIARY_VISION_MODEL" in content
         assert "AUXILIARY_VISION_BASE_URL" in content
         assert "AUXILIARY_VISION_API_KEY" in content
+        assert "AUXILIARY_VISION_API_MODE" in content
         assert "AUXILIARY_WEB_EXTRACT_PROVIDER" in content
         assert "AUXILIARY_WEB_EXTRACT_MODEL" in content
         assert "AUXILIARY_WEB_EXTRACT_BASE_URL" in content
         assert "AUXILIARY_WEB_EXTRACT_API_KEY" in content
+        assert "AUXILIARY_WEB_EXTRACT_API_MODE" in content
 
     def test_gateway_no_compression_env_bridge(self):
         """Gateway should NOT bridge compression config to env vars (config-only)."""
@@ -262,6 +273,7 @@ class TestDefaultConfigShape:
         vision = DEFAULT_CONFIG["auxiliary"]["vision"]
         assert "provider" in vision
         assert "model" in vision
+        assert "api_mode" in vision
         assert vision["provider"] == "auto"
         assert vision["model"] == ""
 
@@ -270,6 +282,7 @@ class TestDefaultConfigShape:
         web = DEFAULT_CONFIG["auxiliary"]["web_extract"]
         assert "provider" in web
         assert "model" in web
+        assert "api_mode" in web
         assert web["provider"] == "auto"
         assert web["model"] == ""
 

--- a/tests/test_cli_provider_resolution.py
+++ b/tests/test_cli_provider_resolution.py
@@ -577,8 +577,8 @@ def test_model_flow_custom_saves_verified_v1_base_url(monkeypatch, capsys):
     monkeypatch.setattr("getpass.getpass", lambda prompt="": "local-key")
 
     # After the probe detects a single model ("llm"), the flow asks
-    # "Use this model? [Y/n]:" — confirm with Enter, then context length.
-    answers = iter(["http://localhost:8000", "", ""])
+    # "Use this model? [Y/n]:", then context length, then API type.
+    answers = iter(["http://localhost:8000", "", "", ""])
     monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
 
     hermes_main._model_flow_custom({})
@@ -589,6 +589,14 @@ def test_model_flow_custom_saves_verified_v1_base_url(monkeypatch, capsys):
     # OPENAI_BASE_URL is no longer saved to .env — config.yaml is authoritative
     assert "OPENAI_BASE_URL" not in saved_env
     assert saved_env["MODEL"] == "llm"
+
+
+def test_prompt_custom_api_mode_choice_maps_openai_responses(monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "2")
+
+    selected = hermes_main._prompt_custom_api_mode_choice()
+
+    assert selected == "codex_responses"
 
 
 def test_cmd_model_passes_explicit_api_mode_to_named_custom_provider(monkeypatch):

--- a/tests/test_cli_provider_resolution.py
+++ b/tests/test_cli_provider_resolution.py
@@ -538,7 +538,7 @@ def test_cmd_model_falls_back_to_auto_on_invalid_provider(monkeypatch, capsys):
         return "openrouter"
 
     monkeypatch.setattr("hermes_cli.auth.resolve_provider", _resolve_provider)
-    monkeypatch.setattr(hermes_main, "_prompt_provider_choice", lambda choices: len(choices) - 1)
+    monkeypatch.setattr(hermes_main, "_prompt_provider_choice", lambda choices, default=0: len(choices) - 1)
     monkeypatch.setattr("sys.stdin", type("FakeTTY", (), {"isatty": lambda self: True})())
 
     hermes_main.cmd_model(SimpleNamespace())
@@ -574,10 +574,11 @@ def test_model_flow_custom_saves_verified_v1_base_url(monkeypatch, capsys):
         lambda: {"model": {"default": "", "provider": "custom", "base_url": ""}},
     )
     monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+    monkeypatch.setattr("getpass.getpass", lambda prompt="": "local-key")
 
     # After the probe detects a single model ("llm"), the flow asks
     # "Use this model? [Y/n]:" — confirm with Enter, then context length.
-    answers = iter(["http://localhost:8000", "local-key", "", ""])
+    answers = iter(["http://localhost:8000", "", ""])
     monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
 
     hermes_main._model_flow_custom({})
@@ -588,6 +589,43 @@ def test_model_flow_custom_saves_verified_v1_base_url(monkeypatch, capsys):
     # OPENAI_BASE_URL is no longer saved to .env — config.yaml is authoritative
     assert "OPENAI_BASE_URL" not in saved_env
     assert saved_env["MODEL"] == "llm"
+
+
+def test_cmd_model_passes_explicit_api_mode_to_named_custom_provider(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {
+            "model": {"default": "gpt-oss", "provider": "custom"},
+            "custom_providers": [
+                {
+                    "name": "Local Responses",
+                    "base_url": "http://localhost:23000/v1",
+                    "model": "gpt-oss",
+                    "api_mode": "codex_responses",
+                }
+            ],
+        },
+    )
+    monkeypatch.setattr("hermes_cli.config.save_config", lambda cfg: None)
+    monkeypatch.setattr("hermes_cli.config.get_env_value", lambda key: "")
+    monkeypatch.setattr("hermes_cli.auth.resolve_provider", lambda requested, **kwargs: "custom")
+    monkeypatch.setattr(hermes_main, "_require_tty", lambda *args: None)
+    monkeypatch.setattr(
+        hermes_main,
+        "_prompt_provider_choice",
+        lambda choices, default=0: next(i for i, choice in enumerate(choices) if "Local Responses" in choice),
+    )
+
+    captured = {}
+
+    def _capture_named_custom(config, provider_info):
+        captured["provider_info"] = provider_info
+
+    monkeypatch.setattr(hermes_main, "_model_flow_named_custom", _capture_named_custom)
+
+    hermes_main.cmd_model(SimpleNamespace())
+
+    assert captured["provider_info"]["api_mode"] == "codex_responses"
 
 
 def test_cmd_model_forwards_nous_login_tls_options(monkeypatch):
@@ -601,7 +639,7 @@ def test_cmd_model_forwards_nous_login_tls_options(monkeypatch):
     monkeypatch.setattr("hermes_cli.config.save_env_value", lambda key, value: None)
     monkeypatch.setattr("hermes_cli.auth.resolve_provider", lambda requested, **kwargs: "nous")
     monkeypatch.setattr("hermes_cli.auth.get_provider_auth_state", lambda provider_id: None)
-    monkeypatch.setattr(hermes_main, "_prompt_provider_choice", lambda choices: 0)
+    monkeypatch.setattr(hermes_main, "_prompt_provider_choice", lambda choices, default=0: 0)
 
     captured = {}
 

--- a/tests/test_model_provider_persistence.py
+++ b/tests/test_model_provider_persistence.py
@@ -260,6 +260,44 @@ class TestProviderPersistsAfterModelSave:
 
 
 class TestCustomProviderApiModePersistence:
+    def test_model_flow_custom_persists_selected_responses_api_mode(self, config_home, monkeypatch):
+        from hermes_cli.main import _model_flow_custom
+        from hermes_cli.config import load_config
+
+        monkeypatch.setattr("hermes_cli.config.get_env_value", lambda key: "")
+        monkeypatch.setattr("hermes_cli.config.save_env_value", lambda key, value: None)
+        monkeypatch.setattr(
+            "hermes_cli.models.probe_api_models",
+            lambda api_key, base_url: {
+                "models": ["gpt-oss"],
+                "probed_url": "http://localhost:23000/v1/models",
+                "resolved_base_url": "http://localhost:23000/v1",
+                "suggested_base_url": None,
+                "used_fallback": False,
+            },
+        )
+        monkeypatch.setattr("hermes_cli.auth._save_model_choice", lambda model: None)
+        monkeypatch.setattr("hermes_cli.auth.deactivate_provider", lambda: None)
+        monkeypatch.setattr("getpass.getpass", lambda prompt="": "")
+
+        answers = iter([
+            "http://localhost:23000/v1",
+            "",
+            "",
+            "2",
+        ])
+        monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+
+        _model_flow_custom(load_config())
+
+        import yaml
+
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        model = config.get("model") or {}
+        providers = config.get("custom_providers") or []
+        assert model.get("api_mode") == "codex_responses"
+        assert providers[0].get("api_mode") == "codex_responses"
+
     def test_model_flow_custom_preserves_existing_explicit_api_mode_for_same_endpoint(self, config_home, monkeypatch):
         from hermes_cli.main import _model_flow_custom
         from hermes_cli.config import load_config
@@ -290,6 +328,7 @@ class TestCustomProviderApiModePersistence:
 
         answers = iter([
             "http://localhost:23000/v1",
+            "",
             "",
             "",
         ])

--- a/tests/test_model_provider_persistence.py
+++ b/tests/test_model_provider_persistence.py
@@ -257,3 +257,120 @@ class TestProviderPersistsAfterModelSave:
         assert model.get("provider") == "opencode-go"
         assert model.get("default") == "minimax-m2.5"
         assert model.get("api_mode") == "anthropic_messages"
+
+
+class TestCustomProviderApiModePersistence:
+    def test_model_flow_custom_preserves_existing_explicit_api_mode_for_same_endpoint(self, config_home, monkeypatch):
+        from hermes_cli.main import _model_flow_custom
+        from hermes_cli.config import load_config
+
+        (config_home / "config.yaml").write_text(
+            "model:\n"
+            "  default: gpt-oss\n"
+            "  provider: custom\n"
+            "  base_url: http://localhost:23000/v1\n"
+            "  api_mode: codex_responses\n"
+        )
+
+        monkeypatch.setattr("hermes_cli.config.get_env_value", lambda key: "")
+        monkeypatch.setattr("hermes_cli.config.save_env_value", lambda key, value: None)
+        monkeypatch.setattr(
+            "hermes_cli.models.probe_api_models",
+            lambda api_key, base_url: {
+                "models": ["gpt-oss"],
+                "probed_url": "http://localhost:23000/v1/models",
+                "resolved_base_url": "http://localhost:23000/v1",
+                "suggested_base_url": None,
+                "used_fallback": False,
+            },
+        )
+        monkeypatch.setattr("hermes_cli.auth._save_model_choice", lambda model: None)
+        monkeypatch.setattr("hermes_cli.auth.deactivate_provider", lambda: None)
+        monkeypatch.setattr("getpass.getpass", lambda prompt="": "")
+
+        answers = iter([
+            "http://localhost:23000/v1",
+            "",
+            "",
+        ])
+        monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+
+        _model_flow_custom(load_config())
+
+        import yaml
+
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        model = config.get("model") or {}
+        assert model.get("api_mode") == "codex_responses"
+
+    def test_save_custom_provider_persists_explicit_api_mode(self, config_home):
+        from hermes_cli.main import _save_custom_provider
+
+        _save_custom_provider(
+            "http://localhost:23000/v1",
+            api_key="",
+            model="gpt-oss",
+            api_mode="codex_responses",
+        )
+
+        import yaml
+
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        providers = config.get("custom_providers") or []
+        assert providers
+        assert providers[0]["base_url"] == "http://localhost:23000/v1"
+        assert providers[0]["api_mode"] == "codex_responses"
+
+    def test_named_custom_provider_activation_syncs_explicit_api_mode(self, config_home):
+        from hermes_cli.main import _model_flow_named_custom
+        from hermes_cli.config import load_config
+
+        with patch("hermes_cli.auth._save_model_choice"), patch("hermes_cli.auth.deactivate_provider"):
+            _model_flow_named_custom(
+                load_config(),
+                {
+                    "name": "Local Responses",
+                    "base_url": "http://localhost:23000/v1",
+                    "api_key": "",
+                    "model": "gpt-oss",
+                    "api_mode": "codex_responses",
+                },
+            )
+
+        import yaml
+
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        model = config.get("model") or {}
+        assert model.get("provider") == "custom"
+        assert model.get("base_url") == "http://localhost:23000/v1"
+        assert model.get("api_mode") == "codex_responses"
+
+    def test_named_custom_provider_without_explicit_api_mode_clears_stale_mode(self, config_home):
+        from hermes_cli.main import _model_flow_named_custom
+        from hermes_cli.config import load_config
+
+        (config_home / "config.yaml").write_text(
+            "model:\n"
+            "  default: stale-model\n"
+            "  provider: custom\n"
+            "  base_url: http://localhost:23000/v1\n"
+            "  api_mode: codex_responses\n"
+        )
+
+        with patch("hermes_cli.auth._save_model_choice"), patch("hermes_cli.auth.deactivate_provider"):
+            _model_flow_named_custom(
+                load_config(),
+                {
+                    "name": "Local Default",
+                    "base_url": "http://localhost:23000/v1",
+                    "api_key": "",
+                    "model": "gpt-oss",
+                },
+            )
+
+        import yaml
+
+        config = yaml.safe_load((config_home / "config.yaml").read_text()) or {}
+        model = config.get("model") or {}
+        assert model.get("provider") == "custom"
+        assert "api_mode" not in model

--- a/tests/test_run_agent_codex_responses.py
+++ b/tests/test_run_agent_codex_responses.py
@@ -148,7 +148,8 @@ def _codex_ack_message_response(text: str):
 
 
 class _FakeResponsesStream:
-    def __init__(self, *, final_response=None, final_error=None):
+    def __init__(self, *, events=None, final_response=None, final_error=None):
+        self._events = list(events or [])
         self._final_response = final_response
         self._final_error = final_error
 
@@ -159,7 +160,7 @@ class _FakeResponsesStream:
         return False
 
     def __iter__(self):
-        return iter(())
+        return iter(self._events)
 
     def get_final_response(self):
         if self._final_error is not None:
@@ -187,6 +188,15 @@ def _codex_request_kwargs():
         "tools": None,
         "store": False,
     }
+
+
+def _custom_responses_empty_terminal():
+    return SimpleNamespace(
+        output=[],
+        usage=SimpleNamespace(input_tokens=5, output_tokens=3, total_tokens=8),
+        status="completed",
+        model="gpt-5.4",
+    )
 
 
 def test_api_mode_uses_explicit_provider_when_codex(monkeypatch):
@@ -372,6 +382,46 @@ def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     assert calls["create"] == 1
     assert create_stream.closed is True
     assert response.output[0].content[0].text == "streamed create ok"
+
+
+def test_run_codex_stream_custom_provider_hydrates_empty_terminal_output(monkeypatch):
+    _patch_agent_bootstrap(monkeypatch)
+    agent = run_agent.AIAgent(
+        model="gpt-5.4",
+        provider="custom",
+        api_mode="codex_responses",
+        base_url="http://localhost:23000/v1",
+        api_key="test-key",
+        quiet_mode=True,
+        max_iterations=4,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    stream = _FakeResponsesStream(
+        events=[
+            SimpleNamespace(
+                type="response.output_item.done",
+                item=SimpleNamespace(
+                    type="message",
+                    status="completed",
+                    content=[SimpleNamespace(type="output_text", text="custom ok")],
+                    phase="final_answer",
+                    role="assistant",
+                ),
+            ),
+            SimpleNamespace(
+                type="response.completed",
+                response=_custom_responses_empty_terminal(),
+            ),
+        ],
+        final_response=_custom_responses_empty_terminal(),
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs(), client=SimpleNamespace(
+        responses=SimpleNamespace(stream=lambda **kwargs: stream),
+    ))
+
+    assert response.output[0].content[0].text == "custom ok"
 
 
 def test_run_conversation_codex_plain_text(monkeypatch):

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -930,6 +930,25 @@ def test_named_custom_provider_anthropic_api_mode(monkeypatch):
     assert resolved["base_url"] == "https://proxy.example.com/anthropic"
 
 
+def test_named_custom_provider_explicit_responses_api_mode(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "local-responses")
+    monkeypatch.setattr(
+        rp,
+        "_get_named_custom_provider",
+        lambda p: {
+            "name": "local-responses",
+            "base_url": "http://localhost:23000/v1",
+            "api_key": "",
+            "api_mode": "codex_responses",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="local-responses")
+
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["base_url"] == "http://localhost:23000/v1"
+
+
 # ------------------------------------------------------------------
 # fix #2562 — resolve_provider("custom") must not remap to "openrouter"
 # ------------------------------------------------------------------

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -622,6 +622,21 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertEqual(creds["api_key"], "local-key")
         self.assertEqual(creds["api_mode"], "chat_completions")
 
+    def test_direct_endpoint_honors_explicit_api_mode(self):
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "gpt-5.4",
+            "provider": "custom",
+            "base_url": "http://localhost:23000/v1",
+            "api_key": "local-key",
+            "api_mode": "codex_responses",
+        }
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["provider"], "custom")
+        self.assertEqual(creds["base_url"], "http://localhost:23000/v1")
+        self.assertEqual(creds["api_key"], "local-key")
+        self.assertEqual(creds["api_mode"], "codex_responses")
+
     def test_direct_endpoint_falls_back_to_openai_api_key_env(self):
         parent = _make_mock_parent(depth=0)
         cfg = {
@@ -811,6 +826,42 @@ class TestDelegationProviderIntegration(unittest.TestCase):
             self.assertEqual(kwargs["base_url"], "http://localhost:1234/v1")
             self.assertEqual(kwargs["api_key"], "local-key")
             self.assertEqual(kwargs["api_mode"], "chat_completions")
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_direct_endpoint_explicit_api_mode_reaches_child_agent(self, mock_creds, mock_cfg):
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "gpt-5.4",
+            "provider": "custom",
+            "base_url": "http://localhost:23000/v1",
+            "api_key": "local-key",
+            "api_mode": "codex_responses",
+        }
+        mock_creds.return_value = {
+            "model": "gpt-5.4",
+            "provider": "custom",
+            "base_url": "http://localhost:23000/v1",
+            "api_key": "local-key",
+            "api_mode": "codex_responses",
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done", "completed": True, "api_calls": 1
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(goal="Direct responses endpoint test", parent_agent=parent)
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], "gpt-5.4")
+            self.assertEqual(kwargs["provider"], "custom")
+            self.assertEqual(kwargs["base_url"], "http://localhost:23000/v1")
+            self.assertEqual(kwargs["api_key"], "local-key")
+            self.assertEqual(kwargs["api_mode"], "codex_responses")
 
     @patch("tools.delegate_tool._load_config")
     @patch("tools.delegate_tool._resolve_delegation_credentials")

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -38,6 +38,7 @@ MAX_CONCURRENT_CHILDREN = 3
 MAX_DEPTH = 2  # parent (0) -> child (1) -> grandchild rejected (2)
 DEFAULT_MAX_ITERATIONS = 50
 DEFAULT_TOOLSETS = ["terminal", "file", "web"]
+_VALID_API_MODES = {"chat_completions", "codex_responses", "anthropic_messages"}
 
 
 def check_delegate_requirements() -> bool:
@@ -645,6 +646,9 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     configured_provider = str(cfg.get("provider") or "").strip() or None
     configured_base_url = str(cfg.get("base_url") or "").strip() or None
     configured_api_key = str(cfg.get("api_key") or "").strip() or None
+    configured_api_mode = str(cfg.get("api_mode") or "").strip().lower() or None
+    if configured_api_mode not in _VALID_API_MODES:
+        configured_api_mode = None
 
     if configured_base_url:
         api_key = (
@@ -659,13 +663,14 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 
         base_lower = configured_base_url.lower()
         provider = "custom"
-        api_mode = "chat_completions"
-        if "chatgpt.com/backend-api/codex" in base_lower:
-            provider = "openai-codex"
-            api_mode = "codex_responses"
-        elif "api.anthropic.com" in base_lower:
-            provider = "anthropic"
-            api_mode = "anthropic_messages"
+        api_mode = configured_api_mode or "chat_completions"
+        if not configured_api_mode:
+            if "chatgpt.com/backend-api/codex" in base_lower:
+                provider = "openai-codex"
+                api_mode = "codex_responses"
+            elif "api.anthropic.com" in base_lower:
+                provider = "anthropic"
+                api_mode = "anthropic_messages"
 
         return {
             "model": configured_model,


### PR DESCRIPTION
## Summary
- add explicit API type selection for custom endpoints in the shared model/setup flow
- persist the selected API mode to both `model.api_mode` and `custom_providers[].api_mode`
- honor explicit custom `api_mode` in delegation and auxiliary direct-endpoint paths
- bridge auxiliary `api_mode` through CLI/gateway config loading and add regression coverage across setup, persistence, delegation, and auxiliary routing

## Problem
Custom endpoints can expose different wire protocols, but Hermes still treated some "custom" paths as if the transport were effectively fixed.

That was not a good fit for self-hosted or proxied endpoints:
- setup could not ask which API type a custom endpoint actually exposed, even though `custom_providers` already had an `api_mode` field
- direct delegation via `delegation.base_url` still silently defaulted back to `chat_completions` unless a hardcoded URL heuristic matched
- auxiliary direct endpoints (`auxiliary.*.base_url`) and the main custom auxiliary fallback dropped `api_mode` entirely and always built a vanilla OpenAI chat-completions client

In practice, that meant a user could go fully custom and still be blocked by built-in assumptions about transport format. That is not a reasonable behavior for `custom`.

## Why the previous behavior was not ideal
The old behavior mixed two contradictory ideas:
- Hermes exposed a configurable `custom` endpoint concept
- parts of the runtime still assumed that "custom" meant one fixed format unless Hermes could guess otherwise

That made `custom` weaker than advertised. Users should be able to declare the protocol explicitly and have that declaration flow through the whole runtime, instead of editing config by hand or relying on heuristics and provider-specific allowlists.

## Solution
This PR makes the protocol explicit for custom endpoints and propagates it through the runtime.

Changes in this PR:
- add a required 3-way API type picker to the custom endpoint flow
- use the exact UI labels:
  - `OpenAI Chat Completions`
  - `OpenAI Responses API`
  - `Anthropic Messages`
- map those choices directly to:
  - `chat_completions`
  - `codex_responses`
  - `anthropic_messages`
- persist the selected value to both:
  - `model.api_mode`
  - the matching `custom_providers[].api_mode`
- honor explicit `api_mode` for direct delegation endpoints instead of defaulting back to chat completions
- honor explicit `api_mode` for auxiliary direct endpoints and for the main custom endpoint when auxiliary flows reuse it
- bridge auxiliary `api_mode` through CLI and gateway startup so the saved config reaches runtime unchanged
- keep existing behavior unchanged when `api_mode` is not explicitly set

For explicit custom config, there is no heuristic fallback anymore: Hermes uses the declared protocol. When `api_mode` is absent, existing behavior is preserved.

## Setup Wizard Support
The setup wizard now covers this as well.

`setup_model_provider()` already delegates to the shared model/provider flow, so adding the API type picker to `_model_flow_custom()` makes the same explicit choice available in both:
- `hermes setup`
- `hermes model`

That keeps setup-time and post-setup configuration consistent.

## Runtime Note
The runtime side also depends on the upstream generic Responses stream fix that was merged separately:
- `0e336b0e717027cbb81fcb5816246b7aec2d4a47`
- `fix: backfill codex stream output from output_item.done events`

That upstream change removed the need for a custom-only stream workaround here. This PR focuses on making custom endpoint configuration explicit and propagating it correctly.

## Testing
```bash
./venv/bin/pytest tests/agent/test_auxiliary_client.py tests/test_auxiliary_config_bridge.py tests/tools/test_delegate.py tests/test_crossloop_client_cache.py -q
./venv/bin/pytest tests/hermes_cli/test_setup.py tests/test_model_provider_persistence.py tests/test_cli_provider_resolution.py tests/test_run_agent_codex_responses.py -q
```

Results:
- `179 passed in 3.61s`
- `75 passed in 23.93s`

Additional local smoke checks:
- verified an auxiliary direct endpoint with `base_url=http://localhost:23000/v1` and `api_mode=codex_responses` resolves to `CodexAuxiliaryClient`
- verified delegation config resolves `api_mode=codex_responses`
- restarted the local gateway on the patched branch
