### PR TITLE
fix: add ensure_ascii=False to all json.dump calls for CJK readability

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -350,7 +350,7 @@ def save_jobs(jobs: List[Dict[str, Any]]):
     fd, tmp_path = tempfile.mkstemp(dir=str(JOBS_FILE.parent), suffix='.tmp', prefix='.jobs_')
     try:
         with os.fdopen(fd, 'w', encoding='utf-8') as f:
-            json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2)
+            json.dump({"jobs": jobs, "updated_at": _hermes_now().isoformat()}, f, indent=2, ensure_ascii=False)
             f.flush()
             os.fsync(f.fileno())
         os.replace(tmp_path, JOBS_FILE)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -566,7 +566,7 @@ class SessionStore:
         )
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(data, f, indent=2)
+                json.dump(data, f, indent=2, ensure_ascii=False)
                 f.flush()
                 os.fsync(f.fileno())
             os.replace(tmp_path, sessions_file)

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -152,7 +152,7 @@ def _read_json_file(path: Path) -> Optional[dict[str, Any]]:
 
 def _write_json_file(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload))
+    path.write_text(json.dumps(payload, ensure_ascii=False))
 
 
 def _read_pid_record() -> Optional[dict]:
@@ -304,7 +304,7 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
         return False, _read_json_file(lock_path)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
-            json.dump(record, handle)
+            json.dump(record, handle, ensure_ascii=False)
     except Exception:
         try:
             lock_path.unlink(missing_ok=True)

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -152,7 +152,7 @@ def _read_json_file(path: Path) -> Optional[dict[str, Any]]:
 
 def _write_json_file(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(payload, ensure_ascii=False))
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
 
 
 def _read_pid_record() -> Optional[dict]:

--- a/optional-skills/creative/meme-generation/scripts/generate_meme.py
+++ b/optional-skills/creative/meme-generation/scripts/generate_meme.py
@@ -94,7 +94,7 @@ def fetch_imgflip_templates() -> list:
         data = json.loads(_fetch_url(IMGFLIP_API))
         memes = data.get("data", {}).get("memes", [])
         with open(IMGFLIP_CACHE_FILE, "w") as f:
-            json.dump(memes, f)
+            json.dump(memes, f, ensure_ascii=False)
         return memes
     except Exception as e:
         # If fetch fails and we have stale cache, use it

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -262,7 +262,7 @@ def _call(tool_name, args):
 
     # Write request atomically (write to .tmp, then rename)
     tmp = req_file + ".tmp"
-    with open(tmp, "w") as f:
+    with open(tmp, "w", encoding="utf-8") as f:
         json.dump({"tool": tool_name, "args": args, "seq": _seq}, f, ensure_ascii=False)
     os.rename(tmp, req_file)
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -263,7 +263,7 @@ def _call(tool_name, args):
     # Write request atomically (write to .tmp, then rename)
     tmp = req_file + ".tmp"
     with open(tmp, "w") as f:
-        json.dump({"tool": tool_name, "args": args, "seq": _seq}, f)
+        json.dump({"tool": tool_name, "args": args, "seq": _seq}, f, ensure_ascii=False)
     os.rename(tmp, req_file)
 
     # Wait for response with adaptive polling

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -1185,7 +1185,7 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
         if self.config.metrics_enabled:
             metrics_path = output_dir / self.config.metrics_output_file
             with open(metrics_path, 'w') as f:
-                json.dump(self.aggregate_metrics.to_dict(), f, indent=2)
+                json.dump(self.aggregate_metrics.to_dict(), f, indent=2, ensure_ascii=False)
             console.print(f"\n💾 Metrics saved to {metrics_path}")
     
     def _print_summary(self):

--- a/website/scripts/extract-skills.py
+++ b/website/scripts/extract-skills.py
@@ -256,7 +256,7 @@ def main():
 
     os.makedirs(os.path.dirname(OUTPUT), exist_ok=True)
     with open(OUTPUT, "w") as f:
-        json.dump(all_skills, f, indent=2)
+        json.dump(all_skills, f, indent=2, ensure_ascii=False)
 
     print(f"Extracted {len(all_skills)} skills to {OUTPUT}")
     print(f"  {len(local)} local ({sum(1 for s in local if s['source'] == 'built-in')} built-in, "


### PR DESCRIPTION
## Summary

- Add `ensure_ascii=False` to 7 `json.dump`/`json.dumps` call sites that were missing it
- Non-ASCII characters (Chinese, Japanese, emoji) in JSON files are now written as-is in UTF-8 instead of `\uXXXX` escape sequences
- Improves readability of config files like `~/.hermes/cron/jobs.json` and session data when opened in editors

## Changed files

| File | Context |
|------|---------|
| `cron/jobs.py:353` | Cron jobs storage — job names/descriptions with CJK text |
| `gateway/session.py:569` | Session persistence — conversation history with CJK content |
| `gateway/status.py:155` | JSON file utility function `_write_json_file()` |
| `gateway/status.py:307` | PID lock file write |
| `trajectory_compressor.py:1188` | Compression metrics output |
| `tools/code_execution_tool.py:266` | RPC request file for tool execution |
| `website/scripts/extract-skills.py:259` | Skills extraction for website |
| `optional-skills/creative/meme-generation/scripts/generate_meme.py:97` | Imgflip meme cache |

## Verification

After the fix, all non-test `json.dump`/`json.dumps` call sites in the codebase include `ensure_ascii=False`. The existing `utils.atomic_write_json()` helper already had it — these 7 call sites were the ones that bypassed the helper.

## Test plan

- [x] Grep confirms no remaining `json.dump` calls without `ensure_ascii=False` in non-test files
- [ ] Manual: create a cron job with Chinese description, verify `jobs.json` stores readable text
- [ ] Manual: session with CJK messages persists readable content

🤖 Generated with [Claude Code](https://claude.com/claude-code)