### PR TITLE
fix/slack-thread-session-key-mismatch                                                                                                                                                                                 

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -977,10 +977,9 @@ class SlackAdapter(BasePlatformAdapter):
             return False
         
         try:
-            # Build a SessionSource for this thread
-            from gateway.session import SessionSource
+            from gateway.session import SessionSource, build_session_key
             from gateway.config import Platform
-            
+
             source = SessionSource(
                 platform=Platform.SLACK,
                 chat_id=channel_id,
@@ -988,27 +987,14 @@ class SlackAdapter(BasePlatformAdapter):
                 user_id=user_id,
                 thread_id=thread_ts,
             )
-            
-            # Generate the session key using the same logic as SessionStore
-            # This mirrors the logic in build_session_key for group sessions
-            key_parts = ["agent:main", "slack", "group", channel_id, thread_ts]
-            
-            # Include user_id if group_sessions_per_user is enabled
-            # We check the session store config if available
-            group_sessions_per_user = getattr(
-                session_store, "config", {}
+
+            store_config = getattr(session_store, "config", None)
+            session_key = build_session_key(
+                source,
+                group_sessions_per_user=getattr(store_config, "group_sessions_per_user", True),
+                thread_sessions_per_user=getattr(store_config, "thread_sessions_per_user", False),
             )
-            if hasattr(group_sessions_per_user, "group_sessions_per_user"):
-                group_sessions_per_user = group_sessions_per_user.group_sessions_per_user
-            else:
-                group_sessions_per_user = True  # Default
-            
-            if group_sessions_per_user and user_id:
-                key_parts.append(str(user_id))
-            
-            session_key = ":".join(key_parts)
-            
-            # Check if the session exists in the store
+
             session_store._ensure_loaded()
             return session_key in session_store._entries
         except Exception:


### PR DESCRIPTION
## Problem                                                                                                                                                                                         
   
  Thread replies without @mention were silently ignored even when the bot had                                                                                                                               an active session in that thread.

 ## Root Cause                                                                                                                                                                                                
                                                                                                                                                                                                               
  Fixes #5816.                                                                                                                                                                                                 
                                                                                                                                                                                                               
  The bug was introduced in 4ec615b0 ("feat(gateway): Enable Slack thread replies without explicit @mentions") which added `_has_active_session_for_thread()`with a manual key construction that duplicated — but incorrectly — the logic                                                                                                                                 in `build_session_key()`.                                                                                                                                                                                    
                                                                                                                                                                                                               
  The manual implementation applied `group_sessions_per_user` correctly but                                                                                                                                   missed `thread_sessions_per_user=False` (default), which intentionally omits`user_id` for shared thread sessions:                                                                                                                                                                        
                                                                                                                                                                                                               
  Session stored under: `...channel_id:thread_ts`
  Lookup performed with: `...channel_id:thread_ts:user_id` → never matches.                                                                                                                                    
                  
  ## Fix

  Replace manual key construction with `build_session_key()` — single source                                                                                                                                   of truth, introduced in the same session infrastructure the feature was supposed to use.               