### PR TITLE
feat: add Hippius decentralized storage skill (Bittensor Subnet 75)

### DIFF
--- a/skills/storage/hippius/SKILL.md
+++ b/skills/storage/hippius/SKILL.md
@@ -1,0 +1,301 @@
+---
+name: hippius-storage
+description: Decentralized file storage on Bittensor Subnet 75 via Hippius S3-compatible API
+version: 1.0.0
+author: het4rk
+license: MIT
+platforms: [macos, linux]
+metadata:
+  hermes:
+    tags: [Storage, Decentralized, Bittensor, S3, IPFS, Hippius]
+    requires_toolsets: [terminal]
+required_environment_variables:
+  - name: HIPPIUS_S3_ACCESS_KEY
+    prompt: "Hippius S3 Access Key (starts with hip_)"
+    help: "Get your access key at https://console.hippius.com/dashboard/settings"
+    required_for: "S3-compatible storage operations"
+  - name: HIPPIUS_S3_SECRET_KEY
+    prompt: "Hippius S3 Secret Key"
+    help: "Get your secret key at https://console.hippius.com/dashboard/settings"
+    required_for: "S3-compatible storage operations"
+---
+
+# Hippius Decentralized Storage
+
+Hippius is Bittensor Subnet 75's decentralized storage layer, powered by the **Arion** mesh network. It exposes an S3-compatible API endpoint at `https://s3.hippius.com`, meaning any tool that works with AWS S3 (boto3, the AWS CLI, rclone, s3cmd) works with Hippius without modification — just swap the endpoint and credentials.
+
+Files are distributed across 400+ miners in 15+ countries using Reed-Solomon erasure coding with self-healing replication, providing durable, censorship-resistant storage with no single point of failure.
+
+## When to Use
+
+Invoke this skill when the user wants to:
+- Upload files or directories to decentralized storage
+- Download files from Hippius buckets
+- List buckets and objects
+- Share files via time-limited presigned URLs
+- Sync a local directory to/from the Hippius network
+- Create or delete storage buckets
+- Back up data to censorship-resistant, geo-distributed storage
+- Query storage usage statistics
+- Replace or supplement centralized cloud storage (S3, GCS, Azure Blob)
+
+## Quick Reference
+
+| Operation | boto3 method | AWS CLI equivalent |
+|---|---|---|
+| List buckets | `s3.list_buckets()` | `aws s3 ls` |
+| List objects | `s3.list_objects_v2(Bucket=…)` | `aws s3 ls s3://bucket/` |
+| Upload file | `s3.upload_file(…)` | `aws s3 cp file s3://bucket/key` |
+| Download file | `s3.download_file(…)` | `aws s3 cp s3://bucket/key file` |
+| Create bucket | `s3.create_bucket(Bucket=…)` | `aws s3 mb s3://bucket` |
+| Delete object | `s3.delete_object(…)` | `aws s3 rm s3://bucket/key` |
+| Presigned URL | `s3.generate_presigned_url(…)` | `aws s3 presign s3://bucket/key` |
+| Sync directory | n/a | `aws s3 sync ./dir s3://bucket/prefix/` |
+
+---
+
+## Setup
+
+### Install dependencies
+
+```bash
+pip install boto3
+# or for AWS CLI:
+brew install awscli   # macOS
+# apt install awscli  # Debian/Ubuntu
+```
+
+### Configure environment variables
+
+```bash
+export HIPPIUS_S3_ACCESS_KEY="hip_xxxxxxxxxxxxxxxxxxxx"
+export HIPPIUS_S3_SECRET_KEY="your-secret-key"
+```
+
+Add to `~/.zshrc` or `~/.bashrc` to persist across sessions.
+
+### boto3 client (reusable snippet)
+
+```python
+import boto3, os
+
+s3 = boto3.client(
+    "s3",
+    endpoint_url="https://s3.hippius.com",
+    aws_access_key_id=os.environ["HIPPIUS_S3_ACCESS_KEY"],
+    aws_secret_access_key=os.environ["HIPPIUS_S3_SECRET_KEY"],
+    region_name="decentralized",
+)
+```
+
+### AWS CLI profile
+
+```bash
+aws configure --profile hippius
+# AWS Access Key ID:     hip_xxxxxxxxxxxxxxxxxxxx
+# AWS Secret Access Key: your-secret-key
+# Default region name:   decentralized
+# Default output format: json
+```
+
+Then pass `--profile hippius --endpoint-url https://s3.hippius.com` to every `aws s3` command, or set:
+
+```bash
+export AWS_PROFILE=hippius
+export AWS_ENDPOINT_URL=https://s3.hippius.com
+```
+
+---
+
+## Procedures
+
+### Upload a file
+
+**boto3:**
+```python
+s3.upload_file(
+    Filename="/path/to/local/file.txt",
+    Bucket="my-bucket",
+    Key="remote/path/file.txt",
+)
+print("Upload complete")
+```
+
+**AWS CLI:**
+```bash
+aws s3 cp /path/to/local/file.txt s3://my-bucket/remote/path/file.txt \
+    --endpoint-url https://s3.hippius.com --profile hippius
+```
+
+For files larger than 100 MB, multipart upload is triggered automatically. The minimum part size is **10 MB** — do not set `multipart_chunksize` below this value.
+
+```python
+from boto3.s3.transfer import TransferConfig
+
+config = TransferConfig(multipart_chunksize=10 * 1024 * 1024)  # 10 MB minimum
+s3.upload_file("large_file.bin", "my-bucket", "large_file.bin", Config=config)
+```
+
+---
+
+### Download a file
+
+**boto3:**
+```python
+s3.download_file(
+    Bucket="my-bucket",
+    Key="remote/path/file.txt",
+    Filename="/path/to/local/output.txt",
+)
+print("Download complete")
+```
+
+**AWS CLI:**
+```bash
+aws s3 cp s3://my-bucket/remote/path/file.txt /path/to/local/output.txt \
+    --endpoint-url https://s3.hippius.com --profile hippius
+```
+
+---
+
+### List buckets
+
+**boto3:**
+```python
+response = s3.list_buckets()
+for bucket in response.get("Buckets", []):
+    print(bucket["Name"], bucket["CreationDate"])
+```
+
+**AWS CLI:**
+```bash
+aws s3 ls --endpoint-url https://s3.hippius.com --profile hippius
+```
+
+---
+
+### List objects in a bucket
+
+**boto3** (handles pagination automatically):
+```python
+paginator = s3.get_paginator("list_objects_v2")
+for page in paginator.paginate(Bucket="my-bucket", Prefix="optional/prefix/"):
+    for obj in page.get("Contents", []):
+        print(obj["Key"], obj["Size"], obj["LastModified"])
+```
+
+**AWS CLI:**
+```bash
+aws s3 ls s3://my-bucket/optional/prefix/ --recursive \
+    --endpoint-url https://s3.hippius.com --profile hippius
+```
+
+---
+
+### Create a bucket
+
+**boto3:**
+```python
+s3.create_bucket(Bucket="my-new-bucket")
+print("Bucket created")
+```
+
+**AWS CLI:**
+```bash
+aws s3 mb s3://my-new-bucket \
+    --endpoint-url https://s3.hippius.com --profile hippius
+```
+
+Bucket names must be globally unique, lowercase, 3–63 characters, and contain only letters, numbers, and hyphens.
+
+---
+
+### Generate a presigned URL
+
+Share a file without exposing credentials. The URL expires after the specified duration.
+
+**boto3:**
+```python
+url = s3.generate_presigned_url(
+    ClientMethod="get_object",
+    Params={"Bucket": "my-bucket", "Key": "file.txt"},
+    ExpiresIn=3600,  # seconds (1 hour)
+)
+print(url)
+```
+
+**AWS CLI:**
+```bash
+aws s3 presign s3://my-bucket/file.txt --expires-in 3600 \
+    --endpoint-url https://s3.hippius.com --profile hippius
+```
+
+---
+
+### Sync a directory
+
+Mirror a local directory to Hippius (only uploads changed/new files):
+
+```bash
+aws s3 sync ./local-dir/ s3://my-bucket/backup/ \
+    --endpoint-url https://s3.hippius.com --profile hippius
+
+# Reverse: download from Hippius to local
+aws s3 sync s3://my-bucket/backup/ ./local-dir/ \
+    --endpoint-url https://s3.hippius.com --profile hippius
+
+# Delete remote files that no longer exist locally
+aws s3 sync ./local-dir/ s3://my-bucket/backup/ --delete \
+    --endpoint-url https://s3.hippius.com --profile hippius
+```
+
+---
+
+### Query storage stats (helper script)
+
+Run the bundled helper to get a usage overview:
+
+```bash
+python3 skills/storage/hippius/scripts/query_storage.py
+# With a specific bucket:
+python3 skills/storage/hippius/scripts/query_storage.py --bucket my-bucket
+```
+
+---
+
+## Pitfalls
+
+| Issue | Detail |
+|---|---|
+| **Rate limit** | 100 requests/minute per access key. Use pagination and avoid tight loops over the API. |
+| **Multipart minimum part size** | Parts must be at least **10 MB** (except the final part). Setting `multipart_chunksize` below 10 MB will fail. |
+| **No versioning** | Hippius does not support S3 bucket versioning. Overwrites are permanent. |
+| **Region name** | Always set `region_name="decentralized"`. Some boto3 calls fail with a blank or incorrect region. |
+| **Bucket name uniqueness** | Bucket names are global across all Hippius users, not scoped to your account. |
+| **Large file timeouts** | For very large uploads (>1 GB) on slow connections, increase the boto3 socket timeout via `boto3.session.Config(connect_timeout=60, read_timeout=300)`. |
+
+---
+
+## Verification
+
+After completing an operation, verify success:
+
+```bash
+# Confirm upload exists
+aws s3 ls s3://my-bucket/remote/path/file.txt \
+    --endpoint-url https://s3.hippius.com --profile hippius
+
+# Check object metadata
+aws s3api head-object --bucket my-bucket --key remote/path/file.txt \
+    --endpoint-url https://s3.hippius.com --profile hippius
+
+# Confirm download integrity (compare checksums)
+md5sum /path/to/local/file.txt
+# should match the ETag returned by head-object for single-part uploads
+```
+
+## References
+
+- Storage guide and architecture overview: `skills/storage/hippius/references/storage_guide.md`
+- Helper script: `skills/storage/hippius/scripts/query_storage.py`
+- Hippius console: https://console.hippius.com/dashboard/settings

--- a/skills/storage/hippius/references/storage_guide.md
+++ b/skills/storage/hippius/references/storage_guide.md
@@ -1,0 +1,162 @@
+# Hippius Storage Reference Guide
+
+## What is Hippius?
+
+Hippius is the decentralized storage layer of **Bittensor Subnet 75**, operated under the **Arion** mesh network architecture. It provides durable, geo-distributed object storage accessible through a standard S3-compatible API — no proprietary SDK required.
+
+Key facts:
+- **Endpoint:** `https://s3.hippius.com`
+- **Region name (required):** `decentralized`
+- **Rate limit:** 100 requests/minute per access key
+- **Minimum multipart part size:** 10 MB
+- **Versioning:** not supported (overwrites are permanent)
+- **Compatible tools:** boto3, AWS CLI, rclone, s3cmd, MinIO client
+
+---
+
+## Arion Architecture Overview
+
+Arion is the Bittensor subnet validator/miner protocol that powers Hippius storage. Understanding it helps reason about durability and latency.
+
+```
+Client
+  │
+  ▼
+Hippius S3 Gateway  (https://s3.hippius.com)
+  │  Translates S3 API calls to Arion internal protocol
+  ▼
+Arion Coordinator
+  │  Splits objects into shards, applies erasure coding
+  ├──► Miner Node A  (e.g. US-East)
+  ├──► Miner Node B  (e.g. EU-West)
+  ├──► Miner Node C  (e.g. Asia-Pacific)
+  └──► Miner Node … (400+ nodes across 15+ countries)
+```
+
+### Erasure coding
+
+Hippius uses **Reed-Solomon erasure coding** to distribute file shards across multiple miners. A file can be reconstructed even if a fraction of miner nodes are offline. This means:
+- No single point of failure
+- Data survives individual node churn (common in decentralized networks)
+- Reads may be served from the geographically nearest available shard
+
+### Self-healing
+
+The Arion coordinator continuously monitors shard availability. If a miner goes offline and drops below the minimum redundancy threshold, the coordinator re-replicates affected shards to healthy miners automatically.
+
+### Bittensor incentives
+
+Miners earn TAO (Bittensor's native token) for reliably serving storage capacity. Validators score miners based on availability and retrieval latency, creating economic pressure for high uptime.
+
+---
+
+## S3 vs IPFS: Choosing the Right Interface
+
+Hippius supports two access patterns. Use S3 for most automation; use IPFS when content-addressing or public sharing is the priority.
+
+| Aspect | S3-compatible (Hippius) | IPFS |
+|---|---|---|
+| **Addressing** | Mutable path: `s3://bucket/key` | Immutable content hash: `ipfs://QmXyz…` |
+| **Access control** | Bucket policies, presigned URLs | Public by default (hash = address) |
+| **Mutability** | Yes — overwrite keys freely | No — changing content changes the CID |
+| **Tooling** | boto3, AWS CLI, rclone, s3cmd | IPFS CLI, Kubo, web3.storage clients |
+| **Latency** | Low for cached/nearby shards | Variable (DHT lookup required) |
+| **Best for** | Application data, backups, private files | Content distribution, NFT metadata, public archives |
+| **Auth required** | Yes (access key + secret key) | No (public gateway) |
+| **Hippius integration** | Native (primary interface) | Via IPFS pinning API |
+
+### When to use S3 (most cases)
+- Automated backups and archiving
+- Application file storage (user uploads, ML datasets, model weights)
+- Private or access-controlled data
+- Anything that needs mutable keys (overwrite-in-place semantics)
+- Integrating with existing S3-compatible tooling
+
+### When to use IPFS
+- Publishing immutable public content (documentation, media, datasets)
+- NFT metadata or on-chain content references
+- Content you want to verify by hash (tamper-evident archives)
+- Interoperability with the broader IPFS ecosystem
+
+---
+
+## Comparison: Hippius vs Centralised Cloud Storage
+
+| Feature | Hippius (Bittensor SN75) | AWS S3 | Cloudflare R2 |
+|---|---|---|---|
+| **Infrastructure** | 400+ decentralized miners | AWS data centers | Cloudflare edge PoPs |
+| **Censorship resistance** | High (no single operator) | Low | Medium |
+| **Geo-distribution** | 15+ countries, automatic | Requires multi-region config | Global CDN |
+| **Egress fees** | None | ~$0.09/GB | None |
+| **API compatibility** | S3-compatible | Native S3 | S3-compatible |
+| **Versioning** | No | Yes | No |
+| **Uptime SLA** | Network-level (no formal SLA) | 99.99% | 99.9% |
+| **Best for** | Decentralized apps, privacy-sensitive data | General cloud workloads | Static assets, low-egress workloads |
+
+---
+
+## Common Patterns
+
+### Backup script (cron-friendly)
+
+```bash
+#!/bin/bash
+set -e
+DATE=$(date +%Y-%m-%d)
+BACKUP_DIR="/var/backups/myapp"
+BUCKET="myapp-backups"
+
+tar czf /tmp/backup-${DATE}.tar.gz "${BACKUP_DIR}"
+aws s3 cp /tmp/backup-${DATE}.tar.gz "s3://${BUCKET}/daily/backup-${DATE}.tar.gz" \
+    --endpoint-url https://s3.hippius.com --profile hippius
+rm /tmp/backup-${DATE}.tar.gz
+echo "Backup uploaded: s3://${BUCKET}/daily/backup-${DATE}.tar.gz"
+```
+
+### ML dataset upload
+
+```python
+import boto3, os
+
+s3 = boto3.client(
+    "s3",
+    endpoint_url="https://s3.hippius.com",
+    aws_access_key_id=os.environ["HIPPIUS_S3_ACCESS_KEY"],
+    aws_secret_access_key=os.environ["HIPPIUS_S3_SECRET_KEY"],
+    region_name="decentralized",
+)
+
+# Upload an entire dataset directory
+import subprocess
+subprocess.run([
+    "aws", "s3", "sync", "./dataset/", "s3://ml-datasets/my-dataset/",
+    "--endpoint-url", "https://s3.hippius.com",
+    "--profile", "hippius",
+], check=True)
+```
+
+### Presigned URL for secure sharing
+
+```python
+url = s3.generate_presigned_url(
+    ClientMethod="get_object",
+    Params={"Bucket": "my-bucket", "Key": "reports/q4-2025.pdf"},
+    ExpiresIn=86400,  # 24 hours
+)
+# Share this URL — it works without credentials, expires automatically
+print(f"Share link (valid 24h): {url}")
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `InvalidAccessKeyId` | Wrong or missing `HIPPIUS_S3_ACCESS_KEY` | Check env var, ensure key starts with `hip_` |
+| `SignatureDoesNotMatch` | Wrong secret key | Re-check `HIPPIUS_S3_SECRET_KEY` |
+| `NoSuchBucket` | Bucket doesn't exist or wrong name | Run `aws s3 ls` to list your buckets |
+| `EntityTooSmall` on multipart | Part size below 10 MB | Set `multipart_chunksize=10*1024*1024` |
+| `SlowDown` / 503 | Rate limit exceeded (100 req/min) | Add retry logic with exponential backoff |
+| Timeout on large upload | Connection or read timeout | Increase boto3 `read_timeout` to 300+ seconds |
+| boto3 `Could not connect to endpoint` | Wrong endpoint URL | Confirm `endpoint_url="https://s3.hippius.com"` |

--- a/skills/storage/hippius/scripts/query_storage.py
+++ b/skills/storage/hippius/scripts/query_storage.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Hippius storage query helper — list buckets, objects, and usage stats.
+
+Usage:
+    python3 query_storage.py
+    python3 query_storage.py --bucket <bucket-name>
+    python3 query_storage.py --bucket <bucket-name> --prefix <prefix/>
+
+Requires environment variables:
+    HIPPIUS_S3_ACCESS_KEY  — Hippius access key (starts with hip_)
+    HIPPIUS_S3_SECRET_KEY  — Hippius secret key
+"""
+
+import argparse
+import os
+import sys
+
+ENDPOINT = "https://s3.hippius.com"
+REGION = "decentralized"
+
+
+def _client():
+    try:
+        import boto3
+    except ImportError:
+        print("Error: boto3 is not installed. Run: pip install boto3", file=sys.stderr)
+        sys.exit(1)
+
+    access_key = os.environ.get("HIPPIUS_S3_ACCESS_KEY")
+    secret_key = os.environ.get("HIPPIUS_S3_SECRET_KEY")
+
+    if not access_key:
+        print(
+            "Error: HIPPIUS_S3_ACCESS_KEY environment variable is not set.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if not secret_key:
+        print(
+            "Error: HIPPIUS_S3_SECRET_KEY environment variable is not set.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return boto3.client(
+        "s3",
+        endpoint_url=ENDPOINT,
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        region_name=REGION,
+    )
+
+
+def _human_size(num_bytes: int) -> str:
+    """Convert bytes to a human-readable string."""
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if num_bytes < 1024:
+            return f"{num_bytes:.1f} {unit}"
+        num_bytes /= 1024
+    return f"{num_bytes:.1f} PB"
+
+
+def list_buckets(s3) -> list[dict]:
+    response = s3.list_buckets()
+    buckets = response.get("Buckets", [])
+    print(f"\n{'Bucket Name':<40} {'Created'}")
+    print("-" * 70)
+    for b in buckets:
+        created = b["CreationDate"].strftime("%Y-%m-%d %H:%M UTC")
+        print(f"{b['Name']:<40} {created}")
+    print(f"\nTotal: {len(buckets)} bucket(s)")
+    return buckets
+
+
+def list_objects(s3, bucket: str, prefix: str = "") -> None:
+    paginator = s3.get_paginator("list_objects_v2")
+    kwargs = {"Bucket": bucket}
+    if prefix:
+        kwargs["Prefix"] = prefix
+
+    total_objects = 0
+    total_bytes = 0
+
+    print(f"\nObjects in s3://{bucket}/{prefix}")
+    print(f"{'Key':<60} {'Size':>12}  {'Last Modified'}")
+    print("-" * 100)
+
+    for page in paginator.paginate(**kwargs):
+        for obj in page.get("Contents", []):
+            size_str = _human_size(obj["Size"])
+            modified = obj["LastModified"].strftime("%Y-%m-%d %H:%M UTC")
+            key_display = obj["Key"]
+            if len(key_display) > 58:
+                key_display = "…" + key_display[-57:]
+            print(f"{key_display:<60} {size_str:>12}  {modified}")
+            total_objects += 1
+            total_bytes += obj["Size"]
+
+    print("-" * 100)
+    print(f"Total: {total_objects} object(s) — {_human_size(total_bytes)}")
+
+
+def storage_stats(s3, buckets: list[dict]) -> None:
+    """Aggregate storage usage across all buckets."""
+    print("\nStorage usage summary:")
+    print(f"{'Bucket':<40} {'Objects':>10} {'Total Size':>14}")
+    print("-" * 70)
+
+    grand_objects = 0
+    grand_bytes = 0
+
+    paginator = s3.get_paginator("list_objects_v2")
+    for b in buckets:
+        bucket_objects = 0
+        bucket_bytes = 0
+        try:
+            for page in paginator.paginate(Bucket=b["Name"]):
+                for obj in page.get("Contents", []):
+                    bucket_objects += 1
+                    bucket_bytes += obj["Size"]
+        except Exception as exc:
+            print(f"{b['Name']:<40} {'ERROR':>10}  {exc}")
+            continue
+
+        print(
+            f"{b['Name']:<40} {bucket_objects:>10,} {_human_size(bucket_bytes):>14}"
+        )
+        grand_objects += bucket_objects
+        grand_bytes += bucket_bytes
+
+    print("-" * 70)
+    print(f"{'TOTAL':<40} {grand_objects:>10,} {_human_size(grand_bytes):>14}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Query Hippius decentralized storage (Bittensor Subnet 75)."
+    )
+    parser.add_argument(
+        "--bucket",
+        metavar="BUCKET",
+        help="Bucket to inspect. If omitted, lists all buckets and prints usage stats.",
+    )
+    parser.add_argument(
+        "--prefix",
+        metavar="PREFIX",
+        default="",
+        help="Key prefix to filter objects within a bucket (default: all objects).",
+    )
+    parser.add_argument(
+        "--stats",
+        action="store_true",
+        help="Print per-bucket storage usage stats across all buckets (slower).",
+    )
+    args = parser.parse_args()
+
+    s3 = _client()
+
+    if args.bucket:
+        list_objects(s3, args.bucket, args.prefix)
+    else:
+        buckets = list_buckets(s3)
+        if args.stats and buckets:
+            storage_stats(s3, buckets)
+        elif buckets:
+            print(
+                "\nTip: pass --stats to see per-bucket usage, or --bucket <name> to list objects."
+            )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds a new `skills/storage/hippius/` skill for [Hippius](https://hippius.com), the S3-compatible decentralized storage layer on **Bittensor Subnet 75** (Arion mesh network)
- Works out-of-the-box with boto3 and the AWS CLI — just swap the endpoint to `https://s3.hippius.com` and credentials to your Hippius keys
- Complements existing Hermes skills by adding censorship-resistant, geo-distributed file management as a first-class operation

## What's included

### `SKILL.md`
Full procedural skill covering:
- Upload, download, list objects, create bucket, sync directory, presigned URL generation
- boto3 **and** AWS CLI examples for every operation
- Pitfalls table: 100 req/min rate limit, 10 MB minimum multipart part size, no versioning
- Verification steps after each operation

### `scripts/query_storage.py`
A standalone boto3 CLI helper:
```
python3 query_storage.py                  # list all buckets
python3 query_storage.py --bucket NAME    # list objects in a bucket
python3 query_storage.py --stats          # per-bucket usage summary
```
Uses `HIPPIUS_S3_ACCESS_KEY` / `HIPPIUS_S3_SECRET_KEY` env vars.

### `references/storage_guide.md`
- Arion architecture overview (Reed-Solomon erasure coding, self-healing, 400+ miners / 15+ countries)
- S3 vs IPFS comparison table (when to use each interface)
- Hippius vs centralised cloud (AWS S3, Cloudflare R2) comparison
- Common patterns: cron backup script, ML dataset upload, presigned sharing
- Troubleshooting table for common errors

## Why Hippius / Bittensor SN75

Hippius brings decentralized, permissionless storage to the Hermes skill ecosystem:
- **No egress fees** — unlike AWS S3
- **Censorship-resistant** — no single operator can remove your data
- **Self-healing** — Reed-Solomon erasure coding + automatic re-replication
- **S3-compatible** — zero friction for anyone already using AWS tooling
- **Bittensor-incentivised** — miners earn TAO for reliable uptime

## Test plan

- [ ] Set `HIPPIUS_S3_ACCESS_KEY` and `HIPPIUS_S3_SECRET_KEY` from [Hippius console](https://console.hippius.com/dashboard/settings)
- [ ] Run `python3 skills/storage/hippius/scripts/query_storage.py` — should list buckets
- [ ] Upload a test file with the boto3 snippet in SKILL.md
- [ ] Download it back and verify checksum matches
- [ ] Generate a presigned URL and confirm it's accessible in a browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Closes #5902