### PR TITLE
fix(openviking): send correct tenant headers and defaults

### DIFF
--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -28,6 +28,9 @@ All config via environment variables in `.env`:
 |---------|---------|-------------|
 | `OPENVIKING_ENDPOINT` | `http://127.0.0.1:1933` | Server URL |
 | `OPENVIKING_API_KEY` | (none) | API key (optional) |
+| `OPENVIKING_ACCOUNT` | `default` | Tenant account for API requests |
+| `OPENVIKING_USER` | `hermes` | Tenant user for API requests |
+| `OPENVIKING_AGENT` | `hermes` | Tenant agent for API requests |
 
 ## Tools
 

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -10,8 +10,9 @@ lifecycle instead of read-only search endpoints.
 Config via environment variables (profile-scoped via each profile's .env):
   OPENVIKING_ENDPOINT  — Server URL (default: http://127.0.0.1:1933)
   OPENVIKING_API_KEY   — API key (required for authenticated servers)
-  OPENVIKING_ACCOUNT   — Tenant account (default: root)
-  OPENVIKING_USER      — Tenant user (default: default)
+  OPENVIKING_ACCOUNT   — Tenant account (default: default)
+  OPENVIKING_USER      — Tenant user (default: hermes)
+  OPENVIKING_AGENT     — Tenant agent (default: hermes)
 
 Capabilities:
   - Automatic memory extraction on session commit (6 categories)
@@ -79,11 +80,12 @@ class _VikingClient:
     """Thin HTTP client for the OpenViking REST API."""
 
     def __init__(self, endpoint: str, api_key: str = "",
-                 account: str = "", user: str = ""):
+                 account: str = "", user: str = "", agent: str = ""):
         self._endpoint = endpoint.rstrip("/")
         self._api_key = api_key
-        self._account = account or os.environ.get("OPENVIKING_ACCOUNT", "root")
-        self._user = user or os.environ.get("OPENVIKING_USER", "default")
+        self._account = account or os.environ.get("OPENVIKING_ACCOUNT", "default")
+        self._user = user or os.environ.get("OPENVIKING_USER", "hermes")
+        self._agent = agent or os.environ.get("OPENVIKING_AGENT", "hermes")
         self._httpx = _get_httpx()
         if self._httpx is None:
             raise ImportError("httpx is required for OpenViking: pip install httpx")
@@ -93,6 +95,7 @@ class _VikingClient:
             "Content-Type": "application/json",
             "X-OpenViking-Account": self._account,
             "X-OpenViking-User": self._user,
+            "X-OpenViking-Agent": self._agent,
         }
         if self._api_key:
             h["X-API-Key"] = self._api_key


### PR DESCRIPTION
Summary
- send correct tenant-scoping headers for OpenViking requests
- align plugin defaults with a real local multi-tenant setup
- document OPENVIKING_AGENT in the plugin README

What changed
- default OPENVIKING_ACCOUNT: root -> default
- default OPENVIKING_USER: default -> hermes
- add OPENVIKING_AGENT default hermes
- send X-OpenViking-Agent header
- update plugin docs accordingly

Why
Hermes' OpenViking plugin was not working correctly against the local OpenViking setup until these tenant headers/defaults were patched. With the old defaults, requests could resolve against the wrong tenant context and fail or behave inconsistently.

Validation
- local OpenViking browse/read/search now work
- retrieval smoke test passes after reset
- plugin works with default/hermes/hermes tenant headers

Related
- fixes/addresses #4825
