### PR TITLE
feat: add ollama-health devops skill

### DIFF
--- a/skills/devops/ollama-health/SKILL.md
+++ b/skills/devops/ollama-health/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: ollama-health
+description: Monitor and manage local Ollama models — check loaded models, VRAM usage, pull/remove models, and diagnose issues
+version: 1.0.0
+author: het4rk
+license: MIT
+platforms: [macos, linux]
+metadata:
+  hermes:
+    tags: [Ollama, LLM, Local, Models, DevOps, Monitoring]
+    requires_toolsets: [terminal]
+---
+
+# Ollama Health Monitor
+
+Monitor and manage your local Ollama instance — check which models are running, how much VRAM they consume, pull or remove models, and diagnose slow inference.
+
+## When to Use
+
+- Verify Ollama is running and its API is responsive
+- See which models are currently loaded into VRAM
+- Inventory all installed models and their disk sizes
+- Pull new models or update existing ones
+- Diagnose slow or timed-out inference requests
+- Free disk space by removing unused models
+- Restart the Ollama service after config changes
+
+## Quick Reference
+
+| Command | Purpose |
+|---|---|
+| `ollama ps` | Show running models with VRAM usage |
+| `ollama list` | List all installed models with sizes |
+| `curl http://localhost:11434/api/tags` | API: list installed models (JSON) |
+| `curl http://localhost:11434/api/ps` | API: list running models (JSON) |
+| `ollama pull <model>` | Download or update a model |
+| `ollama rm <model>` | Remove an installed model |
+| `ollama show <model>` | Show model details (params, quantization, size) |
+| `ollama serve` | Start the Ollama server manually |
+| `ollama version` | Print Ollama version |
+
+---
+
+## Procedures
+
+### 1. Health Check
+
+Verify that the Ollama process is running and the API is responsive:
+
+```bash
+# Check if Ollama process is running
+pgrep -x ollama && echo "Ollama process: running" || echo "Ollama process: not found"
+
+# Confirm API responds
+curl -sf http://localhost:11434/ && echo "API: OK" || echo "API: unreachable"
+
+# Full version check via API
+curl -s http://localhost:11434/api/version | python3 -m json.tool
+```
+
+If the API is unreachable, start Ollama:
+```bash
+ollama serve &       # foreground (dev)
+# or use the service manager — see Restart section below
+```
+
+---
+
+### 2. Model Inventory
+
+List what is installed vs. what is currently loaded in VRAM:
+
+```bash
+# All installed models (name, size, modified date)
+ollama list
+
+# Models currently loaded into VRAM
+ollama ps
+```
+
+Via API (useful inside scripts):
+```bash
+# Installed models
+curl -s http://localhost:11434/api/tags | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for m in data.get('models', []):
+    size_gb = m['size'] / 1e9
+    print(f\"{m['name']:<45} {size_gb:.2f} GB\")
+"
+
+# Running models + VRAM
+curl -s http://localhost:11434/api/ps | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+models = data.get('models', [])
+if not models:
+    print('No models currently loaded in VRAM.')
+else:
+    for m in models:
+        vram_gb = m.get('size_vram', 0) / 1e9
+        print(f\"{m['name']:<45} VRAM: {vram_gb:.2f} GB\")
+"
+```
+
+For a formatted full report, run the bundled script:
+```bash
+python3 skills/devops/ollama-health/scripts/ollama_status.py
+```
+
+---
+
+### 3. Diagnose Slow Inference
+
+Slow first-response times are almost always caused by the model not being pre-loaded.
+
+**Step 1 — Is the model loaded?**
+```bash
+ollama ps
+```
+If the target model does not appear, it will be loaded on the next request (cold-start latency is normal).
+
+**Step 2 — Check VRAM pressure**
+```bash
+# macOS (Apple Silicon)
+sudo powermetrics --samplers gpu_power -n 1 2>/dev/null | grep -i "gpu active\|gpu memory"
+
+# Linux (NVIDIA)
+nvidia-smi --query-gpu=memory.used,memory.free,memory.total --format=csv,noheader
+
+# Linux (AMD)
+rocm-smi --showmeminfo vram 2>/dev/null
+```
+
+If available VRAM is low, unload unused models:
+```bash
+# Unload a model by setting keep_alive to 0
+curl -s http://localhost:11434/api/generate \
+  -d "{\"model\": \"<model-to-unload>\", \"keep_alive\": 0}" > /dev/null
+```
+
+**Step 3 — Check quantization level**
+```bash
+ollama show <model>
+# Look for "quantization" in the output — lower Q (Q2/Q3) is faster but less accurate
+```
+
+**Step 4 — Review Ollama logs for errors**
+```bash
+# macOS
+tail -n 100 ~/.ollama/logs/server.log
+
+# Linux (systemd)
+journalctl -u ollama -n 100 --no-pager
+```
+
+---
+
+### 4. Pull / Update a Model
+
+```bash
+# Pull a model (or update to latest)
+ollama pull llama3.2
+
+# Pull a specific version/tag
+ollama pull mistral:7b-instruct-q4_K_M
+
+# Track pull progress
+ollama pull nomic-embed-text
+```
+
+To pull and immediately verify:
+```bash
+MODEL="llama3.2"
+ollama pull "$MODEL" && ollama show "$MODEL"
+```
+
+---
+
+### 5. Clean Up Unused Models
+
+Free disk space by removing models you no longer use:
+
+```bash
+# List all installed models with sizes
+ollama list
+
+# Remove a specific model
+ollama rm mistral:7b
+
+# Remove multiple models
+for model in phi3:mini orca-mini gemma:2b; do
+  ollama rm "$model" && echo "Removed $model"
+done
+```
+
+To find the largest installed models:
+```bash
+curl -s http://localhost:11434/api/tags | python3 -c "
+import sys, json
+models = json.load(sys.stdin).get('models', [])
+for m in sorted(models, key=lambda x: x['size'], reverse=True):
+    print(f\"{m['size']/1e9:.2f} GB  {m['name']}\")
+"
+```
+
+---
+
+### 6. Restart Ollama Service
+
+**macOS (launchctl)**
+```bash
+# Check if the launchd service is loaded
+launchctl list | grep ollama
+
+# Stop Ollama
+launchctl stop com.ollama.ollama 2>/dev/null || pkill ollama
+
+# Start Ollama (via app or launchd)
+open -a Ollama                          # if installed as macOS app
+# or
+launchctl start com.ollama.ollama       # if registered with launchd
+# or
+ollama serve &                          # manual start
+```
+
+**Linux (systemd)**
+```bash
+# Check status
+systemctl status ollama
+
+# Restart
+sudo systemctl restart ollama
+
+# Enable on boot
+sudo systemctl enable ollama
+
+# View recent logs
+journalctl -u ollama -n 50 --no-pager
+```
+
+---
+
+## Bundled Script
+
+`scripts/ollama_status.py` prints a full status report covering:
+- API reachability and Ollama version
+- All installed models with sizes
+- Models currently loaded in VRAM
+
+```bash
+python3 skills/devops/ollama-health/scripts/ollama_status.py
+
+# Or with a custom host:
+OLLAMA_HOST=http://192.168.1.10:11434 python3 skills/devops/ollama-health/scripts/ollama_status.py
+```
+
+---
+
+## Pitfalls
+
+- **Cold-start latency is expected.** The first inference call loads the model from disk into VRAM, which can take several seconds to over a minute for large models. Subsequent calls within the `keep_alive` window (default: 5 minutes) are fast.
+- **MoE models can time out on cold start.** Mixture-of-Experts architectures like `qwen2.5:72b-instruct-a22b` or Hermes models using MoE routing load a large number of expert weights and may appear to hang for 60–120 seconds. Increase your client timeout or pre-warm the model with a dummy prompt.
+- **VRAM limits depend on hardware.** On Apple Silicon, system RAM is shared with the GPU — ensure you have enough free unified memory. On NVIDIA/AMD, check `nvidia-smi` / `rocm-smi` for accurate VRAM usage.
+- **Multiple models can share VRAM** if they fit, but Ollama will evict the least-recently-used model automatically when memory is needed.
+- **`ollama ps` shows zero entries** when no model has been used recently — models are evicted after the `keep_alive` timeout.
+
+---
+
+## Verification Steps
+
+1. `curl -sf http://localhost:11434/ && echo OK` — API responds
+2. `ollama list` — returns at least one model (or empty list with no error)
+3. `ollama ps` — runs without error (may show empty if no model loaded)
+4. `python3 skills/devops/ollama-health/scripts/ollama_status.py` — status report renders cleanly
+5. `ollama pull <small-model>` (e.g. `ollama pull tinyllama`) — pull succeeds end-to-end

--- a/skills/devops/ollama-health/scripts/ollama_status.py
+++ b/skills/devops/ollama-health/scripts/ollama_status.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+ollama_status.py — Ollama model health status report
+
+Hits the local Ollama API and prints a formatted summary of:
+  - API reachability and Ollama version
+  - All installed models with sizes
+  - Models currently loaded in VRAM
+
+Usage:
+    python3 ollama_status.py
+
+    # Custom host
+    OLLAMA_HOST=http://192.168.1.10:11434 python3 ollama_status.py
+"""
+
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "http://localhost:11434").rstrip("/")
+
+# ── ANSI colours (disabled when not a tty) ────────────────────────────────────
+_USE_COLOR = sys.stdout.isatty()
+
+def _c(code: str, text: str) -> str:
+    return f"\033[{code}m{text}\033[0m" if _USE_COLOR else text
+
+GREEN  = lambda t: _c("32", t)
+YELLOW = lambda t: _c("33", t)
+RED    = lambda t: _c("31", t)
+BOLD   = lambda t: _c("1",  t)
+DIM    = lambda t: _c("2",  t)
+
+
+# ── HTTP helpers ──────────────────────────────────────────────────────────────
+
+def _get(path: str, timeout: int = 5) -> dict:
+    url = f"{OLLAMA_HOST}{path}"
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode())
+
+
+def _fmt_bytes(n: int) -> str:
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if n < 1024:
+            return f"{n:.1f} {unit}"
+        n /= 1024
+    return f"{n:.1f} PB"
+
+
+# ── Sections ──────────────────────────────────────────────────────────────────
+
+def check_api() -> bool:
+    """Return True if Ollama API is reachable."""
+    print(BOLD("── Ollama API ──────────────────────────────────────────────"))
+    try:
+        data = _get("/api/version")
+        version = data.get("version", "unknown")
+        print(f"  Status  : {GREEN('reachable')}")
+        print(f"  Version : {version}")
+        print(f"  Host    : {OLLAMA_HOST}")
+        return True
+    except urllib.error.URLError as exc:
+        print(f"  Status  : {RED('unreachable')}  ({exc.reason})")
+        print(f"  Host    : {OLLAMA_HOST}")
+        print()
+        print(DIM("  Start Ollama with:  ollama serve"))
+        return False
+    except Exception as exc:  # noqa: BLE001
+        print(f"  Status  : {RED('error')}  ({exc})")
+        return False
+
+
+def show_installed_models() -> None:
+    """Print all installed models with sizes."""
+    print()
+    print(BOLD("── Installed Models ────────────────────────────────────────"))
+    try:
+        data = _get("/api/tags")
+        models = data.get("models", [])
+        if not models:
+            print(f"  {DIM('No models installed.')}")
+            return
+
+        col_name = 46
+        header = f"  {'NAME':<{col_name}}  {'SIZE':>9}  {'MODIFIED'}"
+        print(DIM(header))
+        print(DIM("  " + "-" * (col_name + 22)))
+        total = 0
+        for m in sorted(models, key=lambda x: x.get("name", "")):
+            name    = m.get("name", "?")
+            size    = m.get("size", 0)
+            total  += size
+            mod_raw = m.get("modified_at", "")
+            mod     = mod_raw[:10] if mod_raw else "-"
+            print(f"  {name:<{col_name}}  {_fmt_bytes(size):>9}  {mod}")
+        print(DIM("  " + "-" * (col_name + 22)))
+        print(f"  {'Total':<{col_name}}  {_fmt_bytes(total):>9}")
+    except Exception as exc:  # noqa: BLE001
+        print(f"  {RED('Error fetching installed models:')} {exc}")
+
+
+def show_running_models() -> None:
+    """Print models currently loaded in VRAM."""
+    print()
+    print(BOLD("── Running Models (VRAM) ───────────────────────────────────"))
+    try:
+        data = _get("/api/ps")
+        models = data.get("models", [])
+        if not models:
+            print(f"  {DIM('No models currently loaded in VRAM.')}")
+            return
+
+        col_name = 46
+        header = f"  {'NAME':<{col_name}}  {'SIZE':>9}  {'VRAM':>9}  EXPIRES"
+        print(DIM(header))
+        print(DIM("  " + "-" * (col_name + 34)))
+        for m in models:
+            name       = m.get("name", "?")
+            size       = m.get("size", 0)
+            size_vram  = m.get("size_vram", 0)
+            expires_raw = m.get("expires_at", "")
+            expires    = expires_raw[11:16] if len(expires_raw) >= 16 else "-"
+            vram_str   = _fmt_bytes(size_vram) if size_vram else DIM("  n/a   ")
+            print(
+                f"  {name:<{col_name}}  {_fmt_bytes(size):>9}  "
+                f"{vram_str:>9}  {expires}"
+            )
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            # Older Ollama builds don't have /api/ps
+            _show_running_fallback()
+        else:
+            print(f"  {RED('Error fetching running models:')} {exc}")
+    except Exception as exc:  # noqa: BLE001
+        print(f"  {RED('Error fetching running models:')} {exc}")
+
+
+def _show_running_fallback() -> None:
+    """Fall back to `ollama ps` CLI when /api/ps is unavailable."""
+    try:
+        result = subprocess.run(
+            ["ollama", "ps"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            lines = result.stdout.strip().splitlines()
+            if len(lines) <= 1:
+                print(f"  {DIM('No models currently loaded (ollama ps).')}")
+            else:
+                for line in lines:
+                    print(f"  {line}")
+        else:
+            print(f"  {YELLOW('ollama ps not available or no models loaded.')}")
+    except FileNotFoundError:
+        print(f"  {YELLOW('ollama CLI not found; cannot show running models.')}")
+    except Exception as exc:  # noqa: BLE001
+        print(f"  {RED('Error running ollama ps:')} {exc}")
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+def main() -> None:
+    print()
+    print(BOLD("╔══════════════════════════════════════════════════════════╗"))
+    print(BOLD("║             Ollama Model Health Status                   ║"))
+    print(BOLD("╚══════════════════════════════════════════════════════════╝"))
+    print()
+
+    ok = check_api()
+    if not ok:
+        print()
+        sys.exit(1)
+
+    show_installed_models()
+    show_running_models()
+    print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `skills/devops/ollama-health/` — a new DevOps skill for monitoring and managing a local [Ollama](https://ollama.com) instance from within Hermes
- Covers: health checks, model inventory + VRAM usage, slow-inference diagnosis, pull/remove workflows, and service restart on macOS (`launchctl`) and Linux (`systemd`)
- Includes `scripts/ollama_status.py`: a zero-dependency Python script (stdlib only) that hits the Ollama REST API and prints a clean status report

## Motivation

Hermes users who run local models via Ollama (e.g. `ollama pull hermes3`) frequently need to diagnose cold-start latency, VRAM pressure, or a hung Ollama process. Today that means leaving the agent and running shell commands manually. This skill gives Hermes the vocabulary to handle those requests end-to-end — from "is Ollama running?" to "which models are eating my VRAM?" to "restart the service."

## What's included

```
skills/devops/ollama-health/
├── SKILL.md                    ← skill definition + procedures
└── scripts/
    └── ollama_status.py        ← formatted API status report
```

**SKILL.md covers:**
- Quick reference table of key CLI + API commands
- Step-by-step procedures for 6 common workflows
- Pitfalls (cold-start latency, MoE timeouts, VRAM limits)
- Verification steps

**`ollama_status.py`** uses only the Python standard library (`urllib`, `json`, `subprocess`) — no pip install required. Supports a custom `OLLAMA_HOST` env var for remote Ollama instances.

## Test plan

- [ ] `python3 skills/devops/ollama-health/scripts/ollama_status.py` — runs cleanly with Ollama running and with Ollama stopped
- [ ] `OLLAMA_HOST=http://other-host:11434 python3 ...` — respects custom host
- [ ] Verify SKILL.md frontmatter parses correctly against the hermes skill schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Closes #5904