### PR TITLE
fix(skills): classify builtin skills by dir_name when frontmatter name differs

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -530,7 +530,7 @@ def do_list(source_filter: str = "all", console: Optional[Console] = None) -> No
             source_display = hub_entry.get("source", "hub")
             trust = hub_entry.get("trust_level", "community")
             hub_count += 1
-        elif name in builtin_names:
+        elif name in builtin_names or skill.get("dir_name", name) in builtin_names:
             source_type = "builtin"
             source_display = "builtin"
             trust = "builtin"

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -148,6 +148,36 @@ def test_do_list_filter_builtin(three_source_env):
     output = _capture(source_filter="builtin")
 
     assert "builtin-skill" in output
+
+
+def test_do_list_builtin_dir_name_mismatch(monkeypatch, hub_env):
+    """Builtin skill whose directory name differs from frontmatter name is still classified as builtin.
+
+    Regression test for issue #5433: skills_sync stores manifest keys by directory name
+    while _find_all_skills returns frontmatter name; when they differ the skill was wrongly
+    shown as local.
+    """
+    import tools.skills_hub as hub
+    import tools.skills_sync as skills_sync
+    import tools.skills_tool as skills_tool
+
+    # directory name is "vllm" but SKILL.md frontmatter says "serving-llms-vllm"
+    _skills = [
+        {"name": "serving-llms-vllm", "dir_name": "vllm", "category": "mlops", "description": "vllm"},
+    ]
+    _manifest = {"vllm": "deadbeef"}  # manifest key = directory name
+
+    monkeypatch.setattr(hub, "HubLockFile", lambda: _DummyLockFile([]))
+    monkeypatch.setattr(skills_tool, "_find_all_skills", lambda: list(_skills))
+    monkeypatch.setattr(skills_sync, "_read_manifest", lambda: dict(_manifest))
+
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    do_list(console=console)
+    output = sink.getvalue()
+
+    assert "serving-llms-vllm" in output
+    assert "0 hub-installed, 1 builtin, 0 local" in output
     assert "hub-skill" not in output
     assert "local-skill" not in output
 

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -580,6 +580,7 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                 seen_names.add(name)
                 skills.append({
                     "name": name,
+                    "dir_name": skill_dir.name,
                     "description": description,
                     "category": category,
                 })


### PR DESCRIPTION
## Problem

Closes #5433

                                Installed Skills                                
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┓
┃ Name                              ┃ Category             ┃ Source  ┃ Trust   ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━┩
│ dogfood                           │                      │ builtin │ builtin │
│ apple-notes                       │ apple                │ builtin │ builtin │
│ apple-reminders                   │ apple                │ builtin │ builtin │
│ findmy                            │ apple                │ builtin │ builtin │
│ imessage                          │ apple                │ builtin │ builtin │
│ claude-code                       │ autonomous-ai-agents │ builtin │ builtin │
│ codex                             │ autonomous-ai-agents │ builtin │ builtin │
│ hermes-agent                      │ autonomous-ai-agents │ builtin │ builtin │
│ opencode                          │ autonomous-ai-agents │ builtin │ builtin │
│ ascii-art                         │ creative             │ builtin │ builtin │
│ ascii-video                       │ creative             │ builtin │ builtin │
│ excalidraw                        │ creative             │ builtin │ builtin │
│ manim-video                       │ creative             │ builtin │ builtin │
│ p5js                              │ creative             │ builtin │ builtin │
│ popular-web-designs               │ creative             │ builtin │ builtin │
│ songwriting-and-ai-music          │ creative             │ builtin │ builtin │
│ jupyter-live-kernel               │ data-science         │ builtin │ builtin │
│ webhook-subscriptions             │ devops               │ builtin │ builtin │
│ himalaya                          │ email                │ builtin │ builtin │
│ minecraft-modpack-server          │ gaming               │ builtin │ builtin │
│ pokemon-player                    │ gaming               │ builtin │ builtin │
│ codebase-inspection               │ github               │ builtin │ builtin │
│ github-auth                       │ github               │ builtin │ builtin │
│ github-code-review                │ github               │ builtin │ builtin │
│ github-issues                     │ github               │ builtin │ builtin │
│ github-pr-workflow                │ github               │ builtin │ builtin │
│ github-repo-management            │ github               │ builtin │ builtin │
│ find-nearby                       │ leisure              │ builtin │ builtin │
│ mcporter                          │ mcp                  │ builtin │ builtin │
│ native-mcp                        │ mcp                  │ builtin │ builtin │
│ gif-search                        │ media                │ builtin │ builtin │
│ heartmula                         │ media                │ builtin │ builtin │
│ songsee                           │ media                │ builtin │ builtin │
│ youtube-content                   │ media                │ builtin │ builtin │
│ audiocraft-audio-generation       │ mlops                │ local   │ local   │
│ axolotl                           │ mlops                │ builtin │ builtin │
│ clip                              │ mlops                │ builtin │ builtin │
│ dspy                              │ mlops                │ builtin │ builtin │
│ evaluating-llms-harness           │ mlops                │ local   │ local   │
│ fine-tuning-with-trl              │ mlops                │ local   │ local   │
│ gguf-quantization                 │ mlops                │ local   │ local   │
│ grpo-rl-training                  │ mlops                │ builtin │ builtin │
│ guidance                          │ mlops                │ builtin │ builtin │
│ huggingface-hub                   │ mlops                │ builtin │ builtin │
│ llama-cpp                         │ mlops                │ builtin │ builtin │
│ modal-serverless-gpu              │ mlops                │ local   │ local   │
│ obliteratus                       │ mlops                │ builtin │ builtin │
│ outlines                          │ mlops                │ builtin │ builtin │
│ peft-fine-tuning                  │ mlops                │ local   │ local   │
│ pytorch-fsdp                      │ mlops                │ builtin │ builtin │
│ segment-anything-model            │ mlops                │ local   │ local   │
│ serving-llms-vllm                 │ mlops                │ local   │ local   │
│ stable-diffusion-image-generation │ mlops                │ local   │ local   │
│ unsloth                           │ mlops                │ builtin │ builtin │
│ weights-and-biases                │ mlops                │ builtin │ builtin │
│ whisper                           │ mlops                │ builtin │ builtin │
│ obsidian                          │ note-taking          │ builtin │ builtin │
│ google-workspace                  │ productivity         │ builtin │ builtin │
│ linear                            │ productivity         │ builtin │ builtin │
│ nano-pdf                          │ productivity         │ builtin │ builtin │
│ notion                            │ productivity         │ builtin │ builtin │
│ ocr-and-documents                 │ productivity         │ builtin │ builtin │
│ powerpoint                        │ productivity         │ builtin │ builtin │
│ godmode                           │ red-teaming          │ builtin │ builtin │
│ arxiv                             │ research             │ builtin │ builtin │
│ blogwatcher                       │ research             │ builtin │ builtin │
│ llm-wiki                          │ research             │ builtin │ builtin │
│ multi-platform-sentiment-research │ research             │ local   │ local   │
│ polymarket                        │ research             │ builtin │ builtin │
│ research-paper-writing            │ research             │ builtin │ builtin │
│ openhue                           │ smart-home           │ builtin │ builtin │
│ xitter                            │ social-media         │ builtin │ builtin │
│ plan                              │ software-development │ builtin │ builtin │
│ requesting-code-review            │ software-development │ builtin │ builtin │
│ subagent-driven-development       │ software-development │ builtin │ builtin │
│ systematic-debugging              │ software-development │ builtin │ builtin │
│ test-driven-development           │ software-development │ builtin │ builtin │
│ writing-plans                     │ software-development │ builtin │ builtin │
│ perplexity-search                 │ web                  │ local   │ local   │
│ web-access                        │ web                  │ local   │ local   │
└───────────────────────────────────┴──────────────────────┴─────────┴─────────┘
0 hub-installed, 68 builtin, 12 local misclassifies some bundled skills as **local** instead of **builtin** when the skill's directory name differs from its SKILL.md frontmatter `name`.

Root cause: `skills_sync` stores manifest keys by directory name (e.g. `vllm`), but `_find_all_skills()` returns frontmatter names (e.g. `serving-llms-vllm`). The builtin check in `do_list()` compared them directly, failing silently.

Affected examples from #5433: `audiocraft-audio-generation`, `serving-llms-vllm`, `segment-anything-model`, etc.

## Fix

Two minimal changes:

1. **`tools/skills_tool.py`** – expose `dir_name` (the directory name) alongside `name` (frontmatter) in each skill dict returned by `_find_all_skills()`. All other callers ignore the new key.

2. **`hermes_cli/skills_hub.py`** – in `do_list()`, check `skill["dir_name"]` against the manifest as a fallback when the frontmatter name isn't found.

## Test plan

- [x] New regression test `test_do_list_builtin_dir_name_mismatch` in `tests/hermes_cli/test_skills_hub.py`: simulates a skill where directory name (`vllm`) differs from frontmatter name (`serving-llms-vllm`) and asserts it is shown as builtin with count `0 hub-installed, 1 builtin, 0 local`
- [x] Existing `test_do_list_distinguishes_hub_builtin_and_local` continues to pass (same-name case unchanged)