### PR TITLE
fix(gateway): show_reasoning 💭 block lost when streaming is active

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -575,6 +575,81 @@ def _resolve_gateway_display_bool(
     return bool(value)
 
 
+def _build_gateway_reasoning_block(
+    user_config: Any,
+    platform: Any,
+    last_reasoning: Any,
+    *,
+    default: bool = False,
+) -> str:
+    """Render reasoning once for both batch and streamed delivery."""
+    if not isinstance(user_config, dict) or not isinstance(last_reasoning, str):
+        return ""
+    try:
+        platform_key = _platform_config_key(platform)
+        if not _resolve_gateway_display_bool(
+            user_config,
+            platform_key,
+            "show_reasoning",
+            default=default,
+            platform=platform,
+            require_platform_override_for={Platform.MATTERMOST},
+        ):
+            return ""
+
+        lines = last_reasoning.strip().splitlines()
+        if not lines:
+            return ""
+        display_reasoning = "\n".join(lines[:15])
+        if len(lines) > 15:
+            display_reasoning += f"\n_... ({len(lines) - 15} more lines)_"
+
+        from gateway.display_config import resolve_display_setting
+
+        reasoning_style = resolve_display_setting(
+            user_config,
+            platform_key,
+            "reasoning_style",
+            "code",
+        )
+        if reasoning_style == "subtext":
+            quoted = "\n".join(
+                f"-# {line}" if line else "-#"
+                for line in display_reasoning.splitlines()
+            )
+            return f"-# 💭 Reasoning\n{quoted}"
+        if reasoning_style == "blockquote":
+            quoted = "\n".join(
+                f"> {line}" if line else ">"
+                for line in display_reasoning.splitlines()
+            )
+            return f"> 💭 **Reasoning:**\n{quoted}"
+        return f"💭 **Reasoning:**\n```\n{display_reasoning}\n```"
+    except Exception:
+        # Optional scratch-text display must never block the main response or
+        # fail open when configuration/plugin platform data is malformed.
+        return ""
+
+
+def _is_successful_streamed_delivery(already_sent: Any, failed: Any) -> bool:
+    """Preserve the established truthy result-flag compatibility contract."""
+    return bool(already_sent) and not bool(failed)
+
+
+def _gateway_reasoning_delivery_mode(
+    response: str,
+    *,
+    streamed_success: bool,
+    intentional_silence: bool,
+) -> str:
+    """Choose one mutually exclusive reasoning path."""
+    if intentional_silence:
+        return "none"
+    if streamed_success:
+        return "trailing"
+    return "prepend" if response else "none"
+
+
 def _telegramize_command_mentions(text: str, platform: Any) -> str:
     """Rewrite slash-command mentions to Telegram-valid command names.
 
@@ -11800,59 +11875,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         session_entry.session_id,
                     )
 
-            # Prepend reasoning/thinking if display is enabled (per-platform).
-            # Mattermost requires explicit per-platform opt-in because this is
-            # scratch text, not ordinary final-answer content.
+            # Render reasoning once so non-streamed and streamed replies use
+            # the same platform opt-in and reasoning_style.
+            _reasoning_block = ""
             try:
-                _show_reasoning_effective = _resolve_gateway_display_bool(
-                    _load_gateway_config(),
-                    _platform_config_key(source.platform),
-                    "show_reasoning",
-                    default=bool(getattr(self, "_show_reasoning", False)),
-                    platform=source.platform,
-                    require_platform_override_for={Platform.MATTERMOST},
-                )
+                _reasoning_config = _load_gateway_config()
             except Exception:
-                _show_reasoning_effective = (
-                    False
-                    if source.platform == Platform.MATTERMOST
-                    else getattr(self, "_show_reasoning", False)
+                _reasoning_config = None
+            _streamed_success = _is_successful_streamed_delivery(
+                agent_result.get("already_sent"),
+                agent_result.get("failed"),
+            )
+            _reasoning_delivery_mode = _gateway_reasoning_delivery_mode(
+                response,
+                streamed_success=_streamed_success,
+                intentional_silence=_intentional_silence,
+            )
+            if _reasoning_delivery_mode != "none":
+                _reasoning_block = _build_gateway_reasoning_block(
+                    _reasoning_config,
+                    source.platform,
+                    agent_result.get("last_reasoning"),
+                    default=bool(getattr(self, "_show_reasoning", False)),
                 )
-            if _show_reasoning_effective and response and not _intentional_silence:
-                last_reasoning = agent_result.get("last_reasoning")
-                if last_reasoning:
-                    # Collapse long reasoning to keep messages readable
-                    lines = last_reasoning.strip().splitlines()
-                    if len(lines) > 15:
-                        display_reasoning = "\n".join(lines[:15])
-                        display_reasoning += f"\n_... ({len(lines) - 15} more lines)_"
-                    else:
-                        display_reasoning = last_reasoning.strip()
-                    # Render style is per-platform: Discord defaults to "-# "
-                    # subtext (native small grey metadata text); other
-                    # platforms keep the fenced code block.
-                    try:
-                        from gateway.display_config import resolve_display_setting
-                        _reasoning_style = resolve_display_setting(
-                            _load_gateway_config(),
-                            _platform_config_key(source.platform),
-                            "reasoning_style",
-                            "code",
-                        )
-                    except Exception:
-                        _reasoning_style = "code"
-                    if _reasoning_style == "subtext":
-                        _quoted = "\n".join(
-                            f"-# {ln}" if ln else "-#" for ln in display_reasoning.splitlines()
-                        )
-                        response = f"-# 💭 Reasoning\n{_quoted}\n\n{response}"
-                    elif _reasoning_style == "blockquote":
-                        _quoted = "\n".join(
-                            f"> {ln}" if ln else ">" for ln in display_reasoning.splitlines()
-                        )
-                        response = f"> 💭 **Reasoning:**\n{_quoted}\n\n{response}"
-                    else:
-                        response = f"💭 **Reasoning:**\n```\n{display_reasoning}\n```\n\n{response}"
+                if _reasoning_block and _reasoning_delivery_mode == "prepend":
+                    response = f"{_reasoning_block}\n\n{response}"
 
             # Runtime-metadata footer — only on the FINAL message of the turn.
             # Off by default (display.runtime_footer.enabled=false).  When
@@ -11872,7 +11919,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)
                 _footer_line = ""
-            if _footer_line and response and not agent_result.get("already_sent") and not _intentional_silence:
+            if _footer_line and response and not _streamed_success and not _intentional_silence:
                 response = f"{response}\n\n{_footer_line}"
 
             # Emit agent:end hook
@@ -12208,13 +12255,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # content the user hasn't seen (streaming only sent earlier
             # partial output before the failure).  Without this guard,
             # users see the agent "stop responding without explanation."
-            if agent_result.get("already_sent") and not agent_result.get("failed"):
-                if response:
-                    _media_adapter = self._adapter_for_source(source)
-                    if _media_adapter:
-                        await self._deliver_media_from_response(
-                            response, event, _media_adapter,
-                        )
+            if _streamed_success:
+                await self._deliver_streamed_response_extras(
+                    response,
+                    event,
+                    source,
+                    _reasoning_block
+                    if _reasoning_delivery_mode == "trailing"
+                    else "",
+                )
                 # Streaming already delivered the body text, but the footer was
                 # intentionally held back (see the `not already_sent` gate above).
                 # Send it now as a small trailing message so Telegram/Discord/etc.
@@ -14404,6 +14453,44 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             chat_type=getattr(source, "chat_type", None),
             reply_to_message_id=reply_to_message_id or getattr(source, "message_id", None),
         )
+
+    async def _send_streamed_reasoning(self, source, event, reasoning_block: str) -> None:
+        """Send reasoning that cannot be prepended to an already-streamed body."""
+        try:
+            adapter = self._adapter_for_source(source)
+            if adapter:
+                await adapter.send(
+                    source.chat_id,
+                    reasoning_block,
+                    metadata=self._thread_metadata_for_source(
+                        source,
+                        self._reply_anchor_for_event(event),
+                    ),
+                )
+        except Exception as exc:
+            logger.warning("Failed to send streamed reasoning block: %s", exc)
+
+    async def _deliver_streamed_response_extras(
+        self,
+        response: str,
+        event,
+        source,
+        reasoning_block: str,
+    ) -> None:
+        """Deliver unsent response media before the trailing reasoning block."""
+        if response:
+            try:
+                media_adapter = self._adapter_for_source(source)
+                if media_adapter:
+                    await self._deliver_media_from_response(
+                        response,
+                        event,
+                        media_adapter,
+                    )
+            except Exception as exc:
+                logger.warning("Failed to deliver media from streamed response: %s", exc)
+        if reasoning_block:
+            await self._send_streamed_reasoning(source, event, reasoning_block)
 
     def _thread_metadata_for_target(
         self,
@@ -17060,6 +17147,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "tools": [],
             "history_offset": len(history),
             "session_id": session_id,
+            "failed": False,
             "response_previewed": _stream_consumer is not None and bool(full_response),
         }
 
@@ -19299,6 +19387,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "last_reasoning": result.get("last_reasoning"),
                 "messages": result_holder[0].get("messages", []) if result_holder[0] else [],
                 "api_calls": result_holder[0].get("api_calls", 0) if result_holder[0] else 0,
+                "failed": bool(result_holder[0].get("failed", False)) if result_holder[0] else False,
                 "completed": result_holder[0].get("completed") if result_holder[0] else None,
                 "interrupted": result_holder[0].get("interrupted", False) if result_holder[0] else False,
                 "partial": result_holder[0].get("partial", False) if result_holder[0] else False,

--- a/tests/gateway/test_proxy_mode.py
+++ b/tests/gateway/test_proxy_mode.py
@@ -428,6 +428,7 @@ class TestRunAgentViaProxy:
         assert "messages" in result
         assert "api_calls" in result
         assert "tools" in result
+        assert result["failed"] is False
         assert "history_offset" in result
         assert result["history_offset"] == 2  # len(history)
         assert "session_id" in result

--- a/tests/gateway/test_run_cleanup_progress.py
+++ b/tests/gateway/test_run_cleanup_progress.py
@@ -131,11 +131,10 @@ class FailingAgent:
         if cb is not None:
             cb("tool.started", "terminal", "pwd", {})
             time.sleep(0.25)
-        # Empty final_response + failed=True is the shape the gateway
-        # actually returns on provider errors (see gateway/run.py where
-        # failed keys are only propagated when final_response is empty).
+        # A provider failure can carry a non-empty user-facing diagnostic; the
+        # gateway must preserve failed=True on that normal response branch.
         return {
-            "final_response": "",
+            "final_response": "simulated provider failure",
             "messages": [],
             "api_calls": 1,
             "failed": True,
@@ -295,6 +294,7 @@ async def test_cleanup_skipped_on_failed_run(monkeypatch, tmp_path):
     )
 
     assert result.get("failed") is True
+    assert result["final_response"] == "simulated provider failure"
     # Whatever callback is registered should not trigger any deletion —
     # the cleanup callback is skipped on failed runs.
     cb = adapter.pop_post_delivery_callback(session_key)

--- a/tests/gateway/test_streaming_reasoning_delivery.py
+++ b/tests/gateway/test_streaming_reasoning_delivery.py
@@ -1,0 +1,193 @@
+"""Regression tests for reasoning display after a streamed gateway reply."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.run import (
+    GatewayRunner,
+    _build_gateway_reasoning_block,
+    _gateway_reasoning_delivery_mode,
+    _is_successful_streamed_delivery,
+)
+
+
+def test_reasoning_block_uses_platform_style():
+    config = {"display": {"show_reasoning": True}}
+
+    assert _build_gateway_reasoning_block(
+        config,
+        Platform.TELEGRAM,
+        "first\nsecond",
+    ) == "💭 **Reasoning:**\n```\nfirst\nsecond\n```"
+    assert _build_gateway_reasoning_block(
+        config,
+        Platform.DISCORD,
+        "first\nsecond",
+    ) == "-# 💭 Reasoning\n-# first\n-# second"
+
+
+def test_mattermost_requires_platform_reasoning_opt_in():
+    global_only = {"display": {"show_reasoning": True}}
+    explicit = {
+        "display": {
+            "show_reasoning": False,
+            "platforms": {"mattermost": {"show_reasoning": True}},
+        }
+    }
+
+    assert _build_gateway_reasoning_block(
+        global_only,
+        Platform.MATTERMOST,
+        "private scratch text",
+    ) == ""
+    assert _build_gateway_reasoning_block(
+        explicit,
+        Platform.MATTERMOST,
+        "opted in",
+    ) == "💭 **Reasoning:**\n```\nopted in\n```"
+
+
+@pytest.mark.parametrize("config", [None, [], "bad"])
+def test_reasoning_renderer_fails_closed_for_unavailable_config(config):
+    assert _build_gateway_reasoning_block(
+        config,
+        Platform.TELEGRAM,
+        "private scratch text",
+        default=True,
+    ) == ""
+
+
+@pytest.mark.parametrize("last_reasoning", [None, {"text": "secret"}, b"secret"])
+def test_reasoning_renderer_rejects_non_text_payloads(last_reasoning):
+    assert _build_gateway_reasoning_block(
+        {"display": {"show_reasoning": True}},
+        Platform.TELEGRAM,
+        last_reasoning,
+    ) == ""
+
+
+def test_reasoning_block_preserves_line_limit():
+    block = _build_gateway_reasoning_block(
+        {"display": {"show_reasoning": True}},
+        Platform.TELEGRAM,
+        "\n".join(f"line {number}" for number in range(18)),
+    )
+
+    assert "line 14" in block
+    assert "line 15" not in block
+    assert "_... (3 more lines)_" in block
+
+
+@pytest.mark.parametrize(
+    ("response", "already_sent", "failed", "silence", "expected"),
+    [
+        ("body", False, False, False, "prepend"),
+        ("body", True, False, False, "trailing"),
+        ("", True, False, False, "trailing"),
+        ("error", True, True, False, "prepend"),
+        ("", True, True, False, "none"),
+        ("body", True, False, True, "none"),
+    ],
+)
+def test_reasoning_delivery_mode_is_exactly_one_path(
+    response,
+    already_sent,
+    failed,
+    silence,
+    expected,
+):
+    streamed_success = _is_successful_streamed_delivery(already_sent, failed)
+    assert _gateway_reasoning_delivery_mode(
+        response,
+        streamed_success=streamed_success,
+        intentional_silence=silence,
+    ) == expected
+
+
+@pytest.mark.parametrize(
+    ("already_sent", "failed", "expected"),
+    [(1, 0, True), ("sent", "", True), (True, 1, False), (None, False, False)],
+)
+def test_streamed_success_preserves_truthy_flag_compatibility(
+    already_sent,
+    failed,
+    expected,
+):
+    assert _is_successful_streamed_delivery(already_sent, failed) is expected
+
+
+@pytest.mark.asyncio
+async def test_streamed_reasoning_uses_source_adapter_and_thread_metadata():
+    source = SimpleNamespace(chat_id="chat-1", thread_id="topic-1")
+    event = SimpleNamespace(message_id="message-1")
+    adapter = SimpleNamespace(send=AsyncMock())
+    runner = object.__new__(GatewayRunner)
+    runner._adapter_for_source = lambda actual_source: adapter
+    runner._reply_anchor_for_event = lambda actual_event: actual_event.message_id
+    runner._thread_metadata_for_source = lambda actual_source, anchor: {
+        "thread_id": actual_source.thread_id,
+        "reply_to_message_id": anchor,
+    }
+
+    await runner._send_streamed_reasoning(source, event, "reasoning block")
+
+    adapter.send.assert_awaited_once_with(
+        "chat-1",
+        "reasoning block",
+        metadata={
+            "thread_id": "topic-1",
+            "reply_to_message_id": "message-1",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_streamed_extras_deliver_media_before_reasoning():
+    calls = []
+    source = SimpleNamespace(chat_id="chat-1")
+    event = SimpleNamespace(message_id="message-1")
+    runner = object.__new__(GatewayRunner)
+    runner._adapter_for_source = lambda _source: object()
+    runner._deliver_media_from_response = AsyncMock(
+        side_effect=lambda *_args: calls.append("media")
+    )
+    runner._send_streamed_reasoning = AsyncMock(
+        side_effect=lambda *_args: calls.append("reasoning")
+    )
+
+    await runner._deliver_streamed_response_extras(
+        "streamed body with MEDIA tag",
+        event,
+        source,
+        "reasoning block",
+    )
+
+    assert calls == ["media", "reasoning"]
+
+
+@pytest.mark.asyncio
+async def test_media_failure_does_not_suppress_streamed_reasoning():
+    source = SimpleNamespace(chat_id="chat-1")
+    event = SimpleNamespace(message_id="message-1")
+    runner = object.__new__(GatewayRunner)
+    runner._adapter_for_source = lambda _source: object()
+    runner._deliver_media_from_response = AsyncMock(
+        side_effect=RuntimeError("upload failed")
+    )
+    runner._send_streamed_reasoning = AsyncMock()
+
+    await runner._deliver_streamed_response_extras(
+        "streamed body with MEDIA tag",
+        event,
+        source,
+        "reasoning block",
+    )
+
+    runner._send_streamed_reasoning.assert_awaited_once_with(
+        source,
+        event,
+        "reasoning block",
+    )


### PR DESCRIPTION
Fixes #5892.

## What changed

- Rebased the salvage onto current `main` and removed the superseded Anthropic extraction work.
- Reuse the current per-platform `show_reasoning` and `reasoning_style` resolution for both batch and streamed replies, including Mattermost's explicit opt-in.
- After a successful streamed body, deliver pending media first, then the reasoning block through `_adapter_for_source(source)` with thread metadata, followed by the existing runtime footer.
- Preserve the producer's `failed` flag so streamed partial output never suppresses a fresh failure diagnostic.

## Verification

- 138 focused gateway tests passed, including streamed success/failure, empty residual responses, platform styles, Mattermost opt-in, source adapter/thread routing, media ordering, and media-failure isolation.
- Ruff passed on all changed files.

The implementation was adversarially reviewed and reworked before this update.
