### PR TITLE
feat(gateway): add EMAIL_SUPPRESS_OUTBOUND kill switch for draft-only mailboxes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -272,6 +272,14 @@ BROWSER_INACTIVITY_TIMEOUT=120
 # EMAIL_POLL_INTERVAL=15
 # EMAIL_ALLOWED_USERS=your@email.com
 # EMAIL_HOME_ADDRESS=your@email.com
+# Draft-only / approval-required mailbox: when set, the adapter will
+# never deliver outbound mail via SMTP. Inbound polling continues.
+# Use this for human-in-the-loop flows where replies are routed through
+# a separate approval channel (e.g. a chat platform). Also serves as a
+# defense against prompt injection from inbound email content.
+# Accepted values: true/false, 1/0, yes/no, on/off (case-insensitive).
+# Invalid values fail loudly at startup — there is no silent default.
+# EMAIL_SUPPRESS_OUTBOUND=false
 
 # Gateway-wide: allow ALL users without an allowlist (default: false = deny)
 # Only set to true if you intentionally want open access.

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -64,6 +64,34 @@ MAX_MESSAGE_LENGTH = 50_000
 # Supported image extensions for inline detection
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
 
+# Recognized values for boolean env vars on this adapter. Anything else
+# raises ValueError at adapter init — there's no silent fallback because
+# this is a safety flag and a typo (e.g. EMAIL_SUPRESS_OUTBOUND=true)
+# silently defaulting to false would mean leaked email.
+_BOOL_TRUTHY = frozenset({"true", "1", "yes", "on"})
+_BOOL_FALSY = frozenset({"false", "0", "no", "off", ""})
+
+
+def _parse_bool_env(name: str) -> bool:
+    """Parse a boolean env var with strict validation.
+
+    Returns False when the var is unset or empty. Accepts truthy values
+    {true, 1, yes, on} and falsy values {false, 0, no, off}, all
+    case-insensitive and whitespace-tolerant. Anything else raises
+    ValueError so a typo or unexpected value fails loudly at adapter
+    init time rather than silently defaulting to false.
+    """
+    raw = os.getenv(name, "")
+    val = raw.strip().lower()
+    if val in _BOOL_TRUTHY:
+        return True
+    if val in _BOOL_FALSY:
+        return False
+    raise ValueError(
+        f"Invalid value for {name}: {raw!r}. Expected one of "
+        f"true/false, 1/0, yes/no, on/off (case-insensitive), or unset."
+    )
+
 def _is_automated_sender(address: str, headers: dict) -> bool:
     """Return True if this email is from an automated/noreply source."""
     addr = address.lower()
@@ -227,6 +255,23 @@ class EmailAdapter(BasePlatformAdapter):
         self._smtp_host = os.getenv("EMAIL_SMTP_HOST", "")
         self._smtp_port = int(os.getenv("EMAIL_SMTP_PORT", "587"))
         self._poll_interval = int(os.getenv("EMAIL_POLL_INTERVAL", "15"))
+
+        # Outbound suppression flag — when set, the adapter never delivers
+        # outbound mail via SMTP, regardless of what the agent emits.
+        # Inbound IMAP polling continues normally. Use this for draft-only
+        # / approval-required mailboxes where replies are routed through a
+        # separate human-approval channel (e.g. a chat platform). The flag
+        # also serves as a defense against prompt injection from inbound
+        # email content: an attacker who hijacks the agent via a crafted
+        # message cannot make the adapter SMTP anything outbound.
+        self._suppress_outbound = _parse_bool_env("EMAIL_SUPPRESS_OUTBOUND")
+        if self._suppress_outbound:
+            logger.warning(
+                "[Email] EMAIL_SUPPRESS_OUTBOUND=true — adapter will NOT "
+                "send any outbound mail via SMTP. Inbound polling remains "
+                "active. Outbound replies must be routed through a "
+                "separate channel (e.g. human approval on a chat platform)."
+            )
 
         # Skip attachments — configured via config.yaml:
         #   platforms:
@@ -465,7 +510,18 @@ class EmailAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Send an email reply to the given address."""
+        """Send an email reply to the given address.
+
+        When ``EMAIL_SUPPRESS_OUTBOUND=true`` is set, this method
+        unconditionally short-circuits and returns success without
+        contacting SMTP. See ``__init__`` for the rationale.
+        """
+        if self._suppress_outbound:
+            logger.info(
+                "[Email] Suppressed outbound to %s (EMAIL_SUPPRESS_OUTBOUND=true)",
+                chat_id,
+            )
+            return SendResult(success=True, message_id=None)
         try:
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(
@@ -482,7 +538,24 @@ class EmailAdapter(BasePlatformAdapter):
         body: str,
         reply_to_msg_id: Optional[str] = None,
     ) -> str:
-        """Send an email via SMTP. Runs in executor thread."""
+        """Send an email via SMTP. Runs in executor thread.
+
+        Backstop: when ``EMAIL_SUPPRESS_OUTBOUND=true`` is set, public
+        send methods short-circuit before reaching this function. If
+        execution somehow reaches here with the flag set, that indicates
+        a bug (e.g. a new public send path was added without the guard)
+        and we refuse to contact SMTP rather than leak the message.
+        """
+        if self._suppress_outbound:
+            logger.error(
+                "[Email] BUG: _send_email reached with EMAIL_SUPPRESS_OUTBOUND=true. "
+                "A public send path is bypassing the suppression guard. "
+                "Refusing to contact SMTP. to_addr=%s",
+                to_addr,
+            )
+            raise RuntimeError(
+                "EMAIL_SUPPRESS_OUTBOUND is set; refusing to send mail via SMTP"
+            )
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
@@ -542,7 +615,18 @@ class EmailAdapter(BasePlatformAdapter):
         file_name: Optional[str] = None,
         reply_to: Optional[str] = None,
     ) -> SendResult:
-        """Send a file as an email attachment."""
+        """Send a file as an email attachment.
+
+        When ``EMAIL_SUPPRESS_OUTBOUND=true`` is set, this method
+        unconditionally short-circuits and returns success without
+        contacting SMTP. See ``__init__`` for the rationale.
+        """
+        if self._suppress_outbound:
+            logger.info(
+                "[Email] Suppressed outbound document to %s (EMAIL_SUPPRESS_OUTBOUND=true)",
+                chat_id,
+            )
+            return SendResult(success=True, message_id=None)
         try:
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(
@@ -565,7 +649,21 @@ class EmailAdapter(BasePlatformAdapter):
         file_path: str,
         file_name: Optional[str] = None,
     ) -> str:
-        """Send an email with a file attachment via SMTP."""
+        """Send an email with a file attachment via SMTP.
+
+        Backstop: see _send_email for rationale.
+        """
+        if self._suppress_outbound:
+            logger.error(
+                "[Email] BUG: _send_email_with_attachment reached with "
+                "EMAIL_SUPPRESS_OUTBOUND=true. A public send path is "
+                "bypassing the suppression guard. Refusing to contact SMTP. "
+                "to_addr=%s",
+                to_addr,
+            )
+            raise RuntimeError(
+                "EMAIL_SUPPRESS_OUTBOUND is set; refusing to send mail via SMTP"
+            )
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -776,6 +776,185 @@ class TestSendMethods(unittest.TestCase):
         self.assertEqual(info["subject"], "Test")
 
 
+class TestSuppressOutbound(unittest.TestCase):
+    """Test EMAIL_SUPPRESS_OUTBOUND kill switch.
+
+    When EMAIL_SUPPRESS_OUTBOUND=true is set, the adapter must never
+    contact SMTP from any send path, regardless of what the agent emits
+    or what additional send methods may be added later. Inbound IMAP
+    polling is unaffected.
+    """
+
+    _BASE_ENV = {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_IMAP_HOST": "imap.test.com",
+        "EMAIL_SMTP_HOST": "smtp.test.com",
+    }
+
+    def _make_adapter(self, suppress_value=None):
+        """Build an EmailAdapter with EMAIL_SUPPRESS_OUTBOUND optionally set.
+
+        ``suppress_value`` of None means leave the env var unset entirely.
+        Any other value is set as the env var literally (so we can test
+        truthy parsing, falsy parsing, and invalid values).
+        """
+        from gateway.config import PlatformConfig
+        env = dict(self._BASE_ENV)
+        if suppress_value is not None:
+            env["EMAIL_SUPPRESS_OUTBOUND"] = suppress_value
+        # Make sure no leaked value from another test bleeds in.
+        with patch.dict(os.environ, env, clear=False):
+            os.environ.pop("EMAIL_SUPPRESS_OUTBOUND", None)
+            if suppress_value is not None:
+                os.environ["EMAIL_SUPPRESS_OUTBOUND"] = suppress_value
+            from gateway.platforms.email import EmailAdapter
+            adapter = EmailAdapter(PlatformConfig(enabled=True))
+        return adapter
+
+    def test_unset_defaults_to_false(self):
+        """Without the env var set, the flag must default to False."""
+        adapter = self._make_adapter(suppress_value=None)
+        self.assertFalse(adapter._suppress_outbound)
+
+    def test_explicit_false_sends_normally(self):
+        """EMAIL_SUPPRESS_OUTBOUND=false must permit normal SMTP sends."""
+        import asyncio
+        adapter = self._make_adapter(suppress_value="false")
+        self.assertFalse(adapter._suppress_outbound)
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            result = asyncio.run(
+                adapter.send("user@test.com", "Hello from Hermes!")
+            )
+
+            self.assertTrue(result.success)
+            mock_server.send_message.assert_called_once()
+
+    def test_send_suppressed_when_flag_set(self):
+        """send() must not contact SMTP when the flag is set."""
+        import asyncio
+        adapter = self._make_adapter(suppress_value="true")
+        self.assertTrue(adapter._suppress_outbound)
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            result = asyncio.run(
+                adapter.send("user@test.com", "Hello — should be dropped")
+            )
+
+            self.assertTrue(result.success)
+            self.assertIsNone(result.message_id)
+            mock_smtp.assert_not_called()
+
+    def test_send_image_suppressed_when_flag_set(self):
+        """send_image() (which routes through send()) must also suppress."""
+        import asyncio
+        adapter = self._make_adapter(suppress_value="true")
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            result = asyncio.run(
+                adapter.send_image(
+                    "user@test.com",
+                    "https://img.com/photo.jpg",
+                    "caption text",
+                )
+            )
+
+            self.assertTrue(result.success)
+            self.assertIsNone(result.message_id)
+            mock_smtp.assert_not_called()
+
+    def test_send_document_suppressed_when_flag_set(self):
+        """send_document() must also suppress, on its own code path."""
+        import asyncio
+        import tempfile
+        adapter = self._make_adapter(suppress_value="true")
+
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            f.write(b"Test document content")
+            tmp_path = f.name
+
+        try:
+            with patch("smtplib.SMTP") as mock_smtp:
+                result = asyncio.run(
+                    adapter.send_document(
+                        "user@test.com", tmp_path, "Here is the file"
+                    )
+                )
+
+                self.assertTrue(result.success)
+                self.assertIsNone(result.message_id)
+                mock_smtp.assert_not_called()
+        finally:
+            os.unlink(tmp_path)
+
+    def test_truthy_values_all_parse_as_true(self):
+        """All recognized truthy spellings must enable suppression."""
+        for val in ("true", "TRUE", "True", "1", "yes", "YES", "on", "ON", " true "):
+            with self.subTest(value=val):
+                adapter = self._make_adapter(suppress_value=val)
+                self.assertTrue(
+                    adapter._suppress_outbound,
+                    f"{val!r} should parse as truthy",
+                )
+
+    def test_falsy_values_all_parse_as_false(self):
+        """All recognized falsy spellings must leave suppression off."""
+        for val in ("false", "FALSE", "0", "no", "NO", "off", "OFF", "", "  "):
+            with self.subTest(value=val):
+                adapter = self._make_adapter(suppress_value=val)
+                self.assertFalse(
+                    adapter._suppress_outbound,
+                    f"{val!r} should parse as falsy",
+                )
+
+    def test_invalid_value_raises_at_init(self):
+        """A typo or unrecognized value must fail loudly at adapter init.
+
+        This is intentional: silent fallback to false on a typo would
+        mean leaked email, which is the worst possible failure mode for
+        a safety flag.
+        """
+        for val in ("maybe", "yep", "tru", "y", "enabled", "2"):
+            with self.subTest(value=val):
+                with self.assertRaises(ValueError) as ctx:
+                    self._make_adapter(suppress_value=val)
+                self.assertIn("EMAIL_SUPPRESS_OUTBOUND", str(ctx.exception))
+
+    def test_send_email_backstop_raises(self):
+        """If a future code path bypasses the public-method guard and
+        invokes _send_email directly, the backstop must refuse to SMTP.
+        """
+        adapter = self._make_adapter(suppress_value="true")
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            with self.assertRaises(RuntimeError):
+                adapter._send_email("user@test.com", "should never send")
+            mock_smtp.assert_not_called()
+
+    def test_send_email_with_attachment_backstop_raises(self):
+        """Same backstop on the attachment code path."""
+        import tempfile
+        adapter = self._make_adapter(suppress_value="true")
+
+        with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
+            f.write(b"x")
+            tmp_path = f.name
+
+        try:
+            with patch("smtplib.SMTP") as mock_smtp:
+                with self.assertRaises(RuntimeError):
+                    adapter._send_email_with_attachment(
+                        "user@test.com", "body", tmp_path, "f.txt"
+                    )
+                mock_smtp.assert_not_called()
+        finally:
+            os.unlink(tmp_path)
+
+
 class TestConnectDisconnect(unittest.TestCase):
     """Test IMAP/SMTP connection lifecycle."""
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -203,6 +203,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `EMAIL_HOME_ADDRESS_NAME` | Display name for the email home target |
 | `EMAIL_POLL_INTERVAL` | Email polling interval in seconds |
 | `EMAIL_ALLOW_ALL_USERS` | Allow all inbound email senders |
+| `EMAIL_SUPPRESS_OUTBOUND` | Kill switch: when truthy, the email adapter will never deliver outbound mail via SMTP. Inbound polling continues. Use for draft-only / approval-required mailboxes where replies are routed through a separate channel (e.g. human approval on a chat platform). Accepted values: `true`/`false`, `1`/`0`, `yes`/`no`, `on`/`off` (case-insensitive). Invalid values fail loudly at startup. |
 | `DINGTALK_CLIENT_ID` | DingTalk bot AppKey from developer portal ([open.dingtalk.com](https://open.dingtalk.com)) |
 | `DINGTALK_CLIENT_SECRET` | DingTalk bot AppSecret from developer portal |
 | `DINGTALK_ALLOWED_USERS` | Comma-separated DingTalk user IDs allowed to message the bot |

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -174,6 +174,35 @@ Email access follows the same pattern as all other Hermes platforms:
 
 ---
 
+## Draft-only / approval-required mode
+
+For mailboxes where you want the agent to read inbound mail but **never** auto-reply via SMTP — for example, when every outbound reply must pass through human approval on a chat platform first — set:
+
+```bash
+EMAIL_SUPPRESS_OUTBOUND=true
+```
+
+When this flag is set, the adapter:
+
+- Continues polling IMAP and dispatching inbound messages to the agent normally
+- **Unconditionally drops** all outbound SMTP from `send()`, `send_image()`, and `send_document()`, regardless of what the agent emits
+- Logs each suppressed call so operators can verify the kill switch is active
+- Logs a `WARNING` at startup so the operating mode is visible in gateway logs
+
+This is enforced at the adapter, not via prompt engineering, so it cannot be bypassed by an LLM forgetting an instruction or by prompt injection from inbound email content. It also serves as a defense-in-depth measure for any mailbox where automated outbound mail is undesirable (compliance, staging, testing).
+
+A typical human-in-the-loop architecture using this flag:
+
+1. Agent receives inbound email via IMAP polling
+2. Agent (with `platform_toolsets.email: [messaging]` locking it down to the `send_message` tool only) cross-posts a draft to a chat platform via `send_message`
+3. The agent's response, whatever it contains, is dropped at the SMTP boundary
+4. A human approves the draft on the chat platform
+5. The approved reply is sent through a separate path (e.g., a Gmail API skill) that does not go through this adapter
+
+The flag accepts: `true`, `false`, `1`, `0`, `yes`, `no`, `on`, `off` (case-insensitive). Anything else raises `ValueError` at adapter init — there is no silent fallback, because a typo in a safety flag means leaked email.
+
+---
+
 ## Environment Variables Reference
 
 | Variable | Required | Default | Description |
@@ -188,3 +217,4 @@ Email access follows the same pattern as all other Hermes platforms:
 | `EMAIL_ALLOWED_USERS` | No | — | Comma-separated allowed sender addresses |
 | `EMAIL_HOME_ADDRESS` | No | — | Default delivery target for cron jobs |
 | `EMAIL_ALLOW_ALL_USERS` | No | `false` | Allow all senders (not recommended) |
+| `EMAIL_SUPPRESS_OUTBOUND` | No | `false` | Kill switch: when set, the adapter never delivers outbound mail via SMTP. Inbound polling is unaffected. Use for draft-only / approval-required mailboxes (see [Draft-only mode](#draft-only--approval-required-mode) below). Accepted values: `true`/`false`, `1`/`0`, `yes`/`no`, `on`/`off`. Invalid values fail loudly at startup. |


### PR DESCRIPTION
## What does this PR do?

Adds an `EMAIL_SUPPRESS_OUTBOUND` env var to the email gateway adapter that, when truthy, unconditionally drops all outbound SMTP from `send()`, `send_image()`, and `send_document()`. Inbound IMAP polling is unaffected — the agent still receives inbound mail and can act on it via other tools (e.g. cross-posting drafts to a chat platform via `send_message`). The flag is enforced at the adapter, not via prompts, so it cannot be bypassed by an LLM forgetting an instruction or by prompt injection from inbound email content.

This unlocks human-in-the-loop email workflows where every outbound reply must be approved on a separate channel before going out, and it provides a hard safety guarantee that no other mechanism in the codebase currently offers for the email adapter.

### Why a kill switch and not a prompt instruction?

A prompt-level instruction ("end every reply with `[SILENT]`" etc.) relies on the LLM emitting exactly the right token, which is fragile. Any deviation — `Done. [SILENT]`, `[SILENT] (handled in chat)`, a forgotten marker — leaks an email. A kill switch enforced at the adapter is a hard guarantee that does not depend on prompt discipline or model reliability.

The marker-based approach is still the right primitive for *per-message* agent discretion (and is used by `cron/scheduler.py` and `gateway/builtin_hooks/boot_md.py`). This PR addresses the orthogonal case of *operator-level* configuration: "this mailbox NEVER auto-replies, full stop."

## Related Issue

(no existing issue — search of open/closed issues + PRs returned no prior art for this on the email adapter; happy to file one if preferred)

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix (defense against prompt injection from inbound mail)

## Changes Made

- **`gateway/platforms/email.py`**:
  - Add module-level `_parse_bool_env(name)` helper with strict validation. Accepts `true/false`, `1/0`, `yes/no`, `on/off` (case-insensitive, whitespace-tolerant), or unset. Anything else raises `ValueError` at parse time. No silent default — a typo in a safety flag would mean leaked email.
  - Add `self._suppress_outbound` to `EmailAdapter.__init__`, parsed from `EMAIL_SUPPRESS_OUTBOUND`. Logs a `WARNING` at adapter init if true so the operating mode is visible in default log output.
  - Add public-method short-circuit in `send()` and `send_document()`: when the flag is set, log `INFO` and return `SendResult(success=True, message_id=None)` without contacting SMTP. `send_image()` is covered transitively because it routes through `send()`.
  - Add backstops in `_send_email()` and `_send_email_with_attachment()` that log `ERROR` and raise `RuntimeError` if reached with the flag set. Should never fire under normal use; protects against future code paths bypassing the public-method guard.

- **`tests/gateway/test_email.py`** — add `TestSuppressOutbound` class with 11 test cases covering: default-off, explicit-false, all three public send paths suppressed, all recognized truthy/falsy spellings (via `subTest`), invalid-value rejection at init, and both private-method backstops.

- **`.env.example`** — add commented `EMAIL_SUPPRESS_OUTBOUND=false` block in the Email section with rationale.

- **`website/docs/reference/environment-variables.md`** — add row to the `EMAIL_*` table.

- **`website/docs/user-guide/messaging/email.md`** — add row to the env vars reference table and a new "Draft-only / approval-required mode" section explaining the use case, semantics, and a typical HITL architecture.

## How to Test

1. **Unit tests**: `pytest tests/gateway/test_email.py -q` → 79 passed, 24 subtests passed (the 11 new tests in `TestSuppressOutbound` cover the full surface).
2. **Manual verification (suppression on)**:
   - Set `EMAIL_SUPPRESS_OUTBOUND=true` in `~/.hermes/.env`
   - Restart the gateway. Confirm the WARNING log line appears at startup: *"EMAIL_SUPPRESS_OUTBOUND=true — adapter will NOT send any outbound mail via SMTP..."*
   - Send any inbound email to the mailbox.
   - Verify the agent processes the message normally and that nothing lands in the Sent folder. Adapter logs should show: *"[Email] Suppressed outbound to <addr> (EMAIL_SUPPRESS_OUTBOUND=true)"*
3. **Manual verification (suppression off, regression check)**:
   - Set `EMAIL_SUPPRESS_OUTBOUND=false` (or unset).
   - Restart the gateway and verify the WARNING does not appear.
   - Send an inbound email. Verify the agent's reply is delivered as normal.
4. **Invalid value**:
   - Set `EMAIL_SUPPRESS_OUTBOUND=maybe` and start the gateway.
   - Verify the email adapter fails to start with a `ValueError` listing the accepted values.

Tested on Arch Linux with Python 3.11 against the project's bundled venv.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(gateway): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (related but distinct: #4308 clarifies the cron `[SILENT]` sentinel semantics; #3471 adds an optional skill for Himalaya-based draft workflows. Both operate at different layers — this PR is the underlying adapter primitive.)
- [x] My PR contains **only** changes related to this feature
- [x] I've run `pytest tests/gateway/test_email.py -q` and all 79 tests pass. The full `pytest tests/` run has pre-existing failures in `test_hermes_logging.py`, `test_delegate.py`, `test_skill_manager_tool.py`, and `test_matrix.py` — verified to exist on clean `origin/main` without this PR's changes; none touch `gateway/platforms/email.py`.
- [x] I've added tests for my changes (11 new cases)
- [x] I've tested on my platform: Arch Linux, Python 3.11

### Documentation & Housekeeping

- [x] Documentation updated: `website/docs/reference/environment-variables.md`, `website/docs/user-guide/messaging/email.md`, `.env.example`
- [x] `cli-config.yaml.example` — N/A (env var only, no yaml key)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — N/A (pure Python, no platform-specific calls; env var parsing uses stdlib only)
- [x] Tool descriptions/schemas — N/A
