### PR TITLE
fix(security): replace create_subprocess_shell with create_subprocess_exec to prevent command injection

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2155,8 +2155,10 @@ class GatewayRunner:
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
                         try:
-                            proc = await asyncio.create_subprocess_shell(
-                                exec_cmd,
+                            import shlex
+                            args = shlex.split(exec_cmd)
+                            proc = await asyncio.create_subprocess_exec(
+                                *args,
                                 stdout=asyncio.subprocess.PIPE,
                                 stderr=asyncio.subprocess.PIPE,
                             )


### PR DESCRIPTION
## Fix

Replaced with `asyncio.create_subprocess_exec()` using `shlex.split()`
to parse the command into an argument list. This bypasses the shell
interpreter entirely — metacharacters are treated as literal characters,
not shell syntax.
```python
# After (safe)
args = shlex.split(command)
await asyncio.create_subprocess_exec(*args, ...)
```

## Type of Change

- [x] 🔒 Security fix (command injection)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] `shlex` is Python standard library — no new dependencies
- [x] No behavior change for legitimate commands without metacharacters