### PR TITLE
fix(codex): preserve streamed output when terminal response is empty

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3382,6 +3382,7 @@ class AIAgent:
         first_delta_fired = False
         for attempt in range(max_stream_retries + 1):
             try:
+                streamed_output_items: List[Any] = []
                 with active_client.responses.stream(**api_kwargs) as stream:
                     for event in stream:
                         if self._interrupt_requested:
@@ -3402,12 +3403,29 @@ class AIAgent:
                         # Track tool calls to suppress text streaming
                         elif "function_call" in event_type:
                             has_tool_calls = True
+                        elif event_type == "response.output_item.done":
+                            item = getattr(event, "item", None)
+                            if item is not None:
+                                streamed_output_items.append(item)
                         # Fire reasoning callbacks
                         elif "reasoning" in event_type and "delta" in event_type:
                             reasoning_text = getattr(event, "delta", "")
                             if reasoning_text:
                                 self._fire_reasoning_delta(reasoning_text)
-                    return stream.get_final_response()
+                    final_response = stream.get_final_response()
+                    output = getattr(final_response, "output", None)
+                    if isinstance(output, list) and output:
+                        return final_response
+                    if streamed_output_items:
+                        return SimpleNamespace(
+                            output=streamed_output_items,
+                            usage=getattr(final_response, "usage", None),
+                            status=getattr(final_response, "status", None),
+                            model=getattr(final_response, "model", None),
+                            error=getattr(final_response, "error", None),
+                            id=getattr(final_response, "id", None),
+                        )
+                    return final_response
             except RuntimeError as exc:
                 err_text = str(exc)
                 missing_completed = "response.completed" in err_text

--- a/tests/test_run_agent_codex_responses.py
+++ b/tests/test_run_agent_codex_responses.py
@@ -148,7 +148,8 @@ def _codex_ack_message_response(text: str):
 
 
 class _FakeResponsesStream:
-    def __init__(self, *, final_response=None, final_error=None):
+    def __init__(self, *, events=None, final_response=None, final_error=None):
+        self._events = list(events or [])
         self._final_response = final_response
         self._final_error = final_error
 
@@ -159,7 +160,7 @@ class _FakeResponsesStream:
         return False
 
     def __iter__(self):
-        return iter(())
+        return iter(self._events)
 
     def get_final_response(self):
         if self._final_error is not None:
@@ -372,6 +373,44 @@ def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     assert calls["create"] == 1
     assert create_stream.closed is True
     assert response.output[0].content[0].text == "streamed create ok"
+
+
+def test_run_codex_stream_reconstructs_empty_terminal_response_from_stream_items(monkeypatch):
+    agent = _build_agent(monkeypatch)
+
+    streamed_item = SimpleNamespace(
+        type="message",
+        phase="final_answer",
+        status="completed",
+        content=[SimpleNamespace(type="output_text", text="ok")],
+    )
+    terminal_response = SimpleNamespace(
+        output=[],
+        usage=SimpleNamespace(input_tokens=5, output_tokens=1, total_tokens=6),
+        status="completed",
+        model="gpt-5.4",
+        error=None,
+        id="resp_123",
+    )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=lambda **kwargs: _FakeResponsesStream(
+                events=[
+                    SimpleNamespace(type="response.created"),
+                    SimpleNamespace(type="response.output_item.done", item=streamed_item),
+                ],
+                final_response=terminal_response,
+            ),
+            create=lambda **kwargs: None,
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert len(response.output) == 1
+    assert response.output[0].content[0].text == "ok"
+    assert response.model == "gpt-5.4"
 
 
 def test_run_conversation_codex_plain_text(monkeypatch):


### PR DESCRIPTION
## Summary
- preserve streamed `response.output_item.done` items in the Codex Responses stream path
- reconstruct a usable final response when `response.completed` arrives with empty `output`
- add a regression test covering empty terminal responses after successful stream output

## Problem
Some `openai-codex` / `gpt-5.4` responses stream normal `response.output_text.delta` and `response.output_item.done` events, but the terminal `response.completed.response` object can still arrive with `output=[]`.

Hermes currently trusts only the terminal response object, drops the streamed assistant message, classifies the turn as malformed (`response.output is empty`), and prematurely switches to fallback.

## Verification
- `pytest tests/test_run_agent_codex_responses.py -q`
- live smoke test via `AIAgent(provider="openai-codex", model="gpt-5.4")` returning `ok`
