### PR TITLE
fix(cli): route error messages through ChatConsole inside patch_stdout

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2163,7 +2163,7 @@ class HermesCLI:
             )
         except Exception as exc:
             message = format_runtime_provider_error(exc)
-            self.console.print(f"[bold red]{message}[/]")
+            ChatConsole().print(f"[bold red]{message}[/]")
             return False
 
         api_key = runtime.get("api_key")
@@ -2378,7 +2378,7 @@ class HermesCLI:
                     self._pending_title = None
             return True
         except Exception as e:
-            self.console.print(f"[bold red]Failed to initialize agent: {e}[/]")
+            ChatConsole().print(f"[bold red]Failed to initialize agent: {e}[/]")
             return False
     
     def show_banner(self):
@@ -4538,13 +4538,13 @@ class HermesCLI:
                             if output:
                                 self.console.print(_rich_text_from_ansi(output))
                             else:
-                                self.console.print("[dim]Command returned no output[/]")
+                                ChatConsole().print("[dim]Command returned no output[/]")
                         except subprocess.TimeoutExpired:
-                            self.console.print("[bold red]Quick command timed out (30s)[/]")
+                            ChatConsole().print("[bold red]Quick command timed out (30s)[/]")
                         except Exception as e:
-                            self.console.print(f"[bold red]Quick command error: {e}[/]")
+                            ChatConsole().print(f"[bold red]Quick command error: {e}[/]")
                     else:
-                        self.console.print(f"[bold red]Quick command '{base_cmd}' has no command defined[/]")
+                        ChatConsole().print(f"[bold red]Quick command '{base_cmd}' has no command defined[/]")
                 elif qcmd.get("type") == "alias":
                     target = qcmd.get("target", "").strip()
                     if target:
@@ -4553,9 +4553,9 @@ class HermesCLI:
                         aliased_command = f"{target} {user_args}".strip()
                         return self.process_command(aliased_command)
                     else:
-                        self.console.print(f"[bold red]Quick command '{base_cmd}' has no target defined[/]")
+                        ChatConsole().print(f"[bold red]Quick command '{base_cmd}' has no target defined[/]")
                 else:
-                    self.console.print(f"[bold red]Quick command '{base_cmd}' has unsupported type (supported: 'exec', 'alias')[/]")
+                    ChatConsole().print(f"[bold red]Quick command '{base_cmd}' has unsupported type (supported: 'exec', 'alias')[/]")
             # Check for plugin-registered slash commands
             elif base_cmd.lstrip("/") in _get_plugin_cmd_handler_names():
                 from hermes_cli.plugins import get_plugin_command_handler
@@ -4580,7 +4580,7 @@ class HermesCLI:
                     if hasattr(self, '_pending_input'):
                         self._pending_input.put(msg)
                 else:
-                    self.console.print(f"[bold red]Failed to load skill for {base_cmd}[/]")
+                    ChatConsole().print(f"[bold red]Failed to load skill for {base_cmd}[/]")
             else:
                 # Prefix matching: if input uniquely identifies one command, execute it.
                 # Matches against both built-in COMMANDS and installed skill commands so
@@ -4641,14 +4641,14 @@ class HermesCLI:
         )
 
         if not msg:
-            self.console.print("[bold red]Failed to load the bundled /plan skill[/]")
+            ChatConsole().print("[bold red]Failed to load the bundled /plan skill[/]")
             return
 
         _cprint(f"  📝 Plan mode queued via skill. Markdown plan target: {plan_path}")
         if hasattr(self, '_pending_input'):
             self._pending_input.put(msg)
         else:
-            self.console.print("[bold red]Plan mode unavailable: input queue not initialized[/]")
+            ChatConsole().print("[bold red]Plan mode unavailable: input queue not initialized[/]")
     
     def _handle_background_command(self, cmd: str):
         """Handle /background <prompt> — run a prompt in a separate background session.


### PR DESCRIPTION
## Summary

- Several error messages in the interactive chat loop used `self.console.print()` with Rich markup, which writes raw ANSI escape sequences to stdout
- Inside prompt_toolkit's `patch_stdout` context, `StdoutProxy` mangles these into garbled text like `?[1;31m...` instead of rendering colors
- This is the same class of bug fixed in #2262 — that fix covered agent output but missed error paths in `_ensure_runtime_credentials`, `_ensure_agent`, quick commands, skill loading, and plan mode

## Changes

Replace `self.console.print()` with `ChatConsole().print()` for 11 error/status messages reachable during the interactive session:

- `_ensure_runtime_credentials`: provider not configured error
- `_ensure_agent`: agent initialization failure
- Quick command handling: timeout, no output, missing config, unsupported type
- Skill loading failure
- Plan mode unavailability

## How to reproduce

1. Start `hermes` without any API key configured
2. Type anything and press Enter
3. Observe garbled ANSI codes: `?[1;31mNo inference provider configured...`

After this fix, the error message renders correctly with red color.

## Test plan

- [ ] Start CLI without API key → error message renders red text, no garbled escapes
- [ ] Trigger quick command errors → same correct rendering
- [ ] Verify banner and normal output still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)