### PR TITLE
refactor(delegate): unify tool schema to tasks-only interface

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -61,12 +61,20 @@ class TestDelegateRequirements(unittest.TestCase):
     def test_schema_valid(self):
         self.assertEqual(DELEGATE_TASK_SCHEMA["name"], "delegate_task")
         props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
-        self.assertIn("goal", props)
         self.assertIn("tasks", props)
-        self.assertIn("context", props)
-        self.assertIn("toolsets", props)
         self.assertIn("max_iterations", props)
         self.assertEqual(props["tasks"]["maxItems"], 3)
+        self.assertEqual(props["tasks"]["minItems"], 1)
+        # Top-level goal/context/toolsets removed from schema (unified into tasks)
+        self.assertNotIn("goal", props)
+        self.assertNotIn("context", props)
+        self.assertNotIn("toolsets", props)
+        # Per-task items have goal, context, toolsets
+        task_props = props["tasks"]["items"]["properties"]
+        self.assertIn("goal", task_props)
+        self.assertIn("context", task_props)
+        self.assertIn("toolsets", task_props)
+        self.assertEqual(DELEGATE_TASK_SCHEMA["parameters"]["required"], ["tasks"])
 
 
 class TestChildSystemPrompt(unittest.TestCase):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -520,9 +520,8 @@ def delegate_task(
     """
     Spawn one or more child agents to handle delegated tasks.
 
-    Supports two modes:
-      - Single: provide goal (+ optional context, toolsets)
-      - Batch:  provide tasks array [{goal, context, toolsets}, ...]
+    Primary interface: provide tasks=[{goal, context, toolsets}, ...]
+    Legacy interface: provide goal (+ optional context, toolsets) — normalized to tasks internally.
 
     Returns JSON with results array, one entry per task.
     """
@@ -842,89 +841,70 @@ def _load_config() -> dict:
 DELEGATE_TASK_SCHEMA = {
     "name": "delegate_task",
     "description": (
-        "Spawn one or more subagents to work on tasks in isolated contexts. "
+        "Spawn subagents to work on tasks in isolated contexts. "
         "Each subagent gets its own conversation, terminal session, and toolset. "
         "Only the final summary is returned -- intermediate tool results "
         "never enter your context window.\n\n"
-        "TWO MODES (one of 'goal' or 'tasks' is required):\n"
-        "1. Single task: provide 'goal' (+ optional context, toolsets)\n"
-        "2. Batch (parallel): provide 'tasks' array with up to 3 items. "
-        "All run concurrently and results are returned together.\n\n"
-        "WHEN TO USE delegate_task:\n"
-        "- Reasoning-heavy subtasks (debugging, code review, research synthesis)\n"
-        "- Tasks that would flood your context with intermediate data\n"
-        "- Parallel independent workstreams (research A and B simultaneously)\n\n"
-        "WHEN NOT TO USE (use these instead):\n"
-        "- Mechanical multi-step work with no reasoning needed -> use execute_code\n"
-        "- Single tool call -> just call the tool directly\n"
-        "- Tasks needing user interaction -> subagents cannot use clarify\n\n"
+        "Provide a 'tasks' array with 1-3 items. "
+        "Each task needs a 'goal' and optional 'context' and 'toolsets'. "
+        "Multiple tasks run in parallel.\n\n"
+        "USE FOR: reasoning-heavy subtasks, context-heavy work, parallel independent workstreams.\n"
+        "DO NOT USE FOR: single tool calls (call directly), mechanical multi-step work (use execute_code), "
+        "tasks needing user interaction (subagents cannot use clarify).\n\n"
         "IMPORTANT:\n"
         "- Subagents have NO memory of your conversation. Pass all relevant "
-        "info (file paths, error messages, constraints) via the 'context' field.\n"
-        "- Subagents CANNOT call: delegate_task, clarify, memory, send_message, "
-        "execute_code.\n"
-        "- Each subagent gets its own terminal session (separate working directory and state).\n"
+        "info via 'context'.\n"
+        "- Subagents CANNOT call: delegate_task, clarify, memory, send_message, execute_code.\n"
         "- Results are always returned as an array, one entry per task."
     ),
     "parameters": {
         "type": "object",
         "properties": {
-            "goal": {
-                "type": "string",
-                "description": (
-                    "What the subagent should accomplish. Be specific and "
-                    "self-contained -- the subagent knows nothing about your "
-                    "conversation history."
-                ),
-            },
-            "context": {
-                "type": "string",
-                "description": (
-                    "Background information the subagent needs: file paths, "
-                    "error messages, project structure, constraints. The more "
-                    "specific you are, the better the subagent performs."
-                ),
-            },
-            "toolsets": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": (
-                    "Toolsets to enable for this subagent. "
-                    "Default: inherits your enabled toolsets. "
-                    "Common patterns: ['terminal', 'file'] for code work, "
-                    "['web'] for research, ['terminal', 'file', 'web'] for "
-                    "full-stack tasks."
-                ),
-            },
             "tasks": {
                 "type": "array",
                 "items": {
                     "type": "object",
                     "properties": {
-                        "goal": {"type": "string", "description": "Task goal"},
-                        "context": {"type": "string", "description": "Task-specific context"},
+                        "goal": {
+                            "type": "string",
+                            "description": (
+                                "What the subagent should accomplish. Be specific and "
+                                "self-contained -- the subagent knows nothing about your "
+                                "conversation history."
+                            ),
+                        },
+                        "context": {
+                            "type": "string",
+                            "description": (
+                                "Background information the subagent needs: file paths, "
+                                "error messages, project structure, constraints."
+                            ),
+                        },
                         "toolsets": {
                             "type": "array",
                             "items": {"type": "string"},
-                            "description": "Toolsets for this specific task. Use 'web' for network access, 'terminal' for shell.",
+                            "description": (
+                                "Toolsets for this task. Default: inherits parent toolsets. "
+                                "Use 'web' for network access, 'terminal' for shell."
+                            ),
                         },
                         "acp_command": {
                             "type": "string",
-                            "description": "Per-task ACP command override (e.g. 'claude'). Overrides the top-level acp_command for this task only.",
+                            "description": "ACP command override (e.g. 'claude', 'copilot').",
                         },
                         "acp_args": {
                             "type": "array",
                             "items": {"type": "string"},
-                            "description": "Per-task ACP args override.",
+                            "description": "ACP command arguments override.",
                         },
                     },
                     "required": ["goal"],
                 },
+                "minItems": 1,
                 "maxItems": 3,
                 "description": (
-                    "Batch mode: up to 3 tasks to run in parallel. Each gets "
-                    "its own subagent with isolated context and terminal session. "
-                    "When provided, top-level goal/context/toolsets are ignored."
+                    "1-3 tasks to delegate. Each gets its own subagent with "
+                    "isolated context and terminal session. Multiple tasks run in parallel."
                 ),
             },
             "max_iterations": {
@@ -934,25 +914,8 @@ DELEGATE_TASK_SCHEMA = {
                     "Only set lower for simple tasks."
                 ),
             },
-            "acp_command": {
-                "type": "string",
-                "description": (
-                    "Override ACP command for child agents (e.g. 'claude', 'copilot'). "
-                    "When set, children use ACP subprocess transport instead of inheriting "
-                    "the parent's transport. Enables spawning Claude Code (claude --acp --stdio) "
-                    "or other ACP-capable agents from any parent, including Discord/Telegram/CLI."
-                ),
-            },
-            "acp_args": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": (
-                    "Arguments for the ACP command (default: ['--acp', '--stdio']). "
-                    "Only used when acp_command is set. Example: ['--acp', '--stdio', '--model', 'claude-opus-4-6']"
-                ),
-            },
         },
-        "required": [],
+        "required": ["tasks"],
     },
 }
 
@@ -965,13 +928,8 @@ registry.register(
     toolset="delegation",
     schema=DELEGATE_TASK_SCHEMA,
     handler=lambda args, **kw: delegate_task(
-        goal=args.get("goal"),
-        context=args.get("context"),
-        toolsets=args.get("toolsets"),
         tasks=args.get("tasks"),
         max_iterations=args.get("max_iterations"),
-        acp_command=args.get("acp_command"),
-        acp_args=args.get("acp_args"),
         parent_agent=kw.get("parent_agent")),
     check_fn=check_delegate_requirements,
     emoji="🔀",


### PR DESCRIPTION
## Summary

The `delegate_task` tool schema advertised two separate interfaces for the same thing:

1. **Top-level** `goal`, `context`, `toolsets` — for single-task delegation
2. **Per-task** `tasks[].goal`, `tasks[].context`, `tasks[].toolsets` — for batch delegation

The `acp_command` and `acp_args` params were similarly duplicated at both levels. This wasted schema tokens on every conversation and created ambiguity — the description even had to explain that "when tasks is provided, top-level goal/context/toolsets are ignored."

Internally, `delegate_task()` already normalizes both modes into a single task list (line 557-563), so the dual schema was purely cosmetic.

## Changes

- Remove top-level `goal`, `context`, `toolsets`, `acp_command`, `acp_args` from `DELEGATE_TASK_SCHEMA`
- Make `tasks` required with `minItems: 1`, `maxItems: 3`
- Move full descriptions into per-task properties (previously terse)
- Shorten tool description by ~40% while preserving key guidance
- Remove top-level params from registry handler dispatch
- Update schema validation test

## Backward Compatibility

- `delegate_task()` function still accepts `goal=`, `context=`, `toolsets=`, `acp_command=`, `acp_args=` as kwargs — normalized to tasks internally
- All 85 existing delegation tests pass unchanged (including `test_single_task_mode` which exercises the legacy `goal=` interface)
- All 244 related tests pass (model_tools, interrupt propagation, run_agent)

## Token Savings

Net -34 lines from the schema definition, reducing prompt overhead on every conversation that has delegation enabled.

## Test Plan

```
python -m pytest tests/tools/test_delegate.py tests/tools/test_delegate_toolset_scope.py tests/agent/test_subagent_progress.py -n0 -q  # 85 passed
python -m pytest tests/test_model_tools.py tests/test_interrupt_propagation.py tests/test_cli_interrupt_subagent.py tests/test_run_agent.py -n0 -q  # 244 passed
```