### PR TITLE
feat(telegram): filter group messages by thread ownership via group_topics config

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1923,16 +1923,48 @@ class TelegramAdapter(BasePlatformAdapter):
         """Apply Telegram group trigger rules.
 
         DMs remain unrestricted. Group/supergroup messages are accepted when:
+        - the message thread belongs to this profile (when ``group_topics`` is configured)
         - the chat is explicitly allowlisted in ``free_response_chats``
         - ``require_mention`` is disabled
         - the message is a command
         - the message replies to the bot
         - the bot is @mentioned
         - the text/caption matches a configured regex wake-word pattern
+
+        When multiple gateway instances share the same Telegram group but own
+        different forum topics (via ``group_topics`` in config), each instance
+        silently drops messages from threads it does not own.  This prevents
+        cross-talk between profiles.
         """
         if not self._is_group_chat(message):
             return True
-        if str(getattr(getattr(message, "chat", None), "id", "")) in self._telegram_free_response_chats():
+
+        # --- Forum topic thread ownership filter ---
+        # When group_topics is configured for a chat, only accept messages
+        # from threads explicitly listed in the config.  This allows multiple
+        # gateway profiles to coexist in the same Telegram group, each
+        # handling only its own forum topics.
+        chat = getattr(message, "chat", None)
+        chat_id_str = str(getattr(chat, "id", ""))
+        thread_id_raw = getattr(message, "message_thread_id", None)
+        group_topics_config: list = self.config.extra.get("group_topics", [])
+
+        if group_topics_config and chat_id_str:
+            for chat_entry in group_topics_config:
+                if str(chat_entry.get("chat_id", "")) == chat_id_str:
+                    # This chat is configured — enforce thread ownership.
+                    owned_threads = {
+                        str(t["thread_id"])
+                        for t in chat_entry.get("topics", [])
+                        if t.get("thread_id") is not None
+                    }
+                    if owned_threads:
+                        msg_thread = str(thread_id_raw) if thread_id_raw is not None else None
+                        if msg_thread not in owned_threads:
+                            return False
+                    break
+
+        if chat_id_str in self._telegram_free_response_chats():
             return True
         if not self._telegram_require_mention():
             return True

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock
 from gateway.config import Platform, PlatformConfig, load_gateway_config
 
 
-def _make_adapter(require_mention=None, free_response_chats=None, mention_patterns=None):
+def _make_adapter(require_mention=None, free_response_chats=None, mention_patterns=None, group_topics=None):
     from gateway.platforms.telegram import TelegramAdapter
 
     extra = {}
@@ -15,6 +15,8 @@ def _make_adapter(require_mention=None, free_response_chats=None, mention_patter
         extra["free_response_chats"] = free_response_chats
     if mention_patterns is not None:
         extra["mention_patterns"] = mention_patterns
+    if group_topics is not None:
+        extra["group_topics"] = group_topics
 
     adapter = object.__new__(TelegramAdapter)
     adapter.platform = Platform.TELEGRAM
@@ -28,7 +30,7 @@ def _make_adapter(require_mention=None, free_response_chats=None, mention_patter
     return adapter
 
 
-def _group_message(text="hello", *, chat_id=-100, reply_to_bot=False, entities=None, caption=None, caption_entities=None):
+def _group_message(text="hello", *, chat_id=-100, reply_to_bot=False, entities=None, caption=None, caption_entities=None, message_thread_id=None):
     reply_to_message = None
     if reply_to_bot:
         reply_to_message = SimpleNamespace(from_user=SimpleNamespace(id=999))
@@ -39,6 +41,7 @@ def _group_message(text="hello", *, chat_id=-100, reply_to_bot=False, entities=N
         caption_entities=caption_entities or [],
         chat=SimpleNamespace(id=chat_id, type="group"),
         reply_to_message=reply_to_message,
+        message_thread_id=message_thread_id,
     )
 
 
@@ -108,3 +111,114 @@ def test_config_bridges_telegram_group_settings(monkeypatch, tmp_path):
     assert __import__("os").environ["TELEGRAM_REQUIRE_MENTION"] == "true"
     assert json.loads(__import__("os").environ["TELEGRAM_MENTION_PATTERNS"]) == [r"^\s*chompy\b"]
     assert __import__("os").environ["TELEGRAM_FREE_RESPONSE_CHATS"] == "-123"
+
+
+# ── group_topics thread ownership filtering ──────────────────────────
+
+
+def test_group_topics_accepts_owned_thread():
+    """Messages in a thread listed in group_topics should be accepted."""
+    adapter = _make_adapter(
+        require_mention=False,
+        group_topics=[{"chat_id": -100, "topics": [{"name": "My Topic", "thread_id": 39}]}],
+    )
+    msg = _group_message("hello", chat_id=-100, message_thread_id=39)
+    assert adapter._should_process_message(msg) is True
+
+
+def test_group_topics_rejects_unowned_thread():
+    """Messages in a thread NOT listed in group_topics should be rejected."""
+    adapter = _make_adapter(
+        require_mention=False,
+        group_topics=[{"chat_id": -100, "topics": [{"name": "My Topic", "thread_id": 39}]}],
+    )
+    msg = _group_message("hello", chat_id=-100, message_thread_id=4)
+    assert adapter._should_process_message(msg) is False
+
+
+def test_group_topics_rejects_no_thread_when_topics_configured():
+    """Messages with no thread_id should be rejected when group_topics is configured."""
+    adapter = _make_adapter(
+        require_mention=False,
+        group_topics=[{"chat_id": -100, "topics": [{"name": "My Topic", "thread_id": 39}]}],
+    )
+    msg = _group_message("hello", chat_id=-100, message_thread_id=None)
+    assert adapter._should_process_message(msg) is False
+
+
+def test_group_topics_accepts_all_when_not_configured():
+    """Without group_topics, all threads should be accepted (backwards compat)."""
+    adapter = _make_adapter(require_mention=False)
+    msg = _group_message("hello", chat_id=-100, message_thread_id=4)
+    assert adapter._should_process_message(msg) is True
+
+
+def test_group_topics_accepts_all_for_unlisted_chat():
+    """Messages from a chat not listed in group_topics should be accepted."""
+    adapter = _make_adapter(
+        require_mention=False,
+        group_topics=[{"chat_id": -200, "topics": [{"name": "Other", "thread_id": 10}]}],
+    )
+    msg = _group_message("hello", chat_id=-100, message_thread_id=4)
+    assert adapter._should_process_message(msg) is True
+
+
+def test_group_topics_rejects_even_commands_in_wrong_thread():
+    """Commands in unowned threads should still be rejected."""
+    adapter = _make_adapter(
+        require_mention=True,
+        group_topics=[{"chat_id": -100, "topics": [{"name": "My Topic", "thread_id": 39}]}],
+    )
+    msg = _group_message("/status", chat_id=-100, message_thread_id=4)
+    assert adapter._should_process_message(msg, is_command=True) is False
+
+
+def test_group_topics_rejects_mention_in_wrong_thread():
+    """@mentions in unowned threads should still be rejected."""
+    text = "hi @hermes_bot"
+    adapter = _make_adapter(
+        require_mention=True,
+        group_topics=[{"chat_id": -100, "topics": [{"name": "My Topic", "thread_id": 39}]}],
+    )
+    msg = _group_message(text, chat_id=-100, message_thread_id=4, entities=[_mention_entity(text)])
+    assert adapter._should_process_message(msg) is False
+
+
+def test_group_topics_multiple_threads():
+    """A profile can own multiple threads in the same chat."""
+    adapter = _make_adapter(
+        require_mention=False,
+        group_topics=[{
+            "chat_id": -100,
+            "topics": [
+                {"name": "Topic A", "thread_id": 10},
+                {"name": "Topic B", "thread_id": 20},
+            ],
+        }],
+    )
+    assert adapter._should_process_message(_group_message("hi", chat_id=-100, message_thread_id=10)) is True
+    assert adapter._should_process_message(_group_message("hi", chat_id=-100, message_thread_id=20)) is True
+    assert adapter._should_process_message(_group_message("hi", chat_id=-100, message_thread_id=30)) is False
+
+
+def test_group_topics_empty_topics_list_accepts_all():
+    """A chat entry with an empty topics list should accept all threads."""
+    adapter = _make_adapter(
+        require_mention=False,
+        group_topics=[{"chat_id": -100, "topics": []}],
+    )
+    msg = _group_message("hello", chat_id=-100, message_thread_id=4)
+    assert adapter._should_process_message(msg) is True
+
+
+def test_group_topics_thread_id_type_coercion():
+    """thread_id comparison should handle int vs string coercion."""
+    adapter = _make_adapter(
+        require_mention=False,
+        group_topics=[{"chat_id": "-100", "topics": [{"name": "Topic", "thread_id": "39"}]}],
+    )
+    msg = _group_message("hello", chat_id=-100, message_thread_id=39)
+    assert adapter._should_process_message(msg) is True
+
+
+


### PR DESCRIPTION
## Summary

When multiple gateway profiles share the same Telegram group but handle different forum topics (via `group_topics` in config), each profile's gateway currently processes **all** messages in the group. This causes cross-talk — messages intended for one profile get handled by another.

## Problem

`_should_process_message()` checks for @mentions, replies, commands, and free-response chats — but has **no awareness of forum topic threads**. The `group_topics` config only labels topics with names and skills; it does not filter which threads a profile should handle.

When two profiles are configured like:

```yaml
# Profile A
group_topics:
  - chat_id: -100123
    topics:
      - name: "Project Alpha"
        thread_id: 39

# Profile B
group_topics:
  - chat_id: -100123
    topics:
      - name: "Project Beta"
        thread_id: 4
```

Both gateways process messages from **both** threads 39 and 4.

## Solution

Add thread ownership filtering to `_should_process_message()` that runs **before** all other group rules (including commands and @mentions):

1. When `group_topics` is configured for a chat, build a set of owned `thread_id` values
2. If the incoming message's `message_thread_id` is not in the owned set, reject it immediately
3. If `group_topics` is not configured for that chat, accept all threads (backwards compatible)

## Backwards Compatibility

- Profiles without `group_topics` config: no change
- Chats not listed in `group_topics`: no change
- Empty `topics` list: no change
- String vs int `thread_id` values: handled via string coercion

## Tests

10 new test cases covering: owned/unowned thread acceptance/rejection, no-thread messages, unlisted chats, command/mention rejection in wrong threads, multiple owned threads, empty topics list, and int/string type coercion.