### PR TITLE
fix: sync bundled skills to all profiles during update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3566,7 +3566,7 @@ def cmd_update(args):
         try:
             from hermes_cli.profiles import list_profiles, get_active_profile_name, seed_profile_skills
             active = get_active_profile_name()
-            other_profiles = [p for p in list_profiles() if not p.is_default and p.name != active]
+            other_profiles = [p for p in list_profiles() if p.name != active]
             if other_profiles:
                 print()
                 print("→ Syncing bundled skills to other profiles...")


### PR DESCRIPTION
## Summary

When running `hermes update` from a named profile, the default profile (~/.hermes) was excluded from the cross-profile bundled skill sync. The filter `not p.is_default and p.name != active` meant the default profile never appeared in the "other profiles" list.

One-line fix: remove `not p.is_default and` so all profiles (including default) receive bundled skill updates regardless of which profile runs the update.

## What changed
- `hermes_cli/main.py`: Changed the profile filter in `cmd_update()`'s skill sync loop from `not p.is_default and p.name != active` to `p.name != active`

## Test plan
- `tests/hermes_cli/test_cmd_update.py` — 14 passed
- `tests/tools/test_skills_sync.py` — 22 passed  
- `tests/hermes_cli/test_profiles.py` — 80 passed

Reported by olafgeibig.