### PR TITLE
fix(honcho): use underscores instead of dots for peer IDs to satisfy API regex

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -285,6 +285,15 @@ PLATFORM_HINTS = {
         "only — no markdown, no formatting. SMS messages are limited to ~1600 "
         "characters, so be brief and direct."
     ),
+    "matrix": (
+        "You are connected via Matrix, a decentralized encrypted messaging protocol. "
+        "You have Matrix-specific tools available: matrix_send_reaction (react with emoji), "
+        "matrix_redact_message (delete messages), matrix_create_room (create new rooms), "
+        "matrix_invite_user (invite users to rooms), matrix_fetch_history (read room history), "
+        "and matrix_set_presence (set your online status). "
+        "Messages support full HTML formatting via org.matrix.custom.html. "
+        "Use markdown naturally — it will be converted to proper HTML."
+    ),
 }
 
 CONTEXT_FILE_MAX_CHARS = 20_000

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -123,6 +123,14 @@ class MatrixAdapter(BasePlatformAdapter):
         # Each entry: (room, event, timestamp)
         self._pending_megolm: list = []
 
+        # Thinking / agentic collapsible fields
+        self._thinking_enabled: bool = config.extra.get(
+            "thinking_fields_enabled",
+            os.getenv("MATRIX_THINKING_FIELDS_ENABLED", "true").lower()
+            in ("true", "1", "yes"),
+        )
+        self._thinking_manager: Optional[Any] = None  # Lazy init after connect
+
     def _is_duplicate_event(self, event_id) -> bool:
         """Return True if this event was already processed. Tracks the ID otherwise."""
         if not event_id:
@@ -294,12 +302,26 @@ class MatrixAdapter(BasePlatformAdapter):
 
         # Start the sync loop.
         self._sync_task = asyncio.create_task(self._sync_loop())
+
+        # Inject adapter reference for Matrix tools
+        try:
+            from tools.matrix_tools import set_matrix_adapter
+            set_matrix_adapter(self)
+        except ImportError:
+            pass
+
         self._mark_connected()
         return True
 
     async def disconnect(self) -> None:
         """Disconnect from Matrix."""
         self._closing = True
+
+        if self._thinking_manager:
+            try:
+                await self._thinking_manager.abort_all("Gateway restarting")
+            except Exception as exc:
+                logger.debug("Matrix: could not abort active introspection fields on disconnect: %s", exc)
 
         if self._sync_task and not self._sync_task.done():
             self._sync_task.cancel()
@@ -319,6 +341,13 @@ class MatrixAdapter(BasePlatformAdapter):
                 logger.info("Matrix: exported Megolm keys for next restart")
             except Exception as exc:
                 logger.debug("Matrix: could not export keys on disconnect: %s", exc)
+
+        # Clear adapter reference for Matrix tools
+        try:
+            from tools.matrix_tools import set_matrix_adapter
+            set_matrix_adapter(None)
+        except ImportError:
+            pass
 
         if self._client:
             await self._client.close()
@@ -483,6 +512,168 @@ class MatrixAdapter(BasePlatformAdapter):
         if isinstance(resp, nio.RoomSendResponse):
             return SendResult(success=True, message_id=resp.event_id)
         return SendResult(success=False, error=getattr(resp, "message", str(resp)))
+
+    # ------------------------------------------------------------------
+    # Thinking fields — collapsible <details> blocks for agentic tasks
+    # ------------------------------------------------------------------
+
+    def _get_thinking_manager(self):
+        """Lazy-init the ThinkingManager (requires connected client)."""
+        if self._thinking_manager is None and self._client:
+            from gateway.platforms.matrix_thinking import ThinkingManager
+
+            self._thinking_manager = ThinkingManager(self)
+        return self._thinking_manager
+
+    async def start_thinking(
+        self,
+        room_id: str,
+        task_id: str,
+        initial_summary: str = "Processing request...",
+        model_label: str = "",
+        initial_content_md: str = "",
+    ) -> Optional[str]:
+        """Start a collapsible thinking field. Returns event_id or None."""
+        if not self._thinking_enabled or not self._client:
+            return None
+        mgr = self._get_thinking_manager()
+        if not mgr:
+            return None
+        return await mgr.start(
+            room_id,
+            task_id,
+            initial_summary,
+            field_kind="thinking",
+            model_label=model_label,
+            initial_content_md=initial_content_md,
+        )
+
+    async def update_thinking(
+        self,
+        task_id: str,
+        step_info: str,
+        content_md: str = "",
+        model_label: Optional[str] = None,
+        append_line: bool = True,
+    ) -> None:
+        """Live-update thinking field (buffered + lossless)."""
+        if not self._thinking_enabled or not self._thinking_manager:
+            return
+        await self._thinking_manager.update(
+            task_id,
+            step_info,
+            content_md,
+            field_kind="thinking",
+            model_label=model_label,
+            append_line=append_line,
+        )
+
+    async def finalize_thinking(
+        self,
+        task_id: str,
+        final_summary: str = "Task complete",
+        collapse: bool = True,
+        model_label: Optional[str] = None,
+    ) -> None:
+        """Finalize and optionally collapse thinking field."""
+        if not self._thinking_enabled or not self._thinking_manager:
+            return
+        await self._thinking_manager.finalize(
+            task_id,
+            final_summary,
+            collapse,
+            field_kind="thinking",
+            model_label=model_label,
+        )
+
+    async def abort_thinking(
+        self,
+        task_id: str,
+        reason: str = "Aborted",
+        model_label: Optional[str] = None,
+    ) -> None:
+        """Abort a thinking session on error/timeout."""
+        if not self._thinking_manager:
+            return
+        await self._thinking_manager.abort(
+            task_id,
+            reason,
+            field_kind="thinking",
+            model_label=model_label,
+        )
+
+    async def start_tool_activity(
+        self,
+        room_id: str,
+        task_id: str,
+        initial_summary: str = "Tool activity",
+        model_label: str = "",
+        initial_content_md: str = "",
+    ) -> Optional[str]:
+        if not self._thinking_enabled or not self._client:
+            return None
+        mgr = self._get_thinking_manager()
+        if not mgr:
+            return None
+        return await mgr.start(
+            room_id,
+            task_id,
+            initial_summary,
+            field_kind="tools",
+            model_label=model_label,
+            initial_content_md=initial_content_md,
+        )
+
+    async def update_tool_activity(
+        self,
+        task_id: str,
+        step_info: str,
+        content_md: str = "",
+        model_label: Optional[str] = None,
+        append_line: bool = True,
+    ) -> None:
+        if not self._thinking_enabled or not self._thinking_manager:
+            return
+        await self._thinking_manager.update(
+            task_id,
+            step_info,
+            content_md,
+            field_kind="tools",
+            model_label=model_label,
+            append_line=append_line,
+        )
+
+    async def finalize_tool_activity(
+        self,
+        task_id: str,
+        final_summary: str = "Tool activity complete",
+        collapse: bool = True,
+        model_label: Optional[str] = None,
+    ) -> None:
+        if not self._thinking_enabled or not self._thinking_manager:
+            return
+        await self._thinking_manager.finalize(
+            task_id,
+            final_summary,
+            collapse,
+            field_kind="tools",
+            model_label=model_label,
+        )
+
+    async def abort_tool_activity(
+        self,
+        task_id: str,
+        reason: str = "Tool activity aborted",
+        model_label: Optional[str] = None,
+    ) -> None:
+        if not self._thinking_manager:
+            return
+        await self._thinking_manager.abort(
+            task_id,
+            reason,
+            field_kind="tools",
+            model_label=model_label,
+        )
 
     async def send_image(
         self,

--- a/gateway/platforms/matrix_thinking.py
+++ b/gateway/platforms/matrix_thinking.py
@@ -1,0 +1,511 @@
+"""Matrix collapsible introspection fields for agent reasoning and tool activity.
+
+Lossless, reviewable, rate-limited live introspection for Matrix agent runs.
+Uses stable Matrix primitives only:
+  - m.room.message with org.matrix.custom.html + <details><summary>
+  - Live message edits via m.replace relation + m.new_content
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+if TYPE_CHECKING:
+    from gateway.platforms.matrix import MatrixAdapter
+
+logger = logging.getLogger(__name__)
+
+_MIN_EDIT_INTERVAL = 3.0
+_MAX_BODY_SIZE = 60_000
+
+
+@dataclass
+class ThinkingSession:
+    """Tracks one active introspection field per task/kind."""
+
+    room_id: str
+    event_id: str
+    task_id: str
+    started_at: float
+    last_update: float
+    step_count: int = 0
+    content_lines: list = field(default_factory=list)
+    finalized: bool = False
+    field_kind: str = "thinking"
+    title: str = "Hermes Agent"
+    summary: str = ""
+    model_label: str = ""
+    dirty: bool = False
+    flush_task: Optional[asyncio.Task] = None
+
+
+class ThinkingManager:
+    """Manages buffered Matrix introspection fields.
+
+    Supports two lossless buffered field types:
+      - thinking
+      - tools
+    """
+
+    def __init__(self, adapter: "MatrixAdapter"):
+        self._adapter = adapter
+        self._sessions: Dict[str, ThinkingSession] = {}
+        self._lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def start(
+        self,
+        room_id: str,
+        task_id: str,
+        initial_summary: str = "Processing request...",
+        *,
+        field_kind: str = "thinking",
+        model_label: str = "",
+        initial_content_md: str = "",
+    ) -> Optional[str]:
+        """Send initial field and return event_id, or None on failure."""
+        import nio
+
+        key = self._session_key(task_id, field_kind)
+        async with self._lock:
+            _, existing = self._lookup_session_locked(task_id, field_kind)
+            if existing and not existing.finalized:
+                if model_label:
+                    existing.model_label = model_label
+                if initial_content_md:
+                    existing.content_lines.append(initial_content_md)
+                    existing.dirty = True
+                    self._ensure_flush_locked(key, existing, 0.0)
+                return existing.event_id
+
+        now = time.time()
+        title = self._field_title(field_kind)
+        initial_lines = [initial_content_md] if initial_content_md else []
+        html_body = self._build_html(
+            summary=initial_summary,
+            step=0,
+            ts=now,
+            content_html=self._lines_to_html(initial_lines),
+            open_tag=True,
+            field_kind=field_kind,
+            model_label=model_label,
+        )
+        plaintext = self._plaintext_summary(title, initial_summary, model_label=model_label)
+        content = self._msg_content(html_body, plaintext)
+
+        try:
+            resp = await asyncio.wait_for(
+                self._adapter._client.room_send(
+                    room_id,
+                    "m.room.message",
+                    content,
+                    ignore_unverified_devices=True,
+                ),
+                timeout=30,
+            )
+        except Exception as exc:
+            logger.error("Matrix introspection: failed to start %s in %s: %s", field_kind, room_id, exc)
+            return None
+
+        if not isinstance(resp, nio.RoomSendResponse):
+            logger.error(
+                "Matrix introspection: unexpected response %s",
+                getattr(resp, "message", resp),
+            )
+            return None
+
+        session = ThinkingSession(
+            room_id=room_id,
+            event_id=resp.event_id,
+            task_id=task_id,
+            started_at=now,
+            last_update=now,
+            field_kind=field_kind,
+            title=title,
+            summary=initial_summary,
+            model_label=model_label,
+            content_lines=initial_lines,
+        )
+        async with self._lock:
+            self._sessions[key] = session
+
+        logger.info(
+            "Matrix introspection started in %s (task=%s kind=%s event=%s)",
+            room_id,
+            task_id,
+            field_kind,
+            resp.event_id,
+        )
+        return resp.event_id
+
+    async def update(
+        self,
+        task_id: str,
+        step_info: str,
+        content_md: str = "",
+        *,
+        field_kind: str = "thinking",
+        model_label: Optional[str] = None,
+        append_line: bool = True,
+    ) -> None:
+        """Append data losslessly and flush on a rate-limited schedule."""
+        key = self._session_key(task_id, field_kind)
+        snapshot = None
+
+        async with self._lock:
+            key, session = self._lookup_session_locked(task_id, field_kind)
+            if not session or session.finalized:
+                return
+
+            if step_info:
+                session.summary = step_info
+            if model_label:
+                session.model_label = model_label
+            if content_md and append_line:
+                session.content_lines.append(content_md)
+            session.step_count += 1
+            session.dirty = True
+
+            now = time.time()
+            elapsed = now - session.last_update
+            if elapsed >= _MIN_EDIT_INTERVAL and (session.flush_task is None or session.flush_task.done()):
+                snapshot = self._snapshot_locked(session)
+                session.last_update = now
+                session.dirty = False
+            else:
+                delay = max(0.0, _MIN_EDIT_INTERVAL - elapsed)
+                self._ensure_flush_locked(key, session, delay)
+
+        if snapshot:
+            await self._send_edit_snapshot(snapshot)
+
+    async def finalize(
+        self,
+        task_id: str,
+        final_summary: str = "Task complete",
+        collapse: bool = True,
+        *,
+        field_kind: str = "thinking",
+        model_label: Optional[str] = None,
+    ) -> None:
+        """Flush all buffered data, then collapse the field."""
+        key = self._session_key(task_id, field_kind)
+        snapshot = None
+        flush_task = None
+
+        async with self._lock:
+            key, session = self._lookup_session_locked(task_id, field_kind)
+            if not session:
+                return
+            session.finalized = True
+            if field_kind == "thinking" and final_summary and not final_summary.startswith(("✅", "⚠️")):
+                session.summary = f"✅ {final_summary}"
+            else:
+                session.summary = final_summary
+            if model_label:
+                session.model_label = model_label
+            flush_task = session.flush_task
+            session.flush_task = None
+            snapshot = self._snapshot_locked(session)
+
+        if flush_task and not flush_task.done():
+            flush_task.cancel()
+            try:
+                await flush_task
+            except asyncio.CancelledError:
+                pass
+
+        await self._send_edit_snapshot(snapshot, final=True, collapse=collapse)
+
+        async with self._lock:
+            self._sessions.pop(key, None)
+
+    async def abort(
+        self,
+        task_id: str,
+        reason: str = "Aborted",
+        *,
+        field_kind: str = "thinking",
+        model_label: Optional[str] = None,
+    ) -> None:
+        """Abort a field while preserving all buffered content."""
+        await self.finalize(
+            task_id,
+            f"⚠️ {reason}",
+            collapse=True,
+            field_kind=field_kind,
+            model_label=model_label,
+        )
+
+    def has_session(self, task_id: str, field_kind: str = "thinking") -> bool:
+        key = self._session_key(task_id, field_kind)
+        return key in self._sessions or (field_kind == "thinking" and task_id in self._sessions)
+
+    async def cleanup_stale(self, max_age: float = 1800) -> None:
+        now = time.time()
+        async with self._lock:
+            stale = [
+                key
+                for key, session in self._sessions.items()
+                if now - session.started_at > max_age
+            ]
+            for key in stale:
+                session = self._sessions.pop(key, None)
+                if session and session.flush_task and not session.flush_task.done():
+                    session.flush_task.cancel()
+                logger.warning("Matrix introspection: cleaned up stale session %s", key)
+
+    async def abort_all(self, reason: str = "Gateway restarting") -> None:
+        """Abort all active fields before shutdown/restart to avoid dangling blocks."""
+        async with self._lock:
+            snapshots = [
+                (key, session.task_id, session.field_kind, session.flush_task)
+                for key, session in self._sessions.items()
+            ]
+
+        for _key, task_id, field_kind, flush_task in snapshots:
+            if flush_task and not flush_task.done():
+                flush_task.cancel()
+                try:
+                    await flush_task
+                except asyncio.CancelledError:
+                    pass
+            await self.abort(task_id, reason, field_kind=field_kind)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _session_key(task_id: str, field_kind: str) -> str:
+        return f"{task_id}:{field_kind}"
+
+    def _lookup_session_locked(
+        self, task_id: str, field_kind: str
+    ) -> tuple[str, Optional[ThinkingSession]]:
+        key = self._session_key(task_id, field_kind)
+        session = self._sessions.get(key)
+        if session is None and field_kind == "thinking":
+            session = self._sessions.get(task_id)
+            if session is not None:
+                key = task_id
+        return key, session
+
+    @staticmethod
+    def _field_title(field_kind: str) -> str:
+        return "Tool Activity" if field_kind == "tools" else "Hermes Agent"
+
+    @staticmethod
+    def _field_icon(field_kind: str) -> str:
+        return "🛠️" if field_kind == "tools" else "🤔"
+
+    def _snapshot_locked(self, session: ThinkingSession) -> Dict[str, Any]:
+        return {
+            "room_id": session.room_id,
+            "event_id": session.event_id,
+            "task_id": session.task_id,
+            "started_at": session.started_at,
+            "step": session.step_count,
+            "summary": session.summary,
+            "content_lines": list(session.content_lines),
+            "field_kind": session.field_kind,
+            "title": session.title,
+            "model_label": session.model_label,
+        }
+
+    def _ensure_flush_locked(self, key: str, session: ThinkingSession, delay: float) -> None:
+        if session.flush_task is None or session.flush_task.done():
+            session.flush_task = asyncio.create_task(self._delayed_flush(key, delay))
+
+    async def _delayed_flush(self, key: str, delay: float) -> None:
+        try:
+            await asyncio.sleep(delay)
+            await self._flush(key)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.debug("Matrix introspection: delayed flush failed for %s: %s", key, exc)
+
+    async def _flush(self, key: str) -> None:
+        snapshot = None
+        async with self._lock:
+            session = self._sessions.get(key)
+            if not session or session.finalized:
+                return
+            session.flush_task = None
+            if not session.dirty:
+                return
+            snapshot = self._snapshot_locked(session)
+            session.last_update = time.time()
+            session.dirty = False
+
+        await self._send_edit_snapshot(snapshot)
+
+    async def _send_edit_snapshot(
+        self,
+        snapshot: Dict[str, Any],
+        *,
+        final: bool = False,
+        collapse: bool = True,
+    ) -> None:
+        elapsed = self._elapsed_str(snapshot["started_at"])
+        content_html = self._lines_to_html(snapshot["content_lines"])
+        summary = snapshot["summary"] or ("Complete" if final else "Working")
+        open_tag = not final or not collapse
+
+        html_body = self._build_html(
+            summary=summary,
+            step=snapshot["step"],
+            ts=time.time(),
+            content_html=content_html,
+            open_tag=open_tag,
+            elapsed=elapsed,
+            final=final,
+            field_kind=snapshot["field_kind"],
+            model_label=snapshot.get("model_label") or "",
+        )
+        plaintext = self._plaintext_summary(
+            snapshot["title"],
+            summary,
+            elapsed=elapsed,
+            model_label=snapshot.get("model_label") or "",
+        )
+        edit_content = self._edit_content(snapshot["event_id"], html_body, plaintext)
+
+        try:
+            await asyncio.wait_for(
+                self._adapter._client.room_send(
+                    snapshot["room_id"],
+                    "m.room.message",
+                    edit_content,
+                    ignore_unverified_devices=True,
+                ),
+                timeout=15,
+            )
+        except Exception as exc:
+            logger.debug(
+                "Matrix introspection: edit failed for task %s kind %s: %s",
+                snapshot["task_id"],
+                snapshot["field_kind"],
+                exc,
+            )
+            # Mark dirty again for non-final sessions so later updates/finalization retry.
+            if not final:
+                key = self._session_key(snapshot["task_id"], snapshot["field_kind"])
+                async with self._lock:
+                    session = self._sessions.get(key)
+                    if session and not session.finalized:
+                        session.dirty = True
+                        self._ensure_flush_locked(key, session, _MIN_EDIT_INTERVAL)
+
+    # ------------------------------------------------------------------
+    # HTML generation
+    # ------------------------------------------------------------------
+
+    def _build_html(
+        self,
+        summary: str,
+        step: int,
+        ts: float,
+        content_html: str,
+        open_tag: bool = True,
+        elapsed: str = "",
+        final: bool = False,
+        field_kind: str = "thinking",
+        model_label: str = "",
+    ) -> str:
+        open_attr = " open" if open_tag else ""
+        timestamp = time.strftime("%H:%M:%S", time.localtime(ts))
+        step_info = f"Step {step}" if step > 0 else "Starting"
+        elapsed_info = f" • {elapsed}" if elapsed else ""
+        icon = self._field_icon(field_kind)
+        title = self._field_title(field_kind)
+
+        if len(content_html.encode("utf-8")) > _MAX_BODY_SIZE:
+            content_html = content_html[:_MAX_BODY_SIZE] + "\n… (truncated)"
+
+        meta_html = (
+            f"<p><em>Model: {html.escape(model_label)}</em></p>" if model_label else ""
+        )
+        details_body = meta_html
+        if content_html:
+            details_body += f"<pre><code>{content_html}</code></pre>"
+
+        return (
+            f"<details{open_attr}>"
+            f"<summary>{icon} <strong>{html.escape(title)}</strong> "
+            f"({step_info}{elapsed_info} • {timestamp}) — "
+            f"{html.escape(summary)}</summary>"
+            f"{details_body}"
+            f"</details>"
+        )
+
+    def _lines_to_html(self, lines: list) -> str:
+        if not lines:
+            return ""
+        return "\n".join(html.escape(line) for line in lines)
+
+    @staticmethod
+    def _elapsed_str(started_at: float) -> str:
+        elapsed = time.time() - started_at
+        if elapsed < 60:
+            return f"{elapsed:.0f}s"
+        minutes = int(elapsed // 60)
+        seconds = int(elapsed % 60)
+        return f"{minutes}m{seconds}s"
+
+    def _plaintext_summary(
+        self,
+        title: str,
+        summary: str,
+        *,
+        elapsed: str = "",
+        model_label: str = "",
+    ) -> str:
+        icon = "🛠️" if title == "Tool Activity" else "🤔"
+        parts = [f"{icon} {title} — {summary}"]
+        if elapsed:
+            parts.append(f"({elapsed})")
+        if model_label:
+            parts.append(f"[{model_label}]")
+        return " ".join(parts)
+
+    # ------------------------------------------------------------------
+    # Message content builders
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _msg_content(html_body: str, plaintext: str) -> Dict[str, Any]:
+        return {
+            "msgtype": "m.text",
+            "body": plaintext,
+            "format": "org.matrix.custom.html",
+            "formatted_body": html_body,
+        }
+
+    @staticmethod
+    def _edit_content(original_event_id: str, html_body: str, plaintext: str) -> Dict[str, Any]:
+        new_content = {
+            "msgtype": "m.text",
+            "body": plaintext,
+            "format": "org.matrix.custom.html",
+            "formatted_body": html_body,
+        }
+        return {
+            **new_content,
+            "body": f"* {plaintext}",
+            "formatted_body": f"* {html_body}",
+            "m.new_content": new_content,
+            "m.relates_to": {
+                "rel_type": "m.replace",
+                "event_id": original_event_id,
+            },
+        }

--- a/model_tools.py
+++ b/model_tools.py
@@ -158,6 +158,7 @@ def _discover_tools():
         "tools.send_message_tool",
         # "tools.honcho_tools",  # Removed — Honcho is now a memory provider plugin
         "tools.homeassistant_tool",
+        "tools.matrix_tools",
     ]
     import importlib
     for mod_name in _modules:

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -47,7 +47,7 @@ def resolve_active_host() -> str:
         from hermes_cli.profiles import get_active_profile_name
         profile = get_active_profile_name()
         if profile and profile not in ("default", "custom"):
-            return f"{HOST}.{profile}"
+            return f"{HOST}_{profile}"
     except Exception:
         pass
     return HOST

--- a/tools/matrix_tools.py
+++ b/tools/matrix_tools.py
@@ -1,0 +1,467 @@
+"""Matrix room management and interaction tools.
+
+Registers LLM-callable tools for controlling Matrix rooms and interactions:
+- ``matrix_send_reaction`` -- react to a message with an emoji
+- ``matrix_redact_message`` -- redact (delete) a message
+- ``matrix_create_room`` -- create a new Matrix room
+- ``matrix_invite_user`` -- invite a user to a room
+- ``matrix_fetch_history`` -- fetch recent message history from a room
+- ``matrix_set_presence`` -- set the bot's presence status
+
+The adapter instance is injected at runtime via ``set_matrix_adapter()``.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import threading
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Adapter reference (set at runtime by MatrixAdapter.connect)
+# ---------------------------------------------------------------------------
+
+_adapter: Optional[Any] = None
+_adapter_lock = threading.Lock()
+def set_matrix_adapter(adapter: Optional[Any]) -> None:
+    """Set (or clear) the running MatrixAdapter instance."""
+    global _adapter
+    with _adapter_lock:
+        _adapter = adapter
+
+
+def _check_matrix_available() -> bool:
+    """Tool is only available when a MatrixAdapter is connected."""
+    return _adapter is not None
+
+
+# ---------------------------------------------------------------------------
+# Async bridge (sync handler → async adapter methods)
+# ---------------------------------------------------------------------------
+
+_MAX_EMOJI_LEN = 32
+_MAX_REASON_LEN = 500
+_MAX_NAME_LEN = 255
+_MAX_TOPIC_LEN = 1000
+_MAX_STATUS_LEN = 255
+_ALLOWED_PRESETS = frozenset(("private_chat", "public_chat"))
+
+
+def _run_async(coro):
+    """Run an async coroutine from a sync handler.
+
+    Schedules the coroutine on the adapter's own event loop via
+    ``run_coroutine_threadsafe`` when possible, to avoid creating a
+    second event loop that can't share matrix-nio client state.
+    Falls back to ``asyncio.run()`` only when no loop is available.
+    """
+    # Prefer the adapter's event loop for nio client safety.
+    adapter_loop = getattr(_adapter, "_loop", None) if _adapter else None
+    if adapter_loop is not None and adapter_loop.is_running():
+        future = asyncio.run_coroutine_threadsafe(coro, adapter_loop)
+        try:
+            return future.result(timeout=30)
+        except TimeoutError:
+            future.cancel()
+            raise
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    if loop and loop.is_running():
+        # Schedule on the current running loop.
+        future = asyncio.run_coroutine_threadsafe(coro, loop)
+        try:
+            return future.result(timeout=30)
+        except TimeoutError:
+            future.cancel()
+            raise
+    else:
+        return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+def _ensure_adapter():
+    """Return the adapter or raise if unavailable."""
+    with _adapter_lock:
+        adapter = _adapter
+    if adapter is None:
+        raise RuntimeError("Matrix adapter is not connected")
+    return adapter
+
+
+def _handle_send_reaction(args: dict, **kw) -> str:
+    """Handler for matrix_send_reaction tool."""
+    room_id = args.get("room_id", "").strip()
+    event_id = args.get("event_id", "").strip()
+    emoji = args.get("emoji", "").strip()
+
+    if not room_id or not room_id.startswith("!"):
+        return json.dumps({"error": "room_id is required and must start with '!'"})
+    if not event_id or not event_id.startswith("$"):
+        return json.dumps({"error": "event_id is required and must start with '$'"})
+    if not emoji:
+        return json.dumps({"error": "emoji is required and must be non-empty"})
+    if len(emoji) > _MAX_EMOJI_LEN:
+        return json.dumps({"error": f"emoji must be at most {_MAX_EMOJI_LEN} characters"})
+
+    try:
+        adapter = _ensure_adapter()
+        result = _run_async(adapter._send_reaction(room_id, event_id, emoji))
+        return json.dumps({"success": bool(result)})
+    except Exception as e:
+        logger.error("matrix_send_reaction error: %s", e)
+        return json.dumps({"error": f"Failed to send reaction: {e}"})
+
+
+def _handle_redact_message(args: dict, **kw) -> str:
+    """Handler for matrix_redact_message tool."""
+    room_id = args.get("room_id", "").strip()
+    event_id = args.get("event_id", "").strip()
+    reason = args.get("reason", "")
+
+    if not room_id or not room_id.startswith("!"):
+        return json.dumps({"error": "room_id is required and must start with '!'"})
+    if not event_id or not event_id.startswith("$"):
+        return json.dumps({"error": "event_id is required and must start with '$'"})
+    if len(reason) > _MAX_REASON_LEN:
+        reason = reason[:_MAX_REASON_LEN]
+
+    try:
+        adapter = _ensure_adapter()
+        result = _run_async(adapter.redact_message(room_id, event_id, reason=reason))
+        return json.dumps({"success": bool(result)})
+    except Exception as e:
+        logger.error("matrix_redact_message error: %s", e)
+        return json.dumps({"error": f"Failed to redact message: {e}"})
+
+
+def _handle_create_room(args: dict, **kw) -> str:
+    """Handler for matrix_create_room tool."""
+    name = args.get("name", "")
+    topic = args.get("topic", "")
+    invite = args.get("invite", [])
+    is_direct = args.get("is_direct", False)
+    preset = args.get("preset", "private_chat")
+
+    if name and len(name) > _MAX_NAME_LEN:
+        name = name[:_MAX_NAME_LEN]
+    if topic and len(topic) > _MAX_TOPIC_LEN:
+        topic = topic[:_MAX_TOPIC_LEN]
+    if invite and not isinstance(invite, list):
+        return json.dumps({"error": "invite must be a list of user IDs"})
+    for uid in (invite or []):
+        if not isinstance(uid, str) or not uid.startswith("@"):
+            return json.dumps({"error": f"Invalid user ID in invite list: {uid!r} (must start with '@')"})
+    if preset not in _ALLOWED_PRESETS:
+        return json.dumps({"error": f"Invalid preset: {preset!r}. Must be one of: {', '.join(sorted(_ALLOWED_PRESETS))}"})
+    if preset == "public_chat" and os.getenv("MATRIX_ALLOW_PUBLIC_ROOMS", "").lower() not in ("true", "1", "yes"):
+        return json.dumps({"error": "Public room creation is disabled by default. Set MATRIX_ALLOW_PUBLIC_ROOMS=true to allow."})
+
+    try:
+        adapter = _ensure_adapter()
+        room_id = _run_async(adapter.create_room(
+            name=name, topic=topic, invite=invite,
+            is_direct=is_direct, preset=preset,
+        ))
+        if room_id:
+            return json.dumps({"success": True, "room_id": room_id})
+        return json.dumps({"success": False, "error": "Room creation failed"})
+    except Exception as e:
+        logger.error("matrix_create_room error: %s", e)
+        return json.dumps({"error": f"Failed to create room: {e}"})
+
+
+def _handle_invite_user(args: dict, **kw) -> str:
+    """Handler for matrix_invite_user tool."""
+    room_id = args.get("room_id", "").strip()
+    user_id = args.get("user_id", "").strip()
+
+    if not room_id or not room_id.startswith("!"):
+        return json.dumps({"error": "room_id is required and must start with '!'"})
+    if not user_id or not user_id.startswith("@"):
+        return json.dumps({"error": "user_id is required and must start with '@'"})
+
+    try:
+        adapter = _ensure_adapter()
+        result = _run_async(adapter.invite_user(room_id, user_id))
+        return json.dumps({"success": bool(result)})
+    except Exception as e:
+        logger.error("matrix_invite_user error: %s", e)
+        return json.dumps({"error": f"Failed to invite user: {e}"})
+
+
+def _handle_fetch_history(args: dict, **kw) -> str:
+    """Handler for matrix_fetch_history tool."""
+    room_id = args.get("room_id", "").strip()
+    limit = args.get("limit", 50)
+
+    if not room_id or not room_id.startswith("!"):
+        return json.dumps({"error": "room_id is required and must start with '!'"})
+    if not isinstance(limit, int) or limit < 1:
+        limit = 50
+    if limit > 200:
+        limit = 200
+
+    try:
+        adapter = _ensure_adapter()
+        messages = _run_async(adapter.fetch_room_history(room_id, limit=limit))
+        return json.dumps({"count": len(messages), "messages": messages})
+    except Exception as e:
+        logger.error("matrix_fetch_history error: %s", e)
+        return json.dumps({"error": f"Failed to fetch history: {e}"})
+
+
+def _handle_set_presence(args: dict, **kw) -> str:
+    """Handler for matrix_set_presence tool."""
+    state = args.get("state", "").strip().lower()
+    status_msg = args.get("status_msg", "")
+
+    if state not in ("online", "offline", "unavailable"):
+        return json.dumps({"error": f"Invalid state: {state!r}. Must be 'online', 'offline', or 'unavailable'"})
+    if len(status_msg) > _MAX_STATUS_LEN:
+        status_msg = status_msg[:_MAX_STATUS_LEN]
+
+    try:
+        adapter = _ensure_adapter()
+        result = _run_async(adapter.set_presence(state=state, status_msg=status_msg))
+        return json.dumps({"success": bool(result)})
+    except Exception as e:
+        logger.error("matrix_set_presence error: %s", e)
+        return json.dumps({"error": f"Failed to set presence: {e}"})
+
+
+# ---------------------------------------------------------------------------
+# Tool schemas
+# ---------------------------------------------------------------------------
+
+MATRIX_SEND_REACTION_SCHEMA = {
+    "name": "matrix_send_reaction",
+    "description": (
+        "Send an emoji reaction to a message in a Matrix room. "
+        "Requires the room_id and event_id of the target message."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "room_id": {
+                "type": "string",
+                "description": (
+                    "The Matrix room ID (starts with '!', e.g. '!abc123:matrix.org')."
+                ),
+            },
+            "event_id": {
+                "type": "string",
+                "description": (
+                    "The event ID of the message to react to (starts with '$')."
+                ),
+            },
+            "emoji": {
+                "type": "string",
+                "description": "The emoji to react with (e.g. '👍', '❤️', '🎉').",
+            },
+        },
+        "required": ["room_id", "event_id", "emoji"],
+    },
+}
+
+MATRIX_REDACT_MESSAGE_SCHEMA = {
+    "name": "matrix_redact_message",
+    "description": (
+        "Redact (delete) a message or event from a Matrix room. "
+        "The message content will be removed but a tombstone remains."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "room_id": {
+                "type": "string",
+                "description": "The Matrix room ID (starts with '!').",
+            },
+            "event_id": {
+                "type": "string",
+                "description": "The event ID of the message to redact (starts with '$').",
+            },
+            "reason": {
+                "type": "string",
+                "description": "Optional reason for the redaction.",
+            },
+        },
+        "required": ["room_id", "event_id"],
+    },
+}
+
+MATRIX_CREATE_ROOM_SCHEMA = {
+    "name": "matrix_create_room",
+    "description": (
+        "Create a new Matrix room. Returns the room_id on success. "
+        "Can optionally set a name, topic, invite users, and configure visibility."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string",
+                "description": "Human-readable room name.",
+            },
+            "topic": {
+                "type": "string",
+                "description": "Room topic/description.",
+            },
+            "invite": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "List of Matrix user IDs to invite (e.g. ['@user:matrix.org'])."
+                ),
+            },
+            "is_direct": {
+                "type": "boolean",
+                "description": "Mark as a direct message room. Default: false.",
+            },
+            "preset": {
+                "type": "string",
+                "description": (
+                    "Room preset: 'private_chat' (default), 'public_chat', "
+                    "or see allowed presets."
+                ),
+            },
+        },
+        "required": [],
+    },
+}
+
+MATRIX_INVITE_USER_SCHEMA = {
+    "name": "matrix_invite_user",
+    "description": "Invite a user to a Matrix room.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "room_id": {
+                "type": "string",
+                "description": "The Matrix room ID (starts with '!').",
+            },
+            "user_id": {
+                "type": "string",
+                "description": (
+                    "The Matrix user ID to invite (starts with '@', "
+                    "e.g. '@user:matrix.org')."
+                ),
+            },
+        },
+        "required": ["room_id", "user_id"],
+    },
+}
+
+MATRIX_FETCH_HISTORY_SCHEMA = {
+    "name": "matrix_fetch_history",
+    "description": (
+        "Fetch recent message history from a Matrix room. "
+        "Returns messages in chronological order with sender, body, and timestamp."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "room_id": {
+                "type": "string",
+                "description": "The Matrix room ID (starts with '!').",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of messages to fetch (default: 50, max: 200).",
+            },
+        },
+        "required": ["room_id"],
+    },
+}
+
+MATRIX_SET_PRESENCE_SCHEMA = {
+    "name": "matrix_set_presence",
+    "description": (
+        "Set the bot's presence status on Matrix. "
+        "Controls whether the bot appears as online, offline, or unavailable."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "state": {
+                "type": "string",
+                "description": "Presence state: 'online', 'offline', or 'unavailable'.",
+            },
+            "status_msg": {
+                "type": "string",
+                "description": "Optional human-readable status message.",
+            },
+        },
+        "required": ["state"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+from tools.registry import registry
+
+registry.register(
+    name="matrix_send_reaction",
+    toolset="matrix",
+    schema=MATRIX_SEND_REACTION_SCHEMA,
+    handler=_handle_send_reaction,
+    check_fn=_check_matrix_available,
+    emoji="💬",
+)
+
+registry.register(
+    name="matrix_redact_message",
+    toolset="matrix",
+    schema=MATRIX_REDACT_MESSAGE_SCHEMA,
+    handler=_handle_redact_message,
+    check_fn=_check_matrix_available,
+    emoji="💬",
+)
+
+registry.register(
+    name="matrix_create_room",
+    toolset="matrix",
+    schema=MATRIX_CREATE_ROOM_SCHEMA,
+    handler=_handle_create_room,
+    check_fn=_check_matrix_available,
+    emoji="💬",
+)
+
+registry.register(
+    name="matrix_invite_user",
+    toolset="matrix",
+    schema=MATRIX_INVITE_USER_SCHEMA,
+    handler=_handle_invite_user,
+    check_fn=_check_matrix_available,
+    emoji="💬",
+)
+
+registry.register(
+    name="matrix_fetch_history",
+    toolset="matrix",
+    schema=MATRIX_FETCH_HISTORY_SCHEMA,
+    handler=_handle_fetch_history,
+    check_fn=_check_matrix_available,
+    emoji="💬",
+)
+
+registry.register(
+    name="matrix_set_presence",
+    toolset="matrix",
+    schema=MATRIX_SET_PRESENCE_SCHEMA,
+    handler=_handle_set_presence,
+    check_fn=_check_matrix_available,
+    emoji="💬",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -203,6 +203,12 @@ TOOLSETS = {
         "includes": []
     },
 
+    "matrix": {
+        "description": "Matrix protocol tools - reactions, moderation, room management, history, presence",
+        "tools": ["matrix_send_reaction", "matrix_redact_message", "matrix_create_room", "matrix_invite_user", "matrix_fetch_history", "matrix_set_presence"],
+        "includes": []
+    },
+
 
     # Scenario-specific toolsets
     
@@ -336,7 +342,7 @@ TOOLSETS = {
     "hermes-matrix": {
         "description": "Matrix bot toolset - decentralized encrypted messaging (full access)",
         "tools": _HERMES_CORE_TOOLS,
-        "includes": []
+        "includes": ["matrix"]
     },
 
     "hermes-dingtalk": {


### PR DESCRIPTION
The Honcho API recently enforced a strict regex `^[a-zA-Z0-9_-]+$` for peer IDs. Hermes was using dots (e.g., `hermes.forge`), which caused the API to reject all requests. This patch changes the separator to an underscore.

Verified via canary tests: underscores are accepted, dots are rejected.