### PR TITLE
feat(tools): add "no_mcp" sentinel to exclude MCP servers per platform

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -570,6 +570,7 @@ def _get_platform_tools(
     # MCP servers are expected to be available on all platforms by default.
     # If the platform explicitly lists one or more MCP server names, treat that
     # as an allowlist. Otherwise include every globally enabled MCP server.
+    # Special sentinel: "no_mcp" in the toolset list disables all MCP servers.
     mcp_servers = config.get("mcp_servers") or {}
     enabled_mcp_servers = {
         name
@@ -577,10 +578,15 @@ def _get_platform_tools(
         if isinstance(server_cfg, dict)
         and _parse_enabled_flag(server_cfg.get("enabled", True), default=True)
     }
-    explicit_mcp_servers = explicit_passthrough & enabled_mcp_servers
-    enabled_toolsets.update(explicit_passthrough - enabled_mcp_servers)
+    # Allow "no_mcp" sentinel to opt out of all MCP servers for this platform
+    if "no_mcp" in toolset_names:
+        explicit_mcp_servers = set()
+        enabled_toolsets.update(explicit_passthrough - enabled_mcp_servers - {"no_mcp"})
+    else:
+        explicit_mcp_servers = explicit_passthrough & enabled_mcp_servers
+        enabled_toolsets.update(explicit_passthrough - enabled_mcp_servers)
     if include_default_mcp_servers:
-        if explicit_mcp_servers:
+        if explicit_mcp_servers or "no_mcp" in toolset_names:
             enabled_toolsets.update(explicit_mcp_servers)
         else:
             enabled_toolsets.update(enabled_mcp_servers)

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -72,6 +72,45 @@ def test_get_platform_tools_keeps_enabled_mcp_servers_with_explicit_builtin_sele
     assert "web-search-prime" in enabled
 
 
+def test_get_platform_tools_no_mcp_sentinel_excludes_all_mcp_servers():
+    """The 'no_mcp' sentinel in platform_toolsets excludes all MCP servers."""
+    config = {
+        "platform_toolsets": {"cli": ["web", "terminal", "no_mcp"]},
+        "mcp_servers": {
+            "exa": {"url": "https://mcp.exa.ai/mcp"},
+            "web-search-prime": {"url": "https://api.z.ai/api/mcp/web_search_prime/mcp"},
+        },
+    }
+
+    enabled = _get_platform_tools(config, "cli")
+
+    assert "web" in enabled
+    assert "terminal" in enabled
+    assert "exa" not in enabled
+    assert "web-search-prime" not in enabled
+    assert "no_mcp" not in enabled
+
+
+def test_get_platform_tools_no_mcp_sentinel_does_not_affect_other_platforms():
+    """The 'no_mcp' sentinel only affects the platform it's configured on."""
+    config = {
+        "platform_toolsets": {
+            "api_server": ["web", "terminal", "no_mcp"],
+        },
+        "mcp_servers": {
+            "exa": {"url": "https://mcp.exa.ai/mcp"},
+        },
+    }
+
+    # api_server should exclude MCP
+    api_enabled = _get_platform_tools(config, "api_server")
+    assert "exa" not in api_enabled
+
+    # cli (not configured with no_mcp) should include MCP
+    cli_enabled = _get_platform_tools(config, "cli")
+    assert "exa" in cli_enabled
+
+
 def test_toolset_has_keys_for_vision_accepts_codex_auth(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     (tmp_path / "auth.json").write_text(


### PR DESCRIPTION
## What does this PR do?

Adds a `no_mcp` sentinel value for `platform_toolsets` configuration. When present in a platform's toolset list, all MCP servers are excluded for that platform. Other platforms are unaffected.

**Problem:** MCP servers are included on all platforms by default. There is no way to opt a platform out of MCP servers entirely. When using the API server as an execution backend for automated pipelines (e.g., n8n workflows spawning Hermes agents for each pipeline step), every agent session gets the full MCP tool schema injected — inflating prompt tokens from ~9K to ~57K and doubling response times.

**Solution:** A simple sentinel value `no_mcp` that triggers the existing explicit-allowlist code path with an empty set.

```yaml
platform_toolsets:
  api_server:
    - terminal
    - file
    - web
    - no_mcp    # exclude all MCP servers for this platform
```

## Related Issue

N/A — discovered while building n8n → Hermes automation pipelines where each pipeline step spawns an agent via the API server.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/tools_config.py`: Added `no_mcp` sentinel check in `_get_platform_tools()`. When present in the toolset list, sets `explicit_mcp_servers` to empty and skips default MCP server injection. The sentinel is filtered out of the final toolset.
- `tests/hermes_cli/test_tools_config.py`: Two new tests — one verifying MCP exclusion works, one verifying it does not affect other platforms.

## How to Test

1. Add MCP servers to `config.yaml`
2. Add `no_mcp` to a platform's toolset list: `platform_toolsets: { api_server: [terminal, web, no_mcp] }`
3. Hit the API server — MCP tools should not be available
4. Use CLI or other platforms — MCP tools should still be present
5. Run tests: `pytest tests/hermes_cli/test_tools_config.py -v` (21 passed)

## Checklist

- [x] Contributing guide read
- [x] Conventional commits
- [x] No duplicate PRs
- [x] Focused single change
- [x] Tests pass (`pytest tests/hermes_cli/test_tools_config.py` — 21 passed)
- [x] Tests added (2 new tests)
- [x] Tested on Ubuntu 24.04
- [x] Cross-platform safe (pure Python dict logic, no OS dependency)