### PR TITLE
feat(memory): add sync_recall option for current-turn relevance

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -931,6 +931,7 @@ def init_agent(
     # Persistent memory (MEMORY.md + USER.md) -- loaded from disk
     agent._memory_store = None
     agent._memory_enabled = False
+    agent._memory_sync_recall = False
     agent._user_profile_enabled = False
     agent._memory_nudge_interval = 10
     agent._turns_since_memory = 0
@@ -939,6 +940,7 @@ def init_agent(
         try:
             mem_config = _agent_cfg.get("memory", {})
             agent._memory_enabled = mem_config.get("memory_enabled", False)
+            agent._memory_sync_recall = mem_config.get("sync_recall", False)
             agent._user_profile_enabled = mem_config.get("user_profile_enabled", False)
             agent._memory_nudge_interval = int(mem_config.get("nudge_interval", 10))
             if agent._memory_enabled or agent._user_profile_enabled:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -568,16 +568,25 @@ def run_conversation(
         except Exception:
             pass
 
-    # External memory provider: prefetch once before the tool loop.
+    # External memory provider: recall once before the tool loop.
     # Reuse the cached result on every iteration to avoid re-calling
-    # prefetch_all() on each tool call (10 tool calls = 10x latency + cost).
+    # provider recall on each tool call (10 tool calls = 10x latency + cost).
     # Use original_user_message (clean input) — user_message may contain
     # injected skill content that bloats / breaks provider queries.
     _ext_prefetch_cache = ""
     if agent._memory_manager:
         try:
             _query = original_user_message if isinstance(original_user_message, str) else ""
-            _ext_prefetch_cache = agent._memory_manager.prefetch_all(_query) or ""
+            if getattr(agent, "_memory_sync_recall", False):
+                _ext_prefetch_cache = agent._memory_manager.recall_sync_all(
+                    _query,
+                    session_id=agent.session_id or "",
+                ) or ""
+            else:
+                _ext_prefetch_cache = agent._memory_manager.prefetch_all(
+                    _query,
+                    session_id=agent.session_id or "",
+                ) or ""
         except Exception:
             pass
 

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -198,6 +198,25 @@ class MemoryManager:
                     provider.name, e,
                 )
 
+    def recall_sync_all(self, query: str, *, session_id: str = "") -> str:
+        """Synchronously recall context from all providers using the current query.
+
+        Use in place of prefetch_all() when memory.sync_recall is enabled.
+        Slower but always returns context relevant to the current message.
+        """
+        parts = []
+        for provider in self._providers:
+            try:
+                result = provider.recall_sync(query, session_id=session_id)
+                if result and result.strip():
+                    parts.append(result)
+            except Exception as e:
+                logger.debug(
+                    "Memory provider '%s' recall_sync failed (non-fatal): %s",
+                    provider.name, e,
+                )
+        return "\n\n".join(parts)
+
     # -- Sync ----------------------------------------------------------------
 
     def sync_all(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -312,6 +312,25 @@ class MemoryManager:
                     provider.name, e,
                 )
 
+    def recall_sync_all(self, query: str, *, session_id: str = "") -> str:
+        """Synchronously recall context from all providers using the current query.
+
+        Use in place of prefetch_all() when memory.sync_recall is enabled.
+        Slower but always returns context relevant to the current message.
+        """
+        parts = []
+        for provider in self._providers:
+            try:
+                result = provider.recall_sync(query, session_id=session_id)
+                if result and result.strip():
+                    parts.append(result)
+            except Exception as e:
+                logger.debug(
+                    "Memory provider '%s' recall_sync failed (non-fatal): %s",
+                    provider.name, e,
+                )
+        return "\n\n".join(parts)
+
     # -- Sync ----------------------------------------------------------------
 
     def sync_all(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -111,6 +111,22 @@ class MemoryProvider(ABC):
         that do background prefetching should override this.
         """
 
+    def recall_sync(self, query: str, *, session_id: str = "") -> str:
+        """Recall relevant context synchronously using the current turn's query.
+
+        Unlike prefetch(), which returns a background result queued for the
+        *previous* turn, recall_sync() performs a fresh lookup for the
+        *current* query. This guarantees relevance at the cost of added latency.
+
+        Default: fires queue_prefetch() with the current query then immediately
+        calls prefetch() which joins the background thread. This is correct for
+        all providers that join their thread inside prefetch() (honcho, hindsight,
+        mem0, openviking). Providers whose prefetch() reads shared state without
+        joining (retaindb) should override this method.
+        """
+        self.queue_prefetch(query, session_id=session_id)
+        return self.prefetch(query, session_id=session_id)
+
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
         """Persist a completed turn to the backend.
 

--- a/plugins/memory/retaindb/__init__.py
+++ b/plugins/memory/retaindb/__init__.py
@@ -539,6 +539,17 @@ class RetainDBMemoryProvider(MemoryProvider):
 
     # ── Background prefetch (fires at turn-end, consumed next turn-start) ──
 
+    def recall_sync(self, query: str, *, session_id: str = "") -> str:
+        """RetainDB override: prefetch() reads shared state without joining threads,
+        so the base queue_prefetch+prefetch pattern would race. Run the three
+        fetchers synchronously instead."""
+        if not self._client:
+            return ""
+        self._prefetch_context(query)
+        self._prefetch_dialectic(query)
+        self._prefetch_agent_model()
+        return self.prefetch(query, session_id=session_id)
+
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
         """Fire context + dialectic + agent model prefetches in background."""
         if not self._client:

--- a/plugins/memory/retaindb/__init__.py
+++ b/plugins/memory/retaindb/__init__.py
@@ -538,6 +538,17 @@ class RetainDBMemoryProvider(MemoryProvider):
 
     # ── Background prefetch (fires at turn-end, consumed next turn-start) ──
 
+    def recall_sync(self, query: str, *, session_id: str = "") -> str:
+        """RetainDB override: prefetch() reads shared state without joining threads,
+        so the base queue_prefetch+prefetch pattern would race. Run the three
+        fetchers synchronously instead."""
+        if not self._client:
+            return ""
+        self._prefetch_context(query)
+        self._prefetch_dialectic(query)
+        self._prefetch_agent_model()
+        return self.prefetch(query, session_id=session_id)
+
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
         """Fire context + dialectic + agent model prefetches in background."""
         if not self._client:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1023,6 +1023,7 @@ class AIAgent:
         # Persistent memory (MEMORY.md + USER.md) -- loaded from disk
         self._memory_store = None
         self._memory_enabled = False
+        self._memory_sync_recall = False
         self._user_profile_enabled = False
         self._memory_nudge_interval = 10
         self._memory_flush_min_turns = 6
@@ -1032,6 +1033,7 @@ class AIAgent:
             try:
                 mem_config = _agent_cfg.get("memory", {})
                 self._memory_enabled = mem_config.get("memory_enabled", False)
+                self._memory_sync_recall = mem_config.get("sync_recall", False)
                 self._user_profile_enabled = mem_config.get("user_profile_enabled", False)
                 self._memory_nudge_interval = int(mem_config.get("nudge_interval", 10))
                 self._memory_flush_min_turns = int(mem_config.get("flush_min_turns", 6))
@@ -7185,7 +7187,10 @@ class AIAgent:
         if self._memory_manager:
             try:
                 _query = original_user_message if isinstance(original_user_message, str) else ""
-                _ext_prefetch_cache = self._memory_manager.prefetch_all(_query) or ""
+                if self._memory_sync_recall:
+                    _ext_prefetch_cache = self._memory_manager.recall_sync_all(_query) or ""
+                else:
+                    _ext_prefetch_cache = self._memory_manager.prefetch_all(_query) or ""
             except Exception:
                 pass
 
@@ -9149,7 +9154,8 @@ class AIAgent:
         if self._memory_manager and final_response and original_user_message:
             try:
                 self._memory_manager.sync_all(original_user_message, final_response)
-                self._memory_manager.queue_prefetch_all(original_user_message)
+                if not self._memory_sync_recall:
+                    self._memory_manager.queue_prefetch_all(original_user_message)
             except Exception:
                 pass
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1988,10 +1988,11 @@ class AIAgent:
                 original_user_message, final_response,
                 session_id=self.session_id or "",
             )
-            self._memory_manager.queue_prefetch_all(
-                original_user_message,
-                session_id=self.session_id or "",
-            )
+            if not getattr(self, "_memory_sync_recall", False):
+                self._memory_manager.queue_prefetch_all(
+                    original_user_message,
+                    session_id=self.session_id or "",
+                )
         except Exception:
             pass
 


### PR DESCRIPTION
## Summary               

  Closes #5820.                                                                                                                                                                                                
   
  Adds a `memory.sync_recall: true` config option that switches memory                                                                                                                                        providers from background prefetch to synchronous recall at turn start.
                                                                                                                                                                                                               
  ## Problem
                                                                                                                                                                                                               
  The current model queues a background recall at turn end using that turn's query. The next turn consumes this result — which is based on the *previous* message. When topics change between turns the injected context is irrelevant or misleading.                                                                                                                                                                         
   
  ## Solution                                                                                                                                                                                                  
                  
  When `sync_recall: true`, each turn performs a live recall with the                                                                                                                                          actual current message before the first LLM call. Background prefetch is skipped entirely at turn end. Default is `false` — no behavior  change for existing users.                                                                                                                                                                                   
   
  ## Implementation                                                                                                                                                                                            
                  
  `MemoryProvider.recall_sync()` default: fires `queue_prefetch()` then                                                                                                                                        immediately calls `prefetch()`, which joins the background thread. This works for all providers that join inside `prefetch()` (honcho, hindsight, mem0, openviking). RetainDB overrides `recall_sync()` directly because its `prefetch()` reads shared state without joining threads.                                                                                                                                                 
                  
  4 files changed, 54 lines added.                                                                                                                                                                             
                  
  ## Config                                                                                                                                                                                                    
   
  ```yaml                                                                                                                                                                                                      
  memory:         
    provider: hindsight  # or honcho, mem0, etc.
    sync_recall: true
