### PR TITLE
fix(approval): log exception instead of silently denying when approval callback raises

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -384,7 +384,20 @@ def prompt_dangerous_approval(command: str, description: str,
         try:
             return approval_callback(command, description,
                                      allow_permanent=allow_permanent)
-        except Exception:
+        except Exception as e:
+            # Surface the failure instead of silently denying. A swallowed
+            # exception here produces the canonical "BLOCKED: User denied.
+            # Do NOT retry." string with no visible prompt and no log line,
+            # which is impossible to debug from the outside. Common cause:
+            # the prompt_toolkit callback is invoked while the outer event
+            # loop is paused inside a tool call (e.g. after smart-approval
+            # escalates a flagged command), and the callback raises. Log
+            # full traceback so the next occurrence is diagnosable.
+            logger.exception(
+                "Approval callback raised; treating as deny. "
+                "command=%r description=%r error=%s",
+                command[:200], description, e,
+            )
             return "deny"
 
     os.environ["HERMES_SPINNER_PAUSE"] = "1"


### PR DESCRIPTION
## Problem

`prompt_dangerous_approval()` in `tools/approval.py` catches every exception from the registered approval callback and returns `"deny"` with no logging:

```python
if approval_callback is not None:
    try:
        return approval_callback(command, description,
                                 allow_permanent=allow_permanent)
    except Exception:
        return "deny"
```

The result is the canonical `BLOCKED: User denied. Do NOT retry.` string with **no visible prompt and no log line**. From the user's perspective, the model issued a flagged command and the agent instantly denied it without ever asking — looks like the user denied something they never saw. From the model's perspective, the deny string instructs it to give up, so it stops trying. There is no breadcrumb anywhere indicating that the callback raised.

## When this hits in practice

The most common trigger is the `approvals.mode: smart` path:

1. Model issues a flagged-but-benign command (e.g. `python -c "print(1)"`, which is explicitly called out at `approval.py:509` as a known false positive).
2. `_smart_approve()` calls the auxiliary LLM. If the LLM escalates (rather than approving), control falls through to `prompt_dangerous_approval()`.
3. The CLI's `approval_callback` is a prompt_toolkit-backed prompt. It's invoked from inside a tool-call context where the outer prompt_toolkit event loop is paused, and nested prompt creation raises.
4. The bare `except` swallows the exception → returns `"deny"` → user sees an instant block they never approved or denied.

I spent two debug sessions tracking this down because there was no log line to grep for. Wrote a skill specifically to recognize the symptom (`hermes-approval-block-diagnosis`).

## Fix

Same fail-safe behavior (return `"deny"` on error), but log the full traceback via `logger.exception()` so the next occurrence is diagnosable:

```python
        except Exception as e:
            logger.exception(
                "Approval callback raised; treating as deny. "
                "command=%r description=%r error=%s",
                command[:200], description, e,
            )
            return "deny"
```

No behavior change for working callbacks. Pure observability fix.

## Verification

Syntax-checked locally (`python -c 'import ast; ast.parse(open("tools/approval.py").read())'`). Running locally on two machines (Mac Studio + MacBook Pro) for ~12 hours; smart-approval flows behave identically to before, and no spurious tracebacks.