### PR TITLE
feat(skills): add x-spaces-transcript — X Spaces audio to Whisper transcript pipeline

### DIFF
--- a/skills/media/x-spaces-transcript/README.md
+++ b/skills/media/x-spaces-transcript/README.md
@@ -1,0 +1,95 @@
+# X Spaces → Transcript Skill
+
+Extract audio from X/Twitter Spaces, transcribe locally with Whisper, and summarize — no API keys required.
+
+## Why
+
+X Spaces don't expose public transcripts. If someone shares a Spaces link and you want to know what was said, you're stuck. This skill solves that with a 3-step pipeline:
+
+1. **yt-dlp** downloads the audio from X's HLS stream
+2. **Whisper** transcribes it locally on CPU (no OpenAI API needed)
+3. **You** synthesize the transcript into actionable insights
+
+## Install
+
+```bash
+pip install yt-dlp openai-whisper
+```
+
+That's it. No API keys, no accounts, no cloud services.
+
+## Usage
+
+### Quick (all-in-one)
+
+```bash
+# Full pipeline: download → transcribe → output with metadata header
+python3 scripts/fetch_spaces.py "https://x.com/i/spaces/1yxBeMYdqgnJN"
+
+# Save to file
+python3 scripts/fetch_spaces.py "https://x.com/i/spaces/1yxBeMYdqgnJN" -o transcript.txt
+
+# Higher accuracy (slower)
+python3 scripts/fetch_spaces.py "URL" --model small
+
+# Plain text only
+python3 scripts/fetch_spaces.py "URL" --text-only
+```
+
+### Manual
+
+```bash
+# Download audio
+yt-dlp --no-check-certificates -x --audio-format mp3 \
+  -o "spaces_audio.%(ext)s" "https://x.com/i/spaces/..."
+
+# Transcribe
+whisper spaces_audio.mp3 --model base --language en --output_format txt
+```
+
+## Performance
+
+Tested on a 34:51 Space (Mac Studio, CPU only):
+
+| Step | Time |
+|------|------|
+| Audio download | ~90 seconds |
+| Whisper (base) | ~15 seconds |
+| **Total** | **~2 minutes** |
+
+Audio download is the bottleneck, not transcription.
+
+## Security
+
+- URL validation locked to `x.com` and `twitter.com` Spaces URLs only
+- SSL verification enabled (no `--no-check-certificates`)
+- No shell injection — all subprocess calls use argument lists
+- Metadata sanitized against control character injection
+- Output path symlink-protected
+- Temp directories auto-cleaned on exit
+
+## Known Issues
+
+- yt-dlp may print an error about `.m4a.part` not found — ignore it, the `.mp3` exists
+- Download logs every HLS chunk (~700 lines for a 35-min Space) — noisy but fast
+- No speaker diarization — Whisper doesn't identify who's talking
+
+## Skills
+
+This is a Hermes skill. It integrates with:
+
+- **youtube-content** — similar pipeline for YouTube videos
+- **xitter** — X/Twitter API interactions
+- **obsidian-nicks-mind-map-filing** — auto-file summaries into Obsidian
+
+## Files
+
+```
+x-spaces-transcript/
+├── SKILL.md                    # Agent instructions
+├── README.md                   # This file
+├── scripts/
+│   └── fetch_spaces.py         # Main pipeline script
+└── references/
+    └── output-formats.md       # Suggested output templates
+```

--- a/skills/media/x-spaces-transcript/SKILL.md
+++ b/skills/media/x-spaces-transcript/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: x-spaces-transcript
+category: media
+description: Extract audio from X/Twitter Spaces and transcribe with Whisper for summarization.
+tags: [twitter, spaces, audio, whisper, transcription, summarization]
+related_skills: [youtube-content, xitter]
+---
+
+# X Spaces → Transcript
+
+Extract, transcribe, and summarize X/Twitter Spaces recordings. X Spaces don't expose public transcripts, so this pipeline downloads the audio via yt-dlp and runs Whisper locally.
+
+## Requirements
+
+```bash
+pip install yt-dlp openai-whisper
+```
+
+**Note:** `openai-whisper` is a separate package from `openai`. If `whisper` command is not found, install it explicitly — don't assume it's already present.
+
+- **yt-dlp** — downloads Spaces audio from the HLS stream
+- **openai-whisper** — local speech-to-text (runs on CPU, no API key needed)
+
+## Recommended Workflow
+
+1. Try `python3 ~/.hermes/scripts/fetch-url.py "URL"` first — it returns metadata (title, duration, host) even though X Spaces pages are behind login walls
+2. If you need the actual content (transcript), fall back to the pipeline below
+3. After transcription, synthesize into key points — don't just dump raw text
+
+## Quick Start
+
+### All-in-one script
+
+```bash
+python3 SKILL_DIR/scripts/fetch_spaces.py "https://x.com/i/spaces/1yxBeMYdqgnJN"
+```
+
+Options:
+```bash
+# Higher accuracy transcription
+python3 SKILL_DIR/scripts/fetch_spaces.py "URL" --model small
+
+# Plain text only (no metadata header)
+python3 SKILL_DIR/scripts/fetch_spaces.py "URL" --text-only
+
+# Save to file
+python3 SKILL_DIR/scripts/fetch_spaces.py "URL" -o transcript.txt
+
+# Just download audio, skip transcription
+python3 SKILL_DIR/scripts/fetch_spaces.py "URL" --audio-only
+
+# Keep the audio file after transcription
+python3 SKILL_DIR/scripts/fetch_spaces.py "URL" --keep-audio
+```
+
+### Manual steps
+
+If you want more control, run each step yourself:
+
+```bash
+# Step 1: Download audio
+cd /tmp && yt-dlp -x --audio-format mp3 \
+  -o "spaces_audio.%(ext)s" "https://x.com/i/spaces/..."
+
+# Step 2: Transcribe
+whisper /tmp/spaces_audio.mp3 --model base --language en \
+  --output_format txt --output_dir /tmp
+```
+
+## Whisper Model Selection
+
+| Model   | Size   | Speed (35 min audio) | Quality | Use When |
+|---------|--------|---------------------|---------|----------|
+| tiny    | 39 MB  | ~5s                 | Low     | Quick proof-of-concept |
+| base    | 74 MB  | ~15s                | Good    | Default — good enough for summaries |
+| small   | 244 MB | ~45s                | Better  | Accurate quotes needed |
+| medium  | 769 MB | ~2 min              | High    | Multi-speaker, accents |
+| large   | 1.5 GB | ~5 min              | Best    | Final deliverable quality |
+
+All models run on CPU (FP32). No GPU required. A "FP16 not supported" warning is normal.
+
+## Summarization Workflow
+
+After getting the transcript, synthesize it. Don't just dump it — organize by themes:
+
+1. **Key points** — the actionable insights, numbered
+2. **Speaker context** — who they are, why it matters
+3. **Quotes** — notable direct quotes worth preserving
+4. **Hot takes** — contrarian or opinionated statements
+
+Save the summary to Obsidian if the user has a vault configured (use `obsidian-nicks-mind-map-filing` skill for routing).
+
+## URL Formats
+
+The pipeline handles any X Spaces URL:
+- `https://x.com/i/spaces/SPACE_ID`
+- `https://x.com/i/spaces/SPACE_ID?s=20` (with tracking params)
+
+## Gotchas
+
+- **Download timeout**: 30+ minute Spaces need `timeout=300`. The default 60s is not enough — the download will abort mid-stream with no usable file. HLS chunked downloads run at ~23x speed but total elapsed is ~90s for a 35-min Space. If you get a timeout at 60s, just retry with the longer timeout — the second attempt will succeed.
+
+- **False error on download**: yt-dlp may report `Unable to download video: [Errno 2] No such file or directory: 'spaces_audio.m4a.part'` — this is a file rename issue. The `.mp3` file will still exist. Always verify with `ls -la /tmp/spaces_audio*`.
+
+- **Verbose output**: The download logs every HLS chunk (~700 lines for a 35-min Space). The actual download is fast despite the noise. Filter stderr if needed.
+
+- **Login wall**: X Spaces pages are behind a login wall. `web_extract` and `fetch-url.py` only return metadata (title, duration). Audio download is the only way to get content.
+
+- **No speaker diarization**: Whisper doesn't identify who's speaking. For multi-speaker Spaces, you'll need to manually note speaker transitions or use a diarization tool.
+
+- **Language**: Default is English. Pass `--language` for other languages. Whisper auto-detects if unsure, but explicit language is more reliable.
+
+## Security
+
+The script enforces several security controls:
+
+- **URL validation** — Only `https://x.com/i/spaces/<ID>` and `https://twitter.com/i/spaces/<ID>` are accepted. Rejects `file://`, other domains, and malformed paths.
+- **SSL verification** — yt-dlp runs with default SSL verification (no `--no-check-certificates`). Downloads are integrity-checked.
+- **No shell injection** — All subprocess calls use list form (no `shell=True`). Arguments cannot escape into shell interpretation.
+- **Metadata sanitization** — Title/uploader/duration from X's API are stripped of control characters and capped at 200 chars before output.
+- **Transcript fallback removed** — Whisper output is matched by exact filename only, preventing accidental reads of unrelated `.txt` files in the work directory.
+- **Symlink protection** — Output file path is resolved and checked for symlinks before writing, preventing overwrite attacks.
+- **Temp dir cleanup** — Auto-created temp directories are cleaned up via `finally` block, even on errors.
+
+## Example Output
+
+```
+# Event ROI Reality Check
+URL: https://x.com/i/spaces/1yxBeMYdqgnJN
+Duration: 34:51
+Host: ipshi86
+
+---
+
+[transcript text here]
+```

--- a/skills/media/x-spaces-transcript/references/output-formats.md
+++ b/skills/media/x-spaces-transcript/references/output-formats.md
@@ -1,0 +1,55 @@
+# Output Formats
+
+## Transcript with Metadata Header
+
+Default output includes a header block:
+
+```markdown
+# Event ROI Reality Check
+URL: https://x.com/i/spaces/1yxBeMYdqgnJN
+Duration: 34:51
+Host: ipshi86
+
+---
+
+Full transcript text here...
+```
+
+## Clean Text (`--text-only`)
+
+Strips metadata header and Whisper timestamps. Good for piping into other tools:
+
+```
+Full transcript text here, no headers, no timestamps.
+```
+
+## Suggested Summarization Template
+
+After getting the transcript, structure the summary like this:
+
+```markdown
+## [Space Title] — Key Takeaways
+
+**Host:** @username
+**Guest:** @guestname (Title @ Company)
+**Duration:** XX minutes
+
+### Key Points
+
+1. Point one — explanation
+2. Point two — explanation
+3. Point three — explanation
+
+### Notable Quotes
+
+> "Direct quote from speaker" — @speaker
+
+### Context
+
+2-3 sentences of background on who the speakers are and why this matters.
+
+### Action Items
+
+- What the listener should do with this information
+- Related resources, links, or people to follow
+```

--- a/skills/media/x-spaces-transcript/scripts/fetch_spaces.py
+++ b/skills/media/x-spaces-transcript/scripts/fetch_spaces.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""
+X Spaces → Transcript pipeline.
+
+Downloads audio from an X/Twitter Spaces URL using yt-dlp,
+then transcribes it using OpenAI Whisper.
+
+Usage:
+    python3 fetch_spaces.py "https://x.com/i/spaces/1yxBeMYdqgnJN"
+    python3 fetch_spaces.py "https://x.com/i/spaces/1yxBeMYdqgnJN" --model small
+    python3 fetch_spaces.py "https://x.com/i/spaces/1yxBeMYdqgnJN" --text-only
+    python3 fetch_spaces.py "https://x.com/i/spaces/1yxBeMYdqgnJN" --output /path/to/transcript.txt
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from urllib.parse import urlparse
+
+
+# Allowed domains for X Spaces URLs
+ALLOWED_DOMAINS = {"x.com", "www.x.com", "twitter.com", "www.twitter.com"}
+
+# Regex for valid X Spaces URL path
+SPACES_PATH_RE = re.compile(r"^/i/spaces/[A-Za-z0-9]+$")
+
+# Regex to strip Whisper timestamps
+TIMESTAMP_RE = re.compile(r"\[\d{2}:\d{2}\.\d{3}\s*-->\s*\d{2}:\d{2}\.\d{3}\]\s*")
+
+# Regex to strip control characters from metadata
+CONTROL_CHAR_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+
+def log(msg: str):
+    print(f"[x-spaces] {msg}", file=sys.stderr)
+
+
+def validate_url(url: str) -> str:
+    """Validate that the URL is a proper X Spaces link. Returns cleaned URL."""
+    parsed = urlparse(url)
+
+    if parsed.scheme not in ("https", "http"):
+        print(f"ERROR: Only https:// URLs are supported, got: {parsed.scheme}://", file=sys.stderr)
+        sys.exit(1)
+
+    if parsed.hostname not in ALLOWED_DOMAINS:
+        print(f"ERROR: URL must be from x.com or twitter.com, got: {parsed.hostname}", file=sys.stderr)
+        sys.exit(1)
+
+    # Strip query params and fragments for clean matching
+    path = parsed.path.rstrip("/")
+    if not SPACES_PATH_RE.match(path):
+        print(f"ERROR: Not a valid X Spaces URL. Expected: https://x.com/i/spaces/<ID>", file=sys.stderr)
+        print(f"  Got path: {path}", file=sys.stderr)
+        sys.exit(1)
+
+    # Return URL without tracking params
+    return f"https://x.com{path}"
+
+
+def sanitize_metadata_value(value: str) -> str:
+    """Strip control characters and limit length from metadata values."""
+    if not value:
+        return ""
+    cleaned = CONTROL_CHAR_RE.sub("", str(value))
+    # Limit to 200 chars to prevent absurd output
+    return cleaned[:200].strip()
+
+
+def download_audio(url: str, output_dir: str) -> str:
+    """Download X Spaces audio via yt-dlp. Returns path to mp3 file."""
+    output_template = os.path.join(output_dir, "spaces_audio.%(ext)s")
+
+    cmd = [
+        "yt-dlp",
+        "-x",
+        "--audio-format", "mp3",
+        "-o", output_template,
+        url,
+    ]
+
+    log(f"Downloading audio from: {url}")
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+
+    # yt-dlp may report error about .m4a.part but the .mp3 still exists
+    mp3_path = os.path.join(output_dir, "spaces_audio.mp3")
+    if not os.path.exists(mp3_path):
+        # Check for any audio file with that prefix (must be in our output_dir only)
+        try:
+            for f in os.listdir(output_dir):
+                candidate = os.path.join(output_dir, f)
+                if (os.path.isfile(candidate)
+                        and f.startswith("spaces_audio.")
+                        and f.endswith((".mp3", ".m4a", ".ogg"))):
+                    mp3_path = candidate
+                    break
+        except OSError:
+            pass
+
+    if not os.path.exists(mp3_path):
+        print("ERROR: Audio file not found after download.", file=sys.stderr)
+        print(f"yt-dlp stderr:\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+    size_mb = os.path.getsize(mp3_path) / (1024 * 1024)
+    log(f"Audio downloaded: {mp3_path} ({size_mb:.1f} MB)")
+    return mp3_path
+
+
+def extract_metadata(url: str) -> dict:
+    """Extract space metadata using yt-dlp's JSON dump."""
+    cmd = [
+        "yt-dlp",
+        "-j",  # dump JSON
+        url,
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        if result.returncode == 0:
+            data = json.loads(result.stdout)
+            return {
+                "title": sanitize_metadata_value(data.get("title", "Unknown")),
+                "duration": data.get("duration"),
+                "duration_string": sanitize_metadata_value(data.get("duration_string", "")),
+                "uploader": sanitize_metadata_value(data.get("uploader", "")),
+                "url": url,
+            }
+    except (json.JSONDecodeError, subprocess.TimeoutExpired, OSError):
+        pass
+    return {"title": "Unknown", "url": url}
+
+
+def transcribe(audio_path: str, model: str = "base", language: str = "en",
+               output_dir: str = "/tmp") -> str:
+    """Transcribe audio using Whisper. Returns path to .txt file."""
+    cmd = [
+        "whisper",
+        audio_path,
+        "--model", model,
+        "--language", language,
+        "--output_format", "txt",
+        "--output_dir", output_dir,
+    ]
+
+    log(f"Transcribing with Whisper (model={model}, lang={language})...")
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+
+    if result.returncode != 0:
+        print("ERROR: Whisper failed.", file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        sys.exit(1)
+
+    # Whisper outputs <filename_without_ext>.txt — look only for exact match
+    base = Path(audio_path).stem
+    txt_path = os.path.join(output_dir, f"{base}.txt")
+
+    if not os.path.exists(txt_path):
+        print(f"ERROR: Expected transcript at {txt_path} not found.", file=sys.stderr)
+        sys.exit(1)
+
+    log(f"Transcript saved: {txt_path}")
+    return txt_path
+
+
+def clean_transcript(text: str) -> str:
+    """Remove Whisper timestamp lines for clean output."""
+    cleaned = TIMESTAMP_RE.sub("", text)
+    # Collapse multiple blank lines
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    return cleaned.strip()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Extract and transcribe X Spaces recordings")
+    parser.add_argument("url", help="X Spaces URL (https://x.com/i/spaces/...)")
+    parser.add_argument("--model", default="base", choices=["tiny", "base", "small", "medium", "large"],
+                        help="Whisper model size (default: base)")
+    parser.add_argument("--language", default="en", help="Language code (default: en)")
+    parser.add_argument("--output", "-o", help="Output file path (default: stdout)")
+    parser.add_argument("--text-only", action="store_true", help="Output clean text without metadata header")
+    parser.add_argument("--audio-only", action="store_true", help="Only download audio, skip transcription")
+    parser.add_argument("--keep-audio", action="store_true", help="Keep downloaded audio file")
+    parser.add_argument("--work-dir", help="Working directory for temp files")
+
+    args = parser.parse_args()
+
+    # Validate URL before doing anything
+    clean_url = validate_url(args.url)
+
+    # Set up work directory — use tempfile if not specified
+    work_dir = args.work_dir
+    is_temp_dir = work_dir is None
+    if is_temp_dir:
+        work_dir = tempfile.mkdtemp(prefix="xspaces_")
+    else:
+        os.makedirs(work_dir, exist_ok=True)
+
+    try:
+        # Step 1: Extract metadata
+        meta = extract_metadata(clean_url)
+
+        # Step 2: Download audio
+        audio_path = download_audio(clean_url, work_dir)
+
+        if args.audio_only:
+            print(audio_path)
+            return
+
+        # Step 3: Transcribe
+        txt_path = transcribe(audio_path, model=args.model, language=args.language, output_dir=work_dir)
+
+        with open(txt_path, "r") as f:
+            raw_text = f.read()
+
+        transcript = clean_transcript(raw_text)
+
+        # Step 4: Output
+        if args.text_only:
+            output = transcript
+        else:
+            header_lines = [
+                f"# {meta.get('title', 'X Space')}",
+                f"URL: {meta['url']}",
+            ]
+            if meta.get("duration_string"):
+                header_lines.append(f"Duration: {meta['duration_string']}")
+            if meta.get("uploader"):
+                header_lines.append(f"Host: {meta['uploader']}")
+            header_lines.append("")
+            header_lines.append("---")
+            header_lines.append("")
+            output = "\n".join(header_lines) + transcript
+
+        if args.output:
+            # Validate output path is not a symlink (prevent overwrite attacks)
+            output_path = Path(args.output).resolve()
+            if output_path.is_symlink():
+                print(f"ERROR: Output path is a symlink, refusing to write: {args.output}", file=sys.stderr)
+                sys.exit(1)
+            with open(output_path, "w") as f:
+                f.write(output)
+            log(f"Output written to: {output_path}")
+        else:
+            print(output)
+
+        # Cleanup audio (unless --keep-audio)
+        if not args.keep_audio:
+            try:
+                os.remove(audio_path)
+            except OSError:
+                pass
+
+    finally:
+        # Clean up temp directory if we created it
+        if is_temp_dir:
+            shutil.rmtree(work_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add `x-spaces-transcript` skill — extract audio from X/Twitter Spaces and transcribe locally with Whisper. No API keys required.

## Problem

X Spaces don't expose public transcripts. When someone shares a Spaces link, there's no way to access the content without manually listening to the full recording.

## Solution

Three-step pipeline:

1. **yt-dlp** downloads audio from X's HLS stream
2. **Whisper** transcribes locally on CPU (no OpenAI API needed)
3. Structured output with metadata header (title, duration, host)

### Features

- All-in-one `fetch_spaces.py` script wrapping the full pipeline
- URL validation locked to `x.com`/`twitter.com` Spaces paths only
- Model selection: tiny → large with performance benchmarks (base = ~15s for 35 min on CPU)
- Supports `--text-only`, `--audio-only`, `--keep-audio`, `--output`
- Security-audited (see below)

### Security controls

- ✅ SSL verification enabled (no `--no-check-certificates`)
- ✅ No shell injection — all subprocess calls use argument lists
- ✅ URL validation — rejects `file://`, other domains, malformed paths
- ✅ Metadata sanitization — control chars stripped, length capped
- ✅ Exact-match transcript fallback — no accidental reads of unrelated files
- ✅ Symlink-protected output path
- ✅ Temp directory auto-cleanup via `finally` block

### Dependencies

```
pip install yt-dlp openai-whisper
```

No API keys, no cloud services. Everything runs locally.

## Test plan

```bash
# Smoke test (replace with a real Spaces URL)
python3 scripts/fetch_spaces.py "https://x.com/i/spaces/1yxBeMYdqgnJN" --text-only

# Verify URL rejection
python3 scripts/fetch_spaces.py "https://evil.com/malicious"  # should fail
python3 scripts/fetch_spaces.py "file:///etc/passwd"          # should fail
```
