### PR TITLE
feat(api): accept conversation_history in request body

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -815,9 +815,11 @@ class APIServerAdapter(BasePlatformAdapter):
         else:
             return web.json_response(_openai_error("'input' must be a string or array"), status=400)
 
-        # Reconstruct conversation history from previous_response_id
-        conversation_history: List[Dict[str, str]] = []
-        if previous_response_id:
+        # Accept conversation_history from the request body (allows external
+        # clients to supply their own history instead of relying on server-side
+        # response chaining via previous_response_id).
+        conversation_history: List[Dict[str, str]] = body.get("conversation_history", [])
+        if not conversation_history and previous_response_id:
             stored = self._response_store.get(previous_response_id)
             if stored is None:
                 return web.json_response(_openai_error(f"Previous response not found: {previous_response_id}"), status=404)
@@ -1403,8 +1405,11 @@ class APIServerAdapter(BasePlatformAdapter):
 
         instructions = body.get("instructions")
         previous_response_id = body.get("previous_response_id")
-        conversation_history: List[Dict[str, str]] = []
-        if previous_response_id:
+        # Accept conversation_history from the request body (allows external
+        # clients to supply their own history instead of relying on server-side
+        # response chaining via previous_response_id).
+        conversation_history: List[Dict[str, str]] = body.get("conversation_history", [])
+        if not conversation_history and previous_response_id:
             stored = self._response_store.get(previous_response_id)
             if stored:
                 conversation_history = list(stored.get("conversation_history", []))


### PR DESCRIPTION
## Summary

Allow external clients (native desktop apps, custom frontends) to supply their own conversation history directly in the `/v1/responses` and `/v1/runs` request bodies, instead of relying solely on server-side response chaining via `previous_response_id`.

## Motivation

Native apps that manage their own message persistence (SQLite, Core Data, etc.) already have the full conversation history client-side. Forcing them through the `previous_response_id` chain means:

1. The gateway's in-memory `_response_store` becomes a single point of failure — if the gateway restarts, all chains break
2. Clients must make an extra round-trip to establish the chain before sending the actual message
3. Stateless/load-balanced deployments can't share the in-memory store

Accepting `conversation_history` directly in the body solves all three.

## Changes

- `_handle_responses()` and `_handle_runs()` in `api_server.py` now read `body.get("conversation_history", [])` first
- Falls back to existing `previous_response_id` chain if no history is provided
- Zero breaking changes — existing clients that don't send `conversation_history` behave identically

## Testing

Tested with a native macOS SwiftUI client sending full conversation history in every request body. Confirmed:
- Multi-turn conversations maintain full context
- Streaming (`/v1/runs`) and non-streaming (`/v1/responses`) both work
- Omitting `conversation_history` preserves existing `previous_response_id` behavior