### PR TITLE
feat(delegation): surface subagent tool progress through SSE and gateway callbacks

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1349,7 +1349,18 @@ class APIServerAdapter(BasePlatformAdapter):
                     "timestamp": ts,
                     "text": preview or "",
                 })
-            # _thinking and subagent_progress are intentionally not forwarded
+            elif event_type == "subagent_progress":
+                # Forward each child-agent tool call as a structured SSE event so
+                # API consumers (web UIs, integrations) can surface delegation
+                # activity in real time without polling or scraping log output.
+                _push({
+                    "event": "subagent.progress",
+                    "run_id": run_id,
+                    "timestamp": ts,
+                    "tool": tool_name or "",
+                    "preview": preview or tool_name or "",
+                })
+            # _thinking is intentionally not forwarded (too noisy for chat)
 
         return _callback
 

--- a/tests/agent/test_subagent_progress.py
+++ b/tests/agent/test_subagent_progress.py
@@ -120,26 +120,25 @@ class TestBuildChildProgressCallback:
         assert "💭" in output
         assert "search for papers" in output
 
-    def test_gateway_batched_progress(self):
-        """Gateway path should batch tool calls and flush at BATCH_SIZE."""
+    def test_gateway_immediate_relay(self):
+        """Gateway path should relay each tool call immediately (no batching)."""
         parent = MagicMock()
         parent._delegate_spinner = None
         parent_cb = MagicMock()
         parent.tool_progress_callback = parent_cb
-        
+
         cb = _build_child_progress_callback(0, parent)
-        
-        # Send 4 tool calls — shouldn't flush yet (BATCH_SIZE = 5)
+
+        # Each tool.started fires immediately — 4 calls → 4 relays
         for i in range(4):
             cb("tool.started", f"tool_{i}", f"arg_{i}", {})
-        parent_cb.assert_not_called()
-        
-        # 5th call should trigger flush
-        cb("tool.started", "tool_4", "arg_4", {})
-        parent_cb.assert_called_once()
-        call_args = parent_cb.call_args
-        assert "tool_0" in call_args[0][1]
-        assert "tool_4" in call_args[0][1]
+
+        assert parent_cb.call_count == 4
+        # Each call uses subagent_progress with the raw tool name
+        first_call = parent_cb.call_args_list[0]
+        assert first_call[0][0] == "subagent_progress"
+        assert first_call[0][1] == "tool_0"
+        assert first_call[0][2] == "arg_0"
 
     def test_thinking_not_relayed_to_gateway(self):
         """Thinking events should NOT be sent to gateway (too noisy)."""
@@ -154,21 +153,34 @@ class TestBuildChildProgressCallback:
         parent_cb.assert_not_called()
 
     def test_parallel_callbacks_independent(self):
-        """Each child's callback should have independent batch state."""
+        """Each child's callback should be an independent closure (no shared state)."""
         parent = MagicMock()
         parent._delegate_spinner = None
-        parent_cb = MagicMock()
-        parent.tool_progress_callback = parent_cb
-        
-        cb0 = _build_child_progress_callback(0, parent)
-        cb1 = _build_child_progress_callback(1, parent)
-        
-        # Send 3 calls to each — neither should flush (batch size = 5)
-        for i in range(3):
-            cb0(f"tool_{i}")
-            cb1(f"other_{i}")
-        
-        parent_cb.assert_not_called()
+
+        calls_0, calls_1 = [], []
+        parent.tool_progress_callback = lambda *a, **kw: None  # dummy
+
+        # Give each child its own tracking list via separate parents
+        parent0 = MagicMock()
+        parent0._delegate_spinner = None
+        parent0.tool_progress_callback = lambda *a, **kw: calls_0.append(a)
+
+        parent1 = MagicMock()
+        parent1._delegate_spinner = None
+        parent1.tool_progress_callback = lambda *a, **kw: calls_1.append(a)
+
+        cb0 = _build_child_progress_callback(0, parent0, task_count=2)
+        cb1 = _build_child_progress_callback(1, parent1, task_count=2)
+
+        cb0("tool.started", "tool_a", "preview_a")
+        cb1("tool.started", "tool_b", "preview_b")
+        cb0("tool.started", "tool_c", "preview_c")
+
+        # cb0 fired twice, cb1 fired once — independent
+        assert len(calls_0) == 2
+        assert len(calls_1) == 1
+        assert calls_0[0][1] == "tool_a"
+        assert calls_1[0][1] == "tool_b"
 
     def test_task_index_prefix_in_batch_mode(self):
         """Batch mode (task_count > 1) should show 1-indexed prefix for all tasks."""
@@ -320,8 +332,9 @@ class TestThinkingCallback:
 class TestBatchFlush:
     """Tests for gateway batch flush on subagent completion."""
 
-    def test_flush_sends_remaining_batch(self):
-        """_flush should send remaining tool names to gateway."""
+    def test_flush_is_noop_events_already_relayed(self):
+        """_flush is a no-op because each event is forwarded immediately.
+        All three tool calls should already be relayed before _flush is called."""
         parent = MagicMock()
         parent._delegate_spinner = None
         parent_cb = MagicMock()
@@ -329,18 +342,16 @@ class TestBatchFlush:
 
         cb = _build_child_progress_callback(0, parent)
 
-        # Send 3 tools (below batch size of 5)
         cb("tool.started", "web_search", "query1", {})
         cb("tool.started", "read_file", "file.txt", {})
         cb("tool.started", "write_file", "out.txt", {})
-        parent_cb.assert_not_called()
 
-        # Flush should send the remaining 3
+        # All 3 relayed immediately
+        assert parent_cb.call_count == 3
+
+        # _flush adds nothing
         cb._flush()
-        parent_cb.assert_called_once()
-        summary = parent_cb.call_args[0][1]
-        assert "web_search" in summary
-        assert "write_file" in summary
+        assert parent_cb.call_count == 3
 
     def test_flush_noop_when_batch_empty(self):
         """_flush should not send anything when batch is empty."""

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -10,6 +10,7 @@ Tests cover:
 - /health endpoint
 - System prompt extraction
 - Error handling (invalid JSON, missing fields)
+- _make_run_event_callback SSE event dispatch (incl. subagent.progress)
 """
 
 import json
@@ -1683,3 +1684,85 @@ class TestSessionIdHeader:
             call_kwargs = mock_run.call_args.kwargs
             assert call_kwargs["conversation_history"] == []
             assert call_kwargs["session_id"] == "some-session"
+            assert call_kwargs["session_id"] == "some-session"
+
+
+# ---------------------------------------------------------------------------
+# _make_run_event_callback — SSE event dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestMakeRunEventCallback:
+    """_make_run_event_callback pushes the correct structured event for each
+    event_type, including the new subagent.progress event added in
+    feat/subagent-progress-events-in-sse."""
+
+    def _make_callback(self, run_id="run_test"):
+        """Return (callback, captured_events) using a synchronous fake loop."""
+        adapter = _make_adapter()
+        captured = []
+
+        # Fake asyncio queue: put_nowait appends to `captured`
+        from unittest.mock import MagicMock
+        fake_q = MagicMock()
+        fake_q.put_nowait.side_effect = captured.append
+        adapter._run_streams = {run_id: fake_q}
+
+        # Fake loop: call_soon_threadsafe executes the callable immediately
+        fake_loop = MagicMock()
+        fake_loop.call_soon_threadsafe.side_effect = lambda fn, arg: fn(arg)
+
+        cb = adapter._make_run_event_callback(run_id, fake_loop)
+        return cb, captured
+
+    def test_tool_started_event(self):
+        cb, events = self._make_callback()
+        cb("tool.started", tool_name="read_file", preview="reading main.py")
+        assert len(events) == 1
+        ev = events[0]
+        assert ev["event"] == "tool.started"
+        assert ev["tool"] == "read_file"
+        assert ev["preview"] == "reading main.py"
+        assert "run_id" in ev and "timestamp" in ev
+
+    def test_tool_completed_event(self):
+        cb, events = self._make_callback()
+        cb("tool.completed", tool_name="read_file", duration=0.42, is_error=False)
+        assert len(events) == 1
+        ev = events[0]
+        assert ev["event"] == "tool.completed"
+        assert ev["tool"] == "read_file"
+        assert ev["duration"] == 0.42
+        assert ev["error"] is False
+
+    def test_subagent_progress_event(self):
+        """subagent.progress is emitted with clean tool name (no prefix)."""
+        cb, events = self._make_callback()
+        cb("subagent_progress", tool_name="bash", preview="running tests")
+        assert len(events) == 1
+        ev = events[0]
+        assert ev["event"] == "subagent.progress"
+        assert ev["tool"] == "bash"
+        assert ev["preview"] == "running tests"
+        assert "run_id" in ev and "timestamp" in ev
+
+    def test_subagent_progress_preview_falls_back_to_tool_name(self):
+        """preview falls back to tool_name when not provided."""
+        cb, events = self._make_callback()
+        cb("subagent_progress", tool_name="write_file", preview="")
+        assert events[0]["preview"] == "write_file"
+
+    def test_thinking_not_forwarded(self):
+        """_thinking events must not produce any SSE output."""
+        cb, events = self._make_callback()
+        cb("_thinking", preview="internal monologue")
+        assert events == []
+
+    def test_unknown_run_id_is_silent(self):
+        """Callback for an evicted run_id must not raise."""
+        adapter = _make_adapter()
+        adapter._run_streams = {}  # run already cleaned up
+        fake_loop = MagicMock()
+        cb = adapter._make_run_event_callback("run_gone", fake_loop)
+        cb("subagent_progress", tool_name="bash", preview="x")  # must not raise
+        fake_loop.call_soon_threadsafe.assert_not_called()

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -24,6 +24,7 @@ from tools.delegate_tool import (
     check_delegate_requirements,
     delegate_task,
     _build_child_agent,
+    _build_child_progress_callback,
     _build_child_system_prompt,
     _strip_blocked_tools,
     _resolve_child_credential_pool,
@@ -1050,6 +1051,85 @@ class TestChildCredentialLeasing(unittest.TestCase):
 
         self.assertEqual(result["status"], "error")
         child._credential_pool.release_lease.assert_called_once_with("cred-a")
+
+
+class TestBuildChildProgressCallback(unittest.TestCase):
+    """_build_child_progress_callback relays tool events to the parent callback
+    immediately (no batching), and passes a clean tool name without any
+    display prefix."""
+
+    def _make_parent_with_cb(self):
+        parent = _make_mock_parent()
+        received = []
+        parent.tool_progress_callback = lambda *a, **kw: received.append((a, kw))
+        parent._delegate_spinner = None  # disable spinner path
+        return parent, received
+
+    def test_returns_none_when_no_display_mechanism(self):
+        parent = _make_mock_parent()
+        parent.tool_progress_callback = None
+        parent._delegate_spinner = None
+        assert _build_child_progress_callback(0, parent, task_count=1) is None
+
+    def test_tool_started_relayed_immediately(self):
+        parent, received = self._make_parent_with_cb()
+        cb = _build_child_progress_callback(0, parent, task_count=1)
+        cb("tool.started", tool_name="bash", preview="echo hi")
+        assert len(received) == 1
+        args, _ = received[0]
+        assert args[0] == "subagent_progress"
+        assert args[1] == "bash"      # clean name, no prefix
+        assert args[2] == "echo hi"
+
+    def test_tool_name_has_no_batch_prefix_single_task(self):
+        """Single-task mode: tool field must not start with '[1] '."""
+        parent, received = self._make_parent_with_cb()
+        cb = _build_child_progress_callback(0, parent, task_count=1)
+        cb("tool.started", tool_name="read_file", preview="reading main.py")
+        tool_arg = received[0][0][1]
+        assert not tool_arg.startswith("[")
+
+    def test_tool_name_has_no_batch_prefix_multi_task(self):
+        """Multi-task mode: SSE tool field is still the raw name, no '[N] ' prefix."""
+        parent, received = self._make_parent_with_cb()
+        cb = _build_child_progress_callback(1, parent, task_count=3)
+        cb("tool.started", tool_name="write_file", preview="saving output.txt")
+        tool_arg = received[0][0][1]
+        assert tool_arg == "write_file"
+
+    def test_each_event_relayed_without_batching(self):
+        """Five rapid tool.started events must each produce one relay call."""
+        parent, received = self._make_parent_with_cb()
+        cb = _build_child_progress_callback(0, parent, task_count=1)
+        for i in range(5):
+            cb("tool.started", tool_name=f"tool_{i}", preview=f"step {i}")
+        assert len(received) == 5
+
+    def test_tool_completed_not_relayed(self):
+        parent, received = self._make_parent_with_cb()
+        cb = _build_child_progress_callback(0, parent, task_count=1)
+        cb("tool.completed", tool_name="bash")
+        assert received == []
+
+    def test_thinking_not_relayed(self):
+        parent, received = self._make_parent_with_cb()
+        cb = _build_child_progress_callback(0, parent, task_count=1)
+        cb("_thinking", preview="some internal monologue")
+        assert received == []
+
+    def test_flush_is_noop(self):
+        parent, received = self._make_parent_with_cb()
+        cb = _build_child_progress_callback(0, parent, task_count=1)
+        cb._flush()  # must not raise and must not emit anything
+        assert received == []
+
+    def test_callback_error_is_swallowed(self):
+        parent = _make_mock_parent()
+        parent.tool_progress_callback = MagicMock(side_effect=RuntimeError("oops"))
+        parent._delegate_spinner = None
+        cb = _build_child_progress_callback(0, parent, task_count=1)
+        # Must not propagate exception to the child agent
+        cb("tool.started", tool_name="bash", preview="x")
 
 
 if __name__ == "__main__":

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -168,10 +168,10 @@ def _build_child_progress_callback(task_index: int, parent_agent, task_count: in
         if parent_cb:
             # Relay immediately so gateway/SSE consumers see each tool call in
             # real time rather than waiting for a batch of N to accumulate.
-            # Pass ``preview`` as the third positional arg so the gateway
-            # callback can surface the richer label instead of just the name.
+            # Pass the raw tool_name (no prefix) so the SSE `tool` field stays
+            # machine-readable; preview carries the human-readable label.
             try:
-                parent_cb("subagent_progress", f"{prefix}{tool_name or ''}", preview or "")
+                parent_cb("subagent_progress", tool_name or "", preview or "")
             except Exception as e:
                 logger.debug("Parent callback failed: %s", e)
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -132,10 +132,6 @@ def _build_child_progress_callback(task_index: int, parent_agent, task_count: in
     # Show 1-indexed prefix only in batch mode (multiple tasks)
     prefix = f"[{task_index + 1}] " if task_count > 1 else ""
 
-    # Gateway: batch tool names, flush periodically
-    _BATCH_SIZE = 5
-    _batch: List[str] = []
-
     def _callback(event_type: str, tool_name: str = None, preview: str = None, args=None, **kwargs):
         # event_type is one of: "tool.started", "tool.completed",
         # "reasoning.available", "_thinking", "subagent_progress"
@@ -156,7 +152,7 @@ def _build_child_progress_callback(task_index: int, parent_agent, task_count: in
         if event_type == "tool.completed":
             return
 
-        # tool.started — display and batch for parent relay
+        # tool.started — display and relay to parent immediately
         if spinner:
             short = (preview[:35] + "...") if preview and len(preview) > 35 else (preview or "")
             from agent.display import get_tool_emoji
@@ -170,24 +166,18 @@ def _build_child_progress_callback(task_index: int, parent_agent, task_count: in
                 logger.debug("Spinner print_above failed: %s", e)
 
         if parent_cb:
-            _batch.append(tool_name or "")
-            if len(_batch) >= _BATCH_SIZE:
-                summary = ", ".join(_batch)
-                try:
-                    parent_cb("subagent_progress", f"🔀 {prefix}{summary}")
-                except Exception as e:
-                    logger.debug("Parent callback failed: %s", e)
-                _batch.clear()
+            # Relay immediately so gateway/SSE consumers see each tool call in
+            # real time rather than waiting for a batch of N to accumulate.
+            # Pass ``preview`` as the third positional arg so the gateway
+            # callback can surface the richer label instead of just the name.
+            try:
+                parent_cb("subagent_progress", f"{prefix}{tool_name or ''}", preview or "")
+            except Exception as e:
+                logger.debug("Parent callback failed: %s", e)
 
     def _flush():
-        """Flush remaining batched tool names to gateway on completion."""
-        if parent_cb and _batch:
-            summary = ", ".join(_batch)
-            try:
-                parent_cb("subagent_progress", f"🔀 {prefix}{summary}")
-            except Exception as e:
-                logger.debug("Parent callback flush failed: %s", e)
-            _batch.clear()
+        """No-op: each event is forwarded immediately, nothing is buffered."""
+        pass
 
     _callback._flush = _flush
     return _callback


### PR DESCRIPTION
## Status

Superseded by the current delegation lifecycle behavior. Lifecycle visibility landed through #72406; per-tool streaming was intentionally excluded to avoid excessive event noise.

## Original scope

Proposed forwarding child-agent tool progress through the Runs SSE stream.
