### PR TITLE
feat: lazy skill loading with per-session deduplication

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -60,7 +60,7 @@ def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tu
         else:
             normalized = raw_identifier.lstrip("/")
 
-        loaded_skill = json.loads(skill_view(normalized, task_id=task_id))
+        loaded_skill = json.loads(skill_view(normalized, task_id=task_id, force=True))
     except Exception:
         return None
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -477,7 +477,7 @@ def _build_job_prompt(job: dict) -> str:
     parts = []
     skipped: list[str] = []
     for skill_name in skill_names:
-        loaded = json.loads(skill_view(skill_name))
+        loaded = json.loads(skill_view(skill_name, force=True))
         if not loaded.get("success"):
             error = loaded.get("error") or f"Failed to load skill '{skill_name}'"
             logger.warning("Cron job '%s': skill not found, skipping — %s", job.get("name", job.get("id")), error)

--- a/run_agent.py
+++ b/run_agent.py
@@ -5936,6 +5936,11 @@ class AIAgent:
             reset_file_dedup(task_id)
         except Exception:
             pass
+        try:
+            from tools.skills_tool import reset_loaded_skills
+            reset_loaded_skills(task_id)
+        except Exception:
+            pass
 
         logger.info(
             "context compression done: session=%s messages=%d->%d tokens=~%s",

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -1046,3 +1046,96 @@ Do the legacy thing.
         assert result["setup_needed"] is False
         assert result["missing_required_environment_variables"] == []
         assert result["readiness_status"] == "available"
+
+
+class TestSkillViewDeduplication:
+    """Tests for the per-session skill deduplication feature (lazy skill loading)."""
+
+    def _make_skill(self, skills_dir, name, content="# Instructions\nDo the thing."):
+        skill_dir = skills_dir / name
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: Test skill {name}\n---\n{content}"
+        )
+
+    def test_first_load_returns_full_content(self, tmp_path):
+        """First skill_view() call returns the full SKILL.md body."""
+        from tools.skills_tool import skill_view, reset_loaded_skills
+        reset_loaded_skills("test-first-load")
+        self._make_skill(tmp_path, "my-skill")
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            result = json.loads(skill_view("my-skill", task_id="test-first-load"))
+        assert result["success"] is True
+        assert result.get("already_loaded") is not True
+        assert "content" in result
+
+    def test_second_load_returns_stub(self, tmp_path):
+        """Second skill_view() call returns the already-loaded stub."""
+        from tools.skills_tool import skill_view, reset_loaded_skills
+        reset_loaded_skills("test-second-load")
+        self._make_skill(tmp_path, "my-skill")
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_view("my-skill", task_id="test-second-load")
+            result = json.loads(skill_view("my-skill", task_id="test-second-load"))
+        assert result["success"] is True
+        assert result.get("already_loaded") is True
+        assert "message" in result
+        assert "force=True" in result["message"]
+
+    def test_force_bypasses_dedup(self, tmp_path):
+        """skill_view() with force=True always returns full content."""
+        from tools.skills_tool import skill_view, reset_loaded_skills
+        reset_loaded_skills("test-force")
+        self._make_skill(tmp_path, "my-skill")
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_view("my-skill", task_id="test-force")
+            result = json.loads(skill_view("my-skill", task_id="test-force", force=True))
+        assert result["success"] is True
+        assert result.get("already_loaded") is not True
+        assert "content" in result
+
+    def test_reset_clears_session_state(self, tmp_path):
+        """reset_loaded_skills() causes the next call to return full content again."""
+        from tools.skills_tool import skill_view, reset_loaded_skills
+        reset_loaded_skills("test-reset")
+        self._make_skill(tmp_path, "my-skill")
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_view("my-skill", task_id="test-reset")
+            reset_loaded_skills("test-reset")
+            result = json.loads(skill_view("my-skill", task_id="test-reset"))
+        assert result["success"] is True
+        assert result.get("already_loaded") is not True
+        assert "content" in result
+
+    def test_dedup_is_per_task_id(self, tmp_path):
+        """Deduplication is scoped to task_id — different sessions are independent."""
+        from tools.skills_tool import skill_view, reset_loaded_skills
+        reset_loaded_skills("session-a")
+        reset_loaded_skills("session-b")
+        self._make_skill(tmp_path, "my-skill")
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_view("my-skill", task_id="session-a")
+            result = json.loads(skill_view("my-skill", task_id="session-b"))
+        assert result["success"] is True
+        assert result.get("already_loaded") is not True
+        assert "content" in result
+
+    def test_file_path_load_not_deduplicated(self, tmp_path):
+        """Linked file loads (file_path set) are never deduplicated."""
+        from tools.skills_tool import skill_view, reset_loaded_skills
+        reset_loaded_skills("test-file-path")
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: my-skill\ndescription: Test\n---\n# Instructions"
+        )
+        refs = skill_dir / "references"
+        refs.mkdir()
+        (refs / "api.md").write_text("# API docs")
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_view("my-skill", task_id="test-file-path")
+            result = json.loads(
+                skill_view("my-skill", file_path="references/api.md", task_id="test-file-path")
+            )
+        assert result["success"] is True
+        assert result.get("already_loaded") is not True

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -68,6 +68,7 @@ Usage:
 
 import json
 import logging
+import threading
 
 from hermes_constants import get_hermes_home
 import os
@@ -102,6 +103,17 @@ _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _EXCLUDED_SKILL_DIRS = frozenset((".git", ".github", ".hub"))
 _REMOTE_ENV_BACKENDS = frozenset({"docker", "singularity", "modal", "ssh", "daytona"})
 _secret_capture_callback = None
+
+# ---------------------------------------------------------------------------
+# Per-session skill deduplication state (lazy loading of skills)
+# Tracks which skills have already been loaded in a given task session so that
+# repeated skill_view() calls return a lightweight instruction to the model instead of
+# re-injecting the full SKILL.md body into the conversation context.
+# Keyed by task_id (str); cleared after context compression via
+# reset_loaded_skills().
+# ---------------------------------------------------------------------------
+_loaded_skills: Dict[str, Set[str]] = {}
+_loaded_skills_lock = threading.Lock()
 
 
 def load_env() -> Dict[str, str]:
@@ -517,6 +529,25 @@ def _is_skill_disabled(name: str, platform: str = None) -> bool:
         return False
 
 
+
+def reset_loaded_skills(task_id: str = None) -> None:
+    """Clear the per-session skill deduplication cache.
+
+    Called after context compression — the previously loaded skill content may have
+    been summarized away, so the model needs the full body if it loads the same
+    skill again.  Without this, post-compression skill_view() calls would have to
+    be called with "force:true" by the model. Not critical, but nice to have.
+
+    Call with a *task_id* to clear just that session, or without arguments to
+    clear all sessions (e.g. on gateway shutdown).
+    """
+    with _loaded_skills_lock:
+        if task_id:
+            _loaded_skills.pop(task_id, None)
+        else:
+            _loaded_skills.clear()
+
+
 def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
     """Recursively find all skills in ~/.hermes/skills/ and external dirs.
 
@@ -784,7 +815,7 @@ def skills_list(category: str = None, task_id: str = None) -> str:
         return json.dumps({"success": False, "error": str(e)}, ensure_ascii=False)
 
 
-def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
+def skill_view(name: str, file_path: str = None, task_id: str = None, force: bool = False) -> str:
     """
     View the content of a skill or a specific file within a skill directory.
 
@@ -792,6 +823,9 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
         name: Name or path of the skill (e.g., "axolotl" or "03-fine-tuning/axolotl")
         file_path: Optional path to a specific file within the skill (e.g., "references/api.md")
         task_id: Optional task identifier used to probe the active backend
+        force: If True, bypass the per-session deduplication cache and always
+            return the full skill body.  Use when the model suspects the earlier
+            load has been compacted away from the conversation context.
 
     Returns:
         JSON string with skill content or error message
@@ -943,6 +977,30 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
                 },
                 ensure_ascii=False,
             )
+
+        # Per-session deduplication: if this skill was already loaded in the
+        # current task session, return an instruction to the model instead of
+        # re-injecting the full body.  The caller can pass force=True to bypass
+        # this when the model can't find the skill text because of compaction.
+        effective_task_id = task_id or "default"
+        if not force and not file_path:
+            with _loaded_skills_lock:
+                already_loaded = resolved_name in _loaded_skills.get(effective_task_id, set())
+            if already_loaded:
+                return json.dumps(
+                    {
+                        "success": True,
+                        "already_loaded": True,
+                        "name": resolved_name,
+                        "message": (
+                            f"Skill '{resolved_name}' was already loaded earlier in this session. "
+                            "Refer to its instructions in your context. "
+                            "If you cannot find them (e.g. after context compression), "
+                            "call skill_view again with force=True to reload."
+                        ),
+                    },
+                    ensure_ascii=False,
+                )
 
         # If a specific file path is requested, read that instead
         if file_path and skill_dir:
@@ -1252,6 +1310,11 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
         if isinstance(metadata, dict):
             result["metadata"] = metadata
 
+        # Record this skill as loaded for the current session (main SKILL.md only).
+        if not file_path:
+            with _loaded_skills_lock:
+                _loaded_skills.setdefault(effective_task_id, set()).add(skill_name)
+
         return json.dumps(result, ensure_ascii=False)
 
     except Exception as e:
@@ -1349,6 +1412,10 @@ SKILL_VIEW_SCHEMA = {
                 "type": "string",
                 "description": "OPTIONAL: Path to a linked file within the skill (e.g., 'references/api.md', 'templates/config.yaml', 'scripts/validate.py'). Omit to get the main SKILL.md content.",
             },
+            "force": {
+                "type": "boolean",
+                "description": "NOTE: Set to true to reload the full skill content where: you've been told the skill was already loaded, but you can't find it in the session (it may have been compressed away).",
+            },
         },
         "required": ["name"],
     },
@@ -1369,7 +1436,8 @@ registry.register(
     toolset="skills",
     schema=SKILL_VIEW_SCHEMA,
     handler=lambda args, **kw: skill_view(
-        args.get("name", ""), file_path=args.get("file_path"), task_id=kw.get("task_id")
+        args.get("name", ""), file_path=args.get("file_path"), task_id=kw.get("task_id"),
+        force=bool(args.get("force", False))
     ),
     check_fn=check_skills_requirements,
     emoji="📚",


### PR DESCRIPTION
# feat: Lazy skill loading (with per-session deduplication)

## The Problem

Every time `skill_view()` is called for the same skill within a session, the full `SKILL.md` body is injected into the conversation history as a tool result. On long sessions, this means the same skill content can appear multiple times in the context, consuming tokens unnecessarily. Context bloat!

## My Proposed Solution

This PR adds per-session deduplication to `skill_view()`. After the first successful load of a skill's full content, subsequent calls within the same task session return to the model a lightweight message instead of the full skill file:

```json
{
  "success": true,
  "already_loaded": true,
  "name": "my-skill",
  "message": "Skill 'my-skill' was already loaded earlier in this session. Refer to its instructions in your context. If you cannot find them (e.g. after context compression), call skill_view again with force=True to reload."
}
```

Feel free to change that message if you like!

The model can call `skill_view("my-skill", force=True)` to bypass the cache and receive the full body again — for example, after context compression has removed the earlier load from the conversation window.

## Changes

### `tools/skills_tool.py`
- Added module-level `_loaded_skills: Dict[str, Set[str]]` dict (keyed by `task_id`) and a `threading.Lock` for thread safety
- Added `force: bool = False` parameter to `skill_view()`
- Added deduplication check: if the skill was already loaded in this session and `force=False`, return the lightweight stub
- After a successful full load, record the skill name in `_loaded_skills[task_id]`
- Added `reset_loaded_skills(task_id=None)` function to clear the cache (called after context compression)
- Updated `SKILL_VIEW_SCHEMA` with the `force` property
- Updated `registry.register` handler to pass `force` through

### `run_agent.py`
- Call `reset_loaded_skills(task_id)` after context compression, alongside the existing `reset_file_dedup(task_id)` call — ensures the model can reload skills whose content was summarised away

### `agent/skill_commands.py`
- Pass `force=True` to `skill_view()` in `_load_skill_payload()` — slash-command skill invocations always need the full body. Sorry, had to add a parameter here, no other way.

### `cron/scheduler.py`
- Pass `force=True` to `skill_view()` in the cron job skill loader — scheduled tasks always need the full body

## Tests

Added `TestSkillViewDeduplication` in `tests/tools/test_skills_tool.py` with 6 cases:
- First load returns full content
- Second load returns the stub
- `force=True` bypasses the stub and returns full content
- `reset_loaded_skills()` clears the cache so the next call returns full content
- Deduplication is scoped per `task_id` — independent sessions don't interfere
- Linked file loads (`file_path` set) are never deduplicated

## Behavior

- Deduplication applies only to main `SKILL.md` loads. Linked file loads (`file_path` argument) are always passed through.
- The `force` parameter is also exposed in the tool schema so the model can use it directly in its tool call JSON. This is important if the context has been compressed and it can't find the skill we "claim" is loaded.
- Thread safety: `_loaded_skills` is protected by a `threading.Lock` for environments that run concurrent tool calls.

Thank you for Hermes Agent, I use it 24/7! - Rufus Lin
