### PR TITLE
fix: HERMES_PORTAL_BASE_URL env var ignored during Nous login

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2577,8 +2577,8 @@ def _login_nous(args, pconfig: ProviderConfig) -> None:
 
     try:
         auth_state = _nous_device_code_login(
-            portal_base_url=getattr(args, "portal_url", None) or pconfig.portal_base_url,
-            inference_base_url=getattr(args, "inference_url", None) or pconfig.inference_base_url,
+            portal_base_url=getattr(args, "portal_url", None),
+            inference_base_url=getattr(args, "inference_url", None),
             client_id=getattr(args, "client_id", None) or pconfig.client_id,
             scope=getattr(args, "scope", None) or pconfig.scope,
             open_browser=not getattr(args, "no_browser", False),


### PR DESCRIPTION
## Problem

Setting `HERMES_PORTAL_BASE_URL` (or `NOUS_PORTAL_BASE_URL`) in `~/.hermes/.env` to point at a staging portal had no effect — `hermes model` always logged in against production.

## Root Cause

`_login_nous()` (line 2580) was doing:

```python
portal_base_url=getattr(args, "portal_url", None) or pconfig.portal_base_url
```

When no `--portal-url` CLI flag was given, this fell through to `pconfig.portal_base_url` (hardcoded `https://portal.nousresearch.com`). Since a truthy value was passed to `_nous_device_code_login()`, its env var fallback chain was dead on arrival:

```python
portal_base_url = (
    portal_base_url                          # already "https://portal.nousresearch.com"
    or os.getenv("HERMES_PORTAL_BASE_URL")   # NEVER REACHED
    or os.getenv("NOUS_PORTAL_BASE_URL")
    or pconfig.portal_base_url
)
```

## Fix

Pass `None` when no CLI flag is provided, so `_nous_device_code_login()` properly checks:

1. `--portal-url` CLI arg
2. `HERMES_PORTAL_BASE_URL` env var
3. `NOUS_PORTAL_BASE_URL` env var
4. `DEFAULT_NOUS_PORTAL_URL` (production default)

Same fix applied to `inference_base_url` for consistency.

## Testing

- All 234 auth-related tests pass
- Manually verified env var loading resolves correctly