### PR TITLE
fix: backfill empty codex output in auxiliary client

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -260,10 +260,43 @@ class _CodexCompletionsAdapter:
         usage = None
 
         try:
+            # Collect output items and text deltas during streaming —
+            # the Codex backend can return empty response.output from
+            # get_final_response() even when items were streamed.
+            collected_output_items: List[Any] = []
+            collected_text_deltas: List[str] = []
             with self._client.responses.stream(**resp_kwargs) as stream:
                 for _event in stream:
-                    pass
+                    _etype = getattr(_event, "type", "")
+                    if _etype == "response.output_item.done":
+                        _done = getattr(_event, "item", None)
+                        if _done is not None:
+                            collected_output_items.append(_done)
+                    elif "output_text.delta" in _etype:
+                        _delta = getattr(_event, "delta", "")
+                        if _delta:
+                            collected_text_deltas.append(_delta)
                 final = stream.get_final_response()
+
+            # Backfill empty output from collected stream events
+            _output = getattr(final, "output", None)
+            if isinstance(_output, list) and not _output:
+                if collected_output_items:
+                    final.output = list(collected_output_items)
+                    logger.debug(
+                        "Codex auxiliary: backfilled %d output items from stream events",
+                        len(collected_output_items),
+                    )
+                elif collected_text_deltas:
+                    assembled = "".join(collected_text_deltas)
+                    final.output = [SimpleNamespace(
+                        type="message", role="assistant", status="completed",
+                        content=[SimpleNamespace(type="output_text", text=assembled)],
+                    )]
+                    logger.debug(
+                        "Codex auxiliary: synthesized from %d deltas (%d chars)",
+                        len(collected_text_deltas), len(assembled),
+                    )
 
             # Extract text and tool calls from the Responses output
             for item in getattr(final, "output", []):


### PR DESCRIPTION
The auxiliary client's `_CodexCompletionsAdapter` (used for compression, vision, web_extract summarization, session_search, memory flush — everything that goes through the auxiliary LLM path when on the codex provider) had the same empty-output bug as the main agent loop.

It streamed responses but discarded all events with `for _event in stream: pass`, then called `get_final_response()` which returns `output=[]` from the chatgpt.com backend. Auxiliary calls silently returned `content=None`.

Now collects `response.output_item.done` and text deltas during streaming and backfills empty output — same pattern as `_run_codex_stream()`.

**Tested live** against chatgpt.com/backend-api/codex with OAuth — log confirms: `Codex auxiliary: backfilled 1 output items from stream events`