### PR TITLE
feat(gateway): add per-request model routing to API server

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -406,6 +406,7 @@ class APIServerAdapter(BasePlatformAdapter):
         session_id: Optional[str] = None,
         stream_delta_callback=None,
         tool_progress_callback=None,
+        model_override: Optional[str] = None,
     ) -> Any:
         """
         Create an AIAgent instance using the gateway's runtime config.
@@ -414,6 +415,11 @@ class APIServerAdapter(BasePlatformAdapter):
         base_url, etc. from config.yaml / env vars.  Toolsets are resolved
         from config.yaml platform_toolsets.api_server (same as all other
         gateway platforms), falling back to the hermes-api-server default.
+
+        When *model_override* is provided, it replaces the config default.
+        If the override matches a named provider in config.yaml (e.g.
+        "ollama/gemma4:26b"), the provider's base_url and api_key are
+        resolved from the providers section.
         """
         from run_agent import AIAgent
         from gateway.run import _resolve_runtime_agent_kwargs, _resolve_gateway_model, _load_gateway_config
@@ -422,7 +428,26 @@ class APIServerAdapter(BasePlatformAdapter):
         runtime_kwargs = _resolve_runtime_agent_kwargs()
         model = _resolve_gateway_model()
 
-        user_config = _load_gateway_config()
+        # Allow callers to override the model (e.g. from the request body).
+        # If the override contains a provider prefix ("ollama/gemma4:26b"),
+        # resolve that provider's base_url and credentials from config.yaml.
+        if model_override:
+            user_config = _load_gateway_config()
+            if "/" in model_override:
+                provider_name, model_name = model_override.split("/", 1)
+                providers = user_config.get("providers") or {}
+                if provider_name in providers:
+                    pcfg = providers[provider_name]
+                    runtime_kwargs["base_url"] = pcfg.get("api") or pcfg.get("base_url")
+                    runtime_kwargs["api_key"] = pcfg.get("api_key") or "no-key-required"
+                    runtime_kwargs["api_mode"] = pcfg.get("transport") or pcfg.get("api_mode") or "chat_completions"
+                    runtime_kwargs["provider"] = provider_name
+                model = model_name
+            else:
+                model = model_override
+        else:
+            user_config = _load_gateway_config()
+
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
 
         max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
@@ -546,6 +571,11 @@ class APIServerAdapter(BasePlatformAdapter):
 
         completion_id = f"chatcmpl-{uuid.uuid4().hex[:29]}"
         model_name = body.get("model", "hermes-agent")
+        # Resolve model override: if the caller specified a model other than
+        # the default "hermes-agent", pass it through to _create_agent so the
+        # request can target a specific provider/model (e.g. "ollama/gemma4:26b"
+        # or "claude-sonnet-4-20250514").
+        _model_override = model_name if model_name != "hermes-agent" else None
         created = int(time.time())
 
         if stream:
@@ -583,6 +613,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 stream_delta_callback=_on_delta,
                 tool_progress_callback=_on_tool_progress,
                 agent_ref=agent_ref,
+                model_override=_model_override,
             ))
 
             return await self._write_sse_chat_completion(
@@ -597,6 +628,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 conversation_history=history,
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
+                model_override=_model_override,
             )
 
         idempotency_key = request.headers.get("Idempotency-Key")
@@ -1269,6 +1301,7 @@ class APIServerAdapter(BasePlatformAdapter):
         stream_delta_callback=None,
         tool_progress_callback=None,
         agent_ref: Optional[list] = None,
+        model_override: Optional[str] = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -1289,6 +1322,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 session_id=session_id,
                 stream_delta_callback=stream_delta_callback,
                 tool_progress_callback=tool_progress_callback,
+                model_override=model_override,
             )
             if agent_ref is not None:
                 agent_ref[0] = agent

--- a/tests/gateway/test_api_server_model_routing.py
+++ b/tests/gateway/test_api_server_model_routing.py
@@ -1,0 +1,131 @@
+"""Tests for API server per-request model routing."""
+
+from unittest.mock import patch, MagicMock
+import pytest
+
+
+class TestModelOverrideParsing:
+    """Test the model_override logic in _create_agent."""
+
+    def _make_adapter(self):
+        """Create a minimal APIServerAdapter for testing."""
+        from gateway.platforms.api_server import APIServerAdapter
+        adapter = APIServerAdapter.__new__(APIServerAdapter)
+        adapter._port = 8642
+        adapter._session_db = None
+        adapter._session_db_lock = __import__("threading").Lock()
+        return adapter
+
+    @patch("gateway.run._load_gateway_config")
+    @patch("gateway.run._resolve_gateway_model")
+    @patch("gateway.run._resolve_runtime_agent_kwargs")
+    @patch("run_agent.AIAgent")
+    def test_no_override_uses_default_model(
+        self, mock_agent_cls, mock_kwargs, mock_model, mock_config
+    ):
+        mock_kwargs.return_value = {"api_key": "test", "base_url": None, "provider": "anthropic", "api_mode": None, "command": None, "args": [], "credential_pool": None}
+        mock_model.return_value = "claude-opus-4-6"
+        mock_config.return_value = {"platform_toolsets": {"api_server": ["terminal"]}}
+        mock_agent_cls.return_value = MagicMock()
+
+        with patch("gateway.run.GatewayRunner._load_fallback_model", return_value=None):
+            adapter = self._make_adapter()
+            adapter._create_agent()
+
+        mock_agent_cls.assert_called_once()
+        call_kwargs = mock_agent_cls.call_args
+        assert call_kwargs[1]["model"] == "claude-opus-4-6"
+
+    @patch("gateway.run._load_gateway_config")
+    @patch("gateway.run._resolve_gateway_model")
+    @patch("gateway.run._resolve_runtime_agent_kwargs")
+    @patch("run_agent.AIAgent")
+    def test_simple_model_override(
+        self, mock_agent_cls, mock_kwargs, mock_model, mock_config
+    ):
+        mock_kwargs.return_value = {"api_key": "test", "base_url": None, "provider": "anthropic", "api_mode": None, "command": None, "args": [], "credential_pool": None}
+        mock_model.return_value = "claude-opus-4-6"
+        mock_config.return_value = {"platform_toolsets": {"api_server": ["terminal"]}}
+        mock_agent_cls.return_value = MagicMock()
+
+        with patch("gateway.run.GatewayRunner._load_fallback_model", return_value=None):
+            adapter = self._make_adapter()
+            adapter._create_agent(model_override="claude-sonnet-4-20250514")
+
+        call_kwargs = mock_agent_cls.call_args
+        assert call_kwargs[1]["model"] == "claude-sonnet-4-20250514"
+
+    @patch("gateway.run._load_gateway_config")
+    @patch("gateway.run._resolve_gateway_model")
+    @patch("gateway.run._resolve_runtime_agent_kwargs")
+    @patch("run_agent.AIAgent")
+    def test_provider_prefixed_override_resolves_config(
+        self, mock_agent_cls, mock_kwargs, mock_model, mock_config
+    ):
+        mock_kwargs.return_value = {"api_key": "test", "base_url": None, "provider": "anthropic", "api_mode": None, "command": None, "args": [], "credential_pool": None}
+        mock_model.return_value = "claude-opus-4-6"
+        mock_config.return_value = {
+            "platform_toolsets": {"api_server": ["terminal"]},
+            "providers": {
+                "ollama": {
+                    "api": "http://localhost:11434/v1",
+                    "api_key": "no-key",
+                    "transport": "chat_completions",
+                },
+            },
+        }
+        mock_agent_cls.return_value = MagicMock()
+
+        with patch("gateway.run.GatewayRunner._load_fallback_model", return_value=None):
+            adapter = self._make_adapter()
+            adapter._create_agent(model_override="ollama/gemma4:26b")
+
+        call_kwargs = mock_agent_cls.call_args
+        assert call_kwargs[1]["model"] == "gemma4:26b"
+        assert call_kwargs[1]["base_url"] == "http://localhost:11434/v1"
+        assert call_kwargs[1]["provider"] == "ollama"
+
+    @patch("gateway.run._load_gateway_config")
+    @patch("gateway.run._resolve_gateway_model")
+    @patch("gateway.run._resolve_runtime_agent_kwargs")
+    @patch("run_agent.AIAgent")
+    def test_unknown_provider_prefix_keeps_model_string(
+        self, mock_agent_cls, mock_kwargs, mock_model, mock_config
+    ):
+        """If the provider prefix doesn't match config, use the model part as-is."""
+        mock_kwargs.return_value = {"api_key": "test", "base_url": None, "provider": "anthropic", "api_mode": None, "command": None, "args": [], "credential_pool": None}
+        mock_model.return_value = "claude-opus-4-6"
+        mock_config.return_value = {"platform_toolsets": {"api_server": ["terminal"]}, "providers": {}}
+        mock_agent_cls.return_value = MagicMock()
+
+        with patch("gateway.run.GatewayRunner._load_fallback_model", return_value=None):
+            adapter = self._make_adapter()
+            adapter._create_agent(model_override="unknown/some-model")
+
+        call_kwargs = mock_agent_cls.call_args
+        # Model should be "some-model" (provider prefix stripped)
+        assert call_kwargs[1]["model"] == "some-model"
+        # Provider should NOT have been overridden
+        assert call_kwargs[1]["provider"] == "anthropic"
+
+
+class TestChatCompletionsModelPassthrough:
+    """Test that the model field from request body reaches _create_agent."""
+
+    def test_hermes_agent_model_does_not_override(self):
+        """model='hermes-agent' should use the config default."""
+        model_name = "hermes-agent"
+        override = model_name if model_name != "hermes-agent" else None
+        assert override is None
+
+    def test_custom_model_creates_override(self):
+        """A non-default model name should create an override."""
+        model_name = "claude-sonnet-4-20250514"
+        override = model_name if model_name != "hermes-agent" else None
+        assert override == "claude-sonnet-4-20250514"
+
+    def test_provider_model_creates_override(self):
+        """A provider/model string should create an override."""
+        model_name = "ollama/gemma4:26b"
+        override = model_name if model_name != "hermes-agent" else None
+        assert override == "ollama/gemma4:26b"


### PR DESCRIPTION
## What does this PR do?

The API server `/v1/chat/completions` endpoint now respects the `model` field from the request body. When a model other than `"hermes-agent"` is specified, it overrides the `config.yaml` default for that request.

**Problem:** The API server always uses the model configured in `config.yaml`. There is no way to route individual requests to different models or providers. When using the API server as a backend for automation pipelines (e.g., n8n workflows), every step uses the same model — even when cheaper models would suffice for implementation tasks and local models could handle research/writing.

**Solution:** Pass the request body's `model` field through to `_create_agent` as a `model_override`. Two formats are supported:

```json
// Simple model name — uses default provider with different model
{"model": "claude-sonnet-4-20250514", "messages": [...]}

// Provider-prefixed — resolves provider config from config.yaml
{"model": "ollama/gemma4:26b", "messages": [...]}
```

The provider-prefixed format looks up the provider name in `config.yaml`'s `providers` section and resolves `base_url`, `api_key`, and `transport` automatically.

## Related Issue

N/A — discovered while building multi-model n8n automation pipelines (architecture → implement → review) where different steps benefit from different models.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/platforms/api_server.py`: Added `model_override` parameter to `_create_agent()` and `_run_agent()`. When provided, overrides the config default. Provider-prefixed models (e.g. `"ollama/gemma4:26b"`) resolve credentials from the `providers` config section. Wired into both streaming and non-streaming `/v1/chat/completions` paths.
- `tests/gateway/test_api_server_model_routing.py`: 7 new tests covering default behavior, simple override, provider-prefixed override, and unknown provider handling.

## How to Test

1. Configure a provider in `config.yaml`:
   ```yaml
   providers:
     ollama:
       api: http://localhost:11434/v1
       transport: chat_completions
   ```
2. Send a request with a model override:
   ```bash
   curl -X POST http://localhost:8642/v1/chat/completions \
     -H "Content-Type: application/json" \
     -d '{"model": "ollama/gemma4:26b", "messages": [{"role": "user", "content": "Hello"}]}'
   ```
3. Verify it routes to Ollama instead of the default provider.
4. Send `"model": "hermes-agent"` — should use the config default as before.
5. Run tests: `pytest tests/gateway/test_api_server_model_routing.py -v` (7 passed)

## Checklist

- [x] Contributing guide read
- [x] Conventional commits
- [x] No duplicate PRs
- [x] Focused single change
- [x] Tests pass (7 new tests)
- [x] Tested on Ubuntu 24.04 (verified with Ollama/Gemma, Anthropic/Sonnet, and default Opus)
- [x] Cross-platform safe (pure Python, no OS dependency)
- [x] Backward compatible — `"model": "hermes-agent"` (or omitted) behaves identically to before