### PR TITLE
fix(gateway): handle Windows OSError/SystemError in os.kill probes (#5760)

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -267,6 +267,12 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
                 os.kill(existing_pid, 0)
             except (ProcessLookupError, PermissionError):
                 stale = True
+            except (OSError, SystemError):
+                # Windows: os.kill(pid, 0) on a stale or invalid PID raises
+                # OSError (WinError 87 "The parameter is incorrect") or
+                # SystemError, instead of the POSIX ProcessLookupError. Treat
+                # both as evidence the previous owner is gone.
+                stale = True
             else:
                 current_start = _get_process_start_time(existing_pid)
                 if (
@@ -369,6 +375,13 @@ def get_running_pid() -> Optional[int]:
     try:
         os.kill(pid, 0)  # signal 0 = existence check, no actual signal sent
     except (ProcessLookupError, PermissionError):
+        remove_pid_file()
+        return None
+    except (OSError, SystemError):
+        # Windows: os.kill(pid, 0) on a stale or invalid PID raises OSError
+        # (WinError 87 "The parameter is incorrect") or SystemError, instead
+        # of the POSIX ProcessLookupError. Without this clause the gateway
+        # fails to start whenever a crashed instance leaves a stale PID file.
         remove_pid_file()
         return None
 

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -155,3 +155,90 @@ class TestScopedLocks:
 
         status.release_scoped_lock("telegram-bot-token", "secret")
         assert not lock_path.exists()
+
+
+class TestGatewayWindowsCompatibility:
+    """Regression: os.kill(pid, 0) on Windows raises OSError or SystemError
+    instead of the POSIX ProcessLookupError, blocking gateway startup (#5760)."""
+
+    def test_get_running_pid_treats_oserror_as_stale(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        pid_path.write_text(json.dumps({
+            "pid": 99999,
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway"],
+            "start_time": 123,
+        }))
+
+        def fake_kill(pid, sig):
+            raise OSError(22, "Invalid argument")
+
+        monkeypatch.setattr(status.os, "kill", fake_kill)
+
+        assert status.get_running_pid() is None
+        assert not pid_path.exists()
+
+    def test_get_running_pid_treats_systemerror_as_stale(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        pid_path.write_text(json.dumps({
+            "pid": 99999,
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway"],
+            "start_time": 123,
+        }))
+
+        def fake_kill(pid, sig):
+            raise SystemError("<built-in function kill> returned a result with an exception set")
+
+        monkeypatch.setattr(status.os, "kill", fake_kill)
+
+        assert status.get_running_pid() is None
+        assert not pid_path.exists()
+
+    def test_acquire_scoped_lock_treats_oserror_as_stale(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": 123,
+            "kind": "hermes-gateway",
+        }))
+
+        def fake_kill(pid, sig):
+            raise OSError(22, "Invalid argument")
+
+        monkeypatch.setattr(status.os, "kill", fake_kill)
+
+        acquired, _ = status.acquire_scoped_lock(
+            "telegram-bot-token", "secret", metadata={"platform": "telegram"}
+        )
+
+        assert acquired is True
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()
+
+    def test_acquire_scoped_lock_treats_systemerror_as_stale(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "telegram-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": 123,
+            "kind": "hermes-gateway",
+        }))
+
+        def fake_kill(pid, sig):
+            raise SystemError("<built-in function kill> returned a result with an exception set")
+
+        monkeypatch.setattr(status.os, "kill", fake_kill)
+
+        acquired, _ = status.acquire_scoped_lock(
+            "telegram-bot-token", "secret", metadata={"platform": "telegram"}
+        )
+
+        assert acquired is True
+        payload = json.loads(lock_path.read_text())
+        assert payload["pid"] == os.getpid()


### PR DESCRIPTION
## Summary

Fixes #5760. On Windows, `os.kill(pid, 0)` does not behave like POSIX. When the PID is invalid or the process has already exited, CPython raises:

- `OSError: [WinError 87] The parameter is incorrect` (instead of `ProcessLookupError`)
- `SystemError: <built-in function kill> returned a result with an exception set` (when the C-level wrapper sets an exception but returns a non-standard error)

`gateway/status.py` only catches `(ProcessLookupError, PermissionError)` in two places, so on Windows the exception escapes and:

- `acquire_scoped_lock` (line 267) blocks the Telegram platform connection
- `get_running_pid` (line 370) blocks gateway startup entirely

Both happen whenever a previous gateway instance leaves a stale PID file behind, which is the common case after a crash.

## Fix

Add `except (OSError, SystemError)` clauses next to the existing `(ProcessLookupError, PermissionError)` clauses at both call sites. The new clauses follow the same code path (treat the previous owner as gone) and only widen behavior on Windows — POSIX still hits the original `ProcessLookupError` / `PermissionError` branches first.

## Tests

Added 4 new tests in `tests/gateway/test_status.py::TestGatewayWindowsCompatibility` covering both call sites under both `OSError` and `SystemError`. They monkeypatch `status.os.kill` to raise the Windows-style exception and assert:

- `get_running_pid()` returns `None` and removes the stale PID file
- `acquire_scoped_lock()` treats the existing record as stale and acquires the lock cleanly

Verified manually against the patched module before pushing — all four new scenarios pass and the existing "kill returns None means alive" path still works.

## Test plan

- [x] Patched module syntax-checked locally
- [x] All 4 new tests pass against the patched module
- [x] Negative case (`os.kill` succeeds -> process treated as alive) still works
- [ ] CI green on Linux/macOS/Windows