### PR TITLE
fix(auxiliary): normalize /anthropic base URLs to /v1 for OpenAI-compatible clients

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -129,6 +129,22 @@ def _pool_runtime_api_key(entry: Any) -> str:
     return str(key or "").strip()
 
 
+def _to_openai_base_url(base_url: str) -> str:
+    """Normalize an Anthropic-style base URL to OpenAI-compatible format.
+
+    Some providers (MiniMax, MiniMax-CN) use an ``/anthropic`` path suffix for
+    their Anthropic Messages API endpoint.  The auxiliary client uses the OpenAI
+    SDK (chat completions), which requires the ``/v1`` path instead.  Passing the
+    raw ``inference_base_url`` causes requests to land on
+    ``/anthropic/chat/completions`` — a 404 on every provider that separates the
+    two API surfaces.
+    """
+    url = str(base_url or "").strip().rstrip("/")
+    if url.endswith("/anthropic"):
+        return url[: -len("/anthropic")] + "/v1"
+    return url
+
+
 def _pool_runtime_base_url(entry: Any, fallback: str = "") -> str:
     if entry is None:
         return str(fallback or "").strip().rstrip("/")
@@ -634,7 +650,9 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
             if not api_key:
                 continue
 
-            base_url = _pool_runtime_base_url(entry, pconfig.inference_base_url) or pconfig.inference_base_url
+            base_url = _to_openai_base_url(
+                _pool_runtime_base_url(entry, pconfig.inference_base_url) or pconfig.inference_base_url
+            )
             model = _API_KEY_PROVIDER_AUX_MODELS.get(provider_id, "default")
             logger.debug("Auxiliary text client: %s (%s) via pool", pconfig.name, model)
             extra = {}
@@ -651,7 +669,9 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
         if not api_key:
             continue
 
-        base_url = str(creds.get("base_url", "")).strip().rstrip("/") or pconfig.inference_base_url
+        base_url = _to_openai_base_url(
+            str(creds.get("base_url", "")).strip().rstrip("/") or pconfig.inference_base_url
+        )
         model = _API_KEY_PROVIDER_AUX_MODELS.get(provider_id, "default")
         logger.debug("Auxiliary text client: %s (%s)", pconfig.name, model)
         extra = {}

--- a/tests/test_minimax_auxiliary_endpoint.py
+++ b/tests/test_minimax_auxiliary_endpoint.py
@@ -1,0 +1,55 @@
+"""Tests for MiniMax auxiliary client URL normalization (issue #5781).
+
+MiniMax exposes two API surfaces on different URL paths:
+  - /anthropic  — Anthropic Messages API (used by the main agent loop)
+  - /v1         — OpenAI-compatible chat completions (used by auxiliary client)
+
+The auxiliary client builds an OpenAI() instance with the provider's
+inference_base_url, which for MiniMax is ``.../anthropic``.  Without
+normalization the OpenAI SDK appends ``/chat/completions`` and every
+auxiliary request lands on ``.../anthropic/chat/completions`` — a 404.
+
+_to_openai_base_url() strips the ``/anthropic`` suffix and replaces it with
+``/v1`` so the auxiliary client always points at the right path.
+"""
+
+import sys
+import os
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from agent.auxiliary_client import _to_openai_base_url
+
+
+class TestToOpenaiBaseUrl:
+    def test_minimax_global_anthropic_suffix_replaced(self):
+        assert _to_openai_base_url("https://api.minimax.io/anthropic") == "https://api.minimax.io/v1"
+
+    def test_minimax_cn_anthropic_suffix_replaced(self):
+        assert _to_openai_base_url("https://api.minimaxi.com/anthropic") == "https://api.minimaxi.com/v1"
+
+    def test_trailing_slash_stripped_before_replace(self):
+        assert _to_openai_base_url("https://api.minimax.io/anthropic/") == "https://api.minimax.io/v1"
+
+    def test_v1_url_unchanged(self):
+        assert _to_openai_base_url("https://api.openai.com/v1") == "https://api.openai.com/v1"
+
+    def test_openrouter_url_unchanged(self):
+        assert _to_openai_base_url("https://openrouter.ai/api/v1") == "https://openrouter.ai/api/v1"
+
+    def test_url_with_anthropic_in_domain_unchanged(self):
+        # ``/anthropic`` must appear as a path suffix, not in the domain
+        assert _to_openai_base_url("https://api.anthropic.com") == "https://api.anthropic.com"
+
+    def test_url_with_anthropic_subpath_unchanged(self):
+        # Only strip a terminal ``/anthropic``, not a mid-path segment
+        assert _to_openai_base_url("https://example.com/anthropic/extra") == "https://example.com/anthropic/extra"
+
+    def test_empty_string(self):
+        assert _to_openai_base_url("") == ""
+
+    def test_none_equivalent_empty_string(self):
+        # Callers may pass None when a URL is unset
+        assert _to_openai_base_url(None) == ""


### PR DESCRIPTION
Fixes #5781.

## Root cause

MiniMax and MiniMax-CN set `inference_base_url` to the `/anthropic` path (e.g. `https://api.minimax.io/anthropic`) because that is the correct endpoint for the Anthropic Messages API used by the main agent loop.

The auxiliary client constructs an `OpenAI()` instance using the same URL. The OpenAI SDK then appends `/chat/completions`, sending every auxiliary/compression request to `https://api.minimax.io/anthropic/chat/completions` — a 404. The fallback model handles compression instead, at potentially higher cost and lower quality.

## What changed

- Added `_to_openai_base_url()` in `agent/auxiliary_client.py`: strips a terminal `/anthropic` suffix and replaces it with `/v1` before any `OpenAI()` client is constructed.
- Applied at both resolution paths in `_resolve_api_key_provider()`: the credential pool path (line ~652) and the plain credentials path (line ~669).
- No changes to `auth.py` or `ProviderConfig` — the normalization lives entirely in the auxiliary client layer where it belongs.

## Tests

```
python -m pytest tests/test_minimax_auxiliary_endpoint.py -v
9 passed
```

Covers: MiniMax global, MiniMax-CN, trailing slash, non-`/anthropic` URLs (OpenAI, OpenRouter), `/anthropic` in domain name (not stripped), `/anthropic` as mid-path segment (not stripped), empty string, None.