### PR TITLE
fix(security): apply provider env var blocklist to Docker environment to prevent credential leakage

### DIFF
--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -18,6 +18,7 @@ import uuid
 from typing import Optional
 
 from tools.environments.base import BaseEnvironment
+from tools.environments.local import _HERMES_PROVIDER_ENV_BLOCKLIST
 from tools.interrupt import is_interrupted
 
 logger = logging.getLogger(__name__)
@@ -510,6 +511,8 @@ class DockerEnvironment(BaseEnvironment):
             forward_keys |= get_all_passthrough()
         except Exception:
             pass
+        # Strip Hermes-managed secrets so they never leak into the container.
+        forward_keys -= _HERMES_PROVIDER_ENV_BLOCKLIST
         hermes_env = _load_hermes_env_vars() if forward_keys else {}
         for key in sorted(forward_keys):
             value = os.getenv(key)


### PR DESCRIPTION
## What does this PR do?

`tools/environments/docker.py` forwarded environment variables to Docker
containers via `forward_env` and `get_all_passthrough()` without applying
the provider credential blocklist that `local.py` already enforces.

This meant that Hermes-managed secrets like `OPENAI_API_KEY`,
`ANTHROPIC_API_KEY`, `TELEGRAM_BOT_TOKEN`, and other provider credentials
could leak into Docker containers — even when not explicitly requested —
if they were present in the host environment.

## Fix

Import `_HERMES_PROVIDER_ENV_BLOCKLIST` from `local.py` (single source
of truth) and subtract it from `forward_keys` before passing env vars
to the container:
```python
from tools.environments.local import _HERMES_PROVIDER_ENV_BLOCKLIST
# ...
forward_keys -= _HERMES_PROVIDER_ENV_BLOCKLIST
```

This ensures provider credentials are **never** forwarded to Docker
containers regardless of `docker_forward_env` or `env_passthrough`
configuration. When a new provider is added to the blocklist in
`local.py`, Docker is automatically protected too.

## Type of Change

- [x] 🔒 Security fix (credential leakage)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Single source of truth — blocklist maintained only in `local.py`
- [x] No behavior change for non-credential environment variables