### PR TITLE
fix(auxiliary_client): inject KimiCLI User-Agent for custom endpoint sync clients

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -639,7 +639,7 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
             logger.debug("Auxiliary text client: %s (%s) via pool", pconfig.name, model)
             extra = {}
             if "api.kimi.com" in base_url.lower():
-                extra["default_headers"] = {"User-Agent": "KimiCLI/1.0"}
+                extra["default_headers"] = {"User-Agent": "KimiCLI/1.3"}
             elif "api.githubcopilot.com" in base_url.lower():
                 from hermes_cli.models import copilot_default_headers
 
@@ -656,7 +656,7 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
         logger.debug("Auxiliary text client: %s (%s)", pconfig.name, model)
         extra = {}
         if "api.kimi.com" in base_url.lower():
-            extra["default_headers"] = {"User-Agent": "KimiCLI/1.0"}
+            extra["default_headers"] = {"User-Agent": "KimiCLI/1.3"}
         elif "api.githubcopilot.com" in base_url.lower():
             from hermes_cli.models import copilot_default_headers
 
@@ -1087,7 +1087,7 @@ def _to_async_client(sync_client, model: str):
 
         async_kwargs["default_headers"] = copilot_default_headers()
     elif "api.kimi.com" in base_lower:
-        async_kwargs["default_headers"] = {"User-Agent": "KimiCLI/1.0"}
+        async_kwargs["default_headers"] = {"User-Agent": "KimiCLI/1.3"}
     return AsyncOpenAI(**async_kwargs), model
 
 
@@ -1211,7 +1211,13 @@ def resolve_provider_client(
                 )
                 return None, None
             final_model = model or _read_main_model() or "gpt-4o-mini"
-            client = OpenAI(api_key=custom_key, base_url=custom_base)
+            extra = {}
+            if "api.kimi.com" in custom_base.lower():
+                extra["default_headers"] = {"User-Agent": "KimiCLI/1.3"}
+            elif "api.githubcopilot.com" in custom_base.lower():
+                from hermes_cli.models import copilot_default_headers
+                extra["default_headers"] = copilot_default_headers()
+            client = OpenAI(api_key=custom_key, base_url=custom_base, **extra)
             return (_to_async_client(client, final_model) if async_mode
                     else (client, final_model))
         # Try custom first, then codex, then API-key providers
@@ -1266,7 +1272,7 @@ def resolve_provider_client(
         # Provider-specific headers
         headers = {}
         if "api.kimi.com" in base_url.lower():
-            headers["User-Agent"] = "KimiCLI/1.0"
+            headers["User-Agent"] = "KimiCLI/1.3"
         elif "api.githubcopilot.com" in base_url.lower():
             from hermes_cli.models import copilot_default_headers
 


### PR DESCRIPTION
## Summary

Fixes #5796

When `auxiliary.vision.base_url` is explicitly set to a Kimi coding endpoint, the sync custom-endpoint path in `resolve_provider_client()` was creating a plain `OpenAI()` client without the required `KimiCLI` User-Agent header. This caused sync vision calls (e.g. `browser_vision`) to fail with 403, while async calls succeeded.

## Root Cause

The `KimiCLI/1.x` header was injected in:
- `_resolve_api_key_provider()` (auto-detected pool path)
- `_to_async_client()` (async converter)

But the **explicit custom endpoint shortcut** in `resolve_provider_client()` was missing it entirely.

## Changes

- Inject `default_headers={"User-Agent": "KimiCLI/1.3"}` in the custom endpoint branch of `resolve_provider_client()`
- Bump all existing `KimiCLI/1.0` sites to `KimiCLI/1.3` for consistency

## Verification

| Client | User-Agent | Result |
|--------|-----------|--------|
| Sync (before) | `OpenAI/Python 2.30.0` | 403 |
| Async | `KimiCLI/1.0` | 200 OK |
| Sync (after) | `KimiCLI/1.3` | 200 OK |

## Related

- Distinct from #4661 / #4967 (temperature hardcoding issue)