### PR TITLE
docs(cron): clarify default model/provider behavior for scheduled jobs

### DIFF
--- a/website/docs/guides/daily-briefing-bot.md
+++ b/website/docs/guides/daily-briefing-bot.md
@@ -90,6 +90,8 @@ Try different prompts until you get output you love. Add instructions like "use 
 
 Now let's schedule this to run automatically every morning. You can do this in two ways.
 
+Before creating cron jobs, ensure Hermes has a default model and provider configured globally. If you want a specific job to use different values, set explicit per-job model/provider overrides when creating it.
+
 ### Option A: Natural Language (in chat)
 
 Just tell Hermes what you want:

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -314,6 +314,8 @@ For `update`, pass `skills=[]` to remove all attached skills.
 
 Jobs are stored in `~/.hermes/cron/jobs.json`. Output from job runs is saved to `~/.hermes/cron/output/{job_id}/{timestamp}.md`.
 
+Jobs may store `model` and `provider` as `null`. When those fields are omitted, Hermes resolves them at execution time from the global configuration. They only appear in the job record when a per-job override is set.
+
 The storage uses atomic file writes so interrupted writes do not leave a partially written job file behind.
 
 ## Self-contained prompts still matter


### PR DESCRIPTION
## What does this PR do?

Clarifies cron model/provider behavior in the docs so readers do not assume those fields must always be stored on the job itself.

This adds:
- a note in the daily briefing tutorial telling users to ensure a default model/provider is configured before creating cron jobs
- a note in the cron docs explaining that `model` and `provider` may be `null` in stored jobs and are resolved at runtime from global config unless explicitly overridden per job

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `website/docs/guides/daily-briefing-bot.md` to warn users to configure a default model/provider before creating cron jobs
- Updated `website/docs/user-guide/features/cron.md` to explain that stored cron jobs may have `model`/`provider` set to `null` and that Hermes resolves them at execution time from global config

## How to Test

1. Open the daily briefing tutorial and navigate to `Step 2: Create the Cron Job`
2. Confirm the new note makes the default model/provider requirement explicit before job creation
3. Open the cron docs and confirm the `Job storage` section explains runtime resolution of `null` `model`/`provider` fields

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: GitHub web editor for docs-only changes

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
