### PR TITLE
fix: word-wrap streaming output at word boundaries

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2187,9 +2187,24 @@ class HermesCLI:
 
         # Emit complete lines, keep partial remainder in buffer
         _tc = getattr(self, "_stream_text_ansi", "")
+        _wrap_w = shutil.get_terminal_size().columns - 1  # -1 avoids edge wrap
         while "\n" in self._stream_buf:
             line, self._stream_buf = self._stream_buf.split("\n", 1)
-            _cprint(f"{_tc}{line}{_RST}" if _tc else line)
+            # Word-wrap long lines so words don't break mid-character.
+            # Preserve leading whitespace (code blocks) and don't break URLs.
+            if len(line) > _wrap_w and _wrap_w > 20:
+                _indent = len(line) - len(line.lstrip(" "))
+                _wrapped = textwrap.wrap(
+                    line, width=_wrap_w,
+                    initial_indent="",
+                    subsequent_indent=" " * _indent,
+                    break_long_words=False,
+                    break_on_hyphens=False,
+                )
+                for wl in (_wrapped or [line]):
+                    _cprint(f"{_tc}{wl}{_RST}" if _tc else wl)
+            else:
+                _cprint(f"{_tc}{line}{_RST}" if _tc else line)
 
     def _flush_stream(self) -> None:
         """Emit any remaining partial line from the stream buffer and close the box."""
@@ -2198,7 +2213,21 @@ class HermesCLI:
 
         if self._stream_buf:
             _tc = getattr(self, "_stream_text_ansi", "")
-            _cprint(f"{_tc}{self._stream_buf}{_RST}" if _tc else self._stream_buf)
+            _wrap_w = shutil.get_terminal_size().columns - 1
+            line = self._stream_buf
+            if len(line) > _wrap_w and _wrap_w > 20:
+                _indent = len(line) - len(line.lstrip(" "))
+                _wrapped = textwrap.wrap(
+                    line, width=_wrap_w,
+                    initial_indent="",
+                    subsequent_indent=" " * _indent,
+                    break_long_words=False,
+                    break_on_hyphens=False,
+                )
+                for wl in (_wrapped or [line]):
+                    _cprint(f"{_tc}{wl}{_RST}" if _tc else wl)
+            else:
+                _cprint(f"{_tc}{line}{_RST}" if _tc else line)
             self._stream_buf = ""
 
         # Close the response box


### PR DESCRIPTION
## Problem

Long lines from the LLM are printed to the terminal via `_cprint()` without word wrapping. The terminal emulator wraps at the column boundary, which can split words mid-character. This is particularly noticeable on narrower terminals or when the web chat UI has a smaller viewport.

## Solution

Added word-aware wrapping using `textwrap.wrap()` in both `_emit_stream_text()` (live streaming) and `_flush_stream()` (final partial line). The wrapping:

- **Wraps at word boundaries** instead of character boundaries
- **Preserves leading whitespace** for code blocks (continuation lines maintain the same indentation)
- **Won't break long tokens** like URLs (`break_long_words=False`)
- **Conservative hyphenation** (`break_on_hyphens=False`)
- **Falls back to raw line** if `textwrap.wrap()` returns empty (e.g., a single word wider than the terminal)
- **Only activates** when the line exceeds the terminal width and the terminal is wider than 20 columns (avoids pathological cases)
- Uses `columns - 1` to avoid edge-case wrapping at the exact column boundary

## Testing

Tested with various edge cases:
- Long paragraphs wrap at word boundaries
- Indented code preserves indentation on continuation lines
- Long URLs stay on one line (overflow rather than break)
- Empty lines are preserved
- Short lines pass through unchanged