### PR TITLE
fix: capture Codex Responses text deltas in auxiliary adapter

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -253,16 +253,25 @@ class _CodexCompletionsAdapter:
         usage = None
 
         try:
+            # The Codex backend requires streaming. Also, in practice it may emit
+            # response.output_text.delta events while returning an empty
+            # final.output array. So we must collect deltas during the stream.
             with self._client.responses.stream(**resp_kwargs) as stream:
-                for _event in stream:
-                    pass
+                for event in stream:
+                    etype = getattr(event, "type", None)
+                    if etype == "response.output_text.delta":
+                        delta = getattr(event, "delta", "")
+                        if delta:
+                            text_parts.append(delta)
                 final = stream.get_final_response()
 
-            # Extract text and tool calls from the Responses output
-            for item in getattr(final, "output", []):
+            # Extract tool calls from the final Responses output (if present).
+            # Only use final.output message parts if we didn't already collect
+            # streamed text deltas (prevents duplication when both are present).
+            for item in getattr(final, "output", []) or []:
                 item_type = getattr(item, "type", None)
-                if item_type == "message":
-                    for part in getattr(item, "content", []):
+                if item_type == "message" and not text_parts:
+                    for part in getattr(item, "content", []) or []:
                         ptype = getattr(part, "type", None)
                         if ptype in ("output_text", "text"):
                             text_parts.append(getattr(part, "text", ""))

--- a/tests/test_codex_aux_stream_deltas.py
+++ b/tests/test_codex_aux_stream_deltas.py
@@ -1,0 +1,49 @@
+import types
+
+
+def test_codex_aux_adapter_collects_stream_deltas_when_final_output_empty():
+    """Regression test.
+
+    Some Codex-backed Responses API calls emit text only via
+    `response.output_text.delta` events while returning an empty `final.output`
+    array. Our Codex Responses -> chat.completions adapter must collect deltas
+    so downstream callers (vision, web extract, compression) see content.
+    """
+
+    from agent.auxiliary_client import _CodexCompletionsAdapter
+
+    class _Event:
+        def __init__(self, delta: str):
+            self.type = "response.output_text.delta"
+            self.delta = delta
+
+    class _Stream:
+        def __init__(self):
+            self._events = [_Event("Usage"), _Event(" dashboard")]
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def __iter__(self):
+            return iter(self._events)
+
+        def get_final_response(self):
+            # Mimic a ParsedResponse with empty output.
+            return types.SimpleNamespace(output=[], usage=None)
+
+    class _Responses:
+        def stream(self, **_kwargs):
+            return _Stream()
+
+    class _FakeClient:
+        def __init__(self):
+            self.responses = _Responses()
+
+    adapter = _CodexCompletionsAdapter(real_client=_FakeClient(), model="gpt-5.2-codex")
+
+    resp = adapter.create(messages=[{"role": "user", "content": "hi"}])
+
+    assert resp.choices[0].message.content == "Usage dashboard"


### PR DESCRIPTION
## Summary

Codex-backed Responses streaming can emit assistant text only via `response.output_text.delta` events while returning an empty `final.output` array.

Our Codex Responses → `chat.completions` adapter previously only read `final.output`, which could produce `content=None` and trigger generic fallback text in downstream tools (e.g. `vision_analyze`).

This PR collects streamed text deltas during the Responses stream and falls back to `final.output` only when no deltas were observed.

## Test Plan

- `pytest -q tests/test_codex_aux_stream_deltas.py`

## Notes

- To avoid duplication, the adapter prefers streamed deltas when present and only uses message parts from `final.output` when no deltas were observed.
