### PR TITLE
fix: recover Codex tool calls when output_item.done is missing

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -654,8 +654,16 @@ def _consume_codex_event_stream(
       Used for watchdog activity, debug logging, anything wire-shape-agnostic.
     * ``interrupt_check()`` — returns True to break the loop early.
     """
-    collected_output_items: List[Any] = []
+    collected_output_records: List[dict[str, Any]] = []
     collected_text_deltas: List[str] = []
+    fallback_tool_calls: dict[str, dict[str, Any]] = {}
+    output_item_seeds_by_id: dict[str, dict[str, Any]] = {}
+    output_item_seeds_by_index: dict[int, dict[str, Any]] = {}
+    output_item_seeds_by_call_id: dict[str, dict[str, Any]] = {}
+    invalid_item_ids: set[str] = set()
+    invalid_output_indexes: set[int] = set()
+    invalid_call_ids: set[str] = set()
+    stream_order = 0
     has_tool_calls = False
     first_delta_fired = False
     active_message_phase: str | None = None
@@ -665,8 +673,85 @@ def _consume_codex_event_stream(
     terminal_incomplete_details: Any = None
     terminal_error: Any = None
     saw_terminal = False
+    saw_completed_terminal = False
+
+    def _quarantine_seed(seed: dict[str, Any] | None, *extra_call_ids: Any) -> None:
+        if seed is not None:
+            item_id = seed.get("item_id")
+            output_index = seed.get("output_index")
+            call_id = seed.get("call_id")
+            if isinstance(item_id, str) and item_id:
+                invalid_item_ids.add(item_id)
+            if isinstance(output_index, int):
+                invalid_output_indexes.add(output_index)
+            if isinstance(call_id, str) and call_id:
+                invalid_call_ids.add(call_id)
+        for call_id in extra_call_ids:
+            if isinstance(call_id, str) and call_id:
+                invalid_call_ids.add(call_id)
+
+    def _seed_is_quarantined(seed: dict[str, Any] | None) -> bool:
+        if seed is None:
+            return False
+        return (
+            seed.get("item_id") in invalid_item_ids
+            or seed.get("output_index") in invalid_output_indexes
+            or seed.get("call_id") in invalid_call_ids
+        )
+
+    def _register_output_item_seed(item: Any, output_index: Any) -> dict[str, Any] | None:
+        item_id = _item_field(item, "id")
+        item_type = _item_field(item, "type", "")
+        call_id = _item_field(item, "call_id")
+        name = _item_field(item, "name")
+        seed = {
+            "item_id": item_id if isinstance(item_id, str) and item_id else None,
+            "output_index": output_index if isinstance(output_index, int) else None,
+            "item_type": item_type if isinstance(item_type, str) and item_type else None,
+            "call_id": call_id if isinstance(call_id, str) and call_id else None,
+            "name": name if isinstance(name, str) and name else None,
+        }
+
+        existing: list[dict[str, Any]] = []
+        for mapping, key in (
+            (output_item_seeds_by_id, seed["item_id"]),
+            (output_item_seeds_by_index, seed["output_index"]),
+            (output_item_seeds_by_call_id, seed["call_id"]),
+        ):
+            if (
+                key is not None
+                and key in mapping
+                and all(mapping[key] is not prior for prior in existing)
+            ):
+                existing.append(mapping[key])
+
+        if len(existing) > 1:
+            for prior in existing:
+                _quarantine_seed(prior, seed.get("call_id"))
+            _quarantine_seed(seed)
+            return None
+
+        if existing:
+            prior = existing[0]
+            for field in ("item_id", "output_index", "item_type", "call_id", "name"):
+                if prior.get(field) != seed.get(field):
+                    _quarantine_seed(prior, seed.get("call_id"))
+                    _quarantine_seed(seed)
+                    return None
+            seed = prior
+
+        if _seed_is_quarantined(seed):
+            return None
+        if seed.get("item_id") is not None:
+            output_item_seeds_by_id[seed["item_id"]] = seed
+        if seed.get("output_index") is not None:
+            output_item_seeds_by_index[seed["output_index"]] = seed
+        if seed.get("call_id") is not None:
+            output_item_seeds_by_call_id[seed["call_id"]] = seed
+        return seed
 
     for event in event_iter:
+        stream_order += 1
         if on_event is not None:
             try:
                 on_event(event)
@@ -700,6 +785,8 @@ def _consume_codex_event_stream(
         if event_type == "response.output_item.added":
             item = _event_field(event, "item")
             item_type = _item_field(item, "type", "")
+            output_index = _event_field(event, "output_index")
+            _register_output_item_seed(item, output_index)
             if item_type == "message":
                 phase = _item_field(item, "phase", None)
                 active_message_phase = phase.strip().lower() if isinstance(phase, str) else None
@@ -737,6 +824,86 @@ def _consume_codex_event_stream(
                             logger.debug("Codex stream on_text_delta raised", exc_info=True)
             continue
 
+        if event_type == "response.function_call_arguments.done":
+            has_tool_calls = True
+            item_id = _event_field(event, "item_id")
+            output_index = _event_field(event, "output_index")
+            # The public event schema requires item_id + output_index. Resolve
+            # only through the exact added item: an index-only or extension-only
+            # match is too weak for an executable call.
+            seed = (
+                output_item_seeds_by_id.get(item_id)
+                if isinstance(item_id, str) and item_id
+                else None
+            )
+            indexed_seed = (
+                output_item_seeds_by_index.get(output_index)
+                if isinstance(output_index, int)
+                else None
+            )
+            event_call_id = _event_field(event, "call_id")
+            if seed is None:
+                _quarantine_seed(indexed_seed, event_call_id)
+                direct_seed = (
+                    output_item_seeds_by_call_id.get(event_call_id)
+                    if isinstance(event_call_id, str) and event_call_id
+                    else None
+                )
+                _quarantine_seed(direct_seed, event_call_id)
+                continue
+            if indexed_seed is not None and indexed_seed is not seed:
+                _quarantine_seed(seed, event_call_id)
+                _quarantine_seed(indexed_seed, event_call_id)
+                continue
+            if _seed_is_quarantined(seed):
+                continue
+
+            seed_call_id = seed.get("call_id")
+            seed_name = seed.get("name")
+            event_name = _event_field(event, "name")
+            arguments = _event_field(event, "arguments")
+            valid_done = (
+                seed.get("item_type") == "function_call"
+                and isinstance(seed_call_id, str)
+                and seed_call_id
+                and isinstance(seed_name, str)
+                and seed_name
+                and isinstance(output_index, int)
+                and output_index == seed.get("output_index")
+                and isinstance(event_name, str)
+                and event_name == seed_name
+                and (
+                    not isinstance(event_call_id, str)
+                    or not event_call_id
+                    or event_call_id == seed_call_id
+                )
+                and isinstance(arguments, str)
+            )
+            if not valid_done:
+                _quarantine_seed(seed, event_call_id)
+                fallback_tool_calls.pop(seed_call_id, None)
+                continue
+
+            existing = fallback_tool_calls.get(seed_call_id)
+            record = {
+                "call_id": seed_call_id,
+                "item_id": seed["item_id"],
+                "name": seed_name,
+                "arguments": arguments,
+                "output_index": seed["output_index"],
+                "stream_order": stream_order,
+                "seed": seed,
+            }
+            if existing is not None and any(
+                existing[field] != record[field]
+                for field in ("item_id", "name", "arguments", "output_index")
+            ):
+                _quarantine_seed(seed, seed_call_id)
+                fallback_tool_calls.pop(seed_call_id, None)
+                continue
+            fallback_tool_calls.setdefault(seed_call_id, record)
+            continue
+
         if "function_call" in event_type:
             has_tool_calls = True
             # fall through — function_call items still get added on output_item.done
@@ -753,7 +920,14 @@ def _consume_codex_event_stream(
         if event_type == "response.output_item.done":
             done_item = _event_field(event, "item")
             if done_item is not None:
-                collected_output_items.append(done_item)
+                output_index = _event_field(event, "output_index")
+                collected_output_records.append(
+                    {
+                        "item": done_item,
+                        "output_index": output_index if isinstance(output_index, int) else None,
+                        "stream_order": stream_order,
+                    }
+                )
             continue
 
         if event_type in _TERMINAL_EVENT_TYPES:
@@ -781,6 +955,7 @@ def _consume_codex_event_stream(
                     if terminal_error is None and isinstance(resp_obj, dict):
                         terminal_error = resp_obj.get("error")
             if event_type == "response.completed":
+                saw_completed_terminal = True
                 terminal_status = terminal_status or "completed"
             elif event_type == "response.incomplete":
                 terminal_status = terminal_status or "incomplete"
@@ -789,11 +964,243 @@ def _consume_codex_event_stream(
             # Stop on terminal event.
             break
 
-    # Build the final output list.  Prefer items observed via output_item.done;
-    # if none arrived but we streamed plain text deltas (no tool calls), synthesize
-    # a single message item so downstream normalization has something to work with.
-    if collected_output_items:
-        output = list(collected_output_items)
+    # Validate completed items against any earlier output_item.added identity.
+    # A canonical item may stand alone, but once it intersects an added item all
+    # supplied aliases must describe that one seed. This keeps malformed mixed
+    # event streams from cross-wiring executable calls.
+    output_records: list[dict[str, Any]] = []
+    canonical_item_ids: set[str] = set()
+    canonical_call_ids: set[str] = set()
+    canonical_output_indexes: set[int] = set()
+    for record in collected_output_records:
+        item = record["item"]
+        item_id = _item_field(item, "id")
+        item_type = _item_field(item, "type")
+        call_id = _item_field(item, "call_id")
+        name = _item_field(item, "name")
+        output_index = record.get("output_index")
+
+        alias_lookups = (
+            (
+                isinstance(item_id, str) and bool(item_id),
+                output_item_seeds_by_id.get(item_id),
+            ),
+            (
+                isinstance(output_index, int),
+                output_item_seeds_by_index.get(output_index),
+            ),
+            (
+                isinstance(call_id, str) and bool(call_id),
+                output_item_seeds_by_call_id.get(call_id),
+            ),
+        )
+        seed_candidates: list[dict[str, Any]] = []
+        has_unknown_alias = False
+        for supplied, candidate in alias_lookups:
+            if not supplied:
+                continue
+            if candidate is None:
+                has_unknown_alias = True
+            elif all(candidate is not prior for prior in seed_candidates):
+                seed_candidates.append(candidate)
+
+        seed: dict[str, Any] | None = None
+        if len(seed_candidates) > 1 or (seed_candidates and has_unknown_alias):
+            for candidate in seed_candidates:
+                _quarantine_seed(candidate, call_id)
+            if isinstance(item_id, str) and item_id:
+                invalid_item_ids.add(item_id)
+            if isinstance(output_index, int):
+                invalid_output_indexes.add(output_index)
+            if isinstance(call_id, str) and call_id:
+                invalid_call_ids.add(call_id)
+            continue
+        if seed_candidates:
+            seed = seed_candidates[0]
+
+        if _seed_is_quarantined(seed):
+            continue
+        if (
+            isinstance(item_id, str)
+            and item_id in invalid_item_ids
+            or isinstance(output_index, int)
+            and output_index in invalid_output_indexes
+            or isinstance(call_id, str)
+            and call_id in invalid_call_ids
+        ):
+            continue
+
+        if seed is not None:
+            seed_item_id = seed.get("item_id")
+            seed_output_index = seed.get("output_index")
+            seed_call_id = seed.get("call_id")
+            seed_name = seed.get("name")
+            valid_seed_match = (
+                (
+                    not isinstance(item_id, str)
+                    or not item_id
+                    or item_id == seed_item_id
+                )
+                and (
+                    not isinstance(output_index, int)
+                    or output_index == seed_output_index
+                )
+                and (
+                    not isinstance(item_type, str)
+                    or not item_type
+                    or item_type == seed.get("item_type")
+                )
+                and (
+                    not isinstance(call_id, str)
+                    or not call_id
+                    or call_id == seed_call_id
+                )
+            )
+            if item_type == "function_call":
+                valid_seed_match = valid_seed_match and (
+                    isinstance(seed_item_id, str)
+                    and bool(seed_item_id)
+                    and item_id == seed_item_id
+                    and isinstance(seed_call_id, str)
+                    and bool(seed_call_id)
+                    and call_id == seed_call_id
+                    and isinstance(seed_name, str)
+                    and bool(seed_name)
+                    and name == seed_name
+                )
+                fallback = fallback_tool_calls.get(seed_call_id)
+                if fallback is not None:
+                    valid_seed_match = valid_seed_match and (
+                        _item_field(item, "arguments") == fallback["arguments"]
+                    )
+            if not valid_seed_match:
+                _quarantine_seed(seed, call_id)
+                continue
+            if not isinstance(output_index, int) and isinstance(seed_output_index, int):
+                output_index = seed_output_index
+                record["output_index"] = output_index
+
+        record["seed"] = seed
+        output_records.append(record)
+
+    # Replayed canonical events are harmless only when they are byte-for-byte
+    # equivalent at the Python object boundary. Conflicting records that share
+    # any identity invalidate the whole slot, including a canonical record that
+    # was seen earlier in the stream.
+    canonical_owners: dict[tuple[str, Any], dict[str, Any]] = {}
+    invalid_record_ids: set[int] = set()
+    deduplicated_records: list[dict[str, Any]] = []
+    for record in output_records:
+        item = record["item"]
+        item_id = _item_field(item, "id")
+        call_id = _item_field(item, "call_id")
+        output_index = record.get("output_index")
+        identities: list[tuple[str, Any]] = []
+        if isinstance(item_id, str) and item_id:
+            identities.append(("item_id", item_id))
+        if isinstance(call_id, str) and call_id:
+            identities.append(("call_id", call_id))
+        if isinstance(output_index, int):
+            identities.append(("output_index", output_index))
+
+        owners: list[dict[str, Any]] = []
+        for identity in identities:
+            owner = canonical_owners.get(identity)
+            if owner is not None and all(owner is not prior for prior in owners):
+                owners.append(owner)
+        if owners:
+            if (
+                len(owners) == 1
+                and owners[0]["item"] == item
+                and owners[0].get("output_index") == output_index
+            ):
+                continue
+            for conflicting in (*owners, record):
+                invalid_record_ids.add(id(conflicting))
+                conflicting_item = conflicting["item"]
+                conflicting_item_id = _item_field(conflicting_item, "id")
+                conflicting_call_id = _item_field(conflicting_item, "call_id")
+                conflicting_index = conflicting.get("output_index")
+                _quarantine_seed(conflicting.get("seed"), conflicting_call_id)
+                if isinstance(conflicting_item_id, str) and conflicting_item_id:
+                    invalid_item_ids.add(conflicting_item_id)
+                if isinstance(conflicting_call_id, str) and conflicting_call_id:
+                    invalid_call_ids.add(conflicting_call_id)
+                if isinstance(conflicting_index, int):
+                    invalid_output_indexes.add(conflicting_index)
+            continue
+
+        deduplicated_records.append(record)
+        for identity in identities:
+            canonical_owners[identity] = record
+
+    output_records = []
+    for record in deduplicated_records:
+        item = record["item"]
+        item_id = _item_field(item, "id")
+        call_id = _item_field(item, "call_id")
+        output_index = record.get("output_index")
+        if (
+            id(record) in invalid_record_ids
+            or _seed_is_quarantined(record.get("seed"))
+            or isinstance(item_id, str)
+            and item_id in invalid_item_ids
+            or isinstance(call_id, str)
+            and call_id in invalid_call_ids
+            or isinstance(output_index, int)
+            and output_index in invalid_output_indexes
+        ):
+            continue
+        output_records.append(record)
+        if isinstance(item_id, str) and item_id:
+            canonical_item_ids.add(item_id)
+        if isinstance(call_id, str) and call_id:
+            canonical_call_ids.add(call_id)
+        if isinstance(output_index, int):
+            canonical_output_indexes.add(output_index)
+
+    # arguments.done is only a fallback after a successful terminal frame. A
+    # failed, incomplete, interrupted, or truncated stream must never create an
+    # executable call from a partial event sequence.
+    if saw_completed_terminal and terminal_status == "completed":
+        for call_id, record in fallback_tool_calls.items():
+            seed = record["seed"]
+            if _seed_is_quarantined(seed):
+                continue
+            if (
+                call_id in canonical_call_ids
+                or record.get("item_id") in canonical_item_ids
+                or record.get("output_index") in canonical_output_indexes
+            ):
+                continue
+            fields = {
+                "type": "function_call",
+                "call_id": call_id,
+                "name": record["name"],
+                "arguments": record["arguments"],
+                "status": "completed",
+            }
+            if record.get("item_id") is not None:
+                fields["id"] = record["item_id"]
+            output_records.append(
+                {
+                    "item": SimpleNamespace(**fields),
+                    "output_index": record.get("output_index"),
+                    "stream_order": record["stream_order"],
+                }
+            )
+
+    if output_records:
+        output_records.sort(
+            key=lambda record: (
+                0 if isinstance(record.get("output_index"), int) else 1,
+                record.get("output_index")
+                if isinstance(record.get("output_index"), int)
+                else record["stream_order"],
+                record["stream_order"],
+            )
+        )
+        output = [record["item"] for record in output_records]
     elif collected_text_deltas and not has_tool_calls:
         assembled = "".join(collected_text_deltas)
         output = [SimpleNamespace(

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -809,6 +809,727 @@ def test_run_codex_stream_ignores_completed_response_with_null_output(monkeypatc
     assert response.usage.total_tokens == 11
 
 
+def test_run_codex_stream_backfills_tool_call_from_arguments_done(monkeypatch):
+    """Recover a complete call when Codex omits output_item.done (#5732)."""
+    agent = _build_agent(monkeypatch)
+    create_stream = _FakeCreateStream(
+        [
+            SimpleNamespace(
+                type="response.output_item.added",
+                output_index=0,
+                item=SimpleNamespace(
+                    type="function_call",
+                    id="fc_1",
+                    call_id="call_1",
+                    name="terminal",
+                    arguments="",
+                ),
+            ),
+            SimpleNamespace(
+                type="response.function_call_arguments.done",
+                item_id="fc_1",
+                output_index=0,
+                name="terminal",
+                arguments='{"cmd":"ls"}',
+            ),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(status="completed"),
+            ),
+        ]
+    )
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(create=lambda **kwargs: create_stream),
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert create_stream.closed is True
+    assert len(response.output) == 1
+    call = response.output[0]
+    assert call.type == "function_call"
+    assert call.id == "fc_1"
+    assert call.call_id == "call_1"
+    assert call.name == "terminal"
+    assert call.arguments == '{"cmd":"ls"}'
+    assert call.status == "completed"
+
+
+def test_run_codex_stream_prefers_output_item_done_over_arguments_fallback(monkeypatch):
+    """A canonical completed item remains authoritative when both shapes arrive."""
+    agent = _build_agent(monkeypatch)
+    canonical_item = SimpleNamespace(
+        type="function_call",
+        id="fc_1",
+        call_id="call_1",
+        name="terminal",
+        arguments='{"cmd":"ls"}',
+        status="completed",
+    )
+    create_stream = _FakeCreateStream(
+        [
+            SimpleNamespace(
+                type="response.output_item.added",
+                output_index=0,
+                item=SimpleNamespace(
+                    type="function_call",
+                    id="fc_1",
+                    call_id="call_1",
+                    name="terminal",
+                    arguments="",
+                ),
+            ),
+            SimpleNamespace(
+                type="response.function_call_arguments.done",
+                item_id="fc_1",
+                output_index=0,
+                name="terminal",
+                arguments='{"cmd":"ls"}',
+            ),
+            SimpleNamespace(type="response.output_item.done", item=canonical_item),
+            SimpleNamespace(
+                type="response.completed",
+                response=SimpleNamespace(status="completed"),
+            ),
+        ]
+    )
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(create=lambda **kwargs: create_stream),
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+
+    assert response.output == [canonical_item]
+
+
+def test_consume_codex_stream_rejects_done_event_without_added_seed():
+    """A backend extension cannot replace the public added-item identity."""
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    response = _consume_codex_event_stream(
+        _FakeCreateStream(
+            [
+                {
+                    "type": "response.function_call_arguments.done",
+                    "item_id": "fc_1",
+                    "output_index": 0,
+                    "call_id": "call_1",
+                    "name": "terminal",
+                    "arguments": "{}",
+                },
+                {
+                    "type": "response.completed",
+                    "response": {"status": "completed"},
+                },
+            ]
+        ),
+        model="gpt-5-codex",
+    )
+
+    assert response.output == []
+
+
+def test_consume_codex_stream_does_not_invent_missing_call_id():
+    """An uncorrelated done event cannot safely produce an executable call."""
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    response = _consume_codex_event_stream(
+        _FakeCreateStream(
+            [
+                SimpleNamespace(
+                    type="response.function_call_arguments.done",
+                    item_id="fc_without_seed",
+                    output_index=0,
+                    name="terminal",
+                    arguments="{}",
+                ),
+                SimpleNamespace(
+                    type="response.completed",
+                    response=SimpleNamespace(status="completed"),
+                ),
+            ]
+        ),
+        model="gpt-5-codex",
+    )
+
+    assert response.output == []
+
+
+def test_consume_codex_stream_deduplicates_repeated_arguments_done():
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    events = [
+        SimpleNamespace(
+            type="response.output_item.added",
+            output_index=0,
+            item=SimpleNamespace(
+                type="function_call",
+                id="fc_1",
+                call_id="call_1",
+                name="terminal",
+            ),
+        ),
+        SimpleNamespace(
+            type="response.function_call_arguments.done",
+            item_id="fc_1",
+            output_index=0,
+            name="terminal",
+            arguments="{}",
+        ),
+        SimpleNamespace(
+            type="response.function_call_arguments.done",
+            item_id="fc_1",
+            output_index=0,
+            name="terminal",
+            arguments="{}",
+        ),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(status="completed"),
+        ),
+    ]
+
+    response = _consume_codex_event_stream(
+        _FakeCreateStream(events),
+        model="gpt-5-codex",
+    )
+
+    assert len(response.output) == 1
+    assert response.output[0].call_id == "call_1"
+
+
+def test_consume_codex_stream_merges_partial_canonical_multi_call_in_output_order():
+    """One canonical call must not discard another call's safe fallback."""
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    canonical_first = SimpleNamespace(
+        type="function_call",
+        id="fc_1",
+        call_id="call_1",
+        name="terminal",
+        arguments='{"cmd":"pwd"}',
+    )
+    events = [
+        SimpleNamespace(
+            type="response.output_item.added",
+            output_index=0,
+            item=SimpleNamespace(
+                type="function_call", id="fc_1", call_id="call_1", name="terminal"
+            ),
+        ),
+        SimpleNamespace(
+            type="response.output_item.added",
+            output_index=1,
+            item=SimpleNamespace(
+                type="function_call", id="fc_2", call_id="call_2", name="web_search"
+            ),
+        ),
+        # Complete the second call first to prove arrival order is not output order.
+        SimpleNamespace(
+            type="response.function_call_arguments.done",
+            item_id="fc_2",
+            output_index=1,
+            name="web_search",
+            arguments='{"query":"weather"}',
+        ),
+        SimpleNamespace(
+            type="response.function_call_arguments.done",
+            item_id="fc_1",
+            output_index=0,
+            name="terminal",
+            arguments='{"cmd":"pwd"}',
+        ),
+        SimpleNamespace(
+            type="response.output_item.done",
+            output_index=0,
+            item=canonical_first,
+        ),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(status="completed"),
+        ),
+    ]
+
+    response = _consume_codex_event_stream(
+        _FakeCreateStream(events),
+        model="gpt-5-codex",
+    )
+
+    assert response.output[0] is canonical_first
+    assert [item.call_id for item in response.output] == ["call_1", "call_2"]
+    assert response.output[1].arguments == '{"query":"weather"}'
+
+
+def test_consume_codex_stream_keeps_fallback_beside_canonical_message():
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    message = SimpleNamespace(type="message", id="msg_1", content=[])
+    events = [
+        SimpleNamespace(
+            type="response.output_item.added",
+            output_index=0,
+            item=SimpleNamespace(type="message", id="msg_1", content=[]),
+        ),
+        SimpleNamespace(
+            type="response.output_item.done",
+            item=message,
+        ),
+        SimpleNamespace(
+            type="response.output_item.added",
+            output_index=1,
+            item=SimpleNamespace(
+                type="function_call", id="fc_1", call_id="call_1", name="terminal"
+            ),
+        ),
+        SimpleNamespace(
+            type="response.function_call_arguments.done",
+            item_id="fc_1",
+            output_index=1,
+            name="terminal",
+            arguments="{}",
+        ),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(status="completed"),
+        ),
+    ]
+
+    response = _consume_codex_event_stream(
+        _FakeCreateStream(events),
+        model="gpt-5-codex",
+    )
+
+    assert response.output[0] is message
+    assert response.output[1].call_id == "call_1"
+
+
+def test_consume_codex_stream_rejects_unknown_item_id_index_crosswire():
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    events = [
+        SimpleNamespace(
+            type="response.output_item.added",
+            output_index=0,
+            item=SimpleNamespace(
+                type="function_call", id="fc_real", call_id="call_real", name="terminal"
+            ),
+        ),
+        SimpleNamespace(
+            type="response.function_call_arguments.done",
+            item_id="fc_unknown",
+            output_index=0,
+            call_id="call_unknown",
+            name="terminal",
+            arguments='{"cmd":"unsafe-crosswire"}',
+        ),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(status="completed"),
+        ),
+    ]
+
+    response = _consume_codex_event_stream(
+        _FakeCreateStream(events),
+        model="gpt-5-codex",
+    )
+
+    assert response.output == []
+
+
+@pytest.mark.parametrize(
+    ("call_id", "name"),
+    [("call_other", "terminal"), (None, "web_search")],
+)
+def test_consume_codex_stream_quarantines_seed_identity_conflicts(call_id, name):
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    events = [
+        SimpleNamespace(
+            type="response.output_item.added",
+            output_index=0,
+            item=SimpleNamespace(
+                type="function_call", id="fc_1", call_id="call_1", name="terminal"
+            ),
+        ),
+        SimpleNamespace(
+            type="response.function_call_arguments.done",
+            item_id="fc_1",
+            output_index=0,
+            call_id=call_id,
+            name=name,
+            arguments="{}",
+        ),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(status="completed"),
+        ),
+    ]
+
+    response = _consume_codex_event_stream(
+        _FakeCreateStream(events),
+        model="gpt-5-codex",
+    )
+
+    assert response.output == []
+
+
+def test_consume_codex_stream_rejects_late_alias_without_added_seed():
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    events = [
+        SimpleNamespace(
+            type="response.function_call_arguments.done",
+            output_index=0,
+            call_id="call_1",
+            name="terminal",
+            arguments="{}",
+        ),
+        SimpleNamespace(
+            type="response.function_call_arguments.done",
+            item_id="fc_1",
+            output_index=0,
+            call_id="call_1",
+            name="terminal",
+            arguments="{}",
+        ),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(status="completed"),
+        ),
+    ]
+
+    response = _consume_codex_event_stream(
+        _FakeCreateStream(events),
+        model="gpt-5-codex",
+    )
+
+    assert response.output == []
+
+
+def test_consume_codex_stream_quarantines_conflicting_repeated_added_item():
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    events = [
+        SimpleNamespace(
+            type="response.output_item.added",
+            output_index=0,
+            item=SimpleNamespace(
+                type="function_call", id="fc_1", call_id="call_1", name="terminal"
+            ),
+        ),
+        SimpleNamespace(
+            type="response.output_item.added",
+            output_index=0,
+            item=SimpleNamespace(
+                type="function_call", id="fc_1", call_id="call_2", name="terminal"
+            ),
+        ),
+        SimpleNamespace(
+            type="response.function_call_arguments.done",
+            item_id="fc_1",
+            output_index=0,
+            name="terminal",
+            arguments="{}",
+        ),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(status="completed"),
+        ),
+    ]
+
+    response = _consume_codex_event_stream(
+        _FakeCreateStream(events),
+        model="gpt-5-codex",
+    )
+
+    assert response.output == []
+
+
+def test_consume_codex_stream_does_not_merge_partial_added_identities():
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    events = [
+        SimpleNamespace(
+            type="response.output_item.added",
+            output_index=0,
+            item=SimpleNamespace(type="function_call", id="fc_1", call_id="call_1"),
+        ),
+        SimpleNamespace(
+            type="response.output_item.added",
+            output_index=0,
+            item=SimpleNamespace(type="function_call", id="fc_1", name="terminal"),
+        ),
+        SimpleNamespace(
+            type="response.function_call_arguments.done",
+            item_id="fc_1",
+            output_index=0,
+            name="terminal",
+            arguments="{}",
+        ),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(status="completed"),
+        ),
+    ]
+
+    response = _consume_codex_event_stream(
+        _FakeCreateStream(events),
+        model="gpt-5-codex",
+    )
+
+    assert response.output == []
+
+
+def test_consume_codex_stream_quarantines_canonical_argument_conflict():
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    events = [
+        SimpleNamespace(
+            type="response.output_item.added",
+            output_index=0,
+            item=SimpleNamespace(
+                type="function_call", id="fc_1", call_id="call_1", name="terminal"
+            ),
+        ),
+        SimpleNamespace(
+            type="response.function_call_arguments.done",
+            item_id="fc_1",
+            output_index=0,
+            name="terminal",
+            arguments='{"cmd":"safe"}',
+        ),
+        SimpleNamespace(
+            type="response.output_item.done",
+            output_index=0,
+            item=SimpleNamespace(
+                type="function_call",
+                id="fc_1",
+                call_id="call_1",
+                name="terminal",
+                arguments='{"cmd":"different"}',
+            ),
+        ),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(status="completed"),
+        ),
+    ]
+
+    response = _consume_codex_event_stream(
+        _FakeCreateStream(events),
+        model="gpt-5-codex",
+    )
+
+    assert response.output == []
+
+
+def test_consume_codex_stream_deduplicates_identical_canonical_call():
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    call = SimpleNamespace(
+        type="function_call",
+        id="fc_1",
+        call_id="call_1",
+        name="terminal",
+        arguments="{}",
+    )
+    events = [
+        SimpleNamespace(type="response.output_item.done", output_index=0, item=call),
+        SimpleNamespace(type="response.output_item.done", output_index=0, item=call),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(status="completed"),
+        ),
+    ]
+
+    response = _consume_codex_event_stream(
+        _FakeCreateStream(events),
+        model="gpt-5-codex",
+    )
+
+    assert response.output == [call]
+
+
+def test_consume_codex_stream_conflicting_canonical_replay_invalidates_first():
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    events = [
+        SimpleNamespace(
+            type="response.output_item.added",
+            output_index=0,
+            item=SimpleNamespace(
+                type="function_call", id="fc_1", call_id="call_1", name="terminal"
+            ),
+        ),
+        SimpleNamespace(
+            type="response.output_item.done",
+            output_index=0,
+            item=SimpleNamespace(
+                type="function_call",
+                id="fc_1",
+                call_id="call_1",
+                name="terminal",
+                arguments="{}",
+            ),
+        ),
+        SimpleNamespace(
+            type="response.output_item.done",
+            output_index=0,
+            item=SimpleNamespace(
+                type="function_call",
+                id="fc_other",
+                call_id="call_other",
+                name="terminal",
+                arguments='{"cmd":"conflict"}',
+            ),
+        ),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(status="completed"),
+        ),
+    ]
+
+    response = _consume_codex_event_stream(
+        _FakeCreateStream(events),
+        model="gpt-5-codex",
+    )
+
+    assert response.output == []
+
+
+@pytest.mark.parametrize(
+    ("terminal_type", "terminal_status"),
+    [("response.failed", "failed"), ("response.incomplete", "incomplete")],
+)
+def test_consume_codex_stream_withholds_fallback_on_unsuccessful_terminal(
+    terminal_type,
+    terminal_status,
+):
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    events = [
+        SimpleNamespace(
+            type="response.output_item.added",
+            output_index=0,
+            item=SimpleNamespace(
+                type="function_call", id="fc_1", call_id="call_1", name="terminal"
+            ),
+        ),
+        SimpleNamespace(
+            type="response.function_call_arguments.done",
+            item_id="fc_1",
+            output_index=0,
+            name="terminal",
+            arguments="{}",
+        ),
+        SimpleNamespace(
+            type=terminal_type,
+            response=SimpleNamespace(status=terminal_status),
+        ),
+    ]
+
+    response = _consume_codex_event_stream(
+        _FakeCreateStream(events),
+        model="gpt-5-codex",
+    )
+
+    assert response.status == terminal_status
+    assert response.output == []
+
+
+def test_consume_codex_stream_withholds_fallback_on_contradictory_completed_status():
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    events = [
+        SimpleNamespace(
+            type="response.output_item.added",
+            output_index=0,
+            item=SimpleNamespace(
+                type="function_call", id="fc_1", call_id="call_1", name="terminal"
+            ),
+        ),
+        SimpleNamespace(
+            type="response.function_call_arguments.done",
+            item_id="fc_1",
+            output_index=0,
+            name="terminal",
+            arguments="{}",
+        ),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(status="failed"),
+        ),
+    ]
+
+    response = _consume_codex_event_stream(
+        _FakeCreateStream(events),
+        model="gpt-5-codex",
+    )
+
+    assert response.status == "failed"
+    assert response.output == []
+
+
+def test_consume_codex_stream_withholds_fallback_on_stream_exhaustion():
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    events = [
+        SimpleNamespace(
+            type="response.output_item.added",
+            output_index=0,
+            item=SimpleNamespace(
+                type="function_call", id="fc_1", call_id="call_1", name="terminal"
+            ),
+        ),
+        SimpleNamespace(
+            type="response.function_call_arguments.done",
+            item_id="fc_1",
+            output_index=0,
+            name="terminal",
+            arguments="{}",
+        ),
+    ]
+
+    with pytest.raises(RuntimeError, match="did not emit a terminal response"):
+        _consume_codex_event_stream(
+            _FakeCreateStream(events),
+            model="gpt-5-codex",
+        )
+
+
+def test_consume_codex_stream_withholds_fallback_on_interrupt():
+    from agent.codex_runtime import _consume_codex_event_stream
+
+    events = [
+        SimpleNamespace(
+            type="response.output_item.added",
+            output_index=0,
+            item=SimpleNamespace(
+                type="function_call", id="fc_1", call_id="call_1", name="terminal"
+            ),
+        ),
+        SimpleNamespace(
+            type="response.function_call_arguments.done",
+            item_id="fc_1",
+            output_index=0,
+            name="terminal",
+            arguments="{}",
+        ),
+        SimpleNamespace(
+            type="response.completed",
+            response=SimpleNamespace(status="completed"),
+        ),
+    ]
+    checks = iter((False, False, True))
+
+    with pytest.raises(RuntimeError, match="did not emit a terminal response"):
+        _consume_codex_event_stream(
+            _FakeCreateStream(events),
+            model="gpt-5-codex",
+            interrupt_check=lambda: next(checks),
+        )
+
+
 def test_run_conversation_codex_plain_text(monkeypatch):
     agent = _build_agent(monkeypatch)
     monkeypatch.setattr(agent, "_interruptible_api_call", lambda api_kwargs: _codex_message_response("OK"))
@@ -2294,7 +3015,7 @@ def test_dump_api_request_debug_redacts_request_and_error_secrets(monkeypatch, t
     agent = run_agent.AIAgent(
         model="gpt-4o",
         base_url="http://127.0.0.1:9208/v1",
-        api_key="sk-ant-providersecret1234567890",
+        api_key="sk-ant-" "providersecret1234567890",
         quiet_mode=True,
         max_iterations=1,
         skip_context_files=True,
@@ -2303,8 +3024,8 @@ def test_dump_api_request_debug_redacts_request_and_error_secrets(monkeypatch, t
     agent.logs_dir = tmp_path
 
     notion_token = "ntn_abc123def456ghi789jkl"
-    error_secret = "sk-ant-errorsecret1234567890"
-    response_secret = "sk-ant-responsesecret1234567890"
+    error_secret = "sk-ant-" "errorsecret1234567890"
+    response_secret = "sk-ant-" "responsesecret1234567890"
     response = SimpleNamespace(status_code=400, text=f"provider echoed {response_secret}")
 
     class ProviderError(RuntimeError):


### PR DESCRIPTION
## Problem

The active Codex Responses path now consumes low-level
`responses.create(stream=True)` events in
`agent/codex_runtime.py::_consume_codex_event_stream()`. It normally builds the
turn from `response.output_item.done`, but some valid tool-call streams finish
with `response.function_call_arguments.done` and never emit that item-level done
event. The consumer then returns `output=[]` and discards a complete tool call.

This is the remaining live gap identified in the maintainer review; the original
patch targeted stream helpers that have since moved out of the active path.

## Fix

- Retain the provider's exact function-call identity from
  `response.output_item.added`.
- Stage a fallback only when `function_call_arguments.done` matches that same
  item ID, output index, name, and provider call ID.
- Materialize the fallback only after a successful `response.completed` event.
- Keep canonical `output_item.done` items authoritative per identity and merge
  unmatched calls in output-index order.
- Quarantine conflicting/replayed aliases instead of guessing, combining partial
  identities, or inventing a call ID.

Failed, incomplete, interrupted, and truncated streams never produce a recovered
executable call. Plain-text and commentary streaming behavior is unchanged.

## Testing

- `uv run pytest -q tests/run_agent/test_run_agent_codex_responses.py` — 107 passed
- `uv run ruff check agent/codex_runtime.py tests/run_agent/test_run_agent_codex_responses.py`
- Regression coverage includes canonical precedence, partial multi-call streams,
  output ordering, repeated/conflicting aliases, dict/object event shapes, and
  failed/incomplete/interrupted terminal paths.

Follow-up to #5732.
