### PR TITLE
feat(matrix): add rich formatting toggle

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -595,6 +595,8 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["MATRIX_FREE_RESPONSE_ROOMS"] = str(frc)
                 if "auto_thread" in matrix_cfg and not os.getenv("MATRIX_AUTO_THREAD"):
                     os.environ["MATRIX_AUTO_THREAD"] = str(matrix_cfg["auto_thread"]).lower()
+                if "rich_formatting" in matrix_cfg and not os.getenv("MATRIX_RICH_FORMATTING"):
+                    os.environ["MATRIX_RICH_FORMATTING"] = str(matrix_cfg["rich_formatting"]).lower()
 
     except Exception as e:
         logger.warning(

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -15,6 +15,8 @@ Environment variables:
     MATRIX_HOME_ROOM        Room ID for cron/notification delivery
     MATRIX_REACTIONS        Set "false" to disable processing lifecycle reactions
                             (eyes/checkmark/cross). Default: true
+    MATRIX_RICH_FORMATTING  Set "false" to disable Matrix formatted_body HTML
+                            and send plain text only. Default: true
     MATRIX_REQUIRE_MENTION      Require @mention in rooms (default: true)
     MATRIX_FREE_RESPONSE_ROOMS  Comma-separated room IDs exempt from mention requirement
     MATRIX_AUTO_THREAD          Auto-create threads for room messages (default: true)
@@ -170,6 +172,9 @@ class MatrixAdapter(BasePlatformAdapter):
         # Reactions: configurable via MATRIX_REACTIONS (default: true).
         self._reactions_enabled: bool = os.getenv(
             "MATRIX_REACTIONS", "true"
+        ).lower() not in ("false", "0", "no")
+        self._rich_formatting_enabled: bool = os.getenv(
+            "MATRIX_RICH_FORMATTING", "true"
         ).lower() not in ("false", "0", "no")
 
     def _is_duplicate_event(self, event_id) -> bool:
@@ -442,11 +447,7 @@ class MatrixAdapter(BasePlatformAdapter):
                 "body": chunk,
             }
 
-            # Convert markdown to HTML for rich rendering.
-            html = self._markdown_to_html(chunk)
-            if html and html != chunk:
-                msg_content["format"] = "org.matrix.custom.html"
-                msg_content["formatted_body"] = html
+            self._apply_rich_formatting(msg_content, chunk)
 
             # Reply-to support.
             if reply_to:
@@ -565,12 +566,13 @@ class MatrixAdapter(BasePlatformAdapter):
             },
         }
 
-        html = self._markdown_to_html(formatted)
-        if html and html != formatted:
-            msg_content["m.new_content"]["format"] = "org.matrix.custom.html"
-            msg_content["m.new_content"]["formatted_body"] = html
-            msg_content["format"] = "org.matrix.custom.html"
-            msg_content["formatted_body"] = f"* {html}"
+        if self._rich_formatting_enabled:
+            html = self._markdown_to_html(formatted)
+            if html and html != formatted:
+                msg_content["m.new_content"]["format"] = "org.matrix.custom.html"
+                msg_content["m.new_content"]["formatted_body"] = html
+                msg_content["format"] = "org.matrix.custom.html"
+                msg_content["formatted_body"] = f"* {html}"
 
         resp = await self._client.room_send(chat_id, "m.room.message", msg_content)
         if isinstance(resp, nio.RoomSendResponse):
@@ -1657,10 +1659,7 @@ class MatrixAdapter(BasePlatformAdapter):
             "msgtype": "m.emote",
             "body": text,
         }
-        html = self._markdown_to_html(text)
-        if html and html != text:
-            msg_content["format"] = "org.matrix.custom.html"
-            msg_content["formatted_body"] = html
+        self._apply_rich_formatting(msg_content, text)
 
         try:
             resp = await self._client.room_send(
@@ -1686,10 +1685,7 @@ class MatrixAdapter(BasePlatformAdapter):
             "msgtype": "m.notice",
             "body": text,
         }
-        html = self._markdown_to_html(text)
-        if html and html != text:
-            msg_content["format"] = "org.matrix.custom.html"
-            msg_content["formatted_body"] = html
+        self._apply_rich_formatting(msg_content, text)
 
         try:
             resp = await self._client.room_send(
@@ -1705,6 +1701,16 @@ class MatrixAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    def _apply_rich_formatting(self, msg_content: Dict[str, Any], text: str) -> None:
+        """Attach Matrix rich HTML when enabled and the conversion changes the text."""
+        if not self._rich_formatting_enabled:
+            return
+
+        html = self._markdown_to_html(text)
+        if html and html != text:
+            msg_content["format"] = "org.matrix.custom.html"
+            msg_content["formatted_body"] = html
 
     async def _refresh_dm_cache(self) -> None:
         """Refresh the DM room cache from m.direct account data.

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1049,6 +1049,67 @@ class TestMatrixEncryptedSendFallback:
         assert second_call.kwargs.get("ignore_unverified_devices") is True
 
 
+class TestMatrixRichFormattingToggle:
+    @pytest.mark.asyncio
+    async def test_send_includes_formatted_body_by_default(self, monkeypatch):
+        monkeypatch.delenv("MATRIX_RICH_FORMATTING", raising=False)
+        adapter = _make_adapter()
+
+        fake_nio = _make_fake_nio()
+        fake_client = MagicMock()
+        fake_client.room_send = AsyncMock(return_value=fake_nio.RoomSendResponse("$event-rich"))
+        adapter._client = fake_client
+        adapter._markdown_to_html = MagicMock(return_value="<h1>hello</h1>")
+
+        with patch.dict("sys.modules", {"nio": fake_nio}):
+            result = await adapter.send("!room:example.org", "# hello")
+
+        assert result.success is True
+        sent_content = fake_client.room_send.await_args.args[2]
+        assert sent_content["format"] == "org.matrix.custom.html"
+        assert sent_content["formatted_body"] == "<h1>hello</h1>"
+
+    @pytest.mark.asyncio
+    async def test_send_omits_formatted_body_when_disabled(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_RICH_FORMATTING", "false")
+        adapter = _make_adapter()
+
+        fake_nio = _make_fake_nio()
+        fake_client = MagicMock()
+        fake_client.room_send = AsyncMock(return_value=fake_nio.RoomSendResponse("$event-plain"))
+        adapter._client = fake_client
+        adapter._markdown_to_html = MagicMock(return_value="<h1>hello</h1>")
+
+        with patch.dict("sys.modules", {"nio": fake_nio}):
+            result = await adapter.send("!room:example.org", "# hello")
+
+        assert result.success is True
+        sent_content = fake_client.room_send.await_args.args[2]
+        assert "format" not in sent_content
+        assert "formatted_body" not in sent_content
+
+    @pytest.mark.asyncio
+    async def test_edit_message_omits_formatted_body_when_disabled(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_RICH_FORMATTING", "false")
+        adapter = _make_adapter()
+
+        fake_nio = _make_fake_nio()
+        fake_client = MagicMock()
+        fake_client.room_send = AsyncMock(return_value=fake_nio.RoomSendResponse("$edit-plain"))
+        adapter._client = fake_client
+        adapter._markdown_to_html = MagicMock(return_value="<h1>hello</h1>")
+
+        with patch.dict("sys.modules", {"nio": fake_nio}):
+            result = await adapter.edit_message("!room:example.org", "$msg1", "# hello")
+
+        assert result.success is True
+        sent_content = fake_client.room_send.await_args.args[2]
+        assert "format" not in sent_content
+        assert "formatted_body" not in sent_content
+        assert "format" not in sent_content["m.new_content"]
+        assert "formatted_body" not in sent_content["m.new_content"]
+
+
 # ---------------------------------------------------------------------------
 # E2EE: Auto-trust devices
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_matrix_mention.py
+++ b/tests/gateway/test_matrix_mention.py
@@ -446,12 +446,14 @@ class TestMatrixConfigBridge:
         monkeypatch.delenv("MATRIX_REQUIRE_MENTION", raising=False)
         monkeypatch.delenv("MATRIX_FREE_RESPONSE_ROOMS", raising=False)
         monkeypatch.delenv("MATRIX_AUTO_THREAD", raising=False)
+        monkeypatch.delenv("MATRIX_RICH_FORMATTING", raising=False)
 
         yaml_content = {
             "matrix": {
                 "require_mention": False,
                 "free_response_rooms": ["!room1:example.org", "!room2:example.org"],
                 "auto_thread": False,
+                "rich_formatting": False,
             }
         }
 
@@ -474,10 +476,13 @@ class TestMatrixConfigBridge:
                 monkeypatch.setenv("MATRIX_FREE_RESPONSE_ROOMS", str(frc))
             if "auto_thread" in matrix_cfg and not os.getenv("MATRIX_AUTO_THREAD"):
                 monkeypatch.setenv("MATRIX_AUTO_THREAD", str(matrix_cfg["auto_thread"]).lower())
+            if "rich_formatting" in matrix_cfg and not os.getenv("MATRIX_RICH_FORMATTING"):
+                monkeypatch.setenv("MATRIX_RICH_FORMATTING", str(matrix_cfg["rich_formatting"]).lower())
 
         assert os.getenv("MATRIX_REQUIRE_MENTION") == "false"
         assert os.getenv("MATRIX_FREE_RESPONSE_ROOMS") == "!room1:example.org,!room2:example.org"
         assert os.getenv("MATRIX_AUTO_THREAD") == "false"
+        assert os.getenv("MATRIX_RICH_FORMATTING") == "false"
 
     def test_env_vars_take_precedence_over_yaml(self, monkeypatch):
         """Env vars should not be overwritten by YAML values."""

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -240,6 +240,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `MATRIX_REQUIRE_MENTION` | Require `@mention` in rooms (default: `true`). Set to `false` to respond to all messages. |
 | `MATRIX_FREE_RESPONSE_ROOMS` | Comma-separated room IDs where bot responds without `@mention` |
 | `MATRIX_AUTO_THREAD` | Auto-create threads for room messages (default: `true`) |
+| `MATRIX_RICH_FORMATTING` | Send Matrix `formatted_body` HTML rich formatting (default: `true`). Set to `false` for plain-text replies. |
 | `HASS_TOKEN` | Home Assistant Long-Lived Access Token (enables HA platform + tools) |
 | `HASS_URL` | Home Assistant URL (default: `http://homeassistant.local:8123`) |
 | `WEBHOOK_ENABLED` | Enable the webhook platform adapter (`true`/`false`) |

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -62,6 +62,7 @@ matrix:
   free_response_rooms:            # Rooms exempt from mention requirement
     - "!abc123:matrix.org"
   auto_thread: true               # Auto-create threads for responses (default: true)
+  rich_formatting: true           # Send Matrix formatted_body HTML (default: true)
 ```
 
 Or via environment variables:
@@ -70,6 +71,7 @@ Or via environment variables:
 MATRIX_REQUIRE_MENTION=true
 MATRIX_FREE_RESPONSE_ROOMS=!abc123:matrix.org,!def456:matrix.org
 MATRIX_AUTO_THREAD=true
+MATRIX_RICH_FORMATTING=true
 ```
 
 :::note
@@ -208,9 +210,17 @@ Optional behavior settings in `~/.hermes/config.yaml`:
 
 ```yaml
 group_sessions_per_user: true
+
+matrix:
+  rich_formatting: true
 ```
 
 - `group_sessions_per_user: true` keeps each participant's context isolated inside shared rooms
+- `matrix.rich_formatting: false` disables Matrix `formatted_body` HTML and sends plain text only
+
+:::tip
+If Element Mobile is rendering Hermes messages with odd spacing, floating bullets, or broken heading text, try setting `matrix.rich_formatting: false` or `MATRIX_RICH_FORMATTING=false` and restart the gateway.
+:::
 
 ### Start the Gateway
 


### PR DESCRIPTION
## Summary

This adds a Matrix-specific escape hatch for clients that render Hermes `formatted_body` poorly, especially Element Mobile.

Hermes currently converts outbound Matrix markdown into HTML and sends it as `org.matrix.custom.html`. That works for some clients, but users have reported broken rendering on Element Mobile after the rich-formatting changes landed: excessive spacing, floating bullets, heading text rendering oddly, and inconsistent layout depending on whether the model happened to emit markdown.

This PR adds a toggle so Matrix users can disable rich HTML formatting and fall back to plain text without giving up the Matrix adapter entirely.

Relevant user report:
- Discord thread: https://discord.com/channels/1053877538025386074/1491085310065512478

## Changes

- add `MATRIX_RICH_FORMATTING` env toggle to the Matrix adapter
- default remains `true` to preserve current behavior
- when disabled, Hermes skips `formatted_body` / `org.matrix.custom.html` and sends plain text only
- bridge `matrix.rich_formatting` from `config.yaml` into `MATRIX_RICH_FORMATTING`
- add tests covering the toggle behavior
- document the new setting in Matrix docs and env var reference

## Example

```yaml
matrix:
  rich_formatting: false
```

or

```bash
MATRIX_RICH_FORMATTING=false
```

## Why

This is intended as a practical workaround for Matrix clients, especially Element Mobile, that do not render Hermes' current HTML formatting well.

From user testing, the deeper issue appears to be the current markdown-to-HTML strategy itself, especially:
- `nl2br`
- block-level heading tags
- list/table-heavy HTML inside chat bubbles

So this PR is the safe short-term fix: give affected users a way to opt out.

## Long-term Direction

A better long-term fix is probably not "more HTML," but a safer Matrix formatting subset:
- prefer inline formatting like `<strong>`, `<em>`, `<code>`, and links
- avoid heading tags in chat bubbles
- avoid aggressive line-break conversion
- possibly avoid tables / other block-heavy formatting in `formatted_body`

That would preserve nicer rendering where supported without making Element Mobile unreadable.

## Testing

```bash
source venv/bin/activate
python -m pytest tests/gateway/test_matrix.py tests/gateway/test_matrix_mention.py -q -n 0
```

