### PR TITLE
fix(gateway): implement SSRF protection for Discord image downloads

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -55,6 +55,7 @@ from gateway.platforms.base import (
     cache_document_from_bytes,
     SUPPORTED_DOCUMENT_TYPES,
 )
+from tools.url_safety import is_safe_url
 
 
 def _clean_discord_id(entry: str) -> str:
@@ -1284,6 +1285,10 @@ class DiscordAdapter(BasePlatformAdapter):
         """Send an image natively as a Discord file attachment."""
         if not self._client:
             return SendResult(success=False, error="Not connected")
+
+        if not is_safe_url(image_url):
+            logger.warning("[%s] Blocked unsafe image URL during Discord send_image", self.name)
+            return await super().send_image(chat_id, image_url, caption, reply_to, metadata=metadata)
 
         try:
             import aiohttp

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -41,6 +41,7 @@ def _ensure_discord_mock():
 
 _ensure_discord_mock()
 
+from gateway.platforms.base import SendResult  # noqa: E402
 from gateway.platforms.discord import DiscordAdapter  # noqa: E402
 
 
@@ -78,3 +79,30 @@ async def test_send_retries_without_reference_when_reply_target_is_system_messag
     assert channel.send.await_count == 2
     assert send_calls[0]["reference"] is ref_msg
     assert send_calls[1]["reference"] is None
+
+
+@pytest.mark.asyncio
+async def test_send_image_blocks_unsafe_urls_before_download(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._client = SimpleNamespace(
+        get_channel=MagicMock(),
+        fetch_channel=AsyncMock(),
+    )
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="fallback"))
+    monkeypatch.setattr("gateway.platforms.discord.is_safe_url", lambda _url: False)
+
+    result = await adapter.send_image(
+        "555",
+        "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+        "blocked",
+    )
+
+    assert result.success is True
+    assert result.message_id == "fallback"
+    adapter._client.get_channel.assert_not_called()
+    adapter._client.fetch_channel.assert_not_awaited()
+    adapter.send.assert_awaited_once_with(
+        chat_id="555",
+        content="blocked\nhttp://169.254.169.254/latest/meta-data/iam/security-credentials/",
+        reply_to=None,
+    )


### PR DESCRIPTION
## Summary

This PR fixes a high-impact SSRF issue in the Discord gateway image send flow.

`gateway/run.py` can pass model-produced `image_url` values into `adapter.send_image(...)`, and `DiscordAdapter.send_image()` was downloading those URLs directly with `aiohttp` before uploading them as Discord attachments.

That meant a remote chat user could potentially steer the model into emitting an internal URL such as:

- `http://127.0.0.1/...`
- `http://169.254.169.254/...`
- other private/internal network targets

and cause the gateway host to fetch it.

## Root Cause

`DiscordAdapter.send_image()` accepted arbitrary image URLs and performed a network fetch without applying the existing SSRF protections already used elsewhere in the codebase.

## Fix

Added a pre-download safety check in `gateway/platforms/discord.py` using `tools.url_safety.is_safe_url`.

Behavior after this change:

- safe public image URLs continue through the normal native attachment flow
- unsafe/internal URLs are blocked before any outbound request is made
- blocked URLs fall back to the base adapter behavior, which sends the URL as text instead of fetching it

## Security Impact

This closes a server-side request forgery path from untrusted remote chat input into the Discord gateway host.

Without this fix, an attacker could potentially use model-steered image output to probe or access:

- localhost services
- cloud metadata endpoints
- private/internal network resources reachable from the gateway machine

## Tests

Added a regression test in `tests/gateway/test_discord_send.py` that verifies:

- unsafe URLs are rejected before any Discord channel lookup/download path runs
- the adapter falls back to plain text send behavior instead

## Files Changed

- `gateway/platforms/discord.py`
- `tests/gateway/test_discord_send.py`