### PR TITLE
feat: centralize Responses API input conversion across agent paths

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -54,6 +54,11 @@ from typing import Any, Dict, List, Optional, Tuple
 from openai import OpenAI
 
 from agent.credential_pool import load_pool
+from agent.responses_api import (
+    chat_messages_to_responses_input as shared_chat_messages_to_responses_input,
+    convert_content_for_responses as shared_convert_content_for_responses,
+    normalize_responses_input_items as shared_normalize_responses_input_items,
+)
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
 
@@ -150,51 +155,7 @@ def _pool_runtime_base_url(entry: Any, fallback: str = "") -> str:
 
 
 def _convert_content_for_responses(content: Any) -> Any:
-    """Convert chat.completions content to Responses API format.
-
-    chat.completions uses:
-      {"type": "text", "text": "..."}
-      {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}}
-
-    Responses API uses:
-      {"type": "input_text", "text": "..."}
-      {"type": "input_image", "image_url": "data:image/png;base64,..."}
-
-    If content is a plain string, it's returned as-is (the Responses API
-    accepts strings directly for text-only messages).
-    """
-    if isinstance(content, str):
-        return content
-    if not isinstance(content, list):
-        return str(content) if content else ""
-
-    converted: List[Dict[str, Any]] = []
-    for part in content:
-        if not isinstance(part, dict):
-            continue
-        ptype = part.get("type", "")
-        if ptype == "text":
-            converted.append({"type": "input_text", "text": part.get("text", "")})
-        elif ptype == "image_url":
-            # chat.completions nests the URL: {"image_url": {"url": "..."}}
-            image_data = part.get("image_url", {})
-            url = image_data.get("url", "") if isinstance(image_data, dict) else str(image_data)
-            entry: Dict[str, Any] = {"type": "input_image", "image_url": url}
-            # Preserve detail if specified
-            detail = image_data.get("detail") if isinstance(image_data, dict) else None
-            if detail:
-                entry["detail"] = detail
-            converted.append(entry)
-        elif ptype in ("input_text", "input_image"):
-            # Already in Responses format — pass through
-            converted.append(part)
-        else:
-            # Unknown content type — try to preserve as text
-            text = part.get("text", "")
-            if text:
-                converted.append({"type": "input_text", "text": text})
-
-    return converted or ""
+    return shared_convert_content_for_responses(content)
 
 
 class _CodexCompletionsAdapter:
@@ -210,26 +171,23 @@ class _CodexCompletionsAdapter:
         model = kwargs.get("model", self._model)
         temperature = kwargs.get("temperature")
 
-        # Separate system/instructions from conversation messages.
-        # Convert chat.completions multimodal content blocks to Responses
-        # API format (input_text / input_image instead of text / image_url).
+        # Separate system/instructions from replayable conversation messages.
         instructions = "You are a helpful assistant."
-        input_msgs: List[Dict[str, Any]] = []
+        replay_messages: List[Dict[str, Any]] = []
         for msg in messages:
             role = msg.get("role", "user")
             content = msg.get("content") or ""
             if role == "system":
                 instructions = content if isinstance(content, str) else str(content)
             else:
-                input_msgs.append({
-                    "role": role,
-                    "content": _convert_content_for_responses(content),
-                })
+                replay_messages.append(msg)
 
         resp_kwargs: Dict[str, Any] = {
             "model": model,
             "instructions": instructions,
-            "input": input_msgs or [{"role": "user", "content": ""}],
+            "input": shared_normalize_responses_input_items(
+                shared_chat_messages_to_responses_input(replay_messages)
+            ) or [{"role": "user", "content": ""}],
             "store": False,
         }
 

--- a/agent/responses_api.py
+++ b/agent/responses_api.py
@@ -81,6 +81,36 @@ def stringify_tool_output(content: Any) -> str:
     return str(content)
 
 
+def convert_content_from_responses(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+
+    parts = content if isinstance(content, list) else [content]
+    text_parts: List[str] = []
+    for part in parts:
+        if isinstance(part, str):
+            text_parts.append(part)
+            continue
+        if not isinstance(part, dict):
+            text = str(part) if part else ""
+            if text:
+                text_parts.append(text)
+            continue
+
+        ptype = part.get("type", "")
+        if ptype in {"text", "input_text", "output_text"}:
+            text = part.get("text", "")
+            if text is not None:
+                text_parts.append(str(text))
+            continue
+
+        text = part.get("text", "")
+        if text:
+            text_parts.append(str(text))
+
+    return "\n".join(chunk for chunk in text_parts if chunk)
+
+
 def chat_messages_to_responses_input(
     messages: List[Dict[str, Any]],
     *,
@@ -178,6 +208,77 @@ def chat_messages_to_responses_input(
             )
 
     return items
+
+
+def responses_input_to_chat_messages(
+    raw_items: Any,
+    *,
+    split_tool_id: Callable[[Any], Tuple[Optional[str], Optional[str]]] = split_responses_tool_id,
+) -> List[Dict[str, Any]]:
+    normalized_items = normalize_responses_input_items(raw_items)
+    messages: List[Dict[str, Any]] = []
+    current_assistant_index: Optional[int] = None
+
+    def _ensure_assistant_message() -> Dict[str, Any]:
+        nonlocal current_assistant_index
+        if current_assistant_index is not None:
+            return messages[current_assistant_index]
+
+        assistant_message: Dict[str, Any] = {"role": "assistant", "content": ""}
+        messages.append(assistant_message)
+        current_assistant_index = len(messages) - 1
+        return assistant_message
+
+    for item in normalized_items:
+        item_type = item.get("type")
+        if item_type == "reasoning":
+            assistant_message = _ensure_assistant_message()
+            reasoning_items = assistant_message.setdefault("codex_reasoning_items", [])
+            if isinstance(reasoning_items, list):
+                reasoning_items.append(dict(item))
+            continue
+
+        if item_type == "function_call":
+            assistant_message = _ensure_assistant_message()
+            tool_calls = assistant_message.setdefault("tool_calls", [])
+            if not isinstance(tool_calls, list):
+                tool_calls = []
+                assistant_message["tool_calls"] = tool_calls
+            tool_calls.append(
+                {
+                    "id": item["call_id"],
+                    "call_id": item["call_id"],
+                    "type": "function",
+                    "function": {
+                        "name": item["name"],
+                        "arguments": item["arguments"],
+                    },
+                }
+            )
+            continue
+
+        if item_type == "function_call_output":
+            call_id, _ = split_tool_id(item.get("call_id"))
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": call_id or item["call_id"],
+                    "content": stringify_tool_output(item.get("output", "")),
+                }
+            )
+            current_assistant_index = None
+            continue
+
+        role = item.get("role")
+        if role in {"user", "assistant"}:
+            message = {
+                "role": role,
+                "content": convert_content_from_responses(item.get("content", "")),
+            }
+            messages.append(message)
+            current_assistant_index = len(messages) - 1 if role == "assistant" else None
+
+    return messages
 
 
 def normalize_responses_input_items(raw_items: Any) -> List[Dict[str, Any]]:

--- a/agent/responses_api.py
+++ b/agent/responses_api.py
@@ -1,0 +1,252 @@
+"""Shared helpers for OpenAI Responses API message conversion."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+
+def deterministic_call_id(fn_name: str, arguments: str, index: int = 0) -> str:
+    seed = f"{fn_name}:{arguments}:{index}"
+    digest = hashlib.sha256(seed.encode("utf-8", errors="replace")).hexdigest()[:12]
+    return f"call_{digest}"
+
+
+def split_responses_tool_id(raw_id: Any) -> tuple[Optional[str], Optional[str]]:
+    if not isinstance(raw_id, str):
+        return None, None
+    value = raw_id.strip()
+    if not value:
+        return None, None
+    if "|" in value:
+        call_id, response_item_id = value.split("|", 1)
+        return call_id.strip() or None, response_item_id.strip() or None
+    if value.startswith("fc_"):
+        return None, value
+    return value, None
+
+
+def convert_content_for_responses(content: Any) -> Any:
+    if isinstance(content, str):
+        return content
+
+    parts = content if isinstance(content, list) else [content]
+    converted: List[Dict[str, Any]] = []
+
+    for part in parts:
+        if isinstance(part, str):
+            converted.append({"type": "input_text", "text": part})
+            continue
+        if not isinstance(part, dict):
+            text = str(part) if part else ""
+            if text:
+                converted.append({"type": "input_text", "text": text})
+            continue
+
+        ptype = part.get("type", "")
+        if ptype in {"text", "output_text", "input_text"}:
+            text = part.get("text", "")
+            if text is not None:
+                converted.append({"type": "input_text", "text": str(text)})
+            continue
+        if ptype in {"image_url", "input_image"}:
+            image_data = part.get("image_url", {})
+            url = image_data.get("url", "") if isinstance(image_data, dict) else str(image_data or "")
+            entry: Dict[str, Any] = {"type": "input_image", "image_url": url}
+            detail = image_data.get("detail") if isinstance(image_data, dict) else part.get("detail")
+            if detail:
+                entry["detail"] = detail
+            converted.append(entry)
+            continue
+
+        text = part.get("text", "")
+        if text:
+            converted.append({"type": "input_text", "text": str(text)})
+
+    if not converted:
+        return ""
+    if len(converted) == 1 and converted[0].get("type") == "input_text":
+        return converted[0]["text"]
+    return converted
+
+
+def stringify_tool_output(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, (dict, list)):
+        return json.dumps(content, ensure_ascii=False)
+    return str(content)
+
+
+def chat_messages_to_responses_input(
+    messages: List[Dict[str, Any]],
+    *,
+    reasoning_items_getter: Optional[Callable[[Dict[str, Any]], Optional[List[Dict[str, Any]]]]] = None,
+    split_tool_id: Callable[[Any], Tuple[Optional[str], Optional[str]]] = split_responses_tool_id,
+    deterministic_id: Callable[[str, str, int], str] = deterministic_call_id,
+) -> List[Dict[str, Any]]:
+    items: List[Dict[str, Any]] = []
+
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+
+        role = msg.get("role")
+        if role == "system":
+            continue
+
+        if role in {"user", "assistant"}:
+            content = convert_content_for_responses(msg.get("content", ""))
+
+            if role == "assistant":
+                has_reasoning = False
+                if reasoning_items_getter is not None:
+                    for ri in reasoning_items_getter(msg) or []:
+                        if isinstance(ri, dict) and ri.get("encrypted_content"):
+                            items.append(ri)
+                            has_reasoning = True
+
+                has_visible_content = bool(content.strip()) if isinstance(content, str) else bool(content)
+                if has_visible_content:
+                    items.append({"role": "assistant", "content": content})
+                elif has_reasoning:
+                    items.append({"role": "assistant", "content": ""})
+
+                tool_calls = msg.get("tool_calls")
+                if isinstance(tool_calls, list):
+                    for tc in tool_calls:
+                        if not isinstance(tc, dict):
+                            continue
+                        fn = tc.get("function", {})
+                        fn_name = fn.get("name")
+                        if not isinstance(fn_name, str) or not fn_name.strip():
+                            continue
+
+                        embedded_call_id, embedded_response_item_id = split_tool_id(tc.get("id"))
+                        call_id = tc.get("call_id")
+                        if not isinstance(call_id, str) or not call_id.strip():
+                            call_id = embedded_call_id
+                        if not isinstance(call_id, str) or not call_id.strip():
+                            if (
+                                isinstance(embedded_response_item_id, str)
+                                and embedded_response_item_id.startswith("fc_")
+                                and len(embedded_response_item_id) > len("fc_")
+                            ):
+                                call_id = f"call_{embedded_response_item_id[len('fc_'):]}"
+                            else:
+                                raw_args = str(fn.get("arguments", "{}"))
+                                call_id = deterministic_id(fn_name, raw_args, len(items))
+                        call_id = call_id.strip()
+
+                        arguments = fn.get("arguments", "{}")
+                        if isinstance(arguments, dict):
+                            arguments = json.dumps(arguments, ensure_ascii=False)
+                        elif not isinstance(arguments, str):
+                            arguments = str(arguments)
+                        arguments = arguments.strip() or "{}"
+
+                        items.append(
+                            {
+                                "type": "function_call",
+                                "call_id": call_id,
+                                "name": fn_name,
+                                "arguments": arguments,
+                            }
+                        )
+                continue
+
+            items.append({"role": role, "content": content})
+            continue
+
+        if role == "tool":
+            raw_tool_call_id = msg.get("tool_call_id")
+            call_id, _ = split_tool_id(raw_tool_call_id)
+            if not isinstance(call_id, str) or not call_id.strip():
+                if isinstance(raw_tool_call_id, str) and raw_tool_call_id.strip():
+                    call_id = raw_tool_call_id.strip()
+            if not isinstance(call_id, str) or not call_id.strip():
+                continue
+            items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": call_id,
+                    "output": stringify_tool_output(msg.get("content", "")),
+                }
+            )
+
+    return items
+
+
+def normalize_responses_input_items(raw_items: Any) -> List[Dict[str, Any]]:
+    if not isinstance(raw_items, list):
+        raise ValueError("Codex Responses input must be a list of input items.")
+
+    normalized: List[Dict[str, Any]] = []
+    for idx, item in enumerate(raw_items):
+        if not isinstance(item, dict):
+            raise ValueError(f"Codex Responses input[{idx}] must be an object.")
+
+        item_type = item.get("type")
+        if item_type == "function_call":
+            call_id = item.get("call_id")
+            name = item.get("name")
+            if not isinstance(call_id, str) or not call_id.strip():
+                raise ValueError(f"Codex Responses input[{idx}] function_call is missing call_id.")
+            if not isinstance(name, str) or not name.strip():
+                raise ValueError(f"Codex Responses input[{idx}] function_call is missing name.")
+
+            arguments = item.get("arguments", "{}")
+            if isinstance(arguments, dict):
+                arguments = json.dumps(arguments, ensure_ascii=False)
+            elif not isinstance(arguments, str):
+                arguments = str(arguments)
+            arguments = arguments.strip() or "{}"
+
+            normalized.append(
+                {
+                    "type": "function_call",
+                    "call_id": call_id.strip(),
+                    "name": name.strip(),
+                    "arguments": arguments,
+                }
+            )
+            continue
+
+        if item_type == "function_call_output":
+            call_id = item.get("call_id")
+            if not isinstance(call_id, str) or not call_id.strip():
+                raise ValueError(f"Codex Responses input[{idx}] function_call_output is missing call_id.")
+            normalized.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": call_id.strip(),
+                    "output": stringify_tool_output(item.get("output", "")),
+                }
+            )
+            continue
+
+        if item_type == "reasoning":
+            encrypted = item.get("encrypted_content")
+            if isinstance(encrypted, str) and encrypted:
+                reasoning_item = {"type": "reasoning", "encrypted_content": encrypted}
+                item_id = item.get("id")
+                if isinstance(item_id, str) and item_id:
+                    reasoning_item["id"] = item_id
+                summary = item.get("summary")
+                reasoning_item["summary"] = summary if isinstance(summary, list) else []
+                normalized.append(reasoning_item)
+            continue
+
+        role = item.get("role")
+        if role in {"user", "assistant"}:
+            normalized.append({"role": role, "content": convert_content_for_responses(item.get("content", ""))})
+            continue
+
+        raise ValueError(
+            f"Codex Responses input[{idx}] has unsupported item shape (type={item_type!r}, role={role!r})."
+        )
+
+    return normalized

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -35,6 +35,7 @@ except ImportError:
     AIOHTTP_AVAILABLE = False
     web = None  # type: ignore[assignment]
 
+from agent.responses_api import responses_input_to_chat_messages
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -789,29 +790,23 @@ class APIServerAdapter(BasePlatformAdapter):
             previous_response_id = self._response_store.get_conversation(conversation)
             # No error if conversation doesn't exist yet — it's a new conversation
 
-        # Normalize input to message list
-        input_messages: List[Dict[str, str]] = []
+        # Normalize Responses input items into the agent's internal transcript format.
+        input_messages: List[Dict[str, Any]] = []
         if isinstance(raw_input, str):
             input_messages = [{"role": "user", "content": raw_input}]
         elif isinstance(raw_input, list):
+            request_items: List[Dict[str, Any]] = []
             for item in raw_input:
                 if isinstance(item, str):
-                    input_messages.append({"role": "user", "content": item})
+                    request_items.append({"role": "user", "content": item})
                 elif isinstance(item, dict):
-                    role = item.get("role", "user")
-                    content = item.get("content", "")
-                    # Handle content that may be a list of content parts
-                    if isinstance(content, list):
-                        text_parts = []
-                        for part in content:
-                            if isinstance(part, dict) and part.get("type") == "input_text":
-                                text_parts.append(part.get("text", ""))
-                            elif isinstance(part, dict) and part.get("type") == "output_text":
-                                text_parts.append(part.get("text", ""))
-                            elif isinstance(part, str):
-                                text_parts.append(part)
-                        content = "\n".join(text_parts)
-                    input_messages.append({"role": role, "content": content})
+                    request_items.append(item)
+                else:
+                    return web.json_response(_openai_error("'input' array items must be strings or objects"), status=400)
+            try:
+                input_messages = responses_input_to_chat_messages(request_items)
+            except ValueError as exc:
+                return web.json_response(_openai_error(str(exc)), status=400)
         else:
             return web.json_response(_openai_error("'input' must be a string or array"), status=400)
 
@@ -831,7 +826,10 @@ class APIServerAdapter(BasePlatformAdapter):
             conversation_history.append(msg)
 
         # Last input message is the user_message
-        user_message = input_messages[-1].get("content", "") if input_messages else ""
+        user_message = ""
+        if input_messages and input_messages[-1].get("role") == "user":
+            candidate = input_messages[-1].get("content", "")
+            user_message = candidate if isinstance(candidate, str) else str(candidate or "")
         if not user_message:
             return web.json_response(_openai_error("No user message found in input"), status=400)
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -3677,6 +3677,7 @@ class AIAgent:
         """Execute one streaming Responses API request and return the final response."""
         import httpx as _httpx
 
+        api_kwargs = self._preflight_codex_api_kwargs(api_kwargs, allow_stream=False)
         active_client = client or self._ensure_primary_openai_client(reason="codex_stream_direct")
         max_stream_retries = 1
         has_tool_calls = False

--- a/run_agent.py
+++ b/run_agent.py
@@ -92,6 +92,12 @@ from agent.context_compressor import ContextCompressor
 from agent.subdirectory_hints import SubdirectoryHintTracker
 from agent.prompt_caching import apply_anthropic_cache_control
 from agent.prompt_builder import build_skills_system_prompt, build_context_files_prompt, load_soul_md, TOOL_USE_ENFORCEMENT_GUIDANCE, TOOL_USE_ENFORCEMENT_MODELS, DEVELOPER_ROLE_MODELS, GOOGLE_MODEL_OPERATIONAL_GUIDANCE, OPENAI_MODEL_EXECUTION_GUIDANCE
+from agent.responses_api import (
+    chat_messages_to_responses_input as shared_chat_messages_to_responses_input,
+    deterministic_call_id as shared_deterministic_call_id,
+    normalize_responses_input_items as shared_normalize_responses_input_items,
+    split_responses_tool_id as shared_split_responses_tool_id,
+)
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from agent.display import (
     KawaiiSpinner, build_tool_preview as _build_tool_preview,
@@ -3042,33 +3048,13 @@ class AIAgent:
 
     @staticmethod
     def _deterministic_call_id(fn_name: str, arguments: str, index: int = 0) -> str:
-        """Generate a deterministic call_id from tool call content.
-
-        Used as a fallback when the API doesn't provide a call_id.
-        Deterministic IDs prevent cache invalidation — random UUIDs would
-        make every API call's prefix unique, breaking OpenAI's prompt cache.
-        """
-        import hashlib
-        seed = f"{fn_name}:{arguments}:{index}"
-        digest = hashlib.sha256(seed.encode("utf-8", errors="replace")).hexdigest()[:12]
-        return f"call_{digest}"
+        """Generate a deterministic call_id from tool call content."""
+        return shared_deterministic_call_id(fn_name, arguments, index)
 
     @staticmethod
     def _split_responses_tool_id(raw_id: Any) -> tuple[Optional[str], Optional[str]]:
         """Split a stored tool id into (call_id, response_item_id)."""
-        if not isinstance(raw_id, str):
-            return None, None
-        value = raw_id.strip()
-        if not value:
-            return None, None
-        if "|" in value:
-            call_id, response_item_id = value.split("|", 1)
-            call_id = call_id.strip() or None
-            response_item_id = response_item_id.strip() or None
-            return call_id, response_item_id
-        if value.startswith("fc_"):
-            return None, value
-        return value, None
+        return shared_split_responses_tool_id(raw_id)
 
     def _derive_responses_function_call_id(
         self,
@@ -3101,187 +3087,15 @@ class AIAgent:
 
     def _chat_messages_to_responses_input(self, messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Convert internal chat-style messages to Responses input items."""
-        items: List[Dict[str, Any]] = []
-
-        for msg in messages:
-            if not isinstance(msg, dict):
-                continue
-            role = msg.get("role")
-            if role == "system":
-                continue
-
-            if role in {"user", "assistant"}:
-                content = msg.get("content", "")
-                content_text = str(content) if content is not None else ""
-
-                if role == "assistant":
-                    # Replay encrypted reasoning items from previous turns
-                    # so the API can maintain coherent reasoning chains.
-                    codex_reasoning = msg.get("codex_reasoning_items")
-                    has_codex_reasoning = False
-                    if isinstance(codex_reasoning, list):
-                        for ri in codex_reasoning:
-                            if isinstance(ri, dict) and ri.get("encrypted_content"):
-                                items.append(ri)
-                                has_codex_reasoning = True
-
-                    if content_text.strip():
-                        items.append({"role": "assistant", "content": content_text})
-                    elif has_codex_reasoning:
-                        # The Responses API requires a following item after each
-                        # reasoning item (otherwise: missing_following_item error).
-                        # When the assistant produced only reasoning with no visible
-                        # content, emit an empty assistant message as the required
-                        # following item.
-                        items.append({"role": "assistant", "content": ""})
-
-                    tool_calls = msg.get("tool_calls")
-                    if isinstance(tool_calls, list):
-                        for tc in tool_calls:
-                            if not isinstance(tc, dict):
-                                continue
-                            fn = tc.get("function", {})
-                            fn_name = fn.get("name")
-                            if not isinstance(fn_name, str) or not fn_name.strip():
-                                continue
-
-                            embedded_call_id, embedded_response_item_id = self._split_responses_tool_id(
-                                tc.get("id")
-                            )
-                            call_id = tc.get("call_id")
-                            if not isinstance(call_id, str) or not call_id.strip():
-                                call_id = embedded_call_id
-                            if not isinstance(call_id, str) or not call_id.strip():
-                                if (
-                                    isinstance(embedded_response_item_id, str)
-                                    and embedded_response_item_id.startswith("fc_")
-                                    and len(embedded_response_item_id) > len("fc_")
-                                ):
-                                    call_id = f"call_{embedded_response_item_id[len('fc_'):]}"
-                                else:
-                                    _raw_args = str(fn.get("arguments", "{}"))
-                                    call_id = self._deterministic_call_id(fn_name, _raw_args, len(items))
-                            call_id = call_id.strip()
-
-                            arguments = fn.get("arguments", "{}")
-                            if isinstance(arguments, dict):
-                                arguments = json.dumps(arguments, ensure_ascii=False)
-                            elif not isinstance(arguments, str):
-                                arguments = str(arguments)
-                            arguments = arguments.strip() or "{}"
-
-                            items.append({
-                                "type": "function_call",
-                                "call_id": call_id,
-                                "name": fn_name,
-                                "arguments": arguments,
-                            })
-                    continue
-
-                items.append({"role": role, "content": content_text})
-                continue
-
-            if role == "tool":
-                raw_tool_call_id = msg.get("tool_call_id")
-                call_id, _ = self._split_responses_tool_id(raw_tool_call_id)
-                if not isinstance(call_id, str) or not call_id.strip():
-                    if isinstance(raw_tool_call_id, str) and raw_tool_call_id.strip():
-                        call_id = raw_tool_call_id.strip()
-                if not isinstance(call_id, str) or not call_id.strip():
-                    continue
-                items.append({
-                    "type": "function_call_output",
-                    "call_id": call_id,
-                    "output": str(msg.get("content", "") or ""),
-                })
-
-        return items
+        return shared_chat_messages_to_responses_input(
+            messages,
+            reasoning_items_getter=lambda msg: msg.get("codex_reasoning_items"),
+            split_tool_id=self._split_responses_tool_id,
+            deterministic_id=self._deterministic_call_id,
+        )
 
     def _preflight_codex_input_items(self, raw_items: Any) -> List[Dict[str, Any]]:
-        if not isinstance(raw_items, list):
-            raise ValueError("Codex Responses input must be a list of input items.")
-
-        normalized: List[Dict[str, Any]] = []
-        for idx, item in enumerate(raw_items):
-            if not isinstance(item, dict):
-                raise ValueError(f"Codex Responses input[{idx}] must be an object.")
-
-            item_type = item.get("type")
-            if item_type == "function_call":
-                call_id = item.get("call_id")
-                name = item.get("name")
-                if not isinstance(call_id, str) or not call_id.strip():
-                    raise ValueError(f"Codex Responses input[{idx}] function_call is missing call_id.")
-                if not isinstance(name, str) or not name.strip():
-                    raise ValueError(f"Codex Responses input[{idx}] function_call is missing name.")
-
-                arguments = item.get("arguments", "{}")
-                if isinstance(arguments, dict):
-                    arguments = json.dumps(arguments, ensure_ascii=False)
-                elif not isinstance(arguments, str):
-                    arguments = str(arguments)
-                arguments = arguments.strip() or "{}"
-
-                normalized.append(
-                    {
-                        "type": "function_call",
-                        "call_id": call_id.strip(),
-                        "name": name.strip(),
-                        "arguments": arguments,
-                    }
-                )
-                continue
-
-            if item_type == "function_call_output":
-                call_id = item.get("call_id")
-                if not isinstance(call_id, str) or not call_id.strip():
-                    raise ValueError(f"Codex Responses input[{idx}] function_call_output is missing call_id.")
-                output = item.get("output", "")
-                if output is None:
-                    output = ""
-                if not isinstance(output, str):
-                    output = str(output)
-
-                normalized.append(
-                    {
-                        "type": "function_call_output",
-                        "call_id": call_id.strip(),
-                        "output": output,
-                    }
-                )
-                continue
-
-            if item_type == "reasoning":
-                encrypted = item.get("encrypted_content")
-                if isinstance(encrypted, str) and encrypted:
-                    reasoning_item = {"type": "reasoning", "encrypted_content": encrypted}
-                    item_id = item.get("id")
-                    if isinstance(item_id, str) and item_id:
-                        reasoning_item["id"] = item_id
-                    summary = item.get("summary")
-                    if isinstance(summary, list):
-                        reasoning_item["summary"] = summary
-                    else:
-                        reasoning_item["summary"] = []
-                    normalized.append(reasoning_item)
-                continue
-
-            role = item.get("role")
-            if role in {"user", "assistant"}:
-                content = item.get("content", "")
-                if content is None:
-                    content = ""
-                if not isinstance(content, str):
-                    content = str(content)
-
-                normalized.append({"role": role, "content": content})
-                continue
-
-            raise ValueError(
-                f"Codex Responses input[{idx}] has unsupported item shape (type={item_type!r}, role={role!r})."
-            )
-
-        return normalized
+        return shared_normalize_responses_input_items(raw_items)
 
     def _preflight_codex_api_kwargs(
         self,

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3,6 +3,7 @@
 import json
 import os
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -701,6 +702,70 @@ class TestAuxiliaryPoolAwareness:
         assert call_kwargs["api_key"] == "gh-cli-token"
         assert call_kwargs["base_url"] == "https://api.githubcopilot.com"
         assert call_kwargs["default_headers"]["Editor-Version"]
+
+
+class TestCodexResponsesAdapter:
+    def test_adapter_converts_tool_messages_to_function_call_output(self):
+        captured = {}
+
+        final_response = SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    type="message",
+                    content=[SimpleNamespace(type="output_text", text="done")],
+                )
+            ],
+            usage=None,
+        )
+
+        class _FakeStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def __iter__(self):
+                return iter(())
+
+            def get_final_response(self):
+                return final_response
+
+        class _FakeResponses:
+            def stream(self, **kwargs):
+                captured["kwargs"] = kwargs
+                return _FakeStream()
+
+        fake_client = SimpleNamespace(responses=_FakeResponses())
+
+        from agent.auxiliary_client import _CodexCompletionsAdapter
+
+        adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.3-codex")
+        adapter.create(
+            messages=[
+                {"role": "user", "content": "Run terminal"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "terminal", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_1", "content": '{"ok":true}'},
+            ]
+        )
+
+        input_items = captured["kwargs"]["input"]
+        assert any(item.get("type") == "function_call" and item.get("call_id") == "call_1" for item in input_items)
+        assert any(
+            item.get("type") == "function_call_output" and item.get("call_id") == "call_1"
+            for item in input_items
+        )
+        assert not any(item.get("role") == "tool" for item in input_items)
 
     def test_vision_auto_uses_anthropic_when_no_higher_priority_backend(self, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-api03-key")

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -709,6 +709,57 @@ class TestResponsesEndpoint:
             assert len(call_kwargs["conversation_history"]) == 1
 
     @pytest.mark.asyncio
+    async def test_responses_input_preserves_function_call_transcript(self, adapter):
+        """Native Responses items should become internal assistant/tool transcript entries."""
+        mock_result = {"final_response": "Done", "messages": [], "api_calls": 1}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": [
+                            {"role": "user", "content": "Run terminal"},
+                            {
+                                "type": "function_call",
+                                "call_id": "call_abc123",
+                                "name": "terminal",
+                                "arguments": '{"command":"pwd"}',
+                            },
+                            {
+                                "type": "function_call_output",
+                                "call_id": "call_abc123",
+                                "output": "/tmp",
+                            },
+                            {"role": "user", "content": "What happened?"},
+                        ],
+                    },
+                )
+
+            assert resp.status == 200
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["user_message"] == "What happened?"
+            assert call_kwargs["conversation_history"] == [
+                {"role": "user", "content": "Run terminal"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call_abc123",
+                            "call_id": "call_abc123",
+                            "type": "function",
+                            "function": {"name": "terminal", "arguments": '{"command":"pwd"}'},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "call_abc123", "content": "/tmp"},
+            ]
+
+    @pytest.mark.asyncio
     async def test_instructions_as_ephemeral_prompt(self, adapter):
         """The instructions field maps to ephemeral_system_prompt."""
         mock_result = {"final_response": "Ahoy!", "messages": [], "api_calls": 1}

--- a/tests/test_run_agent_codex_responses.py
+++ b/tests/test_run_agent_codex_responses.py
@@ -598,6 +598,21 @@ def test_preflight_codex_api_kwargs_allows_reasoning_and_temperature(monkeypatch
     assert result["max_output_tokens"] == 4096
 
 
+def test_run_codex_stream_rejects_invalid_tool_role_input_without_preflight(monkeypatch):
+    agent = _build_agent(monkeypatch)
+
+    with pytest.raises(ValueError, match="unsupported item shape"):
+        agent._run_codex_stream(
+            {
+                "model": "gpt-5-codex",
+                "instructions": "You are Hermes.",
+                "input": [{"role": "tool", "content": "bad raw tool replay"}],
+                "tools": [],
+                "store": False,
+            }
+        )
+
+
 def test_run_conversation_codex_replay_payload_keeps_call_id(monkeypatch):
     agent = _build_agent(monkeypatch)
     responses = [_codex_tool_call_response(), _codex_message_response("done")]


### PR DESCRIPTION
## Summary
- add shared `agent.responses_api` helpers for Responses API message conversion
- route both `run_agent.py` and the auxiliary Codex adapter through the same conversion path
- convert assistant tool calls and tool outputs into `function_call` / `function_call_output` items instead of replaying raw `role=tool` messages
- add a regression test covering the auxiliary Responses adapter path

## Problem
Hermes already had one correct Responses conversion path in `run_agent.py`, but `agent/auxiliary_client.py` still kept its own adapter logic.

That split was fragile: one path normalized tool transcripts correctly, while another could still replay chat-style `role=tool` messages into Responses `input[]`. Providers that implement the OpenAI Responses contract reject that shape with a 400 because `tool` is not a valid input role there.

## Why this approach
This bug should not be fixed with another provider-specific patch.

The underlying problem was duplicated conversion logic across Responses-capable call paths. As long as those paths drift independently, custom gateways and Codex-compatible providers can regress in different ways.

This PR fixes it centrally by moving the conversion rules into shared helpers and making every Responses-capable path use the same normalization logic.

## Testing
- `env -u OPENAI_BASE_URL -u OPENAI_API_KEY -u OPENROUTER_API_KEY HOME=$(mktemp -d) ./venv/bin/pytest tests/agent/test_auxiliary_client.py::TestCodexResponsesAdapter::test_adapter_converts_tool_messages_to_function_call_output tests/test_run_agent_codex_responses.py -q`

Closes #5709
