### PR TITLE
fix: guard against None tirith path in security scanner

### DIFF
--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -616,6 +616,12 @@ def check_command_security(command: str) -> dict:
     timeout = cfg["tirith_timeout"]
     fail_open = cfg["tirith_fail_open"]
 
+    if tirith_path is None:
+        logger.warning("tirith path resolved to None; scanning disabled")
+        if fail_open:
+            return {"action": "allow", "findings": [], "summary": "tirith path unavailable"}
+        return {"action": "block", "findings": [], "summary": "tirith path unavailable (fail-closed)"}
+
     try:
         result = subprocess.run(
             [tirith_path, "check", "--json", "--non-interactive",


### PR DESCRIPTION
## Problem

When `_resolve_tirith_path()` returns `None` (e.g. install failed on unsupported platform or all resolution paths exhausted), `check_command_security()` passed `None` directly to `subprocess.run()` as the first list element:

```python
result = subprocess.run(
    [tirith_path, "check", "--json", ...],
```

This caused a `TypeError: expected str, bytes or os.PathLike object, not NoneType` that propagated all the way up and crashed the terminal tool's security guard, triggering cascading fallbacks and API call burn.

## Fix

Add a None check before the subprocess call:

```python
if tirith_path is None:
    logger.warning("tirith path resolved to None; scanning disabled")
    if fail_open:
        return {"action": "allow", "findings": [], "summary": "tirith path unavailable"}
    return {"action": "block", "findings": [], "summary": "tirith path unavailable (fail-closed)"}
```

This mirrors the existing error handling for `OSError` and `TimeoutExpired` -- the outcome respects the `fail_open` config setting.

## Testing

- Existing `OSError` and `TimeoutExpired` handlers already verify the fail_open behavior
- The new path adds identical behavior for the `None` case