### PR TITLE
fix(cli): OAuth providers missing from /model picker — wrong import and key lookup

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -797,9 +797,9 @@ def list_authenticated_providers(
         if overlay.auth_type in ("oauth_device_code", "oauth_external", "external_process"):
             # These use auth stores, not env vars — check for auth.json entries
             try:
-                from hermes_cli.auth import _read_auth_store
-                store = _read_auth_store()
-                if store and pid in store:
+                from hermes_cli.auth import _load_auth_store
+                store = _load_auth_store()
+                if store and (pid in store.get("providers", {}) or pid in store.get("credential_pool", {})):
                     has_creds = True
             except Exception:
                 pass


### PR DESCRIPTION
## Summary

Fixes #5910 — OAuth-authenticated providers (Nous Portal, OpenAI Codex, Copilot) never appear in the `/model` gateway picker because `list_authenticated_providers()` uses a non-existent function and checks the wrong dict keys.

## Root Cause

Two bugs in `hermes_cli/model_switch.py`, section 2 ("Hermes-only providers"):

1. **Wrong function name**: `_read_auth_store` does not exist — the correct function is `_load_auth_store`. The `ImportError` was silently caught by `except Exception: pass`, so the entire OAuth credential check was skipped.

2. **Wrong key lookup**: `_load_auth_store()` returns a dict with top-level keys (`version`, `providers`, `credential_pool`, `active_provider`, `updated_at`), not provider IDs. So `pid in store` was always `False`.

## Fix

```diff
-                from hermes_cli.auth import _read_auth_store
-                store = _read_auth_store()
-                if store and pid in store:
+                from hermes_cli.auth import _load_auth_store
+                store = _load_auth_store()
+                if store and (pid in store.get("providers", {}) or pid in store.get("credential_pool", {})):
```

## Impact

- `/model` in gateway now correctly shows OAuth providers (nous, openai-codex, copilot) alongside env-var-based providers
- Users who authenticated via `hermes auth add nous` can switch to Nous models via `/model`

## Verification

- Searched codebase for `_read_auth_store` — this function does not exist; only `_load_auth_store` is defined in `auth.py` (line 551)
- Verified `_load_auth_store()` return structure matches the fix (providers under `store["providers"]`)
- Single file change, 3 lines modified