### PR TITLE
fix(holographic): broaden recall trigger scope and surface fact_feedback reminder

### DIFF
--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -47,7 +47,7 @@ FACT_STORE_SCHEMA = {
         "• reason — Compositional: facts connected to MULTIPLE entities simultaneously.\n"
         "• contradict — Memory hygiene: find facts making conflicting claims.\n"
         "• update/remove/list — CRUD operations.\n\n"
-        "IMPORTANT: Before answering questions about the user, ALWAYS probe or reason first."
+        "IMPORTANT: Before answering questions about the user, their projects, tools, or any topic likely stored here, ALWAYS probe or reason first. Use fact_feedback to rate facts after using them — this trains trust scores."
     ),
     "parameters": {
         "type": "object",
@@ -198,7 +198,8 @@ class HolographicMemoryProvider(MemoryProvider):
             f"# Holographic Memory\n"
             f"Active. {total} facts stored with entity resolution and trust scoring.\n"
             f"Use fact_store to search, probe entities, reason across entities, or add facts.\n"
-            f"Use fact_feedback to rate facts after using them (trains trust scores)."
+            f"Use fact_feedback to rate facts after using them (trains trust scores).\n"
+            f"IMPORTANT: Before answering questions about the user, their projects, tools, or any topic likely stored here, ALWAYS probe or reason first."
         )
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:


### PR DESCRIPTION
## Summary

The `fact_store` recall directive only triggered on *"questions about the user"*, which left project state, tool quirks, architecture decisions, and other stored facts completely outside the recall loop. Agents routinely skipped probing when the question wasn't explicitly about the user — the narrow scope was the bug.

Additionally, the `IMPORTANT` directive only appeared in the tool schema description, which is not visible at the start of each turn. The active-store system prompt banner had no recall reminder at all.

## Changes

**`plugins/memory/holographic/__init__.py`** — 3 lines changed, 2 added:

1. **Tool schema** (`FACT_STORE_SCHEMA` description): broaden trigger scope and add `fact_feedback` reminder
   - Before: `IMPORTANT: Before answering questions about the user, ALWAYS probe or reason first.`
   - After: `IMPORTANT: Before answering questions about the user, their projects, tools, or any topic likely stored here, ALWAYS probe or reason first. Use fact_feedback to rate facts after using them — this trains trust scores.`

2. **System prompt banner** (`get_system_prompt_injection`): mirror the `IMPORTANT` directive in the active-store banner so it is present at turn start, not just in the tool schema
   - Added: `IMPORTANT: Before answering questions about the user, their projects, tools, or any topic likely stored here, ALWAYS probe or reason first.`

## Rationale

The fact store supports four categories (user_pref, project, tool, general) but the recall prompt only mentioned the user. In practice this meant project state facts, tool quirks, and architectural decisions were never recalled automatically. Only explicit user-profile queries triggered a probe.

The banner addition ensures the directive is in the agent's working context every turn rather than requiring the agent to inspect the tool schema first.

## Testing

- No logic changes — purely prompt copy
- Existing holographic memory tests unaffected
- `plugins/memory/holographic/__init__.py` lints clean