### PR TITLE
Fix Codex stream handling when final response output is empty

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3868,6 +3868,7 @@ class AIAgent:
         has_tool_calls = False
         first_delta_fired = False
         self._reasoning_deltas_fired = False
+        terminal_response = None
         # Accumulate streamed text so we can recover if get_final_response()
         # returns empty output (e.g. chatgpt.com backend-api sends
         # response.incomplete instead of response.completed).
@@ -3911,8 +3912,10 @@ class AIAgent:
                             if done_item is not None:
                                 collected_output_items.append(done_item)
                         # Log non-completed terminal events for diagnostics
-                        elif event_type in ("response.incomplete", "response.failed"):
+                        elif event_type in ("response.completed", "response.incomplete", "response.failed"):
                             resp_obj = getattr(event, "response", None)
+                            if resp_obj is not None:
+                                terminal_response = resp_obj
                             status = getattr(resp_obj, "status", None) if resp_obj else None
                             incomplete_details = getattr(resp_obj, "incomplete_details", None) if resp_obj else None
                             logger.warning(
@@ -3923,6 +3926,15 @@ class AIAgent:
                                 self._client_log_context(),
                             )
                     final_response = stream.get_final_response()
+                    if terminal_response is not None:
+                        _final_output = getattr(final_response, "output", None)
+                        _terminal_output = getattr(terminal_response, "output", None)
+                        if (
+                            isinstance(_terminal_output, list)
+                            and _terminal_output
+                            and (not isinstance(_final_output, list) or not _final_output)
+                        ):
+                            final_response = terminal_response
                     # PATCH: ChatGPT Codex backend streams valid output items
                     # but get_final_response() can return an empty output list.
                     # Backfill from collected items or synthesize from deltas.

--- a/tests/test_run_agent_codex_responses.py
+++ b/tests/test_run_agent_codex_responses.py
@@ -374,6 +374,34 @@ def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     assert response.output[0].content[0].text == "streamed create ok"
 
 
+def test_run_codex_stream_uses_terminal_event_response_when_final_response_is_empty(monkeypatch):
+    agent = _build_agent(monkeypatch)
+
+    terminal_response = _codex_message_response("terminal event ok")
+    empty_final = SimpleNamespace(output=[], status="completed", model="gpt-5-codex")
+
+    mock_stream = MagicMock()
+    mock_stream.__enter__ = MagicMock(return_value=mock_stream)
+    mock_stream.__exit__ = MagicMock(return_value=False)
+    mock_stream.__iter__ = MagicMock(
+        return_value=iter(
+            [
+                SimpleNamespace(type="response.created"),
+                SimpleNamespace(type="response.completed", response=terminal_response),
+            ]
+        )
+    )
+    mock_stream.get_final_response.return_value = empty_final
+
+    mock_client = MagicMock()
+    mock_client.responses.stream.return_value = mock_stream
+
+    response = agent._run_codex_stream(_codex_request_kwargs(), client=mock_client)
+
+    assert response is terminal_response
+    assert response.output[0].content[0].text == "terminal event ok"
+
+
 def test_run_conversation_codex_plain_text(monkeypatch):
     agent = _build_agent(monkeypatch)
     monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: _codex_message_response("OK"))


### PR DESCRIPTION
## Problem

Hermes can fail on `gpt-5.4` / Codex Responses streams with:

`Invalid API response: response.output is empty`

This can happen even on very small prompts, and leads Hermes to retry as if the provider returned a malformed or rate-limited response.

## Root cause

In `_run_codex_stream()`, Hermes already tries several recovery paths:
- `stream.get_final_response()`
- `response.output_item.done`
- synthesized output from streamed text deltas

However, it does not recover the final response object attached to terminal stream events like `response.completed`.

If the provider/backend returns the usable final payload on `event.response`, while `get_final_response()` returns an object with `output=[]`, Hermes currently treats that as an invalid response and retries.

## Fix

- capture `event.response` for terminal stream events
- prefer that terminal response when `get_final_response()` has empty `output`
- add regression coverage for this response shape

## User impact

This avoids false malformed/rate-limit retries on `gpt-5.4` / Codex Responses streams and restores expected behavior for affected sessions.

## Test coverage

Adds a regression test for the case where:
- the stream emits `response.completed` with a valid `response`
- `get_final_response()` returns `output=[]`
- Hermes should use the terminal event response instead of rejecting it
