### PR TITLE
fix(matrix): add sync timeout, callback diagnostics, and mention-drop logging

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -766,7 +766,10 @@ class MatrixAdapter(BasePlatformAdapter):
 
         while not self._closing:
             try:
-                resp = await self._client.sync(timeout=30000)
+                resp = await asyncio.wait_for(
+                    self._client.sync(timeout=30000),
+                    timeout=45.0,
+                )
                 if isinstance(resp, nio.SyncError):
                     if self._closing:
                         return
@@ -950,6 +953,13 @@ class MatrixAdapter(BasePlatformAdapter):
         """Handle incoming text messages (and decrypted megolm events)."""
         import nio
 
+        logger.debug(
+            "Matrix: callback fired — event %s from %s in %s",
+            getattr(event, "event_id", "?"),
+            getattr(event, "sender", "?"),
+            room.room_id,
+        )
+
         # Ignore own messages.
         if event.sender == self._user_id:
             return
@@ -1020,6 +1030,12 @@ class MatrixAdapter(BasePlatformAdapter):
             formatted_body = source_content.get("formatted_body")
             if require_mention and not is_free_room and not in_bot_thread:
                 if not self._is_bot_mentioned(body, formatted_body):
+                    logger.debug(
+                        "Matrix: ignoring message %s in %s — no @mention "
+                        "(set MATRIX_REQUIRE_MENTION=false to disable)",
+                        getattr(event, "event_id", "?"),
+                        room.room_id,
+                    )
                     return
 
         # Strip mention from body when present (including in DMs).
@@ -1088,6 +1104,13 @@ class MatrixAdapter(BasePlatformAdapter):
     async def _on_room_message_media(self, room: Any, event: Any) -> None:
         """Handle incoming media messages (images, audio, video, files)."""
         import nio
+
+        logger.debug(
+            "Matrix: media callback fired — event %s from %s in %s",
+            getattr(event, "event_id", "?"),
+            getattr(event, "sender", "?"),
+            room.room_id,
+        )
 
         # Ignore own messages.
         if event.sender == self._user_id:
@@ -1263,6 +1286,12 @@ class MatrixAdapter(BasePlatformAdapter):
             if require_mention and not is_free_room and not in_bot_thread:
                 formatted_body = source_content.get("formatted_body")
                 if not self._is_bot_mentioned(body, formatted_body):
+                    logger.debug(
+                        "Matrix: ignoring media event %s in %s — no @mention "
+                        "(set MATRIX_REQUIRE_MENTION=false to disable)",
+                        getattr(event, "event_id", "?"),
+                        room.room_id,
+                    )
                     return
 
         # Strip mention from body when present (including in DMs).


### PR DESCRIPTION
## Problem

  Fixes #5819.

  Users on Matrix report the bot connects and syncs historical messages but silently ignores all new messages with zero log output, even with LOG_LEVEL=DEBUG.

  ## Root Causes

  **1. No asyncio-level timeout on sync() in _sync_loop** timeout=30000 is the Matrix long-poll parameter sent to the server — not an HTTP client timeout. If the TCP connection hangs, the coroutine never returns and the sync loop stalls indefinitely with no log output.

  **2. No callback-entry logging**
  With LOG_LEVEL=DEBUG there was no way to tell whether nio was calling the callback at all vs. a filter dropping the message downstream.

  **3. MATRIX_REQUIRE_MENTION silently drops messages**
  The mention-gating filter (default: true) drops group room messages without @mention by returning with no log. Users on default config in group rooms see exactly the symptom in #5819.

  ## Changes

  - Wrap _sync_loop sync call with asyncio.wait_for(timeout=45.0)
  - Add logger.debug at entry of _on_room_message and _on_room_message_media
  - Add logger.debug when MATRIX_REQUIRE_MENTION drops a message

  ## Related

  - #3280 — SyncError backoff (merged, v2026.4.3)
  - #5829 — separate PR targeting #5819 via different root cause


