### PR TITLE
feat: add Bittensor wallet management skill

### DIFF
--- a/skills/crypto/bittensor/SKILL.md
+++ b/skills/crypto/bittensor/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: bittensor-wallet
+description: Manage Bittensor wallets, check balances, stake TAO tokens, and query subnet info using btcli
+version: 1.0.0
+author: het4rk
+platforms:
+  - macos
+  - linux
+tags:
+  - Crypto
+  - Bittensor
+  - TAO
+  - Wallet
+  - Staking
+  - Subnet
+requires_toolsets:
+  - terminal
+---
+
+# Bittensor Wallet Management
+
+Manage Bittensor wallets, monitor TAO balances, view staking positions, and query subnet information using `btcli` — the official Bittensor CLI.
+
+## When to Use
+
+- Check TAO wallet balance (coldkey or hotkey)
+- View staking positions across subnets
+- List active subnets and their metagraphs
+- Query miner/validator emissions
+- Transfer TAO between wallets
+- Monitor subnet health and registrations
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Check balance | `btcli wallet balance --wallet.name <name>` |
+| View stake | `btcli stake show --wallet.name <name>` |
+| List subnets | `btcli subnet list` |
+| Query metagraph | `btcli subnet metagraph --netuid <N>` |
+| Transfer TAO | `btcli wallet transfer --dest <ss58addr> --amount <TAO>` |
+| Check emissions | `btcli subnet metagraph --netuid <N>` (see Emission column) |
+
+## Procedure
+
+### Check Wallet Balance
+
+```bash
+# List all wallets
+btcli wallet list
+
+# Check balance for a specific wallet
+btcli wallet balance --wallet.name default
+
+# Check balance for all wallets
+btcli wallet balance --all
+```
+
+**What to look for:** `Free Balance` (spendable TAO) vs `Staked Balance` (locked in subnets).
+
+---
+
+### View Staking Positions
+
+```bash
+# Show all stakes for a wallet
+btcli stake show --wallet.name <wallet_name>
+
+# Show stakes with detailed hotkey info
+btcli stake show --wallet.name <wallet_name> --all
+```
+
+**Output columns:** Hotkey address, Subnet UID, Stake (TAO), Emission rate (ρ/block).
+
+---
+
+### List Active Subnets
+
+```bash
+# List all subnets
+btcli subnet list
+
+# Filter to see specific fields (pipe through grep/awk)
+btcli subnet list | grep -E "NETUID|Tempo|Emission"
+```
+
+**Key columns:** NETUID, Name, Tempo (blocks/epoch), Emission (TAO/block), Neurons registered.
+
+---
+
+### Query Subnet Metagraph
+
+```bash
+# Full metagraph for a subnet (e.g., subnet 1)
+btcli subnet metagraph --netuid 1
+
+# Metagraph for subnet 18 (cortex.t)
+btcli subnet metagraph --netuid 18
+```
+
+**Output includes:** UID, Hotkey, Stake, Rank, Trust, Consensus, Incentive, Dividends, Emission, Last Update.
+
+---
+
+### Check Emissions
+
+```bash
+# View per-neuron emissions in a subnet
+btcli subnet metagraph --netuid <N>
+
+# View subnet-level emission allocations
+btcli subnet list
+```
+
+Emissions are denominated in ρ (rho) per block. Multiply by ~7200 blocks/day for daily TAO.
+
+---
+
+### Transfer TAO
+
+```bash
+# Transfer TAO to another address
+btcli wallet transfer \
+  --wallet.name <wallet_name> \
+  --dest <ss58_destination_address> \
+  --amount <TAO_amount>
+```
+
+> **Warning:** Double-check the destination SS58 address. TAO transfers are irreversible.
+
+---
+
+## Pitfalls
+
+- **Coldkey vs Hotkey confusion:** Coldkeys hold the actual TAO balance. Hotkeys are used for staking/mining operations. Never expose your coldkey.
+- **Network fees:** Each transaction costs a small TAO fee. Ensure you have enough free balance.
+- **Metagraph staleness:** The metagraph is updated each tempo (~100 blocks). Data may be up to ~20 minutes old.
+- **dTAO subnets:** Subnets with dynamic TAO (dTAO) use subnet-specific tokens (αTokens). Use `btcli subnet metagraph` to see alpha stake vs TAO stake.
+- **Registration costs:** Registering a hotkey on a subnet requires TAO burn or proof-of-work. Check current cost with `btcli subnet register --help`.
+- **Wallet path:** Default wallet directory is `~/.bittensor/wallets/`. Use `--wallet.path` to override.
+
+## Verification
+
+After any wallet operation, verify success:
+
+```bash
+# Confirm balance after transfer
+btcli wallet balance --wallet.name <wallet_name>
+
+# Confirm stake after staking/unstaking
+btcli stake show --wallet.name <wallet_name>
+
+# Check transaction on-chain
+# Visit: https://taostats.io or https://x.taostats.io
+```

--- a/skills/crypto/bittensor/references/bittensor_guide.md
+++ b/skills/crypto/bittensor/references/bittensor_guide.md
@@ -1,0 +1,171 @@
+# Bittensor Reference Guide
+
+## Architecture Overview
+
+Bittensor is a decentralized network that incentivizes the production and validation of machine intelligence. It runs on its own blockchain (Subtensor) and uses **TAO** as its native token.
+
+### Core Components
+
+| Component | Description |
+|-----------|-------------|
+| **Subtensor** | The Bittensor blockchain (Substrate-based) |
+| **Subnet** | A specialized ML task network (netuid 0–64+) |
+| **Miner** | Produces intelligence/outputs for a subnet |
+| **Validator** | Scores miners and sets weights |
+| **TAO** | Native token used for staking and emissions |
+
+### Network Topology
+
+```
+Bittensor Network
+├── Root Network (netuid 0) — controls subnet emissions
+├── Subnet 1 (Text prompting)
+├── Subnet 18 (Cortex.t — reasoning)
+├── Subnet 19 (Vision)
+└── ... (64+ subnets)
+```
+
+Each subnet is an independent incentive mechanism where miners compete to perform a specific ML task.
+
+---
+
+## Wallet Structure
+
+Bittensor uses a **dual-key** architecture:
+
+### Coldkey
+- Master key that holds your TAO balance
+- Used for transfers and high-security operations
+- **Never expose the coldkey mnemonic**
+- Stored at: `~/.bittensor/wallets/<name>/coldkey`
+
+### Hotkey
+- Operational key used for mining/validating
+- Can be registered on subnets
+- Lower security risk if compromised (no direct TAO access)
+- Stored at: `~/.bittensor/wallets/<name>/hotkeys/<hotkey_name>`
+
+### Wallet Directory Structure
+
+```
+~/.bittensor/wallets/
+└── default/
+    ├── coldkey          # encrypted coldkey
+    ├── coldkeypub.txt   # public coldkey (SS58 address)
+    └── hotkeys/
+        ├── default      # default hotkey
+        └── validator    # additional hotkeys
+```
+
+---
+
+## Staking Mechanics
+
+### How Staking Works
+
+1. TAO is moved from your coldkey to a hotkey (staking)
+2. The hotkey registers on a subnet
+3. Validators/miners on the subnet earn emissions based on performance
+4. Emissions flow back to the hotkey, then can be unstaked to coldkey
+
+### Staking Commands
+
+```bash
+# Stake TAO to a hotkey
+btcli stake add \
+  --wallet.name <coldkey_name> \
+  --wallet.hotkey <hotkey_name> \
+  --amount <TAO>
+
+# Unstake TAO from a hotkey
+btcli stake remove \
+  --wallet.name <coldkey_name> \
+  --wallet.hotkey <hotkey_name> \
+  --amount <TAO>
+
+# View all stakes
+btcli stake show --wallet.name <coldkey_name>
+```
+
+### Emission Distribution
+
+- The root network (netuid 0) controls how TAO is distributed across subnets
+- Within each subnet, validators set weights on miners
+- Yuma Consensus converts weights → ranks → emissions
+- ~7200 blocks per day × emission_rate = daily TAO earnings
+
+---
+
+## dTAO (Dynamic TAO)
+
+dTAO is Bittensor's mechanism for decentralizing subnet emission control.
+
+### Key Concepts
+
+| Term | Description |
+|------|-------------|
+| **αToken** | Subnet-specific token (e.g., α18 for subnet 18) |
+| **Alpha stake** | TAO staked into a subnet's liquidity pool |
+| **τ/α price** | Exchange rate between TAO and the subnet's αToken |
+| **Moving price** | EMA of the τ/α price used for emission calculation |
+
+### How dTAO Works
+
+1. Each subnet has its own token (αToken)
+2. Stakers buy αTokens by depositing TAO into the subnet pool
+3. The subnet's emission share is proportional to its αToken market cap
+4. Validators stake αTokens (not raw TAO) to participate in a subnet
+
+### dTAO Commands
+
+```bash
+# View subnet token info
+btcli subnet list  # shows dTAO price and market cap columns
+
+# Stake into a subnet's alpha pool
+btcli stake add --netuid <N> --wallet.name <name> --amount <TAO>
+```
+
+---
+
+## Common Workflows
+
+### Onboarding a New Miner
+
+1. Create a wallet: `btcli wallet new_coldkey --wallet.name miner1`
+2. Create a hotkey: `btcli wallet new_hotkey --wallet.name miner1 --wallet.hotkey default`
+3. Fund the coldkey (transfer TAO from exchange)
+4. Register on a subnet: `btcli subnet register --netuid <N> --wallet.name miner1`
+5. Start your miner process (subnet-specific)
+6. Monitor: `btcli subnet metagraph --netuid <N>`
+
+### Checking Profitability
+
+```bash
+# Get your UID's emission in a subnet
+btcli subnet metagraph --netuid <N>
+# Look for your hotkey's row → Emission column (ρ/block)
+
+# Estimate daily TAO:
+# daily_TAO = emission_per_block × 7200
+```
+
+### Recovering a Wallet
+
+```bash
+# Restore coldkey from mnemonic
+btcli wallet regen_coldkey --wallet.name <name> --mnemonic "word1 word2 ..."
+
+# Restore hotkey from mnemonic
+btcli wallet regen_hotkey --wallet.name <name> --wallet.hotkey <hk_name> --mnemonic "..."
+```
+
+---
+
+## Useful Resources
+
+- **Bittensor Docs:** https://docs.bittensor.com
+- **TAO Stats:** https://taostats.io
+- **Subnet Explorer:** https://x.taostats.io
+- **GitHub:** https://github.com/opentensor/bittensor
+- **btcli Reference:** `btcli --help`

--- a/skills/crypto/bittensor/scripts/network_status.py
+++ b/skills/crypto/bittensor/scripts/network_status.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+Bittensor Network Status Script
+Checks wallet balance, staking info, and subnet list via btcli.
+"""
+
+import subprocess
+import sys
+import shutil
+import argparse
+from typing import Optional
+
+
+def run_btcli(*args: str, timeout: int = 30) -> tuple[int, str, str]:
+    """Run a btcli command and return (returncode, stdout, stderr)."""
+    cmd = ["btcli"] + list(args)
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return result.returncode, result.stdout, result.stderr
+    except subprocess.TimeoutExpired:
+        return 1, "", f"Command timed out after {timeout}s: {' '.join(cmd)}"
+    except FileNotFoundError:
+        return 1, "", "btcli not found in PATH"
+
+
+def check_btcli_installed() -> bool:
+    """Return True if btcli is available in PATH."""
+    return shutil.which("btcli") is not None
+
+
+def get_btcli_version() -> Optional[str]:
+    """Return btcli version string, or None on failure."""
+    rc, stdout, _ = run_btcli("--version")
+    if rc == 0 and stdout.strip():
+        return stdout.strip()
+    return None
+
+
+def show_wallet_balance(wallet_name: str) -> None:
+    """Print wallet balance for the given wallet name."""
+    print(f"\n{'='*50}")
+    print(f"Wallet Balance: {wallet_name}")
+    print("=" * 50)
+    rc, stdout, stderr = run_btcli("wallet", "balance", f"--wallet.name={wallet_name}")
+    if rc == 0:
+        print(stdout)
+    else:
+        print(f"[ERROR] {stderr or 'Failed to retrieve balance'}")
+
+
+def show_stake_info(wallet_name: str) -> None:
+    """Print staking information for the given wallet name."""
+    print(f"\n{'='*50}")
+    print(f"Staking Info: {wallet_name}")
+    print("=" * 50)
+    rc, stdout, stderr = run_btcli("stake", "show", f"--wallet.name={wallet_name}")
+    if rc == 0:
+        print(stdout)
+    else:
+        print(f"[ERROR] {stderr or 'Failed to retrieve stake info'}")
+
+
+def list_subnets() -> None:
+    """Print the list of active Bittensor subnets."""
+    print(f"\n{'='*50}")
+    print("Active Subnets")
+    print("=" * 50)
+    rc, stdout, stderr = run_btcli("subnet", "list")
+    if rc == 0:
+        print(stdout)
+    else:
+        print(f"[ERROR] {stderr or 'Failed to list subnets'}")
+
+
+def show_metagraph(netuid: int) -> None:
+    """Print metagraph for a specific subnet."""
+    print(f"\n{'='*50}")
+    print(f"Metagraph: Subnet {netuid}")
+    print("=" * 50)
+    rc, stdout, stderr = run_btcli(
+        "subnet", "metagraph", f"--netuid={netuid}", timeout=60
+    )
+    if rc == 0:
+        print(stdout)
+    else:
+        print(f"[ERROR] {stderr or f'Failed to retrieve metagraph for netuid {netuid}'}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Bittensor network status — wallet balance, stake, and subnet info"
+    )
+    parser.add_argument(
+        "--wallet",
+        default="default",
+        metavar="NAME",
+        help="Wallet name to query (default: 'default')",
+    )
+    parser.add_argument(
+        "--netuid",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Subnet UID to query metagraph for (optional)",
+    )
+    parser.add_argument(
+        "--skip-subnets",
+        action="store_true",
+        help="Skip the subnet list (faster)",
+    )
+    args = parser.parse_args()
+
+    # Check installation
+    if not check_btcli_installed():
+        print("[ERROR] btcli is not installed or not in PATH.")
+        print("Install it with: pip install bittensor")
+        return 1
+
+    version = get_btcli_version()
+    print(f"btcli version: {version or 'unknown'}")
+
+    show_wallet_balance(args.wallet)
+    show_stake_info(args.wallet)
+
+    if not args.skip_subnets:
+        list_subnets()
+
+    if args.netuid is not None:
+        show_metagraph(args.netuid)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a new `skills/crypto/bittensor/` skill for managing Bittensor wallets via `btcli`.

- **SKILL.md** — full skill doc with procedures for balance checks, staking, subnet list, metagraph queries, and TAO transfers
- **scripts/network_status.py** — standalone Python script that checks btcli installation, queries wallet balance, stake info, and subnet list
- **references/bittensor_guide.md** — reference covering Bittensor architecture, coldkey/hotkey structure, staking mechanics, dTAO, and common workflows

## Test plan

- [ ] `btcli wallet balance --wallet.name default` returns balance
- [ ] `btcli subnet list` returns active subnets
- [ ] `python3 scripts/network_status.py --wallet default` runs without errors
- [ ] All commands in SKILL.md Quick Reference are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)