### PR TITLE
fix(security): use hmac.compare_digest for API key comparison to prevent timing attacks

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -20,6 +20,7 @@ Requires:
 """
 
 import asyncio
+import hmac
 import json
 import logging
 import os
@@ -370,7 +371,7 @@ class APIServerAdapter(BasePlatformAdapter):
         auth_header = request.headers.get("Authorization", "")
         if auth_header.startswith("Bearer "):
             token = auth_header[7:].strip()
-            if token == self._api_key:
+            if hmac.compare_digest(token, self._api_key):
                 return None  # Auth OK
 
         return web.json_response(


### PR DESCRIPTION
## What does this PR do?

The API server validated Bearer tokens using Python's `==` operator:
```python
# Before (vulnerable)
if token == self._api_key:
```

String equality with `==` is not constant-time — it short-circuits on
the first mismatched character. An attacker can measure response times
to determine how many characters of their guess match the real key,
eventually recovering it character by character (timing attack).

## Fix

Replaced with `hmac.compare_digest()` which always takes the same time
regardless of where the strings differ:
```python
# After (safe)
if hmac.compare_digest(token, self._api_key):
```

## Type of Change

- [x] 🔒 Security fix (timing attack)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] `hmac` is Python standard library — no new dependencies
- [x] No behavior change for valid or invalid tokens