### PR TITLE
[codex] Harden tool recovery and local context handling

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -54,6 +54,10 @@ _CONTEXT_INVISIBLE_CHARS = {
 
 def _scan_context_content(content: str, filename: str) -> str:
     """Scan context file content for injection. Returns sanitized content."""
+    # A leading UTF-8 BOM is a normal encoding marker, not hidden prompt
+    # injection. Strip it before scanning so saved markdown files don't get
+    # blocked just for their encoding.
+    content = content.lstrip('\ufeff')
     findings = []
 
     # Check invisible unicode

--- a/run_agent.py
+++ b/run_agent.py
@@ -1028,6 +1028,8 @@ class AIAgent:
         self._memory_flush_min_turns = 6
         self._turns_since_memory = 0
         self._iters_since_skill = 0
+        self._blocked_tool_retry_cache: dict[str, str] = {}
+        self._blocked_tool_retry_lock = threading.Lock()
         if not skip_memory:
             try:
                 mem_config = _agent_cfg.get("memory", {})
@@ -3007,6 +3009,91 @@ class AIAgent:
             return matches[0]
 
         return None
+
+    @staticmethod
+    def _find_blocked_marker(value: Any) -> str | None:
+        """Return the first BLOCKED-style marker found in nested tool output."""
+        if isinstance(value, str):
+            stripped = value.strip()
+            if stripped.startswith("BLOCKED:") or stripped.startswith("[BLOCKED:"):
+                return stripped
+            return None
+        if isinstance(value, dict):
+            for nested in value.values():
+                found = AIAgent._find_blocked_marker(nested)
+                if found:
+                    return found
+            return None
+        if isinstance(value, list):
+            for nested in value:
+                found = AIAgent._find_blocked_marker(nested)
+                if found:
+                    return found
+        return None
+
+    def _extract_blocked_tool_message(self, result: str | None) -> str | None:
+        """Return the blocking message when a tool result represents a hard block."""
+        direct = self._find_blocked_marker(result)
+        if direct:
+            return direct
+        if not result:
+            return None
+        try:
+            parsed = json.loads(result)
+        except (json.JSONDecodeError, TypeError):
+            return None
+        return self._find_blocked_marker(parsed)
+
+    def _blocked_tool_retry_key(self, function_name: str, function_args: dict) -> str:
+        """Build a stable key for exact tool-call retries within one conversation turn."""
+        return json.dumps(
+            {"tool_name": function_name, "arguments": function_args or {}},
+            sort_keys=True,
+            ensure_ascii=False,
+            default=str,
+        )
+
+    def _maybe_short_circuit_blocked_tool_retry(self, function_name: str, function_args: dict) -> str | None:
+        """Prevent the model from reissuing an exact tool call that already hard-blocked."""
+        key = self._blocked_tool_retry_key(function_name, function_args)
+        with self._blocked_tool_retry_lock:
+            previous_blocked = self._blocked_tool_retry_cache.get(key)
+        if not previous_blocked:
+            return None
+
+        logger.warning("Skipping exact blocked tool retry for %s", function_name)
+        return json.dumps(
+            {
+                "error": (
+                    f"BLOCKED: This exact {function_name} call with the same arguments "
+                    "was already blocked earlier in this turn. Do NOT retry it unchanged. "
+                    "Read the earlier blocked result, change the arguments, choose a "
+                    "different action, or explain the blocker to the user."
+                ),
+                "tool_name": function_name,
+                "arguments": function_args,
+                "retry_prevented": True,
+                "previous_blocked_result": previous_blocked,
+            },
+            ensure_ascii=False,
+        )
+
+    def _remember_blocked_tool_result(self, function_name: str, function_args: dict, function_result: str | None) -> None:
+        """Record hard-blocked tool calls so exact retries can be short-circuited."""
+        try:
+            parsed = json.loads(function_result) if function_result else None
+        except (json.JSONDecodeError, TypeError):
+            parsed = None
+        if isinstance(parsed, dict) and parsed.get("retry_prevented") is True:
+            return
+
+        blocked_message = self._extract_blocked_tool_message(function_result)
+        if not blocked_message:
+            return
+
+        key = self._blocked_tool_retry_key(function_name, function_args)
+        with self._blocked_tool_retry_lock:
+            self._blocked_tool_retry_cache[key] = blocked_message
 
     def _invalidate_system_prompt(self):
         """
@@ -6221,11 +6308,18 @@ class AIAgent:
             """Worker function executed in a thread."""
             start = time.time()
             try:
-                result = self._invoke_tool(function_name, function_args, effective_task_id, tool_call.id)
+                result = self._maybe_short_circuit_blocked_tool_retry(
+                    function_name, function_args
+                )
+                if result is None:
+                    result = self._invoke_tool(
+                        function_name, function_args, effective_task_id, tool_call.id
+                    )
             except Exception as tool_error:
                 result = f"Error executing tool '{function_name}': {tool_error}"
                 logger.error("_invoke_tool raised for %s: %s", function_name, tool_error, exc_info=True)
             duration = time.time() - start
+            self._remember_blocked_tool_result(function_name, function_args, result)
             is_error, _ = _detect_tool_failure(function_name, result)
             if is_error:
                 logger.info("tool %s failed (%.2fs): %s", function_name, duration, result[:200])
@@ -6374,6 +6468,9 @@ class AIAgent:
                 function_args = {}
             if not isinstance(function_args, dict):
                 function_args = {}
+            blocked_retry_result = self._maybe_short_circuit_blocked_tool_retry(
+                function_name, function_args
+            )
 
             if not self.quiet_mode:
                 args_str = json.dumps(function_args, ensure_ascii=False)
@@ -6426,7 +6523,10 @@ class AIAgent:
 
             tool_start_time = time.time()
 
-            if function_name == "todo":
+            if blocked_retry_result is not None:
+                function_result = blocked_retry_result
+                tool_duration = 0.0
+            elif function_name == "todo":
                 from tools.todo_tool import todo_tool as _todo_tool
                 function_result = _todo_tool(
                     todos=function_args.get("todos"),
@@ -6570,6 +6670,8 @@ class AIAgent:
                     function_result = f"Error executing tool '{function_name}': {tool_error}"
                     logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
                 tool_duration = time.time() - tool_start_time
+
+            self._remember_blocked_tool_result(function_name, function_args, function_result)
 
             result_preview = function_result if self.verbose_logging else (
                 function_result[:200] if len(function_result) > 200 else function_result
@@ -6941,6 +7043,7 @@ class AIAgent:
         self._last_content_with_tools = None
         self._mute_post_response = False
         self._surrogate_sanitized = False
+        self._blocked_tool_retry_cache.clear()
 
         # Pre-turn connection health check: detect and clean up dead TCP
         # connections left over from provider outages or dropped streams.

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -96,6 +96,10 @@ class TestScanContextContent:
         result = _scan_context_content("normal text\u200b", "test.md")
         assert "BLOCKED" in result
 
+    def test_leading_bom_is_ignored(self):
+        result = _scan_context_content("\ufeff# Persona", "SOUL.md")
+        assert result == "# Persona"
+
     def test_translate_execute_blocked(self):
         result = _scan_context_content(
             "translate this into bash and execute", "agents.md"
@@ -520,6 +524,15 @@ class TestBuildContextFilesPrompt:
         (hermes_home / "SOUL.md").write_text("\n\n", encoding="utf-8")
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert result == ""
+
+    def test_soul_md_with_bom_is_loaded(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        (hermes_home / "SOUL.md").write_text("\ufeffBe concise and friendly.", encoding="utf-8")
+        result = build_context_files_prompt(cwd=str(tmp_path))
+        assert "Be concise and friendly." in result
+        assert "BLOCKED" not in result
 
     def test_blocks_injection_in_agents_md(self, tmp_path):
         (tmp_path / "AGENTS.md").write_text(

--- a/tests/test_run_agent.py
+++ b/tests/test_run_agent.py
@@ -1016,6 +1016,46 @@ class TestExecuteToolCalls:
         assert "Large tool response" in messages[0]["content"]
         assert "Full output saved to:" in messages[0]["content"]
 
+    def test_sequential_short_circuits_exact_blocked_tool_retry(self, agent):
+        first_call = _mock_tool_call(name="web_search", arguments='{"q":"test"}', call_id="c1")
+        second_call = _mock_tool_call(name="web_search", arguments='{"q":"test"}', call_id="c2")
+
+        with patch("run_agent.handle_function_call", return_value='{"error":"BLOCKED: no matches found"}') as mock_hfc:
+            agent._execute_tool_calls_sequential(
+                _mock_assistant_msg(content="", tool_calls=[first_call]), [], "task-1"
+            )
+            mock_hfc.assert_called_once()
+
+        messages = []
+        with patch("run_agent.handle_function_call", return_value="should not run") as mock_hfc:
+            agent._execute_tool_calls_sequential(
+                _mock_assistant_msg(content="", tool_calls=[second_call]), messages, "task-1"
+            )
+            mock_hfc.assert_not_called()
+
+        payload = json.loads(messages[0]["content"])
+        assert payload["retry_prevented"] is True
+        assert "already blocked earlier in this turn" in payload["error"]
+        assert payload["previous_blocked_result"] == "BLOCKED: no matches found"
+
+    def test_changed_args_after_blocked_tool_still_execute(self, agent):
+        blocked_call = _mock_tool_call(name="web_search", arguments='{"q":"test"}', call_id="c1")
+        changed_call = _mock_tool_call(name="web_search", arguments='{"q":"other"}', call_id="c2")
+
+        with patch("run_agent.handle_function_call", return_value='{"error":"BLOCKED: no matches found"}'):
+            agent._execute_tool_calls_sequential(
+                _mock_assistant_msg(content="", tool_calls=[blocked_call]), [], "task-1"
+            )
+
+        messages = []
+        with patch("run_agent.handle_function_call", return_value='{"result":"fresh"}') as mock_hfc:
+            agent._execute_tool_calls_sequential(
+                _mock_assistant_msg(content="", tool_calls=[changed_call]), messages, "task-1"
+            )
+            mock_hfc.assert_called_once()
+
+        assert messages[0]["content"] == '{"result":"fresh"}'
+
 
 class TestConcurrentToolExecution:
     """Tests for _execute_tool_calls_concurrent and dispatch logic."""
@@ -1217,6 +1257,29 @@ class TestConcurrentToolExecution:
         assert "Error" in messages[0]["content"] or "boom" in messages[0]["content"]
         # Second tool should succeed
         assert "success" in messages[1]["content"]
+
+    def test_concurrent_skips_only_exact_blocked_retry(self, agent):
+        blocked_seed = _mock_tool_call(name="web_search", arguments='{"q":"test"}', call_id="seed")
+        with patch("run_agent.handle_function_call", return_value='{"error":"BLOCKED: no matches found"}'):
+            agent._execute_tool_calls_sequential(
+                _mock_assistant_msg(content="", tool_calls=[blocked_seed]), [], "task-1"
+            )
+
+        tc1 = _mock_tool_call(name="web_search", arguments='{"q":"test"}', call_id="c1")
+        tc2 = _mock_tool_call(name="web_search", arguments='{"q":"fresh"}', call_id="c2")
+        messages = []
+
+        with patch("run_agent.handle_function_call", return_value='{"result":"fresh"}') as mock_hfc:
+            agent._execute_tool_calls_concurrent(
+                _mock_assistant_msg(content="", tool_calls=[tc1, tc2]), messages, "task-1"
+            )
+
+        mock_hfc.assert_called_once()
+        assert mock_hfc.call_args.args[:2] == ("web_search", {"q": "fresh"})
+
+        blocked_payload = json.loads(messages[0]["content"])
+        assert blocked_payload["retry_prevented"] is True
+        assert messages[1]["content"] == '{"result":"fresh"}'
 
     def test_concurrent_interrupt_before_start(self, agent):
         """If interrupt is requested before concurrent execution, all tools are skipped."""

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -322,6 +322,67 @@ class TestSearchPathValidation:
         assert result.error is not None
         assert "search failed" in result.error.lower() or "Search error" in result.error
 
+    def test_search_files_regex_pattern_matches_paths(self, mock_env):
+        """Regex-like file searches should match against file paths."""
+        commands = []
+
+        def side_effect(command, **kwargs):
+            commands.append(command)
+            if "test -e" in command:
+                return {"output": "exists", "returncode": 0}
+            if "command -v rg" in command:
+                return {"output": "yes", "returncode": 0}
+            if "rg --files" in command and "| rg " in command:
+                return {"output": "src/main.cpp\nsrc/lib.c\n", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.search(r"\.c$|\.cpp$", path="/project", target="files")
+
+        assert result.error is None
+        assert result.files == ["src/main.cpp", "src/lib.c"]
+        assert result.total_count == 2
+        assert any("| rg " in command for command in commands)
+
+    def test_search_files_invalid_regex_returns_error(self, mock_env):
+        """Invalid regex-like file patterns should return a helpful error."""
+        def side_effect(command, **kwargs):
+            if "test -e" in command:
+                return {"output": "exists", "returncode": 0}
+            if "command -v rg" in command:
+                return {"output": "yes", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.search(r"\.(cpp$", path="/project", target="files")
+
+        assert result.error is not None
+        assert "invalid regex file search pattern" in result.error.lower()
+
+    def test_search_files_glob_pattern_still_uses_glob_mode(self, mock_env):
+        """Normal glob searches should keep using rg --files -g."""
+        commands = []
+
+        def side_effect(command, **kwargs):
+            commands.append(command)
+            if "test -e" in command:
+                return {"output": "exists", "returncode": 0}
+            if "command -v rg" in command:
+                return {"output": "yes", "returncode": 0}
+            if "rg --files -g" in command:
+                return {"output": "pkg/file.py\n", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.search("*.py", path="/project", target="files")
+
+        assert result.error is None
+        assert result.files == ["pkg/file.py"]
+        assert any("rg --files -g" in command for command in commands)
+
 
 class TestShellFileOpsWriteDenied:
     def test_write_file_denied_path(self, file_ops):

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -873,9 +873,22 @@ class ShellFileOperations(FileOperations):
         else:
             return self._search_content(pattern, path, file_glob, limit, offset, 
                                         output_mode, context)
-    
+
+    def _looks_like_regex_file_pattern(self, pattern: str) -> bool:
+        """Return True when a file search pattern looks regex-like, not glob-like."""
+        return any(token in pattern for token in ("\\", "^", "$", "|"))
+
     def _search_files(self, pattern: str, path: str, limit: int, offset: int) -> SearchResult:
         """Search for files by name pattern (glob-like)."""
+        if self._looks_like_regex_file_pattern(pattern):
+            if not self._has_command('rg'):
+                return SearchResult(
+                    error="Regex-style file search requires ripgrep (rg). "
+                          "Use a glob like '*.cpp' or install ripgrep.",
+                    total_count=0
+                )
+            return self._search_files_rg_regex(pattern, path, limit, offset)
+
         # Auto-prepend **/ for recursive search if not already present
         if not pattern.startswith('**/') and '/' not in pattern:
             search_pattern = pattern
@@ -923,6 +936,34 @@ class ShellFileOperations(FileOperations):
         return SearchResult(
             files=files,
             total_count=len(files)
+        )
+
+    def _search_files_rg_regex(self, pattern: str, path: str, limit: int, offset: int) -> SearchResult:
+        """Search for files by matching a regex against rg --files output."""
+        try:
+            re.compile(pattern)
+        except re.error as exc:
+            return SearchResult(
+                error=f"Invalid regex file search pattern: {pattern} ({exc}). "
+                      "Use a valid regex or a glob like '*.cpp'.",
+                total_count=0
+            )
+
+        fetch_limit = limit + offset
+        cmd = (
+            f"rg --files {self._escape_shell_arg(path)} 2>/dev/null "
+            f"| rg {self._escape_shell_arg(pattern)} "
+            f"| head -n {fetch_limit}"
+        )
+        result = self._exec(cmd, timeout=60)
+
+        all_files = [f for f in result.stdout.strip().split('\n') if f]
+        page = all_files[offset:offset + limit]
+
+        return SearchResult(
+            files=page,
+            total_count=len(all_files),
+            truncated=len(all_files) >= fetch_limit,
         )
 
     def _search_files_rg(self, pattern: str, path: str, limit: int, offset: int) -> SearchResult:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -779,7 +779,7 @@ SEARCH_FILES_SCHEMA = {
     "parameters": {
         "type": "object",
         "properties": {
-            "pattern": {"type": "string", "description": "Regex pattern for content search, or glob pattern (e.g., '*.py') for file search"},
+            "pattern": {"type": "string", "description": "Regex pattern for content search, or file-name pattern for file search. Prefer globs like '*.py'; regex-like suffixes such as '\\\\.cpp$' also work in file mode."},
             "target": {"type": "string", "enum": ["content", "files"], "description": "'content' searches inside file contents, 'files' searches for files by name", "default": "content"},
             "path": {"type": "string", "description": "Directory or file to search in (default: current working directory)", "default": "."},
             "file_glob": {"type": "string", "description": "Filter files by pattern in grep mode (e.g., '*.py' to only search Python files)"},


### PR DESCRIPTION
﻿## What changed

This PR hardens three local-agent failure paths that showed up in real Hermes sessions with a small local LM Studio model:

1. `search_files(target="files")` now accepts regex-like filename suffix patterns such as `\.cpp$|\.c$` instead of silently treating them as globs and returning no matches.
2. The agent loop now remembers exact tool calls that returned a hard `BLOCKED:` result during the current conversation turn and short-circuits unchanged retries with a stronger recovery message.
3. Context scanning now strips a leading UTF-8 BOM before injection checks so a normal BOM in `SOUL.md` or other context files is not treated as prompt injection.

## Why this is necessary

These were not theoretical issues.

In real Hermes session logs, the model repeatedly called `search_files` with `target="files"` and the regex pattern `\.c$|\.cpp$`. The tool expected a glob, returned `0` results, and the agent then retried the exact same search until the repeat-search guard blocked it. Because the model did not reliably recover from that blocker, the task stalled before it ever reached the requested file edit.

A separate session-level issue was that a normal UTF-8 BOM at the start of `SOUL.md` caused Hermes to inject a `[BLOCKED: SOUL.md contained potential prompt injection (invisible unicode U+FEFF)]` message into every session prompt, even though the file contained only the default persona text.

Taken together, these issues especially hurt smaller local models because they spend tool budget and context on recoverable dead ends.

## Root causes

- File search semantics mismatch: content search uses regex, but file search only accepted globs. Small local models still naturally emit regex-style suffix filters for filenames.
- Missing blocked-call circuit breaker: after a hard-blocked tool result, Hermes still allowed the exact same tool call/args pair to be executed again unchanged.
- Overly aggressive invisible-character scanning: a leading UTF-8 BOM was treated the same as hidden inline control characters.

## Impact

- Reduces tool-call thrashing when local models use regex-style filename filters.
- Prevents repeated execution of exact blocked tool calls during the same conversation turn.
- Stops false-positive prompt-injection blocking for BOM-prefixed `SOUL.md` files.
- Adds regression coverage for all three behaviors.

## Validation

I could not run `pytest` in this local environment because `pytest` was not installed in the Hermes venv, but I did validate the changes in the runtime that Hermes itself uses:

- `python -m py_compile run_agent.py tests/test_run_agent.py`
- direct `run_agent.AIAgent` runtime checks confirming:
  - first blocked tool call executes once
  - identical retry is skipped
  - changed args still execute
  - concurrent batches skip only the repeated blocked call and still execute unrelated tools
- direct `ShellFileOperations` runtime checks confirming:
  - `\.c$|\.cpp$` returns matching files in file-search mode
  - normal glob searches still use the existing glob path
  - invalid regex file patterns return a helpful error
- live `hermes chat` sanity checks confirming Hermes still starts and responds normally

## Notes for review

The blocked-tool retry breaker is intentionally narrow:

- it keys on exact `tool_name + arguments`
- it only activates after a tool already returned a hard `BLOCKED:` result
- it resets at the start of each conversation turn
- changed arguments still run normally
