### PR TITLE
fix(gateway): block SSRF in shared media cache downloads

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -28,6 +28,8 @@ sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
 from gateway.config import Platform, PlatformConfig
 from gateway.session import SessionSource, build_session_key
 from hermes_constants import get_hermes_dir
+from tools.url_safety import is_safe_url
+from tools.website_policy import check_website_access
 
 
 GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE = (
@@ -110,6 +112,88 @@ def cache_image_from_bytes(data: bytes, ext: str = ".jpg") -> str:
     return str(filepath)
 
 
+def _enforce_media_download_url_policy(url: str) -> None:
+    """Reject blocked or private/internal media URLs before downloading."""
+    blocked = check_website_access(url)
+    if blocked:
+        raise PermissionError(blocked["message"])
+    if not is_safe_url(url):
+        raise PermissionError(
+            "Blocked: URL targets a private or internal network address"
+        )
+
+
+def _build_media_redirect_guard():
+    """Re-check each redirect target so public URLs cannot bounce into SSRF."""
+
+    async def _guard(response):
+        if response.is_redirect and response.next_request:
+            _enforce_media_download_url_policy(str(response.next_request.url))
+
+    return _guard
+
+
+async def _cache_media_from_url(
+    url: str,
+    *,
+    ext: str,
+    retries: int,
+    accept_header: str,
+    cache_writer,
+    retry_log_label: str,
+) -> str:
+    """Download media with retry logic and SSRF-safe URL validation."""
+    import httpx
+    import logging as _logging
+    _log = _logging.getLogger(__name__)
+
+    _enforce_media_download_url_policy(url)
+
+    last_exc = None
+    async with httpx.AsyncClient(
+        timeout=30.0,
+        follow_redirects=True,
+        event_hooks={"response": [_build_media_redirect_guard()]},
+    ) as client:
+        for attempt in range(retries + 1):
+            try:
+                response = await client.get(
+                    url,
+                    headers={
+                        "User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)",
+                        "Accept": accept_header,
+                    },
+                )
+                response.raise_for_status()
+                _enforce_media_download_url_policy(str(response.url))
+                return cache_writer(response.content, ext)
+            except PermissionError:
+                raise
+            except (httpx.TimeoutException, httpx.HTTPStatusError) as exc:
+                last_exc = exc
+                if (
+                    isinstance(exc, httpx.HTTPStatusError)
+                    and exc.response.status_code < 429
+                ):
+                    raise
+                if attempt < retries:
+                    wait = 1.5 * (attempt + 1)
+                    _log.debug(
+                        "%s retry %d/%d for %s (%.1fs): %s",
+                        retry_log_label,
+                        attempt + 1,
+                        retries,
+                        _safe_url_for_log(url),
+                        wait,
+                        exc,
+                    )
+                    await asyncio.sleep(wait)
+                    continue
+                raise
+
+    raise last_exc
+
+
 async def cache_image_from_url(url: str, ext: str = ".jpg", retries: int = 2) -> str:
     """
     Download an image from a URL and save it to the local cache.
@@ -125,42 +209,14 @@ async def cache_image_from_url(url: str, ext: str = ".jpg", retries: int = 2) ->
     Returns:
         Absolute path to the cached image file as a string.
     """
-    import asyncio
-    import httpx
-    import logging as _logging
-    _log = _logging.getLogger(__name__)
-
-    last_exc = None
-    async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
-        for attempt in range(retries + 1):
-            try:
-                response = await client.get(
-                    url,
-                    headers={
-                        "User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)",
-                        "Accept": "image/*,*/*;q=0.8",
-                    },
-                )
-                response.raise_for_status()
-                return cache_image_from_bytes(response.content, ext)
-            except (httpx.TimeoutException, httpx.HTTPStatusError) as exc:
-                last_exc = exc
-                if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code < 429:
-                    raise
-                if attempt < retries:
-                    wait = 1.5 * (attempt + 1)
-                    _log.debug(
-                        "Media cache retry %d/%d for %s (%.1fs): %s",
-                        attempt + 1,
-                        retries,
-                        _safe_url_for_log(url),
-                        wait,
-                        exc,
-                    )
-                    await asyncio.sleep(wait)
-                    continue
-                raise
-    raise last_exc
+    return await _cache_media_from_url(
+        url,
+        ext=ext,
+        retries=retries,
+        accept_header="image/*,*/*;q=0.8",
+        cache_writer=cache_image_from_bytes,
+        retry_log_label="Media cache",
+    )
 
 
 def cleanup_image_cache(max_age_hours: int = 24) -> int:
@@ -233,42 +289,14 @@ async def cache_audio_from_url(url: str, ext: str = ".ogg", retries: int = 2) ->
     Returns:
         Absolute path to the cached audio file as a string.
     """
-    import asyncio
-    import httpx
-    import logging as _logging
-    _log = _logging.getLogger(__name__)
-
-    last_exc = None
-    async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
-        for attempt in range(retries + 1):
-            try:
-                response = await client.get(
-                    url,
-                    headers={
-                        "User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)",
-                        "Accept": "audio/*,*/*;q=0.8",
-                    },
-                )
-                response.raise_for_status()
-                return cache_audio_from_bytes(response.content, ext)
-            except (httpx.TimeoutException, httpx.HTTPStatusError) as exc:
-                last_exc = exc
-                if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code < 429:
-                    raise
-                if attempt < retries:
-                    wait = 1.5 * (attempt + 1)
-                    _log.debug(
-                        "Audio cache retry %d/%d for %s (%.1fs): %s",
-                        attempt + 1,
-                        retries,
-                        _safe_url_for_log(url),
-                        wait,
-                        exc,
-                    )
-                    await asyncio.sleep(wait)
-                    continue
-                raise
-    raise last_exc
+    return await _cache_media_from_url(
+        url,
+        ext=ext,
+        retries=retries,
+        accept_header="audio/*,*/*;q=0.8",
+        cache_writer=cache_audio_from_bytes,
+        retry_log_label="Audio cache",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_media_download_retry.py
+++ b/tests/gateway/test_media_download_retry.py
@@ -48,6 +48,7 @@ class TestCacheImageFromUrl:
         fake_response = MagicMock()
         fake_response.content = b"\xff\xd8\xff fake jpeg"
         fake_response.raise_for_status = MagicMock()
+        fake_response.url = "http://example.com/img.jpg"
 
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(return_value=fake_response)
@@ -72,6 +73,7 @@ class TestCacheImageFromUrl:
         fake_response = MagicMock()
         fake_response.content = b"image data"
         fake_response.raise_for_status = MagicMock()
+        fake_response.url = "http://example.com/img.jpg"
 
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(
@@ -102,6 +104,7 @@ class TestCacheImageFromUrl:
         ok_response = MagicMock()
         ok_response.content = b"image data"
         ok_response.raise_for_status = MagicMock()
+        ok_response.url = "http://example.com/img.jpg"
 
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(
@@ -170,6 +173,83 @@ class TestCacheImageFromUrl:
         assert mock_client.get.call_count == 1
         mock_sleep.assert_not_called()
 
+    def test_blocks_private_url_before_network_request(self, tmp_path, monkeypatch):
+        """Private/internal URLs must be rejected before httpx connects."""
+        monkeypatch.setattr("gateway.platforms.base.IMAGE_CACHE_DIR", tmp_path / "img")
+
+        from gateway.platforms import base as base_module
+
+        monkeypatch.setattr(base_module, "check_website_access", lambda url: None)
+        monkeypatch.setattr(base_module, "is_safe_url", lambda url: False)
+
+        async def run():
+            with patch("httpx.AsyncClient") as mock_client:
+                with pytest.raises(
+                    PermissionError,
+                    match="private or internal network address",
+                ):
+                    await base_module.cache_image_from_url(
+                        "http://169.254.169.254/latest/meta-data/",
+                        ext=".jpg",
+                    )
+                mock_client.assert_not_called()
+
+        asyncio.run(run())
+
+    def test_blocks_redirect_to_private_address(self, tmp_path, monkeypatch):
+        """A public image URL must not be allowed to redirect into internal IPs."""
+        monkeypatch.setattr("gateway.platforms.base.IMAGE_CACHE_DIR", tmp_path / "img")
+
+        from gateway.platforms import base as base_module
+
+        monkeypatch.setattr(base_module, "check_website_access", lambda url: None)
+        monkeypatch.setattr(
+            base_module,
+            "is_safe_url",
+            lambda url: "169.254.169.254" not in url,
+        )
+
+        class RedirectingClient:
+            def __init__(self, *args, **kwargs):
+                self._event_hooks = kwargs.get("event_hooks", {})
+                self.get_calls = 0
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+            async def get(self, url, headers=None):
+                self.get_calls += 1
+                redirect_response = MagicMock()
+                redirect_response.is_redirect = True
+                redirect_response.next_request = httpx.Request(
+                    "GET",
+                    "http://169.254.169.254/latest/meta-data/",
+                )
+                for hook in self._event_hooks.get("response", []):
+                    await hook(redirect_response)
+
+                final_response = MagicMock()
+                final_response.url = "http://example.com/final.jpg"
+                final_response.content = b"image data"
+                final_response.raise_for_status = MagicMock()
+                return final_response
+
+        async def run():
+            with patch("httpx.AsyncClient", RedirectingClient):
+                with pytest.raises(
+                    PermissionError,
+                    match="private or internal network address",
+                ):
+                    await base_module.cache_image_from_url(
+                        "http://example.com/image.jpg",
+                        ext=".jpg",
+                    )
+
+        asyncio.run(run())
+
 
 # ---------------------------------------------------------------------------
 # cache_audio_from_url (base.py)
@@ -185,6 +265,7 @@ class TestCacheAudioFromUrl:
         fake_response = MagicMock()
         fake_response.content = b"\x00\x01 fake audio"
         fake_response.raise_for_status = MagicMock()
+        fake_response.url = "http://example.com/voice.ogg"
 
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(return_value=fake_response)
@@ -209,6 +290,7 @@ class TestCacheAudioFromUrl:
         fake_response = MagicMock()
         fake_response.content = b"audio data"
         fake_response.raise_for_status = MagicMock()
+        fake_response.url = "http://example.com/voice.ogg"
 
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(
@@ -239,6 +321,7 @@ class TestCacheAudioFromUrl:
         ok_response = MagicMock()
         ok_response.content = b"audio data"
         ok_response.raise_for_status = MagicMock()
+        ok_response.url = "http://example.com/voice.ogg"
 
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(
@@ -266,6 +349,7 @@ class TestCacheAudioFromUrl:
         ok_response = MagicMock()
         ok_response.content = b"audio data"
         ok_response.raise_for_status = MagicMock()
+        ok_response.url = "http://example.com/voice.ogg"
 
         mock_client = AsyncMock()
         mock_client.get = AsyncMock(
@@ -333,6 +417,30 @@ class TestCacheAudioFromUrl:
         # Only 1 attempt, no sleep
         assert mock_client.get.call_count == 1
         mock_sleep.assert_not_called()
+
+    def test_blocks_website_policy_before_network_request(self, tmp_path, monkeypatch):
+        """Configured website policy must block audio downloads before fetching."""
+        monkeypatch.setattr("gateway.platforms.base.AUDIO_CACHE_DIR", tmp_path / "audio")
+
+        from gateway.platforms import base as base_module
+
+        monkeypatch.setattr(
+            base_module,
+            "check_website_access",
+            lambda url: {"message": "Blocked by website policy"},
+        )
+        monkeypatch.setattr(base_module, "is_safe_url", lambda url: True)
+
+        async def run():
+            with patch("httpx.AsyncClient") as mock_client:
+                with pytest.raises(PermissionError, match="Blocked by website policy"):
+                    await base_module.cache_audio_from_url(
+                        "https://blocked.example/audio.ogg",
+                        ext=".ogg",
+                    )
+                mock_client.assert_not_called()
+
+        asyncio.run(run())
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION

## Summary
This PR fixes an SSRF issue in the shared gateway media caching helpers. Image/audio URL downloads now enforce website-policy and private-network URL checks before request execution, across redirects, and on the final resolved URL.

## Vulnerability Details
- **Type**: SSRF
- **Impact**: Untrusted media URLs could trigger server-side requests to localhost, link-local, or private network targets through shared adapter code paths.
- **Affected file(s)**: `gateway/platforms/base.py`

## Root Cause
`cache_image_from_url()` and `cache_audio_from_url()` fetched arbitrary URLs with redirects enabled, but did not validate the initial URL, redirect targets, or final resolved URL using Hermes' existing SSRF protections.

## Fix
Added centralized URL-policy enforcement for shared media downloads and reused it for both image and audio caching helpers.

## Reproduction
Before the fix, a user-controlled media URL could point directly to an internal address or redirect to one after an apparently public initial request.

## Testing
- [x] Added regression test in `tests/`
- [x] `pytest tests/ -v` passes
- [x] Tested on: Windows
- [x] No new dependencies added

Verified:
- `python -m pytest tests/gateway/test_media_download_retry.py -q` → 27 passed
- `python -m pytest tests/gateway/test_platform_base.py -q` → 59 passed
