### PR TITLE
fix: route MiniMax auxiliary/compression clients to /v1 endpoint

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -580,7 +580,7 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
             if not api_key:
                 continue
 
-            base_url = _pool_runtime_base_url(entry, pconfig.inference_base_url) or pconfig.inference_base_url
+            base_url = _pool_runtime_base_url(entry, pconfig.inference_base_url) or pconfig.auxiliary_base_url or pconfig.inference_base_url
             model = _API_KEY_PROVIDER_AUX_MODELS.get(provider_id, "default")
             logger.debug("Auxiliary text client: %s (%s) via pool", pconfig.name, model)
             extra = {}
@@ -597,7 +597,15 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
         if not api_key:
             continue
 
-        base_url = str(creds.get("base_url", "")).strip().rstrip("/") or pconfig.inference_base_url
+        creds_base = str(creds.get("base_url", "")).strip().rstrip("/")
+        # Prefer auxiliary_base_url when the resolved base URL was not
+        # overridden by the user (i.e. it still equals inference_base_url).
+        if pconfig.auxiliary_base_url and (
+            not creds_base or creds_base == pconfig.inference_base_url.rstrip("/")
+        ):
+            base_url = pconfig.auxiliary_base_url
+        else:
+            base_url = creds_base or pconfig.inference_base_url
         model = _API_KEY_PROVIDER_AUX_MODELS.get(provider_id, "default")
         logger.debug("Auxiliary text client: %s (%s)", pconfig.name, model)
         extra = {}
@@ -1083,7 +1091,15 @@ def resolve_provider_client(
                          provider, ", ".join(tried_sources))
             return None, None
 
-        base_url = str(creds.get("base_url", "")).strip().rstrip("/") or pconfig.inference_base_url
+        creds_base = str(creds.get("base_url", "")).strip().rstrip("/")
+        # Prefer auxiliary_base_url when the resolved base URL was not
+        # overridden by the user (i.e. it still equals inference_base_url).
+        if pconfig.auxiliary_base_url and (
+            not creds_base or creds_base == pconfig.inference_base_url.rstrip("/")
+        ):
+            base_url = pconfig.auxiliary_base_url
+        else:
+            base_url = creds_base or pconfig.inference_base_url
 
         default_model = _API_KEY_PROVIDER_AUX_MODELS.get(provider, "")
         final_model = model or default_model

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -93,6 +93,11 @@ class ProviderConfig:
     api_key_env_vars: tuple = ()
     # Optional env var for base URL override
     base_url_env_var: str = ""
+    # Base URL for auxiliary/compression clients (OpenAI SDK).
+    # When inference_base_url targets a non-OpenAI-compatible surface
+    # (e.g. /anthropic), set this to the provider's OpenAI-compatible
+    # endpoint so the OpenAI SDK appends /chat/completions correctly.
+    auxiliary_base_url: str = ""
 
 
 PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
@@ -148,6 +153,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url="https://api.minimax.io/anthropic",
         api_key_env_vars=("MINIMAX_API_KEY",),
         base_url_env_var="MINIMAX_BASE_URL",
+        auxiliary_base_url="https://api.minimax.io/v1",
     ),
     "anthropic": ProviderConfig(
         id="anthropic",
@@ -171,6 +177,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url="https://api.minimaxi.com/anthropic",
         api_key_env_vars=("MINIMAX_CN_API_KEY",),
         base_url_env_var="MINIMAX_CN_BASE_URL",
+        auxiliary_base_url="https://api.minimaxi.com/v1",
     ),
     "deepseek": ProviderConfig(
         id="deepseek",

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -444,12 +444,35 @@ class TestExplicitProviderRouting:
             assert client is not None
 
     def test_explicit_minimax(self, monkeypatch):
-        """provider='minimax' should use MINIMAX_API_KEY."""
+        """provider='minimax' should use MINIMAX_API_KEY and auxiliary /v1 endpoint."""
         monkeypatch.setenv("MINIMAX_API_KEY", "mm-test-key")
         with patch("agent.auxiliary_client.OpenAI") as mock_openai:
             mock_openai.return_value = MagicMock()
             client, model = resolve_provider_client("minimax")
             assert client is not None
+            call_kwargs = mock_openai.call_args.kwargs
+            assert "/v1" in call_kwargs["base_url"]
+            assert "/anthropic" not in call_kwargs["base_url"]
+
+    def test_explicit_minimax_cn(self, monkeypatch):
+        """provider='minimax-cn' should use auxiliary /v1 endpoint, not /anthropic."""
+        monkeypatch.setenv("MINIMAX_CN_API_KEY", "mm-cn-test-key")
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            client, model = resolve_provider_client("minimax-cn")
+            assert client is not None
+            call_kwargs = mock_openai.call_args.kwargs
+            assert call_kwargs["base_url"] == "https://api.minimaxi.com/v1"
+
+    def test_provider_without_auxiliary_base_url_uses_inference(self, monkeypatch):
+        """Providers without auxiliary_base_url should fall back to inference_base_url."""
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "ds-test-key")
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            client, model = resolve_provider_client("deepseek")
+            assert client is not None
+            call_kwargs = mock_openai.call_args.kwargs
+            assert call_kwargs["base_url"] == "https://api.deepseek.com/v1"
 
     def test_explicit_deepseek(self, monkeypatch):
         """provider='deepseek' should use DEEPSEEK_API_KEY."""


### PR DESCRIPTION
## Summary

Fixes #5781 — MiniMax auxiliary/compression clients were routing to `/anthropic` instead of `/v1`, causing 404 errors.

## Root Cause

MiniMax's `inference_base_url` is `https://api.minimax.io/anthropic` (correct for main inference using Anthropic Messages format). However, `_resolve_api_key_provider()` in `auxiliary_client.py` reused the same URL when constructing OpenAI SDK clients for auxiliary/compression tasks. The OpenAI SDK appends `/chat/completions`, resulting in requests to `/anthropic/chat/completions` → 404.

## Fix (Option B from issue)

Added `auxiliary_base_url` field to `ProviderConfig`:

- **`hermes_cli/auth.py`**: Added `auxiliary_base_url` field; set to `https://api.minimax.io/v1` for minimax and `https://api.minimaxi.com/v1` for minimax-cn
- **`agent/auxiliary_client.py`**: Three call sites now prefer `auxiliary_base_url` when available, falling back to existing `inference_base_url` logic
- **`tests/agent/test_auxiliary_client.py`**: Added tests for both MiniMax variants + fallback behavior for providers without `auxiliary_base_url`

## Testing

- All 3 new test cases pass
- Existing auxiliary_client tests unaffected (80/82 pass; 2 pre-existing flaky)