### PR TITLE
fix(gateway): show full session id and title in /status

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3345,25 +3345,36 @@ class GatewayRunner:
         """Handle /status command."""
         source = event.source
         session_entry = self.session_store.get_or_create_session(source)
-        
+
         connected_platforms = [p.value for p in self.adapters.keys()]
-        
+
         # Check if there's an active agent
         session_key = session_entry.session_key
         is_running = session_key in self._running_agents
-        
+
+        title = None
+        if self._session_db:
+            try:
+                title = self._session_db.get_session_title(session_entry.session_id)
+            except Exception:
+                title = None
+
         lines = [
             "📊 **Hermes Gateway Status**",
             "",
-            f"**Session ID:** `{session_entry.session_id[:12]}...`",
+            f"**Session ID:** `{session_entry.session_id}`",
+        ]
+        if title:
+            lines.append(f"**Title:** {title}")
+        lines.extend([
             f"**Created:** {session_entry.created_at.strftime('%Y-%m-%d %H:%M')}",
             f"**Last Activity:** {session_entry.updated_at.strftime('%Y-%m-%d %H:%M')}",
             f"**Tokens:** {session_entry.total_tokens:,}",
             f"**Agent Running:** {'Yes ⚡' if is_running else 'No'}",
             "",
             f"**Connected Platforms:** {', '.join(connected_platforms)}",
-        ]
-        
+        ])
+
         return "\n".join(lines)
     
     async def _handle_stop_command(self, event: MessageEvent) -> str:

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -51,7 +51,8 @@ def _make_runner(session_entry: SessionEntry):
     runner._running_agents = {}
     runner._pending_messages = {}
     runner._pending_approvals = {}
-    runner._session_db = None
+    runner._session_db = MagicMock()
+    runner._session_db.get_session_title.return_value = None
     runner._reasoning_config = None
     runner._provider_routing = {}
     runner._fallback_model = None
@@ -82,10 +83,32 @@ async def test_status_command_reports_running_agent_without_interrupt(monkeypatc
 
     result = await runner._handle_message(_make_event("/status"))
 
+    assert "**Session ID:** `sess-1`" in result
     assert "**Tokens:** 321" in result
     assert "**Agent Running:** Yes ⚡" in result
+    assert "**Title:**" not in result
     running_agent.interrupt.assert_not_called()
     assert runner._pending_messages == {}
+
+
+@pytest.mark.asyncio
+async def test_status_command_includes_session_title_when_present():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=321,
+    )
+    runner = _make_runner(session_entry)
+    runner._session_db.get_session_title.return_value = "My titled session"
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**Session ID:** `sess-1`" in result
+    assert "**Title:** My titled session" in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Bug Description

`/status` currently truncates the session id to the first 12 characters, which makes copy/paste and exact session identification annoying. It also omits the session title even when one has already been set.

## Root Cause

`GatewayRunner._handle_status_command()` slices `session_entry.session_id[:12]` directly and never consults the session database for an existing title.

## Fix

- show the full session id in `/status`
- include `**Title:** ...` when a session title exists
- keep the output unchanged when no title is set
- add regression tests for both behaviors

## How to Verify

1. Start a gateway session and run `/status`
2. Confirm the full session id is shown, not a truncated prefix
3. Set a title with `/title My Session Name`, then run `/status` again
4. Confirm the title is displayed in the status output

## Test Plan

- [x] Added regression test for this bug
- [x] Existing targeted tests still pass
- [ ] Manual verification of the fix

Targeted test run:
- `~/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_status_command.py -q -o addopts=''`

## Risk Assessment

Low — this only changes `/status` presentation and reads an already-existing title field from the session DB.
