### PR TITLE
fix(setup): re-exec into fresh process when launching chat after setup

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2853,15 +2853,18 @@ def _offer_launch_chat():
     """Prompt the user to jump straight into chat after setup."""
     print()
     if prompt_yes_no("Launch hermes chat now?", True):
-        from hermes_cli.main import cmd_chat
-        from types import SimpleNamespace
-        cmd_chat(SimpleNamespace(
-            query=None, resume=None, continue_last=None, model=None,
-            provider=None, effort=None, skin=None, oneshot=False,
-            quiet=False, verbose=False, toolsets=None, skills=None,
-            yolo=False, source=None, worktree=False, checkpoints=False,
-            pass_session_id=False, max_turns=None,
-        ))
+        # Re-exec into a fresh process so prompt_toolkit gets a clean
+        # stdin / asyncio event-loop — calling cmd_chat() in-process
+        # after the setup wizard's interactive prompts leaves fd 0 in a
+        # state that the selector can't register (OSError: Invalid argument).
+        hermes_bin = shutil.which("hermes")
+        if hermes_bin:
+            os.execvp(hermes_bin, ["hermes", "chat"])
+        else:
+            os.execvp(
+                sys.executable,
+                [sys.executable, "-m", "hermes_cli.main", "chat"],
+            )
 
 
 def _run_first_time_quick_setup(config: dict, hermes_home, is_existing: bool):


### PR DESCRIPTION
## Summary

- `_offer_launch_chat()` calls `cmd_chat()` in-process after the setup wizard's interactive `input()` prompts, but stdin (fd 0) is left in a state that prompt_toolkit's asyncio selector cannot register, causing `OSError: [Errno 22] Invalid argument`
- Replace the in-process call with `os.execvp()`, matching the existing pattern in `main.py` (`cmd_sessions` browse at L5175-5183)
- Prefer the installed `hermes` binary via `shutil.which()`, fall back to `python -m hermes_cli.main`

## Traceback

```
File ".../vt100.py", line 165, in _attached_input
    loop.add_reader(fd, callback_wrapper)
  File ".../selector_events.py", line 271, in _add_reader
    self._selector.register(fd, selectors.EVENT_READ, ...)
  File ".../selectors.py", line 523, in register
    self._selector.control([kev], 0, 0)
OSError: [Errno 22] Invalid argument
```

## Test plan

- [ ] Run `hermes setup` on a fresh config (first-time quick setup path)
- [ ] Answer "Y" to "Launch hermes chat now?" — chat should open without crash
- [ ] Verify the same works when `hermes` is not on PATH (fallback to `python -m hermes_cli.main`)