### PR TITLE
fix: make compact banner respect active skin

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1036,21 +1036,57 @@ COMPACT_BANNER = """
 
 def _build_compact_banner() -> str:
     """Build a compact banner that fits the current terminal width."""
+    try:
+        from hermes_cli.skin_engine import get_active_skin
+        _skin = get_active_skin()
+    except Exception:
+        _skin = None
+
+    skin_name = getattr(_skin, "name", "default") if _skin else "default"
+    border_color = _skin.get_color("banner_border", "#FFD700") if _skin else "#FFD700"
+    title_color = _skin.get_color("banner_title", "#FFBF00") if _skin else "#FFBF00"
+    text_color = _skin.get_color("banner_text", "#CD7F32") if _skin else "#CD7F32"
+    dim_color = _skin.get_color("banner_dim", "#B8860B") if _skin else "#B8860B"
+
+    if skin_name == "default":
+        line1 = "⚕ NOUS HERMES - AI Agent Framework"
+        line2_main = "Messenger of the Digital Gods"
+        line2_suffix = "Nous Research"
+        tiny_line = "⚕ NOUS HERMES"
+    else:
+        agent_name = _skin.get_branding("agent_name", "Hermes Agent") if _skin else "Hermes Agent"
+        welcome = _skin.get_branding("welcome", f"Welcome to {agent_name}!") if _skin else f"Welcome to {agent_name}!"
+        welcome = welcome.replace(" Type your message or /help for commands.", "")
+        line1 = f"{agent_name} - AI Agent Framework"
+        line2_main = welcome
+        line2_suffix = "Nous Research"
+        tiny_line = agent_name
+
     w = min(shutil.get_terminal_size().columns - 2, 64)
     if w < 30:
-        return "\n[#FFBF00]⚕ NOUS HERMES[/] [dim #B8860B]- Nous Research[/]\n"
+        return f"\n[{title_color}]{tiny_line}[/] [dim {dim_color}]- Nous Research[/]\n"
+
     inner = w - 2  # inside the box border
     bar = "═" * w
-    line1 = "⚕ NOUS HERMES - AI Agent Framework"
-    line2 = "Messenger of the Digital Gods  ·  Nous Research"
+    content_width = inner - 2
+
     # Truncate and pad to fit
-    line1 = line1[:inner - 2].ljust(inner - 2)
-    line2 = line2[:inner - 2].ljust(inner - 2)
+    line1 = line1[:content_width].ljust(content_width)
+
+    line2_sep = "  ·  "
+    line2_main_max = max(content_width - len(line2_sep) - len(line2_suffix), 0)
+    if len(line2_main) > line2_main_max:
+        if line2_main_max > 3:
+            line2_main = line2_main[:line2_main_max - 3] + "..."
+        else:
+            line2_main = line2_main[:line2_main_max]
+    line2_prefix = f"{line2_main}{line2_sep}".ljust(max(content_width - len(line2_suffix), 0))
+
     return (
-        f"\n[bold #FFD700]╔{bar}╗[/]\n"
-        f"[bold #FFD700]║[/] [#FFBF00]{line1}[/] [bold #FFD700]║[/]\n"
-        f"[bold #FFD700]║[/] [dim #B8860B]{line2}[/] [bold #FFD700]║[/]\n"
-        f"[bold #FFD700]╚{bar}╝[/]\n"
+        f"\n[bold {border_color}]╔{bar}╗[/]\n"
+        f"[bold {border_color}]║[/] [{title_color}]{line1}[/] [bold {border_color}]║[/]\n"
+        f"[bold {border_color}]║[/] [{text_color}]{line2_prefix}[/][dim {dim_color}]{line2_suffix}[/] [bold {border_color}]║[/]\n"
+        f"[bold {border_color}]╚{bar}╝[/]\n"
     )
 
 

--- a/tests/test_cli_skin_integration.py
+++ b/tests/test_cli_skin_integration.py
@@ -1,7 +1,7 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from cli import HermesCLI, _rich_text_from_ansi
+from cli import HermesCLI, _build_compact_banner, _rich_text_from_ansi
 from hermes_cli.skin_engine import get_active_skin, set_active_skin
 
 
@@ -86,6 +86,38 @@ class TestCliSkinPromptIntegration:
         assert "Skin set to: ares (saved)" in output
         assert "Prompt + TUI colors updated." in output
         assert cli._app.style is not None
+
+
+class TestCompactBannerSkinIntegration:
+    def test_default_compact_banner_keeps_legacy_nous_hermes_branding(self):
+        set_active_skin("default")
+
+        with patch("cli.shutil.get_terminal_size", return_value=SimpleNamespace(columns=64)):
+            banner = _build_compact_banner()
+
+        assert "NOUS HERMES" in banner
+        assert "Messenger of the Digital Gods" in banner
+
+    def test_poseidon_compact_banner_uses_skin_branding_instead_of_nous_hermes(self):
+        set_active_skin("poseidon")
+
+        with patch("cli.shutil.get_terminal_size", return_value=SimpleNamespace(columns=64)):
+            banner = _build_compact_banner()
+
+        assert "Poseidon Agent" in banner
+        assert "NOUS HERMES" not in banner
+        assert "Messenger of the Digital Gods" not in banner
+
+    def test_poseidon_compact_banner_uses_skin_colors(self):
+        set_active_skin("poseidon")
+        skin = get_active_skin()
+
+        with patch("cli.shutil.get_terminal_size", return_value=SimpleNamespace(columns=64)):
+            banner = _build_compact_banner()
+
+        assert skin.get_color("banner_border") in banner
+        assert skin.get_color("banner_title") in banner
+        assert skin.get_color("banner_dim") in banner
 
 
 class TestAnsiRichTextHelper:


### PR DESCRIPTION
## Summary
- make the compact CLI banner respect the active skin's branding and colors
- preserve the legacy `NOUS HERMES` compact banner for the default skin
- add regression tests covering default + poseidon compact-banner behavior

## Why
The full startup banner is already skin-aware, but the compact fallback still used hardcoded `NOUS HERMES` branding and gold colors. That created an inconsistent UX in narrow terminals: e.g. the full banner would show Poseidon branding, while the compact banner would snap back to the legacy Hermes banner.

This keeps the change intentionally small:
- full banner behavior is unchanged
- only the compact fallback is updated
- default skin remains backward-compatible

Before:
<img width="1058" height="704" alt="CleanShot 2026-04-07 at 10 58 01" src="https://github.com/user-attachments/assets/1cb2ba82-bb73-4e3a-9e16-ec04d90117bb" />
After:
<img width="642" height="377" alt="CleanShot 2026-04-07 at 16 05 21" src="https://github.com/user-attachments/assets/8d316b11-6c0d-4840-9fda-5f04ae69b821" />



## Test Plan
- `source /Users/ahmad.ragab/.hermes/hermes-agent/venv/bin/activate && pytest tests/test_cli_skin_integration.py -k compact_banner -q`
- `source /Users/ahmad.ragab/.hermes/hermes-agent/venv/bin/activate && pytest tests/test_cli_skin_integration.py -q`