### PR TITLE
fix(api_server): preserve conversation history when /v1/runs input is a message array

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1411,6 +1411,23 @@ class APIServerAdapter(BasePlatformAdapter):
                 if instructions is None:
                     instructions = stored.get("instructions")
 
+        # When ``input`` is an array of messages (the OpenAI-style multi-turn
+        # format used by web and API clients), all messages except the final
+        # user turn represent the conversation history.  Without this block,
+        # ``run_conversation`` only receives the last message and the agent
+        # has no knowledge of anything said earlier in the session.
+        if not conversation_history and isinstance(raw_input, list) and len(raw_input) > 1:
+            for msg in raw_input[:-1]:
+                if isinstance(msg, dict) and msg.get("role") and msg.get("content"):
+                    content = msg["content"]
+                    if isinstance(content, list):
+                        # Flatten multi-part content blocks to a single string
+                        content = " ".join(
+                            part.get("text", "") for part in content
+                            if isinstance(part, dict) and part.get("type") == "text"
+                        )
+                    conversation_history.append({"role": msg["role"], "content": str(content)})
+
         session_id = body.get("session_id") or run_id
         ephemeral_system_prompt = instructions
 


### PR DESCRIPTION
## Problem

`POST /v1/runs` accepts `input` as either a plain string or an OpenAI-style array of `{role, content}` objects. When a client sends a multi-turn array, the handler extracts only the last element as `user_message` and leaves `conversation_history` empty:

```python
user_message = raw_input if isinstance(raw_input, str) else (raw_input[-1].get("content", "") ...)
```

The prior turns are silently discarded. Every run starts from a blank slate — the agent has no memory of anything said before the current message. This affects any API client or web frontend that sends the full conversation as an array on each request (the standard OpenAI-compatible pattern).

## Reproduction

```python
import requests

# Turn 1
requests.post("/v1/runs", json={"input": "My name is Alice"})

# Turn 2 — agent doesn't know the name
requests.post("/v1/runs", json={
    "input": [
        {"role": "user",      "content": "My name is Alice"},
        {"role": "assistant", "content": "Hello Alice!"},
        {"role": "user",      "content": "What is my name?"},  # agent answers "I don't know"
    ]
})
```

## Fix

When `input` is a list with more than one entry and `conversation_history` has not already been populated via `previous_response_id`, treat all items except the final user turn as conversation history before passing to `run_conversation`.

Multi-part content blocks (e.g. image attachments) are flattened to their text portions so the history remains a plain `{role, content}` dict as expected by `run_conversation`.

## Testing

Verified manually: after this change, a web client sending the full message array on each request correctly maintains context across turns — the agent can reference earlier messages in the same conversation.

No existing tests are broken. A targeted test for this path would be straightforward to add if the maintainers prefer it before merge.