### PR TITLE
fix(runtime): support direct openai provider

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -807,6 +807,7 @@ def resolve_provider(
 
     # Normalize provider aliases
     _PROVIDER_ALIASES = {
+        "openai": "openrouter",
         "glm": "zai", "z-ai": "zai", "z.ai": "zai", "zhipu": "zai",
         "google": "gemini", "google-gemini": "gemini", "google-ai-studio": "gemini",
         "kimi": "kimi-coding", "moonshot": "kimi-coding",

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -126,6 +126,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
     ),
+    "openai": ProviderConfig(
+        id="openai",
+        name="OpenAI",
+        auth_type="api_key",
+        inference_base_url="https://api.openai.com/v1",
+        api_key_env_vars=("OPENAI_API_KEY",),
+        base_url_env_var="OPENAI_BASE_URL",
+    ),
     "gemini": ProviderConfig(
         id="gemini",
         name="Google AI Studio",
@@ -807,7 +815,6 @@ def resolve_provider(
 
     # Normalize provider aliases
     _PROVIDER_ALIASES = {
-        "openai": "openrouter",
         "glm": "zai", "z-ai": "zai", "z.ai": "zai", "zhipu": "zai",
         "google": "gemini", "google-gemini": "gemini", "google-ai-studio": "gemini",
         "kimi": "kimi-coding", "moonshot": "kimi-coding",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -484,6 +484,7 @@ _PROVIDER_LABELS = {
 }
 
 _PROVIDER_ALIASES = {
+    "openai": "openrouter",
     "glm": "zai",
     "z-ai": "zai",
     "z.ai": "zai",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -484,7 +484,6 @@ _PROVIDER_LABELS = {
 }
 
 _PROVIDER_ALIASES = {
-    "openai": "openrouter",
     "glm": "zai",
     "z-ai": "zai",
     "z.ai": "zai",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -152,9 +152,6 @@ class ProviderDef:
 # Uses models.dev IDs where possible.
 
 ALIASES: Dict[str, str] = {
-    # openrouter
-    "openai": "openrouter",     # bare "openai" → route through aggregator
-
     # zai
     "glm": "zai",
     "z-ai": "zai",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -148,6 +148,9 @@ def _resolve_runtime_from_pool_entry(
     if provider == "openai-codex":
         api_mode = "codex_responses"
         base_url = base_url or DEFAULT_CODEX_BASE_URL
+    elif provider == "openai":
+        configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
+        api_mode = configured_mode or _detect_api_mode_for_url(base_url) or "chat_completions"
     elif provider == "anthropic":
         api_mode = "anthropic_messages"
         cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
@@ -728,6 +731,13 @@ def resolve_runtime_provider(
         api_mode = "chat_completions"
         if provider == "copilot":
             api_mode = _copilot_runtime_api_mode(model_cfg, creds.get("api_key", ""))
+        elif provider == "openai":
+            configured_provider = str(model_cfg.get("provider") or "").strip().lower()
+            configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
+            if configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
+                api_mode = configured_mode
+            else:
+                api_mode = _detect_api_mode_for_url(base_url) or "chat_completions"
         else:
             configured_provider = str(model_cfg.get("provider") or "").strip().lower()
             # Only honor persisted api_mode when it belongs to the same provider family.

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -144,6 +144,7 @@ class TestNormalizeProvider:
         assert normalize_provider("") == "openrouter"
 
     def test_known_aliases(self):
+        assert normalize_provider("openai") == "openrouter"
         assert normalize_provider("glm") == "zai"
         assert normalize_provider("kimi") == "kimi-coding"
         assert normalize_provider("moonshot") == "kimi-coding"

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -144,7 +144,7 @@ class TestNormalizeProvider:
         assert normalize_provider("") == "openrouter"
 
     def test_known_aliases(self):
-        assert normalize_provider("openai") == "openrouter"
+        assert normalize_provider("openai") == "openai"
         assert normalize_provider("glm") == "zai"
         assert normalize_provider("kimi") == "kimi-coding"
         assert normalize_provider("moonshot") == "kimi-coding"

--- a/tests/test_api_key_providers.py
+++ b/tests/test_api_key_providers.py
@@ -158,6 +158,9 @@ class TestResolveProvider:
     def test_alias_glm(self):
         assert resolve_provider("glm") == "zai"
 
+    def test_alias_openai(self):
+        assert resolve_provider("openai") == "openrouter"
+
     def test_alias_z_ai(self):
         assert resolve_provider("z-ai") == "zai"
 

--- a/tests/test_api_key_providers.py
+++ b/tests/test_api_key_providers.py
@@ -111,6 +111,11 @@ class TestProviderRegistry:
         assert "openai-codex" in PROVIDER_REGISTRY
         assert PROVIDER_REGISTRY["openai-codex"].auth_type == "oauth_external"
 
+    def test_openai_provider_is_api_key(self):
+        assert "openai" in PROVIDER_REGISTRY
+        assert PROVIDER_REGISTRY["openai"].auth_type == "api_key"
+        assert PROVIDER_REGISTRY["openai"].inference_base_url == "https://api.openai.com/v1"
+
 
 # =============================================================================
 # Provider Resolution tests
@@ -155,11 +160,11 @@ class TestResolveProvider:
     def test_explicit_ai_gateway(self):
         assert resolve_provider("ai-gateway") == "ai-gateway"
 
+    def test_explicit_openai(self):
+        assert resolve_provider("openai") == "openai"
+
     def test_alias_glm(self):
         assert resolve_provider("glm") == "zai"
-
-    def test_alias_openai(self):
-        assert resolve_provider("openai") == "openrouter"
 
     def test_alias_z_ai(self):
         assert resolve_provider("z-ai") == "zai"

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -947,6 +947,40 @@ def test_resolve_provider_openrouter_unchanged():
     assert resolve_provider("openrouter") == "openrouter"
 
 
+def test_resolve_runtime_provider_openai_alias_uses_openrouter(monkeypatch):
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "model": {
+                "provider": "openai",
+                "default": "openai/gpt-4.1-mini",
+            }
+        },
+    )
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(rp, "load_pool", lambda provider: None)
+    monkeypatch.setattr(
+        rp,
+        "_resolve_openrouter_runtime",
+        lambda **kwargs: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "or-key",
+            "source": "env",
+            "requested_provider": kwargs["requested_provider"],
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider()
+
+    assert resolved["provider"] == "openrouter"
+    assert resolved["requested_provider"] == "openai"
+
+
 def test_custom_provider_runtime_preserves_provider_name(monkeypatch):
     """resolve_runtime_provider with provider='custom' must return provider='custom'."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)

--- a/tests/test_runtime_provider_resolution.py
+++ b/tests/test_runtime_provider_resolution.py
@@ -960,25 +960,26 @@ def test_resolve_runtime_provider_openai_alias_uses_openrouter(monkeypatch):
             }
         },
     )
-    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openrouter")
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "openai")
     monkeypatch.setattr(rp, "load_pool", lambda provider: None)
     monkeypatch.setattr(
         rp,
-        "_resolve_openrouter_runtime",
-        lambda **kwargs: {
-            "provider": "openrouter",
-            "api_mode": "chat_completions",
-            "base_url": "https://openrouter.ai/api/v1",
-            "api_key": "or-key",
+        "resolve_api_key_provider_credentials",
+        lambda provider: {
+            "provider": provider,
+            "api_key": "openai-key",
+            "base_url": "https://api.openai.com/v1",
             "source": "env",
-            "requested_provider": kwargs["requested_provider"],
         },
     )
 
     resolved = rp.resolve_runtime_provider()
 
-    assert resolved["provider"] == "openrouter"
+    assert resolved["provider"] == "openai"
     assert resolved["requested_provider"] == "openai"
+    assert resolved["base_url"] == "https://api.openai.com/v1"
+    assert resolved["api_key"] == "openai-key"
+    assert resolved["api_mode"] == "codex_responses"
 
 
 def test_custom_provider_runtime_preserves_provider_name(monkeypatch):


### PR DESCRIPTION
## Summary
- add `openai` as a first-class direct provider backed by `OPENAI_API_KEY` and `https://api.openai.com/v1`
- stop remapping `model.provider: openai` to OpenRouter
- keep runtime/model validation tests aligned with the direct OpenAI path

## Why
The original PR fixed the crash by routing `openai` to OpenRouter, but that was the wrong backend for this config. Hermes should treat `model.provider: openai` as direct OpenAI API usage, so Discord sessions use the OpenAI API instead of failing provider resolution or silently switching to OpenRouter.

## Testing
- `uv run --extra dev python -m pytest tests/hermes_cli/test_model_validation.py tests/test_runtime_provider_resolution.py -q`
- `uv run --extra dev python -m pytest tests/test_api_key_providers.py -q -k "openai or explicit_openai or provider_is_api_key"`

## Notes
- `uv run --extra dev python -m pytest tests/test_api_key_providers.py -q` still reports two unrelated `TestHasAnyProviderConfigured` failures in this environment.
