### PR TITLE
fix(anthropic): guard thinking kwargs for older SDKs

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -11,9 +11,11 @@ Auth supports:
 """
 
 import copy
+import inspect
 import json
 import logging
 import os
+from functools import lru_cache
 from pathlib import Path
 
 from hermes_constants import get_hermes_home
@@ -88,6 +90,24 @@ def _get_anthropic_max_output(model: str) -> int:
 def _supports_adaptive_thinking(model: str) -> bool:
     """Return True for Claude 4.6 models that support adaptive thinking."""
     return any(v in model for v in ("4-6", "4.6"))
+
+
+@lru_cache(maxsize=None)
+def _anthropic_messages_create_supports(arg_name: str) -> bool:
+    """Return whether the installed Anthropic SDK accepts a given kwarg.
+
+    Hermes can be updated without reinstalling Python dependencies. Older
+    anthropic SDK versions accepted neither `thinking` nor `output_config`.
+    In that case, reasoning kwargs must be omitted for compatibility.
+    """
+    if _anthropic_sdk is None:
+        return True
+    try:
+        from anthropic.resources.messages import Messages
+
+        return arg_name in inspect.signature(Messages.create).parameters
+    except Exception:
+        return True
 
 
 # Beta headers for enhanced features (sent with ALL auth types)
@@ -1313,18 +1333,25 @@ def build_anthropic_kwargs(
     # Haiku models do NOT support extended thinking at all — skip entirely.
     if reasoning_config and isinstance(reasoning_config, dict):
         if reasoning_config.get("enabled") is not False and "haiku" not in model.lower():
-            effort = str(reasoning_config.get("effort", "medium")).lower()
-            budget = THINKING_BUDGET.get(effort, 8000)
-            if _supports_adaptive_thinking(model):
-                kwargs["thinking"] = {"type": "adaptive"}
-                kwargs["output_config"] = {
-                    "effort": ADAPTIVE_EFFORT_MAP.get(effort, "medium")
-                }
+            if not _anthropic_messages_create_supports("thinking"):
+                logger.info(
+                    "Installed anthropic SDK lacks `thinking` support; "
+                    "skipping reasoning kwargs for compatibility."
+                )
             else:
-                kwargs["thinking"] = {"type": "enabled", "budget_tokens": budget}
-                # Anthropic requires temperature=1 when thinking is enabled on older models
-                kwargs["temperature"] = 1
-                kwargs["max_tokens"] = max(effective_max_tokens, budget + 4096)
+                effort = str(reasoning_config.get("effort", "medium")).lower()
+                budget = THINKING_BUDGET.get(effort, 8000)
+                if _supports_adaptive_thinking(model):
+                    kwargs["thinking"] = {"type": "adaptive"}
+                    if _anthropic_messages_create_supports("output_config"):
+                        kwargs["output_config"] = {
+                            "effort": ADAPTIVE_EFFORT_MAP.get(effort, "medium")
+                        }
+                else:
+                    kwargs["thinking"] = {"type": "enabled", "budget_tokens": budget}
+                    # Anthropic requires temperature=1 when thinking is enabled on older models
+                    kwargs["temperature"] = 1
+                    kwargs["max_tokens"] = max(effective_max_tokens, budget + 4096)
 
     return kwargs
 

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -967,6 +967,37 @@ class TestBuildAnthropicKwargs:
         )
         assert "thinking" not in kwargs
 
+    def test_reasoning_skipped_when_sdk_lacks_thinking_kwarg(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._anthropic_messages_create_supports",
+            lambda arg_name: False if arg_name == "thinking" else True,
+        )
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-20250514",
+            messages=[{"role": "user", "content": "think hard"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        assert "thinking" not in kwargs
+        assert "output_config" not in kwargs
+        assert kwargs["max_tokens"] == 4096
+
+    def test_adaptive_thinking_omits_output_config_if_sdk_lacks_it(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._anthropic_messages_create_supports",
+            lambda arg_name: arg_name != "output_config",
+        )
+        kwargs = build_anthropic_kwargs(
+            model="claude-sonnet-4-6",
+            messages=[{"role": "user", "content": "think hard"}],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        assert kwargs["thinking"] == {"type": "adaptive"}
+        assert "output_config" not in kwargs
+
     def test_default_max_tokens_uses_model_output_limit(self):
         """When max_tokens is None, use the model's native output limit."""
         kwargs = build_anthropic_kwargs(


### PR DESCRIPTION
Fixes #5777.

Root cause
- Hermes now adds Anthropic `thinking` / `output_config` kwargs when reasoning is enabled.
- Older anthropic SDKs do not accept those kwargs.
- `hermes update` can update the repo without reinstalling Python deps, so an older SDK can still be in the existing env.
- That turns into `Messages.create() got an unexpected keyword argument 'thinking'` before the request even reaches MiniMax.

What changed
- Added a small SDK compatibility check against `anthropic.resources.messages.Messages.create`.
- If the installed SDK does not support `thinking`, Hermes now skips reasoning kwargs instead of crashing.
- If `thinking` is supported but `output_config` is not, Hermes sends adaptive thinking without `output_config`.
- Added regression tests for both cases.

Repro / verification
- Reproduced locally with a project-local `.venv311` using `anthropic==0.39.0`.
- Before fix: kwargs included `thinking`, and a `Messages.create(...)`-style call raised the same TypeError.
- After fix: kwargs omit `thinking`/`output_config`, and the same call shape succeeds.

Checks
- python -m pytest -o addopts='' tests/test_anthropic_adapter.py -q -k 'reasoning_config or reasoning_disabled or sdk_lacks_thinking or adaptive_thinking_omits_output_config'
- python -m py_compile agent/anthropic_adapter.py tests/test_anthropic_adapter.py
