### PR TITLE
fix(openviking): prevent v0.3.3 HTTP 500s by normalizing /.overview.md and /.abstract.md pseudo-URIs before content reads

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -490,6 +490,23 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
     # -- Tool implementations ------------------------------------------------
 
+    @staticmethod
+    def _unwrap_result(resp: Any) -> Any:
+        """Return OpenViking payload body regardless of wrapped/unwrapped shape."""
+        if isinstance(resp, dict) and "result" in resp:
+            return resp.get("result")
+        return resp
+
+    @staticmethod
+    def _normalize_summary_uri(uri: str) -> str:
+        """Map pseudo summary files to their parent directory URI for L0/L1 reads."""
+        if not uri:
+            return uri
+        for suffix in ("/.abstract.md", "/.overview.md", "/.read.md", "/.full.md"):
+            if uri.endswith(suffix):
+                return uri[: -len(suffix)] or "viking://"
+        return uri
+
     def _tool_search(self, args: dict) -> str:
         query = args.get("query", "")
         if not query:
@@ -533,17 +550,26 @@ class OpenVikingMemoryProvider(MemoryProvider):
             return json.dumps({"error": "uri is required"})
 
         level = args.get("level", "overview")
+
+        # OpenViking v0.3.3 expects directory URIs for abstract/overview.
+        resolved_uri = self._normalize_summary_uri(uri) if level in ("abstract", "overview") else uri
+
         # Map our level names to OpenViking GET endpoints
         if level == "abstract":
-            resp = self._client.get("/api/v1/content/abstract", params={"uri": uri})
+            resp = self._client.get("/api/v1/content/abstract", params={"uri": resolved_uri})
         elif level == "full":
-            resp = self._client.get("/api/v1/content/read", params={"uri": uri})
+            resp = self._client.get("/api/v1/content/read", params={"uri": resolved_uri})
         else:  # overview
-            resp = self._client.get("/api/v1/content/overview", params={"uri": uri})
+            resp = self._client.get("/api/v1/content/overview", params={"uri": resolved_uri})
 
-        result = resp.get("result", "")
-        # result is a plain string from the content endpoints
-        content = result if isinstance(result, str) else result.get("content", "")
+        result = self._unwrap_result(resp)
+        # Content endpoints may return either plain strings or objects.
+        if isinstance(result, str):
+            content = result
+        elif isinstance(result, dict):
+            content = result.get("content", "") or result.get("text", "")
+        else:
+            content = ""
 
         # Truncate very long content to avoid flooding the context
         if len(content) > 8000:
@@ -551,6 +577,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
         return json.dumps({
             "uri": uri,
+            "resolved_uri": resolved_uri,
             "level": level,
             "content": content,
         }, ensure_ascii=False)
@@ -563,19 +590,27 @@ class OpenVikingMemoryProvider(MemoryProvider):
         endpoint_map = {"tree": "/api/v1/fs/tree", "list": "/api/v1/fs/ls", "stat": "/api/v1/fs/stat"}
         endpoint = endpoint_map.get(action, "/api/v1/fs/ls")
         resp = self._client.get(endpoint, params={"uri": path})
-        result = resp.get("result", {})
+        result = self._unwrap_result(resp)
 
         # Format list/tree results for readability
-        if action in ("list", "tree") and isinstance(result, list):
-            entries = []
-            for e in result[:50]:  # cap at 50 entries
-                entries.append({
-                    "name": e.get("rel_path", e.get("name", "")),
-                    "uri": e.get("uri", ""),
-                    "type": "dir" if e.get("isDir") else "file",
-                    "abstract": e.get("abstract", ""),
-                })
-            return json.dumps({"path": path, "entries": entries}, ensure_ascii=False)
+        if action in ("list", "tree"):
+            raw_entries = result
+            if isinstance(result, dict):
+                raw_entries = result.get("entries") or result.get("items") or result.get("children") or []
+
+            if isinstance(raw_entries, list):
+                entries = []
+                for e in raw_entries[:50]:  # cap at 50 entries
+                    uri = e.get("uri", "")
+                    name = e.get("rel_path") or e.get("name") or (uri.rsplit("/", 1)[-1] if uri else "")
+                    is_dir = bool(e.get("isDir") or e.get("is_dir") or e.get("type") == "dir")
+                    entries.append({
+                        "name": name,
+                        "uri": uri,
+                        "type": "dir" if is_dir else "file",
+                        "abstract": e.get("abstract", ""),
+                    })
+                return json.dumps({"path": path, "entries": entries}, ensure_ascii=False)
 
         return json.dumps(result, ensure_ascii=False)
 

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -551,16 +551,28 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
         level = args.get("level", "overview")
 
-        # OpenViking v0.3.3 expects directory URIs for abstract/overview.
-        resolved_uri = self._normalize_summary_uri(uri) if level in ("abstract", "overview") else uri
+        summary_level = level in ("abstract", "overview")
+        # OpenViking expects directory URIs for pseudo summary files
+        # (e.g. viking://user/hermes/.overview.md).
+        resolved_uri = self._normalize_summary_uri(uri) if summary_level else uri
+        used_fallback = False
 
-        # Map our level names to OpenViking GET endpoints
+        # Map our level names to OpenViking GET endpoints.
+        endpoint = "/api/v1/content/read"
         if level == "abstract":
-            resp = self._client.get("/api/v1/content/abstract", params={"uri": resolved_uri})
-        elif level == "full":
-            resp = self._client.get("/api/v1/content/read", params={"uri": resolved_uri})
-        else:  # overview
-            resp = self._client.get("/api/v1/content/overview", params={"uri": resolved_uri})
+            endpoint = "/api/v1/content/abstract"
+        elif level == "overview":
+            endpoint = "/api/v1/content/overview"
+
+        try:
+            resp = self._client.get(endpoint, params={"uri": resolved_uri})
+        except Exception:
+            # OpenViking may return HTTP 500 for abstract/overview reads on normal
+            # file URIs (mem_*.md). For those, gracefully fallback to full read.
+            if not summary_level or resolved_uri != uri:
+                raise
+            resp = self._client.get("/api/v1/content/read", params={"uri": uri})
+            used_fallback = True
 
         result = self._unwrap_result(resp)
         # Content endpoints may return either plain strings or objects.
@@ -571,16 +583,26 @@ class OpenVikingMemoryProvider(MemoryProvider):
         else:
             content = ""
 
-        # Truncate very long content to avoid flooding the context
-        if len(content) > 8000:
-            content = content[:8000] + "\n\n[... truncated, use a more specific URI or abstract level]"
+        # Truncate long content to avoid flooding context.
+        max_len = 8000
+        if level == "overview":
+            max_len = 4000
+        elif level == "abstract":
+            max_len = 1200
 
-        return json.dumps({
+        if len(content) > max_len:
+            content = content[:max_len] + "\n\n[... truncated, use a more specific URI or full level]"
+
+        payload = {
             "uri": uri,
             "resolved_uri": resolved_uri,
             "level": level,
             "content": content,
-        }, ensure_ascii=False)
+        }
+        if used_fallback:
+            payload["fallback"] = "content/read"
+
+        return json.dumps(payload, ensure_ascii=False)
 
     def _tool_browse(self, args: dict) -> str:
         action = args.get("action", "list")

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -12,7 +12,10 @@ class FakeVikingClient:
 
     def get(self, path, params=None, **kwargs):
         self.calls.append((path, params or {}))
-        return self.responses[(path, tuple(sorted((params or {}).items())))]
+        response = self.responses[(path, tuple(sorted((params or {}).items())))]
+        if isinstance(response, Exception):
+            raise response
+        return response
 
 
 class TestOpenVikingSummaryUriNormalization:
@@ -67,6 +70,55 @@ class TestOpenVikingRead:
             "/api/v1/content/read",
             {"uri": "viking://user/hermes/memories/profile.md"},
         )]
+
+    def test_overview_file_uri_falls_back_to_content_read_on_summary_error(self):
+        provider = OpenVikingMemoryProvider()
+        file_uri = "viking://user/hermes/memories/entities/mem_abc.md"
+        provider._client = FakeVikingClient(
+            {
+                (
+                    "/api/v1/content/overview",
+                    (("uri", file_uri),),
+                ): RuntimeError("500 Internal Server Error"),
+                (
+                    "/api/v1/content/read",
+                    (("uri", file_uri),),
+                ): {"result": {"content": "fallback full content"}},
+            }
+        )
+
+        result = json.loads(provider._tool_read({"uri": file_uri, "level": "overview"}))
+
+        assert result["uri"] == file_uri
+        assert result["resolved_uri"] == file_uri
+        assert result["level"] == "overview"
+        assert result["fallback"] == "content/read"
+        assert result["content"] == "fallback full content"
+        assert provider._client.calls == [
+            ("/api/v1/content/overview", {"uri": file_uri}),
+            ("/api/v1/content/read", {"uri": file_uri}),
+        ]
+
+    def test_summary_uri_error_does_not_fallback_and_raises(self):
+        provider = OpenVikingMemoryProvider()
+        provider._client = FakeVikingClient(
+            {
+                (
+                    "/api/v1/content/overview",
+                    (("uri", "viking://user/hermes"),),
+                ): RuntimeError("500 Internal Server Error"),
+            }
+        )
+
+        try:
+            provider._tool_read({"uri": "viking://user/hermes/.overview.md", "level": "overview"})
+            assert False, "Expected summary endpoint error to be raised"
+        except RuntimeError:
+            pass
+
+        assert provider._client.calls == [
+            ("/api/v1/content/overview", {"uri": "viking://user/hermes"}),
+        ]
 
 
 class TestOpenVikingBrowse:

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -1,0 +1,101 @@
+"""Tests for plugins/memory/openviking/__init__.py — URI normalization and payload handling."""
+
+import json
+
+from plugins.memory.openviking import OpenVikingMemoryProvider
+
+
+class FakeVikingClient:
+    def __init__(self, responses):
+        self.responses = responses
+        self.calls = []
+
+    def get(self, path, params=None, **kwargs):
+        self.calls.append((path, params or {}))
+        return self.responses[(path, tuple(sorted((params or {}).items())))]
+
+
+class TestOpenVikingSummaryUriNormalization:
+    def test_normalize_summary_uri_maps_pseudo_files_to_parent_directory(self):
+        assert OpenVikingMemoryProvider._normalize_summary_uri("viking://user/hermes/.overview.md") == "viking://user/hermes"
+        assert OpenVikingMemoryProvider._normalize_summary_uri("viking://resources/.abstract.md") == "viking://resources"
+        assert OpenVikingMemoryProvider._normalize_summary_uri("viking://") == "viking://"
+        assert OpenVikingMemoryProvider._normalize_summary_uri("viking://user/hermes/memories/profile.md") == "viking://user/hermes/memories/profile.md"
+
+
+class TestOpenVikingRead:
+    def test_overview_read_normalizes_uri_and_unwraps_result(self):
+        provider = OpenVikingMemoryProvider()
+        provider._client = FakeVikingClient(
+            {
+                (
+                    "/api/v1/content/overview",
+                    (("uri", "viking://user/hermes"),),
+                ): {"result": {"content": "overview text"}},
+            }
+        )
+
+        result = json.loads(provider._tool_read({"uri": "viking://user/hermes/.overview.md", "level": "overview"}))
+
+        assert result["uri"] == "viking://user/hermes/.overview.md"
+        assert result["resolved_uri"] == "viking://user/hermes"
+        assert result["level"] == "overview"
+        assert result["content"] == "overview text"
+        assert provider._client.calls == [(
+            "/api/v1/content/overview",
+            {"uri": "viking://user/hermes"},
+        )]
+
+    def test_full_read_keeps_original_uri(self):
+        provider = OpenVikingMemoryProvider()
+        provider._client = FakeVikingClient(
+            {
+                (
+                    "/api/v1/content/read",
+                    (("uri", "viking://user/hermes/memories/profile.md"),),
+                ): {"result": "full text"},
+            }
+        )
+
+        result = json.loads(provider._tool_read({"uri": "viking://user/hermes/memories/profile.md", "level": "full"}))
+
+        assert result["uri"] == "viking://user/hermes/memories/profile.md"
+        assert result["resolved_uri"] == "viking://user/hermes/memories/profile.md"
+        assert result["level"] == "full"
+        assert result["content"] == "full text"
+        assert provider._client.calls == [(
+            "/api/v1/content/read",
+            {"uri": "viking://user/hermes/memories/profile.md"},
+        )]
+
+
+class TestOpenVikingBrowse:
+    def test_list_browse_unwraps_and_normalizes_entry_shapes(self):
+        provider = OpenVikingMemoryProvider()
+        provider._client = FakeVikingClient(
+            {
+                (
+                    "/api/v1/fs/ls",
+                    (("uri", "viking://user/hermes"),),
+                ): {
+                    "result": {
+                        "entries": [
+                            {"name": "memories", "uri": "viking://user/hermes/memories", "type": "dir"},
+                            {"rel_path": "profile.md", "uri": "viking://user/hermes/memories/profile.md", "isDir": False, "abstract": "Profile"},
+                        ]
+                    }
+                },
+            }
+        )
+
+        result = json.loads(provider._tool_browse({"action": "list", "path": "viking://user/hermes"}))
+
+        assert result["path"] == "viking://user/hermes"
+        assert result["entries"] == [
+            {"name": "memories", "uri": "viking://user/hermes/memories", "type": "dir", "abstract": ""},
+            {"name": "profile.md", "uri": "viking://user/hermes/memories/profile.md", "type": "file", "abstract": "Profile"},
+        ]
+        assert provider._client.calls == [(
+            "/api/v1/fs/ls",
+            {"uri": "viking://user/hermes"},
+        )]


### PR DESCRIPTION
## Why this is necessary

I self host my own openviking setup and several hermes agents against it (local models + gpt 5.4) here and I kept running into this. This patch fixes it. Coded with hermes agent / gpt 5.3 codex.

OpenViking v0.3.3 content endpoints (`/api/v1/content/overview`, `/api/v1/content/abstract`) expect **directory URIs**.

The Hermes OpenViking plugin currently forwards pseudo-summary file URIs like:
- `viking://user/hermes/.overview.md`
- `viking://resources/.abstract.md`

That mismatch causes **server-side HTTP 500** responses, so `viking_read(level=overview|abstract)` fails even though the backend is healthy and reachable.

## Reproduction (before this patch)
- `viking_read(uri="viking://user/hermes/.overview.md", level="overview")` -> 500
- `viking_read(uri="viking://resources/.abstract.md", level="abstract")` -> 500

## What this PR changes
1. Normalize pseudo-summary URIs (`/.overview.md`, `/.abstract.md`, `/.read.md`, `/.full.md`) to their parent directory URI for abstract/overview reads.
2. Keep full reads intact (no behavioral regression for `level=full`).
3. Add response unwrapping for wrapped/unwrapped payloads.
4. Harden browse parsing for fs list/tree response shape differences (`list` vs `dict`, `isDir` vs `is_dir`, missing `name`).

## Verification
Validated against a live OpenViking `v0.3.3` server:
- overview read now resolves `viking://user/hermes/.overview.md` -> `viking://user/hermes` and succeeds
- abstract read now resolves `viking://resources/.abstract.md` -> `viking://resources` and succeeds
- full read of `viking://user/hermes/memories/profile.md` still succeeds
- browse list still returns valid entries

## Impact
This fixes a real integration breakage where normal user-facing `viking_read` calls fail with 500 due to URI shape mismatch, while preserving existing full-read behavior.