### PR TITLE
fix(gateway/webhook): don't pop delivery_info on send

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -76,8 +76,17 @@ class WebhookAdapter(BasePlatformAdapter):
         self._routes: Dict[str, dict] = dict(self._static_routes)
         self._runner = None
 
-        # Delivery info keyed by session chat_id — consumed by send()
+        # Delivery info keyed by session chat_id.
+        #
+        # Read by every send() invocation for the chat_id (status messages
+        # AND the final response).  Cleaned up via TTL on each POST so the
+        # dict stays bounded — see _prune_delivery_info().  Do NOT pop on
+        # send(), or interim status messages (e.g. fallback notifications,
+        # context-pressure warnings) will consume the entry before the
+        # final response arrives, causing the response to silently fall
+        # back to the "log" deliver type.
         self._delivery_info: Dict[str, dict] = {}
+        self._delivery_info_created: Dict[str, float] = {}
 
         # Reference to gateway runner for cross-platform delivery (set externally)
         self.gateway_runner = None
@@ -160,10 +169,14 @@ class WebhookAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Deliver the agent's response to the configured destination.
 
-        chat_id is ``webhook:{route}:{delivery_id}`` — we pop the delivery
-        info stored during webhook receipt so it doesn't leak memory.
+        chat_id is ``webhook:{route}:{delivery_id}``.  The delivery info
+        stored during webhook receipt is read with ``.get()`` (not popped)
+        so that interim status messages emitted before the final response
+        — fallback-model notifications, context-pressure warnings, etc. —
+        do not consume the entry and silently downgrade the final response
+        to the ``log`` deliver type.  TTL cleanup happens on POST.
         """
-        delivery = self._delivery_info.pop(chat_id, {})
+        delivery = self._delivery_info.get(chat_id, {})
         deliver_type = delivery.get("deliver", "log")
 
         if deliver_type == "log":
@@ -189,6 +202,23 @@ class WebhookAdapter(BasePlatformAdapter):
         return SendResult(
             success=False, error=f"Unknown deliver type: {deliver_type}"
         )
+
+    def _prune_delivery_info(self, now: float) -> None:
+        """Drop delivery_info entries older than the idempotency TTL.
+
+        Mirrors the cleanup pattern used for ``_seen_deliveries``.  Called
+        on each POST so the dict size is bounded by ``rate_limit * TTL``
+        even if many webhooks fire and never receive a final response.
+        """
+        cutoff = now - self._idempotency_ttl
+        stale = [
+            k
+            for k, t in self._delivery_info_created.items()
+            if t < cutoff
+        ]
+        for k in stale:
+            self._delivery_info.pop(k, None)
+            self._delivery_info_created.pop(k, None)
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         return {"name": chat_id, "type": "webhook"}
@@ -384,7 +414,9 @@ class WebhookAdapter(BasePlatformAdapter):
         # same route get independent agent runs (not queued/interrupted).
         session_chat_id = f"webhook:{route_name}:{delivery_id}"
 
-        # Store delivery info for send() — consumed (popped) on delivery
+        # Store delivery info for send().  Read by every send() invocation
+        # for this chat_id (interim status messages and the final response),
+        # so we do NOT pop on send.  TTL-based cleanup keeps the dict bounded.
         deliver_config = {
             "deliver": route_config.get("deliver", "log"),
             "deliver_extra": self._render_delivery_extra(
@@ -393,6 +425,8 @@ class WebhookAdapter(BasePlatformAdapter):
             "payload": payload,
         }
         self._delivery_info[session_chat_id] = deliver_config
+        self._delivery_info_created[session_chat_id] = now
+        self._prune_delivery_info(now)
 
         # Build source and event
         source = self.build_source(

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -590,8 +590,15 @@ class TestSessionIsolation:
 class TestDeliveryCleanup:
 
     @pytest.mark.asyncio
-    async def test_delivery_info_cleaned_after_send(self):
-        """send() pops delivery_info so the entry doesn't leak memory."""
+    async def test_delivery_info_survives_multiple_sends(self):
+        """send() must NOT pop delivery_info.
+
+        Interim status messages (fallback notifications, context-pressure
+        warnings, etc.) flow through the same send() path as the final
+        response.  If the entry were popped on the first send, the final
+        response would silently downgrade to the ``log`` deliver type.
+        Regression test for that bug.
+        """
         adapter = _make_adapter()
         chat_id = "webhook:test:d-xyz"
         adapter._delivery_info[chat_id] = {
@@ -599,10 +606,40 @@ class TestDeliveryCleanup:
             "deliver_extra": {},
             "payload": {"x": 1},
         }
+        adapter._delivery_info_created[chat_id] = time.time()
 
-        result = await adapter.send(chat_id, "Agent response here")
-        assert result.success is True
-        assert chat_id not in adapter._delivery_info
+        # First send (e.g. an interim status message)
+        result1 = await adapter.send(chat_id, "Status: switching to fallback")
+        assert result1.success is True
+        # Entry must still be present so the final send can read it
+        assert chat_id in adapter._delivery_info
+
+        # Second send (the final agent response)
+        result2 = await adapter.send(chat_id, "Final agent response")
+        assert result2.success is True
+        assert chat_id in adapter._delivery_info
+
+    @pytest.mark.asyncio
+    async def test_delivery_info_pruned_via_ttl(self):
+        """Stale delivery_info entries are dropped on the next POST."""
+        adapter = _make_adapter()
+        adapter._idempotency_ttl = 60  # short TTL for the test
+        now = time.time()
+
+        # Stale entry — older than TTL
+        adapter._delivery_info["webhook:test:old"] = {"deliver": "log"}
+        adapter._delivery_info_created["webhook:test:old"] = now - 120
+
+        # Fresh entry — should survive
+        adapter._delivery_info["webhook:test:new"] = {"deliver": "log"}
+        adapter._delivery_info_created["webhook:test:new"] = now - 5
+
+        adapter._prune_delivery_info(now)
+
+        assert "webhook:test:old" not in adapter._delivery_info
+        assert "webhook:test:old" not in adapter._delivery_info_created
+        assert "webhook:test:new" in adapter._delivery_info
+        assert "webhook:test:new" in adapter._delivery_info_created
 
 
 # ===================================================================

--- a/tests/gateway/test_webhook_integration.py
+++ b/tests/gateway/test_webhook_integration.py
@@ -259,8 +259,9 @@ class TestCrossPlatformDelivery:
         mock_tg_adapter.send.assert_awaited_once_with(
             "12345", "I've acknowledged the alert.", metadata=None
         )
-        # Delivery info should be cleaned up
-        assert chat_id not in adapter._delivery_info
+        # Delivery info is retained after send() so interim status messages
+        # don't strand the final response (TTL-based cleanup happens on POST).
+        assert chat_id in adapter._delivery_info
 
 
 # ===================================================================
@@ -333,5 +334,6 @@ class TestGitHubCommentDelivery:
             text=True,
             timeout=30,
         )
-        # Delivery info cleaned up
-        assert chat_id not in adapter._delivery_info
+        # Delivery info is retained after send() so interim status messages
+        # don't strand the final response (TTL-based cleanup happens on POST).
+        assert chat_id in adapter._delivery_info


### PR DESCRIPTION
## Summary

The webhook adapter silently downgrades the configured `deliver` type to `"log"` whenever the agent emits *any* interim status message before the final response. The most common trigger is fallback-model activation:

```
[webhook] POST event=unknown route=agentmail-email delivery=...
[webhook] Response for ...: 🔄 Primary model failed — switching to fallback: claude-opus-4.6 via anthropic
gateway.run: response ready: platform=webhook ... response=912 chars
[Webhook] Sending response (912 chars) to webhook:agentmail-email:...
[webhook] Response for ...: <agent's actual response>     ← logged, never delivered
```

The user configured `--deliver telegram --deliver-chat-id <id>`, but the response lands in the gateway log instead of Telegram. No warning, no error.

## Root cause

`gateway/platforms/webhook.py::send()` consumed `_delivery_info[chat_id]` via `.pop()`:

```python
delivery = self._delivery_info.pop(chat_id, {})
deliver_type = delivery.get("deliver", "log")
```

That works when the agent run produces exactly one outbound message — the final response. But interim status messages flow through the same `send()` path. When `run_agent.py::_emit_status()` fires (e.g. on fallback activation, context-pressure warnings, or any other lifecycle event routed through `status_callback`), the gateway calls `adapter.send(chat_id, message, ...)` for the *same* chat_id. That first call pops the entry. The subsequent final-response `send()` call sees an empty dict, falls back to `deliver_type = "log"`, and writes the response to the gateway log instead of crossing over to the configured platform.

This is easy to hit in practice. Anyone with `fallback_providers` configured runs into it the first time their primary provider hiccups on a webhook-triggered run. Routes that work perfectly in dev silently drop responses in prod.

The bug is not specific to fallback notifications — it affects *any* code path that emits an interim status message before the final response.

## Fix

1. Read `_delivery_info` with `.get()` instead of `.pop()` so multiple `send()` calls for the same `chat_id` all see the same delivery config.
2. Add a parallel `_delivery_info_created: Dict[str, float]` timestamp dict.
3. Add `_prune_delivery_info(now)` that drops entries older than `_idempotency_ttl` (1h, the same window already used by `_seen_deliveries`).
4. Call `_prune_delivery_info()` on each POST, mirroring the existing cleanup pattern for `_seen_deliveries`.

Worst-case bound on `_delivery_info` size is now `rate_limit * TTL = 30/min * 60min = 1800` entries, each ~1 KB → under 2 MB. In practice it'll be much smaller because most webhooks complete in seconds.

## Tests

- `test_delivery_info_cleaned_after_send` is replaced with `test_delivery_info_survives_multiple_sends` — the regression test for this bug. It asserts that two consecutive `send()` calls for the same `chat_id` both see the delivery config.
- New `test_delivery_info_pruned_via_ttl` covers the TTL cleanup behavior.
- Two integration tests in `test_webhook_integration.py` that previously asserted `chat_id not in adapter._delivery_info` after `send()` now assert the opposite, with a comment explaining why.

All 40 tests in `tests/gateway/test_webhook_adapter.py` and `tests/gateway/test_webhook_integration.py` pass:

```
$ pytest tests/gateway/test_webhook_adapter.py tests/gateway/test_webhook_integration.py -q
........................................                                 [100%]
40 passed in 0.89s
```

## End-to-end verification

Reproduced and verified locally with a dynamic subscription:

```
hermes webhook subscribe agentmail-email \
  --prompt "{text}\n\nReview this email and decide what to do..." \
  --deliver telegram \
  --deliver-chat-id <user-id> \
  --secret INSECURE_NO_AUTH
```

With `gpt-5.4` as primary (currently flaky in my environment) and `claude-opus-4.6` as fallback:

- **Before the fix:** every POST hit the fallback path, the fallback notification consumed `_delivery_info`, and the final response landed in the gateway log. Zero Telegram messages delivered.
- **After the fix:** same conditions, fallback still fires, and the final response is delivered to Telegram as expected.

## Notes

- Behavior change is intentional: `_delivery_info` entries now live until TTL expiry instead of being consumed on send. This is consistent with the existing `_seen_deliveries` lifecycle and is what the cross-platform delivery contract actually requires.
- No public API changes.
- No config changes.
