### PR TITLE
fix(cli): map Shift+Enter newline sequence

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -77,6 +77,8 @@ _hermes_home = get_hermes_home()
 _project_env = Path(__file__).parent / '.env'
 load_hermes_dotenv(hermes_home=_hermes_home, project_env=_project_env)
 
+_XTERM_SHIFT_ENTER_SEQUENCE = "\x1b[27;2;13~"  # xterm-style CSI for Shift+Enter when modifiers are encoded
+
 
 # =============================================================================
 # Configuration Loading
@@ -175,6 +177,20 @@ def _get_chrome_debug_candidates(system: str) -> list[str]:
         )
 
     return candidates
+
+
+def _enable_shift_enter_newline_support() -> bool:
+    """Shift-Enter terminals should reuse the existing newline handler."""
+    try:
+        from prompt_toolkit.input.ansi_escape_sequences import ANSI_SEQUENCES
+        from prompt_toolkit.keys import Keys
+    except Exception:
+        return False
+
+    if ANSI_SEQUENCES.get(_XTERM_SHIFT_ENTER_SEQUENCE) == Keys.ControlM:
+        ANSI_SEQUENCES[_XTERM_SHIFT_ENTER_SEQUENCE] = Keys.ControlJ
+
+    return ANSI_SEQUENCES.get(_XTERM_SHIFT_ENTER_SEQUENCE) == Keys.ControlJ
 
 
 def load_cli_config() -> Dict[str, Any]:
@@ -7056,7 +7072,9 @@ class HermesCLI:
                             f"— command scanning will use pattern matching only{_RST}")
         except Exception:
             pass  # Non-fatal — fail-open at scan time if unavailable
-        
+
+        _enable_shift_enter_newline_support()
+
         # Key bindings for the input area
         kb = KeyBindings()
         

--- a/tests/test_cli_shift_enter.py
+++ b/tests/test_cli_shift_enter.py
@@ -1,0 +1,34 @@
+from prompt_toolkit.input import ansi_escape_sequences
+from prompt_toolkit.input.vt100_parser import Vt100Parser
+from prompt_toolkit.keys import Keys
+
+import cli as cli_mod
+
+
+def test_shift_enter_sequence_remaps_to_newline(monkeypatch):
+    """Ensure the CSI 27;2;13~ sequence gets remapped to the newline handler."""
+    monkeypatch.setitem(
+        ansi_escape_sequences.ANSI_SEQUENCES,
+        cli_mod._XTERM_SHIFT_ENTER_SEQUENCE,
+        Keys.ControlM,
+    )
+
+    assert cli_mod._enable_shift_enter_newline_support() is True
+    assert (
+        ansi_escape_sequences.ANSI_SEQUENCES[cli_mod._XTERM_SHIFT_ENTER_SEQUENCE]
+        == Keys.ControlJ
+    )
+
+    seen = []
+    parser = Vt100Parser(seen.append)
+    parser.feed_and_flush(cli_mod._XTERM_SHIFT_ENTER_SEQUENCE)
+
+    assert [keypress.key for keypress in seen] == [Keys.ControlJ]
+
+
+def test_regular_enter_still_submits():
+    """Plain Enter should remain mapped to ControlM/submit."""
+    seen = []
+    parser = Vt100Parser(seen.append)
+    parser.feed_and_flush("\r")
+    assert [keypress.key for keypress in seen] == [Keys.ControlM]

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -102,7 +102,7 @@ Type `/` to see an autocomplete dropdown of all commands:
 
 ### Multi-line input
 
-Press `Alt+Enter` or `Ctrl+J` to add a new line. Great for pasting code or writing detailed prompts.
+Press `Shift+Enter` to add a new line when your terminal supports it, with `Alt+Enter` and `Ctrl+J` as dependable fallbacks for pasting code or writing detailed prompts.
 
 ### Interrupt the agent
 

--- a/website/docs/guides/tips.md
+++ b/website/docs/guides/tips.md
@@ -36,7 +36,7 @@ Before writing a long prompt explaining how to do something, check if there's al
 
 ### Multi-Line Input
 
-Press **Alt+Enter** (or **Ctrl+J**) to insert a newline without sending. This lets you compose multi-line prompts, paste code blocks, or structure complex requests before hitting Enter to send.
+Press **Shift+Enter** when your terminal supports it, with **Alt+Enter** and **Ctrl+J** as reliable fallbacks, to insert a newline without sending. This lets you compose multi-line prompts, paste code blocks, or structure complex requests before hitting Enter to send.
 
 ### Paste Detection
 

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -88,7 +88,7 @@ When resuming a previous session (`hermes -c` or `hermes --resume <id>`), a "Pre
 | Key | Action |
 |-----|--------|
 | `Enter` | Send message |
-| `Alt+Enter` or `Ctrl+J` | New line (multi-line input) |
+| `Shift+Enter`, `Alt+Enter`, or `Ctrl+J` | New line (multi-line input). `Shift+Enter` depends on terminal support; `Alt+Enter` and `Ctrl+J` stay as portable fallbacks. |
 | `Alt+V` | Paste an image from the clipboard when supported by the terminal |
 | `Ctrl+V` | Paste text and opportunistically attach clipboard images |
 | `Ctrl+B` | Start/stop voice recording when voice mode is enabled (`voice.record_key`, default: `ctrl+b`) |
@@ -191,7 +191,7 @@ personalities:
 
 There are two ways to enter multi-line messages:
 
-1. **`Alt+Enter` or `Ctrl+J`** — inserts a new line
+1. **`Shift+Enter`, `Alt+Enter`, or `Ctrl+J`** — inserts a new line. `Shift+Enter` works where the terminal exposes it; `Alt+Enter`/`Ctrl+J` keep working everywhere.
 2. **Backslash continuation** — end a line with `\` to continue:
 
 ```
@@ -201,7 +201,7 @@ There are two ways to enter multi-line messages:
 ```
 
 :::info
-Pasting multi-line text is supported — use `Alt+Enter` or `Ctrl+J` to insert newlines, or simply paste content directly.
+Pasting multi-line text is supported — use `Shift+Enter` when your terminal surfaces it, or rely on `Alt+Enter` / `Ctrl+J` as reliable fallbacks. You can also paste content directly.
 :::
 
 ## Interrupting the Agent


### PR DESCRIPTION
## What does this PR do?

Small fix to support SHIFT+ENTER by handling the xterm-style CSI `^[ [27;2;13~`

## Related Issue

Fixes https://github.com/NousResearch/hermes-agent/issues/5346

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

Small fix in `cli.py`: remaps the CSI from Ctrl+M to Ctrl+J, which is the existing supported codepoint

## How to Test

Manual test.  Success depends on your terminal.

* Tested using `ghostty` with default configuration settings.  SHIFT+ENTER just works.
* Tested using `iterm2` with custom configuration settings:
  - Settings -> Profiles -> Keys -> KeyBindings
  - Add a new binding: Keyboard Shortcut: (press CTRL+ENTER); Action: "Send Escape Sequence"; Esc+ `[27;2;13~`
  - See screenshots at the end.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: MacOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<img width="1216" height="209" alt="Screenshot 2026-04-07 at 9 16 26 AM" src="https://github.com/user-attachments/assets/6cfd82cc-7d9f-4274-aec0-c5acfa97da43" />

<img width="762" height="169" alt="Screenshot 2026-04-07 at 9 20 16 AM" src="https://github.com/user-attachments/assets/cc88f89b-2223-462b-9710-df3a2507b179" />
