### PR TITLE
fix(api_server): update tool_progress_callback signature for Open WebUI streaming

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -563,8 +563,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 if delta is not None:
                     _stream_q.put(delta)
 
-            def _on_tool_progress(name, preview, args):
+            def _on_tool_progress(event_type, name, preview, args, **kwargs):
                 """Inject tool progress into the SSE stream for Open WebUI."""
+                if event_type != "tool.started":
+                    return  # Only show tool start events in chat stream
                 if name.startswith("_"):
                     return  # Skip internal events (_thinking)
                 from agent.display import get_tool_emoji


### PR DESCRIPTION
## Problem

Commit `cc2b56b2` changed the `tool_progress_callback` signature from:
```python
callback(name, preview, args)  # 3 args
```
to:
```python  
callback(event_type, name, preview, args, **kwargs)  # 4+ args
```

However, the API server's chat completion streaming callback (`_on_tool_progress`) was **not updated**, causing tool calls to not display in Open WebUI.

### What went wrong
When the agent called:
```python
tool_progress_callback("tool.started", "web_search", "query: foo", {...})
```

The API server interpreted:
- `name` = `"tool.started"` (the event type!)
- `preview` = `"web_search"` (the actual tool name)
- `args` = `"query: foo"` (the preview text)

This broke the `name.startswith("_")` check and displayed the wrong information.

## Fix

Updated `_on_tool_progress` in `gateway/platforms/api_server.py` to:
1. Accept the new 4-argument signature `(event_type, name, preview, args, **kwargs)`
2. Filter for `event_type == "tool.started"` to only show tool start events
3. Accept `**kwargs` for optional `duration`/`is_error` parameters

## Testing

- [x] Tool calls now display correctly in Open WebUI
- [x] Verified the fix matches the pattern used in `_make_run_event_callback` (line 1328)

---
**Note:** This fix is minimal and only affects the Open WebUI streaming path. The `/v1/runs` endpoint already had the correct signature from the original commit.
