### PR TITLE
feat(skills): add fleet-ssh skill for multi-host SSH management

### DIFF
--- a/skills/devops/fleet-ssh/SKILL.md
+++ b/skills/devops/fleet-ssh/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: fleet-ssh
+description: Manage multiple machines via SSH — run commands, check status, deploy files, and monitor health across a fleet
+version: 1.0.0
+author: het4rk
+license: MIT
+platforms: [macos, linux]
+metadata:
+  hermes:
+    tags: [SSH, Fleet, DevOps, Remote, Management, Monitoring]
+    requires_toolsets: [terminal]
+    config:
+      - key: fleet.hosts_file
+        description: "Path to fleet hosts inventory file"
+        default: "~/.hermes/fleet/hosts.yaml"
+        prompt: "Path to your fleet hosts file"
+---
+
+# Fleet SSH Management
+
+Manage multiple machines via SSH — run commands across your entire fleet, check health, deploy files, and monitor uptime, load, and disk usage in parallel.
+
+## When to Use
+
+- Run a shell command across multiple machines simultaneously
+- Check the health of your fleet (uptime, load, disk, memory)
+- Deploy a file or script to all hosts
+- Tail logs from a remote machine
+- Check if a process is running across fleet nodes
+- Coordinate tasks on homelab servers, mining rigs, or distributed compute nodes
+
+## Prerequisites
+
+- SSH key-based authentication configured for all hosts (no password prompts)
+- Python 3.7+ with `pyyaml` installed (`pip install pyyaml`)
+- `ssh` and `scp` available in `$PATH`
+
+Verify SSH key auth works:
+```bash
+ssh -o BatchMode=yes user@host "echo ok"
+```
+
+## Fleet Inventory
+
+Create your hosts inventory at `~/.hermes/fleet/hosts.yaml` (or the path set in config):
+
+```yaml
+hosts:
+  - name: node0
+    host: 10.0.0.1
+    user: admin
+  - name: node1
+    host: 10.0.0.2
+    user: admin
+  - name: node2
+    host: 10.0.0.3
+    user: deploy
+    port: 2222        # optional, defaults to 22
+    tags: [gpu, mining]
+```
+
+A template is available at `templates/hosts.yaml` in this skill directory.
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Run command on one host | `ssh user@host "command"` |
+| Run command on all hosts | See procedure below |
+| Check fleet health | `python3 scripts/fleet_status.py` |
+| Deploy file to all hosts | `for` loop with `scp` — see procedure |
+| Tail remote logs | `ssh user@host "tail -f /var/log/syslog"` |
+| Check process across fleet | `ssh user@host "pgrep -x proc_name"` |
+
+## Procedures
+
+### 1. Run Command on a Single Host
+
+```bash
+ssh admin@10.0.0.1 "uptime"
+```
+
+With a non-default port:
+```bash
+ssh -p 2222 admin@10.0.0.3 "df -h /"
+```
+
+### 2. Run Command Across All Hosts (Parallel)
+
+Parse `hosts.yaml` and fire background SSH jobs, then wait for all to finish:
+
+```bash
+#!/usr/bin/env bash
+# run_all.sh <command>
+HOSTS_FILE="${FLEET_HOSTS_FILE:-$HOME/.hermes/fleet/hosts.yaml}"
+CMD="$*"
+
+# Parse YAML with Python (avoids dependency on yq)
+eval "$(python3 - <<'EOF'
+import yaml, sys
+with open("$HOSTS_FILE") as f:
+    data = yaml.safe_load(f)
+for h in data["hosts"]:
+    port = h.get("port", 22)
+    print(f'ssh -p {port} -o ConnectTimeout=10 -o BatchMode=yes {h["user"]}@{h["host"]} "$CMD" &')
+print("wait")
+EOF
+)"
+```
+
+Or run it inline as a one-liner (requires `yq`):
+```bash
+HOSTS_FILE=~/.hermes/fleet/hosts.yaml
+CMD="uptime"
+yq -r '.hosts[] | "\(.user)@\(.host)"' "$HOSTS_FILE" | \
+  xargs -P8 -I{} ssh -o ConnectTimeout=10 -o BatchMode=yes {} "$CMD"
+```
+
+### 3. Check Fleet Health
+
+Use the bundled script to get uptime, load, disk, and memory for every host:
+
+```bash
+python3 skills/devops/fleet-ssh/scripts/fleet_status.py
+# or after copying to PATH:
+fleet_status.py
+```
+
+Sample output:
+```
+Fleet Health Report — 2024-01-15 14:32:01
+═══════════════════════════════════════════════════════════════
+Host      Address      Status  Uptime          Load   Disk%  Mem%
+─────────────────────────────────────────────────────────────────
+node0     10.0.0.1     UP      3 days, 4:12    0.42   34%    61%
+node1     10.0.0.2     UP      1 day, 22:05    1.20   67%    45%
+node2     10.0.0.3     DOWN    —               —      —      —
+═══════════════════════════════════════════════════════════════
+2/3 hosts reachable
+```
+
+To use a custom hosts file:
+```bash
+FLEET_HOSTS_FILE=/path/to/hosts.yaml python3 scripts/fleet_status.py
+```
+
+### 4. Deploy File to All Hosts
+
+```bash
+#!/usr/bin/env bash
+# deploy_file.sh <local_path> <remote_path>
+LOCAL="$1"
+REMOTE="$2"
+HOSTS_FILE="${FLEET_HOSTS_FILE:-$HOME/.hermes/fleet/hosts.yaml}"
+
+python3 - <<EOF
+import yaml, subprocess, sys
+
+with open("$HOSTS_FILE") as f:
+    data = yaml.safe_load(f)
+
+procs = []
+for h in data["hosts"]:
+    port = str(h.get("port", 22))
+    dest = f'{h["user"]}@{h["host"]}:{REMOTE}'
+    cmd = ["scp", "-P", port, "-o", "ConnectTimeout=10", "-o", "BatchMode=yes", "$LOCAL", dest]
+    print(f"Deploying to {h['name']} ({dest})...")
+    procs.append((h["name"], subprocess.Popen(cmd)))
+
+for name, p in procs:
+    rc = p.wait()
+    status = "OK" if rc == 0 else f"FAILED (rc={rc})"
+    print(f"  {name}: {status}")
+EOF
+```
+
+### 5. Tail Remote Logs
+
+Tail a log on a specific host (interactive, Ctrl-C to stop):
+```bash
+ssh admin@10.0.0.1 "tail -f /var/log/syslog"
+```
+
+Tail the same log across multiple hosts (one terminal pane each, requires `tmux`):
+```bash
+HOSTS_FILE=~/.hermes/fleet/hosts.yaml
+python3 -c "
+import yaml
+with open('$HOSTS_FILE') as f:
+    hosts = yaml.safe_load(f)['hosts']
+for i, h in enumerate(hosts):
+    cmd = f'tmux new-window -n {h[\"name\"]} \"ssh {h[\"user\"]}@{h[\"host\"]} tail -f /var/log/syslog\"'
+    import os; os.system(cmd)
+"
+```
+
+### 6. Check if a Process is Running Across Fleet
+
+```bash
+PROCESS="nginx"
+HOSTS_FILE="${FLEET_HOSTS_FILE:-$HOME/.hermes/fleet/hosts.yaml}"
+
+python3 - <<EOF
+import yaml, subprocess
+
+with open("$HOSTS_FILE") as f:
+    hosts = yaml.safe_load(f)["hosts"]
+
+for h in hosts:
+    port = str(h.get("port", 22))
+    result = subprocess.run(
+        ["ssh", "-p", port, "-o", "ConnectTimeout=5", "-o", "BatchMode=yes",
+         f'{h["user"]}@{h["host"]}', f"pgrep -x $PROCESS > /dev/null && echo RUNNING || echo NOT RUNNING"],
+        capture_output=True, text=True, timeout=10
+    )
+    status = result.stdout.strip() or "UNREACHABLE"
+    print(f"{h['name']:12s} {h['host']:15s}  $PROCESS: {status}")
+EOF
+```
+
+## Pitfalls
+
+- **SSH key auth required**: Password prompts will hang in parallel mode. Use `ssh-copy-id user@host` to install your key first.
+- **ConnectTimeout**: Always set `-o ConnectTimeout=10` (or similar) to avoid blocking on offline hosts.
+- **Output interleaving**: Parallel SSH output can interleave. Prefix each line with the hostname or collect output per-host before printing.
+- **Known hosts**: First-time connections prompt for host key confirmation. Pre-populate `~/.ssh/known_hosts` with `ssh-keyscan`:
+  ```bash
+  ssh-keyscan -H 10.0.0.1 10.0.0.2 10.0.0.3 >> ~/.ssh/known_hosts
+  ```
+- **StrictHostKeyChecking**: For trusted internal networks, add `-o StrictHostKeyChecking=accept-new` to auto-accept new host keys.
+- **Sudo commands**: Use `ssh user@host "sudo command"` only if passwordless sudo is configured; otherwise it will hang.
+
+## Verification
+
+After setting up your `hosts.yaml`, verify the skill is working:
+
+```bash
+# 1. Confirm SSH key auth works for each host
+python3 -c "
+import yaml, subprocess
+with open('$HOME/.hermes/fleet/hosts.yaml') as f:
+    for h in yaml.safe_load(f)['hosts']:
+        r = subprocess.run(['ssh', '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=5',
+                            f'{h[\"user\"]}@{h[\"host\"]}', 'echo ok'],
+                           capture_output=True, text=True)
+        print(h['name'], '✓' if r.stdout.strip() == 'ok' else '✗ ' + r.stderr.strip())
+"
+
+# 2. Run fleet health check
+python3 skills/devops/fleet-ssh/scripts/fleet_status.py
+
+# 3. Run a test command across all hosts
+FLEET_HOSTS_FILE=~/.hermes/fleet/hosts.yaml python3 -c "
+import yaml, subprocess
+with open('$HOME/.hermes/fleet/hosts.yaml') as f:
+    for h in yaml.safe_load(f)['hosts']:
+        r = subprocess.run(['ssh', f'{h[\"user\"]}@{h[\"host\"]}', 'hostname'],
+                           capture_output=True, text=True)
+        print(h['name'], '->', r.stdout.strip())
+"
+```

--- a/skills/devops/fleet-ssh/scripts/fleet_status.py
+++ b/skills/devops/fleet-ssh/scripts/fleet_status.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""
+fleet_status.py — SSH health check across a fleet of hosts.
+
+Reads ~/.hermes/fleet/hosts.yaml (or $FLEET_HOSTS_FILE) and reports
+uptime, load average, disk usage, and memory for each host in parallel.
+
+Usage:
+    python3 fleet_status.py
+    FLEET_HOSTS_FILE=/path/to/hosts.yaml python3 fleet_status.py
+"""
+
+import os
+import subprocess
+import sys
+import threading
+from datetime import datetime
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("Error: pyyaml is required. Install with: pip install pyyaml")
+
+DEFAULT_HOSTS_FILE = Path.home() / ".hermes" / "fleet" / "hosts.yaml"
+CONNECT_TIMEOUT = 10  # seconds per host
+
+# Collects one line of stats from a remote host via SSH.
+REMOTE_CMD = (
+    "uptime_str=$(uptime -p 2>/dev/null || uptime); "
+    "load=$(cat /proc/loadavg 2>/dev/null | awk '{print $1}' || sysctl -n vm.loadavg 2>/dev/null | awk '{print $2}'); "
+    "disk=$(df -h / | awk 'NR==2{print $5}'); "
+    "mem=$(free 2>/dev/null | awk '/^Mem:/{printf \"%.0f%%\", $3/$2*100}' || "
+    "      vm_stat 2>/dev/null | python3 -c \""
+    "import sys; lines=sys.stdin.read().splitlines(); "
+    "pages={l.split(':')[0].strip(): int(l.split(':')[1].strip().rstrip('.')) "
+    "       for l in lines if ':' in l}; "
+    "total=pages.get('Pages free',0)+pages.get('Pages active',0)+pages.get('Pages inactive',0)+pages.get('Pages wired down',0); "
+    "used=pages.get('Pages active',0)+pages.get('Pages wired down',0); "
+    "print(f'{used*100//total}%') if total else print('n/a')"
+    "\"); "
+    "echo \"${uptime_str}|${load}|${disk}|${mem}\""
+)
+
+
+def check_host(host: dict, results: dict) -> None:
+    name = host["name"]
+    address = host["host"]
+    user = host["user"]
+    port = str(host.get("port", 22))
+
+    ssh_cmd = [
+        "ssh",
+        "-p", port,
+        "-o", f"ConnectTimeout={CONNECT_TIMEOUT}",
+        "-o", "BatchMode=yes",
+        "-o", "StrictHostKeyChecking=accept-new",
+        f"{user}@{address}",
+        REMOTE_CMD,
+    ]
+
+    try:
+        result = subprocess.run(
+            ssh_cmd,
+            capture_output=True,
+            text=True,
+            timeout=CONNECT_TIMEOUT + 5,
+        )
+        if result.returncode == 0 and "|" in result.stdout:
+            parts = result.stdout.strip().split("|")
+            uptime = parts[0].strip() if len(parts) > 0 else "n/a"
+            load = parts[1].strip() if len(parts) > 1 else "n/a"
+            disk = parts[2].strip() if len(parts) > 2 else "n/a"
+            mem = parts[3].strip() if len(parts) > 3 else "n/a"
+            # Shorten "up X days, Y hours, Z minutes" style output
+            uptime = uptime.replace("up ", "").strip()
+            results[name] = {
+                "status": "UP",
+                "address": address,
+                "uptime": uptime[:20],
+                "load": load,
+                "disk": disk,
+                "mem": mem,
+                "error": None,
+            }
+        else:
+            results[name] = {
+                "status": "DOWN",
+                "address": address,
+                "uptime": "—",
+                "load": "—",
+                "disk": "—",
+                "mem": "—",
+                "error": result.stderr.strip()[:60] if result.stderr else "no output",
+            }
+    except subprocess.TimeoutExpired:
+        results[name] = {
+            "status": "TIMEOUT",
+            "address": address,
+            "uptime": "—",
+            "load": "—",
+            "disk": "—",
+            "mem": "—",
+            "error": "connection timed out",
+        }
+    except Exception as exc:
+        results[name] = {
+            "status": "ERROR",
+            "address": address,
+            "uptime": "—",
+            "load": "—",
+            "disk": "—",
+            "mem": "—",
+            "error": str(exc)[:60],
+        }
+
+
+def load_hosts(hosts_file: Path) -> list:
+    if not hosts_file.exists():
+        sys.exit(
+            f"Hosts file not found: {hosts_file}\n"
+            f"Create it or set FLEET_HOSTS_FILE env var.\n"
+            f"See skills/devops/fleet-ssh/templates/hosts.yaml for an example."
+        )
+    with open(hosts_file) as f:
+        data = yaml.safe_load(f)
+    hosts = data.get("hosts", [])
+    if not hosts:
+        sys.exit(f"No hosts defined in {hosts_file}")
+    return hosts
+
+
+def print_report(hosts: list, results: dict) -> None:
+    now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    width = 75
+    header = f"Fleet Health Report — {now}"
+
+    print()
+    print(header)
+    print("═" * width)
+    print(
+        f"{'Host':<12} {'Address':<16} {'Status':<8} {'Uptime':<22} {'Load':<7} {'Disk':>5}  {'Mem':>5}"
+    )
+    print("─" * width)
+
+    up_count = 0
+    for host in hosts:
+        name = host["name"]
+        r = results.get(name, {"status": "UNKNOWN", "address": host["host"],
+                                "uptime": "—", "load": "—", "disk": "—", "mem": "—"})
+        if r["status"] == "UP":
+            up_count += 1
+        print(
+            f"{name:<12} {r['address']:<16} {r['status']:<8} {r['uptime']:<22} "
+            f"{r['load']:<7} {r['disk']:>5}  {r['mem']:>5}"
+        )
+        if r.get("error") and r["status"] != "UP":
+            print(f"  {'':12} {'':16} └─ {r['error']}")
+
+    print("═" * width)
+    total = len(hosts)
+    print(f"{up_count}/{total} hosts reachable")
+    print()
+
+
+def main() -> None:
+    hosts_file = Path(os.environ.get("FLEET_HOSTS_FILE", DEFAULT_HOSTS_FILE)).expanduser()
+    hosts = load_hosts(hosts_file)
+
+    print(f"Checking {len(hosts)} host(s) from {hosts_file} ...")
+
+    results: dict = {}
+    threads = []
+    for host in hosts:
+        t = threading.Thread(target=check_host, args=(host, results), daemon=True)
+        threads.append(t)
+        t.start()
+    for t in threads:
+        t.join()
+
+    print_report(hosts, results)
+
+    # Exit with non-zero if any host is down
+    down = [h["name"] for h in hosts if results.get(h["name"], {}).get("status") != "UP"]
+    if down:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/devops/fleet-ssh/templates/hosts.yaml
+++ b/skills/devops/fleet-ssh/templates/hosts.yaml
@@ -1,0 +1,31 @@
+# Fleet hosts inventory — copy to ~/.hermes/fleet/hosts.yaml and edit.
+#
+# Required fields per host:
+#   name  — short identifier used in reports
+#   host  — IP address or hostname
+#   user  — SSH login user
+#
+# Optional fields:
+#   port  — SSH port (default: 22)
+#   tags  — list of arbitrary labels for grouping
+
+hosts:
+  - name: node0
+    host: 10.0.0.1
+    user: admin
+
+  - name: node1
+    host: 10.0.0.2
+    user: admin
+
+  - name: node2
+    host: 10.0.0.3
+    user: deploy
+    port: 2222
+    tags: [gpu, mining]
+
+  # Example: cloud instance
+  # - name: cloud-01
+  #   host: 203.0.113.10
+  #   user: ubuntu
+  #   tags: [cloud, prod]


### PR DESCRIPTION
## Summary

- Adds `skills/devops/fleet-ssh/` — a new Hermes skill that enables acting as a fleet operator over SSH
- Includes `fleet_status.py` script that checks uptime, load, disk, and memory across all hosts in parallel
- Ships a `templates/hosts.yaml` inventory template for defining your fleet

## What this enables

Hermes can now:
- **Run commands** across multiple machines simultaneously (parallel SSH)
- **Monitor fleet health** — uptime, load average, disk usage, memory per host
- **Deploy files** to all hosts via `scp` loops
- **Tail remote logs** from any host
- **Check process status** across every node in the fleet

Useful for homelab operators, mining fleets, and distributed compute setups. The hosts inventory is a simple `hosts.yaml` file; the skill handles parallel execution, timeouts, and output formatting.

## Files

| File | Purpose |
|------|---------|
| `SKILL.md` | Full skill doc — procedures, quick-ref table, pitfalls, verification |
| `scripts/fleet_status.py` | Parallel SSH health checker; exits non-zero if any host is down |
| `templates/hosts.yaml` | Example inventory to copy to `~/.hermes/fleet/hosts.yaml` |

## Test plan

- [ ] Copy `templates/hosts.yaml` to `~/.hermes/fleet/hosts.yaml`, fill in real hosts
- [ ] Confirm SSH key auth: `ssh -o BatchMode=yes user@host "echo ok"`
- [ ] Run `python3 skills/devops/fleet-ssh/scripts/fleet_status.py` and verify report
- [ ] Test parallel command: loop from SKILL.md procedures section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Closes #5903