### PR TITLE
fix: check credential pool in get_nous_auth_status() fallback

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1971,8 +1971,10 @@ def get_nous_auth_status() -> Dict[str, Any]:
                         "has_refresh_token": bool(getattr(entry, "refresh_token", None)),
                         "source": f"pool:{getattr(entry, 'label', 'unknown')}",
                     }
+    except ImportError:
+        logger.debug("Credential pool support is unavailable while checking Nous auth status")
     except Exception:
-        pass
+        logger.debug("Failed to inspect Nous credential pool while checking auth status", exc_info=True)
 
     return {
         "logged_in": False,

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1934,24 +1934,52 @@ def resolve_nous_runtime_credentials(
 # =============================================================================
 
 def get_nous_auth_status() -> Dict[str, Any]:
-    """Status snapshot for `hermes status` output."""
+    """Status snapshot for `hermes status` output.
+
+    Checks the legacy provider state first, then falls back to the
+    credential pool (where ``hermes auth add`` stores credentials).
+    This mirrors the approach used by ``get_codex_auth_status()``.
+    """
     state = get_provider_auth_state("nous")
-    if not state:
+    if state and state.get("access_token"):
         return {
-            "logged_in": False,
-            "portal_base_url": None,
-            "inference_base_url": None,
-            "access_expires_at": None,
-            "agent_key_expires_at": None,
-            "has_refresh_token": False,
+            "logged_in": True,
+            "portal_base_url": state.get("portal_base_url"),
+            "inference_base_url": state.get("inference_base_url"),
+            "access_expires_at": state.get("expires_at"),
+            "agent_key_expires_at": state.get("agent_key_expires_at"),
+            "has_refresh_token": bool(state.get("refresh_token")),
         }
+
+    # Fall back to credential pool — credentials added via `hermes auth add`
+    # or migrated entries live here and won't appear in the providers section.
+    try:
+        from agent.credential_pool import load_pool
+        pool = load_pool("nous")
+        if pool and pool.has_credentials():
+            entry = pool.select()
+            if entry is not None:
+                token = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
+                if token:
+                    return {
+                        "logged_in": True,
+                        "portal_base_url": getattr(entry, "portal_base_url", None),
+                        "inference_base_url": getattr(entry, "inference_base_url", None) or getattr(entry, "base_url", None),
+                        "access_expires_at": getattr(entry, "expires_at", None),
+                        "agent_key_expires_at": getattr(entry, "agent_key_expires_at", None),
+                        "has_refresh_token": bool(getattr(entry, "refresh_token", None)),
+                        "source": f"pool:{getattr(entry, 'label', 'unknown')}",
+                    }
+    except Exception:
+        pass
+
     return {
-        "logged_in": bool(state.get("access_token")),
-        "portal_base_url": state.get("portal_base_url"),
-        "inference_base_url": state.get("inference_base_url"),
-        "access_expires_at": state.get("expires_at"),
-        "agent_key_expires_at": state.get("agent_key_expires_at"),
-        "has_refresh_token": bool(state.get("refresh_token")),
+        "logged_in": False,
+        "portal_base_url": None,
+        "inference_base_url": None,
+        "access_expires_at": None,
+        "agent_key_expires_at": None,
+        "has_refresh_token": False,
     }
 
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1938,7 +1938,8 @@ def get_nous_auth_status() -> Dict[str, Any]:
 
     Checks the legacy provider state first, then falls back to the
     credential pool (where ``hermes auth add`` stores credentials).
-    This mirrors the approach used by ``get_codex_auth_status()``.
+    Like ``get_codex_auth_status()``, this consults both legacy provider
+    state and the credential pool, but not necessarily in the same order.
     """
     state = get_provider_auth_state("nous")
     if state and state.get("access_token"):

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1958,7 +1958,7 @@ def get_nous_auth_status() -> Dict[str, Any]:
         from agent.credential_pool import load_pool
         pool = load_pool("nous")
         if pool and pool.has_credentials():
-            entry = pool.select()
+            entry = pool.peek()
             if entry is not None:
                 token = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
                 if token:


### PR DESCRIPTION
## Summary

`hermes doctor` and `hermes status` report Nous Portal auth as "not logged in" even when valid credentials exist in the credential pool and `hermes auth list` correctly shows them.

## Problem

`get_nous_auth_status()` only checks the legacy `providers` section of `auth.json`. Credentials added via `hermes auth add` (or migrated into the pool) live in the `credential_pool` section and are invisible to the doctor/status checks:

```
auth.json:
  "providers": {}                    ← get_nous_auth_status() checks here (empty)
  "credential_pool": {
    "nous": [{ ...valid token... }]  ← hermes auth list checks here (has credential)
  }
```

## Fix

Add a credential pool fallback to `get_nous_auth_status()` — the same pattern already used by `get_codex_auth_status()`. When the legacy provider state is empty, it now checks the credential pool before reporting "not logged in".

## Testing

- All 104 related tests pass (`nous`, `doctor`, `credential_pool`, `auth_status`)
- All 15 `test_auth_commands` tests pass
- Verified manually: `get_nous_auth_status()` now returns `logged_in: True` with `source: pool:Hermes (VLXXLG2QGM)` for pool-stored credentials

Fixes #5807