### PR TITLE
feat: add manim-kids skill for elementary math animations

### DIFF
--- a/skills/creative/manim-kids/README.md
+++ b/skills/creative/manim-kids/README.md
@@ -1,0 +1,33 @@
+# manim-kids
+
+Animated math and science videos for elementary-age kids (ages 6-10) using [Manim Community Edition](https://www.manim.community/).
+
+Built for visual learners and neurodivergent kids who need more than worksheets. Produces short, vivid, mascot-driven explainer clips that make abstract concepts physical and obvious.
+
+## What it does
+
+- Generates Manim Python scripts that produce 2-5 minute animated math videos
+- Features Pip, a friendly circle mascot who learns alongside the viewer
+- Uses a concrete-to-abstract ladder: real objects -> shapes -> diagrams -> equations
+- Color-coded operations (blue=addition, green=multiplication, etc.) for consistent visual language
+- Reward animations (confetti, star bursts) after key reveals
+- Voice-first pacing with 3-second question pauses for active thinking
+
+## Target concepts
+
+Primarily third grade math: multiplication as groups, division as sharing, fractions, area, perimeter, rounding, telling time. Full K-5 concept map included in references.
+
+## Dependencies
+
+Python 3.10+, Manim CE, LaTeX, ffmpeg. Run `scripts/setup.sh` to verify.
+
+## References
+
+| File | Contents |
+|------|----------|
+| `references/mascot.md` | Pip implementation, expressions, positioning |
+| `references/rewards.md` | Celebration animations, confetti, star burst |
+| `references/concrete-to-abstract.md` | The 4-rung pedagogical ladder with examples |
+| `references/elementary-math.md` | K-5 concept map with visual metaphors |
+| `references/engagement.md` | Hooks, humor, question pauses, surprise patterns |
+| `references/voice-and-pacing.md` | Narration workflow, TTS integration, pacing |

--- a/skills/creative/manim-kids/SKILL.md
+++ b/skills/creative/manim-kids/SKILL.md
@@ -1,0 +1,322 @@
+---
+name: manim-kids
+description: "Animated math and science videos for elementary-age kids (ages 6-10) using Manim Community Edition. Mascot-driven, voice-first, pattern-discovery pedagogy designed for visual learners and neurodivergent kids who need more than worksheets. Produces short, vivid, dopamine-aware explainer clips that make abstract concepts physical and obvious."
+version: 1.0.0
+---
+
+# Manim Kids -- Animated Learning for Young Minds
+
+## Who This Is For
+
+Kids ages 6-10. Especially the ones the classroom isn't reaching -- the visual thinkers, the pattern-spotters, the kids who zone out during worksheets but light up when you show them WHY something works. Neurodivergent kids. Gifted kids. Kids who need to SEE the math before they can DO the math.
+
+These videos don't replace a teacher. They give a kid a private "aha moment" they can replay.
+
+## Creative Standard
+
+**This is a show, not a lecture.** Every video should feel like a favorite YouTube channel, not a classroom smartboard. The bar is "my kid asks to watch another one."
+
+**The mascot is the teacher.** Pip (a friendly bouncing circle with expressive dot-eyes) appears in every video. Pip points at things, reacts to reveals, celebrates correct answers, and occasionally gets confused (on purpose) so the kid can feel smarter than the character. Pip is never condescending. Pip is a curious friend who's figuring things out alongside the viewer.
+
+**Voice-first, text-second.** Eight-year-olds read slowly. Narration carries the content. On-screen text is for labels, equations, and punchlines -- never paragraphs. If you have to choose between a sentence of text and an animation, animate.
+
+**30-second rule.** No scene runs longer than 30-45 seconds. Each scene is one idea. A "video" is 3-8 scenes, total runtime 2-5 minutes. Attention is precious -- earn it every half-minute.
+
+**Show, don't tell. Then ask.** Never explain a concept with words first. Show the visual pattern. Let it sit. THEN name it. The equation is the last thing, never the first.
+
+**Pattern discovery over instruction.** Don't say "3 times 4 equals 12." Show three groups of four objects. Show them merge. Show the number 12 appear. Let the kid's brain do the connecting. The "aha" is the product -- manufacture it carefully.
+
+**Surprise and humor.** Every video needs at least one unexpected moment. Pip gets bonked by a falling number. Objects arrange themselves into a smiley face before becoming a math problem. A fraction pizza gets "eaten" with a cartoon chomp sound effect label. Delight is a learning accelerator.
+
+**Reward the brain.** Celebration animations after every reveal: confetti bursts, Pip doing a spin, stars radiating outward, a satisfying color wash. Not patronizing -- genuinely satisfying. Think video game feedback, not gold star stickers.
+
+## Design Principles
+
+### 1. Concrete-to-Abstract Ladder
+
+Every concept gets four passes, always in this order:
+
+```
+REAL OBJECT  -->  SIMPLE SHAPE  -->  DIAGRAM  -->  SYMBOL
+  (pizza)        (colored circle)   (fraction bar)  (1/2)
+```
+
+Never skip a rung. Never start at the symbol. The whole point is building the bridge from physical intuition to mathematical notation.
+
+### 2. Color Is Meaning
+
+Operations and concepts get permanent colors. Every video, every time:
+
+| Concept | Color | Hex |
+|---------|-------|-----|
+| Addition / combining | Blue | `#58C4DD` |
+| Subtraction / removing | Coral red | `#FF6B6B` |
+| Multiplication / groups | Green | `#83C167` |
+| Division / splitting | Purple | `#B07CD8` |
+| Equals / result | Gold | `#FFD93D` |
+| Question / unknown | Orange | `#FF9F43` |
+| Pip (mascot) | White with blue outline | `#FFFFFF` / `#58C4DD` |
+
+A kid who watches ten of these videos will start FEELING that green means groups before they consciously know it. That's the goal.
+
+### 3. Spatial Consistency
+
+Math builds left-to-right, top-to-bottom. Inputs on the left, outputs on the right. The thing being explained is always center stage. Supporting context lives at the edges. Never surprise a kid with something appearing behind where they were looking.
+
+### 4. Motion Vocabulary
+
+Consistent animation meanings:
+
+| Motion | Meaning |
+|--------|---------|
+| **Grow from center** | New concept appearing |
+| **Slide together** | Combining / adding |
+| **Slide apart** | Separating / subtracting |
+| **Replicate + arrange** | Multiplication (groups forming) |
+| **Split with line** | Division / fractions |
+| **Transform/morph** | "This IS that" (equivalence) |
+| **Bounce** | Emphasis, counting |
+| **Fade to dim** | "Remember this is here, but look over here now" |
+| **Confetti burst** | Celebration / correct answer |
+
+### 5. The Pip System
+
+Pip is built from simple Manim primitives -- a `Circle` body, two `Dot` eyes, and optional expression arcs. See `references/mascot.md` for full implementation.
+
+Pip states:
+- **Neutral** -- watching, present
+- **Excited** -- eyes widen (scale up), small bounce
+- **Thinking** -- one eye slightly up, head tilt (rotate)
+- **Surprised** -- eyes big, jump back
+- **Celebrating** -- spin + confetti
+- **Pointing** -- arrow extends from body toward target
+
+Pip lives in the bottom-right quadrant by default. Never overlaps the main content. Moves to point at things, then returns home.
+
+### 6. Narration Pacing
+
+| Moment | Pace | Pause after |
+|--------|------|-------------|
+| Introducing something new | Slow, clear | 2.0s |
+| Counting objects | Rhythmic, bouncy | 0.5s per item |
+| Asking a question | Slightly slower, rising tone | 3.0s (let them think!) |
+| Revealing the answer | Normal | 1.5s |
+| "Did you see that?" callback | Warm, conspiratorial | 1.0s |
+| Celebration | Upbeat, quick | 1.0s |
+
+The 3-second pause after questions is sacred. That's where learning happens -- in the kid's head, not on the screen.
+
+### 7. Repetition With Variation
+
+The same concept shown three ways:
+
+1. **Physical metaphor** (apples, pizza, toy cars -- concrete objects the kid knows)
+2. **Abstract shapes** (colored circles, blocks, bars)
+3. **Mathematical notation** (numbers, operators, equations)
+
+Each pass is a new scene with different visuals but the same underlying structure. The kid's brain pattern-matches across representations. That IS understanding.
+
+## Stack
+
+Same as `manim-video`:
+
+| Layer | Tool | Purpose |
+|-------|------|---------|
+| Core | Manim Community Edition | Scene rendering, animation engine |
+| Math | LaTeX (texlive/MiKTeX) | Equation rendering via `MathTex` |
+| Video I/O | ffmpeg | Scene stitching, format conversion |
+| TTS (optional) | ElevenLabs / edge-tts | Warm, friendly narration voice |
+
+## Pipeline
+
+```
+CONCEPT --> LADDER --> SCRIPT --> RENDER --> STITCH --> NARRATE (optional)
+```
+
+1. **CONCEPT** -- Identify the math/science concept and the target misconception
+2. **LADDER** -- Map the concrete-to-abstract progression (4 rungs)
+3. **SCRIPT** -- Write `script.py` with short scenes, Pip appearances, rewards
+4. **RENDER** -- `manim -ql script.py` for draft, `-qm` for delivery (720p is fine for kids)
+5. **STITCH** -- ffmpeg concat into final clip
+6. **NARRATE** (optional) -- Add TTS voiceover synced to animations
+
+## Project Structure
+
+```
+project-name/
+  concept.md             # What we're teaching and why
+  script.py              # All scenes
+  concat.txt             # ffmpeg scene list
+  final.mp4              # Output
+  media/
+    videos/script/720p30/
+```
+
+## Scene Templates
+
+### Template: Concept Introduction (Scene 1 of any video)
+
+```python
+class Scene1_Hook(Scene):
+    def construct(self):
+        self.camera.background_color = BG
+
+        # Pip enters
+        pip = Pip().to_corner(DR, buff=0.8)
+        self.play(pip.enter(), run_time=0.8)
+        self.wait(0.5)
+
+        # Show the real-world object / situation
+        # (customize: pizza, apples, toy cars, etc.)
+        objects = VGroup(*[create_object() for _ in range(N)])
+        objects.arrange_in_grid(rows=R, buff=0.4).move_to(ORIGIN)
+        self.play(LaggedStart(*[GrowFromCenter(o) for o in objects], lag_ratio=0.1))
+        self.wait(1.0)
+
+        # Pip reacts
+        self.play(pip.look_at(objects))
+        self.wait(0.5)
+
+        # Optional: narration cue
+        self.add_subcaption("Hmm, how many do we have here?", duration=3)
+        self.play(pip.think())
+        self.wait(3.0)  # LET THE KID COUNT
+```
+
+### Template: Reveal + Celebration (Final scene)
+
+```python
+class SceneN_Reveal(Scene):
+    def construct(self):
+        self.camera.background_color = BG
+
+        pip = Pip().to_corner(DR, buff=0.8)
+        self.add(pip)
+
+        # Show the equation forming from the visual
+        equation = MathTex(r"3 \times 4 = 12", font_size=56, color=GOLD)
+        self.play(Write(equation), run_time=2.0)
+        self.wait(1.5)
+
+        # Pip celebrates
+        self.play(pip.celebrate())
+
+        # Confetti burst
+        confetti = create_confetti(equation.get_center())
+        self.play(*[GrowFromCenter(c) for c in confetti], run_time=0.5)
+        self.wait(0.3)
+        self.play(*[FadeOut(c, shift=UP*0.5) for c in confetti], run_time=1.0)
+
+        self.wait(1.0)
+        self.play(FadeOut(Group(*self.mobjects)))
+```
+
+## Visual Specifications
+
+### Typography
+
+```python
+MONO = "Menlo"  # or "DejaVu Sans Mono"
+
+# Sizes tuned for young readers
+TITLE_SIZE = 56    # Big, bold, unmissable
+LABEL_SIZE = 36    # Object labels, counts
+EQUATION_SIZE = 48 # Final equations
+CAPTION_SIZE = 28  # Subcaptions (if any on-screen text)
+```
+
+All text uses monospace. Minimum font_size=24 for readability on tablets/phones.
+
+### Color Palette
+
+```python
+# Background
+BG = "#1A1A2E"       # Deep navy -- easy on eyes, high contrast
+
+# Operation colors (NEVER change these across videos)
+BLUE = "#58C4DD"     # Addition
+RED = "#FF6B6B"      # Subtraction
+GREEN = "#83C167"    # Multiplication
+PURPLE = "#B07CD8"   # Division
+GOLD = "#FFD93D"     # Results / equals
+ORANGE = "#FF9F43"   # Questions / unknowns
+
+# Pip
+PIP_BODY = "#FFFFFF"
+PIP_OUTLINE = "#58C4DD"
+PIP_EYES = "#1A1A2E"
+
+# Supporting
+DIM = 0.3            # Opacity for background/context elements
+BRIGHT = 1.0         # Opacity for focus elements
+```
+
+### Animation Timing
+
+| Animation | run_time | wait() after |
+|-----------|----------|-------------|
+| Pip enters | 0.8s | 0.5s |
+| Object appears | 0.6s | 0.3s |
+| Objects arrange | 1.2s | 1.0s |
+| Key reveal | 2.0s | 2.0s |
+| Question pause | -- | 3.0s |
+| Answer reveal | 1.5s | 1.5s |
+| Celebration | 0.5s | 1.0s |
+| Scene cleanup | 0.5s | 0.3s |
+
+### Rendering
+
+**Draft**: `manim -ql` (480p 15fps) -- for iteration
+**Delivery**: `manim -qm` (720p 30fps) -- final output for kids
+**Never -qh** unless specifically requested. Kids watch on tablets. 720p is perfect.
+
+## Grade-Level Concept Map
+
+See `references/elementary-math.md` for the full concept progression, but here's the K-3 core:
+
+### Third Grade Focus
+
+| Concept | Visual Metaphor | Key Animation |
+|---------|----------------|---------------|
+| Multiplication as groups | Groups of objects forming | Slide-together, count bounce |
+| Division as sharing | Objects dealing into piles | Split animation |
+| Fractions (1/2, 1/3, 1/4) | Pizza, chocolate bar, pie | Cut line, color halves |
+| Area (length x width) | Grid of square tiles filling | Tile-by-tile fill |
+| Number line | Road with mileposts | Pip walking/hopping along |
+| Rounding | Number line with "gravity wells" | Numbers sliding to nearest 10 |
+| Telling time | Analog clock with moving hands | Hands sweeping, Pip pointing |
+| Perimeter | Ant walking around a shape | Traced path with counter |
+
+## Reference Documents
+
+Load detailed implementation guides on demand:
+
+| Reference | Contents |
+|-----------|----------|
+| `mascot` | Pip implementation -- Circle body, Dot eyes, expression states, enter/exit/point/celebrate methods, positioning |
+| `rewards` | Celebration animations -- confetti, star burst, color wash, Pip spin, sound effect cues |
+| `concrete-to-abstract` | The 4-rung ladder pattern with examples for each math operation |
+| `elementary-math` | Full K-5 concept map with visual metaphors and animation patterns per topic |
+| `engagement` | Hooks, humor patterns, surprise reveals, question-pause technique, callback structure |
+| `voice-and-pacing` | Narration-first workflow, TTS integration, pacing tables, script writing for young audiences |
+
+## Critical Implementation Notes
+
+### From manim-video (still apply)
+
+- Raw strings for LaTeX: `MathTex(r"\frac{1}{2}")`
+- `buff >= 0.5` on all `.to_edge()` calls
+- `self.camera.background_color = BG` in every scene
+- `Group(*self.mobjects)` for mixed-type FadeOut (not VGroup)
+- Use `ReplacementTransform` to swap, not `Write` on top
+- Monospace fonts only (Pango kerning bug with proportional fonts)
+
+### Kids-specific
+
+- **No dense text.** Maximum 6 words on screen at once. Prefer 2-3.
+- **No abstract-first.** Never show an equation without first showing what it represents visually.
+- **Count everything.** When objects appear, bounce-count them. Numbers appearing one by one as Pip "counts" is deeply satisfying.
+- **Pause after questions.** 3 seconds minimum. The screen should feel like it's waiting for the kid to think.
+- **Big, bold, round.** Prefer circles and rounded rectangles over sharp geometry. Feels friendlier.
+- **Left-to-right flow.** Always. Math reads left to right for this age group.
+- **One operation per video.** Don't mix addition and multiplication in the same video. Build one concept solidly.

--- a/skills/creative/manim-kids/references/concrete-to-abstract.md
+++ b/skills/creative/manim-kids/references/concrete-to-abstract.md
@@ -1,0 +1,224 @@
+# Concrete-to-Abstract Ladder
+
+The core pedagogical pattern. Every math concept is taught through four progressive representations, always in the same order. Never skip a rung.
+
+## The Four Rungs
+
+```
+RUNG 1: REAL OBJECT      -- Something the kid knows from life
+RUNG 2: SIMPLE SHAPE      -- Geometric abstraction (circles, blocks)
+RUNG 3: DIAGRAM            -- Structured visual (number line, bar, grid)
+RUNG 4: SYMBOL             -- Mathematical notation (digits, operators)
+```
+
+Each rung is its own scene (30-45 seconds). The full ladder takes 3-5 scenes depending on complexity.
+
+## Why This Order Matters
+
+Kids build mental models from physical experience upward. When you show `3 + 4 = 7` first, the equation is arbitrary -- just symbols to memorize. When you show 3 apples joining 4 apples and the kid counts 7, THEN show the equation, the symbols have meaning anchored in physical reality.
+
+Neurodivergent and visual-spatial learners especially need this grounding. The abstract symbol is the LAST thing they should see, not the first.
+
+## Example: Multiplication (3 x 4 = 12)
+
+### Rung 1: Real Objects (Scene)
+
+Show 3 bags. Each bag opens to reveal 4 toy cars.
+
+```python
+# Three paper bags appear
+bags = VGroup(*[create_bag() for _ in range(3)])
+bags.arrange(RIGHT, buff=1.0).move_to(UP * 0.5)
+self.play(LaggedStart(*[GrowFromCenter(b) for b in bags], lag_ratio=0.2))
+
+# Each bag "opens" and 4 toy cars slide out
+for bag in bags:
+    cars = VGroup(*[create_car(color=GREEN) for _ in range(4)])
+    cars.arrange(DOWN, buff=0.2).next_to(bag, DOWN, buff=0.3)
+    self.play(
+        bag.animate.set_opacity(0.4),
+        LaggedStart(*[FadeIn(c, shift=DOWN*0.3) for c in cars], lag_ratio=0.1),
+        run_time=1.0,
+    )
+self.wait(1.5)
+
+# Pip: "Hmm, how many cars is that?"
+self.add_subcaption("Hmm, how many cars is that?", duration=3)
+self.play(pip.think())
+self.wait(3.0)  # LET THEM COUNT
+```
+
+### Rung 2: Simple Shapes (Scene)
+
+Same structure, now with colored dots.
+
+```python
+# 3 groups of 4 green circles
+groups = VGroup()
+for i in range(3):
+    group = VGroup(*[
+        Circle(radius=0.2, color=GREEN, fill_opacity=0.8)
+        for _ in range(4)
+    ])
+    group.arrange_in_grid(rows=2, cols=2, buff=0.15)
+    groups.add(group)
+groups.arrange(RIGHT, buff=0.8).move_to(ORIGIN)
+
+# Groups appear one at a time
+for g in groups:
+    self.play(LaggedStart(*[GrowFromCenter(c) for c in g], lag_ratio=0.05))
+    self.wait(0.5)
+
+# Draw dashed boundary around each group
+for g in groups:
+    border = SurroundingRectangle(g, color=GREEN, buff=0.15, corner_radius=0.1)
+    border.set_stroke(opacity=0.5)
+    self.play(Create(border), run_time=0.4)
+
+# Label groups: "3 groups"
+label = Text("3 groups of 4", font_size=LABEL_SIZE, font=MONO, color=GREEN)
+label.to_edge(UP, buff=0.5)
+self.play(FadeIn(label))
+self.wait(1.5)
+```
+
+### Rung 3: Diagram (Scene)
+
+Array/grid representation -- a 3x4 grid of squares.
+
+```python
+# 3 rows, 4 columns grid
+grid = VGroup()
+for row in range(3):
+    for col in range(4):
+        sq = Square(side_length=0.5, color=GREEN, fill_opacity=0.6)
+        sq.move_to(RIGHT * col * 0.6 + DOWN * row * 0.6)
+        grid.add(sq)
+grid.center()
+
+# Fill row by row with bounce count
+for row in range(3):
+    row_squares = grid[row*4 : (row+1)*4]
+    self.play(
+        LaggedStart(*[GrowFromCenter(s) for s in row_squares], lag_ratio=0.08),
+        run_time=0.6,
+    )
+    # Row label
+    row_label = Text(f"4", font_size=24, font=MONO, color=GREEN)
+    row_label.next_to(row_squares, RIGHT, buff=0.3)
+    self.play(FadeIn(row_label), run_time=0.3)
+
+# Column count
+col_label = Text("3 rows", font_size=24, font=MONO, color=GREEN)
+col_label.next_to(grid, LEFT, buff=0.5)
+self.play(FadeIn(col_label))
+
+# Total
+total = Text("= 12", font_size=36, font=MONO, color=GOLD)
+total.next_to(grid, DOWN, buff=0.5)
+self.play(Write(total), run_time=1.0)
+self.wait(1.5)
+```
+
+### Rung 4: Symbol (Scene)
+
+The equation, built piece by piece from what they just saw.
+
+```python
+# "3" appears (green, like the groups)
+three = MathTex("3", font_size=56, color=GREEN)
+three.move_to(LEFT * 2)
+self.play(Write(three), run_time=0.6)
+self.add_subcaption("3...", duration=1)
+self.wait(0.5)
+
+# "x" appears
+times = MathTex(r"\times", font_size=56, color=WHITE)
+times.next_to(three, RIGHT, buff=0.3)
+self.play(Write(times), run_time=0.4)
+self.add_subcaption("times...", duration=0.8)
+self.wait(0.3)
+
+# "4" appears (green, like the group size)
+four = MathTex("4", font_size=56, color=GREEN)
+four.next_to(times, RIGHT, buff=0.3)
+self.play(Write(four), run_time=0.6)
+self.add_subcaption("4...", duration=1)
+self.wait(0.5)
+
+# "=" appears
+equals = MathTex("=", font_size=56, color=WHITE)
+equals.next_to(four, RIGHT, buff=0.3)
+self.play(Write(equals), run_time=0.3)
+
+# "12" appears in GOLD -- the big reveal
+twelve = MathTex("12", font_size=56, color=GOLD)
+twelve.next_to(equals, RIGHT, buff=0.3)
+self.play(Write(twelve), run_time=1.0)
+self.add_subcaption("equals twelve!", duration=2)
+
+# CELEBRATE
+self.play(pip.celebrate())
+play_confetti(self, twelve.get_center())
+self.wait(1.5)
+```
+
+## Ladder Patterns for Each Operation
+
+### Addition: Slide Together
+
+| Rung | Visual | Animation |
+|------|--------|-----------|
+| Real | 3 red apples + 4 green apples | Groups slide together |
+| Shape | Blue circles merge into one group | Slide + recount |
+| Diagram | Number line: hop from 3, land on 7 | Pip walks along |
+| Symbol | `3 + 4 = 7` built left-to-right | Write piece by piece |
+
+### Subtraction: Take Away
+
+| Rung | Visual | Animation |
+|------|--------|-----------|
+| Real | 7 cookies, 3 get eaten (chomp!) | FadeOut with humor |
+| Shape | Red circles disappear from group | Shrink + vanish |
+| Diagram | Number line: hop backward from 7 | Pip walks back |
+| Symbol | `7 - 3 = 4` | Coral-red coloring |
+
+### Division: Fair Sharing
+
+| Rung | Visual | Animation |
+|------|--------|-----------|
+| Real | 12 candies dealt to 3 kids | Objects slide to recipients |
+| Shape | Purple circles sort into equal piles | Rearrange animation |
+| Diagram | Bar split into 3 equal sections | Cut lines appear |
+| Symbol | `12 / 3 = 4` | Purple coloring |
+
+### Fractions: Parts of a Whole
+
+| Rung | Visual | Animation |
+|------|--------|-----------|
+| Real | Pizza cut in half, one slice colored | Cut line, fill half |
+| Shape | Circle with colored sector | Arc + fill |
+| Diagram | Fraction bar (rectangle split) | Sections fill |
+| Symbol | `1/2` with MathTex | Fraction appears |
+
+## Transition Between Rungs
+
+Never hard-cut between rungs. Use a brief morph or dissolve:
+
+```python
+# Morph real objects into abstract shapes
+for apple, circle in zip(apples, shapes):
+    self.play(
+        ReplacementTransform(apple, circle),
+        run_time=0.8,
+    )
+```
+
+This visual continuity reinforces that the abstract shape IS the real object -- just simplified.
+
+## Common Mistakes
+
+- **Starting at Rung 3 or 4.** "Let me show you on the number line" -- no. Show real objects first.
+- **Skipping Rung 2.** The intermediate abstraction is where the real learning happens. It bridges physical to diagrammatic.
+- **Rushing Rung 4.** The equation should feel like a reward, not an assignment. Slow reveal, gold color, celebration.
+- **Same objects every time.** Vary: apples, cars, stars, cookies, blocks. Same structure, different wrapper.

--- a/skills/creative/manim-kids/references/elementary-math.md
+++ b/skills/creative/manim-kids/references/elementary-math.md
@@ -1,0 +1,241 @@
+# Elementary Math Concept Map
+
+Grade-level concept progressions with visual metaphors and recommended animation patterns. Each entry maps a math concept to the concrete objects, shapes, diagrams, and animations that make it click for young learners.
+
+## Kindergarten (Ages 5-6)
+
+### Counting (1-20)
+
+**Visual**: Objects appear one at a time with bounce. Number counter increments.
+**Animation**: `GrowFromCenter` each object + `play_bounce_count()`.
+**Metaphor**: Counting toys into a toy box, stars appearing in the sky.
+**Pip**: Nods with each count.
+
+```
+Objects:  *  * *  * * *  (appear one by one)
+Counter:  1  2 3  4 5 6  (increments)
+```
+
+### More / Less / Same
+
+**Visual**: Two groups side by side. One is clearly bigger. Lines connect matching pairs -- leftover objects highlight.
+**Animation**: Matching pairs slide toward each other and connect with lines. Unmatched objects glow.
+**Metaphor**: Two plates of cookies. "Who has more?"
+
+### Shapes
+
+**Visual**: Shape appears, label appears, shape morphs into a real object (circle -> wheel, square -> window).
+**Animation**: `Create(shape)` then `ReplacementTransform(shape, real_object)`.
+**Pip**: Points at each shape.
+
+---
+
+## First Grade (Ages 6-7)
+
+### Addition (sums to 20)
+
+**Visual**: Two groups of objects slide together and merge.
+**Animation**: Left group + right group -> `animate.shift()` together, recount.
+**Color**: BLUE for all addition elements.
+**Ladder**:
+1. Real: 3 toy cars + 5 toy cars
+2. Shape: Blue circles merging
+3. Diagram: Number line -- hop from 3, count 5 hops, land on 8
+4. Symbol: `3 + 5 = 8`
+
+### Subtraction (from 20)
+
+**Visual**: Group of objects, some get removed (fly away, get eaten, disappear).
+**Animation**: `FadeOut(objects, shift=UP)` or shrink + vanish for humor.
+**Color**: RED/CORAL for subtraction elements.
+**Ladder**:
+1. Real: 8 cookies, 3 get eaten (cartoon chomp subcaption)
+2. Shape: Red circles shrink away
+3. Diagram: Number line -- hop backward
+4. Symbol: `8 - 3 = 5`
+
+### Place Value (tens and ones)
+
+**Visual**: Loose blocks that snap into rods of 10. "23 = 2 rods + 3 loose blocks."
+**Animation**: 10 blocks slide together and `ReplacementTransform` into a rod.
+**Metaphor**: Bundling sticks, stacking cups.
+
+---
+
+## Second Grade (Ages 7-8)
+
+### Addition with carrying
+
+**Visual**: Ones column fills past 10 -> 10 ones morph into 1 ten-rod that slides to the tens column.
+**Animation**: Step-by-step column addition with visual carry.
+**Key moment**: The "carry" is shown as a physical movement, not a written digit.
+
+### Skip counting (2s, 5s, 10s)
+
+**Visual**: Number line with Pip hopping in fixed jumps. Landing spots light up.
+**Animation**: Pip hops along number line, each landing creates a splash effect.
+**Pattern discovery**: "What do you notice about these numbers?"
+
+### Measurement
+
+**Visual**: Object next to a ruler. Unit markers count off. "The pencil is 6 units long."
+**Animation**: Unit blocks tile along the object, counter increments.
+**Metaphor**: Pip walking along the object, counting steps.
+
+### Money (coins and bills)
+
+**Visual**: Coins with value labels. Coins slide together, values add up.
+**Color**: Gold for all money. Values in white.
+**Key pattern**: Quarter (25) + quarter (25) = 50. Show with bounce count by 25s.
+
+---
+
+## Third Grade (Ages 8-9) -- PRIMARY TARGET
+
+### Multiplication as groups
+
+**THE core concept for this age. Treat it as the most important topic.**
+
+**Visual**: N groups of M objects. Groups form, then merge. Array grid forms.
+**Color**: GREEN for all multiplication elements.
+**Multiple representations**:
+1. Groups of objects (bags of marbles, boxes of crayons)
+2. Array grid (rows x columns of dots/squares)
+3. Number line with repeated jumps
+4. Equation with `x` or `times` symbol
+
+**Key animations**:
+- Groups forming from scattered objects (`arrange_in_grid`)
+- Array filling row by row
+- Pip counting by the group size ("4... 8... 12!")
+
+```python
+# Multiplication as repeated addition (number line)
+for jump in range(3):
+    arc = ArcBetweenPoints(
+        start=number_line.n2p(jump * 4),
+        end=number_line.n2p((jump + 1) * 4),
+        angle=-0.5,
+        color=GREEN,
+    )
+    self.play(Create(arc), run_time=0.6)
+    # Landing label
+    label = Text(str((jump + 1) * 4), font_size=24, font=MONO, color=GOLD)
+    label.next_to(number_line.n2p((jump + 1) * 4), DOWN, buff=0.3)
+    self.play(FadeIn(label))
+```
+
+### Division as sharing
+
+**Visual**: Objects dealt out to recipients one at a time (round-robin).
+**Color**: PURPLE for division.
+**Animation**: Objects slide from center pile to recipient positions. Counter per recipient increments.
+**Key insight**: Division is the reverse of multiplication. Show 12 / 3 = 4, then immediately show 3 x 4 = 12 with the same objects.
+
+### Fractions (1/2, 1/3, 1/4, unit fractions)
+
+**Visual**: Whole object (pizza, chocolate bar) gets cut. Parts are colored.
+**Color**: Use the operation color of the context (e.g., GREEN if dividing pizza into equal groups).
+**Animations**:
+- Cut line appears (DashedLine)
+- One part fills with color, others dim
+- Fraction label appears: `MathTex(r"\frac{1}{4}")`
+
+**Key concept**: "The bottom number is how many EQUAL pieces. The top number is how many you HAVE."
+
+```python
+# Pizza fraction
+pizza = Circle(radius=1.5, color=ORANGE, fill_opacity=0.8)
+# Cut into 4
+for i in range(4):
+    angle = i * TAU / 4
+    cut = Line(
+        start=pizza.get_center(),
+        end=pizza.get_center() + np.array([1.5*np.cos(angle), 1.5*np.sin(angle), 0]),
+        color=WHITE, stroke_width=2,
+    )
+    self.play(Create(cut), run_time=0.4)
+
+# Color one slice
+slice_highlight = AnnularSector(
+    inner_radius=0, outer_radius=1.5,
+    angle=TAU/4, start_angle=0,
+    color=GOLD, fill_opacity=0.6,
+).move_to(pizza.get_center())
+self.play(FadeIn(slice_highlight))
+
+# Label
+frac = MathTex(r"\frac{1}{4}", font_size=48, color=GOLD)
+frac.next_to(pizza, RIGHT, buff=1.0)
+self.play(Write(frac))
+```
+
+### Area (length x width)
+
+**Visual**: Rectangle fills with unit square tiles, row by row.
+**Animation**: Tiles fill left-to-right, row-by-row. Counter shows running total.
+**Connection to multiplication**: "3 rows of 5 tiles = 3 x 5 = 15 square units."
+**Pip**: Points at rows, counts.
+
+### Rounding (to nearest 10, 100)
+
+**Visual**: Number line with "gravity wells" at 10, 20, 30... Numbers slide to the nearest well.
+**Animation**: Number appears, wobbles, then slides (with a satisfying snap) to the nearest ten.
+**Key insight**: "Is 37 closer to 30 or 40? Look at the ones digit."
+**Pip**: Points at the midpoint (5) -- "this is the tipping point!"
+
+### Telling time
+
+**Visual**: Analog clock with hands. Hour hand is thick and short, minute hand is thin and long.
+**Animation**: Hands sweep to positions. Labels appear.
+**Key pattern**: Clock face is a number line bent into a circle. Show this transformation.
+
+### Perimeter
+
+**Visual**: Ant walks around the outside of a shape. Each side gets a length label. Counter adds up.
+**Animation**: Traced path with Pip "walking" the perimeter. Side lengths bounce as they're added.
+**Metaphor**: "How far does the ant walk to get all the way around?"
+
+---
+
+## Fourth-Fifth Grade Preview (Ages 9-11)
+
+These are stretch concepts for advanced third graders:
+
+### Multi-digit multiplication
+
+**Visual**: Area model (rectangle split into parts). 23 x 14 = (20+3)(10+4).
+**Animation**: Rectangle splits into 4 sub-rectangles, each calculated, then summed.
+
+### Equivalent fractions
+
+**Visual**: Same pizza, different number of cuts. 1/2 = 2/4 = 4/8.
+**Animation**: Additional cuts appear, but the colored area stays the same.
+
+### Decimals
+
+**Visual**: Place value chart extending right past the decimal point. 10ths column = one rod cut into 10 pieces.
+**Animation**: Rod from place value splits into 10 equal pieces.
+
+### Negative numbers
+
+**Visual**: Number line extending left past zero. Temperature metaphor (thermometer going below zero).
+**Animation**: Number line slides to reveal negative territory. Pip shivers.
+
+---
+
+## Animation Patterns Quick Reference
+
+| Concept | Primary animation | Color |
+|---------|------------------|-------|
+| Counting | Bounce count | GOLD (counter) |
+| Addition | Slide together | BLUE |
+| Subtraction | FadeOut / shrink | RED |
+| Multiplication | Array fill / group form | GREEN |
+| Division | Deal out / split | PURPLE |
+| Fractions | Cut + color fill | Context-dependent |
+| Number line | Hop with arcs | Context-dependent |
+| Place value | Bundle into rods | BLUE (ones), GREEN (tens) |
+| Area | Tile fill | GREEN |
+| Perimeter | Trace walk | ORANGE |
+| Rounding | Gravity slide + snap | GOLD |

--- a/skills/creative/manim-kids/references/engagement.md
+++ b/skills/creative/manim-kids/references/engagement.md
@@ -1,0 +1,187 @@
+# Engagement Patterns
+
+Techniques for keeping 6-10 year olds watching, thinking, and wanting more. These aren't gimmicks -- they're the difference between educational content that gets watched once and content that gets replayed.
+
+## The Hook (First 5 Seconds)
+
+Every video opens with something visually interesting BEFORE any teaching happens. The hook earns the kid's attention. Without it, they're gone.
+
+### Hook Types
+
+**The Question Hook**: Start with a visual puzzle.
+```
+"If I have 3 bags with 4 marbles each... how many marbles is that?"
+[Show bags, show Pip thinking, show question mark]
+[3-second pause -- the kid is already doing math]
+```
+
+**The Surprise Hook**: Start with something unexpected.
+```
+[Objects arranged in a weird pattern]
+[They rearrange into a recognizable shape]
+"Wait... that's a SQUARE made of circles!"
+```
+
+**The Challenge Hook**: "I bet you can't figure this out."
+```
+[Show a visual pattern with one element missing]
+"Can you guess what goes here?"
+[Pip points at the gap]
+```
+
+**The Story Hook**: A tiny narrative.
+```
+"Pip has a problem. There are 12 cookies, and 3 friends want to share equally."
+[Show Pip looking worried at a pile of cookies]
+"How many does each friend get?"
+```
+
+## The Question Pause
+
+The single most important technique in the entire skill. When you ask the viewer a question, you MUST pause for 3 seconds.
+
+```python
+# ASK
+self.add_subcaption("How many groups do you see?", duration=3)
+self.play(pip.think())
+
+# PAUSE -- this is where learning happens
+self.wait(3.0)
+
+# Only THEN reveal
+self.play(pip.excited())
+answer = Text("3 groups!", font_size=36, font=MONO, color=GOLD)
+self.play(Write(answer))
+```
+
+Why 3 seconds? Research on children's educational media consistently shows that pauses of 3+ seconds increase engagement and recall. The kid talks to the screen. They count on their fingers. They feel smart when the answer matches theirs.
+
+**Never skip or shorten this pause.** It feels long when you're making the video. It feels perfect when you're 8.
+
+## The Callback
+
+Reference something from earlier in the video. Creates continuity and rewards attention.
+
+```
+Scene 1: "Remember those 3 bags of marbles?"
+Scene 4: [Same bags reappear briefly] "Those bags again! But now we know: 3 times 4..."
+```
+
+Implementation:
+```python
+# Scene 4 callback
+ghost_bags = original_bags.copy().set_opacity(0.3)
+self.play(FadeIn(ghost_bags), run_time=0.5)
+self.wait(0.8)
+self.play(FadeOut(ghost_bags), run_time=0.5)
+```
+
+## Progressive Reveal
+
+Never show everything at once. Build up step by step. Each step is a mini-reveal that keeps the kid watching.
+
+Bad:
+```
+[All 12 objects appear at once]
+[Equation appears]
+```
+
+Good:
+```
+[First group of 4 appears] ... pause ...
+[Second group of 4 appears] ... pause ...
+[Third group of 4 appears] ... pause ...
+[Groups slide together] ... pause ...
+[Number 12 appears] ... CELEBRATE
+```
+
+The rhythm of reveal-pause-reveal-pause creates anticipation. The kid starts predicting what comes next. Prediction is engagement.
+
+## Surprise Moments
+
+Every video needs at least one moment that breaks the pattern in a delightful way. These are the moments kids remember and tell their parents about.
+
+### Types of Surprise
+
+**The Accidental**: Pip gets bonked by a falling number. Objects arrange themselves into a face before becoming a math problem.
+
+```python
+# Number falls from above and "bonks" Pip
+falling_num = MathTex("7", font_size=48, color=GOLD)
+falling_num.move_to(pip.get_center() + UP * 4)
+self.play(
+    falling_num.animate.move_to(pip.get_center() + UP * 0.3),
+    run_time=0.5,
+    rate_func=rush_into,
+)
+self.play(pip.surprised())
+self.wait(0.5)
+# Pip shakes it off
+self.play(pip.nod(), falling_num.animate.next_to(pip, UP, buff=0.3))
+```
+
+**The Transformation**: Something morphs into something unexpected.
+```python
+# Circles rearrange into a smiley face before becoming a math array
+# First: smiley
+self.play(
+    circles[0].animate.move_to(LEFT*0.5 + UP*0.3),   # left eye
+    circles[1].animate.move_to(RIGHT*0.5 + UP*0.3),  # right eye
+    circles[2:].animate.arrange_submobjects(arc_center=ORIGIN),  # smile
+)
+self.wait(1.0)
+self.play(pip.excited())
+# Then: snap to grid
+self.play(*[c.animate.move_to(grid_pos) for c, grid_pos in zip(circles, positions)])
+```
+
+**The Scale Shift**: Zoom in or out to reveal something new.
+```python
+# Zoom out to reveal the small problem is part of a bigger pattern
+self.play(
+    self.camera.frame.animate.scale(2).shift(UP),
+    run_time=1.5,
+)
+# Bigger pattern is now visible
+```
+
+## Humor for Kids
+
+Rules:
+- **Physical comedy over wordplay.** 8-year-olds love slapstick. Things falling, bumping, bouncing.
+- **Pip is the comedian.** The mascot can be silly. The math is never silly.
+- **Undercut expectations.** Set up a pattern, then break it once. "1, 2, 3, 4... wait, where's 5?" [5 slides in late, out of breath]
+- **Food is always funny.** Fractions with pizza, subtraction with cookies being eaten, multiplication with candy.
+
+## Difficulty Scaffolding
+
+Within a single video, start easy and build:
+
+```
+Scene 1: 2 + 1 = 3    (trivial -- confidence builder)
+Scene 2: 3 + 4 = 7    (moderate -- the real lesson)
+Scene 3: 8 + 5 = 13   (stretch -- carrying!)
+```
+
+The easy problem isn't filler -- it gives the kid a win that makes them confident for the harder one.
+
+## Rewatch Hooks
+
+Elements that make a kid want to watch again:
+
+- **Hidden details**: A tiny object in the background doing something funny
+- **Counter/collection**: "Pip found 3 stars in this video! Can you spot them all?"
+- **Foreshadowing**: "Remember this shape... you'll see it again later"
+- **Speed variations**: Some moments are slightly fast -- rewatching catches new details
+
+## Anti-Patterns (What NOT To Do)
+
+| Bad | Why | Do Instead |
+|-----|-----|-----------|
+| Wall of text explaining the concept | Kids can't read fast enough | Animate with narration |
+| "Today we'll learn about..." | Boring, school-like | Jump into the visual hook |
+| Equation first, then examples | Abstract-first kills curiosity | Concrete-to-abstract ladder |
+| Every scene the same length | Monotonous rhythm | Vary: 15s, 30s, 45s, 20s |
+| Telling the answer immediately | Robs the kid of the discovery | 3-second question pause |
+| Praising ("Good job!") | Patronizing after age 6 | Celebrate with visuals, not words |
+| Multiple concepts in one video | Overwhelm | One operation per video |

--- a/skills/creative/manim-kids/references/mascot.md
+++ b/skills/creative/manim-kids/references/mascot.md
@@ -1,0 +1,178 @@
+# Pip -- The Mascot System
+
+Pip is a friendly circle character built from basic Manim primitives. Pip appears in every manim-kids video as a curious companion who learns alongside the viewer.
+
+## Construction
+
+```python
+class Pip(VGroup):
+    """Friendly circle mascot with expressive dot-eyes."""
+
+    def __init__(self, radius=0.4, **kwargs):
+        super().__init__(**kwargs)
+        self.body = Circle(
+            radius=radius,
+            color=PIP_OUTLINE,
+            fill_color=PIP_BODY,
+            fill_opacity=1,
+            stroke_width=3,
+        )
+        # Eyes -- two dots, slightly above center
+        eye_y = radius * 0.15
+        eye_spread = radius * 0.35
+        self.left_eye = Dot(
+            point=LEFT * eye_spread + UP * eye_y,
+            radius=0.06,
+            color=PIP_EYES,
+        )
+        self.right_eye = Dot(
+            point=RIGHT * eye_spread + UP * eye_y,
+            radius=0.06,
+            color=PIP_EYES,
+        )
+        self.add(self.body, self.left_eye, self.right_eye)
+
+    # --- Expressions ---
+
+    def enter(self):
+        """Bouncy entrance from below."""
+        self.shift(DOWN * 2)
+        return Succession(
+            self.animate.shift(UP * 2.3),
+            self.animate.shift(DOWN * 0.3),
+            rate_func=smooth,
+        )
+
+    def exit(self):
+        """Slide out downward."""
+        return self.animate.shift(DOWN * 2).set_opacity(0)
+
+    def look_at(self, target):
+        """Eyes shift slightly toward target mobject."""
+        direction = normalize(target.get_center() - self.get_center())
+        shift = direction * 0.05
+        return AnimationGroup(
+            self.left_eye.animate.shift(shift),
+            self.right_eye.animate.shift(shift),
+            run_time=0.3,
+        )
+
+    def look_center(self):
+        """Reset eyes to neutral position."""
+        return AnimationGroup(
+            self.left_eye.animate.move_to(
+                self.body.get_center() + LEFT * 0.35 * self.body.radius + UP * 0.15 * self.body.radius
+            ),
+            self.right_eye.animate.move_to(
+                self.body.get_center() + RIGHT * 0.35 * self.body.radius + UP * 0.15 * self.body.radius
+            ),
+            run_time=0.3,
+        )
+
+    def think(self):
+        """Head tilt + one eye up = thinking."""
+        return Succession(
+            self.animate.rotate(0.15),
+            Wait(0.5),
+        )
+
+    def think_reset(self):
+        """Return from thinking pose."""
+        return self.animate.rotate(-0.15)
+
+    def excited(self):
+        """Eyes widen + small bounce."""
+        return Succession(
+            AnimationGroup(
+                self.left_eye.animate.scale(1.5),
+                self.right_eye.animate.scale(1.5),
+                self.animate.shift(UP * 0.15),
+            ),
+            AnimationGroup(
+                self.left_eye.animate.scale(1 / 1.5),
+                self.right_eye.animate.scale(1 / 1.5),
+                self.animate.shift(DOWN * 0.15),
+            ),
+            run_time=0.6,
+        )
+
+    def surprised(self):
+        """Eyes go big + jump back."""
+        return Succession(
+            AnimationGroup(
+                self.left_eye.animate.scale(2.0),
+                self.right_eye.animate.scale(2.0),
+                self.animate.shift(LEFT * 0.3 + UP * 0.2),
+            ),
+            AnimationGroup(
+                self.left_eye.animate.scale(0.5),
+                self.right_eye.animate.scale(0.5),
+                self.animate.shift(RIGHT * 0.3 + DOWN * 0.2),
+            ),
+            run_time=0.8,
+        )
+
+    def celebrate(self):
+        """Full spin + return to rest."""
+        return Rotate(self, angle=TAU, run_time=0.6, rate_func=smooth)
+
+    def nod(self):
+        """Small vertical bob = agreement/counting."""
+        return Succession(
+            self.animate.shift(DOWN * 0.1),
+            self.animate.shift(UP * 0.1),
+            run_time=0.3,
+        )
+
+    def point_at(self, target, scene):
+        """Extend an arrow from Pip toward target, hold, retract."""
+        arrow = Arrow(
+            start=self.get_center(),
+            end=target.get_center(),
+            color=PIP_OUTLINE,
+            stroke_width=3,
+            max_tip_length_to_length_ratio=0.15,
+        )
+        return Succession(
+            Create(arrow, run_time=0.4),
+            Wait(1.5),
+            FadeOut(arrow, run_time=0.3),
+        )
+```
+
+## Positioning Rules
+
+- **Default position**: bottom-right corner (`self.to_corner(DR, buff=0.8)`)
+- **Never overlap content**: Pip is a companion, not a distraction
+- **Moves to point**: When pointing at something, Pip shifts toward it, points, then returns
+- **Scale**: Default radius 0.4. Scale down to 0.3 if the scene is crowded.
+
+## Expression Choreography
+
+Match Pip's expressions to the narrative beat:
+
+| Narrative moment | Pip expression | Timing |
+|-----------------|---------------|--------|
+| Video opens | `enter()` | First 1s |
+| New objects appear | `look_at(objects)` | As objects land |
+| "How many?" question | `think()` | During question pause |
+| Kid should be counting | `nod()` per item | Bounce with each count |
+| Answer revealed | `excited()` | 0.3s before equation appears |
+| Final equation shown | `celebrate()` | Immediately after |
+| Scene ends | `exit()` or just stay | Last 0.5s |
+
+## Multiple Pips
+
+For comparison scenes (e.g., showing two different approaches), use two Pips with different outline colors:
+
+```python
+pip_a = Pip().set_color(BLUE).to_corner(DL, buff=0.8)
+pip_b = Pip().set_color(GREEN).to_corner(DR, buff=0.8)
+```
+
+## Accessibility
+
+- Pip's expressions are purely geometric (scale, position, rotation) -- no color-dependent states
+- Works at any resolution
+- No text on Pip -- expressions are self-evident
+- High contrast against dark background (white body, blue outline)

--- a/skills/creative/manim-kids/references/rewards.md
+++ b/skills/creative/manim-kids/references/rewards.md
@@ -1,0 +1,177 @@
+# Reward Animations
+
+Celebration animations that fire after key reveals. These are the dopamine hits -- they signal "you got it!" and make the kid want to keep watching.
+
+## Design Philosophy
+
+- **Earned, not given.** Rewards follow a reveal or answer, never just a scene transition.
+- **Fast and punchy.** 0.5s animation, 1.0s hold, 0.5s fadeout. Total: 2s max.
+- **Varied per video.** Don't use the same celebration every time. Rotate through 3-4 types.
+- **Never patronizing.** Think "video game level complete," not "good job, sweetie."
+
+## Confetti Burst
+
+The signature celebration. Colored circles scatter outward from a point.
+
+```python
+def create_confetti(center, n=20, spread=3.0):
+    """Create confetti dots ready to burst outward from center."""
+    colors = [BLUE, RED, GREEN, GOLD, PURPLE, ORANGE]
+    confetti = VGroup()
+    for i in range(n):
+        dot = Dot(
+            point=center,
+            radius=np.random.uniform(0.04, 0.1),
+            color=colors[i % len(colors)],
+        )
+        # Random target position in a circle around center
+        angle = np.random.uniform(0, TAU)
+        dist = np.random.uniform(0.5, spread)
+        dot.target_pos = center + np.array([
+            dist * np.cos(angle),
+            dist * np.sin(angle),
+            0,
+        ])
+        confetti.add(dot)
+    return confetti
+
+
+def play_confetti(scene, center, n=20):
+    """Full confetti animation: burst outward, fade upward."""
+    confetti = create_confetti(center, n)
+    scene.add(*confetti)
+
+    # Burst outward
+    scene.play(
+        *[dot.animate.move_to(dot.target_pos) for dot in confetti],
+        run_time=0.5,
+        rate_func=rush_from,
+    )
+
+    # Float up and fade
+    scene.play(
+        *[dot.animate.shift(UP * 0.5).set_opacity(0) for dot in confetti],
+        run_time=0.8,
+        rate_func=smooth,
+    )
+    scene.remove(*confetti)
+```
+
+## Star Burst
+
+Stars radiate outward from the answer. More "magical" than confetti.
+
+```python
+def play_star_burst(scene, center, n=8):
+    """Stars radiate outward in a ring."""
+    stars = VGroup()
+    for i in range(n):
+        star = Star(
+            n=5,
+            outer_radius=0.15,
+            inner_radius=0.07,
+            color=GOLD,
+            fill_opacity=1,
+        ).move_to(center)
+        angle = i * TAU / n
+        star.target_pos = center + np.array([
+            1.5 * np.cos(angle),
+            1.5 * np.sin(angle),
+            0,
+        ])
+        stars.add(star)
+
+    scene.play(
+        *[GrowFromCenter(s) for s in stars],
+        run_time=0.3,
+    )
+    scene.play(
+        *[s.animate.move_to(s.target_pos).set_opacity(0).scale(0.3) for s in stars],
+        run_time=0.7,
+        rate_func=rush_from,
+    )
+    scene.remove(*stars)
+```
+
+## Color Wash
+
+The background briefly pulses with a warm color. Subtle but satisfying.
+
+```python
+def play_color_wash(scene, color=GOLD, opacity=0.15):
+    """Background pulses with a warm color."""
+    wash = Rectangle(
+        width=config.frame_width,
+        height=config.frame_height,
+        fill_color=color,
+        fill_opacity=0,
+        stroke_width=0,
+    )
+    scene.play(
+        wash.animate.set_fill(opacity=opacity),
+        run_time=0.3,
+    )
+    scene.play(
+        wash.animate.set_fill(opacity=0),
+        run_time=0.7,
+    )
+    scene.remove(wash)
+```
+
+## Pip Spin + Confetti Combo
+
+The full celebration -- use for the final reveal of each video.
+
+```python
+def play_full_celebration(scene, pip, answer_mobject):
+    """Pip celebrates + confetti from the answer. The big finish."""
+    scene.play(pip.celebrate(), run_time=0.6)
+    play_confetti(scene, answer_mobject.get_center(), n=25)
+    scene.wait(1.0)
+```
+
+## Bounce Counter
+
+Not a celebration per se, but deeply satisfying -- objects bounce one by one as a number increments.
+
+```python
+def play_bounce_count(scene, objects, counter_pos=UP * 2.5):
+    """Bounce each object and increment a visible counter."""
+    counter = Integer(0, font_size=48, color=GOLD).move_to(counter_pos)
+    scene.play(FadeIn(counter))
+
+    for i, obj in enumerate(objects):
+        new_counter = Integer(i + 1, font_size=48, color=GOLD).move_to(counter_pos)
+        scene.play(
+            obj.animate.shift(UP * 0.2).set_color(GOLD),
+            run_time=0.15,
+        )
+        scene.play(
+            obj.animate.shift(DOWN * 0.2).set_color(obj.original_color),
+            Transform(counter, new_counter),
+            run_time=0.15,
+        )
+    scene.wait(0.5)
+    return counter
+```
+
+## When To Use What
+
+| Moment | Reward | Intensity |
+|--------|--------|-----------|
+| Counting complete | Bounce counter | Low |
+| Intermediate step | Color wash | Low |
+| Key insight revealed | Star burst | Medium |
+| Final answer | Pip spin + confetti | High |
+| Video complete | Full celebration | Maximum |
+
+## Sound Effect Cues
+
+Manim can't play audio during rendering, but subcaptions can cue sound effects for post-production:
+
+```python
+self.add_subcaption("[SFX: pop]", duration=0.5)   # Object appears
+self.add_subcaption("[SFX: ding]", duration=0.5)   # Correct answer
+self.add_subcaption("[SFX: whoosh]", duration=0.5) # Confetti burst
+self.add_subcaption("[SFX: boing]", duration=0.3)  # Bounce count
+```

--- a/skills/creative/manim-kids/references/voice-and-pacing.md
+++ b/skills/creative/manim-kids/references/voice-and-pacing.md
@@ -1,0 +1,167 @@
+# Voice and Pacing
+
+Narration-first design for young learners. The voice carries 80% of the teaching. On-screen text is for reinforcement, not information delivery.
+
+## Voice Character
+
+The narrator is warm, curious, and slightly playful. Not a teacher voice. Not a kids' TV host voice. Think "cool older sibling explaining something they find genuinely interesting."
+
+**Tone attributes**:
+- Conversational, not instructional
+- Genuinely curious ("I wonder what happens if...")
+- Slightly conspiratorial ("Here's the cool part...")
+- Never condescending ("Great job!" is banned)
+- Allows silence (pauses are part of the voice)
+
+## Script Writing
+
+### Structure Per Scene
+
+```
+[VISUAL CUE] Narration text. (timing note)
+
+[Objects appear] "Look at this." (1s pause)
+[Pip enters] "Pip sees three groups." (point at groups)
+[Question] "How many is that altogether?" (3s PAUSE)
+[Reveal] "Twelve! Three groups of four makes twelve." (celebration)
+```
+
+### Language Rules
+
+- **Short sentences.** Max 10 words. Usually 5-7.
+- **Active voice.** "We have three groups" not "Three groups are present."
+- **Present tense.** "Look, here come the circles" not "The circles will appear."
+- **Concrete nouns.** "Three apples" not "three items" or "three objects."
+- **Questions.** At least 2 per video. Always followed by a 3-second pause.
+- **Sound words.** "Pop!" "Whoosh!" "Boing!" -- subcaption cues for the animation.
+
+### Vocabulary by Grade
+
+| Grade | Math vocabulary to use | Avoid |
+|-------|----------------------|-------|
+| K-1 | add, take away, more, less, same, group | sum, difference, combine |
+| 2 | plus, minus, equal, skip count | operation, equation |
+| 3 | times, multiply, groups of, divide, share, fraction, equal parts | product, quotient, numerator, denominator (introduce LATE) |
+
+Introduce formal terms AFTER the concept is visually established, never before.
+
+## Pacing Table
+
+| Moment | Narration speed | On-screen | Duration |
+|--------|----------------|-----------|----------|
+| Hook | Normal | Visual surprise | 3-5s |
+| Setup | Slow, clear | Objects appearing | 5-8s |
+| Build | Normal | Animations playing | 10-15s |
+| Question | Slower, rising inflection | Pip thinking, question mark | 2s narration |
+| Pause | SILENCE | Still frame, Pip waiting | 3s |
+| Reveal | Normal, slightly excited | Answer + reward | 3-5s |
+| Celebration | Quick, upbeat | Confetti, Pip spin | 2s |
+| Transition | Normal | FadeOut cleanup | 1-2s |
+
+**Total scene: 25-40 seconds.** Never exceed 45s.
+
+## Subcaption Strategy
+
+Since Manim renders video without audio, all narration is written as subcaptions. These serve three purposes:
+
+1. **TTS script**: If voiceover is added later, subcaptions become the TTS input
+2. **Subtitle track**: Auto-generated .srt file for accessibility
+3. **Timing guide**: Ensures animations sync with intended narration
+
+```python
+# Narration via subcaptions
+self.add_subcaption("Look at these three groups.", duration=2)
+self.play(FadeIn(groups), run_time=1.0)
+self.wait(1.0)
+
+self.add_subcaption("Each group has four circles.", duration=2.5)
+self.play(Indicate(groups[0], color=GOLD), run_time=0.5)
+self.wait(2.0)
+
+self.add_subcaption("How many circles is that altogether?", duration=3.5)
+self.play(pip.think())
+self.wait(3.0)  # Sacred question pause
+
+self.add_subcaption("Let's count!", duration=1.5)
+self.play(pip.excited())
+```
+
+## TTS Integration (Optional)
+
+For full narrated videos, use ElevenLabs or edge-tts:
+
+### ElevenLabs (higher quality)
+
+```python
+# Extract subcaptions to narration script
+# Then generate audio segments matching scene timing
+
+import requests
+
+def generate_narration(text, voice_id="pNInz6obpgDQGcFmaJgB"):
+    """Generate narration clip for one subcaption."""
+    resp = requests.post(
+        f"https://api.elevenlabs.io/v1/text-to-speech/{voice_id}",
+        headers={"xi-api-key": os.environ["ELEVENLABS_KEY"]},
+        json={
+            "text": text,
+            "model_id": "eleven_turbo_v2",
+            "voice_settings": {
+                "stability": 0.6,        # Slightly varied for warmth
+                "similarity_boost": 0.8,
+                "style": 0.3,            # Subtle expressiveness
+            }
+        },
+    )
+    return resp.content  # MP3 bytes
+```
+
+### Edge-TTS (free, decent quality)
+
+```bash
+# Generate narration from subcaption text
+edge-tts --voice "en-US-AnaNeural" --text "Look at these three groups." --write-media scene1.mp3
+```
+
+`en-US-AnaNeural` is a warm, clear female voice that works well for kids' content. `en-US-GuyNeural` for a male alternative.
+
+### Audio Muxing
+
+```bash
+# Combine narration with rendered video
+ffmpeg -i final.mp4 -i narration.mp3 \
+  -c:v copy -c:a aac -shortest \
+  final_narrated.mp4
+```
+
+## Rhythm and Flow
+
+A well-paced kids' video has a musical quality. The rhythm alternates between tension (question, build) and release (answer, celebration):
+
+```
+BUILD   ... BUILD   ... QUESTION ... pause ... REVEAL!  ... celebrate ...
+BUILD   ... BUILD   ... QUESTION ... pause ... REVEAL!  ... celebrate ...
+FINAL BUILD ... FINAL QUESTION ... long pause ... BIG REVEAL!! ... BIG CELEBRATE!
+```
+
+Each cycle is one scene. The final cycle gets more time and a bigger celebration. The kid knows the pattern by scene 2 and starts anticipating -- anticipation IS engagement.
+
+## Video Length Guide
+
+| Content | Scenes | Total time | Notes |
+|---------|--------|-----------|-------|
+| Single concept intro | 4-5 | 2-3 min | One ladder traversal |
+| Concept with practice | 6-8 | 3-5 min | Ladder + 2-3 practice examples |
+| Comparison (e.g., mult vs add) | 6-8 | 3-5 min | Two short ladders + contrast |
+
+Never exceed 5 minutes. If the concept needs more time, split into two videos ("Part 1: What is multiplication?" "Part 2: Multiplication tricks").
+
+## Silence Is Not Empty
+
+The pauses in these videos are the most important parts. During silence:
+- The kid is counting
+- The kid is guessing the answer
+- The kid is connecting what they see to what they know
+- The kid is talking to the screen
+
+**Never fill silence with music, sound effects, or narration during a question pause.** The silence IS the learning tool.

--- a/skills/creative/manim-kids/scripts/setup.sh
+++ b/skills/creative/manim-kids/scripts/setup.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Verify dependencies for manim-kids skill.
+# Same requirements as manim-video.
+
+set -e
+
+echo "Checking manim-kids dependencies..."
+echo ""
+
+check() {
+  if command -v "$1" &>/dev/null; then
+    printf "  %-12s %s\n" "$1" "$(eval "$2" 2>&1 | head -1)"
+  else
+    printf "  %-12s MISSING -- %s\n" "$1" "$3"
+    return 1
+  fi
+}
+
+MISSING=0
+
+check python3  "python3 --version"        "Install Python 3.10+"           || MISSING=$((MISSING+1))
+check manim    "manim --version"           "pip install manim"              || MISSING=$((MISSING+1))
+check pdflatex "pdflatex --version"        "Install texlive-full or mactex" || MISSING=$((MISSING+1))
+check ffmpeg   "ffmpeg -version"           "Install ffmpeg"                 || MISSING=$((MISSING+1))
+
+echo ""
+if [ $MISSING -eq 0 ]; then
+  echo "All dependencies satisfied."
+else
+  echo "$MISSING missing dependency(ies). Install them and re-run."
+  exit 1
+fi


### PR DESCRIPTION
## Summary

New creative skill: **manim-kids** -- animated math and science videos for elementary-age kids (ages 6-10) using Manim Community Edition.

Designed for visual learners and neurodivergent kids who need concrete-to-abstract progression rather than symbol-first instruction. Built on top of the existing `manim-video` skill's technical foundation but with completely different pedagogical DNA.

### Key design elements

- **Pip mascot** -- a friendly bouncing circle with expressive dot-eyes that appears in every video as a curious learning companion
- **Concrete-to-abstract ladder** -- every concept traverses 4 rungs: real object -> simple shape -> diagram -> mathematical symbol. Never skip, never start at the symbol.
- **Color-coded operations** -- addition is always blue, multiplication always green, subtraction always red, division always purple. Builds subconscious association across all videos.
- **30-second scene rule** -- no scene exceeds 45s. Total video runtime 2-5 minutes.
- **3-second question pauses** -- when the narrator asks a question, the screen goes silent for 3 seconds. This is where learning happens.
- **Reward animations** -- confetti bursts, star radiations, Pip celebrations after every reveal. Video game feedback, not gold star stickers.
- **Voice-first** -- narration carries content, on-screen text is for labels and equations only. Max 6 words on screen at once.

### Reference documents (6)

| Reference | Contents |
|-----------|----------|
| `mascot.md` | Pip construction, expression states, positioning, choreography |
| `rewards.md` | Celebration animations with code patterns |
| `concrete-to-abstract.md` | The 4-rung ladder with full multiplication example |
| `elementary-math.md` | K-5 concept map with visual metaphors per topic |
| `engagement.md` | Hooks, humor, question pauses, surprise patterns |
| `voice-and-pacing.md` | Narration workflow, TTS integration, pacing tables |

### Concept coverage

Primary focus is third grade (ages 8-9): multiplication as groups, division as sharing, fractions, area, perimeter, rounding, telling time. Full K-5 map included for extension.

## Motivation

Traditional school materials don't work for every kid. Visual-spatial and neurodivergent learners often need to SEE the math before they can DO the math. These videos give a kid a private "aha moment" they can replay -- the geometry before the algebra, the pizza before the fraction.

## Test plan

- [ ] Verify `scripts/setup.sh` checks dependencies correctly
- [ ] Generate a test video (e.g., "multiplication as groups: 3 x 4 = 12") using the skill
- [ ] Confirm Pip mascot renders correctly with expressions
- [ ] Confirm reward animations (confetti, star burst) render
- [ ] Verify subcaption timing matches narration pacing guidelines