### PR TITLE
fix(model): detect auth-store credential_pool for mapped providers

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -787,6 +787,14 @@ def list_authenticated_providers(
         # Check if any env var is set
         has_creds = any(os.environ.get(ev) for ev in env_vars)
         if not has_creds:
+            try:
+                from hermes_cli.auth import _load_auth_store
+                store = _load_auth_store()
+                if store and hermes_id in store.get("credential_pool", {}):
+                    has_creds = True
+            except Exception:
+                pass
+        if not has_creds:
             continue
 
         # Use curated list, falling back to models.dev if no curated list

--- a/tests/hermes_cli/test_overlay_slug_resolution.py
+++ b/tests/hermes_cli/test_overlay_slug_resolution.py
@@ -81,3 +81,22 @@ def test_kilo_overlay_uses_hermes_slug():
 
     kilo_mdev = next((p for p in providers if p["slug"] == "kilo"), None)
     assert kilo_mdev is None, "kilo slug should not appear (resolved to kilocode)"
+
+
+
+def test_mapped_provider_credential_pool_visibility(monkeypatch):
+    """Mapped providers should appear when credentials live only in auth-store credential_pool."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {"google-ai-studio": {"env": ["GEMINI_API_KEY"]}})
+    monkeypatch.setattr("agent.models_dev.PROVIDER_TO_MODELS_DEV", {"gemini": "google-ai-studio"})
+    monkeypatch.setattr(
+        "hermes_cli.auth._load_auth_store",
+        lambda: {"providers": {}, "credential_pool": {"gemini": {"token": "fake"}}},
+    )
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+
+    providers = list_authenticated_providers(current_provider="gemini")
+
+    gemini = next((p for p in providers if p["slug"] == "gemini"), None)
+    assert gemini is not None, "gemini should appear when auth-store credential_pool has creds"
+    assert gemini["is_current"] is True
+    assert gemini["total_models"] > 0


### PR DESCRIPTION
## Summary
- treat Hermes auth-store `credential_pool` entries as valid credentials during `/model` provider listing for Hermes-mapped providers
- preserve provider visibility when credentials exist in Hermes auth storage but are not exported as environment variables in the current process
- add a regression test covering the mapped-provider `credential_pool` path

## Repro
With credentials present only in Hermes auth storage under `credential_pool` and no matching provider env var exported:
- clean upstream omits `gemini` from `/model`
- this patch makes `gemini` appear correctly with its curated models

## Scope
This PR only fixes the mapped-provider `credential_pool` discovery gap in `list_authenticated_providers()`.

It does not attempt broader slug-normalization cleanup, and it no longer includes the earlier `openai-codex` curated-model delta because current upstream already has that behavior.

## Validation
- smoke-tested `list_authenticated_providers()` against clean `origin/main`
- verified the difference again with a real local auth-store containing `gemini` only in `credential_pool`
- ran:
  - `./.venv/bin/python -m pytest tests/hermes_cli/test_overlay_slug_resolution.py -q`
  - `./.venv/bin/python -m pytest tests/hermes_cli/test_model_switch_custom_providers.py -q`
