### PR TITLE
Handle empty Codex streamed output items

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3868,6 +3868,7 @@ class AIAgent:
         has_tool_calls = False
         first_delta_fired = False
         streamed_text_parts: List[str] = []
+        streamed_output_items: List[Any] = []
         self._reasoning_deltas_fired = False
         for attempt in range(max_stream_retries + 1):
             try:
@@ -3892,6 +3893,11 @@ class AIAgent:
                         # Track tool calls to suppress text streaming
                         elif "function_call" in event_type:
                             has_tool_calls = True
+                        elif event_type == "response.output_item.done":
+                            item = getattr(event, "item", None)
+                            if getattr(item, "type", None) == "function_call":
+                                has_tool_calls = True
+                                streamed_output_items.append(item)
                         # Fire reasoning callbacks
                         elif "reasoning" in event_type and "delta" in event_type:
                             reasoning_text = getattr(event, "delta", "")
@@ -3918,6 +3924,12 @@ class AIAgent:
                                 content=[SimpleNamespace(type="output_text", text=streamed_text)],
                             )
                         ]
+                    elif (
+                        isinstance(output_items, list)
+                        and len(output_items) == 0
+                        and streamed_output_items
+                    ):
+                        final_response.output = list(streamed_output_items)
                     return final_response
             except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
                 if attempt < max_stream_retries:
@@ -3969,11 +3981,27 @@ class AIAgent:
             return stream_or_response
 
         terminal_response = None
+        streamed_text_parts: List[str] = []
+        streamed_output_items: List[Any] = []
         try:
             for event in stream_or_response:
                 event_type = getattr(event, "type", None)
                 if not event_type and isinstance(event, dict):
                     event_type = event.get("type")
+                if event_type == "response.output_text.delta":
+                    delta_text = getattr(event, "delta", None)
+                    if delta_text is None and isinstance(event, dict):
+                        delta_text = event.get("delta")
+                    if isinstance(delta_text, str) and delta_text:
+                        streamed_text_parts.append(delta_text)
+                    continue
+                if event_type == "response.output_item.done":
+                    item = getattr(event, "item", None)
+                    if item is None and isinstance(event, dict):
+                        item = event.get("item")
+                    if getattr(item, "type", None) == "function_call":
+                        streamed_output_items.append(item)
+                    continue
                 if event_type not in {"response.completed", "response.incomplete", "response.failed"}:
                     continue
 
@@ -3981,6 +4009,26 @@ class AIAgent:
                 if terminal_response is None and isinstance(event, dict):
                     terminal_response = event.get("response")
                 if terminal_response is not None:
+                    output_items = getattr(terminal_response, "output", None)
+                    streamed_text = "".join(streamed_text_parts).strip()
+                    if (
+                        isinstance(output_items, list)
+                        and len(output_items) == 0
+                        and streamed_text
+                    ):
+                        terminal_response.output = [
+                            SimpleNamespace(
+                                type="message",
+                                status="completed",
+                                content=[SimpleNamespace(type="output_text", text=streamed_text)],
+                            )
+                        ]
+                    elif (
+                        isinstance(output_items, list)
+                        and len(output_items) == 0
+                        and streamed_output_items
+                    ):
+                        terminal_response.output = list(streamed_output_items)
                     return terminal_response
         finally:
             close_fn = getattr(stream_or_response, "close", None)
@@ -4603,6 +4651,15 @@ class AIAgent:
                         if self.api_mode == "anthropic_messages":
                             self._try_refresh_anthropic_client_credentials()
                             result["response"] = _call_anthropic()
+                        elif self.api_mode == "codex_responses":
+                            request_client_holder["client"] = self._create_request_openai_client(
+                                reason="codex_stream_request"
+                            )
+                            result["response"] = self._run_codex_stream(
+                                api_kwargs,
+                                client=request_client_holder["client"],
+                                on_first_delta=on_first_delta,
+                            )
                         else:
                             result["response"] = _call_chat_completions()
                         return  # success

--- a/run_agent.py
+++ b/run_agent.py
@@ -3867,6 +3867,7 @@ class AIAgent:
         max_stream_retries = 1
         has_tool_calls = False
         first_delta_fired = False
+        streamed_text_parts: List[str] = []
         self._reasoning_deltas_fired = False
         for attempt in range(max_stream_retries + 1):
             try:
@@ -3879,6 +3880,7 @@ class AIAgent:
                         if "output_text.delta" in event_type or event_type == "response.output_text.delta":
                             delta_text = getattr(event, "delta", "")
                             if delta_text and not has_tool_calls:
+                                streamed_text_parts.append(delta_text)
                                 if not first_delta_fired:
                                     first_delta_fired = True
                                     if on_first_delta:
@@ -3895,7 +3897,28 @@ class AIAgent:
                             reasoning_text = getattr(event, "delta", "")
                             if reasoning_text:
                                 self._fire_reasoning_delta(reasoning_text)
-                    return stream.get_final_response()
+                    final_response = stream.get_final_response()
+                    output_items = getattr(final_response, "output", None)
+                    streamed_text = "".join(streamed_text_parts).strip()
+                    if (
+                        isinstance(output_items, list)
+                        and len(output_items) == 0
+                        and streamed_text
+                        and not has_tool_calls
+                    ):
+                        # Some Codex Responses backends now emit the assistant
+                        # answer only through output_text.delta events while the
+                        # terminal response object arrives with output=[].
+                        # Rehydrate a minimal message item so the existing
+                        # parser/validator can consume the streamed answer.
+                        final_response.output = [
+                            SimpleNamespace(
+                                type="message",
+                                status="completed",
+                                content=[SimpleNamespace(type="output_text", text=streamed_text)],
+                            )
+                        ]
+                    return final_response
             except (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError) as exc:
                 if attempt < max_stream_retries:
                     logger.debug(

--- a/tests/test_run_agent_codex_responses.py
+++ b/tests/test_run_agent_codex_responses.py
@@ -375,6 +375,42 @@ def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     assert response.output[0].content[0].text == "streamed create ok"
 
 
+def test_run_codex_stream_fallback_rehydrates_text_when_terminal_output_is_empty(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    create_stream = _FakeCreateStream(
+        [
+            SimpleNamespace(type="response.created"),
+            SimpleNamespace(type="response.output_text.delta", delta="po"),
+            SimpleNamespace(type="response.output_text.delta", delta="ng"),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(
+                    output=[],
+                    usage=SimpleNamespace(input_tokens=5, output_tokens=3, total_tokens=8),
+                    status="completed",
+                    model="gpt-5.4",
+                ),
+            ),
+        ]
+    )
+
+    def _fake_stream(**kwargs):
+        return _FakeResponsesStream(
+            final_error=RuntimeError("Didn't receive a `response.completed` event.")
+        )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=_fake_stream,
+            create=lambda **kwargs: create_stream,
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    assert create_stream.closed is True
+    assert response.output[0].content[0].text == "pong"
+
+
 def test_run_codex_stream_rehydrates_text_when_final_output_is_empty(monkeypatch):
     agent = _build_agent(monkeypatch)
 
@@ -402,6 +438,42 @@ def test_run_codex_stream_rehydrates_text_when_final_output_is_empty(monkeypatch
     response = agent._run_codex_stream(_codex_request_kwargs())
     assert response.output[0].type == "message"
     assert response.output[0].content[0].text == "pong"
+
+
+def test_run_codex_stream_rehydrates_function_calls_when_final_output_is_empty(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    function_item = SimpleNamespace(
+        type="function_call",
+        id="fc_1",
+        call_id="call_1",
+        name="memory",
+        arguments='{"action":"add","target":"memory","content":"x"}',
+        status="completed",
+    )
+
+    def _fake_stream(**kwargs):
+        return _FakeResponsesStream(
+            events=[
+                SimpleNamespace(type="response.output_item.added", item=SimpleNamespace(type="reasoning")),
+                SimpleNamespace(type="response.output_item.done", item=function_item),
+            ],
+            final_response=SimpleNamespace(
+                output=[],
+                usage=SimpleNamespace(input_tokens=5, output_tokens=3, total_tokens=8),
+                status="completed",
+                model="gpt-5.4",
+            ),
+        )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=_fake_stream,
+            create=lambda **kwargs: _codex_message_response("fallback"),
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    assert response.output == [function_item]
 
 
 def test_run_conversation_codex_plain_text(monkeypatch):

--- a/tests/test_run_agent_codex_responses.py
+++ b/tests/test_run_agent_codex_responses.py
@@ -148,9 +148,10 @@ def _codex_ack_message_response(text: str):
 
 
 class _FakeResponsesStream:
-    def __init__(self, *, final_response=None, final_error=None):
+    def __init__(self, *, final_response=None, final_error=None, events=None):
         self._final_response = final_response
         self._final_error = final_error
+        self._events = list(events or [])
 
     def __enter__(self):
         return self
@@ -159,7 +160,7 @@ class _FakeResponsesStream:
         return False
 
     def __iter__(self):
-        return iter(())
+        return iter(self._events)
 
     def get_final_response(self):
         if self._final_error is not None:
@@ -372,6 +373,35 @@ def test_run_codex_stream_fallback_parses_create_stream_events(monkeypatch):
     assert calls["create"] == 1
     assert create_stream.closed is True
     assert response.output[0].content[0].text == "streamed create ok"
+
+
+def test_run_codex_stream_rehydrates_text_when_final_output_is_empty(monkeypatch):
+    agent = _build_agent(monkeypatch)
+
+    def _fake_stream(**kwargs):
+        return _FakeResponsesStream(
+            events=[
+                SimpleNamespace(type="response.output_text.delta", delta="po"),
+                SimpleNamespace(type="response.output_text.delta", delta="ng"),
+            ],
+            final_response=SimpleNamespace(
+                output=[],
+                usage=SimpleNamespace(input_tokens=5, output_tokens=3, total_tokens=8),
+                status="completed",
+                model="gpt-5.4",
+            ),
+        )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=_fake_stream,
+            create=lambda **kwargs: _codex_message_response("fallback"),
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    assert response.output[0].type == "message"
+    assert response.output[0].content[0].text == "pong"
 
 
 def test_run_conversation_codex_plain_text(monkeypatch):


### PR DESCRIPTION
## Summary
- preserve streamed assistant text when Codex completes with `response.output=[]`
- preserve streamed `function_call` items when Codex emits tool calls during streaming but the terminal response is empty
- add regression coverage for both the direct streaming path and the `responses.create(stream=True)` fallback path

## Why
Some Codex Responses backends stream valid output events and still finish with a terminal response whose `output` list is empty.

Hermes currently treats that payload shape as invalid, which causes retries and eventual failure even though the backend already emitted usable output. I reproduced two real cases:

- plain assistant text arriving through `response.output_text.delta`
- tool calls arriving through `response.output_item.done` with `item.type == "function_call"`

The second case is important because it breaks tool-using prompts on `gpt-5.4`: Hermes loses the streamed tool call, sees an empty final response, and aborts instead of continuing the tool loop.

## Fix
- rehydrate a minimal assistant message from streamed text deltas when the final response is empty
- rehydrate streamed `function_call` items from `response.output_item.done` when the final response is empty
- apply the same recovery logic to the `responses.create(stream=True)` fallback path

## Validation
- `python -m pytest tests/test_run_agent_codex_responses.py -q`
- reproduced against real Hermes installs on host and Docker with `openai-codex` + `gpt-5.4`
- verified that the previously failing prompt now completes, executes tools, and returns a final response

## Notes
I intentionally did not keep a `stream=False` fallback in this PR. Against the ChatGPT Codex backend, `responses.create(..., stream=False)` returns `400` with `Stream must be set to true`, so the safe upstream fix is to recover from the streamed events Hermes already received.
