### PR TITLE
feat: h2c_extract — multi-source session skeleton extractor

### DIFF
--- a/tools/h2c_extract/DESIGN.md
+++ b/tools/h2c_extract/DESIGN.md
@@ -1,0 +1,364 @@
+# H2C Protocol v2.1 — Multi-Source Passive Session Sync
+
+> **Hermes ← Claude Code + Codex CLI: Zero-Intrusion Session Intelligence**
+
+## 1. Problem
+
+### 1.1 Two Scenarios
+
+| | Scene 1: Hermes dispatches CC | Scene 2: User works with AI CLI directly |
+|---|---|---|
+| Info flow | Bidirectional, real-time | One-way, post-hoc |
+| Hermes visibility | Full (via RFC-001) | **Zero** |
+| Frequency | Low (formal tasks) | **High (daily driver)** |
+
+Scene 2 is the primary usage pattern. User opens Claude Code or Codex, discusses architecture, writes code, makes decisions — Hermes knows nothing.
+
+### 1.2 What Hermes Needs
+
+Not everything is worth syncing. From Hermes' role (scheduler, memory keeper, planner):
+
+| Info Type | Value | Example |
+|---|---|---|
+| **Decisions** | High | "Chose ASE over LAMMPS for Python integration" |
+| **Progress** | High | "Data loader complete, next: train baseline" |
+| **Problems/Blockers** | High | "xyz parser has edge case, workaround in place" |
+| Detailed code diffs | Low | Git already records this |
+| Debugging process | Low | Noise, not useful for Hermes |
+
+**Three words: decisions, progress, problems.**
+
+### 1.3 The Discussion-Only Gap
+
+Not all valuable sessions produce commits or file changes:
+- Architecture discussions with a chosen direction
+- Tech stack evaluation with conclusions
+- Paper analysis with key takeaways
+- Work planning for next week
+
+These **pure discussion sessions** have the highest decision density but leave zero trace in git or filesystem. Any sync mechanism that relies solely on file changes or git history will miss them entirely.
+
+## 2. Architecture: Direct JSONL Extraction
+
+### 2.1 Key Insight
+
+Both Claude Code and Codex store session data locally as `.jsonl` files. These files record every message — user, assistant, tool calls, tool results — regardless of whether files were changed or commits were made.
+
+| Source | Session Location | Format |
+|---|---|---|
+| Claude Code | `~/.claude/projects/**/*.jsonl` | `type: user/assistant`, `message.content` |
+| Codex CLI | `~/.codex/sessions/**/*.jsonl` + `~/.codex/archived_sessions/*.jsonl` | `type: response_item`, `payload` with role |
+
+**Hermes can read both directly. No hooks needed. No CLI modification needed.**
+
+### 2.2 Data Profile
+
+Analysis of real session files shows the same pattern across both sources:
+
+| Content | Size % | Useful for Hermes? |
+|---|---|---|
+| Tool outputs + images (base64) | ~97% | No — pure noise |
+| Assistant text blocks (spoken responses) | ~0.2% | **Core value** |
+| Tool call metadata (what tools were called) | Small | Useful metadata |
+| User text blocks (what user asked) | Small | Context |
+| System / thinking / developer prompts | Small | No |
+
+**The useful information is less than 1% of file size.** A simple filter extracts it at zero token cost.
+
+### 2.3 Pipeline
+
+```
+AI CLI works normally (zero modification)
+       |
+       ├── ~/.claude/projects/**/*.jsonl (Claude Code)
+       └── ~/.codex/sessions/**/*.jsonl  (Codex CLI)
+       |
+h2c_extract.py (rule-based filter, zero token cost)
+  - Adapter pattern: ClaudeCodeParser / CodexParser
+  - Extract: user text + assistant text + tool metadata
+  - Drop: tool_result, image, thinking, system, developer
+  - Sanitize: redact secrets, truncate long blocks
+  - Tag: code-change / discussion-only / debugging
+       |
+~/.hermes/inbox/ (conversation skeletons, ~15-20KB each)
+  - cc_*.md  (from Claude Code)
+  - cx_*.md  (from Codex CLI)
+       |
+Hermes reads inbox (cheap model, on wake-up or cron)
+  - Generate structured summary (~500 words)
+  - Update Hermes memory
+  - Update Wiki (if needed)
+  - Archive processed files
+```
+
+### 2.4 Why Not Stop Hook? (v1 Design, Deprecated)
+
+| Issue | Detail |
+|---|---|
+| CC writes blind | Doesn't know what Hermes needs, may produce useless output |
+| Crash = data loss | Hook doesn't fire on abnormal exit |
+| Discussion sessions | Hook quality depends on remaining context at exit |
+| Maintenance burden | Requires hook installation per CLI |
+| Fragmentation | 10 short sessions = 10 fragments Hermes must reconcile |
+| Single-source | Only works for one CLI, not extensible |
+
+The JSONL approach eliminates all of these: data is already written, always complete, and Hermes extracts what it needs on its own terms. Adding a new source is just a new parser class.
+
+## 3. Multi-Source Parser Architecture
+
+### 3.1 Adapter Pattern
+
+```
+SessionParser (ABC)
+  ├── discover_files()      → list[Path]
+  ├── parse()               → list[DialogTurn]
+  ├── get_session_id()      → str
+  ├── get_project_name()    → str
+  └── get_session_date()    → str
+       │
+       ├── ClaudeCodeParser
+       │     source_name = "cc"
+       │     Reads: ~/.claude/projects/**/*.jsonl
+       │     Filters: subagents/ directory
+       │     Strips: <system-reminder>, <command-message>, etc.
+       │
+       └── CodexParser
+             source_name = "codex"
+             Reads: ~/.codex/sessions/**/*.jsonl
+                  + ~/.codex/archived_sessions/*.jsonl
+             Extracts: session_meta.payload.cwd for project name
+             Strips: <permissions>, <app-context>, etc.
+             Attaches: function_call items to preceding assistant turn
+```
+
+Both parsers output identical `list[DialogTurn]`. Everything downstream (tagging, truncation, output) is shared.
+
+### 3.2 Format Differences Handled
+
+| Aspect | Claude Code | Codex CLI |
+|---|---|---|
+| Message type field | `type: "user"/"assistant"` | `payload.type: "message"`, `payload.role` |
+| Tool calls | `content[].type = "tool_use"` | `payload.type = "function_call"` |
+| Tool results | `content[].type = "tool_result"` | `payload.type = "function_call_output"` |
+| System noise | `<system-reminder>`, `<command-message>` | `<permissions>`, `<app-context>`, `<environment_context>` |
+| Session ID | Filename UUID | UUID extracted from `rollout-DATE-UUID.jsonl` |
+| Project name | Encoded in parent directory name | `session_meta.payload.cwd` (first line) |
+| Code change tools | Edit, Write, MultiEdit | write_file, edit_file, apply_diff |
+
+### 3.3 Adding New Sources
+
+To add a third CLI (e.g., Gemini CLI, Cursor):
+1. Create a new `XxxParser(SessionParser)` class
+2. Implement the 5 abstract methods
+3. Add to `_get_parsers()` list
+4. Add source-specific system tags if needed
+
+No changes needed to tagging, output, or sync logic.
+
+## 4. Technical Specification
+
+### 4.1 Extraction: What to Keep
+
+```
+Per session file, extract only:
+
+1. user text blocks     → What user asked / requested (context)
+2. assistant text blocks → AI's analysis, decisions, conclusions (core)
+3. tool metadata        → Which tools were called, on which files (fact layer)
+
+Skip everything else:
+- tool_result / function_call_output (tool output, often massive)
+- image blocks (base64, megabytes of noise)
+- thinking blocks (internal reasoning, not actionable)
+- system / developer messages (prompts, reminders)
+```
+
+### 4.2 Output Format: Conversation Skeleton
+
+Markdown, not JSON — optimized for cheap model readability:
+
+```markdown
+---
+session: 86fcda92
+date: 2026-04-07
+project: coding
+source: cc
+tags: [discussion-only]
+files_touched: []
+---
+
+**User**: Look at this design file
+**CC**: This is the H2C Protocol v2.0 design doc describing one-way passive memory sync...
+**User**: There are two scenarios...
+**CC**: H2C Protocol mainly solves the information gap in Scene 2...
+```
+
+Codex sessions use `**Codex**:` instead of `**CC**:` as the assistant label.
+
+### 4.3 Compression Rules
+
+| Text block size | Strategy |
+|---|---|
+| < 500 chars | Keep as-is |
+| 500-2000 chars | Keep first 300 + last 200 + `[...omitted N chars...]` |
+| > 2000 chars | Keep first 300 + last 200, replace code blocks with `[code: ~N lines]` |
+
+**Per-file cap**: MAX_SKELETON_CHARS = 20,000. Files exceeding this are trimmed from the top (keeping most recent context).
+
+### 4.4 Auto-Tagging
+
+Source-aware tagging:
+
+| Tag | Claude Code trigger | Codex trigger |
+|---|---|---|
+| `code-change` | Edit, Write, MultiEdit used | write_file, edit_file, apply_diff used |
+| `discussion-only` | No tool calls at all | No tool calls at all |
+| `debugging` | "error", "bug", "fail" etc. in text | Same |
+| `multi-agent` | Agent tool used | N/A |
+
+### 4.5 Incremental Sync
+
+- Track processed files by `(filepath, mtime)` in `~/.hermes/h2c-state.json`
+- Only process new or modified session files
+- Skip files modified within last 5 minutes (may still be active)
+- Checkpoint progress every 50 files (crash-safe)
+- Skip `subagents/` directory for Claude Code
+
+### 4.6 Sensitive Data Filtering
+
+Mandatory regex-based redaction before writing to inbox:
+
+| Pattern | Replacement |
+|---|---|
+| `sk-*`, `key-*` | `[API_KEY_REDACTED]` |
+| `ghp_*`, `gho_*` | `[GITHUB_TOKEN_REDACTED]` |
+| JWT (`eyJ...`) | `[JWT_REDACTED]` |
+| `Bearer *` | `[BEARER_TOKEN_REDACTED]` |
+| `password=*`, `secret=*` | `[PASSWORD_REDACTED]` / `[SECRET_REDACTED]` |
+
+**Note**: Passwords spoken directly in conversation (not in `key=value` format) are NOT caught by regex. Hermes should treat inbox contents as semi-sensitive and not store raw skeletons long-term.
+
+### 4.7 Directory Structure
+
+```
+~/.hermes/
+├── inbox/                          ← Conversation skeletons (Hermes reads here)
+│   ├── 2026-04-07_cc_86fcda92.md   ← Claude Code session
+│   ├── 2026-04-07_cx_019d0e55.md   ← Codex session
+│   └── ...
+├── inbox-archive/                  ← Processed skeletons (Hermes moves here)
+│   └── ...
+├── h2c-state.json                  ← Sync state (processed files tracking)
+└── skills/h2c-protocol/
+    ├── DESIGN.md                   ← This file
+    ├── RFC-001.md                  ← Scene 1 protocol (Hermes dispatches CC)
+    └── h2c_extract.py              ← Extraction script (multi-source)
+```
+
+## 5. Layered Compression Model
+
+```
+Layer 0: Raw .jsonl              (0.5-4MB per session, both sources)
+    ↓  h2c_extract.py — rule-based filter (zero token cost)
+Layer 1: Conversation skeleton   (~15-20KB) → inbox/
+    ↓  Hermes reads (cheap model)
+Layer 2: Structured summary      (~500 words) → Hermes memory
+    ↓  Hermes decides (cheap model)
+Layer 3: Wiki update             (if needed) → ~/.hermes/wiki/
+```
+
+Cost flows downhill: expensive model (CC/Codex) does the original thinking, script does mechanical extraction, cheap model (Hermes) does semantic compression.
+
+## 6. Relationship to RFC-001
+
+| | RFC-001 (Scene 1) | This Design (Scene 2) |
+|---|---|---|
+| Direction | Hermes → CC (dispatch) | AI CLI → Hermes (passive sync) |
+| Trigger | Hermes writes `inbox/current-task.md` | Hermes/cron runs `h2c_extract.py` |
+| CLI awareness | CC reads task, reports via `activity.jsonl` | CLI is unaware, works normally |
+| Data source | Structured events (`activity.jsonl`) | Raw session files (`.jsonl`) |
+| Sources | Claude Code only | Claude Code + Codex (extensible) |
+| Complementary | Yes — RFC-001 tasks also generate `.jsonl` sessions that this pipeline captures |
+
+Both protocols feed into the same Hermes memory and Wiki. They cover different scenarios but converge at the consumption layer.
+
+## 7. Usage
+
+```bash
+# Sync all sources (Claude Code + Codex)
+python3 ~/.hermes/skills/h2c-protocol/h2c_extract.py sync
+
+# Sync only Claude Code
+python3 ~/.hermes/skills/h2c-protocol/h2c_extract.py sync --source cc
+
+# Sync only Codex
+python3 ~/.hermes/skills/h2c-protocol/h2c_extract.py sync --source codex
+
+# Re-process everything
+python3 ~/.hermes/skills/h2c-protocol/h2c_extract.py sync --force
+
+# Check status
+python3 ~/.hermes/skills/h2c-protocol/h2c_extract.py status
+```
+
+## 8. Implementation Plan
+
+### PR 1: h2c_extract.py (This PR)
+
+1. `h2c_extract.py` — Multi-source extraction script
+   - `SessionParser` ABC with `ClaudeCodeParser` and `CodexParser`
+   - Session file discovery + incremental sync with checkpointing
+   - Conversation skeleton extraction with per-block and per-file size caps
+   - Sensitive data redaction (regex-based)
+   - Source-aware auto-tagging
+   - Markdown output to `~/.hermes/inbox/`
+2. Updated `DESIGN.md` — This document
+3. Updated `RFC-001.md` — Unchanged (Scene 1 protocol)
+
+### PR 2: Hermes Consumption (Future)
+
+- Hermes reads `inbox/`, generates structured summaries
+- Updates Hermes internal memory
+- Updates Wiki (`DECISIONS.md`, `ARCHITECTURE.md`)
+- Archives processed skeletons to `inbox-archive/`
+- Daily digest via configured messaging channel
+
+### PR 3: Trigger Automation (Future)
+
+- macOS launchd plist for periodic sync (every 10 minutes)
+- Optional CC Stop Hook as instant trigger (launchd as fallback)
+- Hermes cron integration
+
+## 9. Edge Cases
+
+| Case | Handling |
+|---|---|
+| CLI crashes mid-session | `.jsonl` is append-only; partial data is still extractable |
+| Very short sessions (< 3 user messages) | Skip — not enough signal |
+| Low-value sessions (help/usage only) | Skip — detected by content filter |
+| Multiple sessions same project same day | Each gets its own skeleton file (keyed by source + session ID) |
+| Session still active (CLI running) | Skip files modified within last 5 minutes |
+| Sensitive info leaks through regex | Hermes should not store raw skeletons long-term |
+| Conversational passwords (not key=value) | Not caught by regex; documented limitation |
+| Session file deleted during scan | `stat()` protected with fallback; skipped gracefully |
+| Disk full during write | `write_skeleton` catches OSError, cleans up temp file |
+
+## 10. Validated Results
+
+First full sync (2026-04-07):
+
+| Metric | Value |
+|---|---|
+| Claude Code sessions discovered | 4,569 |
+| Claude Code skeletons written | 163 |
+| Codex sessions discovered | 319 |
+| Codex skeletons written | 71 |
+| **Total skeletons** | **234** |
+| Largest skeleton | 38KB (within 20KB trim target) |
+| Total inbox size | 3.5MB |
+| Processing errors | 0 |
+
+---
+
+*Status: Implemented and validated. Three rounds of strict code review passed.*
+*Supersedes: v1.0 (Stop Hook approach) and v2.0 (CC-only).*

--- a/tools/h2c_extract/README.md
+++ b/tools/h2c_extract/README.md
@@ -1,0 +1,177 @@
+# H2C Extract
+
+从 Claude Code 和 Codex CLI 的会话文件中提取对话骨架，供 Hermes 消费。
+
+## 原理
+
+两个 AI CLI 都会在本地保存 `.jsonl` 格式的会话记录。这个脚本直接读取这些文件，过滤掉 97% 的噪音（工具输出、图片、系统提示），只保留用户问了什么、AI 回答了什么、改了哪些文件。
+
+**不需要修改任何 CLI 配置，不需要 hook，不需要 AI 主动输出任何东西。**
+
+## 前置条件
+
+- Python 3.10+
+- 装过 Claude Code（`~/.claude/` 目录存在）和/或 Codex CLI（`~/.codex/` 目录存在）
+
+不需要安装任何依赖，纯标准库。
+
+## 快速开始
+
+```bash
+# 查看状态（有多少会话待处理）
+python3 ~/.hermes/skills/h2c-protocol/h2c_extract.py status
+
+# 同步所有源（Claude Code + Codex）
+python3 ~/.hermes/skills/h2c-protocol/h2c_extract.py sync
+
+# 查看生成的骨架文件
+ls ~/.hermes/inbox/
+```
+
+## 命令
+
+```bash
+# 同步所有源
+python3 h2c_extract.py sync
+
+# 只同步 Claude Code
+python3 h2c_extract.py sync --source cc
+
+# 只同步 Codex
+python3 h2c_extract.py sync --source codex
+
+# 强制重新处理所有文件（忽略已处理记录）
+python3 h2c_extract.py sync --force
+
+# 查看同步状态
+python3 h2c_extract.py status
+```
+
+## 输出
+
+骨架文件输出到 `~/.hermes/inbox/`，按来源区分：
+
+```
+~/.hermes/inbox/
+├── 2026-04-07_cc_86fcda92.md   ← Claude Code 会话
+├── 2026-04-07_cx_019d0e55.md   ← Codex 会话
+└── ...
+```
+
+每个文件是一段可读的 markdown 对话摘要：
+
+```markdown
+---
+session: 86fcda92
+date: 2026-04-07
+project: my-project
+source: cc
+tags: [code-change, debugging]
+files_touched: [src/app.py, tests/test_app.py]
+---
+
+**User**: 这个数据加载器有 bug，xyz 格式解析出错
+**CC**: 看了一下代码，问题在 parse_xyz() 函数的边界处理...
+*[Tools: Edit(dataloader.py), Bash x2]*
+**CC**: 修复了，主要改动是...
+```
+
+### 自动标签
+
+| 标签 | 含义 |
+|---|---|
+| `code-change` | 会话中有文件编辑 |
+| `discussion-only` | 纯讨论，没有工具调用（决策密度通常最高） |
+| `debugging` | 包含 error/bug/fix 等关键词 |
+| `multi-agent` | 使用了 Agent 工具（仅 CC） |
+
+## 自动触发
+
+### 方式一：macOS launchd（推荐）
+
+创建 `~/Library/LaunchAgents/com.hermes.h2c-extract.plist`（将 `YOUR_USERNAME` 替换为实际用户名）：
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.hermes.h2c-extract</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/python3</string>
+        <string>/Users/YOUR_USERNAME/.hermes/skills/h2c-protocol/h2c_extract.py</string>
+        <string>sync</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>600</integer>
+    <key>StandardOutPath</key>
+    <string>/Users/YOUR_USERNAME/.hermes/logs/h2c-extract.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/YOUR_USERNAME/.hermes/logs/h2c-extract.log</string>
+</dict>
+</plist>
+```
+
+```bash
+# 加载
+mkdir -p ~/.hermes/logs
+launchctl load ~/Library/LaunchAgents/com.hermes.h2c-extract.plist
+
+# 卸载
+launchctl unload ~/Library/LaunchAgents/com.hermes.h2c-extract.plist
+
+# 手动触发一次
+launchctl start com.hermes.h2c-extract
+```
+
+### 方式二：Claude Code Stop Hook（即时同步）
+
+在 `~/.claude/settings.json` 的 hooks 中添加：
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ~/.hermes/skills/h2c-protocol/h2c_extract.py sync --source cc"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+每次 CC 会话结束时自动同步。配合 launchd 使用，launchd 兜底 crash 和 Codex 的同步。
+
+## Hermes 消费
+
+Hermes 读取 `~/.hermes/inbox/` 下的骨架文件，处理完后移到 `~/.hermes/inbox-archive/`：
+
+```bash
+# Hermes 侧示例（伪代码）
+for file in ~/.hermes/inbox/*.md:
+    summary = hermes.summarize(file)
+    hermes.update_memory(summary)
+    mv file ~/.hermes/inbox-archive/
+```
+
+## 文件说明
+
+```
+~/.hermes/skills/h2c-protocol/
+├── h2c_extract.py   ← 提取脚本（本工具）
+├── DESIGN.md        ← 设计文档（架构决策和技术规格）
+├── RFC-001.md       ← 场景 1 协议（Hermes 指挥 CC，与本工具无关）
+└── README.md        ← 本文件
+
+~/.hermes/
+├── inbox/           ← 输出目录（骨架文件）
+├── inbox-archive/   ← 归档目录（Hermes 处理后移入）
+└── h2c-state.json   ← 同步状态（记录已处理文件）
+```

--- a/tools/h2c_extract/h2c_extract.py
+++ b/tools/h2c_extract/h2c_extract.py
@@ -1,0 +1,892 @@
+#!/usr/bin/env python3
+"""
+H2C Extract — Extract conversation skeletons from AI coding sessions.
+
+Supports both Claude Code and Codex CLI session formats.
+Reads .jsonl session files, extracts useful signal (user text,
+assistant text, tool metadata), and outputs readable markdown
+skeletons to ~/.hermes/inbox/ for Hermes consumption.
+
+Commands:
+    python3 h2c_extract.py sync              # Incremental sync (all sources)
+    python3 h2c_extract.py sync --source cc  # Only Claude Code
+    python3 h2c_extract.py sync --source codex  # Only Codex
+    python3 h2c_extract.py sync --force      # Re-process all files
+    python3 h2c_extract.py status            # Show sync status
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import re
+import sys
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+# ── Constants ──
+
+HERMES_DIR = Path.home() / ".hermes"
+INBOX_DIR = HERMES_DIR / "inbox"
+ARCHIVE_DIR = HERMES_DIR / "inbox-archive"
+STATE_FILE = HERMES_DIR / "h2c-state.json"
+
+CC_SESSIONS_DIR = Path.home() / ".claude" / "projects"
+CODEX_SESSIONS_DIR = Path.home() / ".codex" / "sessions"
+CODEX_ARCHIVE_DIR = Path.home() / ".codex" / "archived_sessions"
+
+MIN_MESSAGES = 3
+STALE_SECONDS = 300
+TEXT_KEEP_THRESHOLD = 500
+TEXT_HEAD_CHARS = 300
+TEXT_TAIL_CHARS = 200
+MAX_SKELETON_CHARS = 20_000
+SAVE_INTERVAL = 50
+CODE_BLOCK_PLACEHOLDER = "[code: ~{n} lines]"
+
+_USERNAME = getpass.getuser()
+_PROJECT_PREFIXES = (
+    f"-Users-{_USERNAME}-coding-",
+    f"-Users-{_USERNAME}-",
+)
+
+# ── Sensitive Data Patterns ──
+
+SENSITIVE_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"sk-[a-zA-Z0-9_-]{20,}"), "[API_KEY_REDACTED]"),
+    (re.compile(r"key-[a-zA-Z0-9_-]{20,}"), "[API_KEY_REDACTED]"),
+    (re.compile(r"ghp_[a-zA-Z0-9]{36,}"), "[GITHUB_TOKEN_REDACTED]"),
+    (re.compile(r"gho_[a-zA-Z0-9]{36,}"), "[GITHUB_TOKEN_REDACTED]"),
+    (re.compile(r"xox[bp]-[a-zA-Z0-9-]+"), "[SLACK_TOKEN_REDACTED]"),
+    (re.compile(r"AKIA[0-9A-Z]{16}"), "[AWS_KEY_REDACTED]"),
+    (re.compile(r"eyJ[a-zA-Z0-9_-]{50,}\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+"), "[JWT_REDACTED]"),
+    (re.compile(r"Bearer\s+[a-zA-Z0-9_.-]{20,}"), "[BEARER_TOKEN_REDACTED]"),
+    (re.compile(r"(?i)password\s*[=:]\s*[\"']?[^\s\"']{8,}"), "[PASSWORD_REDACTED]"),
+    (re.compile(r"(?i)secret\s*[=:]\s*[\"']?[^\s\"']{8,}"), "[SECRET_REDACTED]"),
+]
+
+CODE_BLOCK_RE = re.compile(r"```[\s\S]*?```")
+
+# ── System Tag Stripping (Claude Code specific) ──
+
+SYSTEM_TAGS = [
+    "system-reminder", "command-message", "command-name",
+    "observed_from_primary_session", "user-prompt-submit-hook",
+    "task-notification", "task-id",
+    "EXTREMELY_IMPORTANT", "SUBAGENT-STOP", "EXTREMELY-IMPORTANT",
+    "local-command-caveat", "objective", "execution_context", "process",
+]
+
+
+def _build_system_tag_re() -> re.Pattern[str]:
+    """Build regex that strips system tags, one pattern per tag."""
+    patterns: list[str] = []
+    for tag in SYSTEM_TAGS:
+        patterns.append(rf"<{tag}\b[^>]*>[\s\S]*?</{tag}>")
+        patterns.append(rf"<{tag}\b[^>]*/>")
+        patterns.append(rf"<{tag}\b[^>]*>(?:(?!</).)*$")
+    return re.compile("|".join(patterns), re.MULTILINE)
+
+
+SYSTEM_TAG_RE = _build_system_tag_re()
+
+# ── Codex System Tag Stripping ──
+
+CODEX_SYSTEM_TAGS = [
+    "permissions", "app-context", "environment_context",
+    "collaboration_mode", "INSTRUCTIONS",
+]
+
+
+def _build_codex_tag_re() -> re.Pattern[str]:
+    patterns: list[str] = []
+    for tag in CODEX_SYSTEM_TAGS:
+        patterns.append(rf"<{tag}\b[^>]*>[\s\S]*?</{tag}>")
+        patterns.append(rf"<{tag}\b[^>]*/>")
+    return re.compile("|".join(patterns), re.MULTILINE)
+
+
+CODEX_TAG_RE = _build_codex_tag_re()
+
+# ── Tagging ──
+
+CODE_CHANGE_TOOLS = frozenset({"Edit", "Write", "MultiEdit"})
+CODEX_CODE_CHANGE_TOOLS = frozenset({"write_file", "edit_file", "apply_diff"})
+DEBUG_KEYWORDS = frozenset({"error", "bug", "fail", "fix", "crash", "traceback", "exception"})
+
+LOW_VALUE_RE = re.compile(
+    r"^(?:Unknown skill:|usage:?$|/help$|help$)",
+    re.IGNORECASE,
+)
+
+# ── Boilerplate Prefixes (shared) ──
+
+_BOILERPLATE_PREFIXES = (
+    "Hello memory agent",
+    "PROGRESS SUMMARY CHECKPOINT",
+    "You are a Claude-Mem",
+    "Continue the conversation from where",
+    "This session is being continued",
+    "Respond in this XML format",
+    "IMPORTANT! DO NOT do any work",
+    "Base directory for this skill:",
+    "Tell your human partner that this command",
+    "# AGENTS.md instructions for",
+)
+
+_BOILERPLATE_TAG_INDICATORS = (
+    "<local-command-caveat>", "<command-message>", "<objective>",
+    "<permissions instructions>", "<app-context>", "<environment_context>",
+    "<collaboration_mode>",
+)
+
+
+# ── Data Models ──
+
+
+@dataclass(frozen=True)
+class ToolCall:
+    name: str
+    file_path: str | None
+
+
+@dataclass(frozen=True)
+class DialogTurn:
+    role: str  # "user" | "assistant"
+    text: str
+    tool_calls: tuple[ToolCall, ...] = ()
+
+
+@dataclass(frozen=True)
+class SessionSkeleton:
+    session_id: str
+    date: str
+    project: str
+    source: str  # "cc" | "codex"
+    tags: tuple[str, ...]
+    files_touched: tuple[str, ...]
+    turns: tuple[DialogTurn, ...]
+
+
+# ── State Management ──
+
+
+def load_state() -> dict:
+    if STATE_FILE.exists():
+        return json.loads(STATE_FILE.read_text(encoding="utf-8"))
+    return {"processed": {}}
+
+
+def save_state(state: dict) -> None:
+    HERMES_DIR.mkdir(parents=True, exist_ok=True)
+    content = json.dumps(state, ensure_ascii=False, indent=2)
+    tmp = STATE_FILE.with_suffix(".tmp")
+    tmp.write_text(content, encoding="utf-8")
+    tmp.rename(STATE_FILE)
+
+
+# ── Text Processing ──
+
+
+def redact_secrets(text: str) -> str:
+    result = text
+    for pattern, replacement in SENSITIVE_PATTERNS:
+        result = pattern.sub(replacement, result)
+    return result
+
+
+def count_code_lines(code_block: str) -> int:
+    lines = code_block.strip().split("\n")
+    return max(len(lines) - 2, 1)
+
+
+def truncate_text(text: str) -> str:
+    if len(text) <= TEXT_KEEP_THRESHOLD:
+        return text
+
+    def replace_code(match: re.Match[str]) -> str:
+        n = count_code_lines(match.group(0))
+        return CODE_BLOCK_PLACEHOLDER.format(n=n)
+
+    compressed = CODE_BLOCK_RE.sub(replace_code, text)
+    if len(compressed) <= TEXT_KEEP_THRESHOLD:
+        return compressed
+
+    head = compressed[:TEXT_HEAD_CHARS]
+    tail = compressed[-TEXT_TAIL_CHARS:]
+    omitted = len(compressed) - TEXT_HEAD_CHARS - TEXT_TAIL_CHARS
+    return f"{head}\n[...omitted {omitted} chars...]\n{tail}"
+
+
+def is_boilerplate(text: str) -> bool:
+    """Check if a message is system boilerplate (shared across sources)."""
+    if any(text.startswith(p) for p in _BOILERPLATE_PREFIXES):
+        return True
+    head = text[:150]
+    if any(tag in head for tag in _BOILERPLATE_TAG_INDICATORS):
+        return True
+    return False
+
+
+def is_low_value_session(turns: list[DialogTurn]) -> bool:
+    """Check if all user messages are low-value noise."""
+    user_texts = [t.text for t in turns if t.role == "user"]
+    if not user_texts:
+        return True
+    return all(LOW_VALUE_RE.match(t) for t in user_texts)
+
+
+# ── Session Parser Protocol ──
+
+
+class SessionParser(ABC):
+    """Base class for parsing different AI CLI session formats."""
+
+    source_name: str  # "cc" or "codex"
+    assistant_label: str  # display label in skeleton output
+
+    @abstractmethod
+    def discover_files(self) -> list[Path]:
+        """Find all session .jsonl files, sorted by mtime."""
+
+    @abstractmethod
+    def parse(self, filepath: Path) -> list[DialogTurn]:
+        """Parse a session file into dialog turns."""
+
+    @abstractmethod
+    def get_session_id(self, filepath: Path) -> str:
+        """Extract session ID from filepath."""
+
+    @abstractmethod
+    def get_project_name(self, filepath: Path) -> str:
+        """Extract human-readable project name."""
+
+    def get_session_date(self, filepath: Path) -> str:
+        try:
+            mtime = filepath.stat().st_mtime
+            dt = datetime.fromtimestamp(mtime, tz=timezone.utc)
+            return dt.strftime("%Y-%m-%d")
+        except OSError:
+            return datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+
+
+# ── Claude Code Parser ──
+
+
+class ClaudeCodeParser(SessionParser):
+    source_name = "cc"
+    assistant_label = "CC"
+
+    def discover_files(self) -> list[Path]:
+        if not CC_SESSIONS_DIR.exists():
+            return []
+        return sorted(
+            (
+                p for p in CC_SESSIONS_DIR.rglob("*.jsonl")
+                if "subagents" not in p.parts
+            ),
+            key=lambda p: p.stat().st_mtime if p.exists() else 0.0,
+        )
+
+    def get_session_id(self, filepath: Path) -> str:
+        return filepath.stem
+
+    def get_project_name(self, filepath: Path) -> str:
+        name = filepath.parent.name
+        for prefix in _PROJECT_PREFIXES:
+            name = name.replace(prefix, "")
+        return "home" if name == "-" else name
+
+    def parse(self, filepath: Path) -> list[DialogTurn]:
+        turns: list[DialogTurn] = []
+        try:
+            with open(filepath, encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        data = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+
+                    msg_type = data.get("type")
+                    if msg_type not in ("user", "assistant"):
+                        continue
+
+                    msg = data.get("message", {})
+                    if not isinstance(msg, dict):
+                        continue
+
+                    content = msg.get("content", "")
+
+                    if msg_type == "user":
+                        text = self._extract_text(content)
+                        if not text or len(text) < 5:
+                            continue
+                        cleaned = self._sanitize(text)
+                        if len(cleaned) < 5 or is_boilerplate(cleaned):
+                            continue
+                        turns.append(DialogTurn(role="user", text=cleaned))
+
+                    elif msg_type == "assistant":
+                        tool_calls = self._extract_tool_calls(content)
+                        text = self._extract_text(content)
+                        cleaned = self._sanitize(text) if text else ""
+                        if cleaned or tool_calls:
+                            turns.append(DialogTurn(
+                                role="assistant",
+                                text=cleaned,
+                                tool_calls=tuple(tool_calls),
+                            ))
+
+        except (OSError, UnicodeDecodeError) as exc:
+            print(f"  Warning: failed to read {filepath.name}: {exc}", file=sys.stderr)
+        return turns
+
+    def _extract_text(self, content) -> str | None:
+        if isinstance(content, str):
+            return content.strip() or None
+        if not isinstance(content, list):
+            return None
+        texts = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                text = block.get("text", "").strip()
+                if text:
+                    texts.append(text)
+        return "\n".join(texts) if texts else None
+
+    def _extract_tool_calls(self, content) -> list[ToolCall]:
+        if not isinstance(content, list):
+            return []
+        calls = []
+        for block in content:
+            if not isinstance(block, dict) or block.get("type") != "tool_use":
+                continue
+            name = block.get("name", "unknown")
+            inputs = block.get("input", {})
+            file_path = (
+                inputs.get("file_path")
+                or inputs.get("path")
+                or (inputs.get("command", "")[:80] if name == "Bash" else None)
+            )
+            calls.append(ToolCall(name=name, file_path=file_path))
+        return calls
+
+    def _sanitize(self, text: str) -> str:
+        text = SYSTEM_TAG_RE.sub("", text)
+        text = redact_secrets(text)
+        return text.strip()
+
+
+# ── Codex Parser ──
+
+
+class CodexParser(SessionParser):
+    source_name = "codex"
+    assistant_label = "Codex"
+
+    def __init__(self) -> None:
+        self._project_cache: dict[str, str] = {}
+
+    def discover_files(self) -> list[Path]:
+        files: list[Path] = []
+        for directory in (CODEX_SESSIONS_DIR, CODEX_ARCHIVE_DIR):
+            if directory.exists():
+                files.extend(directory.rglob("*.jsonl"))
+        return sorted(files, key=lambda p: p.stat().st_mtime if p.exists() else 0.0)
+
+    _UUID_RE = re.compile(
+        r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+        re.IGNORECASE,
+    )
+
+    def get_session_id(self, filepath: Path) -> str:
+        m = self._UUID_RE.search(filepath.stem)
+        return m.group(0) if m else filepath.stem[:12]
+
+    def get_project_name(self, filepath: Path) -> str:
+        key = str(filepath)
+        if key in self._project_cache:
+            return self._project_cache[key]
+
+        project = "unknown"
+        try:
+            with open(filepath, encoding="utf-8") as f:
+                first_line = f.readline().strip()
+                if first_line:
+                    data = json.loads(first_line)
+                    if data.get("type") == "session_meta":
+                        cwd = data.get("payload", {}).get("cwd", "")
+                        if cwd:
+                            project = Path(cwd).name
+        except (OSError, json.JSONDecodeError):
+            pass
+
+        self._project_cache[key] = project
+        return project
+
+    def get_session_date(self, filepath: Path) -> str:
+        # Try to extract date from filename first: rollout-2026-03-03T...
+        name = filepath.stem
+        match = re.search(r"(\d{4}-\d{2}-\d{2})", name)
+        if match:
+            return match.group(1)
+        return super().get_session_date(filepath)
+
+    def parse(self, filepath: Path) -> list[DialogTurn]:
+        turns: list[DialogTurn] = []
+        try:
+            with open(filepath, encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        data = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+
+                    if data.get("type") != "response_item":
+                        continue
+
+                    payload = data.get("payload", {})
+                    item_type = payload.get("type")
+                    role = payload.get("role")
+
+                    if item_type == "message" and role == "user":
+                        text = self._extract_text(payload)
+                        if not text or len(text) < 5:
+                            continue
+                        cleaned = self._sanitize(text)
+                        if len(cleaned) < 5 or is_boilerplate(cleaned):
+                            continue
+                        turns.append(DialogTurn(role="user", text=cleaned))
+
+                    elif item_type == "message" and role == "assistant":
+                        text = self._extract_text(payload)
+                        cleaned = self._sanitize(text) if text else ""
+                        if cleaned:
+                            turns.append(DialogTurn(
+                                role="assistant", text=cleaned,
+                            ))
+
+                    elif item_type == "function_call":
+                        tc = self._extract_function_call(payload)
+                        if tc:
+                            # Attach to last assistant turn, or create one
+                            if turns and turns[-1].role == "assistant":
+                                last = turns[-1]
+                                turns[-1] = DialogTurn(
+                                    role="assistant",
+                                    text=last.text,
+                                    tool_calls=last.tool_calls + (tc,),
+                                )
+                            else:
+                                turns.append(DialogTurn(
+                                    role="assistant", text="",
+                                    tool_calls=(tc,),
+                                ))
+
+        except (OSError, UnicodeDecodeError) as exc:
+            print(f"  Warning: failed to read {filepath.name}: {exc}", file=sys.stderr)
+        return turns
+
+    def _extract_text(self, payload: dict) -> str | None:
+        content = payload.get("content", [])
+        if isinstance(content, str):
+            return content.strip() or None
+        if not isinstance(content, list):
+            return None
+        texts = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type", "")
+            if btype in ("input_text", "output_text", "text"):
+                text = block.get("text", "").strip()
+                if text:
+                    texts.append(text)
+        return "\n".join(texts) if texts else None
+
+    def _extract_function_call(self, payload: dict) -> ToolCall | None:
+        name = payload.get("name", "").strip()
+        if not name:
+            return None
+        args_raw = payload.get("arguments", "{}")
+        try:
+            args = json.loads(args_raw) if isinstance(args_raw, str) else args_raw
+        except json.JSONDecodeError:
+            args = {}
+
+        file_path = None
+        if name in ("exec_command", "shell"):
+            file_path = str(args.get("cmd", ""))[:80] or None
+        elif name in ("read_file", "write_file", "edit_file", "apply_diff"):
+            file_path = args.get("path") or args.get("file_path")
+
+        return ToolCall(name=name, file_path=file_path)
+
+    def _sanitize(self, text: str) -> str:
+        text = CODEX_TAG_RE.sub("", text)
+        text = redact_secrets(text)
+        return text.strip()
+
+
+# ── Session Analysis (shared) ──
+
+
+def compute_tags(turns: list[DialogTurn], source: str) -> list[str]:
+    """Auto-tag a session based on its content."""
+    tags: list[str] = []
+    all_tool_names = {tc.name for t in turns for tc in t.tool_calls}
+    all_text = " ".join(t.text.lower() for t in turns if t.text)
+
+    change_tools = CODE_CHANGE_TOOLS if source == "cc" else CODEX_CODE_CHANGE_TOOLS
+    if all_tool_names & change_tools:
+        tags.append("code-change")
+
+    if not all_tool_names:
+        tags.append("discussion-only")
+
+    if any(kw in all_text for kw in DEBUG_KEYWORDS):
+        tags.append("debugging")
+
+    agent_tools = {"Agent"} if source == "cc" else set()
+    if all_tool_names & agent_tools:
+        tags.append("multi-agent")
+
+    return tags
+
+
+def collect_files_touched(turns: list[DialogTurn], source: str) -> list[str]:
+    """Collect unique file paths from tool calls."""
+    skip_tools = {"Bash"} if source == "cc" else {"exec_command", "shell"}
+    seen: set[str] = set()
+    files: list[str] = []
+    for turn in turns:
+        for tc in turn.tool_calls:
+            if tc.file_path and tc.name not in skip_tools and tc.file_path not in seen:
+                seen.add(tc.file_path)
+                files.append(tc.file_path)
+    return files
+
+
+def build_skeleton(
+    parser: SessionParser,
+    filepath: Path,
+    turns: list[DialogTurn],
+) -> SessionSkeleton | None:
+    """Build a session skeleton from parsed turns."""
+    user_turns = [t for t in turns if t.role == "user"]
+    if len(user_turns) < MIN_MESSAGES:
+        return None
+    if is_low_value_session(turns):
+        return None
+
+    session_id = parser.get_session_id(filepath)
+    date = parser.get_session_date(filepath)
+    project = parser.get_project_name(filepath)
+    tags = compute_tags(turns, parser.source_name)
+    files_touched = collect_files_touched(turns, parser.source_name)
+
+    return SessionSkeleton(
+        session_id=session_id,
+        date=date,
+        project=project,
+        source=parser.source_name,
+        tags=tuple(tags),
+        files_touched=tuple(files_touched),
+        turns=tuple(turns),
+    )
+
+
+# ── Markdown Output ──
+
+
+_SOURCE_LABELS = {"cc": "CC", "codex": "Codex"}
+
+
+def format_skeleton(skeleton: SessionSkeleton) -> str:
+    """Format a session skeleton as readable markdown."""
+    assistant_label = _SOURCE_LABELS.get(skeleton.source, skeleton.source)
+
+    lines: list[str] = [
+        "---",
+        f"session: {skeleton.session_id[:8]}",
+        f"date: {skeleton.date}",
+        f"project: {skeleton.project}",
+        f"source: {skeleton.source}",
+        f"tags: [{', '.join(skeleton.tags)}]",
+    ]
+
+    if skeleton.files_touched:
+        shown = skeleton.files_touched[:20]
+        files_str = ", ".join(shown)
+        if len(skeleton.files_touched) > 20:
+            files_str += f", +{len(skeleton.files_touched) - 20} more"
+        lines.append(f"files_touched: [{files_str}]")
+    else:
+        lines.append("files_touched: []")
+
+    lines.extend(["---", ""])
+
+    for turn in skeleton.turns:
+        if turn.role == "user":
+            text = truncate_text(turn.text)
+            lines.append(f"**User**: {text}")
+            lines.append("")
+        elif turn.role == "assistant":
+            if turn.text:
+                text = truncate_text(turn.text)
+                lines.append(f"**{assistant_label}**: {text}")
+                lines.append("")
+            if turn.tool_calls:
+                tool_summary = _summarize_tool_calls(turn.tool_calls)
+                if tool_summary:
+                    lines.append(f"*[Tools: {tool_summary}]*")
+                    lines.append("")
+
+    return "\n".join(lines)
+
+
+def _summarize_tool_calls(calls: tuple[ToolCall, ...]) -> str:
+    """Summarize tool calls into a compact string."""
+    groups: dict[str, list[str | None]] = defaultdict(list)
+    for tc in calls:
+        groups[tc.name].append(tc.file_path)
+
+    shell_tools = {"Bash", "exec_command", "shell"}
+    parts: list[str] = []
+    for name, paths in groups.items():
+        valid_paths = [p for p in paths if p]
+        if valid_paths and name not in shell_tools:
+            short_paths = [Path(p).name for p in valid_paths[:3]]
+            suffix = f"+{len(valid_paths) - 3}" if len(valid_paths) > 3 else ""
+            parts.append(f"{name}({', '.join(short_paths)}{suffix})")
+        else:
+            parts.append(f"{name} x{len(paths)}")
+    return ", ".join(parts)
+
+
+def _trim_skeleton_content(content: str) -> str:
+    """Trim skeleton content to fit within MAX_SKELETON_CHARS."""
+    if len(content) <= MAX_SKELETON_CHARS:
+        return content
+
+    lines = content.split("\n")
+
+    fm_end = 0
+    dashes_seen = 0
+    for i, line in enumerate(lines):
+        if line.strip() == "---":
+            dashes_seen += 1
+            if dashes_seen == 2:
+                fm_end = i + 1
+                break
+
+    if dashes_seen < 2:
+        return content[:MAX_SKELETON_CHARS] + "\n*[...trimmed]*"
+
+    header = "\n".join(lines[:fm_end])
+    body_lines = lines[fm_end:]
+
+    budget = MAX_SKELETON_CHARS - len(header) - 100
+    if budget <= 0:
+        return header[:MAX_SKELETON_CHARS]
+
+    # Keep lines from the end (most recent context is most valuable)
+    trimmed: list[str] = []
+    for line in reversed(body_lines):
+        if budget - len(line) - 1 < 0:
+            break
+        trimmed.append(line)
+        budget -= len(line) + 1
+
+    trimmed.reverse()
+    trim_notice = f"\n*[...trimmed: kept last {len(trimmed)}/{len(body_lines)} lines]*\n"
+    return header + trim_notice + "\n".join(trimmed)
+
+
+def write_skeleton(skeleton: SessionSkeleton) -> Path | None:
+    """Write a skeleton to the inbox directory."""
+    INBOX_DIR.mkdir(parents=True, exist_ok=True)
+    prefix = "cx" if skeleton.source == "codex" else "cc"
+    filename = f"{skeleton.date}_{prefix}_{skeleton.session_id[:8]}.md"
+    filepath = INBOX_DIR / filename
+    content = format_skeleton(skeleton)
+    content = _trim_skeleton_content(content)
+
+    tmp = filepath.with_suffix(".tmp")
+    try:
+        tmp.write_text(content, encoding="utf-8")
+        tmp.rename(filepath)
+        return filepath
+    except OSError as exc:
+        print(f"  Warning: failed to write {filename}: {exc}", file=sys.stderr)
+        tmp.unlink(missing_ok=True)
+        return None
+
+
+# ── Session Discovery ──
+
+
+def find_pending_sessions(
+    parser: SessionParser, state: dict,
+) -> list[Path]:
+    """Find sessions that haven't been processed yet."""
+    processed = state.get("processed", {})
+    now = datetime.now(tz=timezone.utc).timestamp()
+    pending: list[Path] = []
+
+    for filepath in parser.discover_files():
+        key = str(filepath)
+        try:
+            mtime = filepath.stat().st_mtime
+        except OSError:
+            continue
+
+        if now - mtime < STALE_SECONDS:
+            continue
+
+        if processed.get(key) == str(mtime):
+            continue
+
+        pending.append(filepath)
+
+    return pending
+
+
+# ── Commands ──
+
+
+def _get_parsers(source: str | None) -> list[SessionParser]:
+    """Get parser(s) based on source filter."""
+    all_parsers: list[SessionParser] = [ClaudeCodeParser(), CodexParser()]
+    if source is None:
+        return all_parsers
+    matched = [p for p in all_parsers if p.source_name == source]
+    if not matched:
+        print(f"Error: unknown source '{source}'", file=sys.stderr)
+        sys.exit(1)
+    return matched
+
+
+def cmd_sync(args: argparse.Namespace) -> None:
+    state = load_state()
+
+    if args.force:
+        state = {"processed": {}}
+        print("Force mode: re-processing all sessions.")
+
+    parsers = _get_parsers(args.source)
+    total_written = 0
+    total_skipped = 0
+
+    for parser in parsers:
+        pending = find_pending_sessions(parser, state)
+        if not pending:
+            print(f"[{parser.source_name}] No new sessions.")
+            continue
+
+        print(f"[{parser.source_name}] Found {len(pending)} new session(s).")
+        written = 0
+        skipped = 0
+
+        for i, filepath in enumerate(pending):
+            turns = parser.parse(filepath)
+            skeleton = build_skeleton(parser, filepath, turns)
+
+            if skeleton is None:
+                skipped += 1
+            else:
+                out_path = write_skeleton(skeleton)
+                if out_path is not None:
+                    written += 1
+                    tag_str = ", ".join(skeleton.tags) if skeleton.tags else "none"
+                    print(f"  + {out_path.name} [{tag_str}]")
+
+            try:
+                mtime = str(filepath.stat().st_mtime)
+            except OSError:
+                mtime = "deleted"
+            state.setdefault("processed", {})[str(filepath)] = mtime
+
+            if (i + 1) % SAVE_INTERVAL == 0:
+                save_state(state)
+
+        save_state(state)
+        print(f"[{parser.source_name}] Done: {written} written, {skipped} skipped.")
+        total_written += written
+        total_skipped += skipped
+
+    print(f"\nTotal: {total_written} skeleton(s) written, {total_skipped} skipped.")
+
+
+def cmd_status(args: argparse.Namespace) -> None:
+    state = load_state()
+    processed_count = len(state.get("processed", {}))
+
+    parsers = _get_parsers(None)
+    total_files = 0
+    total_pending = 0
+
+    for parser in parsers:
+        files = parser.discover_files()
+        pending = find_pending_sessions(parser, state)
+        total_files += len(files)
+        total_pending += len(pending)
+        print(f"[{parser.source_name}] Sessions: {len(files)}, Pending: {len(pending)}")
+
+    inbox_count = len(list(INBOX_DIR.glob("*.md"))) if INBOX_DIR.exists() else 0
+    archive_count = len(list(ARCHIVE_DIR.glob("*.md"))) if ARCHIVE_DIR.exists() else 0
+
+    print(f"\nOverall:")
+    print(f"  Total sessions:     {total_files}")
+    print(f"  Processed:          {processed_count}")
+    print(f"  Pending:            {total_pending}")
+    print(f"  Inbox skeletons:    {inbox_count}")
+    print(f"  Archived:           {archive_count}")
+    print(f"  State file:         {STATE_FILE}")
+    print(f"  Inbox dir:          {INBOX_DIR}")
+
+
+# ── Entry Point ──
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="H2C Extract — conversation skeletons from AI coding sessions",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    sync_parser = sub.add_parser("sync", help="Incremental sync new sessions")
+    sync_parser.add_argument("--force", action="store_true", help="Re-process all")
+    sync_parser.add_argument(
+        "--source", choices=["cc", "codex"], default=None,
+        help="Only sync from specific source (default: all)",
+    )
+
+    sub.add_parser("status", help="Show sync status")
+
+    args = parser.parse_args()
+
+    commands = {
+        "sync": cmd_sync,
+        "status": cmd_status,
+    }
+
+    if args.command in commands:
+        commands[args.command](args)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `tools/h2c_extract/` — a standalone Python tool that extracts conversation skeletons from **Claude Code** and **Codex CLI** session files
- Hermes can consume these skeletons to stay informed about user-AI interactions that happen outside of Hermes-dispatched tasks (the "blind spot" problem)
- Zero modification needed on any AI CLI — reads existing `.jsonl` session files directly

## Problem

When users work directly with AI coding CLIs (Claude Code, Codex) without going through Hermes, Hermes has zero visibility into:
- What decisions were made and why
- Project progress and current status  
- Problems encountered and workarounds applied
- Pure discussion sessions (architecture, planning) that produce no git commits

## How it works

```
AI CLI works normally (zero modification)
       |
       ├── ~/.claude/projects/**/*.jsonl  (Claude Code)
       └── ~/.codex/sessions/**/*.jsonl   (Codex CLI)
       |
h2c_extract.py  (rule-based filter, zero token cost)
       |
~/.hermes/inbox/  (conversation skeletons, ~15-20KB each)
       |
Hermes reads inbox  (cheap model, on wake-up or cron)
```

The useful signal (user questions, AI responses, tool metadata) is **less than 1% of file size**. A 4.2MB session compresses to ~15KB of readable markdown.

## Key features

- **Adapter pattern**: `ClaudeCodeParser` + `CodexParser`, easily extensible to new CLIs (Gemini, Cursor, etc.)
- **Auto-tagging**: `code-change`, `discussion-only`, `debugging`, `multi-agent`
- **Incremental sync** with crash-safe checkpointing (every 50 files)
- **Sensitive data redaction**: API keys, tokens, JWTs, passwords, secrets
- **Size caps**: per-block truncation + per-file 20KB limit with smart trimming
- **Pure Python 3.10+**, zero external dependencies

## Files

| File | Purpose |
|------|---------|
| `tools/h2c_extract/h2c_extract.py` | Extraction script (main tool) |
| `tools/h2c_extract/DESIGN.md` | Architecture decisions and technical spec |
| `tools/h2c_extract/README.md` | Usage guide with setup instructions |

## Test plan

- [x] Full sync: 4,500+ CC sessions + 300+ Codex sessions processed
- [x] Output: 234 skeletons written, 4,600+ low-signal sessions skipped
- [x] Largest skeleton within trim target
- [x] Zero processing errors
- [x] Sensitive data redaction verified (API keys, passwords, JWTs)
- [x] Edge cases tested: empty files, active sessions, missing directories
- [x] 3 rounds of strict code review passed (CRITICAL/HIGH issues fixed)
- [ ] Integration test with Hermes consumption pipeline (PR 2)