### PR TITLE
fix: OAuth providers missing from /model picker

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -791,9 +791,9 @@ def list_authenticated_providers(
         if overlay.auth_type in ("oauth_device_code", "oauth_external", "external_process"):
             # These use auth stores, not env vars — check for auth.json entries
             try:
-                from hermes_cli.auth import _read_auth_store
-                store = _read_auth_store()
-                if store and pid in store:
+                from hermes_cli.auth import _load_auth_store
+                store = _load_auth_store()
+                if store and (pid in store.get("providers", {}) or pid in store.get("credential_pool", {})):
                     has_creds = True
             except Exception:
                 pass


### PR DESCRIPTION
## Summary

- Fix `_read_auth_store` → `_load_auth_store` import typo in `list_authenticated_providers()` that causes a silent `ImportError`
- Fix `pid in store` → check `store["providers"]` and `store["credential_pool"]` where OAuth credentials are actually stored
- Affects Nous Portal, OpenAI Codex, and Copilot — none appear in `/model` picker despite valid OAuth credentials

## Details

Two compounding bugs in `hermes_cli/model_switch.py` (section 2 of `list_authenticated_providers()`):

1. **Import typo** (line 794): `from hermes_cli.auth import _read_auth_store` — this function doesn't exist (`_load_auth_store` is the correct name). The `ImportError` is caught by `except Exception: pass`, so the entire OAuth credential check is silently skipped.

2. **Key lookup** (line 796): `pid in store` checks top-level keys `['version', 'providers', 'active_provider', 'updated_at', 'credential_pool']`, but provider entries are nested under `store["providers"]` and `store["credential_pool"]`. So even after fixing the import, the check always returns `False`.

Env-var providers (Kimi, OpenRouter, Anthropic) are unaffected — they're found via section 1's env var check, not this code path.

## Diff

```diff
-                from hermes_cli.auth import _read_auth_store
-                store = _read_auth_store()
-                if store and pid in store:
+                from hermes_cli.auth import _load_auth_store
+                store = _load_auth_store()
+                if store and (pid in store.get("providers", {}) or pid in store.get("credential_pool", {})):
```

## Test plan

- [x] Verified locally: `/model` now shows Nous Portal, OpenAI Codex alongside Kimi after fix
- [x] Confirmed `_load_auth_store` is the correct export from `hermes_cli/auth.py` (line 592)
- [x] Confirmed auth.json schema: OAuth entries stored under `providers` and `credential_pool` keys

Fixes #5910

🤖 Generated with [Claude Code](https://claude.com/claude-code)