### PR TITLE
fix: drop incompatible model slugs on auxiliary client cache hit

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1621,6 +1621,23 @@ def cleanup_stale_async_clients() -> None:
             del _client_cache[key]
 
 
+def _is_openrouter_client(client: Any) -> bool:
+    for obj in (client, getattr(client, "_client", None), getattr(client, "client", None)):
+        if obj and "openrouter" in str(getattr(obj, "base_url", "") or "").lower():
+            return True
+    return False
+
+
+def _compat_model(client: Any, model: Optional[str], cached_default: Optional[str]) -> Optional[str]:
+    """Drop OpenRouter-format model slugs (with '/') for non-OpenRouter clients.
+
+    Mirrors the guard in resolve_provider_client() which is skipped on cache hits.
+    """
+    if model and "/" in model and not _is_openrouter_client(client):
+        return cached_default
+    return model or cached_default
+
+
 def _get_cached_client(
     provider: str,
     model: str = None,
@@ -1662,9 +1679,11 @@ def _get_cached_client(
                     _force_close_async_httpx(cached_client)
                     del _client_cache[cache_key]
                 else:
-                    return cached_client, model or cached_default
+                    effective = _compat_model(cached_client, model, cached_default)
+                    return cached_client, effective
             else:
-                return cached_client, model or cached_default
+                effective = _compat_model(cached_client, model, cached_default)
+                return cached_client, effective
     # Build outside the lock
     client, default_model = resolve_provider_client(
         provider,


### PR DESCRIPTION
## Summary

Fixes #5809

`_get_cached_client()` bypasses the model slug compatibility check in `resolve_provider_client()` on cache hits, allowing OpenRouter-format model slugs (e.g. `google/gemini-3-flash-preview`) to reach non-OpenRouter providers.

### The bug

`resolve_provider_client()` has a guard (line ~1097) that drops model slugs containing `/` when the resolved provider is not OpenRouter:

```python
if model and "/" in model and resolved and "/" not in resolved:
    model = None  # Drop incompatible slug
```

But `_get_cached_client()` returns `model or cached_default` on cache hits (lines 1665/1667) without ever calling `resolve_provider_client()`, so this guard is skipped.

**Example:** When `provider=openai-codex`, the first auxiliary call caches a `CodexAuxiliaryClient` under key `("auto", ...)`. A subsequent compression call with `model="google/gemini-3-flash-preview"` (from `config.yaml` `compression.summary_model`) hits the cache and passes the slug to the Codex API, which doesn't understand it.

### Fix

Add `_compat_model()` helper that mirrors the `/`-check from `resolve_provider_client()`, called on both sync and async cache-hit return paths. When the cached client is not OpenRouter, model slugs containing `/` are dropped in favor of the cached default.

### Testing

- 96/96 tests pass in `tests/agent/test_auxiliary_client.py`
- 5/5 tests pass in `tests/test_crossloop_client_cache.py`