### PR TITLE
fix: backfill empty output in codex create-stream fallback

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3997,11 +3997,22 @@ class AIAgent:
             return stream_or_response
 
         terminal_response = None
+        _accumulated_output_items = []
         try:
             for event in stream_or_response:
                 event_type = getattr(event, "type", None)
                 if not event_type and isinstance(event, dict):
                     event_type = event.get("type")
+
+                # Capture completed output items for backfilling — same
+                # ChatGPT Codex backend quirk handled in _run_codex_stream.
+                if event_type == "response.output_item.done":
+                    item = getattr(event, "item", None)
+                    if item is None and isinstance(event, dict):
+                        item = event.get("item")
+                    if item is not None:
+                        _accumulated_output_items.append(item)
+
                 if event_type not in {"response.completed", "response.incomplete", "response.failed"}:
                     continue
 
@@ -4009,6 +4020,10 @@ class AIAgent:
                 if terminal_response is None and isinstance(event, dict):
                     terminal_response = event.get("response")
                 if terminal_response is not None:
+                    # Backfill empty output from collected stream items.
+                    _out = getattr(terminal_response, "output", None)
+                    if _accumulated_output_items and isinstance(_out, list) and not _out:
+                        terminal_response.output = list(_accumulated_output_items)
                     return terminal_response
         finally:
             close_fn = getattr(stream_or_response, "close", None)


### PR DESCRIPTION
## Summary

- The ChatGPT Codex backend (`chatgpt.com/backend-api/codex`) sends valid output items via `response.output_item.done` stream events but returns `output: []` in the `response.completed` event
- `_run_codex_stream` already handles this by collecting items and backfilling the response — this PR applies the same fix to `_run_codex_create_stream_fallback` so the fallback path doesn't hit the "response.output is empty" retry loop

## Test plan

- [ ] Run Hermes with `gpt-5.4` via the ChatGPT Codex backend and verify responses work without "response.output is empty" errors
- [ ] Verify the create-stream fallback path (triggered by transport errors) also returns valid output
- [ ] Existing tests pass (`pytest tests/test_run_agent_codex_responses.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)