### PR TITLE
feat: add Chutes AI as a first-class model provider

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -26,9 +26,11 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
     "gemini", "zai", "kimi-coding", "minimax", "minimax-cn", "anthropic", "deepseek",
     "opencode-zen", "opencode-go", "ai-gateway", "kilocode", "alibaba",
+    "chutes",
     "custom", "local",
     # Common aliases
     "google", "google-gemini", "google-ai-studio",
+    "chutes-ai",
     "glm", "z-ai", "z.ai", "zhipu", "github", "github-copilot",
     "github-models", "kimi", "moonshot", "claude", "deep-seek",
     "opencode", "zen", "go", "vercel", "kilo", "dashscope", "aliyun", "qwen",
@@ -132,6 +134,10 @@ DEFAULT_CONTEXT_LENGTHS = {
     "mimo-v2-pro": 1048576,
     "mimo-v2-omni": 1048576,
     "zai-org/GLM-5": 202752,
+    # Chutes AI — TEE (Trusted Execution Environment) models
+    "chutes/DeepSeek-V3.2-TEE": 65536,
+    "chutes/Qwen3-32B-TEE": 131072,
+    "chutes/Kimi-K2.5-TEE": 262144,
 }
 
 _CONTEXT_LENGTH_KEYS = (

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -24,6 +24,7 @@ model:
   #   "minimax"      - MiniMax global (requires: MINIMAX_API_KEY)
   #   "minimax-cn"   - MiniMax China (requires: MINIMAX_CN_API_KEY)
   #   "huggingface"  - Hugging Face Inference (requires: HF_TOKEN)
+  #   "chutes"       - Chutes AI (requires: CHUTES_API_KEY)
   #   "kilocode"     - KiloCode gateway (requires: KILOCODE_API_KEY)
   #   "ai-gateway"   - Vercel AI Gateway (requires: AI_GATEWAY_API_KEY)
   #

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -231,6 +231,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="api_key",
         inference_base_url="https://router.huggingface.co/v1",
         api_key_env_vars=("HF_TOKEN",),
+    "chutes": ProviderConfig(
+        id="chutes",
+        name="Chutes AI",
+        auth_type="api_key",
+        inference_base_url="https://llm.chutes.ai/v1",
+        api_key_env_vars=("CHUTES_API_KEY",),
+        base_url_env_var="CHUTES_BASE_URL",
+    ),
         base_url_env_var="HF_BASE_URL",
     ),
 }
@@ -777,6 +785,7 @@ def resolve_provider(
         "aigateway": "ai-gateway", "vercel": "ai-gateway", "vercel-ai-gateway": "ai-gateway",
         "opencode": "opencode-zen", "zen": "opencode-zen",
         "hf": "huggingface", "hugging-face": "huggingface", "huggingface-hub": "huggingface",
+        "chutes-ai": "chutes",
         "go": "opencode-go", "opencode-go-sub": "opencode-go",
         "kilo": "kilocode", "kilo-code": "kilocode", "kilo-gateway": "kilocode",
         # Local server aliases — route through the generic custom provider

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -263,6 +263,11 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "XiaomiMiMo/MiMo-V2-Flash",
         "moonshotai/Kimi-K2-Thinking",
     ],
+    "chutes": [
+        "chutes/DeepSeek-V3.2-TEE",
+        "chutes/Qwen3-32B-TEE",
+        "chutes/Kimi-K2.5-TEE",
+    ],
 }
 
 _PROVIDER_LABELS = {
@@ -284,6 +289,7 @@ _PROVIDER_LABELS = {
     "kilocode": "Kilo Code",
     "alibaba": "Alibaba Cloud (DashScope)",
     "huggingface": "Hugging Face",
+    "chutes": "Chutes AI",
     "custom": "Custom endpoint",
 }
 
@@ -322,6 +328,7 @@ _PROVIDER_ALIASES = {
     "aliyun": "alibaba",
     "qwen": "alibaba",
     "alibaba-cloud": "alibaba",
+    "chutes-ai": "chutes",
     "hf": "huggingface",
     "hugging-face": "huggingface",
     "huggingface-hub": "huggingface",


### PR DESCRIPTION
Adds Chutes AI as a built-in model provider for Hermes, following the same pattern as existing providers (DeepSeek, MiniMax, Hugging Face, etc).

Chutes is a serverless AI inference provider with TEE (Trusted Execution Environment) models. OpenAI-compatible API.

## Changes

4 files modified, 23 lines added (all additive, no breaking changes):

- hermes_cli/auth.py - Register Chutes in PROVIDER_REGISTRY with API key auth and env var support (CHUTES_API_KEY) plus alias
- hermes_cli/models.py - Add model catalog (DeepSeek-V3.2-TEE, Qwen3-32B-TEE, Kimi-K2.5-TEE), display label, and chutes-ai alias
- agent/model_metadata.py - Add provider prefix recognition and context window lengths
- cli-config.yaml.example - Document Chutes as a provider option

## Provider Details

Provider ID: chutes
Base URL: https://llm.chutes.ai/v1
API Type: OpenAI-compatible (chat_completions)
Auth: API key (env: CHUTES_API_KEY)
