### PR TITLE
fix(codex): route auth failures to fallback provider chain

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2155,6 +2155,8 @@ class HermesCLI:
             format_runtime_provider_error,
         )
 
+        _primary_exc = None
+        runtime = None
         try:
             runtime = resolve_runtime_provider(
                 requested=self.requested_provider,
@@ -2162,7 +2164,34 @@ class HermesCLI:
                 explicit_base_url=self._explicit_base_url,
             )
         except Exception as exc:
-            message = format_runtime_provider_error(exc)
+            _primary_exc = exc
+
+        # Primary provider auth failed — try fallback providers before giving up.
+        if runtime is None and _primary_exc is not None:
+            from hermes_cli.auth import AuthError
+            if isinstance(_primary_exc, AuthError):
+                _fb_chain = self._fallback_model if isinstance(self._fallback_model, list) else []
+                for _fb in _fb_chain:
+                    _fb_provider = (_fb.get("provider") or "").strip().lower()
+                    _fb_model = (_fb.get("model") or "").strip()
+                    if not _fb_provider or not _fb_model:
+                        continue
+                    try:
+                        runtime = resolve_runtime_provider(requested=_fb_provider)
+                        logger.warning(
+                            "Primary provider auth failed (%s). Falling through to fallback: %s/%s",
+                            _primary_exc, _fb_provider, _fb_model,
+                        )
+                        _cprint(f"⚠️  Primary auth failed — switching to fallback: {_fb_provider} / {_fb_model}")
+                        self.requested_provider = _fb_provider
+                        self.model = _fb_model
+                        _primary_exc = None
+                        break
+                    except Exception:
+                        continue
+
+        if runtime is None:
+            message = format_runtime_provider_error(_primary_exc) if _primary_exc else "Provider resolution failed."
             self.console.print(f"[bold red]{message}[/]")
             return False
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -7380,9 +7380,27 @@ class AIAgent:
                     error_details = []
                     if self.api_mode == "codex_responses":
                         output_items = getattr(response, "output", None) if response is not None else None
+                        _codex_resp_status = str(getattr(response, "status", "") or "").strip().lower() if response is not None else ""
                         if response is None:
                             response_invalid = True
                             error_details.append("response is None")
+                        elif _codex_resp_status in {"failed", "cancelled"}:
+                            # Provider returned a terminal failure (e.g. quota exhaustion).
+                            # Treat as invalid so the fallback chain is triggered instead of
+                            # letting the error bubble up outside the retry/fallback loop.
+                            _codex_error_obj = getattr(response, "error", None)
+                            _codex_error_msg = (
+                                _codex_error_obj.get("message") if isinstance(_codex_error_obj, dict)
+                                else str(_codex_error_obj) if _codex_error_obj
+                                else f"Responses API returned status '{_codex_resp_status}'"
+                            )
+                            logging.warning(
+                                "Codex response status='%s' (error=%s). Routing to fallback. %s",
+                                _codex_resp_status, _codex_error_msg,
+                                self._client_log_context(),
+                            )
+                            response_invalid = True
+                            error_details.append(f"response.status={_codex_resp_status}: {_codex_error_msg}")
                         elif not isinstance(output_items, list):
                             response_invalid = True
                             error_details.append("response.output is not a list")


### PR DESCRIPTION
## Problem

Two code paths where Codex authentication failures silently bypassed the fallback provider chain instead of switching to the next configured provider.

### 1. `cli.py` — pre-turn credential check blocks fallback entirely

`_ensure_runtime_credentials()` is called before every agent turn. It calls `resolve_runtime_provider(requested=self.requested_provider)`. When the provider is explicitly configured (e.g. `provider: openai-codex` in config.yaml — the typical setup), `resolve_runtime_provider` re-raises `AuthError` on token refresh failure rather than falling through. This error is caught, printed in bold red, and the function returns `False` — so the agent never starts and `fallback_providers` is never consulted.

**Symptom:** User sees a raw `Codex token refresh failed with status 401` error in the Hermes TUI instead of a transparent switch to the fallback model.

### 2. `run_agent.py` — `response.status=failed` escapes the retry/fallback loop

Inside the `codex_responses` validity gate (inner retry loop), a response with `status in {failed, cancelled}` and non-empty `output_items` was treated as valid (the `not isinstance(output_items, list)` check passed) and broke out of the loop. It then reached `_normalize_codex_response()` — which is called *outside* the retry loop and raises `RuntimeError` on terminal status codes. That exception propagated to the outer `except Exception` handler which has no fallback logic.

**Symptom:** Quota exhaustion on the Codex provider (which returns `response.status=failed`) showed a raw GPT error instead of switching to the fallback chain.

## Fix

**`cli.py`:** On `AuthError` in `_ensure_runtime_credentials`, iterate `fallback_providers` and try each in order. On first success, swap `self.requested_provider` and `self.model` to the fallback and continue normally. Only fail if every provider in the chain is exhausted.

**`run_agent.py`:** Add an explicit `elif _codex_resp_status in {failed, cancelled}:` check *before* the `not isinstance(output_items, list)` check inside the codex validity gate. Sets `response_invalid = True` with a `logging.warning` so the existing `_try_activate_fallback()` path fires.

## Testing

Reproduced locally with an expired Codex OAuth token (401 on refresh) and with quota exhaustion (`response.status=failed`). Both now transparently switch to the first working `fallback_providers` entry.