### PR TITLE
fix: pause typing indicator during approval waits

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -485,6 +485,9 @@ class BasePlatformAdapter(ABC):
         self._background_tasks: set[asyncio.Task] = set()
         # Chats where auto-TTS on voice input is disabled (set by /voice off)
         self._auto_tts_disabled_chats: set = set()
+        # Chats where typing indicator is paused (e.g. during approval waits).
+        # _keep_typing skips send_typing when the chat_id is in this set.
+        self._typing_paused: set = set()
 
     @property
     def has_fatal_error(self) -> bool:
@@ -944,10 +947,16 @@ class BasePlatformAdapter(ABC):
         
         Telegram/Discord typing status expires after ~5 seconds, so we refresh every 2
         to recover quickly after progress messages interrupt it.
+        
+        Skips send_typing when the chat is in ``_typing_paused`` (e.g. while
+        the agent is waiting for dangerous-command approval).  This is critical
+        for Slack's Assistant API where ``assistant_threads_setStatus`` disables
+        the compose box — pausing lets the user type ``/approve`` or ``/deny``.
         """
         try:
             while True:
-                await self.send_typing(chat_id, metadata=metadata)
+                if chat_id not in self._typing_paused:
+                    await self.send_typing(chat_id, metadata=metadata)
                 await asyncio.sleep(interval)
         except asyncio.CancelledError:
             pass  # Normal cancellation when handler completes
@@ -961,7 +970,20 @@ class BasePlatformAdapter(ABC):
                     await self.stop_typing(chat_id)
                 except Exception:
                     pass
-    
+            self._typing_paused.discard(chat_id)
+
+    def pause_typing_for_chat(self, chat_id: str) -> None:
+        """Pause typing indicator for a chat (e.g. during approval waits).
+
+        Thread-safe (CPython GIL) — can be called from the sync agent thread
+        while ``_keep_typing`` runs on the async event loop.
+        """
+        self._typing_paused.add(chat_id)
+
+    def resume_typing_for_chat(self, chat_id: str) -> None:
+        """Resume typing indicator for a chat after approval resolves."""
+        self._typing_paused.discard(chat_id)
+
     # ── Processing lifecycle hooks ──────────────────────────────────────────
     # Subclasses override these to react to message processing events
     # (e.g. Discord adds 👀/✅/❌ reactions).

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5431,6 +5431,11 @@ class GatewayRunner:
         if not count:
             return "No pending command to approve."
 
+        # Resume typing indicator — agent is about to continue processing.
+        _adapter = self.adapters.get(source.platform)
+        if _adapter:
+            _adapter.resume_typing_for_chat(source.chat_id)
+
         count_msg = f" ({count} commands)" if count > 1 else ""
         logger.info("User approved %d dangerous command(s) via /approve%s", count, scope_msg)
         return f"✅ Command{'s' if count > 1 else ''} approved{scope_msg}{count_msg}. The agent is resuming..."
@@ -5462,6 +5467,11 @@ class GatewayRunner:
         count = resolve_gateway_approval(session_key, "deny", resolve_all=resolve_all)
         if not count:
             return "No pending command to deny."
+
+        # Resume typing indicator — agent continues (with BLOCKED result).
+        _adapter = self.adapters.get(source.platform)
+        if _adapter:
+            _adapter.resume_typing_for_chat(source.chat_id)
 
         count_msg = f" ({count} commands)" if count > 1 else ""
         logger.info("User denied %d dangerous command(s) via /deny", count)
@@ -6713,6 +6723,15 @@ class GatewayRunner:
                 UX.  Otherwise fall back to a plain text message with
                 ``/approve`` instructions.
                 """
+                # Pause the typing indicator while the agent waits for
+                # user approval.  Critical for Slack's Assistant API where
+                # assistant_threads_setStatus disables the compose box — the
+                # user literally cannot type /approve while "is thinking..."
+                # is active.  The approval message send auto-clears the Slack
+                # status; pausing prevents _keep_typing from re-setting it.
+                # Typing resumes in _handle_approve_command/_handle_deny_command.
+                _status_adapter.pause_typing_for_chat(_status_chat_id)
+
                 cmd = approval_data.get("command", "")
                 desc = approval_data.get("description", "dangerous command")
 


### PR DESCRIPTION
## Summary

When the agent waits for dangerous-command approval, the `_keep_typing` loop kept refreshing the typing indicator. On Slack's Assistant API, `assistant_threads_setStatus` **disables the compose box** while active — users literally cannot type `/approve` or `/deny` to respond to approval prompts. The approval message send briefly clears the status, but `_keep_typing` re-sets it within 2 seconds.

This was reported by Willard on the Nous Slack.

## Changes

**`gateway/platforms/base.py`:**
- Added `_typing_paused: set` to `BasePlatformAdapter.__init__`
- `_keep_typing` skips `send_typing` when `chat_id` is in the paused set
- New methods: `pause_typing_for_chat()` / `resume_typing_for_chat()` — thread-safe (CPython GIL)

**`gateway/run.py`:**
- `_approval_notify_sync`: pauses typing before sending the approval prompt
- `_handle_approve_command`: resumes typing after approval (agent continues)
- `_handle_deny_command`: resumes typing after denial (agent continues with BLOCKED)

## How it works

1. Agent hits dangerous command → `_approval_notify_sync` fires → typing paused
2. Approval message sent → auto-clears Slack's assistant status
3. `_keep_typing` loop continues but skips `send_typing` → compose box stays unlocked
4. User sends `/approve` or `/deny` → handler resumes typing → agent resumes
5. If timeout, typing stays paused → agent finishes shortly → typing task cancelled in `finally`

Benefits all platforms, not just Slack — no reason to show typing while idle.

## Tests

All 134 base adapter + Slack tests pass. All 16 non-pre-existing gateway approval tests pass. 6 pre-existing approval E2E failures confirmed unrelated (same on main).