### PR TITLE
fix(gateway): handle /provider without config.yaml

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3785,6 +3785,7 @@ class GatewayRunner:
 
         # Resolve current provider from config
         current_provider = "openrouter"
+        model_cfg = {}
         config_path = _hermes_home / 'config.yaml'
         try:
             if config_path.exists():

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3785,6 +3785,7 @@ class GatewayRunner:
 
         # Resolve current provider from config
         current_provider = "openrouter"
+        current_base_url = ""
         model_cfg = {}
         config_path = _hermes_home / 'config.yaml'
         try:
@@ -3794,8 +3795,16 @@ class GatewayRunner:
                 model_cfg = cfg.get("model", {})
                 if isinstance(model_cfg, dict):
                     current_provider = model_cfg.get("provider", current_provider)
+                    current_base_url = model_cfg.get("base_url", "")
         except Exception:
             pass
+
+        source = event.source
+        session_key = self._session_key_for_source(source)
+        override = getattr(self, "_session_model_overrides", {}).get(session_key, {})
+        if override:
+            current_provider = override.get("provider", current_provider)
+            current_base_url = override.get("base_url", current_base_url)
 
         current_provider = normalize_provider(current_provider)
         if current_provider == "auto":
@@ -3807,7 +3816,9 @@ class GatewayRunner:
 
         # Detect custom endpoint from config base_url
         if current_provider == "openrouter":
-            _cfg_base = model_cfg.get("base_url", "") if isinstance(model_cfg, dict) else ""
+            _cfg_base = current_base_url or (
+                model_cfg.get("base_url", "") if isinstance(model_cfg, dict) else ""
+            )
             if _cfg_base and "openrouter.ai" not in _cfg_base:
                 current_provider = "custom"
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -90,6 +90,7 @@ def make_runner(session_entry: SessionEntry) -> "GatewayRunner":
     runner._reasoning_config = None
     runner._provider_routing = {}
     runner._fallback_model = None
+    runner._session_model_overrides = {}
     runner._show_reasoning = False
 
     runner._is_user_authorized = lambda _source: True

--- a/tests/e2e/test_telegram_commands.py
+++ b/tests/e2e/test_telegram_commands.py
@@ -105,10 +105,6 @@ class TestTelegramSlashCommands:
         send_status.assert_called_once()
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason="Bug: _handle_provider_command references unbound model_cfg when config.yaml is absent",
-        strict=False,
-    )
     async def test_provider_shows_current_provider(self, adapter):
         send = await send_and_capture(adapter, "/provider")
 

--- a/tests/e2e/test_telegram_commands.py
+++ b/tests/e2e/test_telegram_commands.py
@@ -13,6 +13,7 @@ import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
+import yaml
 
 from gateway.platforms.base import SendResult
 from tests.e2e.conftest import (
@@ -111,6 +112,34 @@ class TestTelegramSlashCommands:
         send.assert_called_once()
         response_text = send.call_args[1].get("content") or send.call_args[0][1]
         assert "provider" in response_text.lower()
+
+    @pytest.mark.asyncio
+    async def test_provider_uses_session_override(self, adapter, runner, source, tmp_path, monkeypatch):
+        import gateway.run as gateway_run
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump({
+                "model": {
+                    "provider": "openrouter",
+                    "base_url": "https://openrouter.ai/api/v1",
+                }
+            }),
+            encoding="utf-8",
+        )
+
+        session_key = runner._session_key_for_source(source)
+        runner._session_model_overrides[session_key] = {
+            "provider": "anthropic",
+            "base_url": "https://api.anthropic.com",
+        }
+
+        send = await send_and_capture(adapter, "/provider")
+
+        send.assert_called_once()
+        response_text = send.call_args[1].get("content") or send.call_args[0][1]
+        assert "`anthropic`" in response_text
+        assert "← active" in response_text
 
     @pytest.mark.asyncio
     async def test_verbose_responds(self, adapter):


### PR DESCRIPTION
## What does this PR do?

Fixes two gateway `/provider` issues:

1. `/provider` could crash when `config.yaml` was absent because
   `GatewayRunner._handle_provider_command()` read `model_cfg` outside the
   `config_path.exists()` branch.
2. `/provider` could report the config provider instead of the effective
   session provider after a session-only `/model` switch, because it did not
   apply `_session_model_overrides` the way `/model` already does.

This change initializes the config-derived state defensively and makes
`/provider` resolve the same session override state as `/model`.

## Related Issue

N/A — no existing upstream issue found. The original crash was already
hinted at by the `xfail` in `tests/e2e/test_telegram_commands.py`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `gateway/run.py` to initialize config-derived state safely when
  `config.yaml` is missing
- Updated `gateway/run.py` so `/provider` applies `_session_model_overrides`
  before rendering the current provider
- Updated `tests/e2e/test_telegram_commands.py` to remove the existing
  `xfail` and add regression coverage for session override precedence
- Updated `tests/e2e/conftest.py` to seed `_session_model_overrides` on the
  mocked gateway runner

## How to Test

1. Run the focused Telegram gateway command suite:
   `uv run --extra dev python -m pytest tests/e2e/test_telegram_commands.py -q`
2. Confirm all tests pass
3. Optionally verify manually:
   - run the gateway without a `config.yaml` and send `/provider`
   - perform a session-only `/model` switch, then send `/provider`
   - Hermes should respond without crashing and should show the effective
     session provider

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --extra dev python -m pytest tests/e2e/test_telegram_commands.py -q`
- Result: `16 passed`
