### PR TITLE
feat: add Targon confidential GPU compute skill (Bittensor SN4)

### DIFF
--- a/skills/mlops/cloud/targon/SKILL.md
+++ b/skills/mlops/cloud/targon/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: targon-compute
+description: Provision and manage confidential GPU compute on Targon (Bittensor SN4). Use when you need decentralized GPU rentals (H200, 4090), serverless function deployment, or privacy-preserving AI workloads with hardware-level confidential computing.
+version: 1.0.0
+author: het4rk
+license: MIT
+dependencies: [targon-sdk>=0.1.0]
+metadata:
+  hermes:
+    tags: [Compute, GPU, Bittensor, Targon, Decentralized, Confidential]
+required_environment_variables: [TARGON_API_KEY]
+platforms: [macos, linux]
+
+---
+
+# Targon Confidential GPU Compute (Bittensor SN4)
+
+Targon (Subnet 4) by Manifold Labs is a decentralized, confidential AI cloud built on the Bittensor network. It combines hardware-level confidential computing (Intel TDX, AMD SEV, NVIDIA Confidential Computing) with decentralized GPU supply to provide private, verifiable AI infrastructure.
+
+**Free credits**: Use promo code `starter10` at https://targon.com to get **$10 free credits** — no credit card required to start.
+
+## When to Use
+
+**Use Targon when:**
+- You need GPU rentals with hardware-enforced privacy guarantees (TVM — Targon Virtual Machine)
+- Running sensitive ML workloads where data must not be visible to the host
+- You want decentralized, censorship-resistant compute (no single cloud vendor lock-in)
+- Deploying serverless inference endpoints or batch jobs on H200s or RTX 4090s
+- You need SSH access to a dedicated GPU node for training, fine-tuning, or custom setups
+- Cost-sensitive workloads: H200s from $2/hr, competitive 4090 rates
+
+**Use alternatives instead:**
+- **Modal / RunPod**: For purely centralized workloads where confidentiality is not a concern
+- **Vast.ai**: For lowest-cost 4090 rentals without confidentiality requirements
+- **AWS/GCP**: For deep cloud ecosystem integration (managed databases, IAM, etc.)
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Install SDK | `pip install targon-sdk` |
+| Authenticate | `targon setup` |
+| List available GPUs | `targon inventory` |
+| Rent a GPU | `targon run --gpu H200 --image <docker-image>` |
+| Deploy serverless | `targon deploy --file app.py` |
+| SSH into rental | `ssh <RENTAL_ID>@ssh.deployments.targon.com` |
+| Check active rentals | `targon list` |
+| Stop a rental | `targon stop <RENTAL_ID>` |
+
+## Procedure
+
+### 1. Install and Authenticate
+
+```bash
+pip install targon-sdk
+
+# Interactive setup — opens browser for API key retrieval
+targon setup
+```
+
+Or set the API key directly:
+
+```bash
+export TARGON_API_KEY="your_api_key_here"
+```
+
+Get your API key at https://targon.com (use promo code `starter10` for $10 free credits).
+
+### 2. Check Available GPU Inventory
+
+```bash
+# List available GPU types and counts
+targon inventory
+
+# Filter by GPU type
+targon inventory --gpu H200
+targon inventory --gpu 4090
+```
+
+### 3. Provision a GPU Rental
+
+```bash
+# Rent an H200 with a PyTorch Docker image
+targon run \
+  --gpu H200 \
+  --image pytorch/pytorch:2.2.0-cuda12.1-cudnn8-runtime \
+  --name my-training-job
+
+# Rent a 4090 with custom startup command
+targon run \
+  --gpu 4090 \
+  --image nvcr.io/nvidia/cuda:12.3.0-base-ubuntu22.04 \
+  --cmd "bash -c 'nvidia-smi && sleep infinity'" \
+  --name my-inference-node
+```
+
+Once provisioned, retrieve the rental ID:
+
+```bash
+targon list
+# Output: RENTAL_ID  GPU    STATUS   STARTED
+#         abc123     H200   running  2 min ago
+```
+
+### 4. SSH into a Rental
+
+```bash
+# Direct SSH access — no VPN or bastion required
+ssh abc123@ssh.deployments.targon.com
+
+# Copy files to rental
+scp model.py abc123@ssh.deployments.targon.com:/workspace/
+```
+
+Your SSH public key is registered during `targon setup`. You can add additional keys in the Targon dashboard.
+
+### 5. Deploy a Serverless Function
+
+```python
+# app.py — Targon serverless function
+from targon import endpoint
+
+@endpoint(gpu="H200")
+def run_inference(payload: dict) -> dict:
+    import torch
+    # your model inference logic here
+    result = {"output": "inference result"}
+    return result
+```
+
+```bash
+# Deploy to serverless
+targon deploy --file app.py --name my-inference-api
+
+# Output: Deployed at https://api.targon.com/v1/functions/my-inference-api
+```
+
+### 6. Monitor Usage and Billing
+
+```bash
+# Check credit balance and usage
+targon usage
+
+# View active and past rentals
+targon list --all
+
+# Stop a rental (billing stops immediately)
+targon stop abc123
+```
+
+You can also run the included status script:
+
+```bash
+python scripts/targon_status.py
+```
+
+### 7. Use the Python SDK Directly
+
+```python
+import os
+from targon import TargonClient
+
+client = TargonClient(api_key=os.environ["TARGON_API_KEY"])
+
+# List inventory
+inventory = client.inventory.list()
+for gpu in inventory:
+    print(f"{gpu.type}: {gpu.available} available @ ${gpu.price_per_hour}/hr")
+
+# Provision a rental
+rental = client.rentals.create(
+    gpu_type="H200",
+    image="pytorch/pytorch:2.2.0-cuda12.1-cudnn8-runtime",
+    name="my-job",
+)
+print(f"Rental ID: {rental.id}, Status: {rental.status}")
+```
+
+## Pitfalls
+
+- **Billing continues until you stop the rental.** Always run `targon stop <RENTAL_ID>` when done. There is no automatic shutdown.
+- **SSH key must be added before provisioning.** Run `targon setup` first to register your public key. Adding keys after provisioning requires a restart.
+- **Docker image must be CUDA-compatible.** Use `nvidia/cuda` or framework images (PyTorch, TensorFlow). Plain Ubuntu images won't have GPU drivers.
+- **Serverless cold starts**: First invocation may take 30–60 seconds while the container launches. Subsequent calls are fast (<50ms).
+- **API key scope**: The `TARGON_API_KEY` environment variable must be set for both the CLI and SDK. `targon setup` writes it to `~/.targon/config`.
+- **Confidential computing overhead**: TVM adds a small overhead (~2–5%) vs. standard GPU access. This is expected and the trade-off for hardware-level privacy.
+
+## Verification
+
+After provisioning a rental, verify everything is working:
+
+```bash
+# 1. Confirm rental is running
+targon list
+# Should show your rental with status "running"
+
+# 2. SSH in and check GPU
+ssh <RENTAL_ID>@ssh.deployments.targon.com
+nvidia-smi
+# Should show your H200 or 4090
+
+# 3. Verify confidential compute is active (H200 only)
+# nvidia-smi conf-compute --query-cc-settings
+# Should show "CC mode: ON"
+
+# 4. Run a quick CUDA sanity check
+python3 -c "import torch; print(torch.cuda.get_device_name(0)); print(torch.cuda.is_available())"
+```
+
+## References
+
+- **[Compute Guide](references/compute_guide.md)** — Architecture, GPU specs, pricing, security model, and common workflows
+- **[Status Script](scripts/targon_status.py)** — Check CLI health, active rentals, inventory, and billing
+- **Targon Docs**: https://docs.targon.com
+- **Targon Site**: https://targon.com
+- **GitHub**: https://github.com/manifold-inc/targon

--- a/skills/mlops/cloud/targon/references/compute_guide.md
+++ b/skills/mlops/cloud/targon/references/compute_guide.md
@@ -1,0 +1,279 @@
+# Targon Compute Guide
+
+Reference documentation for Targon (Bittensor Subnet 4) — decentralized confidential GPU cloud by Manifold Labs.
+
+---
+
+## Architecture Overview
+
+### What is Targon?
+
+Targon is **Bittensor Subnet 4 (SN4)**, operated by Manifold Labs. It functions as a decentralized AI cloud marketplace where:
+
+- **Miners** contribute GPU resources (H200s, RTX 4090s, CPUs) and are rewarded in TAO (Bittensor's native token).
+- **Validators** verify that miners are performing genuine compute and not cheating.
+- **Users** pay in USD (credit card or crypto) to rent compute capacity.
+
+Unlike centralized clouds (AWS, GCP, Azure), no single entity controls the hardware. Demand and supply are matched on-chain, and miner rewards are algorithmically determined by the Bittensor protocol.
+
+### Targon Virtual Machine (TVM)
+
+The TVM is Targon's privacy layer. Every rental runs inside a **hardware-enforced confidential enclave**:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Targon Virtual Machine (TVM)                               │
+│  ┌──────────────────────────────────────────────────────┐   │
+│  │  Your workload (model weights, data, code)           │   │
+│  │  ← encrypted in memory, invisible to host OS         │   │
+│  └──────────────────────────────────────────────────────┘   │
+│  ┌──────────────────────────────────────────────────────┐   │
+│  │  Confidential Computing Layer                        │   │
+│  │  Intel TDX / AMD SEV / NVIDIA Confidential Computing │   │
+│  └──────────────────────────────────────────────────────┘   │
+│                Host (miner) hardware                        │
+└─────────────────────────────────────────────────────────────┘
+```
+
+The miner who owns the GPU **cannot read your data** — the enclave is isolated at the hardware level. This is the key differentiator from RunPod, Vast.ai, and other peer-to-peer GPU marketplaces.
+
+### Bittensor SN4 Connection
+
+Targon integrates with Bittensor's incentive mechanism:
+
+1. Miners register on SN4 and stake TAO.
+2. Validators periodically send synthetic workloads and verify results.
+3. Miners are scored on uptime, latency, and correctness.
+4. TAO emissions reward high-scoring miners, creating economic incentives for quality hardware.
+
+Users benefit indirectly: miners are economically incentivized to maintain 99%+ uptime and low-latency connections, with the Bittensor protocol as the enforcement layer.
+
+---
+
+## GPU Types Available
+
+### NVIDIA H200
+
+| Spec | Value |
+|------|-------|
+| VRAM | 141 GB HBM3e |
+| Memory Bandwidth | 4.8 TB/s |
+| FP8 Tensor TOPS | 3,958 |
+| BF16 Tensor TFLOPS | 1,979 |
+| Confidential Computing | Yes (NVIDIA CC) |
+| Recommended For | Large model training (70B+), multi-GPU inference, fine-tuning Llama 3 405B |
+| Price | ~$2/hr |
+
+The H200 is the flagship GPU on Targon. Its 141 GB HBM3e VRAM makes it the best choice for running large models without quantization or for training at full precision.
+
+### NVIDIA RTX 4090
+
+| Spec | Value |
+|------|-------|
+| VRAM | 24 GB GDDR6X |
+| Memory Bandwidth | 1,008 GB/s |
+| FP8 Tensor TOPS | 1,321 |
+| Confidential Computing | No (consumer card) |
+| Recommended For | Inference, fine-tuning models up to 13B, diffusion models, RLHF experiments |
+| Price | Competitive with market |
+
+The 4090 is the cost-effective option for workloads that fit within 24 GB. It lacks hardware confidential computing, so sensitive data should run on H200s.
+
+---
+
+## Serverless vs. Rental
+
+| Feature | Serverless | Rental (SSH) |
+|---------|-----------|--------------|
+| Access method | HTTP endpoint | SSH + direct GPU |
+| Billing | Per-request / per-second | Per-hour |
+| Cold starts | Yes (30–60s first call) | No (persistent) |
+| Idle cost | None (scales to zero) | Full hourly rate |
+| GPU persistence | Ephemeral | Persistent until stopped |
+| Custom CUDA libs | Docker image | Full system access |
+| Multi-GPU training | Not supported | Supported |
+| Use case | Inference APIs, batch jobs | Training, fine-tuning, research |
+
+**Choose Serverless when:**
+- Running inference with variable or low traffic
+- Deploying a model as an API with auto-scaling
+- Minimizing costs by paying only for actual compute time
+
+**Choose Rental when:**
+- Running multi-day training jobs
+- Needing persistent storage or custom kernel builds
+- Debugging interactively over SSH
+- Using multi-GPU setups (DDP, FSDP)
+
+---
+
+## Pricing Overview
+
+| Resource | Price | Notes |
+|----------|-------|-------|
+| H200 GPU | ~$2/hr | 141 GB HBM3e, confidential compute |
+| RTX 4090 | Market rate | 24 GB GDDR6X |
+| CPU Instances | From $0.10/hr | For data preprocessing, orchestration |
+| Serverless | Per-second | Only pay when function runs |
+
+**Promo code**: `starter10` — get **$10 free credits** at https://targon.com. No credit card required to start.
+
+Pricing is denominated in USD. Payments can be made by credit card or crypto. Manifold Labs may adjust rates based on market conditions; always check https://targon.com/pricing for current rates.
+
+---
+
+## Security Model
+
+### Intel TDX (Trust Domain Extensions)
+
+Intel TDX is a CPU-level isolation mechanism available on 4th/5th-gen Xeon Scalable processors. A TDX Trust Domain (TD) is a hardware-isolated VM whose memory is encrypted with a key that the host OS, hypervisor, and other VMs cannot access. The TDX module is part of the CPU microcode, not the OS — the miner's kernel cannot intercept or inspect VM memory.
+
+**Remote attestation**: TDX generates a cryptographically signed attestation report (backed by Intel SGX infrastructure) that proves to users which code is running inside the TD and that it hasn't been tampered with.
+
+### AMD SEV (Secure Encrypted Virtualization)
+
+AMD SEV and SEV-SNP (Secure Nested Paging) encrypt VM memory using keys held exclusively by the AMD Secure Processor. SEV-SNP adds integrity protection, preventing the hypervisor from replaying or remapping pages. Like TDX, SEV supports remote attestation via AMD's Key Distribution Service (KDS).
+
+### NVIDIA Confidential Computing (CC)
+
+NVIDIA H100/H200 GPUs support CC mode, which establishes an encrypted channel between the CPU enclave (TDX/SEV) and the GPU. GPU VRAM is encrypted, PCIe DMA transfers are protected, and the host cannot read GPU memory. This is critical for AI workloads: model weights and activations in GPU VRAM are inaccessible to the miner.
+
+Without NVIDIA CC, even if the CPU is inside a TDX enclave, data copied to the GPU is exposed on the PCIe bus and in GPU VRAM. H200 rentals on Targon use NVIDIA CC to close this gap.
+
+### Full Stack Privacy
+
+```
+User's model/data
+      │
+      ▼
+[Encrypted with TDX/SEV key] ── CPU Memory
+      │
+[NVIDIA CC encrypted channel] ── PCIe Bus
+      │
+      ▼
+[Encrypted GPU VRAM] ── H200 GPU
+```
+
+At no point does the miner's host OS or other system software have access to plaintext model weights, training data, or intermediate activations.
+
+---
+
+## Common Workflows
+
+### LLM Training (H200, 70B+ models)
+
+```bash
+# 1. Rent an H200
+targon run \
+  --gpu H200 \
+  --image nvcr.io/nvidia/pytorch:24.01-py3 \
+  --name llm-training
+
+# 2. SSH in
+ssh <RENTAL_ID>@ssh.deployments.targon.com
+
+# 3. Clone your training code and start
+git clone https://github.com/your-org/training-repo
+cd training-repo
+torchrun --nproc_per_node=1 train.py \
+  --model_name_or_path meta-llama/Llama-3-70b \
+  --dataset_path /data/train.jsonl \
+  --output_dir /workspace/checkpoints
+```
+
+### Inference Server (vLLM on H200)
+
+```bash
+# Rent and deploy vLLM
+targon run \
+  --gpu H200 \
+  --image vllm/vllm-openai:latest \
+  --cmd "python -m vllm.entrypoints.openai.api_server \
+    --model meta-llama/Llama-3-8b-instruct \
+    --host 0.0.0.0 --port 8000" \
+  --name vllm-server
+
+# Test the endpoint (via SSH tunnel)
+ssh -L 8000:localhost:8000 <RENTAL_ID>@ssh.deployments.targon.com -N &
+curl http://localhost:8000/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model": "meta-llama/Llama-3-8b-instruct", "prompt": "Hello", "max_tokens": 50}'
+```
+
+### Fine-tuning with LoRA (4090)
+
+```bash
+# Cost-effective fine-tuning on 4090
+targon run \
+  --gpu 4090 \
+  --image pytorch/pytorch:2.2.0-cuda12.1-cudnn8-runtime \
+  --name lora-finetune
+
+ssh <RENTAL_ID>@ssh.deployments.targon.com
+
+pip install transformers peft accelerate datasets trl
+python finetune_lora.py \
+  --base_model mistralai/Mistral-7B-v0.1 \
+  --data_path data.jsonl \
+  --output_dir /workspace/lora-adapter
+```
+
+### Serverless Batch Inference
+
+```python
+# batch_inference.py
+from targon import endpoint
+
+@endpoint(gpu="H200", timeout=300)
+def batch_classify(texts: list[str]) -> list[dict]:
+    from transformers import pipeline
+    classifier = pipeline("text-classification", model="distilbert-base-uncased-finetuned-sst-2-english")
+    return classifier(texts, batch_size=32)
+```
+
+```bash
+targon deploy --file batch_inference.py --name batch-classifier
+
+# Invoke
+curl -X POST https://api.targon.com/v1/functions/batch-classifier \
+  -H "Authorization: Bearer $TARGON_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"texts": ["great product", "terrible experience", "okay I guess"]}'
+```
+
+### Diffusion Model Image Generation (4090)
+
+```bash
+targon run \
+  --gpu 4090 \
+  --image pytorch/pytorch:2.2.0-cuda12.1-cudnn8-runtime \
+  --name sdxl-gen
+
+ssh <RENTAL_ID>@ssh.deployments.targon.com
+pip install diffusers accelerate transformers
+
+python3 << 'EOF'
+from diffusers import StableDiffusionXLPipeline
+import torch
+
+pipe = StableDiffusionXLPipeline.from_pretrained(
+    "stabilityai/stable-diffusion-xl-base-1.0",
+    torch_dtype=torch.float16,
+).to("cuda")
+
+image = pipe("A photorealistic mountain landscape at sunset").images[0]
+image.save("output.png")
+EOF
+```
+
+---
+
+## Resources
+
+- **Targon Docs**: https://docs.targon.com
+- **Targon Dashboard**: https://targon.com
+- **Manifold Labs GitHub**: https://github.com/manifold-inc/targon
+- **Bittensor Subnet 4**: https://taostats.io/subnet/4
+- **NVIDIA Confidential Computing**: https://www.nvidia.com/en-us/data-center/solutions/confidential-computing/
+- **Intel TDX Overview**: https://www.intel.com/content/www/us/en/developer/tools/trust-domain-extensions/overview.html
+- **AMD SEV-SNP**: https://www.amd.com/en/developer/sev.html

--- a/skills/mlops/cloud/targon/scripts/targon_status.py
+++ b/skills/mlops/cloud/targon/scripts/targon_status.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Targon Compute Status — check CLI health, active rentals, GPU inventory, and billing.
+
+Usage:
+    python targon_status.py
+    python targon_status.py --json
+    python targon_status.py --inventory-only
+    python targon_status.py --rentals-only
+"""
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _run(cmd: list[str], *, capture: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        cmd,
+        capture_output=capture,
+        text=True,
+        env={**os.environ},
+    )
+
+
+def _check_cli() -> dict[str, Any]:
+    """Return CLI availability and version info."""
+    path = shutil.which("targon")
+    if path is None:
+        return {
+            "installed": False,
+            "path": None,
+            "version": None,
+            "message": "targon CLI not found. Install with: pip install targon-sdk",
+        }
+    result = _run(["targon", "--version"])
+    version = result.stdout.strip() or result.stderr.strip() or "unknown"
+    return {"installed": True, "path": path, "version": version, "message": "OK"}
+
+
+def _check_api_key() -> dict[str, Any]:
+    """Check whether TARGON_API_KEY is set (does not validate against server)."""
+    key = os.environ.get("TARGON_API_KEY", "")
+    config_path = os.path.expanduser("~/.targon/config")
+    config_exists = os.path.isfile(config_path)
+    if key:
+        masked = key[:6] + "..." + key[-4:] if len(key) > 10 else "***"
+        return {"set": True, "source": "env", "masked": masked}
+    if config_exists:
+        return {"set": True, "source": "config_file", "masked": "(from ~/.targon/config)"}
+    return {
+        "set": False,
+        "source": None,
+        "masked": None,
+        "message": "Set TARGON_API_KEY env var or run `targon setup`",
+    }
+
+
+def _list_rentals() -> dict[str, Any]:
+    """Parse active rentals from `targon list`."""
+    result = _run(["targon", "list"])
+    if result.returncode != 0:
+        return {"ok": False, "error": result.stderr.strip(), "rentals": []}
+
+    lines = result.stdout.strip().splitlines()
+    # Best-effort parse: skip header line, split on whitespace
+    rentals = []
+    for line in lines[1:]:
+        if not line.strip():
+            continue
+        parts = line.split()
+        if len(parts) >= 3:
+            rentals.append(
+                {
+                    "id": parts[0],
+                    "gpu": parts[1] if len(parts) > 1 else "?",
+                    "status": parts[2] if len(parts) > 2 else "?",
+                    "started": " ".join(parts[3:]) if len(parts) > 3 else "",
+                }
+            )
+    return {"ok": True, "raw": result.stdout.strip(), "rentals": rentals}
+
+
+def _list_inventory() -> dict[str, Any]:
+    """Parse GPU inventory from `targon inventory`."""
+    result = _run(["targon", "inventory"])
+    if result.returncode != 0:
+        return {"ok": False, "error": result.stderr.strip(), "gpus": []}
+
+    lines = result.stdout.strip().splitlines()
+    gpus = []
+    for line in lines[1:]:
+        if not line.strip():
+            continue
+        parts = line.split()
+        if len(parts) >= 2:
+            gpus.append(
+                {
+                    "type": parts[0],
+                    "available": parts[1] if len(parts) > 1 else "?",
+                    "price_per_hour": parts[2] if len(parts) > 2 else "?",
+                }
+            )
+    return {"ok": True, "raw": result.stdout.strip(), "gpus": gpus}
+
+
+def _check_usage() -> dict[str, Any]:
+    """Get billing/credit balance from `targon usage`."""
+    result = _run(["targon", "usage"])
+    if result.returncode != 0:
+        return {"ok": False, "error": result.stderr.strip(), "raw": ""}
+    return {"ok": True, "raw": result.stdout.strip()}
+
+
+# ── display ───────────────────────────────────────────────────────────────────
+
+def _print_section(title: str) -> None:
+    print(f"\n{'─' * 50}")
+    print(f"  {title}")
+    print("─" * 50)
+
+
+def _display(cli: dict, api_key: dict, rentals: dict, inventory: dict, usage: dict) -> None:
+    # CLI health
+    _print_section("CLI Status")
+    if cli["installed"]:
+        print(f"  [OK] targon CLI found at {cli['path']}")
+        print(f"       Version: {cli['version']}")
+    else:
+        print(f"  [MISSING] {cli['message']}")
+
+    # API key
+    _print_section("API Key")
+    if api_key["set"]:
+        print(f"  [OK] Key detected ({api_key['source']}): {api_key['masked']}")
+    else:
+        print(f"  [NOT SET] {api_key.get('message', '')}")
+
+    if not cli["installed"]:
+        print("\n  Cannot query rentals or inventory — install the CLI first.")
+        return
+
+    # Active rentals
+    _print_section("Active Rentals")
+    if not rentals["ok"]:
+        print(f"  [ERROR] {rentals['error']}")
+    elif not rentals["rentals"]:
+        print("  No active rentals.")
+    else:
+        print(f"  {'ID':<20} {'GPU':<10} {'STATUS':<12} STARTED")
+        for r in rentals["rentals"]:
+            print(f"  {r['id']:<20} {r['gpu']:<10} {r['status']:<12} {r['started']}")
+
+    # GPU inventory
+    _print_section("GPU Inventory")
+    if not inventory["ok"]:
+        print(f"  [ERROR] {inventory['error']}")
+    elif not inventory["gpus"]:
+        print("  No inventory data returned.")
+        if inventory.get("raw"):
+            print(f"\n  Raw output:\n{inventory['raw']}")
+    else:
+        print(f"  {'GPU TYPE':<16} {'AVAILABLE':<12} PRICE/HR")
+        for g in inventory["gpus"]:
+            print(f"  {g['type']:<16} {g['available']:<12} {g['price_per_hour']}")
+
+    # Billing
+    _print_section("Billing / Usage")
+    if not usage["ok"]:
+        print(f"  [ERROR] {usage['error']}")
+    elif usage["raw"]:
+        for line in usage["raw"].splitlines():
+            print(f"  {line}")
+    else:
+        print("  No usage data available.")
+
+    print()
+
+
+# ── main ──────────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Check Targon CLI health, active rentals, GPU inventory, and billing."
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    parser.add_argument("--inventory-only", action="store_true", help="Show only GPU inventory")
+    parser.add_argument("--rentals-only", action="store_true", help="Show only active rentals")
+    args = parser.parse_args()
+
+    cli = _check_cli()
+    api_key = _check_api_key()
+
+    if cli["installed"]:
+        rentals = _list_rentals()
+        inventory = _list_inventory()
+        usage = _check_usage()
+    else:
+        rentals = {"ok": False, "error": "CLI not installed", "rentals": []}
+        inventory = {"ok": False, "error": "CLI not installed", "gpus": []}
+        usage = {"ok": False, "error": "CLI not installed", "raw": ""}
+
+    if args.json:
+        output = {
+            "cli": cli,
+            "api_key": api_key,
+            "rentals": rentals,
+            "inventory": inventory,
+            "usage": usage,
+        }
+        print(json.dumps(output, indent=2))
+        return
+
+    if args.inventory_only:
+        _print_section("GPU Inventory")
+        if inventory["ok"] and inventory["gpus"]:
+            print(f"  {'GPU TYPE':<16} {'AVAILABLE':<12} PRICE/HR")
+            for g in inventory["gpus"]:
+                print(f"  {g['type']:<16} {g['available']:<12} {g['price_per_hour']}")
+        elif inventory["ok"]:
+            print(f"\n  Raw output:\n{inventory.get('raw', '')}")
+        else:
+            print(f"  [ERROR] {inventory['error']}")
+        print()
+        return
+
+    if args.rentals_only:
+        _print_section("Active Rentals")
+        if rentals["ok"] and rentals["rentals"]:
+            print(f"  {'ID':<20} {'GPU':<10} {'STATUS':<12} STARTED")
+            for r in rentals["rentals"]:
+                print(f"  {r['id']:<20} {r['gpu']:<10} {r['status']:<12} {r['started']}")
+        elif rentals["ok"]:
+            print("  No active rentals.")
+        else:
+            print(f"  [ERROR] {rentals['error']}")
+        print()
+        return
+
+    _display(cli, api_key, rentals, inventory, usage)
+
+    # Exit with non-zero if CLI is missing or API key is unset
+    if not cli["installed"] or not api_key["set"]:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What is Targon?

[Targon](https://targon.com) is **Bittensor Subnet 4 (SN4)**, operated by [Manifold Labs](https://github.com/manifold-inc/targon). It is a decentralized confidential AI cloud that combines:

- **Decentralized GPU supply** — miners contribute hardware (H200s, RTX 4090s) and are rewarded via the Bittensor protocol
- **Hardware-level privacy** — every rental runs inside a Targon Virtual Machine (TVM) backed by Intel TDX, AMD SEV-SNP, and NVIDIA Confidential Computing; the miner cannot read your data, model weights, or activations
- **Competitive pricing** — H200 from $2/hr, with promo code `starter10` giving $10 free credits to get started

## Why it's useful for Hermes users

Hermes users running ML workloads (training, fine-tuning, inference) often need on-demand GPU access. Targon fills a unique niche:

- **Privacy-sensitive workloads**: proprietary model weights or training data that must not be visible to the host
- **Decentralized / censorship-resistant compute**: no single cloud vendor can revoke access
- **Cost-effective H200 access**: $2/hr is significantly below major cloud providers for the same GPU tier
- **Simple CLI workflow**: `targon setup` → `targon run` → `ssh <id>@ssh.deployments.targon.com` — minimal friction

## Files added

```
skills/mlops/cloud/targon/
├── SKILL.md                        # Full skill — When to Use, Quick Reference,
│                                   # Procedure (7 steps), Pitfalls, Verification
├── scripts/
│   └── targon_status.py            # Standalone status checker: CLI health,
│                                   # active rentals, GPU inventory, billing
└── references/
    └── compute_guide.md            # Deep-dive: TVM architecture, Intel TDX /
                                    # AMD SEV / NVIDIA CC security model, GPU
                                    # specs, serverless vs rental, pricing,
                                    # and 5 common workflow examples
```

## Testing

The skill was validated against the modal skill's structure and conventions. `targon_status.py` uses only stdlib (no external dependencies) and gracefully handles missing CLI / API key.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Closes #5905