### PR TITLE
fix(setup): graceful fallback when matrix-nio[e2e] install fails

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2069,6 +2069,53 @@ def _setup_matrix():
                 )
             if result.returncode == 0:
                 print_success(f"{matrix_pkg} installed")
+            elif want_e2ee:
+                # E2EE install failed — likely python-olm can't build (needs libolm).
+                stderr_text = (result.stderr or "").strip()
+                is_olm_error = "olm" in stderr_text.lower()
+                print_warning("E2EE install failed.")
+                if is_olm_error:
+                    print_info("  python-olm requires the libolm C library.")
+                    if sys.platform == "darwin":
+                        print_info("  Install it with: brew install libolm")
+                    elif sys.platform.startswith("linux"):
+                        print_info("  Install it with: apt install libolm-dev  (or your distro's equivalent)")
+                    else:
+                        print_info("  Install the libolm C library for your platform.")
+                    print_info(f"  Then retry: pip install '{matrix_pkg}'")
+                else:
+                    print_info(f"  Run manually: pip install '{matrix_pkg}'")
+                    if stderr_text:
+                        print_info(f"  Error: {stderr_text.splitlines()[-1]}")
+                print()
+                # Offer plain matrix-nio fallback so the user isn't stuck.
+                if prompt_yes_no("Install matrix-nio without E2EE instead? (you can add E2EE later)", True):
+                    fallback_pkg = "matrix-nio"
+                    print_info(f"Installing {fallback_pkg}...")
+                    if uv_bin:
+                        fb_result = subprocess.run(
+                            [uv_bin, "pip", "install", "--python", sys.executable, fallback_pkg],
+                            capture_output=True, text=True,
+                        )
+                    else:
+                        fb_result = subprocess.run(
+                            [sys.executable, "-m", "pip", "install", fallback_pkg],
+                            capture_output=True, text=True,
+                        )
+                    if fb_result.returncode == 0:
+                        print_success(f"{fallback_pkg} installed (without E2EE)")
+                        save_env_value("MATRIX_ENCRYPTION", "false")
+                        print_info("  E2EE disabled. Re-run 'hermes setup' after installing libolm to enable it.")
+                    else:
+                        # Fallback also failed — disable E2EE so gateway doesn't try it.
+                        save_env_value("MATRIX_ENCRYPTION", "false")
+                        print_warning(f"Install failed — run manually: pip install '{fallback_pkg}'")
+                        if fb_result.stderr:
+                            print_info(f"  Error: {fb_result.stderr.strip().splitlines()[-1]}")
+                else:
+                    # User declined fallback — disable E2EE since the install failed.
+                    save_env_value("MATRIX_ENCRYPTION", "false")
+                    print_info("  E2EE disabled. Install libolm and re-run 'hermes setup' to enable it.")
             else:
                 print_warning(f"Install failed — run manually: pip install '{matrix_pkg}'")
                 if result.stderr:

--- a/tests/hermes_cli/test_matrix_e2ee_setup.py
+++ b/tests/hermes_cli/test_matrix_e2ee_setup.py
@@ -1,0 +1,247 @@
+"""Tests for Matrix E2EE setup fallback in hermes_cli/setup.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_env(monkeypatch, tmp_path):
+    """Redirect env file writes to a temp dir so tests don't touch real config."""
+    env_file = tmp_path / ".env"
+    env_file.touch()
+    monkeypatch.setattr("hermes_cli.setup.get_env_value", lambda key: None)
+    saved = {}
+
+    def _save(key, value):
+        saved[key] = value
+
+    monkeypatch.setattr("hermes_cli.setup.save_env_value", _save)
+    return saved
+
+
+def _make_result(returncode, stderr=""):
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout="", stderr=stderr)
+
+
+def _nio_import_raises():
+    """Context manager that makes __import__('nio') raise ImportError."""
+    real_import = __import__
+
+    def _selective_import(name, *args, **kwargs):
+        if name == "nio":
+            raise ImportError("No module named 'nio'")
+        return real_import(name, *args, **kwargs)
+
+    return patch("builtins.__import__", side_effect=_selective_import)
+
+
+class TestMatrixE2EEFallback:
+    """When matrix-nio[e2e] install fails, setup should offer a plain fallback."""
+
+    def test_e2ee_install_fails_olm_offers_and_accepts_fallback(self, monkeypatch, mock_env):
+        """If E2EE install fails with olm error, offer plain fallback; user accepts."""
+        from hermes_cli import setup as setup_mod
+
+        prompt_answers = iter([
+            "https://matrix.example.org",  # homeserver URL
+            "syt_fake_token",              # access token
+            "",                            # user_id (optional, skip)
+            "",                            # allowed users (skip)
+            "",                            # home room (skip)
+        ])
+        yes_no_answers = iter([True, True])  # want E2EE=yes, accept fallback=yes
+
+        monkeypatch.setattr(setup_mod, "prompt", lambda *a, **kw: next(prompt_answers))
+        monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda *a, **kw: next(yes_no_answers))
+
+        call_log = []
+
+        def _mock_run(cmd, **kwargs):
+            call_log.append(cmd)
+            if len(call_log) == 1:
+                return _make_result(1, stderr="error: python-olm build failed: make static returned 2")
+            return _make_result(0)
+
+        monkeypatch.setattr(subprocess, "run", _mock_run)
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+        with _nio_import_raises():
+            setup_mod._setup_matrix()
+
+        # Should have flipped encryption to false after fallback succeeded
+        assert mock_env.get("MATRIX_ENCRYPTION") == "false"
+        assert len(call_log) == 2
+        assert "matrix-nio[e2e]" in str(call_log[0])
+        assert "matrix-nio" in str(call_log[1])
+        assert "[e2e]" not in str(call_log[1])
+
+    def test_e2ee_install_succeeds_no_fallback(self, monkeypatch, mock_env):
+        """If E2EE install succeeds on first try, no fallback needed."""
+        from hermes_cli import setup as setup_mod
+
+        prompt_answers = iter([
+            "https://matrix.example.org",
+            "syt_fake_token",
+            "",   # user_id
+            "",   # allowed users
+            "",   # home room
+        ])
+        yes_no_answers = iter([True])  # want E2EE=yes
+
+        monkeypatch.setattr(setup_mod, "prompt", lambda *a, **kw: next(prompt_answers))
+        monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda *a, **kw: next(yes_no_answers))
+
+        call_log = []
+
+        def _mock_run(cmd, **kwargs):
+            call_log.append(cmd)
+            return _make_result(0)
+
+        monkeypatch.setattr(subprocess, "run", _mock_run)
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+        with _nio_import_raises():
+            setup_mod._setup_matrix()
+
+        assert mock_env.get("MATRIX_ENCRYPTION") == "true"
+        assert len(call_log) == 1
+
+    def test_non_e2ee_install_fails_no_fallback_offered(self, monkeypatch, mock_env):
+        """If user chose no E2EE and plain install fails, just show error."""
+        from hermes_cli import setup as setup_mod
+
+        prompt_answers = iter([
+            "https://matrix.example.org",
+            "syt_fake_token",
+            "",   # user_id
+            "",   # allowed users
+            "",   # home room
+        ])
+        yes_no_answers = iter([False])  # want E2EE=no
+
+        monkeypatch.setattr(setup_mod, "prompt", lambda *a, **kw: next(prompt_answers))
+        monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda *a, **kw: next(yes_no_answers))
+
+        call_log = []
+
+        def _mock_run(cmd, **kwargs):
+            call_log.append(cmd)
+            return _make_result(1, stderr="some pip error")
+
+        monkeypatch.setattr(subprocess, "run", _mock_run)
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+        with _nio_import_raises():
+            setup_mod._setup_matrix()
+
+        # No MATRIX_ENCRYPTION saved (user said no to E2EE)
+        assert "MATRIX_ENCRYPTION" not in mock_env
+        assert len(call_log) == 1
+        assert "[e2e]" not in str(call_log[0])
+
+    def test_e2ee_fails_user_declines_fallback_disables_encryption(self, monkeypatch, mock_env):
+        """If E2EE install fails and user declines fallback, MATRIX_ENCRYPTION must be false."""
+        from hermes_cli import setup as setup_mod
+
+        prompt_answers = iter([
+            "https://matrix.example.org",
+            "syt_fake_token",
+            "",   # user_id
+            "",   # allowed users
+            "",   # home room
+        ])
+        yes_no_answers = iter([True, False])  # want E2EE=yes, decline fallback=no
+
+        monkeypatch.setattr(setup_mod, "prompt", lambda *a, **kw: next(prompt_answers))
+        monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda *a, **kw: next(yes_no_answers))
+
+        call_log = []
+
+        def _mock_run(cmd, **kwargs):
+            call_log.append(cmd)
+            return _make_result(1, stderr="python-olm failed to build")
+
+        monkeypatch.setattr(subprocess, "run", _mock_run)
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+        with _nio_import_raises():
+            setup_mod._setup_matrix()
+
+        # E2EE was initially set to true but must be flipped to false
+        assert mock_env.get("MATRIX_ENCRYPTION") == "false"
+        # Only 1 subprocess call (the failed e2e attempt)
+        assert len(call_log) == 1
+
+    def test_e2ee_fails_fallback_also_fails_disables_encryption(self, monkeypatch, mock_env):
+        """If both E2EE and plain fallback install fail, MATRIX_ENCRYPTION must be false."""
+        from hermes_cli import setup as setup_mod
+
+        prompt_answers = iter([
+            "https://matrix.example.org",
+            "syt_fake_token",
+            "",   # user_id
+            "",   # allowed users
+            "",   # home room
+        ])
+        yes_no_answers = iter([True, True])  # want E2EE=yes, accept fallback=yes
+
+        monkeypatch.setattr(setup_mod, "prompt", lambda *a, **kw: next(prompt_answers))
+        monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda *a, **kw: next(yes_no_answers))
+
+        call_log = []
+
+        def _mock_run(cmd, **kwargs):
+            call_log.append(cmd)
+            # Both attempts fail
+            if len(call_log) == 1:
+                return _make_result(1, stderr="python-olm build failed")
+            return _make_result(1, stderr="pip install matrix-nio also failed")
+
+        monkeypatch.setattr(subprocess, "run", _mock_run)
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+        with _nio_import_raises():
+            setup_mod._setup_matrix()
+
+        # Encryption must be disabled even when everything fails
+        assert mock_env.get("MATRIX_ENCRYPTION") == "false"
+        assert len(call_log) == 2
+
+    def test_e2ee_fails_empty_stderr(self, monkeypatch, mock_env):
+        """If E2EE install fails with empty stderr, show generic message."""
+        from hermes_cli import setup as setup_mod
+
+        prompt_answers = iter([
+            "https://matrix.example.org",
+            "syt_fake_token",
+            "",   # user_id
+            "",   # allowed users
+            "",   # home room
+        ])
+        yes_no_answers = iter([True, True])  # want E2EE=yes, accept fallback=yes
+
+        monkeypatch.setattr(setup_mod, "prompt", lambda *a, **kw: next(prompt_answers))
+        monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda *a, **kw: next(yes_no_answers))
+
+        call_log = []
+
+        def _mock_run(cmd, **kwargs):
+            call_log.append(cmd)
+            if len(call_log) == 1:
+                return _make_result(1, stderr="")  # empty stderr
+            return _make_result(0)
+
+        monkeypatch.setattr(subprocess, "run", _mock_run)
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+        with _nio_import_raises():
+            setup_mod._setup_matrix()
+
+        # Fallback should still work even with empty stderr
+        assert mock_env.get("MATRIX_ENCRYPTION") == "false"
+        assert len(call_log) == 2


### PR DESCRIPTION
## Problem

When a user enables E2EE during `hermes setup` for Matrix, the setup tries to `pip install matrix-nio[e2e]`. This pulls in `python-olm`, which requires the `libolm` C library to build. On most systems (especially macOS), `libolm` isn't installed, so the build fails with a cryptic `make static` error.

Previously:
- Before commit 914f7461: the setup **crashed** with `NameError: name 'shutil' is not defined` (#5060, #5134)
- After that fix: the setup shows a generic "Install failed — run manually" message with no explanation of what's actually wrong or how to fix it

Users are left stuck — they want Matrix but can't get past the setup wizard.

## Fix

When `matrix-nio[e2e]` install fails and the user chose E2EE:

1. **Detect the olm failure** — check stderr for `olm`/`python-olm` keywords
2. **Show platform-specific fix instructions**:
   - macOS: `brew install libolm`
   - Linux: `apt install libolm-dev`
3. **Offer a plain matrix-nio fallback** — "Install matrix-nio without E2EE instead?"
4. If accepted, install `matrix-nio` (no E2EE deps), set `MATRIX_ENCRYPTION=false`, and tell the user to re-run setup after installing libolm

This way the user always gets a working Matrix gateway, and can upgrade to E2EE later.

## Verification

```bash
python -m pytest tests/hermes_cli/test_matrix_e2ee_setup.py -q --override-ini="addopts="
# 3 passed
```

Tests cover:
- E2EE install fails with olm error → fallback offered and accepted → plain nio installed, encryption disabled
- E2EE install succeeds → no fallback needed
- Non-E2EE install fails → generic error (no fallback path since no E2EE was requested)

Closes #5134
Closes #5060
